### PR TITLE
Fix help config-set command parsing and add ingest paths to full preset

### DIFF
--- a/extensions/memory-hybrid/cli/register.ts
+++ b/extensions/memory-hybrid/cli/register.ts
@@ -602,8 +602,11 @@ export function registerHybridMemCli(mem: Chainable, ctx: HybridMemCliContext): 
       console.log(result.message);
     }));
 
-  mem
-    .command("help config-set <key>")
+  const helpCmd = mem
+    .command("help")
+    .description("Help commands for config keys");
+  helpCmd
+    .command("config-set <key>")
     .description("Show current value and a short description for a config key (e.g. autoCapture, credentials.enabled).")
     .action(withExit(async (key: string) => {
       const result = await runConfigSetHelp(key);

--- a/extensions/memory-hybrid/config.ts
+++ b/extensions/memory-hybrid/config.ts
@@ -517,6 +517,7 @@ export const PRESET_OVERRIDES: Record<ConfigMode, Record<string, unknown>> = {
       analyzeViaSpawn: false,
     },
     search: { hydeEnabled: true },
+    ingest: { paths: ["skills/**/*.md", "TOOLS.md", "AGENTS.md"] },
     distill: { extractDirectives: true, extractReinforcement: true },
   },
 };


### PR DESCRIPTION
- Fix bug where 'help config-set <key>' received wrong positional argument by using nested command pattern (helpCmd.command) instead of flat command
- Add default ingest paths to full preset to match documentation that shows ingest as enabled (✓) for Full mode

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CLI command-structure change plus a preset default update; limited blast radius and no security-sensitive logic touched.
> 
> **Overview**
> Fixes the `hybrid-mem` CLI help routing by introducing a `help` parent command and nesting `config-set <key>` under it, so `help config-set <key>` passes the correct positional argument.
> 
> Updates the `full` config preset to include default `ingest.paths` (e.g. `skills/**/*.md`, `TOOLS.md`, `AGENTS.md`) so Full mode enables workspace ingestion by default.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 50dcb6f8eb24e07749349ef869a5533cf0bd9ae0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->