### PR TITLE
fix(vectordb): auto-reconnect after close() — fixes 'VectorDB is closed' during concurrent agent ops

### DIFF
--- a/extensions/memory-hybrid/tests/db-connection.test.ts
+++ b/extensions/memory-hybrid/tests/db-connection.test.ts
@@ -201,37 +201,49 @@ describe("VectorDB auto-reconnects after close()", () => {
     expect(typeof id).toBe("string");
   });
 
-  it("search succeeds after close()", async () => {
+  it("search succeeds after close() and returns the known stored fact", async () => {
+    // "initial fact" with vector [0.1, 0.2, 0.3] was stored in beforeEach.
+    // After close + auto-reconnect, search must find it — not just return any array.
     db.close();
-    // Should auto-reconnect and return results (or empty), not throw
     const results = await db.search([0.1, 0.2, 0.3], 5, 0);
     expect(Array.isArray(results)).toBe(true);
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0].entry.text).toBe("initial fact");
   });
 
-  it("hasDuplicate succeeds after close()", async () => {
+  it("hasDuplicate returns true for the known stored vector after close()", async () => {
+    // The exact same vector [0.1, 0.2, 0.3] was stored in beforeEach (distance = 0, score = 1.0).
+    // hasDuplicate must return true — not just any boolean. Returning false would mean
+    // reconnect silently failed and the error was swallowed.
     db.close();
-    // Should auto-reconnect and return a boolean, not throw
-    const isDup = await db.hasDuplicate([0.1, 0.2, 0.3]);
-    expect(typeof isDup).toBe("boolean");
+    const isDup = await db.hasDuplicate([0.1, 0.2, 0.3], 0.95);
+    expect(isDup).toBe(true);
   });
 
-  it("count succeeds after close()", async () => {
+  it("count returns the actual row count after close()", async () => {
+    // Exactly 1 row stored in beforeEach. Count must return 1 — not just any number.
+    // Returning 0 would mean reconnect silently failed and the error was swallowed.
     db.close();
-    // Should auto-reconnect and return a count, not throw
     const n = await db.count();
-    expect(typeof n).toBe("number");
+    expect(n).toBe(1);
   });
 
-  it("multiple operations after close() all succeed", async () => {
+  it("multiple concurrent operations after close() return real results", async () => {
     db.close();
-    // Simulate multiple concurrent calls (e.g., 3-4 agents retrying after restart)
+    // Simulate multiple concurrent calls (e.g., 3-4 agents retrying after restart).
+    // Assertions verify actual content — not just that values are defined/typed.
     const [id1, id2, results] = await Promise.all([
       db.store({ text: "agent1 fact", vector: [0.1, 0.2, 0.3], importance: 0.7, category: "fact" }),
       db.store({ text: "agent2 fact", vector: [0.4, 0.5, 0.6], importance: 0.7, category: "fact" }),
       db.search([0.1, 0.2, 0.3], 3, 0),
     ]);
-    expect(id1).toBeDefined();
-    expect(id2).toBeDefined();
-    expect(Array.isArray(results)).toBe(true);
+    expect(typeof id1).toBe("string");
+    expect(id1.length).toBeGreaterThan(0);
+    expect(typeof id2).toBe("string");
+    expect(id2.length).toBeGreaterThan(0);
+    // Search was concurrent with the stores but ran against the already-open reconnected DB.
+    // At minimum the "initial fact" stored in beforeEach must be present.
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0].entry.text).toBe("initial fact");
   });
 });


### PR DESCRIPTION
## Problem

During concurrent subagent runs (3-4 agents simultaneously), LanceDB operations fail with:

```
memory-hybrid: LanceDB search failed: Error: VectorDB is closed
memory-hybrid: LanceDB hasDuplicate failed: Error: VectorDB is closed
memory-hybrid: LanceDB store failed: Error: VectorDB is closed
memory-hybrid: vector store failed: Error: VectorDB is closed
```

## Root Cause

`VectorDB.close()` sets `this.closed = true`, which permanently prevents **all** subsequent operations via `ensureInitialized()`:

```typescript
// Before fix — throws forever, no recovery
private async ensureInitialized(): Promise<void> {
  if (this.closed) throw new Error("VectorDB is closed");
  ...
}
```

`close()` is called by:
1. `plugin-service.stop()` — on gateway shutdown / deferred SIGUSR1 restart
2. `closeOldDatabases()` in `register()` — on hot-reload

**The race**: when `stop()` fires during a deferred restart, in-flight async memory operations (embedding calls still awaiting, LanceDB ops queued) call `ensureInitialized()` after `close()`, hitting the permanent error.

### Why FactsDB/CredentialsDB don't have this problem

Both SQLite backends use a `liveDb` getter that auto-reopens when `!this.db.open`:

```typescript
// FactsDB/CredentialsDB — auto-reconnects
private get liveDb(): Database.Database {
  if (!this.db.open) {
    this.db = new Database(this.dbPath);
    this.applyPragmas();
  }
  return this.db;
}
```

VectorDB had no equivalent recovery path.

## Fix

Mirror the FactsDB/CredentialsDB pattern in `ensureInitialized()` — instead of throwing permanently, reset the closed state and reconnect:

```typescript
private async ensureInitialized(): Promise<void> {
  // Auto-reconnect: mirrors FactsDB/CredentialsDB liveDb() pattern
  if (this.closed) {
    this.logWarn("memory-hybrid: VectorDB was closed; reconnecting...");
    this.closed = false;
    this.table = null;
    this.db = null;
    this.initPromise = null;
  }
  ...
}
```

Safe because Node.js's single-threaded event loop guarantees the synchronous reset block is atomic; concurrent callers share the same `initPromise`.

## Tests

5 new tests in `db-connection.test.ts` (the dedicated reconnect test file for FactsDB/CredentialsDB):

- `store succeeds after close()`
- `search succeeds after close()`
- `hasDuplicate succeeds after close()`
- `count succeeds after close()`
- `multiple operations after close() all succeed` — simulates 3-4 concurrent agents

All 14 tests pass (9 existing + 5 new). The 2 pre-existing `version-command.test.ts` failures are unrelated (version comparison test environment issue on `main`).

## Checklist

- [x] Root cause identified and documented
- [x] Fix implemented with minimal change (8 lines in ensureInitialized)
- [x] 5 tests covering all VectorDB public methods after close()
- [x] `npx tsc --noEmit` — zero new errors (3 pre-existing errors unchanged)
- [x] Full test suite: 698 pass / 2 fail (pre-existing)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes VectorDB lifecycle/reconnection behavior and init concurrency, which can affect connection management and error handling under restart and load, but is scoped and covered by new tests.
> 
> **Overview**
> Fixes `VectorDB` so operations can recover after `close()` (e.g., restart/hot-reload) instead of permanently failing with "VectorDB is closed".
> 
> `ensureInitialized()` now awaits any in-flight initialization, resets/cleans up state when `closed` (including closing any late-opened connection), and `close()` no longer clears `initPromise` to avoid starting a second concurrent init. Adds a `VectorDB` reconnect test suite validating `store`, `search`, `hasDuplicate`, `count`, and concurrent calls after `close()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 11155211356be1c175dcba992a7d1e07cd7dc038. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->