### PR TITLE
Potential fix for code scanning alert no. 4: Prototype-polluting function

### DIFF
--- a/extensions/memory-hybrid/index.ts
+++ b/extensions/memory-hybrid/index.ts
@@ -42,6 +42,7 @@ import { WriteAheadLog } from "./backends/wal.js";
 import { VectorDB } from "./backends/vector-db.js";
 import { FactsDB, MEMORY_LINK_TYPES, type MemoryLinkType } from "./backends/facts-db.js";
 import { registerHybridMemCliWithApi } from "./setup/cli-context.js";
+import { deepMerge } from "./cli/handlers.js";
 import { Embeddings, safeEmbed } from "./services/embeddings.js";
 import { chatComplete, distillBatchTokenLimit, distillMaxOutputTokens, createPendingLLMWarnings } from "./services/chat.js";
 import { extractProceduresFromSessions } from "./services/procedure-extractor.js";
@@ -414,6 +415,7 @@ export const _testing = {
   mergeResults,
   filterByScope,
   safeEmbed,
+  deepMerge,
   // Encryption primitives (used by CredentialsDB)
   deriveKey,
   encryptValue,

--- a/extensions/memory-hybrid/package-lock.json
+++ b/extensions/memory-hybrid/package-lock.json
@@ -526,22 +526,6 @@
         "node": ">= 18"
       }
     },
-    "node_modules/@lancedb/lancedb-darwin-x64": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@lancedb/lancedb-darwin-x64/-/lancedb-darwin-x64-0.23.0.tgz",
-      "integrity": "sha512-u1zU8Wk2k3SmA0N2I1m7qg5A1JXcV1F2vG3CJ2S4q7ZlQ3R5FQ7Cq9y7iZ2ZMcduYt2c9nqUTZ6c9n1jYyF5sw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 18"
-      }
-    },
     "node_modules/@lancedb/lancedb-linux-arm64-gnu": {
       "version": "0.23.0",
       "resolved": "https://registry.npmjs.org/@lancedb/lancedb-linux-arm64-gnu/-/lancedb-linux-arm64-gnu-0.23.0.tgz",
@@ -637,9 +621,6 @@
       "engines": {
         "node": ">= 18"
       }
-    },
-    "node_modules/@lancedb/lancedb/node_modules/@lancedb/lancedb-darwin-x64": {
-      "optional": true
     },
     "node_modules/@opentelemetry/api": {
       "version": "1.9.0",

--- a/extensions/memory-hybrid/tests/deep-merge.test.ts
+++ b/extensions/memory-hybrid/tests/deep-merge.test.ts
@@ -1,0 +1,355 @@
+/**
+ * deep-merge.test.ts — Unit tests for the deepMerge function.
+ *
+ * ## Coverage
+ *
+ * ### Prototype Pollution Prevention
+ * - Verifies that `__proto__` keys are skipped during merge
+ * - Verifies that `constructor` keys are skipped during merge
+ * - Verifies that `prototype` keys are skipped during merge
+ * - Ensures Object.prototype is not polluted after merge operations
+ * - Tests nested objects with prototype-related keys
+ *
+ * ### Normal Merge Behavior
+ * - Merges simple properties correctly
+ * - Recursively merges nested objects
+ * - Only adds properties that are undefined in target
+ * - Does not overwrite existing properties in target
+ * - Handles arrays correctly (treats them as values, not objects to merge)
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { _testing } from "../index.js";
+
+const { deepMerge } = _testing;
+
+describe("deepMerge - Prototype Pollution Prevention", () => {
+  beforeEach(() => {
+    // Ensure Object.prototype is clean before each test
+    delete (Object.prototype as Record<string, unknown>).polluted;
+    delete (Object.prototype as Record<string, unknown>).isAdmin;
+    delete (Object.prototype as Record<string, unknown>).evilProperty;
+  });
+
+  it("blocks __proto__ key from polluting Object.prototype", () => {
+    const target = {};
+    const maliciousSource = JSON.parse('{"__proto__": {"polluted": "yes"}}');
+    
+    deepMerge(target, maliciousSource);
+    
+    // Verify Object.prototype was not polluted
+    expect((Object.prototype as Record<string, unknown>).polluted).toBeUndefined();
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+  });
+
+  it("blocks constructor key from being merged", () => {
+    const target: Record<string, unknown> = {};
+    const maliciousSource = {
+      constructor: {
+        prototype: {
+          isAdmin: true,
+        },
+      },
+    };
+    
+    deepMerge(target, maliciousSource);
+    
+    // Verify Object.prototype was not polluted
+    expect((Object.prototype as Record<string, unknown>).isAdmin).toBeUndefined();
+    expect(({} as Record<string, unknown>).isAdmin).toBeUndefined();
+    // Target should not have constructor key added
+    expect(target.constructor).toBeDefined(); // constructor exists naturally on objects
+    expect((target.constructor as Record<string, unknown>).prototype).not.toHaveProperty("isAdmin");
+  });
+
+  it("blocks prototype key from being merged", () => {
+    const target: Record<string, unknown> = {};
+    const maliciousSource = {
+      prototype: {
+        evilProperty: "evil",
+      },
+    };
+    
+    deepMerge(target, maliciousSource);
+    
+    // Verify the prototype key was not added to target
+    expect(target.prototype).toBeUndefined();
+    expect((Object.prototype as Record<string, unknown>).evilProperty).toBeUndefined();
+  });
+
+  it("blocks nested __proto__ in deep objects", () => {
+    const target: Record<string, unknown> = {
+      config: {},
+    };
+    const maliciousSource = {
+      config: JSON.parse('{"__proto__": {"polluted": "nested"}}'),
+    };
+    
+    deepMerge(target, maliciousSource);
+    
+    // Verify Object.prototype was not polluted
+    expect((Object.prototype as Record<string, unknown>).polluted).toBeUndefined();
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+  });
+
+  it("handles multiple dangerous keys in same object", () => {
+    const target: Record<string, unknown> = {};
+    const maliciousSource = JSON.parse(`{
+      "__proto__": {"polluted1": "yes"},
+      "constructor": {"polluted2": "yes"},
+      "prototype": {"polluted3": "yes"},
+      "safeKey": "safeValue"
+    }`);
+    
+    deepMerge(target, maliciousSource);
+    
+    // Verify Object.prototype was not polluted
+    expect((Object.prototype as Record<string, unknown>).polluted1).toBeUndefined();
+    expect((Object.prototype as Record<string, unknown>).polluted2).toBeUndefined();
+    expect((Object.prototype as Record<string, unknown>).polluted3).toBeUndefined();
+    
+    // But safe keys should be merged
+    expect(target.safeKey).toBe("safeValue");
+  });
+
+  it("prevents pollution through deeply nested __proto__", () => {
+    const target: Record<string, unknown> = {
+      level1: {
+        level2: {},
+      },
+    };
+    const maliciousSource = {
+      level1: {
+        level2: JSON.parse('{"__proto__": {"deepPollution": "yes"}}'),
+      },
+    };
+    
+    deepMerge(target, maliciousSource);
+    
+    // Verify Object.prototype was not polluted at any level
+    expect((Object.prototype as Record<string, unknown>).deepPollution).toBeUndefined();
+    expect(({} as Record<string, unknown>).deepPollution).toBeUndefined();
+  });
+});
+
+describe("deepMerge - Normal Merge Behavior", () => {
+  it("merges simple properties correctly", () => {
+    const target: Record<string, unknown> = { a: 1 };
+    const source: Record<string, unknown> = { b: 2 };
+    
+    deepMerge(target, source);
+    
+    expect(target).toEqual({ a: 1, b: 2 });
+  });
+
+  it("recursively merges nested objects", () => {
+    const target: Record<string, unknown> = {
+      config: {
+        database: { host: "localhost" },
+      },
+    };
+    const source: Record<string, unknown> = {
+      config: {
+        database: { port: 5432 },
+        cache: { enabled: true },
+      },
+    };
+    
+    deepMerge(target, source);
+    
+    expect(target).toEqual({
+      config: {
+        database: { host: "localhost", port: 5432 },
+        cache: { enabled: true },
+      },
+    });
+  });
+
+  it("does not overwrite existing properties in target", () => {
+    const target: Record<string, unknown> = { a: 1, b: 2 };
+    const source: Record<string, unknown> = { b: 999, c: 3 };
+    
+    deepMerge(target, source);
+    
+    // b should remain 2, not be overwritten to 999
+    expect(target).toEqual({ a: 1, b: 2, c: 3 });
+  });
+
+  it("only adds properties that are undefined in target", () => {
+    const target: Record<string, unknown> = {
+      existing: "keep this",
+      nested: { prop: "original" },
+    };
+    const source: Record<string, unknown> = {
+      existing: "don't use this",
+      nested: { prop: "don't use this", newProp: "add this" },
+      newKey: "add this too",
+    };
+    
+    deepMerge(target, source);
+    
+    expect(target).toEqual({
+      existing: "keep this",
+      nested: { prop: "original", newProp: "add this" },
+      newKey: "add this too",
+    });
+  });
+
+  it("handles arrays as values, not objects to merge", () => {
+    const target: Record<string, unknown> = {
+      items: [1, 2, 3],
+    };
+    const source: Record<string, unknown> = {
+      items: [4, 5, 6],
+      newArray: [7, 8, 9],
+    };
+    
+    deepMerge(target, source);
+    
+    // Arrays should not be merged; existing array is kept, new array is added
+    expect(target.items).toEqual([1, 2, 3]);
+    expect(target.newArray).toEqual([7, 8, 9]);
+  });
+
+  it("handles null values correctly", () => {
+    const target: Record<string, unknown> = { a: null };
+    const source: Record<string, unknown> = { a: { nested: "value" }, b: null };
+    
+    deepMerge(target, source);
+    
+    // null in target should not be merged into
+    expect(target.a).toBeNull();
+    expect(target.b).toBeNull();
+  });
+
+  it("handles empty objects", () => {
+    const target: Record<string, unknown> = {};
+    const source: Record<string, unknown> = { a: 1, b: { c: 2 } };
+    
+    deepMerge(target, source);
+    
+    expect(target).toEqual({ a: 1, b: { c: 2 } });
+  });
+
+  it("handles source with no properties", () => {
+    const target: Record<string, unknown> = { a: 1 };
+    const source: Record<string, unknown> = {};
+    
+    deepMerge(target, source);
+    
+    expect(target).toEqual({ a: 1 });
+  });
+
+  it("merges multiple levels of nesting", () => {
+    const target: Record<string, unknown> = {
+      level1: {
+        level2: {
+          level3: {
+            existing: "value",
+          },
+        },
+      },
+    };
+    const source: Record<string, unknown> = {
+      level1: {
+        level2: {
+          level3: {
+            newProp: "newValue",
+          },
+          newLevel3: "added",
+        },
+      },
+    };
+    
+    deepMerge(target, source);
+    
+    expect(target).toEqual({
+      level1: {
+        level2: {
+          level3: {
+            existing: "value",
+            newProp: "newValue",
+          },
+          newLevel3: "added",
+        },
+      },
+    });
+  });
+
+  it("preserves different data types", () => {
+    const target: Record<string, unknown> = {
+      string: "text",
+      number: 42,
+      boolean: true,
+    };
+    const source: Record<string, unknown> = {
+      newString: "more text",
+      newNumber: 100,
+      newBoolean: false,
+      newNull: null,
+    };
+    
+    deepMerge(target, source);
+    
+    expect(target).toEqual({
+      string: "text",
+      number: 42,
+      boolean: true,
+      newString: "more text",
+      newNumber: 100,
+      newBoolean: false,
+      newNull: null,
+    });
+  });
+});
+
+describe("deepMerge - Edge Cases", () => {
+  it("handles objects with numeric keys", () => {
+    const target: Record<string, unknown> = { "0": "zero" };
+    const source: Record<string, unknown> = { "1": "one" };
+    
+    deepMerge(target, source);
+    
+    expect(target).toEqual({ "0": "zero", "1": "one" });
+  });
+
+  it("handles objects with special characters in keys", () => {
+    const target: Record<string, unknown> = { "key-with-dash": "value1" };
+    const source: Record<string, unknown> = { "key.with.dot": "value2", "key with space": "value3" };
+    
+    deepMerge(target, source);
+    
+    expect(target).toEqual({
+      "key-with-dash": "value1",
+      "key.with.dot": "value2",
+      "key with space": "value3",
+    });
+  });
+
+  it("does not merge when target property is not an object", () => {
+    const target: Record<string, unknown> = {
+      config: "string value",
+    };
+    const source: Record<string, unknown> = {
+      config: { nested: "object" },
+    };
+    
+    deepMerge(target, source);
+    
+    // config should remain a string, not be replaced or merged
+    expect(target.config).toBe("string value");
+  });
+
+  it("does not merge when source property is not an object", () => {
+    const target: Record<string, unknown> = {
+      config: { existing: "value" },
+    };
+    const source: Record<string, unknown> = {
+      config: "string value",
+    };
+    
+    deepMerge(target, source);
+    
+    // config should remain an object, not be replaced
+    expect(target.config).toEqual({ existing: "value" });
+  });
+});


### PR DESCRIPTION
Potential fix for [https://github.com/markus-lassfolk/openclaw-hybrid-memory/security/code-scanning/4](https://github.com/markus-lassfolk/openclaw-hybrid-memory/security/code-scanning/4)

To fix this type of issue in general, the merge/assignment function must not allow prototype-related keys (`__proto__`, `constructor`, and often `prototype`) from untrusted objects to be assigned into arbitrary targets. Two standard approaches are: (1) only recursively merge when the destination already has an own property with that key, or (2) explicitly block dangerous keys from being read or written during the merge.

Here, the smallest, least-invasive fix is to add an explicit guard inside `deepMerge` that skips keys that could lead to prototype pollution. We can do this at the start of the `for` loop over `Object.keys(source)`, before we read `source[key]` or `target[key]`. This does not change existing functionality for all normal config keys, because typical configuration will not use `__proto__`, `constructor`, or `prototype` as keys. It will, however, prevent any path that might introduce those special keys from ever being merged into `target`, eliminating the ability to mutate `Object.prototype` or other prototypes.

Concretely, in `extensions/memory-hybrid/cli/handlers.ts`, within the `deepMerge` function at lines 542–551, we should:

- Insert a check such as:

  ```ts
  if (key === "__proto__" || key === "constructor" || key === "prototype") {
    continue;
  }
  ```

  immediately after entering the `for (const key of Object.keys(source))` loop.

We do not need any new imports or helper methods; this fix is entirely local to the function.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change that only skips three special keys during config merging; main risk is edge-case configs that legitimately used those keys.
> 
> **Overview**
> Fixes a potential prototype-pollution vector in the CLI config installation merge by hard-blocking `__proto__`, `constructor`, and `prototype` keys inside `deepMerge`.
> 
> Refactors `deepMerge` into an exported utility and wires it into the plugin’s `_testing` exports, adding a comprehensive Vitest suite covering both pollution prevention and expected merge semantics (non-overwrite, recursive object merge, arrays treated as values).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8beca287e8082053784af7d582b412c04159cacf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->