### PR TITLE
Potential fix for code scanning alert no. 1: Shell command built from environment values

### DIFF
--- a/packages/openclaw-hybrid-memory-install/install.js
+++ b/packages/openclaw-hybrid-memory-install/install.js
@@ -26,6 +26,24 @@ const tmpDir = path.join(
 );
 
 function run(cmd, args = [], opts = {}) {
+  const isWindows = process.platform === "win32";
+
+  // On Windows, avoid running npm via a shell (cmd.exe) to prevent shell interpretation
+  // of arguments that may contain user-controlled data (e.g., version from process.argv).
+  if (isWindows && cmd === "npm") {
+    const npmExecPath = process.env.npm_execpath;
+    if (!npmExecPath) {
+      throw new Error(
+        "Unable to locate npm safely on Windows (npm_execpath is not set). " +
+          "Please run this installer via npm or npx so npm_execpath is available."
+      );
+    }
+    return execFileSync(process.execPath, [npmExecPath, ...args], {
+      stdio: "inherit",
+      ...opts,
+    });
+  }
+
   return execFileSync(cmd, args, { stdio: "inherit", ...opts });
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/markus-lassfolk/openclaw-hybrid-memory/security/code-scanning/1](https://github.com/markus-lassfolk/openclaw-hybrid-memory/security/code-scanning/1)

In general, the fix is to avoid passing a single shell command string to `execSync` that embeds data derived from the filesystem (or any untrusted source). Instead, call `execFileSync` (or `spawnSync`) with the executable name and an array of arguments so the shell is not invoked and file names are not interpreted as shell syntax. For static commands with no dynamic parts (like `npm install --omit=dev`), `execSync` with a string is less risky but it is simpler and safer to standardize everything on the argument-array style.

In this file, the primary risk arises from the `tar` invocation: `run(`tar -xzf ${JSON.stringify(tgzPath)} -C ${JSON.stringify(pluginDir)} --strip-components=1`);`. We should (1) change `run` so that it supports taking a command plus an array of arguments and internally uses `execFileSync`; and (2) update all uses of `run` to pass the command and arguments separately. This removes the shell and ensures `tgzPath` and `pluginDir` are passed verbatim to `tar`, regardless of spaces or metacharacters. Concretely:
- Import `execFileSync` from `child_process` instead of `execSync`.
- Redefine `run` to accept `(cmd, args = [], opts = {})` and call `execFileSync(cmd, args, {...})`.
- Update:
  - `run("npm pack openclaw-hybrid-memory@${version}", { cwd: tmpDir });` → `run("npm", ["pack", \`openclaw-hybrid-memory@${version}\`], { cwd: tmpDir });`
  - `run("tar -xzf ...");` → `run("tar", ["-xzf", tgzPath, "-C", pluginDir, "--strip-components=1"]);`
  - `run("npm install --omit=dev", { cwd: pluginDir });` → `run("npm", ["install", "--omit=dev"], { cwd: pluginDir });`.
No external dependencies are required beyond Node’s standard library.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to installer process execution; main risk is potential Windows environment incompatibility if `npm_execpath` isn’t set.
> 
> **Overview**
> Switches the `openclaw-hybrid-memory-install` installer to run external commands via `execFileSync` with explicit argument arrays instead of shell-interpreted command strings.
> 
> Adds a Windows-specific safe path for `npm` execution using `npm_execpath` (and errors if it’s missing), and updates the `npm pack`, `tar` extract, and `npm install` steps accordingly to reduce command-injection risk from user-/env-provided values (e.g., version, paths).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cc7466baa10249be60a26758330848dd3064fb61. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->