### PR TITLE
Potential fix for code scanning alert no. 6: Prototype-polluting function

### DIFF
--- a/scripts/install-hybrid-config.mjs
+++ b/scripts/install-hybrid-config.mjs
@@ -106,6 +106,10 @@ const fullDefaults = {
 
 function deepMerge(target, source) {
   for (const key of Object.keys(source)) {
+    // Prevent prototype pollution via special property names
+    if (key === "__proto__" || key === "constructor" || key === "prototype") {
+      continue;
+    }
     const srcVal = source[key];
     const tgtVal = target[key];
     if (srcVal !== null && typeof srcVal === "object" && !Array.isArray(srcVal) && tgtVal !== null && typeof tgtVal === "object" && !Array.isArray(tgtVal)) {


### PR DESCRIPTION
Potential fix for [https://github.com/markus-lassfolk/openclaw-hybrid-memory/security/code-scanning/6](https://github.com/markus-lassfolk/openclaw-hybrid-memory/security/code-scanning/6)

In general, to fix prototype pollution in deep merge/extend functions, you must prevent writes to or recursion through dangerous property names like `__proto__`, `constructor`, and `prototype`, or otherwise ensure you only operate on safe own properties of plain objects. This can be done by either skipping such keys altogether or validating that the target is a plain object that you control.

For this specific `deepMerge(target, source)` function, the minimal, behavior‑preserving fix is to add a guard at the start of the loop over `Object.keys(source)` to skip dangerous keys. This keeps all existing merge semantics (including the special `jobs` handling) for normal keys, while forbidding assignments like `target["__proto__"] = ...` or recursive merging into `target.constructor.prototype`. We should add a simple `if` that checks `key === "__proto__" || key === "constructor" || key === "prototype"` and continues the loop, thereby blocking both direct and nested prototype pollution vectors. No new imports are required, and all changes are confined to the `deepMerge` function around lines 107–125 in `scripts/install-hybrid-config.mjs`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change that only affects how configs are merged; main risk is edge-case configs that intentionally used these reserved keys now being ignored.
> 
> **Overview**
> Hardens `scripts/install-hybrid-config.mjs` by updating `deepMerge` to *skip dangerous keys* (`__proto__`, `constructor`, `prototype`) when merging defaults into `openclaw.json`, preventing prototype pollution during config installation/updates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4645881164ee766da159d1cb81ac2cd0a5f8fe49. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->