### PR TITLE
Potential fix for code scanning alert no. 3: Bad HTML filtering regexp

### DIFF
--- a/extensions/memory-hybrid/cli/proposals.ts
+++ b/extensions/memory-hybrid/cli/proposals.ts
@@ -116,9 +116,8 @@ export function capProposalConfidence(confidence: number, targetFile: string, su
 function buildAppendBlock(proposalId: string, observation: string, suggestedChange: string, timestamp: string): string {
   const escapeHtmlComment = (text: string): string =>
     text
-      // Neutralize both standard and lenient HTML comment end markers.
-      .replace(/--!>/g, "-- !>")
-      .replace(/-->/g, "-- >")
+      // Neutralize both standard (-->) and lenient (--!>) HTML comment end markers.
+      .replace(/--!?>/g, "-- >")
       // Prevent starting a new HTML comment inside the observation.
       .replace(/<!--/g, "<! --");
   const safeObservation = escapeHtmlComment(observation);


### PR DESCRIPTION
Potential fix for [https://github.com/markus-lassfolk/openclaw-hybrid-memory/security/code-scanning/3](https://github.com/markus-lassfolk/openclaw-hybrid-memory/security/code-scanning/3)

In general, to fix this, ensure that any attempt to escape or neutralize HTML comment delimiters accounts for all forms browsers recognize, including `-->` and `--!>`, and ideally avoids trying to be too clever with ad‑hoc regexes. The goal here is just to make sure user-provided text cannot terminate the generated HTML comment.

The best targeted fix without changing behavior is to improve `escapeHtmlComment` so it:
1. Handles both `-->` and `--!>` as potential comment terminators and neutralizes them.
2. Still neutralizes `<!--` so the user cannot start a nested comment.
3. Does so using simple string operations (or slightly adjusted regexes) rather than partial parsing.

One straightforward approach:
- Replace any `--!>` with something that is no longer a valid end marker, e.g. `-- !>`.
- Replace any `-->` with `-- >` as the code already does.
- Replace any `<!--` with `<! --` as the code already does.

We only need to change the implementation of `escapeHtmlComment` in `extensions/memory-hybrid/cli/proposals.ts` at line 117–118. No additional imports are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized input-sanitization tweak in CLI output formatting; main risk is unintended alteration of edge-case observation text rendering.
> 
> **Overview**
> Hardens `buildAppendBlock`’s `escapeHtmlComment` in `extensions/memory-hybrid/cli/proposals.ts` to better prevent user-provided `observation` text from terminating the generated HTML comments.
> 
> The escaping now neutralizes both standard (`-->`) and browser-lenient (`--!>`) comment end markers via a broader regex, while still rewriting `<!--` to prevent starting a nested comment.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d657cd9be61e2994a994358239809cf2542a23c5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->