### PR TITLE
fix: add "env" to safe-config-write known keys allowlist

### DIFF
--- a/scripts/safe-config-write.sh
+++ b/scripts/safe-config-write.sh
@@ -31,7 +31,7 @@ validate_config() {
     fi
 
     # 2. Schema check: detect unknown top-level keys
-    local known_keys='["meta","wizard","update","auth","agents","tools","messages","commands","channels","talk","gateway","memory","plugins","models"]'
+    local known_keys='["meta","wizard","update","auth","agents","tools","messages","commands","channels","talk","gateway","memory","plugins","models","env"]'
     local unknown
     unknown=$(python3 -c "
 import json, sys


### PR DESCRIPTION
The config watcher was rejecting valid `openclaw.json` files containing an `env` top-level key, triggering auto-revert and reporting to GlitchTip.

**Root cause:** `env` was missing from the `known_keys` allowlist in `safe-config-write.sh`.

**GlitchTip:** [Issue #26](http://192.168.1.99:8000/openclaw/issues/26)
Closes #135

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a one-line allowlist expansion in a config validation script, only affecting whether configs with top-level `env` are accepted vs rejected/auto-reverted.
> 
> **Overview**
> Updates `scripts/safe-config-write.sh` to treat `env` as a valid top-level key in `openclaw.json` by adding it to the `known_keys` allowlist.
> 
> This prevents the watcher/validator from flagging configs containing `env` as “unknown keys” and triggering an auto-revert/error report.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bad556fd1d1921291c00bf08f3254e16f0a7ffdc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->