### PR TITLE
fix: resolve pre-existing TypeScript strict mode errors

### DIFF
--- a/extensions/memory-hybrid/backends/vector-db.ts
+++ b/extensions/memory-hybrid/backends/vector-db.ts
@@ -196,11 +196,6 @@ export class VectorDB {
     }
   }
 
-  /** Returns the current close generation (for re-embedding loops to abort on hot reload). */
-  getCloseGeneration(): number {
-    return this.closeGeneration;
-  }
-
   /** Get initialized table or throw descriptive error. */
   private getTable(): lancedb.Table {
     if (!this.table) {

--- a/extensions/memory-hybrid/tests/deep-merge.test.ts
+++ b/extensions/memory-hybrid/tests/deep-merge.test.ts
@@ -58,7 +58,7 @@ describe("deepMerge - Prototype Pollution Prevention", () => {
     expect(({} as Record<string, unknown>).isAdmin).toBeUndefined();
     // Target should not have constructor key added
     expect(target.constructor).toBeDefined(); // constructor exists naturally on objects
-    expect((target.constructor as Record<string, unknown>).prototype).not.toHaveProperty("isAdmin");
+    expect((target.constructor as unknown as Record<string, unknown>).prototype).not.toHaveProperty("isAdmin");
   });
 
   it("blocks prototype key from being merged", () => {

--- a/extensions/memory-hybrid/tests/procedure-extractor.test.ts
+++ b/extensions/memory-hybrid/tests/procedure-extractor.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   parseSessionJsonl,
   minimalRecipe,
+  type ParsedSession,
 } from "../services/procedure-extractor.js";
 import type { ProcedureStep } from "../types/memory.js";
 
@@ -57,7 +58,7 @@ describe("procedure-extractor", () => {
           },
         }),
       ];
-      const result = parseSessionJsonl(lines.join("\n"), "session-1");
+      const result = parseSessionJsonl(lines.join("\n"), "session-1") as ParsedSession | null;
       expect(result).not.toBeNull();
       expect(result!.taskIntent).toBe("Check Moltbook notifications");
       expect(result!.steps).toHaveLength(2);
@@ -94,7 +95,7 @@ describe("procedure-extractor", () => {
           },
         }),
       ];
-      const result = parseSessionJsonl(lines.join("\n"), "s2");
+      const result = parseSessionJsonl(lines.join("\n"), "s2") as ParsedSession | null;
       expect(result).not.toBeNull();
       expect(result!.success).toBe(false);
       expect(result!.errorMessage).toContain("404");
@@ -118,7 +119,7 @@ describe("procedure-extractor", () => {
           },
         }),
       ];
-      const result = parseSessionJsonl(lines.join("\n"), "s3");
+      const result = parseSessionJsonl(lines.join("\n"), "s3") as ParsedSession | null;
       expect(result).not.toBeNull();
       expect(result!.taskIntent).toHaveLength(300);
     });


### PR DESCRIPTION
## Summary
- Remove duplicate `getCloseGeneration()` implementation in `backends/vector-db.ts` (TS2393 duplicate function implementation)
- Fix `Function → Record<string, unknown>` cast in `tests/deep-merge.test.ts` via `as unknown as` intermediate cast (TS2352)
- Add `ParsedSession` type cast in `tests/procedure-extractor.test.ts` to narrow the `ParsedSession | { skipReason }` union (TS2339)

## Test plan
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm test` — 44 test files, 947 tests passed, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are limited to removing a duplicate method declaration and adding type casts in tests; no production logic paths are altered.
> 
> **Overview**
> Resolves pre-existing TypeScript strict-mode errors by removing a duplicate `VectorDB.getCloseGeneration()` declaration in `vector-db.ts`.
> 
> Updates tests to satisfy strict typing: adjusts the `constructor` cast in `deep-merge.test.ts` and narrows `parseSessionJsonl()` results in `procedure-extractor.test.ts` by importing/casting to `ParsedSession`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d63867be937457dd8af904a3d58d6caeaeafc3bc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->