### PR TITLE
feat(graph): shortest-path traversal between memories — closes #140

### DIFF
--- a/extensions/memory-hybrid/config.ts
+++ b/extensions/memory-hybrid/config.ts
@@ -280,6 +280,14 @@ export type GraphRetrievalConfig = {
   maxExpandedResults: number;
 };
 
+/** Shortest-path traversal configuration (Issue #140). */
+export type PathConfig = {
+  /** Enable memory_path tool (default: true). */
+  enabled: boolean;
+  /** Hard cap on maxDepth accepted by memory_path (default: 10). */
+  maxPathDepth: number;
+};
+
 /** Enhanced ambient retrieval with multi-query generation (Issue #156). */
 export type AmbientConfig = {
   /** Enable enhanced ambient retrieval (default: false). */
@@ -456,6 +464,8 @@ export type HybridMemoryConfig = {
   ambient: AmbientConfig;
   /** GraphRAG retrieval: semantic search + graph expansion (Issue #145, default: enabled, defaultExpand: false). */
   graphRetrieval: GraphRetrievalConfig;
+  /** Shortest-path traversal between memories via BFS (Issue #140, default: enabled). */
+  path: PathConfig;
   /** Set when user specified a mode in config; used by verify to show "Mode: Normal" etc. */
   mode?: ConfigMode | "custom";
 };
@@ -1749,6 +1759,16 @@ export const hybridConfigSchema = {
           : 20,
     };
 
+    // Parse path config (Issue #140, default: enabled, maxPathDepth: 10)
+    const pathRaw = cfg.path as Record<string, unknown> | undefined;
+    const path: PathConfig = {
+      enabled: pathRaw?.enabled !== false,
+      maxPathDepth:
+        typeof pathRaw?.maxPathDepth === "number" && pathRaw.maxPathDepth > 0
+          ? Math.min(20, Math.floor(pathRaw.maxPathDepth))
+          : 10,
+    };
+
     const staleWarningRaw = activeTaskRaw?.staleWarning as Record<string, unknown> | undefined;
     const activeTask: ActiveTaskConfig = {
       enabled: activeTaskRaw?.enabled !== false,
@@ -1812,6 +1832,7 @@ export const hybridConfigSchema = {
       })(),
       ambient,
       graphRetrieval,
+      path,
       mode: hasPresetOverrides ? "custom" : appliedMode,
     };
   },

--- a/extensions/memory-hybrid/index.ts
+++ b/extensions/memory-hybrid/index.ts
@@ -66,6 +66,8 @@ import {
 } from "./services/retrieval-orchestrator.js";
 import { expandGraph, formatLinkPath, HOP_SCORE_DECAY } from "./services/graph-retrieval.js";
 export type { GraphExpandedResult, LinkPathStep, GraphFactLookup } from "./services/graph-retrieval.js";
+import { findShortestPath, resolveInput, formatPath } from "./services/shortest-path.js";
+export type { ShortestPathResult, PathStep, ShortestPathLookup } from "./services/shortest-path.js";
 import { gatherIngestFiles } from "./services/ingest-utils.js";
 import type { MemoryEntry, SearchResult, ScopeFilter } from "./types/memory.js";
 import { MEMORY_SCOPES } from "./types/memory.js";
@@ -478,6 +480,10 @@ export const _testing = {
   expandGraph,
   formatLinkPath,
   HOP_SCORE_DECAY,
+  // Shortest-path traversal (Issue #140)
+  findShortestPath,
+  resolveInput,
+  formatPath,
 };
 
 export { versionInfo } from "./versionInfo.js";

--- a/extensions/memory-hybrid/services/shortest-path.ts
+++ b/extensions/memory-hybrid/services/shortest-path.ts
@@ -1,0 +1,246 @@
+/**
+ * Shortest-Path Traversal Service (Issue #140).
+ *
+ * Finds the shortest path between two facts/entities in the memory graph via
+ * bidirectional BFS on the memory_links table.  Both outgoing (getLinksFrom)
+ * and incoming (getLinksTo) edges are traversed so the graph is treated as
+ * undirected for reachability purposes.
+ *
+ * Usage:
+ *   const result = findShortestPath(factsDb, startId, endId, { maxDepth: 5 });
+ *   // result.steps = ordered list of PathStep; result.hops = step count
+ */
+
+import type { MemoryEntry } from "../types/memory.js";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/** One edge traversed in the shortest path. */
+export interface PathStep {
+  /** Fact we traversed FROM. */
+  fromFactId: string;
+  /** Fact we arrived AT. */
+  toFactId: string;
+  /** Edge type (e.g. RELATED_TO, PART_OF, CAUSED_BY). */
+  linkType: string;
+  /** Edge strength 0–1. */
+  strength: number;
+}
+
+/** Returned by findShortestPath when a path is found. */
+export interface ShortestPathResult {
+  /** Ordered steps from fromFactId to toFactId. Empty when from === to (0 hops). */
+  steps: PathStep[];
+  /** Number of hops (= steps.length). */
+  hops: number;
+  /** Resolved start fact ID. */
+  fromFactId: string;
+  /** Resolved end fact ID. */
+  toFactId: string;
+  /** The MemoryEntry objects along the path (index 0 = start, last = end). */
+  chain: MemoryEntry[];
+}
+
+/** Minimal interface the service needs from FactsDB. */
+export interface ShortestPathLookup {
+  getById(id: string): MemoryEntry | null;
+  getLinksFrom(factId: string): Array<{ id: string; targetFactId: string; linkType: string; strength: number }>;
+  getLinksTo(factId: string): Array<{ id: string; sourceFactId: string; linkType: string; strength: number }>;
+  /** Optional: resolve entity name → facts. Used by resolveInput. */
+  lookup?(entity: string): Array<{ entry: MemoryEntry; score: number }>;
+}
+
+/** Options for findShortestPath. */
+export interface ShortestPathOptions {
+  /** Maximum path length in edges (default: 5, hard-capped by config). */
+  maxDepth?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Core algorithm
+// ---------------------------------------------------------------------------
+
+/**
+ * Find the shortest path between two facts via bidirectional BFS.
+ *
+ * The graph is treated as undirected — both getLinksFrom and getLinksTo are
+ * traversed in each BFS step.
+ *
+ * @param db  - A FactsDB-compatible lookup interface.
+ * @param startId - Fact ID to start from.
+ * @param endId   - Fact ID to reach.
+ * @param options - Optional: maxDepth (default 5).
+ * @returns ShortestPathResult if a path is found within maxDepth, null otherwise.
+ */
+export function findShortestPath(
+  db: ShortestPathLookup,
+  startId: string,
+  endId: string,
+  options: ShortestPathOptions = {},
+): ShortestPathResult | null {
+  const maxDepth = Math.max(0, options.maxDepth ?? 5);
+
+  // Same start and end → trivial path
+  if (startId === endId) {
+    const entry = db.getById(startId);
+    if (!entry) return null;
+    return { steps: [], hops: 0, fromFactId: startId, toFactId: endId, chain: [entry] };
+  }
+
+  // Both endpoints must exist
+  if (!db.getById(startId) || !db.getById(endId)) return null;
+
+  if (maxDepth === 0) return null;
+
+  // fwd: factId → ordered path (PathStep[]) from startId to that factId
+  const fwd = new Map<string, PathStep[]>();
+  // bwd: factId → ordered path (PathStep[]) from that factId to endId
+  const bwd = new Map<string, PathStep[]>();
+
+  fwd.set(startId, []);
+  bwd.set(endId, []);
+
+  let fwdFrontier: string[] = [startId];
+  let bwdFrontier: string[] = [endId];
+
+  // Alternate expanding forward (odd hops) and backward (even hops).
+  // Each outer iteration spends 1 hop in one direction.
+  for (let hop = 1; hop <= maxDepth; hop++) {
+    if (hop % 2 === 1) {
+      // Expand forward by 1 hop
+      const next: string[] = [];
+      for (const nodeId of fwdFrontier) {
+        const pathToNode = fwd.get(nodeId)!;
+        for (const { neighborId, linkType, strength } of getNeighbors(db, nodeId)) {
+          if (fwd.has(neighborId)) continue; // already visited forward
+          const step: PathStep = { fromFactId: nodeId, toFactId: neighborId, linkType, strength };
+          const newPath = [...pathToNode, step];
+          fwd.set(neighborId, newPath);
+          next.push(neighborId);
+          if (bwd.has(neighborId)) {
+            return buildResult(db, startId, endId, newPath, bwd.get(neighborId)!);
+          }
+        }
+      }
+      fwdFrontier = next;
+    } else {
+      // Expand backward by 1 hop
+      const next: string[] = [];
+      for (const nodeId of bwdFrontier) {
+        const pathFromNode = bwd.get(nodeId)!;
+        for (const { neighborId, linkType, strength } of getNeighbors(db, nodeId)) {
+          if (bwd.has(neighborId)) continue; // already visited backward
+          // Step goes FROM neighborId TO nodeId (closer to end)
+          const step: PathStep = { fromFactId: neighborId, toFactId: nodeId, linkType, strength };
+          const newPath = [step, ...pathFromNode];
+          bwd.set(neighborId, newPath);
+          next.push(neighborId);
+          if (fwd.has(neighborId)) {
+            return buildResult(db, startId, endId, fwd.get(neighborId)!, newPath);
+          }
+        }
+      }
+      bwdFrontier = next;
+    }
+
+    if (fwdFrontier.length === 0 && bwdFrontier.length === 0) break;
+  }
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Entity name resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve an input string to a fact ID.
+ *
+ * Strategy:
+ * 1. If the input matches a known fact ID (getById succeeds) → return it.
+ * 2. Otherwise treat as entity name: call db.lookup(input) and return the
+ *    first result's ID, or null if none found or lookup unavailable.
+ *
+ * @param db    - FactsDB-compatible lookup interface.
+ * @param input - Raw user input (fact ID or entity name).
+ * @returns Resolved fact ID, or null if not resolvable.
+ */
+export function resolveInput(db: ShortestPathLookup, input: string): string | null {
+  if (!input || !input.trim()) return null;
+  const trimmed = input.trim();
+
+  // Try as a direct fact ID first
+  if (db.getById(trimmed)) return trimmed;
+
+  // Try as entity name via lookup
+  if (db.lookup) {
+    const results = db.lookup(trimmed);
+    if (results.length > 0) return results[0].entry.id;
+  }
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Formatting
+// ---------------------------------------------------------------------------
+
+/**
+ * Format a shortest path as a human-readable chain string.
+ *
+ * @example
+ * formatPath([{ fromFactId: "abc", toFactId: "def", linkType: "RELATED_TO", strength: 0.8 }])
+ * // "abc… —[RELATED_TO]→ def…"
+ */
+export function formatPath(steps: PathStep[]): string {
+  if (steps.length === 0) return "(same fact)";
+  const parts: string[] = [steps[0].fromFactId.slice(0, 8) + "\u2026"];
+  for (const step of steps) {
+    parts.push(`\u2014[${step.linkType}]\u2192`);
+    parts.push(step.toFactId.slice(0, 8) + "\u2026");
+  }
+  return parts.join(" ");
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/** Collect all neighbors (outgoing + incoming) of a node as a flat list. */
+function getNeighbors(
+  db: ShortestPathLookup,
+  nodeId: string,
+): Array<{ neighborId: string; linkType: string; strength: number }> {
+  const result: Array<{ neighborId: string; linkType: string; strength: number }> = [];
+  for (const link of db.getLinksFrom(nodeId)) {
+    result.push({ neighborId: link.targetFactId, linkType: link.linkType, strength: link.strength });
+  }
+  for (const link of db.getLinksTo(nodeId)) {
+    result.push({ neighborId: link.sourceFactId, linkType: link.linkType, strength: link.strength });
+  }
+  return result;
+}
+
+/** Combine forward + backward paths into a ShortestPathResult. */
+function buildResult(
+  db: ShortestPathLookup,
+  startId: string,
+  endId: string,
+  fwdPath: PathStep[],
+  bwdPath: PathStep[],
+): ShortestPathResult {
+  const steps = [...fwdPath, ...bwdPath];
+  // Build chain: all unique fact IDs in traversal order
+  const ids: string[] = [startId];
+  for (const step of steps) {
+    if (step.toFactId !== ids[ids.length - 1]) ids.push(step.toFactId);
+  }
+  const chain: MemoryEntry[] = [];
+  for (const id of ids) {
+    const entry = db.getById(id);
+    if (entry) chain.push(entry);
+  }
+  return { steps, hops: steps.length, fromFactId: startId, toFactId: endId, chain };
+}

--- a/extensions/memory-hybrid/tests/shortest-path.test.ts
+++ b/extensions/memory-hybrid/tests/shortest-path.test.ts
@@ -1,0 +1,630 @@
+/**
+ * Tests for Issue #140 — Shortest-Path Traversal: memory_path BFS.
+ *
+ * Coverage:
+ *   - findShortestPath: same start and end returns 0-hop path
+ *   - findShortestPath: start fact not found returns null
+ *   - findShortestPath: end fact not found returns null
+ *   - findShortestPath: no links returns null
+ *   - findShortestPath: direct edge (1 hop) via outgoing link
+ *   - findShortestPath: direct edge (1 hop) via incoming link (bidirectional)
+ *   - findShortestPath: 2-hop path (A→B→C)
+ *   - findShortestPath: 3-hop path (A→B→C→D)
+ *   - findShortestPath: 4-hop path found with bidirectional BFS
+ *   - findShortestPath: maxDepth=1 blocks 2-hop path
+ *   - findShortestPath: maxDepth=2 blocks 3-hop path
+ *   - findShortestPath: maxDepth=0 returns null even for direct neighbors
+ *   - findShortestPath: shortest path chosen when multiple paths exist
+ *   - findShortestPath: chain contains correct MemoryEntry objects
+ *   - findShortestPath: steps contain correct link types
+ *   - findShortestPath: steps contain correct strength values
+ *   - findShortestPath: hops count equals steps.length
+ *   - findShortestPath: disconnected graph returns null
+ *   - findShortestPath: various link types traversed
+ *   - findShortestPath: integration with real FactsDB
+ *   - resolveInput: returns fact ID when input matches getById
+ *   - resolveInput: returns null for unknown ID without lookup
+ *   - resolveInput: resolves entity name via db.lookup
+ *   - resolveInput: returns null when entity not found
+ *   - resolveInput: empty/whitespace input returns null
+ *   - formatPath: empty steps returns "(same fact)"
+ *   - formatPath: single step formatted correctly
+ *   - formatPath: multi-step path formatted correctly
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { _testing } from "../index.js";
+import type { MemoryEntry } from "../types/memory.js";
+import type { ShortestPathLookup } from "../services/shortest-path.js";
+
+const { findShortestPath, resolveInput, formatPath, FactsDB } = _testing;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeEntry(id: string, overrides: Partial<MemoryEntry> = {}): MemoryEntry {
+  return {
+    id,
+    text: `Text for ${id}`,
+    category: "fact",
+    importance: 0.7,
+    entity: null,
+    key: null,
+    value: null,
+    source: "conversation",
+    createdAt: 1_700_000_000,
+    sourceDate: null,
+    decayClass: "stable",
+    expiresAt: null,
+    lastConfirmedAt: 1_700_000_000,
+    confidence: 1.0,
+    summary: null,
+    tags: null,
+    recallCount: 0,
+    lastAccessed: null,
+    supersededAt: null,
+    supersededBy: null,
+    supersedesId: null,
+    validFrom: null,
+    validUntil: null,
+    tier: "warm",
+    scope: "global",
+    scopeTarget: null,
+    procedureType: null,
+    successCount: 0,
+    lastValidated: null,
+    sourceSessions: null,
+    reinforcedCount: 0,
+    lastReinforcedAt: null,
+    reinforcedQuotes: null,
+    ...overrides,
+  };
+}
+
+type MockLink = { id: string; targetFactId: string; linkType: string; strength: number };
+type MockInLink = { id: string; sourceFactId: string; linkType: string; strength: number };
+
+function buildMockDb(
+  entries: MemoryEntry[],
+  linksFrom: Record<string, MockLink[]>,
+  linksTo: Record<string, MockInLink[]>,
+  lookupMap?: Record<string, MemoryEntry[]>,
+): ShortestPathLookup {
+  const entryMap = new Map(entries.map((e) => [e.id, e]));
+  return {
+    getById: (id: string) => entryMap.get(id) ?? null,
+    getLinksFrom: (id: string) => linksFrom[id] ?? [],
+    getLinksTo: (id: string) => linksTo[id] ?? [],
+    lookup: lookupMap
+      ? (entity: string) =>
+          (lookupMap[entity] ?? []).map((e) => ({ entry: e, score: 1.0 }))
+      : undefined,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// findShortestPath — trivial cases
+// ---------------------------------------------------------------------------
+
+describe("findShortestPath: trivial cases", () => {
+  it("returns 0-hop path when start equals end", () => {
+    const a = makeEntry("a");
+    const db = buildMockDb([a], {}, {});
+    const result = findShortestPath(db, "a", "a");
+    expect(result).not.toBeNull();
+    expect(result!.hops).toBe(0);
+    expect(result!.steps).toHaveLength(0);
+    expect(result!.fromFactId).toBe("a");
+    expect(result!.toFactId).toBe("a");
+    expect(result!.chain).toHaveLength(1);
+    expect(result!.chain[0].id).toBe("a");
+  });
+
+  it("returns null when start fact not found", () => {
+    const b = makeEntry("b");
+    const db = buildMockDb([b], {}, {});
+    const result = findShortestPath(db, "nonexistent", "b");
+    expect(result).toBeNull();
+  });
+
+  it("returns null when end fact not found", () => {
+    const a = makeEntry("a");
+    const db = buildMockDb([a], {}, {});
+    const result = findShortestPath(db, "a", "nonexistent");
+    expect(result).toBeNull();
+  });
+
+  it("returns null when both nodes exist but no links between them", () => {
+    const a = makeEntry("a");
+    const b = makeEntry("b");
+    const db = buildMockDb([a, b], {}, {});
+    const result = findShortestPath(db, "a", "b");
+    expect(result).toBeNull();
+  });
+
+  it("returns null for disconnected graph with links to other nodes", () => {
+    const a = makeEntry("a");
+    const b = makeEntry("b");
+    const c = makeEntry("c");
+    const d = makeEntry("d");
+    // a-b connected, c-d connected, no cross links
+    const db = buildMockDb(
+      [a, b, c, d],
+      { a: [{ id: "l1", targetFactId: "b", linkType: "RELATED_TO", strength: 1.0 }] },
+      { b: [{ id: "l1", sourceFactId: "a", linkType: "RELATED_TO", strength: 1.0 }],
+        d: [{ id: "l2", sourceFactId: "c", linkType: "RELATED_TO", strength: 1.0 }] },
+    );
+    const result = findShortestPath(db, "a", "d");
+    expect(result).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findShortestPath — 1-hop paths
+// ---------------------------------------------------------------------------
+
+describe("findShortestPath: 1-hop paths", () => {
+  it("finds direct path via outgoing edge (A→B)", () => {
+    const a = makeEntry("a");
+    const b = makeEntry("b");
+    const db = buildMockDb(
+      [a, b],
+      { a: [{ id: "l1", targetFactId: "b", linkType: "RELATED_TO", strength: 0.9 }] },
+      {},
+    );
+    const result = findShortestPath(db, "a", "b");
+    expect(result).not.toBeNull();
+    expect(result!.hops).toBe(1);
+    expect(result!.steps).toHaveLength(1);
+    expect(result!.steps[0].fromFactId).toBe("a");
+    expect(result!.steps[0].toFactId).toBe("b");
+    expect(result!.steps[0].linkType).toBe("RELATED_TO");
+    expect(result!.steps[0].strength).toBeCloseTo(0.9);
+  });
+
+  it("finds direct path via incoming edge (B→A traversed as A←B)", () => {
+    const a = makeEntry("a");
+    const b = makeEntry("b");
+    // A has an incoming link from B (B is source, A is target)
+    const db = buildMockDb(
+      [a, b],
+      {},
+      { a: [{ id: "l1", sourceFactId: "b", linkType: "CAUSED_BY", strength: 0.8 }] },
+    );
+    // Path from b to a: b→a via the link (b is source, a is target)
+    const result = findShortestPath(db, "b", "a");
+    expect(result).not.toBeNull();
+    expect(result!.hops).toBe(1);
+    expect(result!.steps[0].linkType).toBe("CAUSED_BY");
+  });
+
+  it("returns correct chain for 1-hop path", () => {
+    const a = makeEntry("a");
+    const b = makeEntry("b");
+    const db = buildMockDb(
+      [a, b],
+      { a: [{ id: "l1", targetFactId: "b", linkType: "PART_OF", strength: 1.0 }] },
+      {},
+    );
+    const result = findShortestPath(db, "a", "b");
+    expect(result!.chain).toHaveLength(2);
+    expect(result!.chain[0].id).toBe("a");
+    expect(result!.chain[1].id).toBe("b");
+  });
+
+  it("hops equals steps.length", () => {
+    const a = makeEntry("a");
+    const b = makeEntry("b");
+    const db = buildMockDb(
+      [a, b],
+      { a: [{ id: "l1", targetFactId: "b", linkType: "DEPENDS_ON", strength: 0.5 }] },
+      {},
+    );
+    const result = findShortestPath(db, "a", "b");
+    expect(result!.hops).toBe(result!.steps.length);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findShortestPath — multi-hop paths
+// ---------------------------------------------------------------------------
+
+describe("findShortestPath: multi-hop paths", () => {
+  it("finds 2-hop path A→B→C", () => {
+    const a = makeEntry("a");
+    const b = makeEntry("b");
+    const c = makeEntry("c");
+    const db = buildMockDb(
+      [a, b, c],
+      {
+        a: [{ id: "l1", targetFactId: "b", linkType: "RELATED_TO", strength: 1.0 }],
+        b: [{ id: "l2", targetFactId: "c", linkType: "PART_OF", strength: 0.7 }],
+      },
+      {},
+    );
+    const result = findShortestPath(db, "a", "c");
+    expect(result).not.toBeNull();
+    expect(result!.hops).toBe(2);
+    expect(result!.steps[0].fromFactId).toBe("a");
+    expect(result!.steps[0].toFactId).toBe("b");
+    expect(result!.steps[1].fromFactId).toBe("b");
+    expect(result!.steps[1].toFactId).toBe("c");
+  });
+
+  it("finds 3-hop path A→B→C→D", () => {
+    const a = makeEntry("a");
+    const b = makeEntry("b");
+    const c = makeEntry("c");
+    const d = makeEntry("d");
+    const db = buildMockDb(
+      [a, b, c, d],
+      {
+        a: [{ id: "l1", targetFactId: "b", linkType: "RELATED_TO", strength: 1.0 }],
+        b: [{ id: "l2", targetFactId: "c", linkType: "CAUSED_BY", strength: 1.0 }],
+        c: [{ id: "l3", targetFactId: "d", linkType: "PART_OF", strength: 1.0 }],
+      },
+      {},
+    );
+    const result = findShortestPath(db, "a", "d", { maxDepth: 5 });
+    expect(result).not.toBeNull();
+    expect(result!.hops).toBe(3);
+  });
+
+  it("finds 4-hop path with bidirectional BFS", () => {
+    // A→B→C→D→E; bidirectional BFS meets at C:
+    //   fwd (hop1): a→b; fwd (hop3): b→c
+    //   bwd (hop2): e←d; bwd (hop4): d←c → c is in fwd!
+    const [a, b, c, d, e] = ["a", "b", "c", "d", "e"].map((id) => makeEntry(id));
+    const db = buildMockDb(
+      [a, b, c, d, e],
+      {
+        a: [{ id: "l1", targetFactId: "b", linkType: "RELATED_TO", strength: 1.0 }],
+        b: [{ id: "l2", targetFactId: "c", linkType: "RELATED_TO", strength: 1.0 }],
+        c: [{ id: "l3", targetFactId: "d", linkType: "RELATED_TO", strength: 1.0 }],
+        d: [{ id: "l4", targetFactId: "e", linkType: "RELATED_TO", strength: 1.0 }],
+      },
+      {
+        b: [{ id: "l1", sourceFactId: "a", linkType: "RELATED_TO", strength: 1.0 }],
+        c: [{ id: "l2", sourceFactId: "b", linkType: "RELATED_TO", strength: 1.0 }],
+        d: [{ id: "l3", sourceFactId: "c", linkType: "RELATED_TO", strength: 1.0 }],
+        e: [{ id: "l4", sourceFactId: "d", linkType: "RELATED_TO", strength: 1.0 }],
+      },
+    );
+    const result = findShortestPath(db, "a", "e", { maxDepth: 5 });
+    expect(result).not.toBeNull();
+    expect(result!.hops).toBe(4);
+    expect(result!.fromFactId).toBe("a");
+    expect(result!.toFactId).toBe("e");
+  });
+
+  it("fromFactId and toFactId are preserved in result", () => {
+    const a = makeEntry("a");
+    const b = makeEntry("b");
+    const db = buildMockDb(
+      [a, b],
+      { a: [{ id: "l1", targetFactId: "b", linkType: "RELATED_TO", strength: 1.0 }] },
+      {},
+    );
+    const result = findShortestPath(db, "a", "b");
+    expect(result!.fromFactId).toBe("a");
+    expect(result!.toFactId).toBe("b");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findShortestPath — maxDepth limits
+// ---------------------------------------------------------------------------
+
+describe("findShortestPath: maxDepth enforcement", () => {
+  it("maxDepth=0 returns null even for nodes that are neighbors", () => {
+    const a = makeEntry("a");
+    const b = makeEntry("b");
+    const db = buildMockDb(
+      [a, b],
+      { a: [{ id: "l1", targetFactId: "b", linkType: "RELATED_TO", strength: 1.0 }] },
+      {},
+    );
+    const result = findShortestPath(db, "a", "b", { maxDepth: 0 });
+    expect(result).toBeNull();
+  });
+
+  it("maxDepth=1 finds 1-hop path", () => {
+    const a = makeEntry("a");
+    const b = makeEntry("b");
+    const db = buildMockDb(
+      [a, b],
+      { a: [{ id: "l1", targetFactId: "b", linkType: "RELATED_TO", strength: 1.0 }] },
+      {},
+    );
+    const result = findShortestPath(db, "a", "b", { maxDepth: 1 });
+    expect(result).not.toBeNull();
+    expect(result!.hops).toBe(1);
+  });
+
+  it("maxDepth=1 blocks 2-hop path", () => {
+    const a = makeEntry("a");
+    const b = makeEntry("b");
+    const c = makeEntry("c");
+    const db = buildMockDb(
+      [a, b, c],
+      {
+        a: [{ id: "l1", targetFactId: "b", linkType: "RELATED_TO", strength: 1.0 }],
+        b: [{ id: "l2", targetFactId: "c", linkType: "RELATED_TO", strength: 1.0 }],
+      },
+      {},
+    );
+    const result = findShortestPath(db, "a", "c", { maxDepth: 1 });
+    expect(result).toBeNull();
+  });
+
+  it("maxDepth=2 blocks 3-hop path", () => {
+    const [a, b, c, d] = ["a", "b", "c", "d"].map((id) => makeEntry(id));
+    const db = buildMockDb(
+      [a, b, c, d],
+      {
+        a: [{ id: "l1", targetFactId: "b", linkType: "RELATED_TO", strength: 1.0 }],
+        b: [{ id: "l2", targetFactId: "c", linkType: "RELATED_TO", strength: 1.0 }],
+        c: [{ id: "l3", targetFactId: "d", linkType: "RELATED_TO", strength: 1.0 }],
+      },
+      {},
+    );
+    const result = findShortestPath(db, "a", "d", { maxDepth: 2 });
+    expect(result).toBeNull();
+  });
+
+  it("maxDepth=3 finds 3-hop path", () => {
+    // A→B→C→D; bidirectional BFS meets at C:
+    //   fwd (hop1): a→b; fwd (hop3): b→c → c is in bwd!
+    //   bwd (hop2): d←c; bwd.get(c)=[c→d]
+    const [a, b, c, d] = ["a", "b", "c", "d"].map((id) => makeEntry(id));
+    const db = buildMockDb(
+      [a, b, c, d],
+      {
+        a: [{ id: "l1", targetFactId: "b", linkType: "RELATED_TO", strength: 1.0 }],
+        b: [{ id: "l2", targetFactId: "c", linkType: "RELATED_TO", strength: 1.0 }],
+        c: [{ id: "l3", targetFactId: "d", linkType: "RELATED_TO", strength: 1.0 }],
+      },
+      {
+        b: [{ id: "l1", sourceFactId: "a", linkType: "RELATED_TO", strength: 1.0 }],
+        c: [{ id: "l2", sourceFactId: "b", linkType: "RELATED_TO", strength: 1.0 }],
+        d: [{ id: "l3", sourceFactId: "c", linkType: "RELATED_TO", strength: 1.0 }],
+      },
+    );
+    const result = findShortestPath(db, "a", "d", { maxDepth: 3 });
+    expect(result).not.toBeNull();
+    expect(result!.hops).toBe(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findShortestPath — shortest path selection
+// ---------------------------------------------------------------------------
+
+describe("findShortestPath: shortest path selection", () => {
+  it("returns 1-hop direct path even when longer alternative exists", () => {
+    const a = makeEntry("a");
+    const b = makeEntry("b");
+    const c = makeEntry("c");
+    // a→b directly, and a→c→b (2 hops)
+    const db = buildMockDb(
+      [a, b, c],
+      {
+        a: [
+          { id: "l1", targetFactId: "b", linkType: "RELATED_TO", strength: 1.0 },
+          { id: "l2", targetFactId: "c", linkType: "PART_OF", strength: 0.5 },
+        ],
+        c: [{ id: "l3", targetFactId: "b", linkType: "CAUSED_BY", strength: 0.3 }],
+      },
+      {},
+    );
+    const result = findShortestPath(db, "a", "b");
+    expect(result!.hops).toBe(1);
+    expect(result!.steps[0].fromFactId).toBe("a");
+    expect(result!.steps[0].toFactId).toBe("b");
+  });
+
+  it("finds 2-hop path when 1-hop is unavailable", () => {
+    const a = makeEntry("a");
+    const b = makeEntry("b");
+    const c = makeEntry("c");
+    const db = buildMockDb(
+      [a, b, c],
+      {
+        a: [{ id: "l1", targetFactId: "c", linkType: "RELATED_TO", strength: 1.0 }],
+        c: [{ id: "l2", targetFactId: "b", linkType: "PART_OF", strength: 1.0 }],
+      },
+      {},
+    );
+    const result = findShortestPath(db, "a", "b");
+    expect(result!.hops).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findShortestPath — link types and strengths
+// ---------------------------------------------------------------------------
+
+describe("findShortestPath: link types and strengths", () => {
+  it("traverses SUPERSEDES links", () => {
+    const a = makeEntry("a");
+    const b = makeEntry("b");
+    const db = buildMockDb(
+      [a, b],
+      { a: [{ id: "l1", targetFactId: "b", linkType: "SUPERSEDES", strength: 1.0 }] },
+      {},
+    );
+    const result = findShortestPath(db, "a", "b");
+    expect(result!.steps[0].linkType).toBe("SUPERSEDES");
+  });
+
+  it("traverses INSTANCE_OF and DERIVED_FROM links", () => {
+    const a = makeEntry("a");
+    const b = makeEntry("b");
+    const c = makeEntry("c");
+    const db = buildMockDb(
+      [a, b, c],
+      {
+        a: [{ id: "l1", targetFactId: "b", linkType: "INSTANCE_OF", strength: 0.9 }],
+        b: [{ id: "l2", targetFactId: "c", linkType: "DERIVED_FROM", strength: 0.8 }],
+      },
+      {},
+    );
+    const result = findShortestPath(db, "a", "c");
+    expect(result!.steps[0].linkType).toBe("INSTANCE_OF");
+    expect(result!.steps[1].linkType).toBe("DERIVED_FROM");
+  });
+
+  it("preserves edge strength in steps", () => {
+    const a = makeEntry("a");
+    const b = makeEntry("b");
+    const db = buildMockDb(
+      [a, b],
+      { a: [{ id: "l1", targetFactId: "b", linkType: "RELATED_TO", strength: 0.42 }] },
+      {},
+    );
+    const result = findShortestPath(db, "a", "b");
+    expect(result!.steps[0].strength).toBeCloseTo(0.42);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveInput
+// ---------------------------------------------------------------------------
+
+describe("resolveInput", () => {
+  it("returns fact ID when input directly matches getById", () => {
+    const a = makeEntry("fact-abc-123");
+    const db = buildMockDb([a], {}, {});
+    expect(resolveInput(db, "fact-abc-123")).toBe("fact-abc-123");
+  });
+
+  it("returns null for unknown ID when no lookup is provided", () => {
+    const db = buildMockDb([], {}, {});
+    expect(resolveInput(db, "unknown-id")).toBeNull();
+  });
+
+  it("resolves entity name via db.lookup", () => {
+    const a = makeEntry("entity-fact-id");
+    const db = buildMockDb([a], {}, {}, { "myEntity": [a] });
+    expect(resolveInput(db, "myEntity")).toBe("entity-fact-id");
+  });
+
+  it("returns null when entity name not found via lookup", () => {
+    const db = buildMockDb([], {}, {}, { "other": [] });
+    expect(resolveInput(db, "unknown-entity")).toBeNull();
+  });
+
+  it("returns null for empty string", () => {
+    const db = buildMockDb([], {}, {});
+    expect(resolveInput(db, "")).toBeNull();
+  });
+
+  it("returns null for whitespace-only string", () => {
+    const db = buildMockDb([], {}, {});
+    expect(resolveInput(db, "   ")).toBeNull();
+  });
+
+  it("prefers fact ID over entity name when ID exists", () => {
+    const a = makeEntry("real-id");
+    const b = makeEntry("entity-id");
+    const db = buildMockDb([a, b], {}, {}, { "real-id": [b] });
+    // "real-id" matches getById directly → returns "real-id", not "entity-id"
+    expect(resolveInput(db, "real-id")).toBe("real-id");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatPath
+// ---------------------------------------------------------------------------
+
+describe("formatPath", () => {
+  it("returns (same fact) for empty steps", () => {
+    expect(formatPath([])).toBe("(same fact)");
+  });
+
+  it("formats single step correctly", () => {
+    const steps = [{ fromFactId: "abcdef12", toFactId: "12345678", linkType: "RELATED_TO", strength: 1.0 }];
+    const out = formatPath(steps);
+    expect(out).toContain("abcdef12");
+    expect(out).toContain("RELATED_TO");
+    expect(out).toContain("12345678");
+  });
+
+  it("formats multi-step path with all nodes", () => {
+    const steps = [
+      { fromFactId: "aaa", toFactId: "bbb", linkType: "PART_OF", strength: 1.0 },
+      { fromFactId: "bbb", toFactId: "ccc", linkType: "CAUSED_BY", strength: 0.5 },
+    ];
+    const out = formatPath(steps);
+    expect(out).toContain("aaa");
+    expect(out).toContain("PART_OF");
+    expect(out).toContain("bbb");
+    expect(out).toContain("CAUSED_BY");
+    expect(out).toContain("ccc");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration with real FactsDB
+// ---------------------------------------------------------------------------
+
+describe("findShortestPath: integration with FactsDB", () => {
+  let tmpDir: string;
+  let factsDb: InstanceType<typeof FactsDB>;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "shortest-path-test-"));
+    factsDb = new FactsDB(join(tmpDir, "test.db"));
+  });
+
+  afterEach(() => {
+    factsDb.close();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("finds direct path in real DB", () => {
+    const aId = factsDb.store({ text: "Fact A", category: "fact", importance: 0.7, source: "test", entity: null, key: null, value: null }).id;
+    const bId = factsDb.store({ text: "Fact B", category: "fact", importance: 0.7, source: "test", entity: null, key: null, value: null }).id;
+    factsDb.createLink(aId, bId, "RELATED_TO", 1.0);
+
+    const result = findShortestPath(factsDb, aId, bId, { maxDepth: 5 });
+    expect(result).not.toBeNull();
+    expect(result!.hops).toBe(1);
+    expect(result!.steps[0].linkType).toBe("RELATED_TO");
+  });
+
+  it("finds 2-hop path in real DB", () => {
+    const aId = factsDb.store({ text: "Fact A", category: "fact", importance: 0.7, source: "test", entity: null, key: null, value: null }).id;
+    const bId = factsDb.store({ text: "Fact B", category: "fact", importance: 0.7, source: "test", entity: null, key: null, value: null }).id;
+    const cId = factsDb.store({ text: "Fact C", category: "fact", importance: 0.7, source: "test", entity: null, key: null, value: null }).id;
+    factsDb.createLink(aId, bId, "PART_OF", 1.0);
+    factsDb.createLink(bId, cId, "CAUSED_BY", 0.8);
+
+    const result = findShortestPath(factsDb, aId, cId, { maxDepth: 5 });
+    expect(result).not.toBeNull();
+    expect(result!.hops).toBe(2);
+  });
+
+  it("returns null when no path in real DB", () => {
+    const aId = factsDb.store({ text: "Fact A", category: "fact", importance: 0.7, source: "test", entity: null, key: null, value: null }).id;
+    const bId = factsDb.store({ text: "Fact B", category: "fact", importance: 0.7, source: "test", entity: null, key: null, value: null }).id;
+
+    const result = findShortestPath(factsDb, aId, bId, { maxDepth: 5 });
+    expect(result).toBeNull();
+  });
+
+  it("chain contains correct MemoryEntry objects in real DB", () => {
+    const aId = factsDb.store({ text: "Fact A", category: "fact", importance: 0.7, source: "test", entity: null, key: null, value: null }).id;
+    const bId = factsDb.store({ text: "Fact B", category: "fact", importance: 0.7, source: "test", entity: null, key: null, value: null }).id;
+    factsDb.createLink(aId, bId, "RELATED_TO", 1.0);
+
+    const result = findShortestPath(factsDb, aId, bId, { maxDepth: 5 });
+    expect(result!.chain).toHaveLength(2);
+    expect(result!.chain[0].text).toBe("Fact A");
+    expect(result!.chain[1].text).toBe("Fact B");
+  });
+});

--- a/extensions/memory-hybrid/tools/graph-tools.ts
+++ b/extensions/memory-hybrid/tools/graph-tools.ts
@@ -12,6 +12,7 @@ import { stringEnum } from "openclaw/plugin-sdk";
 import type { FactsDB, MemoryLinkType } from "../backends/facts-db.js";
 import { MEMORY_LINK_TYPES } from "../backends/facts-db.js";
 import type { HybridMemoryConfig } from "../config.js";
+import { findShortestPath, resolveInput, formatPath } from "../services/shortest-path.js";
 
 export interface PluginContext {
   factsDb: FactsDB;
@@ -136,6 +137,89 @@ export function registerGraphTools(
         },
       },
       { name: "memory_graph" },
+    );
+  }
+
+  // Shortest-path tool (when path is enabled)
+  if (cfg.path.enabled) {
+    api.registerTool(
+      {
+        name: "memory_path",
+        label: "Memory Path",
+        description:
+          "Find the shortest path between two memories via BFS on the memory graph. " +
+          "Both `from` and `to` accept a fact ID or an entity name (resolved automatically). " +
+          "Returns the chain of facts and link types, or reports no path within maxDepth.",
+        parameters: Type.Object({
+          from: Type.String({ description: "Start fact ID or entity name" }),
+          to: Type.String({ description: "End fact ID or entity name" }),
+          maxDepth: Type.Optional(
+            Type.Number({ description: `Max hops to traverse (default 5, max ${cfg.path.maxPathDepth})` }),
+          ),
+        }),
+        async execute(_toolCallId: string, params: Record<string, unknown>) {
+          const { from, to, maxDepth = 5 } = params as {
+            from: string;
+            to: string;
+            maxDepth?: number;
+          };
+
+          const depthCap = Math.min(cfg.path.maxPathDepth, Math.max(1, Math.floor(maxDepth)));
+
+          const fromId = resolveInput(factsDb, from);
+          if (!fromId) {
+            return {
+              content: [{ type: "text", text: `Could not resolve start: "${from}" (not a known fact ID or entity name)` }],
+              details: { error: "from_not_found", from },
+            };
+          }
+
+          const toId = resolveInput(factsDb, to);
+          if (!toId) {
+            return {
+              content: [{ type: "text", text: `Could not resolve end: "${to}" (not a known fact ID or entity name)` }],
+              details: { error: "to_not_found", to },
+            };
+          }
+
+          const result = findShortestPath(factsDb, fromId, toId, { maxDepth: depthCap });
+
+          if (!result) {
+            return {
+              content: [{ type: "text", text: `No path found between "${from}" and "${to}" within ${depthCap} hops.` }],
+              details: { found: false, fromId, toId, maxDepth: depthCap },
+            };
+          }
+
+          const lines: string[] = [
+            `Path found: ${result.hops} hop${result.hops === 1 ? "" : "s"}`,
+            "",
+            formatPath(result.steps),
+            "",
+            "Chain:",
+          ];
+          for (let i = 0; i < result.chain.length; i++) {
+            const entry = result.chain[i];
+            const step = result.steps[i - 1];
+            if (step) {
+              lines.push(`  —[${step.linkType}]→`);
+            }
+            lines.push(`  [${entry.id.slice(0, 8)}…] ${entry.text.slice(0, 80)}${entry.text.length > 80 ? "…" : ""}`);
+          }
+
+          return {
+            content: [{ type: "text", text: lines.join("\n") }],
+            details: {
+              found: true,
+              fromId,
+              toId,
+              hops: result.hops,
+              steps: result.steps,
+            },
+          };
+        },
+      },
+      { name: "memory_path" },
     );
   }
 }


### PR DESCRIPTION
Closes #140.

## Summary

- Implements `memory_path` tool: bidirectional BFS shortest-path between two facts or entity names
- Adds `services/shortest-path.ts` with `findShortestPath`, `resolveInput`, and `formatPath`
- Registers tool in `graph-tools.ts` (guarded by `cfg.path.enabled`, default `true`)
- Adds `PathConfig` (`enabled`, `maxPathDepth: 10`) to `HybridMemoryConfig` and config parser
- 37 tests covering trivial/1-4-hop paths, maxDepth limits, entity resolution, and real FactsDB integration

## Test plan

- [ ] `npx tsc --noEmit` — zero errors ✅
- [ ] `npm test` — 1332 passed, 3 skipped ✅
- [ ] `memory_path` resolves entity names and fact IDs
- [ ] Returns chain of facts + link types, or "no path" message
- [ ] `maxDepth` capped at `cfg.path.maxPathDepth` (default 10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new graph traversal tool and config surface that queries the link graph via BFS, which can impact performance/behavior based on depth limits and tool registration conditions. Mostly additive with good test coverage, but it touches plugin exports and tool wiring.
> 
> **Overview**
> Adds a new `memory_path` tool to find the shortest connection between two memories (fact IDs or entity names), returning a hop-by-hop chain with link types and a structured `details` payload.
> 
> Introduces `services/shortest-path.ts` implementing bidirectional BFS over incoming/outgoing links plus helpers `resolveInput` and `formatPath`, and exports these via `index.ts` (including `_testing`).
> 
> Extends config with a new `path` section (`enabled`, `maxPathDepth`) and parsing/clamping logic, and adds a comprehensive `shortest-path.test.ts` suite covering edge cases, depth limits, and real `FactsDB` integration.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 54ac7fd3e133c4b793f8c9b29fd47acb3c415bcc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->