### PR TITLE
feat: remaining 7 milestone-a features (unified)

### DIFF
--- a/extensions/memory-hybrid/backends/facts-db.ts
+++ b/extensions/memory-hybrid/backends/facts-db.ts
@@ -172,6 +172,9 @@ export class FactsDB {
     // ---- Contradiction tracking (Issue #157) ----
     this.migrateContradictionsTable();
 
+    // ---- Topic cluster storage (Issue #146) ----
+    this.migrateClusterTables();
+
     // ---- Future-date decay freeze (#144) ----
     this.migrateDecayFreezeColumn();
   }
@@ -830,7 +833,7 @@ export class FactsDB {
       successCount,
       lastValidated: lastValidated ?? undefined,
       sourceSessions: sourceSessionsRaw ?? undefined,
-      // Fix #8: normalize to null (not undefined) to match rowToEntry() behaviour
+      // normalize to null (not undefined) to match rowToEntry() behaviour
       decayFreezeUntil: decayFreezeUntil,
     };
   }
@@ -1743,6 +1746,34 @@ export class FactsDB {
     quotes.push(newSnippet.slice(0, 200));
     if (quotes.length > 10) quotes = quotes.slice(-10);
     return JSON.stringify(quotes);
+  }
+
+  /**
+   * Boost the confidence of a fact by a delta, clamped at maxConfidence.
+   * Also increments reinforced_count and updates last_reinforced_at.
+   * Returns true if the fact was found and updated.
+   */
+  boostConfidence(id: string, delta: number, maxConfidence = 1.0): boolean {
+    const nowSec = Math.floor(Date.now() / 1000);
+
+    const tx = this.liveDb.transaction(() => {
+      const row = this.liveDb
+        .prepare(`SELECT confidence FROM facts WHERE id = ?`)
+        .get(id) as { confidence: number } | undefined;
+      if (!row) return false;
+
+      const current = typeof row.confidence === "number" ? row.confidence : 1.0;
+      const boosted = Math.min(maxConfidence, current + delta);
+
+      this.liveDb
+        .prepare(
+          `UPDATE facts SET confidence = ?, reinforced_count = reinforced_count + 1, last_reinforced_at = ? WHERE id = ?`,
+        )
+        .run(boosted, nowSec, id);
+      return true;
+    });
+
+    return tx() as boolean;
   }
 
   /**
@@ -3439,6 +3470,117 @@ export class FactsDB {
     linkedCount += this.autoDetectInstanceOf(newFactId, text, knownEntities);
 
     return { linkedCount, supersededIds };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Topic cluster storage (Issue #146)
+  // ---------------------------------------------------------------------------
+
+  /** Create clusters and cluster_members tables for topic cluster storage. */
+  private migrateClusterTables(): void {
+    this.liveDb.exec(`
+      CREATE TABLE IF NOT EXISTS clusters (
+        id TEXT PRIMARY KEY,
+        label TEXT NOT NULL,
+        fact_count INTEGER NOT NULL DEFAULT 0,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+      )
+    `);
+    this.liveDb.exec(`
+      CREATE TABLE IF NOT EXISTS cluster_members (
+        cluster_id TEXT NOT NULL REFERENCES clusters(id) ON DELETE CASCADE,
+        fact_id TEXT NOT NULL,
+        PRIMARY KEY (cluster_id, fact_id)
+      )
+    `);
+    this.liveDb.exec(`CREATE INDEX IF NOT EXISTS idx_cluster_members_fact ON cluster_members(fact_id)`);
+  }
+
+  /**
+   * Get all unique fact IDs that participate in at least one memory link
+   * (as source or target). Used by cluster detection.
+   */
+  getAllLinkedFactIds(): string[] {
+    const rows = this.liveDb
+      .prepare(
+        `SELECT DISTINCT id FROM (
+          SELECT source_fact_id AS id FROM memory_links
+          UNION
+          SELECT target_fact_id AS id FROM memory_links
+        )`,
+      )
+      .all() as Array<{ id: string }>;
+    return rows.map((r) => r.id);
+  }
+
+  /**
+   * Get all edges from memory_links as sourceFactId/targetFactId pairs.
+   * Used for building the cluster adjacency map in a single query.
+   */
+  getAllLinks(): Array<{ sourceFactId: string; targetFactId: string }> {
+    const rows = this.liveDb
+      .prepare(`SELECT source_fact_id, target_fact_id FROM memory_links`)
+      .all() as Array<{ source_fact_id: string; target_fact_id: string }>;
+    return rows.map((r) => ({
+      sourceFactId: r.source_fact_id,
+      targetFactId: r.target_fact_id,
+    }));
+  }
+
+  /**
+   * Persist detected clusters, replacing all existing cluster data.
+   * Runs in a single transaction for atomicity.
+   */
+  saveClusters(clusters: Array<{ id: string; label: string; factIds: string[]; factCount: number; createdAt: number; updatedAt: number }>): void {
+    const insertCluster = this.liveDb.prepare(
+      `INSERT OR REPLACE INTO clusters (id, label, fact_count, created_at, updated_at) VALUES (?, ?, ?, ?, ?)`,
+    );
+    const insertMember = this.liveDb.prepare(
+      `INSERT OR IGNORE INTO cluster_members (cluster_id, fact_id) VALUES (?, ?)`,
+    );
+
+    this.liveDb.transaction(() => {
+      // Replace all clusters
+      this.liveDb.exec(`DELETE FROM cluster_members`);
+      this.liveDb.exec(`DELETE FROM clusters`);
+      for (const cluster of clusters) {
+        insertCluster.run(cluster.id, cluster.label, cluster.factCount, cluster.createdAt, cluster.updatedAt);
+        for (const factId of cluster.factIds) {
+          insertMember.run(cluster.id, factId);
+        }
+      }
+    })();
+  }
+
+  /** Get all stored clusters (without member IDs). Sorted by fact_count desc. */
+  getClusters(): Array<{ id: string; label: string; factCount: number; createdAt: number; updatedAt: number }> {
+    const rows = this.liveDb
+      .prepare(`SELECT id, label, fact_count, created_at, updated_at FROM clusters ORDER BY fact_count DESC`)
+      .all() as Array<{ id: string; label: string; fact_count: number; created_at: number; updated_at: number }>;
+    return rows.map((r) => ({
+      id: r.id,
+      label: r.label,
+      factCount: r.fact_count,
+      createdAt: r.created_at,
+      updatedAt: r.updated_at,
+    }));
+  }
+
+  /** Get member fact IDs for a specific cluster. */
+  getClusterMembers(clusterId: string): string[] {
+    const rows = this.liveDb
+      .prepare(`SELECT fact_id FROM cluster_members WHERE cluster_id = ?`)
+      .all(clusterId) as Array<{ fact_id: string }>;
+    return rows.map((r) => r.fact_id);
+  }
+
+  /** Get the cluster ID that a given fact belongs to (null if not in any cluster). */
+  getFactClusterId(factId: string): string | null {
+    const row = this.liveDb
+      .prepare(`SELECT cluster_id FROM cluster_members WHERE fact_id = ?`)
+      .get(factId) as { cluster_id: string } | undefined;
+    return row?.cluster_id ?? null;
   }
 
   close(): void {

--- a/extensions/memory-hybrid/cli/handlers.ts
+++ b/extensions/memory-hybrid/cli/handlers.ts
@@ -101,6 +101,8 @@ const MAINTENANCE_CRON_JOBS: Array<Record<string, unknown> & { modelTier?: "defa
   { pluginJobId: PLUGIN_JOB_ID_PREFIX + "weekly-persona-proposals", name: "weekly-persona-proposals", schedule: { kind: "cron", expr: "0 10 * * 0" }, channel: "system", message: "Run: openclaw hybrid-mem generate-proposals. This creates persona proposals from recent reflection insights. If there are pending proposals, notify the user in this system channel with a concise summary of the proposals. Exit 0 if personaProposals disabled.", isolated: true, modelTier: "heavy", enabled: true },
   // 1st of month 05:00 | monthly-consolidation | consolidate → build-languages → backfill-decay
   { pluginJobId: PLUGIN_JOB_ID_PREFIX + "monthly-consolidation", name: "monthly-consolidation", schedule: { kind: "cron", expr: "0 5 1 * *" }, channel: "system", message: "Run monthly consolidation:\n1. openclaw hybrid-mem consolidate --threshold 0.92\n2. openclaw hybrid-mem build-languages\n3. openclaw hybrid-mem backfill-decay\nReport what was merged, languages detected. Check feature configs. Exit 0 if all disabled.", isolated: true, modelTier: "heavy", enabled: true },
+  // Daily 02:45 | nightly-dream-cycle | dream-cycle (prune → consolidate → reflect)
+  { pluginJobId: PLUGIN_JOB_ID_PREFIX + "nightly-dream-cycle", name: "nightly-dream-cycle", schedule: { kind: "cron", expr: "45 2 * * *" }, channel: "system", message: "Run nightly dream cycle: openclaw hybrid-mem dream-cycle\nThis runs in order: (1) prune expired/decayed facts, (2) consolidate old episodic events into facts, (3) reflect on recent facts to extract patterns, (4) extract rules if enough patterns accumulated.\nCheck if nightlyCycle.enabled is true in config before running. Exit 0 if disabled. Report counts: facts pruned, events consolidated, patterns found, rules generated.", isolated: true, modelTier: "default", enabled: true },
 ];
 
 /** Resolve model for a cron job def and return a job record suitable for the store (has model, no modelTier). */
@@ -120,6 +122,7 @@ const LEGACY_JOB_MATCHERS: Record<string, (j: Record<string, unknown>) => boolea
   [PLUGIN_JOB_ID_PREFIX + "weekly-deep-maintenance"]: (j) => /weekly-deep-maintenance|deep maintenance/i.test(String(j.name ?? "")),
   [PLUGIN_JOB_ID_PREFIX + "weekly-persona-proposals"]: (j) => /weekly-persona-proposals|persona proposals/i.test(String(j.name ?? "")),
   [PLUGIN_JOB_ID_PREFIX + "monthly-consolidation"]: (j) => /monthly-consolidation/i.test(String(j.name ?? "")),
+  [PLUGIN_JOB_ID_PREFIX + "nightly-dream-cycle"]: (j) => /nightly-dream-cycle|dream.cycle/i.test(String(j.name ?? "")),
 };
 
 /**
@@ -150,7 +153,7 @@ function ensureMaintenanceCronJobs(
   const cronDir = join(openclawDir, "cron");
   const cronStorePath = join(cronDir, "jobs.json");
   mkdirSync(cronDir, { recursive: true });
-  let store: { jobs?: unknown[] } = existsSync(cronStorePath) ? (JSON.parse(readFileSync(cronStorePath, "utf-8")) as { jobs?: unknown[] }) : {};
+  const store: { jobs?: unknown[] } = existsSync(cronStorePath) ? (JSON.parse(readFileSync(cronStorePath, "utf-8")) as { jobs?: unknown[] }) : {};
   if (!Array.isArray(store.jobs)) store.jobs = [];
   const jobsArr = store.jobs as Array<Record<string, unknown>>;
   let jobsChanged = false;
@@ -254,6 +257,7 @@ export interface HandlerContext {
   openai: OpenAI;
   cfg: HybridMemoryConfig;
   credentialsDb: CredentialsDB | null;
+  aliasDb: import("../services/retrieval-aliases.js").AliasDB | null;
   wal: WriteAheadLog | null;
   proposalsDb: ProposalsDB | null;
   resolvedSqlitePath: string;
@@ -293,7 +297,7 @@ export async function runStoreForCli(
   opts: StoreCliOpts,
   log: { warn: (m: string) => void },
 ): Promise<StoreCliResult> {
-  const { factsDb, vectorDb, embeddings, openai, cfg, credentialsDb } = ctx;
+  const { factsDb, vectorDb, embeddings, openai, cfg, credentialsDb, aliasDb } = ctx;
   const text = opts.text;
   if (factsDb.hasDuplicate(text)) return { outcome: "duplicate" };
   const sourceDate = opts.sourceDate ? parseSourceDate(opts.sourceDate) : null;
@@ -395,6 +399,7 @@ export async function runStoreForCli(
           if (classification.action === "NOOP") return { outcome: "noop", reason: classification.reason ?? "" };
           if (classification.action === "DELETE" && classification.targetId) {
             factsDb.supersede(classification.targetId, null);
+            aliasDb?.deleteByFactId(classification.targetId);
             return { outcome: "retracted", targetId: classification.targetId, reason: classification.reason ?? "" };
           }
           if (classification.action === "UPDATE" && classification.targetId) {
@@ -417,6 +422,7 @@ export async function runStoreForCli(
                 scopeTarget,
               });
               factsDb.supersede(classification.targetId, newEntry.id);
+              aliasDb?.deleteByFactId(classification.targetId);
               try {
                 if (!(await vectorDb.hasDuplicate(vector))) {
                   await vectorDb.store({ text, vector, importance: CLI_STORE_IMPORTANCE, category, id: newEntry.id });
@@ -454,7 +460,10 @@ export async function runStoreForCli(
       scopeTarget,
       ...(supersedesId ? { validFrom: nowSec, supersedesId } : {}),
     });
-    if (supersedesId) factsDb.supersede(supersedesId, entry.id);
+    if (supersedesId) {
+      factsDb.supersede(supersedesId, entry.id);
+      aliasDb?.deleteByFactId(supersedesId);
+    }
     try {
       const vector = await embeddings.embed(text);
       if (!(await vectorDb.hasDuplicate(vector))) {
@@ -600,10 +609,15 @@ export function runInstallForCli(opts: { dryRun: boolean }): InstallCliResult {
       const memToSkills = pluginCfg?.memoryToSkills as Record<string, unknown> | undefined;
       const schedule = typeof memToSkills?.schedule === "string" && (memToSkills.schedule as string).trim().length > 0 ? (memToSkills.schedule as string).trim() : undefined;
       const notify = memToSkills?.notify !== false;
+      const dreamCycleRaw = pluginCfg?.nightlyCycle as Record<string, unknown> | undefined;
+      const dreamCycleSchedule = typeof dreamCycleRaw?.schedule === "string" && (dreamCycleRaw.schedule as string).trim().length > 0 ? (dreamCycleRaw.schedule as string).trim() : undefined;
+      const installScheduleOverrides: Record<string, string> = {};
+      if (schedule) installScheduleOverrides[PLUGIN_JOB_ID_PREFIX + "nightly-memory-to-skills"] = schedule;
+      if (dreamCycleSchedule) installScheduleOverrides[PLUGIN_JOB_ID_PREFIX + "nightly-dream-cycle"] = dreamCycleSchedule;
       ensureMaintenanceCronJobs(openclawDir, pluginConfig, {
         normalizeExisting: false,
         reEnableDisabled: false,
-        scheduleOverrides: schedule ? { [PLUGIN_JOB_ID_PREFIX + "nightly-memory-to-skills"]: schedule } : undefined,
+        scheduleOverrides: Object.keys(installScheduleOverrides).length > 0 ? installScheduleOverrides : undefined,
         messageOverrides: { [PLUGIN_JOB_ID_PREFIX + "nightly-memory-to-skills"]: buildMemoryToSkillsMessage(notify) },
       });
     } catch (err) {
@@ -1281,14 +1295,17 @@ export async function runVerifyForCli(
         const cronStorePath = join(cronDir, "jobs.json");
 
         try {
-          const scheduleOverrides =
-            typeof cfg.memoryToSkills?.schedule === "string" && cfg.memoryToSkills.schedule.trim().length > 0
-              ? { [PLUGIN_JOB_ID_PREFIX + "nightly-memory-to-skills"]: cfg.memoryToSkills.schedule }
-              : undefined;
+          const scheduleOverrides: Record<string, string> = {};
+          if (typeof cfg.memoryToSkills?.schedule === "string" && cfg.memoryToSkills.schedule.trim().length > 0) {
+            scheduleOverrides[PLUGIN_JOB_ID_PREFIX + "nightly-memory-to-skills"] = cfg.memoryToSkills.schedule;
+          }
+          if (typeof cfg.nightlyCycle?.schedule === "string" && cfg.nightlyCycle.schedule.trim().length > 0) {
+            scheduleOverrides[PLUGIN_JOB_ID_PREFIX + "nightly-dream-cycle"] = cfg.nightlyCycle.schedule;
+          }
           const { added, normalized } = ensureMaintenanceCronJobs(openclawDir, getCronModelConfig(cfg), {
             normalizeExisting: true,
             reEnableDisabled: false,
-            scheduleOverrides,
+            scheduleOverrides: Object.keys(scheduleOverrides).length > 0 ? scheduleOverrides : undefined,
             messageOverrides: { [PLUGIN_JOB_ID_PREFIX + "nightly-memory-to-skills"]: buildMemoryToSkillsMessage(cfg.memoryToSkills?.notify !== false) },
           });
           added.forEach((name) => applied.push(`Added ${name} job to ${cronStorePath}`));
@@ -1814,7 +1831,7 @@ export async function runExtractDailyForCli(
   opts: { days: number; dryRun: boolean; verbose?: boolean },
   sink: ExtractDailySink,
 ): Promise<ExtractDailyResult> {
-  const { factsDb, vectorDb, embeddings, openai, cfg, credentialsDb } = ctx;
+  const { factsDb, vectorDb, embeddings, openai, cfg, credentialsDb, aliasDb } = ctx;
   const memoryDir = join(homedir(), ".openclaw", "memory");
   const daysBack = opts.days;
   let totalExtracted = 0;
@@ -1941,6 +1958,7 @@ export async function runExtractDailyForCli(
               if (classification.action === "NOOP") continue;
               if (classification.action === "DELETE" && classification.targetId) {
                 factsDb.supersede(classification.targetId, null);
+                aliasDb?.deleteByFactId(classification.targetId);
                 continue;
               }
               if (classification.action === "UPDATE" && classification.targetId) {
@@ -1955,6 +1973,7 @@ export async function runExtractDailyForCli(
                     supersedesId: classification.targetId,
                   });
                   factsDb.supersede(classification.targetId, newEntry.id);
+                  aliasDb?.deleteByFactId(classification.targetId);
                   try {
                     if (!(await vectorDb.hasDuplicate(vecForStore))) {
                       await vectorDb.store({ text: trimmed, vector: vecForStore, importance: BATCH_STORE_IMPORTANCE, category, id: newEntry.id });
@@ -2649,7 +2668,7 @@ export async function runDistillForCli(
  * Migrate credentials to vault
  */
 export async function runMigrateToVaultForCli(ctx: HandlerContext): Promise<MigrateToVaultResult | null> {
-  const { factsDb, vectorDb, embeddings, credentialsDb, resolvedSqlitePath } = ctx;
+  const { factsDb, vectorDb, embeddings, credentialsDb, aliasDb, resolvedSqlitePath } = ctx;
   if (!credentialsDb) return null;
   const migrationFlagPath = join(dirname(resolvedSqlitePath), CREDENTIAL_REDACTION_MIGRATION_FLAG);
   try {
@@ -2658,6 +2677,7 @@ export async function runMigrateToVaultForCli(ctx: HandlerContext): Promise<Migr
       vectorDb,
       embeddings,
       credentialsDb,
+      aliasDb,
       migrationFlagPath,
       markDone: true,
     });
@@ -3095,14 +3115,17 @@ export async function runUpgradeForCli(
   try {
     const openclawDir = join(homedir(), ".openclaw");
     const pluginConfig = getCronModelConfig(cfg);
-    const scheduleOverrides =
-      typeof cfg.memoryToSkills?.schedule === "string" && cfg.memoryToSkills.schedule.trim().length > 0
-        ? { [PLUGIN_JOB_ID_PREFIX + "nightly-memory-to-skills"]: cfg.memoryToSkills.schedule }
-        : undefined;
+    const scheduleOverrides: Record<string, string> = {};
+    if (typeof cfg.memoryToSkills?.schedule === "string" && cfg.memoryToSkills.schedule.trim().length > 0) {
+      scheduleOverrides[PLUGIN_JOB_ID_PREFIX + "nightly-memory-to-skills"] = cfg.memoryToSkills.schedule;
+    }
+    if (typeof cfg.nightlyCycle?.schedule === "string" && cfg.nightlyCycle.schedule.trim().length > 0) {
+      scheduleOverrides[PLUGIN_JOB_ID_PREFIX + "nightly-dream-cycle"] = cfg.nightlyCycle.schedule;
+    }
     const { added, normalized } = ensureMaintenanceCronJobs(openclawDir, pluginConfig, {
       normalizeExisting: true,
       reEnableDisabled: false,
-      scheduleOverrides,
+      scheduleOverrides: Object.keys(scheduleOverrides).length > 0 ? scheduleOverrides : undefined,
       messageOverrides: { [PLUGIN_JOB_ID_PREFIX + "nightly-memory-to-skills"]: buildMemoryToSkillsMessage(cfg.memoryToSkills?.notify !== false) },
     });
     if (added.length > 0 || normalized.length > 0) {

--- a/extensions/memory-hybrid/cli/manage.ts
+++ b/extensions/memory-hybrid/cli/manage.ts
@@ -41,6 +41,7 @@ import { runContextAudit } from "../services/context-audit.js";
 export type ManageContext = {
   factsDb: FactsDB;
   vectorDb: VectorDB;
+  aliasDb?: import("../services/retrieval-aliases.js").AliasDB | null;
   versionInfo: { pluginVersion: string; memoryManagerVersion: string; schemaVersion: number };
   embeddings: EmbeddingProvider;
   mergeResults: typeof mergeResults;
@@ -136,12 +137,14 @@ export type ManageContext = {
   runExtractReinforcement?: (opts: { days?: number; verbose?: boolean; dryRun?: boolean }) => Promise<{ sessionsScanned: number }>;
   runGenerateAutoSkills?: (opts: { dryRun: boolean; verbose?: boolean }) => Promise<{ generated: number; skipped?: number; paths?: string[] }>;
   runGenerateProposals?: (opts: { dryRun: boolean; verbose?: boolean }) => Promise<{ created: number }>;
+  runDreamCycle?: () => Promise<import("../services/dream-cycle.js").DreamCycleResult>;
 };
 
 export function registerManageCommands(mem: Chainable, ctx: ManageContext): void {
   const {
     factsDb,
     vectorDb,
+    aliasDb,
     versionInfo,
     embeddings,
     mergeResults: merge,
@@ -185,6 +188,7 @@ export function registerManageCommands(mem: Chainable, ctx: ManageContext): void
     runGenerateAutoSkills,
     runGenerateProposals,
     resolvePath,
+    runDreamCycle,
   } = ctx;
 
   const BACKFILL_DECAY_MARKER = ".backfill-decay-done";
@@ -528,6 +532,7 @@ export function registerManageCommands(mem: Chainable, ctx: ManageContext): void
         factsDb,
         vectorDb,
         embeddings,
+        aliasDb,
         minScore: cfg.autoRecall?.minScore ?? 0.3,
         autoRecallLimit: cfg.autoRecall?.limit ?? 10,
       });
@@ -1212,6 +1217,31 @@ export function registerManageCommands(mem: Chainable, ctx: ManageContext): void
       }
       console.log(`Reflection (meta) complete: extracted ${res.metaExtracted} meta-patterns, stored ${res.metaStored} ${dryRun ? "(dry-run)" : ""}`);
     }));
+
+  if (runDreamCycle) {
+    mem
+      .command("dream-cycle")
+      .description("Run nightly dream cycle: prune expired/decayed facts, consolidate old episodic events, reflect to extract patterns, optionally extract rules")
+      .action(withExit(async () => {
+        let res;
+        try {
+          res = await runDreamCycle();
+        } catch (err) {
+          capturePluginError(err instanceof Error ? err : new Error(String(err)), { subsystem: "cli", operation: "dream-cycle" });
+          throw err;
+        }
+        if (res.skipped) {
+          console.log("Dream cycle skipped (nightlyCycle.enabled = false in config).");
+          return;
+        }
+        console.log(`Dream cycle complete: ${res.digestSummary}`);
+        console.log(`  Facts pruned: ${res.factsPruned}`);
+        console.log(`  Facts decayed: ${res.factsDecayed}`);
+        console.log(`  Events consolidated: ${res.eventsConsolidated} → ${res.factsCreated} facts`);
+        console.log(`  Patterns found: ${res.patternsFound}`);
+        console.log(`  Rules generated: ${res.rulesGenerated}`);
+      }));
+  }
 
   mem
     .command("classify")

--- a/extensions/memory-hybrid/cli/register.ts
+++ b/extensions/memory-hybrid/cli/register.ts
@@ -6,6 +6,7 @@
 import type { FactsDB } from "../backends/facts-db.js";
 import type { VectorDB } from "../backends/vector-db.js";
 import type { EmbeddingProvider } from "../services/embeddings.js";
+import type { AliasDB } from "../services/retrieval-aliases.js";
 import type { SearchResult } from "../types/memory.js";
 import { mergeResults, filterByScope } from "../services/merge-results.js";
 import type { ScopeFilter } from "../types/memory.js";
@@ -76,6 +77,7 @@ export type { ActiveTaskContext };
 export type HybridMemCliContext = {
   factsDb: FactsDB;
   vectorDb: VectorDB;
+  aliasDb?: AliasDB | null;
   versionInfo: { pluginVersion: string; memoryManagerVersion: string; schemaVersion: number };
   embeddings: EmbeddingProvider;
   mergeResults: typeof mergeResults;
@@ -125,6 +127,7 @@ export type HybridMemCliContext = {
   runReflectionRules: (opts: { dryRun: boolean; model: string; verbose?: boolean }) => Promise<{ rulesExtracted: number; rulesStored: number }>;
   runReflectionMeta: (opts: { dryRun: boolean; model: string; verbose?: boolean }) => Promise<{ metaExtracted: number; metaStored: number }>;
   reflectionConfig: { enabled: boolean; defaultWindow: number; minObservations: number; model: string };
+  runDreamCycle: () => Promise<import("../services/dream-cycle.js").DreamCycleResult>;
   runClassify: (opts: { dryRun: boolean; limit: number; model?: string }) => Promise<{
     reclassified: number;
     total: number;

--- a/extensions/memory-hybrid/config.ts
+++ b/extensions/memory-hybrid/config.ts
@@ -268,6 +268,32 @@ export type SearchConfig = {
   hydeModel?: string;
 };
 
+/** Topic cluster detection configuration (Issue #146). */
+export type ClustersConfig = {
+  /** Enable topic cluster detection (default: true). */
+  enabled: boolean;
+  /** Minimum number of facts to form a cluster (default: 3). */
+  minClusterSize: number;
+  /** Reserved: Days between full re-cluster runs; 0 = disabled (default: 7). Currently not used by any automatic scheduling. */
+  refreshIntervalDays: number;
+  /** Reserved: Model for label generation; null = rule-based only (default: null). Currently not passed to detectClusters. */
+  labelModel: string | null;
+};
+
+/** Memory health dashboard configuration (Issue #148). */
+export type HealthConfig = {
+  /** Enable memory_health tool (default: true). */
+  enabled: boolean;
+};
+
+/** Knowledge gap analysis configuration (Issue #141). */
+export type GapsConfig = {
+  /** Enable the memory_gaps tool (default: true when graph is enabled). */
+  enabled: boolean;
+  /** Minimum cosine similarity to suggest a missing link (default: 0.8). */
+  similarityThreshold: number;
+};
+
 /** GraphRAG retrieval configuration (Issue #145). */
 export type GraphRetrievalConfig = {
   /** Enable GraphRAG expansion in memory_recall (default: true). */
@@ -278,6 +304,40 @@ export type GraphRetrievalConfig = {
   maxExpandDepth: number;
   /** Maximum number of graph-expanded results appended to direct matches (default: 20). */
   maxExpandedResults: number;
+};
+
+/** Nightly dream cycle: automated prune → consolidate → reflect pipeline (Issue #143). */
+export type NightlyCycleConfig = {
+  /** Enable the nightly dream cycle (default: false). */
+  enabled: boolean;
+  /** Cron expression for nightly run (default: "45 2 * * *" = 2:45 AM). */
+  schedule: string;
+  /** Reflection window in days (default: 7). */
+  reflectWindowDays: number;
+  /** Prune mode: "expired" = pruneExpired only, "decay" = decayConfidence only, "both" = both (default: "both"). */
+  pruneMode: "expired" | "decay" | "both";
+  /** LLM model for reflection step (default: resolved from llm config). */
+  model?: string;
+  /** Days before consolidating episodic events into facts (default: 7). */
+  consolidateAfterDays: number;
+};
+
+/** Multi-hook retrieval aliases (Issue #149). */
+export type AliasesConfig = {
+  /** Enable alias generation and embedding search (default: false). */
+  enabled: boolean;
+  /** Maximum aliases per fact (default: 5). */
+  maxAliases: number;
+  /** Model for alias generation; when unset, runtime uses getDefaultCronModel(cfg, "nano"). */
+  model?: string;
+};
+
+/** Shortest-path traversal configuration (Issue #140). */
+export type PathConfig = {
+  /** Enable memory_path tool (default: true). */
+  enabled: boolean;
+  /** Hard cap on maxDepth accepted by memory_path (default: 10). */
+  maxPathDepth: number;
 };
 
 /** Enhanced ambient retrieval with multi-query generation (Issue #156). */
@@ -292,6 +352,20 @@ export type AmbientConfig = {
   maxQueriesPerTrigger: number;
   /** Token budget for ambient context injection (default: 2000). */
   budgetTokens: number;
+};
+
+/** Confidence reinforcement on repeated mentions (Issue #147). */
+export type ReinforcementConfig = {
+  /** Enable confidence reinforcement (default: true). */
+  enabled: boolean;
+  /** Confidence delta applied when a semantically similar fact is stored again (default: 0.1). */
+  passiveBoost: number;
+  /** Confidence delta applied when a fact is retrieved via memory_recall (default: 0.05). */
+  activeBoost: number;
+  /** Upper cap for confidence after reinforcement (default: 1.0). */
+  maxConfidence: number;
+  /** Cosine similarity threshold above which a new fact is treated as a repeat of an existing one (default: 0.85). */
+  similarityThreshold: number;
 };
 
 /** Multi-strategy retrieval pipeline configuration (Issue #152: RRF scoring pipeline). */
@@ -480,6 +554,20 @@ export type HybridMemoryConfig = {
 
 
 
+  /** Nightly dream cycle: automated prune → consolidate → reflect (Issue #143, default: disabled). */
+  nightlyCycle: NightlyCycleConfig;
+  /** Confidence reinforcement on repeated mentions (Issue #147, default: enabled). */
+  reinforcement: ReinforcementConfig;
+  /** Topic cluster detection: BFS connected-component analysis on memory_links (Issue #146). */
+  clusters: ClustersConfig;
+  /** Memory health dashboard (Issue #148, default: enabled). */
+  health: HealthConfig;
+  /** Knowledge gap analysis — orphan/weak detection and suggested links (Issue #141, default: enabled). */
+  gaps: GapsConfig;
+  /** Multi-hook retrieval aliases: generate and index alternative phrasings per fact (Issue #149, default: disabled). */
+  aliases: AliasesConfig;
+  /** Shortest-path traversal between memories via BFS (Issue #140, default: enabled). */
+  path: PathConfig;
   /** Set when user specified a mode in config; used by verify to show "Mode: Normal" etc. */
   mode?: ConfigMode | "custom";
 };
@@ -1066,10 +1154,6 @@ export const hybridConfigSchema = {
       throw new Error(`embedding.model is required when provider='${embeddingProvider}'. Specify the model name (e.g., 'nomic-embed-text' for Ollama).`);
     }
     const singleModel = typeof embedding?.model === "string" ? embedding.model : DEFAULT_MODEL;
-    // Validate that OpenAI provider only uses OpenAI models
-    if (embeddingProvider === "openai" && !isOpenAIModel(singleModel)) {
-      throw new Error(`embedding.model '${singleModel}' is not a valid OpenAI model. When provider='openai', use one of: text-embedding-3-small, text-embedding-3-large, text-embedding-ada-002.`);
-    }
     const modelsRaw = Array.isArray(embedding?.models) ? (embedding.models as string[]).filter((m) => typeof m === "string" && (m as string).trim().length > 0).map((m) => (m as string).trim()) : [];
     let embeddingModels: string[] | undefined;
     // Parse models for all providers (#6): for openai, these are the model preference list;
@@ -1079,11 +1163,9 @@ export const hybridConfigSchema = {
       for (const m of modelsRaw) {
         try {
           vectorDimsForModel(m);
-          if (!isOpenAIModel(m)) {
-            const reason = embeddingProvider === "openai"
-              ? "only OpenAI models are allowed"
-              : "the models field must contain OpenAI fallback model names";
-            console.warn(`memory-hybrid: embedding.models — model "${m}" is not an OpenAI model and will be skipped. For provider='${embeddingProvider}', ${reason} (e.g. text-embedding-3-small, text-embedding-3-large, text-embedding-ada-002).`);
+          // For ollama/onnx providers, models field contains OpenAI fallback names — reject non-OpenAI models
+          if (embeddingProvider !== "openai" && !isOpenAIModel(m)) {
+            console.warn(`memory-hybrid: embedding.models — model "${m}" is not an OpenAI model and will be skipped. For provider='${embeddingProvider}', the models field must contain OpenAI fallback model names (e.g. text-embedding-3-small, text-embedding-3-large, text-embedding-ada-002).`);
             continue;
           }
           valid.push(m);
@@ -1841,6 +1923,24 @@ export const hybridConfigSchema = {
           : 2000,
     };
 
+    // Parse clusters config (Issue #146, default: enabled, minClusterSize: 3, refreshIntervalDays: 7)
+    const clustersRaw = cfg.clusters as Record<string, unknown> | undefined;
+    const clusters: ClustersConfig = {
+      enabled: clustersRaw?.enabled !== false,
+      minClusterSize:
+        typeof clustersRaw?.minClusterSize === "number" && clustersRaw.minClusterSize >= 1
+          ? Math.floor(clustersRaw.minClusterSize)
+          : 3,
+      refreshIntervalDays:
+        typeof clustersRaw?.refreshIntervalDays === "number" && clustersRaw.refreshIntervalDays >= 0
+          ? Math.floor(clustersRaw.refreshIntervalDays)
+          : 7,
+      labelModel:
+        typeof clustersRaw?.labelModel === "string" && clustersRaw.labelModel.trim().length > 0
+          ? clustersRaw.labelModel.trim()
+          : null,
+    };
+
     // Parse graphRetrieval config (Issue #145, default: enabled, defaultExpand: false)
     const graphRetrievalRaw = cfg.graphRetrieval as Record<string, unknown> | undefined;
     const graphRetrieval: GraphRetrievalConfig = {
@@ -1854,6 +1954,82 @@ export const hybridConfigSchema = {
         typeof graphRetrievalRaw?.maxExpandedResults === "number" && graphRetrievalRaw.maxExpandedResults >= 0
           ? Math.min(50, Math.floor(graphRetrievalRaw.maxExpandedResults))
           : 20,
+    };
+
+    // Parse nightly dream cycle config (Issue #143, default: disabled)
+    const nightlyCycleRaw = cfg.nightlyCycle as Record<string, unknown> | undefined;
+    const nightlyCycle: NightlyCycleConfig = {
+      enabled: nightlyCycleRaw?.enabled === true,
+      schedule: typeof nightlyCycleRaw?.schedule === "string" && nightlyCycleRaw.schedule.trim().length > 0
+        ? nightlyCycleRaw.schedule.trim()
+        : "45 2 * * *",
+      reflectWindowDays: typeof nightlyCycleRaw?.reflectWindowDays === "number" && nightlyCycleRaw.reflectWindowDays >= 1
+        ? Math.min(90, Math.floor(nightlyCycleRaw.reflectWindowDays))
+        : 7,
+      pruneMode: (nightlyCycleRaw?.pruneMode === "expired" || nightlyCycleRaw?.pruneMode === "decay" || nightlyCycleRaw?.pruneMode === "both")
+        ? nightlyCycleRaw.pruneMode as "expired" | "decay" | "both"
+        : "both",
+      model: typeof nightlyCycleRaw?.model === "string" && nightlyCycleRaw.model.trim().length > 0
+        ? nightlyCycleRaw.model.trim()
+        : undefined,
+      consolidateAfterDays: typeof nightlyCycleRaw?.consolidateAfterDays === "number" && nightlyCycleRaw.consolidateAfterDays >= 1
+        ? Math.min(365, Math.floor(nightlyCycleRaw.consolidateAfterDays))
+        : 7,
+    };
+
+    // Parse reinforcement config (Issue #147, default: enabled)
+    const reinforcementRaw = cfg.reinforcement as Record<string, unknown> | undefined;
+    const reinforcement: ReinforcementConfig = {
+      enabled: reinforcementRaw?.enabled !== false,
+      passiveBoost:
+        typeof reinforcementRaw?.passiveBoost === "number" && reinforcementRaw.passiveBoost >= 0 && reinforcementRaw.passiveBoost <= 1
+          ? reinforcementRaw.passiveBoost
+          : 0.1,
+      activeBoost:
+        typeof reinforcementRaw?.activeBoost === "number" && reinforcementRaw.activeBoost >= 0 && reinforcementRaw.activeBoost <= 1
+          ? reinforcementRaw.activeBoost
+          : 0.05,
+      maxConfidence:
+        typeof reinforcementRaw?.maxConfidence === "number" && reinforcementRaw.maxConfidence > 0 && reinforcementRaw.maxConfidence <= 1
+          ? reinforcementRaw.maxConfidence
+          : 1.0,
+      similarityThreshold:
+        typeof reinforcementRaw?.similarityThreshold === "number" && reinforcementRaw.similarityThreshold > 0 && reinforcementRaw.similarityThreshold <= 1
+          ? reinforcementRaw.similarityThreshold
+          : 0.85,
+    };
+
+    // Parse knowledge gaps config (Issue #141)
+    const gapsRaw = cfg.gaps as Record<string, unknown> | undefined;
+    const gaps: GapsConfig = {
+      enabled: gapsRaw?.enabled !== false,
+      similarityThreshold:
+        typeof gapsRaw?.similarityThreshold === "number" &&
+        gapsRaw.similarityThreshold >= 0 &&
+        gapsRaw.similarityThreshold <= 1
+          ? gapsRaw.similarityThreshold
+          : 0.8,
+    };
+
+    // Parse aliases config (Issue #149, default: disabled)
+    const aliasesRaw = cfg.aliases as Record<string, unknown> | undefined;
+    const aliases: AliasesConfig = {
+      enabled: aliasesRaw?.enabled === true,
+      maxAliases:
+        typeof aliasesRaw?.maxAliases === "number" && aliasesRaw.maxAliases > 0
+          ? Math.min(10, Math.floor(aliasesRaw.maxAliases))
+          : 5,
+      model: typeof aliasesRaw?.model === "string" ? aliasesRaw.model : undefined,
+    };
+
+    // Parse path config (Issue #140, default: enabled, maxPathDepth: 10)
+    const pathRaw = cfg.path as Record<string, unknown> | undefined;
+    const path: PathConfig = {
+      enabled: pathRaw?.enabled !== false,
+      maxPathDepth:
+        typeof pathRaw?.maxPathDepth === "number" && pathRaw.maxPathDepth > 0
+          ? Math.min(20, Math.floor(pathRaw.maxPathDepth))
+          : 10,
     };
 
     const staleWarningRaw = activeTaskRaw?.staleWarning as Record<string, unknown> | undefined;
@@ -1934,6 +2110,18 @@ export const hybridConfigSchema = {
       ambient,
       graphRetrieval,
       futureDateProtection,
+      nightlyCycle,
+      reinforcement,
+      clusters,
+      health: (() => {
+        const healthRaw = cfg.health as Record<string, unknown> | undefined;
+        return {
+          enabled: healthRaw?.enabled !== false,
+        };
+      })(),
+      gaps,
+      aliases,
+      path,
       mode: hasPresetOverrides ? "custom" : appliedMode,
     };
   },

--- a/extensions/memory-hybrid/index.ts
+++ b/extensions/memory-hybrid/index.ts
@@ -43,7 +43,7 @@ import { VectorDB } from "./backends/vector-db.js";
 import { FactsDB, MEMORY_LINK_TYPES, type MemoryLinkType, type ContradictionRecord } from "./backends/facts-db.js";
 import { registerHybridMemCliWithApi } from "./setup/cli-context.js";
 import { deepMerge } from "./cli/handlers.js";
-import { Embeddings, type EmbeddingProvider, OllamaEmbeddingProvider, FallbackEmbeddingProvider, createEmbeddingProvider, safeEmbed } from "./services/embeddings.js";
+import { Embeddings, safeEmbed, type EmbeddingProvider } from "./services/embeddings.js";
 import { chatComplete, distillBatchTokenLimit, distillMaxOutputTokens, createPendingLLMWarnings } from "./services/chat.js";
 import { extractProceduresFromSessions } from "./services/procedure-extractor.js";
 import { generateAutoSkills } from "./services/procedure-skill-generator.js";
@@ -66,6 +66,20 @@ import {
 } from "./services/retrieval-orchestrator.js";
 import { expandGraph, formatLinkPath, HOP_SCORE_DECAY } from "./services/graph-retrieval.js";
 export type { GraphExpandedResult, LinkPathStep, GraphFactLookup } from "./services/graph-retrieval.js";
+import { findShortestPath, resolveInput, formatPath } from "./services/shortest-path.js";
+export type { ShortestPathResult, PathStep, ShortestPathLookup } from "./services/shortest-path.js";
+import {
+  analyzeKnowledgeGaps,
+  detectOrphans,
+  detectWeak,
+  detectSuggestedLinks,
+  computeIsolationScore,
+  computeRankScore,
+} from "./services/knowledge-gaps.js";
+export type { GapFact, SuggestedLink, KnowledgeGapReport, GapMode, GapFactsDB, GapVectorDB, GapEmbeddings } from "./services/knowledge-gaps.js";
+import { detectClusters, generateClusterLabel } from "./services/topic-clusters.js";
+export type { TopicCluster, ClusterDetectionResult, ClusterDetectionOptions, ClusterFactLookup } from "./services/topic-clusters.js";
+import { AliasDB, generateAliases, storeAliases, searchAliasStrategy } from "./services/retrieval-aliases.js";
 import { gatherIngestFiles } from "./services/ingest-utils.js";
 import type { MemoryEntry, SearchResult, ScopeFilter } from "./types/memory.js";
 import { MEMORY_SCOPES } from "./types/memory.js";
@@ -200,6 +214,7 @@ let credentialsDb: CredentialsDB | null = null;
 let wal: WriteAheadLog | null = null;
 let proposalsDb: ProposalsDB | null = null;
 let eventLog: EventLog | null = null;
+let aliasDb: AliasDB | null = null;
 let pendingLLMWarnings = createPendingLLMWarnings();
 
 // Timer references (wrapped in objects so they can be passed by reference)
@@ -215,7 +230,7 @@ const timers = {
 };
 
 /** Last progressive index fact IDs (1-based position → fact id) so memory_recall(id: 1) can resolve. */
-let lastProgressiveIndexIds: string[] = [];
+const lastProgressiveIndexIds: string[] = [];
 
 /** Runtime-detected agent identity. Used for dynamic scope filtering and default store scope. */
 // Runtime-detected agent identity
@@ -248,7 +263,7 @@ let lastProgressiveIndexIds: string[] = [];
 // and tools will see the updated value (fixes pass-by-value bug from refactor).
 const currentAgentIdRef: { value: string | null } = { value: null };
 
-let restartPendingCleared = false;
+const restartPendingCleared = false;
 
 const memoryHybridPlugin = {
   id: PLUGIN_ID,
@@ -262,10 +277,11 @@ const memoryHybridPlugin = {
   register(api: ClawdbotPluginApi) {
     // Reopen guard: ensure any previous instance is closed before creating new one (avoids duplicate
     // DB instances if host calls register() before stop(), e.g. on SIGUSR1 or rapid reload).
-    closeOldDatabases({ factsDb, vectorDb, credentialsDb, proposalsDb, eventLog });
+    closeOldDatabases({ factsDb, vectorDb, credentialsDb, proposalsDb, eventLog, aliasDb });
     credentialsDb = null;
     proposalsDb = null;
     eventLog = null;
+    aliasDb = null;
     pendingLLMWarnings = createPendingLLMWarnings();
 
     try {
@@ -285,6 +301,7 @@ const memoryHybridPlugin = {
       wal = dbContext.wal;
       proposalsDb = dbContext.proposalsDb;
       eventLog = dbContext.eventLog;
+      aliasDb = dbContext.aliasDb;
       resolvedLancePath = dbContext.resolvedLancePath;
       resolvedSqlitePath = dbContext.resolvedSqlitePath;
     } catch (err) {
@@ -340,8 +357,10 @@ const memoryHybridPlugin = {
       openai,
       cfg,
       credentialsDb,
+      aliasDb,
       wal,
       proposalsDb,
+      eventLog,
       resolvedSqlitePath,
       resolvedLancePath,
       pluginId: PLUGIN_ID,
@@ -364,6 +383,7 @@ const memoryHybridPlugin = {
       openai,
       cfg,
       credentialsDb,
+      aliasDb,
       wal,
       currentAgentIdRef,
       lastProgressiveIndexIds,
@@ -453,9 +473,6 @@ export const _testing = {
   EventLog,
   VectorDB,
   Embeddings,
-  OllamaEmbeddingProvider,
-  FallbackEmbeddingProvider,
-  createEmbeddingProvider,
   WriteAheadLog,
   // Classification (for tests)
   parseClassificationResponse,
@@ -481,6 +498,25 @@ export const _testing = {
   expandGraph,
   formatLinkPath,
   HOP_SCORE_DECAY,
+  // Shortest-path traversal (Issue #140)
+  findShortestPath,
+  resolveInput,
+  formatPath,
+  // Knowledge gap analysis (Issue #141)
+  analyzeKnowledgeGaps,
+  detectOrphans,
+  detectWeak,
+  detectSuggestedLinks,
+  computeIsolationScore,
+  computeRankScore,
+  // Topic cluster detection (Issue #146)
+  detectClusters,
+  generateClusterLabel,
+  // Retrieval aliases (Issue #149)
+  AliasDB,
+  generateAliases,
+  storeAliases,
+  searchAliasStrategy,
 };
 
 export { versionInfo } from "./versionInfo.js";

--- a/extensions/memory-hybrid/lifecycle/hooks.ts
+++ b/extensions/memory-hybrid/lifecycle/hooks.ts
@@ -19,6 +19,7 @@ import type { VectorDB } from "../backends/vector-db.js";
 import type { EmbeddingProvider } from "../services/embeddings.js";
 import type { WriteAheadLog } from "../backends/wal.js";
 import type { CredentialsDB } from "../backends/credentials-db.js";
+import type { AliasDB } from "../services/retrieval-aliases.js";
 import type { MemoryEntry, ScopeFilter, SearchResult } from "../types/memory.js";
 import { mergeResults, filterByScope } from "../services/merge-results.js";
 import { chatCompleteWithRetry, type PendingLLMWarnings } from "../services/chat.js";
@@ -63,6 +64,7 @@ export interface LifecycleContext {
   openai: OpenAI;
   cfg: HybridMemoryConfig;
   credentialsDb: CredentialsDB | null;
+  aliasDb: AliasDB | null;
   wal: WriteAheadLog | null;
   currentAgentIdRef: { value: string | null };
   lastProgressiveIndexIds: string[];
@@ -1774,6 +1776,7 @@ export function createLifecycleHooks(ctx: LifecycleContext) {
                   if (classification.action === "NOOP") continue;
                   if (classification.action === "DELETE" && classification.targetId) {
                     ctx.factsDb.supersede(classification.targetId, null);
+                    ctx.aliasDb?.deleteByFactId(classification.targetId);
                     api.logger.info?.(`memory-hybrid: auto-capture DELETE — retracted ${classification.targetId}`);
                     continue;
                   }
@@ -1806,6 +1809,7 @@ export function createLifecycleHooks(ctx: LifecycleContext) {
                         supersedesId: classification.targetId,
                       });
                       ctx.factsDb.supersede(classification.targetId, newEntry.id);
+                      ctx.aliasDb?.deleteByFactId(classification.targetId);
                       try {
                         if (vector && !(await ctx.vectorDb.hasDuplicate(vector))) {
                           await ctx.vectorDb.store({ text: textToStore, vector, importance: finalImportance, category, id: newEntry.id });

--- a/extensions/memory-hybrid/services/consolidation.ts
+++ b/extensions/memory-hybrid/services/consolidation.ts
@@ -92,9 +92,10 @@ export async function runConsolidate(
   openai: OpenAI,
   opts: ConsolidateOptions,
   logger: { info: (msg: string) => void; warn: (msg: string) => void },
+  aliasDb?: import("./retrieval-aliases.js").AliasDB | null,
 ): Promise<ConsolidateResult> {
   const facts = factsDb.getFactsForConsolidation(opts.limit);
-  let candidateFacts = opts.includeStructured
+  const candidateFacts = opts.includeStructured
     ? facts
     : facts.filter((f) => !isStructuredForConsolidation(f.text, f.entity, f.key));
   if (candidateFacts.length < 2) {
@@ -225,6 +226,7 @@ export async function runConsolidate(
     }
     for (const id of clusterIds) {
       factsDb.delete(id);
+      aliasDb?.deleteByFactId(id);
       deleted++;
     }
     merged++;

--- a/extensions/memory-hybrid/services/credential-migration.ts
+++ b/extensions/memory-hybrid/services/credential-migration.ts
@@ -21,6 +21,7 @@ export interface MigrateCredentialsOptions {
   vectorDb: VectorDB;
   embeddings: EmbeddingProvider;
   credentialsDb: CredentialsDB;
+  aliasDb?: import("./retrieval-aliases.js").AliasDB | null;
   migrationFlagPath: string;
   markDone: boolean;
 }
@@ -39,7 +40,7 @@ export interface MigrateCredentialsResult {
 export async function migrateCredentialsToVault(
   opts: MigrateCredentialsOptions,
 ): Promise<MigrateCredentialsResult> {
-  const { factsDb, vectorDb, embeddings, credentialsDb, migrationFlagPath, markDone } = opts;
+  const { factsDb, vectorDb, embeddings, credentialsDb, aliasDb, migrationFlagPath, markDone } = opts;
   let migrated = 0;
   let skipped = 0;
   const errors: string[] = [];
@@ -71,6 +72,7 @@ export async function migrateCredentialsToVault(
         notes: parsed.notes,
       });
       factsDb.delete(entry.id);
+      aliasDb?.deleteByFactId(entry.id);
       try {
         await vectorDb.delete(entry.id);
       } catch (err) {

--- a/extensions/memory-hybrid/services/dream-cycle.ts
+++ b/extensions/memory-hybrid/services/dream-cycle.ts
@@ -1,0 +1,413 @@
+/**
+ * Dream Cycle Service — Automated nightly reflection + pruning pipeline (Issue #143).
+ *
+ * Sequence:
+ *  1. memory_prune (decay confidence + remove expired facts)
+ *  2. Episodic consolidation (merge old event log entries into consolidated facts, DERIVED_FROM links)
+ *  3. memory_reflect (synthesize patterns from recent facts)
+ *  4. memory_reflect_rules (optional, if enough new patterns accumulated)
+ *  5. Generate daily digest summary
+ *
+ * Designed to be cheap ($0.003/night target) using a Flash-tier model.
+ * Self-contained — does not require an active agent session.
+ */
+
+import type { FactsDB } from "../backends/facts-db.js";
+import type { VectorDB } from "../backends/vector-db.js";
+import type { EmbeddingProvider } from "./embeddings.js";
+import type OpenAI from "openai";
+import type { EventLog, EventLogEntry } from "../backends/event-log.js";
+import type { MemoryCategory } from "../types/memory.js";
+import {
+  runReflection,
+  runReflectionRules,
+  type ReflectionConfig,
+} from "./reflection.js";
+import { capturePluginError } from "./error-reporter.js";
+
+/** Prune modes for the dream cycle. */
+export type DreamCyclePruneMode = "expired" | "decay" | "both";
+
+/** Configuration for the nightly dream cycle. */
+export interface DreamCycleConfig {
+  enabled: boolean;
+  schedule: string;
+  reflectWindowDays: number;
+  pruneMode: DreamCyclePruneMode;
+  model: string;
+  consolidateAfterDays: number;
+}
+
+/** Result returned by a single dream cycle run. */
+export interface DreamCycleResult {
+  /** Facts removed by pruneExpired(). */
+  factsPruned: number;
+  /** Facts whose confidence was decayed. */
+  factsDecayed: number;
+  /** Episodic event log entries successfully consolidated. */
+  eventsConsolidated: number;
+  /** New consolidated facts created from episodic events. */
+  factsCreated: number;
+  /** New patterns stored by runReflection(). */
+  patternsFound: number;
+  /** New rules stored by runReflectionRules(). */
+  rulesGenerated: number;
+  /** Human-readable summary of the cycle. */
+  digestSummary: string;
+  /** True when the cycle was skipped because nightlyCycle.enabled = false. */
+  skipped: boolean;
+}
+
+// Minimum patterns stored in one cycle before we also run reflect-rules.
+const MIN_PATTERNS_FOR_RULES = 3;
+
+// ---------------------------------------------------------------------------
+// Episodic consolidation helpers (exported for testing)
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract the primary text content from an event log entry.
+ * Checks common content field names in priority order.
+ */
+export function extractEventText(event: EventLogEntry): string {
+  const c = event.content;
+  if (typeof c.text === "string" && c.text.trim().length > 0) return c.text.trim();
+  if (typeof c.decision === "string" && c.decision.trim().length > 0) return c.decision.trim();
+  if (typeof c.summary === "string" && c.summary.trim().length > 0) return c.summary.trim();
+  if (typeof c.action === "string" && c.action.trim().length > 0) return c.action.trim();
+  if (typeof c.description === "string" && c.description.trim().length > 0) return c.description.trim();
+  // Fall back to any string value in the content object
+  for (const v of Object.values(c)) {
+    if (typeof v === "string" && v.trim().length > 0) return v.trim();
+  }
+  return "";
+}
+
+/**
+ * Group event log entries by their primary entity.
+ * Events with no entities are grouped under the "__default__" key.
+ */
+export function groupEventsByEntity(events: EventLogEntry[]): Map<string, EventLogEntry[]> {
+  const groups = new Map<string, EventLogEntry[]>();
+  for (const event of events) {
+    const primaryEntity = event.entities?.[0] ?? "__default__";
+    if (!groups.has(primaryEntity)) groups.set(primaryEntity, []);
+    groups.get(primaryEntity)!.push(event);
+  }
+  return groups;
+}
+
+/**
+ * Build the digest summary string from cycle counts.
+ * Exported so it can be tested independently.
+ */
+export function buildDigestSummary(counts: {
+  factsPruned: number;
+  factsDecayed: number;
+  eventsConsolidated: number;
+  factsCreated: number;
+  patternsFound: number;
+  rulesGenerated: number;
+}): string {
+  const parts: string[] = [];
+  if (counts.factsPruned > 0) parts.push(`${counts.factsPruned} facts pruned`);
+  if (counts.factsDecayed > 0) parts.push(`${counts.factsDecayed} facts decayed`);
+  if (counts.eventsConsolidated > 0) {
+    parts.push(`${counts.eventsConsolidated} events consolidated into ${counts.factsCreated} facts`);
+  }
+  if (counts.patternsFound > 0) parts.push(`${counts.patternsFound} patterns extracted`);
+  if (counts.rulesGenerated > 0) parts.push(`${counts.rulesGenerated} rules generated`);
+  if (parts.length === 0) return "No changes.";
+  return parts.join(", ") + ".";
+}
+
+// ---------------------------------------------------------------------------
+// Episodic consolidation
+// ---------------------------------------------------------------------------
+
+/**
+ * Run episodic consolidation:
+ *  1. Fetch unconsolidated event log entries older than consolidateAfterDays.
+ *  2. Group by primary entity.
+ *  3. For each group, create a consolidated fact.
+ *  4. For each source event, create a short-lived "episodic source" fact and a
+ *     DERIVED_FROM link pointing from the consolidated fact to the source fact.
+ *  5. Mark all events as consolidated in the event log.
+ *  6. Prune the immediately-expired source facts (DERIVED_FROM links remain for provenance).
+ */
+export async function runEpisodicConsolidation(
+  factsDb: FactsDB,
+  eventLog: EventLog,
+  consolidateAfterDays: number,
+  logger: { info: (msg: string) => void; warn: (msg: string) => void },
+): Promise<{ eventsConsolidated: number; factsCreated: number }> {
+  const events = eventLog.getUnconsolidated(consolidateAfterDays);
+  if (events.length === 0) {
+    return { eventsConsolidated: 0, factsCreated: 0 };
+  }
+
+  const groups = groupEventsByEntity(events);
+  let factsCreated = 0;
+  let eventsConsolidated = 0;
+  const ephemeralSourceFactIds: string[] = [];
+
+  for (const [entity, groupEvents] of groups) {
+    if (groupEvents.length === 0) continue;
+
+    // Collect text from all events in this group
+    const eventTexts = groupEvents
+      .map((e) => extractEventText(e))
+      .filter((t) => t.length >= 3);
+
+    if (eventTexts.length === 0) {
+      // Mark events as consolidated with a sentinel value to prevent re-processing
+      // Use a namespaced sentinel to distinguish from real fact IDs
+      eventLog.markConsolidated(groupEvents.map((e) => e.id), "__skipped_no_text__");
+      eventsConsolidated += groupEvents.length;
+      continue;
+    }
+
+    // Build merged text for the consolidated fact
+    const entityLabel = entity !== "__default__" ? entity : null;
+    const mergedText =
+      eventTexts.length === 1
+        ? eventTexts[0]
+        : `[consolidated from ${eventTexts.length} events${entityLabel ? ` about ${entityLabel}` : ""}] ${eventTexts.slice(0, 5).join("; ")}`;
+
+    // Create the consolidated fact
+    let consolidatedFact;
+    try {
+      consolidatedFact = factsDb.store({
+        text: mergedText.slice(0, 500),
+        category: "fact" as MemoryCategory,
+        importance: 0.5,
+        entity: entityLabel,
+        key: "consolidated",
+        value: null,
+        source: "dream-cycle",
+        decayClass: "stable",
+        tags: ["dream-cycle", "consolidated"],
+      });
+    } catch (err) {
+      logger.warn(`memory-hybrid: dream-cycle — failed to store consolidated fact for entity "${entity}": ${err}`);
+      capturePluginError(err instanceof Error ? err : new Error(String(err)), {
+        operation: "dream-cycle-consolidate",
+        subsystem: "facts-db",
+      });
+      continue;
+    }
+
+    // For each event, create a minimal ephemeral source fact and a DERIVED_FROM link.
+    // The source facts expire immediately; DERIVED_FROM links persist as provenance.
+    const nowSec = Math.floor(Date.now() / 1000);
+    for (const event of groupEvents) {
+      const srcText = extractEventText(event);
+      if (srcText.length < 3) continue;
+
+      try {
+        const srcFact = factsDb.store({
+          text: srcText.slice(0, 300),
+          category: "fact" as MemoryCategory,
+          importance: 0.1,
+          entity: entityLabel,
+          key: "episodic_source",
+          value: event.eventType,
+          source: "dream-cycle-src",
+          decayClass: "checkpoint",
+          expiresAt: nowSec - 1, // Immediately expired — will be pruned right away
+          confidence: 0.5,
+        });
+        ephemeralSourceFactIds.push(srcFact.id);
+        // consolidated_fact -DERIVED_FROM-> source_fact (provenance)
+        factsDb.createLink(consolidatedFact.id, srcFact.id, "DERIVED_FROM", 1.0);
+      } catch (err) {
+        logger.warn(`memory-hybrid: dream-cycle — failed to create source fact for event ${event.id}: ${err}`);
+        capturePluginError(err instanceof Error ? err : new Error(String(err)), {
+          operation: "dream-cycle-src-fact",
+          subsystem: "facts-db",
+        });
+      }
+    }
+
+    // Mark all events in the group as consolidated into the new fact
+    eventLog.markConsolidated(groupEvents.map((e) => e.id), consolidatedFact.id);
+
+    factsCreated++;
+    eventsConsolidated += groupEvents.length;
+
+    logger.info(
+      `memory-hybrid: dream-cycle — consolidated ${groupEvents.length} events` +
+        (entityLabel ? ` for entity "${entityLabel}"` : "") +
+        ` → fact ${consolidatedFact.id.slice(0, 8)}`,
+    );
+  }
+
+  // Delete only the ephemeral source facts created during this consolidation.
+  // DERIVED_FROM links to them are preserved by design (see delete() in facts-db.ts).
+  for (const id of ephemeralSourceFactIds) {
+    factsDb.delete(id);
+  }
+
+  return { eventsConsolidated, factsCreated };
+}
+
+// ---------------------------------------------------------------------------
+// Main dream cycle orchestration
+// ---------------------------------------------------------------------------
+
+/**
+ * Run the full nightly dream cycle:
+ *  prune → episodic consolidation → reflect → reflect-rules (optional) → digest
+ */
+export async function runDreamCycle(
+  factsDb: FactsDB,
+  vectorDb: VectorDB,
+  embeddings: EmbeddingProvider,
+  openai: OpenAI,
+  eventLog: EventLog | null,
+  config: DreamCycleConfig,
+  logger: { info: (msg: string) => void; warn: (msg: string) => void },
+): Promise<DreamCycleResult> {
+  if (!config.enabled) {
+    return {
+      factsPruned: 0,
+      factsDecayed: 0,
+      eventsConsolidated: 0,
+      factsCreated: 0,
+      patternsFound: 0,
+      rulesGenerated: 0,
+      digestSummary: "Dream cycle disabled.",
+      skipped: true,
+    };
+  }
+
+  logger.info("memory-hybrid: dream-cycle — starting nightly cycle");
+
+  // ── Step 1: Prune ────────────────────────────────────────────────────────
+  let factsPruned = 0;
+  let factsDecayed = 0;
+  if (config.pruneMode === "expired" || config.pruneMode === "both") {
+    try {
+      factsPruned = factsDb.pruneExpired();
+      logger.info(`memory-hybrid: dream-cycle — pruned ${factsPruned} expired facts`);
+    } catch (err) {
+      logger.warn(`memory-hybrid: dream-cycle — pruneExpired failed: ${err}`);
+      capturePluginError(err instanceof Error ? err : new Error(String(err)), {
+        operation: "dream-cycle-prune-expired",
+        subsystem: "facts-db",
+      });
+    }
+  }
+  if (config.pruneMode === "decay" || config.pruneMode === "both") {
+    try {
+      factsDecayed = factsDb.decayConfidence();
+      logger.info(`memory-hybrid: dream-cycle — decayed ${factsDecayed} facts`);
+    } catch (err) {
+      logger.warn(`memory-hybrid: dream-cycle — decayConfidence failed: ${err}`);
+      capturePluginError(err instanceof Error ? err : new Error(String(err)), {
+        operation: "dream-cycle-decay",
+        subsystem: "facts-db",
+      });
+    }
+  }
+
+  // ── Step 2: Episodic consolidation ───────────────────────────────────────
+  let eventsConsolidated = 0;
+  let factsCreated = 0;
+  if (eventLog) {
+    try {
+      const consolidationResult = await runEpisodicConsolidation(
+        factsDb,
+        eventLog,
+        config.consolidateAfterDays,
+        logger,
+      );
+      eventsConsolidated = consolidationResult.eventsConsolidated;
+      factsCreated = consolidationResult.factsCreated;
+    } catch (err) {
+      logger.warn(`memory-hybrid: dream-cycle — consolidation step failed: ${err}`);
+      capturePluginError(err instanceof Error ? err : new Error(String(err)), {
+        operation: "dream-cycle-consolidation",
+        subsystem: "event-log",
+      });
+    }
+  }
+
+  // ── Step 3: Reflect ───────────────────────────────────────────────────────
+  let patternsFound = 0;
+  const reflectionConfig: ReflectionConfig = {
+    enabled: true,
+    defaultWindow: config.reflectWindowDays,
+    minObservations: 2,
+  };
+  try {
+    const reflectionResult = await runReflection(
+      factsDb,
+      vectorDb,
+      embeddings,
+      openai,
+      reflectionConfig,
+      {
+        window: config.reflectWindowDays,
+        dryRun: false,
+        model: config.model,
+        fallbackModels: [],
+      },
+      logger,
+    );
+    patternsFound = reflectionResult.patternsStored;
+    logger.info(`memory-hybrid: dream-cycle — reflection complete: ${patternsFound} patterns stored`);
+  } catch (err) {
+    logger.warn(`memory-hybrid: dream-cycle — reflection step failed: ${err}`);
+    capturePluginError(err instanceof Error ? err : new Error(String(err)), {
+      operation: "dream-cycle-reflect",
+      subsystem: "reflection",
+    });
+  }
+
+  // ── Step 4: Reflect-rules (optional) ────────────────────────────────────
+  let rulesGenerated = 0;
+  if (patternsFound >= MIN_PATTERNS_FOR_RULES) {
+    try {
+      const rulesResult = await runReflectionRules(
+        factsDb,
+        vectorDb,
+        embeddings,
+        openai,
+        { dryRun: false, model: config.model, fallbackModels: [] },
+        logger,
+      );
+      rulesGenerated = rulesResult.rulesStored;
+      logger.info(`memory-hybrid: dream-cycle — reflect-rules complete: ${rulesGenerated} rules stored`);
+    } catch (err) {
+      logger.warn(`memory-hybrid: dream-cycle — reflect-rules step failed: ${err}`);
+      capturePluginError(err instanceof Error ? err : new Error(String(err)), {
+        operation: "dream-cycle-reflect-rules",
+        subsystem: "reflection",
+      });
+    }
+  }
+
+  // ── Step 5: Digest summary ───────────────────────────────────────────────
+  const digestSummary = buildDigestSummary({
+    factsPruned,
+    factsDecayed,
+    eventsConsolidated,
+    factsCreated,
+    patternsFound,
+    rulesGenerated,
+  });
+
+  logger.info(`memory-hybrid: dream-cycle — complete. ${digestSummary}`);
+
+  return {
+    factsPruned,
+    factsDecayed,
+    eventsConsolidated,
+    factsCreated,
+    patternsFound,
+    rulesGenerated,
+    digestSummary,
+    skipped: false,
+  };
+}

--- a/extensions/memory-hybrid/services/embeddings.ts
+++ b/extensions/memory-hybrid/services/embeddings.ts
@@ -162,7 +162,11 @@ export class Embeddings implements EmbeddingProvider {
         if (resp.data.length !== batch.length) {
           throw new Error(`OpenAI embed returned ${resp.data.length} embeddings for ${batch.length} inputs`);
         }
-        allResults.push(...resp.data.map((item) => item.embedding));
+        allResults.push(
+          ...resp.data
+            .sort((a, b) => a.index - b.index)
+            .map((item) => item.embedding),
+        );
       }
       if (lastErr !== undefined && allResults.length === i) {
         capturePluginError(lastErr, {
@@ -247,8 +251,11 @@ export class OllamaEmbeddingProvider implements EmbeddingProvider {
  */
 export class FallbackEmbeddingProvider implements EmbeddingProvider {
   private active: EmbeddingProvider;
+  private readonly primary: EmbeddingProvider;
   private readonly fallback: EmbeddingProvider | null;
   private switched = false;
+  private lastRetryAttempt = 0;
+  private readonly retryIntervalMs = 60000;
   private readonly onSwitch?: (err: unknown) => void;
   readonly dimensions: number;
   modelName: string;
@@ -259,6 +266,7 @@ export class FallbackEmbeddingProvider implements EmbeddingProvider {
     onSwitch?: (err: unknown) => void,
   ) {
     this.active = primary;
+    this.primary = primary;
     this.fallback = fallback;
     this.onSwitch = onSwitch;
     this.dimensions = primary.dimensions;
@@ -266,7 +274,22 @@ export class FallbackEmbeddingProvider implements EmbeddingProvider {
   }
 
   async embed(text: string): Promise<number[]> {
-    if (this.switched || !this.fallback) {
+    if (!this.fallback) {
+      return this.active.embed(text);
+    }
+    if (this.switched && Date.now() - this.lastRetryAttempt >= this.retryIntervalMs) {
+      this.lastRetryAttempt = Date.now();
+      try {
+        const result = await this.primary.embed(text);
+        this.active = this.primary;
+        this.switched = false;
+        this.modelName = this.active.modelName;
+        return result;
+      } catch (_err) {
+        // Primary still failing — continue using fallback
+      }
+    }
+    if (this.switched) {
       return this.active.embed(text);
     }
     try {
@@ -275,13 +298,29 @@ export class FallbackEmbeddingProvider implements EmbeddingProvider {
       this.onSwitch?.(err);
       this.active = this.fallback;
       this.switched = true;
+      this.lastRetryAttempt = Date.now();
       this.modelName = this.active.modelName;
       return this.active.embed(text);
     }
   }
 
   async embedBatch(texts: string[]): Promise<number[][]> {
-    if (this.switched || !this.fallback) {
+    if (!this.fallback) {
+      return this.active.embedBatch(texts);
+    }
+    if (this.switched && Date.now() - this.lastRetryAttempt >= this.retryIntervalMs) {
+      this.lastRetryAttempt = Date.now();
+      try {
+        const result = await this.primary.embedBatch(texts);
+        this.active = this.primary;
+        this.switched = false;
+        this.modelName = this.active.modelName;
+        return result;
+      } catch (_err) {
+        // Primary still failing — continue using fallback
+      }
+    }
+    if (this.switched) {
       return this.active.embedBatch(texts);
     }
     try {
@@ -290,6 +329,7 @@ export class FallbackEmbeddingProvider implements EmbeddingProvider {
       this.onSwitch?.(err);
       this.active = this.fallback;
       this.switched = true;
+      this.lastRetryAttempt = Date.now();
       this.modelName = this.active.modelName;
       return this.active.embedBatch(texts);
     }

--- a/extensions/memory-hybrid/services/export-memory.ts
+++ b/extensions/memory-hybrid/services/export-memory.ts
@@ -80,7 +80,7 @@ export function runExport(
   const sourceSet = new Set(sources.map((s) => s.toLowerCase().trim()).filter(Boolean));
 
   const all = factsDb.getAll({ includeSuperseded: false });
-  let facts = all.filter((f) => {
+  const facts = all.filter((f) => {
     if (!includeCreds && (f.entity?.toLowerCase() === "credentials" || f.category === "credential")) return false;
     if (sourceSet.size > 0) {
       const src = (f.source ?? "conversation").toLowerCase();

--- a/extensions/memory-hybrid/services/knowledge-gaps.ts
+++ b/extensions/memory-hybrid/services/knowledge-gaps.ts
@@ -1,0 +1,321 @@
+/**
+ * Knowledge Gap Analysis Service (Issue #141).
+ *
+ * Detects three categories of knowledge gaps in the memory graph:
+ *  1. Orphans  — facts with zero inbound or outbound links
+ *  2. Weak     — facts with exactly 1 link total (dead ends)
+ *  3. Suggested links — semantically similar pairs with no existing link
+ *
+ * Each gap fact is ranked by age × isolation score so that old, isolated facts
+ * bubble to the top (they have been waiting longest for connections).
+ */
+
+import type { MemoryEntry } from "../types/memory.js";
+
+// ---------------------------------------------------------------------------
+// Minimal interfaces (avoid circular deps — only what the service needs)
+// ---------------------------------------------------------------------------
+
+export interface GapFactsDB {
+  getAll(options?: { includeSuperseded?: boolean }): MemoryEntry[];
+  getLinksFrom(factId: string): Array<{ id: string; targetFactId: string; linkType: string; strength: number }>;
+  getLinksTo(factId: string): Array<{ id: string; sourceFactId: string; linkType: string; strength: number }>;
+}
+
+export interface GapVectorDB {
+  search(
+    vector: number[],
+    limit: number,
+    minScore: number,
+  ): Promise<Array<{ entry: { id: string }; score: number }>>;
+}
+
+export interface GapEmbeddings {
+  embed(text: string): Promise<number[]>;
+}
+
+// ---------------------------------------------------------------------------
+// Public output types
+// ---------------------------------------------------------------------------
+
+export type GapMode = "orphans" | "weak" | "all";
+
+/** A fact identified as an orphan (0 links) or weak (1 link). */
+export interface GapFact {
+  factId: string;
+  text: string;
+  createdAt: number;
+  linkCount: number;
+  /** 1.0 for orphan, 0.5 for weak */
+  isolationScore: number;
+  /** age_factor × isolationScore — higher = more urgently needs a connection */
+  rankScore: number;
+}
+
+/** A pair of facts that are semantically similar but have no existing link. */
+export interface SuggestedLink {
+  sourceId: string;
+  targetId: string;
+  sourceText: string;
+  targetText: string;
+  similarity: number;
+}
+
+export interface KnowledgeGapReport {
+  orphans: GapFact[];
+  weak: GapFact[];
+  suggestedLinks: SuggestedLink[];
+}
+
+// ---------------------------------------------------------------------------
+// Scoring helpers
+// ---------------------------------------------------------------------------
+
+/** 30-day period used to normalise age. */
+const AGE_UNIT_SEC = 30 * 86_400;
+
+/**
+ * Compute isolation score from a link count.
+ *  0 links → 1.0 (fully isolated / orphan)
+ *  1 link  → 0.5 (weak — dead end)
+ *  n links → 1 / (n + 1)  (diminishing isolation)
+ */
+export function computeIsolationScore(linkCount: number): number {
+  if (linkCount === 0) return 1.0;
+  if (linkCount === 1) return 0.5;
+  return 1 / (linkCount + 1);
+}
+
+/**
+ * Rank score = age_factor × isolation_score.
+ * age_factor = max(1, ageSeconds / AGE_UNIT_SEC) so brand-new facts still score ≥ 1.
+ */
+export function computeRankScore(
+  createdAt: number,
+  isolationScore: number,
+  nowSec: number,
+): number {
+  const ageSeconds = Math.max(0, nowSec - createdAt);
+  const ageFactor = Math.max(1, ageSeconds / AGE_UNIT_SEC);
+  return ageFactor * isolationScore;
+}
+
+// ---------------------------------------------------------------------------
+// Core detection functions
+// ---------------------------------------------------------------------------
+
+/**
+ * Detect orphan facts — facts with zero inbound AND outbound links.
+ * Results are ranked by age × isolation score (descending).
+ */
+export function detectOrphans(
+  factsDb: GapFactsDB,
+  limit: number,
+  nowSec: number,
+  linkCounts?: Map<string, number>,
+): GapFact[] {
+  const facts = factsDb.getAll({ includeSuperseded: false });
+  const results: GapFact[] = [];
+
+  for (const fact of facts) {
+    const linkCount = linkCounts?.get(fact.id) ?? 
+      factsDb.getLinksFrom(fact.id).length + factsDb.getLinksTo(fact.id).length;
+    if (linkCount === 0) {
+      const isolationScore = computeIsolationScore(linkCount);
+      results.push({
+        factId: fact.id,
+        text: fact.text,
+        createdAt: fact.createdAt,
+        linkCount,
+        isolationScore,
+        rankScore: computeRankScore(fact.createdAt, isolationScore, nowSec),
+      });
+    }
+  }
+
+  results.sort((a, b) => b.rankScore - a.rankScore);
+  return results.slice(0, limit);
+}
+
+/**
+ * Detect weak-link facts — facts with exactly 1 total link (inbound + outbound).
+ * Results are ranked by age × isolation score (descending).
+ */
+export function detectWeak(
+  factsDb: GapFactsDB,
+  limit: number,
+  nowSec: number,
+  linkCounts?: Map<string, number>,
+): GapFact[] {
+  const facts = factsDb.getAll({ includeSuperseded: false });
+  const results: GapFact[] = [];
+
+  for (const fact of facts) {
+    const linkCount = linkCounts?.get(fact.id) ?? 
+      factsDb.getLinksFrom(fact.id).length + factsDb.getLinksTo(fact.id).length;
+    if (linkCount === 1) {
+      const isolationScore = computeIsolationScore(linkCount);
+      results.push({
+        factId: fact.id,
+        text: fact.text,
+        createdAt: fact.createdAt,
+        linkCount,
+        isolationScore,
+        rankScore: computeRankScore(fact.createdAt, isolationScore, nowSec),
+      });
+    }
+  }
+
+  results.sort((a, b) => b.rankScore - a.rankScore);
+  return results.slice(0, limit);
+}
+
+/**
+ * Detect suggested links — semantically similar pairs of facts that currently
+ * have no direct link.
+ *
+ * Strategy (efficient):
+ *  1. Consider only orphan and weak-link facts (most in need of connections).
+ *  2. For each candidate fact, embed its text and search the vector index.
+ *  3. Filter out pairs that already share a direct link.
+ *  4. Deduplicate symmetric pairs (A→B and B→A are the same suggestion).
+ *  5. Return up to `limit` suggestions sorted by similarity descending.
+ *
+ * Candidates are ordered by rank score so the most isolated/oldest facts are
+ * processed first and hit the `limit` budget first.
+ */
+export async function detectSuggestedLinks(
+  factsDb: GapFactsDB,
+  vectorDb: GapVectorDB,
+  embeddings: GapEmbeddings,
+  threshold: number,
+  limit: number,
+  nowSec: number,
+  linkCounts?: Map<string, number>,
+): Promise<SuggestedLink[]> {
+  const facts = factsDb.getAll({ includeSuperseded: false });
+
+  // Build a lookup map for fast id → MemoryEntry access.
+  const factMap = new Map<string, MemoryEntry>(facts.map((f) => [f.id, f]));
+
+  // Collect orphan + weak candidates and rank them.
+  const candidates: Array<{ fact: MemoryEntry; rankScore: number }> = [];
+  for (const fact of facts) {
+    const linkCount = linkCounts?.get(fact.id) ?? 
+      factsDb.getLinksFrom(fact.id).length + factsDb.getLinksTo(fact.id).length;
+    if (linkCount <= 1) {
+      const iso = computeIsolationScore(linkCount);
+      candidates.push({
+        fact,
+        rankScore: computeRankScore(fact.createdAt, iso, nowSec),
+      });
+    }
+  }
+  candidates.sort((a, b) => b.rankScore - a.rankScore);
+
+  const suggestions: SuggestedLink[] = [];
+  const seenPairs = new Set<string>();
+
+  // Process candidates until we have enough suggestions or run out of candidates.
+  const MAX_CANDIDATES = 50; // cap for performance
+  for (const { fact } of candidates.slice(0, MAX_CANDIDATES)) {
+    if (suggestions.length >= limit) break;
+
+    let vector: number[];
+    try {
+      vector = await embeddings.embed(fact.text);
+    } catch {
+      continue; // skip if embedding fails
+    }
+
+    // Use the threshold as minScore so the vector DB pre-filters.
+    const similar = await vectorDb.search(vector, 10, threshold);
+
+    // Collect this fact's direct neighbours for fast lookup.
+    const directNeighbours = new Set<string>();
+    for (const l of factsDb.getLinksFrom(fact.id)) directNeighbours.add(l.targetFactId);
+    for (const l of factsDb.getLinksTo(fact.id)) directNeighbours.add(l.sourceFactId);
+
+    for (const r of similar) {
+      if (suggestions.length >= limit) break;
+
+      const otherId = r.entry.id;
+      if (otherId === fact.id) continue;
+      if (directNeighbours.has(otherId)) continue;
+
+      // Canonical pair key (order-independent)
+      const pairKey = fact.id < otherId ? `${fact.id}:${otherId}` : `${otherId}:${fact.id}`;
+      if (seenPairs.has(pairKey)) continue;
+      seenPairs.add(pairKey);
+
+      const other = factMap.get(otherId);
+      if (!other) continue;
+
+      suggestions.push({
+        sourceId: fact.id,
+        targetId: otherId,
+        sourceText: fact.text,
+        targetText: other.text,
+        similarity: r.score,
+      });
+    }
+  }
+
+  suggestions.sort((a, b) => b.similarity - a.similarity);
+  return suggestions.slice(0, limit);
+}
+
+// ---------------------------------------------------------------------------
+// Main entry point
+// ---------------------------------------------------------------------------
+
+/**
+ * Analyse knowledge gaps in the memory graph.
+ *
+ * @param factsDb   - SQLite facts DB adapter.
+ * @param vectorDb  - LanceDB vector search adapter (needed for suggestedLinks).
+ * @param embeddings - Embedding provider (needed for suggestedLinks).
+ * @param mode      - Which gaps to detect.
+ * @param limit     - Max items per category.
+ * @param threshold - Minimum cosine similarity for suggested links (default 0.8).
+ * @param nowSec    - Current epoch time in seconds (injectable for tests).
+ */
+export async function analyzeKnowledgeGaps(
+  factsDb: GapFactsDB,
+  vectorDb: GapVectorDB,
+  embeddings: GapEmbeddings,
+  mode: GapMode,
+  limit: number,
+  threshold: number,
+  nowSec?: number,
+): Promise<KnowledgeGapReport> {
+  const now = nowSec ?? Math.floor(Date.now() / 1000);
+
+  let linkCounts: Map<string, number> | undefined;
+  if (mode === "all") {
+    const facts = factsDb.getAll({ includeSuperseded: false });
+    linkCounts = new Map<string, number>();
+    for (const fact of facts) {
+      const out = factsDb.getLinksFrom(fact.id);
+      const inn = factsDb.getLinksTo(fact.id);
+      linkCounts.set(fact.id, out.length + inn.length);
+    }
+  }
+
+  const orphans: GapFact[] =
+    mode === "orphans" || mode === "all"
+      ? detectOrphans(factsDb, limit, now, linkCounts)
+      : [];
+
+  const weak: GapFact[] =
+    mode === "weak" || mode === "all"
+      ? detectWeak(factsDb, limit, now, linkCounts)
+      : [];
+
+  const suggestedLinks: SuggestedLink[] =
+    mode === "all"
+      ? await detectSuggestedLinks(factsDb, vectorDb, embeddings, threshold, limit, now, linkCounts)
+      : [];
+
+  return { orphans, weak, suggestedLinks };
+}

--- a/extensions/memory-hybrid/services/memory-diagnostics.ts
+++ b/extensions/memory-hybrid/services/memory-diagnostics.ts
@@ -19,11 +19,12 @@ export async function runMemoryDiagnostics(opts: {
   factsDb: FactsDB;
   vectorDb: VectorDB;
   embeddings: EmbeddingProvider;
+  aliasDb?: import("./retrieval-aliases.js").AliasDB | null;
   scopeFilter?: ScopeFilter | null;
   minScore?: number;
   autoRecallLimit?: number;
 }): Promise<MemoryDiagnosticsResult> {
-  const { factsDb, vectorDb, embeddings, scopeFilter, minScore = 0.3, autoRecallLimit = 10 } = opts;
+  const { factsDb, vectorDb, embeddings, aliasDb, scopeFilter, minScore = 0.3, autoRecallLimit = 10 } = opts;
   const markerText = `__hybrid_mem_diag__ ${randomUUID()}`;
   let markerId = "";
 
@@ -80,6 +81,7 @@ export async function runMemoryDiagnostics(opts: {
       if (markerId) {
         factsDb.delete(markerId);
         await vectorDb.delete(markerId);
+        aliasDb?.deleteByFactId(markerId);
       }
     } catch (err) {
       capturePluginError(err instanceof Error ? err : new Error(String(err)), {

--- a/extensions/memory-hybrid/services/passive-observer.ts
+++ b/extensions/memory-hybrid/services/passive-observer.ts
@@ -19,7 +19,7 @@ import type { FactsDB } from '../backends/facts-db.js'
 import type { VectorDB } from '../backends/vector-db.js'
 import type { EmbeddingProvider } from './embeddings.js'
 import type OpenAI from 'openai'
-import type { MemoryCategory } from '../config.js'
+import type { MemoryCategory, ReinforcementConfig } from '../config.js'
 import { chunkTextByChars } from '../utils/text.js'
 import { loadPrompt, fillPrompt } from '../utils/prompt-loader.js'
 import { chatCompleteWithRetry, LLMRetryError } from './chat.js'
@@ -55,6 +55,7 @@ export interface ObserverRunResult {
   chunksProcessed: number
   factsExtracted: number
   factsStored: number
+  factsReinforced: number
   errors: number
 }
 
@@ -240,6 +241,8 @@ export async function runPassiveObserver(
     dryRun?: boolean
     /** Fallback sessions dir from procedures config (used when config.sessionsDir is not set). */
     proceduresSessionsDir?: string
+    /** Confidence reinforcement config (Issue #147). When set and enabled, similar facts get confidence boost instead of silent skip. */
+    reinforcement?: ReinforcementConfig
   },
   logger: { info: (msg: string) => void; warn: (msg: string) => void },
 ): Promise<ObserverRunResult> {
@@ -248,6 +251,7 @@ export async function runPassiveObserver(
     chunksProcessed: 0,
     factsExtracted: 0,
     factsStored: 0,
+    factsReinforced: 0,
     errors: 0,
   }
 
@@ -331,13 +335,21 @@ export async function runPassiveObserver(
   // ---------------------------------------------------------------------------
   const recentFacts = factsDb.getRecentFacts(7, { excludeCategories: [] }) // last 7 days
   const recentVectors: (number[] | null)[] = []
+  const recentFactIds: (string | null)[] = []
   for (const f of recentFacts.slice(0, 200)) {
     try {
       recentVectors.push(normalizeVector(await embeddings.embed(f.text)))
+      recentFactIds.push(f.id)
     } catch {
       recentVectors.push(null)
+      recentFactIds.push(null)
     }
   }
+
+  const reinforcementEnabled = opts.reinforcement?.enabled !== false && opts.reinforcement != null
+  const passiveBoost = opts.reinforcement?.passiveBoost ?? 0.1
+  const maxConfidence = opts.reinforcement?.maxConfidence ?? 1.0
+  const similarityThreshold = opts.reinforcement?.similarityThreshold ?? config.deduplicationThreshold
 
   const prompt = loadPrompt('passive-observer')
 
@@ -438,12 +450,25 @@ export async function runPassiveObserver(
 
         const normVec = normalizeVector(vec)
 
-        // Dedup check against recent facts
+        // Dedup check against recent facts — reinforce instead of skip when enabled
         let isDuplicate = false
-        for (const rv of recentVectors) {
+        for (let ri = 0; ri < recentVectors.length; ri++) {
+          const rv = recentVectors[ri]
           if (!rv || rv.length === 0) continue
-          if (dotProductSimilarity(normVec, rv) >= config.deduplicationThreshold) {
+          if (dotProductSimilarity(normVec, rv) >= similarityThreshold) {
             isDuplicate = true
+            // Confidence reinforcement: boost the matched fact instead of silently skipping (Issue #147)
+            if (reinforcementEnabled && !opts.dryRun) {
+              const matchedId = recentFactIds[ri]
+              if (matchedId) {
+                try {
+                  const boosted = factsDb.boostConfidence(matchedId, passiveBoost, maxConfidence)
+                  if (boosted) result.factsReinforced++
+                } catch {
+                  // Non-fatal — don't fail passive observer because of boost error
+                }
+              }
+            }
             break
           }
         }
@@ -455,6 +480,7 @@ export async function runPassiveObserver(
           )
           result.factsStored++
           recentVectors.push(normVec)
+          recentFactIds.push(null)
           continue
         }
 
@@ -492,6 +518,7 @@ export async function runPassiveObserver(
         }
 
         recentVectors.push(normVec)
+        recentFactIds.push(stored.id)
         result.factsStored++
       }
     }

--- a/extensions/memory-hybrid/services/reflection.ts
+++ b/extensions/memory-hybrid/services/reflection.ts
@@ -195,7 +195,7 @@ export async function runReflection(
   const existingPatternFacts = factsDb.getByCategory("pattern").filter(
     (f) => !f.supersededAt && (f.expiresAt === null || f.expiresAt > nowSec),
   );
-  let existingVectors: (number[] | null)[] = [];
+  const existingVectors: (number[] | null)[] = [];
   if (existingPatternFacts.length > 0) {
     for (let i = 0; i < existingPatternFacts.length; i += 20) {
       const batch = existingPatternFacts.slice(i, i + 20);
@@ -366,7 +366,7 @@ export async function runReflectionRules(
   const existingRuleFacts = factsDb.getByCategory("rule").filter(
     (f) => !f.supersededAt && (f.expiresAt === null || f.expiresAt > nowSec),
   );
-  let existingVectors: (number[] | null)[] = [];
+  const existingVectors: (number[] | null)[] = [];
   for (let i = 0; i < existingRuleFacts.length; i += 20) {
     const batch = existingRuleFacts.slice(i, i + 20);
     for (const f of batch) {
@@ -519,7 +519,7 @@ export async function runReflectionMeta(
   const existingMetaFacts = factsDb.getByCategory("pattern").filter(
     (f) => !f.supersededAt && (f.expiresAt === null || f.expiresAt > nowSec) && (f.tags?.includes("meta") === true),
   );
-  let existingVectors: (number[] | null)[] = [];
+  const existingVectors: (number[] | null)[] = [];
   for (let i = 0; i < existingMetaFacts.length; i += 20) {
     const batch = existingMetaFacts.slice(i, i + 20);
     for (const f of batch) {

--- a/extensions/memory-hybrid/services/reinforcement-extract.ts
+++ b/extensions/memory-hybrid/services/reinforcement-extract.ts
@@ -228,7 +228,7 @@ export function runReinforcementExtract(opts: RunReinforcementExtractOpts): Rein
       // Look back for the most recent assistant message (expanded window to handle tool messages)
       let precedingAssistant = "";
       let recalledMemoryIds: string[] = [];
-      let toolCallSequence: string[] = [];
+      const toolCallSequence: string[] = [];
       for (let j = i - 1; j >= 0 && j >= Math.max(0, i - 20); j--) {
         if (messages[j].role === "user") {
           // Stop at previous user message to avoid crossing conversation turn boundaries

--- a/extensions/memory-hybrid/services/retrieval-aliases.ts
+++ b/extensions/memory-hybrid/services/retrieval-aliases.ts
@@ -1,0 +1,243 @@
+/**
+ * Multi-hook retrieval aliases (Issue #149).
+ *
+ * At storage time, generate 3-5 alternative phrasings per fact and index
+ * their embeddings — so facts can be found from multiple semantic angles.
+ */
+
+import Database from "better-sqlite3";
+import { mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+import { randomUUID } from "node:crypto";
+import type OpenAI from "openai";
+import type { EmbeddingProvider } from "./embeddings.js";
+import { chatComplete } from "./chat.js";
+import { capturePluginError } from "./error-reporter.js";
+import type { AliasesConfig } from "../config.js";
+import { cosineSimilarity } from "./ambient-retrieval.js";
+
+// ---------------------------------------------------------------------------
+// AliasDB
+// ---------------------------------------------------------------------------
+
+/** A single alias row (without embedding). */
+export interface AliasRow {
+  id: string;
+  factId: string;
+  aliasText: string;
+}
+
+/** A search result from alias embeddings. */
+export interface AliasSearchResult {
+  factId: string;
+  score: number;
+}
+
+/**
+ * SQLite-backed storage for fact_aliases.
+ * Schema: (id TEXT PK, factId TEXT, aliasText TEXT, embedding BLOB)
+ *
+ * Embeddings are stored as raw Float32Array binary blobs for compact,
+ * fast deserialization during linear cosine-similarity search.
+ */
+export class AliasDB {
+  private db: Database.Database;
+
+  constructor(dbPath: string) {
+    mkdirSync(dirname(dbPath), { recursive: true });
+    this.db = new Database(dbPath);
+    this.db.pragma("journal_mode = WAL");
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS fact_aliases (
+        id TEXT PRIMARY KEY,
+        factId TEXT NOT NULL,
+        aliasText TEXT NOT NULL,
+        embedding BLOB NOT NULL
+      )
+    `);
+    this.db.exec(
+      `CREATE INDEX IF NOT EXISTS idx_fact_aliases_factId ON fact_aliases(factId)`,
+    );
+  }
+
+  /** Store a single alias with its embedding. Returns the generated row id. */
+  store(factId: string, aliasText: string, embedding: number[]): string {
+    const id = randomUUID();
+    const blob = Buffer.from(new Float32Array(embedding).buffer);
+    this.db
+      .prepare(
+        `INSERT INTO fact_aliases (id, factId, aliasText, embedding) VALUES (?, ?, ?, ?)`,
+      )
+      .run(id, factId, aliasText, blob);
+    return id;
+  }
+
+  /** Return all alias rows (without embedding) for a given fact. */
+  getByFactId(factId: string): AliasRow[] {
+    return this.db
+      .prepare(
+        `SELECT id, factId, aliasText FROM fact_aliases WHERE factId = ?`,
+      )
+      .all(factId) as AliasRow[];
+  }
+
+  /** Delete all aliases for a fact (e.g., when the fact is superseded). */
+  deleteByFactId(factId: string): void {
+    this.db.prepare(`DELETE FROM fact_aliases WHERE factId = ?`).run(factId);
+  }
+
+  /** Total alias count. */
+  count(): number {
+    const row = this.db
+      .prepare(`SELECT COUNT(*) as n FROM fact_aliases`)
+      .get() as { n: number };
+    return row.n;
+  }
+
+  /**
+   * Search alias embeddings by cosine similarity.
+   *
+   * Loads all alias embeddings, computes cosine similarity with queryVector,
+   * deduplicates by factId (keeps best score per fact), and returns up to
+   * `limit` results above `minScore`, sorted descending by score.
+   */
+  search(
+    queryVector: number[],
+    limit: number,
+    minScore: number,
+  ): AliasSearchResult[] {
+    const rows = this.db
+      .prepare(`SELECT factId, embedding FROM fact_aliases`)
+      .all() as Array<{ factId: string; embedding: Buffer }>;
+
+    // Track best score per factId to deduplicate across aliases for the same fact
+    const bestByFact = new Map<string, number>();
+    for (const row of rows) {
+      const floats = new Float32Array(
+        row.embedding.buffer,
+        row.embedding.byteOffset,
+        row.embedding.byteLength / 4,
+      );
+      const score = cosineSimilarity(queryVector, Array.from(floats));
+      if (score >= minScore) {
+        const existing = bestByFact.get(row.factId);
+        if (existing === undefined || score > existing) {
+          bestByFact.set(row.factId, score);
+        }
+      }
+    }
+
+    return Array.from(bestByFact.entries())
+      .map(([factId, score]) => ({ factId, score }))
+      .sort((a, b) => b.score - a.score)
+      .slice(0, limit);
+  }
+
+  close(): void {
+    this.db.close();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Alias generation
+// ---------------------------------------------------------------------------
+
+/**
+ * Generate alternative phrasings for a fact using an LLM.
+ *
+ * Returns up to maxAliases unique strings (excluding the original text).
+ * On LLM error returns an empty array — alias generation is non-blocking.
+ */
+export async function generateAliases(
+  factText: string,
+  openai: OpenAI,
+  model: string,
+  maxAliases: number,
+): Promise<string[]> {
+  const prompt =
+    `Generate ${maxAliases} alternative phrasings for the following fact. ` +
+    `The alternatives should differ in wording but preserve the meaning, ` +
+    `to enable retrieval of this fact from different semantic angles. ` +
+    `Return only the alternatives, one per line, no numbering or bullets.\n\n` +
+    `Fact: ${factText}`;
+
+  try {
+    const response = await chatComplete({
+      model,
+      content: prompt,
+      temperature: 0.7,
+      openai,
+    });
+    const lines = response
+      .split("\n")
+      .map((l) => l.trim().replace(/^([-*•]\s+|\d+[.)]\s*)/, ""))
+      .filter((l) => l.length > 0 && l !== factText);
+    return [...new Set(lines)].slice(0, maxAliases);
+  } catch (err) {
+    capturePluginError(
+      err instanceof Error ? err : new Error(String(err)),
+      { subsystem: "aliases", operation: "generate-aliases" },
+    );
+    return [];
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Storage orchestration
+// ---------------------------------------------------------------------------
+
+/**
+ * Generate aliases for a fact, embed each, and persist to AliasDB.
+ *
+ * Non-blocking: embedding failures for individual aliases are logged and
+ * skipped. The function is typically called with `void` after fact storage.
+ */
+export async function storeAliases(
+  factId: string,
+  factText: string,
+  config: AliasesConfig,
+  model: string,
+  openai: OpenAI,
+  embeddings: EmbeddingProvider,
+  aliasDb: AliasDB,
+  logWarn?: (msg: string) => void,
+): Promise<void> {
+  if (!config.enabled) return;
+
+  const aliases = await generateAliases(factText, openai, model, config.maxAliases);
+
+  for (const alias of aliases) {
+    try {
+      const vec = await embeddings.embed(alias);
+      aliasDb.store(factId, alias, vec);
+    } catch (err) {
+      capturePluginError(
+        err instanceof Error ? err : new Error(String(err)),
+        { subsystem: "aliases", operation: "store-alias-embedding" },
+      );
+      logWarn?.(`memory-hybrid: alias embedding failed: ${err}`);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Retrieval strategy
+// ---------------------------------------------------------------------------
+
+/**
+ * Search alias embeddings for a query vector.
+ * Returns ranked results (rank 1 = best match) compatible with RRF fusion.
+ */
+export function searchAliasStrategy(
+  aliasDb: AliasDB,
+  queryVector: number[],
+  topK: number,
+  minScore = 0.3,
+): Array<{ factId: string; rank: number; source: "aliases" }> {
+  const results = aliasDb.search(queryVector, topK, minScore);
+  return results.map((r, i) => ({
+    factId: r.factId,
+    rank: i + 1,
+    source: "aliases" as const,
+  }));
+}

--- a/extensions/memory-hybrid/services/retrieval-orchestrator.ts
+++ b/extensions/memory-hybrid/services/retrieval-orchestrator.ts
@@ -23,6 +23,7 @@ import {
   type FactMetadata,
 } from "./rrf-fusion.js";
 import type { RetrievalConfig } from "../config.js";
+import { searchAliasStrategy, type AliasDB } from "./retrieval-aliases.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -235,6 +236,7 @@ export async function runRetrievalPipeline(
   includeSuperseded?: boolean,
   scopeFilter?: unknown,
   asOf?: number,
+  aliasDb?: AliasDB | null,
 ): Promise<OrchestratorResult> {
   const k = config.rrf_k;
   const { strategies, semanticTopK, fts5TopK } = config;
@@ -262,6 +264,16 @@ export async function runRetrievalPipeline(
   if (strategies.includes("graph")) {
     strategyPromises.push(
       Promise.resolve(["graph", runGraphStrategy()] as [string, RankedResult[]]),
+    );
+  }
+
+  // Issue #149: alias search — participates in RRF fusion as "aliases" strategy
+  if (aliasDb && queryVector) {
+    strategyPromises.push(
+      Promise.resolve([
+        "aliases",
+        searchAliasStrategy(aliasDb, queryVector, semanticTopK),
+      ] as [string, RankedResult[]]),
     );
   }
 

--- a/extensions/memory-hybrid/services/rrf-fusion.ts
+++ b/extensions/memory-hybrid/services/rrf-fusion.ts
@@ -19,7 +19,7 @@ export interface RankedResult {
   /** 1-based rank within the strategy's result list (1 = best). */
   rank: number;
   /** Which strategy produced this result. */
-  source: "semantic" | "fts5" | "graph";
+  source: "semantic" | "fts5" | "graph" | "aliases";
 }
 
 /** A fused result after RRF combining and post-RRF score adjustments. */

--- a/extensions/memory-hybrid/services/shortest-path.ts
+++ b/extensions/memory-hybrid/services/shortest-path.ts
@@ -1,0 +1,246 @@
+/**
+ * Shortest-Path Traversal Service (Issue #140).
+ *
+ * Finds the shortest path between two facts/entities in the memory graph via
+ * bidirectional BFS on the memory_links table.  Both outgoing (getLinksFrom)
+ * and incoming (getLinksTo) edges are traversed so the graph is treated as
+ * undirected for reachability purposes.
+ *
+ * Usage:
+ *   const result = findShortestPath(factsDb, startId, endId, { maxDepth: 5 });
+ *   // result.steps = ordered list of PathStep; result.hops = step count
+ */
+
+import type { MemoryEntry } from "../types/memory.js";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/** One edge traversed in the shortest path. */
+export interface PathStep {
+  /** Fact we traversed FROM. */
+  fromFactId: string;
+  /** Fact we arrived AT. */
+  toFactId: string;
+  /** Edge type (e.g. RELATED_TO, PART_OF, CAUSED_BY). */
+  linkType: string;
+  /** Edge strength 0–1. */
+  strength: number;
+}
+
+/** Returned by findShortestPath when a path is found. */
+export interface ShortestPathResult {
+  /** Ordered steps from fromFactId to toFactId. Empty when from === to (0 hops). */
+  steps: PathStep[];
+  /** Number of hops (= steps.length). */
+  hops: number;
+  /** Resolved start fact ID. */
+  fromFactId: string;
+  /** Resolved end fact ID. */
+  toFactId: string;
+  /** The MemoryEntry objects along the path (index 0 = start, last = end). */
+  chain: MemoryEntry[];
+}
+
+/** Minimal interface the service needs from FactsDB. */
+export interface ShortestPathLookup {
+  getById(id: string): MemoryEntry | null;
+  getLinksFrom(factId: string): Array<{ id: string; targetFactId: string; linkType: string; strength: number }>;
+  getLinksTo(factId: string): Array<{ id: string; sourceFactId: string; linkType: string; strength: number }>;
+  /** Optional: resolve entity name → facts. Used by resolveInput. */
+  lookup?(entity: string): Array<{ entry: MemoryEntry; score: number }>;
+}
+
+/** Options for findShortestPath. */
+export interface ShortestPathOptions {
+  /** Maximum path length in edges (default: 5, hard-capped by config). */
+  maxDepth?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Core algorithm
+// ---------------------------------------------------------------------------
+
+/**
+ * Find the shortest path between two facts via bidirectional BFS.
+ *
+ * The graph is treated as undirected — both getLinksFrom and getLinksTo are
+ * traversed in each BFS step.
+ *
+ * @param db  - A FactsDB-compatible lookup interface.
+ * @param startId - Fact ID to start from.
+ * @param endId   - Fact ID to reach.
+ * @param options - Optional: maxDepth (default 5).
+ * @returns ShortestPathResult if a path is found within maxDepth, null otherwise.
+ */
+export function findShortestPath(
+  db: ShortestPathLookup,
+  startId: string,
+  endId: string,
+  options: ShortestPathOptions = {},
+): ShortestPathResult | null {
+  const maxDepth = Math.max(0, options.maxDepth ?? 5);
+
+  // Same start and end → trivial path
+  if (startId === endId) {
+    const entry = db.getById(startId);
+    if (!entry) return null;
+    return { steps: [], hops: 0, fromFactId: startId, toFactId: endId, chain: [entry] };
+  }
+
+  // Both endpoints must exist
+  if (!db.getById(startId) || !db.getById(endId)) return null;
+
+  if (maxDepth === 0) return null;
+
+  // fwd: factId → ordered path (PathStep[]) from startId to that factId
+  const fwd = new Map<string, PathStep[]>();
+  // bwd: factId → ordered path (PathStep[]) from that factId to endId
+  const bwd = new Map<string, PathStep[]>();
+
+  fwd.set(startId, []);
+  bwd.set(endId, []);
+
+  let fwdFrontier: string[] = [startId];
+  let bwdFrontier: string[] = [endId];
+
+  // Alternate expanding forward (odd hops) and backward (even hops).
+  // Each outer iteration spends 1 hop in one direction.
+  for (let hop = 1; hop <= maxDepth; hop++) {
+    if (hop % 2 === 1) {
+      // Expand forward by 1 hop
+      const next: string[] = [];
+      for (const nodeId of fwdFrontier) {
+        const pathToNode = fwd.get(nodeId)!;
+        for (const { neighborId, linkType, strength } of getNeighbors(db, nodeId)) {
+          if (fwd.has(neighborId)) continue; // already visited forward
+          const step: PathStep = { fromFactId: nodeId, toFactId: neighborId, linkType, strength };
+          const newPath = [...pathToNode, step];
+          fwd.set(neighborId, newPath);
+          next.push(neighborId);
+          if (bwd.has(neighborId)) {
+            return buildResult(db, startId, endId, newPath, bwd.get(neighborId)!);
+          }
+        }
+      }
+      fwdFrontier = next;
+    } else {
+      // Expand backward by 1 hop
+      const next: string[] = [];
+      for (const nodeId of bwdFrontier) {
+        const pathFromNode = bwd.get(nodeId)!;
+        for (const { neighborId, linkType, strength } of getNeighbors(db, nodeId)) {
+          if (bwd.has(neighborId)) continue; // already visited backward
+          // Step goes FROM neighborId TO nodeId (closer to end)
+          const step: PathStep = { fromFactId: neighborId, toFactId: nodeId, linkType, strength };
+          const newPath = [step, ...pathFromNode];
+          bwd.set(neighborId, newPath);
+          next.push(neighborId);
+          if (fwd.has(neighborId)) {
+            return buildResult(db, startId, endId, fwd.get(neighborId)!, newPath);
+          }
+        }
+      }
+      bwdFrontier = next;
+    }
+
+    if (fwdFrontier.length === 0 && bwdFrontier.length === 0) break;
+  }
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Entity name resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve an input string to a fact ID.
+ *
+ * Strategy:
+ * 1. If the input matches a known fact ID (getById succeeds) → return it.
+ * 2. Otherwise treat as entity name: call db.lookup(input) and return the
+ *    first result's ID, or null if none found or lookup unavailable.
+ *
+ * @param db    - FactsDB-compatible lookup interface.
+ * @param input - Raw user input (fact ID or entity name).
+ * @returns Resolved fact ID, or null if not resolvable.
+ */
+export function resolveInput(db: ShortestPathLookup, input: string): string | null {
+  if (!input || !input.trim()) return null;
+  const trimmed = input.trim();
+
+  // Try as a direct fact ID first
+  if (db.getById(trimmed)) return trimmed;
+
+  // Try as entity name via lookup
+  if (db.lookup) {
+    const results = db.lookup(trimmed);
+    if (results.length > 0) return results[0].entry.id;
+  }
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Formatting
+// ---------------------------------------------------------------------------
+
+/**
+ * Format a shortest path as a human-readable chain string.
+ *
+ * @example
+ * formatPath([{ fromFactId: "abc", toFactId: "def", linkType: "RELATED_TO", strength: 0.8 }])
+ * // "abc… —[RELATED_TO]→ def…"
+ */
+export function formatPath(steps: PathStep[]): string {
+  if (steps.length === 0) return "(same fact)";
+  const parts: string[] = [steps[0].fromFactId.slice(0, 8) + "\u2026"];
+  for (const step of steps) {
+    parts.push(`\u2014[${step.linkType}]\u2192`);
+    parts.push(step.toFactId.slice(0, 8) + "\u2026");
+  }
+  return parts.join(" ");
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/** Collect all neighbors (outgoing + incoming) of a node as a flat list. */
+function getNeighbors(
+  db: ShortestPathLookup,
+  nodeId: string,
+): Array<{ neighborId: string; linkType: string; strength: number }> {
+  const result: Array<{ neighborId: string; linkType: string; strength: number }> = [];
+  for (const link of db.getLinksFrom(nodeId)) {
+    result.push({ neighborId: link.targetFactId, linkType: link.linkType, strength: link.strength });
+  }
+  for (const link of db.getLinksTo(nodeId)) {
+    result.push({ neighborId: link.sourceFactId, linkType: link.linkType, strength: link.strength });
+  }
+  return result;
+}
+
+/** Combine forward + backward paths into a ShortestPathResult. */
+function buildResult(
+  db: ShortestPathLookup,
+  startId: string,
+  endId: string,
+  fwdPath: PathStep[],
+  bwdPath: PathStep[],
+): ShortestPathResult {
+  const steps = [...fwdPath, ...bwdPath];
+  // Build chain: all unique fact IDs in traversal order
+  const ids: string[] = [startId];
+  for (const step of steps) {
+    if (step.toFactId !== ids[ids.length - 1]) ids.push(step.toFactId);
+  }
+  const chain: MemoryEntry[] = [];
+  for (const id of ids) {
+    const entry = db.getById(id);
+    if (entry) chain.push(entry);
+  }
+  return { steps, hops: steps.length, fromFactId: startId, toFactId: endId, chain };
+}

--- a/extensions/memory-hybrid/services/tools-md-section.ts
+++ b/extensions/memory-hybrid/services/tools-md-section.ts
@@ -64,7 +64,7 @@ export function insertRulesUnderSection(
   const content = existsSync(filePath) ? readFileSync(filePath, "utf-8") : "";
   const lines = content.split("\n");
   const existingSet = new Set<string>();
-  let sectionStart = findSectionStart(lines, sectionTitle);
+  const sectionStart = findSectionStart(lines, sectionTitle);
 
   if (sectionStart >= 0) {
     const sectionEnd = findSectionEnd(lines, sectionStart);

--- a/extensions/memory-hybrid/services/topic-clusters.ts
+++ b/extensions/memory-hybrid/services/topic-clusters.ts
@@ -1,0 +1,278 @@
+/**
+ * Topic Cluster Detection (Issue #146).
+ *
+ * Detects and labels topic clusters — groups of densely interconnected facts
+ * forming natural knowledge domains. Uses BFS connected-component analysis on
+ * the memory_links graph.
+ *
+ * Usage:
+ *   const result = detectClusters(factsDb, { minClusterSize: 3 });
+ *   // result.clusters: TopicCluster[] sorted by size desc
+ */
+
+import { randomUUID } from "node:crypto";
+import type { MemoryEntry } from "../types/memory.js";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/** A detected topic cluster of interconnected facts. */
+export interface TopicCluster {
+  /** UUID for this cluster. */
+  id: string;
+  /** 2-3 word label derived from dominant entity/tags in cluster. */
+  label: string;
+  /** Fact IDs belonging to this cluster (sorted for stability). */
+  factIds: string[];
+  /** Number of facts (= factIds.length). */
+  factCount: number;
+  /** Epoch seconds when cluster was first detected. */
+  createdAt: number;
+  /** Epoch seconds when cluster was last updated. */
+  updatedAt: number;
+}
+
+/** Options for cluster detection. */
+export interface ClusterDetectionOptions {
+  /** Minimum number of facts to form a cluster (default: 3). */
+  minClusterSize?: number;
+  /** Reserved: model for label generation; null = rule-based only (default: null). */
+  labelModel?: string | null;
+  /**
+   * Map from canonical component key (sorted IDs joined by ",") to existing cluster metadata.
+   * Enables stable cluster IDs and createdAt timestamps across incremental re-runs.
+   */
+  existingClusterIds?: Map<string, { id: string; createdAt: number }>;
+}
+
+/** Result of a cluster detection run. */
+export interface ClusterDetectionResult {
+  /** Detected clusters above minClusterSize threshold, sorted by size desc. */
+  clusters: TopicCluster[];
+  /** Number of linked facts that belong to no cluster (below threshold). */
+  isolatedFacts: number;
+  /** Total number of unique fact IDs that appear in at least one link. */
+  totalLinkedFacts: number;
+}
+
+/**
+ * Minimal FactsDB interface needed for cluster detection.
+ * FactsDB already satisfies this interface.
+ */
+export interface ClusterFactLookup {
+  /**
+   * Get all unique fact IDs that participate in at least one memory link
+   * (as source or target).
+   */
+  getAllLinkedFactIds(): string[];
+  /**
+   * Get all edges in the memory_links graph as [sourceFactId, targetFactId] pairs.
+   * Used for building the adjacency map in one efficient DB query.
+   */
+  getAllLinks(): Array<{ sourceFactId: string; targetFactId: string }>;
+  /** Get a fact entry by ID. Returns null when not found or expired. */
+  getById(id: string): MemoryEntry | null;
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a bidirectional adjacency map from edge pairs.
+ * Nodes with no edges are seeded from factIds to ensure they appear in the map
+ * even when getAllLinks() returns no edges for them (isolated case).
+ */
+function buildAdjacency(
+  factIds: string[],
+  edges: Array<{ sourceFactId: string; targetFactId: string }>,
+): Map<string, Set<string>> {
+  const adj = new Map<string, Set<string>>();
+
+  // Seed all known nodes
+  for (const id of factIds) {
+    if (!adj.has(id)) adj.set(id, new Set());
+  }
+
+  // Add edges (bidirectional)
+  for (const { sourceFactId, targetFactId } of edges) {
+    if (!adj.has(sourceFactId)) adj.set(sourceFactId, new Set());
+    if (!adj.has(targetFactId)) adj.set(targetFactId, new Set());
+    adj.get(sourceFactId)!.add(targetFactId);
+    adj.get(targetFactId)!.add(sourceFactId);
+  }
+
+  return adj;
+}
+
+/**
+ * BFS from startId, collecting all reachable fact IDs.
+ * Marks visited nodes in the shared `visited` set.
+ */
+function bfsComponent(
+  startId: string,
+  adj: Map<string, Set<string>>,
+  visited: Set<string>,
+): string[] {
+  const component: string[] = [];
+  const queue: string[] = [startId];
+  visited.add(startId);
+
+  let head = 0;
+  while (head < queue.length) {
+    const current = queue[head++];
+    component.push(current);
+    const neighbors = adj.get(current);
+    if (neighbors) {
+      for (const neighbor of neighbors) {
+        if (!visited.has(neighbor)) {
+          visited.add(neighbor);
+          queue.push(neighbor);
+        }
+      }
+    }
+  }
+
+  return component;
+}
+
+// ---------------------------------------------------------------------------
+// Label generation
+// ---------------------------------------------------------------------------
+
+/**
+ * Generate a 2-3 word label for a cluster using a rule-based approach.
+ *
+ * Priority:
+ * 1. Most frequent entity across cluster members
+ * 2. Most frequent tag across cluster members
+ * 3. Most frequent category
+ * 4. Generic fallback "knowledge cluster"
+ */
+export function generateClusterLabel(entries: MemoryEntry[]): string {
+  if (entries.length === 0) return "knowledge cluster";
+
+  // 1. Entity frequency
+  const entityCounts = new Map<string, number>();
+  for (const entry of entries) {
+    const e = entry.entity?.trim();
+    if (e) entityCounts.set(e, (entityCounts.get(e) ?? 0) + 1);
+  }
+  if (entityCounts.size > 0) {
+    const topEntity = [...entityCounts.entries()].sort((a, b) => b[1] - a[1])[0][0];
+    // Limit to 3 words, lowercase
+    return topEntity.split(/[\s_-]+/).slice(0, 3).join(" ").toLowerCase();
+  }
+
+  // 2. Tag frequency (entry.tags is already string[] | null after DB mapping)
+  const tagCounts = new Map<string, number>();
+  for (const entry of entries) {
+    const tags = Array.isArray(entry.tags) ? entry.tags : [];
+    for (const tag of tags) {
+      const t = tag.trim();
+      if (t) tagCounts.set(t, (tagCounts.get(t) ?? 0) + 1);
+    }
+  }
+  if (tagCounts.size > 0) {
+    const topTag = [...tagCounts.entries()].sort((a, b) => b[1] - a[1])[0][0];
+    return topTag.split(/[\s_-]+/).slice(0, 3).join(" ").toLowerCase();
+  }
+
+  // 3. Category frequency
+  const categoryCounts = new Map<string, number>();
+  for (const entry of entries) {
+    const cat = entry.category;
+    categoryCounts.set(cat, (categoryCounts.get(cat) ?? 0) + 1);
+  }
+  if (categoryCounts.size > 0) {
+    const topCat = [...categoryCounts.entries()].sort((a, b) => b[1] - a[1])[0][0];
+    return `${topCat} cluster`;
+  }
+
+  return "knowledge cluster";
+}
+
+// ---------------------------------------------------------------------------
+// Main detection function
+// ---------------------------------------------------------------------------
+
+/**
+ * Detect topic clusters by BFS connected-component analysis on the memory_links graph.
+ *
+ * Algorithm:
+ * 1. Load all fact IDs that participate in at least one link.
+ * 2. Build a bidirectional adjacency map from all links.
+ * 3. BFS from each unvisited fact to find connected components.
+ * 4. Filter components below minClusterSize.
+ * 5. Generate a rule-based label for each cluster.
+ *
+ * @param factsDb  FactsDB-compatible interface (ClusterFactLookup).
+ * @param options  Detection options.
+ * @returns        ClusterDetectionResult with clusters sorted by size desc.
+ */
+export function detectClusters(
+  factsDb: ClusterFactLookup,
+  options: ClusterDetectionOptions = {},
+): ClusterDetectionResult {
+  const { minClusterSize = 3, existingClusterIds } = options;
+
+  const linkedFactIds = factsDb.getAllLinkedFactIds();
+  const totalLinkedFacts = linkedFactIds.length;
+
+  if (totalLinkedFacts === 0) {
+    return { clusters: [], isolatedFacts: 0, totalLinkedFacts: 0 };
+  }
+
+  // Build adjacency from all links at once (efficient: single DB query)
+  const allEdges = factsDb.getAllLinks();
+  const adj = buildAdjacency(linkedFactIds, allEdges);
+
+  // BFS connected-component analysis
+  const visited = new Set<string>();
+  const components: string[][] = [];
+
+  for (const factId of adj.keys()) {
+    if (!visited.has(factId)) {
+      components.push(bfsComponent(factId, adj, visited));
+    }
+  }
+
+  const now = Math.floor(Date.now() / 1000);
+  let isolatedFacts = 0;
+  const clusters: TopicCluster[] = [];
+
+  for (const component of components) {
+    if (component.length < minClusterSize) {
+      isolatedFacts += component.length;
+      continue;
+    }
+
+    const sortedIds = [...component].sort();
+    const componentKey = sortedIds.join(",");
+    const existing = existingClusterIds?.get(componentKey);
+    const clusterId = existing?.id ?? randomUUID();
+    const createdAt = existing?.createdAt ?? now;
+
+    // Load entries for label generation (skips missing/expired facts)
+    const entries: MemoryEntry[] = [];
+    for (const id of sortedIds) {
+      const entry = factsDb.getById(id);
+      if (entry) entries.push(entry);
+    }
+
+    clusters.push({
+      id: clusterId,
+      label: generateClusterLabel(entries),
+      factIds: sortedIds,
+      factCount: sortedIds.length,
+      createdAt,
+      updatedAt: now,
+    });
+  }
+
+  // Sort by size descending (largest cluster first)
+  clusters.sort((a, b) => b.factCount - a.factCount);
+
+  return { clusters, isolatedFacts, totalLinkedFacts };
+}

--- a/extensions/memory-hybrid/setup/cli-context.ts
+++ b/extensions/memory-hybrid/setup/cli-context.ts
@@ -17,6 +17,7 @@ import type { FindDuplicatesResult } from "../cli/types.js";
 import { runFindDuplicates } from "../services/find-duplicates.js";
 import { runConsolidate } from "../services/consolidation.js";
 import { runReflection, runReflectionRules, runReflectionMeta } from "../services/reflection.js";
+import { runDreamCycle, type DreamCycleResult } from "../services/dream-cycle.js";
 import { runClassifyForCli } from "../services/auto-classifier.js";
 import { runBuildLanguageKeywords } from "../services/language-keywords-build.js";
 import { runExport } from "../services/export-memory.js";
@@ -156,6 +157,7 @@ export const HYBRID_MEM_CLI_COMMANDS = [
   "hybrid-mem reflect",
   "hybrid-mem reflect-rules",
   "hybrid-mem reflect-meta",
+  "hybrid-mem dream-cycle",
   "hybrid-mem verify",
   "hybrid-mem credentials migrate-to-vault",
   "hybrid-mem distill-window",
@@ -208,6 +210,7 @@ export interface CliContextServices {
     sources?: string[];
     mode?: "replace" | "additive";
   }) => Promise<{ factsExported: number; proceduresExported: number; filesWritten: number; outputPath: string }>;
+  runDreamCycle: () => Promise<DreamCycleResult>;
   getMemoryCategories: () => string[];
   mergeResults: HybridMemCliContext["mergeResults"];
   parseSourceDate: (v: string | number | null | undefined) => number | null;
@@ -222,30 +225,33 @@ export interface HybridMemCliRegistrationContext {
   openai: HandlerContext["openai"];
   cfg: HandlerContext["cfg"];
   credentialsDb: HandlerContext["credentialsDb"];
+  aliasDb: HandlerContext["aliasDb"];
   wal: HandlerContext["wal"];
   proposalsDb: HandlerContext["proposalsDb"];
   resolvedSqlitePath: string;
   resolvedLancePath: string;
   pluginId: string;
   detectCategory: HandlerContext["detectCategory"];
+  /** Optional event log for episodic consolidation in dream cycle. */
+  eventLog?: import("../backends/event-log.js").EventLog | null;
 }
 
 function buildCliContextServices(
   ctx: HybridMemCliRegistrationContext,
   api: ClawdbotPluginApi,
 ): CliContextServices {
-  const { factsDb, vectorDb, embeddings, openai, cfg, resolvedSqlitePath } = ctx;
+  const { factsDb, vectorDb, embeddings, openai, cfg, resolvedSqlitePath, aliasDb } = ctx;
   const discoveredPath = join(dirname(resolvedSqlitePath), ".discovered-categories.json");
   const logSink = { info: (m: string) => console.log(m), warn: (m: string) => console.warn(m) };
   return {
     runFindDuplicates: (opts) =>
       runFindDuplicates(factsDb, vectorDb, embeddings, safeEmbed, opts, api.logger),
     runConsolidate: (opts) => {
-      // Skip if API key is missing (OpenAI provider requires API key)
-      if (!cfg.embedding?.apiKey) {
+      // Skip if OpenAI provider is configured but API key is missing
+      if (cfg.embedding?.provider === "openai" && !cfg.embedding?.apiKey) {
         return Promise.resolve({ clustersFound: 0, merged: 0, deleted: 0 });
       }
-      return runConsolidate(factsDb, vectorDb, embeddings, openai, opts, api.logger);
+      return runConsolidate(factsDb, vectorDb, embeddings, openai, opts, api.logger, aliasDb);
     },
     runReflection: (opts) => {
       const { defaultModel, fallbackModels } = resolveReflectionModelAndFallbacks(cfg, "default");
@@ -287,6 +293,26 @@ function buildCliContextServices(
           schemaVersion: versionInfo.schemaVersion,
         }),
       ),
+    runDreamCycle: () => {
+      const { defaultModel } = resolveReflectionModelAndFallbacks(cfg, "default");
+      const dreamModel = cfg.nightlyCycle.model ?? defaultModel;
+      return runDreamCycle(
+        factsDb,
+        vectorDb,
+        embeddings,
+        openai,
+        ctx.eventLog ?? null,
+        {
+          enabled: cfg.nightlyCycle.enabled,
+          schedule: cfg.nightlyCycle.schedule,
+          reflectWindowDays: cfg.nightlyCycle.reflectWindowDays,
+          pruneMode: cfg.nightlyCycle.pruneMode,
+          model: dreamModel,
+          consolidateAfterDays: cfg.nightlyCycle.consolidateAfterDays,
+        },
+        logSink,
+      );
+    },
     getMemoryCategories: () => [...getMemoryCategories()],
     mergeResults,
     parseSourceDate,
@@ -614,6 +640,7 @@ export function createHybridMemCliContext(
   return {
     factsDb: handlerCtx.factsDb,
     vectorDb: handlerCtx.vectorDb,
+    aliasDb: handlerCtx.aliasDb,
     versionInfo: services.versionInfo,
     embeddings: handlerCtx.embeddings,
     mergeResults: services.mergeResults,
@@ -647,6 +674,7 @@ export function createHybridMemCliContext(
     runReflection: services.runReflection,
     runReflectionRules: services.runReflectionRules,
     runReflectionMeta: services.runReflectionMeta,
+    runDreamCycle: services.runDreamCycle,
     reflectionConfig: {
       ...handlerCtx.cfg.reflection,
       model: handlerCtx.cfg.reflection.model ?? getDefaultCronModel(getCronModelConfig(handlerCtx.cfg), "default"),

--- a/extensions/memory-hybrid/setup/init-databases.ts
+++ b/extensions/memory-hybrid/setup/init-databases.ts
@@ -16,6 +16,7 @@ import { setKeywordsPath } from "../utils/language-keywords.js";
 import { setMemoryCategories, getMemoryCategories } from "../config.js";
 import { migrateCredentialsToVault, CREDENTIAL_REDACTION_MIGRATION_FLAG } from "../services/credential-migration.js";
 import { capturePluginError } from "../services/error-reporter.js";
+import { AliasDB } from "../services/retrieval-aliases.js";
 
 /** Known provider OpenAI-compatible base URLs. */
 const GOOGLE_GEMINI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/openai/";
@@ -192,6 +193,7 @@ export interface DatabaseContext {
   wal: WriteAheadLog | null;
   proposalsDb: ProposalsDB | null;
   eventLog: EventLog;
+  aliasDb: AliasDB | null;
   resolvedLancePath: string;
   resolvedSqlitePath: string;
   health: HealthStatus;
@@ -313,6 +315,14 @@ export function initializeDatabases(
   const eventLog = new EventLog(eventLogPath);
   api.logger.info(`memory-hybrid: event log initialized (${eventLogPath})`);
 
+  // Initialize alias DB (Issue #149)
+  let aliasDb: AliasDB | null = null;
+  if (cfg.aliases?.enabled) {
+    const aliasPath = join(dirname(resolvedSqlitePath), "aliases.db");
+    aliasDb = new AliasDB(aliasPath);
+    api.logger.info(`memory-hybrid: retrieval aliases enabled (${aliasPath})`);
+  }
+
   // Load previously discovered categories so they remain available after restart
   const discoveredPath = join(dirname(resolvedSqlitePath), ".discovered-categories.json");
   if (existsSync(discoveredPath)) {
@@ -406,6 +416,7 @@ export function initializeDatabases(
             vectorDb,
             embeddings,
             credentialsDb,
+            aliasDb,
             migrationFlagPath,
             markDone: false, // Flag already created atomically above
           });
@@ -536,6 +547,7 @@ export function initializeDatabases(
     wal,
     proposalsDb,
     eventLog,
+    aliasDb,
     resolvedLancePath,
     resolvedSqlitePath,
     health,
@@ -552,8 +564,9 @@ export function closeOldDatabases(context: {
   credentialsDb?: CredentialsDB | null;
   proposalsDb?: ProposalsDB | null;
   eventLog?: EventLog | null;
+  aliasDb?: AliasDB | null;
 }): void {
-  const { factsDb, vectorDb, credentialsDb, proposalsDb, eventLog } = context;
+  const { factsDb, vectorDb, credentialsDb, proposalsDb, eventLog, aliasDb } = context;
 
   if (typeof factsDb?.close === "function") {
     try {
@@ -588,6 +601,13 @@ export function closeOldDatabases(context: {
       eventLog.close();
     } catch (err) {
       capturePluginError(err instanceof Error ? err : new Error(String(err)), { operation: "close-databases", subsystem: "eventLog" });
+    }
+  }
+  if (aliasDb) {
+    try {
+      aliasDb.close();
+    } catch (err) {
+      capturePluginError(err instanceof Error ? err : new Error(String(err)), { operation: "close-databases", subsystem: "aliasDb" });
     }
   }
 }

--- a/extensions/memory-hybrid/setup/plugin-service.ts
+++ b/extensions/memory-hybrid/setup/plugin-service.ts
@@ -340,14 +340,14 @@ export function createPluginService(ctx: PluginServiceContext) {
               openai,
               cfg.passiveObserver,
               cfg.categories,
-              { model: observerModel, fallbackModels: observerFallbacks, dbDir, proceduresSessionsDir: cfg.procedures.sessionsDir },
+              { model: observerModel, fallbackModels: observerFallbacks, dbDir, proceduresSessionsDir: cfg.procedures.sessionsDir, reinforcement: cfg.reinforcement },
               api.logger,
             );
-            if (result.factsStored > 0 || result.factsExtracted > 0) {
+            if (result.factsStored > 0 || result.factsExtracted > 0 || result.factsReinforced > 0) {
               api.logger.info(
                 `memory-hybrid: passive-observer — scanned ${result.sessionsScanned} sessions, ` +
                 `${result.chunksProcessed} chunks, ${result.factsExtracted} extracted, ` +
-                `${result.factsStored} stored`,
+                `${result.factsStored} stored, ${result.factsReinforced} reinforced`,
               );
             }
           } catch (err) {

--- a/extensions/memory-hybrid/setup/register-hooks.ts
+++ b/extensions/memory-hybrid/setup/register-hooks.ts
@@ -26,6 +26,7 @@ export interface HooksContext {
   openai: OpenAI;
   cfg: HybridMemoryConfig;
   credentialsDb: CredentialsDB | null;
+  aliasDb: import("../services/retrieval-aliases.js").AliasDB | null;
   wal: WriteAheadLog | null;
   currentAgentIdRef: { value: string | null };
   lastProgressiveIndexIds: string[];
@@ -59,6 +60,7 @@ export function registerLifecycleHooks(ctx: HooksContext, api: ClawdbotPluginApi
       openai: ctx.openai,
       cfg: ctx.cfg,
       credentialsDb: ctx.credentialsDb,
+      aliasDb: ctx.aliasDb,
       wal: ctx.wal,
       currentAgentIdRef: ctx.currentAgentIdRef,
       lastProgressiveIndexIds: ctx.lastProgressiveIndexIds,

--- a/extensions/memory-hybrid/setup/register-tools.ts
+++ b/extensions/memory-hybrid/setup/register-tools.ts
@@ -13,6 +13,7 @@ import type { CredentialsDB } from "../backends/credentials-db.js";
 import type { ProposalsDB } from "../backends/proposals-db.js";
 import type { EventLog } from "../backends/event-log.js";
 import type { EmbeddingProvider } from "../services/embeddings.js";
+import type { AliasDB } from "../services/retrieval-aliases.js";
 import type { PendingLLMWarnings } from "../services/chat.js";
 import type OpenAI from "openai";
 import type { HybridMemoryConfig } from "../config.js";
@@ -42,6 +43,7 @@ export interface ToolsContext {
   lastProgressiveIndexIds: string[];
   currentAgentIdRef: { value: string | null };
   pendingLLMWarnings: PendingLLMWarnings;
+  aliasDb?: AliasDB | null;
   resolvedSqlitePath: string;
   timers: {
     proposalsPruneTimer: { value: ReturnType<typeof setInterval> | null };
@@ -85,6 +87,7 @@ export function registerTools(ctx: ToolsContext, api: ClawdbotPluginApi): void {
     credentialsDb,
     proposalsDb,
     eventLog,
+    aliasDb,
     lastProgressiveIndexIds,
     currentAgentIdRef,
     pendingLLMWarnings,
@@ -101,7 +104,7 @@ export function registerTools(ctx: ToolsContext, api: ClawdbotPluginApi): void {
 
   // Memory tools (core recall, store, forget operations)
   registerMemoryTools(
-    { factsDb, vectorDb, cfg, embeddings, openai, wal, credentialsDb, eventLog, lastProgressiveIndexIds, currentAgentIdRef, pendingLLMWarnings },
+    { factsDb, vectorDb, cfg, embeddings, openai, wal, credentialsDb, eventLog, aliasDb, lastProgressiveIndexIds, currentAgentIdRef, pendingLLMWarnings },
     api,
     buildToolScopeFilter,
     (operation, data, logger) => walWrite(wal, operation, data, logger),

--- a/extensions/memory-hybrid/tests/confidence-reinforcement.test.ts
+++ b/extensions/memory-hybrid/tests/confidence-reinforcement.test.ts
@@ -1,0 +1,436 @@
+/**
+ * Tests for Confidence Reinforcement on Repeated Mentions (Issue #147).
+ *
+ * Tests cover:
+ * - boostConfidence method in FactsDB
+ * - Config parsing for reinforcement section
+ * - Passive-observer reinforcement path
+ * - Decay + reinforcement interaction
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { _testing } from "../index.js";
+import { hybridConfigSchema } from "../config.js";
+import {
+  runPassiveObserver,
+  type PassiveObserverConfig,
+} from "../services/passive-observer.js";
+import type { ReinforcementConfig } from "../config.js";
+
+const { FactsDB } = _testing;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeDb(dir: string) {
+  return new FactsDB(join(dir, "facts.db"));
+}
+
+function storeFact(db: InstanceType<typeof FactsDB>, text = "User prefers TypeScript", confidence = 0.8) {
+  return db.store({
+    text,
+    category: "preference",
+    importance: 0.7,
+    entity: null,
+    key: null,
+    value: null,
+    source: "test",
+    confidence,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// 1. boostConfidence — basic behaviour
+// ---------------------------------------------------------------------------
+
+describe("FactsDB.boostConfidence", () => {
+  let tmpDir: string;
+  let db: InstanceType<typeof FactsDB>;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "reinf-test-"));
+    db = makeDb(tmpDir);
+  });
+
+  afterEach(() => {
+    db.close();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("boosts confidence by the given delta", () => {
+    const fact = storeFact(db, "User likes dark mode", 0.6);
+    const updated = db.boostConfidence(fact.id, 0.1);
+    expect(updated).toBe(true);
+    const retrieved = db.getById(fact.id);
+    expect(retrieved?.confidence).toBeCloseTo(0.7, 5);
+  });
+
+  it("caps confidence at maxConfidence", () => {
+    const fact = storeFact(db, "User uses vim", 0.95);
+    db.boostConfidence(fact.id, 0.1, 1.0);
+    const retrieved = db.getById(fact.id);
+    expect(retrieved?.confidence).toBeCloseTo(1.0, 5);
+  });
+
+  it("does not exceed a custom maxConfidence cap", () => {
+    const fact = storeFact(db, "User prefers Python", 0.7);
+    db.boostConfidence(fact.id, 0.2, 0.8);
+    const retrieved = db.getById(fact.id);
+    expect(retrieved?.confidence).toBeCloseTo(0.8, 5);
+  });
+
+  it("increments reinforced_count on each boost", () => {
+    const fact = storeFact(db, "Project uses React", 0.5);
+    db.boostConfidence(fact.id, 0.05);
+    db.boostConfidence(fact.id, 0.05);
+    db.boostConfidence(fact.id, 0.05);
+    const retrieved = db.getById(fact.id) as { reinforcedCount?: number } & object;
+    const reinf = retrieved && "reinforcedCount" in retrieved ? retrieved.reinforcedCount : undefined;
+    expect(reinf).toBe(3);
+  });
+
+  it("updates last_reinforced_at timestamp", () => {
+    const before = Math.floor(Date.now() / 1000) - 1;
+    const fact = storeFact(db, "Team decided on monorepo", 0.7);
+    db.boostConfidence(fact.id, 0.1);
+    const retrieved = db.getById(fact.id) as { lastReinforcedAt?: number | null } & object;
+    const ts = retrieved && "lastReinforcedAt" in retrieved ? retrieved.lastReinforcedAt : undefined;
+    expect(ts).toBeGreaterThanOrEqual(before);
+  });
+
+  it("returns false for unknown fact id", () => {
+    const result = db.boostConfidence("non-existent-uuid", 0.1);
+    expect(result).toBe(false);
+  });
+
+  it("handles zero delta (no-op boost)", () => {
+    const fact = storeFact(db, "Stack: Node.js 20", 0.6);
+    db.boostConfidence(fact.id, 0.0);
+    const retrieved = db.getById(fact.id);
+    expect(retrieved?.confidence).toBeCloseTo(0.6, 5);
+  });
+
+  it("handles multiple consecutive boosts correctly", () => {
+    const fact = storeFact(db, "Database is PostgreSQL", 0.5);
+    for (let i = 0; i < 5; i++) {
+      db.boostConfidence(fact.id, 0.1, 1.0);
+    }
+    const retrieved = db.getById(fact.id);
+    // 0.5 + 5*0.1 = 1.0, capped at 1.0
+    expect(retrieved?.confidence).toBeCloseTo(1.0, 5);
+  });
+
+  it("boosts from initial confidence of 1.0 without exceeding cap", () => {
+    const fact = storeFact(db, "Default confidence fact", 1.0);
+    db.boostConfidence(fact.id, 0.1, 1.0);
+    const retrieved = db.getById(fact.id);
+    expect(retrieved?.confidence).toBeCloseTo(1.0, 5);
+  });
+
+  it("works after storing multiple facts (correct fact is boosted)", () => {
+    const f1 = storeFact(db, "Fact A", 0.5);
+    const f2 = storeFact(db, "Fact B", 0.5);
+    db.boostConfidence(f1.id, 0.2);
+    const r1 = db.getById(f1.id);
+    const r2 = db.getById(f2.id);
+    expect(r1?.confidence).toBeCloseTo(0.7, 5);
+    expect(r2?.confidence).toBeCloseTo(0.5, 5);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Config parsing
+// ---------------------------------------------------------------------------
+
+describe("parseConfig — reinforcement section", () => {
+  const BASE_CFG = {
+    embedding: { provider: "openai", model: "text-embedding-3-small", apiKey: "sk-test-key-12345678" },
+  };
+
+  it("uses defaults when reinforcement is not specified", () => {
+    const cfg = hybridConfigSchema.parse(BASE_CFG);
+    expect(cfg.reinforcement.enabled).toBe(true);
+    expect(cfg.reinforcement.passiveBoost).toBeCloseTo(0.1, 5);
+    expect(cfg.reinforcement.activeBoost).toBeCloseTo(0.05, 5);
+    expect(cfg.reinforcement.maxConfidence).toBeCloseTo(1.0, 5);
+    expect(cfg.reinforcement.similarityThreshold).toBeCloseTo(0.85, 5);
+  });
+
+  it("parses custom reinforcement values", () => {
+    const cfg = hybridConfigSchema.parse({
+      ...BASE_CFG,
+      reinforcement: { enabled: true, passiveBoost: 0.2, activeBoost: 0.08, maxConfidence: 0.9, similarityThreshold: 0.9 },
+    });
+    expect(cfg.reinforcement.passiveBoost).toBeCloseTo(0.2, 5);
+    expect(cfg.reinforcement.activeBoost).toBeCloseTo(0.08, 5);
+    expect(cfg.reinforcement.maxConfidence).toBeCloseTo(0.9, 5);
+    expect(cfg.reinforcement.similarityThreshold).toBeCloseTo(0.9, 5);
+  });
+
+  it("respects enabled: false", () => {
+    const cfg = hybridConfigSchema.parse({
+      ...BASE_CFG,
+      reinforcement: { enabled: false },
+    });
+    expect(cfg.reinforcement.enabled).toBe(false);
+  });
+
+  it("clamps out-of-range passiveBoost to default", () => {
+    const cfg = hybridConfigSchema.parse({
+      ...BASE_CFG,
+      reinforcement: { passiveBoost: 5.0 }, // > 1.0, invalid
+    });
+    expect(cfg.reinforcement.passiveBoost).toBeCloseTo(0.1, 5);
+  });
+
+  it("clamps out-of-range maxConfidence to default", () => {
+    const cfg = hybridConfigSchema.parse({
+      ...BASE_CFG,
+      reinforcement: { maxConfidence: 2.0 }, // > 1.0, invalid
+    });
+    expect(cfg.reinforcement.maxConfidence).toBeCloseTo(1.0, 5);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Decay + reinforcement interaction
+// ---------------------------------------------------------------------------
+
+describe("Decay + reinforcement interaction", () => {
+  let tmpDir: string;
+  let db: InstanceType<typeof FactsDB>;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "reinf-decay-test-"));
+    db = makeDb(tmpDir);
+  });
+
+  afterEach(() => {
+    db.close();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("reinforced fact has higher confidence than unreinforced after boost", () => {
+    const reinforced = storeFact(db, "Frequently mentioned fact", 0.6);
+    const plain = storeFact(db, "Only-mentioned-once fact", 0.6);
+    db.boostConfidence(reinforced.id, 0.1);
+    const r = db.getById(reinforced.id);
+    const p = db.getById(plain.id);
+    expect((r?.confidence ?? 0)).toBeGreaterThan(p?.confidence ?? 0);
+  });
+
+  it("multiple reinforcements counteract decay (confidence stays high)", () => {
+    const fact = storeFact(db, "Important persistent fact", 0.5);
+    // Simulate repeated mentions: multiple passive boosts
+    for (let i = 0; i < 5; i++) {
+      db.boostConfidence(fact.id, 0.1, 1.0);
+    }
+    const retrieved = db.getById(fact.id);
+    expect(retrieved?.confidence).toBeGreaterThanOrEqual(0.9);
+  });
+
+  it("single-mention fact stays at original confidence without boost", () => {
+    const fact = storeFact(db, "One-time fact", 0.7);
+    const retrieved = db.getById(fact.id);
+    // No boost applied — confidence unchanged
+    expect(retrieved?.confidence).toBeCloseTo(0.7, 5);
+  });
+
+  it("reinforce_count reflects how many times fact was boosted", () => {
+    const fact = storeFact(db, "Boosted three times", 0.5);
+    db.boostConfidence(fact.id, 0.05);
+    db.boostConfidence(fact.id, 0.05);
+    db.boostConfidence(fact.id, 0.05);
+    const retrieved = db.getById(fact.id) as { reinforcedCount?: number } & object;
+    const count = retrieved && "reinforcedCount" in retrieved ? retrieved.reinforcedCount : undefined;
+    expect(count).toBe(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Passive observer reinforcement path
+// ---------------------------------------------------------------------------
+
+describe("Passive observer — reinforcement on similarity", () => {
+  let tmpDir: string;
+  let sessionsDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "reinf-observer-test-"));
+    sessionsDir = join(tmpDir, "sessions");
+    mkdirSync(sessionsDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function makeConfig(overrides: Partial<PassiveObserverConfig> = {}): PassiveObserverConfig {
+    return {
+      enabled: true,
+      intervalMinutes: 15,
+      maxCharsPerChunk: 8000,
+      minImportance: 0.5,
+      deduplicationThreshold: 0.85,
+      sessionsDir,
+      ...overrides,
+    };
+  }
+
+  function makeFactsDb(existingFacts: Array<{ id: string; text: string; confidence: number }> = []) {
+    const boostCalls: Array<{ id: string; delta: number }> = [];
+    return {
+      getRecentFacts: () => existingFacts.map((f) => ({ id: f.id, text: f.text })),
+      store: vi.fn().mockReturnValue({ id: "new-fact-id" }),
+      boostConfidence: vi.fn().mockImplementation((id: string, delta: number) => {
+        boostCalls.push({ id, delta });
+        return true;
+      }),
+      _boostCalls: boostCalls,
+    };
+  }
+
+  function makeVectorDb() {
+    return { store: vi.fn() };
+  }
+
+  function makeEmbeddings(vec = [1, 0, 0]) {
+    return { embed: vi.fn().mockResolvedValue(vec) };
+  }
+
+  it("factsReinforced is zero when no similar facts exist", async () => {
+    const cfg = makeConfig({ sessionsDir: join(tmpDir, "nonexistent") });
+    const result = await runPassiveObserver(
+      makeFactsDb() as never,
+      makeVectorDb() as never,
+      makeEmbeddings() as never,
+      {} as never,
+      cfg,
+      ["preference", "fact"],
+      { model: "test-model", dbDir: tmpDir },
+      { info: () => {}, warn: () => {} },
+    );
+    expect(result.factsReinforced).toBe(0);
+  });
+
+  it("reinforcement config disabled does not call boostConfidence", async () => {
+    const sessionFile = join(sessionsDir, "session-abc.jsonl");
+    writeFileSync(
+      sessionFile,
+      JSON.stringify({ type: "message", message: { role: "user", content: "I use TypeScript" } }) + "\n",
+    );
+
+    const factsDb = makeFactsDb([{ id: "existing-fact-1", text: "I use TypeScript", confidence: 0.7 }]);
+
+    vi.doMock("../services/chat.js", () => ({
+      chatCompleteWithRetry: vi.fn().mockResolvedValue('[{"text":"I use TypeScript","category":"preference","importance":0.8}]'),
+    }));
+
+    const { runPassiveObserver: runFn } = await import("../services/passive-observer.js");
+
+    const result = await runFn(
+      factsDb as never,
+      makeVectorDb() as never,
+      makeEmbeddings([1, 0, 0]) as never,
+      {} as never,
+      makeConfig(),
+      ["preference", "fact"],
+      {
+        model: "test-model",
+        dbDir: tmpDir,
+        reinforcement: { enabled: false, passiveBoost: 0.1, activeBoost: 0.05, maxConfidence: 1.0, similarityThreshold: 0.85 },
+      },
+      { info: () => {}, warn: () => {} },
+    );
+
+    expect(factsDb.boostConfidence).not.toHaveBeenCalled();
+    vi.doUnmock("../services/chat.js");
+    void result;
+  });
+
+  it("ObserverRunResult includes factsReinforced field", async () => {
+    const cfg = makeConfig({ sessionsDir: join(tmpDir, "nonexistent") });
+    const result = await runPassiveObserver(
+      makeFactsDb() as never,
+      makeVectorDb() as never,
+      makeEmbeddings() as never,
+      {} as never,
+      cfg,
+      ["preference"],
+      { model: "test-model", dbDir: tmpDir },
+      { info: () => {}, warn: () => {} },
+    );
+    expect(typeof result.factsReinforced).toBe("number");
+    expect(result.factsReinforced).toBeGreaterThanOrEqual(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. Migration — columns exist after FactsDB construction
+// ---------------------------------------------------------------------------
+
+describe("FactsDB migration — reinforcement columns", () => {
+  let tmpDir: string;
+  let db: InstanceType<typeof FactsDB>;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "reinf-migration-test-"));
+    db = makeDb(tmpDir);
+  });
+
+  afterEach(() => {
+    db.close();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("facts table has reinforced_count column after migration", () => {
+    const raw = db.getRawDb();
+    const cols = raw.prepare("PRAGMA table_info(facts)").all() as Array<{ name: string }>;
+    expect(cols.some((c) => c.name === "reinforced_count")).toBe(true);
+  });
+
+  it("facts table has last_reinforced_at column after migration", () => {
+    const raw = db.getRawDb();
+    const cols = raw.prepare("PRAGMA table_info(facts)").all() as Array<{ name: string }>;
+    expect(cols.some((c) => c.name === "last_reinforced_at")).toBe(true);
+  });
+
+  it("new facts have reinforced_count = 0 by default", () => {
+    const fact = storeFact(db, "Brand new fact", 0.8);
+    const retrieved = db.getById(fact.id) as { reinforcedCount?: number } & object;
+    const count = retrieved && "reinforcedCount" in retrieved ? retrieved.reinforcedCount : undefined;
+    expect(count ?? 0).toBe(0);
+  });
+
+  it("new facts have last_reinforced_at = null by default", () => {
+    const fact = storeFact(db, "Another new fact", 0.8);
+    const retrieved = db.getById(fact.id) as { lastReinforcedAt?: number | null } & object;
+    const ts = retrieved && "lastReinforcedAt" in retrieved ? retrieved.lastReinforcedAt : undefined;
+    expect(ts ?? null).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. Config — reinforcement type shape
+// ---------------------------------------------------------------------------
+
+describe("ReinforcementConfig type shape", () => {
+  it("config object has all required fields", () => {
+    const rc: ReinforcementConfig = {
+      enabled: true,
+      passiveBoost: 0.1,
+      activeBoost: 0.05,
+      maxConfidence: 1.0,
+      similarityThreshold: 0.85,
+    };
+    expect(rc.enabled).toBe(true);
+    expect(rc.passiveBoost).toBe(0.1);
+    expect(rc.activeBoost).toBe(0.05);
+    expect(rc.maxConfidence).toBe(1.0);
+    expect(rc.similarityThreshold).toBe(0.85);
+  });
+});

--- a/extensions/memory-hybrid/tests/dream-cycle.test.ts
+++ b/extensions/memory-hybrid/tests/dream-cycle.test.ts
@@ -1,0 +1,475 @@
+/**
+ * Dream Cycle tests — Issue #143
+ *
+ * Covers:
+ *  - buildDigestSummary (pure function, 5 tests)
+ *  - extractEventText (pure function, 4 tests)
+ *  - groupEventsByEntity (pure function, 4 tests)
+ *  - runEpisodicConsolidation with real DB (5 tests: DERIVED_FROM, grouping, mark consolidated, empty, text fallback)
+ *  - runDreamCycle with real DB (7 tests: disabled skip, prune, decay, reflect stub, config schedule, full pipeline)
+ *  - NightlyCycleConfig parsing via hybridConfigSchema (3 tests: defaults, enabled, overrides)
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  buildDigestSummary,
+  extractEventText,
+  groupEventsByEntity,
+  runEpisodicConsolidation,
+  runDreamCycle,
+  type DreamCycleConfig,
+} from "../services/dream-cycle.js";
+import { _testing } from "../index.js";
+import { hybridConfigSchema } from "../config.js";
+import type { EventLogEntry } from "../backends/event-log.js";
+
+const { FactsDB, EventLog } = _testing;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeEntry(overrides: Partial<EventLogEntry> = {}): EventLogEntry {
+  return {
+    id: `evt-${Math.random().toString(36).slice(2)}`,
+    sessionId: "sess-1",
+    timestamp: new Date().toISOString(),
+    eventType: "fact_learned",
+    content: { text: "User prefers dark mode" },
+    entities: undefined,
+    consolidatedInto: undefined,
+    metadata: undefined,
+    createdAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+const silentLogger = { info: () => undefined, warn: () => undefined };
+
+// ---------------------------------------------------------------------------
+// buildDigestSummary
+// ---------------------------------------------------------------------------
+
+describe("buildDigestSummary", () => {
+  it("returns 'No changes.' when all counts are zero", () => {
+    const s = buildDigestSummary({ factsPruned: 0, factsDecayed: 0, eventsConsolidated: 0, factsCreated: 0, patternsFound: 0, rulesGenerated: 0 });
+    expect(s).toBe("No changes.");
+  });
+
+  it("reports pruned facts", () => {
+    const s = buildDigestSummary({ factsPruned: 5, factsDecayed: 0, eventsConsolidated: 0, factsCreated: 0, patternsFound: 0, rulesGenerated: 0 });
+    expect(s).toContain("5 facts pruned");
+  });
+
+  it("reports decayed facts", () => {
+    const s = buildDigestSummary({ factsPruned: 0, factsDecayed: 3, eventsConsolidated: 0, factsCreated: 0, patternsFound: 0, rulesGenerated: 0 });
+    expect(s).toContain("3 facts decayed");
+  });
+
+  it("reports events consolidated", () => {
+    const s = buildDigestSummary({ factsPruned: 0, factsDecayed: 0, eventsConsolidated: 10, factsCreated: 2, patternsFound: 0, rulesGenerated: 0 });
+    expect(s).toContain("10 events consolidated into 2 facts");
+  });
+
+  it("reports patterns and rules", () => {
+    const s = buildDigestSummary({ factsPruned: 0, factsDecayed: 0, eventsConsolidated: 0, factsCreated: 0, patternsFound: 4, rulesGenerated: 2 });
+    expect(s).toContain("4 patterns extracted");
+    expect(s).toContain("2 rules generated");
+  });
+
+  it("combines multiple non-zero counts", () => {
+    const s = buildDigestSummary({ factsPruned: 1, factsDecayed: 2, eventsConsolidated: 5, factsCreated: 1, patternsFound: 3, rulesGenerated: 1 });
+    expect(s).toContain("1 facts pruned");
+    expect(s).toContain("2 facts decayed");
+    expect(s).toContain("5 events consolidated");
+    expect(s).toContain("3 patterns extracted");
+    expect(s).toContain("1 rules generated");
+    expect(s.endsWith(".")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractEventText
+// ---------------------------------------------------------------------------
+
+describe("extractEventText", () => {
+  it("extracts 'text' field first", () => {
+    const evt = makeEntry({ content: { text: "hello world", decision: "other" } });
+    expect(extractEventText(evt)).toBe("hello world");
+  });
+
+  it("falls back to 'decision' when no text", () => {
+    const evt = makeEntry({ content: { decision: "use TypeScript" } });
+    expect(extractEventText(evt)).toBe("use TypeScript");
+  });
+
+  it("falls back to any string value", () => {
+    const evt = makeEntry({ content: { foo: "bar baz" } });
+    expect(extractEventText(evt)).toBe("bar baz");
+  });
+
+  it("returns empty string when no string values in content", () => {
+    const evt = makeEntry({ content: { count: 42 } });
+    expect(extractEventText(evt)).toBe("");
+  });
+
+  it("trims whitespace from extracted text", () => {
+    const evt = makeEntry({ content: { text: "  hello  " } });
+    expect(extractEventText(evt)).toBe("hello");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// groupEventsByEntity
+// ---------------------------------------------------------------------------
+
+describe("groupEventsByEntity", () => {
+  it("groups events by their primary entity", () => {
+    const events = [
+      makeEntry({ entities: ["Alice"] }),
+      makeEntry({ entities: ["Alice"] }),
+      makeEntry({ entities: ["Bob"] }),
+    ];
+    const groups = groupEventsByEntity(events);
+    expect(groups.get("Alice")).toHaveLength(2);
+    expect(groups.get("Bob")).toHaveLength(1);
+  });
+
+  it("puts events with no entity under __default__", () => {
+    const events = [makeEntry(), makeEntry()];
+    const groups = groupEventsByEntity(events);
+    expect(groups.get("__default__")).toHaveLength(2);
+  });
+
+  it("uses the first entity when multiple are listed", () => {
+    const events = [makeEntry({ entities: ["Alice", "Bob"] })];
+    const groups = groupEventsByEntity(events);
+    expect(groups.has("Alice")).toBe(true);
+    expect(groups.has("Bob")).toBe(false);
+  });
+
+  it("returns empty map for empty input", () => {
+    const groups = groupEventsByEntity([]);
+    expect(groups.size).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runEpisodicConsolidation — integration with real DB
+// ---------------------------------------------------------------------------
+
+let tmpDir: string;
+let factsDb: InstanceType<typeof FactsDB>;
+let eventLog: InstanceType<typeof EventLog>;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "dream-cycle-test-"));
+  factsDb = new FactsDB(join(tmpDir, "facts.db"));
+  eventLog = new EventLog(join(tmpDir, "event-log.db"));
+});
+
+afterEach(() => {
+  factsDb.close();
+  eventLog.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("runEpisodicConsolidation", () => {
+  it("returns zero counts when no unconsolidated events exist", async () => {
+    const result = await runEpisodicConsolidation(factsDb, eventLog, 0, silentLogger);
+    expect(result.eventsConsolidated).toBe(0);
+    expect(result.factsCreated).toBe(0);
+  });
+
+  it("consolidates old events into facts", async () => {
+    // Insert events old enough to be consolidated (olderThanDays = 0 means any event)
+    const oldTs = new Date(Date.now() - 8 * 24 * 3600 * 1000).toISOString();
+    eventLog.append({ sessionId: "s1", timestamp: oldTs, eventType: "fact_learned", content: { text: "User prefers TypeScript" } });
+    eventLog.append({ sessionId: "s1", timestamp: oldTs, eventType: "fact_learned", content: { text: "User prefers functional style" } });
+
+    const result = await runEpisodicConsolidation(factsDb, eventLog, 7, silentLogger);
+    expect(result.eventsConsolidated).toBe(2);
+    expect(result.factsCreated).toBe(1); // Both go into __default__ group
+  });
+
+  it("creates DERIVED_FROM links for consolidated events", async () => {
+    const oldTs = new Date(Date.now() - 8 * 24 * 3600 * 1000).toISOString();
+    eventLog.append({ sessionId: "s1", timestamp: oldTs, eventType: "fact_learned", content: { text: "Fact about Alice" }, entities: ["Alice"] });
+
+    const result = await runEpisodicConsolidation(factsDb, eventLog, 7, silentLogger);
+    expect(result.factsCreated).toBe(1);
+
+    // Find the consolidated fact
+    const allFacts = factsDb.getByCategory("fact");
+    const consolidated = allFacts.find((f) => f.source === "dream-cycle");
+    expect(consolidated).toBeDefined();
+
+    // Check DERIVED_FROM links from consolidated fact
+    const links = factsDb.getLinksFrom(consolidated!.id);
+    const derivedLinks = links.filter((l) => l.linkType === "DERIVED_FROM");
+    expect(derivedLinks.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("marks events as consolidated in the event log", async () => {
+    const oldTs = new Date(Date.now() - 8 * 24 * 3600 * 1000).toISOString();
+    eventLog.append({ sessionId: "s1", timestamp: oldTs, eventType: "fact_learned", content: { text: "Some event" } });
+
+    await runEpisodicConsolidation(factsDb, eventLog, 7, silentLogger);
+
+    // After consolidation, no unconsolidated events older than 7 days should remain
+    const remaining = eventLog.getUnconsolidated(7);
+    expect(remaining).toHaveLength(0);
+  });
+
+  it("skips events that are not old enough", async () => {
+    // Recent events (not older than 7 days) should NOT be consolidated
+    const recentTs = new Date().toISOString();
+    eventLog.append({ sessionId: "s1", timestamp: recentTs, eventType: "fact_learned", content: { text: "Recent event" } });
+
+    const result = await runEpisodicConsolidation(factsDb, eventLog, 7, silentLogger);
+    expect(result.eventsConsolidated).toBe(0);
+    expect(result.factsCreated).toBe(0);
+  });
+
+  it("groups events by entity into separate consolidated facts", async () => {
+    const oldTs = new Date(Date.now() - 8 * 24 * 3600 * 1000).toISOString();
+    eventLog.append({ sessionId: "s1", timestamp: oldTs, eventType: "fact_learned", content: { text: "Alice prefers coffee" }, entities: ["Alice"] });
+    eventLog.append({ sessionId: "s1", timestamp: oldTs, eventType: "fact_learned", content: { text: "Bob prefers tea" }, entities: ["Bob"] });
+
+    const result = await runEpisodicConsolidation(factsDb, eventLog, 7, silentLogger);
+    expect(result.eventsConsolidated).toBe(2);
+    expect(result.factsCreated).toBe(2); // One per entity group
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runDreamCycle — integration tests
+// ---------------------------------------------------------------------------
+
+describe("runDreamCycle", () => {
+  const baseConfig: DreamCycleConfig = {
+    enabled: true,
+    schedule: "45 2 * * *",
+    reflectWindowDays: 7,
+    pruneMode: "both",
+    model: "gpt-4o-mini",
+    consolidateAfterDays: 7,
+  };
+
+  it("returns skipped=true when enabled=false", async () => {
+    const result = await runDreamCycle(
+      factsDb, {} as never, {} as never, {} as never, null,
+      { ...baseConfig, enabled: false },
+      silentLogger,
+    );
+    expect(result.skipped).toBe(true);
+    expect(result.factsPruned).toBe(0);
+    expect(result.patternsFound).toBe(0);
+    expect(result.digestSummary).toContain("disabled");
+  });
+
+  it("prunes expired facts when pruneMode='expired'", async () => {
+    // Store a fact with expired TTL
+    const nowSec = Math.floor(Date.now() / 1000);
+    factsDb.store({
+      text: "Expired fact about old news",
+      category: "fact",
+      importance: 0.5,
+      entity: null,
+      key: null,
+      value: null,
+      source: "test",
+      decayClass: "session",
+      expiresAt: nowSec - 100,
+    });
+    // Verify it exists
+    expect(factsDb.count()).toBe(1);
+
+    const openaiStub = {
+      chat: { completions: { create: vi.fn().mockRejectedValue(new Error("no key")) } },
+    } as never;
+    const embeddingsStub = { embed: vi.fn().mockRejectedValue(new Error("no key")) } as never;
+
+    const result = await runDreamCycle(
+      factsDb, {} as never, embeddingsStub, openaiStub, null,
+      { ...baseConfig, pruneMode: "expired" },
+      silentLogger,
+    );
+    expect(result.factsPruned).toBe(1);
+    expect(factsDb.count()).toBe(0);
+  });
+
+  it("decays confidence when pruneMode='decay'", async () => {
+    // Store a fact with expiring TTL (needed for decayConfidence to apply)
+    const nowSec = Math.floor(Date.now() / 1000);
+    factsDb.store({
+      text: "A fact with expiring confidence",
+      category: "fact",
+      importance: 0.5,
+      entity: null,
+      key: null,
+      value: null,
+      source: "test",
+      decayClass: "active",
+      confidence: 0.9,
+      // last_confirmed_at and expires_at set so decay applies
+      expiresAt: nowSec + 100,
+    });
+
+    const openaiStub = {
+      chat: { completions: { create: vi.fn().mockRejectedValue(new Error("no key")) } },
+    } as never;
+    const embeddingsStub = { embed: vi.fn().mockRejectedValue(new Error("no key")) } as never;
+
+    const result = await runDreamCycle(
+      factsDb, {} as never, embeddingsStub, openaiStub, null,
+      { ...baseConfig, pruneMode: "decay" },
+      silentLogger,
+    );
+    // decayConfidence only fires for facts that have passed 75% of their TTL;
+    // our test fact is fresh, so decayed count may be 0 — just confirm no throw
+    expect(result.skipped).toBe(false);
+    expect(result.factsPruned).toBe(0); // pruneExpired not called
+  });
+
+  it("includes eventsConsolidated count when eventLog is provided", async () => {
+    const oldTs = new Date(Date.now() - 8 * 24 * 3600 * 1000).toISOString();
+    eventLog.append({ sessionId: "s1", timestamp: oldTs, eventType: "fact_learned", content: { text: "Old event to consolidate" } });
+
+    const openaiStub = {
+      chat: { completions: { create: vi.fn().mockRejectedValue(new Error("no key")) } },
+    } as never;
+    const embeddingsStub = { embed: vi.fn().mockRejectedValue(new Error("no key")) } as never;
+
+    const result = await runDreamCycle(
+      factsDb, {} as never, embeddingsStub, openaiStub, eventLog,
+      baseConfig,
+      silentLogger,
+    );
+    expect(result.eventsConsolidated).toBe(1);
+    expect(result.factsCreated).toBe(1);
+  });
+
+  it("skips consolidation when eventLog is null", async () => {
+    const openaiStub = {
+      chat: { completions: { create: vi.fn().mockRejectedValue(new Error("no key")) } },
+    } as never;
+    const embeddingsStub = { embed: vi.fn().mockRejectedValue(new Error("no key")) } as never;
+
+    const result = await runDreamCycle(
+      factsDb, {} as never, embeddingsStub, openaiStub, null,
+      baseConfig,
+      silentLogger,
+    );
+    expect(result.eventsConsolidated).toBe(0);
+  });
+
+  it("produces a non-empty digest summary", async () => {
+    const openaiStub = {
+      chat: { completions: { create: vi.fn().mockRejectedValue(new Error("no key")) } },
+    } as never;
+    const embeddingsStub = { embed: vi.fn().mockRejectedValue(new Error("no key")) } as never;
+
+    const result = await runDreamCycle(
+      factsDb, {} as never, embeddingsStub, openaiStub, null,
+      baseConfig,
+      silentLogger,
+    );
+    expect(typeof result.digestSummary).toBe("string");
+    expect(result.digestSummary.length).toBeGreaterThan(0);
+  });
+
+  it("permanent facts are not pruned by pruneExpired", async () => {
+    // Permanent facts have no expiresAt — they must survive pruning
+    factsDb.store({
+      text: "A permanent rule that should never be deleted",
+      category: "rule",
+      importance: 0.9,
+      entity: null,
+      key: null,
+      value: null,
+      source: "test",
+      decayClass: "permanent",
+      expiresAt: null,
+    });
+    const beforeCount = factsDb.count();
+
+    const openaiStub = {
+      chat: { completions: { create: vi.fn().mockRejectedValue(new Error("no key")) } },
+    } as never;
+    const embeddingsStub = { embed: vi.fn().mockRejectedValue(new Error("no key")) } as never;
+
+    await runDreamCycle(
+      factsDb, {} as never, embeddingsStub, openaiStub, null,
+      { ...baseConfig, pruneMode: "expired" },
+      silentLogger,
+    );
+    // Permanent fact must still be there
+    expect(factsDb.count()).toBe(beforeCount);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// NightlyCycleConfig — config parsing
+// ---------------------------------------------------------------------------
+
+describe("NightlyCycleConfig parsing", () => {
+  const minimalConfig = {
+    embedding: { provider: "openai", model: "text-embedding-3-small", apiKey: "sk-test-key-that-is-long-enough-to-pass" },
+    sqlitePath: "/tmp/test-facts.db",
+    lanceDbPath: "/tmp/test-lance",
+  };
+
+  it("defaults to disabled with sensible defaults", () => {
+    const cfg = hybridConfigSchema.parse(minimalConfig);
+    expect(cfg.nightlyCycle.enabled).toBe(false);
+    expect(cfg.nightlyCycle.schedule).toBe("45 2 * * *");
+    expect(cfg.nightlyCycle.reflectWindowDays).toBe(7);
+    expect(cfg.nightlyCycle.pruneMode).toBe("both");
+    expect(cfg.nightlyCycle.consolidateAfterDays).toBe(7);
+  });
+
+  it("enables the cycle when enabled: true", () => {
+    const cfg = hybridConfigSchema.parse({
+      ...minimalConfig,
+      nightlyCycle: { enabled: true },
+    });
+    expect(cfg.nightlyCycle.enabled).toBe(true);
+  });
+
+  it("accepts custom schedule, window, pruneMode, and consolidateAfterDays", () => {
+    const cfg = hybridConfigSchema.parse({
+      ...minimalConfig,
+      nightlyCycle: {
+        enabled: true,
+        schedule: "30 2 * * *",
+        reflectWindowDays: 14,
+        pruneMode: "expired",
+        consolidateAfterDays: 3,
+      },
+    });
+    expect(cfg.nightlyCycle.schedule).toBe("30 2 * * *");
+    expect(cfg.nightlyCycle.reflectWindowDays).toBe(14);
+    expect(cfg.nightlyCycle.pruneMode).toBe("expired");
+    expect(cfg.nightlyCycle.consolidateAfterDays).toBe(3);
+  });
+
+  it("clamps reflectWindowDays to max 90", () => {
+    const cfg = hybridConfigSchema.parse({
+      ...minimalConfig,
+      nightlyCycle: { reflectWindowDays: 200 },
+    });
+    expect(cfg.nightlyCycle.reflectWindowDays).toBe(90);
+  });
+
+  it("falls back to 'both' pruneMode for unknown values", () => {
+    const cfg = hybridConfigSchema.parse({
+      ...minimalConfig,
+      nightlyCycle: { pruneMode: "unknown-value" },
+    });
+    expect(cfg.nightlyCycle.pruneMode).toBe("both");
+  });
+});

--- a/extensions/memory-hybrid/tests/health-dashboard.test.ts
+++ b/extensions/memory-hybrid/tests/health-dashboard.test.ts
@@ -1,0 +1,353 @@
+/**
+ * Tests for Issue #148 — Memory Health Dashboard
+ *
+ * Coverage:
+ *   - buildHealthReport: returns correct totalFacts count
+ *   - buildHealthReport: returns correct activeFacts count (excludes expired)
+ *   - buildHealthReport: supersededFacts counts facts with valid_until in the past
+ *   - buildHealthReport: categoryDistribution groups active facts by category
+ *   - buildHealthReport: decayClassDistribution groups all facts by decay class
+ *   - buildHealthReport: tierDistribution groups all facts by tier
+ *   - buildHealthReport: avgConfidence is the mean of active fact confidences
+ *   - buildHealthReport: avgConfidence rounds to 3 decimal places
+ *   - buildHealthReport: orphanFacts counts active facts with no links
+ *   - buildHealthReport: orphanFacts excludes facts that are source of a link
+ *   - buildHealthReport: orphanFacts excludes facts that are target of a link
+ *   - buildHealthReport: staleFacts counts active facts with confidence < 0.3 and non-permanent
+ *   - buildHealthReport: staleFacts excludes permanent decay-class facts
+ *   - buildHealthReport: staleFacts excludes facts with confidence >= 0.3
+ *   - buildHealthReport: totalLinks reflects row count in memory_links
+ *   - buildHealthReport: avgLinksPerFact is computed as total_links*2 / activeFacts
+ *   - buildHealthReport: avgLinksPerFact is 0 when activeFacts is 0
+ *   - buildHealthReport: lastReflectionAt is null when no reflection facts exist
+ *   - buildHealthReport: lastReflectionAt returns ISO string of most recent reflection fact
+ *   - buildHealthReport: lastPruneAt is null when no superseded facts exist
+ *   - buildHealthReport: generatedAt is a valid ISO date string
+ *   - buildHealthReport: storageSizeBytes.sqlite is 0 for a non-existent path
+ *   - registerHealthTools: does not register tool when health.enabled is false
+ *   - registerHealthTools: registers tool when health.enabled is true
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { buildHealthReport, registerHealthTools } from "../tools/health-dashboard.js";
+import { _testing } from "../index.js";
+
+const { FactsDB } = _testing;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeDb(tmpDir: string): InstanceType<typeof FactsDB> {
+  return new FactsDB(join(tmpDir, "facts.db"));
+}
+
+function storeMinimalFact(
+  db: InstanceType<typeof FactsDB>,
+  overrides: {
+    text?: string;
+    category?: string;
+    decayClass?: "permanent" | "stable" | "active" | "session" | "checkpoint";
+    confidence?: number;
+    source?: string;
+    tier?: string;
+    validUntil?: number | null;
+    expiresAt?: number | null;
+  } = {},
+) {
+  const raw = db.getRawDb();
+  const id = `test-${Math.random().toString(36).slice(2)}`;
+  const nowSec = Math.floor(Date.now() / 1000);
+  const {
+    text = "test fact",
+    category = "fact",
+    decayClass = "stable",
+    confidence = 1.0,
+    source = "conversation",
+    tier = "warm",
+    validUntil = null,
+    expiresAt = null,
+  } = overrides;
+  raw.prepare(
+    `INSERT INTO facts (id, text, category, importance, source, created_at, decay_class, confidence, tier, valid_until, expires_at)
+     VALUES (?, ?, ?, 0.7, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(id, text, category, source, nowSec, decayClass, confidence, tier, validUntil, expiresAt);
+  return id;
+}
+
+function addLink(
+  db: InstanceType<typeof FactsDB>,
+  sourceId: string,
+  targetId: string,
+  linkType = "RELATED_TO",
+) {
+  const raw = db.getRawDb();
+  raw
+    .prepare(
+      `INSERT INTO memory_links (id, source_fact_id, target_fact_id, link_type, strength, created_at)
+       VALUES (?, ?, ?, ?, 1.0, ?)`,
+    )
+    .run(
+      `link-${Math.random().toString(36).slice(2)}`,
+      sourceId,
+      targetId,
+      linkType,
+      Math.floor(Date.now() / 1000),
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("buildHealthReport", () => {
+  let tmpDir: string;
+  let factsDb: InstanceType<typeof FactsDB>;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "health-test-"));
+    factsDb = makeDb(tmpDir);
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns correct totalFacts count", () => {
+    storeMinimalFact(factsDb);
+    storeMinimalFact(factsDb);
+    const report = buildHealthReport(factsDb, join(tmpDir, "facts.db"), join(tmpDir, "lance"));
+    expect(report.totalFacts).toBe(2);
+  });
+
+  it("returns correct activeFacts count (excludes expired)", () => {
+    storeMinimalFact(factsDb); // active
+    storeMinimalFact(factsDb, { expiresAt: 1 }); // expired (past epoch)
+    const report = buildHealthReport(factsDb, join(tmpDir, "facts.db"), join(tmpDir, "lance"));
+    expect(report.activeFacts).toBe(1);
+  });
+
+  it("supersededFacts counts facts with valid_until in the past", () => {
+    storeMinimalFact(factsDb); // active
+    storeMinimalFact(factsDb, { validUntil: 1 }); // superseded
+    const report = buildHealthReport(factsDb, join(tmpDir, "facts.db"), join(tmpDir, "lance"));
+    expect(report.supersededFacts).toBe(1);
+  });
+
+  it("categoryDistribution groups active facts by category", () => {
+    storeMinimalFact(factsDb, { category: "preference" });
+    storeMinimalFact(factsDb, { category: "preference" });
+    storeMinimalFact(factsDb, { category: "fact" });
+    const report = buildHealthReport(factsDb, join(tmpDir, "facts.db"), join(tmpDir, "lance"));
+    expect(report.categoryDistribution["preference"]).toBe(2);
+    expect(report.categoryDistribution["fact"]).toBe(1);
+  });
+
+  it("categoryDistribution excludes expired facts", () => {
+    storeMinimalFact(factsDb, { category: "preference" });
+    storeMinimalFact(factsDb, { category: "preference", expiresAt: 1 }); // expired
+    const report = buildHealthReport(factsDb, join(tmpDir, "facts.db"), join(tmpDir, "lance"));
+    expect(report.categoryDistribution["preference"]).toBe(1);
+  });
+
+  it("decayClassDistribution groups all facts by decay class", () => {
+    storeMinimalFact(factsDb, { decayClass: "permanent" });
+    storeMinimalFact(factsDb, { decayClass: "stable" });
+    storeMinimalFact(factsDb, { decayClass: "stable" });
+    const report = buildHealthReport(factsDb, join(tmpDir, "facts.db"), join(tmpDir, "lance"));
+    expect(report.decayClassDistribution["permanent"]).toBe(1);
+    expect(report.decayClassDistribution["stable"]).toBe(2);
+  });
+
+  it("tierDistribution groups all facts by tier", () => {
+    storeMinimalFact(factsDb, { tier: "hot" });
+    storeMinimalFact(factsDb, { tier: "warm" });
+    storeMinimalFact(factsDb, { tier: "warm" });
+    const report = buildHealthReport(factsDb, join(tmpDir, "facts.db"), join(tmpDir, "lance"));
+    expect(report.tierDistribution["hot"]).toBe(1);
+    expect(report.tierDistribution["warm"]).toBe(2);
+  });
+
+  it("avgConfidence is the mean of active fact confidences", () => {
+    storeMinimalFact(factsDb, { confidence: 0.4 });
+    storeMinimalFact(factsDb, { confidence: 0.6 });
+    const report = buildHealthReport(factsDb, join(tmpDir, "facts.db"), join(tmpDir, "lance"));
+    expect(report.avgConfidence).toBeCloseTo(0.5, 2);
+  });
+
+  it("avgConfidence rounds to 3 decimal places", () => {
+    storeMinimalFact(factsDb, { confidence: 1.0 / 3 });
+    const report = buildHealthReport(factsDb, join(tmpDir, "facts.db"), join(tmpDir, "lance"));
+    // Should be 0.333 (3 decimal places max)
+    expect(report.avgConfidence.toString().split(".")[1]?.length ?? 0).toBeLessThanOrEqual(3);
+  });
+
+  it("orphanFacts counts active facts with no links", () => {
+    storeMinimalFact(factsDb, { text: "alone" });
+    const report = buildHealthReport(factsDb, join(tmpDir, "facts.db"), join(tmpDir, "lance"));
+    expect(report.orphanFacts).toBe(1);
+  });
+
+  it("orphanFacts excludes facts that are source of a link", () => {
+    const id1 = storeMinimalFact(factsDb, { text: "linked source" });
+    const id2 = storeMinimalFact(factsDb, { text: "linked target" });
+    addLink(factsDb, id1, id2);
+    const report = buildHealthReport(factsDb, join(tmpDir, "facts.db"), join(tmpDir, "lance"));
+    expect(report.orphanFacts).toBe(0);
+  });
+
+  it("orphanFacts excludes facts that are target of a link", () => {
+    const id1 = storeMinimalFact(factsDb, { text: "source fact" });
+    const id2 = storeMinimalFact(factsDb, { text: "target fact" });
+    addLink(factsDb, id1, id2);
+    const report = buildHealthReport(factsDb, join(tmpDir, "facts.db"), join(tmpDir, "lance"));
+    expect(report.orphanFacts).toBe(0);
+  });
+
+  it("staleFacts counts active facts with confidence < 0.3 and non-permanent decay", () => {
+    storeMinimalFact(factsDb, { confidence: 0.1, decayClass: "stable" });
+    storeMinimalFact(factsDb, { confidence: 0.2, decayClass: "active" });
+    const report = buildHealthReport(factsDb, join(tmpDir, "facts.db"), join(tmpDir, "lance"));
+    expect(report.staleFacts).toBe(2);
+  });
+
+  it("staleFacts excludes permanent decay-class facts", () => {
+    storeMinimalFact(factsDb, { confidence: 0.1, decayClass: "permanent" });
+    const report = buildHealthReport(factsDb, join(tmpDir, "facts.db"), join(tmpDir, "lance"));
+    expect(report.staleFacts).toBe(0);
+  });
+
+  it("staleFacts excludes facts with confidence >= 0.3", () => {
+    storeMinimalFact(factsDb, { confidence: 0.3, decayClass: "stable" });
+    storeMinimalFact(factsDb, { confidence: 0.9, decayClass: "stable" });
+    const report = buildHealthReport(factsDb, join(tmpDir, "facts.db"), join(tmpDir, "lance"));
+    expect(report.staleFacts).toBe(0);
+  });
+
+  it("totalLinks reflects row count in memory_links", () => {
+    const id1 = storeMinimalFact(factsDb);
+    const id2 = storeMinimalFact(factsDb);
+    const id3 = storeMinimalFact(factsDb);
+    addLink(factsDb, id1, id2);
+    addLink(factsDb, id2, id3);
+    const report = buildHealthReport(factsDb, join(tmpDir, "facts.db"), join(tmpDir, "lance"));
+    expect(report.totalLinks).toBe(2);
+  });
+
+  it("avgLinksPerFact is computed as totalLinks*2 / activeFacts", () => {
+    const id1 = storeMinimalFact(factsDb);
+    const id2 = storeMinimalFact(factsDb);
+    addLink(factsDb, id1, id2);
+    const report = buildHealthReport(factsDb, join(tmpDir, "facts.db"), join(tmpDir, "lance"));
+    // 1 link * 2 / 2 facts = 1.0
+    expect(report.avgLinksPerFact).toBeCloseTo(1.0, 2);
+  });
+
+  it("avgLinksPerFact is 0 when no active facts", () => {
+    const report = buildHealthReport(factsDb, join(tmpDir, "facts.db"), join(tmpDir, "lance"));
+    expect(report.avgLinksPerFact).toBe(0);
+  });
+
+  it("lastReflectionAt is null when no reflection facts exist", () => {
+    storeMinimalFact(factsDb, { source: "conversation" });
+    const report = buildHealthReport(factsDb, join(tmpDir, "facts.db"), join(tmpDir, "lance"));
+    expect(report.lastReflectionAt).toBeNull();
+  });
+
+  it("lastReflectionAt returns ISO string of most recent reflection fact", () => {
+    storeMinimalFact(factsDb, { source: "reflection" });
+    const report = buildHealthReport(factsDb, join(tmpDir, "facts.db"), join(tmpDir, "lance"));
+    expect(report.lastReflectionAt).not.toBeNull();
+    expect(() => new Date(report.lastReflectionAt!)).not.toThrow();
+  });
+
+  it("lastPruneAt is null when no superseded facts exist", () => {
+    storeMinimalFact(factsDb);
+    const report = buildHealthReport(factsDb, join(tmpDir, "facts.db"), join(tmpDir, "lance"));
+    expect(report.lastPruneAt).toBeNull();
+  });
+
+  it("generatedAt is a valid ISO date string", () => {
+    const report = buildHealthReport(factsDb, join(tmpDir, "facts.db"), join(tmpDir, "lance"));
+    expect(() => new Date(report.generatedAt)).not.toThrow();
+    expect(new Date(report.generatedAt).toISOString()).toBe(report.generatedAt);
+  });
+
+  it("storageSizeBytes.sqlite is 0 for a non-existent path", () => {
+    const report = buildHealthReport(factsDb, "/nonexistent/path/facts.db", join(tmpDir, "lance"));
+    expect(report.storageSizeBytes.sqlite).toBe(0);
+  });
+
+  it("storageSizeBytes.lance is 0 for a non-existent directory", () => {
+    const report = buildHealthReport(factsDb, join(tmpDir, "facts.db"), "/nonexistent/lance/dir");
+    expect(report.storageSizeBytes.lance).toBe(0);
+  });
+
+  it("storageSizeBytes.total is sqlite + lance", () => {
+    const report = buildHealthReport(factsDb, join(tmpDir, "facts.db"), join(tmpDir, "lance"));
+    expect(report.storageSizeBytes.total).toBe(
+      report.storageSizeBytes.sqlite + report.storageSizeBytes.lance,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// registerHealthTools tests
+// ---------------------------------------------------------------------------
+
+describe("registerHealthTools", () => {
+  let tmpDir: string;
+  let factsDb: InstanceType<typeof FactsDB>;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "health-reg-test-"));
+    factsDb = makeDb(tmpDir);
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("does not register tool when health.enabled is false", () => {
+    const registered: string[] = [];
+    const fakeApi = {
+      registerTool: (def: { name: string }) => { registered.push(def.name); },
+      logger: { info: () => {}, warn: () => {} },
+    } as unknown as Parameters<typeof registerHealthTools>[1];
+
+    registerHealthTools(
+      {
+        factsDb,
+        cfg: { health: { enabled: false } } as unknown as import("../config.js").HybridMemoryConfig,
+        resolvedSqlitePath: join(tmpDir, "facts.db"),
+        resolvedLancePath: join(tmpDir, "lance"),
+      },
+      fakeApi,
+    );
+
+    expect(registered).not.toContain("memory_health");
+  });
+
+  it("registers memory_health tool when health.enabled is true", () => {
+    const registered: string[] = [];
+    const fakeApi = {
+      registerTool: (def: { name: string }) => { registered.push(def.name); },
+      logger: { info: () => {}, warn: () => {} },
+    } as unknown as Parameters<typeof registerHealthTools>[1];
+
+    registerHealthTools(
+      {
+        factsDb,
+        cfg: { health: { enabled: true } } as unknown as import("../config.js").HybridMemoryConfig,
+        resolvedSqlitePath: join(tmpDir, "facts.db"),
+        resolvedLancePath: join(tmpDir, "lance"),
+      },
+      fakeApi,
+    );
+
+    expect(registered).toContain("memory_health");
+  });
+});

--- a/extensions/memory-hybrid/tests/knowledge-gaps.test.ts
+++ b/extensions/memory-hybrid/tests/knowledge-gaps.test.ts
@@ -1,0 +1,625 @@
+/**
+ * Tests for Issue #141 — Knowledge Gap Analysis.
+ *
+ * Coverage:
+ *   - computeIsolationScore: 0 links → 1.0, 1 link → 0.5, n links → 1/(n+1)
+ *   - computeRankScore: age_factor × isolation_score
+ *   - detectOrphans: returns only zero-link facts
+ *   - detectOrphans: excludes facts with any link
+ *   - detectOrphans: sorted by rankScore descending
+ *   - detectOrphans: respects limit
+ *   - detectOrphans: returns empty when no orphans
+ *   - detectWeak: returns only 1-link facts
+ *   - detectWeak: excludes orphans and well-connected facts
+ *   - detectWeak: sorted by rankScore descending
+ *   - detectWeak: respects limit
+ *   - detectWeak: counts both inbound and outbound links
+ *   - detectSuggestedLinks: returns pairs above threshold
+ *   - detectSuggestedLinks: skips already-linked pairs
+ *   - detectSuggestedLinks: skips self-pairs
+ *   - detectSuggestedLinks: deduplicates symmetric pairs
+ *   - detectSuggestedLinks: sorted by similarity descending
+ *   - detectSuggestedLinks: respects limit
+ *   - analyzeKnowledgeGaps: mode="orphans" only returns orphans
+ *   - analyzeKnowledgeGaps: mode="weak" only returns weak
+ *   - analyzeKnowledgeGaps: mode="all" returns all three categories
+ *   - analyzeKnowledgeGaps: uses nowSec parameter correctly
+ *   - Config: gaps config parses with defaults
+ *   - Integration with FactsDB: real DB stores + links used
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { _testing } from "../index.js";
+import type { GapFactsDB, GapVectorDB, GapEmbeddings, GapFact } from "../index.js";
+import type { MemoryEntry } from "../types/memory.js";
+
+const {
+  computeIsolationScore,
+  computeRankScore,
+  detectOrphans,
+  detectWeak,
+  detectSuggestedLinks,
+  analyzeKnowledgeGaps,
+  FactsDB,
+} = _testing;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const NOW_SEC = 1_700_000_000;
+
+function makeEntry(id: string, createdAt = NOW_SEC, overrides: Partial<MemoryEntry> = {}): MemoryEntry {
+  return {
+    id,
+    text: `Fact text for ${id}`,
+    category: "fact",
+    importance: 0.7,
+    entity: null,
+    key: null,
+    value: null,
+    source: "conversation",
+    createdAt,
+    sourceDate: null,
+    decayClass: "stable",
+    expiresAt: null,
+    lastConfirmedAt: createdAt,
+    confidence: 1.0,
+    summary: null,
+    tags: null,
+    recallCount: 0,
+    lastAccessed: null,
+    supersededAt: null,
+    supersededBy: null,
+    supersedesId: null,
+    validFrom: null,
+    validUntil: null,
+    tier: "warm",
+    scope: "global",
+    scopeTarget: null,
+    procedureType: null,
+    successCount: 0,
+    lastValidated: null,
+    sourceSessions: null,
+    reinforcedCount: 0,
+    lastReinforcedAt: null,
+    reinforcedQuotes: null,
+    ...overrides,
+  };
+}
+
+type LinkFrom = { id: string; targetFactId: string; linkType: string; strength: number };
+type LinkTo = { id: string; sourceFactId: string; linkType: string; strength: number };
+
+function buildFactsDb(
+  entries: MemoryEntry[],
+  linksFrom: Record<string, LinkFrom[]> = {},
+  linksTo: Record<string, LinkTo[]> = {},
+): GapFactsDB {
+  return {
+    getAll: () => entries,
+    getLinksFrom: (id) => linksFrom[id] ?? [],
+    getLinksTo: (id) => linksTo[id] ?? [],
+  };
+}
+
+function buildVectorDb(
+  results: Record<string, Array<{ entry: { id: string }; score: number }>>,
+): GapVectorDB {
+  return {
+    search: async (_vector, _limit, minScore) => {
+      // Return the first entry from results (keyed by "default" for simplicity)
+      const all = results["default"] ?? [];
+      return all.filter((r) => r.score >= minScore);
+    },
+  };
+}
+
+function buildSearchVectorDb(
+  factToResults: Map<string, Array<{ entry: { id: string }; score: number }>>,
+): GapVectorDB {
+  return {
+    search: async (_vector, _limit, minScore) => {
+      // We can't easily map vector back to factId in a mock, so return all above threshold
+      const all: Array<{ entry: { id: string }; score: number }> = [];
+      for (const results of factToResults.values()) {
+        all.push(...results);
+      }
+      return all.filter((r) => r.score >= minScore);
+    },
+  };
+}
+
+/** Embeddings mock that always returns a fixed vector. */
+function buildEmbeddings(): GapEmbeddings {
+  return {
+    embed: async (_text) => [1, 0, 0],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// computeIsolationScore
+// ---------------------------------------------------------------------------
+
+describe("computeIsolationScore", () => {
+  it("returns 1.0 for 0 links (fully isolated / orphan)", () => {
+    expect(computeIsolationScore(0)).toBe(1.0);
+  });
+
+  it("returns 0.5 for 1 link (weak)", () => {
+    expect(computeIsolationScore(1)).toBe(0.5);
+  });
+
+  it("returns 1/(n+1) for n > 1 links", () => {
+    expect(computeIsolationScore(2)).toBeCloseTo(1 / 3);
+    expect(computeIsolationScore(3)).toBeCloseTo(1 / 4);
+    expect(computeIsolationScore(9)).toBeCloseTo(1 / 10);
+  });
+
+  it("isolation score decreases as link count increases", () => {
+    const scores = [0, 1, 2, 3, 4, 5].map(computeIsolationScore);
+    for (let i = 0; i < scores.length - 1; i++) {
+      expect(scores[i]).toBeGreaterThan(scores[i + 1]);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeRankScore
+// ---------------------------------------------------------------------------
+
+describe("computeRankScore", () => {
+  it("older facts score higher with same isolation", () => {
+    const sixtyDaysAgo = NOW_SEC - 60 * 86_400; // 2× AGE_UNIT → ageFactor = 2
+    const recent = computeRankScore(NOW_SEC, 1.0, NOW_SEC);
+    const old = computeRankScore(sixtyDaysAgo, 1.0, NOW_SEC);
+    expect(old).toBeGreaterThan(recent);
+  });
+
+  it("higher isolation score gives higher rank for same age", () => {
+    const a = computeRankScore(NOW_SEC, 1.0, NOW_SEC);
+    const b = computeRankScore(NOW_SEC, 0.5, NOW_SEC);
+    expect(a).toBeGreaterThan(b);
+  });
+
+  it("returns at least 1.0 for brand-new facts (age_factor ≥ 1)", () => {
+    const score = computeRankScore(NOW_SEC, 1.0, NOW_SEC);
+    expect(score).toBeGreaterThanOrEqual(1.0);
+  });
+
+  it("handles createdAt in the future gracefully (score = isolationScore)", () => {
+    const future = NOW_SEC + 10_000;
+    const score = computeRankScore(future, 0.5, NOW_SEC);
+    // age = max(0, ...) = 0, ageFactor = max(1, ...) = 1
+    expect(score).toBeCloseTo(0.5);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// detectOrphans
+// ---------------------------------------------------------------------------
+
+describe("detectOrphans", () => {
+  it("returns empty array when no facts", () => {
+    const db = buildFactsDb([]);
+    expect(detectOrphans(db, 10, NOW_SEC)).toHaveLength(0);
+  });
+
+  it("returns all zero-link facts", () => {
+    const a = makeEntry("a");
+    const b = makeEntry("b");
+    const db = buildFactsDb([a, b]);
+    const result = detectOrphans(db, 10, NOW_SEC);
+    expect(result.map((g) => g.factId).sort()).toEqual(["a", "b"]);
+  });
+
+  it("excludes facts that have at least one outgoing link", () => {
+    const a = makeEntry("a");
+    const b = makeEntry("b");
+    const db = buildFactsDb(
+      [a, b],
+      { a: [{ id: "l1", targetFactId: "b", linkType: "RELATED_TO", strength: 1.0 }] },
+    );
+    const result = detectOrphans(db, 10, NOW_SEC);
+    expect(result.map((g) => g.factId)).not.toContain("a");
+  });
+
+  it("excludes facts that have at least one incoming link", () => {
+    const a = makeEntry("a");
+    const b = makeEntry("b");
+    const db = buildFactsDb(
+      [a, b],
+      {},
+      { b: [{ id: "l1", sourceFactId: "a", linkType: "RELATED_TO", strength: 1.0 }] },
+    );
+    const result = detectOrphans(db, 10, NOW_SEC);
+    expect(result.map((g) => g.factId)).not.toContain("b");
+  });
+
+  it("sorts by rankScore descending", () => {
+    const old = makeEntry("old", NOW_SEC - 90 * 86_400); // 3× AGE_UNIT → ageFactor 3
+    const recent = makeEntry("recent", NOW_SEC - 1 * 86_400); // < 1 AGE_UNIT → ageFactor 1
+    const db = buildFactsDb([recent, old]);
+    const result = detectOrphans(db, 10, NOW_SEC);
+    expect(result[0].factId).toBe("old");
+    expect(result[1].factId).toBe("recent");
+  });
+
+  it("respects the limit", () => {
+    const facts = ["a", "b", "c", "d", "e"].map((id) => makeEntry(id));
+    const db = buildFactsDb(facts);
+    const result = detectOrphans(db, 3, NOW_SEC);
+    expect(result).toHaveLength(3);
+  });
+
+  it("sets linkCount=0 and isolationScore=1.0 for orphans", () => {
+    const a = makeEntry("a");
+    const db = buildFactsDb([a]);
+    const [gap] = detectOrphans(db, 10, NOW_SEC);
+    expect(gap.linkCount).toBe(0);
+    expect(gap.isolationScore).toBe(1.0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// detectWeak
+// ---------------------------------------------------------------------------
+
+describe("detectWeak", () => {
+  it("returns empty array when no facts have exactly 1 link", () => {
+    const a = makeEntry("a");
+    const db = buildFactsDb([a]); // 0 links
+    expect(detectWeak(db, 10, NOW_SEC)).toHaveLength(0);
+  });
+
+  it("returns facts with exactly 1 outgoing link", () => {
+    const a = makeEntry("a");
+    const b = makeEntry("b");
+    const db = buildFactsDb(
+      [a, b],
+      { a: [{ id: "l1", targetFactId: "b", linkType: "RELATED_TO", strength: 1.0 }] },
+    );
+    const result = detectWeak(db, 10, NOW_SEC);
+    expect(result.map((g) => g.factId)).toContain("a");
+  });
+
+  it("returns facts with exactly 1 incoming link", () => {
+    const a = makeEntry("a");
+    const b = makeEntry("b");
+    const db = buildFactsDb(
+      [a, b],
+      {},
+      { b: [{ id: "l1", sourceFactId: "a", linkType: "RELATED_TO", strength: 1.0 }] },
+    );
+    const result = detectWeak(db, 10, NOW_SEC);
+    expect(result.map((g) => g.factId)).toContain("b");
+  });
+
+  it("counts inbound + outbound together for link count", () => {
+    // fact 'a' has 1 out + 1 in = 2 total → NOT weak
+    const a = makeEntry("a");
+    const b = makeEntry("b");
+    const c = makeEntry("c");
+    const db = buildFactsDb(
+      [a, b, c],
+      { a: [{ id: "l1", targetFactId: "b", linkType: "RELATED_TO", strength: 1.0 }] },
+      { a: [{ id: "l2", sourceFactId: "c", linkType: "RELATED_TO", strength: 1.0 }] },
+    );
+    const result = detectWeak(db, 10, NOW_SEC);
+    expect(result.map((g) => g.factId)).not.toContain("a");
+  });
+
+  it("excludes orphan facts (0 links)", () => {
+    const a = makeEntry("a"); // orphan
+    const db = buildFactsDb([a]);
+    expect(detectWeak(db, 10, NOW_SEC)).toHaveLength(0);
+  });
+
+  it("sorts by rankScore descending", () => {
+    const oldFact = makeEntry("old", NOW_SEC - 90 * 86_400); // ageFactor 3
+    const recentFact = makeEntry("recent", NOW_SEC); // ageFactor 1
+    const target = makeEntry("target");
+    const db = buildFactsDb(
+      [oldFact, recentFact, target],
+      {
+        old: [{ id: "l1", targetFactId: "target", linkType: "RELATED_TO", strength: 1.0 }],
+        recent: [{ id: "l2", targetFactId: "target", linkType: "RELATED_TO", strength: 1.0 }],
+      },
+    );
+    const result = detectWeak(db, 10, NOW_SEC);
+    const ids = result.map((g) => g.factId);
+    expect(ids.indexOf("old")).toBeLessThan(ids.indexOf("recent"));
+  });
+
+  it("respects the limit", () => {
+    const target = makeEntry("target");
+    const sources = ["a", "b", "c", "d", "e"].map((id) => makeEntry(id));
+    const linksFrom: Record<string, LinkFrom[]> = {};
+    for (const s of sources) {
+      linksFrom[s.id] = [{ id: `l-${s.id}`, targetFactId: "target", linkType: "RELATED_TO", strength: 1.0 }];
+    }
+    const db = buildFactsDb([target, ...sources], linksFrom);
+    const result = detectWeak(db, 3, NOW_SEC);
+    expect(result).toHaveLength(3);
+  });
+
+  it("sets linkCount=1 and isolationScore=0.5 for weak facts", () => {
+    const a = makeEntry("a");
+    const b = makeEntry("b");
+    const db = buildFactsDb(
+      [a, b],
+      { a: [{ id: "l1", targetFactId: "b", linkType: "RELATED_TO", strength: 1.0 }] },
+    );
+    const result = detectWeak(db, 10, NOW_SEC);
+    const gapA = result.find((g) => g.factId === "a");
+    expect(gapA?.linkCount).toBe(1);
+    expect(gapA?.isolationScore).toBe(0.5);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// detectSuggestedLinks
+// ---------------------------------------------------------------------------
+
+describe("detectSuggestedLinks", () => {
+  it("returns empty when no candidates (all facts have ≥2 links)", async () => {
+    const a = makeEntry("a");
+    const b = makeEntry("b");
+    // Both have 2 links
+    const db = buildFactsDb(
+      [a, b],
+      {
+        a: [
+          { id: "l1", targetFactId: "b", linkType: "RELATED_TO", strength: 1.0 },
+          { id: "l2", targetFactId: "b", linkType: "CAUSED_BY", strength: 0.8 },
+        ],
+      },
+      {
+        b: [
+          { id: "l1", sourceFactId: "a", linkType: "RELATED_TO", strength: 1.0 },
+          { id: "l3", sourceFactId: "a", linkType: "CAUSED_BY", strength: 0.8 },
+        ],
+      },
+    );
+    const vectorDb = buildVectorDb({ default: [] });
+    const embeds = buildEmbeddings();
+    const result = await detectSuggestedLinks(db, vectorDb, embeds, 0.8, 10, NOW_SEC);
+    expect(result).toHaveLength(0);
+  });
+
+  it("skips pair when it already has a direct link (outgoing)", async () => {
+    const a = makeEntry("a");
+    const b = makeEntry("b");
+    const db = buildFactsDb(
+      [a, b],
+      { a: [{ id: "l1", targetFactId: "b", linkType: "RELATED_TO", strength: 1.0 }] },
+    );
+    const vectorDb = buildVectorDb({
+      default: [{ entry: { id: "b" }, score: 0.95 }],
+    });
+    const embeds = buildEmbeddings();
+    const result = await detectSuggestedLinks(db, vectorDb, embeds, 0.8, 10, NOW_SEC);
+    // 'a' already links to 'b', so no suggestion
+    expect(result.find((s) => s.sourceId === "a" && s.targetId === "b")).toBeUndefined();
+  });
+
+  it("skips self-pairs (same factId)", async () => {
+    const a = makeEntry("a");
+    const db = buildFactsDb([a]);
+    const vectorDb = buildVectorDb({
+      default: [{ entry: { id: "a" }, score: 0.99 }],
+    });
+    const embeds = buildEmbeddings();
+    const result = await detectSuggestedLinks(db, vectorDb, embeds, 0.8, 10, NOW_SEC);
+    expect(result).toHaveLength(0);
+  });
+
+  it("deduplicates symmetric pairs", async () => {
+    const a = makeEntry("a");
+    const b = makeEntry("b");
+    // Both a and b are candidates (0 links each)
+    // The vector DB returns [b] for a's query, [a] for b's query
+    let callCount = 0;
+    const vectorDb: GapVectorDB = {
+      search: async (_vector, _limit, minScore) => {
+        callCount++;
+        if (callCount === 1) return [{ entry: { id: "b" }, score: 0.9 }].filter((r) => r.score >= minScore);
+        return [{ entry: { id: "a" }, score: 0.9 }].filter((r) => r.score >= minScore);
+      },
+    };
+    const db = buildFactsDb([a, b]);
+    const embeds = buildEmbeddings();
+    const result = await detectSuggestedLinks(db, vectorDb, embeds, 0.8, 10, NOW_SEC);
+    // Only one suggestion for a-b pair, not two
+    const pairs = result.filter(
+      (s) =>
+        (s.sourceId === "a" && s.targetId === "b") ||
+        (s.sourceId === "b" && s.targetId === "a"),
+    );
+    expect(pairs).toHaveLength(1);
+  });
+
+  it("returns suggestions sorted by similarity descending", async () => {
+    const a = makeEntry("a");
+    const b = makeEntry("b");
+    const c = makeEntry("c");
+    const db = buildFactsDb([a, b, c]);
+    let callCount = 0;
+    const vectorDb: GapVectorDB = {
+      search: async (_vector, _limit, minScore) => {
+        callCount++;
+        if (callCount === 1) {
+          return [
+            { entry: { id: "b" }, score: 0.9 },
+            { entry: { id: "c" }, score: 0.85 },
+          ].filter((r) => r.score >= minScore);
+        }
+        return [];
+      },
+    };
+    const embeds = buildEmbeddings();
+    const result = await detectSuggestedLinks(db, vectorDb, embeds, 0.8, 10, NOW_SEC);
+    expect(result.length).toBeGreaterThan(0);
+    for (let i = 0; i < result.length - 1; i++) {
+      expect(result[i].similarity).toBeGreaterThanOrEqual(result[i + 1].similarity);
+    }
+  });
+
+  it("respects the limit", async () => {
+    const facts = ["a", "b", "c", "d"].map((id) => makeEntry(id));
+    const db = buildFactsDb(facts);
+    const vectorDb: GapVectorDB = {
+      search: async (_vector, _limit, minScore) =>
+        facts
+          .filter((f) => f.id !== "a")
+          .map((f) => ({ entry: { id: f.id }, score: 0.9 }))
+          .filter((r) => r.score >= minScore),
+    };
+    const embeds = buildEmbeddings();
+    const result = await detectSuggestedLinks(db, vectorDb, embeds, 0.8, 2, NOW_SEC);
+    expect(result.length).toBeLessThanOrEqual(2);
+  });
+
+  it("skips facts where embedding fails", async () => {
+    const a = makeEntry("a");
+    const b = makeEntry("b");
+    const db = buildFactsDb([a, b]);
+    const vectorDb = buildVectorDb({ default: [{ entry: { id: "b" }, score: 0.9 }] });
+    const embeds: GapEmbeddings = {
+      embed: async () => { throw new Error("embed failed"); },
+    };
+    // Should not throw, just return empty
+    const result = await detectSuggestedLinks(db, vectorDb, embeds, 0.8, 10, NOW_SEC);
+    expect(result).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// analyzeKnowledgeGaps
+// ---------------------------------------------------------------------------
+
+describe("analyzeKnowledgeGaps", () => {
+  it('mode="orphans" returns orphans only, no weak/suggested', async () => {
+    const a = makeEntry("a");
+    const b = makeEntry("b");
+    const db = buildFactsDb(
+      [a, b],
+      { a: [{ id: "l1", targetFactId: "b", linkType: "RELATED_TO", strength: 1.0 }] },
+    );
+    const vectorDb = buildVectorDb({ default: [] });
+    const embeds = buildEmbeddings();
+    const report = await analyzeKnowledgeGaps(db, vectorDb, embeds, "orphans", 20, 0.8, NOW_SEC);
+    // 'b' has 1 incoming → not an orphan. Neither is 'a' (has outgoing). Actually both have 1 link.
+    // Let's test with no-link facts
+    const x = makeEntry("x");
+    const db2 = buildFactsDb([x]);
+    const report2 = await analyzeKnowledgeGaps(db2, vectorDb, embeds, "orphans", 20, 0.8, NOW_SEC);
+    expect(report2.orphans).toHaveLength(1);
+    expect(report2.weak).toHaveLength(0);
+    expect(report2.suggestedLinks).toHaveLength(0);
+  });
+
+  it('mode="weak" returns weak only, no orphans/suggested', async () => {
+    const a = makeEntry("a");
+    const b = makeEntry("b");
+    const db = buildFactsDb(
+      [a, b],
+      { a: [{ id: "l1", targetFactId: "b", linkType: "RELATED_TO", strength: 1.0 }] },
+    );
+    const vectorDb = buildVectorDb({ default: [] });
+    const embeds = buildEmbeddings();
+    const report = await analyzeKnowledgeGaps(db, vectorDb, embeds, "weak", 20, 0.8, NOW_SEC);
+    expect(report.orphans).toHaveLength(0);
+    expect(report.weak.length).toBeGreaterThanOrEqual(0); // a or b may have 1 link
+    expect(report.suggestedLinks).toHaveLength(0);
+  });
+
+  it('mode="all" populates all three categories', async () => {
+    const orphan = makeEntry("orphan");
+    const weakA = makeEntry("weakA");
+    const weakB = makeEntry("weakB");
+    const db = buildFactsDb(
+      [orphan, weakA, weakB],
+      { weakA: [{ id: "l1", targetFactId: "weakB", linkType: "RELATED_TO", strength: 1.0 }] },
+    );
+    const vectorDb: GapVectorDB = {
+      search: async (_vector, _limit, minScore) =>
+        [{ entry: { id: "weakB" }, score: 0.9 }].filter((r) => r.score >= minScore),
+    };
+    const embeds = buildEmbeddings();
+    const report = await analyzeKnowledgeGaps(db, vectorDb, embeds, "all", 20, 0.8, NOW_SEC);
+    expect(report.orphans.map((g) => g.factId)).toContain("orphan");
+    expect(report.weak.length).toBeGreaterThan(0);
+    // suggestedLinks may or may not have entries depending on mock, but it's exercised
+    expect(Array.isArray(report.suggestedLinks)).toBe(true);
+  });
+
+  it("uses the provided nowSec for age calculations", async () => {
+    const oldFact = makeEntry("old", 1_000_000); // very old
+    const db = buildFactsDb([oldFact]);
+    const vectorDb = buildVectorDb({ default: [] });
+    const embeds = buildEmbeddings();
+    const nowFar = 1_000_000 + 365 * 86_400; // 1 year later
+    const report = await analyzeKnowledgeGaps(db, vectorDb, embeds, "orphans", 20, 0.8, nowFar);
+    expect(report.orphans).toHaveLength(1);
+    expect(report.orphans[0].rankScore).toBeGreaterThan(12); // ~12 age_units × 1.0 isolation
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration with real FactsDB
+// ---------------------------------------------------------------------------
+
+describe("knowledge gaps — FactsDB integration", () => {
+  let tmpDir: string;
+  let db: InstanceType<typeof FactsDB>;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "gaps-test-"));
+    db = new FactsDB(join(tmpDir, "facts.db"));
+  });
+
+  afterEach(() => {
+    db.close();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("detects orphan facts in a real DB (no links)", () => {
+    const f = db.store({ text: "Orphan fact", entity: null, key: null, value: null, category: "fact", importance: 0.7, source: "test" });
+    const orphans = detectOrphans(db, 20, NOW_SEC);
+    expect(orphans.map((g) => g.factId)).toContain(f.id);
+  });
+
+  it("does not detect linked fact as orphan", () => {
+    const a = db.store({ text: "Fact A", entity: null, key: null, value: null, category: "fact", importance: 0.7, source: "test" });
+    const b = db.store({ text: "Fact B", entity: null, key: null, value: null, category: "fact", importance: 0.7, source: "test" });
+    db.createLink(a.id, b.id, "RELATED_TO", 1.0);
+    const orphans = detectOrphans(db, 20, NOW_SEC);
+    expect(orphans.map((g) => g.factId)).not.toContain(a.id);
+    expect(orphans.map((g) => g.factId)).not.toContain(b.id);
+  });
+
+  it("detects weak fact in a real DB (exactly 1 link)", () => {
+    const a = db.store({ text: "Fact A", entity: null, key: null, value: null, category: "fact", importance: 0.7, source: "test" });
+    const b = db.store({ text: "Fact B", entity: null, key: null, value: null, category: "fact", importance: 0.7, source: "test" });
+    db.createLink(a.id, b.id, "RELATED_TO", 1.0);
+    const weak = detectWeak(db, 20, NOW_SEC);
+    const weakIds = weak.map((g) => g.factId);
+    // 'a' has 1 out link, 'b' has 1 in link — both are weak
+    expect(weakIds).toContain(a.id);
+    expect(weakIds).toContain(b.id);
+  });
+
+  it("does not detect well-connected fact (≥2 links) as weak", () => {
+    const a = db.store({ text: "Fact A", entity: null, key: null, value: null, category: "fact", importance: 0.7, source: "test" });
+    const b = db.store({ text: "Fact B", entity: null, key: null, value: null, category: "fact", importance: 0.7, source: "test" });
+    const c = db.store({ text: "Fact C", entity: null, key: null, value: null, category: "fact", importance: 0.7, source: "test" });
+    db.createLink(a.id, b.id, "RELATED_TO", 1.0);
+    db.createLink(a.id, c.id, "RELATED_TO", 1.0);
+    const weak = detectWeak(db, 20, NOW_SEC);
+    expect(weak.map((g) => g.factId)).not.toContain(a.id);
+  });
+});

--- a/extensions/memory-hybrid/tests/procedure-extractor.test.ts
+++ b/extensions/memory-hybrid/tests/procedure-extractor.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   parseSessionJsonl,
   minimalRecipe,
+  type ParsedSession,
 } from "../services/procedure-extractor.js";
 import type { ProcedureStep } from "../types/memory.js";
 
@@ -57,7 +58,7 @@ describe("procedure-extractor", () => {
           },
         }),
       ];
-      const result = parseSessionJsonl(lines.join("\n"), "session-1");
+      const result = parseSessionJsonl(lines.join("\n"), "session-1") as ParsedSession | null;
       expect(result).not.toBeNull();
       expect(result!.taskIntent).toBe("Check Moltbook notifications");
       expect(result!.steps).toHaveLength(2);
@@ -94,7 +95,7 @@ describe("procedure-extractor", () => {
           },
         }),
       ];
-      const result = parseSessionJsonl(lines.join("\n"), "s2");
+      const result = parseSessionJsonl(lines.join("\n"), "s2") as ParsedSession | null;
       expect(result).not.toBeNull();
       expect(result!.success).toBe(false);
       expect(result!.errorMessage).toContain("404");
@@ -118,7 +119,7 @@ describe("procedure-extractor", () => {
           },
         }),
       ];
-      const result = parseSessionJsonl(lines.join("\n"), "s3");
+      const result = parseSessionJsonl(lines.join("\n"), "s3") as ParsedSession | null;
       expect(result).not.toBeNull();
       expect(result!.taskIntent).toHaveLength(300);
     });

--- a/extensions/memory-hybrid/tests/retrieval-aliases.test.ts
+++ b/extensions/memory-hybrid/tests/retrieval-aliases.test.ts
@@ -1,0 +1,523 @@
+/**
+ * Tests for Issue #149 — Multi-hook Retrieval Aliases.
+ *
+ * Coverage:
+ *   AliasDB:
+ *     - constructor creates fact_aliases table
+ *     - count() returns 0 for empty DB
+ *     - count() returns correct count after stores
+ *     - store() inserts a row and returns a UUID id
+ *     - getByFactId() returns aliases for known factId
+ *     - getByFactId() returns empty array for unknown factId
+ *     - deleteByFactId() removes all aliases for a fact
+ *     - deleteByFactId() does not affect other facts
+ *     - search() returns empty for empty DB
+ *     - search() finds high-similarity alias (exact match → score ≈ 1)
+ *     - search() excludes results below minScore
+ *     - search() deduplicates factId (keeps best score)
+ *     - search() respects limit parameter
+ *     - search() returns results sorted descending by score
+ *   generateAliases:
+ *     - returns parsed lines from LLM response
+ *     - deduplicates identical aliases
+ *     - excludes original fact text from aliases
+ *     - strips numbering/bullets from lines
+ *     - returns empty array on LLM error
+ *     - respects maxAliases limit
+ *   storeAliases:
+ *     - stores embeddings for each generated alias
+ *     - is a no-op when config.enabled is false
+ *     - handles embedding failure gracefully (partial store)
+ *   searchAliasStrategy:
+ *     - returns ranked results matching AliasDB results
+ *     - returns empty array for empty DB
+ *     - source field is "aliases"
+ *   cosineSimilarity:
+ *     - returns 1.0 for identical vectors
+ *     - returns 0 for orthogonal vectors
+ *     - returns 0 for empty / mismatched length
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomUUID } from "node:crypto";
+import {
+  AliasDB,
+  generateAliases,
+  storeAliases,
+  searchAliasStrategy,
+} from "../services/retrieval-aliases.js";
+import { cosineSimilarity } from "../services/ambient-retrieval.js";
+import type { AliasesConfig } from "../config.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "alias-test-"));
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function makeDb(): AliasDB {
+  return new AliasDB(join(tmpDir, `${randomUUID()}.db`));
+}
+
+/** Build a unit vector in `dims` dimensions along axis 0. */
+function unitVec(dims = 4): number[] {
+  const v = new Array(dims).fill(0);
+  v[0] = 1;
+  return v;
+}
+
+/** Build a unit vector along axis 1. Orthogonal to unitVec(). */
+function orthVec(dims = 4): number[] {
+  const v = new Array(dims).fill(0);
+  v[1] = 1;
+  return v;
+}
+
+const ENABLED_CFG: AliasesConfig = {
+  enabled: true,
+  maxAliases: 3,
+};
+
+const DISABLED_CFG: AliasesConfig = {
+  enabled: false,
+  maxAliases: 3,
+};
+
+// ---------------------------------------------------------------------------
+// cosineSimilarity
+// ---------------------------------------------------------------------------
+
+describe("cosineSimilarity", () => {
+  it("returns 1.0 for identical non-zero vectors", () => {
+    const v = [1, 2, 3, 4];
+    expect(cosineSimilarity(v, v)).toBeCloseTo(1.0);
+  });
+
+  it("returns 0 for orthogonal vectors", () => {
+    expect(cosineSimilarity(unitVec(), orthVec())).toBeCloseTo(0);
+  });
+
+  it("returns 0 for empty vectors", () => {
+    expect(cosineSimilarity([], [])).toBe(0);
+  });
+
+  it("returns 0 for mismatched-length vectors", () => {
+    expect(cosineSimilarity([1, 2], [1, 2, 3])).toBe(0);
+  });
+
+  it("returns 0 for zero vector (denom = 0)", () => {
+    expect(cosineSimilarity([0, 0, 0], [1, 2, 3])).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AliasDB
+// ---------------------------------------------------------------------------
+
+describe("AliasDB constructor", () => {
+  it("creates the fact_aliases table on construction", () => {
+    const db = makeDb();
+    expect(db.count()).toBe(0);
+    db.close();
+  });
+});
+
+describe("AliasDB.count", () => {
+  it("returns 0 for empty DB", () => {
+    const db = makeDb();
+    expect(db.count()).toBe(0);
+    db.close();
+  });
+
+  it("returns correct count after storing aliases", () => {
+    const db = makeDb();
+    const factId = randomUUID();
+    db.store(factId, "alias one", unitVec());
+    db.store(factId, "alias two", orthVec());
+    expect(db.count()).toBe(2);
+    db.close();
+  });
+});
+
+describe("AliasDB.store", () => {
+  it("inserts a row and returns a UUID-shaped id", () => {
+    const db = makeDb();
+    const id = db.store(randomUUID(), "test alias", unitVec());
+    expect(typeof id).toBe("string");
+    expect(id.length).toBeGreaterThan(10);
+    expect(db.count()).toBe(1);
+    db.close();
+  });
+
+  it("stores multiple aliases for the same factId", () => {
+    const db = makeDb();
+    const factId = randomUUID();
+    db.store(factId, "alias a", unitVec());
+    db.store(factId, "alias b", orthVec());
+    expect(db.getByFactId(factId)).toHaveLength(2);
+    db.close();
+  });
+});
+
+describe("AliasDB.getByFactId", () => {
+  it("returns all aliases for a known factId", () => {
+    const db = makeDb();
+    const factId = randomUUID();
+    db.store(factId, "phrase one", unitVec());
+    db.store(factId, "phrase two", orthVec());
+    const rows = db.getByFactId(factId);
+    expect(rows).toHaveLength(2);
+    expect(rows.map((r) => r.aliasText).sort()).toEqual(["phrase one", "phrase two"].sort());
+    db.close();
+  });
+
+  it("returns empty array for unknown factId", () => {
+    const db = makeDb();
+    expect(db.getByFactId(randomUUID())).toEqual([]);
+    db.close();
+  });
+});
+
+describe("AliasDB.deleteByFactId", () => {
+  it("removes all aliases for a fact", () => {
+    const db = makeDb();
+    const factId = randomUUID();
+    db.store(factId, "alias 1", unitVec());
+    db.store(factId, "alias 2", orthVec());
+    expect(db.count()).toBe(2);
+    db.deleteByFactId(factId);
+    expect(db.count()).toBe(0);
+    db.close();
+  });
+
+  it("does not affect aliases for other facts", () => {
+    const db = makeDb();
+    const factA = randomUUID();
+    const factB = randomUUID();
+    db.store(factA, "alias for A", unitVec());
+    db.store(factB, "alias for B", orthVec());
+    db.deleteByFactId(factA);
+    expect(db.count()).toBe(1);
+    expect(db.getByFactId(factB)).toHaveLength(1);
+    db.close();
+  });
+});
+
+describe("AliasDB.search", () => {
+  it("returns empty for empty DB", () => {
+    const db = makeDb();
+    expect(db.search(unitVec(), 5, 0.3)).toEqual([]);
+    db.close();
+  });
+
+  it("finds alias with near-perfect cosine match (same vector)", () => {
+    const db = makeDb();
+    const factId = randomUUID();
+    db.store(factId, "exact alias", unitVec());
+    const results = db.search(unitVec(), 5, 0.3);
+    expect(results).toHaveLength(1);
+    expect(results[0].factId).toBe(factId);
+    expect(results[0].score).toBeCloseTo(1.0);
+    db.close();
+  });
+
+  it("excludes results below minScore", () => {
+    const db = makeDb();
+    const factId = randomUUID();
+    // Store orthogonal vector → similarity ≈ 0
+    db.store(factId, "orthogonal", orthVec());
+    const results = db.search(unitVec(), 5, 0.5);
+    expect(results).toHaveLength(0);
+    db.close();
+  });
+
+  it("deduplicates factId: keeps only best score", () => {
+    const db = makeDb();
+    const factId = randomUUID();
+    // Two aliases for the same fact: one close, one not
+    db.store(factId, "close alias", unitVec());
+    const weakVec = [0.9, 0.1, 0, 0]; // normalise when scoring
+    db.store(factId, "weak alias", weakVec);
+    const results = db.search(unitVec(), 5, 0.3);
+    // Should deduplicate to one result
+    expect(results).toHaveLength(1);
+    expect(results[0].factId).toBe(factId);
+    // Score should be the best (≈1.0)
+    expect(results[0].score).toBeGreaterThan(0.9);
+    db.close();
+  });
+
+  it("respects limit parameter", () => {
+    const db = makeDb();
+    // Three facts, each with an alias similar to unitVec
+    for (let i = 0; i < 3; i++) {
+      const v = unitVec();
+      v[0] = 1 - i * 0.01; // slight variation
+      v[1] = i * 0.01;
+      db.store(randomUUID(), `alias ${i}`, v);
+    }
+    const results = db.search(unitVec(), 2, 0.3);
+    expect(results.length).toBeLessThanOrEqual(2);
+    db.close();
+  });
+
+  it("returns results sorted descending by score", () => {
+    const db = makeDb();
+    // fact A: exactly matches unitVec (score ≈ 1)
+    const factA = randomUUID();
+    db.store(factA, "best", unitVec());
+    // fact B: partially matches (score < 1)
+    const factB = randomUUID();
+    db.store(factB, "partial", [1, 1, 0, 0]);
+    const results = db.search(unitVec(), 5, 0.3);
+    expect(results.length).toBeGreaterThanOrEqual(2);
+    expect(results[0].score).toBeGreaterThanOrEqual(results[1].score);
+    db.close();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// generateAliases
+// ---------------------------------------------------------------------------
+
+describe("generateAliases", () => {
+  it("returns parsed lines from a successful LLM response", async () => {
+    const mockOpenAI = {
+      chat: {
+        completions: {
+          create: vi.fn().mockResolvedValue({
+            choices: [{ message: { content: "Alternative one\nAlternative two\nAlternative three" } }],
+          }),
+        },
+      },
+    } as unknown as import("openai").default;
+
+    const aliases = await generateAliases("The user prefers dark mode.", mockOpenAI, "test-model", 5);
+    expect(aliases).toContain("Alternative one");
+    expect(aliases).toContain("Alternative two");
+    expect(aliases).toContain("Alternative three");
+  });
+
+  it("deduplicates identical lines", async () => {
+    const mockOpenAI = {
+      chat: {
+        completions: {
+          create: vi.fn().mockResolvedValue({
+            choices: [{ message: { content: "Same line\nSame line\nOther line" } }],
+          }),
+        },
+      },
+    } as unknown as import("openai").default;
+
+    const aliases = await generateAliases("Fact", mockOpenAI, "test-model", 5);
+    expect(aliases.filter((a) => a === "Same line")).toHaveLength(1);
+  });
+
+  it("excludes the original fact text from aliases", async () => {
+    const factText = "The user prefers vim.";
+    const mockOpenAI = {
+      chat: {
+        completions: {
+          create: vi.fn().mockResolvedValue({
+            choices: [{ message: { content: `${factText}\nUser likes vim.\nVim is the preferred editor.` } }],
+          }),
+        },
+      },
+    } as unknown as import("openai").default;
+
+    const aliases = await generateAliases(factText, mockOpenAI, "test-model", 5);
+    expect(aliases).not.toContain(factText);
+    expect(aliases).toContain("User likes vim.");
+  });
+
+  it("strips leading numbering and bullets from lines", async () => {
+    const mockOpenAI = {
+      chat: {
+        completions: {
+          create: vi.fn().mockResolvedValue({
+            choices: [
+              { message: { content: "1. First alias\n- Second alias\n* Third alias\n2) Fourth alias" } },
+            ],
+          }),
+        },
+      },
+    } as unknown as import("openai").default;
+
+    const aliases = await generateAliases("Fact", mockOpenAI, "test-model", 5);
+    expect(aliases).toContain("First alias");
+    expect(aliases).toContain("Second alias");
+    expect(aliases).toContain("Third alias");
+    expect(aliases).toContain("Fourth alias");
+  });
+
+  it("returns empty array on LLM error", async () => {
+    const mockOpenAI = {
+      chat: {
+        completions: {
+          create: vi.fn().mockRejectedValue(new Error("LLM unavailable")),
+        },
+      },
+    } as unknown as import("openai").default;
+
+    const aliases = await generateAliases("Fact", mockOpenAI, "test-model", 5);
+    expect(aliases).toEqual([]);
+  });
+
+  it("respects maxAliases limit", async () => {
+    const mockOpenAI = {
+      chat: {
+        completions: {
+          create: vi.fn().mockResolvedValue({
+            choices: [{ message: { content: "A\nB\nC\nD\nE\nF\nG" } }],
+          }),
+        },
+      },
+    } as unknown as import("openai").default;
+
+    const aliases = await generateAliases("Fact", mockOpenAI, "test-model", 3);
+    expect(aliases.length).toBeLessThanOrEqual(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// storeAliases
+// ---------------------------------------------------------------------------
+
+describe("storeAliases", () => {
+  it("stores an embedding for each generated alias", async () => {
+    const factId = randomUUID();
+    const db = makeDb();
+
+    const mockOpenAI = {
+      chat: {
+        completions: {
+          create: vi.fn().mockResolvedValue({
+            choices: [{ message: { content: "Alias alpha\nAlias beta" } }],
+          }),
+        },
+      },
+    } as unknown as import("openai").default;
+
+    const mockEmbeddings = {
+      embed: vi.fn().mockResolvedValue(unitVec()),
+    } as unknown as import("../services/embeddings.js").EmbeddingProvider;
+
+    await storeAliases(factId, "Original fact", ENABLED_CFG, "test-model", mockOpenAI, mockEmbeddings, db);
+
+    expect(db.count()).toBe(2);
+    expect(db.getByFactId(factId)).toHaveLength(2);
+    db.close();
+  });
+
+  it("is a no-op when config.enabled is false", async () => {
+    const db = makeDb();
+    const mockOpenAI = {} as unknown as import("openai").default;
+    const mockEmbeddings = { embed: vi.fn() } as unknown as import("../services/embeddings.js").EmbeddingProvider;
+
+    await storeAliases(randomUUID(), "Fact", DISABLED_CFG, "test-model", mockOpenAI, mockEmbeddings, db);
+
+    expect(db.count()).toBe(0);
+    expect(mockEmbeddings.embed).not.toHaveBeenCalled();
+    db.close();
+  });
+
+  it("skips an alias when embedding fails but stores successful ones", async () => {
+    const factId = randomUUID();
+    const db = makeDb();
+
+    const mockOpenAI = {
+      chat: {
+        completions: {
+          create: vi.fn().mockResolvedValue({
+            choices: [{ message: { content: "Good alias\nAnother good alias" } }],
+          }),
+        },
+      },
+    } as unknown as import("openai").default;
+
+    let callCount = 0;
+    const mockEmbeddings = {
+      embed: vi.fn().mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) throw new Error("Embedding API down");
+        return Promise.resolve(unitVec());
+      }),
+    } as unknown as import("../services/embeddings.js").EmbeddingProvider;
+
+    const warnings: string[] = [];
+    await storeAliases(
+      factId,
+      "Original",
+      ENABLED_CFG,
+      "test-model",
+      mockOpenAI,
+      mockEmbeddings,
+      db,
+      (msg) => warnings.push(msg),
+    );
+
+    // Second alias should be stored despite first failing
+    expect(db.count()).toBe(1);
+    expect(warnings.length).toBeGreaterThan(0);
+    db.close();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// searchAliasStrategy
+// ---------------------------------------------------------------------------
+
+describe("searchAliasStrategy", () => {
+  it("returns empty for empty DB", () => {
+    const db = makeDb();
+    const results = searchAliasStrategy(db, unitVec(), 5);
+    expect(results).toEqual([]);
+    db.close();
+  });
+
+  it("returns ranked results matching DB search results", () => {
+    const db = makeDb();
+    const factId = randomUUID();
+    db.store(factId, "alias one", unitVec());
+
+    const results = searchAliasStrategy(db, unitVec(), 5);
+    expect(results).toHaveLength(1);
+    expect(results[0].factId).toBe(factId);
+    expect(results[0].rank).toBe(1);
+    db.close();
+  });
+
+  it("sets source field to 'aliases'", () => {
+    const db = makeDb();
+    db.store(randomUUID(), "alias", unitVec());
+
+    const results = searchAliasStrategy(db, unitVec(), 5);
+    expect(results[0].source).toBe("aliases");
+    db.close();
+  });
+
+  it("assigns ascending ranks starting at 1", () => {
+    const db = makeDb();
+    // Add two facts with similar vectors
+    db.store(randomUUID(), "best", unitVec());
+    db.store(randomUUID(), "second best", [1, 0.1, 0, 0]);
+
+    const results = searchAliasStrategy(db, unitVec(), 5);
+    expect(results.length).toBeGreaterThanOrEqual(2);
+    const ranks = results.map((r) => r.rank);
+    expect(ranks[0]).toBe(1);
+    expect(ranks[1]).toBe(2);
+    db.close();
+  });
+});

--- a/extensions/memory-hybrid/tests/shortest-path.test.ts
+++ b/extensions/memory-hybrid/tests/shortest-path.test.ts
@@ -1,0 +1,630 @@
+/**
+ * Tests for Issue #140 — Shortest-Path Traversal: memory_path BFS.
+ *
+ * Coverage:
+ *   - findShortestPath: same start and end returns 0-hop path
+ *   - findShortestPath: start fact not found returns null
+ *   - findShortestPath: end fact not found returns null
+ *   - findShortestPath: no links returns null
+ *   - findShortestPath: direct edge (1 hop) via outgoing link
+ *   - findShortestPath: direct edge (1 hop) via incoming link (bidirectional)
+ *   - findShortestPath: 2-hop path (A→B→C)
+ *   - findShortestPath: 3-hop path (A→B→C→D)
+ *   - findShortestPath: 4-hop path found with bidirectional BFS
+ *   - findShortestPath: maxDepth=1 blocks 2-hop path
+ *   - findShortestPath: maxDepth=2 blocks 3-hop path
+ *   - findShortestPath: maxDepth=0 returns null even for direct neighbors
+ *   - findShortestPath: shortest path chosen when multiple paths exist
+ *   - findShortestPath: chain contains correct MemoryEntry objects
+ *   - findShortestPath: steps contain correct link types
+ *   - findShortestPath: steps contain correct strength values
+ *   - findShortestPath: hops count equals steps.length
+ *   - findShortestPath: disconnected graph returns null
+ *   - findShortestPath: various link types traversed
+ *   - findShortestPath: integration with real FactsDB
+ *   - resolveInput: returns fact ID when input matches getById
+ *   - resolveInput: returns null for unknown ID without lookup
+ *   - resolveInput: resolves entity name via db.lookup
+ *   - resolveInput: returns null when entity not found
+ *   - resolveInput: empty/whitespace input returns null
+ *   - formatPath: empty steps returns "(same fact)"
+ *   - formatPath: single step formatted correctly
+ *   - formatPath: multi-step path formatted correctly
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { _testing } from "../index.js";
+import type { MemoryEntry } from "../types/memory.js";
+import type { ShortestPathLookup } from "../services/shortest-path.js";
+
+const { findShortestPath, resolveInput, formatPath, FactsDB } = _testing;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeEntry(id: string, overrides: Partial<MemoryEntry> = {}): MemoryEntry {
+  return {
+    id,
+    text: `Text for ${id}`,
+    category: "fact",
+    importance: 0.7,
+    entity: null,
+    key: null,
+    value: null,
+    source: "conversation",
+    createdAt: 1_700_000_000,
+    sourceDate: null,
+    decayClass: "stable",
+    expiresAt: null,
+    lastConfirmedAt: 1_700_000_000,
+    confidence: 1.0,
+    summary: null,
+    tags: null,
+    recallCount: 0,
+    lastAccessed: null,
+    supersededAt: null,
+    supersededBy: null,
+    supersedesId: null,
+    validFrom: null,
+    validUntil: null,
+    tier: "warm",
+    scope: "global",
+    scopeTarget: null,
+    procedureType: null,
+    successCount: 0,
+    lastValidated: null,
+    sourceSessions: null,
+    reinforcedCount: 0,
+    lastReinforcedAt: null,
+    reinforcedQuotes: null,
+    ...overrides,
+  };
+}
+
+type MockLink = { id: string; targetFactId: string; linkType: string; strength: number };
+type MockInLink = { id: string; sourceFactId: string; linkType: string; strength: number };
+
+function buildMockDb(
+  entries: MemoryEntry[],
+  linksFrom: Record<string, MockLink[]>,
+  linksTo: Record<string, MockInLink[]>,
+  lookupMap?: Record<string, MemoryEntry[]>,
+): ShortestPathLookup {
+  const entryMap = new Map(entries.map((e) => [e.id, e]));
+  return {
+    getById: (id: string) => entryMap.get(id) ?? null,
+    getLinksFrom: (id: string) => linksFrom[id] ?? [],
+    getLinksTo: (id: string) => linksTo[id] ?? [],
+    lookup: lookupMap
+      ? (entity: string) =>
+          (lookupMap[entity] ?? []).map((e) => ({ entry: e, score: 1.0 }))
+      : undefined,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// findShortestPath — trivial cases
+// ---------------------------------------------------------------------------
+
+describe("findShortestPath: trivial cases", () => {
+  it("returns 0-hop path when start equals end", () => {
+    const a = makeEntry("a");
+    const db = buildMockDb([a], {}, {});
+    const result = findShortestPath(db, "a", "a");
+    expect(result).not.toBeNull();
+    expect(result!.hops).toBe(0);
+    expect(result!.steps).toHaveLength(0);
+    expect(result!.fromFactId).toBe("a");
+    expect(result!.toFactId).toBe("a");
+    expect(result!.chain).toHaveLength(1);
+    expect(result!.chain[0].id).toBe("a");
+  });
+
+  it("returns null when start fact not found", () => {
+    const b = makeEntry("b");
+    const db = buildMockDb([b], {}, {});
+    const result = findShortestPath(db, "nonexistent", "b");
+    expect(result).toBeNull();
+  });
+
+  it("returns null when end fact not found", () => {
+    const a = makeEntry("a");
+    const db = buildMockDb([a], {}, {});
+    const result = findShortestPath(db, "a", "nonexistent");
+    expect(result).toBeNull();
+  });
+
+  it("returns null when both nodes exist but no links between them", () => {
+    const a = makeEntry("a");
+    const b = makeEntry("b");
+    const db = buildMockDb([a, b], {}, {});
+    const result = findShortestPath(db, "a", "b");
+    expect(result).toBeNull();
+  });
+
+  it("returns null for disconnected graph with links to other nodes", () => {
+    const a = makeEntry("a");
+    const b = makeEntry("b");
+    const c = makeEntry("c");
+    const d = makeEntry("d");
+    // a-b connected, c-d connected, no cross links
+    const db = buildMockDb(
+      [a, b, c, d],
+      { a: [{ id: "l1", targetFactId: "b", linkType: "RELATED_TO", strength: 1.0 }] },
+      { b: [{ id: "l1", sourceFactId: "a", linkType: "RELATED_TO", strength: 1.0 }],
+        d: [{ id: "l2", sourceFactId: "c", linkType: "RELATED_TO", strength: 1.0 }] },
+    );
+    const result = findShortestPath(db, "a", "d");
+    expect(result).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findShortestPath — 1-hop paths
+// ---------------------------------------------------------------------------
+
+describe("findShortestPath: 1-hop paths", () => {
+  it("finds direct path via outgoing edge (A→B)", () => {
+    const a = makeEntry("a");
+    const b = makeEntry("b");
+    const db = buildMockDb(
+      [a, b],
+      { a: [{ id: "l1", targetFactId: "b", linkType: "RELATED_TO", strength: 0.9 }] },
+      {},
+    );
+    const result = findShortestPath(db, "a", "b");
+    expect(result).not.toBeNull();
+    expect(result!.hops).toBe(1);
+    expect(result!.steps).toHaveLength(1);
+    expect(result!.steps[0].fromFactId).toBe("a");
+    expect(result!.steps[0].toFactId).toBe("b");
+    expect(result!.steps[0].linkType).toBe("RELATED_TO");
+    expect(result!.steps[0].strength).toBeCloseTo(0.9);
+  });
+
+  it("finds direct path via incoming edge (B→A traversed as A←B)", () => {
+    const a = makeEntry("a");
+    const b = makeEntry("b");
+    // A has an incoming link from B (B is source, A is target)
+    const db = buildMockDb(
+      [a, b],
+      {},
+      { a: [{ id: "l1", sourceFactId: "b", linkType: "CAUSED_BY", strength: 0.8 }] },
+    );
+    // Path from b to a: b→a via the link (b is source, a is target)
+    const result = findShortestPath(db, "b", "a");
+    expect(result).not.toBeNull();
+    expect(result!.hops).toBe(1);
+    expect(result!.steps[0].linkType).toBe("CAUSED_BY");
+  });
+
+  it("returns correct chain for 1-hop path", () => {
+    const a = makeEntry("a");
+    const b = makeEntry("b");
+    const db = buildMockDb(
+      [a, b],
+      { a: [{ id: "l1", targetFactId: "b", linkType: "PART_OF", strength: 1.0 }] },
+      {},
+    );
+    const result = findShortestPath(db, "a", "b");
+    expect(result!.chain).toHaveLength(2);
+    expect(result!.chain[0].id).toBe("a");
+    expect(result!.chain[1].id).toBe("b");
+  });
+
+  it("hops equals steps.length", () => {
+    const a = makeEntry("a");
+    const b = makeEntry("b");
+    const db = buildMockDb(
+      [a, b],
+      { a: [{ id: "l1", targetFactId: "b", linkType: "DEPENDS_ON", strength: 0.5 }] },
+      {},
+    );
+    const result = findShortestPath(db, "a", "b");
+    expect(result!.hops).toBe(result!.steps.length);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findShortestPath — multi-hop paths
+// ---------------------------------------------------------------------------
+
+describe("findShortestPath: multi-hop paths", () => {
+  it("finds 2-hop path A→B→C", () => {
+    const a = makeEntry("a");
+    const b = makeEntry("b");
+    const c = makeEntry("c");
+    const db = buildMockDb(
+      [a, b, c],
+      {
+        a: [{ id: "l1", targetFactId: "b", linkType: "RELATED_TO", strength: 1.0 }],
+        b: [{ id: "l2", targetFactId: "c", linkType: "PART_OF", strength: 0.7 }],
+      },
+      {},
+    );
+    const result = findShortestPath(db, "a", "c");
+    expect(result).not.toBeNull();
+    expect(result!.hops).toBe(2);
+    expect(result!.steps[0].fromFactId).toBe("a");
+    expect(result!.steps[0].toFactId).toBe("b");
+    expect(result!.steps[1].fromFactId).toBe("b");
+    expect(result!.steps[1].toFactId).toBe("c");
+  });
+
+  it("finds 3-hop path A→B→C→D", () => {
+    const a = makeEntry("a");
+    const b = makeEntry("b");
+    const c = makeEntry("c");
+    const d = makeEntry("d");
+    const db = buildMockDb(
+      [a, b, c, d],
+      {
+        a: [{ id: "l1", targetFactId: "b", linkType: "RELATED_TO", strength: 1.0 }],
+        b: [{ id: "l2", targetFactId: "c", linkType: "CAUSED_BY", strength: 1.0 }],
+        c: [{ id: "l3", targetFactId: "d", linkType: "PART_OF", strength: 1.0 }],
+      },
+      {},
+    );
+    const result = findShortestPath(db, "a", "d", { maxDepth: 5 });
+    expect(result).not.toBeNull();
+    expect(result!.hops).toBe(3);
+  });
+
+  it("finds 4-hop path with bidirectional BFS", () => {
+    // A→B→C→D→E; bidirectional BFS meets at C:
+    //   fwd (hop1): a→b; fwd (hop3): b→c
+    //   bwd (hop2): e←d; bwd (hop4): d←c → c is in fwd!
+    const [a, b, c, d, e] = ["a", "b", "c", "d", "e"].map((id) => makeEntry(id));
+    const db = buildMockDb(
+      [a, b, c, d, e],
+      {
+        a: [{ id: "l1", targetFactId: "b", linkType: "RELATED_TO", strength: 1.0 }],
+        b: [{ id: "l2", targetFactId: "c", linkType: "RELATED_TO", strength: 1.0 }],
+        c: [{ id: "l3", targetFactId: "d", linkType: "RELATED_TO", strength: 1.0 }],
+        d: [{ id: "l4", targetFactId: "e", linkType: "RELATED_TO", strength: 1.0 }],
+      },
+      {
+        b: [{ id: "l1", sourceFactId: "a", linkType: "RELATED_TO", strength: 1.0 }],
+        c: [{ id: "l2", sourceFactId: "b", linkType: "RELATED_TO", strength: 1.0 }],
+        d: [{ id: "l3", sourceFactId: "c", linkType: "RELATED_TO", strength: 1.0 }],
+        e: [{ id: "l4", sourceFactId: "d", linkType: "RELATED_TO", strength: 1.0 }],
+      },
+    );
+    const result = findShortestPath(db, "a", "e", { maxDepth: 5 });
+    expect(result).not.toBeNull();
+    expect(result!.hops).toBe(4);
+    expect(result!.fromFactId).toBe("a");
+    expect(result!.toFactId).toBe("e");
+  });
+
+  it("fromFactId and toFactId are preserved in result", () => {
+    const a = makeEntry("a");
+    const b = makeEntry("b");
+    const db = buildMockDb(
+      [a, b],
+      { a: [{ id: "l1", targetFactId: "b", linkType: "RELATED_TO", strength: 1.0 }] },
+      {},
+    );
+    const result = findShortestPath(db, "a", "b");
+    expect(result!.fromFactId).toBe("a");
+    expect(result!.toFactId).toBe("b");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findShortestPath — maxDepth limits
+// ---------------------------------------------------------------------------
+
+describe("findShortestPath: maxDepth enforcement", () => {
+  it("maxDepth=0 returns null even for nodes that are neighbors", () => {
+    const a = makeEntry("a");
+    const b = makeEntry("b");
+    const db = buildMockDb(
+      [a, b],
+      { a: [{ id: "l1", targetFactId: "b", linkType: "RELATED_TO", strength: 1.0 }] },
+      {},
+    );
+    const result = findShortestPath(db, "a", "b", { maxDepth: 0 });
+    expect(result).toBeNull();
+  });
+
+  it("maxDepth=1 finds 1-hop path", () => {
+    const a = makeEntry("a");
+    const b = makeEntry("b");
+    const db = buildMockDb(
+      [a, b],
+      { a: [{ id: "l1", targetFactId: "b", linkType: "RELATED_TO", strength: 1.0 }] },
+      {},
+    );
+    const result = findShortestPath(db, "a", "b", { maxDepth: 1 });
+    expect(result).not.toBeNull();
+    expect(result!.hops).toBe(1);
+  });
+
+  it("maxDepth=1 blocks 2-hop path", () => {
+    const a = makeEntry("a");
+    const b = makeEntry("b");
+    const c = makeEntry("c");
+    const db = buildMockDb(
+      [a, b, c],
+      {
+        a: [{ id: "l1", targetFactId: "b", linkType: "RELATED_TO", strength: 1.0 }],
+        b: [{ id: "l2", targetFactId: "c", linkType: "RELATED_TO", strength: 1.0 }],
+      },
+      {},
+    );
+    const result = findShortestPath(db, "a", "c", { maxDepth: 1 });
+    expect(result).toBeNull();
+  });
+
+  it("maxDepth=2 blocks 3-hop path", () => {
+    const [a, b, c, d] = ["a", "b", "c", "d"].map((id) => makeEntry(id));
+    const db = buildMockDb(
+      [a, b, c, d],
+      {
+        a: [{ id: "l1", targetFactId: "b", linkType: "RELATED_TO", strength: 1.0 }],
+        b: [{ id: "l2", targetFactId: "c", linkType: "RELATED_TO", strength: 1.0 }],
+        c: [{ id: "l3", targetFactId: "d", linkType: "RELATED_TO", strength: 1.0 }],
+      },
+      {},
+    );
+    const result = findShortestPath(db, "a", "d", { maxDepth: 2 });
+    expect(result).toBeNull();
+  });
+
+  it("maxDepth=3 finds 3-hop path", () => {
+    // A→B→C→D; bidirectional BFS meets at C:
+    //   fwd (hop1): a→b; fwd (hop3): b→c → c is in bwd!
+    //   bwd (hop2): d←c; bwd.get(c)=[c→d]
+    const [a, b, c, d] = ["a", "b", "c", "d"].map((id) => makeEntry(id));
+    const db = buildMockDb(
+      [a, b, c, d],
+      {
+        a: [{ id: "l1", targetFactId: "b", linkType: "RELATED_TO", strength: 1.0 }],
+        b: [{ id: "l2", targetFactId: "c", linkType: "RELATED_TO", strength: 1.0 }],
+        c: [{ id: "l3", targetFactId: "d", linkType: "RELATED_TO", strength: 1.0 }],
+      },
+      {
+        b: [{ id: "l1", sourceFactId: "a", linkType: "RELATED_TO", strength: 1.0 }],
+        c: [{ id: "l2", sourceFactId: "b", linkType: "RELATED_TO", strength: 1.0 }],
+        d: [{ id: "l3", sourceFactId: "c", linkType: "RELATED_TO", strength: 1.0 }],
+      },
+    );
+    const result = findShortestPath(db, "a", "d", { maxDepth: 3 });
+    expect(result).not.toBeNull();
+    expect(result!.hops).toBe(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findShortestPath — shortest path selection
+// ---------------------------------------------------------------------------
+
+describe("findShortestPath: shortest path selection", () => {
+  it("returns 1-hop direct path even when longer alternative exists", () => {
+    const a = makeEntry("a");
+    const b = makeEntry("b");
+    const c = makeEntry("c");
+    // a→b directly, and a→c→b (2 hops)
+    const db = buildMockDb(
+      [a, b, c],
+      {
+        a: [
+          { id: "l1", targetFactId: "b", linkType: "RELATED_TO", strength: 1.0 },
+          { id: "l2", targetFactId: "c", linkType: "PART_OF", strength: 0.5 },
+        ],
+        c: [{ id: "l3", targetFactId: "b", linkType: "CAUSED_BY", strength: 0.3 }],
+      },
+      {},
+    );
+    const result = findShortestPath(db, "a", "b");
+    expect(result!.hops).toBe(1);
+    expect(result!.steps[0].fromFactId).toBe("a");
+    expect(result!.steps[0].toFactId).toBe("b");
+  });
+
+  it("finds 2-hop path when 1-hop is unavailable", () => {
+    const a = makeEntry("a");
+    const b = makeEntry("b");
+    const c = makeEntry("c");
+    const db = buildMockDb(
+      [a, b, c],
+      {
+        a: [{ id: "l1", targetFactId: "c", linkType: "RELATED_TO", strength: 1.0 }],
+        c: [{ id: "l2", targetFactId: "b", linkType: "PART_OF", strength: 1.0 }],
+      },
+      {},
+    );
+    const result = findShortestPath(db, "a", "b");
+    expect(result!.hops).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findShortestPath — link types and strengths
+// ---------------------------------------------------------------------------
+
+describe("findShortestPath: link types and strengths", () => {
+  it("traverses SUPERSEDES links", () => {
+    const a = makeEntry("a");
+    const b = makeEntry("b");
+    const db = buildMockDb(
+      [a, b],
+      { a: [{ id: "l1", targetFactId: "b", linkType: "SUPERSEDES", strength: 1.0 }] },
+      {},
+    );
+    const result = findShortestPath(db, "a", "b");
+    expect(result!.steps[0].linkType).toBe("SUPERSEDES");
+  });
+
+  it("traverses INSTANCE_OF and DERIVED_FROM links", () => {
+    const a = makeEntry("a");
+    const b = makeEntry("b");
+    const c = makeEntry("c");
+    const db = buildMockDb(
+      [a, b, c],
+      {
+        a: [{ id: "l1", targetFactId: "b", linkType: "INSTANCE_OF", strength: 0.9 }],
+        b: [{ id: "l2", targetFactId: "c", linkType: "DERIVED_FROM", strength: 0.8 }],
+      },
+      {},
+    );
+    const result = findShortestPath(db, "a", "c");
+    expect(result!.steps[0].linkType).toBe("INSTANCE_OF");
+    expect(result!.steps[1].linkType).toBe("DERIVED_FROM");
+  });
+
+  it("preserves edge strength in steps", () => {
+    const a = makeEntry("a");
+    const b = makeEntry("b");
+    const db = buildMockDb(
+      [a, b],
+      { a: [{ id: "l1", targetFactId: "b", linkType: "RELATED_TO", strength: 0.42 }] },
+      {},
+    );
+    const result = findShortestPath(db, "a", "b");
+    expect(result!.steps[0].strength).toBeCloseTo(0.42);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveInput
+// ---------------------------------------------------------------------------
+
+describe("resolveInput", () => {
+  it("returns fact ID when input directly matches getById", () => {
+    const a = makeEntry("fact-abc-123");
+    const db = buildMockDb([a], {}, {});
+    expect(resolveInput(db, "fact-abc-123")).toBe("fact-abc-123");
+  });
+
+  it("returns null for unknown ID when no lookup is provided", () => {
+    const db = buildMockDb([], {}, {});
+    expect(resolveInput(db, "unknown-id")).toBeNull();
+  });
+
+  it("resolves entity name via db.lookup", () => {
+    const a = makeEntry("entity-fact-id");
+    const db = buildMockDb([a], {}, {}, { "myEntity": [a] });
+    expect(resolveInput(db, "myEntity")).toBe("entity-fact-id");
+  });
+
+  it("returns null when entity name not found via lookup", () => {
+    const db = buildMockDb([], {}, {}, { "other": [] });
+    expect(resolveInput(db, "unknown-entity")).toBeNull();
+  });
+
+  it("returns null for empty string", () => {
+    const db = buildMockDb([], {}, {});
+    expect(resolveInput(db, "")).toBeNull();
+  });
+
+  it("returns null for whitespace-only string", () => {
+    const db = buildMockDb([], {}, {});
+    expect(resolveInput(db, "   ")).toBeNull();
+  });
+
+  it("prefers fact ID over entity name when ID exists", () => {
+    const a = makeEntry("real-id");
+    const b = makeEntry("entity-id");
+    const db = buildMockDb([a, b], {}, {}, { "real-id": [b] });
+    // "real-id" matches getById directly → returns "real-id", not "entity-id"
+    expect(resolveInput(db, "real-id")).toBe("real-id");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatPath
+// ---------------------------------------------------------------------------
+
+describe("formatPath", () => {
+  it("returns (same fact) for empty steps", () => {
+    expect(formatPath([])).toBe("(same fact)");
+  });
+
+  it("formats single step correctly", () => {
+    const steps = [{ fromFactId: "abcdef12", toFactId: "12345678", linkType: "RELATED_TO", strength: 1.0 }];
+    const out = formatPath(steps);
+    expect(out).toContain("abcdef12");
+    expect(out).toContain("RELATED_TO");
+    expect(out).toContain("12345678");
+  });
+
+  it("formats multi-step path with all nodes", () => {
+    const steps = [
+      { fromFactId: "aaa", toFactId: "bbb", linkType: "PART_OF", strength: 1.0 },
+      { fromFactId: "bbb", toFactId: "ccc", linkType: "CAUSED_BY", strength: 0.5 },
+    ];
+    const out = formatPath(steps);
+    expect(out).toContain("aaa");
+    expect(out).toContain("PART_OF");
+    expect(out).toContain("bbb");
+    expect(out).toContain("CAUSED_BY");
+    expect(out).toContain("ccc");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration with real FactsDB
+// ---------------------------------------------------------------------------
+
+describe("findShortestPath: integration with FactsDB", () => {
+  let tmpDir: string;
+  let factsDb: InstanceType<typeof FactsDB>;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "shortest-path-test-"));
+    factsDb = new FactsDB(join(tmpDir, "test.db"));
+  });
+
+  afterEach(() => {
+    factsDb.close();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("finds direct path in real DB", () => {
+    const aId = factsDb.store({ text: "Fact A", category: "fact", importance: 0.7, source: "test", entity: null, key: null, value: null }).id;
+    const bId = factsDb.store({ text: "Fact B", category: "fact", importance: 0.7, source: "test", entity: null, key: null, value: null }).id;
+    factsDb.createLink(aId, bId, "RELATED_TO", 1.0);
+
+    const result = findShortestPath(factsDb, aId, bId, { maxDepth: 5 });
+    expect(result).not.toBeNull();
+    expect(result!.hops).toBe(1);
+    expect(result!.steps[0].linkType).toBe("RELATED_TO");
+  });
+
+  it("finds 2-hop path in real DB", () => {
+    const aId = factsDb.store({ text: "Fact A", category: "fact", importance: 0.7, source: "test", entity: null, key: null, value: null }).id;
+    const bId = factsDb.store({ text: "Fact B", category: "fact", importance: 0.7, source: "test", entity: null, key: null, value: null }).id;
+    const cId = factsDb.store({ text: "Fact C", category: "fact", importance: 0.7, source: "test", entity: null, key: null, value: null }).id;
+    factsDb.createLink(aId, bId, "PART_OF", 1.0);
+    factsDb.createLink(bId, cId, "CAUSED_BY", 0.8);
+
+    const result = findShortestPath(factsDb, aId, cId, { maxDepth: 5 });
+    expect(result).not.toBeNull();
+    expect(result!.hops).toBe(2);
+  });
+
+  it("returns null when no path in real DB", () => {
+    const aId = factsDb.store({ text: "Fact A", category: "fact", importance: 0.7, source: "test", entity: null, key: null, value: null }).id;
+    const bId = factsDb.store({ text: "Fact B", category: "fact", importance: 0.7, source: "test", entity: null, key: null, value: null }).id;
+
+    const result = findShortestPath(factsDb, aId, bId, { maxDepth: 5 });
+    expect(result).toBeNull();
+  });
+
+  it("chain contains correct MemoryEntry objects in real DB", () => {
+    const aId = factsDb.store({ text: "Fact A", category: "fact", importance: 0.7, source: "test", entity: null, key: null, value: null }).id;
+    const bId = factsDb.store({ text: "Fact B", category: "fact", importance: 0.7, source: "test", entity: null, key: null, value: null }).id;
+    factsDb.createLink(aId, bId, "RELATED_TO", 1.0);
+
+    const result = findShortestPath(factsDb, aId, bId, { maxDepth: 5 });
+    expect(result!.chain).toHaveLength(2);
+    expect(result!.chain[0].text).toBe("Fact A");
+    expect(result!.chain[1].text).toBe("Fact B");
+  });
+});

--- a/extensions/memory-hybrid/tests/topic-clusters.test.ts
+++ b/extensions/memory-hybrid/tests/topic-clusters.test.ts
@@ -1,0 +1,578 @@
+/**
+ * Tests for Issue #146 — Topic Cluster Detection.
+ *
+ * Coverage:
+ *   - detectClusters: empty graph returns no clusters
+ *   - detectClusters: single isolated fact returns no cluster
+ *   - detectClusters: pair below minClusterSize → isolated
+ *   - detectClusters: triangle of 3 linked facts forms one cluster
+ *   - detectClusters: minClusterSize=2 includes pairs
+ *   - detectClusters: two disconnected components form two separate clusters
+ *   - detectClusters: large connected component identified correctly
+ *   - detectClusters: BFS reaches transitive connections
+ *   - detectClusters: bidirectional traversal (incoming + outgoing edges)
+ *   - detectClusters: cluster factIds are sorted for stability
+ *   - detectClusters: clusters sorted by size desc
+ *   - detectClusters: isolatedFacts count matches below-threshold components
+ *   - detectClusters: totalLinkedFacts reports all linked facts
+ *   - detectClusters: existingClusterIds reuses stable IDs
+ *   - detectClusters: cluster-aware retrieval boosting (factIds usable for filtering)
+ *   - generateClusterLabel: uses most common entity
+ *   - generateClusterLabel: falls back to most common tag when no entity
+ *   - generateClusterLabel: falls back to category when no entity/tag
+ *   - generateClusterLabel: returns generic label for empty entries
+ *   - generateClusterLabel: limits label to 3 words max
+ *   - Integration: FactsDB.getAllLinkedFactIds returns correct IDs
+ *   - Integration: FactsDB.getAllLinks returns all edges
+ *   - Integration: FactsDB.saveClusters persists and getClusters retrieves
+ *   - Integration: FactsDB.getClusterMembers returns member IDs
+ *   - Integration: FactsDB.getFactClusterId resolves cluster for a fact
+ *   - Integration: saveClusters replaces existing data atomically
+ *   - Integration: detectClusters + saveClusters round-trip on real DB
+ *   - Integration: incremental re-cluster reuses cluster IDs when components unchanged
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { _testing } from "../index.js";
+import type { MemoryEntry } from "../types/memory.js";
+import type { ClusterFactLookup, TopicCluster } from "../services/topic-clusters.js";
+
+const { detectClusters, generateClusterLabel, FactsDB } = _testing;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeEntry(id: string, overrides: Partial<MemoryEntry> = {}): MemoryEntry {
+  return {
+    id,
+    text: `Text for ${id}`,
+    category: "fact",
+    importance: 0.7,
+    entity: null,
+    key: null,
+    value: null,
+    source: "conversation",
+    createdAt: 1_700_000_000,
+    sourceDate: null,
+    decayClass: "stable",
+    expiresAt: null,
+    lastConfirmedAt: 1_700_000_000,
+    confidence: 1.0,
+    summary: null,
+    tags: null,
+    recallCount: 0,
+    lastAccessed: null,
+    supersededAt: null,
+    supersededBy: null,
+    supersedesId: null,
+    validFrom: null,
+    validUntil: null,
+    tier: "warm",
+    scope: "global",
+    scopeTarget: null,
+    procedureType: null,
+    successCount: 0,
+    lastValidated: null,
+    sourceSessions: null,
+    reinforcedCount: 0,
+    lastReinforcedAt: null,
+    reinforcedQuotes: null,
+    ...overrides,
+  };
+}
+
+/** Build a minimal ClusterFactLookup mock. */
+function buildMockDb(
+  entries: MemoryEntry[],
+  edges: Array<{ sourceFactId: string; targetFactId: string }>,
+): ClusterFactLookup {
+  const entryMap = new Map(entries.map((e) => [e.id, e]));
+  const linkedIds = new Set<string>();
+  for (const { sourceFactId, targetFactId } of edges) {
+    linkedIds.add(sourceFactId);
+    linkedIds.add(targetFactId);
+  }
+  return {
+    getAllLinkedFactIds: () => [...linkedIds],
+    getAllLinks: () => edges,
+    getById: (id: string) => entryMap.get(id) ?? null,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// detectClusters — empty and trivial cases
+// ---------------------------------------------------------------------------
+
+describe("detectClusters: empty/trivial cases", () => {
+  it("returns no clusters when graph has no linked facts", () => {
+    const db = buildMockDb([], []);
+    const result = detectClusters(db);
+    expect(result.clusters).toHaveLength(0);
+    expect(result.isolatedFacts).toBe(0);
+    expect(result.totalLinkedFacts).toBe(0);
+  });
+
+  it("returns no cluster for a single isolated fact (no links)", () => {
+    // No edges → no linked IDs → nothing to cluster
+    const db = buildMockDb([makeEntry("a")], []);
+    const result = detectClusters(db);
+    expect(result.clusters).toHaveLength(0);
+    expect(result.totalLinkedFacts).toBe(0);
+  });
+
+  it("pair of linked facts (size 2) is below default minClusterSize=3 → isolated", () => {
+    const db = buildMockDb(
+      [makeEntry("a"), makeEntry("b")],
+      [{ sourceFactId: "a", targetFactId: "b" }],
+    );
+    const result = detectClusters(db, { minClusterSize: 3 });
+    expect(result.clusters).toHaveLength(0);
+    expect(result.isolatedFacts).toBe(2);
+    expect(result.totalLinkedFacts).toBe(2);
+  });
+
+  it("pair of linked facts forms a cluster when minClusterSize=2", () => {
+    const db = buildMockDb(
+      [makeEntry("a"), makeEntry("b")],
+      [{ sourceFactId: "a", targetFactId: "b" }],
+    );
+    const result = detectClusters(db, { minClusterSize: 2 });
+    expect(result.clusters).toHaveLength(1);
+    expect(result.clusters[0].factCount).toBe(2);
+    expect(result.isolatedFacts).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// detectClusters — component detection
+// ---------------------------------------------------------------------------
+
+describe("detectClusters: component detection", () => {
+  it("triangle of 3 linked facts forms one cluster (default minClusterSize=3)", () => {
+    const db = buildMockDb(
+      [makeEntry("a"), makeEntry("b"), makeEntry("c")],
+      [
+        { sourceFactId: "a", targetFactId: "b" },
+        { sourceFactId: "b", targetFactId: "c" },
+        { sourceFactId: "a", targetFactId: "c" },
+      ],
+    );
+    const result = detectClusters(db);
+    expect(result.clusters).toHaveLength(1);
+    expect(result.clusters[0].factCount).toBe(3);
+    expect(result.clusters[0].factIds).toEqual(["a", "b", "c"]);
+  });
+
+  it("two disconnected components form two separate clusters", () => {
+    const db = buildMockDb(
+      ["a", "b", "c", "d", "e", "f"].map((id) => makeEntry(id)),
+      [
+        { sourceFactId: "a", targetFactId: "b" },
+        { sourceFactId: "b", targetFactId: "c" },
+        { sourceFactId: "d", targetFactId: "e" },
+        { sourceFactId: "e", targetFactId: "f" },
+      ],
+    );
+    const result = detectClusters(db, { minClusterSize: 3 });
+    expect(result.clusters).toHaveLength(2);
+    const sizes = result.clusters.map((c) => c.factCount).sort((a, b) => b - a);
+    expect(sizes).toEqual([3, 3]);
+  });
+
+  it("BFS reaches transitive connections (chain a→b→c→d)", () => {
+    const db = buildMockDb(
+      ["a", "b", "c", "d"].map((id) => makeEntry(id)),
+      [
+        { sourceFactId: "a", targetFactId: "b" },
+        { sourceFactId: "b", targetFactId: "c" },
+        { sourceFactId: "c", targetFactId: "d" },
+      ],
+    );
+    const result = detectClusters(db, { minClusterSize: 4 });
+    expect(result.clusters).toHaveLength(1);
+    expect(result.clusters[0].factIds).toEqual(["a", "b", "c", "d"]);
+  });
+
+  it("bidirectional traversal: incoming edge expands the component", () => {
+    // Only b→a edge exists; starting from "a" we should still find "b"
+    const db = buildMockDb(
+      ["a", "b", "c"].map((id) => makeEntry(id)),
+      [
+        { sourceFactId: "b", targetFactId: "a" }, // incoming to a
+        { sourceFactId: "a", targetFactId: "c" }, // outgoing from a
+      ],
+    );
+    const result = detectClusters(db, { minClusterSize: 3 });
+    expect(result.clusters).toHaveLength(1);
+    expect(result.clusters[0].factCount).toBe(3);
+  });
+
+  it("multiple components where some are below threshold (mixed)", () => {
+    // Component 1: a-b-c (size 3) — above threshold
+    // Component 2: d-e   (size 2) — below threshold → isolated
+    const db = buildMockDb(
+      ["a", "b", "c", "d", "e"].map((id) => makeEntry(id)),
+      [
+        { sourceFactId: "a", targetFactId: "b" },
+        { sourceFactId: "b", targetFactId: "c" },
+        { sourceFactId: "d", targetFactId: "e" },
+      ],
+    );
+    const result = detectClusters(db, { minClusterSize: 3 });
+    expect(result.clusters).toHaveLength(1);
+    expect(result.clusters[0].factCount).toBe(3);
+    expect(result.isolatedFacts).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// detectClusters — cluster properties
+// ---------------------------------------------------------------------------
+
+describe("detectClusters: cluster properties", () => {
+  it("cluster factIds are sorted lexicographically for stability", () => {
+    const db = buildMockDb(
+      ["c", "a", "b"].map((id) => makeEntry(id)),
+      [
+        { sourceFactId: "c", targetFactId: "a" },
+        { sourceFactId: "a", targetFactId: "b" },
+      ],
+    );
+    const result = detectClusters(db, { minClusterSize: 3 });
+    expect(result.clusters[0].factIds).toEqual(["a", "b", "c"]);
+  });
+
+  it("clusters are sorted by size descending (largest first)", () => {
+    const db = buildMockDb(
+      ["a", "b", "c", "d", "e", "f", "g"].map((id) => makeEntry(id)),
+      [
+        { sourceFactId: "a", targetFactId: "b" },
+        { sourceFactId: "b", targetFactId: "c" },
+        { sourceFactId: "c", targetFactId: "d" }, // 4-node component
+        { sourceFactId: "e", targetFactId: "f" },
+        { sourceFactId: "f", targetFactId: "g" }, // 3-node component
+      ],
+    );
+    const result = detectClusters(db, { minClusterSize: 3 });
+    expect(result.clusters[0].factCount).toBeGreaterThanOrEqual(result.clusters[1].factCount);
+  });
+
+  it("each cluster has a non-empty label", () => {
+    const db = buildMockDb(
+      ["a", "b", "c"].map((id) => makeEntry(id)),
+      [
+        { sourceFactId: "a", targetFactId: "b" },
+        { sourceFactId: "b", targetFactId: "c" },
+      ],
+    );
+    const result = detectClusters(db, { minClusterSize: 3 });
+    expect(result.clusters[0].label.length).toBeGreaterThan(0);
+  });
+
+  it("each cluster has a valid UUID id", () => {
+    const db = buildMockDb(
+      ["a", "b", "c"].map((id) => makeEntry(id)),
+      [
+        { sourceFactId: "a", targetFactId: "b" },
+        { sourceFactId: "b", targetFactId: "c" },
+      ],
+    );
+    const result = detectClusters(db, { minClusterSize: 3 });
+    const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+    expect(result.clusters[0].id).toMatch(uuidRegex);
+  });
+
+  it("existingClusterIds reuses stable IDs for same component", () => {
+    const edges = [
+      { sourceFactId: "a", targetFactId: "b" },
+      { sourceFactId: "b", targetFactId: "c" },
+    ];
+    const db = buildMockDb(["a", "b", "c"].map((id) => makeEntry(id)), edges);
+
+    // First run
+    const firstResult = detectClusters(db, { minClusterSize: 3 });
+    const firstId = firstResult.clusters[0].id;
+    const firstCreatedAt = firstResult.clusters[0].createdAt;
+    const componentKey = firstResult.clusters[0].factIds.join(",");
+
+    // Second run with existing IDs map
+    const existingClusterIds = new Map([[componentKey, { id: firstId, createdAt: firstCreatedAt }]]);
+    const secondResult = detectClusters(db, { minClusterSize: 3, existingClusterIds });
+    expect(secondResult.clusters[0].id).toBe(firstId);
+    expect(secondResult.clusters[0].createdAt).toBe(firstCreatedAt);
+  });
+
+  it("totalLinkedFacts counts all unique facts appearing in links", () => {
+    const db = buildMockDb(
+      ["a", "b", "c", "d"].map((id) => makeEntry(id)),
+      [
+        { sourceFactId: "a", targetFactId: "b" },
+        { sourceFactId: "b", targetFactId: "c" }, // "b" appears twice but counted once
+        { sourceFactId: "c", targetFactId: "d" },
+      ],
+    );
+    const result = detectClusters(db, { minClusterSize: 5 });
+    expect(result.totalLinkedFacts).toBe(4);
+    expect(result.isolatedFacts).toBe(4);
+  });
+
+  it("cluster-aware retrieval: factIds can be used to filter/boost search results", () => {
+    const db = buildMockDb(
+      ["a", "b", "c"].map((id) => makeEntry(id)),
+      [
+        { sourceFactId: "a", targetFactId: "b" },
+        { sourceFactId: "b", targetFactId: "c" },
+      ],
+    );
+    const result = detectClusters(db, { minClusterSize: 3 });
+    const clusterFactSet = new Set(result.clusters[0].factIds);
+    // Simulate retrieval boost: any result in the cluster gets boosted
+    const searchResults = [
+      { factId: "a", score: 0.5 },
+      { factId: "x", score: 0.9 }, // not in cluster
+    ];
+    const boosted = searchResults.map((r) =>
+      clusterFactSet.has(r.factId) ? { ...r, score: r.score + 0.1 } : r,
+    );
+    expect(boosted.find((r) => r.factId === "a")!.score).toBeCloseTo(0.6);
+    expect(boosted.find((r) => r.factId === "x")!.score).toBeCloseTo(0.9);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// generateClusterLabel
+// ---------------------------------------------------------------------------
+
+describe("generateClusterLabel", () => {
+  it("returns generic label for empty entries array", () => {
+    expect(generateClusterLabel([])).toBe("knowledge cluster");
+  });
+
+  it("uses most common entity across cluster members", () => {
+    const entries = [
+      makeEntry("a", { entity: "PostgreSQL" }),
+      makeEntry("b", { entity: "PostgreSQL" }),
+      makeEntry("c", { entity: "Redis" }),
+    ];
+    const label = generateClusterLabel(entries);
+    expect(label).toContain("postgresql");
+  });
+
+  it("falls back to most common tag when no entity", () => {
+    const entries = [
+      makeEntry("a", { tags: ["auth", "security"] }),
+      makeEntry("b", { tags: ["auth"] }),
+      makeEntry("c", { tags: ["logging"] }),
+    ];
+    const label = generateClusterLabel(entries);
+    expect(label).toContain("auth");
+  });
+
+  it("falls back to category when no entity or tag", () => {
+    const entries = [
+      makeEntry("a", { category: "preference" }),
+      makeEntry("b", { category: "preference" }),
+      makeEntry("c", { category: "fact" }),
+    ];
+    const label = generateClusterLabel(entries);
+    expect(label).toContain("preference");
+  });
+
+  it("limits label to 3 words from entity", () => {
+    const entries = [makeEntry("a", { entity: "word1_word2_word3_word4" })];
+    const label = generateClusterLabel(entries);
+    const wordCount = label.split(/\s+/).filter(Boolean).length;
+    expect(wordCount).toBeLessThanOrEqual(3);
+  });
+
+  it("entity label is lowercased", () => {
+    const entries = [makeEntry("a", { entity: "MyBigService" })];
+    const label = generateClusterLabel(entries);
+    expect(label).toBe(label.toLowerCase());
+  });
+
+  it("tag label is lowercased", () => {
+    const entries = [makeEntry("a", { tags: ["MyTag"] })];
+    const label = generateClusterLabel(entries);
+    expect(label).toBe(label.toLowerCase());
+  });
+
+  it("entity wins over tag when both are present", () => {
+    const entries = [
+      makeEntry("a", { entity: "serverX", tags: ["tagA", "tagA", "tagA"] }),
+    ];
+    // entity should take priority
+    const label = generateClusterLabel(entries);
+    expect(label).toContain("serverx");
+  });
+
+  it("picks the most frequent entity (majority wins)", () => {
+    const entries = [
+      makeEntry("a", { entity: "alpha" }),
+      makeEntry("b", { entity: "beta" }),
+      makeEntry("c", { entity: "beta" }),
+    ];
+    const label = generateClusterLabel(entries);
+    expect(label).toBe("beta");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: real FactsDB
+// ---------------------------------------------------------------------------
+
+let tmpDir: string;
+let db: InstanceType<typeof FactsDB>;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "topic-clusters-test-"));
+  db = new FactsDB(join(tmpDir, "facts.db"));
+});
+
+afterEach(() => {
+  db.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function storeFact(text: string, entity: string | null = null) {
+  return db.store({ text, entity, key: null, value: null, category: "fact", importance: 0.7, source: "test" });
+}
+
+describe("Integration: FactsDB cluster methods", () => {
+  it("getAllLinkedFactIds returns IDs from memory_links", () => {
+    const a = storeFact("Alpha");
+    const b = storeFact("Beta");
+    db.createLink(a.id, b.id, "RELATED_TO", 0.8);
+
+    const ids = db.getAllLinkedFactIds();
+    expect(ids).toContain(a.id);
+    expect(ids).toContain(b.id);
+  });
+
+  it("getAllLinkedFactIds deduplicates IDs that appear in multiple links", () => {
+    const a = storeFact("Alpha");
+    const b = storeFact("Beta");
+    const c = storeFact("Gamma");
+    db.createLink(a.id, b.id, "RELATED_TO", 0.8);
+    db.createLink(a.id, c.id, "RELATED_TO", 0.7); // "a" appears in two links
+
+    const ids = db.getAllLinkedFactIds();
+    const aCount = ids.filter((id) => id === a.id).length;
+    expect(aCount).toBe(1); // no duplicates
+  });
+
+  it("getAllLinkedFactIds returns empty array when no links", () => {
+    storeFact("Isolated");
+    const ids = db.getAllLinkedFactIds();
+    expect(ids).toHaveLength(0);
+  });
+
+  it("getAllLinks returns all edges", () => {
+    const a = storeFact("A");
+    const b = storeFact("B");
+    const c = storeFact("C");
+    db.createLink(a.id, b.id, "RELATED_TO", 1.0);
+    db.createLink(b.id, c.id, "PART_OF", 0.9);
+
+    const links = db.getAllLinks();
+    expect(links).toHaveLength(2);
+    const sources = links.map((l) => l.sourceFactId);
+    expect(sources).toContain(a.id);
+    expect(sources).toContain(b.id);
+  });
+
+  it("saveClusters persists and getClusters retrieves", () => {
+    const now = Math.floor(Date.now() / 1000);
+    const clusters = [
+      { id: "cluster-1", label: "test cluster", factIds: ["f1", "f2", "f3"], factCount: 3, createdAt: now, updatedAt: now },
+    ];
+    db.saveClusters(clusters);
+
+    const retrieved = db.getClusters();
+    expect(retrieved).toHaveLength(1);
+    expect(retrieved[0].id).toBe("cluster-1");
+    expect(retrieved[0].label).toBe("test cluster");
+    expect(retrieved[0].factCount).toBe(3);
+  });
+
+  it("getClusterMembers returns all member fact IDs", () => {
+    const now = Math.floor(Date.now() / 1000);
+    const clusters = [
+      { id: "c1", label: "my cluster", factIds: ["f1", "f2", "f3"], factCount: 3, createdAt: now, updatedAt: now },
+    ];
+    db.saveClusters(clusters);
+
+    const members = db.getClusterMembers("c1");
+    expect(members).toHaveLength(3);
+    expect(members).toContain("f1");
+    expect(members).toContain("f2");
+    expect(members).toContain("f3");
+  });
+
+  it("getFactClusterId returns the cluster ID for a member fact", () => {
+    const now = Math.floor(Date.now() / 1000);
+    db.saveClusters([
+      { id: "c1", label: "alpha", factIds: ["f1", "f2", "f3"], factCount: 3, createdAt: now, updatedAt: now },
+    ]);
+    expect(db.getFactClusterId("f1")).toBe("c1");
+    expect(db.getFactClusterId("f99")).toBeNull();
+  });
+
+  it("saveClusters replaces all previous clusters atomically", () => {
+    const now = Math.floor(Date.now() / 1000);
+    db.saveClusters([
+      { id: "old-1", label: "old cluster", factIds: ["a", "b", "c"], factCount: 3, createdAt: now, updatedAt: now },
+    ]);
+    // Save again with completely different clusters
+    db.saveClusters([
+      { id: "new-1", label: "new cluster", factIds: ["x", "y", "z"], factCount: 3, createdAt: now, updatedAt: now },
+    ]);
+    const retrieved = db.getClusters();
+    expect(retrieved).toHaveLength(1);
+    expect(retrieved[0].id).toBe("new-1");
+  });
+
+  it("detectClusters + saveClusters round-trip on real DB", () => {
+    const a = storeFact("Alpha about database");
+    const b = storeFact("Beta about database");
+    const c = storeFact("Gamma about database");
+    db.createLink(a.id, b.id, "RELATED_TO", 0.9);
+    db.createLink(b.id, c.id, "RELATED_TO", 0.8);
+
+    const result = detectClusters(db, { minClusterSize: 3 });
+    expect(result.clusters).toHaveLength(1);
+
+    db.saveClusters(result.clusters);
+    const saved = db.getClusters();
+    expect(saved).toHaveLength(1);
+    expect(saved[0].factCount).toBe(3);
+    const members = db.getClusterMembers(saved[0].id);
+    expect(members).toContain(a.id);
+    expect(members).toContain(b.id);
+    expect(members).toContain(c.id);
+  });
+
+  it("incremental re-cluster reuses cluster IDs when components unchanged", () => {
+    const a = storeFact("A");
+    const b = storeFact("B");
+    const c = storeFact("C");
+    db.createLink(a.id, b.id, "RELATED_TO", 1.0);
+    db.createLink(b.id, c.id, "RELATED_TO", 1.0);
+
+    // First detection
+    const first = detectClusters(db, { minClusterSize: 3 });
+    const firstId = first.clusters[0].id;
+    const firstCreatedAt = first.clusters[0].createdAt;
+    const componentKey = first.clusters[0].factIds.join(",");
+
+    // Second detection with stable ID map
+    const existingClusterIds = new Map([[componentKey, { id: firstId, createdAt: firstCreatedAt }]]);
+    const second = detectClusters(db, { minClusterSize: 3, existingClusterIds });
+    expect(second.clusters[0].id).toBe(firstId);
+    expect(second.clusters[0].createdAt).toBe(firstCreatedAt);
+  });
+});

--- a/extensions/memory-hybrid/tools/graph-tools.ts
+++ b/extensions/memory-hybrid/tools/graph-tools.ts
@@ -12,6 +12,7 @@ import { stringEnum } from "openclaw/plugin-sdk";
 import type { FactsDB, MemoryLinkType } from "../backends/facts-db.js";
 import { MEMORY_LINK_TYPES } from "../backends/facts-db.js";
 import type { HybridMemoryConfig } from "../config.js";
+import { findShortestPath, resolveInput, formatPath } from "../services/shortest-path.js";
 
 export interface PluginContext {
   factsDb: FactsDB;
@@ -136,6 +137,89 @@ export function registerGraphTools(
         },
       },
       { name: "memory_graph" },
+    );
+  }
+
+  // Shortest-path tool (when path is enabled)
+  if (cfg.path.enabled) {
+    api.registerTool(
+      {
+        name: "memory_path",
+        label: "Memory Path",
+        description:
+          "Find the shortest path between two memories via BFS on the memory graph. " +
+          "Both `from` and `to` accept a fact ID or an entity name (resolved automatically). " +
+          "Returns the chain of facts and link types, or reports no path within maxDepth.",
+        parameters: Type.Object({
+          from: Type.String({ description: "Start fact ID or entity name" }),
+          to: Type.String({ description: "End fact ID or entity name" }),
+          maxDepth: Type.Optional(
+            Type.Number({ description: `Max hops to traverse (default 5, max ${cfg.path.maxPathDepth})` }),
+          ),
+        }),
+        async execute(_toolCallId: string, params: Record<string, unknown>) {
+          const { from, to, maxDepth = 5 } = params as {
+            from: string;
+            to: string;
+            maxDepth?: number;
+          };
+
+          const depthCap = Math.min(cfg.path.maxPathDepth, Math.max(1, Math.floor(maxDepth)));
+
+          const fromId = resolveInput(factsDb, from);
+          if (!fromId) {
+            return {
+              content: [{ type: "text", text: `Could not resolve start: "${from}" (not a known fact ID or entity name)` }],
+              details: { error: "from_not_found", from },
+            };
+          }
+
+          const toId = resolveInput(factsDb, to);
+          if (!toId) {
+            return {
+              content: [{ type: "text", text: `Could not resolve end: "${to}" (not a known fact ID or entity name)` }],
+              details: { error: "to_not_found", to },
+            };
+          }
+
+          const result = findShortestPath(factsDb, fromId, toId, { maxDepth: depthCap });
+
+          if (!result) {
+            return {
+              content: [{ type: "text", text: `No path found between "${from}" and "${to}" within ${depthCap} hops.` }],
+              details: { found: false, fromId, toId, maxDepth: depthCap },
+            };
+          }
+
+          const lines: string[] = [
+            `Path found: ${result.hops} hop${result.hops === 1 ? "" : "s"}`,
+            "",
+            formatPath(result.steps),
+            "",
+            "Chain:",
+          ];
+          for (let i = 0; i < result.chain.length; i++) {
+            const entry = result.chain[i];
+            const step = result.steps[i - 1];
+            if (step) {
+              lines.push(`  —[${step.linkType}]→`);
+            }
+            lines.push(`  [${entry.id.slice(0, 8)}…] ${entry.text.slice(0, 80)}${entry.text.length > 80 ? "…" : ""}`);
+          }
+
+          return {
+            content: [{ type: "text", text: lines.join("\n") }],
+            details: {
+              found: true,
+              fromId,
+              toId,
+              hops: result.hops,
+              steps: result.steps,
+            },
+          };
+        },
+      },
+      { name: "memory_path" },
     );
   }
 }

--- a/extensions/memory-hybrid/tools/health-dashboard.ts
+++ b/extensions/memory-hybrid/tools/health-dashboard.ts
@@ -1,0 +1,310 @@
+/**
+ * Memory Health Dashboard Tool
+ *
+ * Registers `memory_health` tool that returns diagnostics:
+ * total facts, category distribution, staleness, orphan count,
+ * avg confidence, link density, storage size, and timestamps.
+ */
+
+import { statSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { Type } from "@sinclair/typebox";
+import type { ClawdbotPluginApi } from "openclaw/plugin-sdk";
+
+import type { FactsDB } from "../backends/facts-db.js";
+import type { HybridMemoryConfig } from "../config.js";
+import { capturePluginError } from "../services/error-reporter.js";
+
+export interface HealthPluginContext {
+  factsDb: FactsDB;
+  cfg: HybridMemoryConfig;
+  resolvedSqlitePath: string;
+  resolvedLancePath: string;
+}
+
+export interface HealthReport {
+  totalFacts: number;
+  activeFacts: number;
+  supersededFacts: number;
+  categoryDistribution: Record<string, number>;
+  decayClassDistribution: Record<string, number>;
+  tierDistribution: Record<string, number>;
+  avgConfidence: number;
+  orphanFacts: number;
+  staleFacts: number;
+  avgLinksPerFact: number;
+  totalLinks: number;
+  lastReflectionAt: string | null;
+  lastPruneAt: string | null;
+  storageSizeBytes: {
+    sqlite: number;
+    lance: number;
+    total: number;
+  };
+  generatedAt: string;
+}
+
+function getDirSize(dirPath: string): number {
+  try {
+    const entries = readdirSync(dirPath, { withFileTypes: true });
+    let total = 0;
+    for (const entry of entries) {
+      const fullPath = join(dirPath, entry.name);
+      if (entry.isFile()) {
+        try {
+          total += statSync(fullPath).size;
+        } catch {
+          // skip unreadable files
+        }
+      } else if (entry.isDirectory()) {
+        total += getDirSize(fullPath);
+      }
+    }
+    return total;
+  } catch {
+    return 0;
+  }
+}
+
+function getFileSize(filePath: string): number {
+  try {
+    return statSync(filePath).size;
+  } catch {
+    return 0;
+  }
+}
+
+export function buildHealthReport(
+  factsDb: FactsDB,
+  resolvedSqlitePath: string,
+  resolvedLancePath: string,
+): HealthReport {
+  const db = factsDb.getRawDb();
+  const nowSec = Math.floor(Date.now() / 1000);
+
+  // Total facts (all rows)
+  const totalRow = db.prepare(`SELECT COUNT(*) AS cnt FROM facts`).get() as { cnt: number };
+  const totalFacts = totalRow.cnt;
+
+  // Active facts (not superseded, not expired)
+  const activeRow = db.prepare(
+    `SELECT COUNT(*) AS cnt FROM facts
+     WHERE (valid_until IS NULL OR valid_until > ?)
+       AND (expires_at IS NULL OR expires_at > ?)`,
+  ).get(nowSec, nowSec) as { cnt: number };
+  const activeFacts = activeRow.cnt;
+
+  // Superseded facts (valid_until <= now or has a superseder)
+  const supersededRow = db.prepare(
+    `SELECT COUNT(*) AS cnt FROM facts
+     WHERE valid_until IS NOT NULL AND valid_until <= ?`,
+  ).get(nowSec) as { cnt: number };
+  const supersededFacts = supersededRow.cnt;
+
+  // Category distribution (active facts only)
+  const catRows = db
+    .prepare(
+      `SELECT category, COUNT(*) AS cnt FROM facts
+       WHERE (valid_until IS NULL OR valid_until > ?)
+         AND (expires_at IS NULL OR expires_at > ?)
+       GROUP BY category ORDER BY cnt DESC`,
+    )
+    .all(nowSec, nowSec) as Array<{ category: string; cnt: number }>;
+  const categoryDistribution: Record<string, number> = {};
+  for (const row of catRows) {
+    categoryDistribution[row.category] = row.cnt;
+  }
+
+  // Decay class distribution (all facts)
+  const decayRows = db
+    .prepare(`SELECT decay_class, COUNT(*) AS cnt FROM facts GROUP BY decay_class ORDER BY cnt DESC`)
+    .all() as Array<{ decay_class: string; cnt: number }>;
+  const decayClassDistribution: Record<string, number> = {};
+  for (const row of decayRows) {
+    decayClassDistribution[row.decay_class] = row.cnt;
+  }
+
+  // Tier distribution
+  const tierRows = db
+    .prepare(`SELECT COALESCE(tier, 'warm') AS tier, COUNT(*) AS cnt FROM facts GROUP BY COALESCE(tier, 'warm') ORDER BY cnt DESC`)
+    .all() as Array<{ tier: string; cnt: number }>;
+  const tierDistribution: Record<string, number> = {};
+  for (const row of tierRows) {
+    tierDistribution[row.tier] = row.cnt;
+  }
+
+  // Average confidence (active facts)
+  const confRow = db
+    .prepare(
+      `SELECT AVG(confidence) AS avg_conf FROM facts
+       WHERE (valid_until IS NULL OR valid_until > ?)
+         AND (expires_at IS NULL OR expires_at > ?)`,
+    )
+    .get(nowSec, nowSec) as { avg_conf: number | null };
+  const avgConfidence = confRow.avg_conf != null ? Math.round(confRow.avg_conf * 1000) / 1000 : 0;
+
+  // Orphan facts: facts with no links (neither source nor target) — active facts only
+  const orphanRow = db
+    .prepare(
+      `SELECT COUNT(*) AS cnt FROM facts
+       WHERE (valid_until IS NULL OR valid_until > ?)
+         AND (expires_at IS NULL OR expires_at > ?)
+         AND id NOT IN (
+           SELECT source_fact_id FROM memory_links
+           UNION
+           SELECT target_fact_id FROM memory_links
+         )`,
+    )
+    .get(nowSec, nowSec) as { cnt: number };
+  const orphanFacts = orphanRow.cnt;
+
+  // Stale facts: confidence < 0.3, not permanent decay class, active
+  const staleRow = db
+    .prepare(
+      `SELECT COUNT(*) AS cnt FROM facts
+       WHERE confidence < 0.3
+         AND decay_class != 'permanent'
+         AND (valid_until IS NULL OR valid_until > ?)
+         AND (expires_at IS NULL OR expires_at > ?)`,
+    )
+    .get(nowSec, nowSec) as { cnt: number };
+  const staleFacts = staleRow.cnt;
+
+  // Total links (only count links where at least one endpoint is an active fact)
+  const linksRow = db.prepare(
+    `SELECT COUNT(*) AS cnt FROM memory_links
+     WHERE source_fact_id IN (
+       SELECT id FROM facts
+       WHERE (valid_until IS NULL OR valid_until > ?)
+         AND (expires_at IS NULL OR expires_at > ?)
+     )
+     OR target_fact_id IN (
+       SELECT id FROM facts
+       WHERE (valid_until IS NULL OR valid_until > ?)
+         AND (expires_at IS NULL OR expires_at > ?)
+     )`,
+  ).get(nowSec, nowSec, nowSec, nowSec) as { cnt: number };
+  const totalLinks = linksRow.cnt;
+
+  // Avg links per active fact
+  const avgLinksPerFact =
+    activeFacts > 0 ? Math.round((totalLinks * 2 * 1000) / activeFacts) / 1000 : 0;
+
+  // Last reflection timestamp
+  const reflRow = db
+    .prepare(
+      `SELECT MAX(created_at) AS last_at FROM facts WHERE source = 'reflection'`,
+    )
+    .get() as { last_at: number | null };
+  const lastReflectionAt =
+    reflRow.last_at != null
+      ? new Date(reflRow.last_at * 1000).toISOString()
+      : null;
+
+  // Last prune: derived from MAX(valid_until) of superseded facts (best approximation)
+  const pruneRow = db
+    .prepare(
+      `SELECT MAX(valid_until) AS last_at FROM facts WHERE valid_until IS NOT NULL AND valid_until <= ?`,
+    )
+    .get(nowSec) as { last_at: number | null };
+  const lastPruneAt =
+    pruneRow.last_at != null
+      ? new Date(pruneRow.last_at * 1000).toISOString()
+      : null;
+
+  // Storage sizes
+  const sqliteSize = getFileSize(resolvedSqlitePath);
+  // Also count WAL / SHM sidecars
+  const sqliteWalSize = getFileSize(resolvedSqlitePath + "-wal");
+  const sqliteShmSize = getFileSize(resolvedSqlitePath + "-shm");
+  const totalSqliteSize = sqliteSize + sqliteWalSize + sqliteShmSize;
+  const lanceSize = getDirSize(resolvedLancePath);
+
+  return {
+    totalFacts,
+    activeFacts,
+    supersededFacts,
+    categoryDistribution,
+    decayClassDistribution,
+    tierDistribution,
+    avgConfidence,
+    orphanFacts,
+    staleFacts,
+    avgLinksPerFact,
+    totalLinks,
+    lastReflectionAt,
+    lastPruneAt,
+    storageSizeBytes: {
+      sqlite: totalSqliteSize,
+      lance: lanceSize,
+      total: totalSqliteSize + lanceSize,
+    },
+    generatedAt: new Date().toISOString(),
+  };
+}
+
+/**
+ * Register the memory_health tool with the plugin API.
+ */
+export function registerHealthTools(ctx: HealthPluginContext, api: ClawdbotPluginApi): void {
+  const { factsDb, cfg, resolvedSqlitePath, resolvedLancePath } = ctx;
+
+  if (!cfg.health.enabled) return;
+
+  api.registerTool(
+    {
+      name: "memory_health",
+      label: "Memory Health",
+      description:
+        "Return a health dashboard for the memory system: total facts, category distribution, " +
+        "staleness indicators, orphan count, average confidence, link density, and storage sizes.",
+      parameters: Type.Object({}),
+      async execute(_toolCallId: string, _params: Record<string, unknown>) {
+        try {
+          const report = buildHealthReport(factsDb, resolvedSqlitePath, resolvedLancePath);
+
+          const lines: string[] = [
+            `Memory Health Dashboard (${report.generatedAt})`,
+            ``,
+            `Facts: ${report.activeFacts} active / ${report.totalFacts} total (${report.supersededFacts} superseded)`,
+            `Stale facts (confidence < 0.3, non-permanent): ${report.staleFacts}`,
+            `Orphan facts (no links): ${report.orphanFacts}`,
+            `Avg confidence: ${report.avgConfidence.toFixed(3)}`,
+            ``,
+            `Links: ${report.totalLinks} total, ${report.avgLinksPerFact.toFixed(2)} avg per active fact`,
+            ``,
+            `Categories: ${Object.entries(report.categoryDistribution)
+              .map(([k, v]) => `${k}=${v}`)
+              .join(", ")}`,
+            `Decay classes: ${Object.entries(report.decayClassDistribution)
+              .map(([k, v]) => `${k}=${v}`)
+              .join(", ")}`,
+            `Tiers: ${Object.entries(report.tierDistribution)
+              .map(([k, v]) => `${k}=${v}`)
+              .join(", ")}`,
+            ``,
+            `Last reflection: ${report.lastReflectionAt ?? "never"}`,
+            `Last prune: ${report.lastPruneAt ?? "none recorded"}`,
+            ``,
+            `Storage: SQLite ${(report.storageSizeBytes.sqlite / 1024).toFixed(1)} KB, ` +
+              `LanceDB ${(report.storageSizeBytes.lance / 1024).toFixed(1)} KB, ` +
+              `Total ${(report.storageSizeBytes.total / 1024).toFixed(1)} KB`,
+          ];
+
+          return {
+            content: [{ type: "text", text: lines.join("\n") }],
+            details: report,
+          };
+        } catch (err) {
+          capturePluginError(err instanceof Error ? err : new Error(String(err)), {
+            subsystem: "memory",
+            operation: "memory-health",
+            phase: "runtime",
+          });
+          throw err;
+        }
+      },
+    },
+    { name: "memory_health" },
+  );
+}

--- a/extensions/memory-hybrid/tools/memory-tools.ts
+++ b/extensions/memory-hybrid/tools/memory-tools.ts
@@ -27,6 +27,7 @@ import {
 } from "../services/auto-capture.js";
 import { capturePluginError, addOperationBreadcrumb } from "../services/error-reporter.js";
 import { runRetrievalPipeline } from "../services/retrieval-orchestrator.js";
+import { storeAliases, type AliasDB } from "../services/retrieval-aliases.js";
 import { expandGraph, formatLinkPath } from "../services/graph-retrieval.js";
 import {
   getMemoryCategories,
@@ -43,12 +44,12 @@ import { MEMORY_SCOPES } from "../types/memory.js";
 import { truncateForStorage } from "../utils/text.js";
 import { extractTags } from "../utils/tags.js";
 import { parseSourceDate } from "../utils/dates.js";
-import { detectFutureDate } from "../utils/date-detector.js";
 
 export interface PluginContext {
   factsDb: FactsDB;
   vectorDb: VectorDB;
   cfg: HybridMemoryConfig;
+  aliasDb?: AliasDB | null;
   embeddings: EmbeddingProvider;
   openai: OpenAI;
   wal: WriteAheadLog | null;
@@ -87,7 +88,7 @@ export function registerMemoryTools(
     minScore?: number
   ) => Promise<MemoryEntry[]>
 ): void {
-  const { factsDb, vectorDb, cfg, embeddings, openai, wal, credentialsDb, eventLog, lastProgressiveIndexIds, currentAgentIdRef, pendingLLMWarnings } = ctx;
+  const { factsDb, vectorDb, cfg, embeddings, openai, wal, credentialsDb, eventLog, lastProgressiveIndexIds, currentAgentIdRef, pendingLLMWarnings, aliasDb } = ctx;
 
   api.registerTool(
     {
@@ -385,6 +386,7 @@ export function registerMemoryTools(
             includeSuperseded,
             scopeFilter,
             asOfSec ?? undefined,
+            cfg.aliases?.enabled ? aliasDb : null,
           );
 
           // Merge entity-lookup results first, then append RRF results (deduped).
@@ -925,6 +927,7 @@ export function registerMemoryTools(
 
             if (classification.action === "DELETE" && classification.targetId) {
               factsDb.supersede(classification.targetId, null);
+              aliasDb?.deleteByFactId(classification.targetId);
               return {
                 content: [{ type: "text", text: `Retracted fact ${classification.targetId}: ${classification.reason}` }],
                 details: { action: "delete", targetId: classification.targetId, reason: classification.reason },
@@ -959,6 +962,7 @@ export function registerMemoryTools(
                   sourceSessions: api.context?.sessionId ?? undefined,
                 });
                 factsDb.supersede(classification.targetId, newEntry.id);
+                aliasDb?.deleteByFactId(classification.targetId);
 
                 const finalImportance = Math.max(importance, oldFact.importance);
                 try {
@@ -1064,8 +1068,6 @@ export function registerMemoryTools(
         }
         const nowSec = Math.floor(Date.now() / 1000);
         const storeSessionId = api.context?.sessionId ?? null;
-        // Detect future dates for decay freeze protection (#144)
-        const decayFreezeUntil = detectFutureDate(textToStore, cfg.futureDateProtection);
         const entry = factsDb.store({
           text: textToStore,
           category: category as MemoryCategory,
@@ -1080,13 +1082,13 @@ export function registerMemoryTools(
           scope,
           scopeTarget,
           sourceSessions: storeSessionId ?? undefined,
-          ...(decayFreezeUntil != null ? { decayFreezeUntil } : {}),
           ...(supersedes?.trim()
             ? { validFrom: nowSec, supersedesId: supersedes.trim() }
             : {}),
         });
         if (supersedes?.trim()) {
           factsDb.supersede(supersedes.trim(), entry.id);
+          aliasDb?.deleteByFactId(supersedes.trim());
         }
 
         try {
@@ -1111,6 +1113,24 @@ export function registerMemoryTools(
         }
 
         walRemove(walEntryId, api.logger);
+
+        // Issue #149: generate and store retrieval aliases (non-blocking)
+        if (cfg.aliases?.enabled && aliasDb) {
+          const aliasModel =
+            cfg.aliases.model ?? getDefaultCronModel(getCronModelConfig(cfg), "nano");
+          void storeAliases(
+            entry.id,
+            textToStore,
+            cfg.aliases,
+            aliasModel,
+            openai,
+            embeddings,
+            aliasDb,
+            (msg) => api.logger.warn(msg),
+          ).catch((err) => {
+            api.logger.warn(`memory-hybrid: alias generation failed: ${err}`);
+          });
+        }
 
         // Contradiction detection (Issue #157): check for same entity+key, different value
         // Pass the stored fact's scope so detection stays within the same scope boundary.
@@ -1345,6 +1365,7 @@ export function registerMemoryTools(
             });
             api.logger.warn(`memory-hybrid: LanceDB delete during tool failed: ${err}`);
           }
+          aliasDb?.deleteByFactId(resolvedId);
 
           if (!sqlDeleted && !lanceDeleted) {
             if (lanceError) {
@@ -1422,6 +1443,7 @@ export function registerMemoryTools(
               });
               api.logger.warn(`memory-hybrid: LanceDB delete during supersede failed: ${err}`);
             }
+            aliasDb?.deleteByFactId(id);
             return {
               content: [
                 {

--- a/extensions/memory-hybrid/tools/utility-tools.ts
+++ b/extensions/memory-hybrid/tools/utility-tools.ts
@@ -10,6 +10,7 @@ import type { HybridMemoryConfig } from "../config.js";
 import { resolveReflectionModelAndFallbacks } from "../config.js";
 import type { WriteAheadLog } from "../backends/wal.js";
 import { capturePluginError } from "../services/error-reporter.js";
+import { detectClusters } from "../services/topic-clusters.js";
 
 export interface PluginContext {
   factsDb: FactsDB;
@@ -355,5 +356,97 @@ export function registerUtilityTools(
       },
     },
     { name: "memory_reflect_meta" },
+  );
+
+  // memory_clusters
+  api.registerTool(
+    {
+      name: "memory_clusters",
+      label: "Memory Clusters",
+      description:
+        "Detect and return topic clusters — groups of densely interconnected facts forming natural knowledge domains. Runs BFS connected-component analysis on the memory graph. Returns cluster labels, sizes, and member fact IDs.",
+      parameters: Type.Object({
+        minClusterSize: Type.Optional(
+          Type.Number({
+            description: "Minimum facts to form a cluster (default from config, typically 3)",
+            minimum: 2,
+          }),
+        ),
+        save: Type.Optional(
+          Type.Boolean({
+            description: "Persist detected clusters to the database (default: true)",
+          }),
+        ),
+      }),
+      async execute(_toolCallId: string, params: Record<string, unknown>) {
+        const clustersCfg = cfg.clusters;
+        if (!clustersCfg.enabled) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: "Topic cluster detection is disabled. Set clusters.enabled: true in plugin config.",
+              },
+            ],
+            details: { error: "clusters_disabled" },
+          };
+        }
+
+        const minClusterSize =
+          typeof params.minClusterSize === "number" && params.minClusterSize >= 2
+            ? Math.floor(params.minClusterSize)
+            : clustersCfg.minClusterSize;
+
+        const shouldSave = params.save !== false;
+
+        try {
+          // Build existingClusterIds map for stable IDs across re-runs
+          const existingClusters = factsDb.getClusters();
+          const existingClusterIds = new Map<string, { id: string; createdAt: number }>();
+          for (const cluster of existingClusters) {
+            const members = factsDb.getClusterMembers(cluster.id);
+            const componentKey = [...members].sort().join(",");
+            existingClusterIds.set(componentKey, { id: cluster.id, createdAt: cluster.createdAt });
+          }
+
+          const result = detectClusters(factsDb, { minClusterSize, existingClusterIds });
+
+          if (shouldSave) {
+            factsDb.saveClusters(result.clusters);
+          }
+
+          const summary = result.clusters
+            .map((c) => `  • ${c.label} (${c.factCount} facts)`)
+            .join("\n");
+
+          const text =
+            result.clusters.length === 0
+              ? `No topic clusters found (need at least ${minClusterSize} interconnected facts per cluster). Total linked facts: ${result.totalLinkedFacts}.`
+              : `Found ${result.clusters.length} topic cluster(s) from ${result.totalLinkedFacts} linked facts (${result.isolatedFacts} below threshold):\n${summary}`;
+
+          return {
+            content: [{ type: "text", text }],
+            details: {
+              clusterCount: result.clusters.length,
+              totalLinkedFacts: result.totalLinkedFacts,
+              isolatedFacts: result.isolatedFacts,
+              clusters: result.clusters.map((c) => ({
+                id: c.id,
+                label: c.label,
+                factCount: c.factCount,
+                factIds: c.factIds,
+              })),
+            },
+          };
+        } catch (err) {
+          capturePluginError(err instanceof Error ? err : new Error(String(err)), {
+            subsystem: "clusters",
+            operation: "memory_clusters",
+          });
+          throw err;
+        }
+      },
+    },
+    { name: "memory_clusters" },
   );
 }


### PR DESCRIPTION
## All remaining Milestone A features in one PR

Merges 7 features onto milestone-a (on top of already-merged #153):

- **#143** Dream Cycle — automated nightly prune→consolidate→reflect
- **#146** Topic Clusters — BFS connected-component analysis
- **#147** Confidence Reinforcement — boost on repeated mentions
- **#148** Health Dashboard — memory_health diagnostic tool
- **#141** Knowledge Gaps — orphan/weak detection + suggested links
- **#149** Retrieval Aliases — multi-hook alternative phrasings
- **#140** Shortest Path — BFS traversal between memories

**62 test files, 1610 tests passing. tsc clean.**

Closes #143, closes #146, closes #147, closes #148, closes #141, closes #149, closes #140.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Broad changes across core memory storage/retrieval, including new SQLite tables, new retrieval strategy participation in RRF fusion, and an automated nightly prune/consolidate/reflect job that can delete/modify data. Regressions could affect recall quality or unexpectedly supersede/prune facts if configs/migrations behave incorrectly.
> 
> **Overview**
> Implements a new **nightly “dream cycle”** pipeline (`dream-cycle.ts`) that can prune expired/decayed facts, consolidate old `event-log` entries into derived facts, run reflection (and optional rule extraction), and exposes it via a new CLI command plus a scheduled cron job (`nightly-dream-cycle`).
> 
> Adds **topic cluster persistence** in `FactsDB` (new `clusters`/`cluster_members` tables + APIs) and new analysis utilities: **shortest-path traversal** (`memory_path` tool + `shortest-path.ts`) and **knowledge-gap detection** (`knowledge-gaps.ts`).
> 
> Introduces **confidence reinforcement** via `FactsDB.boostConfidence()` and updates the passive observer to boost similar existing facts instead of only skipping duplicates; configuration now includes new sections (`nightlyCycle`, `reinforcement`, `clusters`, `gaps`, `aliases`, `path`, `health`) with defaults and parsing.
> 
> Adds **retrieval aliases** backed by a new SQLite `AliasDB` (`aliases.db`), wires alias cleanup into supersede/delete/consolidation/credential migration paths, generates aliases on `memory_store`, and includes alias search as an additional RRF strategy in the retrieval orchestrator when enabled.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b30551fce3ed793dbe59a3ff98af9f4b6d9b3603. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->