### PR TITLE
fix(passive-observer): promote identity facts to global/permanent scope

### DIFF
--- a/extensions/memory-hybrid/services/passive-observer.ts
+++ b/extensions/memory-hybrid/services/passive-observer.ts
@@ -246,7 +246,7 @@ export function parseObserverResponse(raw: string, categories: string[]): Extrac
 export function isIdentityFact(text: string, agentName?: string): boolean {
   const patterns: RegExp[] = [
     /(?:my|your|the (?:agent|assistant|bot)(?:'s)?)\s+(?:email|name|role|account|address|phone|number)/i,
-    /(?:email|account|address|role)\s+(?:is|was|:)\s/i,
+    /(?<!(?:user|customer|their|his|her|[a-z]+)'s\s)(?<!(?:their|his|her)\s)(?:email|account|address|role)\s+(?:is|was|:)\s/i,
   ]
   if (agentName) {
     const escaped = agentName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')

--- a/extensions/memory-hybrid/tests/passive-observer.test.ts
+++ b/extensions/memory-hybrid/tests/passive-observer.test.ts
@@ -833,6 +833,22 @@ describe("isIdentityFact", () => {
     expect(isIdentityFact("YOUR EMAIL IS DORIS@EXAMPLE.COM")).toBe(true);
     expect(isIdentityFact("the ASSISTANT's name is doris", "doris")).toBe(true);
   });
+
+  it("does NOT flag 'The user's email is ...'", () => {
+    expect(isIdentityFact("The user's email is john@example.com")).toBe(false);
+  });
+
+  it("does NOT flag 'John's role is ...'", () => {
+    expect(isIdentityFact("John's role is team lead")).toBe(false);
+  });
+
+  it("does NOT flag 'The customer's address is ...'", () => {
+    expect(isIdentityFact("The customer's address is 123 Main St")).toBe(false);
+  });
+
+  it("does NOT flag 'Their account is ...'", () => {
+    expect(isIdentityFact("Their account is premium-user-123")).toBe(false);
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds `isIdentityFact(text, agentName?)` — a lightweight regex heuristic that detects when a fact describes the agent's own identity (email, name, role, account, etc.)
- When the heuristic fires, the passive observer overrides `scope → global`, `decayClass → permanent`, `importance → max(original, 0.9)` and clears `scopeTarget` before storing the fact
- Adds `agentName?: string` to the `runPassiveObserver` opts so callers can supply the agent's name for name-specific detection (e.g. "Doris's email is …")
- Adds a debug log line when promotion triggers: `passive-observer: promoting identity fact to global/permanent: "…"`
- Non-identity facts are completely unaffected — default session scope preserved

## Test plan

- [ ] `isIdentityFact` unit tests: 14 cases covering agent/assistant/bot patterns, my/your pronouns, standalone `email is …`, agent-name-specific pattern, case-insensitivity, and negative cases (coffee, "Send email to", generic user facts)
- [ ] E2E integration tests: identity fact → `scope=global, decayClass=permanent, scopeTarget=undefined`; regular fact → unchanged session scope; explicit `agentName=Doris` promotion
- [ ] Full suite: 2851 tests pass, 0 type errors (`npx tsc --noEmit`)

Closes #306

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes persistence/scope semantics so some extracted facts become permanent and global, which could increase retention of incorrectly-classified data if the heuristic has false positives.
> 
> **Overview**
> Adds `isIdentityFact()` (regex heuristic, optional `agentName`) and uses it in `runPassiveObserver` to *promote agent-identity facts* (email/name/role/account/etc.) from session-scoped memory to `scope="global"` + `decayClass="permanent"`, clear `scopeTarget`, and bump `importance` to at least `0.9`, with an info log when promotion occurs.
> 
> Extends the passive observer test suite with focused unit tests for `isIdentityFact` and end-to-end coverage verifying promoted vs non-promoted storage behavior (including `agentName`-specific matches).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3c2bf8f62156d78fce94621af2e4f8f57b1a470a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->