### PR TITLE
fix: Cron jobs lose lastRun state on gateway restart — all jobs fire immediately (#305)

### DIFF
--- a/extensions/memory-hybrid/cli/handlers.ts
+++ b/extensions/memory-hybrid/cli/handlers.ts
@@ -87,6 +87,7 @@ import { runCrossAgentLearning } from "../services/cross-agent-learning.js";
 import { computeToolEffectiveness, formatToolEffectivenessReport, ToolEffectivenessStore, generateMonthlyReport } from "../services/tool-effectiveness.js";
 import type { CostTracker } from "../backends/cost-tracker.js";
 import { getModeCostEstimates } from "../services/model-pricing.js";
+import { buildGuardPrefix } from "../services/cron-guard.js";
 
 // Shared cron job definitions used by install and verify --fix.
 // Canonical schedule per #86 (7 jobs, non-overlapping). Model is resolved dynamically from user config via getLLMModelPreference.
@@ -98,7 +99,7 @@ const PLUGIN_JOB_ID_PREFIX = "hybrid-mem:";
  * Minimum run interval guard (in milliseconds) for each job frequency tier.
  * When the cron runner triggers a job (e.g. on gateway restart), the agent-level
  * guard in the message prefix causes it to skip if it already ran within this interval.
- * This prevents expensive re-runs caused by gateway restarts (issue #304).
+ * Guard files are stored persistently in ~/.openclaw/cron/guard/ (issue #305).
  */
 const MIN_INTERVAL_MS: Record<string, number> = {
   daily: 20 * 60 * 60 * 1000,    // 20 hours (daily jobs)
@@ -106,19 +107,7 @@ const MIN_INTERVAL_MS: Record<string, number> = {
   monthly: 25 * 24 * 60 * 60 * 1000, // 25 days (monthly jobs)
 };
 
-/**
- * Build a guard prefix for cron job messages that checks a state file to prevent
- * re-runs within a minimum interval. The agent reads the timestamp file, compares
- * against the current time, and skips if the job ran too recently.
- */
-function buildGuardPrefix(jobName: string, minIntervalMs: number): string {
-  const hours = Math.round(minIntervalMs / (60 * 60 * 1000));
-  const stateFile = `/tmp/hybrid-mem-guard-${jobName}.txt`;
-  return `GUARD CHECK (issue #304): Before running, execute: cat ${stateFile} 2>/dev/null. ` +
-    `If the file contains a Unix timestamp and (current time - that timestamp) < ${hours} hours (${minIntervalMs}ms), ` +
-    `reply "Skipped: ${jobName} already ran within ${hours}h guard window" and do NOT run the commands below. ` +
-    `Otherwise, proceed and AFTER successful completion write the current Unix timestamp: date +%s > ${stateFile}\n\n`;
-}
+// buildGuardPrefix is imported from services/cron-guard.ts (issue #305).
 
 const MAINTENANCE_CRON_JOBS: Array<Record<string, unknown> & { modelTier?: "nano" | "default" | "heavy"; minIntervalMs?: number }> = [
   // Daily 02:00 | nightly-memory-sweep | prune → distill --days 3 → extract-daily
@@ -246,20 +235,42 @@ function ensureMaintenanceCronJobs(
           if (!normalized.includes(name)) normalized.push(name);
         }
         // Issue #304: Add guard prefix to existing job messages to prevent re-runs on gateway restart.
-        // Only update if the message doesn't already have the guard prefix.
+        // Issue #304: Add guard prefix if missing.
+        // Issue #305: Also migrate old /tmp/ guard paths to persistent ~/.openclaw/cron/guard/ paths.
         // The on-disk format uses payload.message (agentTurn jobs), but older entries may use top-level message.
         if (def.minIntervalMs) {
           const jobSlug = name.replace(/\s+/g, "-");
           const guard = buildGuardPrefix(jobSlug, def.minIntervalMs as number);
+          const oldTmpPath = `/tmp/hybrid-mem-guard-${jobSlug}`;
           const payload = existing.payload as { message?: string; kind?: string } | undefined;
-          if (payload && typeof payload.message === "string" && !payload.message.includes("GUARD CHECK")) {
-            payload.message = guard + payload.message;
-            jobsChanged = true;
-            if (!normalized.includes(name)) normalized.push(name);
-          } else if (typeof existing.message === "string" && !existing.message.includes("GUARD CHECK")) {
-            existing.message = guard + existing.message;
-            jobsChanged = true;
-            if (!normalized.includes(name)) normalized.push(name);
+          if (payload && typeof payload.message === "string") {
+            if (!payload.message.includes("GUARD CHECK")) {
+              // Add guard prefix if missing (issue #304)
+              payload.message = guard + payload.message;
+              jobsChanged = true;
+              if (!normalized.includes(name)) normalized.push(name);
+            } else if (payload.message.includes(oldTmpPath)) {
+              // Migrate old /tmp/ guard path to persistent path (issue #305)
+              const doubleLf = payload.message.indexOf("\n\n");
+              if (doubleLf >= 0) {
+                payload.message = guard + payload.message.slice(doubleLf + 2);
+                jobsChanged = true;
+                if (!normalized.includes(name)) normalized.push(name);
+              }
+            }
+          } else if (typeof existing.message === "string") {
+            if (!existing.message.includes("GUARD CHECK")) {
+              existing.message = guard + existing.message;
+              jobsChanged = true;
+              if (!normalized.includes(name)) normalized.push(name);
+            } else if (existing.message.includes(oldTmpPath)) {
+              const doubleLf = existing.message.indexOf("\n\n");
+              if (doubleLf >= 0) {
+                existing.message = guard + existing.message.slice(doubleLf + 2);
+                jobsChanged = true;
+                if (!normalized.includes(name)) normalized.push(name);
+              }
+            }
           }
         }
       }

--- a/extensions/memory-hybrid/services/cron-guard.ts
+++ b/extensions/memory-hybrid/services/cron-guard.ts
@@ -1,0 +1,183 @@
+/**
+ * Persistent cron guard utilities — issue #305.
+ *
+ * Maintains ~/.openclaw/cron/guard/{jobName}.ms files (epoch-ms timestamps)
+ * to track last-run state across gateway restarts AND system reboots.
+ *
+ * ## Problem (issue #305)
+ * All plugin-registered cron jobs show `lastRun: never` after every gateway
+ * restart, even if they ran minutes ago, because:
+ *   1. The OpenClaw cron runner keeps lastRunAtMs state in memory only —
+ *      it may not flush to jobs.json before a crash/restart.
+ *   2. The old guard files lived in /tmp/ and were lost on system reboot.
+ *
+ * ## Fix
+ * - `buildGuardPrefix`: writes guard timestamps to a persistent directory
+ *   (~/.openclaw/cron/guard/) instead of /tmp/.
+ * - `syncCronLastRunFromGuards`: called from plugin-service start() to read
+ *   guard files and back-fill state.lastRunAtMs in jobs.json before the cron
+ *   runner processes the queue on startup.
+ */
+
+import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+/** Subdirectory (relative to openclawDir) where guard files are kept. */
+export const GUARD_SUBDIR = join("cron", "guard");
+
+/** Absolute path of the guard directory. */
+export function getGuardDir(openclawDir?: string): string {
+  return join(openclawDir ?? join(homedir(), ".openclaw"), GUARD_SUBDIR);
+}
+
+/**
+ * Absolute path for a named job's persistent guard file.
+ * Filename convention: {jobName}.ms  (epoch-ms as plain text)
+ */
+export function getGuardFilePath(jobName: string, openclawDir?: string): string {
+  return join(getGuardDir(openclawDir), `${jobName}.ms`);
+}
+
+/**
+ * Read a guard file and return its timestamp in epoch-ms.
+ * Tolerates both epoch-seconds (< 2e12) and epoch-ms formats written by older
+ * code that used `date +%s`.  Returns null if the file is missing or invalid.
+ */
+export function readGuardTimestampMs(jobName: string, openclawDir?: string): number | null {
+  const path = getGuardFilePath(jobName, openclawDir);
+  if (!existsSync(path)) return null;
+  try {
+    const raw = readFileSync(path, "utf-8").trim();
+    const n = Number(raw);
+    if (!Number.isFinite(n) || n <= 0) return null;
+    // Epoch-seconds have ~10 digits (≤ 9_999_999_999); epoch-ms have ~13 digits.
+    // Threshold 1e10 safely distinguishes them for any date until year 2286.
+    return n < 1e10 ? n * 1000 : n;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Build a job-message prefix that instructs the executing agent to check the
+ * persistent guard file and skip if the job ran within the guard window.
+ *
+ * The persistent path (~/.openclaw/cron/guard/) survives system reboots,
+ * unlike the old /tmp/ files used by issue #304.
+ */
+export function buildGuardPrefix(jobName: string, minIntervalMs: number): string {
+  const hours = Math.round(minIntervalMs / (60 * 60 * 1000));
+  const guardFile = getGuardFilePath(jobName);
+  const guardDir = getGuardDir();
+  return (
+    `GUARD CHECK (issue #305): Before running, read the last-run guard file: ` +
+    `cat "${guardFile}" 2>/dev/null. ` +
+    `If the file contains a number T (Unix epoch ms) where (current epoch ms − T) < ${minIntervalMs} ` +
+    `(${hours}h guard window), reply ONLY 'Skipped: ${jobName} — ran within ${hours}h guard window' and stop. ` +
+    `Otherwise proceed with the task below. ` +
+    `AFTER successful completion: mkdir -p "${guardDir}" and write the current Unix epoch ms to "${guardFile}".\n\n`
+  );
+}
+
+type Logger = { info: (s: string) => void; warn: (s: string) => void };
+
+/**
+ * Sync cron job lastRunAtMs from persistent guard files into jobs.json.
+ *
+ * Called from plugin-service start() on every gateway startup.  Reads:
+ *   1. ~/.openclaw/cron/guard/*.ms  (new persistent format, epoch-ms)
+ *   2. /tmp/hybrid-mem-guard-*.txt  (legacy format, epoch-seconds — backward compat)
+ *
+ * For each guard file whose timestamp is newer than the current
+ * state.lastRunAtMs in jobs.json, the state is updated.  This ensures the
+ * cron runner sees a recent lastRunAtMs and does not fire jobs immediately.
+ */
+export function syncCronLastRunFromGuards(logger: Logger, openclawDir?: string): void {
+  const dir = openclawDir ?? join(homedir(), ".openclaw");
+  const guardDir = getGuardDir(dir);
+  const cronStorePath = join(dir, "cron", "jobs.json");
+
+  if (!existsSync(cronStorePath)) return;
+
+  let store: { jobs?: unknown[] };
+  try {
+    store = JSON.parse(readFileSync(cronStorePath, "utf-8")) as { jobs?: unknown[] };
+  } catch {
+    return;
+  }
+  if (!Array.isArray(store.jobs)) return;
+
+  const jobs = store.jobs as Array<Record<string, unknown>>;
+
+  // Collect guard timestamps keyed by jobName (normalized: spaces → hyphens).
+  // The persistent files take precedence over legacy /tmp/ files.
+  const guardTimestamps = new Map<string, number>(); // jobName → epoch-ms
+
+  // 1. Persistent guard files (~/.openclaw/cron/guard/*.ms)
+  if (existsSync(guardDir)) {
+    try {
+      for (const f of readdirSync(guardDir)) {
+        if (!f.endsWith(".ms")) continue;
+        const jobName = f.slice(0, -3); // strip .ms
+        const ts = readGuardTimestampMs(jobName, dir);
+        if (ts !== null) guardTimestamps.set(jobName, ts);
+      }
+    } catch {
+      /* non-fatal — guard dir may be temporarily unreadable */
+    }
+  }
+
+  // 2. Legacy /tmp/hybrid-mem-guard-*.txt files (epoch-seconds, convert to ms)
+  try {
+    for (const f of readdirSync("/tmp")) {
+      if (!f.startsWith("hybrid-mem-guard-") || !f.endsWith(".txt")) continue;
+      const jobName = f.slice("hybrid-mem-guard-".length, -4);
+      if (guardTimestamps.has(jobName)) continue; // persistent wins
+      try {
+        const raw = readFileSync(join("/tmp", f), "utf-8").trim();
+        const n = Number(raw);
+        if (Number.isFinite(n) && n > 0) {
+          guardTimestamps.set(jobName, n < 1e10 ? n * 1000 : n);
+        }
+      } catch {
+        /* non-fatal */
+      }
+    }
+  } catch {
+    /* non-fatal: /tmp might not be readable in some environments */
+  }
+
+  if (guardTimestamps.size === 0) return;
+
+  let synced = 0;
+  for (const job of jobs) {
+    if (typeof job !== "object" || job === null) continue;
+    // Normalize job name to match guard file naming (spaces → hyphens)
+    const jobName = String(job.name ?? "").replace(/\s+/g, "-");
+    const guardTs = guardTimestamps.get(jobName);
+    if (guardTs === undefined) continue;
+
+    const state = (
+      typeof job.state === "object" && job.state !== null ? job.state : {}
+    ) as Record<string, unknown>;
+    const currentLastRun =
+      typeof state.lastRunAtMs === "number" ? state.lastRunAtMs : 0;
+
+    if (guardTs > currentLastRun) {
+      job.state = { ...state, lastRunAtMs: guardTs };
+      synced++;
+    }
+  }
+
+  if (synced > 0) {
+    try {
+      writeFileSync(cronStorePath, JSON.stringify(store, null, 2), "utf-8");
+      logger.info(
+        `memory-hybrid: synced lastRunAtMs for ${synced} cron job(s) from persistent guard files`,
+      );
+    } catch (err) {
+      logger.warn(`memory-hybrid: failed to write cron guard sync to jobs.json: ${err}`);
+    }
+  }
+}

--- a/extensions/memory-hybrid/setup/plugin-service.ts
+++ b/extensions/memory-hybrid/setup/plugin-service.ts
@@ -19,6 +19,7 @@ import {
   capturePluginError,
 } from "../services/error-reporter.js";
 import { walRemove } from "../services/wal-helpers.js";
+import { syncCronLastRunFromGuards } from "../services/cron-guard.js";
 import { runPassiveObserver } from "../services/passive-observer.js";
 import { runAutoClassify } from "../services/auto-classifier.js";
 import { runBuildLanguageKeywords } from "../services/language-keywords-build.js";
@@ -222,6 +223,14 @@ export function createPluginService(ctx: PluginServiceContext) {
             });
           }
         }
+      }
+
+      // Issue #305: Sync cron job lastRunAtMs from persistent guard files so the cron
+      // runner does not immediately re-fire jobs whose state was lost on restart/reboot.
+      try {
+        syncCronLastRunFromGuards(api.logger);
+      } catch (err) {
+        api.logger.warn?.(`memory-hybrid: cron guard sync failed (non-fatal): ${err}`);
       }
 
       // Periodic prune timer

--- a/extensions/memory-hybrid/tests/cron-lastrun-state.test.ts
+++ b/extensions/memory-hybrid/tests/cron-lastrun-state.test.ts
@@ -1,0 +1,375 @@
+/**
+ * Tests for issue #305 — Cron jobs lose lastRun state on gateway restart.
+ *
+ * Verifies that:
+ *   1. syncCronLastRunFromGuards reads persistent guard files and updates
+ *      state.lastRunAtMs in jobs.json for jobs with no or stale lastRunAtMs.
+ *   2. Legacy /tmp/hybrid-mem-guard-*.txt files (epoch-seconds) are also
+ *      handled correctly.
+ *   3. buildGuardPrefix produces a guard message using the persistent
+ *      ~/.openclaw/cron/guard/ path (not /tmp/).
+ *   4. getGuardFilePath returns the expected persistent path.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdirSync, writeFileSync, readFileSync, rmSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomUUID } from "node:crypto";
+
+// Functions under test
+import {
+  buildGuardPrefix,
+  getGuardFilePath,
+  readGuardTimestampMs,
+  syncCronLastRunFromGuards,
+  GUARD_SUBDIR,
+} from "../services/cron-guard.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeOpenclawDir(): string {
+  const dir = join(tmpdir(), `oc-test-${randomUUID()}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function writeCronStore(openclawDir: string, jobs: unknown[]): void {
+  const cronDir = join(openclawDir, "cron");
+  mkdirSync(cronDir, { recursive: true });
+  writeFileSync(join(cronDir, "jobs.json"), JSON.stringify({ jobs }, null, 2), "utf-8");
+}
+
+function readCronStore(openclawDir: string): { jobs: unknown[] } {
+  const raw = readFileSync(join(openclawDir, "cron", "jobs.json"), "utf-8");
+  return JSON.parse(raw) as { jobs: unknown[] };
+}
+
+function writeGuardFile(openclawDir: string, jobName: string, timestampMs: number): void {
+  const guardDir = join(openclawDir, GUARD_SUBDIR);
+  mkdirSync(guardDir, { recursive: true });
+  writeFileSync(join(guardDir, `${jobName}.ms`), String(timestampMs), "utf-8");
+}
+
+const noop = { info: () => {}, warn: () => {} };
+
+// ---------------------------------------------------------------------------
+// buildGuardPrefix
+// ---------------------------------------------------------------------------
+
+describe("buildGuardPrefix", () => {
+  it("uses persistent ~/.openclaw/cron/guard/ path (not /tmp/)", () => {
+    const prefix = buildGuardPrefix("nightly-memory-sweep", 72_000_000);
+    expect(prefix).toContain("cron/guard");
+    expect(prefix).not.toContain("/tmp/");
+  });
+
+  it("references issue #305", () => {
+    const prefix = buildGuardPrefix("weekly-reflection", 432_000_000);
+    expect(prefix).toContain("#305");
+  });
+
+  it("includes the job name and guard window in the prefix", () => {
+    const prefix = buildGuardPrefix("self-correction-analysis", 72_000_000);
+    expect(prefix).toContain("self-correction-analysis");
+    expect(prefix).toContain("72000000");
+    expect(prefix).toContain("20h");
+  });
+
+  it("ends with double newline (separates guard from job content)", () => {
+    const prefix = buildGuardPrefix("monthly-consolidation", 2_160_000_000);
+    expect(prefix.endsWith("\n\n")).toBe(true);
+  });
+
+  it("includes instructions for writing guard file after completion", () => {
+    const prefix = buildGuardPrefix("nightly-dream-cycle", 72_000_000);
+    expect(prefix.toLowerCase()).toMatch(/write|mkdir/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getGuardFilePath
+// ---------------------------------------------------------------------------
+
+describe("getGuardFilePath", () => {
+  it("returns a path ending in {jobName}.ms", () => {
+    const p = getGuardFilePath("nightly-memory-sweep", "/home/user/.openclaw");
+    expect(p).toMatch(/nightly-memory-sweep\.ms$/);
+  });
+
+  it("includes the guard subdirectory", () => {
+    const p = getGuardFilePath("weekly-reflection", "/home/user/.openclaw");
+    expect(p).toContain("cron");
+    expect(p).toContain("guard");
+  });
+
+  it("is under the provided openclawDir", () => {
+    const p = getGuardFilePath("monthly-consolidation", "/custom/dir");
+    expect(p.startsWith("/custom/dir")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// readGuardTimestampMs
+// ---------------------------------------------------------------------------
+
+describe("readGuardTimestampMs", () => {
+  let openclawDir: string;
+
+  beforeEach(() => {
+    openclawDir = makeOpenclawDir();
+  });
+
+  afterEach(() => {
+    rmSync(openclawDir, { recursive: true, force: true });
+  });
+
+  it("returns null when guard file does not exist", () => {
+    expect(readGuardTimestampMs("missing-job", openclawDir)).toBeNull();
+  });
+
+  it("reads epoch-ms timestamp", () => {
+    const ts = Date.now();
+    writeGuardFile(openclawDir, "nightly-memory-sweep", ts);
+    expect(readGuardTimestampMs("nightly-memory-sweep", openclawDir)).toBe(ts);
+  });
+
+  it("converts epoch-seconds (< 2e12) to epoch-ms", () => {
+    // Simulate legacy `date +%s` output
+    const secs = Math.floor(Date.now() / 1000);
+    const guardDir = join(openclawDir, GUARD_SUBDIR);
+    mkdirSync(guardDir, { recursive: true });
+    writeFileSync(join(guardDir, "legacy-job.ms"), String(secs), "utf-8");
+    const result = readGuardTimestampMs("legacy-job", openclawDir);
+    expect(result).toBe(secs * 1000);
+  });
+
+  it("returns null for invalid file content", () => {
+    const guardDir = join(openclawDir, GUARD_SUBDIR);
+    mkdirSync(guardDir, { recursive: true });
+    writeFileSync(join(guardDir, "bad-job.ms"), "not-a-number", "utf-8");
+    expect(readGuardTimestampMs("bad-job", openclawDir)).toBeNull();
+  });
+
+  it("returns null for zero value", () => {
+    const guardDir = join(openclawDir, GUARD_SUBDIR);
+    mkdirSync(guardDir, { recursive: true });
+    writeFileSync(join(guardDir, "zero-job.ms"), "0", "utf-8");
+    expect(readGuardTimestampMs("zero-job", openclawDir)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// syncCronLastRunFromGuards
+// ---------------------------------------------------------------------------
+
+describe("syncCronLastRunFromGuards", () => {
+  let openclawDir: string;
+
+  beforeEach(() => {
+    openclawDir = makeOpenclawDir();
+  });
+
+  afterEach(() => {
+    rmSync(openclawDir, { recursive: true, force: true });
+  });
+
+  it("does nothing when jobs.json does not exist", () => {
+    // Should not throw
+    expect(() => syncCronLastRunFromGuards(noop, openclawDir)).not.toThrow();
+  });
+
+  it("does nothing when guard directory is empty and no matching /tmp/ file", () => {
+    // Use a UUID-suffixed name to avoid matching any real /tmp/hybrid-mem-guard-*.txt files
+    const uniqueName = `test-job-no-guard-${randomUUID()}`;
+    writeCronStore(openclawDir, [{ name: uniqueName, enabled: true }]);
+    syncCronLastRunFromGuards(noop, openclawDir);
+    const store = readCronStore(openclawDir);
+    const job = (store.jobs as Array<Record<string, unknown>>)[0];
+    expect(job.state).toBeUndefined();
+  });
+
+  it("back-fills lastRunAtMs when job has no state", () => {
+    const ts = Date.now() - 2 * 60 * 60 * 1000; // 2h ago
+    writeCronStore(openclawDir, [{ name: "nightly-memory-sweep", enabled: true }]);
+    writeGuardFile(openclawDir, "nightly-memory-sweep", ts);
+
+    syncCronLastRunFromGuards(noop, openclawDir);
+
+    const store = readCronStore(openclawDir);
+    const job = (store.jobs as Array<Record<string, unknown>>)[0];
+    const state = job.state as Record<string, unknown>;
+    expect(state.lastRunAtMs).toBe(ts);
+  });
+
+  it("updates lastRunAtMs when guard timestamp is newer", () => {
+    const oldTs = Date.now() - 24 * 60 * 60 * 1000; // 24h ago
+    const newTs = Date.now() - 2 * 60 * 60 * 1000;   // 2h ago
+    writeCronStore(openclawDir, [
+      { name: "weekly-reflection", enabled: true, state: { lastRunAtMs: oldTs } },
+    ]);
+    writeGuardFile(openclawDir, "weekly-reflection", newTs);
+
+    syncCronLastRunFromGuards(noop, openclawDir);
+
+    const store = readCronStore(openclawDir);
+    const job = (store.jobs as Array<Record<string, unknown>>)[0];
+    const state = job.state as Record<string, unknown>;
+    expect(state.lastRunAtMs).toBe(newTs);
+  });
+
+  it("does NOT downgrade lastRunAtMs when guard timestamp is older", () => {
+    const recentTs = Date.now() - 1 * 60 * 60 * 1000;  // 1h ago
+    const olderTs  = Date.now() - 12 * 60 * 60 * 1000; // 12h ago
+    writeCronStore(openclawDir, [
+      { name: "monthly-consolidation", enabled: true, state: { lastRunAtMs: recentTs } },
+    ]);
+    writeGuardFile(openclawDir, "monthly-consolidation", olderTs);
+
+    syncCronLastRunFromGuards(noop, openclawDir);
+
+    const store = readCronStore(openclawDir);
+    const job = (store.jobs as Array<Record<string, unknown>>)[0];
+    const state = job.state as Record<string, unknown>;
+    expect(state.lastRunAtMs).toBe(recentTs);
+  });
+
+  it("preserves other state fields when updating lastRunAtMs", () => {
+    const ts = Date.now() - 3 * 60 * 60 * 1000;
+    writeCronStore(openclawDir, [
+      {
+        name: "self-correction-analysis",
+        enabled: true,
+        state: { nextRunAtMs: Date.now() + 1_000_000, lastStatus: "ok", consecutiveErrors: 0 },
+      },
+    ]);
+    writeGuardFile(openclawDir, "self-correction-analysis", ts);
+
+    syncCronLastRunFromGuards(noop, openclawDir);
+
+    const store = readCronStore(openclawDir);
+    const job = (store.jobs as Array<Record<string, unknown>>)[0];
+    const state = job.state as Record<string, unknown>;
+    expect(state.lastRunAtMs).toBe(ts);
+    expect(state.lastStatus).toBe("ok");
+    expect(state.consecutiveErrors).toBe(0);
+    expect(typeof state.nextRunAtMs).toBe("number");
+  });
+
+  it("handles multiple jobs independently", () => {
+    const ts1 = Date.now() - 2 * 60 * 60 * 1000;
+    const ts2 = Date.now() - 5 * 60 * 60 * 1000;
+    const recentTs = Date.now() - 1000;
+    writeCronStore(openclawDir, [
+      { name: "nightly-memory-sweep", enabled: true },
+      { name: "weekly-reflection", enabled: true },
+      { name: "monthly-consolidation", enabled: true, state: { lastRunAtMs: recentTs } },
+    ]);
+    writeGuardFile(openclawDir, "nightly-memory-sweep", ts1);
+    writeGuardFile(openclawDir, "weekly-reflection", ts2);
+    // monthly-consolidation has no guard file — should not be changed
+
+    syncCronLastRunFromGuards(noop, openclawDir);
+
+    const store = readCronStore(openclawDir);
+    const jobs = store.jobs as Array<Record<string, unknown>>;
+    expect((jobs[0].state as Record<string, unknown>).lastRunAtMs).toBe(ts1);
+    expect((jobs[1].state as Record<string, unknown>).lastRunAtMs).toBe(ts2);
+    // monthly-consolidation: lastRunAtMs unchanged
+    const monthlyState = jobs[2].state as Record<string, unknown>;
+    expect(monthlyState.lastRunAtMs).toBe(recentTs);
+  });
+
+  it("normalizes job name with spaces (spaces → hyphens) for guard file lookup", () => {
+    const ts = Date.now() - 1 * 60 * 60 * 1000;
+    writeCronStore(openclawDir, [{ name: "nightly memory sweep", enabled: true }]);
+    // Guard file uses hyphens
+    writeGuardFile(openclawDir, "nightly-memory-sweep", ts);
+
+    syncCronLastRunFromGuards(noop, openclawDir);
+
+    const store = readCronStore(openclawDir);
+    const job = (store.jobs as Array<Record<string, unknown>>)[0];
+    const state = job.state as Record<string, unknown>;
+    expect(state.lastRunAtMs).toBe(ts);
+  });
+
+  it("converts epoch-seconds guard file to epoch-ms when syncing", () => {
+    const secs = Math.floor(Date.now() / 1000) - 3600; // 1h ago in seconds
+    const expectedMs = secs * 1000;
+    writeCronStore(openclawDir, [{ name: "nightly-dream-cycle", enabled: true }]);
+    // Write seconds (legacy format)
+    const guardDir = join(openclawDir, GUARD_SUBDIR);
+    mkdirSync(guardDir, { recursive: true });
+    writeFileSync(join(guardDir, "nightly-dream-cycle.ms"), String(secs), "utf-8");
+
+    syncCronLastRunFromGuards(noop, openclawDir);
+
+    const store = readCronStore(openclawDir);
+    const job = (store.jobs as Array<Record<string, unknown>>)[0];
+    const state = job.state as Record<string, unknown>;
+    expect(state.lastRunAtMs).toBe(expectedMs);
+  });
+
+  it("logs info when jobs are updated", () => {
+    const ts = Date.now() - 60_000;
+    writeCronStore(openclawDir, [{ name: "weekly-deep-maintenance", enabled: true }]);
+    writeGuardFile(openclawDir, "weekly-deep-maintenance", ts);
+
+    const messages: string[] = [];
+    syncCronLastRunFromGuards({ info: (m) => messages.push(m), warn: noop.warn }, openclawDir);
+
+    expect(messages.some((m) => m.includes("synced") && m.includes("1"))).toBe(true);
+  });
+
+  it("does not write jobs.json when nothing changes", () => {
+    const recentTs = Date.now() - 1000;
+    writeCronStore(openclawDir, [
+      { name: "nightly-memory-sweep", enabled: true, state: { lastRunAtMs: recentTs } },
+    ]);
+    writeGuardFile(openclawDir, "nightly-memory-sweep", recentTs - 100); // older → no update
+
+    const before = readFileSync(join(openclawDir, "cron", "jobs.json"), "utf-8");
+    syncCronLastRunFromGuards(noop, openclawDir);
+    const after = readFileSync(join(openclawDir, "cron", "jobs.json"), "utf-8");
+
+    expect(after).toBe(before);
+  });
+
+  it("skips jobs.json when file is malformed", () => {
+    const cronDir = join(openclawDir, "cron");
+    mkdirSync(cronDir, { recursive: true });
+    writeFileSync(join(cronDir, "jobs.json"), "{ invalid json", "utf-8");
+    writeGuardFile(openclawDir, "nightly-memory-sweep", Date.now());
+    // Should not throw
+    expect(() => syncCronLastRunFromGuards(noop, openclawDir)).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Guard-prefix migration (ensureMaintenanceCronJobs normalizeExisting)
+// Tested indirectly: the new buildGuardPrefix must not contain /tmp/
+// ---------------------------------------------------------------------------
+
+describe("guard prefix format — persistent path", () => {
+  it("buildGuardPrefix output does not mention /tmp/", () => {
+    const jobs = [
+      "nightly-memory-sweep",
+      "self-correction-analysis",
+      "weekly-reflection",
+      "weekly-extract-procedures",
+      "nightly-memory-to-skills",
+      "weekly-deep-maintenance",
+      "weekly-persona-proposals",
+      "monthly-consolidation",
+      "nightly-dream-cycle",
+    ];
+    for (const name of jobs) {
+      const prefix = buildGuardPrefix(name, 72_000_000);
+      expect(prefix, `${name} guard prefix should not use /tmp/`).not.toContain("/tmp/");
+      expect(prefix, `${name} guard prefix should use cron/guard/`).toContain("cron/guard");
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- **Root cause**: `state.lastRunAtMs` lives in memory and may not flush to `jobs.json` before gateway restart; old guard files in `/tmp/` are wiped on system reboot
- **Fix**: Persistent guard files in `~/.openclaw/cron/guard/{jobName}.ms` (epoch-ms) that survive both restarts and reboots; `syncCronLastRunFromGuards()` back-fills `jobs.json` on every plugin startup
- **Migration**: `ensureMaintenanceCronJobs` with `normalizeExisting: true` (triggered by `verify --fix` / `upgrade`) detects old `/tmp/` paths in job messages and replaces them with the new persistent path
- **Bug fix**: Epoch-seconds detection threshold corrected from `2e12` to `1e10` (current epoch-ms ~1.77e12 was below the old threshold, causing all timestamps to be incorrectly multiplied by 1000)

## Test plan

- [x] 26 new unit tests in `tests/cron-lastrun-state.test.ts` covering `buildGuardPrefix`, `getGuardFilePath`, `readGuardTimestampMs`, and `syncCronLastRunFromGuards`
- [x] Full suite: 2860 tests pass, 0 failures
- [x] `npx tsc --noEmit` clean

Closes #305

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cron scheduling state by reading/writing `~/.openclaw/cron/jobs.json` and introducing new guard-file migration/sync logic; incorrect parsing or path handling could cause missed or repeated job runs.
> 
> **Overview**
> Fixes cron maintenance jobs re-firing immediately after gateway restart/reboot by moving the “min-interval” guard from `/tmp` to persistent `~/.openclaw/cron/guard/{job}.ms` and introducing a startup sync that back-fills `state.lastRunAtMs` in `cron/jobs.json` from those guard files.
> 
> Updates `ensureMaintenanceCronJobs` normalization to add missing guard prefixes *and* migrate existing job messages from legacy `/tmp/hybrid-mem-guard-*` paths to the new persistent format, and adds comprehensive unit tests for guard parsing and lastRun syncing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6a1f88300377245d92efc115b722ddd2fc2e3777. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->