### PR TITLE
fix: override @hono/node-server >=1.19.10 (GHSA-wc8c-qw6v-h7f6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
-(Nothing yet.)
+### Security
+
+- **Override @hono/node-server to >=1.19.10 <2 (GHSA-wc8c-qw6v-h7f6):** Added npm `overrides` to force `@hono/node-server` to a patched version. The unbounded range is capped at `<2` to prevent accidental major-version upgrades.
 
 ---
 


### PR DESCRIPTION
## What
Override transitive dependency `@hono/node-server` to `>=1.19.10` to fix high-severity auth bypass vulnerability (GHSA-wc8c-qw6v-h7f6).

## Why
The dep chain `openclaw → @buape/carbon → @hono/node-server@1.19.9` triggered `npm audit` failure in CI. The fix version is 1.19.10+.

## How
Added `overrides` in `extensions/memory-hybrid/package.json` — cleanest fix for a transitive dep we don't control.

```json
"overrides": { "@hono/node-server": ">=1.19.10" }
```

Verified: `npm audit --audit-level=moderate` now passes with 0 vulnerabilities.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Forces a transitive dependency upgrade via npm `overrides`, which can change runtime behavior if `@hono/node-server` has breaking changes within the allowed range; however the change is narrowly scoped and intended to patch a known vulnerability.
> 
> **Overview**
> Addresses GHSA-wc8c-qw6v-h7f6 by adding an npm `overrides` rule in `extensions/memory-hybrid/package.json` to pin transitive `@hono/node-server` to `>=1.19.10 <2` (explicitly preventing accidental major-version upgrades).
> 
> Updates `CHANGELOG.md` *Unreleased → Security* to document the dependency override and rationale.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0120b0be756f008ee48e4faefbcbcf109bfa3182. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->