### PR TITLE
fix: GlitchTip: LLMRetryError: Failed after 3 attempts: 403 Country, region, or terri (#395)

### DIFF
--- a/extensions/memory-hybrid/tests/chat.test.ts
+++ b/extensions/memory-hybrid/tests/chat.test.ts
@@ -610,7 +610,7 @@ describe("chatCompleteWithRetry — 500 and 404 fallback (#302, #303)", () => {
   });
 });
 
-describe("chatCompleteWithRetry — 403 country/region restriction (#394)", () => {
+describe("chatCompleteWithRetry — 403 country/region restriction (#394, #395)", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     vi.clearAllMocks();
@@ -673,6 +673,18 @@ describe("chatCompleteWithRetry — 403 country/region restriction (#394)", () =
     expect(drained).toHaveLength(1);
     expect(drained[0]).toMatch(/403/);
     expect(drained[0]).toMatch(/country|region|access denied/i);
+  });
+
+  it("#395: withLLMRetry short-circuits on 403 and does not create LLMRetryError", async () => {
+    const err = Object.assign(
+      new Error("403 Country, region, or territory not supported"),
+      { status: 403 },
+    );
+    const fn = vi.fn().mockRejectedValue(err);
+
+    await expect(withLLMRetry(fn, { maxRetries: 3 })).rejects.toThrow("403 Country");
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(errorReporter.capturePluginError).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Summary

- Treat HTTP 403 (country/region restriction, IP block, billing) as a permanent config error — never retry, never report to GlitchTip
- Add `is403Like()` helper in `chat.ts` (parallel to existing `is404Like`)
- `withLLMRetry`: short-circuit on 403 so no `LLMRetryError` is created
- `withLLMRetry`: add 403 to `isTransient` defensive safety net
- `chatComplete`: add `is403Like` to `isConfigError` to suppress reporting
- `chatCompleteWithRetry`: add `finalIs403` guard — skips GlitchTip and queues user-visible warning
- `embeddings.ts`: add `is403OrWrapped()` and suppress `capturePluginError` across all embedding paths (embed, embedBatch, FallbackEmbeddingProvider, ChainEmbeddingProvider, safeEmbed)

## Test plan

- [x] `is403Like` unit tests (status field, message patterns, edge cases)
- [x] `withLLMRetry` short-circuits on 403 (only 1 call, no GlitchTip report)
- [x] `chatCompleteWithRetry` does not report to GlitchTip on 403 (with/without status field)
- [x] `chatCompleteWithRetry` queues user warning on 403
- [x] `FallbackEmbeddingProvider` does not report 403 on embed/embedBatch
- [x] `ChainEmbeddingProvider` does not report 403 on embed/embedBatch
- [x] `safeEmbed` does not report 403
- [x] All 3243 existing tests still pass
- [x] `npx tsc --noEmit` is clean

Closes #395

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes retry/fallback error classification so HTTP 403s short-circuit retries and suppress error reporting; risk is moderate because it alters control flow for LLM/embedding failures and could hide genuinely actionable 403-like errors if detection is too broad.
> 
> **Overview**
> Treats HTTP `403` (country/region restriction, IP/billing blocks) as a *permanent config/access error* across chat and embeddings: adds `is403Like()` detection, prevents `withLLMRetry` from retrying/wrapping 403s into `LLMRetryError`, and extends `chatComplete`/`chatCompleteWithRetry` suppression logic to avoid `capturePluginError` and instead queue a user-facing warning when all models fail with 403.
> 
> Extends embeddings failure handling to also suppress GlitchTip on 403s (including wrapped errors) alongside existing 404/429 suppression, and adds/updates Vitest coverage for `is403Like`, 403 short-circuit behavior, and 403 fallback/warning/reporting scenarios.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d1b9dcc61e2d91c83b9c04eb98d7d112aaf4a372. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->