### PR TITLE
fix(chat): gracefully handle Ollama weekly rate-limit 429 errors

### DIFF
--- a/extensions/memory-hybrid/lifecycle/hooks.ts
+++ b/extensions/memory-hybrid/lifecycle/hooks.ts
@@ -25,7 +25,7 @@ import type { EventLog } from "../backends/event-log.js";
 import type { AliasDB } from "../services/retrieval-aliases.js";
 import type { MemoryEntry, ScopeFilter, SearchResult } from "../types/memory.js";
 import { mergeResults, filterByScope } from "../services/merge-results.js";
-import { chatCompleteWithRetry, is500Like, is404Like, isOllamaOOM, type PendingLLMWarnings } from "../services/chat.js";
+import { chatCompleteWithRetry, is500Like, is404Like, isOllamaOOM, isTimeoutLike, type PendingLLMWarnings } from "../services/chat.js";
 import { computeDynamicSalience } from "../utils/salience.js";
 import { estimateTokens, estimateTokensForDisplay, formatProgressiveIndexLine, truncateForStorage } from "../utils/text.js";
 import { extractTags } from "../utils/tags.js";
@@ -812,7 +812,7 @@ export function createLifecycleHooks(ctx: LifecycleContext) {
                         isOllamaOOM(hydeErr) ||
                         is500Like(hydeErr) ||
                         is404Like(hydeErr) ||
-                        /timed out|llm request timeout|request was aborted|econnrefused/i.test(hydeErr.message);
+                        isTimeoutLike(hydeErr);
                       if (!isTransient) {
                         capturePluginError(hydeErr, {
                           operation: `${opts?.errorPrefix ?? ""}hyde-generation`,

--- a/extensions/memory-hybrid/services/auto-classifier.ts
+++ b/extensions/memory-hybrid/services/auto-classifier.ts
@@ -12,7 +12,7 @@ import type { FactsDB } from "../backends/facts-db.js";
 import { getMemoryCategories, setMemoryCategories, isValidCategory } from "../config.js";
 import { loadPrompt, fillPrompt } from "../utils/prompt-loader.js";
 import { capturePluginError } from "./error-reporter.js";
-import { is500Like, is404Like, isOllamaOOM } from "./chat.js";
+import { is500Like, is404Like, isOllamaOOM, isTimeoutLike } from "./chat.js";
 
 /** Minimum "other" facts before category discovery kicks in. */
 const MIN_OTHER_FOR_DISCOVERY = 15;
@@ -90,7 +90,7 @@ async function discoverCategoriesFromOther(
         isOllamaOOM(discErr) ||
         is500Like(discErr) ||
         is404Like(discErr) ||
-        /timed out|llm request timeout|request was aborted|econnrefused/i.test(discErr.message);
+        isTimeoutLike(discErr);
       if (!isTransient) {
         capturePluginError(discErr, {
           subsystem: "auto-classifier",
@@ -193,7 +193,7 @@ Respond with ONLY a JSON array of category strings, one per fact, in order. Exam
       isOllamaOOM(classifyErr) ||
       is500Like(classifyErr) ||
       is404Like(classifyErr) ||
-      /timed out|llm request timeout|request was aborted|econnrefused/i.test(classifyErr.message);
+      isTimeoutLike(classifyErr);
     if (!isTransient) {
       capturePluginError(classifyErr, {
         operation: 'classify-batch',

--- a/extensions/memory-hybrid/services/chat.ts
+++ b/extensions/memory-hybrid/services/chat.ts
@@ -221,6 +221,19 @@ export function isOllamaOOM(err: unknown): boolean {
 }
 
 /**
+ * Detect timeout-like errors (network timeouts, aborted requests, connection failures).
+ * Covers both our own timeout messages and various provider/network error patterns.
+ * These are transient failures — callers should skip capturePluginError.
+ *
+ * Exported so other modules (passive-observer, auto-classifier) can detect timeouts
+ * for error classification and reporting decisions.
+ */
+export function isTimeoutLike(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  return /timed out|llm request timeout|request was aborted|Request was aborted|ETIMEDOUT|ECONNREFUSED/i.test(err.message);
+}
+
+/**
  * Try to parse a Retry-After delay (in ms) from an API error.
  * Returns undefined when the header is absent or unparseable.
  */
@@ -406,7 +419,7 @@ export async function withLLMRetry<T>(
       }
       // Timeouts: only retry once (attempt 0 → attempt 1), then throw so chatCompleteWithRetry can try next model.
       // (attempt is 0-based: attempt >= 1 means we've already retried once.)
-      const isTimeout = /timed out|llm request timeout|request was aborted|Request was aborted|ETIMEDOUT|ECONNREFUSED/i.test(lastError.message);  // #339: include our own "LLM request timeout" pattern
+      const isTimeout = isTimeoutLike(lastError);
       if (isTimeout && attempt >= 1) {
         throw lastError;
       }
@@ -541,7 +554,7 @@ export async function chatCompleteWithRetry(opts: {
       const isUnconfigured = lastError instanceof UnconfiguredProviderError ||
         (lastError instanceof LLMRetryError && lastError.cause instanceof UnconfiguredProviderError);
       const is429 = is429OrWrapped(lastError);
-      const isTimeout = /timed out|llm request timeout|request was aborted|Request was aborted|ETIMEDOUT|ECONNREFUSED/i.test(lastError.message);  // #339: include our own "LLM request timeout" pattern
+      const isTimeout = isTimeoutLike(lastError);
       const is404 = is404Like(lastError);
       const is403 = is403Like(lastError);
       const is500 = is500Like(lastError);  // #302
@@ -568,7 +581,7 @@ export async function chatCompleteWithRetry(opts: {
   const finalIs403 = is403Like(finalError);  // #394: country/region restriction = operator config issue
   const finalIsOOM = isOllamaOOM(finalError);  // #387: OOM is expected when model too large for RAM
   const finalIs429 = is429OrWrapped(finalError);  // #397
-  const finalIsTimeout = /timed out|llm request timeout|request was aborted|Request was aborted|ETIMEDOUT|ECONNREFUSED/i.test(finalError.message);
+  const finalIsTimeout = isTimeoutLike(finalError);
 
   // When every model failed because provider keys are missing, queue a user-visible chat warning
   // and skip Sentry (this is a config issue, not a bug).

--- a/extensions/memory-hybrid/services/passive-observer.ts
+++ b/extensions/memory-hybrid/services/passive-observer.ts
@@ -32,7 +32,8 @@ import {
   is404Like, 
   is403Like, 
   is500Like,
-  isOllamaOOM
+  isOllamaOOM,
+  isTimeoutLike
 } from './chat.js'
 import { capturePluginError } from './error-reporter.js'
 import { normalizeVector, dotProductSimilarity } from './reflection.js'
@@ -531,10 +532,8 @@ export async function runPassiveObserver(
         const retryAttempt = err instanceof LLMRetryError ? err.attemptNumber : 1
         const errObj = err instanceof Error ? err : new Error(String(err));
         
-        const isTimeout = /timed out|llm request timeout|request was aborted|Request was aborted|ETIMEDOUT|ECONNREFUSED/i.test(errObj.message);
-        
         // Skip reporting transient provider errors to GlitchTip
-        if (!is500Like(errObj) && !isOllamaOOM(errObj) && !isTimeout && !is403Like(errObj) && !is404Like(errObj) && !is429OrWrapped(errObj)) {
+        if (!is500Like(errObj) && !isOllamaOOM(errObj) && !isTimeoutLike(errObj) && !is403Like(errObj) && !is404Like(errObj) && !is429OrWrapped(errObj)) {
           capturePluginError(errObj, {
             operation: 'passive-observer-llm',
             subsystem: 'passive-observer',


### PR DESCRIPTION
Closes #398

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes LLM retry/fallback behavior for some 429 and timeout errors and adjusts error-reporting suppression, which could affect reliability and observability across multiple memory features.
> 
> **Overview**
> Improves LLM error handling in `memory-hybrid` by adding `isPermanentRateLimit()` and treating quota/weekly-limit 429s as *non-retriable*, immediately falling back to the next model instead of exponential backoff.
> 
> Centralizes timeout classification via a new `isTimeoutLike()` helper and reuses it across auto-recall HyDE generation, auto-classification, and `chatCompleteWithRetry`.
> 
> Reduces GlitchTip noise by skipping `capturePluginError` in `passive-observer` for transient/provider/config failures (5xx, 429, 403, 404, OOM, timeouts) rather than reporting all LLM failures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ceeebad0db8c6c598c590866f6cdd96d6190399f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->