### PR TITLE
fix(classifier): add timeout handling and retry for classify-batch

### DIFF
--- a/extensions/memory-hybrid/config/parsers/retrieval.ts
+++ b/extensions/memory-hybrid/config/parsers/retrieval.ts
@@ -25,6 +25,7 @@ export function parseAutoClassifyConfig(cfg: Record<string, unknown>): AutoClass
     batchSize: typeof acCfg?.batchSize === "number" ? acCfg.batchSize : 20,
     suggestCategories: acCfg?.suggestCategories !== false,
     minFactsForNewCategory: typeof acCfg?.minFactsForNewCategory === "number" ? acCfg.minFactsForNewCategory : 10,
+    timeoutMs: typeof acCfg?.timeoutMs === "number" && acCfg.timeoutMs > 0 ? acCfg.timeoutMs : 30000,
   };
 }
 

--- a/extensions/memory-hybrid/config/types/retrieval.ts
+++ b/extensions/memory-hybrid/config/types/retrieval.ts
@@ -9,6 +9,8 @@ export type AutoClassifyConfig = {
   suggestCategories?: boolean;
   /** Minimum facts with the same suggested label before we create that category (default 10). Not told to the LLM. */
   minFactsForNewCategory?: number;
+  /** Timeout in ms for the LLM call; on timeout, retries or returns empty (default: 30000). */
+  timeoutMs?: number;
 };
 
 /** Entity-centric recall: when prompt mentions an entity from the list, merge lookup(entity) facts into candidates */

--- a/extensions/memory-hybrid/services/auto-classifier.ts
+++ b/extensions/memory-hybrid/services/auto-classifier.ts
@@ -42,7 +42,7 @@ function normalizeSuggestedLabel(s: string): string {
 async function discoverCategoriesFromOther(
   factsDb: FactsDB,
   openai: OpenAI,
-  config: { model: string; batchSize: number; suggestCategories?: boolean; minFactsForNewCategory?: number },
+  config: { model: string; batchSize: number; suggestCategories?: boolean; minFactsForNewCategory?: number; timeoutMs?: number },
   logger: { info: (msg: string) => void; warn: (msg: string) => void },
   discoveredCategoriesPath: string,
 ): Promise<string[]> {
@@ -69,7 +69,7 @@ async function discoverCategoriesFromOther(
           messages: [{ role: "user", content: prompt }],
           temperature: 0,
           max_tokens: batch.length * 24,
-        }),
+        }, { timeout: config.timeoutMs ?? 30000 }),
         { maxRetries: 2 }
       );
       const content = resp.choices[0]?.message?.content?.trim() || "[]";
@@ -142,6 +142,7 @@ async function classifyBatch(
   model: string,
   facts: { id: string; text: string }[],
   categories: readonly string[],
+  timeoutMs: number = 30000,
 ): Promise<Map<string, string>> {
   const catList = categories.filter((c) => c !== "other").join(", ");
   const factLines = facts
@@ -166,7 +167,7 @@ Respond with ONLY a JSON array of category strings, one per fact, in order. Exam
         messages: [{ role: "user", content: prompt }],
         temperature: 0,
         max_tokens: facts.length * 20,
-      }),
+      }, { timeout: timeoutMs }),
       { maxRetries: 2 }
     );
 
@@ -251,7 +252,7 @@ function createProgressReporter(
 async function runClassifyForCli(
   factsDb: FactsDB,
   openai: OpenAI,
-  config: { model?: string; batchSize: number; suggestCategories?: boolean; minFactsForNewCategory?: number },
+  config: { model?: string; batchSize: number; suggestCategories?: boolean; minFactsForNewCategory?: number; timeoutMs?: number },
   opts: { dryRun: boolean; limit: number; model?: string },
   discoveredPath: string,
   logger: { info: (msg: string) => void; warn: (msg: string) => void },
@@ -281,7 +282,7 @@ async function runClassifyForCli(
   for (let i = 0; i < others.length; i += config.batchSize) {
     progressReporter?.update(batchIndex + 1);
     const batch = others.slice(i, i + config.batchSize).map((e) => ({ id: e.id, text: e.text }));
-    const results = await classifyBatch(openai, classifyModel, batch, categories);
+    const results = await classifyBatch(openai, classifyModel, batch, categories, config.timeoutMs);
     for (const [id, newCat] of results) {
       if (!opts.dryRun) factsDb.updateCategory(id, newCat);
       totalReclassified++;
@@ -304,7 +305,7 @@ async function runClassifyForCli(
 async function runAutoClassify(
   factsDb: FactsDB,
   openai: OpenAI,
-  config: { model?: string; batchSize: number; suggestCategories?: boolean; minFactsForNewCategory?: number },
+  config: { model?: string; batchSize: number; suggestCategories?: boolean; minFactsForNewCategory?: number; timeoutMs?: number },
   logger: { info: (msg: string) => void; warn: (msg: string) => void },
   opts?: { discoveredCategoriesPath?: string; model?: string },
 ): Promise<{ reclassified: number; suggested: string[] }> {
@@ -337,7 +338,7 @@ async function runAutoClassify(
       text: e.text,
     }));
 
-    const results = await classifyBatch(openai, model, batch, categories);
+    const results = await classifyBatch(openai, model, batch, categories, config.timeoutMs);
 
     for (const [id, newCat] of results) {
       factsDb.updateCategory(id, newCat);


### PR DESCRIPTION
Closes #468

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes how auto-classification LLM calls are executed (adds request timeouts) and introduces a new config field that affects runtime behavior; failures now degrade via retry/empty results rather than hanging.
> 
> **Overview**
> **Adds configurable timeout handling for auto-classification LLM calls.** `autoClassify.timeoutMs` is parsed (default `30000`) and added to `AutoClassifyConfig`.
> 
> This timeout is threaded through category discovery and batch classification (`discoverCategoriesFromOther`, `classifyBatch`, and CLI/scheduled runners) by passing `{ timeout }` into `openai.chat.completions.create`, so slow/blocked calls time out and rely on existing retry/empty-result behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4e01b73e9a06483e16cae6bac03bd0a9ba6b3ddd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->