### PR TITLE
fix: [Ralph Dependency Audit] better-sqlite3 not imported — relies on dynamic require (#516)

### DIFF
--- a/extensions/memory-hybrid/package-lock.json
+++ b/extensions/memory-hybrid/package-lock.json
@@ -10,12 +10,12 @@
       "hasInstallScript": true,
       "dependencies": {
         "@lancedb/lancedb": "^0.26.2",
+        "@types/better-sqlite3": "^7.6.13",
         "better-sqlite3": "^12.0.0",
         "js-yaml": "^4.1.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.0.0",
-        "@types/better-sqlite3": "^7.6.13",
         "@types/js-yaml": "^4.0.9",
         "@types/node": "^25.2.3",
         "@vitest/coverage-v8": "^4.0.18",
@@ -5039,7 +5039,6 @@
       "version": "7.6.13",
       "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
       "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"

--- a/extensions/memory-hybrid/package.json
+++ b/extensions/memory-hybrid/package.json
@@ -43,6 +43,7 @@
   },
   "dependencies": {
     "@lancedb/lancedb": "^0.26.2",
+    "@types/better-sqlite3": "^7.6.13",
     "better-sqlite3": "^12.0.0",
     "js-yaml": "^4.1.1"
   },
@@ -67,7 +68,6 @@
   "devDependencies": {
     "@eslint/js": "^9.0.0",
     "openai": "^6.16.0",
-    "@types/better-sqlite3": "^7.6.13",
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^25.2.3",
     "@vitest/coverage-v8": "^4.0.18",


### PR DESCRIPTION
## Summary

- Moves `@types/better-sqlite3` from `devDependencies` to `dependencies`
- This plugin ships TypeScript source (not pre-compiled JS), so consumers who type-check against the package require `@types/better-sqlite3` at install time
- Without this, downstream consumers get TS7016 errors on `better-sqlite3` imports

## Addresses

**Engineering Goal 3 — Strict Separation of Concerns** and **Engineering Goal 4 — Testability**: consumers should be able to type-check the shipped TypeScript source without additional manual type installs.

## Test plan
- [x] All 132 test files pass (3,346 tests)
- [x] `npx tsc --noEmit` — clean (zero errors)
- [x] `@types/better-sqlite3` present in `dependencies`, absent from `devDependencies`

Closes #516

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency metadata change only; it affects install/packaging behavior but does not alter runtime logic.
> 
> **Overview**
> Ensures downstream consumers can type-check the `memory-hybrid` extension by moving `@types/better-sqlite3` from `devDependencies` to `dependencies`.
> 
> Updates `package.json` and `package-lock.json` so the typings are installed for consumers when the package is used (not just during development).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ecadc9c6bc56c9512acdef1cb46de4acbc5d2ff9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->