### PR TITLE
fix: bug: UnconfiguredProviderError for provider 'local' when mode=local — provider n (#487)

### DIFF
--- a/extensions/memory-hybrid/setup/init-databases.ts
+++ b/extensions/memory-hybrid/setup/init-databases.ts
@@ -819,7 +819,10 @@ export function initializeDatabases(cfg: HybridMemoryConfig, api: ClawdbotPlugin
       : [];
     // Models from agents.defaults.model with an unknown provider prefix (e.g. "Local/S", "custom/X")
     // would throw UnconfiguredProviderError when used, so filter them out here (issue #487).
-    const pluginProviders = (cfg.llm?.providers ?? {}) as Record<string, unknown>;
+    // Normalize provider keys to lowercase to match the lowercased prefix check at line 831 (issue #487 fix).
+    const pluginProviders = Object.fromEntries(
+      Object.entries((cfg.llm?.providers ?? {}) as Record<string, unknown>).map(([k, v]) => [k.toLowerCase(), v]),
+    );
     // Extract gateway config for OAuth routing check (matches buildMultiProviderOpenAI logic)
     const { gatewayBaseUrl, gatewayToken } = extractGatewayConfig(cfg);
     // Normalize auth.order keys to lowercase so lookups match the lowercased prefix.

--- a/extensions/memory-hybrid/tests/provider-routing.test.ts
+++ b/extensions/memory-hybrid/tests/provider-routing.test.ts
@@ -1351,6 +1351,36 @@ describe("gateway model auto-derivation — unknown provider prefix filter", () 
     expect(defaultList).toContain("Local/S");
   });
 
+  it("allows gateway models when user-configured provider key uses capital letters (case-insensitive lookup)", () => {
+    // Regression test for issue #487: user configures llm.providers.Local (capital L) in plugin config.
+    // Model "Local/S" should be kept because canRoute normalizes both the prefix and pluginProviders keys.
+    const cfg = getTestConfig(tmpDir, {
+      llm: {
+        providers: {
+          Local: { baseURL: "http://localhost:8080/v1" }, // Capital L
+        },
+      },
+    });
+    const api = makeMockApi({
+      resolvePath: (p: string) => (p.startsWith("/") ? p : join(tmpDir, p)),
+      config: {
+        agents: {
+          defaults: {
+            model: {
+              primary: "Local/S",
+            },
+          },
+        },
+      },
+    });
+
+    ctx = initializeDatabases(cfg, api as never);
+
+    const defaultList = Array.isArray(cfg.llm?.default) ? cfg.llm.default : [];
+    // Provider "Local" (capital L) is configured → model "Local/S" must be kept
+    expect(defaultList).toContain("Local/S");
+  });
+
   it("keeps bare model names (no provider prefix) during auto-derivation", () => {
     // Bare names like "gpt-4o" have no "/" → canRoute returns true; they are preserved during
     // auto-derivation without prefix filtering (normalizeModelId may route them further).


### PR DESCRIPTION
## Summary

- Filters out gateway models with unrecognised provider prefixes (e.g. `Local/S`, `custom/X`) during `agents.defaults.model` auto-derivation in `init-databases.ts`
- Adds a warn-level log entry for each skipped model so users can diagnose configuration gaps
- Bare model names (no `/`) and models with known built-in prefixes (`google`, `openai`, `anthropic`, `ollama`, `openrouter`, `minimax`) or plugin-configured providers are kept unchanged

## Root Cause

When `mode=local` is set without explicit `llm.default`, the plugin auto-derives LLM model tiers from `api.config.agents.defaults.model`. If the OpenClaw gateway config has a local-inference model like `"Local/S"`, `resolveClient` extracts `"local"` as the provider prefix and throws `UnconfiguredProviderError("local", "Local/S")` — 54 occurrences in GlitchTip since 2026-03-15.

## Test plan

- [x] New test: `"Local/S"` + `"Local/M"` filtered from auto-derived tier lists; known `openai/gpt-4.1-mini` kept; warn logged for each skipped model
- [x] New test: Unknown prefix kept when that prefix is explicitly configured in `llm.providers`
- [x] New test: Bare model names (no `/`) pass through unchanged
- [x] `npm test` — 3349 tests pass
- [x] `tsc --noEmit` — clean

Closes #487

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Routing/auto-derivation logic is adjusted but constrained to model selection and provider lookup; main risk is unintended filtering/allowing of models when deriving tiers from `agents.defaults.model`. Added tests cover the new edge cases, reducing regression risk.
> 
> **Overview**
> Prevents `UnconfiguredProviderError` during `agents.defaults.model` auto-derivation by **filtering out models with unknown provider prefixes**, while keeping bare model names and any models whose provider is built-in, configured via `llm.providers`, or available via `<PREFIX>_API_KEY`.
> 
> Makes provider lookups **case-insensitive** (normalizes `llm.providers` and `auth.order` keys) and treats **OAuth-routable providers** as valid during auto-derivation when the local gateway is configured. Gateway env/config parsing is centralized via `extractGatewayConfig`, and new warnings are logged when models are skipped or when all defaults are filtered out; tests are extended to cover mixed-case providers and OAuth routing behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 946f1b2e7dc18caf291d70da1d00b50f980401ff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->