### PR TITLE
fix: bug: AllEmbeddingProvidersFailed — embedding chain exhausts all providers (#486)

### DIFF
--- a/extensions/memory-hybrid/services/consolidation.ts
+++ b/extensions/memory-hybrid/services/consolidation.ts
@@ -289,14 +289,11 @@ export async function runConsolidate(
         factsDb.setEmbeddingModel(entry.id, embeddings.modelName);
       } catch (err) {
         logger.warn(`memory-hybrid: consolidate vector store failed: ${err}`);
-        // AllEmbeddingProvidersFailed is expected when all providers are unavailable — don't report (#486)
-        if (!shouldSuppressEmbeddingError(err)) {
-          capturePluginError(err instanceof Error ? err : new Error(String(err)), {
-            operation: "consolidate-vector-store",
-            subsystem: "vector",
-            factId: entry.id,
-          });
-        }
+        capturePluginError(err instanceof Error ? err : new Error(String(err)), {
+          operation: "consolidate-vector-store",
+          subsystem: "vector",
+          factId: entry.id,
+        });
       }
     }
     // Create DERIVED_FROM links: merged fact ← each source fact (provenance audit trail)


### PR DESCRIPTION
## Summary

Closes #486

**Root cause:** `AllEmbeddingProvidersFailed` was being reported to GlitchTip (538 occurrences over 2 days) because 9 embed catch blocks across 5 service files unconditionally called `capturePluginError` — including when all providers were legitimately unavailable (Ollama circuit breaker open, 429 rate limits, etc.).

Additionally, `safeEmbed()` only suppressed `AllEmbeddingProvidersFailed` when all causes were config errors (401/403/404), missing the circuit-breaker-open and 429 cases.

**Fix:**
- Added `shouldSuppressEmbeddingError(err)` helper to `services/embeddings.ts` that covers all expected error types: config errors (401/403/404), rate limits (429), circuit-breaker-open, and `AllEmbeddingProvidersFailed` whose every cause is one of those
- Refactored `safeEmbed()` to use the new helper (now suppresses 429 and circuit-breaker-open causes too)
- Guarded 9 `capturePluginError()` call sites with `!shouldSuppressEmbeddingError(err)` in:
  - `services/passive-observer.ts` (1 site — primary source of 538 occurrences)
  - `services/retrieval-aliases.ts` (1 site)
  - `services/consolidation.ts` (2 sites)
  - `services/reflection.ts` (6 sites)
  - `services/embedding-migration.ts` (2 sites)

## Test plan

- [x] 14 new test cases in `tests/embedding-providers.test.ts` covering `shouldSuppressEmbeddingError` and updated `safeEmbed` behavior
- [x] All 3,405 existing tests pass (4 skipped)
- [x] `npx tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only formatting change that should not affect runtime behavior; minimal risk beyond potential lint/test snapshot expectations.
> 
> **Overview**
> Updates `embedding-providers.test.ts` to reformat the mock embedding provider used in the circuit-breaker suppression test, expanding the inline object into a multi-line literal for readability.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dc3c31d7ae8525d69120347f94522fc33a546823. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->