### PR TITLE
fix: improvement: recall pipeline vector-step timeout does not cancel HyDE LLM call — (#558)

### DIFF
--- a/extensions/memory-hybrid/services/chat.ts
+++ b/extensions/memory-hybrid/services/chat.ts
@@ -526,19 +526,24 @@ export async function withLLMRetry<T>(
       } else {
         delay = Math.pow(3, attempt) * 1000; // 1s, 3s, 9s
       }
-      await new Promise((resolve, reject) => {
-        const timeout = setTimeout(resolve, delay);
+      // Abort-aware backoff sleep: if the signal fires while we are waiting, reject immediately
+      // instead of sleeping through the full delay. The listener is removed on normal resolve to
+      // prevent leaks; the { once: true } option is not relied on alone for cleanup.
+      await new Promise<void>((resolve, reject) => {
+        const onAbort = () => {
+          clearTimeout(timeout);
+          const reason = opts!.signal!.reason;
+          const msg = reason instanceof Error ? reason.message : reason != null ? String(reason) : "Aborted";
+          const abortError = new Error(msg);
+          abortError.name = "AbortError";
+          reject(abortError);
+        };
+        const timeout = setTimeout(() => {
+          opts?.signal?.removeEventListener("abort", onAbort);
+          resolve();
+        }, delay);
         if (opts?.signal) {
-          const onAbort = () => {
-            clearTimeout(timeout);
-            const reason = opts.signal!.reason;
-            const abortError =
-              reason instanceof Error ? reason : new Error(reason != null ? String(reason) : "Aborted");
-            abortError.name = "AbortError";
-            reject(abortError);
-          };
           if (opts.signal.aborted) {
-            clearTimeout(timeout);
             onAbort();
           } else {
             opts.signal.addEventListener("abort", onAbort, { once: true });
@@ -591,7 +596,8 @@ export async function chatCompleteWithRetry(opts: {
   for (let i = 0; i < modelsToTry.length; i++) {
     if (signal?.aborted) {
       const reason = (signal as AbortSignal).reason;
-      const abortError = reason instanceof Error ? reason : new Error(reason != null ? String(reason) : "Aborted");
+      const msg = reason instanceof Error ? reason.message : reason != null ? String(reason) : "Aborted";
+      const abortError = new Error(msg);
       abortError.name = "AbortError";
       throw abortError;
     }

--- a/extensions/memory-hybrid/services/recall-pipeline.ts
+++ b/extensions/memory-hybrid/services/recall-pipeline.ts
@@ -165,7 +165,9 @@ export async function runRecallPipelineQuery(
         // The HyDE call above may have completed just before the abort — we must not
         // waste an embedding provider call whose result will be discarded.
         if (directiveAbort.signal.aborted) {
-          throw new Error(`recall pipeline timed out after ${VECTOR_STEP_TIMEOUT_MS}ms`);
+          const abortError = new Error(`recall pipeline timed out after ${VECTOR_STEP_TIMEOUT_MS}ms`);
+          abortError.name = "AbortError";
+          throw abortError;
         }
 
         const vector =

--- a/extensions/memory-hybrid/tests/recall-pipeline.test.ts
+++ b/extensions/memory-hybrid/tests/recall-pipeline.test.ts
@@ -16,7 +16,7 @@
  *   - hydeUsedRef state is mutated correctly across multiple calls
  */
 
-import { describe, it, expect, vi, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { runRecallPipelineQuery, type RecallPipelineDeps } from "../services/recall-pipeline.js";
 import type { SearchResult, MemoryEntry } from "../types/memory.js";
 import { createPendingLLMWarnings } from "../services/chat.js";


### PR DESCRIPTION
## Summary

- Add abort guard before `embeddings.embed` in `recall-pipeline.ts`: checks `directiveAbort.signal.aborted` immediately after HyDE completes and throws early if the 30s vector-step timeout has already fired, preventing a wasted embedding provider call whose result will be discarded
- Add pre-backoff signal check in `withLLMRetry` (`chat.ts`): re-checks `opts.signal.aborted` before each retry backoff sleep so a parent-level abort (e.g. vector-step timeout) unblocks the retry loop immediately
- Add 2 new tests in `recall-pipeline.test.ts`: one using fake timers to fast-forward past the 30s timeout and assert `embed` is not called, plus a regression test verifying `embed` IS still called when HyDE fails for a non-abort reason

## Test plan
- [ ] All existing recall-pipeline tests pass (16/16)
- [ ] New test: `does not call embeddings.embed when vector-step timeout fires while HyDE is running` — passes
- [ ] New test: `still calls embeddings.embed with raw query when HyDE fails non-abort` — passes
- [ ] No TypeScript errors in changed files
- [ ] No console.log added

Closes #558

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches recall-timeout and LLM retry/backoff behavior; mistakes could change cancellation semantics or retry timing, impacting recall latency and provider call volume.
> 
> **Overview**
> Prevents wasted embedding calls in the recall pipeline by **bailing out before `embeddings.embed`** when the vector-step timeout abort has already fired after a long-running HyDE request.
> 
> Makes `withLLMRetry` backoff **abort-aware** (and adds 429-specific backoff honoring `Retry-After`), so parent aborts/timeouts can interrupt retry sleeps immediately instead of waiting out the delay.
> 
> Adds regression tests covering the timeout-abort case (ensuring `embed` is not called) and a non-abort HyDE failure case (ensuring raw-query embedding still runs).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e3cc21b112214ce7f50db8ffd3ec07c26ff62cc5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->