### PR TITLE
fix: improvement: [Ralph Dependency Audit] Regression: @types/better-sqlite3 and @typ (#564)

### DIFF
--- a/extensions/memory-hybrid/package.json
+++ b/extensions/memory-hybrid/package.json
@@ -36,6 +36,8 @@
   },
   "dependencies": {
     "@lancedb/lancedb": "^0.26.2",
+    "@types/better-sqlite3": "^7.6.13",
+    "@types/node": "^25.2.3",
     "better-sqlite3": "^12.0.0"
   },
   "openclaw": {
@@ -56,8 +58,6 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.0",
-    "@types/better-sqlite3": "^7.6.13",
-    "@types/node": "^25.2.3",
     "@vitest/coverage-v8": "^4.0.18",
     "knip": "^5.0.0",
     "typescript": "^5.9.3",


### PR DESCRIPTION
## Summary

- Moves `@types/better-sqlite3` from `devDependencies` to `dependencies`
- Moves `@types/node` from `devDependencies` to `dependencies`
- Fixes regression introduced in a prior PR that accidentally reverted these types back to devDependencies

Downstream consumers who compile the plugin's TypeScript source files need these type definitions to be available at install time, not just during development.

Closes #564

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency metadata change that only affects install/compile-time behavior; main risk is slightly larger dependency footprint for consumers.
> 
> **Overview**
> Ensures downstream consumers compiling `extensions/memory-hybrid` from TypeScript get required type definitions at install time by moving `@types/better-sqlite3` and `@types/node` from `devDependencies` to `dependencies` (fixing a prior regression).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a6240c706cc24b1f390dec3f32e217e643178ae2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->