### PR TITLE
feat: Persona / identity reflection layer on top of hybrid-memory (#647)

### DIFF
--- a/extensions/memory-hybrid/backends/identity-reflection-store.ts
+++ b/extensions/memory-hybrid/backends/identity-reflection-store.ts
@@ -1,0 +1,185 @@
+/**
+ * Identity Reflection Store
+ * Separate SQLite store for identity/persona synthesis outputs.
+ *
+ * Keeps identity-level reflections distinct from factual/workflow memory while
+ * still allowing downstream persona proposal generation to consume them.
+ */
+
+import { DatabaseSync } from "node:sqlite";
+import { randomUUID } from "node:crypto";
+import { mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+import { SQLITE_BUSY_TIMEOUT_MS } from "../utils/constants.js";
+import { capturePluginError } from "../services/error-reporter.js";
+
+type Durability = "durable" | "temporary";
+
+interface IdentityReflectionRow {
+  id: string;
+  run_id: string;
+  question_key: string;
+  question_text: string;
+  insight: string;
+  durability: Durability;
+  confidence: number;
+  evidence: string;
+  source_pattern_count: number;
+  source_rule_count: number;
+  source_meta_count: number;
+  created_at: number;
+}
+
+export interface IdentityReflectionEntry {
+  id: string;
+  runId: string;
+  questionKey: string;
+  questionText: string;
+  insight: string;
+  durability: Durability;
+  confidence: number;
+  evidence: string[];
+  sourcePatternCount: number;
+  sourceRuleCount: number;
+  sourceMetaCount: number;
+  createdAt: number;
+}
+
+export class IdentityReflectionStore {
+  private readonly db: DatabaseSync;
+  private closed = false;
+
+  constructor(dbPath: string) {
+    mkdirSync(dirname(dbPath), { recursive: true });
+    this.db = new DatabaseSync(dbPath);
+    this.db.exec("PRAGMA journal_mode = WAL");
+    this.db.exec(`PRAGMA busy_timeout = ${SQLITE_BUSY_TIMEOUT_MS}`);
+
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS identity_reflections (
+        id                    TEXT PRIMARY KEY,
+        run_id                TEXT NOT NULL,
+        question_key          TEXT NOT NULL,
+        question_text         TEXT NOT NULL,
+        insight               TEXT NOT NULL,
+        durability            TEXT NOT NULL CHECK (durability IN ('durable', 'temporary')),
+        confidence            REAL NOT NULL,
+        evidence              TEXT NOT NULL DEFAULT '[]',
+        source_pattern_count  INTEGER NOT NULL DEFAULT 0,
+        source_rule_count     INTEGER NOT NULL DEFAULT 0,
+        source_meta_count     INTEGER NOT NULL DEFAULT 0,
+        created_at            INTEGER NOT NULL
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_identity_reflections_created
+        ON identity_reflections(created_at DESC);
+
+      CREATE INDEX IF NOT EXISTS idx_identity_reflections_question
+        ON identity_reflections(question_key, created_at DESC);
+    `);
+  }
+
+  create(entry: {
+    runId: string;
+    questionKey: string;
+    questionText: string;
+    insight: string;
+    durability: Durability;
+    confidence: number;
+    evidence?: string[];
+    sourcePatternCount?: number;
+    sourceRuleCount?: number;
+    sourceMetaCount?: number;
+  }): IdentityReflectionEntry {
+    const id = randomUUID();
+    const createdAt = Math.floor(Date.now() / 1000);
+    const evidence = JSON.stringify(entry.evidence ?? []);
+    this.db
+      .prepare(
+        `INSERT INTO identity_reflections (
+           id, run_id, question_key, question_text, insight, durability, confidence, evidence,
+           source_pattern_count, source_rule_count, source_meta_count, created_at
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        id,
+        entry.runId,
+        entry.questionKey,
+        entry.questionText,
+        entry.insight,
+        entry.durability,
+        entry.confidence,
+        evidence,
+        entry.sourcePatternCount ?? 0,
+        entry.sourceRuleCount ?? 0,
+        entry.sourceMetaCount ?? 0,
+        createdAt,
+      );
+
+    return this.get(id)!;
+  }
+
+  get(id: string): IdentityReflectionEntry | null {
+    const row = this.db
+      .prepare(`SELECT * FROM identity_reflections WHERE id = ?`)
+      .get(id) as IdentityReflectionRow | undefined;
+    if (!row) return null;
+    return this.rowToEntry(row);
+  }
+
+  listRecent(limit = 50): IdentityReflectionEntry[] {
+    const rows = this.db
+      .prepare(`SELECT * FROM identity_reflections ORDER BY created_at DESC LIMIT ?`)
+      .all(limit) as IdentityReflectionRow[];
+    return rows.map((row) => this.rowToEntry(row));
+  }
+
+  getLatestByQuestion(questionKey: string): IdentityReflectionEntry | null {
+    const row = this.db
+      .prepare(`SELECT * FROM identity_reflections WHERE question_key = ? ORDER BY created_at DESC LIMIT 1`)
+      .get(questionKey) as IdentityReflectionRow | undefined;
+    if (!row) return null;
+    return this.rowToEntry(row);
+  }
+
+  close(): void {
+    if (this.closed) return;
+    this.closed = true;
+    try {
+      this.db.close();
+    } catch (err) {
+      capturePluginError(err instanceof Error ? err : new Error(String(err)), {
+        operation: "db-close",
+        severity: "info",
+        subsystem: "identity-reflection-store",
+      });
+    }
+  }
+
+  private rowToEntry(row: IdentityReflectionRow): IdentityReflectionEntry {
+    let evidence: string[] = [];
+    try {
+      const parsed = JSON.parse(row.evidence);
+      if (Array.isArray(parsed)) {
+        evidence = parsed.filter((x): x is string => typeof x === "string");
+      }
+    } catch {
+      // Keep malformed JSON non-fatal; callers can still use the insight.
+      evidence = [];
+    }
+    return {
+      id: row.id,
+      runId: row.run_id,
+      questionKey: row.question_key,
+      questionText: row.question_text,
+      insight: row.insight,
+      durability: row.durability,
+      confidence: row.confidence,
+      evidence,
+      sourcePatternCount: row.source_pattern_count,
+      sourceRuleCount: row.source_rule_count,
+      sourceMetaCount: row.source_meta_count,
+      createdAt: row.created_at,
+    };
+  }
+}

--- a/extensions/memory-hybrid/config/parsers/capture.ts
+++ b/extensions/memory-hybrid/config/parsers/capture.ts
@@ -4,6 +4,7 @@ import { expandHomePlaceholders } from "../../utils/path.js";
 import type {
   PassiveObserverConfig,
   ReflectionConfig,
+  IdentityReflectionConfig,
   ProceduresConfig,
   ExtractionConfig,
   ExtractionPreFilterConfig,
@@ -55,6 +56,44 @@ export function parseReflectionConfig(cfg: Record<string, unknown>): ReflectionC
       typeof reflectionRaw?.minObservations === "number" && reflectionRaw.minObservations >= 1
         ? Math.floor(reflectionRaw.minObservations)
         : 2,
+  };
+}
+
+const DEFAULT_IDENTITY_REFLECTION_QUESTIONS = [
+  { key: "protect", prompt: "What do I reliably protect?" },
+  { key: "speak_silence", prompt: "When should I speak, and when should I stay silent?" },
+  { key: "partnership", prompt: "What patterns define good partnership with the user?" },
+  { key: "tradeoffs", prompt: "What kinds of tradeoffs do I keep making?" },
+  { key: "durability", prompt: "Which insights feel temporary vs durable?" },
+] as const;
+
+export function parseIdentityReflectionConfig(cfg: Record<string, unknown>): IdentityReflectionConfig {
+  const raw = cfg.identityReflection as Record<string, unknown> | undefined;
+  const parsedQuestions = Array.isArray(raw?.questions)
+    ? raw.questions
+        .filter((q): q is Record<string, unknown> => !!q && typeof q === "object")
+        .map((q) => ({
+          key: typeof q.key === "string" ? q.key.trim() : "",
+          prompt: typeof q.prompt === "string" ? q.prompt.trim() : "",
+        }))
+        .filter((q) => q.key.length > 0 && q.prompt.length > 0)
+    : [];
+  return {
+    enabled: raw?.enabled === true,
+    model: typeof raw?.model === "string" && raw.model.trim().length > 0 ? raw.model.trim() : undefined,
+    defaultWindow:
+      typeof raw?.defaultWindow === "number" && raw.defaultWindow > 0
+        ? Math.min(90, Math.floor(raw.defaultWindow))
+        : 30,
+    minInsights: typeof raw?.minInsights === "number" && raw.minInsights >= 1 ? Math.floor(raw.minInsights) : 3,
+    maxInsightsPerRun:
+      typeof raw?.maxInsightsPerRun === "number" && raw.maxInsightsPerRun >= 1
+        ? Math.min(20, Math.floor(raw.maxInsightsPerRun))
+        : 8,
+    questions:
+      parsedQuestions.length > 0
+        ? parsedQuestions
+        : DEFAULT_IDENTITY_REFLECTION_QUESTIONS.map((q) => ({ key: q.key, prompt: q.prompt })),
   };
 }
 

--- a/extensions/memory-hybrid/config/parsers/index.ts
+++ b/extensions/memory-hybrid/config/parsers/index.ts
@@ -35,6 +35,7 @@ import {
 import {
   parsePassiveObserverConfig,
   parseReflectionConfig,
+  parseIdentityReflectionConfig,
   parseProceduresConfig,
   parseExtractionConfig,
 } from "./capture.js";
@@ -709,6 +710,7 @@ export function parseConfig(value: unknown): HybridMemoryConfig {
     personaProposals: parsePersonaProposalsConfig(cfg),
     passiveObserver: parsePassiveObserverConfig(cfg),
     reflection: parseReflectionConfig(cfg),
+    identityReflection: parseIdentityReflectionConfig(cfg),
     procedures: parseProceduresConfig(cfg),
     extraction: parseExtractionConfig(cfg),
     memoryTiering: parseMemoryTieringConfig(cfg),

--- a/extensions/memory-hybrid/config/types/capture.ts
+++ b/extensions/memory-hybrid/config/types/capture.ts
@@ -24,6 +24,16 @@ export type ReflectionConfig = {
   minObservations: number; // Min observations to support a pattern (default: 2)
 };
 
+/** Identity reflection: persona-level synthesis from reflection outputs */
+export type IdentityReflectionConfig = {
+  enabled: boolean;
+  model?: string; // when unset, runtime uses getDefaultCronModel(cfg, "default")
+  defaultWindow: number; // Time window in days (default: 30)
+  minInsights: number; // Min pattern/rule/meta insights required (default: 3)
+  maxInsightsPerRun: number; // Max identity insights stored per run (default: 8)
+  questions: Array<{ key: string; prompt: string }>; // Recurring identity questions
+};
+
 /** Two-tier LLM pre-filter configuration for bulk session triage (Issue #290). */
 export type ExtractionPreFilterConfig = {
   /** Enable local LLM pre-filtering (default: false). When true, each session is triaged by a local Ollama model before cloud LLM analysis. */

--- a/extensions/memory-hybrid/prompts/identity-reflection.txt
+++ b/extensions/memory-hybrid/prompts/identity-reflection.txt
@@ -1,0 +1,29 @@
+You are synthesizing identity-level reflections for an AI assistant from prior reflection outputs.
+
+You are given recurring identity questions plus existing reflection insights (patterns, rules, meta-patterns) from the last {{window}} days.
+
+Return JSON only: an array of objects with keys:
+- questionKey: one of the provided question keys
+- insight: 1-3 sentences, concrete and specific (not generic)
+- durability: "durable" or "temporary"
+- confidence: number 0-1
+- evidence: short list (1-3 strings) citing the source patterns/rules/meta that support the insight
+
+Rules:
+- Answer only with valid JSON (no markdown, no commentary).
+- Use only the provided question keys.
+- If evidence is weak, mark as "temporary" with lower confidence.
+- Prefer concise insights that can later be promoted into SOUL.md / IDENTITY.md.
+- Do not repeat raw inputs verbatim; synthesize.
+
+Questions:
+{{questions}}
+
+Patterns:
+{{patterns}}
+
+Rules:
+{{rules}}
+
+Meta-patterns:
+{{meta}}

--- a/extensions/memory-hybrid/services/identity-reflection.ts
+++ b/extensions/memory-hybrid/services/identity-reflection.ts
@@ -1,0 +1,203 @@
+import { randomUUID } from "node:crypto";
+import { chatCompleteWithRetry, LLMRetryError } from "./chat.js";
+import { loadPrompt, fillPrompt } from "../utils/prompt-loader.js";
+import type { FactsDB } from "../backends/facts-db.js";
+import type OpenAI from "openai";
+import type { ScopeFilter } from "../types/memory.js";
+import { capturePluginError } from "./error-reporter.js";
+import type { IdentityReflectionStore } from "../backends/identity-reflection-store.js";
+
+export interface IdentityReflectionQuestion {
+  key: string;
+  prompt: string;
+}
+
+export const DEFAULT_IDENTITY_REFLECTION_QUESTIONS: IdentityReflectionQuestion[] = [
+  { key: "protect", prompt: "What do I reliably protect?" },
+  { key: "speak_silence", prompt: "When should I speak, and when should I stay silent?" },
+  { key: "partnership", prompt: "What patterns define good partnership with the user?" },
+  { key: "tradeoffs", prompt: "What kinds of tradeoffs do I keep making?" },
+  { key: "durability", prompt: "Which insights feel temporary vs durable?" },
+];
+
+export interface IdentityReflectionConfig {
+  enabled: boolean;
+  model?: string;
+  defaultWindow: number;
+  minInsights: number;
+  maxInsightsPerRun: number;
+  questions: IdentityReflectionQuestion[];
+}
+
+export interface IdentityReflectionOptions {
+  dryRun: boolean;
+  model: string;
+  window?: number;
+  verbose?: boolean;
+  fallbackModels?: string[];
+  scopeFilter?: ScopeFilter;
+}
+
+interface ParsedIdentityItem {
+  questionKey: string;
+  insight: string;
+  durability: "durable" | "temporary";
+  confidence: number;
+  evidence: string[];
+}
+
+export interface IdentityReflectionResult {
+  insightsExtracted: number;
+  insightsStored: number;
+  questionsAsked: number;
+}
+
+function normalizeForDedupe(text: string): string {
+  return text.trim().toLowerCase().replace(/\s+/g, " ");
+}
+
+export function parseIdentityReflectionResponse(raw: string): ParsedIdentityItem[] {
+  const firstBracket = raw.indexOf("[");
+  const lastBracket = raw.lastIndexOf("]");
+  const json =
+    firstBracket !== -1 && lastBracket !== -1 && lastBracket >= firstBracket
+      ? raw.slice(firstBracket, lastBracket + 1)
+      : raw;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(parsed)) return [];
+  const out: ParsedIdentityItem[] = [];
+  for (const item of parsed) {
+    if (!item || typeof item !== "object") continue;
+    const obj = item as Record<string, unknown>;
+    const questionKey = typeof obj.questionKey === "string" ? obj.questionKey.trim() : "";
+    const insight = typeof obj.insight === "string" ? obj.insight.trim() : "";
+    const durabilityRaw = typeof obj.durability === "string" ? obj.durability.trim().toLowerCase() : "";
+    const confidenceRaw =
+      typeof obj.confidence === "number" ? obj.confidence : Number.parseFloat(String(obj.confidence ?? ""));
+    const evidence = Array.isArray(obj.evidence)
+      ? obj.evidence.filter((x): x is string => typeof x === "string").map((s) => s.trim())
+      : [];
+    if (!questionKey || !insight) continue;
+    if (insight.length < 20 || insight.length > 800) continue;
+    const durability = durabilityRaw === "durable" ? "durable" : durabilityRaw === "temporary" ? "temporary" : null;
+    if (!durability) continue;
+    const confidence = Number.isFinite(confidenceRaw) ? Math.max(0, Math.min(1, confidenceRaw)) : 0;
+    out.push({
+      questionKey,
+      insight,
+      durability,
+      confidence,
+      evidence: evidence.filter((x) => x.length > 0).slice(0, 5),
+    });
+  }
+  return out;
+}
+
+export async function runIdentityReflection(
+  factsDb: FactsDB,
+  store: IdentityReflectionStore,
+  openai: OpenAI,
+  config: IdentityReflectionConfig,
+  opts: IdentityReflectionOptions,
+  logger: { info: (msg: string) => void; warn: (msg: string) => void },
+): Promise<IdentityReflectionResult> {
+  if (!config.enabled) {
+    return { insightsExtracted: 0, insightsStored: 0, questionsAsked: 0 };
+  }
+
+  const windowDays = Math.min(90, Math.max(1, Math.floor(opts.window ?? config.defaultWindow)));
+  const nowSec = Math.floor(Date.now() / 1000);
+  const windowStart = nowSec - windowDays * 24 * 3600;
+  const scopeFilter = opts.scopeFilter;
+
+  const all = factsDb.getAll({ scopeFilter }).filter((f) => !f.supersededAt && (f.expiresAt === null || f.expiresAt > nowSec));
+  const patterns = all.filter((f) => f.category === "pattern" && !f.tags?.includes("meta") && f.createdAt >= windowStart);
+  const rules = all.filter((f) => f.category === "rule" && f.createdAt >= windowStart);
+  const metas = all.filter((f) => f.category === "pattern" && f.tags?.includes("meta") && f.createdAt >= windowStart);
+  const insightCount = patterns.length + rules.length + metas.length;
+  if (insightCount < config.minInsights) {
+    logger.info(`memory-hybrid: reflect-identity — insufficient reflection insights (${insightCount}/${config.minInsights})`);
+    return { insightsExtracted: 0, insightsStored: 0, questionsAsked: config.questions.length };
+  }
+
+  const questionMap = new Map(config.questions.map((q) => [q.key, q.prompt]));
+  const questionsBlock = config.questions.map((q, i) => `${i + 1}. ${q.key}: ${q.prompt}`).join("\n");
+  const patternsBlock = patterns.slice(0, 30).map((f) => `- ${f.text}`).join("\n");
+  const rulesBlock = rules.slice(0, 30).map((f) => `- ${f.text}`).join("\n");
+  const metasBlock = metas.slice(0, 15).map((f) => `- ${f.text}`).join("\n");
+
+  const prompt = fillPrompt(loadPrompt("identity-reflection"), {
+    window: String(windowDays),
+    questions: questionsBlock,
+    patterns: patternsBlock || "- (none)",
+    rules: rulesBlock || "- (none)",
+    meta: metasBlock || "- (none)",
+  });
+
+  let rawResponse: string;
+  try {
+    rawResponse = await chatCompleteWithRetry({
+      model: opts.model,
+      content: prompt,
+      temperature: 0.2,
+      maxTokens: 1800,
+      openai,
+      fallbackModels: opts.fallbackModels ?? [],
+      label: "memory-hybrid: reflect-identity",
+      feature: "identity-reflection",
+    });
+  } catch (err) {
+    logger.warn(`memory-hybrid: reflect-identity LLM failed: ${err}`);
+    const retryAttempt = err instanceof LLMRetryError ? err.attemptNumber : 1;
+    capturePluginError(err instanceof Error ? err : new Error(String(err)), {
+      operation: "identity-reflection-llm",
+      subsystem: "openai",
+      retryAttempt,
+    });
+    return { insightsExtracted: 0, insightsStored: 0, questionsAsked: config.questions.length };
+  }
+
+  const parsed = parseIdentityReflectionResponse(rawResponse)
+    .filter((x) => questionMap.has(x.questionKey))
+    .slice(0, config.maxInsightsPerRun);
+  if (parsed.length === 0) {
+    return { insightsExtracted: 0, insightsStored: 0, questionsAsked: config.questions.length };
+  }
+
+  let stored = 0;
+  const runId = randomUUID();
+  for (const item of parsed) {
+    const latest = store.getLatestByQuestion(item.questionKey);
+    if (latest && normalizeForDedupe(latest.insight) === normalizeForDedupe(item.insight)) {
+      continue;
+    }
+    if (opts.dryRun) {
+      stored++;
+      continue;
+    }
+    store.create({
+      runId,
+      questionKey: item.questionKey,
+      questionText: questionMap.get(item.questionKey) ?? item.questionKey,
+      insight: item.insight,
+      durability: item.durability,
+      confidence: item.confidence,
+      evidence: item.evidence,
+      sourcePatternCount: patterns.length,
+      sourceRuleCount: rules.length,
+      sourceMetaCount: metas.length,
+    });
+    stored++;
+    if (opts.verbose) {
+      logger.info(
+        `memory-hybrid: reflect-identity — stored ${item.questionKey} (${item.durability}, conf=${item.confidence.toFixed(2)})`,
+      );
+    }
+  }
+  return { insightsExtracted: parsed.length, insightsStored: stored, questionsAsked: config.questions.length };
+}


### PR DESCRIPTION
Implements persona/identity reflection layer. Closes #647.

## Files
- `backends/identity-reflection-store.ts` — new: structured storage for identity reflection insights
- `prompts/identity-reflection.txt` — new: recurring identity questions prompt  
- `services/identity-reflection.ts` — new: identity reflection pipeline service
- `config/parsers/capture.ts` — modified: identity reflection config
- `config/types/capture.ts` — modified: IdentityReflectionConfig type
- `config/parsers/index.ts` — modified: export new parser

## Tests
`npm test` && `npx tsc --noEmit` must pass before merge.

Closes #647

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new LLM-driven synthesis flow plus a new SQLite store and config surface; main risk is runtime/config integration and data persistence behavior rather than changes to existing retrieval or auth paths.
> 
> **Overview**
> Adds an *identity/persona reflection layer* that synthesizes higher-level identity insights from recent reflection outputs (patterns, rules, meta-patterns) using a new `identity-reflection` prompt and LLM call pipeline.
> 
> Introduces a dedicated SQLite-backed `IdentityReflectionStore` (WAL + indexes) to persist per-question insights with durability/confidence/evidence and basic dedupe against the latest stored insight per question.
> 
> Extends config parsing/types to support `identityReflection` settings (enable flag, model override, windows/limits, and customizable question set with defaults) and wires the parser into the main config loader.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 02f605ecb6453d2173e885b2d64ea0a19dce0036. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->