### PR TITLE
feat: Unify retrieval architecture around explicit interactive vs deep modes (#639)

### DIFF
--- a/docs/RETRIEVAL-MODES.md
+++ b/docs/RETRIEVAL-MODES.md
@@ -1,0 +1,30 @@
+# Retrieval Modes
+
+Issue #639 formalizes two retrieval paths with explicit module ownership.
+
+## 1) Interactive Recall Path
+
+- **Mode name:** `interactive-recall-path`
+- **Owner:** `extensions/memory-hybrid/lifecycle/stage-recall.ts`
+- **Contract:** latency-bounded hot path for chat turns
+- **Policy highlights:**
+  - strict stage timeout and vector-step timeout
+  - budget capped by both `autoRecall.maxTokens` and `retrieval.ambientBudgetTokens`
+  - HyDE/query expansion skipped by default when `queryExpansion.skipForInteractiveTurns=true`
+  - graph expansion and LLM reranking are disallowed
+
+## 2) Explicit/Deep Retrieval Path
+
+- **Mode name:** `explicit-deep-retrieval-path`
+- **Owner:** `extensions/memory-hybrid/services/retrieval-orchestrator.ts`
+- **Contract:** richer retrieval for explicit tool requests and deeper analysis
+- **Policy highlights:**
+  - uses `retrieval.explicitBudgetTokens` by default
+  - query expansion, graph strategy, RRF fusion, and reranking are allowed
+  - graceful fallback behavior is preserved when enrichment steps fail
+
+## Policy Source of Truth
+
+`extensions/memory-hybrid/services/retrieval-mode-policy.ts` defines mode names and allowed behavior.
+Both owner modules consume this file to avoid emergent, duplicated retrieval-policy logic.
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -50,6 +50,7 @@ Your OpenClaw agent forgets everything between sessions. Hybrid Memory fixes thi
 |----------|-------------|
 | [Architecture](ARCHITECTURE) | Four-part hybrid architecture, workspace layout, bootstrap files |
 | [How It Works](HOW-IT-WORKS) | End-to-end flow of memory capture, storage, and recall |
+| [Retrieval Modes](RETRIEVAL-MODES) | Ownership and contracts for interactive vs explicit/deep retrieval paths |
 | [Memory Protocol](MEMORY-PROTOCOL) | Paste-ready AGENTS.md block |
 
 ### Features

--- a/extensions/memory-hybrid/lifecycle/stage-recall.ts
+++ b/extensions/memory-hybrid/lifecycle/stage-recall.ts
@@ -20,8 +20,12 @@ import { withTimeout } from "../utils/timeout.js";
 import { estimateTokens } from "../utils/text.js";
 import type { LifecycleContext, RecallResult, RecallStageResult, SessionState } from "./types.js";
 import { runRecallPipelineQuery, type RecallPipelineDeps } from "../services/recall-pipeline.js";
+import {
+  INTERACTIVE_RECALL_POLICY,
+  resolveInteractiveRecallBudgetTokens,
+} from "../services/retrieval-mode-policy.js";
 
-export const RECALL_STAGE_TIMEOUT_MS = 35_000;
+export const RECALL_STAGE_TIMEOUT_MS = INTERACTIVE_RECALL_POLICY.stageTimeoutMs;
 
 export async function runRecallStage(
   event: unknown,
@@ -252,7 +256,7 @@ async function runRecall(
       hydeLabel: "HyDE",
       errorPrefix: "auto-recall-",
       precomputedVector: promptEmbedding ?? undefined,
-      interactive: true,
+      mode: INTERACTIVE_RECALL_POLICY.mode,
     });
 
     if (ambientCfg.enabled && ambientCfg.multiQuery) {
@@ -281,7 +285,7 @@ async function runRecall(
                 hydeLabel: "HyDE",
                 errorPrefix: `ambient-${q.type}-`,
                 limitHydeOnce: true,
-                interactive: true,
+                mode: INTERACTIVE_RECALL_POLICY.mode,
               });
               extraResultSets.push(qResults);
             } catch (err) {
@@ -396,7 +400,7 @@ async function runRecall(
               hydeLabel: "HyDE",
               errorPrefix: "directive-",
               limitHydeOnce: true,
-              interactive: true,
+              mode: INTERACTIVE_RECALL_POLICY.mode,
             });
             directiveCalls += 1;
             addDirectiveResults(results, `entity:${entity}`);
@@ -410,7 +414,7 @@ async function runRecall(
               hydeLabel: "HyDE",
               errorPrefix: "directive-",
               limitHydeOnce: true,
-              interactive: true,
+              mode: INTERACTIVE_RECALL_POLICY.mode,
             });
             directiveCalls += 1;
             addDirectiveResults(results, `keyword:${keyword}`);
@@ -423,7 +427,7 @@ async function runRecall(
             hydeLabel: "HyDE",
             errorPrefix: "directive-",
             limitHydeOnce: true,
-            interactive: true,
+            mode: INTERACTIVE_RECALL_POLICY.mode,
           });
           directiveCalls += 1;
           addDirectiveResults(results, `taskType:${taskType}`);
@@ -435,7 +439,7 @@ async function runRecall(
               hydeLabel: "HyDE",
               errorPrefix: "directive-",
               limitHydeOnce: true,
-              interactive: true,
+              mode: INTERACTIVE_RECALL_POLICY.mode,
             });
             directiveCalls += 1;
             addDirectiveResults(results, "sessionStart");
@@ -501,7 +505,7 @@ async function runRecall(
     // Enforce retrieval.ambientBudgetTokens as a hard total-token cap (#581).
     // autoRecall.maxTokens is a user preference; ambientBudgetTokens is the architectural
     // ceiling — the injected context must not exceed either.
-    const totalBudget = Math.min(ctx.cfg.autoRecall.maxTokens, ctx.cfg.retrieval.ambientBudgetTokens);
+    const totalBudget = resolveInteractiveRecallBudgetTokens(ctx.cfg);
     // Account for issueBlock, hotBlock, and procedureBlock tokens to ensure total stays within budget
     const fixedBlocksTokens = estimateTokens(issueBlock) + estimateTokens(hotBlock) + estimateTokens(procedureBlock);
     const maxTokens = Math.max(0, totalBudget - fixedBlocksTokens);

--- a/extensions/memory-hybrid/services/recall-pipeline.ts
+++ b/extensions/memory-hybrid/services/recall-pipeline.ts
@@ -21,6 +21,13 @@ import { chatCompleteWithRetry, is500Like, is404Like, isOllamaOOM } from "../ser
 import { computeDynamicSalience } from "../utils/salience.js";
 import { capturePluginError } from "../services/error-reporter.js";
 import { getCronModelConfig, getLLMModelPreference } from "../config.js";
+import {
+  EXPLICIT_DEEP_RETRIEVAL_POLICY,
+  INTERACTIVE_RECALL_POLICY,
+  RETRIEVAL_MODE,
+  shouldSkipHydeForMode,
+  type RetrievalMode,
+} from "./retrieval-mode-policy.js";
 
 /** Logger subset required by the recall pipeline (avoids importing ClawdbotPluginApi). */
 export interface RecallLogger {
@@ -58,7 +65,10 @@ export interface RecallPipelineDeps {
   logger: RecallLogger;
 }
 
-const VECTOR_STEP_TIMEOUT_MS = 30_000;
+function getVectorStepTimeoutMs(mode: RetrievalMode): number {
+  if (mode === RETRIEVAL_MODE.INTERACTIVE_RECALL) return INTERACTIVE_RECALL_POLICY.vectorStepTimeoutMs;
+  return EXPLICIT_DEEP_RETRIEVAL_POLICY.vectorStepTimeoutMs;
+}
 
 /**
  * Run a single recall query: FTS + optional vector search, merge, tier-filter.
@@ -83,10 +93,13 @@ export async function runRecallPipelineQuery(
     errorPrefix?: string;
     limitHydeOnce?: boolean;
     precomputedVector?: number[];
+    /** Explicit retrieval mode contract. Prefer this over `interactive`. */
+    mode?: RetrievalMode;
     /**
      * When true, this is an interactive (before_agent_start) recall turn.
      * If `cfg.queryExpansion.skipForInteractiveTurns` is true (the default), HyDE is
      * skipped to prevent LLM latency spikes on the hot user-facing path (#581).
+     * @deprecated Use opts.mode=RETRIEVAL_MODE.INTERACTIVE_RECALL.
      */
     interactive?: boolean;
   },
@@ -95,6 +108,8 @@ export async function runRecallPipelineQuery(
 
   const trimmed = query.trim();
   if (!trimmed) return [];
+  const mode = opts?.mode ?? (opts?.interactive === true ? RETRIEVAL_MODE.INTERACTIVE_RECALL : RETRIEVAL_MODE.EXPLICIT_DEEP);
+  const vectorStepTimeoutMs = getVectorStepTimeoutMs(mode);
 
   const stageMs = { fts: 0, embed: 0, vector: 0, merge: 0 };
   let t0 = Date.now();
@@ -119,9 +134,10 @@ export async function runRecallPipelineQuery(
         let textToEmbed = trimmed;
         // Skip HyDE on interactive turns when skipForInteractiveTurns is enabled (default true).
         // This prevents a full LLM round-trip on the hot before_agent_start path (#581).
-        const hydeBlockedByInteractive = opts?.interactive === true && cfg.queryExpansion.skipForInteractiveTurns;
         const allowHyde =
-          cfg.queryExpansion.enabled && !hydeBlockedByInteractive && (!opts?.limitHydeOnce || !hydeUsedRef.value);
+          cfg.queryExpansion.enabled &&
+          !shouldSkipHydeForMode(mode, cfg.queryExpansion.skipForInteractiveTurns) &&
+          (!opts?.limitHydeOnce || !hydeUsedRef.value);
         t0 = Date.now();
 
         if (allowHyde) {
@@ -175,7 +191,7 @@ export async function runRecallPipelineQuery(
         // The HyDE call above may have completed just before the abort — we must not
         // waste an embedding provider call whose result will be discarded.
         if (directiveAbort.signal.aborted) {
-          const abortError = new Error(`recall pipeline timed out after ${VECTOR_STEP_TIMEOUT_MS}ms`);
+          const abortError = new Error(`recall pipeline timed out after ${vectorStepTimeoutMs}ms`);
           abortError.name = "AbortError";
           throw abortError;
         }
@@ -201,8 +217,8 @@ export async function runRecallPipelineQuery(
       const timeoutPromise = new Promise<never>((_, reject) => {
         timeoutId = setTimeout(() => {
           directiveAbort.abort();
-          reject(new Error(`recall pipeline timed out after ${VECTOR_STEP_TIMEOUT_MS}ms`));
-        }, VECTOR_STEP_TIMEOUT_MS);
+          reject(new Error(`recall pipeline timed out after ${vectorStepTimeoutMs}ms`));
+        }, vectorStepTimeoutMs);
       });
 
       try {

--- a/extensions/memory-hybrid/services/retrieval-mode-policy.ts
+++ b/extensions/memory-hybrid/services/retrieval-mode-policy.ts
@@ -1,0 +1,95 @@
+/**
+ * Retrieval mode policy contracts (Issue #639).
+ *
+ * Retrieval ownership is intentionally split into two explicit paths:
+ * 1) interactive recall path (hot user-facing turn path)
+ * 2) explicit/deep retrieval path (tooling + deeper analysis path)
+ *
+ * Keep policy decisions here so timeout/budget/feature gates are named once and
+ * consumed by owning modules (`lifecycle/stage-recall.ts`, `services/retrieval-orchestrator.ts`).
+ */
+
+import type { HybridMemoryConfig, RetrievalConfig } from "../config.js";
+
+export const RETRIEVAL_MODE = {
+  INTERACTIVE_RECALL: "interactive-recall-path",
+  EXPLICIT_DEEP: "explicit-deep-retrieval-path",
+} as const;
+
+export type RetrievalMode = (typeof RETRIEVAL_MODE)[keyof typeof RETRIEVAL_MODE];
+
+interface RetrievalModePolicyBase {
+  mode: RetrievalMode;
+  owner: "lifecycle/stage-recall.ts" | "services/retrieval-orchestrator.ts";
+  allowGraphStrategy: boolean;
+  allowQueryExpansion: boolean;
+  allowReranking: boolean;
+}
+
+export interface InteractiveRecallPolicy extends RetrievalModePolicyBase {
+  mode: typeof RETRIEVAL_MODE.INTERACTIVE_RECALL;
+  stageTimeoutMs: number;
+  vectorStepTimeoutMs: number;
+}
+
+export interface ExplicitDeepRetrievalPolicy extends RetrievalModePolicyBase {
+  mode: typeof RETRIEVAL_MODE.EXPLICIT_DEEP;
+  vectorStepTimeoutMs: number;
+}
+
+export const INTERACTIVE_RECALL_POLICY: InteractiveRecallPolicy = {
+  mode: RETRIEVAL_MODE.INTERACTIVE_RECALL,
+  owner: "lifecycle/stage-recall.ts",
+  stageTimeoutMs: 35_000,
+  vectorStepTimeoutMs: 30_000,
+  allowGraphStrategy: false,
+  allowQueryExpansion: true,
+  allowReranking: false,
+};
+
+export const EXPLICIT_DEEP_RETRIEVAL_POLICY: ExplicitDeepRetrievalPolicy = {
+  mode: RETRIEVAL_MODE.EXPLICIT_DEEP,
+  owner: "services/retrieval-orchestrator.ts",
+  vectorStepTimeoutMs: 30_000,
+  allowGraphStrategy: true,
+  allowQueryExpansion: true,
+  allowReranking: true,
+};
+
+export function getRetrievalModePolicy(mode: RetrievalMode): InteractiveRecallPolicy | ExplicitDeepRetrievalPolicy {
+  return mode === RETRIEVAL_MODE.INTERACTIVE_RECALL ? INTERACTIVE_RECALL_POLICY : EXPLICIT_DEEP_RETRIEVAL_POLICY;
+}
+
+/**
+ * Interactive recall contract: injection stays within both user-facing autoRecall cap
+ * and architectural ambient cap.
+ */
+export function resolveInteractiveRecallBudgetTokens(cfg: HybridMemoryConfig): number {
+  return Math.min(cfg.autoRecall.maxTokens, cfg.retrieval.ambientBudgetTokens);
+}
+
+/**
+ * Retrieval-orchestrator contract: explicit/deep path uses explicit budget; interactive
+ * mode clamps to ambient budget even if a larger override is requested.
+ */
+export function resolveOrchestratorBudgetTokens(
+  mode: RetrievalMode,
+  retrievalConfig: RetrievalConfig,
+  budgetOverride?: number,
+): number {
+  const defaultBudget =
+    mode === RETRIEVAL_MODE.INTERACTIVE_RECALL ? retrievalConfig.ambientBudgetTokens : retrievalConfig.explicitBudgetTokens;
+  const requested = budgetOverride ?? defaultBudget;
+  if (mode === RETRIEVAL_MODE.INTERACTIVE_RECALL) {
+    return Math.min(requested, retrievalConfig.ambientBudgetTokens);
+  }
+  return requested;
+}
+
+/**
+ * HyDE/query-expansion on interactive turns is allowed only when explicitly configured.
+ */
+export function shouldSkipHydeForMode(mode: RetrievalMode, skipForInteractiveTurns: boolean): boolean {
+  return mode === RETRIEVAL_MODE.INTERACTIVE_RECALL && skipForInteractiveTurns;
+}
+

--- a/extensions/memory-hybrid/services/retrieval-orchestrator.ts
+++ b/extensions/memory-hybrid/services/retrieval-orchestrator.ts
@@ -30,6 +30,12 @@ import { detectClusters, type ClusterFactLookup } from "./topic-clusters.js";
 import { expandGraph, type GraphFactLookup } from "./graph-retrieval.js";
 import type { EmbeddingRegistry } from "./embedding-registry.js";
 import { capturePluginError } from "./error-reporter.js";
+import {
+  getRetrievalModePolicy,
+  RETRIEVAL_MODE,
+  resolveOrchestratorBudgetTokens,
+  type RetrievalMode,
+} from "./retrieval-mode-policy.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -382,6 +388,8 @@ export function invalidateClusterCache(): void {
  * without touching every call site.
  */
 export interface RetrievalPipelineOptions {
+  /** Retrieval mode policy. Defaults to explicit/deep retrieval path. */
+  mode?: RetrievalMode;
   /** Retrieval pipeline configuration. Defaults to `DEFAULT_RETRIEVAL_CONFIG`. */
   config?: RetrievalConfig;
   /** Token budget for packing. Defaults to `config.explicitBudgetTokens`. */
@@ -443,7 +451,9 @@ export async function runRetrievalPipeline(
   options: RetrievalPipelineOptions = {},
 ): Promise<OrchestratorResult> {
   const config = options.config ?? DEFAULT_RETRIEVAL_CONFIG;
-  const budgetTokens = options.budgetTokens ?? config.explicitBudgetTokens;
+  const mode = options.mode ?? RETRIEVAL_MODE.EXPLICIT_DEEP;
+  const modePolicy = getRetrievalModePolicy(mode);
+  const budgetTokens = resolveOrchestratorBudgetTokens(mode, config, options.budgetTokens);
   const nowSec = options.nowSec ?? Math.floor(Date.now() / 1000);
   const {
     tagFilter,
@@ -454,19 +464,22 @@ export async function runRetrievalPipeline(
     clustersConfig,
     embeddingRegistry,
     factsDbForEmbeddings,
-    queryExpander,
+    queryExpander: rawQueryExpander,
     embedFn,
     queryExpansionContext,
-    rerankingConfig,
+    rerankingConfig: rawRerankingConfig,
     rerankingOpenai,
   } = options;
+  const queryExpander = modePolicy.allowQueryExpansion ? rawQueryExpander : null;
+  const rerankingConfig = modePolicy.allowReranking ? rawRerankingConfig : null;
   const runOnce = async (expansion: {
     useLlm: boolean;
     variants: string[] | null;
     skipReranking?: boolean;
   }): Promise<OrchestratorResult> => {
     const k = config.rrf_k;
-    const { strategies, semanticTopK, fts5TopK } = config;
+    const { semanticTopK, fts5TopK } = config;
+    const strategies = modePolicy.allowGraphStrategy ? config.strategies : config.strategies.filter((s) => s !== "graph");
 
     // --- Run strategies in parallel ---
     const strategyPromises: Array<Promise<[string, RankedResult[]]>> = [];

--- a/extensions/memory-hybrid/tests/recall-pipeline.test.ts
+++ b/extensions/memory-hybrid/tests/recall-pipeline.test.ts
@@ -21,6 +21,7 @@ import { runRecallPipelineQuery, type RecallPipelineDeps } from "../services/rec
 import type { SearchResult, MemoryEntry } from "../types/memory.js";
 import { createPendingLLMWarnings } from "../services/chat.js";
 import * as chatModule from "../services/chat.js";
+import { RETRIEVAL_MODE } from "../services/retrieval-mode-policy.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -649,5 +650,41 @@ describe("runRecallPipelineQuery — skipForInteractiveTurns (#581)", () => {
     // HyDE was allowed — interactive=false does not block HyDE
     expect(chatModule.chatCompleteWithRetry).toHaveBeenCalled();
     expect(deps.embeddings.embed).toHaveBeenCalledWith("HyDE generated text");
+  });
+});
+
+describe("runRecallPipelineQuery — retrieval mode policy (#639)", () => {
+  beforeEach(() => {
+    vi.spyOn(chatModule, "chatCompleteWithRetry").mockResolvedValue("HyDE generated text");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("treats mode=interactive-recall-path as hot-path even without interactive flag", async () => {
+    const deps = makeDeps({
+      cfg: {
+        queryExpansion: {
+          enabled: true,
+          maxVariants: 4,
+          cacheSize: 100,
+          timeoutMs: 15_000,
+          skipForInteractiveTurns: true,
+        },
+        retrievalStrategies: ["semantic"],
+        memoryTieringEnabled: false,
+        rawCfg: { llm: undefined } as unknown as RecallPipelineDeps["cfg"]["rawCfg"],
+      },
+    });
+    (deps.factsDb.search as ReturnType<typeof vi.fn>).mockReturnValue([]);
+    (deps.vectorDb.search as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+
+    await runRecallPipelineQuery("interactive mode query", 5, deps, { value: false }, {
+      mode: RETRIEVAL_MODE.INTERACTIVE_RECALL,
+    });
+
+    expect(chatModule.chatCompleteWithRetry).not.toHaveBeenCalled();
+    expect(deps.embeddings.embed).toHaveBeenCalledWith("interactive mode query");
   });
 });

--- a/extensions/memory-hybrid/tests/retrieval-mode-policy.test.ts
+++ b/extensions/memory-hybrid/tests/retrieval-mode-policy.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import {
+  RETRIEVAL_MODE,
+  resolveInteractiveRecallBudgetTokens,
+  resolveOrchestratorBudgetTokens,
+  shouldSkipHydeForMode,
+} from "../services/retrieval-mode-policy.js";
+
+describe("retrieval-mode-policy", () => {
+  it("caps interactive recall budget to min(autoRecall.maxTokens, retrieval.ambientBudgetTokens)", () => {
+    const cfg = {
+      autoRecall: { maxTokens: 800 },
+      retrieval: { ambientBudgetTokens: 600 },
+    } as unknown as import("../config.js").HybridMemoryConfig;
+
+    expect(resolveInteractiveRecallBudgetTokens(cfg)).toBe(600);
+  });
+
+  it("clamps interactive orchestrator budget overrides to ambient budget", () => {
+    const retrievalCfg = {
+      ambientBudgetTokens: 700,
+      explicitBudgetTokens: 4000,
+    } as unknown as import("../config.js").RetrievalConfig;
+
+    expect(resolveOrchestratorBudgetTokens(RETRIEVAL_MODE.INTERACTIVE_RECALL, retrievalCfg, 2500)).toBe(700);
+  });
+
+  it("skips HyDE only for interactive recall mode when skipForInteractiveTurns=true", () => {
+    expect(shouldSkipHydeForMode(RETRIEVAL_MODE.INTERACTIVE_RECALL, true)).toBe(true);
+    expect(shouldSkipHydeForMode(RETRIEVAL_MODE.EXPLICIT_DEEP, true)).toBe(false);
+  });
+});
+

--- a/extensions/memory-hybrid/tests/retrieval-orchestrator.test.ts
+++ b/extensions/memory-hybrid/tests/retrieval-orchestrator.test.ts
@@ -9,6 +9,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { _testing } from "../index.js";
 import { runRetrievalPipeline, DEFAULT_RETRIEVAL_CONFIG } from "../services/retrieval-orchestrator.js";
+import { RETRIEVAL_MODE } from "../services/retrieval-mode-policy.js";
 
 const { FactsDB } = _testing;
 
@@ -63,5 +64,46 @@ describe("runRetrievalPipeline graph strategy", () => {
     const ids = result.fused.map((r) => r.factId);
     expect(ids).toContain(apple.id);
     expect(ids).toContain(banana.id);
+  });
+
+  it("disables graph expansion in interactive recall mode", async () => {
+    const apple = factsDb.store({
+      text: "Apple is tasty",
+      category: "fact",
+      importance: 0.6,
+      entity: null,
+      key: null,
+      value: null,
+      source: "conversation",
+    });
+    const banana = factsDb.store({
+      text: "Banana is yellow",
+      category: "fact",
+      importance: 0.6,
+      entity: null,
+      key: null,
+      value: null,
+      source: "conversation",
+    });
+    factsDb.createLink(apple.id, banana.id, "RELATED_TO", 1.0);
+
+    const vectorDb = { search: async () => [] } as unknown as import("../backends/vector-db.js").VectorDB;
+    const config = {
+      ...DEFAULT_RETRIEVAL_CONFIG,
+      strategies: ["fts5", "graph"] as Array<"fts5" | "graph">,
+      graphWalkDepth: 1,
+      semanticTopK: 5,
+      fts5TopK: 5,
+    };
+
+    const result = await runRetrievalPipeline("apple", null, factsDb.getRawDb(), vectorDb, factsDb, {
+      mode: RETRIEVAL_MODE.INTERACTIVE_RECALL,
+      config,
+      budgetTokens: 2000,
+    });
+
+    const ids = result.fused.map((r) => r.factId);
+    expect(ids).toContain(apple.id);
+    expect(ids).not.toContain(banana.id);
   });
 });


### PR DESCRIPTION
Implements two-path retrieval architecture: interactive recall path (fast, bounded) and explicit deep retrieval path (unbounded). Closes #639.

## Files
- docs/RETRIEVAL-MODES.md — new: architecture doc
- services/retrieval-mode-policy.ts — new: policy definitions
- services/retrieval-orchestrator.ts — modified: deep retrieval path
- lifecycle/stage-recall.ts — modified: interactive path ownership
- tests/retrieval-mode-policy.test.ts — new: tests

Tests: npm test && npx tsc --noEmit must pass.

Closes #639

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes retrieval behavior and feature gating (HyDE, graph expansion, reranking) based on a new mode contract, which can affect recall latency/quality and token budgeting across user-facing and tool paths.
> 
> **Overview**
> Adds a first-class retrieval *mode contract* (`interactive-recall-path` vs `explicit-deep-retrieval-path`) via new `services/retrieval-mode-policy.ts`, centralizing timeouts, token-budget resolution, and feature gates.
> 
> Updates the interactive recall hot path (`lifecycle/stage-recall.ts`) to pass an explicit mode into `runRecallPipelineQuery`, source the stage timeout from policy, and compute budgets via `resolveInteractiveRecallBudgetTokens`.
> 
> Updates deep retrieval orchestration (`services/retrieval-orchestrator.ts`) to accept `mode`, clamp budgets appropriately, and disable graph strategy/query expansion/reranking when policy disallows them; `services/recall-pipeline.ts` similarly derives HyDE skipping and vector-step timeouts from mode (deprecating the `interactive` flag).
> 
> Adds docs (`docs/RETRIEVAL-MODES.md`) and new/updated tests to lock in mode-specific behavior (HyDE skipping, graph disabled in interactive mode, budget clamping).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 83545758a145d90714228d3131b280e555aadc16. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->