### PR TITLE
fix: Autonomous queue can duplicate-dispatch issues before GitHub branch visibility catches up (#634)

### DIFF
--- a/extensions/memory-hybrid/MEMORY_INDEX.md
+++ b/extensions/memory-hybrid/MEMORY_INDEX.md
@@ -1,6 +1,6 @@
 # MEMORY_INDEX
 
-Auto-generated awareness layer. Updated 2026-03-23T17:13:34.476Z.
+Auto-generated awareness layer. Updated 2026-03-23T17:29:35.717Z.
 
 ## Active Clusters
 - none

--- a/extensions/memory-hybrid/services/narrative-recall.ts
+++ b/extensions/memory-hybrid/services/narrative-recall.ts
@@ -131,7 +131,13 @@ function collectNarrativeMatches(
       periodEnd: row.periodEnd,
       tag: row.tag,
       text: row.narrativeText,
-      score: scoreCandidate(`${row.sessionId} ${row.tag} ${row.narrativeText}`, options.query, options.queryTerms, row.periodEnd, options.nowSec),
+      score: scoreCandidate(
+        `${row.sessionId} ${row.tag} ${row.narrativeText}`,
+        options.query,
+        options.queryTerms,
+        row.periodEnd,
+        options.nowSec,
+      ),
     }))
     .sort(compareMatches);
 }
@@ -155,7 +161,9 @@ function collectEventMatches(
     const events = eventLog.getBySession(options.sessionId, 200);
     if (events.length > 0) sessionEvents.set(options.sessionId, events);
   } else {
-    const fromIso = new Date((options.sinceSec ?? options.nowSec - DEFAULT_LOOKBACK_DAYS * 86_400) * 1000).toISOString();
+    const fromIso = new Date(
+      (options.sinceSec ?? options.nowSec - DEFAULT_LOOKBACK_DAYS * 86_400) * 1000,
+    ).toISOString();
     const toIso = new Date(options.nowSec * 1000).toISOString();
     const maxSessions = Math.max(1, options.limit);
     const maxEventsPerSession = Math.max(1, options.maxEventsPerSession);
@@ -204,7 +212,13 @@ function collectEventMatches(
         periodEnd: toSec(last?.timestamp),
         tag: "event-log",
         text: summaryText,
-        score: scoreCandidate(`${sessionId} ${summaryText}`, options.query, options.queryTerms, toSec(last?.timestamp), options.nowSec),
+        score: scoreCandidate(
+          `${sessionId} ${summaryText}`,
+          options.query,
+          options.queryTerms,
+          toSec(last?.timestamp),
+          options.nowSec,
+        ),
       };
     })
     .filter((entry) => entry.periodEnd > 0)
@@ -214,8 +228,12 @@ function collectEventMatches(
 
 function summarizeEvents(events: EventLogEntry[], maxEvents: number): string {
   const ordered = [...events].sort((a, b) => a.timestamp.localeCompare(b.timestamp));
-  const parts = ordered.slice(0, maxEvents).map(describeEvent).filter((part) => part.length > 0);
-  if (parts.length === 0) return `${ordered.length} event(s) recorded for session ${events[0]?.sessionId ?? "unknown"}.`;
+  const parts = ordered
+    .slice(0, maxEvents)
+    .map(describeEvent)
+    .filter((part) => part.length > 0);
+  if (parts.length === 0)
+    return `${ordered.length} event(s) recorded for session ${events[0]?.sessionId ?? "unknown"}.`;
   const summary = parts.join(" Then ");
   return ordered.length > maxEvents ? `${summary} Then ${ordered.length - maxEvents} more event(s) followed.` : summary;
 }
@@ -224,28 +242,45 @@ function describeEvent(event: EventLogEntry): string {
   const prefix = `[${event.timestamp}]`;
   switch (event.eventType) {
     case "decision_made":
-      return typeof event.content.decision === "string" ? `${prefix} decided ${event.content.decision}` : `${prefix} decision recorded`;
+      return typeof event.content.decision === "string"
+        ? `${prefix} decided ${event.content.decision}`
+        : `${prefix} decision recorded`;
     case "action_taken":
-      return typeof event.content.action === "string" ? `${prefix} tried ${event.content.action}` : `${prefix} action recorded`;
+      return typeof event.content.action === "string"
+        ? `${prefix} tried ${event.content.action}`
+        : `${prefix} action recorded`;
     case "fact_learned":
-      return typeof event.content.text === "string" ? `${prefix} learned ${event.content.text}` : `${prefix} fact recorded`;
+      return typeof event.content.text === "string"
+        ? `${prefix} learned ${event.content.text}`
+        : `${prefix} fact recorded`;
     case "entity_mentioned":
       return event.entities && event.entities.length > 0
         ? `${prefix} focused on ${event.entities.join(", ")}`
         : `${prefix} entity mentioned`;
     case "preference_expressed":
-      return typeof event.content.text === "string" ? `${prefix} noted preference ${event.content.text}` : `${prefix} preference recorded`;
+      return typeof event.content.text === "string"
+        ? `${prefix} noted preference ${event.content.text}`
+        : `${prefix} preference recorded`;
     case "correction":
-      return typeof event.content.text === "string" ? `${prefix} corrected ${event.content.text}` : `${prefix} correction recorded`;
+      return typeof event.content.text === "string"
+        ? `${prefix} corrected ${event.content.text}`
+        : `${prefix} correction recorded`;
     default:
       return `${prefix} ${event.eventType}`;
   }
 }
 
-function scoreCandidate(text: string, query: string | null, queryTerms: string[], periodEnd: number, nowSec: number): number {
+function scoreCandidate(
+  text: string,
+  query: string | null,
+  queryTerms: string[],
+  periodEnd: number,
+  nowSec: number,
+): number {
   const normalizedText = text.toLowerCase();
   const phraseBoost = query && normalizedText.includes(query) ? 2 : 0;
-  const overlap = queryTerms.length > 0 ? queryTerms.filter((term) => normalizedText.includes(term)).length / queryTerms.length : 0;
+  const overlap =
+    queryTerms.length > 0 ? queryTerms.filter((term) => normalizedText.includes(term)).length / queryTerms.length : 0;
   const ageSec = Math.max(0, nowSec - periodEnd);
   const recency = Math.max(0, 1 - ageSec / (30 * 86_400));
   return phraseBoost + overlap * 4 + recency;

--- a/extensions/memory-hybrid/services/task-queue-leases.ts
+++ b/extensions/memory-hybrid/services/task-queue-leases.ts
@@ -105,7 +105,17 @@ function blocksAcquire(lease: DispatchLeaseRecord, now: Date): boolean {
     return false;
   }
 
-  const expiresAtMs = parseIsoMs(lease.expiresAt);
+  let expiresAtMs = parseIsoMs(lease.expiresAt);
+
+  // For legacy or partially written records that lack expiresAt, fall back to
+  // completedAt + DEFAULT_COMPLETED_VISIBILITY_WINDOW_MS to enforce cooldown.
+  if (!Number.isFinite(expiresAtMs)) {
+    const completedAtMs = parseIsoMs(lease.completedAt);
+    if (Number.isFinite(completedAtMs)) {
+      expiresAtMs = completedAtMs + DEFAULT_COMPLETED_VISIBILITY_WINDOW_MS;
+    }
+  }
+
   return Number.isFinite(expiresAtMs) && now.getTime() < expiresAtMs;
 }
 
@@ -416,8 +426,12 @@ export async function transitionDispatchLease(input: TransitionDispatchLeaseInpu
       lease.expiresAt = undefined;
     } else if (input.toState === "completed") {
       lease.completedAt = nowIso;
+      // NOTE: `expiresAt` is overloaded:
+      // - for active/leased states, it represents the lease TTL;
+      // - for the `completed` state, it acts as a visibility cooldown / acquire-block-until timestamp.
       lease.expiresAt = new Date(now.getTime() + DEFAULT_COMPLETED_VISIBILITY_WINDOW_MS).toISOString();
     } else {
+      // Other terminal states clear `expiresAt`; callers must not assume it is set for all non-active states.
       lease.completedAt = nowIso;
       lease.expiresAt = undefined;
     }

--- a/extensions/memory-hybrid/tests/task-queue-leases.test.ts
+++ b/extensions/memory-hybrid/tests/task-queue-leases.test.ts
@@ -109,6 +109,55 @@ describe("task queue dispatch leases", () => {
     expect(second.lease?.attempt).toBe(2);
   });
 
+  it("blocks reacquire for legacy completed leases without expiresAt (fallback cooldown)", async () => {
+    // Seed the registry with a legacy completed lease
+    const fs = await import("fs");
+    const p = await import("path");
+    const registryPath = p.join(stateDir, "dispatch-leases.json");
+
+    const legacyRegistry = {
+      version: 1,
+      leases: {
+        "504": {
+          issue: 504,
+          token: "legacy-token-123",
+          state: "completed",
+          leasedAt: "2026-03-16T20:50:00.000Z",
+          updatedAt: "2026-03-16T20:51:00.000Z",
+          completedAt: "2026-03-16T20:51:00.000Z",
+          expiresAt: undefined, // Missing expiresAt
+          attempt: 1,
+          branch: "feat/issue-504",
+          history: [],
+        },
+      },
+    };
+    fs.mkdirSync(p.dirname(registryPath), { recursive: true });
+    fs.writeFileSync(registryPath, JSON.stringify(legacyRegistry));
+
+    // Try to acquire within the 10-minute fallback cooldown window (20:55 is < 21:01)
+    const withinCooldown = await acquireDispatchLease({
+      stateDir,
+      issue: 504,
+      branch: "feat/issue-504-retry",
+      runId: "run-2",
+      now: new Date("2026-03-16T20:55:00.000Z"),
+    });
+    expect(withinCooldown.acquired).toBe(false);
+    expect(withinCooldown.existing?.state).toBe("completed");
+    expect(withinCooldown.reason).toContain("cooling down");
+
+    // Try to acquire after the fallback cooldown elapses (21:02 is > 21:01)
+    const afterCooldown = await acquireDispatchLease({
+      stateDir,
+      issue: 504,
+      branch: "feat/issue-504-retry2",
+      runId: "run-3",
+      now: new Date("2026-03-16T21:02:00.000Z"),
+    });
+    expect(afterCooldown.acquired).toBe(true);
+  });
+
   it("expires active leases by TTL and allows reacquire", async () => {
     const now = new Date("2026-03-16T20:50:00.000Z");
     const first = await acquireDispatchLease({


### PR DESCRIPTION
Closes #634

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes lease acquisition semantics by blocking re-acquire for a short period after `completed`, which can affect dispatch throughput and retry timing if mis-tuned or if timestamps are wrong.
> 
> **Overview**
> Prevents the autonomous queue from double-dispatching the same issue by adding a **post-completion cooldown**: `acquireDispatchLease` now also blocks when an existing lease is `completed` and still within a visibility window (with a fallback for legacy records missing `expiresAt`).
> 
> `transitionDispatchLease` now stamps `completed` leases with a cooldown expiry (reusing `expiresAt`), updates block reasons, and expands tests to cover cooldown behavior and legacy-record handling. Minor formatting-only changes were made in `narrative-recall.ts` plus a timestamp bump in `MEMORY_INDEX.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 63485240e3e9744dbc3b203ffce6d8d706a27aa5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->