### PR TITLE
fix: [GlitchTip #4197] Error: database is not open (#694)

### DIFF
--- a/extensions/memory-hybrid/backends/issue-store.ts
+++ b/extensions/memory-hybrid/backends/issue-store.ts
@@ -95,7 +95,11 @@ export class IssueStore {
         now,
       );
 
-    return this.get(id)!;
+    const result = this.get(id);
+    if (!result) {
+      throw new Error(`Failed to retrieve created issue: ${id}`);
+    }
+    return result;
   }
 
   get(id: string): Issue | null {
@@ -168,7 +172,11 @@ export class IssueStore {
     params.push(id);
     this.db.prepare(`UPDATE issues SET ${sets.join(", ")} WHERE id = ?`).run(...params);
 
-    return this.get(id)!;
+    const result = this.get(id);
+    if (!result) {
+      throw new Error(`Failed to retrieve updated issue: ${id}`);
+    }
+    return result;
   }
 
   transition(id: string, newStatus: IssueStatus, data?: Partial<Issue>): Issue {
@@ -228,7 +236,9 @@ export class IssueStore {
       // Tags filtering (JSON array — done in-memory for simplicity)
       if (filter?.tags && filter.tags.length > 0) {
         const filterTags = filter.tags.map((t) => t.toLowerCase());
-        results = results.filter((issue) => filterTags.some((ft) => issue.tags.map((t) => t.toLowerCase()).includes(ft)));
+        results = results.filter((issue) =>
+          filterTags.some((ft) => issue.tags.map((t) => t.toLowerCase()).includes(ft)),
+        );
       }
 
       // Apply limit after all filtering is complete
@@ -266,13 +276,13 @@ export class IssueStore {
   }
 
   archive(olderThanDays: number): number {
-    return this.withReadFallback("archive", 0, () => {
-      const cutoff = new Date(Date.now() - olderThanDays * 24 * 60 * 60 * 1000).toISOString();
-      const result = this.db
-        .prepare(`DELETE FROM issues WHERE status IN ('verified', 'wont-fix') AND updated_at < ?`)
-        .run(cutoff);
-      return Number(result.changes);
-    });
+    this.ensureOpen("archive");
+
+    const cutoff = new Date(Date.now() - olderThanDays * 24 * 60 * 60 * 1000).toISOString();
+    const result = this.db
+      .prepare(`DELETE FROM issues WHERE status IN ('verified', 'wont-fix') AND updated_at < ?`)
+      .run(cutoff);
+    return Number(result.changes);
   }
 
   private rowToIssue(row: IssueRow): Issue {

--- a/extensions/memory-hybrid/tests/issue-store.test.ts
+++ b/extensions/memory-hybrid/tests/issue-store.test.ts
@@ -492,13 +492,13 @@ describe("IssueStore lifecycle", () => {
     expect(store.get(issue.id)).toBeNull();
   });
 
-  it("archive returns 0 after close", () => {
+  it("archive throws a clear error after close", () => {
     const issue = store.create({ title: "Closed store archive", symptoms: ["s"] });
     store.transition(issue.id, "wont-fix");
 
     store.close();
 
-    expect(store.archive(-1)).toBe(0);
+    expect(() => store.archive(-1)).toThrow("IssueStore.archive called after close()");
   });
 
   it("create throws a clear error after close", () => {


### PR DESCRIPTION
Closes #694

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes lifecycle/error-handling around a SQLite-backed store: read operations now silently return fallbacks after close/closed-db errors while write operations throw, which could mask unexpected closures if callers relied on exceptions.
> 
> **Overview**
> Prevents `IssueStore` from throwing `database is not open` by adding explicit lifecycle guards and a read-only fallback path.
> 
> Write operations (`create`, `update`, `transition`, `linkFact`, `archive`) now fail fast with clear `IssueStore.<op> called after close()` errors, while read operations (`get`, `list`, `search`) return safe defaults (`null`/`[]`) if the store is closed or if SQLite reports a closed database (and logs via `capturePluginError`). Tests are extended to assert the new post-close behaviors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4d52f35f8fafbbe51711b183f599e48c6408d43b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->