### PR TITLE
fix: handle undefined/null input in truncateForStorage

### DIFF
--- a/extensions/memory-hybrid/tests/text-utils.test.ts
+++ b/extensions/memory-hybrid/tests/text-utils.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { truncateForStorage } from "../utils/text.js";
+
+describe("truncateForStorage", () => {
+  it("returns empty string for null", () => {
+    expect(truncateForStorage(null as any, 100)).toBe("");
+  });
+
+  it("returns empty string for undefined", () => {
+    expect(truncateForStorage(undefined as any, 100)).toBe("");
+  });
+
+  it("returns trimmed text under maxChars", () => {
+    expect(truncateForStorage("  hello world  ", 100)).toBe("hello world");
+  });
+
+  it("truncates text over maxChars with suffix", () => {
+    const result = truncateForStorage("a".repeat(200), 50);
+    expect(result).toContain("[truncated]");
+    expect(result.length).toBeLessThan(200);
+  });
+
+  it("handles empty string", () => {
+    expect(truncateForStorage("", 100)).toBe("");
+  });
+
+  it("handles maxChars of zero", () => {
+    expect(truncateForStorage("hello world", 0)).toBe("");
+  });
+});

--- a/extensions/memory-hybrid/utils/text.ts
+++ b/extensions/memory-hybrid/utils/text.ts
@@ -10,8 +10,9 @@ export function truncateText(text: string, maxLen: number, suffix = "…"): stri
   return text.slice(0, maxLen - suffix.length).trim() + suffix;
 }
 
-/** Truncate for storage (config-driven); appends " [truncated]" when truncated. */
-export function truncateForStorage(text: string, maxChars: number): string {
+/** Truncate for storage (config-driven); appends " [truncated]" when truncated. Handles null/undefined gracefully. */
+export function truncateForStorage(text: string | null | undefined, maxChars: number): string {
+  if (text == null) return "";
   if (text.length <= maxChars) return text.trim();
   return `${text.slice(0, maxChars).trim()} [truncated]`;
 }


### PR DESCRIPTION
Fixes #736. Changes the `truncateForStorage` function to gracefully handle `null` and `undefined` input (returning empty string) instead of throwing a TypeError. Also adds a test file with coverage for null, undefined, empty string, and truncation cases.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small defensive change to a text utility plus targeted unit tests; behavior change is limited to returning an empty string for nullish inputs.
> 
> **Overview**
> Fixes `truncateForStorage` to accept `null`/`undefined` and return `""` instead of throwing, while preserving trimming and truncation behavior (including the `" [truncated]"` suffix).
> 
> Adds Vitest coverage for null/undefined, empty input, max length edge cases, and truncation output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cd8ba3f29ca68188af5be19c0a096cc34dcf341c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->