### PR TITLE
fix: handle transient 500 errors from OpenAI more gracefully (#739)

### DIFF
--- a/extensions/memory-hybrid/services/chat.ts
+++ b/extensions/memory-hybrid/services/chat.ts
@@ -202,8 +202,17 @@ export function is500Like(err: unknown): boolean {
   }
   if (err instanceof Error) {
     // Only match HTTP 5xx patterns — not generic "internal error" from JS
-    return /\bHTTP\s+5\d{2}\b|\b5\d{2}\s+(error|status)|status\s+5\d{2}|internal\s+server\s+error/i.test(err.message);
+    return /\bHTTP\s+5\d{2}\b|\b5\d{2}\s+(internal\s+)?(error|status)|status\s+5\d{2}|internal\s+server\s+error/i.test(
+      err.message,
+    );
   }
+  return false;
+}
+
+/** Returns true when the error is a 5xx server error — either directly or wrapped in LLMRetryError. */
+export function is500OrWrapped(err: Error): boolean {
+  if (is500Like(err)) return true;
+  if (err instanceof LLMRetryError && is500Like(err.cause)) return true;
   return false;
 }
 

--- a/extensions/memory-hybrid/services/embeddings/openai-provider.ts
+++ b/extensions/memory-hybrid/services/embeddings/openai-provider.ts
@@ -4,9 +4,9 @@
 
 import OpenAI from "openai";
 import { capturePluginError } from "../error-reporter.js";
-import { withLLMRetry, is429OrWrapped } from "../chat.js";
+import { withLLMRetry } from "../chat.js";
 import type { EmbeddingProvider } from "./types.js";
-import { EMBEDDING_CACHE_MAX, truncateForEmbedding, makeCacheKey, isConfigError } from "./shared.js";
+import { EMBEDDING_CACHE_MAX, truncateForEmbedding, makeCacheKey, shouldSuppressEmbeddingError } from "./shared.js";
 
 /**
  * OpenAI-based embedding provider.
@@ -114,8 +114,8 @@ export class Embeddings implements EmbeddingProvider {
     // lastErr is always defined here: constructor enforces models.length >= 1, so
     // the loop always runs at least once; either it returns early (success) or
     // sets lastErr on every iteration before reaching this point.
-    // Skip reporting config errors (404 model-not-found, 403 country/region restriction, 401 auth failure) and 429 (rate limit) — operator config issues or transient errors, not bugs (#329, #394, #397, #385).
-    if (!isConfigError(lastErr!) && !is429OrWrapped(lastErr!)) {
+    // Skip reporting config errors (404 model-not-found, 403 country/region restriction, 401 auth failure), 429 (rate limit), and 500 errors — operator config issues or transient errors, not bugs (#329, #394, #397, #385, #739).
+    if (!shouldSuppressEmbeddingError(lastErr!)) {
       capturePluginError(lastErr!, {
         subsystem: "embeddings",
         operation: "embed",
@@ -203,8 +203,8 @@ export class Embeddings implements EmbeddingProvider {
         freshVectors.push(...sorted);
       }
       if (lastErr !== undefined && freshVectors.length === i) {
-        // Skip reporting config errors (404 model-not-found, 403 country/region restriction, 401 auth failure) and 429 (rate limit) — operator config issues or transient errors, not bugs (#329, #394, #397, #385).
-        if (!isConfigError(lastErr) && !is429OrWrapped(lastErr)) {
+        // Skip reporting config errors (404 model-not-found, 403 country/region restriction, 401 auth failure), 429 (rate limit), and 500 errors — operator config issues or transient errors, not bugs (#329, #394, #397, #385, #739).
+        if (!shouldSuppressEmbeddingError(lastErr)) {
           capturePluginError(lastErr, {
             subsystem: "embeddings",
             operation: "embedBatch",

--- a/extensions/memory-hybrid/services/embeddings/shared.ts
+++ b/extensions/memory-hybrid/services/embeddings/shared.ts
@@ -4,7 +4,7 @@
 
 import { createHash } from "node:crypto";
 import { capturePluginError } from "../error-reporter.js";
-import { is404Like, is403Like, is401OrWrapped, is429OrWrapped, LLMRetryError } from "../chat.js";
+import { is404Like, is403Like, is401OrWrapped, is429OrWrapped, is500OrWrapped, LLMRetryError } from "../chat.js";
 import type { EmbeddingProvider } from "./types.js";
 import { AllEmbeddingProvidersFailed } from "./types.js";
 
@@ -118,13 +118,24 @@ export function isOllamaConnectionFailure(err: Error): boolean {
  */
 export function shouldSuppressEmbeddingError(err: unknown): boolean {
   if (!(err instanceof Error)) return false;
-  if (isConfigError(err) || is429OrWrapped(err) || isOllamaCircuitBreakerOpen(err) || isOllamaConnectionFailure(err)) {
+  if (
+    isConfigError(err) ||
+    is429OrWrapped(err) ||
+    is500OrWrapped(err) ||
+    isOllamaCircuitBreakerOpen(err) ||
+    isOllamaConnectionFailure(err)
+  ) {
     return true;
   }
   if (err instanceof AllEmbeddingProvidersFailed) {
     if (err.causes.length === 0) return false; // unknown state — report
     return err.causes.every(
-      (c) => isConfigError(c) || is429OrWrapped(c) || isOllamaCircuitBreakerOpen(c) || isOllamaConnectionFailure(c),
+      (c) =>
+        isConfigError(c) ||
+        is429OrWrapped(c) ||
+        is500OrWrapped(c) ||
+        isOllamaCircuitBreakerOpen(c) ||
+        isOllamaConnectionFailure(c),
     );
   }
   return false;

--- a/extensions/memory-hybrid/tests/embedding-providers.test.ts
+++ b/extensions/memory-hybrid/tests/embedding-providers.test.ts
@@ -1518,10 +1518,14 @@ describe("#486: shouldSuppressEmbeddingError — suppression helper", () => {
     ).toBe(true);
   });
 
-  it("does NOT suppress generic transient errors", () => {
+  it("does NOT suppress generic network/connection transient errors", () => {
     expect(shouldSuppressEmbeddingError(new Error("ECONNREFUSED"))).toBe(false);
     expect(shouldSuppressEmbeddingError(new Error("network timeout"))).toBe(false);
-    expect(shouldSuppressEmbeddingError(new Error("500 Internal Server Error"))).toBe(false);
+  });
+
+  it("suppresses 500 server errors", () => {
+    expect(shouldSuppressEmbeddingError(new Error("500 Internal Server Error"))).toBe(true);
+    expect(shouldSuppressEmbeddingError(new Error("500 internal error"))).toBe(true);
   });
 
   it("does NOT suppress non-Error values", () => {


### PR DESCRIPTION
Fixes #739

This PR updates the error handling logic in the memory-hybrid extension to:
1. Correctly recognize `500 internal error` returned by the OpenAI SDK (and other 500/502 server errors).
2. Classify these errors as transient provider noise instead of logic bugs.
3. Suppress GlitchTip/Sentry error reporting for these 500 errors so they don't trigger alerts for downstream dependency failures.
4. Continue relying on `withLLMRetry` to backoff and retry, or gracefully fall back to alternative models.

Tested and verified that 500 errors from APIError are properly caught by `is500Like` and `shouldSuppressEmbeddingError`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to error classification/suppression and a small regex tweak, plus targeted test updates. Primary impact is reduced error reporting for provider-side 5xx failures.
> 
> **Overview**
> Improves detection of transient 5xx provider failures by expanding `is500Like` message matching and adding `is500OrWrapped` to recognize 5xx errors wrapped in `LLMRetryError`.
> 
> Updates embedding error suppression to treat 5xx responses as expected transient noise: `shouldSuppressEmbeddingError` now suppresses 500s (including within `AllEmbeddingProvidersFailed`), and the OpenAI embedding provider routes reporting decisions through this helper. Tests are updated to assert 500 suppression while keeping generic network/transient errors reportable.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f8a6bdd4ec180d5cde5958f1deda90da5eed337a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->