### PR TITLE
fix: replace removed stringEnum with inline implementation

### DIFF
--- a/extensions/memory-hybrid/index.ts
+++ b/extensions/memory-hybrid/index.ts
@@ -28,7 +28,6 @@ import { basename, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { homedir } from "node:os";
 import type { ClawdbotPluginApi } from "openclaw/plugin-sdk";
-import { stringEnum } from "openclaw/plugin-sdk";
 
 import {
   DEFAULT_MEMORY_CATEGORIES,

--- a/extensions/memory-hybrid/tests/__mocks__/openclaw-plugin-sdk.ts
+++ b/extensions/memory-hybrid/tests/__mocks__/openclaw-plugin-sdk.ts
@@ -5,10 +5,6 @@ import { Type } from "@sinclair/typebox";
  * that index.ts actually uses so tests can import the module.
  */
 
-export function stringEnum<T extends readonly string[]>(values: T) {
-  return Type.Union(values.map((v) => Type.Literal(v)));
-}
-
 /** CLI program type for registerCli — use any for action callback to accept Commander-style handlers. */
 type CliProgram = {
   command: (name: string) => CliProgram;

--- a/extensions/memory-hybrid/tools/credential-tools.ts
+++ b/extensions/memory-hybrid/tools/credential-tools.ts
@@ -7,7 +7,7 @@
 
 import { Type } from "@sinclair/typebox";
 import type { ClawdbotPluginApi } from "openclaw/plugin-sdk";
-import { stringEnum } from "openclaw/plugin-sdk";
+import { stringEnum } from "../utils/typebox.js";
 
 import type { CredentialsDB } from "../backends/credentials-db.js";
 import { CREDENTIAL_TYPES, type CredentialType, type HybridMemoryConfig } from "../config.js";

--- a/extensions/memory-hybrid/tools/document-tools.ts
+++ b/extensions/memory-hybrid/tools/document-tools.ts
@@ -27,7 +27,7 @@ import {
   type MemoryCategory,
 } from "../config.js";
 import { extractTags } from "../utils/tags.js";
-import { stringEnum } from "openclaw/plugin-sdk";
+import { stringEnum } from "../utils/typebox.js";
 import type { ProvenanceService } from "../services/provenance.js";
 
 export interface DocumentToolsContext {

--- a/extensions/memory-hybrid/tools/graph-tools.ts
+++ b/extensions/memory-hybrid/tools/graph-tools.ts
@@ -7,7 +7,7 @@
 
 import { Type } from "@sinclair/typebox";
 import type { ClawdbotPluginApi } from "openclaw/plugin-sdk";
-import { stringEnum } from "openclaw/plugin-sdk";
+import { stringEnum } from "../utils/typebox.js";
 
 import type { FactsDB, MemoryLinkType } from "../backends/facts-db.js";
 import { MEMORY_LINK_TYPES } from "../backends/facts-db.js";

--- a/extensions/memory-hybrid/tools/issue-tools.ts
+++ b/extensions/memory-hybrid/tools/issue-tools.ts
@@ -6,7 +6,7 @@
  */
 
 import { Type } from "@sinclair/typebox";
-import { stringEnum } from "openclaw/plugin-sdk";
+import { stringEnum } from "../utils/typebox.js";
 import type { ClawdbotPluginApi } from "openclaw/plugin-sdk";
 
 import type { IssueStore } from "../backends/issue-store.js";

--- a/extensions/memory-hybrid/tools/memory-tools.ts
+++ b/extensions/memory-hybrid/tools/memory-tools.ts
@@ -8,7 +8,7 @@
 import { Type } from "@sinclair/typebox";
 import type OpenAI from "openai";
 import type { ClawdbotPluginApi } from "openclaw/plugin-sdk";
-import { stringEnum } from "openclaw/plugin-sdk";
+import { stringEnum } from "../utils/typebox.js";
 
 import type { BuildToolScopeFilterFn, FindSimilarByEmbeddingFn } from "../api/memory-plugin-api.js";
 import type { FactsDB } from "../backends/facts-db.js";

--- a/extensions/memory-hybrid/tools/persona-tools.ts
+++ b/extensions/memory-hybrid/tools/persona-tools.ts
@@ -5,7 +5,7 @@
 
 import { Type } from "@sinclair/typebox";
 import type { ClawdbotPluginApi } from "openclaw/plugin-sdk";
-import { stringEnum } from "openclaw/plugin-sdk";
+import { stringEnum } from "../utils/typebox.js";
 import { mkdir, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { getFileSnapshot } from "../utils/file-snapshot.js";

--- a/extensions/memory-hybrid/tools/utility-tools.ts
+++ b/extensions/memory-hybrid/tools/utility-tools.ts
@@ -1,6 +1,6 @@
 import { Type } from "@sinclair/typebox";
 import type { ClawdbotPluginApi } from "openclaw/plugin-sdk";
-import { stringEnum } from "openclaw/plugin-sdk";
+import { stringEnum } from "../utils/typebox.js";
 import type OpenAI from "openai";
 
 import type { FactsDB } from "../backends/facts-db.js";

--- a/extensions/memory-hybrid/types/openclaw-plugin-sdk.d.ts
+++ b/extensions/memory-hybrid/types/openclaw-plugin-sdk.d.ts
@@ -5,8 +5,6 @@
 declare module "openclaw/plugin-sdk" {
   import type { TSchema } from "@sinclair/typebox";
 
-  export function stringEnum<T extends readonly string[]>(values: T): TSchema;
-
   type CliProgram = {
     command: (name: string) => CliProgram;
     description: (d: string) => CliProgram;

--- a/extensions/memory-hybrid/utils/typebox.ts
+++ b/extensions/memory-hybrid/utils/typebox.ts
@@ -1,0 +1,9 @@
+import { Type } from "@sinclair/typebox";
+
+export function stringEnum<T extends readonly string[]>(values: T, options: { description?: string } = {}) {
+  return Type.Unsafe<T[number]>({
+    type: "string",
+    enum: [...values],
+    ...options,
+  });
+}


### PR DESCRIPTION
Fixes #761. `stringEnum` was removed from the public `openclaw/plugin-sdk` export surface in 2026.3.24. This PR replaces it with an inline implementation using TypeBox.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: mechanical import swap plus a small helper for enum schemas; main impact is tool parameter schema generation/validation if the new `stringEnum` differs subtly from the old implementation.
> 
> **Overview**
> Removes usage of `stringEnum` from `openclaw/plugin-sdk` and replaces it with a local implementation in `utils/typebox.ts`.
> 
> Updates all tool registrations (credentials, documents, graph, issues, memory, persona, utility) to import `stringEnum` from the new helper, and cleans up the test mock and local `openclaw-plugin-sdk.d.ts` to reflect that `stringEnum` is no longer part of the SDK surface.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 99ee129665a512c947f67f98f8262974a0e96ced. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->