### PR TITLE
fix: handle vector dimension mismatch in LanceDB fallback queries

### DIFF
--- a/extensions/memory-hybrid/backends/vector-db.ts
+++ b/extensions/memory-hybrid/backends/vector-db.ts
@@ -487,6 +487,9 @@ export class VectorDB {
       const filterKey = options.filterKey ?? "default";
       const candidateLimit = options.candidateLimit ?? 25;
 
+      // Dimension pre-check: prevent LanceDB "No vector column found" errors on fallback query mismatch
+      if (vector.length !== this.vectorDim) return null;
+
       const candidates = await this.getSemanticQueryCacheTable().vectorSearch(vector).limit(candidateLimit).toArray();
 
       let bestMatch: SemanticQueryCacheEntry | null = null;

--- a/extensions/memory-hybrid/services/retrieval-aliases.ts
+++ b/extensions/memory-hybrid/services/retrieval-aliases.ts
@@ -154,6 +154,9 @@ class AliasVectorIndex {
     try {
       await this.ensureInitialized();
       if (!this.schemaValid) return [];
+      // Dimension pre-check: prevent LanceDB "No vector column found" errors on fallback query mismatch
+      if (vector.length !== this.vectorDim) return [];
+
       const searchLimit = Math.max(limit * 6, 50);
       const results = await this.getTable().vectorSearch(vector).limit(searchLimit).toArray();
       const bestByFact = new Map<string, number>();


### PR DESCRIPTION
Fixes #735 by adding dimension pre-checks to semantic query cache and alias vector searches to prevent LanceDB 'No vector column found' errors when a fallback embedding has a different dimension.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds simple early-return guards that only affect fallback query paths by returning empty/no-cache results when vector dimensions don’t match, avoiding known LanceDB runtime errors.
> 
> **Overview**
> Prevents LanceDB runtime failures during fallback embedding by adding a **vector-dimension pre-check** before running `vectorSearch`.
> 
> When the query vector’s length doesn’t match the configured `vectorDim`, semantic query cache lookups (`VectorDB.getSemanticQueryCacheMatch`) now return `null` and alias vector searches (`AliasVectorIndex.search`) return an empty result set, avoiding "No vector column found" errors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4ca4b4f10ba6dc69064d181d60938292e232e72f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->