### PR TITLE
fix: add enabled field to selfCorrection and implicitFeedback schemas

### DIFF
--- a/extensions/memory-hybrid/config/types/features.ts
+++ b/extensions/memory-hybrid/config/types/features.ts
@@ -204,7 +204,7 @@ export type ImplicitSignalType =
 /** Implicit feedback detection from behavioral conversation signals (Issue #262). */
 export type ImplicitFeedbackConfig = {
   /** Enable implicit feedback detection (default: true). */
-  enabled: boolean;
+  enabled?: boolean;
   /** Minimum confidence to include a signal (default: 0.5). */
   minConfidence: number;
   /** Signal types to detect; defaults to all types. */

--- a/extensions/memory-hybrid/config/types/index.ts
+++ b/extensions/memory-hybrid/config/types/index.ts
@@ -267,6 +267,7 @@ export type ActiveTaskConfig = {
 
 /** Self-correction pipeline: semantic dedup, TOOLS.md sectioning, auto-rewrite vs approve */
 export type SelfCorrectionConfig = {
+  enabled?: boolean;
   /** Use embedding similarity to skip near-duplicate facts before MEMORY_STORE (default: true). */
   semanticDedup: boolean;
   /** Similarity threshold for semantic dedup, 0–1 (default: 0.92). */


### PR DESCRIPTION
Fixes #751 by making `enabled` an optional boolean on `SelfCorrectionConfig` and `ImplicitFeedbackConfig`. This ensures that setting `selfCorrection.enabled = true` via config.patch works properly without schema validation errors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk type-only change that relaxes config typing/schema for `enabled`, reducing validation friction without altering runtime parsing/behavior.
> 
> **Overview**
> Relaxes config type definitions by making `enabled` optional on `ImplicitFeedbackConfig` and `SelfCorrectionConfig`, so partial config patches can set/omit these flags without failing schema/type validation.
> 
> No runtime logic changes are included; the parsers still default to enabled unless explicitly set to `false`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4f5c6257a56d0834da2307907155b3860c018486. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->