### PR TITLE
fix: VectorDB re-index race condition and ENOTEMPTY on LanceDB 0.27.x

### DIFF
--- a/extensions/memory-hybrid/backends/vector-db.ts
+++ b/extensions/memory-hybrid/backends/vector-db.ts
@@ -215,6 +215,11 @@ export class VectorDB {
         await this.validateOrRepairSemanticQueryCacheTable();
         return;
       } catch (err) {
+        // Re-throw "initialization aborted" errors so resetTableForReindex()'s retry loop can catch them.
+        const msg = err instanceof Error ? err.message : String(err);
+        if (msg.includes("initialization aborted") || msg.includes("concurrent re-registration")) {
+          throw err;
+        }
         this.logWarn(`memory-hybrid: failed to open semantic query cache table, rebuilding: ${err}`);
         try {
           await this.db.dropTable(SEMANTIC_QUERY_CACHE_TABLE);


### PR DESCRIPTION
Fixes #769 and #770.

## Changes

**`extensions/memory-hybrid/backends/vector-db.ts`**

### Fix 1 — Concurrent re-registration race (closes #769)

OpenClaw calls `register()` multiple times during CLI startup. Each call creates a new `VectorDB` and immediately closes the previous one via `closeOldDatabases()`. The problem: the previous VectorDB's `doInitialize()` is still in-flight. After a `tableNames()` or `openTable()` await yields back to the event loop, the concurrent `close()` sets `this.db = null` and `this.closed = true`. When the await completes, `ensureSemanticQueryCacheTable()` throws `"VectorDB connection not initialized."`.

**Fix:**
- Added `this.closed` checks after every `await` inside `doInitialize()` with descriptive "initialization aborted: closed during X (concurrent re-registration)" errors.
- Added a retry loop in `resetTableForReindex()` (up to 10 × 500 ms) that recognises those errors and retries after a brief delay, allowing the startup registration churn to settle.

### Fix 2 — ENOTEMPTY on LanceDB 0.27.x `dropTable()` (closes #770)

LanceDB 0.27.x changed `dropTable()` to call the Rust `rmdir()` syscall, which fails with `ENOTEMPTY` on non-empty directories. The `memories.lance` directory always contains `_transactions/`, `_versions/`, and `data/` sub-directories, so every call to `resetTableForReindex()` was failing.

**Fix:**
- Close the active LanceDB connection first.
- Use Node.js `rmSync(dir, { recursive: true, force: true })` to remove both `memories.lance` and `semantic_query_cache.lance`.
- Reconnect and let `doInitialize()` create fresh empty tables with the current schema.

## Testing

Both bugs reproduce consistently on LanceDB 0.27.x with multiple `register()` calls during CLI startup. After this fix, `openclaw hybrid-mem re-index` completes successfully and embeds all facts.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches LanceDB initialization and re-index teardown logic, including manual filesystem deletion and new retry behavior; mistakes here could break index rebuilds or cause transient startup failures, though changes are scoped to the vector backend.
> 
> **Overview**
> Fixes VectorDB re-index and startup stability issues when plugin re-registration closes an instance mid-initialization. `doInitialize()`/semantic-cache setup now add post-`await` guards that fail fast with explicit “initialization aborted” errors, and semantic-cache open failures rethrow those abort errors so callers can retry.
> 
> Reworks `resetTableForReindex()` to *retry initialization* (10x with delay) when aborted by concurrent re-registration, and replaces `db.dropTable()` with filesystem deletion (`rmSync` of the `.lance` directories) after closing the connection, then reconnects to recreate fresh tables (workaround for LanceDB 0.27.x `ENOTEMPTY`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f6347f80678d64290b86e5f00fe5361aa2e2bc27. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->