### PR TITLE
fix: [Bug] LanceDB data file not found during vector-duplicate-check — race condition with compactor (#768)

### DIFF
--- a/extensions/memory-hybrid/backends/vector-db.ts
+++ b/extensions/memory-hybrid/backends/vector-db.ts
@@ -27,6 +27,7 @@ const _optimizingByPath = new Map<string, boolean>();
 const _optimizeFailuresByPath = new Map<string, number>();
 const _OPTIMIZE_FAILURE_WARN_THRESHOLD = 3;
 const SEMANTIC_QUERY_CACHE_MAX_ROWS_PER_FILTER_KEY = 100;
+const TRANSIENT_VECTOR_QUERY_RETRY_DELAY_MS = 50;
 
 export type VectorDBLogger = { warn: (msg: string) => void };
 
@@ -325,6 +326,23 @@ export class VectorDB {
 
   private isKnownVectorSchemaError(err: unknown): boolean {
     return err instanceof Error && err.message.includes(LANCE_NO_VECTOR_COL_MSG);
+  }
+
+  /**
+   * Detect a transient LanceDB read race where compaction/prune removes old data
+   * files while a query stream is reading a batch.
+   *
+   * Example:
+   * "Failed to get next batch from stream: lance error: Not found: .../memories.lance/data/<file>.lance"
+   */
+  private isTransientMissingDataFileError(err: unknown): boolean {
+    if (!(err instanceof Error)) return false;
+    const msg = err.message;
+    return (
+      msg.includes("Failed to get next batch from stream") &&
+      msg.includes("lance error: Not found:") &&
+      msg.includes(".lance/data/")
+    );
   }
 
   /**
@@ -832,7 +850,7 @@ export class VectorDB {
   }
 
   async hasDuplicate(vector: number[], threshold = 0.95): Promise<boolean> {
-    try {
+    const runDuplicateQuery = async (): Promise<boolean> => {
       await this.ensureInitialized();
       // Same early-exit as search(): schema was already reported invalid at startup.
       if (!this.schemaValid) return false;
@@ -845,7 +863,31 @@ export class VectorDB {
       if (results.length === 0) return false;
       const score = 1 / (1 + (results[0]._distance ?? 0));
       return score >= threshold;
+    };
+
+    try {
+      return await runDuplicateQuery();
     } catch (err) {
+      // Transient race with optimize/compaction: LanceDB can report missing fragment
+      // files while streaming query batches. Retry once after a short delay.
+      if (this.isTransientMissingDataFileError(err)) {
+        this.logWarn(`memory-hybrid: LanceDB hasDuplicate transient stream read race; retrying once: ${err}`);
+        try {
+          await new Promise<void>((resolve) => setTimeout(resolve, TRANSIENT_VECTOR_QUERY_RETRY_DELAY_MS));
+          return await runDuplicateQuery();
+        } catch (retryErr) {
+          if (!this.isKnownVectorSchemaError(retryErr) && !this.isTransientMissingDataFileError(retryErr)) {
+            capturePluginError(retryErr as Error, {
+              operation: "vector-duplicate-check",
+              severity: "info",
+              subsystem: "vector",
+            });
+          }
+          this.logWarn(`memory-hybrid: LanceDB hasDuplicate failed after transient retry: ${retryErr}`);
+          return false;
+        }
+      }
+
       // Errors reaching here mean the dimension pre-check passed but LanceDB still
       // threw — we suppress "No vector column found" since it is an acceptable
       // transient error in this path. All other errors are reported normally.

--- a/extensions/memory-hybrid/tests/vector-db-schema.test.ts
+++ b/extensions/memory-hybrid/tests/vector-db-schema.test.ts
@@ -327,6 +327,72 @@ describe("VectorDB issue #366 — capturePluginError suppressed on schema mismat
   });
 });
 
+describe("VectorDB hasDuplicate() transient stream read race handling (issue #768)", () => {
+  let tmpDir: string;
+  let lanceDir: string;
+
+  beforeEach(async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), "vector-768-test-"));
+    lanceDir = join(tmpDir, "lance");
+    await seedTable(lanceDir, CORRECT_DIM);
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("retries once and returns true when the second attempt succeeds", async () => {
+    const db = new VectorDB(lanceDir, CORRECT_DIM);
+    await db.count(); // initialize tables
+
+    let calls = 0;
+    const transientErr = new Error(
+      "Failed to get next batch from stream: lance error: Not found: /tmp/lancedb/memories.lance/data/missing-file.lance",
+    );
+    (db as any).table = {
+      vectorSearch: () => ({
+        limit: () => ({
+          toArray: async () => {
+            calls++;
+            if (calls === 1) throw transientErr;
+            return [{ _distance: 0 }];
+          },
+        }),
+      }),
+    };
+
+    const result = await db.hasDuplicate(new Array(CORRECT_DIM).fill(0.1), 0.95);
+    expect(result).toBe(true);
+    expect(calls).toBe(2);
+    expect(vi.mocked(errorReporter.capturePluginError)).not.toHaveBeenCalled();
+    await db.close();
+  });
+
+  it("returns false without GlitchTip when transient error persists after retry", async () => {
+    const db = new VectorDB(lanceDir, CORRECT_DIM);
+    await db.count(); // initialize tables
+
+    const transientErr = new Error(
+      "Failed to get next batch from stream: lance error: Not found: /tmp/lancedb/memories.lance/data/missing-file.lance",
+    );
+    const toArray = vi.fn().mockRejectedValue(transientErr);
+    (db as any).table = {
+      vectorSearch: () => ({
+        limit: () => ({
+          toArray,
+        }),
+      }),
+    };
+
+    const result = await db.hasDuplicate(new Array(CORRECT_DIM).fill(0.1), 0.95);
+    expect(result).toBe(false);
+    expect(toArray).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(errorReporter.capturePluginError)).not.toHaveBeenCalled();
+    await db.close();
+  });
+});
+
 describe("VectorDB semantic query cache — suppress known schema errors", () => {
   let tmpDir: string;
   let lanceDir: string;


### PR DESCRIPTION
Closes #768

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: scoped to `VectorDB.hasDuplicate()` error handling, adding a single retry for a specific transient LanceDB read error and new tests to lock in behavior.
> 
> **Overview**
> Fixes a LanceDB compaction/optimize race in `VectorDB.hasDuplicate()` where vector duplicate checks can fail with transient “missing `.lance/data/` file” stream-read errors.
> 
> The duplicate-check path now detects this specific error pattern, waits briefly, retries once, and suppresses GlitchTip reporting for the transient failure (while still reporting genuinely unexpected errors). Adds Vitest coverage for both successful and persistent-transient retry outcomes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 15a54f8c401a0602670a78382087b271466e3832. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->