### PR TITLE
feat: #754 — Flatten config schema

### DIFF
--- a/extensions/memory-hybrid/cli/cmd-config.ts
+++ b/extensions/memory-hybrid/cli/cmd-config.ts
@@ -122,7 +122,7 @@ export function runConfigViewForCli(ctx: HandlerContext, sink: VerifyCliSink): v
       const out = getPluginConfigFromFile(configPath);
       if ("config" in out) rawCfg = out.config;
     }
-  } catch {}
+  } catch (e) {}
 
   // Helper to get raw enabled flag if set, otherwise fallback to parsed config
   const rawEnabled = (key: string, parsedVal: boolean) => {
@@ -165,9 +165,7 @@ export function runConfigViewForCli(ctx: HandlerContext, sink: VerifyCliSink): v
   log(`  Tool effectiveness: ${on(rawEnabled("toolEffectiveness", cfg.toolEffectiveness.enabled))}`);
   log(`  Documents (MarkItDown): ${on(rawEnabled("documents", cfg.documents.enabled))}`);
   log(`  Provenance: ${on(rawEnabled("provenance", cfg.provenance.enabled))}`);
-  log(
-    `  Error reporting: ${on(rawEnabled("errorReporting", cfg.errorReporting?.enabled ?? false))} (consent: ${on(cfg.errorReporting?.consent ?? false)})`,
-  );
+  log(`  Error reporting: ${on(rawEnabled("errorReporting", cfg.errorReporting?.enabled ?? false))}`);
   log(`  Cost tracking: ${on(rawEnabled("costTracking", cfg.costTracking?.enabled ?? false))}`);
   log("");
 

--- a/extensions/memory-hybrid/config/parsers/core.ts
+++ b/extensions/memory-hybrid/config/parsers/core.ts
@@ -241,6 +241,7 @@ export function parseActiveTaskConfig(cfg: Record<string, unknown>): ActiveTaskC
 export function parseSelfCorrectionConfig(cfg: Record<string, unknown>): SelfCorrectionConfig | undefined {
   const scRaw = cfg.selfCorrection as Record<string, unknown> | undefined;
   if (!scRaw || typeof scRaw !== "object") return undefined;
+  if (scRaw.enabled === false) return undefined;
   return {
     semanticDedup: scRaw.semanticDedup !== false,
     semanticDedupThreshold:

--- a/extensions/memory-hybrid/config/parsers/features.ts
+++ b/extensions/memory-hybrid/config/parsers/features.ts
@@ -515,8 +515,10 @@ export function parseImplicitFeedbackConfig(cfg: Record<string, unknown>): Impli
     : ALL_IMPLICIT_SIGNAL_TYPES;
 
   // Issue #754: top-level aliases take precedence over nested keys
-  const topLevelTrajectoryLLMAnalysis = typeof cfg.trajectoryLLMAnalysis === "boolean" ? cfg.trajectoryLLMAnalysis : undefined;
-  const topLevelFeedToSelfCorrection = typeof cfg.feedToSelfCorrection === "boolean" ? cfg.feedToSelfCorrection : undefined;
+  const topLevelTrajectoryLLMAnalysis =
+    typeof cfg.trajectoryLLMAnalysis === "boolean" ? cfg.trajectoryLLMAnalysis : undefined;
+  const topLevelFeedToSelfCorrection =
+    typeof cfg.feedToSelfCorrection === "boolean" ? cfg.feedToSelfCorrection : undefined;
 
   // Deprecation warnings for old nested keys when top-level is also set
   if (topLevelTrajectoryLLMAnalysis !== undefined && raw?.trajectoryLLMAnalysis !== undefined) {

--- a/extensions/memory-hybrid/config/parsers/index.ts
+++ b/extensions/memory-hybrid/config/parsers/index.ts
@@ -652,12 +652,6 @@ export function parseConfig(value: unknown): HybridMemoryConfig {
     );
   }
 
-  // Issue #754: top-level trajectoryLLMAnalysis and feedToSelfCorrection aliases
-  const topLevelTrajectoryLLMAnalysis =
-    typeof cfg.trajectoryLLMAnalysis === "boolean" ? cfg.trajectoryLLMAnalysis : undefined;
-  const topLevelFeedToSelfCorrection =
-    typeof cfg.feedToSelfCorrection === "boolean" ? cfg.feedToSelfCorrection : undefined;
-
   const distill =
     distillRaw && typeof distillRaw === "object"
       ? {
@@ -699,6 +693,9 @@ export function parseConfig(value: unknown): HybridMemoryConfig {
           })(),
         }
       : undefined;
+
+  // Issue #754: parse implicitFeedback early to access resolved values for top-level aliases
+  const implicitFeedback = parseImplicitFeedbackConfig(cfg);
 
   return {
     embedding: {
@@ -761,7 +758,7 @@ export function parseConfig(value: unknown): HybridMemoryConfig {
     workflowTracking: parseWorkflowTrackingConfig(cfg),
     crystallization: parseCrystallizationConfig(cfg),
     selfExtension: parseSelfExtensionConfig(cfg),
-    implicitFeedback: parseImplicitFeedbackConfig(cfg),
+    implicitFeedback,
     closedLoop: parseClosedLoopConfig(cfg),
     frustrationDetection: parseFrustrationDetectionConfig(cfg),
     crossAgentLearning: parseCrossAgentLearningConfig(cfg),
@@ -779,20 +776,12 @@ export function parseConfig(value: unknown): HybridMemoryConfig {
     humanizer: parseHumanizerConfig(cfg),
     // Issue #754: top-level extractReinforcement (top-level wins, else distill.extractReinforcement)
     extractReinforcement:
-      topLevelExtractReinforcement !== undefined ? topLevelExtractReinforcement : distill?.extractReinforcement ?? true,
-    // Issue #754: top-level trajectoryLLMAnalysis and feedToSelfCorrection aliases
-    trajectoryLLMAnalysis:
-      topLevelTrajectoryLLMAnalysis !== undefined
-        ? topLevelTrajectoryLLMAnalysis
-        : cfg.implicitFeedback && typeof cfg.implicitFeedback === "object"
-          ? (cfg.implicitFeedback as Record<string, unknown>).trajectoryLLMAnalysis === true
-          : false,
-    feedToSelfCorrection:
-      topLevelFeedToSelfCorrection !== undefined
-        ? topLevelFeedToSelfCorrection
-        : cfg.implicitFeedback && typeof cfg.implicitFeedback === "object"
-          ? (cfg.implicitFeedback as Record<string, unknown>).feedToSelfCorrection !== false
-          : true,
+      topLevelExtractReinforcement !== undefined
+        ? topLevelExtractReinforcement
+        : (distill?.extractReinforcement ?? true),
+    // Issue #754: top-level trajectoryLLMAnalysis and feedToSelfCorrection aliases (already applied in parseImplicitFeedbackConfig)
+    trajectoryLLMAnalysis: implicitFeedback.trajectoryLLMAnalysis,
+    feedToSelfCorrection: implicitFeedback.feedToSelfCorrection,
     verbosity: parseVerbosityLevel(cfg),
     mode: hasPresetOverrides ? "custom" : appliedMode,
     gateway: parseGatewayConfig(cfg),

--- a/extensions/memory-hybrid/tests/config-view-nightly-cycle.test.ts
+++ b/extensions/memory-hybrid/tests/config-view-nightly-cycle.test.ts
@@ -1,7 +1,5 @@
-import { describe, expect, it, vi, afterEach } from "vitest";
-import { join } from "node:path";
-import { tmpdir } from "node:os";
-import { writeFileSync, rmSync } from "node:fs";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import * as fs from "node:fs";
 
 import type { HandlerContext } from "../cli/handlers.js";
 import { runConfigViewForCli } from "../cli/cmd-config.js";
@@ -50,8 +48,16 @@ function makeCtx(enabled: boolean): HandlerContext {
 }
 
 describe("runConfigViewForCli nightlyCycle output", () => {
+  afterEach(() => {
+    delete process.env.OPENCLAW_CONFIG;
+    try {
+      fs.unlinkSync("/tmp/test-openclaw.json");
+    } catch {
+      // Ignore if file doesn't exist
+    }
+  });
+
   it("shows on when nightlyCycle.enabled is true", () => {
-    vi.stubEnv("OPENCLAW_CONFIG", "/nonexistent/path/openclaw.json");
     const logs: string[] = [];
     runConfigViewForCli(makeCtx(true), { log: (line) => logs.push(line) });
 
@@ -59,41 +65,31 @@ describe("runConfigViewForCli nightlyCycle output", () => {
   });
 
   it("shows off when nightlyCycle.enabled is false", () => {
-    vi.stubEnv("OPENCLAW_CONFIG", "/nonexistent/path/openclaw.json");
     const logs: string[] = [];
     runConfigViewForCli(makeCtx(false), { log: (line) => logs.push(line) });
 
     expect(logs.some((l) => l.includes("Nightly dream cycle: off"))).toBe(true);
   });
-});
 
-const testConfigPath = join(tmpdir(), "test-openclaw-nightly-cycle.json");
-
-afterEach(() => {
-  vi.unstubAllEnvs();
-  try {
-    rmSync(testConfigPath, { force: true });
-  } catch {}
-});
-
-it("shows on when raw config has nightlyCycle.enabled = true even if cfg is false", () => {
-  const logs: string[] = [];
-  // Mock getPluginConfigFromFile by setting env var
-  vi.stubEnv("OPENCLAW_CONFIG", testConfigPath);
-  writeFileSync(
-    testConfigPath,
-    JSON.stringify({
-      plugins: {
-        entries: {
-          "openclaw-hybrid-memory": {
-            config: {
-              nightlyCycle: { enabled: true },
+  it("shows on when raw config has nightlyCycle.enabled = true even if cfg is false", () => {
+    const logs: string[] = [];
+    // Mock getPluginConfigFromFile by setting env var
+    process.env.OPENCLAW_CONFIG = "/tmp/test-openclaw.json";
+    require("fs").writeFileSync(
+      "/tmp/test-openclaw.json",
+      JSON.stringify({
+        plugins: {
+          entries: {
+            "openclaw-hybrid-memory": {
+              config: {
+                nightlyCycle: { enabled: true },
+              },
             },
           },
         },
-      },
-    }),
-  );
-  runConfigViewForCli(makeCtx(false), { log: (line) => logs.push(line) });
-  expect(logs.some((l) => l.includes("Nightly dream cycle: on"))).toBe(true);
+      }),
+    );
+    runConfigViewForCli(makeCtx(false), { log: (line) => logs.push(line) });
+    expect(logs.some((l) => l.includes("Nightly dream cycle: on"))).toBe(true);
+  });
 });


### PR DESCRIPTION
Closes #754

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches config parsing/precedence rules for feature toggles, which can change runtime behavior for existing installations with legacy keys. Scope is localized to config/CLI display and tests, with no direct security-sensitive logic changes.
> 
> **Overview**
> Adjusts `memory-hybrid` config parsing to better support the flattened schema from #754: `trajectoryLLMAnalysis`/`feedToSelfCorrection` precedence is now resolved inside `parseImplicitFeedbackConfig` and then reused in `parseConfig`, and `selfCorrection` is treated as disabled when `selfCorrection.enabled=false`.
> 
> Updates CLI config-view output to stop displaying `errorReporting.consent` and tweaks nightly-cycle config-view tests to use a real temp config path via `OPENCLAW_CONFIG` with explicit cleanup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c819a0bb05d7427399f5f27fc319402ea32cf185. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->