### PR TITLE
fix: #778 — replace deprecated openclaw/plugin-sdk barrel imports with scoped subpaths

### DIFF
--- a/extensions/memory-hybrid/cli/handlers.ts
+++ b/extensions/memory-hybrid/cli/handlers.ts
@@ -42,7 +42,7 @@ export interface HandlerContext {
   /** Category detection for extract-daily and similar; uses language keywords when set */
   detectCategory: (text: string) => MemoryCategory;
   /** OpenClaw plugin API — used for verify to read gateway config (e.g. models.providers for MiniMax etc.) */
-  api?: import("openclaw/plugin-sdk").ClawdbotPluginApi;
+  api?: import("openclaw/plugin-sdk/core").ClawdbotPluginApi;
   /** LLM cost tracker — records per-call token usage (Issue #270). */
   costTracker?: CostTracker | null;
   /** Event Bus for sensor sweep (Issue #236). */

--- a/extensions/memory-hybrid/cli/proposals.ts
+++ b/extensions/memory-hybrid/cli/proposals.ts
@@ -8,7 +8,7 @@ import { dirname, join, relative } from "node:path";
 import { homedir, tmpdir } from "node:os";
 import { spawnSync } from "node:child_process";
 import type { Chainable } from "./shared.js";
-import type { ClawdbotPluginApi } from "openclaw/plugin-sdk";
+import type { ClawdbotPluginApi } from "openclaw/plugin-sdk/core";
 import type { ProposalsDB } from "../backends/proposals-db.js";
 import type { HybridMemoryConfig, IdentityFileType } from "../config.js";
 import { capturePluginError } from "../services/error-reporter.js";

--- a/extensions/memory-hybrid/index.ts
+++ b/extensions/memory-hybrid/index.ts
@@ -27,7 +27,7 @@ import { mkdir, readFile, writeFile, unlink, access } from "node:fs/promises";
 import { basename, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { homedir } from "node:os";
-import type { ClawdbotPluginApi } from "openclaw/plugin-sdk";
+import type { ClawdbotPluginApi } from "openclaw/plugin-sdk/core";
 
 import {
   DEFAULT_MEMORY_CATEGORIES,

--- a/extensions/memory-hybrid/lifecycle/hooks.ts
+++ b/extensions/memory-hybrid/lifecycle/hooks.ts
@@ -7,7 +7,7 @@
 
 import { join, isAbsolute } from "node:path";
 import { homedir } from "node:os";
-import type { ClawdbotPluginApi } from "openclaw/plugin-sdk";
+import type { ClawdbotPluginApi } from "openclaw/plugin-sdk/core";
 import { getCronModelConfig, getDefaultCronModel } from "../config.js";
 import { runSetupStage } from "./stage-setup.js";
 import { runRecallStage } from "./stage-recall.js";

--- a/extensions/memory-hybrid/lifecycle/stage-active-task.ts
+++ b/extensions/memory-hybrid/lifecycle/stage-active-task.ts
@@ -3,7 +3,7 @@
  * Registers before_agent_start to inject ACTIVE-TASK.md summary when enabled.
  */
 
-import type { ClawdbotPluginApi } from "openclaw/plugin-sdk";
+import type { ClawdbotPluginApi } from "openclaw/plugin-sdk/core";
 import { capturePluginError } from "../services/error-reporter.js";
 import { parseDuration } from "../utils/duration.js";
 import { readActiveTaskFile, buildActiveTaskInjection, buildStaleWarningInjection } from "../services/active-task.js";

--- a/extensions/memory-hybrid/lifecycle/stage-auth-failure.ts
+++ b/extensions/memory-hybrid/lifecycle/stage-auth-failure.ts
@@ -3,7 +3,7 @@
  * On before_agent_start, detect auth failure in prompt/messages and inject credential facts.
  */
 
-import type { ClawdbotPluginApi } from "openclaw/plugin-sdk";
+import type { ClawdbotPluginApi } from "openclaw/plugin-sdk/core";
 import type { ScopeFilter } from "../types/memory.js";
 import { mergeResults, filterByScope } from "../services/merge-results.js";
 import { VAULT_POINTER_PREFIX } from "../services/auto-capture.js";

--- a/extensions/memory-hybrid/lifecycle/stage-capture.ts
+++ b/extensions/memory-hybrid/lifecycle/stage-capture.ts
@@ -7,7 +7,7 @@
 
 import { mkdir, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
-import type { ClawdbotPluginApi } from "openclaw/plugin-sdk";
+import type { ClawdbotPluginApi } from "openclaw/plugin-sdk/core";
 import type { MemoryCategory } from "../config.js";
 import { getCronModelConfig, getDefaultCronModel } from "../config.js";
 import { CLI_STORE_IMPORTANCE } from "../utils/constants.js";

--- a/extensions/memory-hybrid/lifecycle/stage-cleanup.ts
+++ b/extensions/memory-hybrid/lifecycle/stage-cleanup.ts
@@ -5,7 +5,7 @@
  */
 
 import { join } from "node:path";
-import type { ClawdbotPluginApi } from "openclaw/plugin-sdk";
+import type { ClawdbotPluginApi } from "openclaw/plugin-sdk/core";
 import { capturePluginError } from "../services/error-reporter.js";
 import { parseDuration } from "../utils/duration.js";
 import {

--- a/extensions/memory-hybrid/lifecycle/stage-credential-hint.ts
+++ b/extensions/memory-hybrid/lifecycle/stage-credential-hint.ts
@@ -5,7 +5,7 @@
 
 import { readFile, unlink, access } from "node:fs/promises";
 import { dirname, join } from "node:path";
-import type { ClawdbotPluginApi } from "openclaw/plugin-sdk";
+import type { ClawdbotPluginApi } from "openclaw/plugin-sdk/core";
 import { capturePluginError } from "../services/error-reporter.js";
 import type { LifecycleContext } from "./types.js";
 

--- a/extensions/memory-hybrid/lifecycle/stage-frustration.ts
+++ b/extensions/memory-hybrid/lifecycle/stage-frustration.ts
@@ -2,7 +2,7 @@
  * Lifecycle: frustration detection and tool-hint injection (Phase 2.3).
  */
 
-import type { ClawdbotPluginApi } from "openclaw/plugin-sdk";
+import type { ClawdbotPluginApi } from "openclaw/plugin-sdk/core";
 import { capturePluginError } from "../services/error-reporter.js";
 import { detectFrustration, buildFrustrationHint, exportAsImplicitSignals } from "../services/frustration-detector.js";
 import { generateToolHint, ToolEffectivenessStore } from "../services/tool-effectiveness.js";

--- a/extensions/memory-hybrid/lifecycle/stage-injection.ts
+++ b/extensions/memory-hybrid/lifecycle/stage-injection.ts
@@ -5,7 +5,7 @@
  * Timeout: 10s.
  */
 
-import type { ClawdbotPluginApi } from "openclaw/plugin-sdk";
+import type { ClawdbotPluginApi } from "openclaw/plugin-sdk/core";
 import { getCronModelConfig, getDefaultCronModel } from "../config.js";
 import { estimateTokens, estimateTokensForDisplay, formatProgressiveIndexLine } from "../utils/text.js";
 import { capturePluginError } from "../services/error-reporter.js";

--- a/extensions/memory-hybrid/lifecycle/stage-recall.ts
+++ b/extensions/memory-hybrid/lifecycle/stage-recall.ts
@@ -6,7 +6,7 @@
  * Config: autoRecall.enabled. Timeout: 35s.
  */
 
-import type { ClawdbotPluginApi } from "openclaw/plugin-sdk";
+import type { ClawdbotPluginApi } from "openclaw/plugin-sdk/core";
 import type { ScopeFilter } from "../types/memory.js";
 import type { SearchResult } from "../types/memory.js";
 import {

--- a/extensions/memory-hybrid/lifecycle/stage-setup.ts
+++ b/extensions/memory-hybrid/lifecycle/stage-setup.ts
@@ -5,7 +5,7 @@
  */
 
 import { existsSync, unlinkSync } from "node:fs";
-import type { ClawdbotPluginApi } from "openclaw/plugin-sdk";
+import type { ClawdbotPluginApi } from "openclaw/plugin-sdk/core";
 import { getRestartPendingPath } from "../utils/constants.js";
 import { capturePluginError } from "../services/error-reporter.js";
 import { withTimeout } from "../utils/timeout.js";

--- a/extensions/memory-hybrid/services/bootstrap-optional.ts
+++ b/extensions/memory-hybrid/services/bootstrap-optional.ts
@@ -1,5 +1,5 @@
 import { dirname, join } from "node:path";
-import type { ClawdbotPluginApi } from "openclaw/plugin-sdk";
+import type { ClawdbotPluginApi } from "openclaw/plugin-sdk/core";
 import { ApitapStore } from "../backends/apitap-store.js";
 import { CredentialsDB } from "../backends/credentials-db.js";
 import { CrystallizationStore } from "../backends/crystallization-store.js";

--- a/extensions/memory-hybrid/services/bootstrap.ts
+++ b/extensions/memory-hybrid/services/bootstrap.ts
@@ -1,4 +1,4 @@
-import type { ClawdbotPluginApi } from "openclaw/plugin-sdk";
+import type { ClawdbotPluginApi } from "openclaw/plugin-sdk/core";
 import { FactsDB } from "../backends/facts-db.js";
 import { VectorDB } from "../backends/vector-db.js";
 import type { BootstrapPhaseConfig, EmbeddingModelConfig, HybridMemoryConfig } from "../config.js";

--- a/extensions/memory-hybrid/services/capture-provenance.ts
+++ b/extensions/memory-hybrid/services/capture-provenance.ts
@@ -1,4 +1,4 @@
-import type { ClawdbotPluginApi } from "openclaw/plugin-sdk";
+import type { ClawdbotPluginApi } from "openclaw/plugin-sdk/core";
 
 export type CaptureOrigin = "interactive" | "system" | "cron";
 

--- a/extensions/memory-hybrid/setup/cli-context.ts
+++ b/extensions/memory-hybrid/setup/cli-context.ts
@@ -8,7 +8,8 @@ import { dirname, isAbsolute, join } from "node:path";
 import { homedir } from "node:os";
 import type { ActiveTaskContext } from "../cli/active-tasks.js";
 import { parseDuration } from "../utils/duration.js";
-import type { ClawdbotPluginApi } from "openclaw/plugin-sdk";
+import type { Command } from "commander";
+import type { ClawdbotPluginApi } from "openclaw/plugin-sdk/core";
 import { registerHybridMemCli, type HybridMemCliContext } from "../cli/register.js";
 import type { HandlerContext } from "../cli/handlers.js";
 import * as handlers from "../cli/handlers.js";
@@ -467,7 +468,7 @@ export function registerHybridMemCliWithApi(api: ClawdbotPluginApi, ctx: HybridM
   };
   const services = buildCliContextServices(ctx, api);
   api.registerCli(
-    ({ program }) => {
+    ({ program }: { program: Command }) => {
       try {
         const cliCtx = createHybridMemCliContext(handlerCtx, api, services);
         registerCliWithHelp(program, cliCtx);

--- a/extensions/memory-hybrid/setup/init-databases.ts
+++ b/extensions/memory-hybrid/setup/init-databases.ts
@@ -3,7 +3,7 @@ import { dirname, join } from "node:path";
 import { existsSync, readFileSync, constants } from "node:fs";
 import { open } from "node:fs/promises";
 import OpenAI from "openai";
-import type { ClawdbotPluginApi } from "openclaw/plugin-sdk";
+import type { ClawdbotPluginApi } from "openclaw/plugin-sdk/core";
 import { resolveSecretRef, normalizeResolvedSecretValue } from "../config/parsers/core.js";
 import type { FactsDB } from "../backends/facts-db.js";
 import type { VectorDB } from "../backends/vector-db.js";

--- a/extensions/memory-hybrid/setup/plugin-service.ts
+++ b/extensions/memory-hybrid/setup/plugin-service.ts
@@ -1,7 +1,7 @@
 import { dirname, join } from "node:path";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
-import type { ClawdbotPluginApi } from "openclaw/plugin-sdk";
+import type { ClawdbotPluginApi } from "openclaw/plugin-sdk/core";
 import type { FactsDB } from "../backends/facts-db.js";
 import type { VectorDB } from "../backends/vector-db.js";
 import type { CredentialsDB } from "../backends/credentials-db.js";

--- a/extensions/memory-hybrid/setup/register-hooks.ts
+++ b/extensions/memory-hybrid/setup/register-hooks.ts
@@ -5,7 +5,7 @@
  * Extracted from index.ts to reduce main file size.
  */
 
-import type { ClawdbotPluginApi } from "openclaw/plugin-sdk";
+import type { ClawdbotPluginApi } from "openclaw/plugin-sdk/core";
 import type { MemoryPluginAPI } from "../api/memory-plugin-api.js";
 import { getMemoryCategories } from "../config.js";
 import { createLifecycleHooks, type LifecycleContext } from "../lifecycle/hooks.js";

--- a/extensions/memory-hybrid/setup/register-tools.ts
+++ b/extensions/memory-hybrid/setup/register-tools.ts
@@ -5,7 +5,7 @@
  * Extracted from index.ts to reduce main file size.
  */
 
-import type { ClawdbotPluginApi } from "openclaw/plugin-sdk";
+import type { ClawdbotPluginApi } from "openclaw/plugin-sdk/core";
 import { toolInstallers, type ToolsContext } from "./tool-installers.js";
 
 /** Tool registration receives the stable plugin API (Phase 3). */

--- a/extensions/memory-hybrid/setup/tool-installers.ts
+++ b/extensions/memory-hybrid/setup/tool-installers.ts
@@ -1,4 +1,4 @@
-import type { ClawdbotPluginApi } from "openclaw/plugin-sdk";
+import type { ClawdbotPluginApi } from "openclaw/plugin-sdk/core";
 import type { MemoryPluginAPI } from "../api/memory-plugin-api.js";
 import type { BootstrapPhaseConfig } from "../config.js";
 import { capturePluginError } from "../services/error-reporter.js";

--- a/extensions/memory-hybrid/tests/dashboard-routes.test.ts
+++ b/extensions/memory-hybrid/tests/dashboard-routes.test.ts
@@ -25,7 +25,7 @@ import {
   type HttpRequestHandler,
 } from "../tools/dashboard-routes.js";
 import { parseHealthConfig } from "../config/parsers/maintenance.js";
-import type { ClawdbotPluginApi } from "openclaw/plugin-sdk";
+import type { ClawdbotPluginApi } from "openclaw/plugin-sdk/core";
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/extensions/memory-hybrid/tools/apitap-tools.ts
+++ b/extensions/memory-hybrid/tools/apitap-tools.ts
@@ -12,7 +12,7 @@
  */
 
 import { Type } from "@sinclair/typebox";
-import type { ClawdbotPluginApi } from "openclaw/plugin-sdk";
+import type { ClawdbotPluginApi } from "openclaw/plugin-sdk/core";
 import type { ApitapStore } from "../backends/apitap-store.js";
 import type { HybridMemoryConfig } from "../config.js";
 import { ApitapService, isEndpointBlocked, validateUrl } from "../services/apitap-service.js";

--- a/extensions/memory-hybrid/tools/credential-tools.ts
+++ b/extensions/memory-hybrid/tools/credential-tools.ts
@@ -6,7 +6,7 @@
  */
 
 import { Type } from "@sinclair/typebox";
-import type { ClawdbotPluginApi } from "openclaw/plugin-sdk";
+import type { ClawdbotPluginApi } from "openclaw/plugin-sdk/core";
 import { stringEnum } from "../utils/typebox.js";
 
 import type { CredentialsDB } from "../backends/credentials-db.js";

--- a/extensions/memory-hybrid/tools/crystallization-tools.ts
+++ b/extensions/memory-hybrid/tools/crystallization-tools.ts
@@ -9,7 +9,7 @@
  */
 
 import { Type } from "@sinclair/typebox";
-import type { ClawdbotPluginApi } from "openclaw/plugin-sdk";
+import type { ClawdbotPluginApi } from "openclaw/plugin-sdk/core";
 import type { CrystallizationStore } from "../backends/crystallization-store.js";
 import type { WorkflowStore } from "../backends/workflow-store.js";
 import type { HybridMemoryConfig } from "../config.js";

--- a/extensions/memory-hybrid/tools/dashboard-routes.ts
+++ b/extensions/memory-hybrid/tools/dashboard-routes.ts
@@ -14,7 +14,7 @@
  *   GET /plugins/memory-dashboard/api/health — JSON health report
  */
 
-import type { ClawdbotPluginApi } from "openclaw/plugin-sdk";
+import type { ClawdbotPluginApi } from "openclaw/plugin-sdk/core";
 import type { HealthConfig } from "../config/types/maintenance.js";
 
 /** Minimal type for the registerHttpRoute API available in OpenClaw v2026.3.8+. */

--- a/extensions/memory-hybrid/tools/document-tools.ts
+++ b/extensions/memory-hybrid/tools/document-tools.ts
@@ -10,7 +10,7 @@ import { Type } from "@sinclair/typebox";
 import { createHash } from "node:crypto";
 import { readdirSync, readFileSync, realpathSync, statSync } from "node:fs";
 import { basename, extname, isAbsolute, relative, resolve } from "node:path";
-import type { ClawdbotPluginApi } from "openclaw/plugin-sdk";
+import type { ClawdbotPluginApi } from "openclaw/plugin-sdk/core";
 import type OpenAI from "openai";
 
 import type { FactsDB } from "../backends/facts-db.js";

--- a/extensions/memory-hybrid/tools/graph-tools.ts
+++ b/extensions/memory-hybrid/tools/graph-tools.ts
@@ -6,7 +6,7 @@
  */
 
 import { Type } from "@sinclair/typebox";
-import type { ClawdbotPluginApi } from "openclaw/plugin-sdk";
+import type { ClawdbotPluginApi } from "openclaw/plugin-sdk/core";
 import { stringEnum } from "../utils/typebox.js";
 
 import type { FactsDB, MemoryLinkType } from "../backends/facts-db.js";

--- a/extensions/memory-hybrid/tools/health-dashboard.ts
+++ b/extensions/memory-hybrid/tools/health-dashboard.ts
@@ -8,7 +8,7 @@
 
 import { join } from "node:path";
 import { Type } from "@sinclair/typebox";
-import type { ClawdbotPluginApi } from "openclaw/plugin-sdk";
+import type { ClawdbotPluginApi } from "openclaw/plugin-sdk/core";
 
 import type { FactsDB } from "../backends/facts-db.js";
 import type { HybridMemoryConfig } from "../config.js";

--- a/extensions/memory-hybrid/tools/issue-tools.ts
+++ b/extensions/memory-hybrid/tools/issue-tools.ts
@@ -7,7 +7,7 @@
 
 import { Type } from "@sinclair/typebox";
 import { stringEnum } from "../utils/typebox.js";
-import type { ClawdbotPluginApi } from "openclaw/plugin-sdk";
+import type { ClawdbotPluginApi } from "openclaw/plugin-sdk/core";
 
 import type { IssueStore } from "../backends/issue-store.js";
 import type { IssueStatus, IssueSeverity } from "../types/issue-types.js";

--- a/extensions/memory-hybrid/tools/memory-tools.ts
+++ b/extensions/memory-hybrid/tools/memory-tools.ts
@@ -7,7 +7,7 @@
 
 import { Type } from "@sinclair/typebox";
 import type OpenAI from "openai";
-import type { ClawdbotPluginApi } from "openclaw/plugin-sdk";
+import type { ClawdbotPluginApi } from "openclaw/plugin-sdk/core";
 import { stringEnum } from "../utils/typebox.js";
 
 import type { BuildToolScopeFilterFn, FindSimilarByEmbeddingFn } from "../api/memory-plugin-api.js";

--- a/extensions/memory-hybrid/tools/persona-tools.ts
+++ b/extensions/memory-hybrid/tools/persona-tools.ts
@@ -4,7 +4,7 @@
  */
 
 import { Type } from "@sinclair/typebox";
-import type { ClawdbotPluginApi } from "openclaw/plugin-sdk";
+import type { ClawdbotPluginApi } from "openclaw/plugin-sdk/core";
 import { stringEnum } from "../utils/typebox.js";
 import { mkdir, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";

--- a/extensions/memory-hybrid/tools/provenance-tools.ts
+++ b/extensions/memory-hybrid/tools/provenance-tools.ts
@@ -5,7 +5,7 @@
  */
 
 import { Type } from "@sinclair/typebox";
-import type { ClawdbotPluginApi } from "openclaw/plugin-sdk";
+import type { ClawdbotPluginApi } from "openclaw/plugin-sdk/core";
 
 import type { FactsDB } from "../backends/facts-db.js";
 import type { EventLog } from "../backends/event-log.js";

--- a/extensions/memory-hybrid/tools/self-extension-tools.ts
+++ b/extensions/memory-hybrid/tools/self-extension-tools.ts
@@ -9,7 +9,7 @@
  */
 
 import { Type } from "@sinclair/typebox";
-import type { ClawdbotPluginApi } from "openclaw/plugin-sdk";
+import type { ClawdbotPluginApi } from "openclaw/plugin-sdk/core";
 import type { ToolProposalStore } from "../backends/tool-proposal-store.js";
 import type { WorkflowStore } from "../backends/workflow-store.js";
 import type { HybridMemoryConfig } from "../config.js";

--- a/extensions/memory-hybrid/tools/utility-tools.ts
+++ b/extensions/memory-hybrid/tools/utility-tools.ts
@@ -1,5 +1,5 @@
 import { Type } from "@sinclair/typebox";
-import type { ClawdbotPluginApi } from "openclaw/plugin-sdk";
+import type { ClawdbotPluginApi } from "openclaw/plugin-sdk/core";
 import { stringEnum } from "../utils/typebox.js";
 import type OpenAI from "openai";
 

--- a/extensions/memory-hybrid/tools/verification-tools.ts
+++ b/extensions/memory-hybrid/tools/verification-tools.ts
@@ -5,7 +5,7 @@
  */
 
 import { Type } from "@sinclair/typebox";
-import type { ClawdbotPluginApi } from "openclaw/plugin-sdk";
+import type { ClawdbotPluginApi } from "openclaw/plugin-sdk/core";
 
 import type { FactsDB } from "../backends/facts-db.js";
 import type { VerificationStore } from "../services/verification-store.js";

--- a/extensions/memory-hybrid/tools/workflow-tools.ts
+++ b/extensions/memory-hybrid/tools/workflow-tools.ts
@@ -6,7 +6,7 @@
  */
 
 import { Type } from "@sinclair/typebox";
-import type { ClawdbotPluginApi } from "openclaw/plugin-sdk";
+import type { ClawdbotPluginApi } from "openclaw/plugin-sdk/core";
 import type { WorkflowStore } from "../backends/workflow-store.js";
 import { extractGoalKeywords } from "../backends/workflow-store.js";
 import { capturePluginError } from "../services/error-reporter.js";

--- a/extensions/memory-hybrid/types/openclaw-plugin-sdk.d.ts
+++ b/extensions/memory-hybrid/types/openclaw-plugin-sdk.d.ts
@@ -1,39 +1,17 @@
 /**
- * Type declarations for openclaw/plugin-sdk.
+ * Type declarations for openclaw/plugin-sdk scoped subpaths.
  * The actual implementation is provided by the OpenClaw runtime at runtime.
  */
+declare module "openclaw/plugin-sdk/core" {
+  import type { OpenClawPluginApi as _OpenClawPluginApi } from "../plugins/types.js";
+
+  // ClawdbotPluginApi is the local plugin API type — a named alias for the SDK's OpenClawPluginApi.
+  // This preserves the plugin's existing type name while using the scoped subpath import.
+  export type ClawdbotPluginApi = _OpenClawPluginApi;
+}
+
+// Also keep the barrel augmentation for backwards-compat (e.g. dynamic imports via import("openclaw/plugin-sdk"))
 declare module "openclaw/plugin-sdk" {
-  import type { TSchema } from "@sinclair/typebox";
-
-  type CliProgram = {
-    command: (name: string) => CliProgram;
-    description: (d: string) => CliProgram;
-    option: (flags: string, desc: string, defaultValue?: string) => CliProgram;
-    requiredOption: (flags: string, desc: string, defaultValue?: string) => CliProgram;
-    argument: (name: string, desc?: string, defaultValue?: string) => CliProgram;
-    action: (fn: (...args: any[]) => any) => CliProgram;
-  };
-
-  export type ClawdbotPluginApi = {
-    resolvePath: (path: string) => string;
-    /** OpenClaw gateway version string (e.g. "2026.3.8"). Available since OpenClaw ≥2026.3.8. */
-    version?: string;
-    logger: {
-      info: (msg: string) => void;
-      warn: (msg: string) => void;
-      error: (msg: string) => void;
-      debug?: (msg: string) => void;
-    };
-    registerService: (opts: { id: string; start: () => void; stop?: () => void }) => void;
-    registerTool: (opts: Record<string, unknown>, options?: Record<string, unknown>) => void;
-    registerCli: (fn: (opts: { program: CliProgram }) => void, options?: { commands?: string[] }) => void;
-    on: (
-      event: string,
-      handler: (
-        ev: unknown,
-      ) => void | Promise<void> | Promise<unknown> | { prependContext?: string } | Promise<{ prependContext?: string }>,
-    ) => void;
-    context?: { agentId?: string; sessionId?: string; userId?: string; sessionKey?: string; messageChannel?: string };
-    [key: string]: unknown;
-  };
+  import type { OpenClawPluginApi as _OpenClawPluginApi } from "../plugins/types.js";
+  export type ClawdbotPluginApi = _OpenClawPluginApi;
 }


### PR DESCRIPTION
## Summary

Migrate all type imports from the deprecated `openclaw/plugin-sdk` barrel to the scoped subpath `openclaw/plugin-sdk/core`. The barrel import triggers `[OPENCLAW_PLUGIN_SDK_COMPAT_DEPRECATED]` warnings from the openclaw 2026.3.24 plugin loader on every isolated session spawn.

## Changes

- **37 source files** updated: `from "openclaw/plugin-sdk"` → `from "openclaw/plugin-sdk/core"`
  - All are `import type` (compile-time erased, no runtime impact)
  - Files span: `index.ts`, `lifecycle/*.ts`, `cli/*.ts`, `setup/*.ts`, `services/*.ts`, `tools/*.ts`, `tests/*.ts`
- **types/openclaw-plugin-sdk.d.ts** updated to augment `openclaw/plugin-sdk/core` with `ClawdbotPluginApi` alias
- **cli/handlers.ts** dynamic import type updated to use scoped subpath
- **setup/cli-context.ts**: Fixed pre-existing implicit-any error in `registerCli` callback (added explicit `{ program: Command }` type annotation)
- **services/context-engine.ts** left unchanged — its dynamic value import of `registerContextEngine` has no scoped subpath available

## Verification

- `tsc --noEmit` passes with 0 errors (previously had 1 pre-existing unrelated error)
- `npm test` passes (1 pre-existing unrelated test failure in `config-view-nightly-cycle.test.ts`)

Closes #778

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is primarily a type-only import migration to avoid deprecated SDK barrel warnings, with a small CLI callback type annotation that shouldn’t affect runtime behavior.
> 
> **Overview**
> Replaces deprecated `openclaw/plugin-sdk` barrel type imports across the `memory-hybrid` extension with scoped `openclaw/plugin-sdk/core` imports to eliminate loader deprecation warnings.
> 
> Updates `types/openclaw-plugin-sdk.d.ts` to declare the new scoped module and keep a backwards-compatible barrel augmentation, and tightens typing in `setup/cli-context.ts` by explicitly typing the `registerCli` callback’s `{ program }` parameter (Commander `Command`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 72d7723dc994f07677b9b8187fc3a1d7a3bff46e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->