### PR TITLE
feat: add hybrid-mem model-info CLI command for embedding dimension introspection

### DIFF
--- a/extensions/memory-hybrid/cli/manage.ts
+++ b/extensions/memory-hybrid/cli/manage.ts
@@ -846,7 +846,8 @@ export function registerManageCommands(mem: Chainable, ctx: ManageContext): void
           console.error(
             "For models not in the catalog, set embedding.dimensions in plugin config to the vector size your provider returns.",
           );
-          process.exit(1);
+          process.exitCode = 1;
+          return;
         }
       }),
     );


### PR DESCRIPTION
## Summary

New CLI command: `openclaw hybrid-mem model-info [model]`

Useful for diagnosing dimension mismatch errors (LanceDB rejects vectors that don't match the stored schema) without having to read source code.

Extracted from WIP PR #814. Zero-risk, self-contained.

## Usage

```bash
# Print current embedding config + catalog cross-check
openclaw hybrid-mem model-info

# === Current embedding config ===
# Provider: openai
# Model: text-embedding-3-large
# Dimensions (resolved in config): 3072
# Catalog dimensions for 'text-embedding-3-large': 3072 (matches config)

# Look up dims for a specific model
openclaw hybrid-mem model-info text-embedding-ada-002
# Model: text-embedding-ada-002
# Vector dimensions: 1536
```

## Test plan
- [ ] `openclaw hybrid-mem model-info` prints current config with catalog cross-check
- [ ] `openclaw hybrid-mem model-info text-embedding-3-large` prints 3072
- [ ] Unknown model prints helpful message and exits non-zero
- [ ] CI green

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a read-only CLI subcommand that prints embedding config and cataloged vector dimensions; no changes to storage, indexing, or runtime retrieval logic.
> 
> **Overview**
> Adds a new `hybrid-mem model-info [model]` CLI command to introspect embedding vector dimensions.
> 
> When run without an argument it prints the current embedding provider/model/dimensions from config and cross-checks against the built-in `vectorDimsForModel` catalog; when given a model name it prints the catalog dimensions or exits non-zero with a guidance message if the model is unknown.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a1d61765643fdbf3f91d2f7f8030553034370c8c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->