### PR TITLE
docs: revamp README for maximum user engagement and easy onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ openclaw hybrid-mem config-mode <mode>
 
 | Mode | Description | LLM Cost | Key Features |
 |------|-------------|----------|--------------|
-| **`local`** | **100% Air-gapped.** Runs entirely on your machine. Uses local ONNX/Ollama embeddings and local SQLite/LanceDB. | **$0.00** | Basic storage, exact match recall, local semantic search. *Zero cloud LLM calls.* |
+| **`local`** | **100% Air-gapped.** (Default). Runs entirely on your machine. Uses local ONNX/Ollama embeddings and local SQLite/LanceDB. | **$0.00** | Basic storage, exact match recall, local semantic search. *Zero cloud LLM calls.* |
 | **`minimal`** | **Fast & Cheap.** Basic cloud integration but turns off expensive background jobs. | **Very Low** | Cloud embeddings, basic cloud routing, no background reflection. |
-| **`enhanced`** | **The Sweet Spot.** (Default). Balances intelligence with cost. | **Low** | Active RAG, background reflection, tool effectiveness tracking. |
+| **`enhanced`** | **The Sweet Spot.** Balances intelligence with cost. | **Low** | Active RAG, background reflection, tool effectiveness tracking. |
 | **`complete`** | **Maximum Intelligence.** Turns on every experimental cognitive feature. | **Medium** | Everything above + deep semantic clustering, self-correction, and autonomous skill crystallization. |
 
 ---


### PR DESCRIPTION
## What this does

Rewrites the README to:
- Lead with a compelling hook — "An AI that actually remembers you"
- Put a 30-second Quick Start block right at the top
- Describe the magic in plain English (auto-capture, auto-recall, learning from reactions, semantic search, background jobs)
- Use emojis and tables to break up text and make it scannable
- Organize docs into clear categories (Getting Started, Reference, Operations, Deep Dives)
- Keep all existing "Credits & Attribution" content intact

## Why it matters

The current README is thorough but leads with implementation details. This version leads with the value proposition so new users instantly understand what they'll get and can get running in under a minute.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes that reorganize and rephrase existing guidance; no runtime or API behavior is modified.
> 
> **Overview**
> Rewrites `README.md` to prioritize a stronger value proposition and faster onboarding, adding a prominent **“Get Running in 30 Seconds”** quickstart and clearer end-to-end install/verify steps.
> 
> Introduces a **configuration modes** section (with a modes table), a concise **core features** table, a simple **How it works** flow diagram, and a reorganized documentation index (Getting Started/Reference/Operations/Deep Dives), plus a short **common commands** block and an example ecosystem link; credits/attribution are retained and lightly reformatted.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6c5186fc521bc870f6008d173c507ea3875c6451. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->