### PR TITLE
fix: [GlitchTip HYBRID-MEMORY-403] memory_workflows fails when WorkflowStore DB is not open (#968)

### DIFF
--- a/extensions/memory-hybrid/tests/workflow-store.test.ts
+++ b/extensions/memory-hybrid/tests/workflow-store.test.ts
@@ -332,6 +332,15 @@ describe("WorkflowStore.getPatterns", () => {
     const patterns = store.getPatterns({ limit: 1 });
     expect(patterns.length).toBeLessThanOrEqual(1);
   });
+
+  it("reopens and returns results when native DB handle was unexpectedly closed", () => {
+    const db = (store as any).db as import("node:sqlite").DatabaseSync;
+    db.close();
+
+    expect(() => store.getPatterns()).not.toThrow();
+    const patterns = store.getPatterns();
+    expect(Array.isArray(patterns)).toBe(true);
+  });
 });
 
 describe("WorkflowStore.prune", () => {

--- a/extensions/memory-hybrid/tests/workflow-tools.test.ts
+++ b/extensions/memory-hybrid/tests/workflow-tools.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from "vitest";
+import { registerWorkflowTools } from "../tools/workflow-tools.js";
+
+function makeMockApi() {
+  const tools = new Map<string, { execute: (...args: unknown[]) => Promise<unknown> }>();
+  return {
+    registerTool(opts: Record<string, unknown>, _options?: Record<string, unknown>) {
+      tools.set(opts.name as string, {
+        execute: opts.execute as (...args: unknown[]) => Promise<unknown>,
+      });
+    },
+    callTool(name: string, params: Record<string, unknown>) {
+      const tool = tools.get(name);
+      if (!tool) throw new Error(`Tool not registered: ${name}`);
+      return tool.execute("test-call-id", params);
+    },
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  };
+}
+
+describe("memory_workflows tool", () => {
+  it("returns a soft error response when workflow DB is not open", async () => {
+    const api = makeMockApi();
+    const workflowStore = {
+      getPatterns: vi.fn(() => {
+        throw new TypeError("The database connection is not open");
+      }),
+    };
+
+    registerWorkflowTools({ workflowStore: workflowStore as any }, api as any);
+
+    const result = (await api.callTool("memory_workflows", {})) as {
+      content: { type: string; text: string }[];
+      details: unknown[];
+    };
+
+    expect(result.details).toEqual([]);
+    expect(result.content[0].text).toContain("temporarily unavailable");
+    expect(result.content[0].text).toContain("database not ready");
+  });
+});


### PR DESCRIPTION
Closes #968

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds/updates tests around handling unexpectedly closed SQLite handles and returning a soft error from `memory_workflows`; no production logic changes, but failures could mask regressions in DB lifecycle handling.
> 
> **Overview**
> Adds regression coverage for WorkflowStore/`memory_workflows` when the underlying SQLite connection is unexpectedly closed.
> 
> `workflow-store.test.ts` now verifies `getPatterns()` transparently recovers (reopens) after the native DB handle is closed, and a new `workflow-tools.test.ts` asserts the `memory_workflows` tool returns a **soft, user-facing “temporarily unavailable”** response (empty `details`) when `getPatterns()` throws a “database connection is not open” error.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 35334824ac37507b247806dad74e3255bdab0b57. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->