### PR TITLE
fix(configSchema): allow llm.disabledProviders (#996)

### DIFF
--- a/extensions/memory-hybrid/openclaw.plugin.json
+++ b/extensions/memory-hybrid/openclaw.plugin.json
@@ -65,6 +65,11 @@
       "label": "LLM tier: heavy",
       "help": "Distillation, self-correction, and other quality-critical steps. Safe to list stronger models here; they are not used for every retrieval helper. CLI: openclaw hybrid-mem config-set llm.heavy '[\"azure-foundry/gpt-5.4\"]'"
     },
+    "llm.disabledProviders": {
+      "label": "Disabled LLM providers",
+      "placeholder": "[\"anthropic\"]",
+      "help": "JSON array of provider ids to exclude from model resolution (e.g. openai, anthropic, google, ollama). CLI: openclaw hybrid-mem config-set llm.disabledProviders '[\"anthropic\"]'"
+    },
     "nightlyCycle.model": {
       "label": "Dream cycle model override",
       "help": "Optional. When set, nightly dream cycle and MEMORY_INDEX LLM use this model instead of llm.default[0]. Leave unset to follow llm.default. CLI: openclaw hybrid-mem config-set nightlyCycle.model azure-foundry/gpt-4.1-mini"
@@ -1562,6 +1567,13 @@
           },
           "localAutoStart": {
             "type": "boolean"
+          },
+          "disabledProviders": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Provider ids to exclude from automatic LLM selection (e.g. openai, anthropic, google). Same as parseLLMConfig / hybrid-mem config-set."
           }
         },
         "description": "LLM model preference lists per tier (default, heavy, nano)"


### PR DESCRIPTION
## Problem
Runtime and CLI support `llm.disabledProviders`, but `openclaw.plugin.json` `configSchema.properties.llm` used `additionalProperties: false` without listing `disabledProviders`, so OpenClaw rejected the plugin config after `config-set`.

## Change
- Add `disabledProviders` (`array` of `string`) under `configSchema.properties.llm.properties`.
- Add `uiHints["llm.disabledProviders"]` for config-set help.

Fixes #996

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk schema-only change that unblocks valid configs; no runtime logic changes beyond accepting an already-supported field.
> 
> **Overview**
> Fixes plugin config validation by adding `llm.disabledProviders` (array of strings) to `openclaw.plugin.json` under `configSchema.properties.llm`, matching existing runtime/CLI support.
> 
> Adds a corresponding `uiHints["llm.disabledProviders"]` entry so `config-set` surfaces help text and examples for disabling specific LLM providers during model resolution.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a91a5f292e927d473fc6ff0e039bd105ff729a58. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->