### PR TITLE
fix(goal-stewardship): post-merge follow-up fixes

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -150,7 +150,7 @@ Status emojis: 🟢 active, 🟡 paused, 🔵 completed. Keep the index under ~3
 
 ## Goal Stewardship (optional)
 
-When enabled (`goalStewardship.enabled: true`), the plugin adds a strategic orchestration layer that autonomously pursues long-running goals across sessions, heartbeats, and idle periods. It consists of a deterministic health watchdog (5-min timer, budget enforcement, staleness detection, mechanical verification) and an LLM stewardship engine (heartbeat-triggered goal assessment and dispatch). Goals are persisted as JSON in `state/goals/` and tracked via agent tools (`goal_register`, `goal_assess`, `goal_update`, `goal_complete`, `goal_abandon`). See [GOAL-STEWARDSHIP-DESIGN.md](GOAL-STEWARDSHIP-DESIGN.md) for the full architecture and [GOAL-STEWARDSHIP-OPERATOR.md](GOAL-STEWARDSHIP-OPERATOR.md) for the operator guide.
+When enabled (`goalStewardship.enabled: true`), the plugin adds a strategic orchestration layer that autonomously pursues long-running goals across sessions and heartbeats using a deterministic health watchdog and an LLM stewardship engine. Goals are persisted as JSON in `state/goals/` and tracked via agent tools (`goal_register`, `goal_assess`, `goal_update`, `goal_complete`, `goal_abandon`). See [GOAL-STEWARDSHIP-DESIGN.md](GOAL-STEWARDSHIP-DESIGN.md) for the full architecture.
 
 ---
 

--- a/extensions/memory-hybrid/cli/goals.ts
+++ b/extensions/memory-hybrid/cli/goals.ts
@@ -188,7 +188,10 @@ export function registerGoalCommands(mem: Chainable, ctx: { cfg: HybridMemoryCon
         assessmentCount: 0,
         consecutiveFailures: 0,
       };
-      if (wasBlocked) patch.status = "active";
+      if (wasBlocked) {
+        patch.status = "active";
+        patch.currentBlockers = [];
+      }
       await updateGoal(dir, goal.id, patch as Parameters<typeof updateGoal>[2], {
         timestamp: new Date().toISOString(),
         action: "budget-reset",

--- a/extensions/memory-hybrid/openclaw.plugin.json
+++ b/extensions/memory-hybrid/openclaw.plugin.json
@@ -568,16 +568,7 @@
     "properties": {
       "mode": {
         "type": "string",
-        "enum": [
-          "essential",
-          "normal",
-          "expert",
-          "full",
-          "local",
-          "minimal",
-          "enhanced",
-          "complete"
-        ],
+        "enum": ["essential", "normal", "expert", "full", "local", "minimal", "enhanced", "complete"],
         "description": "Configuration preset: local | minimal | enhanced | complete. Legacy values (essential, normal, expert, full) are accepted and mapped to local. See docs/CONFIGURATION-MODES.md."
       },
       "embedding": {
@@ -587,12 +578,7 @@
         "properties": {
           "provider": {
             "type": "string",
-            "enum": [
-              "openai",
-              "ollama",
-              "onnx",
-              "google"
-            ],
+            "enum": ["openai", "ollama", "onnx", "google"],
             "default": "openai",
             "description": "Embedding provider. 'openai'/'google' require apiKey. 'ollama' and 'onnx' run locally without an API key."
           },
@@ -632,11 +618,7 @@
             "type": "array",
             "items": {
               "type": "string",
-              "enum": [
-                "openai",
-                "google",
-                "ollama"
-              ]
+              "enum": ["openai", "google", "ollama"]
             },
             "description": "Explicit ordered list of embedding providers to use. When set, only listed providers are tried (in order); auto-inference from available API keys is skipped. Use [\"openai\"] to pin to Azure/OpenAI only and prevent Google from being auto-added as a fallback when GEMINI_API_KEY is also set. Mixing providers with different vector dimensions is not supported \u2014 ensure all listed providers produce the same dimensions as your stored vectors."
           },
@@ -675,13 +657,7 @@
               },
               "injectionFormat": {
                 "type": "string",
-                "enum": [
-                  "full",
-                  "short",
-                  "minimal",
-                  "progressive",
-                  "progressive_hybrid"
-                ]
+                "enum": ["full", "short", "minimal", "progressive", "progressive_hybrid"]
               },
               "recallTiming": {
                 "oneOf": [
@@ -690,11 +666,7 @@
                   },
                   {
                     "type": "string",
-                    "enum": [
-                      "off",
-                      "basic",
-                      "verbose"
-                    ]
+                    "enum": ["off", "basic", "verbose"]
                   }
                 ],
                 "description": "Structured recall timing logs: false/off=disabled, true/basic=completed events only, verbose=started+completed with timestamps."
@@ -806,11 +778,7 @@
               },
               "interactiveEnrichment": {
                 "type": "string",
-                "enum": [
-                  "fast",
-                  "balanced",
-                  "full"
-                ],
+                "enum": ["fast", "balanced", "full"],
                 "description": "Unified control for interactive auto-recall: fast = lowest latency/cost (no HyDE, no ambient multi-query); balanced = default; full = richer (HyDE + ambient multi when configured)."
               },
               "authFailure": {
@@ -901,9 +869,7 @@
           },
           "store": {
             "type": "string",
-            "enum": [
-              "sqlite"
-            ]
+            "enum": ["sqlite"]
           },
           "encryptionKey": {
             "type": "string",
@@ -955,10 +921,7 @@
           },
           "mode": {
             "type": "string",
-            "enum": [
-              "community",
-              "self-hosted"
-            ],
+            "enum": ["community", "self-hosted"],
             "default": "community",
             "description": "community: anonymous telemetry to developers. self-hosted: your own Sentry/GlitchTip instance."
           },
@@ -1011,10 +974,7 @@
             "description": "Controls user-facing upgrade reminders for the version-aware telemetry mute flow."
           }
         },
-        "required": [
-          "enabled",
-          "consent"
-        ],
+        "required": ["enabled", "consent"],
         "description": "Opt-out error reporting to GlitchTip/Sentry (enabled by default, community DSN). Set enabled: false or consent: false to disable. See docs/ERROR-REPORTING.md."
       },
       "distill": {
@@ -1052,11 +1012,7 @@
           },
           "extractionModelTier": {
             "type": "string",
-            "enum": [
-              "nano",
-              "default",
-              "heavy"
-            ],
+            "enum": ["nano", "default", "heavy"],
             "description": "Model tier for extraction pipeline (extract-reinforcement LLM). 'nano' or 'default' saves cost and avoids locking the main model; unset = heavy. Expert/Full presets use 'default'."
           }
         }
@@ -1186,11 +1142,7 @@
             "type": "array",
             "items": {
               "type": "string",
-              "enum": [
-                "SOUL.md",
-                "IDENTITY.md",
-                "USER.md"
-              ]
+              "enum": ["SOUL.md", "IDENTITY.md", "USER.md"]
             },
             "description": "Identity files that can be modified via proposals"
           },
@@ -1252,10 +1204,7 @@
                   "type": "string"
                 }
               },
-              "required": [
-                "key",
-                "prompt"
-              ]
+              "required": ["key", "prompt"]
             },
             "description": "Recurring identity reflection questions"
           }
@@ -1405,11 +1354,7 @@
           },
           "defaultStoreScope": {
             "type": "string",
-            "enum": [
-              "global",
-              "agent",
-              "auto"
-            ],
+            "enum": ["global", "agent", "auto"],
             "description": "Default scope for new facts: 'global' (all agents, backward compatible), 'agent' (specialists auto-scope), or 'auto' (orchestrator\u2192global, specialists\u2192agent). Default: 'global'."
           }
         },
@@ -1494,11 +1439,7 @@
           },
           "pruneMode": {
             "type": "string",
-            "enum": [
-              "expired",
-              "decay",
-              "both"
-            ]
+            "enum": ["expired", "decay", "both"]
           },
           "model": {
             "type": "string"
@@ -1567,11 +1508,7 @@
           },
           "extractionModelTier": {
             "type": "string",
-            "enum": [
-              "nano",
-              "default",
-              "heavy"
-            ]
+            "enum": ["nano", "default", "heavy"]
           },
           "preFilter": {
             "type": "object",
@@ -1799,10 +1736,7 @@
             "description": "Relative to workspace; goal JSON store (default: state/goals)"
           },
           "model": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": ["string", "null"],
             "description": "Optional dedicated stewardship model (default: null = cron default)"
           },
           "heartbeatStewardship": {
@@ -1831,12 +1765,7 @@
               },
               "priority": {
                 "type": "string",
-                "enum": [
-                  "critical",
-                  "high",
-                  "normal",
-                  "low"
-                ]
+                "enum": ["critical", "high", "normal", "low"]
               }
             },
             "description": "Per-goal defaults when registering"
@@ -1898,12 +1827,7 @@
                 "type": "array",
                 "items": {
                   "type": "string",
-                  "enum": [
-                    "critical",
-                    "high",
-                    "normal",
-                    "low"
-                  ]
+                  "enum": ["critical", "high", "normal", "low"]
                 }
               }
             }
@@ -1950,8 +1874,6 @@
         "description": "Long-running goal registry, stewardship injection, and watchdog (see docs/GOAL-STEWARDSHIP-DESIGN.md)"
       }
     },
-    "required": [
-      "embedding"
-    ]
+    "required": ["embedding"]
   }
 }

--- a/extensions/memory-hybrid/services/active-task.ts
+++ b/extensions/memory-hybrid/services/active-task.ts
@@ -20,10 +20,10 @@
  * ```
  */
 
+import { createHash, randomUUID } from "node:crypto";
 import { existsSync } from "node:fs";
-import { readFile, writeFile, mkdir, readdir, rename, unlink, stat, realpath } from "node:fs/promises";
-import { dirname, join, resolve, relative, isAbsolute } from "node:path";
-import { randomUUID, createHash } from "node:crypto";
+import { mkdir, readFile, readdir, realpath, rename, stat, unlink, writeFile } from "node:fs/promises";
+import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { formatDuration } from "../utils/duration.js";
 import { pluginLogger } from "../utils/logger.js";
 import { stableStringify } from "../utils/stable-stringify.js";
@@ -410,7 +410,7 @@ export async function writeActiveTaskFile(
   completed: ActiveTaskEntry[],
 ): Promise<void> {
   await mkdir(dirname(filePath), { recursive: true });
-  
+
   // Preserve existing goals mirror section if present
   let goalsMirror: string | undefined;
   if (existsSync(filePath)) {
@@ -421,7 +421,7 @@ export async function writeActiveTaskFile(
       // Ignore read errors; write without goals section
     }
   }
-  
+
   const content = serializeActiveTaskFile(active, completed, goalsMirror);
   await writeFile(filePath, content, "utf-8");
 }

--- a/extensions/memory-hybrid/services/goal-health.ts
+++ b/extensions/memory-hybrid/services/goal-health.ts
@@ -132,7 +132,10 @@ export async function runGoalHealthCheck(opts: GoalHealthCheckOptions): Promise<
       continue;
     }
 
-    if (goal.consecutiveFailures >= goal.escalateAfterFailures && goal.status === "active") {
+    if (
+      goal.consecutiveFailures >= goal.escalateAfterFailures &&
+      (goal.status === "active" || goal.status === "stalled")
+    ) {
       await updateGoal(
         goalsDir,
         goal.id,

--- a/extensions/memory-hybrid/tests/goal-circuit-breaker.test.ts
+++ b/extensions/memory-hybrid/tests/goal-circuit-breaker.test.ts
@@ -31,20 +31,28 @@ describe("goal-circuit-breaker", () => {
   it("trips on same blocker streak", () => {
     const b = ["blocked by api"];
     let g = baseGoal();
-    // assessment 1
+    // assessment 1: first time seeing this fingerprint — streak 0
     let state = computeCircuitBreakerStateAfterAssess(g, b, 1);
-    expect(state.sameBlockerStreak).toBe(1);
+    expect(state.sameBlockerStreak).toBe(0);
     g = { ...g, ...state, currentBlockers: b, assessmentCount: 1 };
     expect(evaluateCircuitBreakerTrip(cbOn, state, 1).trip).toBe(false);
 
+    // assessment 2: same fingerprint — streak 1
     state = computeCircuitBreakerStateAfterAssess(g, b, 2);
     g = { ...g, ...state, assessmentCount: 2 };
-    expect(state.sameBlockerStreak).toBe(2);
+    expect(state.sameBlockerStreak).toBe(1);
     expect(evaluateCircuitBreakerTrip(cbOn, state, 2).trip).toBe(false);
 
+    // assessment 3: same again — streak 2
     state = computeCircuitBreakerStateAfterAssess(g, b, 3);
+    g = { ...g, ...state, assessmentCount: 3 };
+    expect(state.sameBlockerStreak).toBe(2);
+    expect(evaluateCircuitBreakerTrip(cbOn, state, 3).trip).toBe(false);
+
+    // assessment 4: streak 3, trips at limit
+    state = computeCircuitBreakerStateAfterAssess(g, b, 4);
     expect(state.sameBlockerStreak).toBe(3);
-    expect(evaluateCircuitBreakerTrip(cbOn, state, 3).trip).toBe(true);
+    expect(evaluateCircuitBreakerTrip(cbOn, state, 4).trip).toBe(true);
   });
 
   it("resets streak when blockers change", () => {
@@ -56,7 +64,7 @@ describe("goal-circuit-breaker", () => {
       currentBlockers: ["a"],
     });
     const state = computeCircuitBreakerStateAfterAssess(g, ["b"], 3);
-    expect(state.sameBlockerStreak).toBe(1);
+    expect(state.sameBlockerStreak).toBe(0);
     expect(state.circuitBreakerLastProgressAssessmentCount).toBe(3);
   });
 


### PR DESCRIPTION
## Summary

Follow-up to PR #1063 — fixes that were uncommitted when the PR was merged.

- **reset-budget CLI**: clear `currentBlockers` when unblocking (otherwise goal stays active with stale blockers)
- **Watchdog escalation**: also escalate `stalled` goals with consecutive failures, not just `active`
- **ARCHITECTURE.md**: trim goal stewardship paragraph for readability
- **Circuit breaker tests**: align streak expectations with corrected semantics (first occurrence = 0)

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] All 238 goal stewardship tests pass locally

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches goal stewardship watchdog/CLI behavior, which can change when goals get unblocked or auto-escalated to `blocked`, potentially impacting long-running goal execution. Changes are small and covered by updated circuit-breaker tests, but should be validated in real workflows.
> 
> **Overview**
> Tightens goal stewardship lifecycle handling.
> 
> The `reset-budget` CLI now fully unblocks goals by also clearing `currentBlockers` when transitioning `blocked` → `active`, avoiding stale blocker carryover. The watchdog health check now escalates goals to `blocked` after `escalateAfterFailures` even when the goal is `stalled` (not just `active`).
> 
> Docs and tests are aligned with current semantics: the goal stewardship blurb in `docs/ARCHITECTURE.md` is shortened, and circuit breaker tests are updated so the first repeated-blocker occurrence starts the streak at 0 and trips at the configured limit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit efb4ef5d9faa1398c006029d9a84c4066a0056aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->