### PR TITLE
fix(glitchtip): handle truncated/invalid JSON in credential hint parsing (closes #1078)

### DIFF
--- a/extensions/memory-hybrid/tests/stage-credential-hint.test.ts
+++ b/extensions/memory-hybrid/tests/stage-credential-hint.test.ts
@@ -1,6 +1,6 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
-import { readFile, stat } from "node:fs/promises";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { stat } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { registerCredentialHint } from "../lifecycle/stage-credential-hint.js";
@@ -36,6 +36,10 @@ describe("stage-credential-hint", () => {
     pendingPath = join(dbDir, "credentials-pending.json");
   });
 
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
   it("drops invalid/truncated JSON without throwing or reporting", async () => {
     writeFileSync(pendingPath, '{"hints": ["api_key"]', "utf8");
 
@@ -55,6 +59,7 @@ describe("stage-credential-hint", () => {
 
     await expect(stat(pendingPath)).rejects.toMatchObject({ code: "ENOENT" });
     expect(api.logger.warn).toHaveBeenCalledTimes(1);
+    expect(api.logger.warn).toHaveBeenCalledWith(expect.stringContaining("truncated"));
   });
 
   it("returns prependContext for valid hints and clears file", async () => {


### PR DESCRIPTION
Closes #1078. Adds regression tests for truncated credential hint JSON — verifies graceful handling of SyntaxError: Unexpected end of JSON input.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds test coverage only, validating existing error-handling paths without changing runtime code.
> 
> **Overview**
> Adds `vitest` regression tests for `registerCredentialHint` to ensure `credentials-pending.json` parsing is **graceful on invalid/truncated JSON** (warns once, returns no hook result, and deletes the file).
> 
> Also covers the **happy path** by asserting valid hints produce a `prependContext` injection and that the pending file is cleared afterward.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 356b9012afe45cfc524c881d583c932899cebb61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->