### PR TITLE
feat: cli-metadata registration and loader coordination (issue #1111)

### DIFF
--- a/docs/OPENCLAW-LOADER-COORDINATION.md
+++ b/docs/OPENCLAW-LOADER-COORDINATION.md
@@ -1,0 +1,23 @@
+# OpenClaw loader coordination (issue #1111)
+
+This document tracks **cross-repo** behavior between `openclaw-hybrid-memory` and **OpenClaw core** for when the memory plugin loads and how heavy work runs.
+
+## What this plugin implements
+
+- **`registrationMode === "cli-metadata"`** — [`runMemoryHybridRegister`](../extensions/memory-hybrid/index.ts) exits early after registering CLI metadata for the `hybrid-mem` root command (no database or LanceDB initialization). OpenClaw uses this path in [`loadOpenClawPluginCliRegistry`](https://github.com/openclaw/openclaw) (bundled as `loadOpenClawPluginCliRegistry` in the `openclaw` package).
+- **Full registration** — unchanged for gateway, agents, and `openclaw hybrid-mem …` when the host performs a full plugin load with `registrationMode === "full"`.
+- **Deferred work** — non-critical startup checks (e.g. Python document-bridge dependency probing) may run from the plugin service `start()` hook instead of synchronously during `register()`, where safe.
+
+## What belongs in OpenClaw core (upstream)
+
+These items require changes or policy in the **`openclaw`** repository, not only in this plugin:
+
+1. **Empty `onlyPluginIds` scope** — When `ensurePluginRegistryLoaded({ scope: "channels" })` resolves to an **empty** channel plugin list, the loader should not treat that as “no filter.” Today, normalizing an empty list to `undefined` can cause **all** plugins (including the memory slot) to load for scoped CLI paths such as `openclaw status` / `openclaw health`. A core fix is to interpret “no channel plugins” as “load no channel plugins,” not “load everything.”
+2. **CLI bootstrap policy** — Optionally load or activate **memory-slot** plugins only for gateway, agent/node runs, and explicit `hybrid-mem` (or equivalent), and not for unrelated operational CLI commands. This is a loader / CLI taxonomy decision.
+3. **`activate: false`** — Core still invokes `register()` when building some reports; plugins should minimize work in `register()` for those paths, but **cannot** fully skip execution if core always imports and calls `register()`.
+
+Link the upstream issue or PR here when filed: _(add URL)_.
+
+## References
+
+- Issue: [CLI: load hybrid-memory only for gateway, agents, and `hybrid-mem`](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/1111)

--- a/extensions/memory-hybrid/index.ts
+++ b/extensions/memory-hybrid/index.ts
@@ -77,7 +77,7 @@ import {
   applyPostRrfAdjustments,
   fuseResults,
 } from "./services/rrf-fusion.js";
-import { registerHybridMemCliWithApi } from "./setup/cli-context.js";
+import { registerHybridMemCliMetadataOnly, registerHybridMemCliWithApi } from "./setup/cli-context.js";
 import { versionInfo } from "./versionInfo.js";
 export type { GraphExpandedResult, LinkPathStep, GraphFactLookup } from "./services/graph-retrieval.js";
 import { findShortestPath, formatPath, resolveInput } from "./services/shortest-path.js";
@@ -404,6 +404,12 @@ function runMemoryHybridRegister(api: ClawdbotPluginApi): void {
     throw err;
   }
 
+  // OpenClaw `loadOpenClawPluginCliRegistry` — metadata only; no DBs or native deps (issue #1111).
+  if (api.registrationMode === "cli-metadata") {
+    registerHybridMemCliMetadataOnly(api);
+    return;
+  }
+
   // Clean up old resources before opening new connections to prevent double-opening same paths (Issue #590, #802)
   if (old) {
     // Clear old timer handles to prevent leaks
@@ -487,28 +493,9 @@ function runMemoryHybridRegister(api: ClawdbotPluginApi): void {
   // Python Bridge (lazy -- only when documents.enabled, spawns on first use)
   // ========================================================================
 
-  // Initialized lazily -- PythonBridge only spawns the subprocess on first convert() call
+  // Initialized lazily -- PythonBridge only spawns the subprocess on first convert() call.
+  // Dependency check runs from plugin service start() so `register()` stays lighter (issue #1111).
   const pythonBridge = cfg.documents.enabled ? new PythonBridge(cfg.documents.pythonPath) : null;
-
-  // Eagerly check Python dependencies at startup so missing packages surface
-  // immediately (in logs) rather than on first document conversion (issue #422).
-  if (pythonBridge) {
-    const { ok, missing, spawnError } = pythonBridge.checkDependencies();
-    if (!ok) {
-      if (spawnError) {
-        api.logger.warn(
-          `memory-hybrid: documents.enabled but Python binary not found or failed to spawn: ${spawnError.message}. ` +
-            `Check documents.pythonPath configuration (currently: ${cfg.documents.pythonPath}).`,
-        );
-      } else {
-        const pkgs = missing.join(", ");
-        api.logger.warn(
-          `memory-hybrid: documents.enabled but required Python package(s) not installed: ${pkgs}. ` +
-            `Run: ${cfg.documents.pythonPath} -m pip install ${missing.join(" ")}  (see extensions/memory-hybrid/scripts/requirements.txt)`,
-        );
-      }
-    }
-  }
 
   // ========================================================================
   // Contextual Variant Generator (Issue #159)

--- a/extensions/memory-hybrid/index.ts
+++ b/extensions/memory-hybrid/index.ts
@@ -377,7 +377,7 @@ const memoryHybridPlugin = {
 
 function runMemoryHybridRegister(api: ClawdbotPluginApi): void {
   // OpenClaw `loadOpenClawPluginCliRegistry` — metadata only; no DBs or native deps (issue #1111).
-  // Check this FIRST, before any logger init or config parsing, so an incomplete config 
+  // Check this FIRST, before any logger init or config parsing, so an incomplete config
   // cannot block lightweight metadata registration.
   if (api.registrationMode === "cli-metadata") {
     registerHybridMemCliMetadataOnly(api);

--- a/extensions/memory-hybrid/index.ts
+++ b/extensions/memory-hybrid/index.ts
@@ -376,6 +376,14 @@ const memoryHybridPlugin = {
 };
 
 function runMemoryHybridRegister(api: ClawdbotPluginApi): void {
+  // OpenClaw `loadOpenClawPluginCliRegistry` — metadata only; no DBs or native deps (issue #1111).
+  // Check this FIRST, before any logger init or config parsing, so an incomplete config 
+  // cannot block lightweight metadata registration.
+  if (api.registrationMode === "cli-metadata") {
+    registerHybridMemCliMetadataOnly(api);
+    return;
+  }
+
   // Initialize structured logger early so all runtime code (services/backends/lifecycle)
   // routes through api.logger instead of raw console.*.
   initPluginLogger(api.logger);
@@ -404,13 +412,6 @@ function runMemoryHybridRegister(api: ClawdbotPluginApi): void {
     throw err;
   }
 
-  // OpenClaw `loadOpenClawPluginCliRegistry` — metadata only; no DBs or native deps (issue #1111).
-  if (api.registrationMode === "cli-metadata") {
-    registerHybridMemCliMetadataOnly(api);
-    return;
-  }
-
-  // Clean up old resources before opening new connections to prevent double-opening same paths (Issue #590, #802)
   if (old) {
     // Clear old timer handles to prevent leaks
     if (old.timers.pruneTimer.value) clearInterval(old.timers.pruneTimer.value);

--- a/extensions/memory-hybrid/setup/cli-context.ts
+++ b/extensions/memory-hybrid/setup/cli-context.ts
@@ -143,78 +143,28 @@ const HYBRID_MEM_HELP_ACTIVE_TASKS = `
     task-queue-touch             Create idle current.json if missing; --repair for bad snapshots (#1037)
 `;
 
-const HYBRID_MEM_CLI_COMMANDS = [
-  "hybrid-mem",
-  "hybrid-mem dashboard",
-  "hybrid-mem run-all",
-  "hybrid-mem install",
-  "hybrid-mem stats",
-  "hybrid-mem test",
-  "hybrid-mem context-audit",
-  "hybrid-mem compact",
-  "hybrid-mem prune",
-  "hybrid-mem checkpoint",
-  "hybrid-mem backfill-decay",
-  "hybrid-mem backfill",
-  "hybrid-mem ingest-files",
-  "hybrid-mem distill",
-  "hybrid-mem extract-daily",
-  "hybrid-mem extract-procedures",
-  "hybrid-mem generate-auto-skills",
-  "hybrid-mem generate-proposals",
-  "hybrid-mem extract-directives",
-  "hybrid-mem extract-reinforcement",
-  "hybrid-mem search",
-  "hybrid-mem lookup",
-  "hybrid-mem list",
-  "hybrid-mem show",
-  "hybrid-mem dump",
-  "hybrid-mem proposals list",
-  "hybrid-mem proposals show",
-  "hybrid-mem proposals approve",
-  "hybrid-mem proposals reject",
-  "hybrid-mem corrections list",
-  "hybrid-mem corrections approve",
-  "hybrid-mem review",
-  "hybrid-mem store",
-  "hybrid-mem classify",
-  "hybrid-mem build-languages",
-  "hybrid-mem enrich-entities",
-  "hybrid-mem self-correction-extract",
-  "hybrid-mem self-correction-run",
-  "hybrid-mem analyze-feedback-phrases",
-  "hybrid-mem categories",
-  "hybrid-mem find-duplicates",
-  "hybrid-mem consolidate",
-  "hybrid-mem reflect",
-  "hybrid-mem reflect-rules",
-  "hybrid-mem reflect-meta",
-  "hybrid-mem dream-cycle",
-  "hybrid-mem resolve-contradictions",
-  "hybrid-mem config",
-  "hybrid-mem goals config",
-  "hybrid-mem active-tasks config",
-  "hybrid-mem verify",
-  "hybrid-mem credentials migrate-to-vault",
-  "hybrid-mem distill-window",
-  "hybrid-mem record-distill",
-  "hybrid-mem scope prune-session",
-  "hybrid-mem scope promote",
-  "hybrid-mem uninstall",
-  "hybrid-mem active-tasks",
-  "hybrid-mem active-tasks complete",
-  "hybrid-mem active-tasks stale",
-  "hybrid-mem active-tasks reconcile",
-  "hybrid-mem active-tasks add",
-  "hybrid-mem active-tasks render",
-  "hybrid-mem task-queue-status",
-  "hybrid-mem task-queue-touch",
-  "hybrid-mem cost-report",
-  "hybrid-mem tool-effectiveness",
-  "hybrid-mem cross-agent-learning",
-  "hybrid-mem sensor-sweep",
-  "hybrid-mem sensor-events",
-] as const;
+/**
+ * Root command descriptor for OpenClaw lazy CLI registration (parse-time contract).
+ * Subcommands are registered when the full plugin `register()` runs or when the lazy CLI fires.
+ */
+export const HYBRID_MEM_CLI_ROOT_DESCRIPTOR = {
+  name: "hybrid-mem",
+  description: "Hybrid memory (SQLite + LanceDB): maintenance, verify, search, diagnostics, and ingestion",
+  hasSubcommands: true,
+};
+
+/**
+ * `loadOpenClawPluginCliRegistry` calls `register()` with `registrationMode: "cli-metadata"` only to
+ * collect CLI metadata without activating the full plugin (issue #1111).
+ */
+export function registerHybridMemCliMetadataOnly(api: ClawdbotPluginApi): void {
+  api.registerCli(
+    () => {
+      // Full Commander wiring runs on full registration or when a lazy placeholder loads this plugin.
+    },
+    { descriptors: [HYBRID_MEM_CLI_ROOT_DESCRIPTOR] },
+  );
+}
 
 /** Services that are not in cli/handlers (reflection, consolidate, export, etc.) */
 interface CliContextServices {
@@ -530,7 +480,7 @@ export function registerHybridMemCliWithApi(
         throw err;
       }
     },
-    { commands: [...HYBRID_MEM_CLI_COMMANDS] },
+    { descriptors: [HYBRID_MEM_CLI_ROOT_DESCRIPTOR] },
   );
 }
 

--- a/extensions/memory-hybrid/setup/plugin-service.ts
+++ b/extensions/memory-hybrid/setup/plugin-service.ts
@@ -113,6 +113,7 @@ export function createPluginService(ctx: PluginServiceContext) {
     costTracker,
     auditStore,
     agentHealthStore,
+    pythonBridge,
   } = ctx;
 
   let observerRunning = false;
@@ -127,6 +128,25 @@ export function createPluginService(ctx: PluginServiceContext) {
     id: PLUGIN_ID,
     _getVersionCheckPromise: () => versionCheckPromise,
     start: async () => {
+      // Issue #422: surface missing Python deps early; deferred from register() for lighter CLI (issue #1111).
+      if (pythonBridge) {
+        const { ok, missing, spawnError } = pythonBridge.checkDependencies();
+        if (!ok) {
+          if (spawnError) {
+            api.logger.warn(
+              `memory-hybrid: documents.enabled but Python binary not found or failed to spawn: ${spawnError.message}. ` +
+                `Check documents.pythonPath configuration (currently: ${cfg.documents.pythonPath}).`,
+            );
+          } else {
+            const pkgs = missing.join(", ");
+            api.logger.warn(
+              `memory-hybrid: documents.enabled but required Python package(s) not installed: ${pkgs}. ` +
+                `Run: ${cfg.documents.pythonPath} -m pip install ${missing.join(" ")}  (see extensions/memory-hybrid/scripts/requirements.txt)`,
+            );
+          }
+        }
+      }
+
       const sqlCount = factsDb.count();
       const expired = factsDb.countExpired();
       const versionCheckCachePath =

--- a/extensions/memory-hybrid/tests/plugin-e2e.test.ts
+++ b/extensions/memory-hybrid/tests/plugin-e2e.test.ts
@@ -37,7 +37,9 @@ function makeMockApi() {
     getTool(name: string) {
       return tools.get(name);
     },
-    registerService: vi.fn((svc) => { registeredService = svc; }),
+    registerService: vi.fn((svc) => {
+      registeredService = svc;
+    }),
     _stopRegisteredService: () => registeredService?.stop?.(),
     registerCli: vi.fn(),
     registerLifecycleHook: vi.fn(),

--- a/extensions/memory-hybrid/tests/plugin-e2e.test.ts
+++ b/extensions/memory-hybrid/tests/plugin-e2e.test.ts
@@ -7,7 +7,7 @@
  * - No surprises: expected response shapes and persistence across tool calls
  */
 
-import { mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -149,6 +149,7 @@ describe("Plugin registration e2e", () => {
     const mockApi = {
       ...api,
       pluginConfig,
+      registrationMode: "full" as const,
       resolvePath: (p: string) => (p.startsWith("/") || /^[A-Z]:/.test(p) ? p : join(tmpDir, p)),
     };
     expect(() => memoryHybridPlugin.register(mockApi as never)).not.toThrow();
@@ -158,6 +159,50 @@ describe("Plugin registration e2e", () => {
     expect(mockApi.getTool("memory_recall_timeline")).toBeDefined();
     expect(mockApi.getTool("memory_forget")).toBeDefined();
     expect(mockApi.getTool("memory_promote")).toBeDefined();
+  });
+
+  it("full register() creates on-disk database paths (heavy bootstrap)", () => {
+    const sqlitePath = join(tmpDir, "facts.db");
+    const lancePath = join(tmpDir, "lancedb");
+    const pluginConfig = getMinimalConfig({
+      sqlitePath,
+      lanceDbPath: lancePath,
+    });
+    const mockApi = {
+      ...api,
+      pluginConfig,
+      registrationMode: "full" as const,
+      resolvePath: (p: string) => (p.startsWith("/") || /^[A-Z]:/.test(p) ? p : join(tmpDir, p)),
+    };
+    memoryHybridPlugin.register(mockApi as never);
+    expect(existsSync(sqlitePath)).toBe(true);
+  });
+
+  it("cli-metadata register() does not create database files and only registers CLI metadata (issue #1111)", () => {
+    const sqlitePath = join(tmpDir, "facts.db");
+    const lancePath = join(tmpDir, "lancedb");
+    const pluginConfig = getMinimalConfig({
+      sqlitePath,
+      lanceDbPath: lancePath,
+    });
+    const registerCli = vi.fn();
+    const registerTool = vi.fn();
+    const registerService = vi.fn();
+    const mockApi = {
+      ...api,
+      registerCli,
+      registerTool,
+      registerService,
+      pluginConfig,
+      registrationMode: "cli-metadata" as const,
+      resolvePath: (p: string) => (p.startsWith("/") || /^[A-Z]:/.test(p) ? p : join(tmpDir, p)),
+    };
+    memoryHybridPlugin.register(mockApi as never);
+    expect(existsSync(sqlitePath)).toBe(false);
+    expect(existsSync(lancePath)).toBe(false);
+    expect(registerCli).toHaveBeenCalled();
+    expect(registerTool).not.toHaveBeenCalled();
+    expect(registerService).not.toHaveBeenCalled();
   });
 });
 

--- a/extensions/memory-hybrid/tests/plugin-e2e.test.ts
+++ b/extensions/memory-hybrid/tests/plugin-e2e.test.ts
@@ -28,6 +28,7 @@ const { FactsDB, VectorDB, findSimilarByEmbedding, VerificationStore } = _testin
 const EMBEDDING_DIM = 1536; // text-embedding-3-small
 
 function makeMockApi() {
+  let registeredService: { stop?: () => unknown } | null = null;
   const tools = new Map<string, { execute: (...args: unknown[]) => unknown }>();
   return {
     registerTool(opts: Record<string, unknown>, _options?: unknown) {
@@ -36,7 +37,8 @@ function makeMockApi() {
     getTool(name: string) {
       return tools.get(name);
     },
-    registerService: vi.fn(),
+    registerService: vi.fn((svc) => { registeredService = svc; }),
+    _stopRegisteredService: () => registeredService?.stop?.(),
     registerCli: vi.fn(),
     registerLifecycleHook: vi.fn(),
     registerHttpRoute: vi.fn(),
@@ -138,6 +140,7 @@ describe("Plugin registration e2e", () => {
   });
 
   afterEach(() => {
+    api._stopRegisteredService?.();
     rmSync(tmpDir, { recursive: true, force: true });
   });
 
@@ -234,6 +237,7 @@ describe("Store and recall e2e (real FactsDB + VectorDB, mock embeddings)", () =
   afterEach(() => {
     vectorDb.close();
     factsDb.close();
+    api._stopRegisteredService?.();
     rmSync(tmpDir, { recursive: true, force: true });
   });
 
@@ -357,6 +361,7 @@ describe("Init-databases e2e", () => {
   });
 
   afterEach(() => {
+    api._stopRegisteredService?.();
     rmSync(tmpDir, { recursive: true, force: true });
   });
 
@@ -433,6 +438,7 @@ describe("Core and common flows e2e", () => {
   afterEach(() => {
     vectorDb.close();
     factsDb.close();
+    api._stopRegisteredService?.();
     rmSync(tmpDir, { recursive: true, force: true });
   });
 
@@ -587,6 +593,7 @@ describe("Advanced features e2e", () => {
   afterEach(() => {
     vectorDb.close();
     factsDb.close();
+    api._stopRegisteredService?.();
     rmSync(tmpDir, { recursive: true, force: true });
   });
 


### PR DESCRIPTION
## Summary

Implements [issue #1111](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/1111): avoid heavy hybrid-memory bootstrap when OpenClaw loads plugins for CLI metadata only, and document upstream loader coordination.

## Changes

- **`cli-metadata` path**: `register()` returns early after `registerCli` with a single `hybrid-mem` root descriptor (no SQLite/LanceDB, tools, hooks, or service).
- **Full CLI registration**: Replaced the long enumerated command list with the same root descriptor for OpenClaw lazy CLI compatibility.
- **Deferred work**: Python document-bridge dependency checks run from plugin `service.start()` instead of during `register()`.
- **Docs**: [`docs/OPENCLAW-LOADER-COORDINATION.md`](docs/OPENCLAW-LOADER-COORDINATION.md) describes plugin vs OpenClaw core responsibilities.
- **Tests**: E2E coverage for full vs `cli-metadata` registration.

## Notes

Full ecosystem fix for scoped CLI loading still depends on OpenClaw core (see coordination doc).

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes plugin registration behavior to short-circuit heavy initialization for `cli-metadata`, which could affect CLI/tool availability if the host sets `registrationMode` incorrectly. Also moves Python dependency probing to `service.start()`, slightly changing when/where warnings appear and potentially impacting startup timing.
> 
> **Overview**
> Implements a new **`registrationMode: "cli-metadata"`** path where `register()` exits after registering only a `hybrid-mem` root CLI descriptor, avoiding config parsing, DB/LanceDB initialization, tool registration, and service startup (issue #1111).
> 
> Updates full CLI registration to use the same `HYBRID_MEM_CLI_ROOT_DESCRIPTOR` (replacing the enumerated command list) for OpenClaw lazy CLI compatibility, and defers Python document-bridge dependency checks from `register()` to the plugin service `start()` hook.
> 
> Adds coordination docs in `docs/OPENCLAW-LOADER-COORDINATION.md` and extends e2e tests to cover full vs `cli-metadata` registration and to stop any registered service during test teardown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit acacd27143803470107f928323e63817f420fac2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->