### PR TITLE
fix: biome format fixes for PR #1112

### DIFF
--- a/extensions/memory-hybrid/index.ts
+++ b/extensions/memory-hybrid/index.ts
@@ -377,7 +377,7 @@ const memoryHybridPlugin = {
 
 function runMemoryHybridRegister(api: ClawdbotPluginApi): void {
   // OpenClaw `loadOpenClawPluginCliRegistry` — metadata only; no DBs or native deps (issue #1111).
-  // Check this FIRST, before any logger init or config parsing, so an incomplete config 
+  // Check this FIRST, before any logger init or config parsing, so an incomplete config
   // cannot block lightweight metadata registration.
   if (api.registrationMode === "cli-metadata") {
     registerHybridMemCliMetadataOnly(api);

--- a/extensions/memory-hybrid/tests/plugin-e2e.test.ts
+++ b/extensions/memory-hybrid/tests/plugin-e2e.test.ts
@@ -37,7 +37,9 @@ function makeMockApi() {
     getTool(name: string) {
       return tools.get(name);
     },
-    registerService: vi.fn((svc) => { registeredService = svc; }),
+    registerService: vi.fn((svc) => {
+      registeredService = svc;
+    }),
     _stopRegisteredService: () => registeredService?.stop?.(),
     registerCli: vi.fn(),
     registerLifecycleHook: vi.fn(),


### PR DESCRIPTION
Fixes Format Check (Biome) failure on PR #1112. Applies trailing whitespace fix to index.ts and wraps registerService in plugin-e2e.test.ts.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: whitespace/format-only edits to comments and a test mock; no runtime logic changes.
> 
> **Overview**
> Fixes Biome formatting issues in the `memory-hybrid` extension by removing trailing whitespace in `index.ts` comments and reformatting the `registerService` mock in `plugin-e2e.test.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7327e340c1cbadc1155dc678f946f961f063baf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->