### PR TITLE
fix: Fix #1023 Product UX: build a first-class local Memory Viewer / Mission Control UI

### DIFF
--- a/extensions/memory-hybrid/package.json
+++ b/extensions/memory-hybrid/package.json
@@ -33,7 +33,14 @@
     "type": "git",
     "url": "git+https://github.com/markus-lassfolk/openclaw-hybrid-memory.git"
   },
-  "keywords": ["openclaw", "plugin", "memory", "sqlite", "lancedb", "embeddings"],
+  "keywords": [
+    "openclaw",
+    "plugin",
+    "memory",
+    "sqlite",
+    "lancedb",
+    "embeddings"
+  ],
   "peerDependencies": {
     "@sinclair/typebox": "^0.34.48",
     "openai": "^6.16.0",
@@ -48,7 +55,9 @@
     "onnxruntime-node": "^1.20.0"
   },
   "openclaw": {
-    "extensions": ["./index.ts"]
+    "extensions": [
+      "./index.ts"
+    ]
   },
   "scripts": {
     "test": "vitest run",

--- a/extensions/memory-hybrid/package.json
+++ b/extensions/memory-hybrid/package.json
@@ -33,14 +33,7 @@
     "type": "git",
     "url": "git+https://github.com/markus-lassfolk/openclaw-hybrid-memory.git"
   },
-  "keywords": [
-    "openclaw",
-    "plugin",
-    "memory",
-    "sqlite",
-    "lancedb",
-    "embeddings"
-  ],
+  "keywords": ["openclaw", "plugin", "memory", "sqlite", "lancedb", "embeddings"],
   "peerDependencies": {
     "@sinclair/typebox": "^0.34.48",
     "openai": "^6.16.0",
@@ -55,9 +48,7 @@
     "onnxruntime-node": "^1.20.0"
   },
   "openclaw": {
-    "extensions": [
-      "./index.ts"
-    ]
+    "extensions": ["./index.ts"]
   },
   "scripts": {
     "test": "vitest run",

--- a/extensions/memory-hybrid/routes/dashboard-server.ts
+++ b/extensions/memory-hybrid/routes/dashboard-server.ts
@@ -692,16 +692,14 @@ async function collectMemoryViewerStats(ctx: DashboardContext): Promise<MemoryVi
       /* non-fatal */
     }
     try {
-      if (ctx.verificationStore) {
-        totalVerified = ctx.verificationStore.countVerified();
-      }
+      const vr = roDb.prepare("SELECT COUNT(*) as cnt FROM verified_facts").get() as { cnt: number } | undefined;
+      totalVerified = vr?.cnt ?? 0;
     } catch {
       /* non-fatal */
     }
     try {
-      if (ctx.edictStore) {
-        totalEdicts = ctx.edictStore.count();
-      }
+      const er = roDb.prepare("SELECT COUNT(*) as cnt FROM edicts").get() as { cnt: number } | undefined;
+      totalEdicts = er?.cnt ?? 0;
     } catch {
       /* non-fatal */
     }
@@ -894,7 +892,7 @@ function collectMemoryViewerEdicts(ctx: DashboardContext): MemoryViewerEdict[] {
 function collectMemoryViewerVerified(ctx: DashboardContext, limit = 100): MemoryViewerVerification[] {
   try {
     if (!ctx.verificationStore) return [];
-    const verified = ctx.verificationStore.listLatestVerified(limit);
+    const verified = ctx.verificationStore.listLatestVerified();
     return verified.map((v) => ({
       factId: v.factId,
       canonicalText: v.canonicalText,
@@ -1540,7 +1538,7 @@ export async function createDashboardServer(ctx: DashboardContext, port: number)
         const verifiedFactIds = new Set<string>();
         try {
           if (ctx.verificationStore) {
-            const verified = ctx.verificationStore.listLatestVerified(limit);
+            const verified = ctx.verificationStore.listLatestVerified();
             verified.forEach((v) => verifiedFactIds.add(v.factId));
           }
         } catch {
@@ -1588,7 +1586,7 @@ export async function createDashboardServer(ctx: DashboardContext, port: number)
     }
 
     // GET /api/viewer/facts/:id
-    if (req.method === "GET" && pathname.startsWith("/api/viewer/facts/")) {
+    if (pathname.startsWith("/api/viewer/facts/")) {
       const factId = pathname.replace("/api/viewer/facts/", "");
       if (!factId) {
         res.writeHead(400, { "Content-Type": "application/json" });
@@ -1605,7 +1603,7 @@ export async function createDashboardServer(ctx: DashboardContext, port: number)
         const verifiedFactIds = new Set<string>();
         try {
           if (ctx.verificationStore) {
-            const verified = ctx.verificationStore.listLatestVerified(limit);
+            const verified = ctx.verificationStore.listLatestVerified();
             verified.forEach((v) => verifiedFactIds.add(v.factId));
           }
         } catch {

--- a/extensions/memory-hybrid/routes/dashboard-server.ts
+++ b/extensions/memory-hybrid/routes/dashboard-server.ts
@@ -1586,7 +1586,7 @@ export async function createDashboardServer(ctx: DashboardContext, port: number)
     }
 
     // GET /api/viewer/facts/:id
-    if (pathname.startsWith("/api/viewer/facts/")) {
+    if (req.method === "GET" && pathname.startsWith("/api/viewer/facts/")) {
       const factId = pathname.replace("/api/viewer/facts/", "");
       if (!factId) {
         res.writeHead(400, { "Content-Type": "application/json" });


### PR DESCRIPTION
Fixes #1023

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Memory Viewer stats and verified-marking logic to query SQLite tables directly and to fetch verified facts without applying request limits, which could affect dashboard accuracy/performance on large datasets.
> 
> **Overview**
> Updates the Memory Viewer dashboard server to derive `totalVerified` and `totalEdicts` by directly counting rows in the `verified_facts` and `edicts` SQLite tables (instead of relying on optional store count methods).
> 
> Adjusts verification lookups to call `verificationStore.listLatestVerified()` without passing the current endpoint `limit`, impacting how verified fact IDs are collected for `/api/viewer/verified` and the facts list/detail endpoints.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b254cfce2420e62aa716f9f7ead51e74641df1e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->