### PR TITLE
fix: resolve Bugbot review comments (PR #1115)

### DIFF
--- a/extensions/memory-hybrid/README.md
+++ b/extensions/memory-hybrid/README.md
@@ -112,6 +112,37 @@ Routes are only registered when `health.enabled` is `true` (the default). OpenCl
 
 **Config field:** `health.authenticated` (boolean, default `true`) — controls whether dashboard routes require an authenticated session. Set to `false` only if you intentionally want unauthenticated access.
 
+## Mission Control — Memory Viewer (Issue #1023)
+
+The **Mission Control** local dashboard (`createDashboardServer`) doubles as the **Memory Viewer / Mission Control UI** for hybrid-memory. It serves a rich HTML dashboard at the root and exposes a comprehensive JSON API under `/api/viewer/`.
+
+**Access:** The dashboard runs on `127.0.0.1` only (local-only, no authentication required for local access). The HTTP server port is configured via `dashboard.port` in the plugin config (default `7700`).
+
+> **Important:** The dashboard server is registered separately from the OpenClaw HTTP gateway. It is accessible at `http://127.0.0.1:7700/` (or the configured port) — not through the OpenClaw gateway URL. This is intentional: local-only, no auth overhead, safe for operators on the same machine.
+
+### Memory Viewer API endpoints
+
+All Memory Viewer routes are served by the local Mission Control server on the dashboard port:
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/api/viewer/stats` | GET | Overview: total facts, verified, edicts, issues, episodes, links, breakdown by category/tier/decay/source |
+| `/api/viewer/facts` | GET | Paginated facts list with optional filters: `?category=&entity=&limit=&offset=` |
+| `/api/viewer/facts/:id` | GET | Single fact detail including verification status, provenance, and decay info |
+| `/api/viewer/facts/:id/verify` | POST | Verify a fact (`{ "verifiedBy": "agent" \| "user" \| "system" }`) |
+| `/api/viewer/facts/:id/forget` | POST | Forget (soft-delete) a fact |
+| `/api/viewer/entities` | GET | Top entities by fact count with categories and tags |
+| `/api/viewer/episodes` | GET | Recent episodic memory events with outcome, duration, and session context |
+| `/api/viewer/narratives` | GET | Recent session narratives/summaries |
+| `/api/viewer/issues` | GET | All tracked issues with status, severity, and symptoms |
+| `/api/viewer/workflows` | GET | Workflow patterns and recent tool-sequence traces |
+| `/api/viewer/edicts` | GET | All edicts (verified ground-truth facts) |
+| `/api/viewer/verified` | GET | All verified facts with verification metadata |
+| `/api/viewer/links` | GET | Memory graph links (source → target with type and strength) |
+| `/api/viewer/provenance/:factId` | GET | Provenance chain for a specific fact |
+
+All responses include `Cache-Control: no-cache`. POST endpoints accept JSON body and return `{ ok: boolean, message: string }`.
+
 ## Public API HTTP Routes
 
 `tools/public-api-routes.ts` registers a compact, beginner-friendly REST surface under `/plugins/memory-public/`:

--- a/extensions/memory-hybrid/backends/facts-db/crud.ts
+++ b/extensions/memory-hybrid/backends/facts-db/crud.ts
@@ -84,10 +84,15 @@ export function storeFact(ctx: StoreFactContext, entry: StoreFactInput): MemoryE
   const id = randomUUID();
   const nowSec = Math.floor(Date.now() / 1000);
 
-  const decayClass = entry.decayClass || classifyDecay(entry.entity, entry.key, entry.value, entry.text);
+  const decayClass =
+    entry.decayClass || classifyDecay(entry.entity ?? null, entry.key ?? null, entry.value ?? null, entry.text);
   const expiresAt = entry.expiresAt !== undefined ? entry.expiresAt : calculateExpiry(decayClass, nowSec);
   const importance = entry.importance ?? 0.5;
   const why = entry.why ?? null;
+  const entity = entry.entity ?? null;
+  const key = entry.key ?? null;
+  const value = entry.value ?? null;
+  const source = entry.source ?? "conversation";
   const confidence = entry.confidence ?? 1.0;
   const summary = entry.summary ?? null;
   const embeddingModel = entry.embeddingModel ?? null;
@@ -138,10 +143,10 @@ export function storeFact(ctx: StoreFactContext, entry: StoreFactInput): MemoryE
         why,
         entry.category,
         importance,
-        entry.entity,
-        entry.key,
-        entry.value,
-        entry.source,
+        entity,
+        key,
+        value,
+        source,
         nowSec,
         decayClass,
         adjustedExpiresAt,

--- a/extensions/memory-hybrid/backends/facts-db/index.ts
+++ b/extensions/memory-hybrid/backends/facts-db/index.ts
@@ -65,5 +65,6 @@ export {
   estimateStoredTokensByTier,
   getTokenBudgetStatus,
   linksCount,
+  listForDashboard,
   metaPatternsCount,
 } from "./stats.js";

--- a/extensions/memory-hybrid/package.json
+++ b/extensions/memory-hybrid/package.json
@@ -33,7 +33,14 @@
     "type": "git",
     "url": "git+https://github.com/markus-lassfolk/openclaw-hybrid-memory.git"
   },
-  "keywords": ["openclaw", "plugin", "memory", "sqlite", "lancedb", "embeddings"],
+  "keywords": [
+    "openclaw",
+    "plugin",
+    "memory",
+    "sqlite",
+    "lancedb",
+    "embeddings"
+  ],
   "peerDependencies": {
     "@sinclair/typebox": "^0.34.48",
     "openai": "^6.16.0",
@@ -48,7 +55,9 @@
     "onnxruntime-node": "^1.20.0"
   },
   "openclaw": {
-    "extensions": ["./index.ts"]
+    "extensions": [
+      "./index.ts"
+    ]
   },
   "scripts": {
     "test": "vitest run",

--- a/extensions/memory-hybrid/package.json
+++ b/extensions/memory-hybrid/package.json
@@ -33,14 +33,7 @@
     "type": "git",
     "url": "git+https://github.com/markus-lassfolk/openclaw-hybrid-memory.git"
   },
-  "keywords": [
-    "openclaw",
-    "plugin",
-    "memory",
-    "sqlite",
-    "lancedb",
-    "embeddings"
-  ],
+  "keywords": ["openclaw", "plugin", "memory", "sqlite", "lancedb", "embeddings"],
   "peerDependencies": {
     "@sinclair/typebox": "^0.34.48",
     "openai": "^6.16.0",
@@ -55,9 +48,7 @@
     "onnxruntime-node": "^1.20.0"
   },
   "openclaw": {
-    "extensions": [
-      "./index.ts"
-    ]
+    "extensions": ["./index.ts"]
   },
   "scripts": {
     "test": "vitest run",

--- a/extensions/memory-hybrid/routes/dashboard-server.ts
+++ b/extensions/memory-hybrid/routes/dashboard-server.ts
@@ -18,6 +18,12 @@ import { type AgentHealthView, mergeAgentHealthDashboard } from "../backends/age
 import type { AuditStore } from "../backends/audit-store.js";
 import type { FactsDB } from "../backends/facts-db.js";
 import type { VectorDB } from "../backends/vector-db.js";
+import type { EdictStore } from "../backends/edict-store.js";
+import type { VerificationStore } from "../services/verification-store.js";
+import type { IssueStore } from "../backends/issue-store.js";
+import type { WorkflowStore } from "../backends/workflow-store.js";
+import type { NarrativesDB } from "../backends/narratives-db.js";
+import type { ProvenanceService } from "../services/provenance.js";
 import { getDirSize, getFileSizeAsync, readJsonFile } from "../utils/fs.js";
 import { isValidGhRepoArg } from "../utils/gh-repo-arg.js";
 import { pluginLogger } from "../utils/logger.js";
@@ -45,6 +51,18 @@ interface DashboardContext {
   auditStore?: AuditStore | null;
   /** Per-agent health store (Issue #789). */
   agentHealthStore?: import("../backends/agent-health-store.js").AgentHealthStore | null;
+  /** Edict store for verified ground-truth facts. */
+  edictStore?: EdictStore | null;
+  /** Verification store for critical facts. */
+  verificationStore?: VerificationStore | null;
+  /** Issue store for tracked problems. */
+  issueStore?: IssueStore | null;
+  /** Workflow store for tool-sequence patterns. */
+  workflowStore?: WorkflowStore | null;
+  /** Narratives store for session summaries. */
+  narrativesDb?: NarrativesDB | null;
+  /** Provenance service for fact-to-source tracing. */
+  provenanceService?: ProvenanceService | null;
 }
 
 interface MemoryStats {
@@ -160,6 +178,154 @@ interface DashboardStatus {
   costs: CostStats;
   audit: AuditSummaryPayload;
   agentHealth: AgentHealthPayload;
+}
+
+// ---------------------------------------------------------------------------
+// Memory Viewer types (Issue #1023)
+// ---------------------------------------------------------------------------
+
+interface MemoryViewerStats {
+  totalFacts: number;
+  totalExpired: number;
+  totalSuperseded: number;
+  totalVerified: number;
+  totalEdicts: number;
+  totalIssues: number;
+  totalProcedures: number;
+  totalEpisodes: number;
+  totalLinks: number;
+  vectorCount: number;
+  byCategory: Record<string, number>;
+  byTier: Record<string, number>;
+  byDecayClass: Record<string, number>;
+  bySource: Record<string, number>;
+  entityCount: number;
+}
+
+interface MemoryViewerEpisode {
+  id: string;
+  event: string;
+  outcome: string;
+  timestamp: number;
+  duration?: number;
+  context?: string;
+  agentId?: string;
+  sessionId?: string;
+  importance: number;
+  tags: string[];
+}
+
+interface MemoryViewerFact {
+  id: string;
+  text: string;
+  why?: string | null;
+  category: string;
+  importance: number;
+  entity: string | null;
+  key: string | null;
+  value: string | null;
+  source: string;
+  createdAt: number;
+  decayClass: string;
+  expiresAt: number | null;
+  confidence: number;
+  summary?: string | null;
+  tags: string[];
+  supersededAt?: number | null;
+  supersededBy?: string | null;
+  verified?: boolean;
+  edict?: boolean;
+  scope?: string;
+  provenanceSession?: string | null;
+  reinforcedCount?: number;
+}
+
+interface MemoryViewerEntity {
+  entity: string;
+  factCount: number;
+  categories: string[];
+  tags: string[];
+  lastUpdated: number;
+}
+
+interface MemoryViewerEdict {
+  id: string;
+  text: string;
+  source?: string | null;
+  tags: string[];
+  verifiedAt: number | null;
+  expiresAt: string | null;
+  ttl: string;
+  createdAt: number;
+}
+
+interface MemoryViewerIssue {
+  id: string;
+  title: string;
+  status: string;
+  severity: string;
+  symptoms: string[];
+  rootCause?: string | null;
+  fix?: string | null;
+  tags: string[];
+  detectedAt: string;
+  resolvedAt?: string | null;
+  verifiedAt?: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface MemoryViewerWorkflow {
+  id: string;
+  goal: string;
+  toolSequence: string[];
+  outcome: string;
+  toolCount: number;
+  durationMs: number;
+  successRate: number;
+  sessionId: string;
+  createdAt: string;
+}
+
+interface MemoryViewerNarrative {
+  id: string;
+  sessionId: string;
+  periodStart: number;
+  periodEnd: number;
+  tag: string;
+  narrativeText: string;
+  createdAt: number;
+}
+
+interface MemoryViewerVerification {
+  factId: string;
+  canonicalText: string;
+  verifiedAt: string;
+  verifiedBy: string;
+  nextVerification: string | null;
+  version: number;
+}
+
+interface MemoryViewerProvenance {
+  factId: string;
+  text: string;
+  confidence: number;
+  provenanceSession?: string | null;
+  sourceTurn?: number | null;
+  edges: Array<{
+    edgeType: string;
+    sourceType: string;
+    sourceId: string;
+    sourceText?: string | null;
+    createdAt: string;
+  }>;
+}
+
+interface MemoryViewerLinks {
+  from: string;
+  to: string;
+  type: string;
+  strength: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -486,6 +652,375 @@ function collectAuditSummary(ctx: DashboardContext): AuditSummaryPayload {
       byAgent: {},
       recentFailures: [],
     };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Memory Viewer collectors (Issue #1023)
+// ---------------------------------------------------------------------------
+
+/** Open a read-only handle to the facts DB for internal dashboard use. */
+function openFactsDbReadonly(path: string): import("node:sqlite").DatabaseSync | null {
+  try {
+    const { DatabaseSync: DBSync } = require("node:sqlite");
+    const db = new DBSync(path, { readOnly: true });
+    return db;
+  } catch {
+    return null;
+  }
+}
+
+/** Collect Memory Viewer overview stats. */
+async function collectMemoryViewerStats(ctx: DashboardContext): Promise<MemoryViewerStats> {
+  const factsDb = ctx.factsDb;
+  const totalFacts = factsDb.count();
+  const totalExpired = factsDb.countExpired();
+
+  // Use a read-only connection to the facts DB for counts not exposed by the public API
+  const roDb = openFactsDbReadonly(ctx.resolvedSqlitePath);
+  let totalSuperseded = 0;
+  let totalVerified = 0;
+  let totalEdicts = 0;
+  let totalEpisodes = 0;
+  if (roDb) {
+    try {
+      const sr = roDb.prepare("SELECT COUNT(*) as cnt FROM facts WHERE superseded_at IS NOT NULL").get() as
+        | { cnt: number }
+        | undefined;
+      totalSuperseded = sr?.cnt ?? 0;
+    } catch {
+      /* non-fatal */
+    }
+    try {
+      const vr = roDb.prepare("SELECT COUNT(*) as cnt FROM verified_facts").get() as { cnt: number } | undefined;
+      totalVerified = vr?.cnt ?? 0;
+    } catch {
+      /* non-fatal */
+    }
+    try {
+      const er = roDb.prepare("SELECT COUNT(*) as cnt FROM edicts").get() as { cnt: number } | undefined;
+      totalEdicts = er?.cnt ?? 0;
+    } catch {
+      /* non-fatal */
+    }
+    try {
+      const ar = roDb.prepare("SELECT COUNT(*) as cnt FROM episodes").get() as { cnt: number } | undefined;
+      totalEpisodes = ar?.cnt ?? 0;
+    } catch {
+      /* non-fatal */
+    }
+    try {
+      roDb.close();
+    } catch {
+      /* ignore */
+    }
+  }
+
+  const totalIssues = (() => {
+    try {
+      if (!ctx.issueStore) return 0;
+      return ctx.issueStore.list({}).length;
+    } catch {
+      return 0;
+    }
+  })();
+  const totalProcedures = (() => {
+    try {
+      return factsDb.proceduresCount();
+    } catch {
+      return 0;
+    }
+  })();
+  const totalLinks = (() => {
+    try {
+      return factsDb.linksCount();
+    } catch {
+      return 0;
+    }
+  })();
+  let vectorCount = 0;
+  try {
+    vectorCount = await ctx.vectorDb.count();
+  } catch {
+    /* non-fatal */
+  }
+
+  return {
+    totalFacts,
+    totalExpired,
+    totalSuperseded,
+    totalVerified,
+    totalEdicts,
+    totalIssues,
+    totalProcedures,
+    totalEpisodes,
+    totalLinks,
+    vectorCount,
+    byCategory: factsDb.statsBreakdownByCategory(),
+    byTier: factsDb.statsBreakdownByTier(),
+    byDecayClass: factsDb.statsBreakdownByDecayClass(),
+    bySource: factsDb.statsBreakdownBySource(),
+    entityCount: factsDb.entityCount(),
+  };
+}
+
+/** Collect recent episodes — reads from the episodes table within the facts DB. */
+function collectMemoryViewerEpisodes(ctx: DashboardContext, limit = 50): MemoryViewerEpisode[] {
+  try {
+    const roDb = openFactsDbReadonly(ctx.resolvedSqlitePath);
+    if (!roDb) return [];
+    try {
+      const rows = roDb.prepare("SELECT * FROM episodes ORDER BY timestamp DESC LIMIT ?").all(limit) as Array<
+        Record<string, unknown>
+      >;
+      return rows.map((r) => ({
+        id: String(r.id ?? ""),
+        event: String(r.event ?? ""),
+        outcome: String(r.outcome ?? ""),
+        timestamp: Number(r.timestamp ?? 0),
+        duration: r.duration != null ? Number(r.duration) : undefined,
+        context: r.context != null ? String(r.context) : undefined,
+        agentId: r.agent_id != null ? String(r.agent_id) : undefined,
+        sessionId: r.session_id != null ? String(r.session_id) : undefined,
+        importance: Number(r.importance ?? 0.5),
+        tags: (() => {
+          try {
+            return JSON.parse(String(r.tags ?? "[]"));
+          } catch {
+            return [];
+          }
+        })(),
+      }));
+    } finally {
+      try {
+        roDb.close();
+      } catch {
+        /* ignore */
+      }
+    }
+  } catch {
+    return [];
+  }
+}
+
+/** Collect recent narratives. */
+function collectMemoryViewerNarratives(ctx: DashboardContext, limit = 20): MemoryViewerNarrative[] {
+  try {
+    if (!ctx.narrativesDb) return [];
+    return ctx.narrativesDb.listRecent(limit, "all").map((n) => ({
+      id: n.id,
+      sessionId: n.sessionId,
+      periodStart: n.periodStart,
+      periodEnd: n.periodEnd,
+      tag: n.tag,
+      narrativeText: n.narrativeText,
+      createdAt: n.createdAt,
+    }));
+  } catch {
+    return [];
+  }
+}
+
+/** Collect recent issues. */
+function collectMemoryViewerIssues(ctx: DashboardContext): MemoryViewerIssue[] {
+  try {
+    if (!ctx.issueStore) return [];
+    return ctx.issueStore.list({}).map((issue) => ({
+      id: issue.id,
+      title: issue.title,
+      status: issue.status,
+      severity: issue.severity,
+      symptoms: issue.symptoms,
+      rootCause: issue.rootCause,
+      fix: issue.fix,
+      tags: issue.tags,
+      detectedAt: issue.detectedAt,
+      resolvedAt: issue.resolvedAt,
+      verifiedAt: issue.verifiedAt,
+      createdAt: issue.createdAt,
+      updatedAt: issue.updatedAt,
+    }));
+  } catch {
+    return [];
+  }
+}
+
+/** Collect workflow patterns / recent traces. */
+function collectMemoryViewerWorkflows(ctx: DashboardContext, limit = 100): MemoryViewerWorkflow[] {
+  try {
+    if (!ctx.workflowStore) return [];
+    const traces = ctx.workflowStore.list({ limit });
+    const patterns = ctx.workflowStore.getPatterns({ limit: 20 });
+    const result: MemoryViewerWorkflow[] = traces.map((t) => ({
+      id: t.id,
+      goal: t.goal,
+      toolSequence: t.toolSequence,
+      outcome: t.outcome,
+      toolCount: t.toolCount,
+      durationMs: t.durationMs,
+      successRate:
+        patterns.find((p) => JSON.stringify(p.toolSequence) === JSON.stringify(t.toolSequence))?.successRate ?? 0,
+      sessionId: t.sessionId,
+      createdAt: t.createdAt,
+    }));
+    return result;
+  } catch {
+    return [];
+  }
+}
+
+/** Collect recent edicts. */
+function collectMemoryViewerEdicts(ctx: DashboardContext): MemoryViewerEdict[] {
+  try {
+    if (!ctx.edictStore) return [];
+    return ctx.edictStore.list({}).map((e) => ({
+      id: e.id,
+      text: e.text,
+      source: e.source,
+      tags: e.tags,
+      verifiedAt: e.verifiedAt,
+      expiresAt: e.expiresAt,
+      ttl: String(e.ttl),
+      createdAt: e.createdAt,
+    }));
+  } catch {
+    return [];
+  }
+}
+
+/** Collect verified facts using the public listLatestVerified API. */
+function collectMemoryViewerVerified(ctx: DashboardContext, limit = 100): MemoryViewerVerification[] {
+  try {
+    if (!ctx.verificationStore) return [];
+    const verified = ctx.verificationStore.listLatestVerified();
+    return verified.map((v) => ({
+      factId: v.factId,
+      canonicalText: v.canonicalText,
+      verifiedAt: v.verifiedAt ?? "",
+      verifiedBy: v.verifiedBy ?? "",
+      nextVerification: v.nextVerification ?? null,
+      version: v.version,
+    }));
+  } catch {
+    return [];
+  }
+}
+
+/** Collect top entities. */
+function collectMemoryViewerEntities(ctx: DashboardContext, limit = 50): MemoryViewerEntity[] {
+  try {
+    const raw = ctx.factsDb.getRawDb();
+    const rows = raw
+      .prepare(
+        `SELECT entity, COUNT(*) as cnt, GROUP_CONCAT(DISTINCT category) as cats, GROUP_CONCAT(DISTINCT tags) as tgs, MAX(created_at) as last_updated
+         FROM facts WHERE entity IS NOT NULL AND entity != '' AND superseded_at IS NULL
+         GROUP BY entity ORDER BY cnt DESC LIMIT ?`,
+      )
+      .all(limit) as Array<Record<string, unknown>>;
+    return rows.map((r) => {
+      let cats: string[] = [];
+      try {
+        cats = [...new Set(String(r.cats ?? "").split(","))];
+      } catch {}
+      let tgs: string[] = [];
+      try {
+        const allTags = String(r.tgs ?? "").split(",");
+        tgs = [...new Set(allTags.filter(Boolean))];
+      } catch {}
+      return {
+        entity: String(r.entity ?? ""),
+        factCount: Number(r.cnt ?? 0),
+        categories: cats,
+        tags: tgs,
+        lastUpdated: Number(r.last_updated ?? 0),
+      };
+    });
+  } catch {
+    return [];
+  }
+}
+
+/** Collect provenance edges for a fact. */
+function collectMemoryViewerProvenance(ctx: DashboardContext, factId: string): MemoryViewerProvenance | null {
+  try {
+    if (!ctx.provenanceService) return null;
+    // Note: getProvenance accepts an optional factsDb param for fact text enrichment.
+    // We pass the open FactsDB instance directly for this read-only access.
+    const chain = ctx.provenanceService.getProvenance(factId);
+    return {
+      factId: chain.fact.id,
+      text: chain.fact.text,
+      confidence: chain.fact.confidence,
+      provenanceSession: chain.source.sessionId,
+      sourceTurn: chain.source.turn,
+      edges: chain.edges.map((e) => ({
+        edgeType: e.edgeType,
+        sourceType: e.sourceType,
+        sourceId: e.sourceId,
+        sourceText: e.sourceText,
+        createdAt: e.createdAt,
+      })),
+    };
+  } catch {
+    return null;
+  }
+}
+
+/** Collect fact links from the memory_links table. */
+function collectMemoryViewerLinks(ctx: DashboardContext, limit = 5000): MemoryViewerLinks[] {
+  try {
+    const roDb = openFactsDbReadonly(ctx.resolvedSqlitePath);
+    if (!roDb) return [];
+    try {
+      const rows = roDb.prepare("SELECT * FROM memory_links LIMIT ?").all(limit) as Array<Record<string, unknown>>;
+      return rows.map((r) => ({
+        from: String(r.source_fact_id ?? ""),
+        to: String(r.target_fact_id ?? ""),
+        type: String(r.link_type ?? ""),
+        strength: Number(r.strength ?? 1),
+      }));
+    } finally {
+      try {
+        roDb.close();
+      } catch {
+        /* ignore */
+      }
+    }
+  } catch {
+    return [];
+  }
+}
+
+/** Perform a fact action (verify / forget) and return result. */
+function performFactAction(
+  ctx: DashboardContext,
+  action: "verify" | "forget",
+  factId: string,
+  body: Record<string, unknown>,
+): { ok: boolean; message: string } {
+  try {
+    const factsDb = ctx.factsDb;
+    const fact = factsDb.getById(factId);
+    if (!fact) return { ok: false, message: `Fact not found: ${factId}` };
+
+    if (action === "verify") {
+      if (!ctx.verificationStore) return { ok: false, message: "Verification store not available" };
+      const verifiedBy = (body.verifiedBy as "agent" | "user" | "system") ?? "agent";
+      ctx.verificationStore.verify(factId, fact.text, verifiedBy);
+      return { ok: true, message: `Fact ${factId} verified as ${verifiedBy}` };
+    } else {
+      // forget: supersede with null to mark the fact as superseded (soft-delete).
+      // superseded_at IS NOT NULL filters it out of all recall paths.
+      try {
+        const ok = factsDb.supersede(factId, null);
+        if (!ok) return { ok: false, message: `Could not supersede fact ${factId}` };
+      } catch (err) {
+        return { ok: false, message: `Could not forget fact ${factId}: ${String(err)}` };
+      }
+      return { ok: true, message: `Fact ${factId} forgotten` };
+    }
+  } catch (err) {
+    return { ok: false, message: String(err) };
   }
 }
 
@@ -974,6 +1509,305 @@ export async function createDashboardServer(ctx: DashboardContext, port: number)
         pluginLogger.error(`[dashboard-server] /api/audit/events: ${err instanceof Error ? err.message : String(err)}`);
         res.end(JSON.stringify({ error: "InternalServerError" }));
       }
+      return;
+    }
+
+    // Memory Viewer routes (Issue #1023)
+    // GET /api/viewer/stats
+    if (pathname === "/api/viewer/stats") {
+      collectMemoryViewerStats(ctx)
+        .then((stats) => {
+          res.writeHead(200, { "Content-Type": "application/json", "Cache-Control": "no-cache" });
+          res.end(JSON.stringify(stats));
+        })
+        .catch((err: unknown) => {
+          res.writeHead(500, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ error: String(err) }));
+        });
+      return;
+    }
+
+    // GET /api/viewer/facts?limit=50&offset=0&category=&tier=&entity=&search=
+    if (pathname === "/api/viewer/facts") {
+      try {
+        const limit = Math.min(500, Math.max(1, Number.parseInt(searchParams.get("limit") ?? "50", 10)));
+        // Use the public FactsDB.list() API with filters for the dashboard facts endpoint
+        const categoryFilter = searchParams.get("category") || undefined;
+        const entityFilter = searchParams.get("entity") || undefined;
+        const allFacts = ctx.factsDb.list(limit, { category: categoryFilter, entity: entityFilter });
+        const verifiedFactIds = new Set<string>();
+        try {
+          if (ctx.verificationStore) {
+            const verified = ctx.verificationStore.listLatestVerified();
+            verified.forEach((v) => verifiedFactIds.add(v.factId));
+          }
+        } catch {
+          /* non-fatal */
+        }
+        const facts: MemoryViewerFact[] = allFacts.map((f) => {
+          const record = f as Record<string, unknown>;
+          return {
+            id: String(record.id ?? ""),
+            text: String(record.text ?? ""),
+            why: (record.why as string | null) ?? null,
+            category: String(record.category ?? ""),
+            importance: Number(record.importance ?? 0.5),
+            entity: (record.entity as string | null) ?? null,
+            key: (record.key as string | null) ?? null,
+            value: (record.value as string | null) ?? null,
+            source: String(record.source ?? ""),
+            createdAt: Number(record.created_at ?? 0),
+            decayClass: String(record.decay_class ?? ""),
+            expiresAt: record.expires_at != null ? Number(record.expires_at) : null,
+            confidence: Number(record.confidence ?? 0.5),
+            summary: (record.summary as string | null) ?? null,
+            tags: (() => {
+              try {
+                return JSON.parse(String(record.tags ?? "[]"));
+              } catch {
+                return [];
+              }
+            })(),
+            supersededAt: record.superseded_at != null ? Number(record.superseded_at) : null,
+            supersededBy: (record.superseded_by as string | null) ?? null,
+            verified: verifiedFactIds.has(String(record.id ?? "")),
+            scope: record.scope as string | undefined,
+            provenanceSession: (record.provenance_session as string | null) ?? null,
+            reinforcedCount: record.reinforced_count != null ? Number(record.reinforced_count) : undefined,
+          };
+        });
+        res.writeHead(200, { "Content-Type": "application/json", "Cache-Control": "no-cache" });
+        res.end(JSON.stringify({ facts, total: allFacts.length }));
+      } catch (err: unknown) {
+        res.writeHead(500, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: String(err) }));
+      }
+      return;
+    }
+
+    // GET /api/viewer/facts/:id
+    if (pathname.startsWith("/api/viewer/facts/")) {
+      const factId = pathname.replace("/api/viewer/facts/", "");
+      if (!factId) {
+        res.writeHead(400, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: "Missing fact id" }));
+        return;
+      }
+      try {
+        const fact = ctx.factsDb.getById(factId);
+        if (!fact) {
+          res.writeHead(404, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ error: "Fact not found" }));
+          return;
+        }
+        const verifiedFactIds = new Set<string>();
+        try {
+          if (ctx.verificationStore) {
+            const verified = ctx.verificationStore.listLatestVerified();
+            verified.forEach((v) => verifiedFactIds.add(v.factId));
+          }
+        } catch {
+          /* non-fatal */
+        }
+        const f: MemoryViewerFact = {
+          id: fact.id,
+          text: fact.text,
+          why: fact.why,
+          category: fact.category,
+          importance: fact.importance,
+          entity: fact.entity,
+          key: fact.key,
+          value: fact.value,
+          source: fact.source,
+          createdAt: fact.createdAt,
+          decayClass: fact.decayClass,
+          expiresAt: fact.expiresAt,
+          confidence: fact.confidence,
+          summary: fact.summary ?? null,
+          tags: fact.tags ?? [],
+          supersededAt: fact.supersededAt ?? null,
+          supersededBy: fact.supersededBy ?? null,
+          verified: verifiedFactIds.has(fact.id),
+          scope: fact.scope,
+          provenanceSession: fact.provenanceSession ?? null,
+          reinforcedCount: fact.reinforcedCount,
+        };
+        res.writeHead(200, { "Content-Type": "application/json", "Cache-Control": "no-cache" });
+        res.end(JSON.stringify(f));
+      } catch (err: unknown) {
+        res.writeHead(500, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: String(err) }));
+      }
+      return;
+    }
+
+    // GET /api/viewer/entities
+    if (pathname === "/api/viewer/entities") {
+      try {
+        const limit = Math.min(200, Math.max(1, Number.parseInt(searchParams.get("limit") ?? "50", 10)));
+        const entities = collectMemoryViewerEntities(ctx, limit);
+        res.writeHead(200, { "Content-Type": "application/json", "Cache-Control": "no-cache" });
+        res.end(JSON.stringify(entities));
+      } catch (err: unknown) {
+        res.writeHead(500, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: String(err) }));
+      }
+      return;
+    }
+
+    // GET /api/viewer/episodes
+    if (pathname === "/api/viewer/episodes") {
+      try {
+        const limit = Math.min(500, Math.max(1, Number.parseInt(searchParams.get("limit") ?? "50", 10)));
+        const episodes = collectMemoryViewerEpisodes(ctx, limit);
+        res.writeHead(200, { "Content-Type": "application/json", "Cache-Control": "no-cache" });
+        res.end(JSON.stringify(episodes));
+      } catch (err: unknown) {
+        res.writeHead(500, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: String(err) }));
+      }
+      return;
+    }
+
+    // GET /api/viewer/narratives
+    if (pathname === "/api/viewer/narratives") {
+      try {
+        const limit = Math.min(100, Math.max(1, Number.parseInt(searchParams.get("limit") ?? "20", 10)));
+        const narratives = collectMemoryViewerNarratives(ctx, limit);
+        res.writeHead(200, { "Content-Type": "application/json", "Cache-Control": "no-cache" });
+        res.end(JSON.stringify(narratives));
+      } catch (err: unknown) {
+        res.writeHead(500, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: String(err) }));
+      }
+      return;
+    }
+
+    // GET /api/viewer/issues
+    if (pathname === "/api/viewer/issues") {
+      try {
+        const issues = collectMemoryViewerIssues(ctx);
+        res.writeHead(200, { "Content-Type": "application/json", "Cache-Control": "no-cache" });
+        res.end(JSON.stringify(issues));
+      } catch (err: unknown) {
+        res.writeHead(500, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: String(err) }));
+      }
+      return;
+    }
+
+    // GET /api/viewer/workflows
+    if (pathname === "/api/viewer/workflows") {
+      try {
+        const limit = Math.min(500, Math.max(1, Number.parseInt(searchParams.get("limit") ?? "100", 10)));
+        const workflows = collectMemoryViewerWorkflows(ctx, limit);
+        res.writeHead(200, { "Content-Type": "application/json", "Cache-Control": "no-cache" });
+        res.end(JSON.stringify(workflows));
+      } catch (err: unknown) {
+        res.writeHead(500, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: String(err) }));
+      }
+      return;
+    }
+
+    // GET /api/viewer/edicts
+    if (pathname === "/api/viewer/edicts") {
+      try {
+        const edicts = collectMemoryViewerEdicts(ctx);
+        res.writeHead(200, { "Content-Type": "application/json", "Cache-Control": "no-cache" });
+        res.end(JSON.stringify(edicts));
+      } catch (err: unknown) {
+        res.writeHead(500, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: String(err) }));
+      }
+      return;
+    }
+
+    // GET /api/viewer/verified
+    if (pathname === "/api/viewer/verified") {
+      try {
+        const limit = Math.min(500, Math.max(1, Number.parseInt(searchParams.get("limit") ?? "100", 10)));
+        const verified = collectMemoryViewerVerified(ctx, limit);
+        res.writeHead(200, { "Content-Type": "application/json", "Cache-Control": "no-cache" });
+        res.end(JSON.stringify(verified));
+      } catch (err: unknown) {
+        res.writeHead(500, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: String(err) }));
+      }
+      return;
+    }
+
+    // GET /api/viewer/links
+    if (pathname === "/api/viewer/links") {
+      try {
+        const limit = Math.min(10000, Math.max(1, Number.parseInt(searchParams.get("limit") ?? "5000", 10)));
+        const links = collectMemoryViewerLinks(ctx, limit);
+        res.writeHead(200, { "Content-Type": "application/json", "Cache-Control": "no-cache" });
+        res.end(JSON.stringify(links));
+      } catch (err: unknown) {
+        res.writeHead(500, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: String(err) }));
+      }
+      return;
+    }
+
+    // GET /api/viewer/provenance/:factId
+    if (pathname.startsWith("/api/viewer/provenance/")) {
+      const factId = pathname.replace("/api/viewer/provenance/", "");
+      try {
+        const prov = collectMemoryViewerProvenance(ctx, factId);
+        if (!prov) {
+          res.writeHead(404, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ error: "Provenance not available" }));
+          return;
+        }
+        res.writeHead(200, { "Content-Type": "application/json", "Cache-Control": "no-cache" });
+        res.end(JSON.stringify(prov));
+      } catch (err: unknown) {
+        res.writeHead(500, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: String(err) }));
+      }
+      return;
+    }
+
+    // POST /api/viewer/facts/:id/verify
+    if (req.method === "POST" && pathname.match(/^\/api\/viewer\/facts\/[^/]+\/verify$/)) {
+      const factId = pathname.split("/")[4];
+      let body = "";
+      req.on("data", (chunk: Buffer) => {
+        body += chunk.toString();
+      });
+      req.on("end", () => {
+        try {
+          const parsed = body ? JSON.parse(body) : {};
+          const result = performFactAction(ctx, "verify", factId, parsed);
+          res.writeHead(result.ok ? 200 : 400, { "Content-Type": "application/json" });
+          res.end(JSON.stringify(result));
+        } catch (err: unknown) {
+          res.writeHead(500, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ error: String(err) }));
+        }
+      });
+      return;
+    }
+
+    // POST /api/viewer/facts/:id/forget
+    if (req.method === "POST" && pathname.match(/^\/api\/viewer\/facts\/[^/]+\/forget$/)) {
+      const factId = pathname.split("/")[4];
+      let body = "";
+      req.on("data", (chunk: Buffer) => {
+        body += chunk.toString();
+      });
+      req.on("end", () => {
+        try {
+          const result = performFactAction(ctx, "forget", factId, {});
+          res.writeHead(result.ok ? 200 : 400, { "Content-Type": "application/json" });
+          res.end(JSON.stringify(result));
+        } catch (err: unknown) {
+          res.writeHead(500, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ error: String(err) }));
+        }
+      });
       return;
     }
 

--- a/extensions/memory-hybrid/routes/dashboard-server.ts
+++ b/extensions/memory-hybrid/routes/dashboard-server.ts
@@ -692,14 +692,16 @@ async function collectMemoryViewerStats(ctx: DashboardContext): Promise<MemoryVi
       /* non-fatal */
     }
     try {
-      const vr = roDb.prepare("SELECT COUNT(*) as cnt FROM verified_facts").get() as { cnt: number } | undefined;
-      totalVerified = vr?.cnt ?? 0;
+      if (ctx.verificationStore) {
+        totalVerified = ctx.verificationStore.countVerified();
+      }
     } catch {
       /* non-fatal */
     }
     try {
-      const er = roDb.prepare("SELECT COUNT(*) as cnt FROM edicts").get() as { cnt: number } | undefined;
-      totalEdicts = er?.cnt ?? 0;
+      if (ctx.edictStore) {
+        totalEdicts = ctx.edictStore.count();
+      }
     } catch {
       /* non-fatal */
     }
@@ -892,7 +894,7 @@ function collectMemoryViewerEdicts(ctx: DashboardContext): MemoryViewerEdict[] {
 function collectMemoryViewerVerified(ctx: DashboardContext, limit = 100): MemoryViewerVerification[] {
   try {
     if (!ctx.verificationStore) return [];
-    const verified = ctx.verificationStore.listLatestVerified();
+    const verified = ctx.verificationStore.listLatestVerified(limit);
     return verified.map((v) => ({
       factId: v.factId,
       canonicalText: v.canonicalText,
@@ -1538,7 +1540,7 @@ export async function createDashboardServer(ctx: DashboardContext, port: number)
         const verifiedFactIds = new Set<string>();
         try {
           if (ctx.verificationStore) {
-            const verified = ctx.verificationStore.listLatestVerified();
+            const verified = ctx.verificationStore.listLatestVerified(limit);
             verified.forEach((v) => verifiedFactIds.add(v.factId));
           }
         } catch {
@@ -1603,7 +1605,7 @@ export async function createDashboardServer(ctx: DashboardContext, port: number)
         const verifiedFactIds = new Set<string>();
         try {
           if (ctx.verificationStore) {
-            const verified = ctx.verificationStore.listLatestVerified();
+            const verified = ctx.verificationStore.listLatestVerified(limit);
             verified.forEach((v) => verifiedFactIds.add(v.factId));
           }
         } catch {

--- a/extensions/memory-hybrid/routes/dashboard-server.ts
+++ b/extensions/memory-hybrid/routes/dashboard-server.ts
@@ -1586,7 +1586,7 @@ export async function createDashboardServer(ctx: DashboardContext, port: number)
     }
 
     // GET /api/viewer/facts/:id
-    if (pathname.startsWith("/api/viewer/facts/")) {
+    if (req.method === "GET" && pathname.startsWith("/api/viewer/facts/")) {
       const factId = pathname.replace("/api/viewer/facts/", "");
       if (!factId) {
         res.writeHead(400, { "Content-Type": "application/json" });

--- a/extensions/memory-hybrid/services/verification-store.ts
+++ b/extensions/memory-hybrid/services/verification-store.ts
@@ -360,7 +360,8 @@ export class VerificationStore {
   // listLatestVerified — latest versions for each fact_id
   // -------------------------------------------------------------------------
 
-  listLatestVerified(): VerifiedFact[] {
+  listLatestVerified(limit?: number): VerifiedFact[] {
+    const limitClause = limit ? `LIMIT ${limit}` : "";
     const rows = this.db
       .prepare(
         `SELECT vf.*
@@ -371,7 +372,7 @@ export class VerificationStore {
            GROUP BY fact_id
          ) latest
          ON vf.fact_id = latest.fact_id AND vf.version = latest.max_version
-         ORDER BY vf.verified_at DESC`,
+         ORDER BY vf.verified_at DESC ${limitClause}`,
       )
       .all() as unknown as VerifiedFactRow[];
 
@@ -437,6 +438,12 @@ export class VerificationStore {
   // -------------------------------------------------------------------------
   // close — close the underlying SQLite connection
   // -------------------------------------------------------------------------
+
+  /** Return the total number of verified fact entries (across all fact_ids). */
+  countVerified(): number {
+    const row = this.db.prepare("SELECT COUNT(*) as cnt FROM verified_facts").get() as { cnt: number };
+    return row.cnt;
+  }
 
   close(): void {
     if (this.ownsConnection && this._dbOpen) {

--- a/extensions/memory-hybrid/setup/plugin-service.ts
+++ b/extensions/memory-hybrid/setup/plugin-service.ts
@@ -7,8 +7,13 @@ import type { ClawdbotPluginApi } from "openclaw/plugin-sdk/core";
 import type { CredentialsDB } from "../backends/credentials-db.js";
 import type { EdictStore } from "../backends/edict-store.js";
 import type { FactsDB } from "../backends/facts-db.js";
+import type { IssueStore } from "../backends/issue-store.js";
+import type { NarrativesDB } from "../backends/narratives-db.js";
 import type { ProposalsDB } from "../backends/proposals-db.js";
 import type { VectorDB } from "../backends/vector-db.js";
+import type { VerificationStore } from "../services/verification-store.js";
+import type { WorkflowStore } from "../backends/workflow-store.js";
+import type { AuditStore } from "../backends/audit-store.js";
 import type { WriteAheadLog } from "../backends/wal.js";
 import { ensureHybridMemoryWorkspaceSkillIfMissing, loadOpenclawRootForWorkspace } from "../cli/cmd-install.js";
 import type { HybridMemoryConfig, MemoryCategory } from "../config.js";
@@ -69,6 +74,11 @@ export interface PluginServiceContext {
   costTracker?: import("../backends/cost-tracker.js").CostTracker | null;
   auditStore?: import("../backends/audit-store.js").AuditStore | null;
   agentHealthStore?: import("../backends/agent-health-store.js").AgentHealthStore | null;
+  // Memory Viewer stores (Issue #1023)
+  verificationStore?: VerificationStore | null;
+  issueStore?: IssueStore | null;
+  workflowStore?: WorkflowStore | null;
+  narrativesDb?: NarrativesDB | null;
   // Mutable timer refs that will be updated by the start handler
   timers: {
     pruneTimer: { value: ReturnType<typeof setInterval> | null };
@@ -114,6 +124,10 @@ export function createPluginService(ctx: PluginServiceContext) {
     auditStore,
     agentHealthStore,
     pythonBridge,
+    verificationStore,
+    issueStore,
+    workflowStore,
+    narrativesDb,
   } = ctx;
 
   let observerRunning = false;
@@ -445,6 +459,12 @@ export function createPluginService(ctx: PluginServiceContext) {
               logger: api.logger,
               auditStore,
               agentHealthStore,
+              edictStore,
+              verificationStore,
+              issueStore,
+              workflowStore,
+              narrativesDb,
+              provenanceService,
             },
             cfg.dashboard.port,
           );

--- a/extensions/memory-hybrid/tests/dashboard-server.test.ts
+++ b/extensions/memory-hybrid/tests/dashboard-server.test.ts
@@ -600,9 +600,11 @@ describe("Memory Viewer API (Issue #1023)", () => {
       ctx.factsDb.store({ text: "To verify", category: "fact", source: "test" });
       const { body: lb } = await apiGet(port, "/api/viewer/facts");
       const { facts } = JSON.parse(lb);
+      const target = facts.find((fact: { text: string; id: string }) => fact.text === "To verify");
+      expect(target?.id).toBeTruthy();
       const { status, body } = await apiPost(
         port,
-        `/api/viewer/facts/${facts[0].id}/verify`,
+        `/api/viewer/facts/${target.id}/verify`,
         JSON.stringify({ verifiedBy: "agent" }),
       );
       expect(status).toBe(200);
@@ -615,7 +617,9 @@ describe("Memory Viewer API (Issue #1023)", () => {
       ctx.factsDb.store({ text: "To forget", category: "fact", source: "test" });
       const { body: lb } = await apiGet(port, "/api/viewer/facts");
       const { facts } = JSON.parse(lb);
-      const { status, body } = await apiPost(port, `/api/viewer/facts/${facts[0].id}/forget`, "{}");
+      const target = facts.find((fact: { text: string; id: string }) => fact.text === "To forget");
+      expect(target?.id).toBeTruthy();
+      const { status, body } = await apiPost(port, `/api/viewer/facts/${target.id}/forget`, "{}");
       expect(status).toBe(200);
       expect(JSON.parse(body).ok).toBe(true);
     });

--- a/extensions/memory-hybrid/tests/dashboard-server.test.ts
+++ b/extensions/memory-hybrid/tests/dashboard-server.test.ts
@@ -377,3 +377,247 @@ describeCreateDashboardServer("createDashboardServer", () => {
     }
   });
 });
+
+// ---------------------------------------------------------------------------
+// Memory Viewer API tests (Issue #1023)
+// ---------------------------------------------------------------------------
+
+describe("Memory Viewer API (Issue #1023)", () => {
+  const VECTOR_DIM = 4;
+
+  async function makeContextWithStores(tmpDir: string) {
+    const { FactsDB, VectorDB } = await import("../index.js").then((m) => m._testing);
+    const { EdictStore } = await import("../backends/edict-store.js");
+    const { VerificationStore } = await import("../services/verification-store.js");
+    const { IssueStore } = await import("../backends/issue-store.js");
+    const { WorkflowStore } = await import("../backends/workflow-store.js");
+    const { NarrativesDB } = await import("../backends/narratives-db.js");
+    const { ProvenanceService } = await import("../services/provenance.js");
+
+    const factsDb = new FactsDB(join(tmpDir, "facts.db"));
+    const vectorDb = new VectorDB(join(tmpDir, "lance"), VECTOR_DIM);
+    const edictStore = new EdictStore(join(tmpDir, "edicts.db"));
+    const verificationStore = new VerificationStore(join(tmpDir, "verification.db"));
+    const issueStore = new IssueStore(join(tmpDir, "issues.db"));
+    const workflowStore = new WorkflowStore(join(tmpDir, "workflows.db"));
+    const narrativesDb = new NarrativesDB(join(tmpDir, "narratives.db"));
+    const provenanceService = new ProvenanceService(join(tmpDir, "provenance.db"));
+
+    return {
+      factsDb,
+      vectorDb,
+      edictStore,
+      verificationStore,
+      issueStore,
+      workflowStore,
+      narrativesDb,
+      provenanceService,
+      resolvedSqlitePath: join(tmpDir, "facts.db"),
+      resolvedLancePath: join(tmpDir, "lance"),
+    };
+  }
+
+  async function apiGet(port: number, path: string) {
+    return new Promise<{ status: number; body: string }>((resolve) => {
+      const req = request({ hostname: "127.0.0.1", port, path, method: "GET" }, (res) => {
+        let body = "";
+        res.on("data", (c: Buffer) => {
+          body += c.toString();
+        });
+        res.on("end", () => resolve({ status: res.statusCode ?? 0, body }));
+      });
+      req.on("error", () => resolve({ status: 0, body: "" }));
+      req.setTimeout(5000, () => {
+        req.destroy();
+        resolve({ status: 0, body: "" });
+      });
+      req.end();
+    });
+  }
+
+  async function apiPost(port: number, path: string, body: string) {
+    return new Promise<{ status: number; body: string }>((resolve) => {
+      const req = request(
+        { hostname: "127.0.0.1", port, path, method: "POST", headers: { "Content-Type": "application/json" } },
+        (res) => {
+          let data = "";
+          res.on("data", (c: Buffer) => {
+            data += c.toString();
+          });
+          res.on("end", () => resolve({ status: res.statusCode ?? 0, body: data }));
+        },
+      );
+      req.on("error", () => resolve({ status: 0, body: "" }));
+      req.setTimeout(5000, () => {
+        req.destroy();
+        resolve({ status: 0, body: "" });
+      });
+      req.end(body);
+    });
+  }
+
+  function closeAll(ctx: Awaited<ReturnType<typeof makeContextWithStores>>) {
+    try {
+      ctx.factsDb.close();
+    } catch {
+      /* ignore */
+    }
+    try {
+      ctx.vectorDb.close();
+    } catch {
+      /* ignore */
+    }
+    try {
+      ctx.edictStore.close();
+    } catch {
+      /* ignore */
+    }
+    try {
+      ctx.verificationStore.close();
+    } catch {
+      /* ignore */
+    }
+    try {
+      ctx.issueStore.close();
+    } catch {
+      /* ignore */
+    }
+    try {
+      ctx.workflowStore.close();
+    } catch {
+      /* ignore */
+    }
+    try {
+      ctx.narrativesDb.close();
+    } catch {
+      /* ignore */
+    }
+    try {
+      ctx.provenanceService.close();
+    } catch {
+      /* ignore */
+    }
+  }
+
+  async function withServer(
+    fn: (ctx: Awaited<ReturnType<typeof makeContextWithStores>>, port: number) => Promise<void>,
+  ) {
+    const td = mkdtempSync(join(tmpdir(), "mv-test-"));
+    try {
+      const ctx = await makeContextWithStores(td);
+      const srv = await createDashboardServer(ctx, 0);
+      try {
+        await fn(ctx, srv.port);
+      } finally {
+        // Close stores first (before server), then server, then cleanup temp dir
+        closeAll(ctx);
+        srv.close();
+      }
+    } finally {
+      rmSync(td, { recursive: true, force: true });
+    }
+  }
+
+  it("GET /api/viewer/stats returns overview stats", async () => {
+    await withServer(async (ctx, port) => {
+      ctx.factsDb.store({ text: "Test fact", category: "fact", source: "test" });
+      const { status, body } = await apiGet(port, "/api/viewer/stats");
+      expect(status).toBe(200);
+      const d = JSON.parse(body);
+      expect(typeof d.totalFacts).toBe("number");
+      expect(typeof d.byCategory).toBe("object");
+      expect(typeof d.byTier).toBe("object");
+    });
+  });
+
+  it("GET /api/viewer/facts returns a list of facts", async () => {
+    await withServer(async (ctx, port) => {
+      ctx.factsDb.store({ text: "Test fact", category: "fact", source: "test" });
+      const { status, body } = await apiGet(port, "/api/viewer/facts");
+      expect(status).toBe(200);
+      const d = JSON.parse(body);
+      expect(Array.isArray(d.facts)).toBe(true);
+      expect(d.facts.length).toBeGreaterThan(0);
+      expect(typeof d.facts[0].id).toBe("string");
+    });
+  });
+
+  it("GET /api/viewer/facts/:id returns a single fact", async () => {
+    await withServer(async (ctx, port) => {
+      ctx.factsDb.store({ text: "Target fact", category: "fact", source: "test" });
+      const { body: lb } = await apiGet(port, "/api/viewer/facts");
+      const { facts } = JSON.parse(lb);
+      const { status, body } = await apiGet(port, `/api/viewer/facts/${facts[0].id}`);
+      expect(status).toBe(200);
+      const f = JSON.parse(body);
+      expect(f.id).toBe(facts[0].id);
+      expect(typeof f.text).toBe("string");
+    });
+  });
+
+  it("GET /api/viewer/facts/:id returns 404 for unknown id", async () => {
+    await withServer(async (_ctx, port) => {
+      const { status } = await apiGet(port, "/api/viewer/facts/00000000-0000-0000-0000-000000000000");
+      expect(status).toBe(404);
+    });
+  });
+
+  it("GET /api/viewer/issues returns issues array", async () => {
+    await withServer(async (_ctx, port) => {
+      const { status, body } = await apiGet(port, "/api/viewer/issues");
+      expect(status).toBe(200);
+      expect(Array.isArray(JSON.parse(body))).toBe(true);
+    });
+  });
+
+  it("GET /api/viewer/edicts returns edicts array", async () => {
+    await withServer(async (_ctx, port) => {
+      const { status, body } = await apiGet(port, "/api/viewer/edicts");
+      expect(status).toBe(200);
+      expect(Array.isArray(JSON.parse(body))).toBe(true);
+    });
+  });
+
+  it("GET /api/viewer/entities returns entities array", async () => {
+    await withServer(async (ctx, port) => {
+      ctx.factsDb.store({ text: "Entity test", category: "fact", source: "test", entity: "MyEntity" });
+      const { status, body } = await apiGet(port, "/api/viewer/entities");
+      expect(status).toBe(200);
+      expect(Array.isArray(JSON.parse(body))).toBe(true);
+    });
+  });
+
+  it("GET /api/viewer/workflows returns workflows array", async () => {
+    await withServer(async (_ctx, port) => {
+      const { status, body } = await apiGet(port, "/api/viewer/workflows");
+      expect(status).toBe(200);
+      expect(Array.isArray(JSON.parse(body))).toBe(true);
+    });
+  });
+
+  it("POST /api/viewer/facts/:id/verify verifies a fact", async () => {
+    await withServer(async (ctx, port) => {
+      ctx.factsDb.store({ text: "To verify", category: "fact", source: "test" });
+      const { body: lb } = await apiGet(port, "/api/viewer/facts");
+      const { facts } = JSON.parse(lb);
+      const { status, body } = await apiPost(
+        port,
+        `/api/viewer/facts/${facts[0].id}/verify`,
+        JSON.stringify({ verifiedBy: "agent" }),
+      );
+      expect(status).toBe(200);
+      expect(JSON.parse(body).ok).toBe(true);
+    });
+  });
+
+  it("POST /api/viewer/facts/:id/forget forgets a fact", async () => {
+    await withServer(async (ctx, port) => {
+      ctx.factsDb.store({ text: "To forget", category: "fact", source: "test" });
+      const { body: lb } = await apiGet(port, "/api/viewer/facts");
+      const { facts } = JSON.parse(lb);
+      const { status, body } = await apiPost(port, `/api/viewer/facts/${facts[0].id}/forget`, "{}");
+      expect(status).toBe(200);
+      expect(JSON.parse(body).ok).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes two Bugbot review comments from PR #1115:

### 1. Verified facts limit parameter silently ignored (Low Severity)

 accepts a  parameter but was calling  without it.

**Fix:**
- Added  parameter to 
- Added  clause to the SQL query when limit is provided
- Updated all three call sites to pass  through

### 2. Stats queries wrong database for verified and edict counts (Medium Severity)

 was opening a read-only connection to  (facts DB) and querying  and  tables. These tables live in separate database files ( and ), so queries would always fail silently and return 0.

**Fix:**
- : now uses  (the verification database)
- : now uses  (from the edict store)
- Both gracefully fall back to 0 if stores are unavailable

## Files changed

-  — listLatestVerified now accepts limit
-  — stats now use correct store instances, limit passed to listLatestVerified

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: expands the local Mission Control HTTP API with new fact actions (`verify`/`forget`) and new read-only SQLite queries, which could affect memory data and dashboard stability if misused or if query assumptions are wrong.
> 
> **Overview**
> Fixes Mission Control/Memory Viewer data correctness and API behavior by **adding proper store-backed counts** for verified facts and edicts, and by **supporting an optional limit** in `VerificationStore.listLatestVerified()` (with updated callers passing the limit through).
> 
> Also hardens fact storage defaults in `FactsDB.storeFact` (normalizing optional `entity`/`key`/`value` to `null` and defaulting `source`) and updates docs/tests to cover the local `/api/viewer/*` endpoints and verify/forget actions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ae4299420cdc3cdc0cb75e50748c7db10085049. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->