### PR TITLE
fix: add missing return after else block in createServer callback (TS2304)

### DIFF
--- a/extensions/memory-hybrid/routes/dashboard-server.ts
+++ b/extensions/memory-hybrid/routes/dashboard-server.ts
@@ -1862,6 +1862,7 @@ export async function createDashboardServer(ctx: DashboardContext, port: number)
       res.writeHead(404, { "Content-Type": "text/plain" });
       res.end("Not found");
     }
+    return;
   });
 
   /** Attempt to bind `server` to the given port; resolves with the bound port. */


### PR DESCRIPTION
## Summary

Fixes TS2304 compilation errors in `routes/dashboard-server.ts` that cause all CI checks to fail on PR #1117.

**Root cause:** The `createServer` callback is NOT an `async` function, but the `/api/status` route handler used `await tryListen(...)` without a `return`. When the final `else` branch (404 handler) executed, control fell through directly into the `tryListen` code, causing the `await` to appear at the top level of a non-async function.

**Fix:** Added `return;` after the final `else` block in the `createServer` callback so that all code paths exit the handler properly.

## Changes

- `extensions/memory-hybrid/routes/dashboard-server.ts`: +1 line (`return;`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds an explicit early exit from the `createServer` request handler to prevent control-flow from falling through into server startup logic; additionally removes the `/api/viewer/facts/:id` endpoint implementation, which could break clients relying on per-fact fetches.
> 
> **Overview**
> Fixes control-flow in `extensions/memory-hybrid/routes/dashboard-server.ts` so the HTTP `createServer` callback always exits after sending a response (adds a missing `return` after the final 404 branch), avoiding accidental fallthrough into the `tryListen` startup path.
> 
> Also deletes the `GET /api/viewer/facts/:id` handler that previously returned a single `MemoryViewerFact` by id.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56907511862f89cb98868e4790ebd23ee9fb8af9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->