### PR TITLE
fix: add retry with backoff for GlitchTip 502 errors

### DIFF
--- a/scripts/fetch-glitchtip-issues.sh
+++ b/scripts/fetch-glitchtip-issues.sh
@@ -13,6 +13,14 @@
 # Optional: override project. GlitchTip API uses org_slug and project_slug; if your
 # project ID is 1, try GLITCHTIP_PROJECT=1 (script will try projects/1/issues/ and
 # projects/1/1/issues/). For org/project slugs: GLITCHTIP_ORG=myorg GLITCHTIP_PROJECT=openclaw
+#
+# Optional env vars for retry behaviour:
+#   GLITCHTIP_RETRIES           — number of retry attempts after a transient error (default: 3).
+#                                 A transient error is HTTP 502, 503, or 504 on the primary URL.
+#                                 Total attempts = GLITCHTIP_RETRIES.
+#   GLITCHTIP_RETRY_DELAY_BASE  — base for exponential back-off sleep, in seconds (default: 2).
+#                                 Sleep before retry n is (BASE ** n) seconds.
+#                                 Set to 1 to disable exponential growth (constant delay).
 set -e
 
 BASE="${GLITCHTIP_BASE_URL:-http://192.168.1.99:8000}"
@@ -32,6 +40,22 @@ if [[ "$BASE" =~ ^https?:// && ! "$BASE" =~ ^https:// ]]; then
   echo "Consider using HTTPS: export GLITCHTIP_BASE_URL=https://your-domain.com" >&2
 fi
 
+# Validate retry tunables so we fail fast with a clear message rather than
+# producing a confusing "illegal number" or "division by zero" error under `set -e`.
+RETRIES=${GLITCHTIP_RETRIES:-3}
+DELAY_BASE=${GLITCHTIP_RETRY_DELAY_BASE:-2}
+
+case "$RETRIES" in
+  '' | *[!0-9]*) echo "GLITCHTIP_RETRIES must be a non-negative integer (got: '$RETRIES')" >&2; exit 1 ;;
+esac
+case "$DELAY_BASE" in
+  '' | *[!0-9]*) echo "GLITCHTIP_RETRY_DELAY_BASE must be a non-negative integer (got: '$DELAY_BASE')" >&2; exit 1 ;;
+esac
+if [ "$DELAY_BASE" -eq 0 ]; then
+  echo "GLITCHTIP_RETRY_DELAY_BASE must be >= 1 (got: 0)" >&2
+  exit 1
+fi
+
 # Sentry-style: /api/0/projects/{org}/{project}/issues/
 # Try numeric first (org=1, project=1), then org/1/project/1
 URL1="${BASE}/api/0/projects/${ORG}/${PROJECT}/issues/?query=&statsPeriod=14d"
@@ -40,8 +64,6 @@ URL2="${BASE}/api/0/projects/1/issues/?query=&statsPeriod=14d"
 echo "Fetching issues from GlitchTip (base: $BASE)..." >&2
 
 # ---- Retry wrapper ---------------------------------------------------------
-RETRIES=${GLITCHTIP_RETRIES:-3}
-DELAY_BASE=${GLITCHTIP_RETRY_DELAY_BASE:-2}   # seconds; exponential back-off base
 attempt=0
 
 fetch_once() {
@@ -63,7 +85,7 @@ while [ $attempt -le $RETRIES ]; do
 
   # Fallback to numeric project path on 404 only once
   if [ "$code" = "404" ] && [ "$URL1" != "$URL2" ]; then
-    response=$(fetch_once "$URL2")
+    response=$(fetch_once "$URL2") || true
     code=$(echo "$response" | tail -n1)
     body=$(echo "$response" | sed '$d')
     if [ "$code" = "200" ]; then

--- a/scripts/fetch-glitchtip-issues.sh
+++ b/scripts/fetch-glitchtip-issues.sh
@@ -38,15 +38,32 @@ URL1="${BASE}/api/0/projects/${ORG}/${PROJECT}/issues/?query=&statsPeriod=14d"
 URL2="${BASE}/api/0/projects/1/issues/?query=&statsPeriod=14d"
 
 echo "Fetching issues from GlitchTip (base: $BASE)..." >&2
-if response=$(curl -s -w "\n%{http_code}" -H "Accept: application/json" -H "Authorization: Bearer $TOKEN" "$URL1"); then
+
+# ---- Retry wrapper ---------------------------------------------------------
+RETRIES=${GLITCHTIP_RETRIES:-3}
+DELAY_BASE=${GLITCHTIP_RETRY_DELAY_BASE:-2}   # seconds; exponential back-off base
+attempt=0
+
+fetch_once() {
+  local url="$1"
+  curl -s -w "\n%{http_code}" -H "Accept: application/json" -H "Authorization: Bearer $TOKEN" "$url"
+}
+
+while [ $attempt -le $RETRIES ]; do
+  attempt=$((attempt+1))
+  response=$(fetch_once "$URL1") || true
   code=$(echo "$response" | tail -n1)
   body=$(echo "$response" | sed '$d')
+
+  # Success
   if [ "$code" = "200" ]; then
     echo "$body" | jq . 2>/dev/null || echo "$body"
     exit 0
   fi
+
+  # Fallback to numeric project path on 404 only once
   if [ "$code" = "404" ] && [ "$URL1" != "$URL2" ]; then
-    response=$(curl -s -w "\n%{http_code}" -H "Accept: application/json" -H "Authorization: Bearer $TOKEN" "$URL2")
+    response=$(fetch_once "$URL2")
     code=$(echo "$response" | tail -n1)
     body=$(echo "$response" | sed '$d')
     if [ "$code" = "200" ]; then
@@ -54,9 +71,21 @@ if response=$(curl -s -w "\n%{http_code}" -H "Accept: application/json" -H "Auth
       exit 0
     fi
   fi
+
+  # Retry on transient upstream errors (502/503/504)
+  if [[ "$code" =~ ^(502|503|504)$ ]] && [ $attempt -le $RETRIES ]; then
+    sleep_time=$(( DELAY_BASE ** attempt ))
+    echo "Transient error (HTTP $code). Retry $attempt/$RETRIES after ${sleep_time}s..." >&2
+    sleep "$sleep_time"
+    continue
+  fi
+
+  # Non-retriable or retries exhausted
   echo "HTTP $code" >&2
   echo "$body" | head -c 500 >&2
   echo "" >&2
   exit 1
-fi
+
+done
+
 exit 1


### PR DESCRIPTION
Fixes #1114

Adds exponential-backoff retry logic (502/503/504) to scripts/fetch-glitchtip-issues.sh so transient upstream errors no longer abort the sync job.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are isolated to a standalone shell script and only affect how it handles transient GlitchTip HTTP failures; main risk is longer waits or unexpected looping if retry env vars are mis-set (now validated).
> 
> **Overview**
> Makes `scripts/fetch-glitchtip-issues.sh` resilient to transient GlitchTip outages by adding configurable retries with exponential backoff for HTTP `502/503/504` instead of failing immediately.
> 
> Adds `GLITCHTIP_RETRIES` and `GLITCHTIP_RETRY_DELAY_BASE` (with input validation), wraps the `curl` call in a retry loop, and keeps the existing one-time `404` fallback to the numeric project URL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b700cef2a77e77feff76be71fc8f8af0064cae94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->