### PR TITLE
fix: add Azure AI Foundry Services auth to verify --test-llm

### DIFF
--- a/extensions/memory-hybrid/cli/verify-llm-azure-auth.ts
+++ b/extensions/memory-hybrid/cli/verify-llm-azure-auth.ts
@@ -5,6 +5,16 @@
 
 import { AZURE_OPENAI_API_VERSION } from "../services/embeddings.js";
 import { isAzureOpenAiResourceEndpoint } from "../services/embeddings/shared.js";
+
+/** True when baseURL is an Azure AI Foundry Services endpoint (e.g. https://services.ai.azure.com). */
+function isAzureAiFoundryServicesUrl(baseURL: string): boolean {
+  try {
+    const u = new URL(baseURL);
+    return u.hostname === "services.ai.azure.com" || u.hostname.endsWith(".services.ai.azure.com");
+  } catch {
+    return false;
+  }
+}
 import { createApimGatewayFetch, isAzureApiManagementGatewayUrl } from "../utils/apim-gateway-fetch.js";
 
 export function isAzureFoundryFamilyProvider(provider: string): boolean {
@@ -37,10 +47,14 @@ export function applyAzureFoundryVerifyDirectClientAuth(
       opts.defaultQuery = { "api-version": AZURE_OPENAI_API_VERSION };
     }
   } else if (isAzureOpenAiResourceEndpoint(baseURL)) {
+    // Legacy Azure OpenAI resource (e.g. *.openai.azure.com without /openai/v1)
     opts.defaultHeaders = { ...(opts.defaultHeaders ?? {}), "api-key": apiKey };
     const openAiV1Compat = /\/openai\/v1(?:\/|$)/i.test(baseURL);
     if (!openAiV1Compat) {
       opts.defaultQuery = { "api-version": AZURE_OPENAI_API_VERSION };
     }
+  } else if (isAzureAiFoundryServicesUrl(baseURL)) {
+    // Azure AI Foundry Services endpoint — requires Bearer token auth (#1125)
+    opts.defaultHeaders = { ...(opts.defaultHeaders ?? {}), Authorization: `Bearer ${apiKey}` };
   }
 }


### PR DESCRIPTION
Fixes #1125

Azure AI Foundry Services endpoints (services.ai.azure.com) require Bearer token authentication, not the api-key header used by legacy APIM gateways or *.openai.azure.com resource endpoints.

Without this, any provider using the Azure SDK path in verify --test-llm returns HTTP 401 and false failures are reported.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates request authentication selection for Azure endpoints in the `verify --test-llm` path; incorrect URL matching could cause 401s or mis-auth on Azure Foundry providers. Scope is small and isolated to CLI verification, but it touches auth header behavior.
> 
> **Overview**
> `verify --test-llm` now detects Azure AI Foundry Services endpoints (`*.services.ai.azure.com`) and sends `Authorization: Bearer <token>` instead of the legacy `api-key` header.
> 
> Existing behavior for APIM gateway URLs and legacy `*.openai.azure.com` resource endpoints is preserved (including conditional `api-version` query injection when not using `/openai/v1`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f26dd0e85572559699cddc08563102bf56d7e73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->