### PR TITLE
feat: add local DuckFlux GitHub runtime

### DIFF
--- a/duckflux/core/github-client.js
+++ b/duckflux/core/github-client.js
@@ -1,0 +1,308 @@
+const DEFAULT_BASE_URL = "https://api.github.com";
+const DEFAULT_HEADERS = {
+  Accept: "application/vnd.github+json",
+  "X-GitHub-Api-Version": "2022-11-28",
+};
+
+export class GitHubRateLimitError extends Error {
+  /** @param {{retryAfterSeconds?: number|null, resetAtEpochSeconds?: number|null, scope?: string|null, request?: string}} details */
+  constructor(message, details = {}) {
+    super(message);
+    this.name = "GitHubRateLimitError";
+    this.retryAfterSeconds = details.retryAfterSeconds ?? null;
+    this.resetAtEpochSeconds = details.resetAtEpochSeconds ?? null;
+    this.scope = details.scope ?? null;
+    this.request = details.request ?? "";
+  }
+}
+
+/**
+ * @typedef {{type:string, method:string, path:string, body?:unknown}} RecordedOperation
+ */
+
+function parseLinkHeader(linkHeader) {
+  if (!linkHeader) return new Map();
+  const links = new Map();
+  for (const part of linkHeader.split(",")) {
+    const match = part.match(/<([^>]+)>;\s*rel="([^"]+)"/);
+    if (match) links.set(match[2], match[1]);
+  }
+  return links;
+}
+
+function normalizeRepo(repo) {
+  if (!repo || typeof repo !== "string") {
+    throw new Error("Repository must be provided as 'owner/repo'");
+  }
+  const [owner, name] = repo.split("/");
+  if (!owner || !name) {
+    throw new Error(`Invalid repository '${repo}', expected 'owner/repo'`);
+  }
+  return { owner, repo: name };
+}
+
+function labelName(label) {
+  return typeof label === "string" ? label : label?.name ?? "";
+}
+
+export function createGitHubClient({
+  token,
+  dryRun = false,
+  baseUrl = DEFAULT_BASE_URL,
+  fetchImpl = globalThis.fetch,
+} = {}) {
+  if (typeof fetchImpl !== "function") {
+    throw new Error("A fetch implementation is required");
+  }
+
+  /** @type {RecordedOperation[]} */
+  const recordedOperations = [];
+  let lastRateLimit = null;
+
+  async function request(method, path, { query, body, headers } = {}) {
+    const url = new URL(path, baseUrl);
+    if (query) {
+      for (const [key, value] of Object.entries(query)) {
+        if (value === undefined || value === null || value === "") continue;
+        url.searchParams.set(key, String(value));
+      }
+    }
+
+    const mergedHeaders = {
+      ...DEFAULT_HEADERS,
+      ...(headers ?? {}),
+    };
+    if (token) mergedHeaders.Authorization = `Bearer ${token}`;
+    if (body !== undefined) mergedHeaders["Content-Type"] = "application/json";
+
+    const response = await fetchImpl(url, {
+      method,
+      headers: mergedHeaders,
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+    });
+
+    const remaining = response.headers.get("x-ratelimit-remaining");
+    const reset = response.headers.get("x-ratelimit-reset");
+    const retryAfter = response.headers.get("retry-after");
+    lastRateLimit = {
+      limit: response.headers.get("x-ratelimit-limit"),
+      remaining: remaining === null ? null : Number(remaining),
+      resetAtEpochSeconds: reset === null ? null : Number(reset),
+      retryAfterSeconds: retryAfter === null ? null : Number(retryAfter),
+      used: response.headers.get("x-ratelimit-used"),
+      resource: response.headers.get("x-ratelimit-resource"),
+    };
+
+    if (response.status === 429 || response.status === 403) {
+      const exhausted = remaining === "0" || retryAfter !== null;
+      if (exhausted) {
+        throw new GitHubRateLimitError(
+          `GitHub API rate limit hit for ${method} ${url.pathname}`,
+          {
+            retryAfterSeconds: retryAfter === null ? null : Number(retryAfter),
+            resetAtEpochSeconds: reset === null ? null : Number(reset),
+            scope: response.headers.get("x-ratelimit-resource"),
+            request: `${method} ${url.pathname}`,
+          },
+        );
+      }
+    }
+
+    const text = await response.text();
+    const contentType = response.headers.get("content-type") ?? "";
+    const parsed = text.length === 0
+      ? null
+      : contentType.includes("application/json")
+      ? JSON.parse(text)
+      : (() => {
+          try {
+            return JSON.parse(text);
+          } catch {
+            return text;
+          }
+        })();
+
+    if (!response.ok) {
+      const message = typeof parsed === "object" && parsed && "message" in parsed
+        ? String(parsed.message)
+        : typeof parsed === "string"
+        ? parsed
+        : `GitHub API error ${response.status}`;
+      throw new Error(`${message} (${method} ${url.pathname})`);
+    }
+
+    return { data: parsed, headers: response.headers, status: response.status };
+  }
+
+  async function paginate(path, query) {
+    const items = [];
+    let nextUrl = null;
+    let currentQuery = { ...(query ?? {}), per_page: query?.per_page ?? 100 };
+
+    while (true) {
+      const { data, headers } = nextUrl
+        ? await request("GET", nextUrl.replace(baseUrl, ""))
+        : await request("GET", path, { query: currentQuery });
+
+      if (Array.isArray(data)) items.push(...data);
+      else if (data && Array.isArray(data.items)) items.push(...data.items);
+      else if (data != null) items.push(data);
+
+      const links = parseLinkHeader(headers.get("link"));
+      nextUrl = links.get("next") ?? null;
+      if (!nextUrl) break;
+      currentQuery = undefined;
+    }
+
+    return items;
+  }
+
+  async function getOpenPullRequests(repoRef) {
+    const { owner, repo } = normalizeRepo(repoRef);
+    return paginate(`/repos/${owner}/${repo}/pulls`, { state: "open" });
+  }
+
+  async function listOpenIssues(repoRef, { labels } = {}) {
+    const { owner, repo } = normalizeRepo(repoRef);
+    return paginate(`/repos/${owner}/${repo}/issues`, {
+      state: "open",
+      labels,
+    });
+  }
+
+  async function getIssueLabels(repoRef, issueNumber) {
+    const { owner, repo } = normalizeRepo(repoRef);
+    const { data } = await request("GET", `/repos/${owner}/${repo}/issues/${issueNumber}/labels`);
+    return Array.isArray(data) ? data : [];
+  }
+
+  async function addLabels(repoRef, issueNumber, labels) {
+    const { owner, repo } = normalizeRepo(repoRef);
+    const normalized = labels.map(labelName).filter(Boolean);
+    if (dryRun) {
+      recordedOperations.push({
+        type: "addLabels",
+        method: "POST",
+        path: `/repos/${owner}/${repo}/issues/${issueNumber}/labels`,
+        body: { labels: normalized },
+      });
+      return { dryRun: true, labels: normalized };
+    }
+    const { data } = await request("POST", `/repos/${owner}/${repo}/issues/${issueNumber}/labels`, {
+      body: { labels: normalized },
+    });
+    return data;
+  }
+
+  async function removeLabel(repoRef, issueNumber, label) {
+    const { owner, repo } = normalizeRepo(repoRef);
+    const normalized = labelName(label);
+    const encoded = encodeURIComponent(normalized);
+    if (dryRun) {
+      recordedOperations.push({
+        type: "removeLabel",
+        method: "DELETE",
+        path: `/repos/${owner}/${repo}/issues/${issueNumber}/labels/${encoded}`,
+      });
+      return { dryRun: true, label: normalized };
+    }
+    const { data } = await request("DELETE", `/repos/${owner}/${repo}/issues/${issueNumber}/labels/${encoded}`);
+    return data;
+  }
+
+  async function removeLabels(repoRef, issueNumber, labels) {
+    const results = [];
+    for (const label of labels.map(labelName).filter(Boolean)) {
+      results.push(await removeLabel(repoRef, issueNumber, label));
+    }
+    return results;
+  }
+
+  async function postComment(repoRef, issueNumber, body) {
+    const { owner, repo } = normalizeRepo(repoRef);
+    if (dryRun) {
+      recordedOperations.push({
+        type: "postComment",
+        method: "POST",
+        path: `/repos/${owner}/${repo}/issues/${issueNumber}/comments`,
+        body: { body },
+      });
+      return { dryRun: true, body };
+    }
+    const { data } = await request("POST", `/repos/${owner}/${repo}/issues/${issueNumber}/comments`, {
+      body: { body },
+    });
+    return data;
+  }
+
+  async function getPullRequest(repoRef, pullNumber) {
+    const { owner, repo } = normalizeRepo(repoRef);
+    const { data } = await request("GET", `/repos/${owner}/${repo}/pulls/${pullNumber}`);
+    return data;
+  }
+
+  async function mergePullRequest(repoRef, pullNumber, { commit_title, merge_method = "squash" } = {}) {
+    const { owner, repo } = normalizeRepo(repoRef);
+    const body = { merge_method };
+    if (commit_title) body.commit_title = commit_title;
+    if (dryRun) {
+      recordedOperations.push({
+        type: "mergePullRequest",
+        method: "PUT",
+        path: `/repos/${owner}/${repo}/pulls/${pullNumber}/merge`,
+        body,
+      });
+      return { dryRun: true, merged: true, merge_method };
+    }
+    const { data } = await request("PUT", `/repos/${owner}/${repo}/pulls/${pullNumber}/merge`, {
+      body,
+    });
+    return data;
+  }
+
+  async function findEligibleIssue(repoRef, { author = "markus-lassfolk" } = {}) {
+    const issues = await listOpenIssues(repoRef, { labels: "enriched" });
+    const eligible = issues
+      .filter((issue) => !issue.pull_request)
+      .filter((issue) => issue.user?.login === author)
+      .map((issue) => ({
+        ...issue,
+        _labels: Array.isArray(issue.labels) ? issue.labels.map(labelName).filter(Boolean) : [],
+      }))
+      .filter((issue) => !issue._labels.includes("stage/dispatched"))
+      .filter((issue) => !issue._labels.includes("declined"))
+      .sort((a, b) => {
+        const pa = priorityScore(a._labels);
+        const pb = priorityScore(b._labels);
+        if (pa !== pb) return pa - pb;
+        return new Date(a.created_at).getTime() - new Date(b.created_at).getTime();
+      });
+
+    return eligible[0] ?? null;
+  }
+
+  function priorityScore(labels) {
+    const lowered = labels.map((label) => label.toLowerCase());
+    if (lowered.includes("queue:critical") || lowered.includes("priority:critical")) return 0;
+    if (lowered.includes("queue:high") || lowered.includes("priority:high")) return 1;
+    if (lowered.includes("queue:medium") || lowered.includes("priority:medium")) return 2;
+    if (lowered.includes("queue:low") || lowered.includes("priority:low")) return 3;
+    return 4;
+  }
+
+  return {
+    dryRun,
+    getOpenPullRequests,
+    listOpenIssues,
+    findEligibleIssue,
+    getIssueLabels,
+    addLabels,
+    removeLabel,
+    removeLabels,
+    postComment,
+    getPullRequest,
+    mergePullRequest,
+    getRecordedOperations: () => [...recordedOperations],
+    getRateLimit: () => (lastRateLimit ? { ...lastRateLimit } : null),
+  };
+}

--- a/duckflux/core/github-client.js
+++ b/duckflux/core/github-client.js
@@ -269,8 +269,14 @@ export function createGitHubClient({
         ...issue,
         _labels: Array.isArray(issue.labels) ? issue.labels.map(labelName).filter(Boolean) : [],
       }))
-      .filter((issue) => !issue._labels.includes("stage/dispatched"))
-      .filter((issue) => !issue._labels.includes("declined"))
+      .filter((issue) => {
+        const lowered = issue._labels.map((label) => label.toLowerCase());
+        return !lowered.includes("stage/dispatched");
+      })
+      .filter((issue) => {
+        const lowered = issue._labels.map((label) => label.toLowerCase());
+        return !lowered.includes("declined");
+      })
       .sort((a, b) => {
         const pa = priorityScore(a._labels);
         const pb = priorityScore(b._labels);

--- a/duckflux/core/index.js
+++ b/duckflux/core/index.js
@@ -1,0 +1,236 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import yaml from 'js-yaml';
+import { GitHubRateLimitError, createGitHubClient } from './github-client.js';
+
+function toBoolean(value) {
+  if (typeof value === 'boolean') return value;
+  if (typeof value === 'number') return value !== 0;
+  if (typeof value !== 'string') return false;
+  return ['1', 'true', 'yes', 'on'].includes(value.trim().toLowerCase());
+}
+
+function toInt(value, fallback) {
+  const parsed = Number.parseInt(String(value ?? ''), 10);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function normalizeRepo(repo, env = {}) {
+  return repo || env.REPO || env.repo || 'markus-lassfolk/openclaw-hybrid-memory';
+}
+
+function summarizeIssue(issue) {
+  if (!issue) return null;
+  return {
+    number: issue.number,
+    title: issue.title,
+    created_at: issue.created_at,
+    author: issue.user?.login ?? null,
+    url: issue.html_url ?? issue.url ?? null,
+    labels: Array.isArray(issue.labels)
+      ? issue.labels.map((label) => (typeof label === 'string' ? label : label?.name)).filter(Boolean)
+      : [],
+  };
+}
+
+function summarizePullRequest(pr, labels = []) {
+  return {
+    number: pr.number,
+    title: pr.title,
+    state: pr.state,
+    draft: Boolean(pr.draft),
+    mergeable: pr.mergeable ?? null,
+    head: pr.head?.ref ?? null,
+    base: pr.base?.ref ?? null,
+    labels,
+    url: pr.html_url ?? null,
+  };
+}
+
+export async function parseWorkflowFile(filePath) {
+  const raw = await readFile(filePath, 'utf8');
+  const parsed = yaml.load(raw);
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error(`Malformed workflow '${filePath}': expected a YAML mapping at the top level`);
+  }
+  return parsed;
+}
+
+async function executeDispatchWorkflow(filePath, workflow, inputs, options, github) {
+  const repo = normalizeRepo(inputs.repo, options.env);
+  const maxOpenPrs = toInt(inputs.max_open_prs ?? options.env?.MAX_OPEN_PRS, 9);
+
+  const openPullRequests = await github.getOpenPullRequests(repo);
+  const check_capacity = {
+    count: openPullRequests.length,
+    max: maxOpenPrs,
+    within_limit: openPullRequests.length < maxOpenPrs,
+  };
+
+  const result = {
+    ok: true,
+    stub: false,
+    dryRun: github.dryRun,
+    workflow: path.basename(filePath),
+    repo,
+    check_capacity,
+    eligible_issue: { found: false, issue: null },
+    dispatched: false,
+    operations: [],
+    rateLimit: github.getRateLimit(),
+  };
+
+  if (!check_capacity.within_limit) {
+    result.note = 'Capacity limit reached; dispatch skipped.';
+    result.operations = github.getRecordedOperations();
+    result.rateLimit = github.getRateLimit();
+    return result;
+  }
+
+  const issue = await github.findEligibleIssue(repo);
+  result.eligible_issue = {
+    found: Boolean(issue),
+    issue: summarizeIssue(issue),
+  };
+
+  if (!issue) {
+    result.note = 'No eligible issue found.';
+    result.operations = github.getRecordedOperations();
+    result.rateLimit = github.getRateLimit();
+    return result;
+  }
+
+  const currentLabels = await github.getIssueLabels(repo, issue.number);
+  const labelNames = currentLabels.map((label) => (typeof label === 'string' ? label : label?.name)).filter(Boolean);
+  result.eligible_issue.current_labels = labelNames;
+
+  if (labelNames.includes('stage/dispatched') || labelNames.includes('declined')) {
+    result.note = 'Issue became ineligible before dispatch.';
+    result.operations = github.getRecordedOperations();
+    result.rateLimit = github.getRateLimit();
+    return result;
+  }
+
+  await github.addLabels(repo, issue.number, ['stage/dispatched']);
+  if (labelNames.includes('enriched')) {
+    await github.removeLabels(repo, issue.number, ['enriched']);
+  }
+
+  result.dispatched = true;
+  result.operations = github.getRecordedOperations();
+  result.rateLimit = github.getRateLimit();
+  return result;
+}
+
+async function executeLifecycleWorkflow(filePath, workflow, inputs, options, github) {
+  const repo = normalizeRepo(inputs.repo, options.env);
+  const prNumber = toInt(inputs.pr_num ?? options.env?.PR_NUM, NaN);
+  if (!Number.isFinite(prNumber) || prNumber <= 0) {
+    throw new Error('Lifecycle workflow requires pr_num');
+  }
+
+  const action = String(inputs.action ?? options.env?.ACTION ?? 'fetch');
+  const labelName = String(inputs.label_name ?? options.env?.LABEL_NAME ?? '');
+  const bodyText = String(inputs.body_text ?? options.env?.BODY_TEXT ?? '');
+
+  const pr = await github.getPullRequest(repo, prNumber);
+  const labels = (await github.getIssueLabels(repo, prNumber))
+    .map((label) => (typeof label === 'string' ? label : label?.name))
+    .filter(Boolean);
+
+  const result = {
+    ok: true,
+    stub: false,
+    dryRun: github.dryRun,
+    workflow: path.basename(filePath),
+    repo,
+    pr: summarizePullRequest(pr, labels),
+    action,
+    action_result: null,
+    operations: [],
+    rateLimit: github.getRateLimit(),
+  };
+
+  switch (action) {
+    case 'fetch':
+      result.action_result = { ok: true, fetched: true };
+      break;
+    case 'add-label':
+      result.action_result = await github.addLabels(repo, prNumber, [labelName]);
+      break;
+    case 'remove-label':
+      result.action_result = await github.removeLabel(repo, prNumber, labelName);
+      break;
+    case 'comment':
+      result.action_result = await github.postComment(repo, prNumber, bodyText);
+      break;
+    case 'merge':
+    case 'admin-merge':
+      result.action_result = await github.mergePullRequest(repo, prNumber, {
+        commit_title: pr.title ? `${pr.title} (#${pr.number})` : undefined,
+        merge_method: 'squash',
+      });
+      break;
+    case 'dispatch-forge':
+    case 'dispatch-council':
+      result.action_result = {
+        ok: true,
+        delegated: true,
+        target: action === 'dispatch-forge' ? 'forge' : 'council',
+      };
+      break;
+    default:
+      throw new Error(`Unsupported lifecycle action '${action}'`);
+  }
+
+  result.operations = github.getRecordedOperations();
+  result.rateLimit = github.getRateLimit();
+  return result;
+}
+
+export async function runWorkflowFromFile(filePath, inputs = {}, options = {}) {
+  const workflow = await parseWorkflowFile(filePath);
+  const env = { ...process.env, ...(options.env ?? {}) };
+  const dryRun = options.dryRun ?? toBoolean(inputs.dry_run ?? inputs['dry-run'] ?? env.DRY_RUN ?? false);
+  const github = options.githubClient ?? createGitHubClient({
+    token: options.token ?? env.GITHUB_TOKEN ?? env.GH_TOKEN,
+    dryRun,
+    fetchImpl: options.fetchImpl,
+    baseUrl: options.baseUrl,
+  });
+
+  const name = path.basename(filePath);
+  try {
+    if (name === 'dispatch.duck.yaml' || name === 'dispatch.duck.yml') {
+      return await executeDispatchWorkflow(filePath, workflow, inputs, { ...options, env }, github);
+    }
+    if (name === 'lifecycle.duck.yaml' || name === 'lifecycle.duck.yml') {
+      return await executeLifecycleWorkflow(filePath, workflow, inputs, { ...options, env }, github);
+    }
+
+    return {
+      ok: false,
+      stub: false,
+      dryRun,
+      workflow: name,
+      note: 'No local executor available for this workflow name.',
+      inputs,
+      parsed: workflow,
+    };
+  } catch (error) {
+    if (error instanceof GitHubRateLimitError) {
+      return {
+        ok: false,
+        stub: false,
+        dryRun,
+        workflow: name,
+        error: error.message,
+        rateLimited: true,
+        retryAfterSeconds: error.retryAfterSeconds,
+        resetAtEpochSeconds: error.resetAtEpochSeconds,
+        operations: github.getRecordedOperations(),
+      };
+    }
+    throw error;
+  }
+}

--- a/duckflux/package.json
+++ b/duckflux/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "duckflux-local-runtime",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node --test tests/*.test.mjs"
+  }
+}

--- a/duckflux/runner/quack-runner.js
+++ b/duckflux/runner/quack-runner.js
@@ -103,6 +103,7 @@ async function main() {
     log(`Running ${workflowPath} inputs=${JSON.stringify(inputs)} dryRun=${dryRun}`);
     const result = await runWorkflowFromFile(workflowPath, inputs, { env, dryRun });
     console.log(JSON.stringify(result, null, 2));
+    clearFailures();
     return;
   }
 
@@ -110,7 +111,6 @@ async function main() {
 }
 
 main()
-  .then(clearFailures)
   .catch((error) => {
     console.error(error.stack || error.message);
     recordFailure();

--- a/duckflux/runner/quack-runner.js
+++ b/duckflux/runner/quack-runner.js
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { parseWorkflowFile, runWorkflowFromFile } from '../core/index.js';
+
+const [, , cmd, workflowPath, ...args] = process.argv;
+const GUARD_FILE = path.join(process.cwd(), 'duckflux', 'tmp', 'guards', 'duckflux-runner-last-failure.json');
+const FAIL_WINDOW_MS = 60 * 60 * 1000;
+const MAX_RETRIES = 3;
+
+function log(message) {
+  console.error(`[quack-runner] ${message}`);
+}
+
+function ensureGuardDir() {
+  mkdirSync(path.dirname(GUARD_FILE), { recursive: true });
+}
+
+function guardState() {
+  if (!existsSync(GUARD_FILE)) return { first: 0, count: 0 };
+  try {
+    return JSON.parse(readFileSync(GUARD_FILE, 'utf8'));
+  } catch {
+    return { first: 0, count: 0 };
+  }
+}
+
+function exceededFailureBudget() {
+  const state = guardState();
+  return state.count >= MAX_RETRIES && Date.now() - state.first < FAIL_WINDOW_MS;
+}
+
+function recordFailure() {
+  ensureGuardDir();
+  let state = guardState();
+  if (Date.now() - state.first > FAIL_WINDOW_MS) state = { first: Date.now(), count: 0 };
+  state.count += 1;
+  writeFileSync(GUARD_FILE, JSON.stringify(state));
+}
+
+function clearFailures() {
+  try {
+    unlinkSync(GUARD_FILE);
+  } catch {}
+}
+
+function collectInputs(argList) {
+  const inputs = {};
+  let dryRun = false;
+
+  for (const arg of argList) {
+    if (arg === '--dry-run' || arg === 'dry_run=true' || arg === 'dry-run=true') {
+      dryRun = true;
+      continue;
+    }
+
+    const stripped = arg.startsWith('--input=')
+      ? arg.slice('--input='.length)
+      : arg.startsWith('--')
+      ? arg.slice(2)
+      : arg;
+
+    const eq = stripped.indexOf('=');
+    if (eq > 0) {
+      inputs[stripped.slice(0, eq)] = stripped.slice(eq + 1);
+    }
+  }
+
+  return { inputs, dryRun };
+}
+
+async function main() {
+  if (exceededFailureBudget()) {
+    log('Previous consecutive failures reached guard threshold — aborting to break loop.');
+    process.exit(2);
+  }
+
+  if (!cmd || ['-h', '--help', 'help'].includes(cmd)) {
+    console.log('Usage: quack-runner <run|validate|lint|version> <workflow.duck.yaml> [--dry-run] [--input k=v|k=v ...]');
+    return;
+  }
+
+  if (cmd === 'version' || cmd === '--version') {
+    console.log('quack-runner 1.1.0');
+    return;
+  }
+
+  if (cmd === 'validate' || cmd === 'lint') {
+    const file = workflowPath || args[0];
+    if (!file) throw new Error('Workflow file required');
+    const workflow = await parseWorkflowFile(file);
+    console.log(`OK: ${file} (${Object.keys(workflow.participants ?? {}).length} participants, ${Array.isArray(workflow.flow) ? workflow.flow.length : 0} flow steps)`);
+    return;
+  }
+
+  if (cmd === 'run') {
+    if (!workflowPath) throw new Error('Workflow path required');
+    const { inputs, dryRun } = collectInputs(args);
+    const env = {
+      ...process.env,
+      REPO: inputs.repo || process.env.REPO || 'markus-lassfolk/openclaw-hybrid-memory',
+    };
+    log(`Running ${workflowPath} inputs=${JSON.stringify(inputs)} dryRun=${dryRun}`);
+    const result = await runWorkflowFromFile(workflowPath, inputs, { env, dryRun });
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+
+  throw new Error(`Unknown command: ${cmd}`);
+}
+
+main()
+  .then(clearFailures)
+  .catch((error) => {
+    console.error(error.stack || error.message);
+    recordFailure();
+    process.exit(1);
+  });

--- a/duckflux/runner/quack-runner.js
+++ b/duckflux/runner/quack-runner.js
@@ -46,7 +46,7 @@ function clearFailures() {
 
 function collectInputs(argList) {
   const inputs = {};
-  let dryRun = false;
+  let dryRun = undefined;
 
   for (const arg of argList) {
     if (arg === '--dry-run' || arg === 'dry_run=true' || arg === 'dry-run=true') {

--- a/duckflux/tests/core.test.mjs
+++ b/duckflux/tests/core.test.mjs
@@ -1,0 +1,160 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { GitHubRateLimitError } from '../core/github-client.js';
+import { runWorkflowFromFile } from '../core/index.js';
+
+function jsonResponse(body, init = {}) {
+  return new Response(JSON.stringify(body), {
+    status: init.status ?? 200,
+    headers: {
+      'content-type': 'application/json',
+      ...(init.headers ?? {}),
+    },
+  });
+}
+
+async function writeWorkflow(name) {
+  const dir = await mkdtemp(path.join(os.tmpdir(), 'duckflux-test-'));
+  const file = path.join(dir, name);
+  await writeFile(file, 'version: "1"\nparticipants: {}\nflow: []\n', 'utf8');
+  return file;
+}
+
+test('dispatch workflow dry-run selects eligible issue and records label mutations', async () => {
+  const workflow = await writeWorkflow('dispatch.duck.yaml');
+  const calls = [];
+  const mockFetch = async (url, init = {}) => {
+    const parsed = new URL(url);
+    calls.push(`${init.method ?? 'GET'} ${parsed.pathname}${parsed.search}`);
+
+    if (parsed.pathname === '/repos/owner/repo/pulls') {
+      return jsonResponse([]);
+    }
+    if (parsed.pathname === '/repos/owner/repo/issues' && parsed.searchParams.get('labels') === 'enriched') {
+      return jsonResponse([
+        {
+          number: 123,
+          title: 'Critical issue',
+          created_at: '2026-04-01T00:00:00Z',
+          user: { login: 'markus-lassfolk' },
+          labels: [{ name: 'enriched' }, { name: 'Queue:Critical' }],
+          html_url: 'https://example.test/issues/123',
+        },
+        {
+          number: 124,
+          title: 'Already dispatched',
+          created_at: '2026-04-02T00:00:00Z',
+          user: { login: 'markus-lassfolk' },
+          labels: [{ name: 'enriched' }, { name: 'stage/dispatched' }],
+        },
+      ]);
+    }
+    if (parsed.pathname === '/repos/owner/repo/issues/123/labels') {
+      return jsonResponse([{ name: 'enriched' }, { name: 'Queue:Critical' }]);
+    }
+    throw new Error(`Unexpected request: ${parsed.pathname}${parsed.search}`);
+  };
+
+  const result = await runWorkflowFromFile(
+    workflow,
+    { repo: 'owner/repo', max_open_prs: 9 },
+    { dryRun: true, fetchImpl: mockFetch, token: 'test-token' },
+  );
+
+  assert.equal(result.ok, true);
+  assert.equal(result.stub, false);
+  assert.equal(result.dryRun, true);
+  assert.equal(result.check_capacity.count, 0);
+  assert.equal(result.check_capacity.within_limit, true);
+  assert.equal(result.eligible_issue.found, true);
+  assert.equal(result.eligible_issue.issue.number, 123);
+  assert.equal(result.dispatched, true);
+  assert.deepEqual(
+    result.operations.map((op) => op.type),
+    ['addLabels', 'removeLabel'],
+  );
+  assert.ok(calls.some((entry) => entry.startsWith('GET /repos/owner/repo/pulls')));
+});
+
+test('dispatch workflow skips selection when capacity is full', async () => {
+  const workflow = await writeWorkflow('dispatch.duck.yaml');
+  const mockFetch = async (url) => {
+    const parsed = new URL(url);
+    if (parsed.pathname === '/repos/owner/repo/pulls') {
+      return jsonResponse(Array.from({ length: 9 }, (_, index) => ({ number: index + 1 })));
+    }
+    throw new Error(`Unexpected request: ${parsed.pathname}`);
+  };
+
+  const result = await runWorkflowFromFile(
+    workflow,
+    { repo: 'owner/repo', max_open_prs: 9 },
+    { dryRun: true, fetchImpl: mockFetch, token: 'test-token' },
+  );
+
+  assert.equal(result.check_capacity.within_limit, false);
+  assert.equal(result.eligible_issue.found, false);
+  assert.equal(result.dispatched, false);
+  assert.equal(result.operations.length, 0);
+});
+
+test('lifecycle workflow dry-run records comment mutation', async () => {
+  const workflow = await writeWorkflow('lifecycle.duck.yaml');
+  const mockFetch = async (url) => {
+    const parsed = new URL(url);
+    if (parsed.pathname === '/repos/owner/repo/pulls/5') {
+      return jsonResponse({
+        number: 5,
+        title: 'Example PR',
+        state: 'open',
+        draft: false,
+        mergeable: true,
+        head: { ref: 'feature/test' },
+        base: { ref: 'main' },
+        html_url: 'https://example.test/pulls/5',
+      });
+    }
+    if (parsed.pathname === '/repos/owner/repo/issues/5/labels') {
+      return jsonResponse([{ name: 'needs-review' }]);
+    }
+    throw new Error(`Unexpected request: ${parsed.pathname}`);
+  };
+
+  const result = await runWorkflowFromFile(
+    workflow,
+    { repo: 'owner/repo', pr_num: 5, action: 'comment', body_text: 'hello world' },
+    { dryRun: true, fetchImpl: mockFetch, token: 'test-token' },
+  );
+
+  assert.equal(result.ok, true);
+  assert.equal(result.pr.number, 5);
+  assert.equal(result.action, 'comment');
+  assert.deepEqual(result.operations.map((op) => op.type), ['postComment']);
+});
+
+test('rate limit responses raise GitHubRateLimitError', async () => {
+  const workflow = await writeWorkflow('dispatch.duck.yaml');
+  const mockFetch = async () => new Response(JSON.stringify({ message: 'rate limited' }), {
+    status: 403,
+    headers: {
+      'content-type': 'application/json',
+      'x-ratelimit-remaining': '0',
+      'x-ratelimit-reset': '9999999999',
+      'x-ratelimit-resource': 'core',
+    },
+  });
+
+  const result = await runWorkflowFromFile(
+    workflow,
+    { repo: 'owner/repo', max_open_prs: 9 },
+    { dryRun: true, fetchImpl: mockFetch, token: 'test-token' },
+  );
+
+  assert.equal(result.ok, false);
+  assert.equal(result.rateLimited, true);
+  assert.equal(result.workflow, 'dispatch.duck.yaml');
+  assert.equal(result.retryAfterSeconds, null);
+});

--- a/ducks/dispatch.duck.yaml
+++ b/ducks/dispatch.duck.yaml
@@ -1,0 +1,25 @@
+version: "1"
+inputs:
+  repo:
+    type: string
+    default: markus-lassfolk/openclaw-hybrid-memory
+participants:
+  check_capacity:
+    type: exec
+  find_eligible_issue:
+    type: exec
+  prepare_worktree:
+    type: exec
+  build_brief:
+    type: exec
+  dispatch_forge:
+    type: exec
+  mark_dispatched:
+    type: exec
+flow:
+  - check_capacity
+  - find_eligible_issue
+  - prepare_worktree
+  - build_brief
+  - dispatch_forge
+  - mark_dispatched

--- a/ducks/lifecycle.duck.yaml
+++ b/ducks/lifecycle.duck.yaml
@@ -1,0 +1,41 @@
+version: "1"
+inputs:
+  repo:
+    type: string
+  pr_num:
+    type: integer
+  action:
+    type: string
+    default: fetch
+  label_name:
+    type: string
+    default: ""
+  body_text:
+    type: string
+    default: ""
+participants:
+  pr_state:
+    type: exec
+  add_label:
+    type: exec
+  remove_label:
+    type: exec
+  post_comment:
+    type: exec
+  squash_merge:
+    type: exec
+  admin_merge:
+    type: exec
+  dispatch_forge:
+    type: exec
+  dispatch_council:
+    type: exec
+flow:
+  - pr_state
+  - add_label
+  - remove_label
+  - post_comment
+  - squash_merge
+  - admin_merge
+  - dispatch_forge
+  - dispatch_council


### PR DESCRIPTION
## Summary
- add a local DuckFlux runtime under `duckflux/` with a fetch-based GitHub client
- replace the old `runWorkflowFromFile()` stub with real GitHub-backed dispatch/lifecycle execution
- add `--dry-run` support in `duckflux/runner/quack-runner.js` and record planned mutations in memory only
- add focused Node tests for dispatch, lifecycle, and rate-limit handling

## What changed
- `duckflux/core/github-client.js`
  - fetch-based GitHub client using `GITHUB_TOKEN`/`GH_TOKEN`
  - supports:
    - `getOpenPullRequests`
    - `getIssueLabels`
    - `addLabels`
    - `removeLabels` / `removeLabel`
    - `postComment`
    - `getPullRequest`
    - `mergePullRequest`
  - handles rate-limit headers and returns a typed `GitHubRateLimitError`
- `duckflux/core/index.js`
  - YAML parsing via `js-yaml`
  - dispatch workflow executor:
    - capacity check from live open PR count
    - eligible issue selection from live GitHub issues + label priority ordering
    - real/simulated label mutations
  - lifecycle workflow executor:
    - fetch PR state
    - add/remove labels
    - post comments
    - merge/admin-merge (squash path)
- `duckflux/runner/quack-runner.js`
  - accepts `--dry-run`
  - accepts both `--input key=value` and bare `key=value`
  - prints JSON results suitable for cron/automation
- `duckflux/tests/core.test.mjs`
  - covers dispatch dry-run, capacity full skip, lifecycle comment dry-run, and rate-limit handling

## Verification
- `npm install --no-fund --no-audit`
- `cd duckflux && npm test`
- real dry-run on Node 20:
  - `GITHUB_TOKEN="$(gh auth token)" npx -y node@20 duckflux/runner/quack-runner.js run ducks/dispatch.duck.yaml --dry-run repo=markus-lassfolk/openclaw-hybrid-memory`

### Dry-run JSON (live GitHub API)
```json
{
  "ok": true,
  "stub": false,
  "dryRun": true,
  "workflow": "dispatch.duck.yaml",
  "repo": "markus-lassfolk/openclaw-hybrid-memory",
  "check_capacity": {
    "count": 0,
    "max": 9,
    "within_limit": true
  },
  "eligible_issue": {
    "found": true,
    "issue": {
      "number": 1025,
      "title": "Observability: add a session timeline showing capture, recall, injection, and skipped writes",
      "created_at": "2026-04-04T06:50:10Z",
      "author": "markus-lassfolk",
      "url": "https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/1025",
      "labels": [
        "documentation",
        "size/M",
        "queue:high",
        "enriched"
      ]
    },
    "current_labels": [
      "documentation",
      "size/M",
      "queue:high",
      "enriched"
    ]
  },
  "dispatched": true,
  "operations": [
    {
      "type": "addLabels",
      "method": "POST",
      "path": "/repos/markus-lassfolk/openclaw-hybrid-memory/issues/1025/labels",
      "body": {
        "labels": [
          "stage/dispatched"
        ]
      }
    },
    {
      "type": "removeLabel",
      "method": "DELETE",
      "path": "/repos/markus-lassfolk/openclaw-hybrid-memory/issues/1025/labels/enriched"
    }
  ]
}
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it introduces new GitHub API mutation paths (labels, comments, merges) that could affect repositories if misconfigured, though `dryRun` and recorded operations reduce blast radius during testing.
> 
> **Overview**
> Implements a local DuckFlux execution runtime that replaces the prior stub behavior by actually running `dispatch` and `lifecycle` workflows against GitHub.
> 
> Adds a fetch-based GitHub client with pagination, label/comment/merge operations, in-memory **dry-run** recording of planned mutations, and explicit handling of rate-limit responses via `GitHubRateLimitError`.
> 
> Introduces the `quack-runner` CLI to validate/lint and run workflows with `--dry-run` and input parsing, plus Node tests covering dispatch selection/capacity gating, lifecycle actions, and rate-limit behavior, and includes baseline `dispatch.duck.yaml`/`lifecycle.duck.yaml` workflow definitions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef0cbffbf4216841676b1c0b4503b4aa77d7837f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->