### PR TITLE
fix(memory): enforce session isolation for timeline recall

### DIFF
--- a/extensions/memory-hybrid/tests/memory-recall-timeline.test.ts
+++ b/extensions/memory-hybrid/tests/memory-recall-timeline.test.ts
@@ -82,7 +82,7 @@ describe("memory_recall_timeline tool", () => {
   it("returns narrative summaries with chronological metadata", async () => {
     const api = makeMockApi();
     narrativesDb.store({
-      sessionId: "s-timeline",
+      sessionId: "test-session",
       periodStart: Math.floor(Date.parse("2026-03-22T10:00:00.000Z") / 1000),
       periodEnd: Math.floor(Date.parse("2026-03-22T10:30:00.000Z") / 1000),
       tag: "session",
@@ -128,8 +128,39 @@ describe("memory_recall_timeline tool", () => {
     };
 
     expect(result.details?.count).toBe(1);
-    expect(result.details?.narratives[0]?.sessionId).toBe("s-timeline");
+    expect(result.details?.narratives[0]?.sessionId).toBe("test-session");
     expect(result.details?.narratives[0]?.periodStart).toBe("2026-03-22T10:00:00.000Z");
     expect(result.content?.[0]?.text).toContain("queue compaction");
+  });
+
+  it("rejects caller-supplied sessionId that does not match authenticated context", async () => {
+    const api = makeMockApi();
+    registerMemoryTools(
+      {
+        factsDb,
+        vectorDb: makeMockVectorDb(),
+        cfg: makeCfg(),
+        embeddings: makeMockEmbeddings(),
+        embeddingRegistry: null,
+        openai: {} as never,
+        wal: null,
+        credentialsDb: null,
+        eventLog,
+        narrativesDb,
+        lastProgressiveIndexIds: [],
+        currentAgentIdRef: { value: null },
+        pendingLLMWarnings: createPendingLLMWarnings(),
+      },
+      api as never,
+      noopScopeFilter as never,
+      walWrite,
+      walRemove,
+      findSimilarByEmbedding as never,
+    );
+
+    const tool = api.getTool("memory_recall_timeline");
+    await expect(tool?.execute("tool-call", { sessionId: "other-session" })).rejects.toThrow(
+      /must match the authenticated session context/i,
+    );
   });
 });

--- a/extensions/memory-hybrid/tests/memory-recall-timeline.test.ts
+++ b/extensions/memory-hybrid/tests/memory-recall-timeline.test.ts
@@ -118,7 +118,6 @@ describe("memory_recall_timeline tool", () => {
     const result = (await tool?.execute("tool-call", {
       query: "queue deadlock lease",
       limit: 1,
-      days: 30,
     })) as {
       content?: { type: string; text: string }[];
       details?: {

--- a/extensions/memory-hybrid/tools/memory-tools.ts
+++ b/extensions/memory-hybrid/tools/memory-tools.ts
@@ -434,8 +434,21 @@ export function registerMemoryTools(
         const MIN_SUMMARY_LIMIT = 1;
 
         const query = typeof params.query === "string" && params.query.trim().length > 0 ? params.query.trim() : null;
-        const sessionId =
+        const requestedSessionId =
           typeof params.sessionId === "string" && params.sessionId.trim().length > 0 ? params.sessionId.trim() : null;
+        const contextSessionId =
+          typeof api.context?.sessionId === "string" && api.context.sessionId.trim().length > 0
+            ? api.context.sessionId.trim()
+            : null;
+        if (requestedSessionId && contextSessionId && requestedSessionId !== contextSessionId) {
+          throw new Error("memory_recall_timeline sessionId must match the authenticated session context");
+        }
+        const sessionId = contextSessionId ?? requestedSessionId;
+        if (!sessionId) {
+          throw new Error(
+            "memory_recall_timeline requires an authenticated session context or a trusted server-derived sessionId",
+          );
+        }
 
         let days = typeof params.days === "number" && params.days > 0 ? Math.floor(params.days) : 7;
         days = Math.min(MAX_DAYS_LOOKBACK, Math.max(MIN_DAYS_LOOKBACK, days));
@@ -450,7 +463,7 @@ export function registerMemoryTools(
           sessionId,
           limit,
           nowSec,
-          sinceSec: sessionId ? undefined : nowSec - days * 86_400,
+          sinceSec: undefined,
         });
 
         if (summaries.length === 0) {

--- a/extensions/memory-hybrid/tools/memory-tools.ts
+++ b/extensions/memory-hybrid/tools/memory-tools.ts
@@ -412,13 +412,6 @@ export function registerMemoryTools(
               "Optional session id to fetch a specific session narrative or event timeline. In multi-tenant environments, only pass a sessionId derived from the authenticated context; never accept arbitrary end-user input here, to avoid cross-session data exposure.",
           }),
         ),
-        days: Type.Optional(
-          Type.Number({
-            description: "Look back window in days when sessionId is omitted (default: 7).",
-            minimum: 1,
-            maximum: 365,
-          }),
-        ),
         limit: Type.Optional(
           Type.Number({
             description: "Max summaries to return (default: 3).",
@@ -428,8 +421,6 @@ export function registerMemoryTools(
         ),
       }),
       async execute(_toolCallId: string, params: Record<string, unknown>) {
-        const MAX_DAYS_LOOKBACK = 365;
-        const MIN_DAYS_LOOKBACK = 1;
         const MAX_SUMMARY_LIMIT = 50;
         const MIN_SUMMARY_LIMIT = 1;
 
@@ -440,18 +431,15 @@ export function registerMemoryTools(
           typeof api.context?.sessionId === "string" && api.context.sessionId.trim().length > 0
             ? api.context.sessionId.trim()
             : null;
-        if (requestedSessionId && contextSessionId && requestedSessionId !== contextSessionId) {
-          throw new Error("memory_recall_timeline sessionId must match the authenticated session context");
-        }
-        const sessionId = contextSessionId ?? requestedSessionId;
-        if (!sessionId) {
+        if (!contextSessionId) {
           throw new Error(
-            "memory_recall_timeline requires an authenticated session context or a trusted server-derived sessionId",
+            "memory_recall_timeline requires an authenticated session context",
           );
         }
-
-        let days = typeof params.days === "number" && params.days > 0 ? Math.floor(params.days) : 7;
-        days = Math.min(MAX_DAYS_LOOKBACK, Math.max(MIN_DAYS_LOOKBACK, days));
+        if (requestedSessionId && requestedSessionId !== contextSessionId) {
+          throw new Error("memory_recall_timeline sessionId must match the authenticated session context");
+        }
+        const sessionId = contextSessionId;
 
         let limit = typeof params.limit === "number" && params.limit > 0 ? Math.floor(params.limit) : 3;
         limit = Math.min(MAX_SUMMARY_LIMIT, Math.max(MIN_SUMMARY_LIMIT, limit));
@@ -471,9 +459,7 @@ export function registerMemoryTools(
             content: [
               {
                 type: "text" as const,
-                text: sessionId
-                  ? `No narrative summary found for session ${sessionId}.`
-                  : `No narrative summaries found in the last ${days} day(s).`,
+                text: `No narrative summary found for session ${sessionId}.`,
               },
             ],
             details: { count: 0, narratives: [] },

--- a/extensions/memory-hybrid/tools/memory-tools.ts
+++ b/extensions/memory-hybrid/tools/memory-tools.ts
@@ -432,9 +432,7 @@ export function registerMemoryTools(
             ? api.context.sessionId.trim()
             : null;
         if (!contextSessionId) {
-          throw new Error(
-            "memory_recall_timeline requires an authenticated session context",
-          );
+          throw new Error("memory_recall_timeline requires an authenticated session context");
         }
         if (requestedSessionId && requestedSessionId !== contextSessionId) {
           throw new Error("memory_recall_timeline sessionId must match the authenticated session context");


### PR DESCRIPTION
### Motivation
- Prevent cross-session disclosure from the `memory_recall_timeline` tool which previously accepted caller-supplied `sessionId` and fell back to scanning narratives/events across all sessions when no sessionId was provided.
- Close an information-leak avenue where untrusted callers (or prompt-injected LLMs) could obtain narrative summaries from other sessions.

### Description
- Derive the effective session scope from the authenticated `api.context.sessionId` and treat caller `sessionId` as a hint only after verification. 
- Reject caller-provided `sessionId` when it does not match the authenticated session context and fail closed when no trusted session id is available.
- Always pass a concrete `sessionId` into `recallNarrativeSummaries` (remove the unscoped lookback path) to avoid scanning all sessions.
- Update tests to use the authenticated `test-session` and add a regression test that asserts a mismatched caller `sessionId` is rejected.

### Testing
- Ran `npm exec --prefix /workspace/openclaw-hybrid-memory/extensions/memory-hybrid -- vitest run tests/memory-recall-timeline.test.ts tests/narrative-recall.test.ts` and all tests passed.
- Test output: "Test Files  2 passed (2) / Tests  5 passed (5)" which includes the new regression test for mismatched `sessionId`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69df505949c083269bd1328c456d54bd)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Security-sensitive change to `memory_recall_timeline` session scoping that could affect what data is returned and may break callers that relied on unauthenticated or cross-session access. Main risk is accidental over-restriction or unexpected errors if `api.context.sessionId` is missing/mis-set.
> 
> **Overview**
> **Locks `memory_recall_timeline` to the authenticated session.** The tool now derives its effective `sessionId` solely from `api.context.sessionId`, fails closed when no authenticated session context is present, and rejects any caller-supplied `sessionId` that doesn’t match.
> 
> **Removes unscoped lookback behavior.** The `days` parameter and “scan recent narratives across sessions” path are removed; `recallNarrativeSummaries` is always called with a concrete `sessionId`, and the empty-result message is simplified accordingly.
> 
> **Tests updated/added.** Timeline recall tests now use an authenticated `test-session` and include a regression test asserting mismatched `sessionId` is rejected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b430202c754f2d51dc9a581f5c8c744282e37fdb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->