### PR TITLE
fix(security): gate memory_add_edict writes behind explicit opt-in

### DIFF
--- a/extensions/memory-hybrid/tests/memory-tools-embedding-registry.test.ts
+++ b/extensions/memory-hybrid/tests/memory-tools-embedding-registry.test.ts
@@ -101,6 +101,7 @@ afterEach(() => {
   factsDb.close();
   rmSync(tmpDir, { recursive: true, force: true });
   vi.clearAllMocks();
+  vi.unstubAllEnvs();
   vi.unstubAllGlobals();
 });
 
@@ -157,6 +158,57 @@ describe("memory tools embedding registry wiring", () => {
     expect(names).not.toContain("memory.remove_edict");
     expect(names).not.toContain("memory.edict_stats");
     expect(names.every((name) => /^[a-zA-Z0-9_-]{1,64}$/.test(name))).toBe(true);
+  });
+
+  it("blocks memory_add_edict writes by default unless explicitly enabled", async () => {
+    const api = makeMockApi();
+    const embeddings = makeMockEmbeddings();
+    const embeddingRegistry = buildEmbeddingRegistry(embeddings, embeddings.modelName, []);
+    const cfg = makeCfg();
+    const vectorDb = makeMockVectorDb();
+    const addEdict = vi.fn().mockReturnValue({
+      id: "edict-1",
+      text: "verified fact",
+      tags: [],
+      source: "human:markus",
+      ttl: "never",
+      expiresAt: null,
+    });
+
+    registerMemoryTools(
+      {
+        factsDb,
+        edictStore: { add: addEdict } as never,
+        vectorDb,
+        cfg,
+        embeddings,
+        embeddingRegistry,
+        openai: {} as never,
+        wal: null,
+        credentialsDb: null,
+        eventLog: null,
+        lastProgressiveIndexIds: [],
+        currentAgentIdRef: { value: null },
+        pendingLLMWarnings: createPendingLLMWarnings(),
+      },
+      api as never,
+      noopScopeFilter as never,
+      walWrite,
+      walRemove,
+      findSimilarByEmbedding as never,
+    );
+
+    const tool = api.getTool("memory_add_edict");
+    expect(tool).toBeTruthy();
+
+    const blocked = await tool!.execute("tc-1", { text: "verified fact" });
+    expect(blocked).toMatchObject({ details: { error: "forbidden", reason: "edict_write_disabled" } });
+    expect(addEdict).not.toHaveBeenCalled();
+
+    vi.stubEnv("OPENCLAW_ENABLE_EDICT_WRITE_TOOL", "true");
+    const allowed = await tool!.execute("tc-2", { text: "verified fact", source: "human:markus" });
+    expect(allowed).toMatchObject({ details: { edict: { id: "edict-1" } } });
+    expect(addEdict).toHaveBeenCalledTimes(1);
   });
 
   it("memory_directory list_contacts and org_view return structured results", async () => {

--- a/extensions/memory-hybrid/tools/memory-tools.ts
+++ b/extensions/memory-hybrid/tools/memory-tools.ts
@@ -117,6 +117,11 @@ function hasBoundMemoryToolHelpers(ctx: MemoryToolsContext | LegacyMemoryToolsCo
   return hasAllNewHelpers && !hasLegacyWal;
 }
 
+function isEdictWriteToolEnabled(): boolean {
+  const raw = process.env.OPENCLAW_ENABLE_EDICT_WRITE_TOOL;
+  return raw === "1" || raw?.toLowerCase() === "true";
+}
+
 async function storeRegistryEmbeddings({
   factsDb,
   embeddingRegistry,
@@ -2658,6 +2663,18 @@ export function registerMemoryTools(
       "Only Markus (the human) should use this tool directly.";
     const _execAddEdict = async (_toolCallId: string, params: Record<string, unknown>) => {
       try {
+        if (!isEdictWriteToolEnabled()) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: 'memory_add_edict is disabled. Propose edicts via GitHub comment: [EDICT CANDIDATE] text="..." reason="..." tags=[...].',
+              },
+            ],
+            details: { error: "forbidden", reason: "edict_write_disabled" },
+          };
+        }
+
         const { text, source, tags, ttl, expiresAt } = params as {
           text: string;
           source?: string;

--- a/extensions/memory-hybrid/tools/memory-tools.ts
+++ b/extensions/memory-hybrid/tools/memory-tools.ts
@@ -117,7 +117,7 @@ function hasBoundMemoryToolHelpers(ctx: MemoryToolsContext | LegacyMemoryToolsCo
   return hasAllNewHelpers && !hasLegacyWal;
 }
 
-import { getEnv } from "../utils/env-manager";
+import { getEnv } from "../utils/env-manager.js";
 
 function isEdictWriteToolEnabled(): boolean {
   const raw = getEnv("OPENCLAW_ENABLE_EDICT_WRITE_TOOL");

--- a/extensions/memory-hybrid/tools/memory-tools.ts
+++ b/extensions/memory-hybrid/tools/memory-tools.ts
@@ -57,6 +57,7 @@ import { UUID_REGEX, getSessionLogFileSuffix } from "../utils/constants.js";
 import { detectFutureDate } from "../utils/date-detector.js";
 import { parseSourceDate } from "../utils/dates.js";
 import { embedCallWithTimeoutAndRetry } from "../utils/embed-call.js";
+import { getEnv } from "../utils/env-manager.js";
 import { extractTags } from "../utils/tags.js";
 import { truncateForStorage } from "../utils/text.js";
 
@@ -116,8 +117,6 @@ function hasBoundMemoryToolHelpers(ctx: MemoryToolsContext | LegacyMemoryToolsCo
 
   return hasAllNewHelpers && !hasLegacyWal;
 }
-
-import { getEnv } from "../utils/env-manager.js";
 
 function isEdictWriteToolEnabled(): boolean {
   const raw = getEnv("OPENCLAW_ENABLE_EDICT_WRITE_TOOL");

--- a/extensions/memory-hybrid/tools/memory-tools.ts
+++ b/extensions/memory-hybrid/tools/memory-tools.ts
@@ -117,8 +117,10 @@ function hasBoundMemoryToolHelpers(ctx: MemoryToolsContext | LegacyMemoryToolsCo
   return hasAllNewHelpers && !hasLegacyWal;
 }
 
+import { getEnv } from "../utils/env-manager";
+
 function isEdictWriteToolEnabled(): boolean {
-  const raw = process.env.OPENCLAW_ENABLE_EDICT_WRITE_TOOL;
+  const raw = getEnv("OPENCLAW_ENABLE_EDICT_WRITE_TOOL");
   return raw === "1" || raw?.toLowerCase() === "true";
 }
 

--- a/extensions/memory-hybrid/tools/memory-tools.ts
+++ b/extensions/memory-hybrid/tools/memory-tools.ts
@@ -2849,6 +2849,18 @@ export function registerMemoryTools(
     const _updateEdictDesc = "Update the text, tags, source, or expiry of an existing edict.";
     const _execUpdateEdict = async (_toolCallId: string, params: Record<string, unknown>) => {
       try {
+        if (!isEdictWriteToolEnabled()) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: 'memory_update_edict is disabled. Propose edicts via GitHub comment: [EDICT CANDIDATE] text="..." reason="..." tags=[...].',
+              },
+            ],
+            details: { error: "forbidden", reason: "edict_write_disabled" },
+          };
+        }
+
         const { id, text, source, tags, ttl, expiresAt } = params as {
           id: string;
           text?: string;
@@ -2920,6 +2932,18 @@ export function registerMemoryTools(
     const _removeEdictDesc = "Delete an edict from memory by its id.";
     const _execRemoveEdict = async (_toolCallId: string, params: Record<string, unknown>) => {
       try {
+        if (!isEdictWriteToolEnabled()) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: 'memory_remove_edict is disabled. Propose edicts via GitHub comment: [EDICT CANDIDATE] text="..." reason="..." tags=[...].',
+              },
+            ],
+            details: { error: "forbidden", reason: "edict_write_disabled" },
+          };
+        }
+
         const { id } = params as { id: string };
         const removed = edictStore.remove(id);
         return {


### PR DESCRIPTION
### Motivation
- Prevent untrusted callers from persisting edicts that are force-injected into system prompts, which allowed persistent prompt-injection by any tool caller.

### Description
- Add a runtime gate `isEdictWriteToolEnabled()` and check it in the `memory_add_edict` tool handler to block writes unless explicitly enabled via `OPENCLAW_ENABLE_EDICT_WRITE_TOOL`.
- When disabled, the tool returns a clear `forbidden` response and points to the GitHub `[EDICT CANDIDATE]` proposal flow instead of calling `edictStore.add`.
- Add a regression test to `memory-tools-embedding-registry.test.ts` that verifies the write path is blocked by default and allowed when `OPENCLAW_ENABLE_EDICT_WRITE_TOOL=true`, and restore env cleanup with `vi.unstubAllEnvs()` in `afterEach`.
- Files changed: `extensions/memory-hybrid/tools/memory-tools.ts` and `extensions/memory-hybrid/tests/memory-tools-embedding-registry.test.ts`.

### Testing
- Ran the focused test: `npm --prefix extensions/memory-hybrid run test -- memory-tools-embedding-registry.test.ts`, and it passed (Test Files 1 passed, Tests 5 passed).
- Ran lint for the modified files: `npm --prefix extensions/memory-hybrid run lint -- tools/memory-tools.ts tests/memory-tools-embedding-registry.test.ts`; the command succeeded and reported pre-existing repository lint warnings (no new lint errors introduced by this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69df4dde23d48326aca8b101001e68c5)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes runtime behavior of `memory_add_edict`/`memory_update_edict`/`memory_remove_edict` to deny writes by default, which is security-sensitive and could break existing automation unless the env flag is set.
> 
> **Overview**
> **Edict write tools are now opt-in at runtime.** `memory_add_edict`, `memory_update_edict`, and `memory_remove_edict` return a `forbidden` response unless `OPENCLAW_ENABLE_EDICT_WRITE_TOOL` is set (accepts `true`/`1`), preventing untrusted callers from persisting prompt-injected edicts.
> 
> Adds a regression test that verifies writes are blocked by default and allowed when the env flag is enabled, and ensures env stubs are cleaned up with `vi.unstubAllEnvs()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1af70feb68069d7877f7be37f8f4873b50f4532. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->