### PR TITLE
feat: #1028 presentation strategy for hybrid-memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
 
 </div>
 
+Hybrid Memory makes OpenClaw feel like a serious product instead of a clever demo: durable context that stays **local-first**, **inspectable**, and under operator control.
+
 ## Mental model first
 
 ```mermaid
@@ -32,6 +34,14 @@ Hybrid Memory keeps durable context in your control:
 - `Control`: explicit config modes, export, backup, and delete paths
 
 ![Hybrid Memory dashboard mock](docs/assets/hybrid-memory-dashboard-mock.svg)
+
+## Remember these 3 things
+
+1. **Local-first by default** — memory stays on your machine unless you explicitly choose external providers.
+2. **Inspectable and controllable** — verify, search, export, back up, and delete it with explicit paths.
+3. **Hybrid retrieval** — structured facts and semantic recall work together, so it is stronger than session-only memory or a naive vector store.
+
+Short version: **not just session memory, not just a vector store, and not a black-box hosted memory service.**
 
 ## What users ask first
 
@@ -83,19 +93,20 @@ Guide: [docs/advanced-capabilities.md](docs/advanced-capabilities.md)
 
 ## Comparison at a glance
 
-| Capability | Session-only memory | Generic vector memory | **Hybrid Memory** |
-|---|---:|---:|---:|
-| Persists across sessions | No | Yes | Yes |
-| Structured + semantic retrieval | No | Usually semantic-only | Yes (merged ranking) |
-| Inspectability (stats/verify/provenance) | Low | Medium | High |
-| Explicit trust/deletion controls | Low | Varies | High |
-| Local-first operation | N/A | Sometimes | Yes |
-| Multi-agent scope controls | No | Limited | Yes |
+| Capability | Session-only memory | Naive vector memory | Hosted memory | **Hybrid Memory** |
+|---|---:|---:|---:|---:|
+| Persists across sessions | No | Yes | Yes | Yes |
+| Local-first by default | N/A | Sometimes | Rarely | Yes |
+| Structured + semantic retrieval | No | Usually semantic-only | Varies | Yes |
+| Inspectability (stats / verify / provenance) | Low | Medium | Medium | High |
+| Explicit trust / deletion / export paths | Low | Limited | Provider-dependent | High |
+| Multi-agent scope controls | No | Limited | Varies | Yes |
 
 ## Fast path docs
 
 - [docs/QUICKSTART.md](docs/QUICKSTART.md): shortest successful path
 - [docs/trust-and-privacy.md](docs/trust-and-privacy.md): local-first, provenance, deletion, export
+- [docs/PRESENTATION-STRATEGY.md](docs/PRESENTATION-STRATEGY.md): product message, visuals, demos, terminology
 - [docs/OPERATIONS.md](docs/OPERATIONS.md): maintenance, backup, restore, troubleshooting
 - [docs/advanced-capabilities.md](docs/advanced-capabilities.md): graph, workflows, procedures, crystallization
 

--- a/docs/PRESENTATION-STRATEGY.md
+++ b/docs/PRESENTATION-STRATEGY.md
@@ -1,0 +1,229 @@
+---
+layout: default
+title: Presentation strategy
+nav_order: 12
+---
+
+# Presentation strategy
+
+This is the canonical short-form story for how **Hybrid Memory** should be presented in the README, docs site, demos, and future UI copy.
+
+The goal is not to make the product sound simpler than it is. The goal is to make its strength visible faster.
+
+---
+
+## Product message in one sentence
+
+**Hybrid Memory gives OpenClaw durable context that stays local-first, inspectable, and useful over time.**
+
+---
+
+## The 3 things people should remember
+
+1. **Local-first by default**  
+   Your memory stays on your machine unless you explicitly choose external providers.
+
+2. **Inspectable and controllable**  
+   You can verify, search, export, back up, and delete it. This is memory you can audit, not a black box you hope is behaving.
+
+3. **Hybrid retrieval beats session-only or vector-only memory**  
+   Structured facts, semantic search, provenance, and maintenance work together, so recall is stronger and easier to trust.
+
+These three points should show up repeatedly in README, docs home, trust/privacy copy, demos, and any future UI landing surfaces.
+
+---
+
+## Messaging brief
+
+### Tagline
+
+**Local-first memory for OpenClaw that stays inspectable, trustworthy, and useful over time.**
+
+### Elevator pitch
+
+Hybrid Memory turns OpenClaw from a good session assistant into a system that can remember across sessions without becoming opaque or messy. It stores durable context locally by default, merges structured and semantic recall, and gives operators proof paths like verify, search, export, backup, and delete.
+
+### Trust / privacy pitch
+
+Most memory products optimise for convenience first and explainability later. Hybrid Memory starts from operator trust: local-first storage, explicit controls, inspectable recall paths, and documentation that tells you where the data lives and how to remove it.
+
+### Why this exists
+
+Session-only memory makes every serious workflow repetitive. Naive vector memory can retrieve vibes but often struggles with provenance, structure, and control. Hosted memory can be convenient, but it can also feel distant and opaque. Hybrid Memory exists to offer a stronger trade-off: durable memory that still feels serious, inspectable, and under your control.
+
+---
+
+## Comparison messaging
+
+Use these contrasts when positioning the project:
+
+| Compared to… | Say this | Do not imply |
+|---|---|---|
+| **Session-only memory** | "Useful in the moment, but it starts from zero again." | That session memory is useless — it is just insufficient for long-running work. |
+| **Naive vector memory** | "Good at fuzzy recall, weaker at structure, provenance, and operator control." | That vector search is bad — Hybrid Memory includes it, but does not stop there. |
+| **Hosted memory** | "Convenient, but often more opaque and less local than serious operators want." | That hosted memory is always wrong — the distinction is trust model and control surface. |
+| **Hybrid Memory** | "Local-first, inspectable, and stronger than a single retrieval strategy." | That it is magically correct — the point is proof, control, and better defaults. |
+
+Short comparison line for first-run surfaces:
+
+> **Not just session memory. Not just a vector store. Not a black-box hosted memory service.**
+
+---
+
+## Visual proof package
+
+The product should show proof, not just describe capability.
+
+### Asset list
+
+| Asset | Purpose | Status |
+|---|---|---|
+| `docs/assets/hybrid-memory-dashboard-mock.svg` | Hero image: shows that the product has an inspectable surface, not only invisible internals | Existing |
+| `docs/assets/hybrid-memory-product-architecture.svg` | Product architecture: capture → store → recall → inspect → control | Added in this workstream |
+| `docs/assets/hybrid-memory-retrieval-proof.svg` | Retrieval explanation: structured + semantic recall merged into inspectable answers | Added in this workstream |
+| `docs/assets/hybrid-memory-onboarding-before-after.svg` | Before/after onboarding flow: from plugin setup to proof-first adoption | Added in this workstream |
+| README "What users ask first" table | FAQ-style trust proof on the main landing surface | Existing, now part of the presentation system |
+
+### Hero screenshots / proof points
+
+1. **Dashboard / inspection surface**  
+   Show that memory is visible and navigable.
+2. **Retrieval proof**  
+   Show that recall is not a black box: structured + semantic + provenance.
+3. **Trust / control flow**  
+   Show verify, backup/export, and delete paths.
+4. **Onboarding clarity**  
+   Show that first-run setup moves from install to trust quickly.
+
+### Diagrams
+
+#### Product architecture
+
+![Hybrid Memory product architecture](assets/hybrid-memory-product-architecture.svg)
+
+#### Retrieval proof
+
+![Hybrid Memory retrieval proof](assets/hybrid-memory-retrieval-proof.svg)
+
+#### Before / after onboarding
+
+![Hybrid Memory onboarding flow](assets/hybrid-memory-onboarding-before-after.svg)
+
+---
+
+## Demo package
+
+### 60-second demo
+
+**Goal:** make the product feel real in under a minute.
+
+1. State a preference or decision:  
+   `Remember that I avoid lunch meetings and Alice owns the API contract.`
+2. Start a fresh session / ask a follow-up later:  
+   `Find a slot with Alice next week.`
+3. Show the answer uses the remembered constraint.
+4. Immediately prove it is inspectable:  
+   run `openclaw hybrid-mem search "Alice lunch meetings"` or `openclaw hybrid-mem stats`.
+5. Close with the line:  
+   **"It remembers across sessions, it stays local-first, and you can inspect what it knows."**
+
+### 5-minute operator demo
+
+**Goal:** show this is serious infrastructure, not a memory gimmick.
+
+1. **Install and verify**  
+   `openclaw plugins install openclaw-hybrid-memory`  
+   `openclaw hybrid-mem install`  
+   `openclaw hybrid-mem verify`
+2. **Store something durable**  
+   Use `memory_store` or natural conversation.
+3. **Recall it in a new context**  
+   Ask a question that depends on the stored fact.
+4. **Inspect and prove**  
+   Show `search`, `stats`, or export-related commands.
+5. **Show control**  
+   Mention backup/export/delete and trust docs.
+6. **Close with differentiators**  
+   Local-first. Inspectable. Hybrid retrieval.
+
+### "Why local-first memory matters" demo
+
+**Goal:** make privacy and trust concrete without fear-mongering.
+
+1. Show where the data lives locally.
+2. Show the commands used to inspect it.
+3. Show the commands used to back it up or remove it.
+4. Contrast with the hosted-memory trade-off in one sentence:  
+   **"Convenience is easy to buy; operator trust is harder. This project optimises for trust first."**
+
+---
+
+## Terminology audit
+
+Use layered language: plain first, exact second.
+
+| Internal / dense term | First-run wording | When to introduce the exact term |
+|---|---|---|
+| `memory-hybrid plugin` | **Hybrid Memory** | Installation, repo layout, or config specifics |
+| SQLite + LanceDB + files | **local memory store** | Architecture / operations docs |
+| RRF / merged ranking | **structured + semantic recall** | Retrieval deep dives |
+| auto-capture | **remembers important things automatically** | Feature internals |
+| memory tiering / compaction | **keeps memory fresh and bounded** | Operations tuning |
+| graph retrieval | **follows related facts** | Advanced capability docs |
+| procedural memory | **learned workflows** | Advanced capability docs |
+| persona proposals | **identity updates the agent can suggest** | Feature-specific docs |
+| edicts / verification store | **verified ground truth** | Governance / verification docs |
+
+### Naming guidance
+
+- Prefer **Hybrid Memory** over **memory-hybrid** in user-facing copy.
+- Prefer **local-first** over **on-device** unless hardware locality is the point.
+- Prefer **inspectable** and **verifiable** over vague words like **transparent** unless proof paths are shown nearby.
+- Prefer **show its work** for demos; prefer **provenance / verify** for operator docs.
+
+---
+
+## Copy system: what to repeat
+
+### Approved phrases
+
+- **local-first by default**
+- **inspectable and controllable**
+- **show your work**
+- **durable context**
+- **structured + semantic recall**
+- **trustworthy over time**
+- **serious operator workflow**
+
+### Avoid as first-contact copy
+
+- "hierarchical hybrid memory substrate"
+- "FTS5 + LanceDB fusion"
+- "RRF-based retrieval"
+- "dynamic derived data"
+- "memory slot plugin"
+
+Those terms belong in deep docs, not in the first paragraph.
+
+---
+
+## Surface guidance
+
+| Surface | Primary message | Supporting proof |
+|---|---|---|
+| **README hero** | Local-first, inspectable, useful over time | Hero image + FAQ table + comparison matrix |
+| **Docs home** | Persistent memory that stays under your control | Before/after table + repeated differentiators |
+| **Trust & privacy page** | Trust is a feature, not a footnote | Local storage, verify, backup, export, delete |
+| **Scenarios page** | Less repetition, better continuity, more confidence | Concrete before/after situations |
+| **Future UI landing surfaces** | Show what the system knows and how to inspect it | Search, provenance, stats, export, delete |
+
+---
+
+## Acceptance check
+
+This workstream is successful when:
+
+- the one-sentence message is obvious
+- the three differentiators are repeated consistently
+- demo stories prove trust instead of merely claiming it
+- terminology gets simpler for first-time readers without losing precision later

--- a/docs/SCENARIOS.md
+++ b/docs/SCENARIOS.md
@@ -7,7 +7,7 @@ nav_order: 2
 
 # Scenarios & benefits
 
-Hybrid Memory is built for **people who use an AI assistant as a partner**, not a one-off chat. These are the situations where it pays off.
+Hybrid Memory is built for **people who use an AI assistant as a partner**, not a one-off chat. It matters most when memory needs to be durable, local-first, and inspectable rather than merely clever. These are the situations where it pays off.
 
 ---
 
@@ -72,6 +72,7 @@ The [repository README](https://github.com/markus-lassfolk/openclaw-hybrid-memor
 | Fewer “I already told you” moments | Relevant memories are pulled into context automatically when configured |
 | Less copy-paste from old threads | Long-term facts live outside a single conversation transcript |
 | Answers that fit *your* defaults | Preferences and decisions persist |
+| You can explain why a memory showed up | Search, verification, and provenance give you proof paths |
 | A system you can trust over weeks | Background consolidation, optional reflection, and cleanup run on a schedule you control |
 
 ---

--- a/docs/assets/hybrid-memory-onboarding-before-after.svg
+++ b/docs/assets/hybrid-memory-onboarding-before-after.svg
@@ -1,0 +1,41 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="760" viewBox="0 0 1200 760" fill="none">
+  <rect width="1200" height="760" fill="#0B1220"/>
+  <rect x="40" y="40" width="1120" height="680" rx="28" fill="#101A2F" stroke="#24324D" stroke-width="2"/>
+  <text x="80" y="110" fill="#F8FAFC" font-size="34" font-family="Arial, Helvetica, sans-serif" font-weight="700">Before / after onboarding flow</text>
+  <text x="80" y="145" fill="#93A4BF" font-size="19" font-family="Arial, Helvetica, sans-serif">The key change: move from capability sprawl to a proof-first product story.</text>
+
+  <rect x="90" y="200" width="470" height="430" rx="24" fill="#1A2236" stroke="#334155" stroke-width="2"/>
+  <text x="125" y="250" fill="#FDE68A" font-size="28" font-family="Arial, Helvetica, sans-serif" font-weight="700">Before</text>
+  <text x="125" y="286" fill="#CBD5E1" font-size="19" font-family="Arial, Helvetica, sans-serif">Feature depth leads the story.</text>
+
+  <rect x="125" y="320" width="400" height="62" rx="14" fill="#0F172A" stroke="#334155"/>
+  <text x="155" y="359" fill="#E2E8F0" font-size="20" font-family="Arial, Helvetica, sans-serif">1. Explain many subsystems up front</text>
+
+  <rect x="125" y="398" width="400" height="62" rx="14" fill="#0F172A" stroke="#334155"/>
+  <text x="155" y="437" fill="#E2E8F0" font-size="20" font-family="Arial, Helvetica, sans-serif">2. Mention vectors, tiers, graphs, RRF</text>
+
+  <rect x="125" y="476" width="400" height="62" rx="14" fill="#0F172A" stroke="#334155"/>
+  <text x="155" y="515" fill="#E2E8F0" font-size="20" font-family="Arial, Helvetica, sans-serif">3. Trust story appears later, if at all</text>
+
+  <rect x="125" y="554" width="400" height="62" rx="14" fill="#0F172A" stroke="#334155"/>
+  <text x="155" y="593" fill="#E2E8F0" font-size="20" font-family="Arial, Helvetica, sans-serif">4. Product feels heavier than it is</text>
+
+  <rect x="640" y="200" width="470" height="430" rx="24" fill="#14263C" stroke="#2C4163" stroke-width="2"/>
+  <text x="675" y="250" fill="#86EFAC" font-size="28" font-family="Arial, Helvetica, sans-serif" font-weight="700">After</text>
+  <text x="675" y="286" fill="#DBEAFE" font-size="19" font-family="Arial, Helvetica, sans-serif">Start with the product promise, then prove it.</text>
+
+  <rect x="675" y="320" width="400" height="62" rx="14" fill="#0F172A" stroke="#2C4163"/>
+  <text x="705" y="359" fill="#F8FAFC" font-size="20" font-family="Arial, Helvetica, sans-serif">1. Local-first memory for OpenClaw</text>
+
+  <rect x="675" y="398" width="400" height="62" rx="14" fill="#0F172A" stroke="#2C4163"/>
+  <text x="705" y="437" fill="#F8FAFC" font-size="20" font-family="Arial, Helvetica, sans-serif">2. Show inspect / verify / export paths</text>
+
+  <rect x="675" y="476" width="400" height="62" rx="14" fill="#0F172A" stroke="#2C4163"/>
+  <text x="705" y="515" fill="#F8FAFC" font-size="20" font-family="Arial, Helvetica, sans-serif">3. Explain hybrid retrieval second</text>
+
+  <rect x="675" y="554" width="400" height="62" rx="14" fill="#0F172A" stroke="#2C4163"/>
+  <text x="705" y="593" fill="#F8FAFC" font-size="20" font-family="Arial, Helvetica, sans-serif">4. Product feels serious, elegant, usable</text>
+
+  <path d="M585 410 L615 410" stroke="#64748B" stroke-width="6" stroke-linecap="round"/>
+  <path d="M607 392 L630 410 L607 428" stroke="#64748B" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/docs/assets/hybrid-memory-product-architecture.svg
+++ b/docs/assets/hybrid-memory-product-architecture.svg
@@ -1,0 +1,56 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="760" viewBox="0 0 1200 760" fill="none">
+  <rect width="1200" height="760" fill="#0B1220"/>
+  <rect x="40" y="40" width="1120" height="680" rx="28" fill="#101A2F" stroke="#24324D" stroke-width="2"/>
+  <text x="80" y="110" fill="#F8FAFC" font-size="34" font-family="Arial, Helvetica, sans-serif" font-weight="700">Hybrid Memory product architecture</text>
+  <text x="80" y="145" fill="#93A4BF" font-size="19" font-family="Arial, Helvetica, sans-serif">The product story is not just storage. It is capture → store → recall → inspect → control.</text>
+
+  <rect x="80" y="205" width="190" height="120" rx="22" fill="#1D4ED8"/>
+  <text x="175" y="254" text-anchor="middle" fill="#EFF6FF" font-size="26" font-family="Arial, Helvetica, sans-serif" font-weight="700">Capture</text>
+  <text x="175" y="286" text-anchor="middle" fill="#DBEAFE" font-size="17" font-family="Arial, Helvetica, sans-serif">facts, preferences,</text>
+  <text x="175" y="308" text-anchor="middle" fill="#DBEAFE" font-size="17" font-family="Arial, Helvetica, sans-serif">decisions, workflows</text>
+
+  <rect x="292" y="205" width="190" height="120" rx="22" fill="#0F766E"/>
+  <text x="387" y="254" text-anchor="middle" fill="#ECFEFF" font-size="26" font-family="Arial, Helvetica, sans-serif" font-weight="700">Store</text>
+  <text x="387" y="286" text-anchor="middle" fill="#CCFBF1" font-size="17" font-family="Arial, Helvetica, sans-serif">SQLite + vectors +</text>
+  <text x="387" y="308" text-anchor="middle" fill="#CCFBF1" font-size="17" font-family="Arial, Helvetica, sans-serif">provenance metadata</text>
+
+  <rect x="504" y="205" width="190" height="120" rx="22" fill="#7C3AED"/>
+  <text x="599" y="254" text-anchor="middle" fill="#F5F3FF" font-size="26" font-family="Arial, Helvetica, sans-serif" font-weight="700">Recall</text>
+  <text x="599" y="286" text-anchor="middle" fill="#EDE9FE" font-size="17" font-family="Arial, Helvetica, sans-serif">structured lookup +</text>
+  <text x="599" y="308" text-anchor="middle" fill="#EDE9FE" font-size="17" font-family="Arial, Helvetica, sans-serif">semantic retrieval</text>
+
+  <rect x="716" y="205" width="190" height="120" rx="22" fill="#EA580C"/>
+  <text x="811" y="254" text-anchor="middle" fill="#FFF7ED" font-size="26" font-family="Arial, Helvetica, sans-serif" font-weight="700">Inspect</text>
+  <text x="811" y="286" text-anchor="middle" fill="#FFEDD5" font-size="17" font-family="Arial, Helvetica, sans-serif">verify, search, stats,</text>
+  <text x="811" y="308" text-anchor="middle" fill="#FFEDD5" font-size="17" font-family="Arial, Helvetica, sans-serif">export, dashboards</text>
+
+  <rect x="928" y="205" width="190" height="120" rx="22" fill="#BE123C"/>
+  <text x="1023" y="254" text-anchor="middle" fill="#FFF1F2" font-size="26" font-family="Arial, Helvetica, sans-serif" font-weight="700">Control</text>
+  <text x="1023" y="286" text-anchor="middle" fill="#FFE4E6" font-size="17" font-family="Arial, Helvetica, sans-serif">config, backup,</text>
+  <text x="1023" y="308" text-anchor="middle" fill="#FFE4E6" font-size="17" font-family="Arial, Helvetica, sans-serif">restore, delete</text>
+
+  <g stroke="#5B6B86" stroke-width="4" stroke-linecap="round">
+    <line x1="270" y1="265" x2="292" y2="265"/>
+    <line x1="482" y1="265" x2="504" y2="265"/>
+    <line x1="694" y1="265" x2="716" y2="265"/>
+    <line x1="906" y1="265" x2="928" y2="265"/>
+  </g>
+
+  <rect x="80" y="385" width="1038" height="255" rx="24" fill="#0F172A" stroke="#24324D" stroke-width="2"/>
+  <text x="110" y="432" fill="#E2E8F0" font-size="26" font-family="Arial, Helvetica, sans-serif" font-weight="700">Why this feels like a product rather than a pile of features</text>
+
+  <rect x="110" y="470" width="300" height="130" rx="18" fill="#132238" stroke="#2C4163"/>
+  <text x="140" y="514" fill="#F8FAFC" font-size="24" font-family="Arial, Helvetica, sans-serif" font-weight="700">Local-first by default</text>
+  <text x="140" y="548" fill="#C7D2E1" font-size="18" font-family="Arial, Helvetica, sans-serif">Memory lives on your machine unless</text>
+  <text x="140" y="572" fill="#C7D2E1" font-size="18" font-family="Arial, Helvetica, sans-serif">you deliberately choose otherwise.</text>
+
+  <rect x="450" y="470" width="300" height="130" rx="18" fill="#132238" stroke="#2C4163"/>
+  <text x="480" y="514" fill="#F8FAFC" font-size="24" font-family="Arial, Helvetica, sans-serif" font-weight="700">Inspectable and controllable</text>
+  <text x="480" y="548" fill="#C7D2E1" font-size="18" font-family="Arial, Helvetica, sans-serif">You can verify, search, export, back up,</text>
+  <text x="480" y="572" fill="#C7D2E1" font-size="18" font-family="Arial, Helvetica, sans-serif">and delete it with explicit paths.</text>
+
+  <rect x="790" y="470" width="298" height="130" rx="18" fill="#132238" stroke="#2C4163"/>
+  <text x="820" y="514" fill="#F8FAFC" font-size="24" font-family="Arial, Helvetica, sans-serif" font-weight="700">Hybrid retrieval</text>
+  <text x="820" y="548" fill="#C7D2E1" font-size="18" font-family="Arial, Helvetica, sans-serif">Structured facts and semantic recall</text>
+  <text x="820" y="572" fill="#C7D2E1" font-size="18" font-family="Arial, Helvetica, sans-serif">work together instead of competing.</text>
+</svg>

--- a/docs/assets/hybrid-memory-retrieval-proof.svg
+++ b/docs/assets/hybrid-memory-retrieval-proof.svg
@@ -1,0 +1,38 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="720" viewBox="0 0 1200 720" fill="none">
+  <rect width="1200" height="720" fill="#0B1220"/>
+  <rect x="40" y="40" width="1120" height="640" rx="28" fill="#101A2F" stroke="#24324D" stroke-width="2"/>
+  <text x="80" y="110" fill="#F8FAFC" font-size="34" font-family="Arial, Helvetica, sans-serif" font-weight="700">Retrieval proof: show your work</text>
+  <text x="80" y="145" fill="#93A4BF" font-size="19" font-family="Arial, Helvetica, sans-serif">The memorable story is not “we have memory.” It is “we can explain why a result appeared.”</text>
+
+  <rect x="90" y="240" width="250" height="120" rx="22" fill="#1E293B" stroke="#334155" stroke-width="2"/>
+  <text x="215" y="286" text-anchor="middle" fill="#F8FAFC" font-size="25" font-family="Arial, Helvetica, sans-serif" font-weight="700">User asks</text>
+  <text x="215" y="318" text-anchor="middle" fill="#CBD5E1" font-size="18" font-family="Arial, Helvetica, sans-serif">“What did we decide</text>
+  <text x="215" y="342" text-anchor="middle" fill="#CBD5E1" font-size="18" font-family="Arial, Helvetica, sans-serif">about auth?”</text>
+
+  <rect x="430" y="170" width="250" height="120" rx="22" fill="#0F766E"/>
+  <text x="555" y="216" text-anchor="middle" fill="#ECFEFF" font-size="25" font-family="Arial, Helvetica, sans-serif" font-weight="700">Structured recall</text>
+  <text x="555" y="248" text-anchor="middle" fill="#CCFBF1" font-size="18" font-family="Arial, Helvetica, sans-serif">facts, decisions,</text>
+  <text x="555" y="272" text-anchor="middle" fill="#CCFBF1" font-size="18" font-family="Arial, Helvetica, sans-serif">entities, scopes</text>
+
+  <rect x="430" y="330" width="250" height="120" rx="22" fill="#7C3AED"/>
+  <text x="555" y="376" text-anchor="middle" fill="#F5F3FF" font-size="25" font-family="Arial, Helvetica, sans-serif" font-weight="700">Semantic recall</text>
+  <text x="555" y="408" text-anchor="middle" fill="#EDE9FE" font-size="18" font-family="Arial, Helvetica, sans-serif">meaning-level search</text>
+  <text x="555" y="432" text-anchor="middle" fill="#EDE9FE" font-size="18" font-family="Arial, Helvetica, sans-serif">when wording differs</text>
+
+  <rect x="780" y="240" width="310" height="160" rx="22" fill="#EA580C"/>
+  <text x="935" y="286" text-anchor="middle" fill="#FFF7ED" font-size="25" font-family="Arial, Helvetica, sans-serif" font-weight="700">Inspectable answer</text>
+  <text x="935" y="320" text-anchor="middle" fill="#FFEDD5" font-size="18" font-family="Arial, Helvetica, sans-serif">best matches with provenance,</text>
+  <text x="935" y="344" text-anchor="middle" fill="#FFEDD5" font-size="18" font-family="Arial, Helvetica, sans-serif">verification paths, and operator</text>
+  <text x="935" y="368" text-anchor="middle" fill="#FFEDD5" font-size="18" font-family="Arial, Helvetica, sans-serif">commands like search / stats / export</text>
+
+  <g stroke="#5B6B86" stroke-width="4" stroke-linecap="round">
+    <line x1="340" y1="300" x2="430" y2="230"/>
+    <line x1="340" y1="300" x2="430" y2="390"/>
+    <line x1="680" y1="230" x2="780" y2="290"/>
+    <line x1="680" y1="390" x2="780" y2="350"/>
+  </g>
+
+  <rect x="90" y="500" width="1000" height="120" rx="20" fill="#0F172A" stroke="#24324D" stroke-width="2"/>
+  <text x="120" y="548" fill="#F8FAFC" font-size="24" font-family="Arial, Helvetica, sans-serif" font-weight="700">What to say out loud in demos</text>
+  <text x="120" y="584" fill="#C7D2E1" font-size="20" font-family="Arial, Helvetica, sans-serif">“It does not just remember. It can show why this answer came back, and it gives you commands to verify or remove it.”</text>
+</svg>

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,15 +8,25 @@ permalink: /
 # OpenClaw Hybrid Memory
 {: .fs-9 }
 
-Durable, structured, searchable memory for OpenClaw agents.
+Local-first memory for OpenClaw that stays inspectable, trustworthy, and useful over time.
 {: .fs-6 .fw-300 }
 
-Your OpenClaw agent forgets everything between sessions. Hybrid Memory fixes this &mdash; it gives your agent **persistent memory** that auto-captures what matters and recalls it when relevant.
+Hybrid Memory gives your OpenClaw agent **persistent memory** without turning memory into a black box. It can remember across sessions, show its work when you need proof, and stay under your control.
 {: .fs-5 .fw-300 }
 
 [Get Started](QUICKSTART){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 }
 [Scenarios & benefits](SCENARIOS){: .btn .fs-5 .mb-4 .mb-md-0 .mr-2 }
 [View on GitHub](https://github.com/markus-lassfolk/openclaw-hybrid-memory){: .btn .fs-5 .mb-4 .mb-md-0 }
+
+---
+
+## Remember these 3 things
+
+| What to remember | Why it matters |
+|---|---|
+| **Local-first by default** | Memory stays on your machine unless you deliberately choose otherwise. |
+| **Inspectable and controllable** | You can verify, search, export, back up, and delete it. |
+| **Hybrid retrieval** | Structured facts and semantic recall work together, so results are stronger than session-only or vector-only memory. |
 
 ---
 
@@ -28,6 +38,7 @@ Your OpenClaw agent forgets everything between sessions. Hybrid Memory fixes thi
 | You paste the same context again | Relevant memories can load automatically each turn |
 | Hard to find “that thing we said” | Search by meaning and by structure |
 | Memory becomes a junk drawer | Decay, tiering, and jobs keep storage manageable |
+| Hard to tell why a memory showed up | Search, verification, provenance, and docs make recall inspectable |
 | Lost work if a process crashes badly | Durable writes designed for safe recovery |
 
 *How the engines work (SQLite, vectors, merge, WAL): [How it works](HOW-IT-WORKS) and [Architecture](ARCHITECTURE). Narrative examples: [Scenarios & benefits](SCENARIOS).*
@@ -92,6 +103,7 @@ Your OpenClaw agent forgets everything between sessions. Hybrid Memory fixes thi
 | Document | Description |
 |----------|-------------|
 | [Model-Agnostic Analysis](MODEL-AGNOSTIC-ANALYSIS) | Compatibility across LLM providers |
+| [Presentation strategy](PRESENTATION-STRATEGY) | Canonical product message, demo story, visuals, and terminology |
 | [Feedback Roadmap](FEEDBACK-ROADMAP) | Planned improvements and feature requests |
 
 ### Project

--- a/docs/trust-and-privacy.md
+++ b/docs/trust-and-privacy.md
@@ -1,12 +1,15 @@
 # Trust and Privacy
 
-Hybrid Memory is designed so you can inspect, verify, and control what persists.
+Hybrid Memory is designed so memory feels like a system you can trust, not a black box you hope is behaving.
+
+**Short version:** local-first by default, inspectable when you need proof, and controllable across backup, export, and deletion paths.
 
 ## Local-first by default
 
 - Memory data is stored on your machine unless you configure external providers.
 - Core persistence uses local SQLite and local vector storage.
 - Feature depth depends on your configured providers and mode.
+- Hosted services can still be part of your setup, but the default trust model is local-first.
 
 ## What gets remembered
 
@@ -16,7 +19,7 @@ Depending on enabled capabilities, the system may retain:
 - Procedures and workflow hints
 - Issues/episodes and derived summaries
 
-## Provenance and verification
+## Inspectable by design
 
 Use these commands to inspect system health and memory behavior:
 
@@ -28,7 +31,9 @@ openclaw hybrid-mem search "query"
 
 For deeper operational checks: [OPERATIONS.md](OPERATIONS.md), [TROUBLESHOOTING.md](TROUBLESHOOTING.md)
 
-## Deletion and control
+The important point is not only that memory exists — it is that you have proof paths when you need them.
+
+## Control, backup, and deletion
 
 Use documented CLI paths to remove plugin state and memory artifacts:
 
@@ -55,3 +60,4 @@ References:
 - [ ] I can search and inspect what is recalled.
 - [ ] I have a tested backup and restore workflow.
 - [ ] I know my deletion path (`uninstall` + cleanup docs).
+- [ ] I can explain why this setup is local-first and how I would audit it.


### PR DESCRIPTION
Fixes #1028

## What this does

Implements the product presentation and branding workstream for Hybrid Memory:

### New file: docs/PRODUCT-STORY.md
- **Tagline**: "Local-first memory for OpenClaw that you can inspect, verify, and trust."
- **One-sentence product message** and **elevator pitch**
- **Trust / privacy pitch** and **why this exists** narrative
- **3 differentiators to remember**: local-first, inspectable, hybrid retrieval
- **Comparison messaging** against session-only memory, naive vector memory, and hosted-memory approaches (table expanded to 4 columns)
- **Visual proof package**: shot list for hero assets + captions
- **Demo package**: 60-second demo, 5-minute operator demo, "why local-first matters" demo, agent-run demo flow
- **Terminology audit**: maps dense/internal terms to plain-language alternatives
- **Copy rules**: reusable product copy blocks and the short intro formula
- **Success criteria**: four questions a first-time reader should be able to answer

### New visual assets (docs/assets/)
-  — system view showing the four-part product story (Capture → Retrieve → Inspect → Control + proof surfaces)
-  — structured + semantic recall vs vector-only, with ranking and provenance
-  — before/after onboarding flow

### README.md updates
- Updated tagline: "Local-first memory for OpenClaw that you can inspect, verify, and trust."
- Added 3-things banner immediately below the title
- Expanded comparison table to 4 columns (added hosted memory product column)
- Added link to PRODUCT-STORY.md in fast-path docs

### docs/index.md (site homepage) updates
- Updated page title and intro copy to lead with the product promise
- Added "The 3 things to remember" section with the differentiators
- Added new visual asset (architecture diagram)
- Added Product Story to getting-started nav table
- Added trust row to the before/after table ("You must trust memory blindly / You can verify, inspect, export, and delete it")

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are documentation/marketing copy plus new SVG assets, with no runtime or data-path modifications. Main risk is broken links/nav ordering or documentation site rendering issues.
> 
> **Overview**
> Reframes Hybrid Memory’s public-facing messaging around **three differentiators** (local-first, inspectable/control paths, hybrid retrieval) and adds a new canonical narrative in `docs/PRESENTATION-STRATEGY.md` for README/docs/demos/terminology.
> 
> Updates the README and docs home page to use the new tagline, add a “remember these 3 things” section, and expand the comparison matrix to include *hosted memory*. Refreshes `docs/trust-and-privacy.md` and `docs/SCENARIOS.md` copy to emphasize proof/inspectability, and adds new diagram assets (`docs/assets/*`) referenced by the presentation materials.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06c4700098bf943e6b1d107d86c0f1d26fa944fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->