### PR TITLE
fix: add constrained-recall retrieval mode (filter → rank → hydrate) (#1026)

### DIFF
--- a/extensions/memory-hybrid/backends/facts-db/search.ts
+++ b/extensions/memory-hybrid/backends/facts-db/search.ts
@@ -324,3 +324,129 @@ export function getSupersededTextsSnapshot(cache: SupersededTextsCache, db: Data
   const now = Date.now();
   return cache.getSnapshot(now, () => fetchSupersededFactTextsLower(db));
 }
+
+/**
+ * Retrieve candidate fact IDs using only structured (SQL) filters.
+ * Used by the constrained-recall mode to narrow the candidate set
+ * before semantic/vector ranking (Issue #1026 filter → rank → hydrate pattern).
+ *
+ * Returns up to `limit` fact IDs matching all provided filters.
+ * When no filters are set, returns an empty array (caller should fall back
+ * to unconstrained retrieval).
+ */
+export interface ConstrainedSearchFilters {
+  /** Match facts with this exact entity name. */
+  entity?: string | null;
+  /** Match facts with this tag (SQL LIKE %tag%). */
+  tag?: string | null;
+  /** Match facts with this category. */
+  category?: string | null;
+  /** Match facts with this scope value. */
+  scope?: string | null;
+  /** Match facts with this scope target. */
+  scopeTarget?: string | null;
+  /** Include only facts with this verification tier (e.g. 'critical'). */
+  verificationTier?: string | null;
+  /** Include only facts created/valid from this Unix timestamp onward. */
+  validFromSec?: number | null;
+  /** Include only facts created/valid before this Unix timestamp. */
+  validUntilSec?: number | null;
+  /** Include only facts with this tier (hot/warm/cold). */
+  tier?: string | null;
+  /** Limit to a specific source/session. */
+  sourceSession?: string | null;
+}
+
+/** @deprecated Import from search.ts instead to avoid type divergence. */
+export type { ConstrainedSearchFilters as ConstrainedSearchFiltersFromSearch };
+
+/**
+ * Check if any constrained filter is active.
+ * Extracted helper to avoid duplicating filter-emptiness logic (Issue #1026).
+ */
+export function hasActiveFilters(filters: ConstrainedSearchFilters): boolean {
+  return !!(
+    filters.entity ||
+    filters.tag ||
+    filters.category ||
+    filters.scope ||
+    filters.scopeTarget ||
+    filters.verificationTier ||
+    filters.validFromSec != null ||
+    filters.validUntilSec != null ||
+    filters.tier ||
+    filters.sourceSession
+  );
+}
+
+export function getCandidateIdsByStructuredFilters(
+  db: DatabaseSync,
+  filters: ConstrainedSearchFilters,
+  options: { limit?: number; nowSec?: number } | number = 1000,
+): string[] {
+  const limit = typeof options === "number" ? options : (options.limit ?? 1000);
+  const nowSec =
+    typeof options === "number" ? Math.floor(Date.now() / 1000) : (options.nowSec ?? Math.floor(Date.now() / 1000));
+  if (!hasActiveFilters(filters)) {
+    return [];
+  }
+
+  const params: (string | number | null)[] = [];
+  const conditions: string[] = ["superseded_at IS NULL"];
+
+  if (filters.entity) {
+    conditions.push("lower(entity) = lower(?)");
+    params.push(filters.entity);
+  }
+  if (filters.category) {
+    conditions.push("category = ?");
+    params.push(filters.category);
+  }
+  if (filters.scope) {
+    conditions.push("scope = ?");
+    params.push(filters.scope);
+  }
+  if (filters.scopeTarget) {
+    conditions.push("scope_target = ?");
+    params.push(filters.scopeTarget);
+  }
+  if (filters.tier) {
+    conditions.push("tier = ?");
+    params.push(filters.tier);
+  }
+  if (filters.tag) {
+    conditions.push("(',' || COALESCE(tags, '') || ',') LIKE ?");
+    params.push(`%,${filters.tag.toLowerCase().trim()},%`);
+  }
+  if (filters.validFromSec != null) {
+    conditions.push("valid_from >= ?");
+    params.push(filters.validFromSec);
+  }
+  if (filters.validUntilSec != null) {
+    conditions.push("(valid_until IS NULL OR valid_until > ?)");
+    params.push(filters.validUntilSec);
+  }
+  if (filters.sourceSession) {
+    conditions.push("source_sessions LIKE ?");
+    params.push(`%${filters.sourceSession}%`);
+  }
+
+  // Handle verified_facts JOIN for verificationTier
+  if (filters.verificationTier) {
+    conditions.push(
+      `id IN (SELECT fact_id FROM verified_facts WHERE tier = ? AND (next_verification IS NULL OR next_verification > ?))`,
+    );
+    params.push(filters.verificationTier, nowSec);
+  }
+
+  const sql = `SELECT id FROM facts WHERE ${conditions.join(" AND ")} ORDER BY confidence DESC, COALESCE(source_date, created_at) DESC LIMIT ?`;
+  const finalParams = [...params, limit];
+
+  try {
+    const rows = db.prepare(sql).all(...finalParams) as Array<{ id: string }>;
+    return rows.map((r) => r.id);
+  } catch (err) {
+    // Graceful degradation — malformed filter never blocks retrieval
+    return [];
+  }
+}

--- a/extensions/memory-hybrid/backends/facts-db/search.ts
+++ b/extensions/memory-hybrid/backends/facts-db/search.ts
@@ -341,19 +341,21 @@ export interface ConstrainedSearchFilters {
   tag?: string | null;
   /** Match facts with this category. */
   category?: string | null;
+  /** Match facts with this exact source value. */
+  source?: string | null;
   /** Match facts with this scope value. */
   scope?: string | null;
   /** Match facts with this scope target. */
   scopeTarget?: string | null;
   /** Include only facts with this verification tier (e.g. 'critical'). */
   verificationTier?: string | null;
-  /** Include only facts created/valid from this Unix timestamp onward. */
+  /** Include only facts created/valid from this Unix timestamp onward. `0` is treated as active. */
   validFromSec?: number | null;
-  /** Include only facts created/valid before this Unix timestamp. */
+  /** Include only facts created/valid before this Unix timestamp. `0` is treated as active. */
   validUntilSec?: number | null;
   /** Include only facts with this tier (hot/warm/cold). */
   tier?: string | null;
-  /** Limit to a specific source/session. */
+  /** Limit to a specific source/session. Wildcards are treated literally. */
   sourceSession?: string | null;
 }
 
@@ -369,6 +371,7 @@ export function hasActiveFilters(filters: ConstrainedSearchFilters): boolean {
     filters.entity ||
     filters.tag ||
     filters.category ||
+    filters.source ||
     filters.scope ||
     filters.scopeTarget ||
     filters.verificationTier ||
@@ -377,6 +380,10 @@ export function hasActiveFilters(filters: ConstrainedSearchFilters): boolean {
     filters.tier ||
     filters.sourceSession
   );
+}
+
+function escapeSqlLike(value: string): string {
+  return value.replace(/[\\%_]/g, "\\$&");
 }
 
 export function getCandidateIdsByStructuredFilters(
@@ -401,6 +408,10 @@ export function getCandidateIdsByStructuredFilters(
   if (filters.category) {
     conditions.push("category = ?");
     params.push(filters.category);
+  }
+  if (filters.source) {
+    conditions.push("source = ?");
+    params.push(filters.source);
   }
   if (filters.scope) {
     conditions.push("scope = ?");
@@ -427,8 +438,8 @@ export function getCandidateIdsByStructuredFilters(
     params.push(filters.validUntilSec);
   }
   if (filters.sourceSession) {
-    conditions.push("source_sessions LIKE ?");
-    params.push(`%${filters.sourceSession}%`);
+    conditions.push("source_sessions LIKE ? ESCAPE '\\'");
+    params.push(`%${escapeSqlLike(filters.sourceSession)}%`);
   }
 
   // Handle verified_facts JOIN for verificationTier

--- a/extensions/memory-hybrid/docs/retrieval-modes.md
+++ b/extensions/memory-hybrid/docs/retrieval-modes.md
@@ -84,6 +84,7 @@ Available structured filters (all optional):
 - `entity` — exact entity name match
 - `tag` — LIKE %tag% match
 - `category` — exact category match
+- `source` — exact fact source match
 - `scope` / `scopeTarget` — exact scope match
 - `verificationTier` — only verified facts of a given tier
 - `validFromSec` / `validUntilSec` — temporal window
@@ -116,6 +117,12 @@ const result = await runExplicitDeepRetrieval(
 - "search only verified infra-related memories"
 - "find session notes linked to this entity"
 - "search within one imported document or source domain"
+
+### Tooling exposure
+
+- `memory_recall` can now explicitly request `retrievalMode: "constrained-recall"`
+- Tool callers can pass structured filters such as `entity`, `tag`, `category`, `source`, `verificationTier`, `validFromSec`, `validUntilSec`, and `sourceSession`
+- Tool responses should explain both the **filter basis** and the **rank basis** when constrained recall is used
 
 ### What it does not replace
 

--- a/extensions/memory-hybrid/docs/retrieval-modes.md
+++ b/extensions/memory-hybrid/docs/retrieval-modes.md
@@ -51,3 +51,73 @@ Use this path for explicit tool requests such as `memory_recall`, maintenance fl
 - `services/retrieval-mode-policy.ts` names both modes and defines the default contracts
 
 This split is meant to optimize maintainability and runtime predictability, not just move code around.
+
+## 3. Constrained-recall path (filter → rank → hydrate)
+
+**Owner:** `services/retrieval-orchestrator.ts`
+
+Introduced for Issue #1026. Use this path when you need to search *within a known boundary* — e.g., facts about a specific project, from the last 30 days, or only verified memories.
+
+### Pattern: filter → rank → hydrate
+
+```
+structured filters (SQL)
+    ↓
+vector / FTS ranking within candidate set
+    ↓
+hydrate with provenance, graph context, supersession state, explanation
+```
+
+### Contrast with explicit-deep
+
+| | explicit-deep | constrained-recall |
+|---|---|---|
+| Candidate set | All facts | Pre-filtered via SQL |
+| Fusion | RRF across all strategies | Ranked by semantic score only |
+| Graph expansion | Yes | No |
+| HyDE | Yes | Yes |
+| Use case | Open-ended search | Bounded precision recall |
+
+### ConstrainedSearchFilters
+
+Available structured filters (all optional):
+- `entity` — exact entity name match
+- `tag` — LIKE %tag% match
+- `category` — exact category match
+- `scope` / `scopeTarget` — exact scope match
+- `verificationTier` — only verified facts of a given tier
+- `validFromSec` / `validUntilSec` — temporal window
+- `tier` — hot/warm/cold
+- `sourceSession` — limit to a specific session
+
+### Example usage
+
+```typescript
+const result = await runExplicitDeepRetrieval(
+  "API key rotation",
+  queryVector,
+  db,
+  vectorDb,
+  factsDb,
+  {
+    mode: "constrained-recall",
+    constrainedFilters: {
+      entity: "openclaw-hybrid-memory",
+      validFromSec: Date.now() / 1000 - 30 * 86400, // last 30 days
+      verificationTier: "critical",
+    },
+  },
+);
+```
+
+### Good use cases
+
+- "show facts about project X from the last 30 days"
+- "search only verified infra-related memories"
+- "find session notes linked to this entity"
+- "search within one imported document or source domain"
+
+### What it does not replace
+
+- Broader graph or semantic recall without constraints
+- Interactive recall (use `mode: "interactive-recall"` for that)

--- a/extensions/memory-hybrid/services/retrieval-mode-policy.ts
+++ b/extensions/memory-hybrid/services/retrieval-mode-policy.ts
@@ -1,6 +1,6 @@
 import type { AutoRecallConfig, HybridMemoryConfig, RetrievalConfig } from "../config.js";
 
-export type RetrievalMode = "interactive-recall" | "explicit-deep";
+export type RetrievalMode = "interactive-recall" | "explicit-deep" | "constrained-recall";
 
 /** @deprecated Use string literals directly or InteractiveRecallPolicy / ExplicitDeepRetrievalPolicy types */
 export const RETRIEVAL_MODE = {
@@ -21,6 +21,23 @@ export interface InteractiveRecallPolicy {
   allowAmbientMultiQuery: boolean;
   /** Resolved from `autoRecall.interactiveEnrichment` (default balanced). */
   interactiveEnrichment: "fast" | "balanced" | "full";
+  notes: string[];
+}
+
+export interface ConstrainedRetrievalPolicy {
+  mode: "constrained-recall";
+  ownerModule: "services/retrieval-orchestrator.ts";
+  contract: "structured filter → semantic rank → hydrate for constrained recall scenarios";
+  budgetTokens: number;
+  allowHyde: boolean;
+  allowRrfFusion: boolean;
+  allowQueryExpansion: boolean;
+  allowReranking: boolean;
+  allowGraphExpansion: boolean;
+  allowAliasExpansion: boolean;
+  allowMultiModelSemantic: boolean;
+  /** Apply structured filters BEFORE ranking rather than after. */
+  filterBeforeRank: boolean;
   notes: string[];
 }
 
@@ -45,6 +62,26 @@ export const INTERACTIVE_RECALL_STAGE_TIMEOUT_MS = 120_000;
 const INTERACTIVE_RECALL_VECTOR_TIMEOUT_MS = 26_000;
 const DEFAULT_INTERACTIVE_RECALL_DEGRADATION_QUEUE_DEPTH = 10;
 const DEFAULT_INTERACTIVE_RECALL_DEGRADATION_MAX_LATENCY_MS = 5_000;
+const DEFAULT_CONSTRAINED_RETRIEVAL_POLICY: ConstrainedRetrievalPolicy = {
+  mode: "constrained-recall",
+  ownerModule: "services/retrieval-orchestrator.ts",
+  contract: "structured filter → semantic rank → hydrate for constrained recall scenarios",
+  budgetTokens: 4000,
+  allowHyde: true,
+  allowRrfFusion: false,
+  allowQueryExpansion: true,
+  allowReranking: true,
+  allowGraphExpansion: false,
+  allowAliasExpansion: true,
+  allowMultiModelSemantic: true,
+  filterBeforeRank: true,
+  notes: [
+    "Pre-filters candidate set via structured constraints before semantic ranking.",
+    "Use case: 'show facts about project X from the last 30 days', 'search only verified infra memories'.",
+    "RRF fusion disabled — ranking is purely semantic within the constrained candidate set.",
+    "Hydration includes provenance, graph context, supersession state, and explanation.",
+  ],
+};
 
 /**
  * Resolve the latency-bounded chat-turn policy owned by `lifecycle/stage-recall.ts`.
@@ -133,6 +170,20 @@ export function resolveExplicitDeepRetrievalPolicy(cfg: RetrievalConfig): Explic
 }
 
 /**
+ * Resolve the constrained retrieval policy for filter-before-rank scenarios.
+ * Owned by `services/retrieval-orchestrator.ts`.
+ */
+export function resolveConstrainedRetrievalPolicy(
+  cfg: RetrievalConfig,
+  requestedBudget?: number,
+): ConstrainedRetrievalPolicy {
+  return {
+    ...DEFAULT_CONSTRAINED_RETRIEVAL_POLICY,
+    budgetTokens: requestedBudget ?? cfg.explicitBudgetTokens,
+  };
+}
+
+/**
  * Resolve the interactive recall budget tokens, capping to the minimum of
  * autoRecall.maxTokens and retrieval.ambientBudgetTokens.
  */
@@ -155,7 +206,7 @@ export function resolveOrchestratorBudgetTokens(
       ? Math.min(requestedBudget, retrievalCfg.ambientBudgetTokens)
       : retrievalCfg.ambientBudgetTokens;
   }
-  return requestedBudget !== undefined ? requestedBudget : retrievalCfg.explicitBudgetTokens;
+  return requestedBudget ?? retrievalCfg.explicitBudgetTokens;
 }
 
 /**

--- a/extensions/memory-hybrid/services/retrieval-orchestrator.ts
+++ b/extensions/memory-hybrid/services/retrieval-orchestrator.ts
@@ -1044,7 +1044,15 @@ export async function runExplicitDeepRetrieval(
             sources: [{ strategy: res.source || "unknown", rank: res.rank }],
           });
         } else {
-          deduped.get(res.factId)?.sources.push({ strategy: res.source || "unknown", rank: res.rank });
+          const existing = deduped.get(res.factId)!;
+          existing.sources.push({ strategy: res.source || "unknown", rank: res.rank });
+          if (res.source === "semantic" || res.source?.startsWith("semantic:")) {
+            const semanticScore = 1 / (k + res.rank);
+            if (semanticScore > existing.finalScore) {
+              existing.finalScore = semanticScore;
+              existing.rrfScore = semanticScore;
+            }
+          }
         }
       }
 

--- a/extensions/memory-hybrid/services/retrieval-orchestrator.ts
+++ b/extensions/memory-hybrid/services/retrieval-orchestrator.ts
@@ -646,10 +646,11 @@ export interface RetrievalPipelineOptions {
   /** Retrieval mode shortcut. When provided, derives the policy automatically.
    * 'interactive-recall' -> interactive recall policy (disables graph expansion).
    * 'explicit-deep' -> explicit deep retrieval policy.
+   * 'constrained-recall' -> constrained retrieval policy (filter-before-rank).
    * Overridden by an explicit `policy` option. */
   mode?: import("./retrieval-mode-policy.js").RetrievalMode;
-  /** Explicit/deep retrieval policy. Defaults to resolveExplicitDeepRetrievalPolicy(config). */
-  policy?: ExplicitDeepRetrievalPolicy;
+  /** Retrieval policy. Defaults to resolveExplicitDeepRetrievalPolicy(config). */
+  policy?: ExplicitDeepRetrievalPolicy | InteractiveRecallPolicy | ConstrainedRetrievalPolicy;
   /** Retrieval pipeline configuration. Defaults to `DEFAULT_RETRIEVAL_CONFIG`. */
   config?: RetrievalConfig;
   /** Token budget for packing. Defaults to `config.explicitBudgetTokens`. */
@@ -1040,10 +1041,10 @@ export async function runExplicitDeepRetrieval(
             finalScore: 1 / (k + res.rank),
             rrfScore: 1 / (k + res.rank),
 
-            sources: [{ strategy: (res as any).strategyName || "unknown", rank: res.rank }],
+            sources: [{ strategy: res.source || "unknown", rank: res.rank }],
           });
         } else {
-          deduped.get(res.factId)?.sources.push({ strategy: (res as any).strategyName || "unknown", rank: res.rank });
+          deduped.get(res.factId)?.sources.push({ strategy: res.source || "unknown", rank: res.rank });
         }
       }
 

--- a/extensions/memory-hybrid/services/retrieval-orchestrator.ts
+++ b/extensions/memory-hybrid/services/retrieval-orchestrator.ts
@@ -28,11 +28,14 @@ import { type ScoredFact, rerankResults } from "./reranker.js";
 import { type AliasDB, searchAliasStrategy } from "./retrieval-aliases.js";
 import {
   DEFAULT_INTERACTIVE_RECALL_POLICY,
+  type ConstrainedRetrievalPolicy,
   type ExplicitDeepRetrievalPolicy,
   type InteractiveRecallPolicy,
+  resolveConstrainedRetrievalPolicy,
   resolveExplicitDeepRetrievalPolicy,
   resolveInteractiveRecallPolicy,
 } from "./retrieval-mode-policy.js";
+import { getCandidateIdsByStructuredFilters, hasActiveFilters } from "../backends/facts-db/search.js";
 import {
   type FactMetadata,
   type FusedResult,
@@ -220,6 +223,8 @@ export function packIntoBudget(
 
 /**
  * Run FTS5 full-text search strategy.
+ * When candidateIds is provided (constrained-recall mode), only results within
+ * that candidate set are returned and ranks are reassigned within that filtered set.
  * Returns ranked results (best = rank 1).
  */
 function runFts5Strategy(
@@ -229,9 +234,12 @@ function runFts5Strategy(
   tagFilter?: string,
   includeSuperseded?: boolean,
   asOf?: number,
+  candidateIds?: Set<string> | null,
 ): RankedResult[] {
-  const results = searchFts(db, query, { limit, tagFilter, includeSuperseded, asOf });
-  return results.map((r, i) => ({
+  const effectiveLimit = candidateIds ? Math.max(limit * 5, 200) : limit;
+  const results = searchFts(db, query, { limit: effectiveLimit, tagFilter, includeSuperseded, asOf });
+  const filtered = candidateIds ? results.filter((r) => candidateIds.has(r.factId)) : results;
+  return filtered.slice(0, limit).map((r, i) => ({
     factId: r.factId,
     rank: i + 1,
     source: "fts5" as const,
@@ -240,11 +248,21 @@ function runFts5Strategy(
 
 /**
  * Run semantic (vector) search strategy.
+ * When candidateIds is provided (constrained-recall mode), only results within
+ * that candidate set are returned and ranks are reassigned within that filtered set.
  * Returns ranked results (best = rank 1).
  */
-async function runSemanticStrategy(vectorDb: VectorDB, queryVector: number[], topK: number): Promise<RankedResult[]> {
-  const results: SearchResult[] = await vectorDb.search(queryVector, topK, 0.3);
-  return results.map((r, i) => ({
+async function runSemanticStrategy(
+  vectorDb: VectorDB,
+  queryVector: number[],
+  topK: number,
+  candidateIds?: Set<string> | null,
+): Promise<RankedResult[]> {
+  // Use a larger topK when filtering to account for candidates being filtered out
+  const effectiveTopK = candidateIds ? Math.max(topK * 5, 200) : topK;
+  const results: SearchResult[] = await vectorDb.search(queryVector, effectiveTopK, 0.3);
+  const filtered = candidateIds ? results.filter((r) => candidateIds.has(r.entry.id)) : results;
+  return filtered.slice(0, topK).map((r, i) => ({
     factId: r.entry.id,
     rank: i + 1,
     source: "semantic" as const,
@@ -264,6 +282,7 @@ async function runMultiModelSemanticStrategies(
   registry: EmbeddingRegistry,
   queryText: string,
   topK: number,
+  candidateIds?: Set<string> | null,
 ): Promise<Map<string, RankedResult[]>> {
   const result = new Map<string, RankedResult[]>();
   const models = registry.getModels();
@@ -285,7 +304,8 @@ async function runMultiModelSemanticStrategies(
       continue;
     }
     const { name, queryVec } = s.value;
-    const maxCandidatesPerModel = Math.max(topK * 10, 500);
+    const effectiveTopK = candidateIds ? Math.max(topK * 5, 200) : topK;
+    const maxCandidatesPerModel = Math.max(effectiveTopK * 10, 500);
     const candidates = factsDbWithEmbeddings.getEmbeddingsByModel(name, maxCandidatesPerModel);
     if (candidates.length === 0) continue;
 
@@ -297,12 +317,15 @@ async function runMultiModelSemanticStrategies(
       }))
       .filter((r) => r.score >= 0.3)
       .sort((a, b) => b.score - a.score)
-      .slice(0, topK);
+      .slice(0, effectiveTopK);
 
-    if (scored.length > 0) {
+    const filtered = candidateIds ? scored.filter((r) => candidateIds.has(r.factId)) : scored;
+    const finalResults = filtered.slice(0, topK);
+
+    if (finalResults.length > 0) {
       result.set(
         `semantic:${name}`,
-        scored.map((r, i) => ({
+        finalResults.map((r, i) => ({
           factId: r.factId,
           rank: i + 1,
           source: `semantic:${name}` as const,
@@ -512,6 +535,7 @@ function buildSemanticCacheFilterKey(config: RetrievalConfig, options: Retrieval
     queryExpansionContext: options.queryExpansionContext ?? null,
     embeddingRegistry: describeEmbeddingRegistry(options.embeddingRegistry),
     embeddingFactsEnabled: Boolean(options.factsDbForEmbeddings),
+    constrainedFilters: options.constrainedFilters ?? null,
   });
 }
 
@@ -670,6 +694,11 @@ export interface RetrievalPipelineOptions {
   adaptiveOpenai?: import("openai").default | null;
   /** Document grading configuration. */
   documentGradingConfig?: import("../config.js").DocumentGradingConfig | null;
+  /** Structured pre-filters for constrained-recall mode.
+   * When set, the pipeline first retrieves candidate fact IDs via SQLite structured filters,
+   * then limits semantic/FTS5 ranking to only those candidates.
+   * This implements the "filter → rank → hydrate" pattern (Issue #1026). */
+  constrainedFilters?: import("../backends/facts-db/search.js").ConstrainedSearchFilters;
 }
 
 /**
@@ -699,11 +728,20 @@ export async function runExplicitDeepRetrieval(
   options: RetrievalPipelineOptions = {},
 ): Promise<OrchestratorResult> {
   const config = options.config ?? DEFAULT_RETRIEVAL_CONFIG;
-  let resolvedPolicy: ExplicitDeepRetrievalPolicy | InteractiveRecallPolicy;
+
+  // Check if constrained mode has actual filters before selecting policy
+  const hasConstrainedFilters = options.constrainedFilters && hasActiveFilters(options.constrainedFilters);
+
+  let resolvedPolicy: ExplicitDeepRetrievalPolicy | InteractiveRecallPolicy | ConstrainedRetrievalPolicy;
   if (options.policy) {
-    resolvedPolicy = options.policy;
+    resolvedPolicy = options.policy as
+      | ExplicitDeepRetrievalPolicy
+      | InteractiveRecallPolicy
+      | ConstrainedRetrievalPolicy;
   } else if (options.mode === "interactive-recall") {
     resolvedPolicy = DEFAULT_INTERACTIVE_RECALL_POLICY;
+  } else if (options.mode === "constrained-recall" && hasConstrainedFilters) {
+    resolvedPolicy = resolveConstrainedRetrievalPolicy(config, options.budgetTokens);
   } else {
     resolvedPolicy = resolveExplicitDeepRetrievalPolicy(config);
   }
@@ -730,6 +768,7 @@ export async function runExplicitDeepRetrieval(
     documentGrader,
     adaptiveOpenai,
     documentGradingConfig,
+    constrainedFilters,
   } = options;
 
   const validator = queryValidator ?? validateQueryForMemoryLookup;
@@ -743,6 +782,18 @@ export async function runExplicitDeepRetrieval(
           timeoutMs: documentGradingConfig.timeoutMs,
         })
       : null);
+
+  // -------------------------------------------------------------------------
+  // Constrained-recall: pre-filter candidate set before ranking (Issue #1026)
+  // -------------------------------------------------------------------------
+  let candidateIds: Set<string> | null = null;
+  if (policy.mode === "constrained-recall" && constrainedFilters) {
+    const ids = getCandidateIdsByStructuredFilters(db, constrainedFilters, { limit: 1000, nowSec });
+    if (ids.length === 0) {
+      return { fused: [], packed: [], packedFactIds: [], tokensUsed: 0, entries: [] };
+    }
+    candidateIds = new Set(ids);
+  }
 
   const applyConditionalReranking = async (
     queryText: string,
@@ -819,7 +870,8 @@ export async function runExplicitDeepRetrieval(
         filterKey: semanticCacheFilterKey,
       });
       if (cached) {
-        const cachedResult = buildCachedResult(factsDb, cached.factIds, budgetTokens, {
+        const filteredFactIds = candidateIds ? cached.factIds.filter((id) => candidateIds.has(id)) : cached.factIds;
+        const cachedResult = buildCachedResult(factsDb, filteredFactIds, budgetTokens, {
           includeSuperseded,
           scopeFilter,
           asOf,
@@ -857,19 +909,25 @@ export async function runExplicitDeepRetrieval(
 
     if (strategies.includes("fts5")) {
       strategyPromises.push(
-        safeStrategy("fts5", () => runFts5Strategy(db, queryText, fts5TopK, tagFilter, includeSuperseded, asOf)),
+        safeStrategy("fts5", () =>
+          runFts5Strategy(db, queryText, fts5TopK, tagFilter, includeSuperseded, asOf, candidateIds),
+        ),
       );
     }
 
     if (strategies.includes("semantic") && currentQueryVector) {
       strategyPromises.push(
-        safeStrategy("semantic", () => runSemanticStrategy(vectorDb, currentQueryVector, semanticTopK)),
+        safeStrategy("semantic", () => runSemanticStrategy(vectorDb, currentQueryVector, semanticTopK, candidateIds)),
       );
     }
 
     if ((policy as ExplicitDeepRetrievalPolicy).allowAliasExpansion && aliasDb && currentQueryVector) {
       strategyPromises.push(
-        safeStrategy("aliases", () => searchAliasStrategy(aliasDb, currentQueryVector, semanticTopK)),
+        safeStrategy("aliases", async () => {
+          const results = await searchAliasStrategy(aliasDb, currentQueryVector, semanticTopK);
+          const filtered = candidateIds ? results.filter((r) => candidateIds.has(r.factId)) : results;
+          return filtered.map((r, i) => ({ ...r, rank: i + 1 }));
+        }),
       );
     }
 
@@ -894,7 +952,7 @@ export async function runExplicitDeepRetrieval(
           strategyPromises.push(
             safeStrategy(strategyName, async () => {
               const variantVector = await embedFn(variantQuery);
-              return runSemanticStrategy(vectorDb, variantVector, semanticTopK);
+              return runSemanticStrategy(vectorDb, variantVector, semanticTopK, candidateIds);
             }),
           );
         }
@@ -915,6 +973,7 @@ export async function runExplicitDeepRetrieval(
         embeddingRegistry,
         queryText,
         semanticTopK,
+        candidateIds,
       );
     }
 

--- a/extensions/memory-hybrid/tests/constrained-recall.test.ts
+++ b/extensions/memory-hybrid/tests/constrained-recall.test.ts
@@ -1,0 +1,345 @@
+/**
+ * Constrained-recall mode tests (Issue #1026).
+ * Verifies the "filter → rank → hydrate" retrieval pattern.
+ */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { _testing } from "../index.js";
+import { DEFAULT_RETRIEVAL_CONFIG, runRetrievalPipeline } from "../services/retrieval-orchestrator.js";
+
+const { FactsDB } = _testing;
+
+describe("constrained-recall mode (filter → rank → hydrate)", () => {
+  let tmpDir: string;
+  let factsDb: InstanceType<typeof FactsDB>;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "constrained-recall-test-"));
+    factsDb = new FactsDB(join(tmpDir, "facts.db"));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  const makeVec = (n = 4): Float32Array => new Float32Array(new Array(n).fill(0).map((_, i) => (i === 0 ? 1 : 0)));
+
+  it("returns only facts matching the entity filter", async () => {
+    const apple = factsDb.store({
+      text: "Apple is tasty",
+      category: "fact",
+      importance: 0.6,
+      entity: "fruit",
+      key: null,
+      value: null,
+      source: "conversation",
+    });
+    const banana = factsDb.store({
+      text: "Banana is yellow",
+      category: "fact",
+      importance: 0.6,
+      entity: "fruit",
+      key: null,
+      value: null,
+      source: "conversation",
+    });
+    const carrot = factsDb.store({
+      text: "Carrot is orange",
+      category: "fact",
+      importance: 0.6,
+      entity: "vegetable",
+      key: null,
+      value: null,
+      source: "conversation",
+    });
+
+    factsDb.storeEmbedding(apple.id, "test-model", "canonical", makeVec(), 4);
+    factsDb.storeEmbedding(banana.id, "test-model", "canonical", makeVec(), 4);
+    factsDb.storeEmbedding(carrot.id, "test-model", "canonical", makeVec(), 4);
+
+    const vectorDb = {
+      search: async () => [
+        { entry: factsDb.getById(apple.id)!, score: 0.95 },
+        { entry: factsDb.getById(banana.id)!, score: 0.9 },
+        { entry: factsDb.getById(carrot.id)!, score: 0.85 },
+      ],
+    } as unknown as import("../backends/vector-db.js").VectorDB;
+
+    const result = await runRetrievalPipeline("apple", [1, 0, 0, 0], factsDb.getRawDb(), vectorDb, factsDb, {
+      mode: "constrained-recall",
+      constrainedFilters: { entity: "fruit" },
+      config: { ...DEFAULT_RETRIEVAL_CONFIG, strategies: ["semantic"] },
+      budgetTokens: 5000,
+    });
+
+    const ids = result.fused.map((r) => r.factId);
+    expect(ids).toContain(apple.id);
+    expect(ids).toContain(banana.id);
+    expect(ids).not.toContain(carrot.id);
+  });
+
+  it("excludes facts outside the temporal window when validFromSec is set", async () => {
+    const nowSec = Math.floor(Date.now() / 1000);
+    const recent = factsDb.store({
+      text: "Recent fact",
+      category: "fact",
+      importance: 0.6,
+      entity: "test",
+      key: null,
+      value: null,
+      source: "conversation",
+      validFrom: nowSec - 10 * 86400,
+    });
+    const old = factsDb.store({
+      text: "Old fact",
+      category: "fact",
+      importance: 0.6,
+      entity: "test",
+      key: null,
+      value: null,
+      source: "conversation",
+      validFrom: nowSec - 60 * 86400,
+    });
+
+    factsDb.storeEmbedding(recent.id, "test-model", "canonical", makeVec(), 4);
+    factsDb.storeEmbedding(old.id, "test-model", "canonical", makeVec(), 4);
+
+    const vectorDb = {
+      search: async () => [
+        { entry: factsDb.getById(recent.id)!, score: 0.9 },
+        { entry: factsDb.getById(old.id)!, score: 0.85 },
+      ],
+    } as unknown as import("../backends/vector-db.js").VectorDB;
+
+    const result = await runRetrievalPipeline("test", [1, 0, 0, 0], factsDb.getRawDb(), vectorDb, factsDb, {
+      mode: "constrained-recall",
+      constrainedFilters: { entity: "test", validFromSec: nowSec - 30 * 86400 },
+      config: { ...DEFAULT_RETRIEVAL_CONFIG, strategies: ["semantic"] },
+      budgetTokens: 5000,
+    });
+
+    const ids = result.fused.map((r) => r.factId);
+    expect(ids).toContain(recent.id);
+    expect(ids).not.toContain(old.id);
+  });
+
+  it("returns empty result when no facts match the structured filter", async () => {
+    const apple = factsDb.store({
+      text: "Apple is tasty",
+      category: "fact",
+      importance: 0.6,
+      entity: "fruit",
+      key: null,
+      value: null,
+      source: "conversation",
+    });
+    factsDb.storeEmbedding(apple.id, "test-model", "canonical", makeVec(), 4);
+
+    const vectorDb = {
+      search: async () => [{ entry: factsDb.getById(apple.id)!, score: 0.95 }],
+    } as unknown as import("../backends/vector-db.js").VectorDB;
+
+    const result = await runRetrievalPipeline("apple", [1, 0, 0, 0], factsDb.getRawDb(), vectorDb, factsDb, {
+      mode: "constrained-recall",
+      constrainedFilters: { entity: "nonexistent-project" },
+      config: { ...DEFAULT_RETRIEVAL_CONFIG, strategies: ["semantic"] },
+      budgetTokens: 5000,
+    });
+
+    expect(result.fused).toHaveLength(0);
+    expect(result.packed).toHaveLength(0);
+  });
+
+  it("applies category filter in constrained-recall mode", async () => {
+    const pref = factsDb.store({
+      text: "User preference",
+      category: "preference",
+      importance: 0.7,
+      entity: "ux",
+      key: null,
+      value: null,
+      source: "conversation",
+    });
+    const fact = factsDb.store({
+      text: "Random fact",
+      category: "fact",
+      importance: 0.6,
+      entity: "ux",
+      key: null,
+      value: null,
+      source: "conversation",
+    });
+    factsDb.storeEmbedding(pref.id, "test-model", "canonical", makeVec(), 4);
+    factsDb.storeEmbedding(fact.id, "test-model", "canonical", makeVec(), 4);
+
+    const vectorDb = {
+      search: async () => [
+        { entry: factsDb.getById(pref.id)!, score: 0.9 },
+        { entry: factsDb.getById(fact.id)!, score: 0.85 },
+      ],
+    } as unknown as import("../backends/vector-db.js").VectorDB;
+
+    const result = await runRetrievalPipeline("user preference", [1, 0, 0, 0], factsDb.getRawDb(), vectorDb, factsDb, {
+      mode: "constrained-recall",
+      constrainedFilters: { entity: "ux", category: "preference" },
+      config: { ...DEFAULT_RETRIEVAL_CONFIG, strategies: ["semantic"] },
+      budgetTokens: 5000,
+    });
+
+    const ids = result.fused.map((r) => r.factId);
+    expect(ids).toContain(pref.id);
+    expect(ids).not.toContain(fact.id);
+  });
+
+  it("returns hydrated MemoryEntry objects in the result", async () => {
+    const fact = factsDb.store({
+      text: "Test fact for hydration",
+      category: "fact",
+      importance: 0.8,
+      entity: "test",
+      key: null,
+      value: null,
+      source: "conversation",
+    });
+    factsDb.storeEmbedding(fact.id, "test-model", "canonical", makeVec(), 4);
+
+    const vectorDb = {
+      search: async () => [{ entry: factsDb.getById(fact.id)!, score: 0.95 }],
+    } as unknown as import("../backends/vector-db.js").VectorDB;
+
+    const result = await runRetrievalPipeline("test", [1, 0, 0, 0], factsDb.getRawDb(), vectorDb, factsDb, {
+      mode: "constrained-recall",
+      constrainedFilters: { entity: "test" },
+      config: { ...DEFAULT_RETRIEVAL_CONFIG, strategies: ["semantic"] },
+      budgetTokens: 5000,
+    });
+
+    expect(result.entries).toHaveLength(1);
+    expect(result.entries[0].id).toBe(fact.id);
+    expect(result.entries[0].text).toBe("Test fact for hydration");
+    expect(result.entries[0].category).toBe("fact");
+    expect(result.entries[0].entity).toBe("test");
+  });
+
+  it("includes provenance in serialized output", async () => {
+    const fact = factsDb.store({
+      text: "Fact with provenance",
+      category: "fact",
+      importance: 0.8,
+      entity: "test",
+      key: null,
+      value: null,
+      source: "conversation",
+    });
+    factsDb.storeEmbedding(fact.id, "test-model", "canonical", makeVec(), 4);
+
+    const vectorDb = {
+      search: async () => [{ entry: factsDb.getById(fact.id)!, score: 0.95 }],
+    } as unknown as import("../backends/vector-db.js").VectorDB;
+
+    const result = await runRetrievalPipeline("provenance", [1, 0, 0, 0], factsDb.getRawDb(), vectorDb, factsDb, {
+      mode: "constrained-recall",
+      constrainedFilters: { entity: "test" },
+      config: { ...DEFAULT_RETRIEVAL_CONFIG, strategies: ["semantic"] },
+      budgetTokens: 5000,
+    });
+
+    expect(result.packed).toHaveLength(1);
+    expect(result.packed[0]).toContain("Fact with provenance");
+    expect(result.packed[0]).toMatch(/entity: test/);
+    expect(result.packed[0]).toMatch(/category: fact/);
+  });
+
+  it("superseded facts are excluded from constrained-recall results", async () => {
+    const oldFact = factsDb.store({
+      text: "Old fact superseded",
+      category: "fact",
+      importance: 0.6,
+      entity: "test",
+      key: null,
+      value: null,
+      source: "conversation",
+    });
+    const newFact = factsDb.store({
+      text: "New fact current",
+      category: "fact",
+      importance: 0.8,
+      entity: "test",
+      key: null,
+      value: null,
+      source: "conversation",
+    });
+    factsDb.storeEmbedding(oldFact.id, "test-model", "canonical", makeVec(), 4);
+    factsDb.storeEmbedding(newFact.id, "test-model", "canonical", makeVec(), 4);
+
+    // Mark old fact as superseded
+    factsDb
+      .getRawDb()
+      .prepare("UPDATE facts SET superseded_at = ? WHERE id = ?")
+      .run(Math.floor(Date.now() / 1000), oldFact.id);
+
+    const vectorDb = {
+      search: async () => [
+        { entry: factsDb.getById(oldFact.id)!, score: 0.9 },
+        { entry: factsDb.getById(newFact.id)!, score: 0.85 },
+      ],
+    } as unknown as import("../backends/vector-db.js").VectorDB;
+
+    const result = await runRetrievalPipeline("test", [1, 0, 0, 0], factsDb.getRawDb(), vectorDb, factsDb, {
+      mode: "constrained-recall",
+      constrainedFilters: { entity: "test" },
+      config: { ...DEFAULT_RETRIEVAL_CONFIG, strategies: ["semantic"] },
+      budgetTokens: 5000,
+    });
+
+    const ids = result.fused.map((r) => r.factId);
+    expect(ids).toContain(newFact.id);
+    expect(ids).not.toContain(oldFact.id);
+  });
+
+  it("allows combined entity + tag filter", async () => {
+    // Tags are stored as serialized JSON array; use the tags field in store
+    const taggedFact = factsDb.store({
+      text: "Tagged fact",
+      category: "fact",
+      importance: 0.8,
+      entity: "test",
+      key: null,
+      value: null,
+      source: "conversation",
+      tags: ["zigbee", "homeassistant"],
+    });
+    const untagged = factsDb.store({
+      text: "Untagged fact",
+      category: "fact",
+      importance: 0.6,
+      entity: "test",
+      key: null,
+      value: null,
+      source: "conversation",
+    });
+    factsDb.storeEmbedding(taggedFact.id, "test-model", "canonical", makeVec(), 4);
+    factsDb.storeEmbedding(untagged.id, "test-model", "canonical", makeVec(), 4);
+
+    const vectorDb = {
+      search: async () => [
+        { entry: factsDb.getById(taggedFact.id)!, score: 0.95 },
+        { entry: factsDb.getById(untagged.id)!, score: 0.9 },
+      ],
+    } as unknown as import("../backends/vector-db.js").VectorDB;
+
+    const result = await runRetrievalPipeline("tagged", [1, 0, 0, 0], factsDb.getRawDb(), vectorDb, factsDb, {
+      mode: "constrained-recall",
+      constrainedFilters: { entity: "test", tag: "zigbee" },
+      config: { ...DEFAULT_RETRIEVAL_CONFIG, strategies: ["semantic"] },
+      budgetTokens: 5000,
+    });
+
+    const ids = result.fused.map((r) => r.factId);
+    expect(ids).toContain(taggedFact.id);
+    expect(ids).not.toContain(untagged.id);
+  });
+});

--- a/extensions/memory-hybrid/tests/plugin-e2e.test.ts
+++ b/extensions/memory-hybrid/tests/plugin-e2e.test.ts
@@ -327,6 +327,51 @@ describe("Store and recall e2e (real FactsDB + VectorDB, mock embeddings)", () =
     expect(texts.some((t) => t.includes("banana server port 9999"))).toBe(true);
   });
 
+  it("memory_recall exposes constrained-recall mode with filter and rank explanation", async () => {
+    registerTools(buildE2EContext({ tmpDir, factsDb, vectorDb, cfg, api }) as never, api as never);
+
+    const storeTool = api.getTool("memory_store");
+    const recallTool = api.getTool("memory_recall");
+
+    await storeTool?.execute("call-constrained-1", {
+      text: "UX preference: user prefers compact dashboards",
+      importance: 0.9,
+      category: "preference",
+      entity: "ux",
+    });
+    await storeTool?.execute("call-constrained-2", {
+      text: "UX fact: dashboard service listens on port 8080",
+      importance: 0.8,
+      category: "fact",
+      entity: "ux",
+    });
+
+    const constrainedResult = (await recallTool?.execute("call-constrained-3", {
+      query: "compact dashboard preference",
+      entity: "ux",
+      category: "preference",
+      retrievalMode: "constrained-recall",
+      limit: 5,
+    })) as {
+      content?: { type: string; text: string }[];
+      details?: {
+        count: number;
+        memories?: { text: string }[];
+        retrieval?: { mode?: string; filterBasis?: string[]; rankBasis?: string };
+      };
+    };
+
+    expect(constrainedResult.details?.count).toBeGreaterThanOrEqual(1);
+    const texts = (constrainedResult.details?.memories ?? []).map((m) => m.text);
+    expect(texts.some((t) => t.includes("prefers compact dashboards"))).toBe(true);
+    expect(texts.some((t) => t.includes("listens on port 8080"))).toBe(false);
+    expect(constrainedResult.content?.[0]?.text).toContain("Retrieval: constrained-recall");
+    expect(constrainedResult.content?.[0]?.text).toContain("Filter basis:");
+    expect(constrainedResult.content?.[0]?.text).toContain("Rank basis:");
+    expect(constrainedResult.details?.retrieval?.mode).toBe("constrained-recall");
+    expect(constrainedResult.details?.retrieval?.filterBasis).toContain("category=preference");
+  });
+
   it("memory_forget by memoryId removes the fact", async () => {
     registerTools(buildE2EContext({ tmpDir, factsDb, vectorDb, cfg, api }) as never, api as never);
 

--- a/extensions/memory-hybrid/tools/memory-tools.ts
+++ b/extensions/memory-hybrid/tools/memory-tools.ts
@@ -47,7 +47,12 @@ import { formatNarrativeRange, recallNarrativeSummaries } from "../services/narr
 import type { ProvenanceService } from "../services/provenance.js";
 import { QueryExpander } from "../services/query-expander.js";
 import { type AliasDB, storeAliases } from "../services/retrieval-aliases.js";
-import { resolveExplicitDeepRetrievalPolicy } from "../services/retrieval-mode-policy.js";
+import {
+  resolveConstrainedRetrievalPolicy,
+  resolveExplicitDeepRetrievalPolicy,
+  type ConstrainedRetrievalPolicy,
+  type ExplicitDeepRetrievalPolicy,
+} from "../services/retrieval-mode-policy.js";
 import { buildExplicitSemanticQueryVector, runExplicitDeepRetrieval } from "../services/retrieval-orchestrator.js";
 import type { VerificationStore } from "../services/verification-store.js";
 import { shouldAutoVerify } from "../services/verification-store.js";
@@ -317,6 +322,42 @@ export function registerMemoryTools(
             description: "Optional: filter by topic tag (e.g. nibe, zigbee)",
           }),
         ),
+        category: Type.Optional(
+          Type.String({
+            description: "Optional: constrain results to a specific category/type before ranking.",
+          }),
+        ),
+        source: Type.Optional(
+          Type.String({
+            description: "Optional: constrain results to an exact fact source before ranking (e.g. conversation, ingest, reflection).",
+          }),
+        ),
+        verificationTier: Type.Optional(
+          Type.String({
+            description: "Optional: constrain results to verified facts of a given tier before ranking (e.g. critical).",
+          }),
+        ),
+        validFromSec: Type.Optional(
+          Type.Number({
+            description: "Optional: constrain results to facts whose valid_from is on/after this Unix timestamp before ranking.",
+          }),
+        ),
+        validUntilSec: Type.Optional(
+          Type.Number({
+            description: "Optional: constrain results to facts whose validity extends past this Unix timestamp before ranking.",
+          }),
+        ),
+        sourceSession: Type.Optional(
+          Type.String({
+            description: "Optional: constrain results to facts linked to a specific source session before ranking.",
+          }),
+        ),
+        retrievalMode: Type.Optional(
+          Type.Union([Type.Literal("interactive-recall"), Type.Literal("explicit-deep"), Type.Literal("constrained-recall")], {
+            description:
+              'Optional retrieval strategy selection. Use "constrained-recall" for filter → rank → hydrate searches inside a known boundary.',
+          }),
+        ),
         includeSuperseded: Type.Optional(
           Type.Boolean({
             description: "Include superseded (historical) facts in results. Default: only current facts.",
@@ -511,8 +552,15 @@ export function registerMemoryTools(
       query: queryParam,
       id: idParam,
       limit = 10,
-      entity,
-      tag,
+      entity: entityParam,
+      tag: tagParam,
+      category: categoryParam,
+      source: sourceParam,
+      verificationTier: verificationTierParam,
+      validFromSec,
+      validUntilSec,
+      sourceSession: sourceSessionParam,
+      retrievalMode,
       includeSuperseded = false,
       asOf: asOfParam,
       includeCold = false,
@@ -528,6 +576,13 @@ export function registerMemoryTools(
       limit?: number;
       entity?: string;
       tag?: string;
+      category?: string;
+      source?: string;
+      verificationTier?: string;
+      validFromSec?: number;
+      validUntilSec?: number;
+      sourceSession?: string;
+      retrievalMode?: "interactive-recall" | "explicit-deep" | "constrained-recall";
       includeSuperseded?: boolean;
       asOf?: string;
       includeCold?: boolean;
@@ -538,6 +593,17 @@ export function registerMemoryTools(
       expandGraph?: boolean;
       expandDepth?: number;
     };
+    const normalizeOptionalString = (value: unknown): string | undefined => {
+      if (typeof value !== "string") return undefined;
+      const trimmed = value.trim();
+      return trimmed.length > 0 ? trimmed : undefined;
+    };
+    const entity = normalizeOptionalString(entityParam);
+    const tag = normalizeOptionalString(tagParam);
+    const category = normalizeOptionalString(categoryParam);
+    const source = normalizeOptionalString(sourceParam);
+    const verificationTier = normalizeOptionalString(verificationTierParam);
+    const sourceSession = normalizeOptionalString(sourceSessionParam);
     const asOfSec = asOfParam != null && asOfParam !== "" ? parseSourceDate(asOfParam) : undefined;
 
     // Scope filtering with auto-detection
@@ -686,9 +752,28 @@ export function registerMemoryTools(
       ...(asOfSec != null ? { asOf: asOfSec } : {}),
     };
 
-    // Entity-targeted lookup (always runs when entity filter is set; separate from RRF)
+    const hasAdditionalConstrainedFilters = Boolean(
+      category || source || verificationTier || validFromSec != null || validUntilSec != null || sourceSession,
+    );
+    const shouldUseConstrainedMode = retrievalMode === "constrained-recall" || (!retrievalMode && hasAdditionalConstrainedFilters);
+    const effectiveMode = shouldUseConstrainedMode ? "constrained-recall" : retrievalMode;
+    const constrainedFilters = shouldUseConstrainedMode
+      ? {
+          ...(entity ? { entity } : {}),
+          ...(tag ? { tag } : {}),
+          ...(category ? { category } : {}),
+          ...(source ? { source } : {}),
+          ...(verificationTier ? { verificationTier } : {}),
+          ...(typeof validFromSec === "number" ? { validFromSec: Math.floor(validFromSec) } : {}),
+          ...(typeof validUntilSec === "number" ? { validUntilSec: Math.floor(validUntilSec) } : {}),
+          ...(sourceSession ? { sourceSession } : {}),
+        }
+      : undefined;
+
+    // Entity-targeted lookup is useful for legacy explicit recall, but it bypasses
+    // filter → rank → hydrate semantics, so disable it in constrained mode.
     let entityResults: SearchResult[] = [];
-    if (entity) {
+    if (entity && !shouldUseConstrainedMode) {
       entityResults = factsDb.lookup(entity, undefined, tag, { ...recallOpts, limit: 100 });
     }
 
@@ -697,13 +782,23 @@ export function registerMemoryTools(
     let semanticWarning: string | null = null;
 
     // RRF multi-strategy retrieval pipeline (Issue #152)
-    // When tag is set, skip semantic strategy (same behaviour as before).
+    // Legacy tag-only recall skips semantic search; constrained mode keeps semantic ranking
+    // because tag/entity/category/etc. are applied before ranking inside the candidate set.
     let results: SearchResult[] = [];
     try {
-      const rrfStrategies = tag ? cfg.retrieval.strategies.filter((s) => s !== "semantic") : cfg.retrieval.strategies;
+      const useLegacyTagShortcut = Boolean(tag && !shouldUseConstrainedMode);
+      const rrfStrategies = useLegacyTagShortcut
+        ? cfg.retrieval.strategies.filter((s) => s !== "semantic")
+        : cfg.retrieval.strategies;
       const rrfConfig = { ...cfg.retrieval, strategies: rrfStrategies };
-      const explicitPolicy = resolveExplicitDeepRetrievalPolicy(rrfConfig);
-      if (!tag) {
+      // interactive-recall uses a different policy with its own vector prep; skip for other modes
+      const effectivePolicy =
+        effectiveMode !== "interactive-recall"
+          ? effectiveMode === "constrained-recall"
+            ? resolveConstrainedRetrievalPolicy(rrfConfig)
+            : resolveExplicitDeepRetrievalPolicy(rrfConfig)
+          : undefined;
+      if (!useLegacyTagShortcut && effectivePolicy !== undefined) {
         const vectorPrep = await buildExplicitSemanticQueryVector({
           query,
           cfg,
@@ -711,15 +806,13 @@ export function registerMemoryTools(
           openai,
           pendingLLMWarnings,
           logger: api.logger,
-          policy: explicitPolicy,
+          policy: effectivePolicy as ExplicitDeepRetrievalPolicy,
         });
         queryVector = vectorPrep.queryVector;
         semanticWarning = vectorPrep.warning;
       }
       const queryExpander =
-        cfg.queryExpansion?.enabled && cfg.retrieval.strategies.includes("semantic")
-          ? new QueryExpander(cfg.queryExpansion, openai)
-          : null;
+        cfg.queryExpansion?.enabled && rrfStrategies.includes("semantic") ? new QueryExpander(cfg.queryExpansion, openai) : null;
       const embedFn =
         queryVector != null
           ? (text: string) =>
@@ -727,8 +820,11 @@ export function registerMemoryTools(
           : null;
       const rrfOutput = await runExplicitDeepRetrieval(query, queryVector, factsDb.getRawDb(), vectorDb, factsDb, {
         config: rrfConfig,
-        policy: explicitPolicy,
-        tagFilter: tag ?? undefined,
+        ...(effectiveMode !== "interactive-recall" && effectivePolicy
+          ? { policy: effectivePolicy }
+          : effectiveMode === "interactive-recall" ? { mode: effectiveMode as "interactive-recall" } : {}),
+        ...(useLegacyTagShortcut ? { tagFilter: tag ?? undefined } : {}),
+        ...(constrainedFilters ? { constrainedFilters } : {}),
         includeSuperseded,
         scopeFilter,
         asOf: asOfSec ?? undefined,
@@ -865,18 +961,39 @@ export function registerMemoryTools(
       results = results.slice(0, limit);
     }
 
+    const retrievalExplanation = (() => {
+      if (!shouldUseConstrainedMode || !constrainedFilters) return undefined;
+      const filterPairs = Object.entries(constrainedFilters)
+        .filter(([, value]) => value !== undefined && value !== null && value !== "")
+        .map(([key, value]) => `${key}=${String(value)}`);
+      return {
+        mode: "constrained-recall" as const,
+        contract: "filter → rank → hydrate",
+        filterBasis: filterPairs,
+        rankBasis: "semantic rank inside the structured candidate set (with hydrated provenance/context in the final result)",
+      };
+    })();
+    const retrievalExplanationText = retrievalExplanation
+      ? `Retrieval: constrained-recall (filter → rank → hydrate)\nFilter basis: ${retrievalExplanation.filterBasis.join(", ")}\nRank basis: ${retrievalExplanation.rankBasis}`
+      : undefined;
+
     if (results.length === 0) {
       logRecall(false);
+      const noResultsText = semanticWarning
+        ? `No relevant memories found.\n\n⚠️ ${semanticWarning}`
+        : "No relevant memories found.";
       return {
         content: [
           {
             type: "text",
-            text: semanticWarning
-              ? `No relevant memories found.\n\n⚠️ ${semanticWarning}`
-              : "No relevant memories found.",
+            text: retrievalExplanationText ? `${retrievalExplanationText}\n\n${noResultsText}` : noResultsText,
           },
         ],
-        details: { count: 0, warning: semanticWarning ?? undefined },
+        details: {
+          count: 0,
+          warning: semanticWarning ?? undefined,
+          retrieval: retrievalExplanation,
+        },
       };
     }
 
@@ -957,10 +1074,15 @@ export function registerMemoryTools(
       content: [
         {
           type: "text",
-          text: `Found ${results.length} memories:\n\n${text}${semanticWarning ? `\n\n⚠️ ${semanticWarning}` : ""}`,
+          text: `${retrievalExplanationText ? `${retrievalExplanationText}\n\n` : ""}Found ${results.length} memories:\n\n${text}${semanticWarning ? `\n\n⚠️ ${semanticWarning}` : ""}`,
         },
       ],
-      details: { count: results.length, memories: sanitized, warning: semanticWarning ?? undefined },
+      details: {
+        count: results.length,
+        memories: sanitized,
+        warning: semanticWarning ?? undefined,
+        retrieval: retrievalExplanation,
+      },
     };
   }
 


### PR DESCRIPTION
Fixes #1026

## Summary

Introduces an explicit **constrained-recall** retrieval mode implementing the **filter → rank → hydrate** pattern for bounded recall scenarios.

## What changed

### 
- New  interface with  and 
- New  factory
-  type extended to include 
-  updated for the new mode

### 
- New  interface with optional filters:
  - , , , , 
  - , , , , 
-  — passes structured filters to the pipeline
- When  +  provided:
  1. Pre-fetches candidate fact IDs via pure SQL (no LanceDB/FTS involvement yet)
  2. Semantic and FTS5 strategies filter their results to only those candidates
  3. Results are ranked purely by semantic score (RRF fusion disabled)
  4. Hydrated with provenance, graph context, supersession state

### 
- New  function
- Pure SQL query applying all structured filters atomically
- Returns up to  fact IDs ordered by confidence/date

### 
- New section 3 documenting the constrained-recall path
- Comparison table (explicit-deep vs constrained-recall)
- Example usage and good use cases

### 
- 8 tests covering: entity filter, temporal window, empty filter result,
  category filter, MemoryEntry hydration, provenance in output,
  superseded exclusion, combined entity+tag filter

## Acceptance criteria met

- ✅ Explicit retrieval path exists in code/docs/tooling
- ✅ Structured filters are applied before semantic/vector ranking
- ✅ Results return with clear explanation of filter basis and rank basis
- ✅ Mode integrates with provenance and graph context rather than bypassing them

## Test results

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new retrieval mode that changes how candidate sets are built and how results are fused/ranked when structured filters are provided, which can affect recall quality and outputs across `memory_recall`. Risk is mitigated by graceful fallbacks and added unit/e2e coverage, but touches core retrieval orchestration and SQL filtering.
> 
> **Overview**
> Adds a new **`constrained-recall` retrieval mode** implementing **filter → rank → hydrate** for bounded searches.
> 
> Structured SQL pre-filters (`ConstrainedSearchFilters`) are introduced in `facts-db/search.ts` (with helpers `hasActiveFilters` and `getCandidateIdsByStructuredFilters`) and wired into `runExplicitDeepRetrieval` to prefetch candidate fact IDs, restrict semantic/FTS/alias/multi-model strategies to that set (including semantic-cache filtering), and bypass RRF fusion in favor of semantic-based scoring within the constrained set.
> 
> `memory_recall` now accepts additional structured filter params (`category`, `source`, `verificationTier`, `validFromSec`, `validUntilSec`, `sourceSession`) plus `retrievalMode`, auto-selects constrained mode when these filters are present, and returns an explanation of *filter basis* and *rank basis*. Docs are updated and new unit + e2e tests validate filtering, temporal windows, superseded exclusion, hydration, and tool output explanation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0de292ddb81e09c122120140587ec38fef80289f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->