### PR TITLE
feat(#1029): Epic: hybrid-memory productisation track

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+
+- Added [`docs/PRODUCTISATION-TRACK.md`](docs/PRODUCTISATION-TRACK.md) as the coordinating status page for Epic #1029, with phase order, shipped milestones, open product lanes, and guardrails.
+
 ### Changed
 
+- Linked the new productisation track page from the repository README and docs home so the shipped-vs-open product story is visible without digging through issue history.
 - Updated the changelog with a trivial entry for **issue #1131** to exercise the Forge → Council → Merge pipeline end-to-end after the recent gateway and token fixes.
 
 ---

--- a/README.md
+++ b/README.md
@@ -107,6 +107,15 @@ Guide: [docs/advanced-capabilities.md](docs/advanced-capabilities.md)
 Track progress and shipped product milestones in:
 - [`produkt/hybrid-memory-productisation.md`](produkt/hybrid-memory-productisation.md)
 
+## Productisation status
+
+Track the coordinating product roadmap in [docs/PRODUCTISATION-TRACK.md](docs/PRODUCTISATION-TRACK.md).
+
+Current snapshot:
+- **Shipped:** Memory Viewer / Mission Control, README/onboarding overhaul, public API/export surface
+- **Open lanes:** session observability, messaging/demo package, explicit filter → rank → hydrate retrieval mode
+- **Important:** Epic #1029 is the coordination layer; implementation lands through the child issues
+
 ## Fast path docs
 
 - [docs/QUICKSTART.md](docs/QUICKSTART.md): shortest successful path
@@ -114,6 +123,7 @@ Track progress and shipped product milestones in:
 - [docs/PRESENTATION-STRATEGY.md](docs/PRESENTATION-STRATEGY.md): product message, visuals, demos, terminology
 - [docs/OPERATIONS.md](docs/OPERATIONS.md): maintenance, backup, restore, troubleshooting
 - [docs/advanced-capabilities.md](docs/advanced-capabilities.md): graph, workflows, procedures, crystallization
+- [docs/PRODUCTISATION-TRACK.md](docs/PRODUCTISATION-TRACK.md): shipped productisation milestones and open lanes
 
 ## Common commands
 

--- a/docs/PRODUCTISATION-TRACK.md
+++ b/docs/PRODUCTISATION-TRACK.md
@@ -1,0 +1,84 @@
+---
+layout: default
+title: Productisation Track
+nav_order: 80
+---
+
+# Productisation Track (Epic #1029)
+
+Hybrid Memory already has strong memory depth. This track exists to make that depth **easy to see, trust, and demo**.
+
+## Goal
+
+Make hybrid-memory feel like a first-class product: immediately understandable, inspectable, and demoable without weakening the underlying trust model.
+
+> **Important:** [Epic #1029](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/1029) is a **coordinating issue**, not one giant implementation branch. Product work lands through focused child issues.
+
+## Current phase view
+
+| Phase | Goal | Status | Child issues |
+|---|---|---|---|
+| **Phase 1 — Foundation** | Viewer, top-of-repo legibility, session visibility | **Partially shipped** | [#1023](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/1023) ✅, [#1024](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/1024) ✅, [#1025](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/1025) open |
+| **Phase 2 — Polish** | Messaging, demos, and simple public surface | **Partially shipped** | [#1027](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/1027) ✅, [#1028](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/1028) open |
+| **Phase 3 — Maturation** | Explicit retrieval strategy and layered terminology | **Planned** | [#1026](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/1026) open |
+
+## What is already shipped
+
+### Product entry points
+
+- **Memory Viewer / Mission Control** via the local dashboard and viewer routes documented in `extensions/memory-hybrid/README.md` ([Issue #1023](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/1023), closed)
+- **README / onboarding refresh** with the capture → store → recall → inspect → control mental model, trust/privacy links, and persona-based start paths ([Issue #1024](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/1024), closed)
+- **Simple public API / export surface** documented at [`PUBLIC-API-SURFACE.md`](PUBLIC-API-SURFACE) (`/health`, `/search`, `/timeline`, `/stats`, `/export`) ([Issue #1027](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/1027), closed)
+
+### Trust and operator surface already available
+
+- Local-first storage and inspection paths
+- Verification, provenance, and deletion controls
+- Quick start, operations, backup/restore, and trust/privacy documentation
+- Session distillation and narrative docs that explain how memory is captured and reused over time
+
+## What remains open
+
+### [#1025](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/1025) — Session timeline / observability
+
+Still needed for the product story:
+- one coherent session timeline
+- capture vs injection visibility
+- skipped/suppressed write explanations
+- a human-readable “why this was recalled” surface
+
+### [#1028](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/1028) — Messaging, visuals, and demo story
+
+Still needed for the presentation layer:
+- tagline and elevator pitch
+- hero screenshots / proof points
+- 60-second and 5-minute demo scripts
+- terminology cleanup for first-time readers
+
+### [#1026](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/1026) — Filter → rank → hydrate retrieval
+
+Still needed for the explicit retrieval model:
+- named constrained-search mode in code and docs
+- structured filters before semantic ranking
+- clearer explanation of why results matched and how they were ranked
+
+## Recommended execution order
+
+1. Finish **#1025** so users can inspect capture, recall, injection, and skips without log-diving.
+2. Finish **#1028** so the now-visible product has a sharper story, screenshots, and demo flows.
+3. Finish **#1026** so retrieval becomes a named, teachable product capability instead of an internal implementation detail.
+
+## Guardrails for every phase
+
+- **Local-first remains the hero path** — no hosted-memory dependency required for the baseline experience.
+- **Keep the rich tool API** — the product surface should complement it, not replace it.
+- **Do not weaken verification, provenance, or decay** just to make the UI or docs simpler.
+- **Prefer layered explanations** — simple first, deep internals one click away.
+
+## Related documents
+
+- [Quick Start](QUICKSTART)
+- [Public API Surface](PUBLIC-API-SURFACE)
+- [How It Works](HOW-IT-WORKS)
+- [Architecture](ARCHITECTURE)
+- [Trust and privacy](trust-and-privacy)

--- a/docs/index.md
+++ b/docs/index.md
@@ -105,6 +105,7 @@ Hybrid Memory gives your OpenClaw agent **persistent memory** without turning me
 | [Model-Agnostic Analysis](MODEL-AGNOSTIC-ANALYSIS) | Compatibility across LLM providers |
 | [Presentation strategy](PRESENTATION-STRATEGY) | Canonical product message, demo story, visuals, and terminology |
 | [Feedback Roadmap](FEEDBACK-ROADMAP) | Planned improvements and feature requests |
+| [Productisation Track](PRODUCTISATION-TRACK) | Coordinating view of shipped product work, open lanes, and phase order |
 
 ### Project
 


### PR DESCRIPTION
Fixes #1029

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are documentation-only (new roadmap page plus links) with no runtime/behavioral impact; main risk is minor doc navigation/README consistency issues.
> 
> **Overview**
> Adds a new `docs/PRODUCTISATION-TRACK.md` page to act as the coordinating roadmap for Epic #1029, capturing phase order, shipped milestones, open lanes, and guardrails.
> 
> Updates `README.md`, `docs/index.md`, and `CHANGELOG.md` to link to this track so the shipped-vs-open productisation story is visible from top-level docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae1bd653098d984499c7d404f904eeaa1fceb645. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->