### PR TITLE
fix(memory-hybrid): GlitchTip batch #1151–#1167 (classifier, chat, SQL, embed, vector)

### DIFF
--- a/extensions/memory-hybrid/backends/facts-db/episodes.ts
+++ b/extensions/memory-hybrid/backends/facts-db/episodes.ts
@@ -179,8 +179,12 @@ export function searchEpisodes(
 
   const scopeClause = scopeFilterClausePositional(scopeFilter);
   if (scopeClause.clause) {
-    conditions.push(scopeClause.clause.replace(/^AND /, ""));
-    params.push(...scopeClause.params);
+    // Positional scope fragment is ` AND ( … )`; strip leading AND (not `^AND` — clause starts with spaces).
+    const trimmed = scopeClause.clause.trimStart().replace(/^AND\s+/i, "");
+    if (trimmed) {
+      conditions.push(trimmed);
+      params.push(...scopeClause.params);
+    }
   }
 
   const where = conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";

--- a/extensions/memory-hybrid/backends/vector-db.ts
+++ b/extensions/memory-hybrid/backends/vector-db.ts
@@ -274,9 +274,11 @@ export class VectorDB {
       this.table = null;
       this.semanticQueryCacheTable = null;
       this.db = null;
-      this.logWarn(
-        `memory-hybrid: LanceDB unavailable — continuing without vector search (FTS/SQLite still work). ${err instanceof Error ? err.message : String(err)}`,
-      );
+      if (!isHotReloadRace) {
+        this.logWarn(
+          `memory-hybrid: LanceDB unavailable — continuing without vector search (FTS/SQLite still work). ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
     });
     return this.initPromise;
   }

--- a/extensions/memory-hybrid/backends/vector-db.ts
+++ b/extensions/memory-hybrid/backends/vector-db.ts
@@ -257,10 +257,16 @@ export class VectorDB {
     // Note: this handler marks persistent failure (lanceInitFailed). Transient init errors
     // from hot-reload races are handled via close()+ensureInitialized() or resetTableForReindex().
     this.initPromise = this.doInitialize().catch((err) => {
-      capturePluginError(err as Error, {
-        operation: "vector-db-init",
-        subsystem: "vector",
-      });
+      const msg = err instanceof Error ? err.message : String(err);
+      const isHotReloadRace = msg.includes("concurrent re-registration") || msg.includes("initialization aborted");
+      if (!isHotReloadRace) {
+        capturePluginError(err as Error, {
+          operation: "vector-db-init",
+          subsystem: "vector",
+        });
+      } else {
+        this.logWarn(`memory-hybrid: VectorDB init aborted during hot reload (benign): ${msg}`);
+      }
       this.initPromise = null;
       this.lanceDbAvailable = false;
       this.lanceInitFailed = true;

--- a/extensions/memory-hybrid/backends/vector-db.ts
+++ b/extensions/memory-hybrid/backends/vector-db.ts
@@ -1042,9 +1042,7 @@ export class VectorDB {
         if (!this.vectorDimMismatchLogged) {
           this.vectorDimMismatchLogged = true;
           this.logWarn(
-            `memory-hybrid: vector dimension mismatch — embedding produced ${vector.length}-dim vector but LanceDB table expects ${this.vectorDim}-dim. ` +
-              `Check embedding.preferredProviders and embedding.dimensions in plugin config. Run 'openclaw hybrid-mem verify' for details. ` +
-              `(Further mismatches in this session are silent; fix config and re-index.)`,
+            `memory-hybrid: vector dimension mismatch — embedding produced ${vector.length}-dim vector but LanceDB table expects ${this.vectorDim}-dim. Check embedding.preferredProviders and embedding.dimensions in plugin config. Run 'openclaw hybrid-mem verify' for details. (Further mismatches in this session are silent; fix config and re-index.)`,
           );
         }
         return [];

--- a/extensions/memory-hybrid/backends/vector-db.ts
+++ b/extensions/memory-hybrid/backends/vector-db.ts
@@ -257,10 +257,11 @@ export class VectorDB {
     // Note: this handler marks persistent failure (lanceInitFailed). Transient init errors
     // from hot-reload races are handled via close()+ensureInitialized() or resetTableForReindex().
     this.initPromise = this.doInitialize().catch((err) => {
-      const msg = err instanceof Error ? err.message : String(err);
+      const e = err instanceof Error ? err : new Error(String(err));
+      const msg = e.message;
       const isHotReloadRace = msg.includes("concurrent re-registration") || msg.includes("initialization aborted");
       if (!isHotReloadRace) {
-        capturePluginError(err as Error, {
+        capturePluginError(e, {
           operation: "vector-db-init",
           subsystem: "vector",
         });
@@ -276,7 +277,7 @@ export class VectorDB {
       this.db = null;
       if (!isHotReloadRace) {
         this.logWarn(
-          `memory-hybrid: LanceDB unavailable — continuing without vector search (FTS/SQLite still work). ${err instanceof Error ? err.message : String(err)}`,
+          `memory-hybrid: LanceDB unavailable — continuing without vector search (FTS/SQLite still work). ${e.message}`,
         );
       }
     });

--- a/extensions/memory-hybrid/lifecycle/stage-injection.ts
+++ b/extensions/memory-hybrid/lifecycle/stage-injection.ts
@@ -60,10 +60,14 @@ function buildEdictBlock(ctx: LifecycleContext): string {
     const { renderForPrompt } = ctx.edictStore.getEdicts({ format: "prompt" });
     return renderForPrompt;
   } catch (err) {
-    capturePluginError(err instanceof Error ? err : new Error(String(err)), {
-      subsystem: "stage-injection",
-      operation: "get-edicts",
-    });
+    const e = err instanceof Error ? err : new Error(String(err));
+    // Expected when the plugin is shutting down or the edict DB closed mid-hook (#1162).
+    if (!/database connection is not open/i.test(e.message)) {
+      capturePluginError(e, {
+        subsystem: "stage-injection",
+        operation: "get-edicts",
+      });
+    }
     return "";
   }
 }

--- a/extensions/memory-hybrid/lifecycle/stage-injection.ts
+++ b/extensions/memory-hybrid/lifecycle/stage-injection.ts
@@ -118,7 +118,7 @@ async function runInjection(
     groupByCategory,
     pinnedRecallThreshold,
     lastProgressiveIndexIdsRef,
-    ambientCfg,
+    ambientCfg: _ambientCfg,
     ambientSeenFacts,
   } = r;
   const edictBlock = buildEdictBlock(ctx);
@@ -169,7 +169,7 @@ async function runInjection(
       const sortedCats = [...byCat.keys()].sort();
       lines = [header.trimEnd()];
       for (const cat of sortedCats) {
-        const entries = byCat.get(cat)!;
+        const entries = byCat.get(cat) ?? [];
         lines.push(`  ${cat} (${entries.length}):`);
         for (const e of entries) {
           lines.push(e.line.replace(/^(\s+)(\d+\.)/, "  $2"));

--- a/extensions/memory-hybrid/services/auto-classifier.ts
+++ b/extensions/memory-hybrid/services/auto-classifier.ts
@@ -139,7 +139,7 @@ async function discoverCategoriesFromOther(
           }),
         { maxRetries: 2 },
       );
-      const content = resp.choices[0]?.message?.content?.trim() || "[]";
+      const content = resp.choices?.[0]?.message?.content?.trim() || "[]";
       const labels = tryParseFirstJsonArray(content);
       if (!labels) continue;
       anyBatchSucceeded = true;
@@ -247,7 +247,7 @@ Respond with ONLY a JSON array of category strings, one per fact, in order. Exam
       { maxRetries: 2 },
     );
 
-    const content = resp.choices[0]?.message?.content?.trim() || "[]";
+    const content = resp.choices?.[0]?.message?.content?.trim() || "[]";
     const parsed = tryParseFirstJsonArray(content);
     if (!parsed) return new Map();
 

--- a/extensions/memory-hybrid/services/auto-classifier.ts
+++ b/extensions/memory-hybrid/services/auto-classifier.ts
@@ -355,14 +355,15 @@ async function runClassifyForCli(
   }
 
   const numBatches = Math.ceil(others.length / config.batchSize);
-  if (!progressReporter && numBatches > 0) {
+  let reporter = progressReporter;
+  if (!reporter && numBatches > 0) {
     const sink = { log: (m: string) => logger.info(m) };
-    progressReporter = createProgressReporter(sink, numBatches, "Classifying");
+    reporter = createProgressReporter(sink, numBatches, "Classifying");
   }
   let totalReclassified = 0;
   let batchIndex = 0;
   for (let i = 0; i < others.length; i += config.batchSize) {
-    progressReporter?.update(batchIndex + 1);
+    reporter?.update(batchIndex + 1);
     const batch = others.slice(i, i + config.batchSize).map((e) => ({ id: e.id, text: e.text }));
     const results = await classifyBatch(openai, classifyModel, batch, categories);
     for (const [id, newCat] of results) {
@@ -372,7 +373,7 @@ async function runClassifyForCli(
     batchIndex++;
     if (i + config.batchSize < others.length) await new Promise((r) => setTimeout(r, 500));
   }
-  progressReporter?.done();
+  reporter?.done();
 
   const breakdown = !opts.dryRun ? factsDb.statsBreakdown() : undefined;
   return { reclassified: totalReclassified, total: others.length, breakdown };

--- a/extensions/memory-hybrid/services/chat.ts
+++ b/extensions/memory-hybrid/services/chat.ts
@@ -484,7 +484,7 @@ export async function chatComplete(opts: {
     const resp = (await (feature ? withCostFeature(feature, doCreate) : doCreate())) as OpenAI.Chat.ChatCompletion;
     clearTimeout(timeoutId);
     if (signal) signal.removeEventListener("abort", onAbort);
-    const msg = (resp as any).choices?.[0]?.message;
+    const msg = resp.choices?.[0]?.message;
     const msgContent = msg?.content?.trim();
     if (msgContent) return msgContent;
     // Qwen3 thinking mode (Ollama OpenAI-compat endpoint) puts the response in

--- a/extensions/memory-hybrid/services/chat.ts
+++ b/extensions/memory-hybrid/services/chat.ts
@@ -336,6 +336,12 @@ function isNonRetryableClient400(err: unknown): boolean {
   return false;
 }
 
+/** Gateway/proxy may return HTTP 400 with an empty body — transient, not a plugin bug (#1157). */
+function is400EmptyBodyGatewayError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  return /\b400\b.*\bno body\b/i.test(err.message);
+}
+
 /**
  * Detect malformed Responses API reasoning-output sequencing errors, e.g.:
  * "Item 'rs_...' of type 'reasoning' was provided without its required following item."
@@ -472,7 +478,7 @@ export async function chatComplete(opts: {
     const resp = (await (feature ? withCostFeature(feature, doCreate) : doCreate())) as OpenAI.Chat.ChatCompletion;
     clearTimeout(timeoutId);
     if (signal) signal.removeEventListener("abort", onAbort);
-    const msg = (resp as any).choices[0]?.message;
+    const msg = (resp as any).choices?.[0]?.message;
     const msgContent = msg?.content?.trim();
     if (msgContent) return msgContent;
     // Qwen3 thinking mode (Ollama OpenAI-compat endpoint) puts the response in
@@ -509,7 +515,9 @@ export async function chatComplete(opts: {
       /^5\d{2}\s/.test(msg.trim()) ||
       is500Like(err) || // #302: OpenAI SDK InternalServerError has no numeric prefix
       isOllamaOOM(err) || // #387: Ollama OOM — model too large for available RAM, not a bug
-      isResponsesReasoningSequenceError(err); // #1034: malformed reasoning item sequence — retryable
+      isResponsesReasoningSequenceError(err) || // #1034: malformed reasoning item sequence — retryable
+      is400EmptyBodyGatewayError(error) ||
+      is400EmptyBodyGatewayError(err); // #1157: 400 (no body) from gateway — do not GlitchTip
     const isConfigError =
       err instanceof UnconfiguredProviderError ||
       is404Like(err) || // #303: model not found = wrong model name in config, not a bug
@@ -690,7 +698,8 @@ export async function withLLMRetry<T>(
           /^5\d{2}\s/.test(causeMsg.trim()) ||
           /\b405\s+method\s+not\s+allowed/i.test(causeMsg) ||
           /\b405\s+method\s+not\s+allowed/i.test(fullMsg) ||
-          isResponsesReasoningSequenceError(lastError); // #1034
+          isResponsesReasoningSequenceError(lastError) || // #1034
+          is400EmptyBodyGatewayError(lastError); // #1157
         if (!isTransient) {
           capturePluginError(retryError, {
             subsystem: "chat",

--- a/extensions/memory-hybrid/services/chat.ts
+++ b/extensions/memory-hybrid/services/chat.ts
@@ -342,6 +342,12 @@ function is400EmptyBodyGatewayError(err: unknown): boolean {
   return /\b400\b.*\bno body\b/i.test(err.message);
 }
 
+/** Some Azure/Foundry deployments return 400 when chat params are not supported for the model (#1165). */
+function is400UnsupportedOperationError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  return /\b400\b.*\bunsupported\b/i.test(err.message);
+}
+
 /**
  * Detect malformed Responses API reasoning-output sequencing errors, e.g.:
  * "Item 'rs_...' of type 'reasoning' was provided without its required following item."
@@ -517,7 +523,9 @@ export async function chatComplete(opts: {
       isOllamaOOM(err) || // #387: Ollama OOM — model too large for available RAM, not a bug
       isResponsesReasoningSequenceError(err) || // #1034: malformed reasoning item sequence — retryable
       is400EmptyBodyGatewayError(error) ||
-      is400EmptyBodyGatewayError(err); // #1157: 400 (no body) from gateway — do not GlitchTip
+      is400EmptyBodyGatewayError(err) || // #1157: 400 (no body) from gateway — do not GlitchTip
+      is400UnsupportedOperationError(error) ||
+      is400UnsupportedOperationError(err); // #1165: model/endpoint mismatch
     const isConfigError =
       err instanceof UnconfiguredProviderError ||
       is404Like(err) || // #303: model not found = wrong model name in config, not a bug
@@ -699,7 +707,8 @@ export async function withLLMRetry<T>(
           /\b405\s+method\s+not\s+allowed/i.test(causeMsg) ||
           /\b405\s+method\s+not\s+allowed/i.test(fullMsg) ||
           isResponsesReasoningSequenceError(lastError) || // #1034
-          is400EmptyBodyGatewayError(lastError); // #1157
+          is400EmptyBodyGatewayError(lastError) || // #1157
+          is400UnsupportedOperationError(lastError); // #1165
         if (!isTransient) {
           capturePluginError(retryError, {
             subsystem: "chat",

--- a/extensions/memory-hybrid/services/classification.ts
+++ b/extensions/memory-hybrid/services/classification.ts
@@ -146,7 +146,7 @@ export async function classifyMemoryOperation(
         ),
       { maxRetries: 2 },
     )) as OpenAI.Chat.ChatCompletion;
-    const content = (resp.choices[0]?.message?.content ?? "").trim();
+    const content = (resp.choices?.[0]?.message?.content ?? "").trim();
     return parseClassificationResponse(content, existingFacts);
   } catch (err) {
     capturePluginError(err instanceof Error ? err : new Error(String(err)), {
@@ -282,9 +282,12 @@ function isLenientBatchClassifyResultArray(v: unknown): v is unknown[] {
 
 /**
  * Find a JSON array of batch rows; skip bracket preambles that are not JSON or not our shape (#1007, Copilot PR#1006).
+ * Returns null when nothing matches (caller falls back to sequential classify; no throw — avoids GlitchTip noise #1155–#1156).
  */
-function parseBalancedBatchArrayFromText(text: string): unknown[] {
+function parseBalancedBatchArrayFromText(text: string): unknown[] | null {
   const t = text.trim();
+  if (t.length === 0) return null;
+
   const seen = new Set<string>();
   const tryCandidate = (candidate: string): unknown[] | undefined => {
     const normalized = candidate.trim();
@@ -300,66 +303,45 @@ function parseBalancedBatchArrayFromText(text: string): unknown[] {
     }
   };
 
-  const fromBalancedAt = (offset: number): string | null => extractTopLevelJsonArraySubstring(t.slice(offset));
-
-  const firstBalanced = fromBalancedAt(0);
-  if (firstBalanced) {
-    const parsed = tryCandidate(firstBalanced);
-    if (parsed !== undefined) return parsed;
-  }
-
-  if (t.startsWith("[")) {
-    const parsed = tryCandidate(t);
-    if (parsed !== undefined) return parsed;
-  }
-
-  for (let i = 0; i < t.length; i++) {
-    if (t[i] !== "[") continue;
-    const candidate = fromBalancedAt(i);
-    if (!candidate) continue;
+  let searchFrom = 0;
+  while (searchFrom < t.length) {
+    const relStart = t.indexOf("[", searchFrom);
+    if (relStart < 0) return null;
+    const sliceFromBracket = t.slice(relStart);
+    const candidate = extractTopLevelJsonArraySubstring(sliceFromBracket);
+    if (!candidate) {
+      searchFrom = relStart + 1;
+      continue;
+    }
     const parsed = tryCandidate(candidate);
     if (parsed !== undefined) return parsed;
+    searchFrom = relStart + candidate.length;
   }
-
-  const legacy = t.match(/\[[\s\S]*\]/);
-  if (legacy) {
-    const parsed = tryCandidate(legacy[0]);
-    if (parsed !== undefined) return parsed;
-  }
-
-  throw new Error("no JSON array in batch classify response");
+  return null;
 }
 
 /**
  * Parse model output for {@link classifyMemoryOperationsBatch}. Exported for tests (#1007).
+ * Returns null when no valid batch array can be recovered (expected for some model outputs).
  */
-export function parseBatchClassifyResponseContent(raw: string): unknown {
+export function parseBatchClassifyResponseContent(raw: string): unknown | null {
   let s = raw.trim();
   s = stripThinkingWrapperBlocks(s);
   s = preferMarkdownJsonFenceContent(s);
   s = s.trim();
 
-  // Whole string is a JSON array
   if (s.startsWith("[")) {
-    try {
-      return parseBalancedBatchArrayFromText(s);
-    } catch {
-      /* fall through */
-    }
+    const arr = parseBalancedBatchArrayFromText(s);
+    if (arr) return arr;
   }
 
-  // Whole string is a JSON object wrapping the array (some JSON-mode APIs)
   const fromObject = tryParseBatchClassifyAsObjectWithArray(s);
   if (fromObject) return fromObject;
 
-  // Prose or noise before/after — locate balanced array in the remainder
-  try {
-    return parseBalancedBatchArrayFromText(s);
-  } catch {
-    /* fall through */
-  }
+  const arr = parseBalancedBatchArrayFromText(s);
+  if (arr) return arr;
 
-  throw new Error("no JSON array in batch classify response");
+  return null;
 }
 
 function parseBatchClassificationRow(row: unknown, existingFacts: MemoryEntry[]): MemoryClassification {
@@ -427,34 +409,7 @@ For UPDATE or DELETE, targetId must be one of the existing fact ids listed under
 
   const fullPrompt = `${header}\n${blocks.join("\n\n")}`;
 
-  try {
-    const { withLLMRetry } = await import("./chat.js");
-    const batchMaxOut = Math.min(800, 80 * items.length);
-    const resp = (await withLLMRetry(
-      () =>
-        openai.chat.completions.create(
-          buildClassifyChatBody(model, fullPrompt, batchMaxOut) as unknown as Parameters<
-            OpenAI["chat"]["completions"]["create"]
-          >[0],
-        ),
-      { maxRetries: 2 },
-    )) as OpenAI.Chat.ChatCompletion;
-    const raw = (resp.choices[0]?.message?.content ?? "").trim();
-    const parsed: unknown = parseBatchClassifyResponseContent(raw);
-    if (!Array.isArray(parsed) || parsed.length !== items.length) {
-      throw new Error(
-        `batch classify expected ${items.length} results, got ${Array.isArray(parsed) ? parsed.length : "non-array"}`,
-      );
-    }
-    return items.map((it, i) => parseBatchClassificationRow(parsed[i], it.existingFacts));
-  } catch (err) {
-    capturePluginError(err instanceof Error ? err : new Error(String(err)), {
-      operation: "classify-memory-operations-batch",
-      subsystem: "openai",
-      model,
-      severity: "info",
-    });
-    logger.warn(`memory-hybrid: batch classify failed (${err}); falling back to sequential calls`);
+  const runSequential = async (): Promise<MemoryClassification[]> => {
     const out: MemoryClassification[] = [];
     for (const it of items) {
       out.push(
@@ -470,5 +425,37 @@ For UPDATE or DELETE, targetId must be one of the existing fact ids listed under
       );
     }
     return out;
+  };
+
+  try {
+    const { withLLMRetry } = await import("./chat.js");
+    const batchMaxOut = Math.min(800, 80 * items.length);
+    const resp = (await withLLMRetry(
+      () =>
+        openai.chat.completions.create(
+          buildClassifyChatBody(model, fullPrompt, batchMaxOut) as unknown as Parameters<
+            OpenAI["chat"]["completions"]["create"]
+          >[0],
+        ),
+      { maxRetries: 2 },
+    )) as OpenAI.Chat.ChatCompletion;
+    const raw = (resp.choices?.[0]?.message?.content ?? "").trim();
+    const parsed = parseBatchClassifyResponseContent(raw);
+    if (!Array.isArray(parsed) || parsed.length !== items.length) {
+      logger.warn(
+        `memory-hybrid: batch classify parse/length mismatch (expected ${items.length}, got ${Array.isArray(parsed) ? parsed.length : "non-array"}); falling back to sequential calls`,
+      );
+      return await runSequential();
+    }
+    return items.map((it, i) => parseBatchClassificationRow(parsed[i], it.existingFacts));
+  } catch (err) {
+    capturePluginError(err instanceof Error ? err : new Error(String(err)), {
+      operation: "classify-memory-operations-batch",
+      subsystem: "openai",
+      model,
+      severity: "info",
+    });
+    logger.warn(`memory-hybrid: batch classify failed (${err}); falling back to sequential calls`);
+    return await runSequential();
   }
 }

--- a/extensions/memory-hybrid/services/classification.ts
+++ b/extensions/memory-hybrid/services/classification.ts
@@ -184,8 +184,9 @@ function stripThinkingWrapperBlocks(s: string): string {
 function preferMarkdownJsonFenceContent(s: string): string {
   const re = /```(?:json)?\s*\n?([\s\S]*?)```/gi;
   const chunks: string[] = [];
-  let m: RegExpExecArray | null;
-  while ((m = re.exec(s)) !== null) {
+  for (;;) {
+    const m = re.exec(s);
+    if (m === null) break;
     chunks.push(m[1].trim());
   }
   if (chunks.length === 0) return s;
@@ -207,7 +208,7 @@ function extractTopLevelJsonArraySubstring(s: string): string | null {
   let inString = false;
   let escaped = false;
   for (let i = start; i < s.length; i++) {
-    const ch = s[i]!;
+    const ch = s.charAt(i);
     if (inString) {
       if (escaped) escaped = false;
       else if (ch === "\\") escaped = true;

--- a/extensions/memory-hybrid/services/classification.ts
+++ b/extensions/memory-hybrid/services/classification.ts
@@ -9,6 +9,7 @@ import type { MemoryEntry } from "../types/memory.js";
 import { fillPrompt, loadPrompt } from "../utils/prompt-loader.js";
 import { capturePluginError } from "./error-reporter.js";
 import { isReasoningModel, requiresMaxCompletionTokens } from "./model-capabilities.js";
+import { extractBalancedArraySlice } from "../utils/llm-json-array.js";
 
 /** Chat body for classify completions — mirrors `chatComplete` in `chat.ts` (#1008). */
 function buildClassifyChatBody(
@@ -197,37 +198,6 @@ function preferMarkdownJsonFenceContent(s: string): string {
   return chunks[chunks.length - 1] ?? s;
 }
 
-/**
- * Extract the first top-level JSON array substring with bracket matching (respects strings).
- * Greedy `\\[[\\s\\S]*\\]` breaks when `]` appears inside string values or reasoning trails.
- */
-function extractTopLevelJsonArraySubstring(s: string): string | null {
-  const start = s.indexOf("[");
-  if (start < 0) return null;
-  let depth = 0;
-  let inString = false;
-  let escaped = false;
-  for (let i = start; i < s.length; i++) {
-    const ch = s.charAt(i);
-    if (inString) {
-      if (escaped) escaped = false;
-      else if (ch === "\\") escaped = true;
-      else if (ch === '"') inString = false;
-      continue;
-    }
-    if (ch === '"') {
-      inString = true;
-      continue;
-    }
-    if (ch === "[") depth++;
-    else if (ch === "]") {
-      depth--;
-      if (depth === 0) return s.slice(start, i + 1);
-    }
-  }
-  return null;
-}
-
 const BATCH_OBJECT_ARRAY_KEYS = [
   "classifications",
   "results",
@@ -308,8 +278,7 @@ function parseBalancedBatchArrayFromText(text: string): unknown[] | null {
   while (searchFrom < t.length) {
     const relStart = t.indexOf("[", searchFrom);
     if (relStart < 0) return null;
-    const sliceFromBracket = t.slice(relStart);
-    const candidate = extractTopLevelJsonArraySubstring(sliceFromBracket);
+    const candidate = extractBalancedArraySlice(t, relStart);
     if (!candidate) {
       searchFrom = relStart + 1;
       continue;

--- a/extensions/memory-hybrid/services/embeddings/shared.ts
+++ b/extensions/memory-hybrid/services/embeddings/shared.ts
@@ -3,7 +3,15 @@
  */
 
 import { createHash } from "node:crypto";
-import { LLMRetryError, is401OrWrapped, is403Like, is404Like, is429OrWrapped, is500OrWrapped } from "../chat.js";
+import {
+  LLMRetryError,
+  is401OrWrapped,
+  is403Like,
+  is404Like,
+  is429OrWrapped,
+  is500OrWrapped,
+  isContextLengthError,
+} from "../chat.js";
 import { capturePluginError } from "../error-reporter.js";
 import { is403QuotaOrRateLimitLike } from "../llm-rate-limit-headers.js";
 import type { EmbeddingProvider } from "./types.js";
@@ -103,10 +111,13 @@ export class AsyncSemaphore {
  * OpenAI embedding models have a hard limit of 8192 tokens per input.
  * Using ~4 chars/token heuristic (consistent with estimateTokens in utils/text.ts),
  * we clamp inputs to this character ceiling before hitting the API.
- * Overshooting the estimate slightly is harmless; undershooting wastes a round trip.
+ * Use a conservative ~3 chars/token effective ratio so dense text (code, CJK, markup)
+ * still stays under the provider token count (#1161, #1164).
  */
 const OPENAI_EMBEDDING_MAX_TOKENS = 8192;
-const OPENAI_EMBEDDING_MAX_CHARS = OPENAI_EMBEDDING_MAX_TOKENS * 4; // ~32 768 chars
+
+/** Exported for tests — conservative char ceiling before OpenAI embedding API (#1161, #1164). */
+export const OPENAI_EMBEDDING_INPUT_MAX_CHARS = Math.floor(OPENAI_EMBEDDING_MAX_TOKENS * 3); // ~24 576 chars
 
 /**
  * Truncate text to fit within the OpenAI embedding token limit.
@@ -114,8 +125,8 @@ const OPENAI_EMBEDDING_MAX_CHARS = OPENAI_EMBEDDING_MAX_TOKENS * 4; // ~32 768 c
  * consistent across the codebase without adding a tokenizer dependency here.
  */
 export function truncateForEmbedding(text: string): string {
-  if (text.length <= OPENAI_EMBEDDING_MAX_CHARS) return text;
-  return text.slice(0, OPENAI_EMBEDDING_MAX_CHARS).trimEnd();
+  if (text.length <= OPENAI_EMBEDDING_INPUT_MAX_CHARS) return text;
+  return text.slice(0, OPENAI_EMBEDDING_INPUT_MAX_CHARS).trimEnd();
 }
 
 /** Hash text for cache key (prevents large text strings as Map keys). */
@@ -181,7 +192,8 @@ export function shouldSuppressEmbeddingError(err: unknown): boolean {
     is429OrWrapped(err) ||
     is500OrWrapped(err) ||
     isOllamaCircuitBreakerOpen(err) ||
-    isOllamaConnectionFailure(err)
+    isOllamaConnectionFailure(err) ||
+    isContextLengthError(err)
   ) {
     return true;
   }
@@ -194,7 +206,8 @@ export function shouldSuppressEmbeddingError(err: unknown): boolean {
         is429OrWrapped(c) ||
         is500OrWrapped(c) ||
         isOllamaCircuitBreakerOpen(c) ||
-        isOllamaConnectionFailure(c),
+        isOllamaConnectionFailure(c) ||
+        isContextLengthError(c),
     );
   }
   return false;

--- a/extensions/memory-hybrid/tests/batch-classify-parse.test.ts
+++ b/extensions/memory-hybrid/tests/batch-classify-parse.test.ts
@@ -51,8 +51,8 @@ describe("parseBatchClassifyResponseContent (#1007)", () => {
     expect(parseBatchClassifyResponseContent(raw)).toEqual([row]);
   });
 
-  it("throws when no array can be recovered", () => {
-    expect(() => parseBatchClassifyResponseContent("just prose")).toThrow(/no JSON array/);
+  it("returns null when no array can be recovered (#1155–#1156)", () => {
+    expect(parseBatchClassifyResponseContent("just prose")).toBeNull();
   });
 
   it("parses lenient array when one row is missing action", () => {
@@ -89,12 +89,18 @@ describe("parseBatchClassifyResponseContent (#1007)", () => {
     expect(parseBatchClassifyResponseContent(raw)).toEqual([{ action: "NOOP", targetId: null, reason: "ok" }]);
   });
 
-  it("rejects lenient array where less than half have action", () => {
+  it("returns null when lenient array has too few rows with action", () => {
     const raw = JSON.stringify([
       { targetId: null, reason: "no action" },
       { targetId: null, reason: "also no action" },
       { action: "ADD", targetId: null, reason: "only one" },
     ]);
-    expect(() => parseBatchClassifyResponseContent(`${raw}`)).toThrow(/no JSON array/);
+    expect(parseBatchClassifyResponseContent(`${raw}`)).toBeNull();
+  });
+
+  it("parses batch array after a non-JSON [[placeholder]] line (#1155)", () => {
+    const inner = JSON.stringify([row, row]);
+    const raw = `[[reply_to_current]]\n${inner}`;
+    expect(parseBatchClassifyResponseContent(raw)).toEqual([row, row]);
   });
 });

--- a/extensions/memory-hybrid/tests/chat.test.ts
+++ b/extensions/memory-hybrid/tests/chat.test.ts
@@ -1158,6 +1158,13 @@ describe("withLLMRetry — non-retryable 400 (#1011)", () => {
     vi.useRealTimers();
   });
 
+  it("#1165: does not retry generic 400 unsupported operation (single attempt)", async () => {
+    const err = Object.assign(new Error("400 The requested operation is unsupported."), { status: 400 });
+    const fn = vi.fn().mockRejectedValue(err);
+    await expect(withLLMRetry(fn, { maxRetries: 3 })).rejects.toThrow(/unsupported/i);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
   it("does not retry 400 with empty body phrasing; enriches message with llmContext", async () => {
     const err = Object.assign(new Error("400 status code (no body)"), { status: 400 });
     const fn = vi.fn().mockRejectedValue(err);

--- a/extensions/memory-hybrid/tests/classification-batch.test.ts
+++ b/extensions/memory-hybrid/tests/classification-batch.test.ts
@@ -18,6 +18,24 @@ function makeEntry(id: string, text: string): MemoryEntry {
 }
 
 describe("classifyMemoryOperationsBatch (#862)", () => {
+  it("single classify tolerates missing choices on response (#1159)", async () => {
+    const create = vi.fn().mockResolvedValue({} as { choices?: unknown[] });
+    const openai = { chat: { completions: { create } } } as unknown as OpenAI;
+    const warn = vi.fn();
+    const out = await classifyMemoryOperation(
+      "new fact",
+      null,
+      null,
+      [makeEntry("id1", "old")],
+      openai,
+      "gpt-4.1-nano",
+      { warn },
+    );
+    expect(out.action).toBe("ADD");
+    expect(out.reason).toMatch(/unparseable LLM response|classification failed/);
+    expect(create).toHaveBeenCalledTimes(1);
+  });
+
   it("uses one chat.completions call for multiple candidates", async () => {
     const create = vi.fn().mockResolvedValue({
       choices: [
@@ -108,6 +126,27 @@ describe("classifyMemoryOperationsBatch (#862)", () => {
     expect(out).toHaveLength(2);
     expect(out[0].action).toBe("NOOP");
     expect(out[1].action).toBe("ADD");
+  });
+
+  it("falls back to sequential classify when batch response has no JSON array (#1155)", async () => {
+    const create = vi
+      .fn()
+      .mockResolvedValueOnce({
+        choices: [{ message: { content: "Here are my thoughts — no structured JSON." } }],
+      })
+      .mockResolvedValue({ choices: [{ message: { content: "NOOP | ok" } }] });
+    const openai = { chat: { completions: { create } } } as unknown as OpenAI;
+    const warn = vi.fn();
+    const items = [
+      { candidateText: "a", candidateEntity: null, candidateKey: null, existingFacts: [makeEntry("id1", "old a")] },
+      { candidateText: "b", candidateEntity: null, candidateKey: null, existingFacts: [makeEntry("id2", "old b")] },
+    ];
+    const out = await classifyMemoryOperationsBatch(items, openai, "gpt-4.1-nano", { warn });
+    expect(create).toHaveBeenCalledTimes(3);
+    expect(out).toHaveLength(2);
+    expect(out[0].action).toBe("NOOP");
+    expect(out[1].action).toBe("NOOP");
+    expect(warn.mock.calls.some((c) => /parse\/length mismatch|batch classify/i.test(String(c[0])))).toBe(true);
   });
 });
 

--- a/extensions/memory-hybrid/tests/embedding-providers.test.ts
+++ b/extensions/memory-hybrid/tests/embedding-providers.test.ts
@@ -1304,7 +1304,7 @@ describe("Embeddings (OpenAI) — context-length truncation (#442)", () => {
     vi.clearAllMocks();
   });
 
-  it("#442: truncates text > 32768 chars before calling the API", async () => {
+  it("#442 / #1161: truncates long text before calling the embedding API", async () => {
     const vector = [0.1, 0.2, 0.3];
     const mockCreate = vi.fn().mockImplementation((_params: { input: string }) => {
       return Promise.resolve({ data: [{ embedding: vector }] });
@@ -1312,11 +1312,12 @@ describe("Embeddings (OpenAI) — context-length truncation (#442)", () => {
     const client = { embeddings: { create: mockCreate } } as unknown as import("openai").default;
     const provider = new Embeddings(client, "text-embedding-3-small", 3);
 
-    const longText = "a".repeat(40000); // exceeds 32768 char limit
+    const { OPENAI_EMBEDDING_INPUT_MAX_CHARS } = await import("../services/embeddings/shared.js");
+    const longText = "a".repeat(OPENAI_EMBEDDING_INPUT_MAX_CHARS + 5000);
     await provider.embed(longText);
 
     const calledInput: string = mockCreate.mock.calls[0][0].input;
-    expect(calledInput.length).toBeLessThanOrEqual(32768);
+    expect(calledInput.length).toBeLessThanOrEqual(OPENAI_EMBEDDING_INPUT_MAX_CHARS);
   });
 
   it("#442: does not truncate text within the limit", async () => {
@@ -1334,7 +1335,7 @@ describe("Embeddings (OpenAI) — context-length truncation (#442)", () => {
     expect(calledInput).toBe(shortText);
   });
 
-  it("#442: truncates batch items > 32768 chars in embedBatch", async () => {
+  it("#442 / #1161: truncates long batch items in embedBatch", async () => {
     const vector = [0.1, 0.2, 0.3];
     const mockCreate = vi.fn().mockImplementation((params: { input: string[] }) => {
       return Promise.resolve({
@@ -1344,11 +1345,12 @@ describe("Embeddings (OpenAI) — context-length truncation (#442)", () => {
     const client = { embeddings: { create: mockCreate } } as unknown as import("openai").default;
     const provider = new Embeddings(client, "text-embedding-3-small", 3);
 
-    const texts = ["a".repeat(40000), "short text"];
+    const { OPENAI_EMBEDDING_INPUT_MAX_CHARS } = await import("../services/embeddings/shared.js");
+    const texts = ["a".repeat(OPENAI_EMBEDDING_INPUT_MAX_CHARS + 5000), "short text"];
     await provider.embedBatch(texts);
 
     const calledBatch: string[] = mockCreate.mock.calls[0][0].input;
-    expect(calledBatch[0].length).toBeLessThanOrEqual(32768);
+    expect(calledBatch[0].length).toBeLessThanOrEqual(OPENAI_EMBEDDING_INPUT_MAX_CHARS);
     expect(calledBatch[1]).toBe("short text");
   });
 
@@ -1608,6 +1610,14 @@ describe("#486: shouldSuppressEmbeddingError — suppression helper", () => {
     expect(shouldSuppressEmbeddingError(Object.assign(new Error("401 Unauthorized"), { status: 401 }))).toBe(true);
     expect(shouldSuppressEmbeddingError(Object.assign(new Error("403 Forbidden"), { status: 403 }))).toBe(true);
     expect(shouldSuppressEmbeddingError(Object.assign(new Error("404 Not Found"), { status: 404 }))).toBe(true);
+  });
+
+  it("suppresses embedding context-length / oversize input errors (#1161, #1164)", () => {
+    expect(
+      shouldSuppressEmbeddingError(
+        new Error("400 This model's maximum context length is 8192 tokens, however you requested 9201 tokens"),
+      ),
+    ).toBe(true);
   });
 
   it("suppresses 429 rate limit errors", () => {

--- a/extensions/memory-hybrid/tests/llm-json-array.test.ts
+++ b/extensions/memory-hybrid/tests/llm-json-array.test.ts
@@ -72,4 +72,26 @@ describe("tryParseFirstJsonArray", () => {
   it("returns null when nothing parses as array", () => {
     expect(tryParseFirstJsonArray("[oops")).toBeNull();
   });
+
+  // GitHub #1153 / #1154 (GlitchTip): model echoes tool/template placeholders instead of JSON
+  it("returns null for [[reply_to_current]] placeholder (no SyntaxError)", () => {
+    expect(tryParseFirstJsonArray("[[reply_to_current]]")).toBeNull();
+  });
+
+  it("returns null for truncated [[reply_to_c… placeholder", () => {
+    expect(tryParseFirstJsonArray("[[reply_to_c")).toBeNull();
+  });
+
+  it("finds a valid array after a non-JSON [[placeholder]] line", () => {
+    const raw = `[[reply_to_current]]
+["preference", "entity"]`;
+    expect(tryParseFirstJsonArray(raw)).toEqual(["preference", "entity"]);
+  });
+
+  // GitHub #1151 / #1152: greedy /\[[\s\S]*\]/ grabbed junk + broke JSON.parse; balanced slice + retry fixes this
+  it("finds valid labels after an invalid balanced bracket span", () => {
+    const raw = `[[not valid json inside]]
+["alpha", "beta"]`;
+    expect(tryParseFirstJsonArray(raw)).toEqual(["alpha", "beta"]);
+  });
 });

--- a/extensions/memory-hybrid/tests/llm-json-array.test.ts
+++ b/extensions/memory-hybrid/tests/llm-json-array.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   extractBalancedArraySlice,
   extractFirstJsonArraySubstring,
+  stripBracketContextPreamble,
   stripMarkdownCodeFence,
   tryParseFirstJsonArray,
 } from "../utils/llm-json-array.js";
@@ -93,5 +94,10 @@ describe("tryParseFirstJsonArray", () => {
     const raw = `[[not valid json inside]]
 ["alpha", "beta"]`;
     expect(tryParseFirstJsonArray(raw)).toEqual(["alpha", "beta"]);
+  });
+
+  it("strips [Context: …] preamble before JSON array (#1166)", () => {
+    expect(stripBracketContextPreamble(`[Context: Tool]\n["a"]`)).toBe(`["a"]`);
+    expect(tryParseFirstJsonArray(`[Context: Topics]\n["fact","entity"]`)).toEqual(["fact", "entity"]);
   });
 });

--- a/extensions/memory-hybrid/utils/llm-json-array.ts
+++ b/extensions/memory-hybrid/utils/llm-json-array.ts
@@ -13,6 +13,20 @@ export function stripMarkdownCodeFence(raw: string): string {
 }
 
 /**
+ * Strip gateway/model bracket lines like `[Context: …]` that precede real JSON (#1166).
+ */
+export function stripBracketContextPreamble(raw: string): string {
+  let t = raw.trimStart();
+  for (let i = 0; i < 8; i++) {
+    const m = t.match(/^\[[^\]]*\]\s*/);
+    if (!m) break;
+    if (!/^\[(?:context|Contexts?):/i.test(m[0])) break;
+    t = t.slice(m[0].length).trimStart();
+  }
+  return t;
+}
+
+/**
  * From `s`, extract the balanced `[` … `]` substring starting at index `start` (which must be `[`),
  * respecting double-quoted strings so `]` inside strings does not close the array.
  */
@@ -69,7 +83,7 @@ export function extractFirstJsonArraySubstring(text: string): string | null {
  * Skips prose like `[see below]` or `[batch]` that are not valid JSON arrays.
  */
 export function tryParseFirstJsonArray(raw: string): unknown[] | null {
-  const s = stripMarkdownCodeFence(raw);
+  const s = stripBracketContextPreamble(stripMarkdownCodeFence(raw));
   let searchFrom = 0;
   while (searchFrom < s.length) {
     const start = s.indexOf("[", searchFrom);

--- a/extensions/memory-hybrid/utils/llm-json-array.ts
+++ b/extensions/memory-hybrid/utils/llm-json-array.ts
@@ -83,9 +83,9 @@ export function tryParseFirstJsonArray(raw: string): unknown[] | null {
       const parsed: unknown = JSON.parse(slice);
       if (Array.isArray(parsed)) return parsed;
     } catch {
-      /* try next [ */
+      /* try next [ — skip this whole balanced span (avoids O(n) single-char steps on long junk) */
     }
-    searchFrom = start + 1;
+    searchFrom = start + slice.length;
   }
   return null;
 }


### PR DESCRIPTION
## Summary

Hardening and bugfixes from GlitchTip imports: LLM JSON parsing, batch memory classification, chat/embed error handling, episode scope SQL, embedding input limits, and benign shutdown/hot-reload races.

## Changes (by area)

- **Auto-classifier / LLM JSON:** `tryParseFirstJsonArray` improvements, skip failed balanced spans, strip `[Context:…]` preambles, optional `choices?.[0]`.
- **Batch memory classification:** Return null instead of throwing on unparseable batch JSON; sequential fallback without spurious GlitchTip; scope SQL `AND` fix in episode search.
- **Chat / embeddings:** Transient detection for empty-body 400, unsupported-operation 400; context-length suppression for embeddings; tighter embedding char cap (~8192×3).
- **Lifecycle / stores:** Edict injection skips reporting when SQLite is already closed; VectorDB init skips reporting on concurrent hot-reload abort.

---

Closing keywords (merge this PR to auto-close):

Fixes #1151
Fixes #1152
Fixes #1153
Fixes #1154
Fixes #1155
Fixes #1156
Fixes #1157
Fixes #1158
Fixes #1159
Fixes #1160
Fixes #1161
Fixes #1162
Fixes #1163
Fixes #1164
Fixes #1165
Fixes #1166
Fixes #1167


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes LLM error classification/retry behavior, batch classification fallback logic, and SQL clause construction, which could alter recall/classification results and observability under edge cases.
> 
> **Overview**
> Improves robustness against noisy/invalid LLM outputs by tightening JSON-array extraction (`llm-json-array.ts`), making batch classify parsing return `null` instead of throwing, and falling back to sequential classification when batch responses are unparseable or wrong-length.
> 
> Refines error handling to reduce GlitchTip noise and avoid futile retries: treats some gateway/model-specific HTTP 400s as transient/non-retryable in `chat.ts`, suppresses expected shutdown/hot-reload failures in `stage-injection.ts` and `vector-db.ts`, and extends embeddings to truncate more conservatively and suppress context-length oversize errors.
> 
> Fixes an episodes search SQL bug where the positional scope filter fragment’s leading `AND` was not reliably stripped, preventing malformed `WHERE` clause assembly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4593d6367506aee2cff2041475687d0823879ffb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->