### PR TITLE
feat(cli): maintenance verbose mode and clearer reflection / rate-limit logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ---
 
+## [2026.5.61] - 2026-05-07
+
+### Added
+
+- **Maintenance observability**: `hybrid-mem dream-cycle --verbose` (and parent `-v`) forwards through WAL pre-flush, reflection, reflect-rules, MEMORY_INDEX refresh, continuous verification (`onProgress`, throttled), extract-implicit, cross-agent learning, and tool effectiveness; `run-all --verbose` passes through to extract-procedures and self-correction-run.
+- **Reflection progress logs** (always-on `info`): LLM completion line, dedupe embedding phase with success counts, new-candidate embedding phase, and a final summary (stored / duplicate skips / embed failures).
+- **Embedding rate-limit context**: OpenAI embedding `withLLMRetry` calls include `llmContext` so 429 backoff lines identify `memory-hybrid: embeddings.create` vs chat completions.
+- **Chat rate-limit detail**: `withLLMRetry` warns include operation label, model, and retry attempt index.
+
+### Changed
+
+- **`ContinuousVerifierOptions`**: exported; optional `onProgress` for long verification cycles.
+- **`runCrossAgentLearning` / CLI**: optional `verbose` with per-batch `info` logging when enabled.
+
+### Notes
+
+- Human-oriented upgrade narrative for the **2026.5.x** line: still start from [`release-notes/release-notes-2026.5.61.md`](release-notes/release-notes-2026.5.61.md) (supersedes **2026.5.60** for “current published” pointers).
+
+---
+
 ## [2026.5.60] - 2026-05-06
 
 **Previous baseline:** [2026.4.273] (2026-04-27) — last version published as a GitHub / npm release before this line of work.

--- a/extensions/memory-hybrid/cli/cmd-feedback.ts
+++ b/extensions/memory-hybrid/cli/cmd-feedback.ts
@@ -395,16 +395,9 @@ export async function runCrossAgentLearningForCli(
   // Build OpenAI proxy
   const openai = ctx.openai;
 
-  const baseLog = ctx.logger ?? {};
-  const logger =
-    opts.verbose === true
-      ? {
-          ...baseLog,
-          info: baseLog.info ?? ((msg: string) => console.log(msg)),
-        }
-      : baseLog;
-
-  const result = await runCrossAgentLearning(factsDb, openai, caCfg, logger);
+  const result = await runCrossAgentLearning(factsDb, openai, caCfg, ctx.logger ?? {}, {
+    verbose: opts.verbose === true,
+  });
 
   // Record savings: each generalised pattern avoids re-learning by other agents
   if (result.generalisedStored > 0 && ctx.costTracker) {

--- a/extensions/memory-hybrid/cli/cmd-feedback.ts
+++ b/extensions/memory-hybrid/cli/cmd-feedback.ts
@@ -374,7 +374,10 @@ export interface CrossAgentLearningCliResult {
 /**
  * Run cross-agent learning: scan peer agent databases and generalise shared lessons.
  */
-export async function runCrossAgentLearningForCli(ctx: HandlerContext): Promise<CrossAgentLearningCliResult> {
+export async function runCrossAgentLearningForCli(
+  ctx: HandlerContext,
+  opts: { verbose?: boolean } = {},
+): Promise<CrossAgentLearningCliResult> {
   const { factsDb, cfg } = ctx;
   const caCfg = cfg.crossAgentLearning;
 
@@ -392,7 +395,16 @@ export async function runCrossAgentLearningForCli(ctx: HandlerContext): Promise<
   // Build OpenAI proxy
   const openai = ctx.openai;
 
-  const result = await runCrossAgentLearning(factsDb, openai, caCfg, ctx.logger ?? {});
+  const baseLog = ctx.logger ?? {};
+  const logger =
+    opts.verbose === true
+      ? {
+          ...baseLog,
+          info: (msg: string) => baseLog.info?.(msg) ?? console.log(msg),
+        }
+      : baseLog;
+
+  const result = await runCrossAgentLearning(factsDb, openai, caCfg, logger);
 
   // Record savings: each generalised pattern avoids re-learning by other agents
   if (result.generalisedStored > 0 && ctx.costTracker) {
@@ -417,13 +429,17 @@ export async function runCrossAgentLearningForCli(ctx: HandlerContext): Promise<
  */
 export async function runToolEffectivenessForCli(
   ctx: HandlerContext,
-  _opts: { verbose?: boolean } = {},
+  opts: { verbose?: boolean } = {},
 ): Promise<string> {
   const { cfg } = ctx;
   const teCfg = cfg.toolEffectiveness;
 
   if (teCfg?.enabled === false) {
     return "Tool effectiveness scoring is disabled (toolEffectiveness.enabled = false).";
+  }
+
+  if (opts.verbose) {
+    (ctx.logger?.info ?? console.log)("memory-hybrid: tool-effectiveness — computing scores from workflow traces…");
   }
 
   // Derive the workflow store DB path from the sqlite path

--- a/extensions/memory-hybrid/cli/cmd-feedback.ts
+++ b/extensions/memory-hybrid/cli/cmd-feedback.ts
@@ -400,7 +400,7 @@ export async function runCrossAgentLearningForCli(
     opts.verbose === true
       ? {
           ...baseLog,
-          info: (msg: string) => baseLog.info?.(msg) ?? console.log(msg),
+          info: baseLog.info ?? ((msg: string) => console.log(msg)),
         }
       : baseLog;
 

--- a/extensions/memory-hybrid/cli/cmd-selfcorrection.ts
+++ b/extensions/memory-hybrid/cli/cmd-selfcorrection.ts
@@ -109,6 +109,7 @@ export async function runSelfCorrectionRunForCli(
     approve?: boolean;
     applyTools?: boolean;
     full?: boolean;
+    verbose?: boolean;
   },
 ): Promise<SelfCorrectionRunResult> {
   const { factsDb, vectorDb, embeddings, openai, cfg, logger, proposalsDb } = ctx;
@@ -180,6 +181,9 @@ export async function runSelfCorrectionRunForCli(
         clearScanLock(SCAN_TYPE);
       }
       return { incidentsFound: 0, analysed: 0, autoFixed: 0, proposals: [], reportPath };
+    }
+    if (opts.verbose) {
+      logger.info?.(`memory-hybrid: ${SCAN_TYPE} — ${incidents.length} incident(s); building LLM prompt…`);
     }
     const prompt = fillPrompt(loadPrompt("self-correction-analyze"), {
       incidents_json: JSON.stringify(incidents),

--- a/extensions/memory-hybrid/cli/commands/manage/register-agents-audit-runall.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/register-agents-audit-runall.ts
@@ -292,7 +292,7 @@ export function registerManageAgentsAuditRunall(mem: Chainable, b: ManageBinding
                 {
                   name: "extract-procedures (7 days)",
                   run: async () => {
-                    await runExtractProcedures({ days: 7, dryRun: false });
+                    await runExtractProcedures({ days: 7, dryRun: false, verbose });
                     log("Extract procedures done.");
                   },
                 },
@@ -365,7 +365,7 @@ export function registerManageAgentsAuditRunall(mem: Chainable, b: ManageBinding
           {
             name: "self-correction-run",
             run: async () => {
-              await runSelfCorrectionRun({ dryRun: false });
+              await runSelfCorrectionRun({ dryRun: false, verbose });
               log("Self-correction run done.");
             },
           },

--- a/extensions/memory-hybrid/cli/commands/manage/register-corrections-and-pipeline.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/register-corrections-and-pipeline.ts
@@ -599,11 +599,13 @@ export function registerManageCorrectionsAndPipeline(mem: Chainable, b: ManageBi
       .description(
         "Run nightly dream cycle: prune expired/decayed facts, consolidate old episodic events, reflect to extract patterns, optionally extract rules",
       )
+      .option("--verbose", "Detailed progress (reflection, memory index, WAL flush, nightly follow-up steps)")
       .action(
-        withExit(async () => {
+        withExit(async (opts?: { verbose?: boolean }, cmd?: CommanderOptsParent) => {
+          const verbose = !!opts?.verbose || readHybridMemVerbose(cmd);
           let res;
           try {
-            res = await runDreamCycle();
+            res = await runDreamCycle(verbose ? { verbose: true } : undefined);
           } catch (err) {
             capturePluginError(err instanceof Error ? err : new Error(String(err)), {
               subsystem: "cli",
@@ -628,9 +630,12 @@ export function registerManageCorrectionsAndPipeline(mem: Chainable, b: ManageBi
             cfg.verification.enabled &&
             cfg.verification.continuousVerification
           ) {
+            if (verbose) {
+              console.log("[dream-cycle] Continuous verification (plugin logs show per-fact progress when --verbose)…");
+            }
             let verificationRes;
             try {
-              verificationRes = await runContinuousVerification();
+              verificationRes = await runContinuousVerification(verbose ? { verbose: true } : undefined);
             } catch (err) {
               capturePluginError(err instanceof Error ? err : new Error(String(err)), {
                 subsystem: "cli",
@@ -648,8 +653,16 @@ export function registerManageCorrectionsAndPipeline(mem: Chainable, b: ManageBi
 
           // Extract implicit feedback signals as part of nightly cycle
           if (!res.skipped && runExtractImplicitFeedback && cfg.implicitFeedback?.enabled !== false) {
+            if (verbose) {
+              console.log("[dream-cycle] Extract implicit feedback…");
+            }
             try {
-              const implRes = await runExtractImplicitFeedback({ days: 3, dryRun: false, includeClosedLoop: false });
+              const implRes = await runExtractImplicitFeedback({
+                days: 3,
+                dryRun: false,
+                includeClosedLoop: false,
+                verbose,
+              });
               console.log(
                 `Extract-implicit: ${implRes.signalsExtracted} signals (${implRes.positiveCount}+/${implRes.negativeCount}-) from ${implRes.sessionsScanned} sessions.`,
               );
@@ -663,6 +676,9 @@ export function registerManageCorrectionsAndPipeline(mem: Chainable, b: ManageBi
 
           // Closed-loop effectiveness analysis
           if (!res.skipped && cfg.closedLoop?.enabled !== false && cfg.closedLoop?.runInNightlyCycle !== false) {
+            if (verbose) {
+              console.log("[dream-cycle] Closed-loop effectiveness (local analysis, no LLM)…");
+            }
             try {
               const clReport = runClosedLoopAnalysis(factsDb, cfg.closedLoop ?? { enabled: true });
               console.log(
@@ -687,8 +703,11 @@ export function registerManageCorrectionsAndPipeline(mem: Chainable, b: ManageBi
             cfg.crossAgentLearning?.enabled &&
             cfg.crossAgentLearning?.runInNightlyCycle !== false
           ) {
+            if (verbose) {
+              console.log("[dream-cycle] Cross-agent learning…");
+            }
             try {
-              const caRes = await runCrossAgentLearning();
+              const caRes = await runCrossAgentLearning(verbose ? { verbose: true } : undefined);
               console.log(
                 `Cross-agent learning: ${caRes.generalisedStored} generalised patterns stored from ${caRes.agentsScanned} agents.`,
               );
@@ -708,7 +727,7 @@ export function registerManageCorrectionsAndPipeline(mem: Chainable, b: ManageBi
             cfg.toolEffectiveness?.runInNightlyCycle !== false
           ) {
             try {
-              const teOutput = await runToolEffectiveness({});
+              const teOutput = await runToolEffectiveness({ verbose });
               if (teOutput && !teOutput.startsWith("No tool")) {
                 console.log(`Tool effectiveness: ${teOutput.split("\n")[0]}`);
               }
@@ -726,6 +745,9 @@ export function registerManageCorrectionsAndPipeline(mem: Chainable, b: ManageBi
             cfg.costTracking?.enabled !== false &&
             cfg.costTracking?.pruneInNightlyCycle !== false
           ) {
+            if (verbose) {
+              console.log("[dream-cycle] Prune old cost log rows…");
+            }
             try {
               const pruned = pruneCostLog(cfg.costTracking?.retainDays);
               if (pruned > 0) console.log(`Cost log: pruned ${pruned} old entries.`);
@@ -1054,8 +1076,10 @@ export function registerManageCorrectionsAndPipeline(mem: Chainable, b: ManageBi
   mem
     .command("cross-agent-learning")
     .description("Generalise agent-scoped lessons into global patterns (Issue #263 — Phase 2)")
+    .option("--verbose", "Log each LLM batch and use hybrid-mem -v for full plugin output")
     .action(
-      withExit(async () => {
+      withExit(async (opts?: { verbose?: boolean }, cmd?: CommanderOptsParent) => {
+        const verbose = !!opts?.verbose || readHybridMemVerbose(cmd);
         if (!runCrossAgentLearning) {
           console.error("cross-agent-learning is not available in this context.");
           process.exitCode = 1;
@@ -1067,7 +1091,7 @@ export function registerManageCorrectionsAndPipeline(mem: Chainable, b: ManageBi
         }
         let res;
         try {
-          res = await runCrossAgentLearning();
+          res = await runCrossAgentLearning(verbose ? { verbose: true } : undefined);
         } catch (err) {
           capturePluginError(err instanceof Error ? err : new Error(String(err)), {
             subsystem: "cli",

--- a/extensions/memory-hybrid/cli/context.ts
+++ b/extensions/memory-hybrid/cli/context.ts
@@ -111,7 +111,12 @@ export type ManageContext = {
     skipped?: boolean;
   }>;
   runRecordDistill?: () => Promise<unknown>;
-  runExtractProcedures?: (opts: { days?: number; dryRun: boolean }) => Promise<unknown>;
+  runExtractProcedures?: (opts: {
+    days?: number;
+    dryRun: boolean;
+    verbose?: boolean;
+    full?: boolean;
+  }) => Promise<unknown>;
   runBuildLanguageKeywords: (opts: {
     model?: string;
     dryRun?: boolean;
@@ -157,6 +162,7 @@ export type ManageContext = {
     approve?: boolean;
     applyTools?: boolean;
     full?: boolean;
+    verbose?: boolean;
   }) => Promise<SelfCorrectionRunResult>;
   runExport: (opts: {
     outputPath: string;
@@ -224,9 +230,13 @@ export type ManageContext = {
     verbose?: boolean;
   }) => Promise<{ generated: number; skipped?: number; paths?: string[] }>;
   runGenerateProposals?: (opts: { dryRun: boolean; verbose?: boolean }) => Promise<{ created: number }>;
-  runDreamCycle?: () => Promise<import("../services/dream-cycle.js").DreamCycleResult>;
-  runContinuousVerification?: () => Promise<import("../services/continuous-verifier.js").VerificationCycleResult>;
-  runCrossAgentLearning?: () => Promise<import("../cli/handlers.js").CrossAgentLearningCliResult>;
+  runDreamCycle?: (opts?: { verbose?: boolean }) => Promise<import("../services/dream-cycle.js").DreamCycleResult>;
+  runContinuousVerification?: (opts?: {
+    verbose?: boolean;
+  }) => Promise<import("../services/continuous-verifier.js").VerificationCycleResult>;
+  runCrossAgentLearning?: (opts?: { verbose?: boolean }) => Promise<
+    import("../cli/handlers.js").CrossAgentLearningCliResult
+  >;
   runToolEffectiveness?: (opts?: { verbose?: boolean }) => Promise<string>;
   runCostReport?: (opts: import("../cli/handlers.js").CostReportCliOpts, sink: { log: (msg: string) => void }) => void;
   pruneCostLog?: (retainDays?: number) => number;

--- a/extensions/memory-hybrid/cli/register.ts
+++ b/extensions/memory-hybrid/cli/register.ts
@@ -178,8 +178,10 @@ export type HybridMemCliContext = {
     metaStored: number;
   }>;
   reflectionConfig: { enabled: boolean; defaultWindow: number; minObservations: number; model: string };
-  runDreamCycle: () => Promise<import("../services/dream-cycle.js").DreamCycleResult>;
-  runContinuousVerification: () => Promise<import("../services/continuous-verifier.js").VerificationCycleResult>;
+  runDreamCycle: (opts?: { verbose?: boolean }) => Promise<import("../services/dream-cycle.js").DreamCycleResult>;
+  runContinuousVerification: (opts?: {
+    verbose?: boolean;
+  }) => Promise<import("../services/continuous-verifier.js").VerificationCycleResult>;
   runResolveContradictions: () => Promise<{
     autoResolved: Array<{ contradictionId: string; factIdNew: string; factIdOld: string }>;
     ambiguous: Array<{ contradictionId: string; factIdNew: string; factIdOld: string }>;
@@ -223,6 +225,7 @@ export type HybridMemCliContext = {
     approve?: boolean;
     applyTools?: boolean;
     full?: boolean;
+    verbose?: boolean;
   }) => Promise<SelfCorrectionRunResult>;
   runAnalyzeFeedbackPhrases: (opts: {
     days?: number;
@@ -301,7 +304,9 @@ export type HybridMemCliContext = {
   resolvePath?: (file: string) => string;
   /** Active task working memory context (required when activeTask.enabled = true) */
   activeTask?: ActiveTaskContext;
-  runCrossAgentLearning?: () => Promise<import("../cli/handlers.js").CrossAgentLearningCliResult>;
+  runCrossAgentLearning?: (opts?: { verbose?: boolean }) => Promise<
+    import("../cli/handlers.js").CrossAgentLearningCliResult
+  >;
   runToolEffectiveness?: (opts?: { verbose?: boolean }) => Promise<string>;
   runCostReport?: (opts: import("../cli/handlers.js").CostReportCliOpts, sink: { log: (msg: string) => void }) => void;
   pruneCostLog?: (retainDays?: number) => number;

--- a/extensions/memory-hybrid/openclaw.plugin.json
+++ b/extensions/memory-hybrid/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "openclaw-hybrid-memory",
   "kind": "memory",
-  "version": "2026.5.60",
+  "version": "2026.5.61",
   "contracts": {
     "tools": [
       "active_task_propose_goal",

--- a/extensions/memory-hybrid/package-lock.json
+++ b/extensions/memory-hybrid/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openclaw-hybrid-memory",
-  "version": "2026.5.60",
+  "version": "2026.5.61",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openclaw-hybrid-memory",
-      "version": "2026.5.60",
+      "version": "2026.5.61",
       "hasInstallScript": true,
       "dependencies": {
         "@lancedb/lancedb": "^0.27.1",

--- a/extensions/memory-hybrid/package.json
+++ b/extensions/memory-hybrid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-hybrid-memory",
-  "version": "2026.5.60",
+  "version": "2026.5.61",
   "type": "module",
   "description": "Give your OpenClaw agent lasting memory: structured facts, semantic search, auto-capture & recall, decay, optional credential vault. Part of Hybrid Memory v3.",
   "files": [

--- a/extensions/memory-hybrid/services/chat.ts
+++ b/extensions/memory-hybrid/services/chat.ts
@@ -725,8 +725,11 @@ export async function withLLMRetry<T>(
       if (is429 || isQuota403) {
         const retryAfterMs = parseRetryAfterMs(err);
         delay = retryAfterMs ?? 2 ** (attempt + 1) * 1000;
+        const op = opts?.llmContext?.operation;
+        const modelId = opts?.llmContext?.model;
+        const ctxTag = op || modelId ? ` [${[op, modelId].filter(Boolean).join(" · ")}]` : "";
         pluginLogger.warn(
-          `memory-hybrid: ${isQuota403 ? "Quota/rate limit (403)" : "Rate limited by provider"} — backing off ${delay}ms`,
+          `memory-hybrid: ${isQuota403 ? "Quota/rate limit (403)" : "Rate limited by provider"}${ctxTag} — retry ${attempt + 1}/${maxRetries + 1}, backing off ${delay}ms`,
         );
       } else {
         delay = 3 ** attempt * 1000; // 1s, 3s, 9s

--- a/extensions/memory-hybrid/services/chat.ts
+++ b/extensions/memory-hybrid/services/chat.ts
@@ -8,7 +8,12 @@ import { DEFAULT_CHAT_TIMEOUT_MS } from "../utils/constants.js";
 import { pluginLogger } from "../utils/logger.js";
 import { withCostFeature } from "./cost-context.js";
 import { capturePluginError } from "./error-reporter.js";
-import { is403QuotaOrRateLimitLike, parseGoDurationToMs, parseRetryAfterMs } from "./llm-rate-limit-headers.js";
+import {
+  formatProviderRateLimitHeaderSummary,
+  is403QuotaOrRateLimitLike,
+  parseGoDurationToMs,
+  parseRetryAfterMs,
+} from "./llm-rate-limit-headers.js";
 import {
   type WireApi,
   getDistillBatchTokenLimit as getDistillBatchTokenLimitFromCatalog,
@@ -18,6 +23,7 @@ import {
   resolveWireApi,
 } from "./model-capabilities.js";
 import { callResponsesApi } from "./responses-adapter.js";
+import { recordProviderHttpAttempt, formatRecentHttpAttemptsForRateLimitLog } from "./recent-http-attempts.js";
 
 export { is403QuotaOrRateLimitLike, parseGoDurationToMs, parseRetryAfterMs } from "./llm-rate-limit-headers.js";
 
@@ -608,6 +614,10 @@ export async function withLLMRetry<T>(
   let lastError: Error | undefined;
 
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    recordProviderHttpAttempt({
+      operation: opts?.llmContext?.operation,
+      model: opts?.llmContext?.model,
+    });
     try {
       return await fn();
     } catch (err) {
@@ -728,8 +738,11 @@ export async function withLLMRetry<T>(
         const op = opts?.llmContext?.operation;
         const modelId = opts?.llmContext?.model;
         const ctxTag = op || modelId ? ` [${[op, modelId].filter(Boolean).join(" · ")}]` : "";
+        const hdr = formatProviderRateLimitHeaderSummary(err);
+        const recent = formatRecentHttpAttemptsForRateLimitLog();
+        const attemptTotal = Math.max(1, maxRetries);
         pluginLogger.warn(
-          `memory-hybrid: ${isQuota403 ? "Quota/rate limit (403)" : "Rate limited by provider"}${ctxTag} — retry ${attempt + 1}/${maxRetries}, backing off ${delay}ms`,
+          `memory-hybrid: ${isQuota403 ? "Quota/rate limit (403)" : "Rate limited by provider"}${ctxTag} — retry ${attempt + 1}/${attemptTotal}, backing off ${delay}ms | ${hdr} | ${recent} | rolling counts = outbound HTTP attempts in this process (not token usage); use tokRem/reqRem when headers exist.`,
         );
       } else {
         delay = 3 ** attempt * 1000; // 1s, 3s, 9s

--- a/extensions/memory-hybrid/services/chat.ts
+++ b/extensions/memory-hybrid/services/chat.ts
@@ -729,7 +729,7 @@ export async function withLLMRetry<T>(
         const modelId = opts?.llmContext?.model;
         const ctxTag = op || modelId ? ` [${[op, modelId].filter(Boolean).join(" · ")}]` : "";
         pluginLogger.warn(
-          `memory-hybrid: ${isQuota403 ? "Quota/rate limit (403)" : "Rate limited by provider"}${ctxTag} — retry ${attempt + 1}/${maxRetries + 1}, backing off ${delay}ms`,
+          `memory-hybrid: ${isQuota403 ? "Quota/rate limit (403)" : "Rate limited by provider"}${ctxTag} — retry ${attempt + 1}/${maxRetries}, backing off ${delay}ms`,
         );
       } else {
         delay = 3 ** attempt * 1000; // 1s, 3s, 9s

--- a/extensions/memory-hybrid/services/continuous-verifier.ts
+++ b/extensions/memory-hybrid/services/continuous-verifier.ts
@@ -28,13 +28,18 @@ export interface VerificationCycleResult {
   errors: number;
 }
 
-interface ContinuousVerifierOptions {
+export interface ContinuousVerifierOptions {
   /** Days between verification cycle runs (default: 30). */
   cycleDays?: number;
   /** Model to use for LLM verification calls (default: 'openai/gpt-4.1-nano'). */
   verificationModel?: string;
   /** Per-fact LLM timeout in ms (default: 15000). */
   timeoutMs?: number;
+  /**
+   * Progress hook for long cycles (e.g. `hybrid-mem dream-cycle --verbose`).
+   * Throttled when many facts are due: first, last, every 10th, and all when ≤25 due.
+   */
+  onProgress?: (message: string) => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -91,6 +96,7 @@ export class ContinuousVerifier {
   private readonly model: string;
   private readonly timeoutMs: number;
   private readonly cycleDays: number | undefined;
+  private readonly onProgress?: (message: string) => void;
   private lastRunDate: number | null = null;
 
   constructor(store: VerificationStore, factsDb: FactsDB, openai: OpenAI, options?: ContinuousVerifierOptions) {
@@ -100,6 +106,7 @@ export class ContinuousVerifier {
     this.model = options?.verificationModel ?? DEFAULT_MODEL;
     this.timeoutMs = options?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
     this.cycleDays = options?.cycleDays;
+    this.onProgress = options?.onProgress;
   }
 
   /**
@@ -180,6 +187,10 @@ export class ContinuousVerifier {
       recentByEntity.get(entity)?.push(e.text);
     }
 
+    this.onProgress?.(
+      `memory-hybrid: continuous-verification — ${due.length} fact(s) due, ${recentEntries.length} recent facts loaded for context`,
+    );
+
     for (const fact of due) {
       result.checked++;
       try {
@@ -215,6 +226,14 @@ export class ContinuousVerifier {
             this.factsDb.addTag(underlying.id, "review-needed");
           }
           result.uncertain++;
+        }
+
+        const n = result.checked;
+        const total = due.length;
+        if (this.onProgress && (total <= 25 || n === 1 || n === total || n % 10 === 0)) {
+          this.onProgress(
+            `memory-hybrid: continuous-verification — ${n}/${total} (${outcome}) fact=${fact.factId.slice(0, 8)}…`,
+          );
         }
       } catch (err) {
         capturePluginError(err instanceof Error ? err : new Error(String(err)), {

--- a/extensions/memory-hybrid/services/cross-agent-learning.ts
+++ b/extensions/memory-hybrid/services/cross-agent-learning.ts
@@ -249,6 +249,7 @@ async function callLLMForGeneralisation(
  * @param openai     OpenAI client (multi-provider proxy).
  * @param cfg        Cross-agent learning config.
  * @param logger     Logger (warn-only needed).
+ * @param runOpts    When `verbose` is true, logs each LLM batch on `logger.info` (CLI / dream-cycle `--verbose`).
  * @returns          Summary report.
  */
 export async function runCrossAgentLearning(
@@ -256,6 +257,7 @@ export async function runCrossAgentLearning(
   openai: OpenAI,
   cfg: CrossAgentLearningConfig,
   logger: { warn?: (msg: string) => void; info?: (msg: string) => void } = {},
+  runOpts?: { verbose?: boolean },
 ): Promise<CrossAgentLearningResult> {
   const result: CrossAgentLearningResult = {
     agentsScanned: 0,
@@ -303,9 +305,11 @@ export async function runCrossAgentLearning(
     let batchIndex = 0;
     for (const batch of batches) {
       batchIndex++;
-      logger.info?.(
-        `memory-hybrid: cross-agent-learning — LLM batch ${batchIndex}/${batches.length} (${batch.length} lesson(s), model=${model})`,
-      );
+      if (runOpts?.verbose) {
+        logger.info?.(
+          `memory-hybrid: cross-agent-learning — LLM batch ${batchIndex}/${batches.length} (${batch.length} lesson(s), model=${model})`,
+        );
+      }
       try {
         const prompt = buildGeneralisePrompt(batch);
         const generalised = await callLLMForGeneralisation(openai, model, prompt, fallbackModels, logger);

--- a/extensions/memory-hybrid/services/cross-agent-learning.ts
+++ b/extensions/memory-hybrid/services/cross-agent-learning.ts
@@ -255,7 +255,7 @@ export async function runCrossAgentLearning(
   factsDb: FactsDB,
   openai: OpenAI,
   cfg: CrossAgentLearningConfig,
-  logger: { warn?: (msg: string) => void } = {},
+  logger: { warn?: (msg: string) => void; info?: (msg: string) => void } = {},
 ): Promise<CrossAgentLearningResult> {
   const result: CrossAgentLearningResult = {
     agentsScanned: 0,
@@ -300,7 +300,12 @@ export async function runCrossAgentLearning(
     const model = cfg.model ?? "gpt-4o-mini";
     const fallbackModels = cfg.fallbackModels ?? [];
 
+    let batchIndex = 0;
     for (const batch of batches) {
+      batchIndex++;
+      logger.info?.(
+        `memory-hybrid: cross-agent-learning — LLM batch ${batchIndex}/${batches.length} (${batch.length} lesson(s), model=${model})`,
+      );
       try {
         const prompt = buildGeneralisePrompt(batch);
         const generalised = await callLLMForGeneralisation(openai, model, prompt, fallbackModels, logger);

--- a/extensions/memory-hybrid/services/dream-cycle.ts
+++ b/extensions/memory-hybrid/services/dream-cycle.ts
@@ -53,6 +53,8 @@ export interface DreamCycleConfig {
    * Default: true.
    */
   vacuumOnCycle: boolean;
+  /** When true, log episodic consolidation / reflection / memory-index detail (CLI `--verbose`). */
+  verbose?: boolean;
 }
 
 /** Result returned by a single dream cycle run. */
@@ -169,6 +171,7 @@ export async function runEpisodicConsolidation(
   eventLog: EventLog,
   consolidateAfterDays: number,
   logger: { info: (msg: string) => void; warn: (msg: string) => void },
+  verbose?: boolean,
 ): Promise<{ eventsConsolidated: number; factsCreated: number }> {
   const events = eventLog.getUnconsolidated(consolidateAfterDays);
   if (events.length === 0) {
@@ -176,6 +179,11 @@ export async function runEpisodicConsolidation(
   }
 
   const groups = groupEventsByEntity(events);
+  if (verbose) {
+    logger.info(
+      `memory-hybrid: dream-cycle — episodic consolidation: ${events.length} unconsolidated event(s) in ${groups.size} entity group(s) (≥${consolidateAfterDays}d)`,
+    );
+  }
   let factsCreated = 0;
   let eventsConsolidated = 0;
   const ephemeralSourceFactIds: string[] = [];
@@ -341,8 +349,13 @@ export async function runDreamCycle(
   }
 
   logger.info("memory-hybrid: dream-cycle — starting nightly cycle");
+  const v = !!config.verbose;
+  const step = (n: number, label: string) => {
+    if (v) logger.info(`memory-hybrid: dream-cycle — step ${n}: ${label}`);
+  };
 
   // ── Step 1: Prune ────────────────────────────────────────────────────────
+  step(1, "prune / decay / orphaned links");
   let factsPruned = 0;
   let factsDecayed = 0;
   if (config.pruneMode === "expired" || config.pruneMode === "both") {
@@ -388,6 +401,7 @@ export async function runDreamCycle(
   // ── Step 2: Episodic consolidation ───────────────────────────────────────
   let eventsConsolidated = 0;
   let factsCreated = 0;
+  step(2, "episodic consolidation + event log maintenance");
   if (eventLog) {
     try {
       const consolidationResult = await runEpisodicConsolidation(
@@ -395,6 +409,7 @@ export async function runDreamCycle(
         eventLog,
         config.consolidateAfterDays,
         logger,
+        v,
       );
       eventsConsolidated = consolidationResult.eventsConsolidated;
       factsCreated = consolidationResult.factsCreated;
@@ -405,6 +420,8 @@ export async function runDreamCycle(
         subsystem: "event-log",
       });
     }
+  } else if (v) {
+    logger.info("memory-hybrid: dream-cycle — no event log: skipping episodic consolidation");
   }
 
   // ── Step 2b: Archive stale event log entries ─────────────────────────────
@@ -444,6 +461,7 @@ export async function runDreamCycle(
   }
 
   // ── Step 3: Reflect ───────────────────────────────────────────────────────
+  step(3, "reflection (patterns)");
   let patternsFound = 0;
   const reflectionConfig: ReflectionConfig = {
     enabled: true,
@@ -462,6 +480,7 @@ export async function runDreamCycle(
         dryRun: false,
         model: config.model,
         fallbackModels: config.fallbackModels ?? [],
+        verbose: v,
       },
       logger,
       provenanceService,
@@ -479,13 +498,14 @@ export async function runDreamCycle(
   // ── Step 4: Reflect-rules (optional) ────────────────────────────────────
   let rulesGenerated = 0;
   if (patternsFound >= MIN_PATTERNS_FOR_RULES) {
+    step(4, "reflect-rules");
     try {
       const rulesResult = await runReflectionRules(
         factsDb,
         vectorDb,
         embeddings,
         openai,
-        { dryRun: false, model: config.model, fallbackModels: config.fallbackModels ?? [] },
+        { dryRun: false, model: config.model, fallbackModels: config.fallbackModels ?? [], verbose: v },
         logger,
         provenanceService,
       );
@@ -498,9 +518,14 @@ export async function runDreamCycle(
         subsystem: "reflection",
       });
     }
+  } else if (v) {
+    logger.info(
+      `memory-hybrid: dream-cycle — skipping reflect-rules (${patternsFound} patterns < ${MIN_PATTERNS_FOR_RULES} minimum)`,
+    );
   }
 
   // ── Step 4b: Refresh memory awareness index ─────────────────────────────
+  step(5, "MEMORY_INDEX.md refresh");
   try {
     await writeMemoryIndex(
       factsDb,
@@ -509,6 +534,7 @@ export async function runDreamCycle(
         model: config.model,
         fallbackModels: config.fallbackModels ?? [],
         recentWindowDays: config.reflectWindowDays,
+        verbose: v,
       },
       logger,
     );
@@ -521,6 +547,7 @@ export async function runDreamCycle(
   }
 
   // ── Step 5: Prune log tables ─────────────────────────────────────────────
+  step(6, "prune operational log tables (recall/reinforcement/trajectories)");
   let logRowsPruned = 0;
   if (config.logRetentionDays > 0) {
     try {
@@ -540,6 +567,7 @@ export async function runDreamCycle(
   }
 
   // ── Step 5b: FTS5 optimize ───────────────────────────────────────────────
+  step(7, "FTS5 optimize (facts search)");
   try {
     factsDb.optimizeFts();
     logger.info("memory-hybrid: dream-cycle — FTS5 index optimized");
@@ -554,6 +582,7 @@ export async function runDreamCycle(
   // ── Step 5c: VACUUM + WAL checkpoint ────────────────────────────────────
   let vacuumRan = false;
   if (config.vacuumOnCycle) {
+    step(8, "VACUUM + WAL checkpoint");
     try {
       factsDb.vacuumAndCheckpoint();
       vacuumRan = true;

--- a/extensions/memory-hybrid/services/dream-cycle.ts
+++ b/extensions/memory-hybrid/services/dream-cycle.ts
@@ -1,12 +1,10 @@
 /**
  * Dream Cycle Service — Automated nightly reflection + pruning pipeline (Issue #143).
  *
- * Sequence:
- *  1. memory_prune (decay confidence + remove expired facts)
- *  2. Episodic consolidation (merge old event log entries into consolidated facts, DERIVED_FROM links)
- *  3. memory_reflect (synthesize patterns from recent facts)
- *  4. memory_reflect_rules (optional, if enough new patterns accumulated)
- *  5. Generate daily digest summary
+ * Sequence (verbose `step N:` numbers are assigned in runtime order so skipped optional phases do not leave gaps):
+ *  prune / decay / orphaned links → episodic consolidation + event log maintenance → reflection (patterns) →
+ *  optional reflect-rules (if enough patterns) → MEMORY_INDEX refresh → prune log tables → FTS5 optimize →
+ *  optional VACUUM → digest summary.
  *
  * Designed to be cheap ($0.003/night target) using a Flash-tier model.
  * Self-contained — does not require an active agent session.
@@ -320,7 +318,7 @@ export async function runEpisodicConsolidation(
 
 /**
  * Run the full nightly dream cycle:
- *  prune → episodic consolidation → reflect → reflect-rules (optional) → digest
+ *  prune → consolidation → reflect → optional reflect-rules → memory index → log prune → FTS5 → optional VACUUM → digest.
  */
 export async function runDreamCycle(
   factsDb: FactsDB,

--- a/extensions/memory-hybrid/services/dream-cycle.ts
+++ b/extensions/memory-hybrid/services/dream-cycle.ts
@@ -350,12 +350,13 @@ export async function runDreamCycle(
 
   logger.info("memory-hybrid: dream-cycle — starting nightly cycle");
   const v = !!config.verbose;
-  const step = (n: number, label: string) => {
-    if (v) logger.info(`memory-hybrid: dream-cycle — step ${n}: ${label}`);
+  let stepCounter = 0;
+  const step = (label: string) => {
+    if (v) logger.info(`memory-hybrid: dream-cycle — step ${++stepCounter}: ${label}`);
   };
 
   // ── Step 1: Prune ────────────────────────────────────────────────────────
-  step(1, "prune / decay / orphaned links");
+  step("prune / decay / orphaned links");
   let factsPruned = 0;
   let factsDecayed = 0;
   if (config.pruneMode === "expired" || config.pruneMode === "both") {
@@ -401,7 +402,7 @@ export async function runDreamCycle(
   // ── Step 2: Episodic consolidation ───────────────────────────────────────
   let eventsConsolidated = 0;
   let factsCreated = 0;
-  step(2, "episodic consolidation + event log maintenance");
+  step("episodic consolidation + event log maintenance");
   if (eventLog) {
     try {
       const consolidationResult = await runEpisodicConsolidation(
@@ -461,7 +462,7 @@ export async function runDreamCycle(
   }
 
   // ── Step 3: Reflect ───────────────────────────────────────────────────────
-  step(3, "reflection (patterns)");
+  step("reflection (patterns)");
   let patternsFound = 0;
   const reflectionConfig: ReflectionConfig = {
     enabled: true,
@@ -498,7 +499,7 @@ export async function runDreamCycle(
   // ── Step 4: Reflect-rules (optional) ────────────────────────────────────
   let rulesGenerated = 0;
   if (patternsFound >= MIN_PATTERNS_FOR_RULES) {
-    step(4, "reflect-rules");
+    step("reflect-rules");
     try {
       const rulesResult = await runReflectionRules(
         factsDb,
@@ -525,7 +526,7 @@ export async function runDreamCycle(
   }
 
   // ── Step 4b: Refresh memory awareness index ─────────────────────────────
-  step(5, "MEMORY_INDEX.md refresh");
+  step("MEMORY_INDEX.md refresh");
   try {
     await writeMemoryIndex(
       factsDb,
@@ -547,7 +548,7 @@ export async function runDreamCycle(
   }
 
   // ── Step 5: Prune log tables ─────────────────────────────────────────────
-  step(6, "prune operational log tables (recall/reinforcement/trajectories)");
+  step("prune operational log tables (recall/reinforcement/trajectories)");
   let logRowsPruned = 0;
   if (config.logRetentionDays > 0) {
     try {
@@ -567,7 +568,7 @@ export async function runDreamCycle(
   }
 
   // ── Step 5b: FTS5 optimize ───────────────────────────────────────────────
-  step(7, "FTS5 optimize (facts search)");
+  step("FTS5 optimize (facts search)");
   try {
     factsDb.optimizeFts();
     logger.info("memory-hybrid: dream-cycle — FTS5 index optimized");
@@ -582,7 +583,7 @@ export async function runDreamCycle(
   // ── Step 5c: VACUUM + WAL checkpoint ────────────────────────────────────
   let vacuumRan = false;
   if (config.vacuumOnCycle) {
-    step(8, "VACUUM + WAL checkpoint");
+    step("VACUUM + WAL checkpoint");
     try {
       factsDb.vacuumAndCheckpoint();
       vacuumRan = true;

--- a/extensions/memory-hybrid/services/embeddings/openai-provider.ts
+++ b/extensions/memory-hybrid/services/embeddings/openai-provider.ts
@@ -146,7 +146,10 @@ export class Embeddings implements EmbeddingProvider {
                 input,
                 ...(includeDims ? { dimensions: this.dimensions } : {}),
               }),
-            { maxRetries: 2 },
+            {
+              maxRetries: 2,
+              llmContext: { operation: "memory-hybrid: embeddings.create", model },
+            },
           );
           const vector = vectorFromEmbeddingResponse(resp, this.providerName, this.endpoint, model, "embed");
           if (this.cache.size >= EMBEDDING_CACHE_MAX) {
@@ -235,7 +238,13 @@ export class Embeddings implements EmbeddingProvider {
                   input: truncatedBatch,
                   ...(includeDimsBatch ? { dimensions: this.dimensions } : {}),
                 }),
-              { maxRetries: 2 },
+              {
+                maxRetries: 2,
+                llmContext: {
+                  operation: "memory-hybrid: embeddings.create (batch)",
+                  model,
+                },
+              },
             );
             succeededModel = model;
             this.modelName = model;

--- a/extensions/memory-hybrid/services/llm-rate-limit-headers.ts
+++ b/extensions/memory-hybrid/services/llm-rate-limit-headers.ts
@@ -122,3 +122,92 @@ export function parseRetryAfterMs(err: unknown): number | undefined {
   if (remaining === "0" && !hadResetHint) return 10_000;
   return undefined;
 }
+
+function headersFromObject(obj: unknown): HeaderBag | undefined {
+  if (!obj || typeof obj !== "object") return undefined;
+  const o = obj as { response?: { headers?: unknown }; headers?: unknown };
+  if (o.response?.headers && typeof o.response.headers === "object") {
+    return o.response.headers as HeaderBag;
+  }
+  if (o.headers && typeof o.headers === "object") {
+    return o.headers as HeaderBag;
+  }
+  return undefined;
+}
+
+/**
+ * Walk `.cause` from the innermost LLMRetryError leaf and return the first HTTP header bag found.
+ */
+export function getHeaderBagFromUnknownError(err: unknown): HeaderBag | undefined {
+  let e: unknown = unwrapLlmRetryErrorChain(err);
+  const seen = new Set<unknown>();
+  for (let depth = 0; depth < 12 && e && typeof e === "object"; depth++) {
+    if (seen.has(e)) break;
+    seen.add(e);
+    const bag = headersFromObject(e);
+    if (bag) return bag;
+    const next = (e as { cause?: unknown }).cause;
+    if (next == null) break;
+    e = next;
+  }
+  return undefined;
+}
+
+export type RateLimitLikelyBucket = "requests" | "tokens" | "both" | "unknown";
+
+/** Best-effort: OpenAI-style `x-ratelimit-remaining-*` at zero usually marks the exhausted bucket. */
+export function inferRateLimitBucket(headers: HeaderBag | undefined): RateLimitLikelyBucket {
+  if (!headers) return "unknown";
+  const remTok = getHeaderCaseInsensitive(headers, "x-ratelimit-remaining-tokens");
+  const remReq = getHeaderCaseInsensitive(headers, "x-ratelimit-remaining-requests");
+  const tokNum = remTok != null ? Number.parseInt(String(remTok), 10) : NaN;
+  const reqNum = remReq != null ? Number.parseInt(String(remReq), 10) : NaN;
+  const tok0 = Number.isFinite(tokNum) && tokNum === 0;
+  const req0 = Number.isFinite(reqNum) && reqNum === 0;
+  if (tok0 && req0) return "both";
+  if (tok0) return "tokens";
+  if (req0) return "requests";
+  return "unknown";
+}
+
+/**
+ * One-line summary for logs when a 429 / quota-style 403 fires (provider-dependent headers).
+ */
+export function formatProviderRateLimitHeaderSummary(err: unknown): string {
+  const headers = getHeaderBagFromUnknownError(err);
+  if (!headers) {
+    return "provider headers: none parsed on error chain (RPM vs TPM not inferable from headers alone)";
+  }
+  const parts: string[] = [];
+  const entries: Array<[label: string, headerName: string]> = [
+    ["reqLim", "x-ratelimit-limit-requests"],
+    ["reqRem", "x-ratelimit-remaining-requests"],
+    ["reqReset", "x-ratelimit-reset-requests"],
+    ["tokLim", "x-ratelimit-limit-tokens"],
+    ["tokRem", "x-ratelimit-remaining-tokens"],
+    ["tokReset", "x-ratelimit-reset-tokens"],
+    ["retryAfter", "retry-after"],
+    ["reqId", "x-request-id"],
+    ["azReqId", "x-ms-request-id"],
+  ];
+  for (const [label, name] of entries) {
+    const v = getHeaderCaseInsensitive(headers, name);
+    if (v != null && String(v).trim() !== "") {
+      const val = String(v).replace(/\s+/g, " ").trim();
+      parts.push(`${label}=${val.length > 56 ? val.slice(0, 53) + "..." : val}`);
+    }
+  }
+  const bucket = inferRateLimitBucket(headers);
+  const hint =
+    bucket === "unknown"
+      ? "likely limit: unknown from headers (429 is often RPM or TPM; compare tokRem/reqRem when present)"
+      : bucket === "both"
+        ? "likely exhausted: requests+tokens per provider headers"
+        : bucket === "tokens"
+          ? "likely exhausted: token budget (TPM-style) per provider headers"
+          : "likely exhausted: request budget (RPM-style) per provider headers";
+  if (parts.length === 0) {
+    return `provider headers: no known rate-limit keys on bag; ${hint}`;
+  }
+  return `${parts.join(", ")}; ${hint}`;
+}

--- a/extensions/memory-hybrid/services/llm-rate-limit-headers.ts
+++ b/extensions/memory-hybrid/services/llm-rate-limit-headers.ts
@@ -55,11 +55,14 @@ export function parseGoDurationToMs(input: string): number | undefined {
   let totalMs = 0;
   let matched = false;
   const re = /(\d+(?:\.\d+)?)\s*(ns|us|µs|ms|s|m|h)/gi;
-  let m: RegExpExecArray | null;
-  while ((m = re.exec(s)) !== null) {
+  let m: RegExpExecArray | null = re.exec(s);
+  while (m !== null) {
     matched = true;
     const val = Number.parseFloat(m[1]);
-    if (Number.isNaN(val)) continue;
+    if (Number.isNaN(val)) {
+      m = re.exec(s);
+      continue;
+    }
     const u = m[2].toLowerCase();
     if (u === "ns") totalMs += val / 1e6;
     else if (u === "us" || u === "µs") totalMs += val / 1e3;
@@ -67,6 +70,7 @@ export function parseGoDurationToMs(input: string): number | undefined {
     else if (u === "s") totalMs += val * 1000;
     else if (u === "m") totalMs += val * 60 * 1000;
     else if (u === "h") totalMs += val * 60 * 60 * 1000;
+    m = re.exec(s);
   }
   if (matched) return Math.max(0, Math.ceil(totalMs));
   return undefined;
@@ -160,8 +164,8 @@ export function inferRateLimitBucket(headers: HeaderBag | undefined): RateLimitL
   if (!headers) return "unknown";
   const remTok = getHeaderCaseInsensitive(headers, "x-ratelimit-remaining-tokens");
   const remReq = getHeaderCaseInsensitive(headers, "x-ratelimit-remaining-requests");
-  const tokNum = remTok != null ? Number.parseInt(String(remTok), 10) : NaN;
-  const reqNum = remReq != null ? Number.parseInt(String(remReq), 10) : NaN;
+  const tokNum = remTok != null ? Number.parseInt(String(remTok), 10) : Number.NaN;
+  const reqNum = remReq != null ? Number.parseInt(String(remReq), 10) : Number.NaN;
   const tok0 = Number.isFinite(tokNum) && tokNum === 0;
   const req0 = Number.isFinite(reqNum) && reqNum === 0;
   if (tok0 && req0) return "both";
@@ -194,7 +198,7 @@ export function formatProviderRateLimitHeaderSummary(err: unknown): string {
     const v = getHeaderCaseInsensitive(headers, name);
     if (v != null && String(v).trim() !== "") {
       const val = String(v).replace(/\s+/g, " ").trim();
-      parts.push(`${label}=${val.length > 56 ? val.slice(0, 53) + "..." : val}`);
+      parts.push(`${label}=${val.length > 56 ? `${val.slice(0, 53)}...` : val}`);
     }
   }
   const bucket = inferRateLimitBucket(headers);

--- a/extensions/memory-hybrid/services/memory-index.ts
+++ b/extensions/memory-hybrid/services/memory-index.ts
@@ -29,6 +29,8 @@ interface MemoryIndexOptions {
   model?: string;
   fallbackModels?: string[];
   recentWindowDays?: number;
+  /** Extra progress lines via `logger.info` (e.g. dream-cycle `--verbose`). */
+  verbose?: boolean;
 }
 
 interface MemoryIndexResult {
@@ -242,7 +244,7 @@ function sanitizeIndexMarkdown(content: string): string {
 async function synthesizeMemoryIndex(
   snapshot: MemoryIndexSnapshot,
   openai: OpenAI,
-  options: Pick<MemoryIndexOptions, "model" | "fallbackModels">,
+  options: Pick<MemoryIndexOptions, "model" | "fallbackModels" | "verbose">,
   logger: { info: (msg: string) => void; warn: (msg: string) => void },
 ): Promise<string | null> {
   if (!options.model) return null;
@@ -251,6 +253,12 @@ async function synthesizeMemoryIndex(
     generated_at: snapshot.generatedAt,
     memory_snapshot: JSON.stringify(snapshot, null, 2),
   });
+
+  if (options.verbose) {
+    logger.info(
+      `memory-hybrid: memory-index — LLM synthesis (${prompt.length} chars in prompt, primary model=${options.model})`,
+    );
+  }
 
   try {
     const response = await chatCompleteWithRetry({
@@ -298,6 +306,11 @@ export async function writeMemoryIndex(
   logger: { info: (msg: string) => void; warn: (msg: string) => void },
 ): Promise<MemoryIndexResult> {
   const snapshot = buildMemoryIndexSnapshot(factsDb, options);
+  if (options.verbose) {
+    logger.info(
+      `memory-hybrid: memory-index — snapshot: ${snapshot.clusters.length} clusters, ${snapshot.recentDecisions.length} recent decisions, ${snapshot.keyEntities.length} key entities, ${snapshot.recentPatterns.length} recent patterns/rules`,
+    );
+  }
   const llmMarkdown = await synthesizeMemoryIndex(snapshot, openai, options, logger);
   const content = llmMarkdown || renderMemoryIndexMarkdown(snapshot);
   const outputPath = resolveOutputPath(options);

--- a/extensions/memory-hybrid/services/recent-http-attempts.ts
+++ b/extensions/memory-hybrid/services/recent-http-attempts.ts
@@ -1,0 +1,74 @@
+/**
+ * In-process rolling record of outbound provider HTTP attempts (chat + embeddings).
+ * Used only for diagnostics when rate limits fire — not authoritative billing data.
+ */
+
+export type RecentHttpAttempt = {
+  t: number;
+  operation?: string;
+  model?: string;
+};
+
+const MAX_EVENTS = 500;
+const events: RecentHttpAttempt[] = [];
+
+function pruneOlderThan(cutoffMs: number): void {
+  while (events.length > 0 && events[0].t < cutoffMs) {
+    events.shift();
+  }
+}
+
+/**
+ * Record one outbound attempt before the SDK call (includes retries as separate rows).
+ */
+export function recordProviderHttpAttempt(meta: { operation?: string; model?: string }): void {
+  const now = Date.now();
+  events.push({ t: now, operation: meta.operation, model: meta.model });
+  while (events.length > MAX_EVENTS) {
+    events.shift();
+  }
+  pruneOlderThan(now - 180_000);
+}
+
+function countInWindow(windowMs: number): RecentHttpAttempt[] {
+  const now = Date.now();
+  const start = now - windowMs;
+  pruneOlderThan(start - 1);
+  return events.filter((e) => e.t >= start);
+}
+
+function aggregateByOperationModel(rows: RecentHttpAttempt[]): Map<string, number> {
+  const m = new Map<string, number>();
+  for (const e of rows) {
+    const op = e.operation?.trim() || "?";
+    const mod = e.model?.trim() || "?";
+    const key = `${op} · ${mod}`;
+    m.set(key, (m.get(key) ?? 0) + 1);
+  }
+  return m;
+}
+
+function formatTop(m: Map<string, number>, limit: number): string {
+  return [...m.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, limit)
+    .map(([k, c]) => `${c}× ${k}`)
+    .join("; ");
+}
+
+/**
+ * Summarize recent attempts for rate-limit log lines (this Node process only).
+ */
+export function formatRecentHttpAttemptsForRateLimitLog(): string {
+  const w60 = countInWindow(60_000);
+  const w180 = countInWindow(180_000);
+  const top60 = formatTop(aggregateByOperationModel(w60), 6);
+  const top180 = formatTop(aggregateByOperationModel(w180), 6);
+  const s60 = w60.length === 0 ? "0" : String(w60.length);
+  const s180 = w180.length === 0 ? "0" : String(w180.length);
+  return (
+    `this-process traffic: last60s=${s60} attempt(s) [${top60 || "—"}]; ` +
+    `last180s=${s180} attempt(s) [${top180 || "—"}] ` +
+    `(same IP / subscription as other gateway jobs will share provider limits)`
+  );
+}

--- a/extensions/memory-hybrid/services/recent-http-attempts.ts
+++ b/extensions/memory-hybrid/services/recent-http-attempts.ts
@@ -60,8 +60,8 @@ function formatTop(m: Map<string, number>, limit: number): string {
  * Summarize recent attempts for rate-limit log lines (this Node process only).
  */
 export function formatRecentHttpAttemptsForRateLimitLog(): string {
-  const w60 = countInWindow(60_000);
   const w180 = countInWindow(180_000);
+  const w60 = countInWindow(60_000);
   const top60 = formatTop(aggregateByOperationModel(w60), 6);
   const top180 = formatTop(aggregateByOperationModel(w180), 6);
   const s60 = w60.length === 0 ? "0" : String(w60.length);

--- a/extensions/memory-hybrid/services/recent-http-attempts.ts
+++ b/extensions/memory-hybrid/services/recent-http-attempts.ts
@@ -66,9 +66,5 @@ export function formatRecentHttpAttemptsForRateLimitLog(): string {
   const top180 = formatTop(aggregateByOperationModel(w180), 6);
   const s60 = w60.length === 0 ? "0" : String(w60.length);
   const s180 = w180.length === 0 ? "0" : String(w180.length);
-  return (
-    `this-process traffic: last60s=${s60} attempt(s) [${top60 || "—"}]; ` +
-    `last180s=${s180} attempt(s) [${top180 || "—"}] ` +
-    `(same IP / subscription as other gateway jobs will share provider limits)`
-  );
+  return `this-process traffic: last60s=${s60} attempt(s) [${top60 || "—"}]; last180s=${s180} attempt(s) [${top180 || "—"}] (same IP / subscription as other gateway jobs will share provider limits)`;
 }

--- a/extensions/memory-hybrid/services/recent-http-attempts.ts
+++ b/extensions/memory-hybrid/services/recent-http-attempts.ts
@@ -30,10 +30,15 @@ export function recordProviderHttpAttempt(meta: { operation?: string; model?: st
   pruneOlderThan(now - 180_000);
 }
 
-function countInWindow(windowMs: number): RecentHttpAttempt[] {
+/** Clears the in-process ring buffer (Vitest only). */
+export function resetRecentHttpAttemptsForTests(): void {
+  events.length = 0;
+}
+
+/** Read-only slice for diagnostics — must not mutate `events` (rate-limit logs may run back-to-back; pruning here broke the 180s window). */
+function eventsInWindow(windowMs: number): RecentHttpAttempt[] {
   const now = Date.now();
   const start = now - windowMs;
-  pruneOlderThan(start - 1);
   return events.filter((e) => e.t >= start);
 }
 
@@ -60,8 +65,8 @@ function formatTop(m: Map<string, number>, limit: number): string {
  * Summarize recent attempts for rate-limit log lines (this Node process only).
  */
 export function formatRecentHttpAttemptsForRateLimitLog(): string {
-  const w180 = countInWindow(180_000);
-  const w60 = countInWindow(60_000);
+  const w180 = eventsInWindow(180_000);
+  const w60 = eventsInWindow(60_000);
   const top60 = formatTop(aggregateByOperationModel(w60), 6);
   const top180 = formatTop(aggregateByOperationModel(w180), 6);
   const s60 = w60.length === 0 ? "0" : String(w60.length);

--- a/extensions/memory-hybrid/services/reflection.ts
+++ b/extensions/memory-hybrid/services/reflection.ts
@@ -162,6 +162,12 @@ export async function runReflection(
   const factsBlock = factLines.join("\n");
   const prompt = fillPrompt(loadPrompt("reflection"), { window: String(windowDays), facts: factsBlock });
 
+  if (opts.verbose) {
+    logger.info(
+      `memory-hybrid: reflection — LLM call (${prompt.length} chars, ${recentFacts.length} facts in window, model=${opts.model})`,
+    );
+  }
+
   let rawResponse: string;
   try {
     rawResponse = await chatCompleteWithRetry({
@@ -193,6 +199,10 @@ export async function runReflection(
     return { factsAnalyzed: recentFacts.length, patternsExtracted: 0, patternsStored: 0, window: windowDays };
   }
 
+  logger.info(
+    `memory-hybrid: reflection — LLM completed successfully: ${uniqueNewPatterns.length} candidate pattern(s) after parse (next: embed prior patterns for dedupe, then each new pattern)`,
+  );
+
   if (opts.verbose) {
     logger.info(`memory-hybrid: reflection — extracted ${uniqueNewPatterns.length} patterns:`);
     for (const pattern of uniqueNewPatterns) {
@@ -206,7 +216,15 @@ export async function runReflection(
     .getByCategory("pattern")
     .filter((f) => !f.supersededAt && (f.expiresAt === null || f.expiresAt > nowSec));
   const existingVectors: (number[] | null)[] = [];
+  if (opts.verbose && existingPatternFacts.length > 0) {
+    logger.info(
+      `memory-hybrid: reflection — dedupe: embedding ${existingPatternFacts.length} existing pattern row(s) for cosine similarity (batched, short pause between batches)`,
+    );
+  }
   if (existingPatternFacts.length > 0) {
+    logger.info(
+      `memory-hybrid: reflection — embedding ${existingPatternFacts.length} existing pattern row(s) for dedupe (sequential API calls; rate limits may appear here)`,
+    );
     for (let i = 0; i < existingPatternFacts.length; i += 20) {
       const batch = existingPatternFacts.slice(i, i + 20);
       for (const f of batch) {
@@ -227,15 +245,28 @@ export async function runReflection(
       }
       if (i + 20 < existingPatternFacts.length) await new Promise((r) => setTimeout(r, 200));
     }
+    const dedupeOk = existingVectors.filter((v) => v !== null).length;
+    logger.info(
+      `memory-hybrid: reflection — dedupe corpus done: ${dedupeOk}/${existingPatternFacts.length} embedding(s) succeeded`,
+    );
+  } else {
+    logger.info("memory-hybrid: reflection — no existing pattern facts for dedupe; embedding new candidates only");
   }
 
+  logger.info(
+    `memory-hybrid: reflection — embedding ${uniqueNewPatterns.length} new candidate pattern(s) for duplicate check + storage`,
+  );
+
   let stored = 0;
+  let duplicatesSkipped = 0;
+  let newPatternEmbedFailures = 0;
   const reflectionRunId = provenanceService ? randomUUID() : null;
   for (const patternText of uniqueNewPatterns) {
     let vec: number[];
     try {
       vec = await embeddings.embed(patternText);
     } catch (err) {
+      newPatternEmbedFailures++;
       // AllEmbeddingProvidersFailed is expected when all providers are unavailable — don't report (#486)
       if (!shouldSuppressEmbeddingError(err)) {
         capturePluginError(err instanceof Error ? err : new Error(String(err)), {
@@ -256,6 +287,7 @@ export async function runReflection(
       }
     }
     if (isDuplicate) {
+      duplicatesSkipped++;
       if (opts.verbose) {
         logger.info(`memory-hybrid: reflection — skipped duplicate: ${patternText.slice(0, 60)}...`);
       }
@@ -323,6 +355,10 @@ export async function runReflection(
     stored++;
   }
 
+  logger.info(
+    `memory-hybrid: reflection — finished: ${stored} pattern(s) stored in DB + vector index, ${duplicatesSkipped} skipped as near-duplicate(s), ${newPatternEmbedFailures} new-pattern embed failure(s), ${uniqueNewPatterns.length} candidate(s) total`,
+  );
+
   return {
     factsAnalyzed: recentFacts.length,
     patternsExtracted: uniqueNewPatterns.length,
@@ -354,6 +390,11 @@ export async function runReflectionRules(
   }
   const patternsBlock = patterns.map((p, i) => `${i + 1}. ${p}`).join("\n");
   const prompt = fillPrompt(loadPrompt("reflection-rules"), { patterns: patternsBlock });
+  if (opts.verbose) {
+    logger.info(
+      `memory-hybrid: reflect-rules — LLM call (${prompt.length} chars, ${patterns.length} patterns, model=${opts.model})`,
+    );
+  }
   let rawResponse: string;
   try {
     rawResponse = await chatCompleteWithRetry({
@@ -396,6 +437,10 @@ export async function runReflectionRules(
     return { rulesExtracted: rules.length, rulesStored: 0 };
   }
 
+  logger.info(
+    `memory-hybrid: reflect-rules — LLM completed successfully: ${uniqueRules.length} candidate rule(s) after parse (next: embed prior rules for dedupe, then each new rule)`,
+  );
+
   if (opts.verbose) {
     logger.info(`memory-hybrid: reflect-rules — extracted ${uniqueRules.length} rules:`);
     for (const rule of uniqueRules) {
@@ -406,32 +451,56 @@ export async function runReflectionRules(
     .getByCategory("rule")
     .filter((f) => !f.supersededAt && (f.expiresAt === null || f.expiresAt > nowSec));
   const existingVectors: (number[] | null)[] = [];
-  for (let i = 0; i < existingRuleFacts.length; i += 20) {
-    const batch = existingRuleFacts.slice(i, i + 20);
-    for (const f of batch) {
-      try {
-        existingVectors.push(normalizeVector(await embeddings.embed(f.text)));
-      } catch (err) {
-        // AllEmbeddingProvidersFailed is expected when all providers are unavailable — don't report (#486)
-        if (!shouldSuppressEmbeddingError(err)) {
-          capturePluginError(err instanceof Error ? err : new Error(String(err)), {
-            operation: "reflection-rules-embed-existing",
-            subsystem: "embeddings",
-            factId: f.id,
-          });
-        }
-        existingVectors.push(null);
-      }
-    }
-    if (i + 20 < existingRuleFacts.length) await new Promise((r) => setTimeout(r, 200));
+  if (opts.verbose && existingRuleFacts.length > 0) {
+    logger.info(
+      `memory-hybrid: reflect-rules — dedupe: embedding ${existingRuleFacts.length} existing rule row(s) for cosine similarity`,
+    );
   }
+  if (existingRuleFacts.length > 0) {
+    logger.info(
+      `memory-hybrid: reflect-rules — embedding ${existingRuleFacts.length} existing rule row(s) for dedupe (sequential API calls)`,
+    );
+    for (let i = 0; i < existingRuleFacts.length; i += 20) {
+      const batch = existingRuleFacts.slice(i, i + 20);
+      for (const f of batch) {
+        try {
+          existingVectors.push(normalizeVector(await embeddings.embed(f.text)));
+        } catch (err) {
+          // AllEmbeddingProvidersFailed is expected when all providers are unavailable — don't report (#486)
+          if (!shouldSuppressEmbeddingError(err)) {
+            capturePluginError(err instanceof Error ? err : new Error(String(err)), {
+              operation: "reflection-rules-embed-existing",
+              subsystem: "embeddings",
+              factId: f.id,
+            });
+          }
+          existingVectors.push(null);
+        }
+      }
+      if (i + 20 < existingRuleFacts.length) await new Promise((r) => setTimeout(r, 200));
+    }
+    const dedupeOk = existingVectors.filter((v) => v !== null).length;
+    logger.info(
+      `memory-hybrid: reflect-rules — dedupe corpus done: ${dedupeOk}/${existingRuleFacts.length} embedding(s) succeeded`,
+    );
+  } else {
+    logger.info("memory-hybrid: reflect-rules — no existing rule facts for dedupe; embedding new candidates only");
+  }
+
+  logger.info(
+    `memory-hybrid: reflect-rules — embedding ${uniqueRules.length} new candidate rule(s) for duplicate check + storage`,
+  );
+
   let stored = 0;
+  let rulesDuplicatesSkipped = 0;
+  let newRuleEmbedFailures = 0;
   const reflectionRunId = provenanceService ? randomUUID() : null;
   for (const ruleText of uniqueRules) {
     let vec: number[];
     try {
       vec = await embeddings.embed(ruleText);
     } catch (err) {
+      newRuleEmbedFailures++;
       // AllEmbeddingProvidersFailed is expected when all providers are unavailable — don't report (#486)
       if (!shouldSuppressEmbeddingError(err)) {
         capturePluginError(err instanceof Error ? err : new Error(String(err)), {
@@ -452,6 +521,7 @@ export async function runReflectionRules(
       }
     }
     if (isDuplicate) {
+      rulesDuplicatesSkipped++;
       if (opts.verbose) {
         logger.info(`memory-hybrid: reflect-rules — skipped duplicate: ${ruleText.slice(0, 50)}...`);
       }
@@ -516,6 +586,11 @@ export async function runReflectionRules(
     existingVectors.push(normVec);
     stored++;
   }
+
+  logger.info(
+    `memory-hybrid: reflect-rules — finished: ${stored} rule(s) stored, ${rulesDuplicatesSkipped} skipped as near-duplicate(s), ${newRuleEmbedFailures} new-rule embed failure(s), ${uniqueRules.length} candidate(s) total`,
+  );
+
   return { rulesExtracted: rules.length, rulesStored: stored };
 }
 
@@ -542,6 +617,11 @@ export async function runReflectionMeta(
   }
   const patternsBlock = patterns.map((p, i) => `${i + 1}. ${p}`).join("\n");
   const prompt = fillPrompt(loadPrompt("reflection-meta"), { patterns: patternsBlock });
+  if (opts.verbose) {
+    logger.info(
+      `memory-hybrid: reflect-meta — LLM call (${prompt.length} chars, ${patterns.length} patterns, model=${opts.model})`,
+    );
+  }
   let rawResponse: string;
   try {
     rawResponse = await chatCompleteWithRetry({
@@ -584,6 +664,10 @@ export async function runReflectionMeta(
     return { metaExtracted: metas.length, metaStored: 0 };
   }
 
+  logger.info(
+    `memory-hybrid: reflect-meta — LLM completed successfully: ${uniqueMetas.length} candidate meta-pattern(s) after parse`,
+  );
+
   if (opts.verbose) {
     logger.info(`memory-hybrid: reflect-meta — extracted ${uniqueMetas.length} meta-patterns:`);
     for (const meta of uniqueMetas) {
@@ -596,32 +680,51 @@ export async function runReflectionMeta(
       (f) => !f.supersededAt && (f.expiresAt === null || f.expiresAt > nowSec) && f.tags?.includes("meta") === true,
     );
   const existingVectors: (number[] | null)[] = [];
-  for (let i = 0; i < existingMetaFacts.length; i += 20) {
-    const batch = existingMetaFacts.slice(i, i + 20);
-    for (const f of batch) {
-      try {
-        existingVectors.push(normalizeVector(await embeddings.embed(f.text)));
-      } catch (err) {
-        // AllEmbeddingProvidersFailed is expected when all providers are unavailable — don't report (#486)
-        if (!shouldSuppressEmbeddingError(err)) {
-          capturePluginError(err instanceof Error ? err : new Error(String(err)), {
-            operation: "reflection-meta-embed-existing",
-            subsystem: "embeddings",
-            factId: f.id,
-          });
+  if (existingMetaFacts.length > 0) {
+    logger.info(
+      `memory-hybrid: reflect-meta — embedding ${existingMetaFacts.length} existing meta-pattern row(s) for dedupe`,
+    );
+    for (let i = 0; i < existingMetaFacts.length; i += 20) {
+      const batch = existingMetaFacts.slice(i, i + 20);
+      for (const f of batch) {
+        try {
+          existingVectors.push(normalizeVector(await embeddings.embed(f.text)));
+        } catch (err) {
+          // AllEmbeddingProvidersFailed is expected when all providers are unavailable — don't report (#486)
+          if (!shouldSuppressEmbeddingError(err)) {
+            capturePluginError(err instanceof Error ? err : new Error(String(err)), {
+              operation: "reflection-meta-embed-existing",
+              subsystem: "embeddings",
+              factId: f.id,
+            });
+          }
+          existingVectors.push(null);
         }
-        existingVectors.push(null);
       }
+      if (i + 20 < existingMetaFacts.length) await new Promise((r) => setTimeout(r, 200));
     }
-    if (i + 20 < existingMetaFacts.length) await new Promise((r) => setTimeout(r, 200));
+    const dedupeOk = existingVectors.filter((v) => v !== null).length;
+    logger.info(
+      `memory-hybrid: reflect-meta — dedupe corpus done: ${dedupeOk}/${existingMetaFacts.length} embedding(s) succeeded`,
+    );
+  } else {
+    logger.info("memory-hybrid: reflect-meta — no existing meta-patterns for dedupe; embedding new candidates only");
   }
+
+  logger.info(
+    `memory-hybrid: reflect-meta — embedding ${uniqueMetas.length} new candidate meta-pattern(s) for duplicate check + storage`,
+  );
+
   let stored = 0;
+  let metaDuplicatesSkipped = 0;
+  let newMetaEmbedFailures = 0;
   const reflectionRunId = provenanceService ? randomUUID() : null;
   for (const metaText of uniqueMetas) {
     let vec: number[];
     try {
       vec = await embeddings.embed(metaText);
     } catch (err) {
+      newMetaEmbedFailures++;
       // AllEmbeddingProvidersFailed is expected when all providers are unavailable — don't report (#486)
       if (!shouldSuppressEmbeddingError(err)) {
         capturePluginError(err instanceof Error ? err : new Error(String(err)), {
@@ -642,6 +745,7 @@ export async function runReflectionMeta(
       }
     }
     if (isDuplicate) {
+      metaDuplicatesSkipped++;
       if (opts.verbose) {
         logger.info(`memory-hybrid: reflect-meta — skipped duplicate: ${metaText.slice(0, 50)}...`);
       }
@@ -706,5 +810,10 @@ export async function runReflectionMeta(
     existingVectors.push(normVec);
     stored++;
   }
+
+  logger.info(
+    `memory-hybrid: reflect-meta — finished: ${stored} meta-pattern(s) stored, ${metaDuplicatesSkipped} skipped as near-duplicate(s), ${newMetaEmbedFailures} embed failure(s), ${uniqueMetas.length} candidate(s) total`,
+  );
+
   return { metaExtracted: metas.length, metaStored: stored };
 }

--- a/extensions/memory-hybrid/services/reflection.ts
+++ b/extensions/memory-hybrid/services/reflection.ts
@@ -216,11 +216,6 @@ export async function runReflection(
     .getByCategory("pattern")
     .filter((f) => !f.supersededAt && (f.expiresAt === null || f.expiresAt > nowSec));
   const existingVectors: (number[] | null)[] = [];
-  if (opts.verbose && existingPatternFacts.length > 0) {
-    logger.info(
-      `memory-hybrid: reflection — dedupe: embedding ${existingPatternFacts.length} existing pattern row(s) for cosine similarity (batched, short pause between batches)`,
-    );
-  }
   if (existingPatternFacts.length > 0) {
     logger.info(
       `memory-hybrid: reflection — embedding ${existingPatternFacts.length} existing pattern row(s) for dedupe (sequential API calls; rate limits may appear here)`,
@@ -451,11 +446,6 @@ export async function runReflectionRules(
     .getByCategory("rule")
     .filter((f) => !f.supersededAt && (f.expiresAt === null || f.expiresAt > nowSec));
   const existingVectors: (number[] | null)[] = [];
-  if (opts.verbose && existingRuleFacts.length > 0) {
-    logger.info(
-      `memory-hybrid: reflect-rules — dedupe: embedding ${existingRuleFacts.length} existing rule row(s) for cosine similarity`,
-    );
-  }
   if (existingRuleFacts.length > 0) {
     logger.info(
       `memory-hybrid: reflect-rules — embedding ${existingRuleFacts.length} existing rule row(s) for dedupe (sequential API calls)`,

--- a/extensions/memory-hybrid/services/reflection.ts
+++ b/extensions/memory-hybrid/services/reflection.ts
@@ -218,7 +218,7 @@ export async function runReflection(
   const existingVectors: (number[] | null)[] = [];
   if (existingPatternFacts.length > 0) {
     logger.info(
-      `memory-hybrid: reflection — embedding ${existingPatternFacts.length} existing pattern row(s) for dedupe (sequential API calls; rate limits may appear here)`,
+      `memory-hybrid: reflection — embedding ${existingPatternFacts.length} existing pattern row(s) for dedupe cosine check (API calls in batches of up to 20 with a short pause between batches; rate limits may appear here)`,
     );
     for (let i = 0; i < existingPatternFacts.length; i += 20) {
       const batch = existingPatternFacts.slice(i, i + 20);
@@ -448,7 +448,7 @@ export async function runReflectionRules(
   const existingVectors: (number[] | null)[] = [];
   if (existingRuleFacts.length > 0) {
     logger.info(
-      `memory-hybrid: reflect-rules — embedding ${existingRuleFacts.length} existing rule row(s) for dedupe (sequential API calls)`,
+      `memory-hybrid: reflect-rules — embedding ${existingRuleFacts.length} existing rule row(s) for dedupe cosine check (API calls in batches of up to 20 with a short pause between batches)`,
     );
     for (let i = 0; i < existingRuleFacts.length; i += 20) {
       const batch = existingRuleFacts.slice(i, i + 20);

--- a/extensions/memory-hybrid/setup/cli-context.ts
+++ b/extensions/memory-hybrid/setup/cli-context.ts
@@ -228,8 +228,8 @@ interface CliContextServices {
     sources?: string[];
     mode?: "replace" | "additive";
   }) => Promise<{ factsExported: number; proceduresExported: number; filesWritten: number; outputPath: string }>;
-  runDreamCycle: () => Promise<DreamCycleResult>;
-  runContinuousVerification: () => Promise<VerificationCycleResult>;
+  runDreamCycle: (opts?: { verbose?: boolean }) => Promise<DreamCycleResult>;
+  runContinuousVerification: (opts?: { verbose?: boolean }) => Promise<VerificationCycleResult>;
   runResolveContradictions: () => Promise<{
     autoResolved: Array<{ contradictionId: string; factIdNew: string; factIdOld: string }>;
     ambiguous: Array<{ contradictionId: string; factIdNew: string; factIdOld: string }>;
@@ -398,10 +398,23 @@ function buildCliContextServices(ctx: HybridMemCliRegistrationContext, api: Claw
           schemaVersion: versionInfo.schemaVersion,
         }),
       ),
-    runDreamCycle: async () => {
+    runDreamCycle: async (opts?: { verbose?: boolean }) => {
+      const verbose = !!opts?.verbose;
       const { defaultModel, fallbackModels } = resolveReflectionModelAndFallbacks(cfg, "default");
       const dreamModel = cfg.nightlyCycle.model ?? defaultModel;
-      await runPreConsolidationFlush({ wal, factsDb, vectorDb, embeddings }, api.logger, "dream_cycle_consolidation");
+      if (verbose) {
+        pluginLogger.info("memory-hybrid: dream-cycle — pre-cycle WAL flush (replay pending writes)…");
+      }
+      const flush = await runPreConsolidationFlush(
+        { wal, factsDb, vectorDb, embeddings },
+        api.logger,
+        "dream_cycle_consolidation",
+      );
+      if (verbose) {
+        pluginLogger.info(
+          `memory-hybrid: dream-cycle — WAL flush done (committed=${flush.committed}, skipped=${flush.skipped})`,
+        );
+      }
       return runDreamCycle(
         factsDb,
         vectorDb,
@@ -421,18 +434,27 @@ function buildCliContextServices(ctx: HybridMemCliRegistrationContext, api: Claw
           maxUnconsolidatedAgeDays: cfg.nightlyCycle.maxUnconsolidatedAgeDays,
           logRetentionDays: cfg.nightlyCycle.logRetentionDays,
           vacuumOnCycle: cfg.nightlyCycle.vacuumOnCycle,
+          verbose,
         },
         logSink,
         provenanceService,
       );
     },
-    runContinuousVerification: async () => {
+    runContinuousVerification: async (opts?: { verbose?: boolean }) => {
       if (!verificationStore || !cfg.verification.enabled || !cfg.verification.continuousVerification) {
         return { checked: 0, confirmed: 0, stale: 0, uncertain: 0, errors: 0 };
       }
+      const verbose = !!opts?.verbose;
       return runVerificationCycle(verificationStore, factsDb, openai, {
         cycleDays: cfg.verification.cycleDays,
         verificationModel: cfg.verification.verificationModel,
+        ...(verbose
+          ? {
+              onProgress: (message: string) => {
+                pluginLogger.info(message);
+              },
+            }
+          : {}),
       });
     },
     runResolveContradictions: () => Promise.resolve(factsDb.resolveContradictions()),
@@ -847,7 +869,7 @@ function createHybridMemCliContext(
     runExtractDirectives: (opts) => handlers.runExtractDirectivesForCli(handlerCtx, opts),
     runExtractReinforcement: (opts) => handlers.runExtractReinforcementForCli(handlerCtx, opts),
     runExtractImplicitFeedback: (opts) => handlers.runExtractImplicitFeedbackForCli(handlerCtx, opts),
-    runCrossAgentLearning: () => handlers.runCrossAgentLearningForCli(handlerCtx),
+    runCrossAgentLearning: (opts) => handlers.runCrossAgentLearningForCli(handlerCtx, opts),
     runToolEffectiveness: (opts) => handlers.runToolEffectivenessForCli(handlerCtx, opts),
     runCostReport: (opts, sink) => handlers.runCostReportForCli(handlerCtx, opts, sink),
     pruneCostLog: (retainDays) => (handlerCtx.costTracker ? handlerCtx.costTracker.pruneOldEntries(retainDays) : 0),

--- a/extensions/memory-hybrid/tests/chat.test.ts
+++ b/extensions/memory-hybrid/tests/chat.test.ts
@@ -20,6 +20,7 @@ import {
   parseRetryAfterMs,
   withLLMRetry,
 } from "../services/chat.js";
+import { formatProviderRateLimitHeaderSummary, inferRateLimitBucket } from "../services/llm-rate-limit-headers.js";
 import { isReasoningModel, requiresMaxCompletionTokens, resolveWireApi } from "../services/model-capabilities.js";
 
 vi.mock("../services/error-reporter.js", () => ({
@@ -496,6 +497,57 @@ describe("parseGoDurationToMs / parseRetryAfterMs (OpenAI x-ratelimit-reset-* #9
 
   it("parses plain retry-after seconds only when the value is all digits", () => {
     expect(parseRetryAfterMs({ headers: { "retry-after": "1282" } })).toBe(1_282_000);
+  });
+});
+
+describe("formatProviderRateLimitHeaderSummary / inferRateLimitBucket", () => {
+  it("infers token bucket when remaining-tokens is 0", () => {
+    const headers = {
+      "x-ratelimit-remaining-tokens": "0",
+      "x-ratelimit-remaining-requests": "500",
+    };
+    expect(inferRateLimitBucket(headers)).toBe("tokens");
+  });
+
+  it("infers requests bucket when remaining-requests is 0", () => {
+    const headers = {
+      "x-ratelimit-remaining-requests": "0",
+      "x-ratelimit-remaining-tokens": "80000",
+    };
+    expect(inferRateLimitBucket(headers)).toBe("requests");
+  });
+
+  it("reads headers from nested response.headers", () => {
+    const err = Object.assign(new Error("429"), {
+      status: 429,
+      response: {
+        headers: {
+          "x-ratelimit-remaining-requests": "0",
+          "x-ratelimit-limit-requests": "500",
+          "x-request-id": "req-abc",
+        },
+      },
+    });
+    const summary = formatProviderRateLimitHeaderSummary(err);
+    expect(summary).toContain("reqRem=0");
+    expect(summary).toContain("reqLim=500");
+    expect(summary).toContain("reqId=req-abc");
+    expect(summary).toMatch(/request budget/i);
+  });
+
+  it("unwraps LLMRetryError cause for header summary", () => {
+    const inner = Object.assign(new Error("429"), {
+      response: {
+        headers: {
+          "x-ratelimit-remaining-tokens": "0",
+          "x-ratelimit-limit-tokens": "80000",
+        },
+      },
+    });
+    const wrapped = new LLMRetryError("fail", inner, 2);
+    const summary = formatProviderRateLimitHeaderSummary(wrapped);
+    expect(summary).toContain("tokRem=0");
+    expect(summary).toMatch(/token budget/i);
   });
 });
 

--- a/extensions/memory-hybrid/tests/continuous-verifier.test.ts
+++ b/extensions/memory-hybrid/tests/continuous-verifier.test.ts
@@ -175,9 +175,10 @@ describe("ContinuousVerifier.verifyFact", () => {
     const mockOpenAI = makeMockOpenAI("CONFIRMED – still accurate");
     const verifier = new ContinuousVerifier(store, factsDb, mockOpenAI as never);
 
-    const _id = await store.verify("fact-1", "Server IP is 10.0.0.1", "agent");
+    await store.verify("fact-1", "Server IP is 10.0.0.1", "agent");
     const vf = await store.getVerified("fact-1");
-    const outcome = await verifier.verifyFact(vf!, ["The server is still running at 10.0.0.1"]);
+    if (!vf) throw new Error("expected verified fact");
+    const outcome = await verifier.verifyFact(vf, ["The server is still running at 10.0.0.1"]);
     expect(outcome).toBe("CONFIRMED");
   });
 
@@ -187,7 +188,8 @@ describe("ContinuousVerifier.verifyFact", () => {
 
     await store.verify("fact-2", "Server IP is 10.0.0.1", "agent");
     const vf = await store.getVerified("fact-2");
-    const outcome = await verifier.verifyFact(vf!, []);
+    if (!vf) throw new Error("expected verified fact");
+    const outcome = await verifier.verifyFact(vf, []);
     expect(outcome).toBe("STALE");
   });
 
@@ -197,7 +199,8 @@ describe("ContinuousVerifier.verifyFact", () => {
 
     await store.verify("fact-3", "Admin password reset", "user");
     const vf = await store.getVerified("fact-3");
-    const outcome = await verifier.verifyFact(vf!, []);
+    if (!vf) throw new Error("expected verified fact");
+    const outcome = await verifier.verifyFact(vf, []);
     expect(outcome).toBe("UNCERTAIN");
   });
 
@@ -209,7 +212,8 @@ describe("ContinuousVerifier.verifyFact", () => {
 
     await store.verify("fact-timeout", "Some fact", "agent");
     const vf = await store.getVerified("fact-timeout");
-    const outcome = await verifier.verifyFact(vf!, []);
+    if (!vf) throw new Error("expected verified fact");
+    const outcome = await verifier.verifyFact(vf, []);
     expect(outcome).toBe("UNCERTAIN");
   });
 
@@ -219,7 +223,8 @@ describe("ContinuousVerifier.verifyFact", () => {
 
     await store.verify("fact-err", "Some fact", "user");
     const vf = await store.getVerified("fact-err");
-    const outcome = await verifier.verifyFact(vf!, []);
+    if (!vf) throw new Error("expected verified fact");
+    const outcome = await verifier.verifyFact(vf, []);
     expect(outcome).toBe("UNCERTAIN");
   });
 });

--- a/extensions/memory-hybrid/tests/continuous-verifier.test.ts
+++ b/extensions/memory-hybrid/tests/continuous-verifier.test.ts
@@ -417,6 +417,49 @@ describe("ContinuousVerifier.runCycle — error handling", () => {
 // 9. ContinuousVerifier.runCycle — multiple facts
 // ---------------------------------------------------------------------------
 
+describe("ContinuousVerifier.runCycle — onProgress", () => {
+  it("calls onProgress for preamble and every fact when total due ≤25", async () => {
+    const onProgress = vi.fn();
+    const mockOpenAI = makeMockOpenAI("CONFIRMED");
+    const verifier = new ContinuousVerifier(store, factsDb, mockOpenAI as never, { onProgress });
+    const ids: string[] = [];
+    for (let i = 0; i < 3; i++) {
+      ids.push(await store.verify(`f-prog-${i}`, `Fact ${i}`, "agent"));
+    }
+    const db = (store as unknown as { db: import("node:sqlite").DatabaseSync }).db;
+    for (const id of ids) {
+      db.prepare(`UPDATE verified_facts SET next_verification = '2020-01-01T00:00:00.000Z' WHERE id = ?`).run(id);
+    }
+    await verifier.runCycle();
+    expect(onProgress).toHaveBeenCalledTimes(4);
+    expect(String(onProgress.mock.calls[0][0])).toMatch(/3 fact\(s\) due/);
+    expect(String(onProgress.mock.calls[1][0])).toMatch(/1\/3/);
+    expect(String(onProgress.mock.calls[3][0])).toMatch(/3\/3/);
+  });
+
+  it("throttles per-fact onProgress when total due >25", async () => {
+    const onProgress = vi.fn();
+    const mockOpenAI = makeMockOpenAI("CONFIRMED");
+    const verifier = new ContinuousVerifier(store, factsDb, mockOpenAI as never, { onProgress });
+    const ids: string[] = [];
+    for (let i = 0; i < 30; i++) {
+      ids.push(await store.verify(`f-throttle-${i}`, `Fact row ${i}`, "agent"));
+    }
+    const db = (store as unknown as { db: import("node:sqlite").DatabaseSync }).db;
+    for (const id of ids) {
+      db.prepare(`UPDATE verified_facts SET next_verification = '2020-01-01T00:00:00.000Z' WHERE id = ?`).run(id);
+    }
+    await verifier.runCycle();
+    expect(onProgress).toHaveBeenCalledTimes(5);
+    expect(String(onProgress.mock.calls[0][0])).toMatch(/30 fact\(s\) due/);
+    const progressBodies = onProgress.mock.calls.slice(1).map((c) => String(c[0]));
+    expect(progressBodies.some((m) => m.includes("1/30"))).toBe(true);
+    expect(progressBodies.some((m) => m.includes("10/30"))).toBe(true);
+    expect(progressBodies.some((m) => m.includes("20/30"))).toBe(true);
+    expect(progressBodies.some((m) => m.includes("30/30"))).toBe(true);
+  });
+});
+
 describe("ContinuousVerifier.runCycle — multiple facts", () => {
   it("processes all due facts and aggregates counters correctly", async () => {
     let callCount = 0;

--- a/extensions/memory-hybrid/tests/cross-agent-learning.test.ts
+++ b/extensions/memory-hybrid/tests/cross-agent-learning.test.ts
@@ -13,7 +13,7 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { parseCrossAgentLearningConfig } from "../config/parsers/features.js";
 import type { CrossAgentLearningConfig } from "../config/types/features.js";
 import { _testing } from "../index.js";
@@ -318,6 +318,72 @@ describe("runCrossAgentLearning — LLM mock", () => {
     const globalFacts = getCrossAgentFacts(db);
     expect(globalFacts).toHaveLength(1);
     expect(globalFacts[0]?.importance).toBeGreaterThan(0.7); // boosted
+  });
+
+  it("does not call logger.info for LLM batches when verbose is off", async () => {
+    const now = Math.floor(Date.now() / 1000);
+    for (let i = 0; i < 5; i++) {
+      rawDb(db)
+        .prepare(
+          `INSERT INTO facts (id, text, category, scope, scope_target, confidence, importance, source, created_at, last_confirmed_at, decay_class)
+       VALUES (?, ?, 'pattern', 'agent', ?, 0.8, 0.7, 'test', ?, ?, 'stable')`,
+        )
+        .run(`agent-f-voff-${i}`, `Lesson ${i} for batch logging`, `agent-${i % 2}`, now, now);
+    }
+    const mockOpenAI = {
+      chat: {
+        completions: {
+          create: async () => ({
+            choices: [{ message: { content: "[]" } }],
+          }),
+        },
+      },
+    };
+    const cfg: CrossAgentLearningConfig = {
+      enabled: true,
+      windowDays: 30,
+      batchSize: 2,
+      minSourceConfidence: 0.3,
+      model: "gpt-4o-mini",
+      runInNightlyCycle: true,
+    };
+    const info = vi.fn();
+    await runCrossAgentLearning(db, mockOpenAI as never, cfg, { info });
+    const batchLines = info.mock.calls.filter((c) => String(c[0]).includes("LLM batch"));
+    expect(batchLines).toHaveLength(0);
+  });
+
+  it("calls logger.info once per LLM batch when verbose is on", async () => {
+    const now = Math.floor(Date.now() / 1000);
+    for (let i = 0; i < 5; i++) {
+      rawDb(db)
+        .prepare(
+          `INSERT INTO facts (id, text, category, scope, scope_target, confidence, importance, source, created_at, last_confirmed_at, decay_class)
+       VALUES (?, ?, 'pattern', 'agent', ?, 0.8, 0.7, 'test', ?, ?, 'stable')`,
+        )
+        .run(`agent-f-von-${i}`, `Lesson verbose ${i}`, "agent-x", now, now);
+    }
+    const mockOpenAI = {
+      chat: {
+        completions: {
+          create: async () => ({
+            choices: [{ message: { content: "[]" } }],
+          }),
+        },
+      },
+    };
+    const cfg: CrossAgentLearningConfig = {
+      enabled: true,
+      windowDays: 30,
+      batchSize: 2,
+      minSourceConfidence: 0.3,
+      model: "gpt-4o-mini",
+      runInNightlyCycle: true,
+    };
+    const info = vi.fn();
+    await runCrossAgentLearning(db, mockOpenAI as never, cfg, { info }, { verbose: true });
+    const batchLines = info.mock.calls.filter((c) => String(c[0]).includes("LLM batch"));
+    expect(batchLines).toHaveLength(3);
   });
 
   it("skips duplicate facts in second run", async () => {

--- a/extensions/memory-hybrid/tests/cross-agent-learning.test.ts
+++ b/extensions/memory-hybrid/tests/cross-agent-learning.test.ts
@@ -41,38 +41,6 @@ function rawDb(db: InstanceType<typeof FactsDB>) {
   return db.getRawDb();
 }
 
-/** Insert an agent-scoped fact directly (bypassing store to control all fields). */
-function insertAgentFact(
-  db: InstanceType<typeof FactsDB>,
-  opts: {
-    id?: string;
-    agentId: string;
-    text: string;
-    category?: string;
-    confidence?: number;
-    importance?: number;
-  },
-): string {
-  const id = opts.id ?? Math.random().toString(36).slice(2, 12);
-  const now = Math.floor(Date.now() / 1000);
-  rawDb(db)
-    .prepare(
-      `INSERT INTO facts (id, text, category, scope, scope_target, confidence, importance, source, created_at, last_confirmed_at, decay_class)
-     VALUES (?, ?, ?, 'agent', ?, ?, ?, 'test', ?, ?, 'stable')`,
-    )
-    .run(
-      id,
-      opts.text,
-      opts.category ?? "pattern",
-      opts.agentId,
-      opts.confidence ?? 0.7,
-      opts.importance ?? 0.7,
-      now,
-      now,
-    );
-  return id;
-}
-
 /** Create a mock OpenAI client that returns a fixed JSON response. */
 function makeMockOpenAI(responseJson: unknown): unknown {
   return {

--- a/extensions/memory-hybrid/tests/recent-http-attempts.test.ts
+++ b/extensions/memory-hybrid/tests/recent-http-attempts.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  formatRecentHttpAttemptsForRateLimitLog,
+  recordProviderHttpAttempt,
+  resetRecentHttpAttemptsForTests,
+} from "../services/recent-http-attempts.js";
+
+describe("recent-http-attempts", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    resetRecentHttpAttemptsForTests();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("reports distinct 60s vs 180s counts without read-path pruning", () => {
+    const t0 = new Date("2026-06-01T12:00:00.000Z").getTime();
+    vi.setSystemTime(t0);
+    recordProviderHttpAttempt({ operation: "chat", model: "m1" });
+    vi.advanceTimersByTime(70_000);
+    recordProviderHttpAttempt({ operation: "chat", model: "m1" });
+    vi.advanceTimersByTime(70_000);
+    recordProviderHttpAttempt({ operation: "embed", model: "m2" });
+    const line = formatRecentHttpAttemptsForRateLimitLog();
+    expect(line).toMatch(/last60s=1 attempt/);
+    expect(line).toMatch(/last180s=3 attempt/);
+  });
+
+  it("second format call still sees full 180s slice after first call", () => {
+    const t0 = new Date("2026-06-01T12:00:00.000Z").getTime();
+    vi.setSystemTime(t0);
+    recordProviderHttpAttempt({ operation: "a", model: "x" });
+    vi.advanceTimersByTime(90_000);
+    recordProviderHttpAttempt({ operation: "b", model: "x" });
+    vi.advanceTimersByTime(30_000);
+    expect(formatRecentHttpAttemptsForRateLimitLog()).toMatch(/last180s=2 attempt/);
+    expect(formatRecentHttpAttemptsForRateLimitLog()).toMatch(/last180s=2 attempt/);
+  });
+});

--- a/packages/openclaw-hybrid-memory-install/package.json
+++ b/packages/openclaw-hybrid-memory-install/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-hybrid-memory-install",
-  "version": "2026.5.60",
+  "version": "2026.5.61",
   "description": "Standalone installer for openclaw-hybrid-memory. Use when OpenClaw config validation fails.",
   "bin": {
     "openclaw-hybrid-memory-install": "./install.js"

--- a/release-notes/release-notes-2026.5.50.md
+++ b/release-notes/release-notes-2026.5.50.md
@@ -1,6 +1,6 @@
 # Release Notes — OpenClaw Hybrid Memory 2026.5.50
 
-> **Note:** The published **2026.5.x** line is released as **[2026.5.60](release-notes-2026.5.60.md)** (includes additional fixes and **`contracts.tools`**). Prefer **`release-notes-2026.5.60.md`** for upgrade guidance.
+> **Note:** The published **2026.5.x** line is released as **[2026.5.61](release-notes-2026.5.61.md)** (includes additional fixes, **`contracts.tools`**, and maintenance observability). Prefer **`release-notes-2026.5.61.md`** for upgrade guidance.
 
 **Date:** 2026-05-05
 **Previous baseline:** 2026.4.273

--- a/release-notes/release-notes-2026.5.60.md
+++ b/release-notes/release-notes-2026.5.60.md
@@ -1,5 +1,7 @@
 # Release notes — OpenClaw Hybrid Memory **2026.5.60**
 
+> **Newer build:** **[2026.5.61](release-notes-2026.5.61.md)** is the current **2026.5.x** follow-on (maintenance / reflection observability). This page still describes what first shipped in **2026.5.60**.
+
 **Release date:** 2026-05-06  
 **Previous published release (GitHub / npm):** **2026.4.273** (2026-04-27)
 
@@ -85,4 +87,4 @@ See **[CHANGELOG.md](https://github.com/markus-lassfolk/openclaw-hybrid-memory/b
 
 ## Earlier draft notes (2026.5.50)
 
-An internal **2026.5.50** changelog draft described the same packaging work before the version was advanced to **2026.5.60** for publication. **2026.5.60** is the single published **2026.5.x** target that also includes SQLite compat, **`contracts.tools`**, and CI/verify follow-ups.
+An internal **2026.5.50** changelog draft described the same packaging work before the version was advanced to **2026.5.60** for publication. **2026.5.60** established the **2026.5.x** baseline (SQLite compat, **`contracts.tools`**, CI/verify follow-ups). **2026.5.61** is the current patch on that line for maintenance and reflection observability—see **[release-notes-2026.5.61.md](release-notes-2026.5.61.md)**.

--- a/release-notes/release-notes-2026.5.61.md
+++ b/release-notes/release-notes-2026.5.61.md
@@ -1,0 +1,32 @@
+# Release notes — OpenClaw Hybrid Memory **2026.5.61**
+
+**Baseline:** **[2026.5.60](release-notes-2026.5.60.md)** (OpenClaw **2026.5.x** readiness: `dist/`, `contracts.tools`, peers, SQLite outcome compat, CI smoke-install). **2026.5.61** is a follow-on patch on the same peer line (**OpenClaw `>=2026.5.0 <2027`**) focused on **operator visibility** for maintenance and reflection.
+
+## Who should install
+
+Anyone already on **2026.5.60** who wants clearer logs for **`hybrid-mem dream-cycle`**, **`reflect`**, **`run-all`**, and embedding-heavy reflection steps—especially when diagnosing **429 / rate limits** (chat vs **embeddings.create**).
+
+## What changed (high level)
+
+- **Dream cycle & wrappers**: `--verbose` / parent `-v` propagates through follow-up steps (continuous verification, extract-implicit, cross-agent learning, tool effectiveness); step labels and WAL flush summaries in-plugin.
+- **Reflection**: always-on **`info`** checkpoints after the LLM (candidate count), through **dedupe embedding** (success counts), and a **finished** summary (stored vs duplicates vs embed failures).
+- **Rate-limit lines**: chat retries show operation + model + attempt; embedding API retries are tagged **`memory-hybrid: embeddings.create`** (single and batch).
+
+## Install
+
+```bash
+npm install -g openclaw-hybrid-memory@2026.5.61
+```
+
+Or add/update the plugin in your workspace / gateway config using the same version.
+
+If you use **`openclaw-hybrid-memory-install`**, align it to **2026.5.61** so installer and plugin versions stay in sync.
+
+## Changelog
+
+See **[CHANGELOG.md](https://github.com/markus-lassfolk/openclaw-hybrid-memory/blob/main/CHANGELOG.md)** — section **`[2026.5.61]`**.
+
+## Earlier notes
+
+- **2026.5.60** narrative and compatibility matrix: **[release-notes-2026.5.60.md](release-notes-2026.5.60.md)**.
+- Draft **2026.5.50** context: **[release-notes-2026.5.50.md](release-notes-2026.5.50.md)**.


### PR DESCRIPTION
## Summary

This PR improves observability for nightly and manual maintenance (especially **dream-cycle** and **reflect**), and makes rate-limit lines attributable to the right API (**chat** vs **embeddings**).

## Changes

### CLI / wrappers
- **`hybrid-mem dream-cycle`**: `--verbose` plus parent `-v` / `--verbose`; forwards verbose to core cycle, continuous verification, extract-implicit, cross-agent learning, and tool effectiveness; short section headers on stdout where helpful.
- **`hybrid-mem run-all --verbose`**: passes verbose into **extract-procedures** and **self-correction-run**.
- **`hybrid-mem cross-agent-learning`**: `--verbose` + parent `-v`; logs per LLM batch when enabled.
- **Types**: `runDreamCycle`, `runContinuousVerification`, and `runCrossAgentLearning` accept optional `\{ verbose?: boolean \}` on the CLI context.

### Dream cycle service
- `DreamCycleConfig.verbose`: step labels, episodic consolidation queue line, WAL flush messages from CLI wiring, reflection / reflect-rules / MEMORY_INDEX verbosity.

### Reflection (always-on `info` checkpoints)
- After LLM parse: explicit **LLM completed** line with candidate count.
- Before/after **dedupe embedding** of existing patterns/rules/meta: counts and **`ok/total` succeeded** summary.
- Before embedding new candidates: clear line.
- **Finished** summary: stored vs duplicate vs embed failures vs candidates.
- **reflect-rules** and **reflect-meta**: same pattern.

### Other
- **memory-index**: verbose snapshot + synthesis prompt size when verbose.
- **continuous-verifier**: optional `onProgress` (throttled); **export** `ContinuousVerifierOptions`.
- **chat `withLLMRetry`**: rate-limit warn includes operation, model, retry index.
- **OpenAI embeddings**: `llmContext` on `withLLMRetry` so 429s show `memory-hybrid: embeddings.create` vs chat.

## How to verify
1. `openclaw hybrid-mem dream-cycle --verbose` (with nightly cycle enabled): expect step lines, WAL flush, reflection **LLM completed** → **dedupe corpus done** → **finished** summary.
2. Standalone `reflect --verbose`: same reflection checkpoint lines without dream-cycle wrapper.
3. Under rate limit: log should include `[memory-hybrid: embeddings.create · …]` or chat label + retry `k/n`.

## Notes
- Rebuild/redeploy the plugin so hosts pick up the new logging.


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly adds verbose/progress logging and diagnostic context across maintenance commands and LLM retry handling, with minimal functional behavior change. Risk is low but touches core maintenance workflows (`dream-cycle`, reflection, verifier) and retry logging paths that run frequently.
> 
> **Overview**
> Improves maintenance observability by adding/propagating `--verbose` (and parent `-v`) through `hybrid-mem dream-cycle`, `run-all`, and `cross-agent-learning`, and threading verbose into follow-up steps like continuous verification, implicit feedback extraction, tool effectiveness, and self-correction.
> 
> Adds detailed progress logging across the nightly `dream-cycle` pipeline (step labels, episodic consolidation stats, WAL pre-flush summaries), reflection/reflection-rules/meta (LLM completion checkpoints, dedupe embedding success counts, and final stored/duplicate/failure summaries), and `memory-index` synthesis.
> 
> Enhances rate-limit diagnostics: `withLLMRetry` logs now include operation/model/retry info plus provider header summaries and recent in-process HTTP attempt counts; OpenAI embedding calls pass `llmContext` so 429 backoff lines can distinguish embeddings vs chat. Exports `ContinuousVerifierOptions` and adds optional throttled `onProgress`, with new/updated tests, and bumps versions/docs to `2026.5.61`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd19ab23feceb73ccb68aba850cd7cb5e9a0ec6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->