### PR TITLE
feat: cron observability, richer stats, and verify UX

### DIFF
--- a/docs/CLI-REFERENCE.md
+++ b/docs/CLI-REFERENCE.md
@@ -332,18 +332,21 @@ Steps through pending persona proposals and the latest correction report. For ea
 
 ## Maintenance cron jobs
 
-**Install** and **verify --fix** create or repair maintenance cron jobs in `~/.openclaw/cron/jobs.json`. The canonical list is **8 jobs** (tiering, scope promote, persona proposals, dream cycle, and others; see table below).
+**Install** and **verify --fix** create or repair maintenance cron jobs in `~/.openclaw/cron/jobs.json`. The canonical list is **9 jobs** (see table). **Install/verify** also creates `~/.openclaw/logs/cron-hybrid-mem/` for first-run log paths.
+
+Default job **messages** embed a **bash harness**: one foreground shell (`set -euo pipefail`, `set -x`), per-step `hm_step` that **tees** to `HM_LOG` and appends `exit=<code>` lines to `HM_EXIT`, plus log headers (`HM_JOB`, `RUN_ID`, `openclaw --version`). Logs default to `~/.openclaw/logs/cron-hybrid-mem/` (fallback: `/tmp/openclaw-cron-hybrid-mem-$USER` if that directory is not writable). The message instructs the agent **not** to update the guard file after a failed step and to paste `HM_EXIT` in the reply.
 
 | Job (pluginJobId) | Schedule | Purpose |
 |-------------------|----------|---------|
-| `hybrid-mem:nightly-distill` | 02:00 daily | **nightly-memory-sweep:** prune → distill --days 3 → extract-daily → resolve-contradictions. |
-| `hybrid-mem:self-correction-analysis` | 02:30 daily | **self-correction-analysis:** self-correction-run. Exit 0 if selfCorrection disabled. |
-| `hybrid-mem:nightly-dream-cycle` | 02:45 daily | **nightly-dream-cycle:** dream-cycle (prune → consolidate → reflect). Requires nightlyCycle.enabled. Exit 0 if disabled. |
-| `hybrid-mem:weekly-reflection` | Sun 03:00 | **weekly-reflection:** reflect → reflect-rules → reflect-meta. Requires reflection.enabled. |
-| `hybrid-mem:weekly-extract-procedures` | Sun 04:00 | **weekly-extract-procedures:** extract-procedures → extract-directives → extract-reinforcement → generate-auto-skills. |
-| `hybrid-mem:weekly-deep-maintenance` | Sat 04:00 | **weekly-deep-maintenance:** compact → scope promote. |
-| `hybrid-mem:weekly-persona-proposals` | Sun 10:00 | **weekly-persona-proposals:** generate-proposals (persona proposals from reflection). Requires personaProposals enabled. |
-| `hybrid-mem:monthly-consolidation` | 1st 05:00 | **monthly-consolidation:** consolidate → build-languages → backfill-decay. |
+| `hybrid-mem:nightly-distill` | 02:00 daily | **nightly-memory-sweep:** prune → distill --days 1 → extract-daily (7d) → resolve-contradictions → enrich-entities (see config skips in message). |
+| `hybrid-mem:self-correction-analysis` | 02:30 daily | **self-correction-analysis:** `self-correction-run --verbose`. Skip if selfCorrection disabled. |
+| `hybrid-mem:nightly-dream-cycle` | 02:45 daily | **nightly-dream-cycle:** `dream-cycle --verbose`. Requires nightlyCycle.enabled. |
+| `hybrid-mem:weekly-reflection` | Sun 03:00 | **weekly-reflection:** reflect / reflect-rules / reflect-meta (each `--verbose`). Requires reflection.enabled. |
+| `hybrid-mem:weekly-extract-procedures` | Sun 04:00 | **weekly-extract-procedures:** extract-procedures → extract-directives → extract-reinforcement → generate-auto-skills (each `--verbose` where supported). |
+| `hybrid-mem:weekly-deep-maintenance` | Sat 04:00 | **weekly-deep-maintenance:** compact → vectordb-optimize → scope promote. |
+| `hybrid-mem:weekly-persona-proposals` | Sun 10:00 | **weekly-persona-proposals:** `generate-proposals --verbose`. Requires personaProposals enabled. |
+| `hybrid-mem:monthly-consolidation` | 1st 05:00 | **monthly-consolidation:** consolidate → build-languages → backfill-decay → enrich-entities --limit 500. |
+| `hybrid-mem:sensor-sweep` | every 4h (configurable) | **sensor-sweep:** tier 1 + tier 2. Requires sensorSweep.enabled. |
 
 - **Install:** Adds any missing jobs (does not change existing jobs or re-enable disabled ones).
 - **Verify --fix:** Adds any missing jobs and can normalize schedule/pluginJobId; does not re-enable disabled jobs by default.

--- a/docs/MAINTENANCE-TASKS-MATRIX.md
+++ b/docs/MAINTENANCE-TASKS-MATRIX.md
@@ -15,7 +15,7 @@ This matrix shows **which maintenance tasks run** in each context (installation,
 | **Auto-classify** ("other" → categories) | No            | No                                       | Yes (5 min delay, then every 24 h if enabled)       | No                                                   | No                                |
 | **Proposals prune** (expired)            | No            | No                                       | Yes (every 24 h if personaProposals enabled)        | No                                                   | No                                |
 | **Language keywords build**              | No            | No                                       | Yes (3s if no file, then every N days if autoBuild) | Yes (monthly-consolidation step 2)                   | Yes                               |
-| **Session distill** (facts from logs)    | No            | No                                       | No                                                  | Yes (nightly-memory-sweep step 2)                    | Yes (3 days, if distill enabled)  |
+| **Session distill** (facts from logs)    | No            | No                                       | No                                                  | Yes (nightly-memory-sweep step 2)                    | Yes (1 day window in default cron, if distill enabled)  |
 | **Extract-daily**                        | No            | No                                       | No                                                  | Yes (nightly-memory-sweep step 3)                    | Yes (7 days, if enabled)          |
 | **Extract-directives**                   | No            | No                                       | No                                                  | Yes (weekly-extract-procedures step 2)               | Yes (7 days, if enabled)          |
 | **Extract-reinforcement**                | No            | No                                       | No                                                  | Yes (weekly-extract-procedures step 3)               | Yes (7 days, if enabled)          |
@@ -67,7 +67,7 @@ The plugin **ensures** these job definitions exist in `~/.openclaw/cron/jobs.jso
 
 | Job name                      | Schedule           | Steps (what the job message tells the agent to run)                                          |
 | ----------------------------- | ------------------ | -------------------------------------------------------------------------------------------- |
-| **nightly-memory-sweep**      | Daily 02:00        | 1. prune 2. distill --days 3 3. extract-daily 4. resolve-contradictions 5. enrich-entities   |
+| **nightly-memory-sweep**      | Daily 02:00        | 1. prune 2. distill --days 1 3. extract-daily (7d) 4. resolve-contradictions 5. enrich-entities (default cron message: bash harness + file logs under `~/.openclaw/logs/cron-hybrid-mem/`)   |
 | **self-correction-analysis**  | Daily 02:30        | self-correction-run. Exit 0 if selfCorrection disabled.                                      |
 | **nightly-dream-cycle**       | Daily 02:45        | dream-cycle (prune → consolidate → reflect). Exit 0 if nightlyCycle.enabled false.           |
 | **weekly-reflection**         | Sun 03:00          | reflect → reflect-rules → reflect-meta. Exit 0 if reflection.enabled false.                  |

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -32,7 +32,7 @@ These are **not** required for core functionality but enhance the system for lon
 
 **How to enable when "not defined":**
 
-1. **Recommended:** Run **`openclaw hybrid-mem verify --fix`**. This adds any missing maintenance jobs (9 canonical jobs) when they are missing (without overwriting existing jobs) to `~/.openclaw/cron/jobs.json` (and, if present, the `jobs` array in `~/.openclaw/openclaw.json`). See [CLI-REFERENCE.md § Maintenance cron jobs](CLI-REFERENCE.md#maintenance-cron-jobs) for the full table (nightly-memory-sweep, self-correction-analysis, nightly-dream-cycle, weekly-reflection, weekly-extract-procedures, weekly-deep-maintenance, weekly-persona-proposals, monthly-consolidation).
+1. **Recommended:** Run **`openclaw hybrid-mem verify --fix`**. This adds any missing maintenance jobs (9 canonical jobs) when they are missing (without overwriting existing jobs) to `~/.openclaw/cron/jobs.json` (and, if present, the `jobs` array in `~/.openclaw/openclaw.json`), and ensures `~/.openclaw/logs/cron-hybrid-mem/` exists. See [CLI-REFERENCE.md § Maintenance cron jobs](CLI-REFERENCE.md#maintenance-cron-jobs) for the full table (nightly-memory-sweep, self-correction-analysis, nightly-dream-cycle, weekly-reflection, weekly-extract-procedures, weekly-deep-maintenance, weekly-persona-proposals, monthly-consolidation, sensor-sweep).
 2. **Or** add the job definitions manually to `~/.openclaw/openclaw.json` (under a top-level `jobs` array if your OpenClaw version uses it) or to `~/.openclaw/cron/jobs.json` (see snippets below).
 3. **Or** run the standalone install script from the repo: `node scripts/install-hybrid-config.mjs` (merges full defaults including jobs into openclaw.json).
 

--- a/extensions/memory-hybrid/backends/facts-db/facts-db-layer2.ts
+++ b/extensions/memory-hybrid/backends/facts-db/facts-db-layer2.ts
@@ -25,6 +25,7 @@ import {
   confirmFact as confirmFactImpl,
   decayConfidence as decayConfidenceImpl,
   promoteScope as promoteScopeImpl,
+  listExpiredFactIdsPendingPrune as listExpiredFactIdsPendingPruneImpl,
   pruneExpired as pruneExpiredImpl,
   pruneSessionScope as pruneSessionScopeImpl,
   restoreCheckpoint as restoreCheckpointImpl,
@@ -142,6 +143,11 @@ export class FactsDBLayer2 extends FactsDBLayer1 {
 
   count(): number {
     return countFactsImpl(this.liveDb);
+  }
+
+  /** Fact ids that `pruneExpired()` would delete (same filter as the DELETE). */
+  listExpiredFactIdsPendingPrune(): string[] {
+    return listExpiredFactIdsPendingPruneImpl(this.liveDb);
   }
 
   pruneExpired(): number {

--- a/extensions/memory-hybrid/backends/facts-db/facts-db-layer3.ts
+++ b/extensions/memory-hybrid/backends/facts-db/facts-db-layer3.ts
@@ -55,12 +55,15 @@ import {
 import { FactsDBLayer2 } from "./facts-db-layer2.js";
 import {
   countBySource as countBySourceImpl,
+  countSupersededFacts as countSupersededFactsImpl,
+  countVerifiedFacts as countVerifiedFactsImpl,
   findSessionFactsForPromotion as findSessionFactsForPromotionImpl,
   languageKeywordsCount as languageKeywordsCountImpl,
   optimizeFts as optimizeFtsImpl,
   pruneLogTables as pruneLogTablesImpl,
   pruneOrphanedLinks as pruneOrphanedLinksImpl,
   pruneScopedFacts as pruneScopedFactsImpl,
+  recentActivity as recentActivityImpl,
   scopeStats as scopeStatsImpl,
   selfCorrectionIncidentsCount as selfCorrectionIncidentsCountImpl,
   statsBySource as statsBySourceImpl,
@@ -209,6 +212,21 @@ export class FactsDB extends FactsDBLayer2 {
 
   contradictionsCount(): number {
     return contradictionsCountImpl(this.liveDb);
+  }
+
+  /** Number of facts with `superseded_at IS NOT NULL`. */
+  countSupersededFacts(): number {
+    return countSupersededFactsImpl(this.liveDb);
+  }
+
+  /** Number of rows in `verified_facts` (0 when verification disabled / table absent). */
+  countVerifiedFacts(): number {
+    return countVerifiedFactsImpl(this.liveDb);
+  }
+
+  /** Recent ingestion activity: last 24h / 7d / 30d, plus newest/oldest active timestamps. */
+  recentActivity(): ReturnType<typeof recentActivityImpl> {
+    return recentActivityImpl(this.liveDb);
   }
 
   // ---------------------------------------------------------------------------

--- a/extensions/memory-hybrid/backends/facts-db/housekeeping.ts
+++ b/extensions/memory-hybrid/backends/facts-db/housekeeping.ts
@@ -65,6 +65,64 @@ export function selfCorrectionIncidentsCount(db: DatabaseSync): number {
   return row?.count ?? 0;
 }
 
+export function countSupersededFacts(db: DatabaseSync): number {
+  const row = db.prepare(`SELECT COUNT(*) as count FROM facts WHERE superseded_at IS NOT NULL`).get() as
+    | { count: number }
+    | undefined;
+  return row?.count ?? 0;
+}
+
+export function countVerifiedFacts(db: DatabaseSync): number {
+  try {
+    const row = db.prepare("SELECT COUNT(*) as count FROM verified_facts").get() as { count: number } | undefined;
+    return row?.count ?? 0;
+  } catch {
+    return 0;
+  }
+}
+
+/** Number of active (non-superseded, non-expired) facts created at-or-after `sinceSec`. */
+export function countActiveFactsCreatedSince(db: DatabaseSync, sinceSec: number): number {
+  const nowSec = Math.floor(Date.now() / 1000);
+  const row = db
+    .prepare(
+      `SELECT COUNT(*) as count FROM facts
+         WHERE superseded_at IS NULL
+           AND (expires_at IS NULL OR expires_at > ?)
+           AND created_at >= ?`,
+    )
+    .get(nowSec, sinceSec) as { count: number } | undefined;
+  return row?.count ?? 0;
+}
+
+/** Recent ingestion activity for the rich `stats` view. Cheap (3× COUNT). */
+export function recentActivity(db: DatabaseSync): {
+  last24h: number;
+  last7d: number;
+  last30d: number;
+  newestCreatedAtSec: number | null;
+  oldestActiveCreatedAtSec: number | null;
+} {
+  const nowSec = Math.floor(Date.now() / 1000);
+  const day = 86400;
+  const last24h = countActiveFactsCreatedSince(db, nowSec - day);
+  const last7d = countActiveFactsCreatedSince(db, nowSec - 7 * day);
+  const last30d = countActiveFactsCreatedSince(db, nowSec - 30 * day);
+  const minMaxRow = db
+    .prepare(
+      `SELECT MIN(created_at) as min_ts, MAX(created_at) as max_ts FROM facts
+         WHERE superseded_at IS NULL AND (expires_at IS NULL OR expires_at > ?)`,
+    )
+    .get(nowSec) as { min_ts: number | null; max_ts: number | null } | undefined;
+  return {
+    last24h,
+    last7d,
+    last30d,
+    newestCreatedAtSec: minMaxRow?.max_ts ?? null,
+    oldestActiveCreatedAtSec: minMaxRow?.min_ts ?? null,
+  };
+}
+
 export function countBySource(db: DatabaseSync, source: string): number {
   const row = db
     .prepare("SELECT COUNT(*) as count FROM facts WHERE superseded_at IS NULL AND source = ?")

--- a/extensions/memory-hybrid/backends/facts-db/maintenance.ts
+++ b/extensions/memory-hybrid/backends/facts-db/maintenance.ts
@@ -341,6 +341,19 @@ export function setPreserveTags(
   return getById(id);
 }
 
+/** Same row filter as `pruneExpired` DELETE on `facts` (for CLI `--verbose` preview). */
+export function listExpiredFactIdsPendingPrune(db: DatabaseSync): string[] {
+  const nowSec = Math.floor(Date.now() / 1000);
+  const rows = db
+    .prepare(
+      `SELECT id FROM facts WHERE expires_at IS NOT NULL AND expires_at < @now
+         AND (decay_freeze_until IS NULL OR decay_freeze_until <= @now)
+         AND id NOT IN (SELECT fact_id FROM verified_facts)`,
+    )
+    .all({ "@now": nowSec }) as Array<{ id: string }>;
+  return rows.map((r) => r.id);
+}
+
 export function pruneExpired(db: DatabaseSync): number {
   const nowSec = Math.floor(Date.now() / 1000);
   db.prepare(

--- a/extensions/memory-hybrid/cli/cmd-install.ts
+++ b/extensions/memory-hybrid/cli/cmd-install.ts
@@ -23,6 +23,7 @@ import { findPluginRoot } from "../utils/plugin-root.js";
 
 import type { HybridMemoryConfig } from "../config.js";
 import { type CronModelConfig, getCronModelConfig, getDefaultCronModel } from "../config.js";
+import { buildHybridMemCronTaskMessage } from "../services/cron-job-bash-harness.js";
 import { buildGuardPrefix } from "../services/cron-guard.js";
 import { capturePluginError } from "../services/error-reporter.js";
 import { type PreFilterConfig, preFilterSessions } from "../services/session-pre-filter.js";
@@ -290,15 +291,24 @@ const MIN_INTERVAL_MS: Record<string, number> = {
 const MAINTENANCE_CRON_JOBS: Array<
   Record<string, unknown> & { modelTier?: "nano" | "default" | "heavy"; minIntervalMs?: number; featureGate?: string }
 > = [
-  // Daily 02:00 | nightly-memory-sweep | prune → distill --days 3 → extract-daily
+  // Daily 02:00 | nightly-memory-sweep | prune → distill → extract-daily → resolve-contradictions → enrich
   {
     pluginJobId: `${PLUGIN_JOB_ID_PREFIX}nightly-distill`,
     sessionTarget: "isolated",
     name: "nightly-memory-sweep",
     schedule: { kind: "cron", expr: "0 2 * * *" },
     channel: "system",
-    message:
-      "Nightly memory maintenance. Run in order:\n1. openclaw hybrid-mem prune\n2. openclaw hybrid-mem distill --days 3\n3. openclaw hybrid-mem extract-daily\n4. openclaw hybrid-mem resolve-contradictions\n5. openclaw hybrid-mem enrich-entities --limit 200\nCheck if distill is enabled (config distill.enabled !== false) before steps 2 and 3. If disabled, skip steps 2 and 3. Check if graph is enabled (config graph.enabled === true) before step 5. If graph is disabled, skip step 5. Exit 0 if all steps skipped. Step 5 backfills PERSON/ORG extraction for facts missing mentions (uses LLM). Report counts.",
+    message: buildHybridMemCronTaskMessage("nightly-memory-sweep", {
+      preamble:
+        "Nightly memory maintenance (5 steps). CONFIG: If distill.enabled is false, replace the distill and extract-daily hm_step lines with no-ops, e.g. hm_step \"distill-skipped\" bash -c 'echo distill disabled; exit 0' and hm_step \"extract-daily-skipped\" bash -c 'echo extract-daily skipped; exit 0'. If graph.enabled is false, replace enrich-entities with hm_step \"enrich-skipped\" bash -c 'echo graph disabled; exit 0'. Report counts in your reply.",
+      steps: [
+        { name: "prune", cmd: "openclaw hybrid-mem prune --verbose" },
+        { name: "distill", cmd: "openclaw hybrid-mem distill --days 1 --verbose" },
+        { name: "extract-daily", cmd: "openclaw hybrid-mem extract-daily --days 7 --verbose" },
+        { name: "resolve-contradictions", cmd: "openclaw hybrid-mem resolve-contradictions --verbose" },
+        { name: "enrich-entities", cmd: "openclaw hybrid-mem enrich-entities --limit 200 --verbose" },
+      ],
+    }),
     isolated: true,
     modelTier: "default",
     enabled: true,
@@ -311,8 +321,11 @@ const MAINTENANCE_CRON_JOBS: Array<
     name: "self-correction-analysis",
     schedule: { kind: "cron", expr: "30 2 * * *" },
     channel: "system",
-    message:
-      "Run self-correction analysis: openclaw hybrid-mem self-correction-run. Check if self-correction is enabled (config selfCorrection is truthy). Exit 0 if disabled.",
+    message: buildHybridMemCronTaskMessage("self-correction-analysis", {
+      preamble:
+        "Self-correction analysis. If selfCorrection is disabled in hybrid-memory config, reply that the job was skipped and do not update the guard file.",
+      steps: [{ name: "self-correction-run", cmd: "openclaw hybrid-mem self-correction-run --verbose" }],
+    }),
     isolated: true,
     modelTier: "heavy",
     enabled: true,
@@ -325,8 +338,15 @@ const MAINTENANCE_CRON_JOBS: Array<
     name: "weekly-reflection",
     schedule: { kind: "cron", expr: "0 3 * * 0" },
     channel: "system",
-    message:
-      "Run weekly reflection pipeline:\n1. openclaw hybrid-mem reflect --verbose\n2. openclaw hybrid-mem reflect-rules --verbose\n3. openclaw hybrid-mem reflect-meta --verbose\nCheck reflection.enabled. Exit 0 if disabled.",
+    message: buildHybridMemCronTaskMessage("weekly-reflection", {
+      preamble:
+        "Weekly reflection pipeline. If reflection.enabled is false, skip the script and reply disabled; do not update the guard file.",
+      steps: [
+        { name: "reflect", cmd: "openclaw hybrid-mem reflect --verbose" },
+        { name: "reflect-rules", cmd: "openclaw hybrid-mem reflect-rules --verbose" },
+        { name: "reflect-meta", cmd: "openclaw hybrid-mem reflect-meta --verbose" },
+      ],
+    }),
     isolated: true,
     modelTier: "default",
     enabled: true,
@@ -339,8 +359,16 @@ const MAINTENANCE_CRON_JOBS: Array<
     name: "weekly-extract-procedures",
     schedule: { kind: "cron", expr: "0 4 * * 0" },
     channel: "system",
-    message:
-      "Run weekly extraction pipeline:\n1. openclaw hybrid-mem extract-procedures --days 7\n2. openclaw hybrid-mem extract-directives --days 7\n3. openclaw hybrid-mem extract-reinforcement --days 7\n4. openclaw hybrid-mem generate-auto-skills\nCheck feature configs. Exit 0 if all disabled.",
+    message: buildHybridMemCronTaskMessage("weekly-extract-procedures", {
+      preamble:
+        "Weekly extraction pipeline. If a feature is disabled in config, replace that hm_step with a no-op that logs the skip and exits 0.",
+      steps: [
+        { name: "extract-procedures", cmd: "openclaw hybrid-mem extract-procedures --days 7 --verbose" },
+        { name: "extract-directives", cmd: "openclaw hybrid-mem extract-directives --days 7 --verbose" },
+        { name: "extract-reinforcement", cmd: "openclaw hybrid-mem extract-reinforcement --days 7 --verbose" },
+        { name: "generate-auto-skills", cmd: "openclaw hybrid-mem generate-auto-skills --verbose" },
+      ],
+    }),
     isolated: true,
     modelTier: "nano",
     enabled: true,
@@ -353,8 +381,14 @@ const MAINTENANCE_CRON_JOBS: Array<
     name: "weekly-deep-maintenance",
     schedule: { kind: "cron", expr: "0 4 * * 6" },
     channel: "system",
-    message:
-      "Run weekly deep maintenance:\n1. openclaw hybrid-mem compact\n2. openclaw hybrid-mem vectordb-optimize\n3. openclaw hybrid-mem scope promote\nReport counts for each step.",
+    message: buildHybridMemCronTaskMessage("weekly-deep-maintenance", {
+      preamble: "Weekly deep maintenance. Report counts for each step in your reply.",
+      steps: [
+        { name: "compact", cmd: "openclaw hybrid-mem compact" },
+        { name: "vectordb-optimize", cmd: "openclaw hybrid-mem vectordb-optimize" },
+        { name: "scope-promote", cmd: "openclaw hybrid-mem scope promote" },
+      ],
+    }),
     isolated: true,
     modelTier: "heavy",
     enabled: true,
@@ -367,8 +401,11 @@ const MAINTENANCE_CRON_JOBS: Array<
     name: "weekly-persona-proposals",
     schedule: { kind: "cron", expr: "0 10 * * 0" },
     channel: "system",
-    message:
-      "Run: openclaw hybrid-mem generate-proposals. This creates persona proposals from recent reflection insights. If there are pending proposals, notify the user in this system channel with a concise summary of the proposals. Exit 0 if personaProposals disabled.",
+    message: buildHybridMemCronTaskMessage("weekly-persona-proposals", {
+      preamble:
+        "Generate persona proposals from recent reflection. If personaProposals is disabled, skip and do not update the guard file. If there are pending proposals after a successful run, notify the user in this system channel with a concise summary.",
+      steps: [{ name: "generate-proposals", cmd: "openclaw hybrid-mem generate-proposals --verbose" }],
+    }),
     isolated: true,
     modelTier: "heavy",
     enabled: true,
@@ -381,8 +418,16 @@ const MAINTENANCE_CRON_JOBS: Array<
     name: "monthly-consolidation",
     schedule: { kind: "cron", expr: "0 5 1 * *" },
     channel: "system",
-    message:
-      "Run monthly consolidation:\n1. openclaw hybrid-mem consolidate --threshold 0.92\n2. openclaw hybrid-mem build-languages\n3. openclaw hybrid-mem backfill-decay\n4. openclaw hybrid-mem enrich-entities --limit 500\nCheck if graph is enabled (config graph.enabled === true) before step 4. If graph is disabled, skip step 4. Report what was merged, languages detected, and enrichment counts.",
+    message: buildHybridMemCronTaskMessage("monthly-consolidation", {
+      preamble:
+        "Monthly consolidation. If graph.enabled is false, replace enrich-entities with a no-op hm_step that logs graph disabled and exits 0.",
+      steps: [
+        { name: "consolidate", cmd: "openclaw hybrid-mem consolidate --threshold 0.92" },
+        { name: "build-languages", cmd: "openclaw hybrid-mem build-languages" },
+        { name: "backfill-decay", cmd: "openclaw hybrid-mem backfill-decay" },
+        { name: "enrich-entities", cmd: "openclaw hybrid-mem enrich-entities --limit 500 --verbose" },
+      ],
+    }),
     isolated: true,
     modelTier: "heavy",
     enabled: true,
@@ -396,8 +441,11 @@ const MAINTENANCE_CRON_JOBS: Array<
     name: "nightly-dream-cycle",
     schedule: { kind: "cron", expr: "45 2 * * *" },
     channel: "system",
-    message:
-      "Run nightly dream cycle: openclaw hybrid-mem dream-cycle\nThis runs in order: (1) prune expired/decayed facts, (2) consolidate old episodic events into facts, (3) reflect on recent facts to extract patterns, (4) extract rules if enough patterns accumulated.\nCheck if nightlyCycle.enabled is true in config before running. Exit 0 if disabled. Report counts: facts pruned, events consolidated, patterns found, rules generated.",
+    message: buildHybridMemCronTaskMessage("nightly-dream-cycle", {
+      preamble:
+        "Nightly dream cycle (single CLI). If nightlyCycle.enabled is false, skip and do not update the guard file. Report counts: facts pruned, events consolidated, patterns found, rules generated.",
+      steps: [{ name: "dream-cycle", cmd: "openclaw hybrid-mem dream-cycle --verbose" }],
+    }),
     isolated: true,
     modelTier: "default",
     enabled: true,
@@ -412,8 +460,14 @@ const MAINTENANCE_CRON_JOBS: Array<
     name: "sensor-sweep",
     schedule: { kind: "cron", expr: "0 */4 * * *" },
     channel: "system",
-    message:
-      "Run sensor sweep data collection (no LLM):\n1. openclaw hybrid-mem sensor-sweep --tier 1\n2. openclaw hybrid-mem sensor-sweep --tier 2\nCheck if sensorSweep.enabled is true in config before running. Exit 0 if disabled. Report events written and skipped per sensor.",
+    message: buildHybridMemCronTaskMessage("sensor-sweep", {
+      preamble:
+        "Sensor sweep (no LLM). If sensorSweep.enabled is false, skip and do not update the guard file. Report events written and skipped per sensor.",
+      steps: [
+        { name: "sensor-sweep-tier-1", cmd: "openclaw hybrid-mem sensor-sweep --tier 1" },
+        { name: "sensor-sweep-tier-2", cmd: "openclaw hybrid-mem sensor-sweep --tier 2" },
+      ],
+    }),
     isolated: true,
     modelTier: "nano",
     enabled: true,
@@ -516,6 +570,7 @@ export function ensureMaintenanceCronJobs(
   const cronDir = join(openclawDir, "cron");
   const cronStorePath = join(cronDir, "jobs.json");
   mkdirSync(cronDir, { recursive: true });
+  mkdirSync(join(openclawDir, "logs", "cron-hybrid-mem"), { recursive: true });
   const store: { jobs?: unknown[] } = existsSync(cronStorePath)
     ? (JSON.parse(readFileSync(cronStorePath, "utf-8")) as { jobs?: unknown[] })
     : {};

--- a/extensions/memory-hybrid/cli/cmd-install.ts
+++ b/extensions/memory-hybrid/cli/cmd-install.ts
@@ -23,8 +23,8 @@ import { findPluginRoot } from "../utils/plugin-root.js";
 
 import type { HybridMemoryConfig } from "../config.js";
 import { type CronModelConfig, getCronModelConfig, getDefaultCronModel } from "../config.js";
-import { buildHybridMemCronTaskMessage } from "../services/cron-job-bash-harness.js";
 import { buildGuardPrefix } from "../services/cron-guard.js";
+import { buildHybridMemCronTaskMessage } from "../services/cron-job-bash-harness.js";
 import { capturePluginError } from "../services/error-reporter.js";
 import { type PreFilterConfig, preFilterSessions } from "../services/session-pre-filter.js";
 import { resetAllBackoff } from "../utils/auth-failover.js";
@@ -570,7 +570,15 @@ export function ensureMaintenanceCronJobs(
   const cronDir = join(openclawDir, "cron");
   const cronStorePath = join(cronDir, "jobs.json");
   mkdirSync(cronDir, { recursive: true });
-  mkdirSync(join(openclawDir, "logs", "cron-hybrid-mem"), { recursive: true });
+  try {
+    mkdirSync(join(openclawDir, "logs", "cron-hybrid-mem"), { recursive: true });
+  } catch (err) {
+    capturePluginError(err instanceof Error ? err : new Error(String(err)), {
+      subsystem: "cli",
+      operation: "ensureMaintenanceCronJobs:mkdir-cron-logs",
+      severity: "info",
+    });
+  }
   const store: { jobs?: unknown[] } = existsSync(cronStorePath)
     ? (JSON.parse(readFileSync(cronStorePath, "utf-8")) as { jobs?: unknown[] })
     : {};

--- a/extensions/memory-hybrid/cli/cmd-selfcorrection.ts
+++ b/extensions/memory-hybrid/cli/cmd-selfcorrection.ts
@@ -58,10 +58,11 @@ const DEFAULT_SELF_CORRECTION = {
  * Extract self-correction incidents from sessions.
  */
 export function runSelfCorrectionExtractForCli(
-  _ctx: HandlerContext,
+  ctx: HandlerContext,
   opts: {
     days?: number;
     outputPath?: string;
+    verbose?: boolean;
     /** Pre-filtered session file paths. When provided, skips gatherSessionFiles(). */
     filePaths?: string[];
   },
@@ -70,6 +71,16 @@ export function runSelfCorrectionExtractForCli(
     opts.filePaths ?? gatherSessionFiles({ days: opts.days ?? 3 }).map((f: { path: string; mtime: number }) => f.path);
   if (filePaths.length === 0) {
     return { incidents: [], sessionsScanned: 0 };
+  }
+  if (opts.verbose) {
+    ctx.logger.info?.(`memory-hybrid: self-correction-extract — scanning ${filePaths.length} session file(s)`);
+    const cap = 40;
+    for (let i = 0; i < Math.min(filePaths.length, cap); i++) {
+      ctx.logger.info?.(`  ${filePaths[i]}`);
+    }
+    if (filePaths.length > cap) {
+      ctx.logger.info?.(`  ... and ${filePaths.length - cap} more`);
+    }
   }
   try {
     const result = runSelfCorrectionExtract({
@@ -162,7 +173,11 @@ export async function runSelfCorrectionRunForCli(
           }
         }
       }
-      const extractResult = runSelfCorrectionExtractForCli(ctx, { days: 3, filePaths: scFilePaths });
+      const extractResult = runSelfCorrectionExtractForCli(ctx, {
+        days: 3,
+        filePaths: scFilePaths,
+        verbose: opts.verbose,
+      });
       incidents = extractResult.incidents;
     }
     if (incidents.length === 0) {
@@ -249,6 +264,11 @@ export async function runSelfCorrectionRunForCli(
       const jsonMatch = content.match(/\[[\s\S]*\]/);
       if (jsonMatch) {
         analysed = JSON.parse(jsonMatch[0]) as typeof analysed;
+      }
+      if (opts.verbose && analysed.length > 0) {
+        logger.info?.(
+          `memory-hybrid: ${SCAN_TYPE} — LLM returned ${analysed.length} remediation item(s) (before cap/filter)`,
+        );
       }
     } catch (e) {
       capturePluginError(e as Error, { subsystem: "cli", operation: "runSelfCorrectionRunForCli:llm-analysis" });

--- a/extensions/memory-hybrid/cli/cmd-verify.ts
+++ b/extensions/memory-hybrid/cli/cmd-verify.ts
@@ -53,7 +53,7 @@ import {
   readEffectiveAgentChatPrimaryFromOpenclawJsonRoot,
 } from "../utils/openclaw-agent-defaults.js";
 import { ensureMaintenanceCronJobs, getPluginConfigFromFile } from "./cmd-install.js";
-import { relativeTime } from "./shared.js";
+import { approxIntervalMs, relativeTime } from "./shared.js";
 import { applyAzureFoundryVerifyDirectClientAuth } from "./verify-llm-azure-auth.js";
 
 import type { HandlerContext } from "./handlers.js";
@@ -1165,17 +1165,6 @@ export async function runVerifyForCli(
   ]);
   const nightlyDreamCycleRe = /nightly[- ]?dream[- ]?cycle|dream[- ]?cycle/i;
   const sensorSweepRe = /sensor[- ]?sweep/i;
-  /** Approximate run interval for "stale" detection per cron expression. */
-  function approxIntervalMs(cron?: string | null): number | null {
-    if (!cron) return null;
-    const t = cron.trim();
-    if (/^\d+\s+\d+\s+\*\s+\*\s+\*$/.test(t)) return 24 * 60 * 60 * 1000;
-    if (/^\d+\s+\d+\s+\*\s+\*\s+[0-7]$/.test(t)) return 7 * 24 * 60 * 60 * 1000;
-    if (/^\d+\s+\d+\s+\d+\s+\*\s+\*$/.test(t)) return 30 * 24 * 60 * 60 * 1000;
-    const everyN = /^\d+\s+\*\/(\d+)\s+\*\s+\*\s+\*$/.exec(t);
-    if (everyN) return Number(everyN[1]) * 60 * 60 * 1000;
-    return null;
-  }
 
   /** Normalize job name to slug for matching: lowercase, spaces to single hyphen. */
   function nameToSlug(n: string): string {

--- a/extensions/memory-hybrid/cli/cmd-verify.ts
+++ b/extensions/memory-hybrid/cli/cmd-verify.ts
@@ -123,6 +123,7 @@ export async function runVerifyForCli(
   const OK = noEmoji ? "[OK]" : "✅";
   const FAIL = noEmoji ? "[FAIL]" : "❌";
   const PAUSE = noEmoji ? "[paused]" : "⏸️ ";
+  const WARN_LINE = noEmoji ? "[WARN]" : "⚠️";
   const _ON = noEmoji ? "[on]" : "✅ on";
   const _OFF = noEmoji ? "[off]" : "❌ off";
   const issues: string[] = [];
@@ -1169,7 +1170,7 @@ export async function runVerifyForCli(
     if (!cron) return null;
     const t = cron.trim();
     if (/^\d+\s+\d+\s+\*\s+\*\s+\*$/.test(t)) return 24 * 60 * 60 * 1000;
-    if (/^\d+\s+\d+\s+\*\s+\*\s+[0-6]$/.test(t)) return 7 * 24 * 60 * 60 * 1000;
+    if (/^\d+\s+\d+\s+\*\s+\*\s+[0-7]$/.test(t)) return 7 * 24 * 60 * 60 * 1000;
     if (/^\d+\s+\d+\s+\d+\s+\*\s+\*$/.test(t)) return 30 * 24 * 60 * 60 * 1000;
     const everyN = /^\d+\s+\*\/(\d+)\s+\*\s+\*\s+\*$/.exec(t);
     if (everyN) return Number(everyN[1]) * 60 * 60 * 1000;
@@ -1590,7 +1591,7 @@ export async function runVerifyForCli(
       log("\nAll checks passed.");
     } else {
       log(`\nAll critical checks passed, but ${warnings.length} warning(s):`);
-      for (const w of warnings) log(`  ⚠ ${w}`);
+      for (const w of warnings) log(`  ${WARN_LINE} ${w}`);
       log(
         "  Tip: re-run after the next scheduled window. If 'last: never' persists, confirm the OpenClaw gateway is running and that ~/.openclaw/cron/guard/<job>.ms is being written.",
       );

--- a/extensions/memory-hybrid/cli/cmd-verify.ts
+++ b/extensions/memory-hybrid/cli/cmd-verify.ts
@@ -28,6 +28,7 @@ import {
 import { resolveSecretRef } from "../config/parsers/core.js";
 import { chatComplete } from "../services/chat.js";
 import { CostFeature } from "../services/cost-feature-labels.js";
+import { readGuardTimestampMs } from "../services/cron-guard.js";
 import {
   type EmbeddingConfig,
   GOOGLE_EMBED_DEFAULT_DIMENSIONS,
@@ -37,7 +38,6 @@ import {
 } from "../services/embeddings.js";
 import { formatOpenAiEmbeddingDisplayLabel } from "../services/embeddings/shared.js";
 import { capturePluginError } from "../services/error-reporter.js";
-import { readGuardTimestampMs } from "../services/cron-guard.js";
 import {
   analyzeCronJobsAgainstHeartbeatPatterns,
   extractCronJobMessageEntries,
@@ -1214,6 +1214,17 @@ export async function runVerifyForCli(
     return null;
   }
 
+  /** Prefer the newer of runner state and persistent guard file (state can lag after restart). */
+  function effectiveCronLastRunMs(job: {
+    state?: { lastRunAtMs?: number };
+    lastRunGuardMs?: number | null;
+  }): number | null {
+    const stateMs = typeof job.state?.lastRunAtMs === "number" ? job.state.lastRunAtMs : null;
+    const guardMs = typeof job.lastRunGuardMs === "number" ? job.lastRunGuardMs : null;
+    if (stateMs != null && guardMs != null) return Math.max(stateMs, guardMs);
+    return stateMs ?? guardMs;
+  }
+
   // Helper function to format job status display
   function formatJobStatus(job: JobInfo, label: string, indent: string, log: (msg: string) => void): void {
     const isFeatureGated = job.featureGateDisabled === true;
@@ -1224,12 +1235,14 @@ export async function runVerifyForCli(
 
     if (job.scheduleExpr) parts.push(job.scheduleExpr);
 
-    if (job.state?.lastRunAtMs) {
-      const lastStatus = job.state.lastStatus ?? "unknown";
-      const lastRun = `last: ${relativeTime(job.state.lastRunAtMs)} (${lastStatus})`;
-      parts.push(lastRun);
-    } else if (job.lastRunGuardMs) {
-      parts.push(`last: ${relativeTime(job.lastRunGuardMs)} (guard)`);
+    const stateMs = typeof job.state?.lastRunAtMs === "number" ? job.state.lastRunAtMs : null;
+    const lastMs = effectiveCronLastRunMs(job);
+    if (lastMs != null) {
+      if (stateMs != null && lastMs === stateMs) {
+        parts.push(`last: ${relativeTime(lastMs)} (${job.state?.lastStatus ?? "unknown"})`);
+      } else {
+        parts.push(`last: ${relativeTime(lastMs)} (guard)`);
+      }
     } else {
       parts.push("last: never");
     }
@@ -1237,8 +1250,6 @@ export async function runVerifyForCli(
     if (job.state?.nextRunAtMs) {
       parts.push(`next: ${relativeTime(job.state.nextRunAtMs)}`);
     }
-
-    const lastMs = job.state?.lastRunAtMs ?? job.lastRunGuardMs ?? null;
     const interval = approxIntervalMs(job.scheduleExpr ?? null);
     let stale = false;
     if (job.enabled && interval) {
@@ -1248,7 +1259,7 @@ export async function runVerifyForCli(
     const note = isFeatureGated
       ? "  (disabled by feature gate; will re-enable when feature turns on)"
       : stale
-        ? "  ⚠ overdue"
+        ? `  ${WARN_LINE} overdue`
         : "";
 
     log(`${indent}${statusIcon} ${label.padEnd(30)} ${statusText}  ${parts.join("  ")}${note}`);
@@ -1566,7 +1577,7 @@ export async function runVerifyForCli(
   // Surface overdue / never-run cron jobs as warnings so the summary mentions them even when health checks pass.
   for (const [key, job] of allJobs) {
     if (!job.enabled) continue;
-    const lastMs = job.state?.lastRunAtMs ?? job.lastRunGuardMs ?? null;
+    const lastMs = effectiveCronLastRunMs(job);
     const interval = approxIntervalMs(job.scheduleExpr ?? null);
     if (interval && (lastMs == null || Date.now() - lastMs > interval * 1.5)) {
       warnings.push(

--- a/extensions/memory-hybrid/cli/cmd-verify.ts
+++ b/extensions/memory-hybrid/cli/cmd-verify.ts
@@ -37,6 +37,7 @@ import {
 } from "../services/embeddings.js";
 import { formatOpenAiEmbeddingDisplayLabel } from "../services/embeddings/shared.js";
 import { capturePluginError } from "../services/error-reporter.js";
+import { readGuardTimestampMs } from "../services/cron-guard.js";
 import {
   analyzeCronJobsAgainstHeartbeatPatterns,
   extractCronJobMessageEntries,
@@ -126,6 +127,8 @@ export async function runVerifyForCli(
   const _OFF = noEmoji ? "[off]" : "❌ off";
   const issues: string[] = [];
   const fixes: string[] = [];
+  /** Non-blocking warnings: shown alongside "All checks passed" so signals like a missing heartbeat or overdue cron are not silently buried. */
+  const warnings: string[] = [];
   let configOk = true;
   let sqliteOk = false;
   let lanceOk = false;
@@ -1090,13 +1093,18 @@ export async function runVerifyForCli(
       `${OK} Enabled — heartbeatStewardship: ${gs.heartbeatStewardship ? "on" : "off"} (plugin does not schedule LLM turns; OpenClaw/cron delivers messages)`,
     );
     const matchers = getHeartbeatMatchersForVerify(gs);
-    log(
-      `  Heartbeat patterns compiled: ${matchers.length} matcher(s). See docs/GOAL-STEWARDSHIP-OPERATOR.md (Heartbeat scheduling checklist).`,
-    );
+    const patternsPreview = (gs.heartbeatPatterns ?? []).slice(0, 3);
+    const patternsTail =
+      (gs.heartbeatPatterns?.length ?? 0) > patternsPreview.length
+        ? `, … (${(gs.heartbeatPatterns?.length ?? 0) - patternsPreview.length} more)`
+        : "";
+    const patternsHint = patternsPreview.length > 0 ? `: ${patternsPreview.join(" | ")}${patternsTail}` : "";
+    log(`  Heartbeat patterns compiled: ${matchers.length} matcher(s)${patternsHint}.`);
+    log("  See docs/GOAL-STEWARDSHIP-OPERATOR.md (Heartbeat scheduling checklist).");
     try {
       if (!existsSync(cronStorePath)) {
         log(
-          `${WARN} Cannot confirm heartbeat cron: ${cronStorePath} not found. Add jobs via OpenClaw or run \`openclaw hybrid-mem verify --fix\` for maintenance jobs; for goal stewardship prepend, ensure a job message matches your heartbeatPatterns.`,
+          `${WARN} Cannot confirm heartbeat cron: ${cronStorePath} not found. Run \`openclaw hybrid-mem verify --fix\` to seed maintenance jobs, then add a small heartbeat job whose message matches one of the patterns above.`,
         );
       } else {
         const raw = readFileSync(cronStorePath, "utf-8");
@@ -1111,13 +1119,26 @@ export async function runVerifyForCli(
             `${WARN} No job message text found in cron store (payload.message / message empty). Stewardship prepends only run when the agent sees a user message matching heartbeat patterns.`,
           );
         } else if (h.matchingJobIds.length === 0) {
+          const enabledSample = entries
+            .filter((e) => e.enabled && e.text.length > 0)
+            .slice(0, 3)
+            .map((e) => e.id);
           log(
-            `${WARN} No ENABLED cron job message matches current heartbeat patterns (${withText} job(s) with text, ${h.disabledMatchingJobIds.length} disabled match). Update job messages or goalStewardship.heartbeatPatterns.`,
+            `${WARN} No enabled cron job message matches current heartbeat patterns (${withText} job(s) with text${
+              h.disabledMatchingJobIds.length > 0 ? `; ${h.disabledMatchingJobIds.length} disabled job(s) match` : ""
+            }).`,
           );
+          if (enabledSample.length > 0) {
+            log(`         Checked enabled jobs (sample): ${enabledSample.join(", ")}`);
+          }
+          log(
+            "         Fix: either (a) add a small dedicated heartbeat job whose payload.message contains one of the patterns above (recommended), or (b) extend goalStewardship.heartbeatPatterns to match an existing job message. Maintenance jobs are intentionally not heartbeat-shaped.",
+          );
+          warnings.push("goal stewardship: no enabled cron job message matches heartbeat patterns");
         } else {
           log(`${OK} Cron jobs with heartbeat-matching message: ${h.matchingJobIds.join(", ")}`);
           if (h.disabledMatchingJobIds.length > 0) {
-            log(`ℹ️ (Disabled jobs also matched — excluded from delivery: ${h.disabledMatchingJobIds.join(", ")})`);
+            log(`ℹ (Disabled jobs also matched — excluded from delivery: ${h.disabledMatchingJobIds.join(", ")})`);
           }
         }
       }
@@ -1138,7 +1159,22 @@ export async function runVerifyForCli(
     "weekly-deep-maintenance",
     "monthly-consolidation",
     "weekly-persona-proposals",
+    "nightly-dream-cycle",
+    "sensor-sweep",
   ]);
+  const nightlyDreamCycleRe = /nightly[- ]?dream[- ]?cycle|dream[- ]?cycle/i;
+  const sensorSweepRe = /sensor[- ]?sweep/i;
+  /** Approximate run interval for "stale" detection per cron expression. */
+  function approxIntervalMs(cron?: string | null): number | null {
+    if (!cron) return null;
+    const t = cron.trim();
+    if (/^\d+\s+\d+\s+\*\s+\*\s+\*$/.test(t)) return 24 * 60 * 60 * 1000;
+    if (/^\d+\s+\d+\s+\*\s+\*\s+[0-6]$/.test(t)) return 7 * 24 * 60 * 60 * 1000;
+    if (/^\d+\s+\d+\s+\d+\s+\*\s+\*$/.test(t)) return 30 * 24 * 60 * 60 * 1000;
+    const everyN = /^\d+\s+\*\/(\d+)\s+\*\s+\*\s+\*$/.exec(t);
+    if (everyN) return Number(everyN[1]) * 60 * 60 * 1000;
+    return null;
+  }
 
   /** Normalize job name to slug for matching: lowercase, spaces to single hyphen. */
   function nameToSlug(n: string): string {
@@ -1173,7 +1209,12 @@ export async function runVerifyForCli(
     if (monthlyConsolidationRe.test(nameLower)) {
       return "monthly-consolidation";
     }
-    // Fallback: if slug matches a known key exactly (e.g. "Weekly Reflection" -> "weekly-reflection"), use it
+    if (nightlyDreamCycleRe.test(nameLower)) {
+      return "nightly-dream-cycle";
+    }
+    if (sensorSweepRe.test(nameLower)) {
+      return "sensor-sweep";
+    }
     if (knownJobSlugs.has(normalized)) {
       return normalized;
     }
@@ -1185,16 +1226,20 @@ export async function runVerifyForCli(
 
   // Helper function to format job status display
   function formatJobStatus(job: JobInfo, label: string, indent: string, log: (msg: string) => void): void {
-    const statusIcon = job.enabled ? OK : PAUSE;
-    const statusText = job.enabled ? "enabled " : "disabled";
+    const isFeatureGated = job.featureGateDisabled === true;
+    const statusIcon = job.enabled ? OK : isFeatureGated ? "○" : PAUSE;
+    const statusText = job.enabled ? "enabled " : isFeatureGated ? "gated   " : "disabled";
 
-    let statusDetails = "";
     const parts: string[] = [];
+
+    if (job.scheduleExpr) parts.push(job.scheduleExpr);
 
     if (job.state?.lastRunAtMs) {
       const lastStatus = job.state.lastStatus ?? "unknown";
       const lastRun = `last: ${relativeTime(job.state.lastRunAtMs)} (${lastStatus})`;
       parts.push(lastRun);
+    } else if (job.lastRunGuardMs) {
+      parts.push(`last: ${relativeTime(job.lastRunGuardMs)} (guard)`);
     } else {
       parts.push("last: never");
     }
@@ -1203,26 +1248,40 @@ export async function runVerifyForCli(
       parts.push(`next: ${relativeTime(job.state.nextRunAtMs)}`);
     }
 
-    if (parts.length > 0) {
-      statusDetails = `  ${parts.join("  ")}`;
+    const lastMs = job.state?.lastRunAtMs ?? job.lastRunGuardMs ?? null;
+    const interval = approxIntervalMs(job.scheduleExpr ?? null);
+    let stale = false;
+    if (job.enabled && interval) {
+      if (lastMs == null || Date.now() - lastMs > interval * 1.5) stale = true;
     }
 
-    log(`${indent}${statusIcon} ${label.padEnd(30)} ${statusText}${statusDetails}`);
+    const note = isFeatureGated
+      ? "  (disabled by feature gate; will re-enable when feature turns on)"
+      : stale
+        ? "  ⚠ overdue"
+        : "";
 
-    // Show error details on next line if present
+    log(`${indent}${statusIcon} ${label.padEnd(30)} ${statusText}  ${parts.join("  ")}${note}`);
+
     if (job.state?.lastError && job.state.lastStatus === "error") {
       const errorPreview = job.state.lastError.slice(0, 100);
       log(`${indent}   └─ error: ${errorPreview}${job.state.lastError.length > 100 ? "..." : ""}`);
     }
   }
 
-  // Enhanced job status display
   log("\nScheduled jobs (cron store at ~/.openclaw/cron/jobs.json):");
 
-  // Read all jobs with state information
   interface JobInfo {
     name: string;
     enabled: boolean;
+    /** Set by ensureMaintenanceCronJobs when a feature gate disabled the job. */
+    featureGateDisabled?: boolean;
+    /** Cron expression (string or { expr }) so verify can show schedule + flag overdue. */
+    scheduleExpr?: string | null;
+    /** Lifted from `~/.openclaw/cron/guard/<job>.ms` when the runner has not written `state.lastRunAtMs` yet. */
+    lastRunGuardMs?: number | null;
+    /** Set when the job carries a `pluginJobId` starting with `hybrid-mem:` (treat the `Other` list as truly external). */
+    isHybridMem?: boolean;
     state?: {
       nextRunAtMs?: number;
       lastRunAtMs?: number;
@@ -1244,24 +1303,37 @@ export async function runVerifyForCli(
           const job = j as Record<string, unknown>;
           const name = String(job.name ?? "");
           const enabled = job.enabled !== false;
+          const featureGateDisabled = job.featureGateDisabled === true;
           const state = job.state as
             | { nextRunAtMs?: number; lastRunAtMs?: number; lastStatus?: string; lastError?: string }
             | undefined;
 
-          // Extract payload message for fallback matching
           const payload = job.payload as Record<string, unknown> | undefined;
           const msg = String((payload?.message ?? job.message) || "");
+          const sched = job.schedule as { expr?: string } | string | undefined;
+          const scheduleExpr = typeof sched === "string" ? sched : typeof sched?.expr === "string" ? sched.expr : null;
 
-          // Map job names to our known jobs (check both name and payload message)
+          const pid = String(job.pluginJobId ?? "");
+          const isHybridMem = pid.startsWith("hybrid-mem:");
+          const guardName = name.replace(/\s+/g, "-");
+          const lastRunGuardMs = isHybridMem ? readGuardTimestampMs(guardName, openclawDir) : null;
+
           const canonicalKey = getCanonicalJobKey(name, msg);
           if (canonicalKey) {
-            allJobs.set(canonicalKey, { name, enabled, state });
+            allJobs.set(canonicalKey, {
+              name,
+              enabled,
+              featureGateDisabled,
+              scheduleExpr,
+              lastRunGuardMs,
+              isHybridMem,
+              state,
+            });
           }
         }
       }
     } catch (e) {
       capturePluginError(e as Error, { subsystem: "cli", operation: "runVerifyForCli:read-job-state" });
-      // Continue with incomplete data
     }
   }
 
@@ -1317,12 +1389,30 @@ export async function runVerifyForCli(
     { key: "weekly-deep-maintenance", description: "deep maintenance", docsPath: null },
     { key: "monthly-consolidation", description: "monthly consolidation", docsPath: null },
     { key: "weekly-persona-proposals", description: "persona proposals", docsPath: null },
+    {
+      key: "nightly-dream-cycle",
+      description: "dream cycle",
+      docsPath: null,
+      featureEnabled: cfg.nightlyCycle?.enabled === true,
+    },
+    {
+      key: "sensor-sweep",
+      description: "sensor sweep",
+      docsPath: null,
+      featureEnabled: cfg.sensorSweep?.enabled === true,
+    },
   ];
 
-  for (const { key, description, docsPath } of jobsToDisplay) {
+  for (const entry of jobsToDisplay) {
+    const { key, description, docsPath } = entry;
+    const featureEnabled = (entry as { featureEnabled?: boolean }).featureEnabled;
     const job = allJobs.get(key);
 
     if (!job) {
+      if (featureEnabled === false) {
+        log(`  ○ ${key.padEnd(30)} not installed (feature off in config)`);
+        continue;
+      }
       log(`  ${FAIL} ${key.padEnd(30)} missing`);
       const fixMsg = docsPath
         ? `Optional: Set up ${description} via jobs. See ${docsPath}. Run 'openclaw hybrid-mem verify --fix' to add.`
@@ -1334,13 +1424,13 @@ export async function runVerifyForCli(
     formatJobStatus(job, key, "  ", log);
   }
 
-  // Display any unknown/custom jobs not in the hardcoded list
+  // Truly external jobs: those not in the hybrid-mem canonical list AND not pluginJobId hybrid-mem:*
   const knownKeys = new Set(jobsToDisplay.map((j) => j.key));
-  const unknownJobs = Array.from(allJobs.entries()).filter(([key]) => !knownKeys.has(key));
+  const otherJobs = Array.from(allJobs.entries()).filter(([key, job]) => !knownKeys.has(key) && !job.isHybridMem);
 
-  if (unknownJobs.length > 0) {
-    log("\n  Other custom jobs:");
-    for (const [_key, job] of unknownJobs) {
+  if (otherJobs.length > 0) {
+    log("\n  Other custom jobs (not managed by hybrid-mem):");
+    for (const [_key, job] of otherJobs) {
       formatJobStatus(job, job.name, "    ", log);
     }
   }
@@ -1483,10 +1573,30 @@ export async function runVerifyForCli(
     }
   }
 
+  // Surface overdue / never-run cron jobs as warnings so the summary mentions them even when health checks pass.
+  for (const [key, job] of allJobs) {
+    if (!job.enabled) continue;
+    const lastMs = job.state?.lastRunAtMs ?? job.lastRunGuardMs ?? null;
+    const interval = approxIntervalMs(job.scheduleExpr ?? null);
+    if (interval && (lastMs == null || Date.now() - lastMs > interval * 1.5)) {
+      warnings.push(
+        `cron job ${key} is overdue: last=${lastMs ? new Date(lastMs).toISOString() : "never"}, schedule=${job.scheduleExpr ?? "?"}`,
+      );
+    }
+  }
+
   if (allOk) {
-    log("\nAll checks passed.");
+    if (warnings.length === 0) {
+      log("\nAll checks passed.");
+    } else {
+      log(`\nAll critical checks passed, but ${warnings.length} warning(s):`);
+      for (const w of warnings) log(`  ⚠ ${w}`);
+      log(
+        "  Tip: re-run after the next scheduled window. If 'last: never' persists, confirm the OpenClaw gateway is running and that ~/.openclaw/cron/guard/<job>.ms is being written.",
+      );
+    }
     if (restartPending) {
-      process.exitCode = 2; // Scripting: 2 = restart pending (gateway restart recommended)
+      process.exitCode = 2;
     }
     log(
       "Note: If you see 'plugins.allow is empty' above, it is from OpenClaw. Optional: set plugins.allow to [\"openclaw-hybrid-memory\"] in openclaw.json for an explicit allow-list.",

--- a/extensions/memory-hybrid/cli/commands/manage/register-corrections-and-pipeline.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/register-corrections-and-pipeline.ts
@@ -765,8 +765,10 @@ export function registerManageCorrectionsAndPipeline(mem: Chainable, b: ManageBi
   mem
     .command("resolve-contradictions")
     .description("Resolve unresolved contradictions (auto-resolve obvious cases, report ambiguous pairs)")
+    .option("--verbose", "List every auto-resolved pair and all ambiguous pairs")
     .action(
-      withExit(async () => {
+      withExit(async (opts?: { verbose?: boolean }, cmd?: CommanderOptsParent) => {
+        const verbose = !!opts?.verbose || readHybridMemVerbose(cmd);
         let res;
         try {
           res = await ctx.runResolveContradictions();
@@ -780,12 +782,19 @@ export function registerManageCorrectionsAndPipeline(mem: Chainable, b: ManageBi
         console.log(
           `Contradictions resolved: ${res.autoResolved.length} auto-resolved, ${res.ambiguous.length} ambiguous.`,
         );
-        if (res.ambiguous.length > 0) {
-          console.log("Ambiguous pairs (manual review recommended):");
-          for (const a of res.ambiguous.slice(0, 10)) {
+        if (verbose && res.autoResolved.length > 0) {
+          console.log("Auto-resolved (--verbose):");
+          for (const a of res.autoResolved) {
             console.log(`  - ${a.factIdNew} ↔ ${a.factIdOld} (${a.contradictionId})`);
           }
-          if (res.ambiguous.length > 10) {
+        }
+        if (res.ambiguous.length > 0) {
+          console.log("Ambiguous pairs (manual review recommended):");
+          const ambiguousList = verbose ? res.ambiguous : res.ambiguous.slice(0, 10);
+          for (const a of ambiguousList) {
+            console.log(`  - ${a.factIdNew} ↔ ${a.factIdOld} (${a.contradictionId})`);
+          }
+          if (!verbose && res.ambiguous.length > 10) {
             console.log(`  ...and ${res.ambiguous.length - 10} more`);
           }
         }
@@ -925,13 +934,15 @@ export function registerManageCorrectionsAndPipeline(mem: Chainable, b: ManageBi
     )
     .option("--days <n>", "Days to look back (default 7)", "7")
     .option("--output <path>", "Output path for incidents JSON (default: memory/.self-correction-incidents.json)")
+    .option("--verbose", "Log session files scanned (plugin logger) and incident previews on stdout")
     .action(
-      withExit(async (opts?: { days?: string; output?: string }) => {
+      withExit(async (opts?: { days?: string; output?: string; verbose?: boolean }, cmd?: CommanderOptsParent) => {
         const days = opts?.days ? Number.parseInt(opts.days, 10) : 7;
         const outputPath = opts?.output;
+        const verbose = !!opts?.verbose || readHybridMemVerbose(cmd);
         let res;
         try {
-          res = await runSelfCorrectionExtract({ days, outputPath });
+          res = await runSelfCorrectionExtract({ days, outputPath, verbose });
         } catch (err) {
           capturePluginError(err instanceof Error ? err : new Error(String(err)), {
             subsystem: "cli",
@@ -942,6 +953,14 @@ export function registerManageCorrectionsAndPipeline(mem: Chainable, b: ManageBi
         console.log(
           `Self-correction extract complete: ${res.incidents.length} incidents found, ${res.sessionsScanned} sessions scanned.`,
         );
+        if (verbose && res.incidents.length > 0) {
+          console.log("Incidents (--verbose):");
+          for (const inc of res.incidents) {
+            const preview = inc.userMessage.replace(/\s+/g, " ").slice(0, 120);
+            const tail = inc.userMessage.length > 120 ? "…" : "";
+            console.log(`  ${inc.sessionFile}: ${preview}${tail}`);
+          }
+        }
       }),
     );
 
@@ -955,23 +974,29 @@ export function registerManageCorrectionsAndPipeline(mem: Chainable, b: ManageBi
     .option("--approve", "Auto-approve all corrections (skip review)")
     .option("--no-apply-tools", "Skip TOOLS.md updates (memory-only)")
     .option("--full", "Force full re-scan (bypass 23-hour startup guard)")
+    .option("--verbose", "Log progress before LLM analysis (plugin logger); respects hybrid-mem -v")
     .action(
       withExit(
-        async (opts?: {
-          extractPath?: string;
-          workspace?: string;
-          dryRun?: boolean;
-          model?: string;
-          approve?: boolean;
-          applyTools?: boolean;
-          full?: boolean;
-        }) => {
+        async (
+          opts?: {
+            extractPath?: string;
+            workspace?: string;
+            dryRun?: boolean;
+            model?: string;
+            approve?: boolean;
+            applyTools?: boolean;
+            full?: boolean;
+            verbose?: boolean;
+          },
+          cmd?: CommanderOptsParent,
+        ) => {
           const extractPath = opts?.extractPath;
           const workspace = opts?.workspace;
           const dryRun = !!opts?.dryRun;
           const model = opts?.model ?? ctx.autoClassifyConfig.model;
           const approve = !!opts?.approve;
           const full = !!opts?.full;
+          const verbose = !!opts?.verbose || readHybridMemVerbose(cmd);
           let res;
           try {
             res = await runSelfCorrectionRun({
@@ -982,6 +1007,7 @@ export function registerManageCorrectionsAndPipeline(mem: Chainable, b: ManageBi
               approve,
               applyTools: opts?.applyTools,
               full,
+              verbose,
             });
           } catch (err) {
             capturePluginError(err instanceof Error ? err : new Error(String(err)), {

--- a/extensions/memory-hybrid/cli/commands/manage/register-storage-and-stats.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/register-storage-and-stats.ts
@@ -13,7 +13,7 @@ import { filterByScope } from "../../../services/merge-results.js";
 import type { MemoryEntry, ScopeFilter } from "../../../types/memory.js";
 import { getEnv } from "../../../utils/env-manager.js";
 import { type CommanderOptsParent, readHybridMemVerbose } from "../../global-verbose.js";
-import { type Chainable, withExit } from "../../shared.js";
+import { approxIntervalMs, type Chainable, withExit } from "../../shared.js";
 import type { ManageBindings } from "./bindings.js";
 
 /** Apply optional CLI filters to merged hybrid search results (category/entity/key/source/tier). */
@@ -282,16 +282,6 @@ export function registerManageStorageAndStats(mem: Chainable, b: ManageBindings)
             const staleLabel = noEmojiCron ? "[WARN] stale" : "⚠ stale";
             const fmtStaleWindow = (ms: number) =>
               ms >= dayMs ? `${Math.max(1, Math.round(ms / dayMs))}d` : `${Math.max(1, Math.round(ms / hourMs))}h`;
-            const approxIntervalMs = (cron?: string | null): number | null => {
-              if (!cron) return null;
-              const t = cron.trim();
-              if (/^\d+\s+\d+\s+\*\s+\*\s+\*$/.test(t)) return 24 * 60 * 60 * 1000;
-              if (/^\d+\s+\d+\s+\*\s+\*\s+[0-7]$/.test(t)) return 7 * 24 * 60 * 60 * 1000;
-              if (/^\d+\s+\d+\s+\d+\s+\*\s+\*$/.test(t)) return 30 * 24 * 60 * 60 * 1000;
-              const everyN = /^\d+\s+\*\/(\d+)\s+\*\s+\*\s+\*$/.exec(t);
-              if (everyN) return Number(everyN[1]) * 60 * 60 * 1000;
-              return null;
-            };
             console.log(`Cron jobs (hybrid-mem:*): ${cronJobs.length}`);
             for (const j of cronJobs) {
               const status = j.enabled ? "enabled " : "disabled";

--- a/extensions/memory-hybrid/cli/commands/manage/register-storage-and-stats.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/register-storage-and-stats.ts
@@ -166,7 +166,7 @@ export function registerManageStorageAndStats(mem: Chainable, b: ManageBindings)
           const lanceAbs = Math.abs(lanceDelta);
           const lanceDen = Math.max(sqlCount, lanceCount, 1);
           const lanceDeltaSignificant = lanceAbs > 100 && lanceAbs / lanceDen > 0.05;
-          const totalFacts = activeFacts + supersededFacts;
+          const totalFacts = sqlCount;
           const canonicalDelta = totalFacts - canonicalEmbeddings;
           const canonicalAbs = Math.abs(canonicalDelta);
           const canonicalDen = Math.max(totalFacts, canonicalEmbeddings, 1);
@@ -179,7 +179,7 @@ export function registerManageStorageAndStats(mem: Chainable, b: ManageBindings)
           console.log("");
           console.log(`Total facts (SQLite): ${sqlCount}`);
           console.log(
-            `Active facts: ${activeFacts} (superseded: ${supersededFacts}, expired pending prune: ${expired})`,
+            `Active facts: ${activeFacts}; superseded: ${supersededFacts}; expired pending prune: ${expired}`,
           );
           console.log(
             `Total vectors (LanceDB): ${lanceCount} (canonical embeddings in SQLite: ${canonicalEmbeddings})`,

--- a/extensions/memory-hybrid/cli/commands/manage/register-storage-and-stats.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/register-storage-and-stats.ts
@@ -273,13 +273,24 @@ export function registerManageStorageAndStats(mem: Chainable, b: ManageBindings)
           if (cronJobs.length > 0) {
             const nowMs = Date.now();
             const dayMs = 86_400_000;
+            const approxIntervalMs = (cron?: string | null): number | null => {
+              if (!cron) return null;
+              const t = cron.trim();
+              if (/^\d+\s+\d+\s+\*\s+\*\s+\*$/.test(t)) return 24 * 60 * 60 * 1000;
+              if (/^\d+\s+\d+\s+\*\s+\*\s+[0-6]$/.test(t)) return 7 * 24 * 60 * 60 * 1000;
+              if (/^\d+\s+\d+\s+\d+\s+\*\s+\*$/.test(t)) return 30 * 24 * 60 * 60 * 1000;
+              const everyN = /^\d+\s+\*\/(\d+)\s+\*\s+\*\s+\*$/.exec(t);
+              if (everyN) return Number(everyN[1]) * 60 * 60 * 1000;
+              return null;
+            };
             console.log(`Cron jobs (hybrid-mem:*): ${cronJobs.length}`);
             for (const j of cronJobs) {
               const status = j.enabled ? "enabled " : "disabled";
               const sched = j.scheduleExpr ?? "(no schedule)";
               const last =
                 j.lastRunAtMs != null ? `last ${Math.floor((nowMs - j.lastRunAtMs) / 3600000)}h ago` : "last (never)";
-              const stale = j.enabled && (j.lastRunAtMs == null || nowMs - j.lastRunAtMs > 8 * dayMs);
+              const interval = approxIntervalMs(j.scheduleExpr);
+              const stale = j.enabled && interval && (j.lastRunAtMs == null || nowMs - j.lastRunAtMs > interval * 1.5);
               const tail = stale ? " ⚠ stale (>8d / never)" : "";
               console.log(`  ${status} ${j.name.padEnd(30)} ${sched.padEnd(14)} ${last}${tail}`);
             }
@@ -793,13 +804,7 @@ export function registerManageStorageAndStats(mem: Chainable, b: ManageBindings)
     .option("--list-types", "Print allowed --type values and exit")
     .action(
       withExit(
-        async (opts?: {
-          type?: string;
-          limit?: string;
-          order?: string;
-          json?: boolean;
-          listTypes?: boolean;
-        }) => {
+        async (opts?: { type?: string; limit?: string; order?: string; json?: boolean; listTypes?: boolean }) => {
           if (opts?.listTypes) {
             for (const t of listDumpTypeAliases()) console.log(t);
             return;

--- a/extensions/memory-hybrid/cli/commands/manage/register-storage-and-stats.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/register-storage-and-stats.ts
@@ -166,9 +166,10 @@ export function registerManageStorageAndStats(mem: Chainable, b: ManageBindings)
           const lanceAbs = Math.abs(lanceDelta);
           const lanceDen = Math.max(sqlCount, lanceCount, 1);
           const lanceDeltaSignificant = lanceAbs > 100 && lanceAbs / lanceDen > 0.05;
-          const canonicalDelta = activeFacts - canonicalEmbeddings;
+          const totalFacts = activeFacts + supersededFacts;
+          const canonicalDelta = totalFacts - canonicalEmbeddings;
           const canonicalAbs = Math.abs(canonicalDelta);
-          const canonicalDen = Math.max(activeFacts, canonicalEmbeddings, 1);
+          const canonicalDen = Math.max(totalFacts, canonicalEmbeddings, 1);
           const canonicalDeltaSignificant = canonicalAbs > 100 && canonicalAbs / canonicalDen > 0.05;
 
           console.log("=== Memory Statistics (rich) ===");
@@ -185,7 +186,7 @@ export function registerManageStorageAndStats(mem: Chainable, b: ManageBindings)
           );
           if (lanceDeltaSignificant || canonicalDeltaSignificant) {
             console.log(
-              `  Health: SQLite facts ${sqlCount} vs LanceDB vectors ${lanceCount} (Δ=${lanceDelta}); active facts ${activeFacts} vs canonical embedding rows ${canonicalEmbeddings} (Δ=${canonicalDelta}; embedding rows may include superseded facts). Run 'openclaw hybrid-mem re-index' if you switched embedding model or after a large backfill.`,
+              `  Health: SQLite facts ${sqlCount} vs LanceDB vectors ${lanceCount} (Δ=${lanceDelta}); total facts ${totalFacts} vs canonical embedding rows ${canonicalEmbeddings} (Δ=${canonicalDelta}). Run 'openclaw hybrid-mem re-index' if you switched embedding model or after a large backfill.`,
             );
           }
           console.log("");

--- a/extensions/memory-hybrid/cli/commands/manage/register-storage-and-stats.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/register-storage-and-stats.ts
@@ -11,6 +11,7 @@ import { capturePluginError } from "../../../services/error-reporter.js";
 import { runMemoryDiagnostics } from "../../../services/memory-diagnostics.js";
 import { filterByScope } from "../../../services/merge-results.js";
 import type { MemoryEntry, ScopeFilter } from "../../../types/memory.js";
+import { getEnv } from "../../../utils/env-manager.js";
 import { type CommanderOptsParent, readHybridMemVerbose } from "../../global-verbose.js";
 import { type Chainable, withExit } from "../../shared.js";
 import type { ManageBindings } from "./bindings.js";
@@ -162,10 +163,13 @@ export function registerManageStorageAndStats(mem: Chainable, b: ManageBindings)
           const cronJobs = extras.getCronJobsStatus?.() ?? [];
 
           const lanceDelta = sqlCount - lanceCount;
-          const lanceDeltaSignificant = lanceDelta > 100 && (sqlCount === 0 || lanceDelta / sqlCount > 0.05);
+          const lanceAbs = Math.abs(lanceDelta);
+          const lanceDen = Math.max(sqlCount, lanceCount, 1);
+          const lanceDeltaSignificant = lanceAbs > 100 && lanceAbs / lanceDen > 0.05;
           const canonicalDelta = activeFacts - canonicalEmbeddings;
-          const canonicalDeltaSignificant =
-            canonicalDelta > 100 && (activeFacts === 0 || canonicalDelta / activeFacts > 0.05);
+          const canonicalAbs = Math.abs(canonicalDelta);
+          const canonicalDen = Math.max(activeFacts, canonicalEmbeddings, 1);
+          const canonicalDeltaSignificant = canonicalAbs > 100 && canonicalAbs / canonicalDen > 0.05;
 
           console.log("=== Memory Statistics (rich) ===");
           console.log(`Schema version: ${versionInfo.schemaVersion}`);
@@ -181,7 +185,7 @@ export function registerManageStorageAndStats(mem: Chainable, b: ManageBindings)
           );
           if (lanceDeltaSignificant || canonicalDeltaSignificant) {
             console.log(
-              `  Health: SQLite vs LanceDB Δ=${lanceDelta}; active vs canonical embeddings Δ=${canonicalDelta}. Run 'openclaw hybrid-mem re-index' if you switched embedding model or after a large backfill.`,
+              `  Health: SQLite facts ${sqlCount} vs LanceDB vectors ${lanceCount} (Δ=${lanceDelta}); active facts ${activeFacts} vs canonical embedding rows ${canonicalEmbeddings} (Δ=${canonicalDelta}; embedding rows may include superseded facts). Run 'openclaw hybrid-mem re-index' if you switched embedding model or after a large backfill.`,
             );
           }
           console.log("");
@@ -273,11 +277,16 @@ export function registerManageStorageAndStats(mem: Chainable, b: ManageBindings)
           if (cronJobs.length > 0) {
             const nowMs = Date.now();
             const dayMs = 86_400_000;
+            const hourMs = 3_600_000;
+            const noEmojiCron = getEnv("HYBRID_MEM_NO_EMOJI") === "1";
+            const staleLabel = noEmojiCron ? "[WARN] stale" : "⚠ stale";
+            const fmtStaleWindow = (ms: number) =>
+              ms >= dayMs ? `${Math.max(1, Math.round(ms / dayMs))}d` : `${Math.max(1, Math.round(ms / hourMs))}h`;
             const approxIntervalMs = (cron?: string | null): number | null => {
               if (!cron) return null;
               const t = cron.trim();
               if (/^\d+\s+\d+\s+\*\s+\*\s+\*$/.test(t)) return 24 * 60 * 60 * 1000;
-              if (/^\d+\s+\d+\s+\*\s+\*\s+[0-6]$/.test(t)) return 7 * 24 * 60 * 60 * 1000;
+              if (/^\d+\s+\d+\s+\*\s+\*\s+[0-7]$/.test(t)) return 7 * 24 * 60 * 60 * 1000;
               if (/^\d+\s+\d+\s+\d+\s+\*\s+\*$/.test(t)) return 30 * 24 * 60 * 60 * 1000;
               const everyN = /^\d+\s+\*\/(\d+)\s+\*\s+\*\s+\*$/.exec(t);
               if (everyN) return Number(everyN[1]) * 60 * 60 * 1000;
@@ -291,7 +300,11 @@ export function registerManageStorageAndStats(mem: Chainable, b: ManageBindings)
                 j.lastRunAtMs != null ? `last ${Math.floor((nowMs - j.lastRunAtMs) / 3600000)}h ago` : "last (never)";
               const interval = approxIntervalMs(j.scheduleExpr);
               const stale = j.enabled && interval && (j.lastRunAtMs == null || nowMs - j.lastRunAtMs > interval * 1.5);
-              const tail = stale ? " ⚠ stale (>8d / never)" : "";
+              const staleNote =
+                stale && interval != null
+                  ? ` overdue (no run in >${fmtStaleWindow(interval * 1.5)} vs ~${fmtStaleWindow(interval)} schedule)`
+                  : "";
+              const tail = stale ? ` ${staleLabel}${staleNote}` : "";
               console.log(`  ${status} ${j.name.padEnd(30)} ${sched.padEnd(14)} ${last}${tail}`);
             }
             console.log("");

--- a/extensions/memory-hybrid/cli/commands/manage/register-storage-and-stats.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/register-storage-and-stats.ts
@@ -11,6 +11,7 @@ import { capturePluginError } from "../../../services/error-reporter.js";
 import { runMemoryDiagnostics } from "../../../services/memory-diagnostics.js";
 import { filterByScope } from "../../../services/merge-results.js";
 import type { MemoryEntry, ScopeFilter } from "../../../types/memory.js";
+import { type CommanderOptsParent, readHybridMemVerbose } from "../../global-verbose.js";
 import { type Chainable, withExit } from "../../shared.js";
 import type { ManageBindings } from "./bindings.js";
 
@@ -150,14 +151,39 @@ export function registerManageStorageAndStats(mem: Chainable, b: ManageBindings)
           const selfCorrectionCount = factsDb.selfCorrectionIncidentsCount();
           const languageKeywordsCount = factsDb.languageKeywordsCount();
 
+          const activeFacts = factsDb.getCount();
+          const supersededFacts = factsDb.countSupersededFacts();
+          const canonicalEmbeddings = factsDb.countCanonicalEmbeddings();
+          const unresolvedContradictions = factsDb.contradictionsCount();
+          const verifiedFacts = factsDb.countVerifiedFacts();
+          const activity = factsDb.recentActivity();
+          const decayBreakdown = factsDb.statsBreakdownByDecayClass();
+          const sourceBreakdown = factsDb.statsBySource();
+          const cronJobs = extras.getCronJobsStatus?.() ?? [];
+
+          const lanceDelta = sqlCount - lanceCount;
+          const lanceDeltaSignificant = lanceDelta > 100 && (sqlCount === 0 || lanceDelta / sqlCount > 0.05);
+          const canonicalDelta = activeFacts - canonicalEmbeddings;
+          const canonicalDeltaSignificant =
+            canonicalDelta > 100 && (activeFacts === 0 || canonicalDelta / activeFacts > 0.05);
+
           console.log("=== Memory Statistics (rich) ===");
           console.log(`Schema version: ${versionInfo.schemaVersion}`);
           console.log(`Plugin version: ${versionInfo.pluginVersion}`);
           console.log(`Memory Manager: ${versionInfo.memoryManagerVersion}`);
           console.log("");
           console.log(`Total facts (SQLite): ${sqlCount}`);
-          console.log(`Total vectors (LanceDB): ${lanceCount}`);
-          console.log(`Expired (prunable): ${expired}`);
+          console.log(
+            `Active facts: ${activeFacts} (superseded: ${supersededFacts}, expired pending prune: ${expired})`,
+          );
+          console.log(
+            `Total vectors (LanceDB): ${lanceCount} (canonical embeddings in SQLite: ${canonicalEmbeddings})`,
+          );
+          if (lanceDeltaSignificant || canonicalDeltaSignificant) {
+            console.log(
+              `  Health: SQLite vs LanceDB Δ=${lanceDelta}; active vs canonical embeddings Δ=${canonicalDelta}. Run 'openclaw hybrid-mem re-index' if you switched embedding model or after a large backfill.`,
+            );
+          }
           console.log("");
           const proceduresNote = procedures === 0 ? " (run extract-procedures to populate)" : "";
           console.log(
@@ -170,6 +196,16 @@ export function registerManageStorageAndStats(mem: Chainable, b: ManageBindings)
           console.log(`Reflection (patterns/rules): ${reflectionPatternsCount}/${reflectionRulesCount}`);
           console.log(`Self-correction incidents: ${selfCorrectionCount}`);
           console.log(`Language keywords: ${languageKeywordsCount}`);
+          if (unresolvedContradictions > 0) {
+            console.log(
+              `Contradictions (unresolved): ${unresolvedContradictions} — run 'openclaw hybrid-mem resolve-contradictions'`,
+            );
+          } else {
+            console.log("Contradictions (unresolved): 0");
+          }
+          if (ctx.cfg.verification?.enabled) {
+            console.log(`Verified facts: ${verifiedFacts}`);
+          }
           console.log("");
           console.log(`Graph (links/entities): ${links}/${entities}`);
           console.log(
@@ -191,16 +227,64 @@ export function registerManageStorageAndStats(mem: Chainable, b: ManageBindings)
           console.log(`Categories in memory: ${uniqueInMemory.length} [${uniqueInMemory.slice(0, 3).join(", ")}...]`);
           console.log("");
           console.log(
-            `Breakdown: hot=${breakdown.hot}, warm=${breakdown.warm}, cold=${breakdown.cold}, structural=${breakdown.structural ?? 0}`,
+            `Breakdown by tier: hot=${breakdown.hot}, warm=${breakdown.warm}, cold=${breakdown.cold}, structural=${breakdown.structural ?? 0}`,
           );
+          const decayParts = Object.entries(decayBreakdown)
+            .map(([k, v]) => `${k}=${v}`)
+            .join(", ");
+          if (decayParts) console.log(`Breakdown by decay: ${decayParts}`);
+          const topSources = Object.entries(sourceBreakdown)
+            .sort((a, b) => b[1] - a[1])
+            .slice(0, 5);
+          if (topSources.length > 0) {
+            console.log(
+              `Top sources (active): ${topSources.map(([s, c]) => `${s}=${c}`).join(", ")} (of ${
+                Object.keys(sourceBreakdown).length
+              } sources)`,
+            );
+          }
           console.log("");
-          if (timestamps.distill) console.log(`Last distill: ${timestamps.distill}`);
-          if (timestamps.reflect) console.log(`Last reflect: ${timestamps.reflect}`);
-          if (timestamps.compact) console.log(`Last compact: ${timestamps.compact}`);
-          if (timestamps.distill || timestamps.reflect || timestamps.compact) console.log("");
+          const oldestDays =
+            activity.oldestActiveCreatedAtSec != null
+              ? Math.max(0, Math.floor((Date.now() / 1000 - activity.oldestActiveCreatedAtSec) / 86400))
+              : null;
+          const newestAgeMin =
+            activity.newestCreatedAtSec != null
+              ? Math.max(0, Math.floor((Date.now() / 1000 - activity.newestCreatedAtSec) / 60))
+              : null;
+          console.log(
+            `Recent activity: ${activity.last24h} new in 24h, ${activity.last7d} in 7d, ${activity.last30d} in 30d`,
+          );
+          if (newestAgeMin != null && oldestDays != null) {
+            console.log(`  Newest fact: ${newestAgeMin} min ago. Oldest active: ${oldestDays} days old.`);
+          }
+          console.log("");
+          console.log(`Last distill: ${timestamps.distill ?? "(never)"}`);
+          console.log(`Last reflect: ${timestamps.reflect ?? "(never)"}`);
+          console.log(`Last compact: ${timestamps.compact ?? "(never)"}`);
+          console.log("");
           if (sizes.sqliteBytes != null) console.log(`SQLite size: ${(sizes.sqliteBytes / 1024 / 1024).toFixed(2)} MB`);
           if (sizes.lanceBytes != null) console.log(`LanceDB size: ${(sizes.lanceBytes / 1024 / 1024).toFixed(2)} MB`);
+          if (sizes.sqliteBytes != null && activeFacts > 0) {
+            const bytesPerFact = sizes.sqliteBytes / activeFacts;
+            console.log(`SQLite bytes per active fact: ${bytesPerFact.toFixed(0)}`);
+          }
           if (sizes.sqliteBytes != null || sizes.lanceBytes != null) console.log("");
+          if (cronJobs.length > 0) {
+            const nowMs = Date.now();
+            const dayMs = 86_400_000;
+            console.log(`Cron jobs (hybrid-mem:*): ${cronJobs.length}`);
+            for (const j of cronJobs) {
+              const status = j.enabled ? "enabled " : "disabled";
+              const sched = j.scheduleExpr ?? "(no schedule)";
+              const last =
+                j.lastRunAtMs != null ? `last ${Math.floor((nowMs - j.lastRunAtMs) / 3600000)}h ago` : "last (never)";
+              const stale = j.enabled && (j.lastRunAtMs == null || nowMs - j.lastRunAtMs > 8 * dayMs);
+              const tail = stale ? " ⚠ stale (>8d / never)" : "";
+              console.log(`  ${status} ${j.name.padEnd(30)} ${sched.padEnd(14)} ${last}${tail}`);
+            }
+            console.log("");
+          }
         } else if (efficiency) {
           const byTier = breakdown;
           const bySource = factsDb.statsBySource();
@@ -230,9 +314,20 @@ export function registerManageStorageAndStats(mem: Chainable, b: ManageBindings)
   mem
     .command("prune")
     .description("Remove expired facts (decayed past threshold)")
+    .option("--verbose", "List fact ids that will be removed before pruning")
     .action(
-      withExit(async () => {
+      withExit(async (opts?: { verbose?: boolean }, cmd?: CommanderOptsParent) => {
+        const verbose = !!opts?.verbose || readHybridMemVerbose(cmd);
         const before = factsDb.count();
+        if (verbose) {
+          const pending = factsDb.listExpiredFactIdsPendingPrune();
+          if (pending.length > 0) {
+            console.log("Fact ids to prune (--verbose):");
+            for (const id of pending) console.log(`  ${id}`);
+          } else {
+            console.log("No expired facts pending prune (--verbose).");
+          }
+        }
         const pruned = factsDb.prune();
         const after = factsDb.count();
         console.log(`Pruned ${pruned} expired facts. Before: ${before}, After: ${after}`);

--- a/extensions/memory-hybrid/cli/context.ts
+++ b/extensions/memory-hybrid/cli/context.ts
@@ -140,7 +140,11 @@ export type ManageContext = {
     autoResolved: Array<{ contradictionId: string; factIdNew: string; factIdOld: string }>;
     ambiguous: Array<{ contradictionId: string; factIdNew: string; factIdOld: string }>;
   }>;
-  runSelfCorrectionExtract: (opts: { days?: number; outputPath?: string }) => Promise<SelfCorrectionExtractResult>;
+  runSelfCorrectionExtract: (opts: {
+    days?: number;
+    outputPath?: string;
+    verbose?: boolean;
+  }) => Promise<SelfCorrectionExtractResult>;
   runAnalyzeFeedbackPhrases?: (opts: {
     days?: number;
     model?: string;
@@ -178,6 +182,14 @@ export type ManageContext = {
     getWalPending: () => Promise<number>;
     getLastRunTimestamps: () => { distill?: string; reflect?: string; compact?: string };
     getStorageSizes: () => Promise<{ sqliteBytes?: number; lanceBytes?: number }>;
+    /** Snapshot of `~/.openclaw/cron/jobs.json` rows whose pluginJobId starts with `hybrid-mem:`. */
+    getCronJobsStatus?: () => Array<{
+      name: string;
+      pluginJobId: string;
+      enabled: boolean;
+      scheduleExpr: string | null;
+      lastRunAtMs: number | null;
+    }>;
   };
   listCommands?: {
     listProposals: (opts: {

--- a/extensions/memory-hybrid/cli/register.ts
+++ b/extensions/memory-hybrid/cli/register.ts
@@ -209,7 +209,11 @@ export type HybridMemCliContext = {
     pendingFactIds?: string[];
     enrichedFacts?: import("../services/entity-enrichment-cli.js").EntityEnrichmentVerboseFact[];
   }>;
-  runSelfCorrectionExtract: (opts: { days?: number; outputPath?: string }) => Promise<SelfCorrectionExtractResult>;
+  runSelfCorrectionExtract: (opts: {
+    days?: number;
+    outputPath?: string;
+    verbose?: boolean;
+  }) => Promise<SelfCorrectionExtractResult>;
   runSelfCorrectionRun: (opts: {
     extractPath?: string;
     incidents?: Array<{
@@ -285,9 +289,16 @@ export type HybridMemCliContext = {
     getCredentialsCount: () => number;
     getProposalsPending: () => number;
     getProposalsAvailable: () => boolean;
-    getWalPending: () => number;
+    getWalPending: () => Promise<number> | number;
     getLastRunTimestamps: () => { distill?: string; reflect?: string; compact?: string };
     getStorageSizes: () => Promise<{ sqliteBytes?: number; lanceBytes?: number }>;
+    getCronJobsStatus?: () => Array<{
+      name: string;
+      pluginJobId: string;
+      enabled: boolean;
+      scheduleExpr: string | null;
+      lastRunAtMs: number | null;
+    }>;
   };
   listCommands?: {
     listProposals: (opts: { status?: string }) => Promise<

--- a/extensions/memory-hybrid/cli/shared.ts
+++ b/extensions/memory-hybrid/cli/shared.ts
@@ -93,3 +93,18 @@ export function acquireScanSlot(
 export function clearScanLock(scanType: string): void {
   SCAN_IN_PROGRESS.delete(scanType);
 }
+
+/**
+ * Approximate run interval for "stale" detection per cron expression.
+ * Returns interval in milliseconds, or null if not recognized.
+ */
+export function approxIntervalMs(cron?: string | null): number | null {
+  if (!cron) return null;
+  const t = cron.trim();
+  if (/^\d+\s+\d+\s+\*\s+\*\s+\*$/.test(t)) return 24 * 60 * 60 * 1000;
+  if (/^\d+\s+\d+\s+\*\s+\*\s+[0-7]$/.test(t)) return 7 * 24 * 60 * 60 * 1000;
+  if (/^\d+\s+\d+\s+\d+\s+\*\s+\*$/.test(t)) return 30 * 24 * 60 * 60 * 1000;
+  const everyN = /^\d+\s+\*\/(\d+)\s+\*\s+\*\s+\*$/.exec(t);
+  if (everyN) return Number(everyN[1]) * 60 * 60 * 1000;
+  return null;
+}

--- a/extensions/memory-hybrid/services/cron-job-bash-harness.ts
+++ b/extensions/memory-hybrid/services/cron-job-bash-harness.ts
@@ -10,7 +10,7 @@ export type HybridMemCronStep = { name: string; cmd: string };
 
 /**
  * Bash script body: `set -euo pipefail`, HM_LOG / HM_EXIT, `hm_step`, and labeled steps.
- * Step `name` must be a short shell-safe token (letters, numbers, hyphens).
+ * Step `name` should be short and shell-safe; any character outside `[A-Za-z0-9-]` is replaced with `_`.
  */
 export function buildHybridMemCronBashBody(jobSlug: string, steps: HybridMemCronStep[]): string {
   const lines = steps.map((s) => {

--- a/extensions/memory-hybrid/services/cron-job-bash-harness.ts
+++ b/extensions/memory-hybrid/services/cron-job-bash-harness.ts
@@ -1,0 +1,81 @@
+/**
+ * Default OpenClaw cron *messages* for hybrid-mem jobs: durable file logs, per-step exit
+ * ledger, single bash session — pattern from production operator runs (issue: cron observability).
+ *
+ * The executing agent runs the embedded bash; logs land under ~/.openclaw/logs/cron-hybrid-mem
+ * (or a /tmp fallback if that path is not writable).
+ */
+
+export type HybridMemCronStep = { name: string; cmd: string };
+
+/**
+ * Bash script body: `set -euo pipefail`, HM_LOG / HM_EXIT, `hm_step`, and labeled steps.
+ * Step `name` must be a short shell-safe token (letters, numbers, hyphens).
+ */
+export function buildHybridMemCronBashBody(jobSlug: string, steps: HybridMemCronStep[]): string {
+  const lines = steps.map((s) => {
+    const safe = s.name.replace(/[^a-zA-Z0-9-]/g, "_");
+    return `hm_step "${safe}" ${s.cmd}`;
+  });
+  return [
+    "set -euo pipefail",
+    "set -x",
+    'OW="${OPENCLAW_HOME:-$HOME/.openclaw}"',
+    'HM_LOG_BASE="$OW/logs/cron-hybrid-mem"',
+    'if ! mkdir -p "$HM_LOG_BASE" 2>/dev/null; then',
+    '  HM_LOG_BASE="/tmp/openclaw-cron-hybrid-mem-${USER:-user}"',
+    '  mkdir -p "$HM_LOG_BASE"',
+    "fi",
+    'RUN_ID="$(date -u +%Y%m%dT%H%M%SZ)-$RANDOM"',
+    `HM_JOB="${jobSlug}"`,
+    'HM_LOG="${HM_LOG_BASE}/${HM_JOB}-${RUN_ID}.log"',
+    'HM_EXIT="${HM_LOG_BASE}/${HM_JOB}-${RUN_ID}.exit.txt"',
+    ': >"$HM_LOG"',
+    ': >"$HM_EXIT"',
+    "{",
+    '  echo "HM_JOB=${HM_JOB}"',
+    '  echo "RUN_ID=${RUN_ID}"',
+    '  echo "DAY_UTC=$(date -u +%Y%m%d)"',
+    '  echo "DATE_UTC=$(date -u +%Y-%m-%dT%H:%M:%SZ)"',
+    '  echo "--- openclaw --version ---"',
+    "  (openclaw --version 2>&1 || true)",
+    '  echo "--- steps ---"',
+    '} >>"$HM_LOG"',
+    "",
+    "hm_step() {",
+    '  local label="$1"',
+    "  shift",
+    "  set +e",
+    '  "$@" 2>&1 | tee -a "$HM_LOG"',
+    '  local ec="${PIPESTATUS[0]}"',
+    "  set -e",
+    '  echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) ${label} exit=${ec}" >>"$HM_EXIT"',
+    '  return "$ec"',
+    "}",
+    "",
+    ...lines,
+  ].join("\n");
+}
+
+/**
+ * Full task text (no guard prefix): optional preamble + execution rules + fenced bash.
+ * Guard prefix is applied later by {@link resolveCronJob} in cmd-install.
+ */
+export function buildHybridMemCronTaskMessage(
+  jobSlug: string,
+  options: { preamble?: string; steps: HybridMemCronStep[] },
+): string {
+  const preamble = options.preamble?.trim();
+  const bash = buildHybridMemCronBashBody(jobSlug, options.steps);
+  const orchestration = [
+    "EXECUTION (durable logs + per-step exits)",
+    "Run the bash below in ONE foreground shell session and wait until it exits. Do not background this work and end the turn while commands are still running.",
+    "- HM_LOG: full stdout/stderr for the run. HM_EXIT: one line per hm_step with UTC timestamp and exit= (first command in the pipeline).",
+    "- Only after every hm_step succeeds (exit 0), perform the GUARD CHECK timestamp write. If any hm_step fails, do NOT update the guard file; reply with paths to HM_LOG and HM_EXIT and paste the full contents of HM_EXIT.",
+    "",
+    "```bash",
+    bash,
+    "```",
+  ].join("\n");
+  return [preamble, orchestration].filter(Boolean).join("\n\n");
+}

--- a/extensions/memory-hybrid/setup/cli-context.ts
+++ b/extensions/memory-hybrid/setup/cli-context.ts
@@ -26,6 +26,7 @@ import {
 import { runClassifyForCli } from "../services/auto-classifier.js";
 import { runConsolidate } from "../services/consolidation.js";
 import { type VerificationCycleResult, runVerificationCycle } from "../services/continuous-verifier.js";
+import { readGuardTimestampMs } from "../services/cron-guard.js";
 import { type DreamCycleResult, runDreamCycle } from "../services/dream-cycle.js";
 import { runEntityEnrichmentForCli } from "../services/entity-enrichment-cli.js";
 import { capturePluginError } from "../services/error-reporter.js";
@@ -636,9 +637,13 @@ function buildRichStatsExtras(ctx: HandlerContext): NonNullable<HybridMemCliCont
         const sched = j.schedule as { expr?: string } | string | undefined;
         const scheduleExpr = typeof sched === "string" ? sched : typeof sched?.expr === "string" ? sched.expr : null;
         const state = (typeof j.state === "object" && j.state !== null ? j.state : {}) as Record<string, unknown>;
-        const lastRunAtMs = typeof state.lastRunAtMs === "number" ? state.lastRunAtMs : null;
+        const stateLast = typeof state.lastRunAtMs === "number" ? state.lastRunAtMs : null;
+        const jobName = typeof j.name === "string" ? j.name : pluginJobId;
+        const guardMs = readGuardTimestampMs(jobName.replace(/\s+/g, "-"), owHome);
+        const lastRunAtMs =
+          stateLast != null && guardMs != null ? Math.max(stateLast, guardMs) : (stateLast ?? guardMs);
         out.push({
-          name: typeof j.name === "string" ? j.name : pluginJobId,
+          name: jobName,
           pluginJobId,
           enabled: j.enabled !== false,
           scheduleExpr,

--- a/extensions/memory-hybrid/setup/cli-context.ts
+++ b/extensions/memory-hybrid/setup/cli-context.ts
@@ -605,6 +605,48 @@ function buildRichStatsExtras(ctx: HandlerContext): NonNullable<HybridMemCliCont
       }
       return { sqliteBytes, lanceBytes };
     },
+    getCronJobsStatus: () => {
+      const owHome =
+        process.env.OPENCLAW_HOME?.trim() || join(process.env.HOME ?? process.env.USERPROFILE ?? "", ".openclaw");
+      const cronStorePath = join(owHome, "cron", "jobs.json");
+      if (!existsSync(cronStorePath)) return [];
+      let store: { jobs?: unknown[] };
+      try {
+        store = JSON.parse(readFileSync(cronStorePath, "utf-8")) as { jobs?: unknown[] };
+      } catch (err) {
+        capturePluginError(err instanceof Error ? err : new Error(String(err)), {
+          operation: "stats-read-jobs-json",
+          severity: "info",
+          subsystem: "cli",
+        });
+        return [];
+      }
+      if (!Array.isArray(store.jobs)) return [];
+      const out: Array<{
+        name: string;
+        pluginJobId: string;
+        enabled: boolean;
+        scheduleExpr: string | null;
+        lastRunAtMs: number | null;
+      }> = [];
+      for (const j of store.jobs as Array<Record<string, unknown>>) {
+        if (!j || typeof j !== "object") continue;
+        const pluginJobId = typeof j.pluginJobId === "string" ? j.pluginJobId : "";
+        if (!pluginJobId.startsWith("hybrid-mem:")) continue;
+        const sched = j.schedule as { expr?: string } | string | undefined;
+        const scheduleExpr = typeof sched === "string" ? sched : typeof sched?.expr === "string" ? sched.expr : null;
+        const state = (typeof j.state === "object" && j.state !== null ? j.state : {}) as Record<string, unknown>;
+        const lastRunAtMs = typeof state.lastRunAtMs === "number" ? state.lastRunAtMs : null;
+        out.push({
+          name: typeof j.name === "string" ? j.name : pluginJobId,
+          pluginJobId,
+          enabled: j.enabled !== false,
+          scheduleExpr,
+          lastRunAtMs,
+        });
+      }
+      return out;
+    },
   };
 }
 

--- a/extensions/memory-hybrid/skills/hybrid-memory/references/memory-optimization.md
+++ b/extensions/memory-hybrid/skills/hybrid-memory/references/memory-optimization.md
@@ -56,11 +56,11 @@ If the user prefers **explicit** steps or `run-all` is too heavy, use this **can
 
 ### A. Nightly-style sweep (session + daily files + contradictions)
 
-1. `openclaw hybrid-mem prune`
-2. `openclaw hybrid-mem distill --days 3` (adjust window as needed; `--all` for big backfill)
-3. `openclaw hybrid-mem extract-daily` (as configured)
-4. `openclaw hybrid-mem resolve-contradictions`
-5. `openclaw hybrid-mem enrich-entities --limit 200` (backfill PERSON/ORG rows for facts still missing them; uses LLM when graph is on)
+1. `openclaw hybrid-mem prune` (add `--verbose` for id list when useful)
+2. `openclaw hybrid-mem distill --days 3` (packaged cron uses `--days 1`; adjust window as needed; `--all` for big backfill; `--verbose` in cron)
+3. `openclaw hybrid-mem extract-daily` (as configured; cron uses `--days 7 --verbose`)
+4. `openclaw hybrid-mem resolve-contradictions` (`--verbose` in cron)
+5. `openclaw hybrid-mem enrich-entities --limit 200` (backfill PERSON/ORG rows for facts still missing them; uses LLM when graph is on; `--verbose` in cron)
 
 ### B. Self-correction (after distill if you want fresh incidents)
 
@@ -107,11 +107,11 @@ If the user prefers **explicit** steps or `run-all` is too heavy, use this **can
 
 ## 5. Cron schedule (what runs automatically)
 
-If **`openclaw hybrid-mem install`** / **`verify --fix`** has been run, jobs in `~/.openclaw/cron/jobs.json` mirror roughly:
+If **`openclaw hybrid-mem install`** / **`verify --fix`** has been run, jobs in `~/.openclaw/cron/jobs.json` mirror roughly. Default messages embed a **bash harness**: per-step `tee` to `HM_LOG`, `HM_EXIT` lines with exit codes, and logs under `~/.openclaw/logs/cron-hybrid-mem/` (created on install).
 
 | When | Bundle |
 | --- | --- |
-| Daily 02:00 | prune → distill → extract-daily → resolve-contradictions → enrich-entities |
+| Daily 02:00 | prune → distill (1d in cron) → extract-daily → resolve-contradictions → enrich-entities |
 | Daily 02:30 | self-correction-run |
 | Daily 02:45 | dream-cycle (gated) |
 | Weekly | reflection, procedure pipeline, compact/scope, proposals |

--- a/extensions/memory-hybrid/tests/cron-job-bash-harness.test.ts
+++ b/extensions/memory-hybrid/tests/cron-job-bash-harness.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { buildHybridMemCronBashBody, buildHybridMemCronTaskMessage } from "../services/cron-job-bash-harness.js";
+
+describe("cron-job-bash-harness", () => {
+  it("buildHybridMemCronBashBody includes pipefail, logging paths, hm_step, and steps", () => {
+    const bash = buildHybridMemCronBashBody("nightly-memory-sweep", [
+      { name: "prune", cmd: "openclaw hybrid-mem prune --verbose" },
+    ]);
+    expect(bash).toContain("set -euo pipefail");
+    expect(bash).toContain('HM_LOG_BASE="$OW/logs/cron-hybrid-mem"');
+    expect(bash).toContain('HM_EXIT="${HM_LOG_BASE}/${HM_JOB}-${RUN_ID}.exit.txt"');
+    expect(bash).toContain('local ec="${PIPESTATUS[0]}"');
+    expect(bash).toContain('hm_step "prune" openclaw hybrid-mem prune --verbose');
+    expect(bash).toContain("openclaw --version");
+  });
+
+  it("buildHybridMemCronTaskMessage wraps bash and execution rules", () => {
+    const msg = buildHybridMemCronTaskMessage("sensor-sweep", {
+      preamble: "Preamble line.",
+      steps: [{ name: "t1", cmd: "openclaw hybrid-mem sensor-sweep --tier 1" }],
+    });
+    expect(msg).toContain("Preamble line.");
+    expect(msg).toContain("EXECUTION (durable logs + per-step exits)");
+    expect(msg).toContain("```bash");
+    expect(msg).toContain('hm_step "t1" openclaw hybrid-mem sensor-sweep --tier 1');
+  });
+});


### PR DESCRIPTION
## Summary

This PR bundles operator-focused improvements from recent work: durable default cron messages, clearer `verify` output, richer `stats`, and `--verbose` parity on maintenance subcommands.

## Cron defaults (`cmd-install`)

- New `services/cron-job-bash-harness.ts`: embeds a single-session bash pattern (`set -euo pipefail`, `hm_step`, `HM_LOG` / `HM_EXIT`, `openclaw --version` header) in default job messages.
- `ensureMaintenanceCronJobs` creates `~/.openclaw/logs/cron-hybrid-mem` on install/verify.
- Nightly sweep: explicit five steps, `distill --days 1`, `--verbose` where the CLI supports it.
- Docs: CLI-REFERENCE, MAINTENANCE-TASKS-MATRIX, OPERATIONS, hybrid-memory skill reference.

## CLI `--verbose`

- `prune`, `resolve-contradictions`, `self-correction-extract`, `self-correction-run`: `--verbose` + parent `hybrid-mem -v`; `listExpiredFactIdsPendingPrune` for prune preview.

## `hybrid-mem stats` (rich)

- Active vs superseded facts, canonical embeddings vs Lance count with health hint.
- Unresolved contradictions, verified facts (when verification enabled), decay/source breakdowns, recent activity (24h/7d/30d), newest/oldest active fact ages.
- Always show last distill/reflect/compact (or `(never)`), SQLite bytes per active fact, hybrid-mem cron rows from `jobs.json` with stale hints.

## `hybrid-mem verify`

- Heartbeat block: show pattern preview, sample checked jobs, actionable fix text; warning collected for summary.
- Canonical list includes dream-cycle and sensor-sweep; schedule on each row; guard-file fallback for `last:`; overdue flag; feature-gated jobs labeled; dream/sensor `not installed` when feature off.
- `Other custom jobs` only lists jobs that are not `pluginJobId: hybrid-mem:*`.
- Final line distinguishes `All checks passed` vs `All critical checks passed, but N warning(s)` with overdue cron list.

## Tests

- `tests/cron-job-bash-harness.test.ts` for harness output shape.


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how maintenance cron jobs are provisioned/messaged and expands `verify`/`stats` logic, which could affect operational behavior and user troubleshooting flows if edge cases in cron store parsing or guard timestamps are wrong.
> 
> **Overview**
> Adds a new default **cron job message harness** for `hybrid-mem:*` maintenance jobs that runs all steps in a single bash session with durable per-run logs (`HM_LOG`) and per-step exit ledgers (`HM_EXIT`), and updates install/verify to ensure the `~/.openclaw/logs/cron-hybrid-mem/` directory exists.
> 
> Enhances maintenance and diagnostics UX: multiple maintenance commands gain `--verbose` support (including prune previews via a new `listExpiredFactIdsPendingPrune` DB query), `stats` gains richer health/usage breakdowns (active vs superseded, verified facts, recent activity, source/decay breakdowns, cron job staleness), and `verify` improves scheduled-job reporting (feature-gated rows, schedule display, guard-file fallback for last-run, overdue warnings, and clearer heartbeat guidance).
> 
> Updates docs to reflect the new 9-job canonical cron set (including `sensor-sweep`), revised nightly sweep parameters, and the new logging/observability behavior, and adds tests covering the cron harness output shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85fa32f7cb838ceb57fcf318f83bd77791e96fce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->