### PR TITLE
fix(memory-hybrid): prevent dream-cycle mega-hubs

### DIFF
--- a/extensions/memory-hybrid/config/parsers/maintenance.ts
+++ b/extensions/memory-hybrid/config/parsers/maintenance.ts
@@ -71,6 +71,10 @@ export function parseNightlyCycleConfig(cfg: Record<string, unknown>): NightlyCy
       typeof nightlyCycleRaw?.maxUnconsolidatedAgeDays === "number" && nightlyCycleRaw.maxUnconsolidatedAgeDays >= 1
         ? Math.min(3650, Math.floor(nightlyCycleRaw.maxUnconsolidatedAgeDays))
         : 90,
+    maxEventsPerConsolidation:
+      typeof nightlyCycleRaw?.maxEventsPerConsolidation === "number" && nightlyCycleRaw.maxEventsPerConsolidation >= 1
+        ? Math.min(1000, Math.floor(nightlyCycleRaw.maxEventsPerConsolidation))
+        : 200,
     logRetentionDays:
       typeof nightlyCycleRaw?.logRetentionDays === "number" && nightlyCycleRaw.logRetentionDays >= 0
         ? Math.min(3650, Math.floor(nightlyCycleRaw.logRetentionDays))

--- a/extensions/memory-hybrid/config/types/maintenance.ts
+++ b/extensions/memory-hybrid/config/types/maintenance.ts
@@ -44,6 +44,8 @@ export type NightlyCycleConfig = {
   eventLogArchivePath?: string;
   /** Legacy: max age for unconsolidated event log entries before deletion (default: 90). */
   maxUnconsolidatedAgeDays: number;
+  /** Maximum events to merge into one consolidated fact (default: 200). */
+  maxEventsPerConsolidation: number;
   /**
    * Retention window in days for log tables (recall_log, reinforcement_log, feedback_trajectories).
    * Rows older than this are deleted during the dream cycle. Set to 0 to disable log pruning.

--- a/extensions/memory-hybrid/openclaw.plugin.json
+++ b/extensions/memory-hybrid/openclaw.plugin.json
@@ -1523,6 +1523,9 @@
           },
           "maxUnconsolidatedAgeDays": {
             "type": "number"
+          },
+          "maxEventsPerConsolidation": {
+            "type": "number"
           }
         },
         "description": "Nightly dream cycle: prune, consolidate, reflect"

--- a/extensions/memory-hybrid/routes/dashboard-graph.ts
+++ b/extensions/memory-hybrid/routes/dashboard-graph.ts
@@ -76,11 +76,13 @@ function collectDashboardConnectedIds(factsDb: FactsDB, seeds: string[], maxDept
     const next: string[] = [];
     for (const id of frontier) {
       const links = [...factsDb.getLinksFrom(id), ...factsDb.getLinksTo(id)];
-      const traversable = links.length > DASHBOARD_MAX_LINKS_PER_NODE
-        ? links.filter((link) => link.linkType !== "DERIVED_FROM").slice(0, DASHBOARD_MAX_LINKS_PER_NODE)
-        : links;
+      const traversable =
+        links.length > DASHBOARD_MAX_LINKS_PER_NODE
+          ? links
+              .filter((link) => link.linkType !== "CONTRADICTS" && link.linkType !== "DERIVED_FROM")
+              .slice(0, DASHBOARD_MAX_LINKS_PER_NODE)
+          : links.filter((link) => link.linkType !== "CONTRADICTS");
       for (const link of traversable) {
-        if (link.linkType === "CONTRADICTS") continue;
         const other = "targetFactId" in link ? link.targetFactId : link.sourceFactId;
         if (seen.has(other)) continue;
         seen.add(other);

--- a/extensions/memory-hybrid/routes/dashboard-graph.ts
+++ b/extensions/memory-hybrid/routes/dashboard-graph.ts
@@ -3,6 +3,7 @@
  */
 
 import type { FactsDB } from "../backends/facts-db.js";
+import { filterTraversableLinks } from "../services/graph-retrieval.js";
 
 interface MemoryGraphNode {
   id: string;
@@ -67,8 +68,6 @@ export function collectGraphPayload(factsDb: FactsDB, days: number, maxNodes: nu
   };
 }
 
-const DASHBOARD_MAX_LINKS_PER_NODE = 200;
-
 function collectDashboardConnectedIds(factsDb: FactsDB, seeds: string[], maxDepth: number): string[] {
   const seen = new Set(seeds);
   let frontier = [...seeds];
@@ -76,12 +75,7 @@ function collectDashboardConnectedIds(factsDb: FactsDB, seeds: string[], maxDept
     const next: string[] = [];
     for (const id of frontier) {
       const links = [...factsDb.getLinksFrom(id), ...factsDb.getLinksTo(id)];
-      const traversable =
-        links.length > DASHBOARD_MAX_LINKS_PER_NODE
-          ? links
-              .filter((link) => link.linkType !== "CONTRADICTS" && link.linkType !== "DERIVED_FROM")
-              .slice(0, DASHBOARD_MAX_LINKS_PER_NODE)
-          : links.filter((link) => link.linkType !== "CONTRADICTS");
+      const traversable = filterTraversableLinks(links);
       for (const link of traversable) {
         const other = "targetFactId" in link ? link.targetFactId : link.sourceFactId;
         if (seen.has(other)) continue;

--- a/extensions/memory-hybrid/routes/dashboard-graph.ts
+++ b/extensions/memory-hybrid/routes/dashboard-graph.ts
@@ -67,6 +67,31 @@ export function collectGraphPayload(factsDb: FactsDB, days: number, maxNodes: nu
   };
 }
 
+const DASHBOARD_MAX_LINKS_PER_NODE = 200;
+
+function collectDashboardConnectedIds(factsDb: FactsDB, seeds: string[], maxDepth: number): string[] {
+  const seen = new Set(seeds);
+  let frontier = [...seeds];
+  for (let depth = 0; depth < maxDepth && frontier.length > 0; depth++) {
+    const next: string[] = [];
+    for (const id of frontier) {
+      const links = [...factsDb.getLinksFrom(id), ...factsDb.getLinksTo(id)];
+      const traversable = links.length > DASHBOARD_MAX_LINKS_PER_NODE
+        ? links.filter((link) => link.linkType !== "DERIVED_FROM").slice(0, DASHBOARD_MAX_LINKS_PER_NODE)
+        : links;
+      for (const link of traversable) {
+        if (link.linkType === "CONTRADICTS") continue;
+        const other = "targetFactId" in link ? link.targetFactId : link.sourceFactId;
+        if (seen.has(other)) continue;
+        seen.add(other);
+        next.push(other);
+      }
+    }
+    frontier = next;
+  }
+  return [...seen];
+}
+
 export function collectGraphRecallPayload(factsDb: FactsDB, query: string): GraphRecallPayload {
   const q = query.trim();
   if (!q) {
@@ -78,8 +103,7 @@ export function collectGraphRecallPayload(factsDb: FactsDB, query: string): Grap
     diversityWeight: 1,
   });
   const seeds = results.map((r) => r.entry.id);
-  const expanded = new Set<string>(factsDb.getConnectedFactIds(seeds, 3));
-  const ids = [...expanded].slice(0, 2000);
+  const ids = collectDashboardConnectedIds(factsDb, seeds, 3).slice(0, 2000);
   const entryMap = factsDb.getByIds(ids);
   const nodes: MemoryGraphNode[] = [];
   for (const id of ids) {

--- a/extensions/memory-hybrid/services/dream-cycle.ts
+++ b/extensions/memory-hybrid/services/dream-cycle.ts
@@ -91,7 +91,7 @@ export interface DreamCycleResult {
 // Minimum patterns stored in one cycle before we also run reflect-rules.
 const MIN_PATTERNS_FOR_RULES = 3;
 export const DEFAULT_MAX_EVENTS_PER_CONSOLIDATION = 200;
-const SKIP_CONSOLIDATION_EVENT_TYPES = new Set([
+const SKIP_CONSOLIDATION_TEXT_PATTERNS = new Set([
   "heartbeat",
   "session_end",
   "session_start",
@@ -136,9 +136,8 @@ export function groupEventsByEntity(events: EventLogEntry[]): Map<string, EventL
 }
 
 export function shouldSkipEpisodicConsolidation(event: EventLogEntry): boolean {
-  if (SKIP_CONSOLIDATION_EVENT_TYPES.has(event.eventType)) return true;
   const text = extractEventText(event).toLowerCase();
-  return SKIP_CONSOLIDATION_EVENT_TYPES.has(text);
+  return SKIP_CONSOLIDATION_TEXT_PATTERNS.has(text);
 }
 
 /**

--- a/extensions/memory-hybrid/services/dream-cycle.ts
+++ b/extensions/memory-hybrid/services/dream-cycle.ts
@@ -46,6 +46,8 @@ export interface DreamCycleConfig {
   eventLogArchivePath: string;
   /** Delete unconsolidated event log entries older than this many days. */
   maxUnconsolidatedAgeDays: number;
+  /** Maximum events to merge into one consolidated fact. Default: 200. */
+  maxEventsPerConsolidation: number;
   /**
    * Retention window for log tables (recall_log, reinforcement_log, feedback_trajectories).
    * Rows older than this many days are deleted. 0 = disabled. Default: 30.
@@ -88,6 +90,14 @@ export interface DreamCycleResult {
 
 // Minimum patterns stored in one cycle before we also run reflect-rules.
 const MIN_PATTERNS_FOR_RULES = 3;
+export const DEFAULT_MAX_EVENTS_PER_CONSOLIDATION = 200;
+const SKIP_CONSOLIDATION_EVENT_TYPES = new Set([
+  "heartbeat",
+  "session_end",
+  "session_start",
+  "transport_connect",
+  "transport_disconnect",
+]);
 
 // ---------------------------------------------------------------------------
 // Episodic consolidation helpers (exported for testing)
@@ -123,6 +133,12 @@ export function groupEventsByEntity(events: EventLogEntry[]): Map<string, EventL
     groups.get(primaryEntity)?.push(event);
   }
   return groups;
+}
+
+export function shouldSkipEpisodicConsolidation(event: EventLogEntry): boolean {
+  if (SKIP_CONSOLIDATION_EVENT_TYPES.has(event.eventType)) return true;
+  const text = extractEventText(event).toLowerCase();
+  return SKIP_CONSOLIDATION_EVENT_TYPES.has(text);
 }
 
 /**
@@ -175,27 +191,72 @@ export async function runEpisodicConsolidation(
   consolidateAfterDays: number,
   logger: { info: (msg: string) => void; warn: (msg: string) => void },
   verbose?: boolean,
+  maxEventsPerConsolidation = DEFAULT_MAX_EVENTS_PER_CONSOLIDATION,
 ): Promise<{ eventsConsolidated: number; factsCreated: number }> {
   const events = eventLog.getUnconsolidated(consolidateAfterDays);
   if (events.length === 0) {
     return { eventsConsolidated: 0, factsCreated: 0 };
   }
 
-  const groups = groupEventsByEntity(events);
+  let eventsConsolidated = 0;
+  const skippedEvents = events.filter(shouldSkipEpisodicConsolidation);
+  if (skippedEvents.length > 0) {
+    try {
+      eventLog.markConsolidated(
+        skippedEvents.map((e) => e.id),
+        "SKIP:lifecycle_event",
+      );
+      eventsConsolidated += skippedEvents.length;
+    } catch (err) {
+      logger.warn(`memory-hybrid: dream-cycle — failed to mark lifecycle events as skipped: ${err}`);
+      capturePluginError(err instanceof Error ? err : new Error(String(err)), {
+        operation: "dream-cycle-mark-lifecycle-skip",
+        subsystem: "event-log",
+      });
+    }
+  }
+
+  const consolidatableEvents = events.filter((event) => !shouldSkipEpisodicConsolidation(event));
+  if (consolidatableEvents.length === 0) {
+    return { eventsConsolidated, factsCreated: 0 };
+  }
+
+  const groups = groupEventsByEntity(consolidatableEvents);
   if (verbose) {
     logger.info(
-      `memory-hybrid: dream-cycle — episodic consolidation: ${events.length} unconsolidated event(s) in ${groups.size} entity group(s) (≥${consolidateAfterDays}d)`,
+      `memory-hybrid: dream-cycle — episodic consolidation: ${consolidatableEvents.length} consolidatable event(s) in ${groups.size} entity group(s) (≥${consolidateAfterDays}d); skipped ${skippedEvents.length} lifecycle/noise event(s)`,
     );
   }
   let factsCreated = 0;
-  let eventsConsolidated = 0;
   const ephemeralSourceFactIds: string[] = [];
 
   for (const [entity, groupEvents] of groups) {
     if (groupEvents.length === 0) continue;
 
+    if (entity === "__default__" && groupEvents.length > maxEventsPerConsolidation) {
+      try {
+        eventLog.markConsolidated(
+          groupEvents.map((e) => e.id),
+          "SKIP:default_group_cap",
+        );
+        eventsConsolidated += groupEvents.length;
+        logger.info(
+          `memory-hybrid: dream-cycle — skipped ${groupEvents.length} unattributed event(s): default group exceeds maxEventsPerConsolidation=${maxEventsPerConsolidation}`,
+        );
+      } catch (err) {
+        logger.warn(`memory-hybrid: dream-cycle — failed to mark capped default group as skipped: ${err}`);
+        capturePluginError(err instanceof Error ? err : new Error(String(err)), {
+          operation: "dream-cycle-mark-default-cap-skip",
+          subsystem: "event-log",
+        });
+      }
+      continue;
+    }
+
+    const cappedGroupEvents = groupEvents.slice(0, maxEventsPerConsolidation);
+
     // Collect text from all events in this group
-    const eventTexts = groupEvents.map((e) => extractEventText(e)).filter((t) => t.length >= 3);
+    const eventTexts = cappedGroupEvents.map((e) => extractEventText(e)).filter((t) => t.length >= 3);
 
     if (eventTexts.length === 0) {
       // Mark events as consolidated with a namespaced skip sentinel to prevent re-processing.
@@ -250,7 +311,7 @@ export async function runEpisodicConsolidation(
     // For each event, create a minimal ephemeral source fact and a DERIVED_FROM link.
     // The source facts expire immediately; DERIVED_FROM links persist as provenance.
     const nowSec = Math.floor(Date.now() / 1000);
-    for (const event of groupEvents) {
+    for (const event of cappedGroupEvents) {
       const srcText = extractEventText(event);
       if (srcText.length < 3) continue;
 
@@ -414,6 +475,7 @@ export async function runDreamCycle(
         config.consolidateAfterDays,
         logger,
         v,
+        config.maxEventsPerConsolidation,
       );
       eventsConsolidated = consolidationResult.eventsConsolidated;
       factsCreated = consolidationResult.factsCreated;

--- a/extensions/memory-hybrid/services/dream-cycle.ts
+++ b/extensions/memory-hybrid/services/dream-cycle.ts
@@ -263,10 +263,10 @@ export async function runEpisodicConsolidation(
       // 'SKIP:no_text' is clearly not a real fact UUID — no UUID-based query will match it.
       try {
         eventLog.markConsolidated(
-          groupEvents.map((e) => e.id),
+          cappedGroupEvents.map((e) => e.id),
           "SKIP:no_text",
         );
-        eventsConsolidated += groupEvents.length;
+        eventsConsolidated += cappedGroupEvents.length;
       } catch (err) {
         logger.warn(`memory-hybrid: dream-cycle — failed to mark no-text events as consolidated: ${err}`);
         capturePluginError(err instanceof Error ? err : new Error(String(err)), {
@@ -343,11 +343,11 @@ export async function runEpisodicConsolidation(
     // Mark all events in the group as consolidated into the new fact
     try {
       eventLog.markConsolidated(
-        groupEvents.map((e) => e.id),
+        cappedGroupEvents.map((e) => e.id),
         consolidatedFact.id,
       );
       factsCreated++;
-      eventsConsolidated += groupEvents.length;
+      eventsConsolidated += cappedGroupEvents.length;
     } catch (err) {
       logger.warn(`memory-hybrid: dream-cycle — failed to mark events as consolidated: ${err}`);
       capturePluginError(err instanceof Error ? err : new Error(String(err)), {
@@ -365,7 +365,7 @@ export async function runEpisodicConsolidation(
     }
 
     logger.info(
-      `memory-hybrid: dream-cycle — consolidated ${groupEvents.length} events${entityLabel ? ` for entity "${entityLabel}"` : ""} → fact ${consolidatedFact.id.slice(0, 8)}`,
+      `memory-hybrid: dream-cycle — consolidated ${cappedGroupEvents.length} events${entityLabel ? ` for entity "${entityLabel}"` : ""} → fact ${consolidatedFact.id.slice(0, 8)}`,
     );
   }
 

--- a/extensions/memory-hybrid/services/graph-retrieval.ts
+++ b/extensions/memory-hybrid/services/graph-retrieval.ts
@@ -97,6 +97,12 @@ interface GraphRetrievalOptions {
  * Beyond index 3, the last value is reused.
  */
 export const HOP_SCORE_DECAY: readonly number[] = [1.0, 0.7, 0.5, 0.35];
+export const HUB_GUARD_MAX_LINKS_PER_NODE = 200;
+
+function filterTraversableLinks<T extends { linkType: string }>(links: T[]): T[] {
+  if (links.length <= HUB_GUARD_MAX_LINKS_PER_NODE) return links.filter((link) => link.linkType !== "CONTRADICTS");
+  return links.filter((link) => link.linkType !== "CONTRADICTS" && link.linkType !== "DERIVED_FROM").slice(0, HUB_GUARD_MAX_LINKS_PER_NODE);
+}
 
 // ---------------------------------------------------------------------------
 // Core expansion function
@@ -150,32 +156,9 @@ export function expandGraph(
   const maxSeedScore = Math.max(...seedResults.map((s) => s.score), 0.5);
   const expandedResults: GraphExpandedResult[] = [];
 
-  // Use recursive CTE to perform graph expansion in a single query if available
-  if (factsDb.expandGraphWithCTE) {
-    const expansionRows = factsDb.expandGraphWithCTE(seedIds, maxDepth, getByIdOpts);
-
-    for (const row of expansionRows) {
-      if (row.hopCount === 0) continue;
-
-      const entry = factsDb.getById(row.factId, getByIdOpts);
-      if (!entry) continue;
-
-      const linkPath: LinkPathStep[] = JSON.parse(row.path);
-      const seedScore = seedScoreMap.get(row.seedId) ?? maxSeedScore;
-      const decay = HOP_SCORE_DECAY[row.hopCount] ?? HOP_SCORE_DECAY[HOP_SCORE_DECAY.length - 1];
-      const score = seedScore * decay;
-
-      expandedResults.push({
-        factId: row.factId,
-        entry,
-        expansionSource: "graph",
-        hopCount: row.hopCount,
-        linkPath,
-        score,
-      });
-    }
-  } else {
-    // Fallback: iterative BFS for custom/mock implementations
+  // Iterative BFS keeps traversal guards explicit: high-degree provenance hubs are
+  // intentionally not expanded through, because they can swamp recall results.
+  {
     const nodeMeta = new Map<string, NodeMeta>();
     for (const s of seedResults) {
       nodeMeta.set(s.factId, { hopCount: 0, steps: [], seedId: s.factId });
@@ -221,9 +204,8 @@ export function expandGraph(
         const fromMeta = nodeMeta.get(fromId)!;
 
         // --- Outgoing edges: fromId → targetId ---
-        const outLinks = factsDb.getLinksFrom(fromId);
+        const outLinks = filterTraversableLinks(factsDb.getLinksFrom(fromId));
         for (const link of outLinks) {
-          if (link.linkType === "CONTRADICTS") continue;
           const steps: LinkPathStep[] = [
             ...fromMeta.steps,
             {
@@ -241,9 +223,8 @@ export function expandGraph(
         }
 
         // --- Incoming edges: sourceId → fromId ---
-        const inLinks = factsDb.getLinksTo(fromId);
+        const inLinks = filterTraversableLinks(factsDb.getLinksTo(fromId));
         for (const link of inLinks) {
-          if (link.linkType === "CONTRADICTS") continue;
           const steps: LinkPathStep[] = [
             ...fromMeta.steps,
             {

--- a/extensions/memory-hybrid/services/graph-retrieval.ts
+++ b/extensions/memory-hybrid/services/graph-retrieval.ts
@@ -99,7 +99,7 @@ interface GraphRetrievalOptions {
 export const HOP_SCORE_DECAY: readonly number[] = [1.0, 0.7, 0.5, 0.35];
 export const HUB_GUARD_MAX_LINKS_PER_NODE = 200;
 
-function filterTraversableLinks<T extends { linkType: string }>(links: T[]): T[] {
+export function filterTraversableLinks<T extends { linkType: string }>(links: T[]): T[] {
   if (links.length <= HUB_GUARD_MAX_LINKS_PER_NODE) return links.filter((link) => link.linkType !== "CONTRADICTS");
   return links
     .filter((link) => link.linkType !== "CONTRADICTS" && link.linkType !== "DERIVED_FROM")

--- a/extensions/memory-hybrid/services/graph-retrieval.ts
+++ b/extensions/memory-hybrid/services/graph-retrieval.ts
@@ -101,7 +101,9 @@ export const HUB_GUARD_MAX_LINKS_PER_NODE = 200;
 
 function filterTraversableLinks<T extends { linkType: string }>(links: T[]): T[] {
   if (links.length <= HUB_GUARD_MAX_LINKS_PER_NODE) return links.filter((link) => link.linkType !== "CONTRADICTS");
-  return links.filter((link) => link.linkType !== "CONTRADICTS" && link.linkType !== "DERIVED_FROM").slice(0, HUB_GUARD_MAX_LINKS_PER_NODE);
+  return links
+    .filter((link) => link.linkType !== "CONTRADICTS" && link.linkType !== "DERIVED_FROM")
+    .slice(0, HUB_GUARD_MAX_LINKS_PER_NODE);
 }
 
 // ---------------------------------------------------------------------------

--- a/extensions/memory-hybrid/setup/cli-context.ts
+++ b/extensions/memory-hybrid/setup/cli-context.ts
@@ -433,6 +433,7 @@ function buildCliContextServices(ctx: HybridMemCliRegistrationContext, api: Claw
           eventLogArchivalDays: cfg.eventLog.archivalDays,
           eventLogArchivePath: cfg.eventLog.archivePath,
           maxUnconsolidatedAgeDays: cfg.nightlyCycle.maxUnconsolidatedAgeDays,
+          maxEventsPerConsolidation: cfg.nightlyCycle.maxEventsPerConsolidation,
           logRetentionDays: cfg.nightlyCycle.logRetentionDays,
           vacuumOnCycle: cfg.nightlyCycle.vacuumOnCycle,
           verbose,

--- a/extensions/memory-hybrid/tests/dream-cycle.test.ts
+++ b/extensions/memory-hybrid/tests/dream-cycle.test.ts
@@ -331,10 +331,14 @@ describe("runEpisodicConsolidation", () => {
     expect(result.factsCreated).toBe(0);
   });
 
-
   it("skips lifecycle-like transport noise instead of consolidating it", async () => {
     const oldTs = new Date(Date.now() - 8 * 24 * 3600 * 1000).toISOString();
-    eventLog.append({ sessionId: "s1", timestamp: oldTs, eventType: "action_taken", content: { text: "session_start" } });
+    eventLog.append({
+      sessionId: "s1",
+      timestamp: oldTs,
+      eventType: "action_taken",
+      content: { text: "session_start" },
+    });
     eventLog.append({ sessionId: "s1", timestamp: oldTs, eventType: "action_taken", content: { text: "session_end" } });
 
     const result = await runEpisodicConsolidation(factsDb, eventLog, 7, silentLogger);

--- a/extensions/memory-hybrid/tests/dream-cycle.test.ts
+++ b/extensions/memory-hybrid/tests/dream-cycle.test.ts
@@ -331,6 +331,39 @@ describe("runEpisodicConsolidation", () => {
     expect(result.factsCreated).toBe(0);
   });
 
+
+  it("skips lifecycle-like transport noise instead of consolidating it", async () => {
+    const oldTs = new Date(Date.now() - 8 * 24 * 3600 * 1000).toISOString();
+    eventLog.append({ sessionId: "s1", timestamp: oldTs, eventType: "action_taken", content: { text: "session_start" } });
+    eventLog.append({ sessionId: "s1", timestamp: oldTs, eventType: "action_taken", content: { text: "session_end" } });
+
+    const result = await runEpisodicConsolidation(factsDb, eventLog, 7, silentLogger);
+
+    expect(result.eventsConsolidated).toBe(2);
+    expect(result.factsCreated).toBe(0);
+    expect(factsDb.getByCategory("fact").filter((f) => f.source === "dream-cycle")).toHaveLength(0);
+    expect(eventLog.getUnconsolidated(7)).toHaveLength(0);
+  });
+
+  it("skips oversized default groups instead of creating DERIVED_FROM mega-hubs", async () => {
+    const oldTs = new Date(Date.now() - 8 * 24 * 3600 * 1000).toISOString();
+    for (let i = 0; i < 4; i++) {
+      eventLog.append({
+        sessionId: "s1",
+        timestamp: oldTs,
+        eventType: "fact_learned",
+        content: { text: `Default group event ${i}` },
+      });
+    }
+
+    const result = await runEpisodicConsolidation(factsDb, eventLog, 7, silentLogger, false, 3);
+
+    expect(result.eventsConsolidated).toBe(4);
+    expect(result.factsCreated).toBe(0);
+    expect(factsDb.getByCategory("fact").filter((f) => f.source === "dream-cycle")).toHaveLength(0);
+    expect(eventLog.getUnconsolidated(7)).toHaveLength(0);
+  });
+
   it("groups events by entity into separate consolidated facts", async () => {
     const oldTs = new Date(Date.now() - 8 * 24 * 3600 * 1000).toISOString();
     eventLog.append({
@@ -613,6 +646,7 @@ describe("NightlyCycleConfig parsing", () => {
     expect(cfg.nightlyCycle.pruneMode).toBe("both");
     expect(cfg.nightlyCycle.consolidateAfterDays).toBe(7);
     expect(cfg.nightlyCycle.maxUnconsolidatedAgeDays).toBe(90);
+    expect(cfg.nightlyCycle.maxEventsPerConsolidation).toBe(200);
   });
 
   it("honors nightlyCycle.enabled when set to true", () => {
@@ -633,6 +667,7 @@ describe("NightlyCycleConfig parsing", () => {
         pruneMode: "expired",
         consolidateAfterDays: 3,
         maxUnconsolidatedAgeDays: 30,
+        maxEventsPerConsolidation: 42,
       },
     });
     expect(cfg.nightlyCycle.schedule).toBe("30 2 * * *");
@@ -640,6 +675,7 @@ describe("NightlyCycleConfig parsing", () => {
     expect(cfg.nightlyCycle.pruneMode).toBe("expired");
     expect(cfg.nightlyCycle.consolidateAfterDays).toBe(3);
     expect(cfg.nightlyCycle.maxUnconsolidatedAgeDays).toBe(30);
+    expect(cfg.nightlyCycle.maxEventsPerConsolidation).toBe(42);
   });
 
   it("clamps reflectWindowDays to max 90", () => {

--- a/extensions/memory-hybrid/tests/graph-retrieval.test.ts
+++ b/extensions/memory-hybrid/tests/graph-retrieval.test.ts
@@ -640,6 +640,35 @@ describe("expandGraph: various link types", () => {
     expect(bResult).toBeDefined();
     expect(bResult?.linkPath[0].linkType).toBe(linkType);
   });
+
+
+  it("does not expand through high-degree DERIVED_FROM provenance hubs", () => {
+    const seed = makeEntry("seed");
+    const semantic = makeEntry("semantic");
+    const entries = [seed, semantic];
+    const derivedLinks = [];
+    for (let i = 0; i < 205; i++) {
+      const id = `src-${i}`;
+      entries.push(makeEntry(id));
+      derivedLinks.push({ id: `d-${i}`, targetFactId: id, linkType: "DERIVED_FROM", strength: 1.0 });
+    }
+    const db = buildMockDb(
+      entries,
+      {
+        seed: [
+          ...derivedLinks,
+          { id: "semantic-link", targetFactId: "semantic", linkType: "RELATED_TO", strength: 1.0 },
+        ],
+      },
+      {},
+    );
+
+    const result = expandGraph(db, [{ factId: "seed", score: 1.0, entry: seed }], { maxDepth: 1 });
+
+    expect(result.some((r) => r.factId.startsWith("src-"))).toBe(false);
+    expect(result.some((r) => r.factId === "semantic")).toBe(true);
+  });
+
 });
 
 // ---------------------------------------------------------------------------

--- a/extensions/memory-hybrid/tests/graph-retrieval.test.ts
+++ b/extensions/memory-hybrid/tests/graph-retrieval.test.ts
@@ -641,7 +641,6 @@ describe("expandGraph: various link types", () => {
     expect(bResult?.linkPath[0].linkType).toBe(linkType);
   });
 
-
   it("does not expand through high-degree DERIVED_FROM provenance hubs", () => {
     const seed = makeEntry("seed");
     const semantic = makeEntry("semantic");
@@ -668,7 +667,6 @@ describe("expandGraph: various link types", () => {
     expect(result.some((r) => r.factId.startsWith("src-"))).toBe(false);
     expect(result.some((r) => r.factId === "semantic")).toBe(true);
   });
-
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #1185.

Prevents dream-cycle episodic consolidation from creating giant low-value provenance hubs from lifecycle/default buckets, and adds graph traversal guards so recall/dashboard expansion does not explode through provenance mega-hubs.

## Changes

- Skip lifecycle/noise events before episodic consolidation.
- Add `nightlyCycle.maxEventsPerConsolidation` with default `200`.
- Skip oversized `__default__` groups instead of creating giant `DERIVED_FROM` hubs.
- Add graph expansion guards for high-degree provenance hubs.
- Add dashboard graph recall guard to avoid expanding through high-degree `DERIVED_FROM` hubs.
- Add regression coverage for lifecycle/default consolidation and provenance hub expansion.

## Verification

- `npm --prefix extensions/memory-hybrid test -- dream-cycle.test.ts graph-retrieval.test.ts`
- `npm --prefix extensions/memory-hybrid run build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes episodic consolidation and graph traversal behavior, which can affect recall results and event-log bookkeeping; main risk is unintended skipping/capping leading to missing consolidated facts or reduced graph expansion.
> 
> **Overview**
> Prevents the nightly dream-cycle from generating huge low-signal `DERIVED_FROM` provenance hubs by (a) skipping known lifecycle/noise events and (b) capping/skipping oversized `__default__` (unattributed) consolidation groups via a new `nightlyCycle.maxEventsPerConsolidation` config (default `200`).
> 
> Adds traversal guards for recall/dashboard graph expansion: introduces `filterTraversableLinks` to cap per-node link fanout and avoid expanding through high-degree provenance hubs (drops `DERIVED_FROM` when a node is too “hubby”), and applies the same guard in the dashboard graph recall path. Updates schema/config parsing/wiring and adds regression tests covering the skip/cap behavior and hub-guarded expansion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ca59a3a2734bb6205c37d39a7c028f9b32f6e54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Related

Refs #1192.
