### PR TITLE
fix(memory-hybrid): dedupe implicit feedback lessons

### DIFF
--- a/extensions/memory-hybrid/cli/cmd-feedback.ts
+++ b/extensions/memory-hybrid/cli/cmd-feedback.ts
@@ -60,7 +60,7 @@ function getImplicitFeedbackLessonsStoredToday(rawDb: ReturnType<HandlerContext[
   if (!rawDb) return 0;
   const startOfDaySec = Math.floor(Date.now() / 86400000) * 86400;
   const row = rawDb
-    .prepare("SELECT COUNT(*) as cnt FROM facts WHERE source = 'implicit-feedback' AND created_at >= ? AND superseded_at IS NULL")
+    .prepare("SELECT COUNT(*) as cnt FROM facts WHERE source = 'implicit-feedback' AND key = 'implicit_feedback_signal' AND created_at >= ? AND superseded_at IS NULL")
     .get(startOfDaySec) as { cnt: number } | undefined;
   return row?.cnt ?? 0;
 }

--- a/extensions/memory-hybrid/cli/cmd-feedback.ts
+++ b/extensions/memory-hybrid/cli/cmd-feedback.ts
@@ -32,6 +32,111 @@ import { loadPrompt } from "../utils/prompt-loader.js";
 import { getSessionFilePathsSince } from "./cmd-extract.js";
 import type { HandlerContext } from "./handlers.js";
 
+
+const IMPLICIT_FEEDBACK_LESSON_TAGS = ["implicit-feedback", "trajectory", "feedback"];
+
+function normalizeLessonTokens(text: string): Set<string> {
+  const normalized = text
+    .toLowerCase()
+    .replace(/[^a-z0-9åäö]+/gi, " ")
+    .split(/\s+/)
+    .map((token) => token.trim())
+    .filter((token) => token.length >= 3);
+  return new Set(normalized);
+}
+
+function tokenJaccard(a: string, b: string): number {
+  const left = normalizeLessonTokens(a);
+  const right = normalizeLessonTokens(b);
+  if (left.size === 0 || right.size === 0) return 0;
+  let intersection = 0;
+  for (const token of left) {
+    if (right.has(token)) intersection++;
+  }
+  return intersection / (left.size + right.size - intersection);
+}
+
+function getImplicitFeedbackLessonsStoredToday(rawDb: ReturnType<HandlerContext["factsDb"]["getRawDb"]>): number {
+  if (!rawDb) return 0;
+  const startOfDaySec = Math.floor(Date.now() / 86400000) * 86400;
+  const row = rawDb
+    .prepare("SELECT COUNT(*) as cnt FROM facts WHERE source = 'implicit-feedback' AND created_at >= ? AND superseded_at IS NULL")
+    .get(startOfDaySec) as { cnt: number } | undefined;
+  return row?.cnt ?? 0;
+}
+
+function findSimilarImplicitFeedbackLesson(
+  rawDb: ReturnType<HandlerContext["factsDb"]["getRawDb"]>,
+  lesson: string,
+  threshold: number,
+): string | null {
+  if (!rawDb) return null;
+  const prefix = lesson.trim().slice(0, 80);
+  const rows = rawDb
+    .prepare(
+      `SELECT id, text FROM facts
+       WHERE source = 'implicit-feedback'
+         AND superseded_at IS NULL
+         AND (tags LIKE '%implicit-feedback%' OR tags LIKE '%trajectory%')
+       ORDER BY created_at DESC
+       LIMIT 500`,
+    )
+    .all() as Array<{ id: string; text: string }>;
+  for (const row of rows) {
+    if (row.text === lesson || (prefix.length >= 20 && row.text.startsWith(prefix))) return row.id;
+    if (tokenJaccard(row.text, lesson) >= threshold) return row.id;
+  }
+  return null;
+}
+
+function markImplicitFeedbackLessonRecalled(rawDb: ReturnType<HandlerContext["factsDb"]["getRawDb"]>, factId: string): void {
+  const nowSec = Math.floor(Date.now() / 1000);
+  rawDb
+    ?.prepare(
+      "UPDATE facts SET recall_count = recall_count + 1, access_count = access_count + 1, last_accessed = ?, last_accessed_at = strftime('%Y-%m-%dT%H:%M:%SZ', ?, 'unixepoch') WHERE id = ?",
+    )
+    .run(nowSec, nowSec, factId);
+}
+
+export function cleanupImplicitFeedbackDuplicates(
+  rawDb: ReturnType<HandlerContext["factsDb"]["getRawDb"]>,
+  opts: { threshold?: number; limit?: number } = {},
+): { scanned: number; collapsed: number } {
+  if (!rawDb) return { scanned: 0, collapsed: 0 };
+  const threshold = opts.threshold ?? 0.8;
+  const limit = opts.limit ?? 1000;
+  if (limit <= 0) return { scanned: 0, collapsed: 0 };
+  const rows = rawDb
+    .prepare(
+      `SELECT id, text, recall_count as recallCount, access_count as accessCount, created_at as createdAt
+       FROM facts
+       WHERE source = 'implicit-feedback' AND superseded_at IS NULL
+       ORDER BY created_at ASC, id ASC
+       LIMIT ?`,
+    )
+    .all(limit) as Array<{ id: string; text: string; recallCount: number; accessCount: number; createdAt: number }>;
+  let collapsed = 0;
+  const canonical: Array<{ id: string; text: string }> = [];
+  const nowSec = Math.floor(Date.now() / 1000);
+  const supersede = rawDb.prepare(
+    "UPDATE facts SET superseded_at = ?, superseded_by = ?, valid_until = ? WHERE id = ? AND superseded_at IS NULL",
+  );
+  const reinforce = rawDb.prepare(
+    "UPDATE facts SET recall_count = recall_count + ?, access_count = access_count + ?, last_accessed = ?, last_accessed_at = strftime('%Y-%m-%dT%H:%M:%SZ', ?, 'unixepoch') WHERE id = ?",
+  );
+  for (const row of rows) {
+    const match = canonical.find((candidate) => candidate.text === row.text || tokenJaccard(candidate.text, row.text) >= threshold);
+    if (!match) {
+      canonical.push({ id: row.id, text: row.text });
+      continue;
+    }
+    supersede.run(nowSec, match.id, nowSec, row.id);
+    reinforce.run(Math.max(1, row.recallCount ?? 0), Math.max(0, row.accessCount ?? 0), nowSec, nowSec, match.id);
+    collapsed++;
+  }
+  return { scanned: rows.length, collapsed };
+}
+
 // ---------------------------------------------------------------------------
 // extract-implicit-feedback
 // ---------------------------------------------------------------------------
@@ -283,20 +388,32 @@ export async function runExtractImplicitFeedbackForCli(
               row.tools_used,
               row.turn_count,
             );
-            // Store lessons as PATTERN_FACT entries in factsDb
+            // Store trajectory lessons as implicit-feedback signals, not reflection patterns.
+            let lessonsStoredToday = getImplicitFeedbackLessonsStoredToday(rawDb);
+            const maxLessonsPerDay = implicitCfg.maxLessonsPerDay ?? 50;
+            const lessonDedupeJaccard = implicitCfg.lessonDedupeJaccard ?? 0.8;
             for (const lesson of traj.lessonsExtracted) {
-              if (!lesson.trim() || factsDb.hasDuplicate(lesson)) continue;
+              const trimmedLesson = lesson.trim();
+              if (!trimmedLesson) continue;
+              const similarId = findSimilarImplicitFeedbackLesson(rawDb, trimmedLesson, lessonDedupeJaccard);
+              if (similarId || factsDb.hasDuplicate(trimmedLesson)) {
+                if (similarId) markImplicitFeedbackLessonRecalled(rawDb, similarId);
+                continue;
+              }
+              if (maxLessonsPerDay > 0 && lessonsStoredToday >= maxLessonsPerDay) continue;
               try {
                 factsDb.store({
-                  text: lesson,
-                  category: "pattern",
-                  importance: 0.6,
+                  text: trimmedLesson,
+                  category: "technical",
+                  importance: 0.5,
                   entity: null,
-                  key: null,
-                  value: lesson.slice(0, 200),
+                  key: "implicit_feedback_signal",
+                  value: trimmedLesson.slice(0, 200),
                   source: "implicit-feedback",
-                  tags: ["trajectory", "feedback"],
+                  tags: IMPLICIT_FEEDBACK_LESSON_TAGS,
+                  decayClass: "normal",
                 });
+                lessonsStoredToday++;
               } catch (err) {
                 capturePluginError(err instanceof Error ? err : new Error(String(err)), {
                   operation: "runExtractImplicitFeedbackForCli:store-lesson",
@@ -320,6 +437,24 @@ export async function runExtractImplicitFeedbackForCli(
           subsystem: "implicit-feedback",
         });
       }
+    }
+  }
+
+  if (!opts.dryRun && implicitCfg.autoCleanup !== false && rawDb) {
+    try {
+      const cleanup = cleanupImplicitFeedbackDuplicates(rawDb, {
+        threshold: implicitCfg.lessonDedupeJaccard ?? 0.8,
+        limit: implicitCfg.cleanupLimit ?? 1000,
+      });
+      if (opts.verbose && cleanup.collapsed > 0) {
+        logger?.info?.(`Implicit-feedback cleanup: collapsed ${cleanup.collapsed}/${cleanup.scanned} near-duplicate signal fact(s)`);
+      }
+    } catch (err) {
+      capturePluginError(err instanceof Error ? err : new Error(String(err)), {
+        operation: "runExtractImplicitFeedbackForCli:cleanup-duplicates",
+        severity: "warning",
+        subsystem: "implicit-feedback",
+      });
     }
   }
 

--- a/extensions/memory-hybrid/cli/cmd-feedback.ts
+++ b/extensions/memory-hybrid/cli/cmd-feedback.ts
@@ -114,7 +114,7 @@ export function cleanupImplicitFeedbackDuplicates(
     .prepare(
       `SELECT id, text, recall_count as recallCount, access_count as accessCount, created_at as createdAt
        FROM facts
-       WHERE source = 'implicit-feedback' AND key = 'implicit_feedback_signal' AND superseded_at IS NULL
+       WHERE source = 'implicit-feedback' AND (key = 'implicit_feedback_signal' OR key IS NULL) AND superseded_at IS NULL
        ORDER BY created_at ASC, id ASC
        LIMIT ?`,
     )

--- a/extensions/memory-hybrid/cli/cmd-feedback.ts
+++ b/extensions/memory-hybrid/cli/cmd-feedback.ts
@@ -32,7 +32,6 @@ import { loadPrompt } from "../utils/prompt-loader.js";
 import { getSessionFilePathsSince } from "./cmd-extract.js";
 import type { HandlerContext } from "./handlers.js";
 
-
 const IMPLICIT_FEEDBACK_LESSON_TAGS = ["implicit-feedback", "trajectory", "feedback"];
 
 function normalizeLessonTokens(text: string): Set<string> {
@@ -60,7 +59,9 @@ function getImplicitFeedbackLessonsStoredToday(rawDb: ReturnType<HandlerContext[
   if (!rawDb) return 0;
   const startOfDaySec = Math.floor(Date.now() / 86400000) * 86400;
   const row = rawDb
-    .prepare("SELECT COUNT(*) as cnt FROM facts WHERE source = 'implicit-feedback' AND key = 'implicit_feedback_signal' AND created_at >= ? AND superseded_at IS NULL")
+    .prepare(
+      "SELECT COUNT(*) as cnt FROM facts WHERE source = 'implicit-feedback' AND key = 'implicit_feedback_signal' AND created_at >= ? AND superseded_at IS NULL",
+    )
     .get(startOfDaySec) as { cnt: number } | undefined;
   return row?.cnt ?? 0;
 }
@@ -89,7 +90,10 @@ function findSimilarImplicitFeedbackLesson(
   return null;
 }
 
-function markImplicitFeedbackLessonRecalled(rawDb: ReturnType<HandlerContext["factsDb"]["getRawDb"]>, factId: string): void {
+function markImplicitFeedbackLessonRecalled(
+  rawDb: ReturnType<HandlerContext["factsDb"]["getRawDb"]>,
+  factId: string,
+): void {
   const nowSec = Math.floor(Date.now() / 1000);
   rawDb
     ?.prepare(
@@ -110,7 +114,7 @@ export function cleanupImplicitFeedbackDuplicates(
     .prepare(
       `SELECT id, text, recall_count as recallCount, access_count as accessCount, created_at as createdAt
        FROM facts
-       WHERE source = 'implicit-feedback' AND superseded_at IS NULL
+       WHERE source = 'implicit-feedback' AND key = 'implicit_feedback_signal' AND superseded_at IS NULL
        ORDER BY created_at ASC, id ASC
        LIMIT ?`,
     )
@@ -125,7 +129,9 @@ export function cleanupImplicitFeedbackDuplicates(
     "UPDATE facts SET recall_count = recall_count + ?, access_count = access_count + ?, last_accessed = ?, last_accessed_at = strftime('%Y-%m-%dT%H:%M:%SZ', ?, 'unixepoch') WHERE id = ?",
   );
   for (const row of rows) {
-    const match = canonical.find((candidate) => candidate.text === row.text || tokenJaccard(candidate.text, row.text) >= threshold);
+    const match = canonical.find(
+      (candidate) => candidate.text === row.text || tokenJaccard(candidate.text, row.text) >= threshold,
+    );
     if (!match) {
       canonical.push({ id: row.id, text: row.text });
       continue;
@@ -400,7 +406,7 @@ export async function runExtractImplicitFeedbackForCli(
                 if (similarId) markImplicitFeedbackLessonRecalled(rawDb, similarId);
                 continue;
               }
-              if (maxLessonsPerDay > 0 && lessonsStoredToday >= maxLessonsPerDay) continue;
+              if (lessonsStoredToday >= maxLessonsPerDay) continue;
               try {
                 factsDb.store({
                   text: trimmedLesson,
@@ -447,7 +453,9 @@ export async function runExtractImplicitFeedbackForCli(
         limit: implicitCfg.cleanupLimit ?? 1000,
       });
       if (opts.verbose && cleanup.collapsed > 0) {
-        logger?.info?.(`Implicit-feedback cleanup: collapsed ${cleanup.collapsed}/${cleanup.scanned} near-duplicate signal fact(s)`);
+        logger?.info?.(
+          `Implicit-feedback cleanup: collapsed ${cleanup.collapsed}/${cleanup.scanned} near-duplicate signal fact(s)`,
+        );
       }
     } catch (err) {
       capturePluginError(err instanceof Error ? err : new Error(String(err)), {

--- a/extensions/memory-hybrid/cli/commands/manage/register-storage-and-stats.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/register-storage-and-stats.ts
@@ -160,6 +160,7 @@ export function registerManageStorageAndStats(mem: Chainable, b: ManageBindings)
           const activity = factsDb.recentActivity();
           const decayBreakdown = factsDb.statsBreakdownByDecayClass();
           const sourceBreakdown = factsDb.statsBySource();
+          const implicitFeedbackSignals = sourceBreakdown["implicit-feedback"] ?? 0;
           const cronJobs = extras.getCronJobsStatus?.() ?? [];
 
           const lanceDelta = sqlCount - lanceCount;
@@ -196,6 +197,7 @@ export function registerManageStorageAndStats(mem: Chainable, b: ManageBindings)
           );
           console.log(`Rules: ${rules}`);
           console.log(`Patterns: ${patterns}`);
+          console.log(`Implicit-feedback signals: ${implicitFeedbackSignals}`);
           console.log(`Meta-patterns: ${metaPatterns}`);
           console.log(`Directives: ${directives}`);
           console.log(`Reflection (patterns/rules): ${reflectionPatternsCount}/${reflectionRulesCount}`);

--- a/extensions/memory-hybrid/config/parsers/features.ts
+++ b/extensions/memory-hybrid/config/parsers/features.ts
@@ -558,6 +558,17 @@ export function parseImplicitFeedbackConfig(cfg: Record<string, unknown>): Impli
     // Issue #754: top-level takes precedence; fall back to nested with deprecation warning
     feedToSelfCorrection:
       topLevelFeedToSelfCorrection !== undefined ? topLevelFeedToSelfCorrection : raw?.feedToSelfCorrection !== false,
+    maxLessonsPerDay:
+      typeof raw?.maxLessonsPerDay === "number" && raw.maxLessonsPerDay >= 0
+        ? Math.min(1000, Math.floor(raw.maxLessonsPerDay))
+        : 50,
+    lessonDedupeJaccard:
+      typeof raw?.lessonDedupeJaccard === "number" && raw.lessonDedupeJaccard > 0 && raw.lessonDedupeJaccard <= 1
+        ? raw.lessonDedupeJaccard
+        : 0.8,
+    autoCleanup: raw?.autoCleanup !== false,
+    cleanupLimit:
+      typeof raw?.cleanupLimit === "number" && raw.cleanupLimit >= 0 ? Math.min(10000, Math.floor(raw.cleanupLimit)) : 1000,
     trajectoryLLMAnalysis:
       topLevelTrajectoryLLMAnalysis !== undefined ? topLevelTrajectoryLLMAnalysis : raw?.trajectoryLLMAnalysis === true,
   };

--- a/extensions/memory-hybrid/config/parsers/features.ts
+++ b/extensions/memory-hybrid/config/parsers/features.ts
@@ -568,7 +568,9 @@ export function parseImplicitFeedbackConfig(cfg: Record<string, unknown>): Impli
         : 0.8,
     autoCleanup: raw?.autoCleanup !== false,
     cleanupLimit:
-      typeof raw?.cleanupLimit === "number" && raw.cleanupLimit >= 0 ? Math.min(10000, Math.floor(raw.cleanupLimit)) : 1000,
+      typeof raw?.cleanupLimit === "number" && raw.cleanupLimit >= 0
+        ? Math.min(10000, Math.floor(raw.cleanupLimit))
+        : 1000,
     trajectoryLLMAnalysis:
       topLevelTrajectoryLLMAnalysis !== undefined ? topLevelTrajectoryLLMAnalysis : raw?.trajectoryLLMAnalysis === true,
   };

--- a/extensions/memory-hybrid/config/types/features.ts
+++ b/extensions/memory-hybrid/config/types/features.ts
@@ -224,6 +224,14 @@ export type ImplicitFeedbackConfig = {
   feedToSelfCorrection: boolean;
   /** Use LLM-based trajectory analysis instead of heuristic lesson extraction (default: false). */
   trajectoryLLMAnalysis: boolean;
+  /** Maximum implicit-feedback lessons to store per UTC day (default: 50). */
+  maxLessonsPerDay: number;
+  /** Token-Jaccard threshold for implicit-feedback lesson near-duplicate suppression (default: 0.8). */
+  lessonDedupeJaccard: number;
+  /** Collapse historical near-duplicate implicit-feedback facts after extraction (default: true). */
+  autoCleanup: boolean;
+  /** Maximum historical implicit-feedback facts to scan per cleanup run (default: 1000). */
+  cleanupLimit: number;
 };
 
 /** Frustration signal weights override (Issue #263 — Phase 1). */

--- a/extensions/memory-hybrid/tests/implicit-feedback-routing.test.ts
+++ b/extensions/memory-hybrid/tests/implicit-feedback-routing.test.ts
@@ -285,7 +285,6 @@ describe("implicit feedback routing — negative → pattern facts", () => {
     }
   });
 
-
   it("collapses historical near-duplicate implicit-feedback facts", () => {
     const db = makeDb(tmpDir);
     const first = db.store({

--- a/extensions/memory-hybrid/tests/implicit-feedback-routing.test.ts
+++ b/extensions/memory-hybrid/tests/implicit-feedback-routing.test.ts
@@ -12,7 +12,11 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { type HandlerContext, runExtractImplicitFeedbackForCli } from "../cli/handlers.js";
+import {
+  cleanupImplicitFeedbackDuplicates,
+  type HandlerContext,
+  runExtractImplicitFeedbackForCli,
+} from "../cli/handlers.js";
 import type { ManageContext } from "../cli/manage.js";
 import type { HybridMemoryConfig } from "../config.js";
 import { _testing } from "../index.js";
@@ -279,6 +283,33 @@ describe("implicit feedback routing — negative → pattern facts", () => {
       expect(tags).toContain("implicit-feedback");
       expect(tags).toContain("negative");
     }
+  });
+
+
+  it("collapses historical near-duplicate implicit-feedback facts", () => {
+    const db = makeDb(tmpDir);
+    const first = db.store({
+      text: "User satisfaction increases when the agent provides concrete next steps",
+      category: "technical",
+      source: "implicit-feedback",
+      tags: ["implicit-feedback", "trajectory", "feedback"],
+    });
+    const duplicate = db.store({
+      text: "User satisfaction improves when the agent provides concrete next steps",
+      category: "technical",
+      source: "implicit-feedback",
+      tags: ["implicit-feedback", "trajectory", "feedback"],
+    });
+
+    const result = cleanupImplicitFeedbackDuplicates(rawDb(db), { threshold: 0.7, limit: 100 });
+
+    expect(result.collapsed).toBe(1);
+    const rows = rawDb(db)
+      .prepare("SELECT id, superseded_by as supersededBy, superseded_at as supersededAt FROM facts WHERE id IN (?, ?)")
+      .all(first.id, duplicate.id) as Array<{ id: string; supersededBy: string | null; supersededAt: number | null }>;
+    const duplicateRow = rows.find((row) => row.id === duplicate.id);
+    expect(duplicateRow?.supersededBy).toBe(first.id);
+    expect(duplicateRow?.supersededAt).toBeTypeOf("number");
   });
 
   it("does NOT store implicit-feedback pattern facts when feedToSelfCorrection=false", async () => {


### PR DESCRIPTION
## Summary

Fixes #1186.

Prevents `extract-implicit-feedback` from growing the `pattern` category with near-duplicate trajectory lessons, and adds automatic incremental cleanup for historical near-duplicate implicit-feedback facts.

## Changes

- Route trajectory lessons from `source="implicit-feedback"` to `category="technical"` with explicit `implicit-feedback` tags instead of `category="pattern"`.
- Add token-Jaccard near-duplicate suppression for implicit-feedback lessons.
- Increment `recall_count` / `last_accessed` on the existing similar fact when a near-duplicate is skipped.
- Add `implicitFeedback.maxLessonsPerDay` default `50`.
- Add `implicitFeedback.lessonDedupeJaccard` default `0.8`.
- Add `implicitFeedback.autoCleanup` default `true`.
- Add `implicitFeedback.cleanupLimit` default `1000`.
- Automatically collapse historical near-duplicate implicit-feedback facts by superseding duplicates into a canonical fact and transferring access/recall signal.
- Add rich stats line for `Implicit-feedback signals` so reflection patterns and feedback signals are visible separately.

## Verification

- `npm --prefix extensions/memory-hybrid test -- implicit-feedback-routing.test.ts implicit-feedback.test.ts`
- `npm --prefix extensions/memory-hybrid run build`

## Notes

Cleanup is intentionally incremental and non-destructive: it supersedes duplicate implicit-feedback facts instead of deleting rows. A larger offline migration/reporting job can still be added later for dry-run summaries across very large stores.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new implicit-feedback lesson dedupe and auto-cleanup that mutates the `facts` table (superseding rows and updating recall/access counters), so mis-tuned thresholds/limits could incorrectly collapse distinct lessons or increase write load during extraction.
> 
> **Overview**
> Prevents `extract-implicit-feedback` trajectory lessons from polluting `pattern` facts by storing them as `technical` implicit-feedback signal facts with a stable `key` (`implicit_feedback_signal`) and explicit tags.
> 
> Adds token-Jaccard near-duplicate suppression when storing lessons (including incrementing recall/access on the existing similar fact), daily lesson caps (`maxLessonsPerDay`), and an optional post-run incremental cleanup that supersedes historical near-duplicates and transfers recall/access counts.
> 
> Updates CLI `stats` output to surface an `Implicit-feedback signals` count separately, extends config parsing/types with the new implicit-feedback knobs, and adds a test covering duplicate-collapsing behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7ad102bc7d5be1882d8d312725015f5eca3777c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Related

Refs #1194.
Refs #1189.
