### PR TITLE
feat(memory-hybrid): dream-cycle dedupe observability (#1228) + hydration throttle (#1229)

### DIFF
--- a/extensions/memory-hybrid/backends/vector-db.ts
+++ b/extensions/memory-hybrid/backends/vector-db.ts
@@ -36,7 +36,7 @@ const _optimizingByPath = new Map<string, boolean>();
 const _optimizeFailuresByPath = new Map<string, number>();
 const SEMANTIC_QUERY_CACHE_MAX_ROWS_PER_FILTER_KEY = 100;
 
-type VectorDBLogger = { warn: (msg: string) => void };
+type VectorDBLogger = { warn: (msg: string) => void; info?: (msg: string) => void };
 
 interface SemanticQueryCacheEntry {
   id: string;
@@ -115,6 +115,11 @@ export class VectorDB {
    */
   private isPersistent = false;
   /**
+   * When true (e.g. dream-cycle `--verbose`), emit `pluginLogger.info` milestones during
+   * Lance reconnect and table initialization so long silent phases are distinguishable from hangs (#1228).
+   */
+  private maintenanceVerbose = false;
+  /**
    * Reader-count for the exclusive-writer lock guarding optimize() vs concurrent reads.
    * Issue #768: optimize({cleanupOlderThan}) removes old LanceDB data versions while
    * concurrent search/hasDuplicate calls are in-flight — causing "Not found: ...lance"
@@ -139,6 +144,21 @@ export class VectorDB {
 
   setLogger(logger: VectorDBLogger): void {
     this.logger = logger;
+  }
+
+  /** Enable/disable extra Lance init/reconnect progress lines (used by dream-cycle `--verbose`). */
+  setMaintenanceVerbose(enabled: boolean): void {
+    this.maintenanceVerbose = enabled;
+  }
+
+  private logMaintenanceInfo(msg: string): void {
+    if (!this.maintenanceVerbose) return;
+    const text = `memory-hybrid: ${msg}`;
+    if (this.logger && typeof this.logger.info === "function") {
+      this.logger.info(text);
+    } else {
+      pluginLogger.info(text);
+    }
   }
 
   private logWarn(msg: string): void {
@@ -233,6 +253,9 @@ export class VectorDB {
     // reconnect. Mirrors the FactsDB/CredentialsDB liveDb() pattern for post-restart recovery.
     if (this.closed) {
       this.logWarn("memory-hybrid: VectorDB was closed; reconnecting...");
+      this.logMaintenanceInfo(
+        "VectorDB reconnect — closed flag cleared; reopening Lance connection (connect → openTable → schema check)",
+      );
       this.closed = false;
       // Allow a fresh connection attempt after an explicit close/reopen cycle
       // (e.g., plugin reload). Clear both degraded-mode signals so doInitialize() can retry.
@@ -301,6 +324,8 @@ export class VectorDB {
     // edge case or WSL path mapping), resolve it relative to process.cwd() so the binding
     // can still locate the data directory.
     const resolvedPath = isAbsolute(this.dbPath) ? this.dbPath : pathResolve(this.dbPath);
+    const initStarted = Date.now();
+    this.logMaintenanceInfo(`VectorDB init — connecting (path=${resolvedPath}, vectorDim=${this.vectorDim})`);
 
     try {
       this.db = await lancedb.connect(resolvedPath);
@@ -317,6 +342,7 @@ export class VectorDB {
       );
       return;
     }
+    this.logMaintenanceInfo(`VectorDB init — lancedb.connect done (${Date.now() - initStarted}ms); listing tables`);
     // Guard: a concurrent close() may have nulled this.db between the connect() await and here.
     if (!this.db) throw new Error("VectorDB connection lost during initialization (concurrent close).");
     // Guard: plugin re-registration (hot-reload/SIGUSR1) may have called close() concurrently.
@@ -328,15 +354,18 @@ export class VectorDB {
       throw new Error("VectorDB initialization aborted: closed during tableNames (concurrent re-registration).");
 
     if (tables.includes(LANCE_TABLE)) {
+      this.logMaintenanceInfo(`VectorDB init — opening existing table '${LANCE_TABLE}'`);
       this.table = await this.db.openTable(LANCE_TABLE);
       if (!this.db || this.closed)
         throw new Error("VectorDB initialization aborted: closed during openTable (concurrent re-registration).");
+      this.logMaintenanceInfo("VectorDB init — validating / repairing memories schema");
       await this.validateOrRepairSchema();
       if (!this.db || this.closed)
         throw new Error(
           "VectorDB initialization aborted: closed during validateOrRepairSchema (concurrent re-registration).",
         );
     } else {
+      this.logMaintenanceInfo(`VectorDB init — creating empty table '${LANCE_TABLE}'`);
       this.table = await this.db.createTable(LANCE_TABLE, [
         {
           id: "__schema__",
@@ -355,7 +384,12 @@ export class VectorDB {
       }
     }
 
+    this.logMaintenanceInfo(
+      `VectorDB init — memories table ready (schemaValid=${this.schemaValid}, wasRepaired=${this.wasRepaired})`,
+    );
+    this.logMaintenanceInfo("VectorDB init — semantic query cache table");
     await this.ensureSemanticQueryCacheTable();
+    this.logMaintenanceInfo(`VectorDB init — complete (${Date.now() - initStarted}ms total)`);
   }
 
   private async ensureSemanticQueryCacheTable(): Promise<void> {
@@ -1301,7 +1335,10 @@ export class VectorDB {
    * Used by reflection dedupe to avoid re-embedding the entire corpus each run.
    * Map keys are lowercase UUIDs. Unknown ids and wrong-dimension vectors are omitted.
    */
-  async getVectorsByFactIds(ids: string[]): Promise<Map<string, number[]>> {
+  async getVectorsByFactIds(
+    ids: string[],
+    options?: { onChunkProgress?: (loaded: number, total: number) => void },
+  ): Promise<Map<string, number[]>> {
     const out = new Map<string, number[]>();
     if (!this.lanceDbAvailable || ids.length === 0) return out;
     try {
@@ -1323,6 +1360,7 @@ export class VectorDB {
             const vec = this.vectorColumnToNumbers((row as { vector?: unknown }).vector);
             if (vec && vec.length === this.vectorDim) out.set(id, vec);
           }
+          options?.onChunkProgress?.(Math.min(offset + chunk.length, unique.length), unique.length);
         }
       } finally {
         this.releaseReader(acquired);

--- a/extensions/memory-hybrid/cli/commands/manage/register-corrections-and-pipeline.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/register-corrections-and-pipeline.ts
@@ -452,30 +452,37 @@ export function registerManageCorrectionsAndPipeline(mem: Chainable, b: ManageBi
     .option("--threshold <n>", "Similarity threshold (0-1, default 0.85)", "0.85")
     .option("--include-structured", "Include structured facts (kv, credentials) in search")
     .option("--limit <n>", "Max pairs to return (default 100)", "100")
+    .option("-v, --verbose", "Log embedding batches and Lance scan progress")
     .action(
-      withExit(async (opts?: { threshold?: string; includeStructured?: boolean; limit?: string }) => {
-        const threshold = Number.parseFloat(opts?.threshold ?? "0.85");
-        const includeStructured = !!opts?.includeStructured;
-        const limit = Number.parseInt(opts?.limit ?? "100", 10);
-        let res;
-        try {
-          res = await runFindDuplicates({ threshold, includeStructured, limit });
-        } catch (err) {
-          capturePluginError(err instanceof Error ? err : new Error(String(err)), {
-            subsystem: "cli",
-            operation: "find-duplicates",
-          });
-          throw err;
-        }
-        console.log(
-          `Found ${res.pairs.length} duplicate pairs (threshold=${threshold}, candidates=${res.candidatesCount}, skippedStructured=${res.skippedStructured})`,
-        );
-        for (const p of res.pairs) {
-          console.log(`  [${p.idA}] <-> [${p.idB}] (score=${p.score.toFixed(3)})`);
-          console.log(`    A: ${p.textA.substring(0, 60)}...`);
-          console.log(`    B: ${p.textB.substring(0, 60)}...`);
-        }
-      }),
+      withExit(
+        async (
+          opts?: { threshold?: string; includeStructured?: boolean; limit?: string; verbose?: boolean },
+          cmd?: CommanderOptsParent,
+        ) => {
+          const threshold = Number.parseFloat(opts?.threshold ?? "0.85");
+          const includeStructured = !!opts?.includeStructured;
+          const limit = Number.parseInt(opts?.limit ?? "100", 10);
+          const verbose = !!opts?.verbose || readHybridMemVerbose(cmd);
+          let res;
+          try {
+            res = await runFindDuplicates({ threshold, includeStructured, limit, verbose });
+          } catch (err) {
+            capturePluginError(err instanceof Error ? err : new Error(String(err)), {
+              subsystem: "cli",
+              operation: "find-duplicates",
+            });
+            throw err;
+          }
+          console.log(
+            `Found ${res.pairs.length} duplicate pairs (threshold=${threshold}, candidates=${res.candidatesCount}, skippedStructured=${res.skippedStructured})`,
+          );
+          for (const p of res.pairs) {
+            console.log(`  [${p.idA}] <-> [${p.idB}] (score=${p.score.toFixed(3)})`);
+            console.log(`    A: ${p.textA.substring(0, 60)}...`);
+            console.log(`    B: ${p.textB.substring(0, 60)}...`);
+          }
+        },
+      ),
     );
 
   mem
@@ -486,23 +493,29 @@ export function registerManageCorrectionsAndPipeline(mem: Chainable, b: ManageBi
     .option("--dry-run", "Show what would be consolidated without consolidating")
     .option("--limit <n>", "Max clusters to process (default 10)", "10")
     .option("--model <m>", "LLM model for merging (default: default tier from config)")
+    .option("-v, --verbose", "Log Lance + embedding corpus load progress for clustering")
     .action(
       withExit(
-        async (opts?: {
-          threshold?: string;
-          includeStructured?: boolean;
-          dryRun?: boolean;
-          limit?: string;
-          model?: string;
-        }) => {
+        async (
+          opts?: {
+            threshold?: string;
+            includeStructured?: boolean;
+            dryRun?: boolean;
+            limit?: string;
+            model?: string;
+            verbose?: boolean;
+          },
+          cmd?: CommanderOptsParent,
+        ) => {
           const threshold = Number.parseFloat(opts?.threshold ?? "0.85");
           const includeStructured = !!opts?.includeStructured;
           const dryRun = !!opts?.dryRun;
           const limit = Number.parseInt(opts?.limit ?? "10", 10);
           const model = opts?.model ?? getDefaultCronModel(getCronModelConfig(ctx.cfg), "maintenance");
+          const verbose = !!opts?.verbose || readHybridMemVerbose(cmd);
           let res;
           try {
-            res = await runConsolidate({ threshold, includeStructured, dryRun, limit, model });
+            res = await runConsolidate({ threshold, includeStructured, dryRun, limit, model, verbose });
           } catch (err) {
             capturePluginError(err instanceof Error ? err : new Error(String(err)), {
               subsystem: "cli",

--- a/extensions/memory-hybrid/cli/context.ts
+++ b/extensions/memory-hybrid/cli/context.ts
@@ -66,6 +66,7 @@ export type ManageContext = {
     threshold: number;
     includeStructured: boolean;
     limit: number;
+    verbose?: boolean;
   }) => Promise<FindDuplicatesResult>;
   runConsolidate: (opts: {
     threshold: number;
@@ -73,6 +74,7 @@ export type ManageContext = {
     dryRun: boolean;
     limit: number;
     model: string;
+    verbose?: boolean;
   }) => Promise<{ clustersFound: number; merged: number; deleted: number }>;
   runReflection: (opts: { window: number; dryRun: boolean; model: string; verbose?: boolean }) => Promise<{
     factsAnalyzed: number;

--- a/extensions/memory-hybrid/cli/register.ts
+++ b/extensions/memory-hybrid/cli/register.ts
@@ -155,6 +155,7 @@ export type HybridMemCliContext = {
     threshold: number;
     includeStructured: boolean;
     limit: number;
+    verbose?: boolean;
   }) => Promise<FindDuplicatesResult>;
   runConsolidate: (opts: {
     threshold: number;
@@ -162,6 +163,7 @@ export type HybridMemCliContext = {
     dryRun: boolean;
     limit: number;
     model: string;
+    verbose?: boolean;
   }) => Promise<{ clustersFound: number; merged: number; deleted: number }>;
   runReflection: (opts: { window: number; dryRun: boolean; model: string; verbose?: boolean }) => Promise<{
     factsAnalyzed: number;

--- a/extensions/memory-hybrid/config/parsers/capture.ts
+++ b/extensions/memory-hybrid/config/parsers/capture.ts
@@ -47,6 +47,28 @@ export function parsePassiveObserverConfig(cfg: Record<string, unknown>): Passiv
 
 export function parseReflectionConfig(cfg: Record<string, unknown>): ReflectionConfig {
   const reflectionRaw = cfg.reflection as Record<string, unknown> | undefined;
+  const dhRaw = reflectionRaw?.dedupeHydration as Record<string, unknown> | undefined;
+  const dedupeHydration: ReflectionConfig["dedupeHydration"] =
+    dhRaw && typeof dhRaw === "object"
+      ? {
+          maxEmbedsPerRun:
+            typeof dhRaw.maxEmbedsPerRun === "number" && dhRaw.maxEmbedsPerRun >= 0
+              ? Math.min(2_000_000, Math.floor(dhRaw.maxEmbedsPerRun))
+              : undefined,
+          minIntervalMsBetweenEmbeds:
+            typeof dhRaw.minIntervalMsBetweenEmbeds === "number" && dhRaw.minIntervalMsBetweenEmbeds >= 0
+              ? Math.min(120_000, Math.floor(dhRaw.minIntervalMsBetweenEmbeds))
+              : undefined,
+          maxConsecutive429BeforeDefer:
+            typeof dhRaw.maxConsecutive429BeforeDefer === "number" && dhRaw.maxConsecutive429BeforeDefer >= 1
+              ? Math.min(50, Math.floor(dhRaw.maxConsecutive429BeforeDefer))
+              : undefined,
+          baseBackoffMsAfter429:
+            typeof dhRaw.baseBackoffMsAfter429 === "number" && dhRaw.baseBackoffMsAfter429 >= 0
+              ? Math.min(600_000, Math.floor(dhRaw.baseBackoffMsAfter429))
+              : undefined,
+        }
+      : undefined;
   return {
     enabled: reflectionRaw?.enabled === true,
     model: typeof reflectionRaw?.model === "string" ? reflectionRaw.model : undefined,
@@ -58,6 +80,7 @@ export function parseReflectionConfig(cfg: Record<string, unknown>): ReflectionC
       typeof reflectionRaw?.minObservations === "number" && reflectionRaw.minObservations >= 1
         ? Math.floor(reflectionRaw.minObservations)
         : 2,
+    ...(dedupeHydration && Object.values(dedupeHydration).some((v) => v !== undefined) ? { dedupeHydration } : {}),
   };
 }
 

--- a/extensions/memory-hybrid/config/types/capture.ts
+++ b/extensions/memory-hybrid/config/types/capture.ts
@@ -16,12 +16,28 @@ export type PassiveObserverConfig = {
   sessionsDir?: string;
 };
 
+/**
+ * Throttle + checkpoint for embedding-backed reflection dedupe corpus hydration (#1229).
+ * Omitted fields use built-in defaults (bounded embeds/run, min interval, 429 defer).
+ */
+export type ReflectionDedupeHydrationConfig = {
+  /** Max embedding API calls per run for reflection/reflect-rules/reflect-meta dedupe hydration (0 = unlimited). */
+  maxEmbedsPerRun?: number;
+  /** Minimum delay between consecutive embedding calls in that path (ms). */
+  minIntervalMsBetweenEmbeds?: number;
+  /** Consecutive rate-limit errors before deferring remaining backlog to a later run. */
+  maxConsecutive429BeforeDefer?: number;
+  /** Base backoff (ms) when rate-limited; grows exponentially with consecutive 429s. */
+  baseBackoffMsAfter429?: number;
+};
+
 /** Reflection / pattern synthesis from session history */
 export type ReflectionConfig = {
   enabled: boolean;
   model?: string; // when unset, runtime uses getDefaultCronModel(cfg, "default")
   defaultWindow: number; // Time window in days (default: 14)
   minObservations: number; // Min observations to support a pattern (default: 2)
+  dedupeHydration?: ReflectionDedupeHydrationConfig;
 };
 
 /** Identity reflection: persona-level synthesis from reflection outputs */

--- a/extensions/memory-hybrid/index.ts
+++ b/extensions/memory-hybrid/index.ts
@@ -859,7 +859,7 @@ export function isHybridMemJsonCliInvocation(argv: string[]): boolean {
   for (let i = hybridIdx + 1; i < argv.length; i++) {
     const a = argv[i];
     if (a === "--") return false;
-    if (a === "--json" || a === "--format=json" || a === "--format" && argv[i + 1] === "json") return true;
+    if (a === "--json" || a === "--format=json" || (a === "--format" && argv[i + 1] === "json")) return true;
   }
   return false;
 }

--- a/extensions/memory-hybrid/index.ts
+++ b/extensions/memory-hybrid/index.ts
@@ -225,7 +225,7 @@ import {
   setKeywordsPath,
 } from "./utils/language-keywords.js";
 import { getDirectiveSignalRegex, getReinforcementSignalRegex } from "./utils/language-keywords.js";
-import { initPluginLogger } from "./utils/logger.js";
+import { createJsonCliStderrLogger, initPluginLogger } from "./utils/logger.js";
 import { fillPrompt, loadPrompt } from "./utils/prompt-loader.js";
 import { computeDynamicSalience } from "./utils/salience.js";
 import { buildToolScopeFilter } from "./utils/scope-filter.js";
@@ -404,7 +404,12 @@ function runMemoryHybridRegister(api: ClawdbotPluginApi): void {
   }
 
   // Initialize structured logger early so all runtime code (services/backends/lifecycle)
-  // routes through api.logger instead of raw console.*.
+  // routes through api.logger instead of raw console.*. For JSON CLI invocations, keep
+  // stdout pure by routing *both* pluginLogger and direct api.logger calls to stderr (issue #1234).
+  const jsonCli = isHybridMemJsonCliInvocation(process.argv);
+  if (jsonCli) {
+    api = { ...api, logger: createJsonCliStderrLogger() } as ClawdbotPluginApi;
+  }
   initPluginLogger(api.logger);
 
   // Reopen guard: ensure any previous instance is closed before creating new one (avoids duplicate
@@ -843,6 +848,22 @@ function runMemoryHybridRegister(api: ClawdbotPluginApi): void {
 }
 
 /** Exported for tests. Stops at `--` so `hybrid-mem store -- --help` is not treated as plugin-level help. */
+
+/**
+ * True when this standalone hybrid-mem CLI invocation explicitly requested machine-readable JSON.
+ * Keep this deliberately syntactic and early: it runs before command registration has parsed options.
+ */
+export function isHybridMemJsonCliInvocation(argv: string[]): boolean {
+  const hybridIdx = argv.indexOf("hybrid-mem");
+  if (hybridIdx === -1) return false;
+  for (let i = hybridIdx + 1; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--") return false;
+    if (a === "--json" || a === "--format=json" || a === "--format" && argv[i + 1] === "json") return true;
+  }
+  return false;
+}
+
 export function isHybridMemHelpInvocation(argv: string[]): boolean {
   const hybridIdx = argv.indexOf("hybrid-mem");
   if (hybridIdx === -1) return false;

--- a/extensions/memory-hybrid/services/consolidation.ts
+++ b/extensions/memory-hybrid/services/consolidation.ts
@@ -157,7 +157,7 @@ export async function runConsolidate(
     "consolidate-embed",
     { verbose: opts.verbose === true, progressLabel: "consolidate dedupe corpus" },
   );
-  const vectors = vectorResults.map((v) => (v === null ? [] : v));
+  const vectors = vectorResults.vectors.map((v) => (v === null ? [] : v));
 
   const _idToIndex = new Map(ids.map((id, idx) => [id, idx]));
   const edges: Array<[string, string]> = [];

--- a/extensions/memory-hybrid/services/consolidation.ts
+++ b/extensions/memory-hybrid/services/consolidation.ts
@@ -29,6 +29,8 @@ interface ConsolidateOptions {
   dryRun: boolean;
   limit: number;
   model: string;
+  /** Verbose vector load / dedupe corpus progress (#1228). */
+  verbose?: boolean;
 }
 
 interface ConsolidateResult {
@@ -153,6 +155,7 @@ export async function runConsolidate(
     logger,
     "memory-hybrid: consolidate",
     "consolidate-embed",
+    { verbose: opts.verbose === true, progressLabel: "consolidate dedupe corpus" },
   );
   const vectors = vectorResults.map((v) => (v === null ? [] : v));
 

--- a/extensions/memory-hybrid/services/cron-maintenance-reconciler.ts
+++ b/extensions/memory-hybrid/services/cron-maintenance-reconciler.ts
@@ -367,13 +367,11 @@ export function reconcileHybridMemCronMaintenanceOutcomes(
           .split("\n")
           .filter((line) => line.trim().length > 0)
           .map((line) => readJsonString(line) ?? line);
-        const patchedByTs = new Map(records.map((r) => [String(r.ts ?? `${r.jobId}:${r.summary}`), r]));
-        const merged = allRecords.map((entry) => {
+        const tailStart = Math.max(0, allRecords.length - records.length);
+        const merged = allRecords.map((entry, idx) => {
           if (typeof entry === "string") return entry;
-          const key = String(
-            (entry as CronRunRecord).ts ?? `${(entry as CronRunRecord).jobId}:${(entry as CronRunRecord).summary}`,
-          );
-          return patchedByTs.get(key) ?? entry;
+          if (idx < tailStart) return entry;
+          return records[idx - tailStart] ?? entry;
         });
         writeFileSync(
           runPath,

--- a/extensions/memory-hybrid/services/cron-maintenance-reconciler.ts
+++ b/extensions/memory-hybrid/services/cron-maintenance-reconciler.ts
@@ -1,0 +1,396 @@
+/**
+ * Reconcile hybrid-memory maintenance validation back into OpenClaw cron state.
+ *
+ * Issue #1233: OpenClaw cron marks isolated agent-turn jobs as `ok` when the agent
+ * returns a normal message, even if the embedded hybrid-mem maintenance harness
+ * reported `FAILED` / `maintenanceStatus:"failed"`. This service is intentionally
+ * narrow and idempotent: it only touches `hybrid-mem:*` jobs/runs that are still
+ * recorded as ok and whose summary or run artifacts prove maintenance failed.
+ */
+
+import { existsSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { basename, join } from "node:path";
+import { validateMaintenanceExecution, type ExitValidationResult } from "./cron-exit-validator.js";
+
+const HYBRID_MEM_JOB_PREFIX = "hybrid-mem:";
+const DEFAULT_LOOKBACK_MS = 48 * 60 * 60 * 1000;
+const DEFAULT_MAX_RUN_RECORDS_PER_FILE = 20;
+
+export type CronMaintenanceReconcileLogger = {
+  info?: (s: string) => void;
+  warn?: (s: string) => void;
+  debug?: (s: string) => void;
+};
+
+export interface CronMaintenanceReconcileOptions {
+  openclawDir?: string;
+  nowMs?: number;
+  lookbackMs?: number;
+  maxRunRecordsPerFile?: number;
+}
+
+export interface CronMaintenanceReconcileResult {
+  runsCorrected: number;
+  jobsCorrected: number;
+  inspectedRuns: number;
+  errors: string[];
+}
+
+type CronRunRecord = Record<string, unknown> & {
+  ts?: number;
+  jobId?: string;
+  status?: string;
+  summary?: string;
+  error?: string;
+};
+
+type CronJobRecord = Record<string, unknown> & {
+  id?: string;
+  pluginJobId?: string;
+  name?: string;
+  state?: Record<string, unknown>;
+};
+
+interface FailureEvidence {
+  status: "failed" | "partial";
+  error: string;
+  logPath?: string;
+  exitPath?: string;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : null;
+}
+
+function readJsonFile(path: string): unknown | null {
+  try {
+    return JSON.parse(readFileSync(path, "utf-8"));
+  } catch {
+    return null;
+  }
+}
+
+function parseJsonObjectsFromText(text: string): Record<string, unknown>[] {
+  const objects: Record<string, unknown>[] = [];
+  const needles: number[] = [];
+  let idx = text.indexOf("maintenanceStatus");
+  while (idx >= 0) {
+    needles.push(idx);
+    idx = text.indexOf("maintenanceStatus", idx + 1);
+  }
+
+  for (const needle of needles) {
+    const start = text.lastIndexOf("{", needle);
+    if (start < 0) continue;
+    let depth = 0;
+    let inString = false;
+    let escaped = false;
+    for (let i = start; i < text.length; i++) {
+      const ch = text[i];
+      if (inString) {
+        if (escaped) {
+          escaped = false;
+        } else if (ch === "\\") {
+          escaped = true;
+        } else if (ch === '"') {
+          inString = false;
+        }
+        continue;
+      }
+      if (ch === '"') {
+        inString = true;
+      } else if (ch === "{") {
+        depth++;
+      } else if (ch === "}") {
+        depth--;
+        if (depth === 0) {
+          const parsed = readJsonString(text.slice(start, i + 1));
+          if (parsed) objects.push(parsed);
+          break;
+        }
+      }
+    }
+  }
+  return objects;
+}
+
+function readJsonString(raw: string): Record<string, unknown> | null {
+  try {
+    return asRecord(JSON.parse(raw));
+  } catch {
+    return null;
+  }
+}
+
+function validationToEvidence(validation: ExitValidationResult): FailureEvidence | null {
+  if (validation.maintenanceStatus !== "failed" && validation.maintenanceStatus !== "partial") return null;
+  return {
+    status: validation.maintenanceStatus,
+    error: validation.error ?? `maintenanceStatus=${validation.maintenanceStatus}`,
+    logPath: validation.logPath,
+    exitPath: validation.exitPath,
+  };
+}
+
+function evidenceFromStructuredStatus(obj: Record<string, unknown>): FailureEvidence | null {
+  const status = obj.maintenanceStatus;
+  if (status !== "failed" && status !== "partial") return null;
+  return {
+    status,
+    error: typeof obj.error === "string" && obj.error.trim() ? obj.error.trim() : `maintenanceStatus=${status}`,
+    logPath: typeof obj.logPath === "string" ? obj.logPath : undefined,
+    exitPath: typeof obj.exitPath === "string" ? obj.exitPath : undefined,
+  };
+}
+
+function extractPath(summary: string, label: "HM_EXIT" | "HM_LOG"): string | undefined {
+  const re = new RegExp(`${label}[^\n]*?(?:path)?[^\n]*?[:\\n]\\s*\`?([^\`\n]+?${label === "HM_EXIT" ? "\\.exit\\.txt" : "\\.log"})\`?`, "i");
+  const match = summary.match(re);
+  return match?.[1]?.trim();
+}
+
+const JOB_REQUIRED_STEPS: Record<string, string[]> = {
+  "hybrid-mem:nightly-distill": ["prune", "distill", "extract-daily", "resolve-contradictions", "enrich-entities"],
+  "hybrid-mem:self-correction-analysis": ["self-correction-run"],
+  "hybrid-mem:weekly-reflection": ["reflect", "reflect-rules", "reflect-meta"],
+  "hybrid-mem:weekly-extract-procedures": [
+    "extract-procedures",
+    "extract-directives",
+    "extract-reinforcement",
+    "generate-auto-skills",
+  ],
+  "hybrid-mem:weekly-audit-health": ["audit-health"],
+  "hybrid-mem:maintenance-log-analyzer": ["analyze-maintenance-logs"],
+  "hybrid-mem:weekly-pending-digest": ["digest-pending"],
+  "hybrid-mem:weekly-deep-maintenance": ["compact", "vectordb-optimize", "scope-promote"],
+  "hybrid-mem:weekly-persona-proposals": ["generate-proposals"],
+  "hybrid-mem:monthly-consolidation": [
+    "consolidate",
+    "build-languages",
+    "backfill-decay",
+    "reembed-vectorless",
+    "enrich-entities",
+  ],
+  "hybrid-mem:nightly-dream-cycle": ["dream-cycle"],
+  "hybrid-mem:sensor-sweep": ["sensor-sweep-tier-1", "sensor-sweep-tier-2"],
+  "hybrid-mem:daily-lifecycle-sync": ["lifecycle-sync"],
+};
+
+function requiredStepsFor(jobId: string | undefined): string[] {
+  return jobId ? (JOB_REQUIRED_STEPS[jobId] ?? []) : [];
+}
+
+function evidenceFromSummary(record: CronRunRecord): FailureEvidence | null {
+  const summary = typeof record.summary === "string" ? record.summary : "";
+  if (!summary) return null;
+
+  for (const obj of parseJsonObjectsFromText(summary)) {
+    const evidence = evidenceFromStructuredStatus(obj);
+    if (evidence) return evidence;
+  }
+
+  const exitPath = extractPath(summary, "HM_EXIT");
+  const logPath = extractPath(summary, "HM_LOG");
+  const requiredSteps = requiredStepsFor(String(record.jobId ?? ""));
+  if (exitPath && requiredSteps.length > 0) {
+    const evidence = validationToEvidence(validateMaintenanceExecution(exitPath, logPath, requiredSteps, true));
+    if (evidence) return evidence;
+  }
+
+  // Last-resort textual detection for already-humanized summaries. Keep this strict to avoid false positives.
+  if (/^\s*(?:\d+\.\s*)?(?:\*\*)?FAILED(?:\*\*)?\b/im.test(summary)) {
+    return {
+      status: "failed",
+      error: "Maintenance summary reported FAILED but cron run was recorded ok",
+      logPath,
+      exitPath,
+    };
+  }
+  return null;
+}
+
+function runFileForJob(openclawDir: string, jobId: string): string {
+  return join(openclawDir, "cron", "runs", `${jobId}.jsonl`);
+}
+
+function jobsStorePath(openclawDir: string): string {
+  return join(openclawDir, "cron", "jobs.json");
+}
+
+function isRecent(ts: unknown, cutoffMs: number): boolean {
+  return typeof ts === "number" && Number.isFinite(ts) && ts >= cutoffMs;
+}
+
+function readRunRecords(path: string, maxRecords: number): CronRunRecord[] {
+  if (!existsSync(path)) return [];
+  const lines = readFileSync(path, "utf-8")
+    .split("\n")
+    .filter((line) => line.trim().length > 0);
+  return lines
+    .slice(Math.max(0, lines.length - maxRecords))
+    .map((line) => readJsonString(line))
+    .filter((r): r is CronRunRecord => !!r);
+}
+
+function writeRunRecords(path: string, records: CronRunRecord[]): void {
+  writeFileSync(path, `${records.map((r) => JSON.stringify(r)).join("\n")}\n`, "utf-8");
+}
+
+function patchRunRecord(record: CronRunRecord, evidence: FailureEvidence): boolean {
+  if (record.status !== "ok") return false;
+  record.status = "error";
+  record.error = evidence.error;
+  const diagnostics = asRecord(record.diagnostics) ?? {};
+  record.diagnostics = {
+    ...diagnostics,
+    maintenanceStatus: evidence.status,
+    maintenanceError: evidence.error,
+    logPath: evidence.logPath,
+    exitPath: evidence.exitPath,
+    reconciledBy: "openclaw-hybrid-memory#1233",
+  };
+  return true;
+}
+
+function patchJobState(job: CronJobRecord, run: CronRunRecord, evidence: FailureEvidence, nowMs: number): boolean {
+  const state = asRecord(job.state) ?? {};
+  const lastRunAtMs = typeof state.lastRunAtMs === "number" ? state.lastRunAtMs : undefined;
+  const runAtMs = typeof run.runAtMs === "number" ? run.runAtMs : typeof run.ts === "number" ? run.ts : undefined;
+  if (lastRunAtMs !== undefined && runAtMs !== undefined && Math.abs(lastRunAtMs - runAtMs) > 5 * 60 * 1000) {
+    return false;
+  }
+
+  const previousErrors = typeof state.consecutiveErrors === "number" && Number.isFinite(state.consecutiveErrors)
+    ? Math.max(0, Math.floor(state.consecutiveErrors))
+    : 0;
+  job.state = {
+    ...state,
+    lastRunStatus: "error",
+    lastStatus: "error",
+    lastError: evidence.error,
+    lastErrorReason: "maintenance-validation-failed",
+    consecutiveErrors: previousErrors + 1,
+    consecutiveSkipped: 0,
+    lastDiagnostics: {
+      ...(asRecord(state.lastDiagnostics) ?? {}),
+      maintenanceStatus: evidence.status,
+      maintenanceError: evidence.error,
+      logPath: evidence.logPath,
+      exitPath: evidence.exitPath,
+      reconciledBy: "openclaw-hybrid-memory#1233",
+    },
+    lastDiagnosticSummary: evidence.error,
+    lastRunAtMs: runAtMs ?? lastRunAtMs ?? nowMs,
+  };
+  job.updatedAtMs = nowMs;
+  return true;
+}
+
+function loadJobs(openclawDir: string): { path: string; store: { jobs?: unknown[] } } | null {
+  const path = jobsStorePath(openclawDir);
+  if (!existsSync(path)) return null;
+  const parsed = readJsonFile(path);
+  const store = asRecord(parsed) as { jobs?: unknown[] } | null;
+  if (!store || !Array.isArray(store.jobs)) return null;
+  return { path, store };
+}
+
+function knownHybridRunFiles(openclawDir: string): string[] {
+  const runsDir = join(openclawDir, "cron", "runs");
+  if (!existsSync(runsDir)) return [];
+  try {
+    return readdirSync(runsDir)
+      .filter((name) => name.startsWith(HYBRID_MEM_JOB_PREFIX) && name.endsWith(".jsonl"))
+      .map((name) => join(runsDir, name));
+  } catch {
+    return [];
+  }
+}
+
+export function reconcileHybridMemCronMaintenanceOutcomes(
+  logger: CronMaintenanceReconcileLogger,
+  options: CronMaintenanceReconcileOptions = {},
+): CronMaintenanceReconcileResult {
+  const openclawDir = options.openclawDir ?? join(homedir(), ".openclaw");
+  const nowMs = options.nowMs ?? Date.now();
+  const cutoffMs = nowMs - (options.lookbackMs ?? DEFAULT_LOOKBACK_MS);
+  const maxRunRecords = Math.max(1, options.maxRunRecordsPerFile ?? DEFAULT_MAX_RUN_RECORDS_PER_FILE);
+  const result: CronMaintenanceReconcileResult = { runsCorrected: 0, jobsCorrected: 0, inspectedRuns: 0, errors: [] };
+
+  const jobsState = loadJobs(openclawDir);
+  const jobs = (jobsState?.store.jobs ?? []).filter((j): j is CronJobRecord => !!asRecord(j));
+  const jobsById = new Map<string, CronJobRecord>();
+  for (const job of jobs) {
+    const id = String(job.pluginJobId ?? job.id ?? "");
+    if (id.startsWith(HYBRID_MEM_JOB_PREFIX)) jobsById.set(id, job);
+  }
+
+  let jobsMutated = false;
+  for (const runPath of knownHybridRunFiles(openclawDir)) {
+    let records: CronRunRecord[];
+    try {
+      records = readRunRecords(runPath, maxRunRecords);
+    } catch (err) {
+      result.errors.push(`${runPath}: ${err}`);
+      continue;
+    }
+
+    let runFileMutated = false;
+    for (const record of records) {
+      const jobId = String(record.jobId ?? basename(runPath, ".jsonl"));
+      if (!jobId.startsWith(HYBRID_MEM_JOB_PREFIX)) continue;
+      if (record.status !== "ok") continue;
+      if (!isRecent(record.ts, cutoffMs) && !isRecent(record.runAtMs, cutoffMs)) continue;
+      result.inspectedRuns++;
+
+      const evidence = evidenceFromSummary({ ...record, jobId });
+      if (!evidence) continue;
+      if (patchRunRecord(record, evidence)) {
+        result.runsCorrected++;
+        runFileMutated = true;
+      }
+      const job = jobsById.get(jobId);
+      if (job && patchJobState(job, record, evidence, nowMs)) {
+        result.jobsCorrected++;
+        jobsMutated = true;
+      }
+    }
+
+    if (runFileMutated) {
+      try {
+        const allRecords = readFileSync(runPath, "utf-8")
+          .split("\n")
+          .filter((line) => line.trim().length > 0)
+          .map((line) => readJsonString(line) ?? line);
+        const patchedByTs = new Map(records.map((r) => [String(r.ts ?? `${r.jobId}:${r.summary}`), r]));
+        const merged = allRecords.map((entry) => {
+          if (typeof entry === "string") return entry;
+          const key = String((entry as CronRunRecord).ts ?? `${(entry as CronRunRecord).jobId}:${(entry as CronRunRecord).summary}`);
+          return patchedByTs.get(key) ?? entry;
+        });
+        writeFileSync(runPath, `${merged.map((entry) => (typeof entry === "string" ? entry : JSON.stringify(entry))).join("\n")}\n`, "utf-8");
+      } catch (err) {
+        result.errors.push(`${runPath}: failed to write patched run records: ${err}`);
+      }
+    }
+  }
+
+  if (jobsMutated && jobsState) {
+    try {
+      writeFileSync(jobsState.path, JSON.stringify(jobsState.store, null, 2), "utf-8");
+    } catch (err) {
+      result.errors.push(`${jobsState.path}: failed to write patched job state: ${err}`);
+    }
+  }
+
+  if (result.runsCorrected > 0 || result.jobsCorrected > 0) {
+    logger.warn?.(
+      `memory-hybrid: reconciled ${result.runsCorrected} false-ok cron run(s) and ${result.jobsCorrected} job state(s) from maintenance validation failures`,
+    );
+  } else {
+    logger.debug?.(`memory-hybrid: cron maintenance outcome reconciliation inspected ${result.inspectedRuns} ok run(s); no false-ok records found`);
+  }
+
+  return result;
+}

--- a/extensions/memory-hybrid/services/cron-maintenance-reconciler.ts
+++ b/extensions/memory-hybrid/services/cron-maintenance-reconciler.ts
@@ -145,7 +145,10 @@ function evidenceFromStructuredStatus(obj: Record<string, unknown>): FailureEvid
 }
 
 function extractPath(summary: string, label: "HM_EXIT" | "HM_LOG"): string | undefined {
-  const re = new RegExp(`${label}[^\n]*?(?:path)?[^\n]*?[:\\n]\\s*\`?([^\`\n]+?${label === "HM_EXIT" ? "\\.exit\\.txt" : "\\.log"})\`?`, "i");
+  const re = new RegExp(
+    `${label}[^\n]*?(?:path)?[^\n]*?[:\\n]\\s*\`?([^\`\n]+?${label === "HM_EXIT" ? "\\.exit\\.txt" : "\\.log"})\`?`,
+    "i",
+  );
   const match = summary.match(re);
   return match?.[1]?.trim();
 }
@@ -261,9 +264,10 @@ function patchJobState(job: CronJobRecord, run: CronRunRecord, evidence: Failure
     return false;
   }
 
-  const previousErrors = typeof state.consecutiveErrors === "number" && Number.isFinite(state.consecutiveErrors)
-    ? Math.max(0, Math.floor(state.consecutiveErrors))
-    : 0;
+  const previousErrors =
+    typeof state.consecutiveErrors === "number" && Number.isFinite(state.consecutiveErrors)
+      ? Math.max(0, Math.floor(state.consecutiveErrors))
+      : 0;
   job.state = {
     ...state,
     lastRunStatus: "error",
@@ -366,10 +370,16 @@ export function reconcileHybridMemCronMaintenanceOutcomes(
         const patchedByTs = new Map(records.map((r) => [String(r.ts ?? `${r.jobId}:${r.summary}`), r]));
         const merged = allRecords.map((entry) => {
           if (typeof entry === "string") return entry;
-          const key = String((entry as CronRunRecord).ts ?? `${(entry as CronRunRecord).jobId}:${(entry as CronRunRecord).summary}`);
+          const key = String(
+            (entry as CronRunRecord).ts ?? `${(entry as CronRunRecord).jobId}:${(entry as CronRunRecord).summary}`,
+          );
           return patchedByTs.get(key) ?? entry;
         });
-        writeFileSync(runPath, `${merged.map((entry) => (typeof entry === "string" ? entry : JSON.stringify(entry))).join("\n")}\n`, "utf-8");
+        writeFileSync(
+          runPath,
+          `${merged.map((entry) => (typeof entry === "string" ? entry : JSON.stringify(entry))).join("\n")}\n`,
+          "utf-8",
+        );
       } catch (err) {
         result.errors.push(`${runPath}: failed to write patched run records: ${err}`);
       }
@@ -389,7 +399,9 @@ export function reconcileHybridMemCronMaintenanceOutcomes(
       `memory-hybrid: reconciled ${result.runsCorrected} false-ok cron run(s) and ${result.jobsCorrected} job state(s) from maintenance validation failures`,
     );
   } else {
-    logger.debug?.(`memory-hybrid: cron maintenance outcome reconciliation inspected ${result.inspectedRuns} ok run(s); no false-ok records found`);
+    logger.debug?.(
+      `memory-hybrid: cron maintenance outcome reconciliation inspected ${result.inspectedRuns} ok run(s); no false-ok records found`,
+    );
   }
 
   return result;

--- a/extensions/memory-hybrid/services/dream-cycle.ts
+++ b/extensions/memory-hybrid/services/dream-cycle.ts
@@ -22,6 +22,10 @@ import { writeMemoryIndex } from "./memory-index.js";
 import { formatElapsedSec } from "../utils/maintenance-progress.js";
 import type { ProvenanceService } from "./provenance.js";
 import {
+  DEFAULT_REFLECTION_DEDUPE_HYDRATION,
+  type ReflectionDedupeHydrationResolved,
+} from "./reflection-dedupe-hydration.js";
+import {
   type ReflectionConfig,
   countActivePatternFactsForMaintenance,
   runReflection,
@@ -80,6 +84,11 @@ export interface DreamCycleConfig {
     /** Extra types to treat as noise (merged with built-in deny list). */
     deny?: string[];
   };
+  /**
+   * Resolved embedding throttle + checkpoint policy for reflection dedupe hydration (#1229).
+   * When omitted, {@link DEFAULT_REFLECTION_DEDUPE_HYDRATION} is used.
+   */
+  reflectionDedupeHydration?: ReflectionDedupeHydrationResolved;
 }
 
 /** Result returned by a single dream cycle run. */
@@ -701,6 +710,7 @@ export async function runDreamCycle(
           model: config.model,
           fallbackModels: config.fallbackModels ?? [],
           verbose: v,
+          dedupeHydration: config.reflectionDedupeHydration ?? DEFAULT_REFLECTION_DEDUPE_HYDRATION,
         },
         logger,
         provenanceService,
@@ -728,7 +738,13 @@ export async function runDreamCycle(
           vectorDb,
           embeddings,
           openai,
-          { dryRun: false, model: config.model, fallbackModels: config.fallbackModels ?? [], verbose: v },
+          {
+            dryRun: false,
+            model: config.model,
+            fallbackModels: config.fallbackModels ?? [],
+            verbose: v,
+            dedupeHydration: config.reflectionDedupeHydration ?? DEFAULT_REFLECTION_DEDUPE_HYDRATION,
+          },
           logger,
           provenanceService,
         );

--- a/extensions/memory-hybrid/services/dream-cycle.ts
+++ b/extensions/memory-hybrid/services/dream-cycle.ts
@@ -19,6 +19,7 @@ import { CONSOLIDATED_FACT_DECAY_CLASS } from "../utils/consolidation-controls.j
 import type { EmbeddingProvider } from "./embeddings.js";
 import { capturePluginError } from "./error-reporter.js";
 import { writeMemoryIndex } from "./memory-index.js";
+import { formatElapsedSec } from "../utils/maintenance-progress.js";
 import type { ProvenanceService } from "./provenance.js";
 import {
   type ReflectionConfig,
@@ -315,8 +316,17 @@ export async function runEpisodicConsolidation(
     );
   }
   let factsCreated = 0;
+  const episodicStart = Date.now();
+  const groupTotal = groups.size;
+  let groupIdx = 0;
 
   for (const [entity, groupEvents] of groups) {
+    groupIdx++;
+    if (verbose && groupTotal >= 15 && (groupIdx === 1 || groupIdx === groupTotal || groupIdx % 20 === 0)) {
+      logger.info(
+        `memory-hybrid: dream-cycle — episodic consolidation progress: entity group ${groupIdx}/${groupTotal}, factsCreated=${factsCreated}, eventsMarked=${eventsConsolidated}, elapsed=${formatElapsedSec(episodicStart)}`,
+      );
+    }
     if (groupEvents.length === 0) continue;
 
     if (entity === "__default__" && groupEvents.length > maxEventsPerConsolidation) {
@@ -501,334 +511,358 @@ export async function runDreamCycle(
 
   logger.info("memory-hybrid: dream-cycle — starting nightly cycle");
   const v = !!config.verbose;
+  const vectorDbVerbose = vectorDb as unknown as { setMaintenanceVerbose?: (on: boolean) => void };
+  vectorDbVerbose.setMaintenanceVerbose?.(v);
   let stepCounter = 0;
   const step = (label: string) => {
     if (v) logger.info(`memory-hybrid: dream-cycle — step ${++stepCounter}: ${label}`);
   };
 
-  // ── Step 1: Prune ────────────────────────────────────────────────────────
-  step("prune / decay / orphaned links");
-  let factsPruned = 0;
-  let factsDecayed = 0;
-  if (config.pruneMode === "expired" || config.pruneMode === "both") {
-    try {
-      factsPruned = factsDb.pruneExpired();
-      logger.info(`memory-hybrid: dream-cycle — pruned ${factsPruned} expired facts`);
-    } catch (err) {
-      logger.warn(`memory-hybrid: dream-cycle — pruneExpired failed: ${err}`);
-      capturePluginError(err instanceof Error ? err : new Error(String(err)), {
-        operation: "dream-cycle-prune-expired",
-        subsystem: "facts-db",
-      });
-    }
-  }
-  if (config.pruneMode === "decay" || config.pruneMode === "both") {
-    try {
-      factsDecayed = factsDb.decayConfidence();
-      logger.info(`memory-hybrid: dream-cycle — decayed ${factsDecayed} facts`);
-    } catch (err) {
-      logger.warn(`memory-hybrid: dream-cycle — decayConfidence failed: ${err}`);
-      capturePluginError(err instanceof Error ? err : new Error(String(err)), {
-        operation: "dream-cycle-decay",
-        subsystem: "facts-db",
-      });
-    }
-  }
-
-  // ── Step 1b: Prune orphaned links ────────────────────────────────────────
-  let linksPruned = 0;
   try {
-    linksPruned = factsDb.pruneOrphanedLinks();
-    if (linksPruned > 0) {
-      logger.info(`memory-hybrid: dream-cycle — pruned ${linksPruned} orphaned link(s)`);
+    // ── Step 1: Prune ────────────────────────────────────────────────────────
+    step("prune / decay / orphaned links");
+    let factsPruned = 0;
+    let factsDecayed = 0;
+    if (config.pruneMode === "expired" || config.pruneMode === "both") {
+      try {
+        factsPruned = factsDb.pruneExpired();
+        logger.info(`memory-hybrid: dream-cycle — pruned ${factsPruned} expired facts`);
+      } catch (err) {
+        logger.warn(`memory-hybrid: dream-cycle — pruneExpired failed: ${err}`);
+        capturePluginError(err instanceof Error ? err : new Error(String(err)), {
+          operation: "dream-cycle-prune-expired",
+          subsystem: "facts-db",
+        });
+      }
     }
-  } catch (err) {
-    logger.warn(`memory-hybrid: dream-cycle — pruneOrphanedLinks failed: ${err}`);
-    capturePluginError(err instanceof Error ? err : new Error(String(err)), {
-      operation: "dream-cycle-prune-orphaned-links",
-      subsystem: "facts-db",
-    });
-  }
+    if (config.pruneMode === "decay" || config.pruneMode === "both") {
+      try {
+        factsDecayed = factsDb.decayConfidence();
+        logger.info(`memory-hybrid: dream-cycle — decayed ${factsDecayed} facts`);
+      } catch (err) {
+        logger.warn(`memory-hybrid: dream-cycle — decayConfidence failed: ${err}`);
+        capturePluginError(err instanceof Error ? err : new Error(String(err)), {
+          operation: "dream-cycle-decay",
+          subsystem: "facts-db",
+        });
+      }
+    }
 
-  // ── Step 1c: Decay reclassify (#1189) ────────────────────────────────────
-  // Source-/importance-aware reclassifier. Without this nightly hook, the
-  // reclassifier only ran when an operator manually invoked the CLI, which
-  // meant `decay_class=stable` accumulated and prune found nothing.
-  let decayReclassified = 0;
-  if (config.reclassifyDecayOnCycle !== false) {
-    step("decay reclassify (source/importance/recall)");
+    // ── Step 1b: Prune orphaned links ────────────────────────────────────────
+    let linksPruned = 0;
     try {
-      const report = factsDb.reclassifyDecayClasses({
-        apply: true,
-        inactiveDays: config.reclassifyInactiveDays ?? 90,
-        promoteRecallCount: config.reclassifyPromoteRecallCount ?? 3,
-      });
-      decayReclassified = report.changed;
-      if (decayReclassified > 0) {
-        logger.info(
-          `memory-hybrid: dream-cycle — decay reclassify: ${decayReclassified} facts re-tiered (scanned ${report.scanned}, stable+permanent ${(report.stablePermanentRatioBefore * 100).toFixed(1)}% → ${(report.stablePermanentRatioAfter * 100).toFixed(1)}%)`,
-        );
+      linksPruned = factsDb.pruneOrphanedLinks();
+      if (linksPruned > 0) {
+        logger.info(`memory-hybrid: dream-cycle — pruned ${linksPruned} orphaned link(s)`);
       }
     } catch (err) {
-      logger.warn(`memory-hybrid: dream-cycle — reclassifyDecayClasses failed: ${err}`);
+      logger.warn(`memory-hybrid: dream-cycle — pruneOrphanedLinks failed: ${err}`);
       capturePluginError(err instanceof Error ? err : new Error(String(err)), {
-        operation: "dream-cycle-reclassify-decay",
+        operation: "dream-cycle-prune-orphaned-links",
         subsystem: "facts-db",
       });
     }
-  }
 
-  // ── Step 1d: Refresh denormalized graph degrees (#1192) ──────────────────
-  // Without this, every BFS hop runs `COUNT(*) FROM memory_links` against the same node, which
-  // is O(edges) per call. A single nightly refresh keeps reads cheap while still adapting to
-  // graph changes within a day.
-  if (typeof (factsDb as { refreshFactDegrees?: () => unknown }).refreshFactDegrees === "function") {
-    step("refresh fact degrees");
-    try {
-      const result = (factsDb as { refreshFactDegrees: () => { updated: number } }).refreshFactDegrees();
-      if (v) {
-        logger.info(`memory-hybrid: dream-cycle — refreshed fact degrees for ${result.updated} facts`);
+    // ── Step 1c: Decay reclassify (#1189) ────────────────────────────────────
+    // Source-/importance-aware reclassifier. Without this nightly hook, the
+    // reclassifier only ran when an operator manually invoked the CLI, which
+    // meant `decay_class=stable` accumulated and prune found nothing.
+    let decayReclassified = 0;
+    if (config.reclassifyDecayOnCycle !== false) {
+      step("decay reclassify (source/importance/recall)");
+      try {
+        const decayStart = Date.now();
+        const report = factsDb.reclassifyDecayClasses({
+          apply: true,
+          inactiveDays: config.reclassifyInactiveDays ?? 90,
+          promoteRecallCount: config.reclassifyPromoteRecallCount ?? 3,
+        });
+        decayReclassified = report.changed;
+        if (v) {
+          logger.info(
+            `memory-hybrid: dream-cycle — decay reclassify done: changed=${decayReclassified}, scanned=${report.scanned}, stable+permanent ${(report.stablePermanentRatioBefore * 100).toFixed(1)}% → ${(report.stablePermanentRatioAfter * 100).toFixed(1)}%, elapsed=${formatElapsedSec(decayStart)}`,
+          );
+        } else if (decayReclassified > 0) {
+          logger.info(
+            `memory-hybrid: dream-cycle — decay reclassify: ${decayReclassified} facts re-tiered (scanned ${report.scanned}, stable+permanent ${(report.stablePermanentRatioBefore * 100).toFixed(1)}% → ${(report.stablePermanentRatioAfter * 100).toFixed(1)}%)`,
+          );
+        }
+      } catch (err) {
+        logger.warn(`memory-hybrid: dream-cycle — reclassifyDecayClasses failed: ${err}`);
+        capturePluginError(err instanceof Error ? err : new Error(String(err)), {
+          operation: "dream-cycle-reclassify-decay",
+          subsystem: "facts-db",
+        });
       }
-    } catch (err) {
-      logger.warn(`memory-hybrid: dream-cycle — refreshFactDegrees failed: ${err}`);
-      capturePluginError(err instanceof Error ? err : new Error(String(err)), {
-        operation: "dream-cycle-refresh-degrees",
-        subsystem: "facts-db",
-      });
     }
-  }
 
-  // ── Step 2: Episodic consolidation ───────────────────────────────────────
-  let eventsConsolidated = 0;
-  let factsCreated = 0;
-  step("episodic consolidation + event log maintenance");
-  if (eventLog) {
-    try {
-      const consolidationResult = await runEpisodicConsolidation(
-        factsDb,
-        eventLog,
-        config.consolidateAfterDays,
-        logger,
-        v,
-        config.maxEventsPerConsolidation,
-        config.episodicConsolidationEventTypes ?? null,
-      );
-      eventsConsolidated = consolidationResult.eventsConsolidated;
-      factsCreated = consolidationResult.factsCreated;
-    } catch (err) {
-      logger.warn(`memory-hybrid: dream-cycle — consolidation step failed: ${err}`);
-      capturePluginError(err instanceof Error ? err : new Error(String(err)), {
-        operation: "dream-cycle-consolidation",
-        subsystem: "event-log",
-      });
+    // ── Step 1d: Refresh denormalized graph degrees (#1192) ──────────────────
+    // Without this, every BFS hop runs `COUNT(*) FROM memory_links` against the same node, which
+    // is O(edges) per call. A single nightly refresh keeps reads cheap while still adapting to
+    // graph changes within a day.
+    if (typeof (factsDb as { refreshFactDegrees?: () => unknown }).refreshFactDegrees === "function") {
+      step("refresh fact degrees");
+      try {
+        const result = (factsDb as { refreshFactDegrees: () => { updated: number } }).refreshFactDegrees();
+        if (v) {
+          logger.info(`memory-hybrid: dream-cycle — refreshed fact degrees for ${result.updated} facts`);
+        }
+      } catch (err) {
+        logger.warn(`memory-hybrid: dream-cycle — refreshFactDegrees failed: ${err}`);
+        capturePluginError(err instanceof Error ? err : new Error(String(err)), {
+          operation: "dream-cycle-refresh-degrees",
+          subsystem: "facts-db",
+        });
+      }
     }
-  } else if (v) {
-    logger.info("memory-hybrid: dream-cycle — no event log: skipping episodic consolidation");
-  }
 
-  // ── Step 2b: Archive stale event log entries ─────────────────────────────
-  if (eventLog && config.eventLogArchivalDays > 0) {
-    try {
-      const result = await eventLog.archiveConsolidated(config.eventLogArchivalDays, config.eventLogArchivePath);
-      if (result.archived > 0) {
-        logger.info(
-          `memory-hybrid: dream-cycle — archived ${result.archived} consolidated event log entries older than ${config.eventLogArchivalDays} days`,
+    // ── Step 2: Episodic consolidation ───────────────────────────────────────
+    let eventsConsolidated = 0;
+    let factsCreated = 0;
+    step("episodic consolidation + event log maintenance");
+    if (eventLog) {
+      try {
+        const consolidationResult = await runEpisodicConsolidation(
+          factsDb,
+          eventLog,
+          config.consolidateAfterDays,
+          logger,
+          v,
+          config.maxEventsPerConsolidation,
+          config.episodicConsolidationEventTypes ?? null,
         );
+        eventsConsolidated = consolidationResult.eventsConsolidated;
+        factsCreated = consolidationResult.factsCreated;
+      } catch (err) {
+        logger.warn(`memory-hybrid: dream-cycle — consolidation step failed: ${err}`);
+        capturePluginError(err instanceof Error ? err : new Error(String(err)), {
+          operation: "dream-cycle-consolidation",
+          subsystem: "event-log",
+        });
       }
-    } catch (err) {
-      logger.warn(`memory-hybrid: dream-cycle — archiveConsolidated failed: ${err}`);
-      capturePluginError(err instanceof Error ? err : new Error(String(err)), {
-        operation: "dream-cycle-archive",
-        subsystem: "event-log",
-      });
+    } else if (v) {
+      logger.info("memory-hybrid: dream-cycle — no event log: skipping episodic consolidation");
     }
-  }
 
-  // ── Step 2c: Clean up old unconsolidated events ──────────────────────────
-  if (eventLog && config.maxUnconsolidatedAgeDays > 0) {
-    try {
-      const deleted = eventLog.archiveOld(config.maxUnconsolidatedAgeDays, true);
-      if (deleted > 0) {
-        logger.info(
-          `memory-hybrid: dream-cycle — deleted ${deleted} old event log entries (including unconsolidated) older than ${config.maxUnconsolidatedAgeDays} days`,
-        );
+    // ── Step 2b: Archive stale event log entries ─────────────────────────────
+    if (eventLog && config.eventLogArchivalDays > 0) {
+      try {
+        const result = await eventLog.archiveConsolidated(config.eventLogArchivalDays, config.eventLogArchivePath);
+        if (result.archived > 0) {
+          logger.info(
+            `memory-hybrid: dream-cycle — archived ${result.archived} consolidated event log entries older than ${config.eventLogArchivalDays} days`,
+          );
+        }
+      } catch (err) {
+        logger.warn(`memory-hybrid: dream-cycle — archiveConsolidated failed: ${err}`);
+        capturePluginError(err instanceof Error ? err : new Error(String(err)), {
+          operation: "dream-cycle-archive",
+          subsystem: "event-log",
+        });
       }
-    } catch (err) {
-      logger.warn(`memory-hybrid: dream-cycle — archiveOld failed: ${err}`);
-      capturePluginError(err instanceof Error ? err : new Error(String(err)), {
-        operation: "dream-cycle-archive-old",
-        subsystem: "event-log",
-      });
     }
-  }
 
-  // ── Step 3: Reflect ───────────────────────────────────────────────────────
-  step("reflection (patterns)");
-  let patternsFound = 0;
-  const reflectionConfig: ReflectionConfig = {
-    enabled: true,
-    defaultWindow: config.reflectWindowDays,
-    minObservations: 2,
-  };
-  try {
-    const reflectionResult = await runReflection(
-      factsDb,
-      vectorDb,
-      embeddings,
-      openai,
-      reflectionConfig,
-      {
-        window: config.reflectWindowDays,
-        dryRun: false,
-        model: config.model,
-        fallbackModels: config.fallbackModels ?? [],
-        verbose: v,
-      },
-      logger,
-      provenanceService,
-    );
-    patternsFound = reflectionResult.patternsStored;
-    logger.info(`memory-hybrid: dream-cycle — reflection complete: ${patternsFound} patterns stored`);
-  } catch (err) {
-    logger.warn(`memory-hybrid: dream-cycle — reflection step failed: ${err}`);
-    capturePluginError(err instanceof Error ? err : new Error(String(err)), {
-      operation: "dream-cycle-reflect",
-      subsystem: "reflection",
-    });
-  }
+    // ── Step 2c: Clean up old unconsolidated events ──────────────────────────
+    if (eventLog && config.maxUnconsolidatedAgeDays > 0) {
+      try {
+        const deleted = eventLog.archiveOld(config.maxUnconsolidatedAgeDays, true);
+        if (deleted > 0) {
+          logger.info(
+            `memory-hybrid: dream-cycle — deleted ${deleted} old event log entries (including unconsolidated) older than ${config.maxUnconsolidatedAgeDays} days`,
+          );
+        }
+      } catch (err) {
+        logger.warn(`memory-hybrid: dream-cycle — archiveOld failed: ${err}`);
+        capturePluginError(err instanceof Error ? err : new Error(String(err)), {
+          operation: "dream-cycle-archive-old",
+          subsystem: "event-log",
+        });
+      }
+    }
 
-  const livePatternCountForRules = countActivePatternFactsForMaintenance(factsDb);
-  const patternGateForRules = Math.max(patternsFound, livePatternCountForRules);
-
-  // ── Step 4: Reflect-rules (optional) ────────────────────────────────────
-  let rulesGenerated = 0;
-  if (patternGateForRules >= MIN_PATTERNS_FOR_RULES) {
-    step("reflect-rules");
+    // ── Step 3: Reflect ───────────────────────────────────────────────────────
+    step("reflection (patterns)");
+    let patternsFound = 0;
+    const reflectionConfig: ReflectionConfig = {
+      enabled: true,
+      defaultWindow: config.reflectWindowDays,
+      minObservations: 2,
+    };
     try {
-      const rulesResult = await runReflectionRules(
+      const reflectionResult = await runReflection(
         factsDb,
         vectorDb,
         embeddings,
         openai,
-        { dryRun: false, model: config.model, fallbackModels: config.fallbackModels ?? [], verbose: v },
+        reflectionConfig,
+        {
+          window: config.reflectWindowDays,
+          dryRun: false,
+          model: config.model,
+          fallbackModels: config.fallbackModels ?? [],
+          verbose: v,
+        },
         logger,
         provenanceService,
       );
-      rulesGenerated = rulesResult.rulesStored;
-      logger.info(`memory-hybrid: dream-cycle — reflect-rules complete: ${rulesGenerated} rules stored`);
+      patternsFound = reflectionResult.patternsStored;
+      logger.info(`memory-hybrid: dream-cycle — reflection complete: ${patternsFound} patterns stored`);
     } catch (err) {
-      logger.warn(`memory-hybrid: dream-cycle — reflect-rules step failed: ${err}`);
+      logger.warn(`memory-hybrid: dream-cycle — reflection step failed: ${err}`);
       capturePluginError(err instanceof Error ? err : new Error(String(err)), {
-        operation: "dream-cycle-reflect-rules",
+        operation: "dream-cycle-reflect",
         subsystem: "reflection",
       });
     }
-  } else if (v) {
-    logger.info(
-      `memory-hybrid: dream-cycle — skipping reflect-rules (${patternsFound} stored this cycle, ${livePatternCountForRules} live patterns; need ≥${MIN_PATTERNS_FOR_RULES})`,
-    );
-  }
 
-  // ── Step 4b: Refresh memory awareness index ─────────────────────────────
-  step("MEMORY_INDEX.md refresh");
-  try {
-    await writeMemoryIndex(
-      factsDb,
-      openai,
-      {
-        model: config.model,
-        fallbackModels: config.fallbackModels ?? [],
-        recentWindowDays: config.reflectWindowDays,
-        verbose: v,
-      },
-      logger,
-    );
-  } catch (err) {
-    logger.warn(`memory-hybrid: dream-cycle — memory index update failed: ${err}`);
-    capturePluginError(err instanceof Error ? err : new Error(String(err)), {
-      operation: "dream-cycle-memory-index",
-      subsystem: "reflection",
-    });
-  }
+    const livePatternCountForRules = countActivePatternFactsForMaintenance(factsDb);
+    const patternGateForRules = Math.max(patternsFound, livePatternCountForRules);
 
-  // ── Step 5: Prune log tables ─────────────────────────────────────────────
-  step("prune operational log tables (recall/reinforcement/trajectories)");
-  let logRowsPruned = 0;
-  if (config.logRetentionDays > 0) {
-    try {
-      logRowsPruned = factsDb.pruneLogTables(config.logRetentionDays);
-      if (logRowsPruned > 0) {
-        logger.info(
-          `memory-hybrid: dream-cycle — pruned ${logRowsPruned} log rows older than ${config.logRetentionDays} days`,
+    // ── Step 4: Reflect-rules (optional) ────────────────────────────────────
+    let rulesGenerated = 0;
+    if (patternGateForRules >= MIN_PATTERNS_FOR_RULES) {
+      step("reflect-rules");
+      try {
+        const rulesResult = await runReflectionRules(
+          factsDb,
+          vectorDb,
+          embeddings,
+          openai,
+          { dryRun: false, model: config.model, fallbackModels: config.fallbackModels ?? [], verbose: v },
+          logger,
+          provenanceService,
         );
+        rulesGenerated = rulesResult.rulesStored;
+        logger.info(`memory-hybrid: dream-cycle — reflect-rules complete: ${rulesGenerated} rules stored`);
+      } catch (err) {
+        logger.warn(`memory-hybrid: dream-cycle — reflect-rules step failed: ${err}`);
+        capturePluginError(err instanceof Error ? err : new Error(String(err)), {
+          operation: "dream-cycle-reflect-rules",
+          subsystem: "reflection",
+        });
       }
-    } catch (err) {
-      logger.warn(`memory-hybrid: dream-cycle — pruneLogTables failed: ${err}`);
-      capturePluginError(err instanceof Error ? err : new Error(String(err)), {
-        operation: "dream-cycle-prune-log-tables",
-        subsystem: "facts-db",
-      });
+    } else if (v) {
+      logger.info(
+        `memory-hybrid: dream-cycle — skipping reflect-rules (${patternsFound} stored this cycle, ${livePatternCountForRules} live patterns; need ≥${MIN_PATTERNS_FOR_RULES})`,
+      );
     }
-  }
 
-  // ── Step 5b: FTS5 optimize ───────────────────────────────────────────────
-  step("FTS5 optimize (facts search)");
-  try {
-    factsDb.optimizeFts();
-    logger.info("memory-hybrid: dream-cycle — FTS5 index optimized");
-  } catch (err) {
-    logger.warn(`memory-hybrid: dream-cycle — optimizeFts failed: ${err}`);
-    capturePluginError(err instanceof Error ? err : new Error(String(err)), {
-      operation: "dream-cycle-optimize-fts",
-      subsystem: "facts-db",
-    });
-  }
-
-  // ── Step 5c: VACUUM + WAL checkpoint ────────────────────────────────────
-  let vacuumRan = false;
-  if (config.vacuumOnCycle) {
-    step("VACUUM + WAL checkpoint");
+    // ── Step 4b: Refresh memory awareness index ─────────────────────────────
+    step("MEMORY_INDEX.md refresh");
     try {
-      factsDb.vacuumAndCheckpoint();
-      vacuumRan = true;
-      logger.info("memory-hybrid: dream-cycle — VACUUM + WAL checkpoint complete");
+      await writeMemoryIndex(
+        factsDb,
+        openai,
+        {
+          model: config.model,
+          fallbackModels: config.fallbackModels ?? [],
+          recentWindowDays: config.reflectWindowDays,
+          verbose: v,
+        },
+        logger,
+      );
     } catch (err) {
-      logger.warn(`memory-hybrid: dream-cycle — vacuumAndCheckpoint failed: ${err}`);
+      logger.warn(`memory-hybrid: dream-cycle — memory index update failed: ${err}`);
       capturePluginError(err instanceof Error ? err : new Error(String(err)), {
-        operation: "dream-cycle-vacuum",
+        operation: "dream-cycle-memory-index",
+        subsystem: "reflection",
+      });
+    }
+
+    // ── Step 5: Prune log tables ─────────────────────────────────────────────
+    step("prune operational log tables (recall/reinforcement/trajectories)");
+    let logRowsPruned = 0;
+    if (config.logRetentionDays > 0) {
+      try {
+        logRowsPruned = factsDb.pruneLogTables(config.logRetentionDays);
+        if (logRowsPruned > 0) {
+          logger.info(
+            `memory-hybrid: dream-cycle — pruned ${logRowsPruned} log rows older than ${config.logRetentionDays} days`,
+          );
+        }
+      } catch (err) {
+        logger.warn(`memory-hybrid: dream-cycle — pruneLogTables failed: ${err}`);
+        capturePluginError(err instanceof Error ? err : new Error(String(err)), {
+          operation: "dream-cycle-prune-log-tables",
+          subsystem: "facts-db",
+        });
+      }
+    }
+
+    // ── Step 5b: FTS5 optimize ───────────────────────────────────────────────
+    step("FTS5 optimize (facts search)");
+    try {
+      if (v) {
+        logger.info("memory-hybrid: dream-cycle — FTS5 optimize starting (may take a while on large corpora)…");
+      }
+      const ftsStart = Date.now();
+      factsDb.optimizeFts();
+      logger.info(
+        `memory-hybrid: dream-cycle — FTS5 index optimized` + (v ? ` (elapsed=${formatElapsedSec(ftsStart)})` : ""),
+      );
+    } catch (err) {
+      logger.warn(`memory-hybrid: dream-cycle — optimizeFts failed: ${err}`);
+      capturePluginError(err instanceof Error ? err : new Error(String(err)), {
+        operation: "dream-cycle-optimize-fts",
         subsystem: "facts-db",
       });
     }
+
+    // ── Step 5c: VACUUM + WAL checkpoint ────────────────────────────────────
+    let vacuumRan = false;
+    if (config.vacuumOnCycle) {
+      step("VACUUM + WAL checkpoint");
+      try {
+        if (v) {
+          logger.info("memory-hybrid: dream-cycle — VACUUM + WAL checkpoint starting (often the longest SQLite step)…");
+        }
+        const vacuumStart = Date.now();
+        factsDb.vacuumAndCheckpoint();
+        vacuumRan = true;
+        logger.info(
+          `memory-hybrid: dream-cycle — VACUUM + WAL checkpoint complete` +
+            (v ? ` (elapsed=${formatElapsedSec(vacuumStart)})` : ""),
+        );
+      } catch (err) {
+        logger.warn(`memory-hybrid: dream-cycle — vacuumAndCheckpoint failed: ${err}`);
+        capturePluginError(err instanceof Error ? err : new Error(String(err)), {
+          operation: "dream-cycle-vacuum",
+          subsystem: "facts-db",
+        });
+      }
+    }
+
+    // ── Step 6: Digest summary ───────────────────────────────────────────────
+    const digestSummary = buildDigestSummary({
+      factsPruned,
+      factsDecayed,
+      linksPruned,
+      eventsConsolidated,
+      factsCreated,
+      patternsFound,
+      rulesGenerated,
+      logRowsPruned,
+      vacuumRan,
+      decayReclassified,
+    });
+
+    logger.info(`memory-hybrid: dream-cycle — complete. ${digestSummary}`);
+
+    return {
+      factsPruned,
+      factsDecayed,
+      linksPruned,
+      eventsConsolidated,
+      factsCreated,
+      patternsFound,
+      rulesGenerated,
+      logRowsPruned,
+      vacuumRan,
+      decayReclassified,
+      digestSummary,
+      skipped: false,
+    };
+  } finally {
+    vectorDbVerbose.setMaintenanceVerbose?.(false);
   }
-
-  // ── Step 6: Digest summary ───────────────────────────────────────────────
-  const digestSummary = buildDigestSummary({
-    factsPruned,
-    factsDecayed,
-    linksPruned,
-    eventsConsolidated,
-    factsCreated,
-    patternsFound,
-    rulesGenerated,
-    logRowsPruned,
-    vacuumRan,
-    decayReclassified,
-  });
-
-  logger.info(`memory-hybrid: dream-cycle — complete. ${digestSummary}`);
-
-  return {
-    factsPruned,
-    factsDecayed,
-    linksPruned,
-    eventsConsolidated,
-    factsCreated,
-    patternsFound,
-    rulesGenerated,
-    logRowsPruned,
-    vacuumRan,
-    decayReclassified,
-    digestSummary,
-    skipped: false,
-  };
 }

--- a/extensions/memory-hybrid/services/find-duplicates.ts
+++ b/extensions/memory-hybrid/services/find-duplicates.ts
@@ -8,12 +8,15 @@ import type { VectorDB } from "../backends/vector-db.js";
 import { isStructuredForConsolidation } from "./consolidation.js";
 import type { EmbeddingProvider } from "./embeddings.js";
 import { shouldSuppressEmbeddingError } from "./embeddings.js";
+import { formatElapsedSec } from "../utils/maintenance-progress.js";
 import { capturePluginError } from "./error-reporter.js";
 
 interface FindDuplicatesOptions {
   threshold: number;
   includeStructured: boolean;
   limit: number;
+  /** Extra embedding / Lance search progress (#1228). */
+  verbose?: boolean;
 }
 
 interface FindDuplicatesResult {
@@ -68,6 +71,9 @@ export async function runFindDuplicates(
   const vectors: number[][] = [];
   const validIds: string[] = [];
   let skippedEmbeddings = 0;
+  const verbose = opts.verbose === true;
+  const embedStarted = Date.now();
+  const totalBatches = Math.max(1, Math.ceil(ids.length / BATCH_SIZE));
 
   for (let i = 0; i < ids.length; i += BATCH_SIZE) {
     const batch = ids.slice(i, i + BATCH_SIZE);
@@ -77,6 +83,12 @@ export async function runFindDuplicates(
     });
     const batchTexts = batchFacts.map(({ fact }) => fact.text);
     const vecs = await safeEmbedBatch(embeddings, batchTexts, (msg) => logger.warn(msg));
+    if (verbose) {
+      const bn = Math.floor(i / BATCH_SIZE) + 1;
+      logger.info(
+        `memory-hybrid: find-duplicates — embed batch ${bn}/${totalBatches} (rows ${Math.min(i + BATCH_SIZE, ids.length)}/${ids.length}), elapsed=${formatElapsedSec(embedStarted)}`,
+      );
+    }
     // Whole batch failed: all slots are null — log once instead of once-per-fact to avoid log spam.
     if (vecs.every((v) => v === null || v.length === 0)) {
       logger.warn(
@@ -106,9 +118,15 @@ export async function runFindDuplicates(
   const idToIndex = new Map(validIds.map((id, idx) => [id, idx]));
   const pairs: Array<{ idA: string; idB: string; score: number; textA: string; textB: string }> = [];
   const searchLimit = Math.min(100, validIds.length);
+  const lanceStarted = Date.now();
 
   // Use LanceDB vector search (indexed) instead of O(n^2) pairwise loop
   for (let i = 0; i < validIds.length; i++) {
+    if (verbose && validIds.length > 0 && (i === 0 || i === validIds.length - 1 || (i + 1) % 50 === 0)) {
+      logger.info(
+        `memory-hybrid: find-duplicates — Lance similarity scan ${i + 1}/${validIds.length}, pairsSoFar=${pairs.length}, elapsed=${formatElapsedSec(lanceStarted)}`,
+      );
+    }
     const vi = vectors[i];
     const idA = validIds[i];
     if (!vi || !idA) continue;

--- a/extensions/memory-hybrid/services/memory-index.ts
+++ b/extensions/memory-hybrid/services/memory-index.ts
@@ -5,6 +5,7 @@ import type OpenAI from "openai";
 import type { FactsDB } from "../backends/facts-db.js";
 import type { MemoryEntry } from "../types/memory.js";
 import { getEnv } from "../utils/env-manager.js";
+import { formatElapsedSec } from "../utils/maintenance-progress.js";
 import { fillPrompt, loadPrompt } from "../utils/prompt-loader.js";
 import {
   LLMRetryError,
@@ -329,10 +330,12 @@ export async function writeMemoryIndex(
   options: MemoryIndexOptions,
   logger: { info: (msg: string) => void; warn: (msg: string) => void },
 ): Promise<MemoryIndexResult> {
+  const snapT0 = Date.now();
   const snapshot = buildMemoryIndexSnapshot(factsDb, options);
   if (options.verbose) {
+    const factTotal = factsDb.count();
     logger.info(
-      `memory-hybrid: memory-index — snapshot: ${snapshot.clusters.length} clusters, ${snapshot.recentDecisions.length} recent decisions, ${snapshot.keyEntities.length} key entities, ${snapshot.recentPatterns.length} recent patterns/rules`,
+      `memory-hybrid: memory-index — snapshot built in ${formatElapsedSec(snapT0)} from ${factTotal} fact row(s): ${snapshot.clusters.length} clusters, ${snapshot.recentDecisions.length} recent decisions, ${snapshot.keyEntities.length} key entities, ${snapshot.recentPatterns.length} recent patterns/rules`,
     );
   }
 
@@ -354,7 +357,18 @@ export async function writeMemoryIndex(
     }
   }
 
+  const llmT0 = Date.now();
+  if (options.verbose) {
+    logger.info(
+      "memory-hybrid: memory-index — starting LLM synthesis (or deterministic fallback if unchanged/skipped)…",
+    );
+  }
   const llmMarkdown = await synthesizeMemoryIndex(snapshot, openai, options, logger);
+  if (options.verbose) {
+    logger.info(
+      `memory-hybrid: memory-index — synthesis step finished in ${formatElapsedSec(llmT0)} (${llmMarkdown ? "LLM markdown" : "deterministic template fallback"})`,
+    );
+  }
   const content = llmMarkdown || renderMemoryIndexMarkdown(snapshot);
 
   await mkdir(dirname(outputPath), { recursive: true });

--- a/extensions/memory-hybrid/services/reflection-dedupe-hydration.ts
+++ b/extensions/memory-hybrid/services/reflection-dedupe-hydration.ts
@@ -65,12 +65,22 @@ export function isEmbeddingRateLimitError(err: unknown): boolean {
   return is429OrWrapped(e) || is403QuotaOrRateLimitLike(err);
 }
 
+export interface DedupeHydrationFailedRow {
+  attempts: number;
+  /** Unix seconds. While in the future, this row is skipped so it does not block later rows. */
+  nextRetryAt: number;
+}
+
 export interface DedupeHydrationCheckpoint {
   v: number;
   fp: string;
   model: string;
-  /** Progress into the sorted need-embed index list (0 = none done). */
+  /** Legacy progress into the sorted need-embed index list (0 = none done). */
   nextNeedIdx: number;
+  /** Fact ids known to have been durably hydrated to Lance for this corpus/model. */
+  doneIds?: string[];
+  /** Rows that failed with non-rate-limit errors and should be retried later without blocking the tail. */
+  failed?: Record<string, DedupeHydrationFailedRow>;
   updatedAt: number;
 }
 
@@ -105,11 +115,31 @@ export function readDedupeHydrationCheckpoint(factsDb: FactsDB, stateKey: string
       return null;
     }
     if (typeof o.nextNeedIdx !== "number" || !Number.isFinite(o.nextNeedIdx) || o.nextNeedIdx < 0) return null;
+    const doneIds = Array.isArray(o.doneIds)
+      ? [
+          ...new Set(o.doneIds.filter((id): id is string => typeof id === "string").map((id) => id.toLowerCase())),
+        ].sort()
+      : undefined;
+    const failed: Record<string, DedupeHydrationFailedRow> = {};
+    if (o.failed && typeof o.failed === "object" && !Array.isArray(o.failed)) {
+      for (const [id, raw] of Object.entries(o.failed as Record<string, unknown>)) {
+        if (!raw || typeof raw !== "object" || Array.isArray(raw)) continue;
+        const r = raw as Partial<DedupeHydrationFailedRow>;
+        if (typeof r.attempts !== "number" || !Number.isFinite(r.attempts)) continue;
+        if (typeof r.nextRetryAt !== "number" || !Number.isFinite(r.nextRetryAt)) continue;
+        failed[id.toLowerCase()] = {
+          attempts: Math.max(1, Math.floor(r.attempts)),
+          nextRetryAt: Math.max(0, Math.floor(r.nextRetryAt)),
+        };
+      }
+    }
     return {
       v: REFLECTION_DEDUPE_CHECKPOINT_VERSION,
       fp: o.fp,
       model: o.model,
       nextNeedIdx: Math.floor(o.nextNeedIdx),
+      doneIds: doneIds && doneIds.length > 0 ? doneIds : undefined,
+      failed: Object.keys(failed).length > 0 ? failed : undefined,
       updatedAt: typeof o.updatedAt === "number" ? o.updatedAt : Math.floor(Date.now() / 1000),
     };
   } catch {

--- a/extensions/memory-hybrid/services/reflection-dedupe-hydration.ts
+++ b/extensions/memory-hybrid/services/reflection-dedupe-hydration.ts
@@ -5,7 +5,7 @@
 import { createHash } from "node:crypto";
 import type { FactsDB } from "../backends/facts-db.js";
 import type { MemoryEntry } from "../types/memory.js";
-import { is403QuotaOrRateLimitLike, is429OrWrapped, parseRetryAfterMs } from "./chat.js";
+import { is403QuotaOrRateLimitLike, is429OrWrapped } from "./chat.js";
 
 export const REFLECTION_DEDUPE_CHECKPOINT_VERSION = 1;
 

--- a/extensions/memory-hybrid/services/reflection-dedupe-hydration.ts
+++ b/extensions/memory-hybrid/services/reflection-dedupe-hydration.ts
@@ -1,0 +1,156 @@
+/**
+ * Reflection dedupe corpus hydration: rate limits, checkpoints, lexical fallback (#1229).
+ */
+
+import { createHash } from "node:crypto";
+import type { FactsDB } from "../backends/facts-db.js";
+import type { MemoryEntry } from "../types/memory.js";
+import { is403QuotaOrRateLimitLike, is429OrWrapped, parseRetryAfterMs } from "./chat.js";
+
+export const REFLECTION_DEDUPE_CHECKPOINT_VERSION = 1;
+
+/** Resolved maintenance policy for embedding-backed dedupe hydration. */
+export interface ReflectionDedupeHydrationResolved {
+  /** Max embedding API calls this run (0 = unlimited). */
+  maxEmbedsPerRun: number;
+  /** Minimum delay between consecutive embedding calls (ms). */
+  minIntervalMsBetweenEmbeds: number;
+  /** After this many consecutive rate-limit errors, defer remaining rows to a later run. */
+  maxConsecutive429BeforeDefer: number;
+  /** Base backoff (ms) when rate-limited; combined with Retry-After and exponential growth. */
+  baseBackoffMsAfter429: number;
+}
+
+export const DEFAULT_REFLECTION_DEDUPE_HYDRATION: ReflectionDedupeHydrationResolved = {
+  maxEmbedsPerRun: 800,
+  minIntervalMsBetweenEmbeds: 400,
+  maxConsecutive429BeforeDefer: 3,
+  baseBackoffMsAfter429: 5000,
+};
+
+/** Unlimited embed count but still applies interval + 429 backoff (e.g. consolidate CLI). */
+export const CONSOLIDATE_REFLECTION_DEDUPE_HYDRATION: ReflectionDedupeHydrationResolved = {
+  maxEmbedsPerRun: 0,
+  minIntervalMsBetweenEmbeds: 200,
+  maxConsecutive429BeforeDefer: 5,
+  baseBackoffMsAfter429: 4000,
+};
+
+export function resolveReflectionDedupeHydration(
+  partial?: Partial<ReflectionDedupeHydrationResolved> | null,
+): ReflectionDedupeHydrationResolved {
+  const d = DEFAULT_REFLECTION_DEDUPE_HYDRATION;
+  return {
+    maxEmbedsPerRun:
+      partial?.maxEmbedsPerRun !== undefined && Number.isFinite(partial.maxEmbedsPerRun)
+        ? Math.max(0, Math.min(2_000_000, Math.floor(partial.maxEmbedsPerRun)))
+        : d.maxEmbedsPerRun,
+    minIntervalMsBetweenEmbeds:
+      partial?.minIntervalMsBetweenEmbeds !== undefined && Number.isFinite(partial.minIntervalMsBetweenEmbeds)
+        ? Math.max(0, Math.min(120_000, Math.floor(partial.minIntervalMsBetweenEmbeds)))
+        : d.minIntervalMsBetweenEmbeds,
+    maxConsecutive429BeforeDefer:
+      partial?.maxConsecutive429BeforeDefer !== undefined && Number.isFinite(partial.maxConsecutive429BeforeDefer)
+        ? Math.max(1, Math.min(50, Math.floor(partial.maxConsecutive429BeforeDefer)))
+        : d.maxConsecutive429BeforeDefer,
+    baseBackoffMsAfter429:
+      partial?.baseBackoffMsAfter429 !== undefined && Number.isFinite(partial.baseBackoffMsAfter429)
+        ? Math.max(500, Math.min(600_000, Math.floor(partial.baseBackoffMsAfter429)))
+        : d.baseBackoffMsAfter429,
+  };
+}
+
+export function isEmbeddingRateLimitError(err: unknown): boolean {
+  const e = err instanceof Error ? err : new Error(String(err));
+  return is429OrWrapped(e) || is403QuotaOrRateLimitLike(err);
+}
+
+export interface DedupeHydrationCheckpoint {
+  v: number;
+  fp: string;
+  model: string;
+  /** Progress into the sorted need-embed index list (0 = none done). */
+  nextNeedIdx: number;
+  updatedAt: number;
+}
+
+export function computeDedupeCorpusFingerprint(sortedFactIds: string[], embeddingModelKey: string): string {
+  return createHash("sha256")
+    .update(`${sortedFactIds.join(",")}|${embeddingModelKey}`)
+    .digest("hex")
+    .slice(0, 16);
+}
+
+export type DedupeCorpusCheckpointKind = "pattern" | "rule" | "meta";
+
+export function dedupeHydrationStateKey(kind: DedupeCorpusCheckpointKind): string {
+  switch (kind) {
+    case "pattern":
+      return "reflection_dedupe_hydration_pattern";
+    case "rule":
+      return "reflection_dedupe_hydration_rule";
+    case "meta":
+      return "reflection_dedupe_hydration_meta";
+    default:
+      return "reflection_dedupe_hydration_pattern";
+  }
+}
+
+export function readDedupeHydrationCheckpoint(factsDb: FactsDB, stateKey: string): DedupeHydrationCheckpoint | null {
+  const raw = factsDb.getMaintenanceState(stateKey);
+  if (!raw) return null;
+  try {
+    const o = JSON.parse(raw) as Partial<DedupeHydrationCheckpoint>;
+    if (o.v !== REFLECTION_DEDUPE_CHECKPOINT_VERSION || typeof o.fp !== "string" || typeof o.model !== "string") {
+      return null;
+    }
+    if (typeof o.nextNeedIdx !== "number" || !Number.isFinite(o.nextNeedIdx) || o.nextNeedIdx < 0) return null;
+    return {
+      v: REFLECTION_DEDUPE_CHECKPOINT_VERSION,
+      fp: o.fp,
+      model: o.model,
+      nextNeedIdx: Math.floor(o.nextNeedIdx),
+      updatedAt: typeof o.updatedAt === "number" ? o.updatedAt : Math.floor(Date.now() / 1000),
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function writeDedupeHydrationCheckpoint(
+  factsDb: FactsDB,
+  stateKey: string,
+  cp: Omit<DedupeHydrationCheckpoint, "updatedAt">,
+): void {
+  const payload: DedupeHydrationCheckpoint = { ...cp, updatedAt: Math.floor(Date.now() / 1000) };
+  factsDb.setMaintenanceState(stateKey, JSON.stringify(payload));
+}
+
+export function normalizeReflectionDedupeText(s: string): string {
+  return s.toLowerCase().replace(/\s+/g, " ").trim();
+}
+
+/**
+ * Cheap lexical near-duplicate check when vector for an existing row is missing (#1229).
+ * Uses token Jaccard overlap and normalized substring checks.
+ */
+export function reflectionLexicalNearDuplicateAgainstFact(
+  candidate: string,
+  existingText: string,
+  tokenJaccardMin = 0.82,
+): boolean {
+  const nc = normalizeReflectionDedupeText(candidate);
+  const ne = normalizeReflectionDedupeText(existingText);
+  if (nc.length < 12 || ne.length < 12) return false;
+  if (nc === ne) return true;
+  if (ne.includes(nc) || nc.includes(ne)) return true;
+  const cw = new Set(nc.split(/\s+/).filter((w) => w.length > 1));
+  const ew = new Set(ne.split(/\s+/).filter((w) => w.length > 1));
+  if (cw.size === 0 || ew.size === 0) return false;
+  let inter = 0;
+  for (const w of cw) {
+    if (ew.has(w)) inter++;
+  }
+  const union = new Set([...cw, ...ew]).size;
+  return union > 0 && inter / union >= tokenJaccardMin;
+}

--- a/extensions/memory-hybrid/services/reflection.ts
+++ b/extensions/memory-hybrid/services/reflection.ts
@@ -342,6 +342,7 @@ export async function loadReflectionDedupeCorpusVectors(
               });
             }
             result[j] = null;
+            consecutive429 = 0;
             done = true;
           }
         }

--- a/extensions/memory-hybrid/services/reflection.ts
+++ b/extensions/memory-hybrid/services/reflection.ts
@@ -359,10 +359,6 @@ export async function loadReflectionDedupeCorpusVectors(
       }
     }
 
-    if (!deferredDueToRateLimit && !deferredDueToCap && corpusOpts?.checkpoint) {
-      persistCheckpoint(needEmbedIndices.length);
-    }
-
     const nonNull = result.filter((v) => v !== null).length;
     const complete = !deferredDueToRateLimit && !deferredDueToCap;
     const remainingNeed = Math.max(0, needEmbedIndices.length - checkpointNextIdx);

--- a/extensions/memory-hybrid/services/reflection.ts
+++ b/extensions/memory-hybrid/services/reflection.ts
@@ -40,6 +40,7 @@ import {
   readDedupeHydrationCheckpoint,
   REFLECTION_DEDUPE_CHECKPOINT_VERSION,
   reflectionLexicalNearDuplicateAgainstFact,
+  type DedupeHydrationFailedRow,
   writeDedupeHydrationCheckpoint,
   type DedupeCorpusCheckpointKind,
   type ReflectionDedupeHydrationResolved,
@@ -132,6 +133,8 @@ export interface ReflectionDedupeCorpusOptions {
   progressLabel?: string;
   /** When set, persist/resume hydration cursor across runs (#1229). */
   checkpoint?: ReflectionDedupeCorpusCheckpointOpts;
+  /** When false, checkpoint state is read for resume but never mutated (dry-run semantics). */
+  persistCheckpoint?: boolean;
   /** Throttle + cap; default depends on checkpoint (dream-cycle vs consolidate). */
   hydrationPolicy?: ReflectionDedupeHydrationResolved;
 }
@@ -183,21 +186,35 @@ export async function loadReflectionDedupeCorpusVectors(
       ) => Promise<Map<string, number[]>>;
       isMemoriesVectorSchemaValid?: () => boolean;
       isLanceAvailable?: () => boolean;
+      isLanceDbAvailable?: () => boolean;
+      store?: (entry: {
+        text: string;
+        vector: number[];
+        importance: number;
+        category: string;
+        id: string;
+      }) => Promise<string>;
     };
     const dim = typeof vdb.getVectorDim === "function" ? vdb.getVectorDim() : 0;
     let byId = new Map<string, number[]>();
     const lanceSchemaOk =
       typeof vdb.isMemoriesVectorSchemaValid === "function" ? vdb.isMemoriesVectorSchemaValid() : true;
-    const lanceUp = typeof vdb.isLanceAvailable === "function" ? vdb.isLanceAvailable() : true;
+    const lanceDbAvailable =
+      typeof vdb.isLanceDbAvailable === "function"
+        ? vdb.isLanceDbAvailable()
+        : typeof vdb.isLanceAvailable === "function"
+          ? vdb.isLanceAvailable()
+          : true;
 
     if (verbose && facts.length > 0) {
       logger.info(
-        `${logPrefix} — ${progressLabel}: starting (${facts.length} row(s); Lance available=${lanceUp}, memories vector schema valid=${lanceSchemaOk}, embedModel=${embeddings.modelName ?? "unknown"}; maxEmbedsPerRun=${policy.maxEmbedsPerRun || "∞"}, minIntervalMs=${policy.minIntervalMsBetweenEmbeds})`,
+        `${logPrefix} — ${progressLabel}: starting (${facts.length} row(s); Lance DB available=${lanceDbAvailable}, memories vector schema valid=${lanceSchemaOk}, embedModel=${embeddings.modelName ?? "unknown"}; maxEmbedsPerRun=${policy.maxEmbedsPerRun || "∞"}, minIntervalMs=${policy.minIntervalMsBetweenEmbeds})`,
       );
     }
 
     const prefetchStart = Date.now();
     if (typeof vdb.getVectorsByFactIds === "function") {
+      let lanceBulkFetchFailed = false;
       try {
         if (verbose) {
           logger.info(
@@ -216,10 +233,17 @@ export async function loadReflectionDedupeCorpusVectors(
               }
             : undefined,
         );
-      } catch {
+      } catch (err) {
+        lanceBulkFetchFailed = true;
         byId = new Map();
+        if (verbose) {
+          const logWarn = logger.warn ?? ((m: string) => logger.info(m));
+          logWarn(
+            `${logPrefix} — ${progressLabel}: Lance bulk fetch failed — falling back to embedding API/lexical fallback where needed, elapsed=${formatElapsedSec(prefetchStart)}: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
       }
-      if (verbose) {
+      if (verbose && !lanceBulkFetchFailed) {
         logger.info(
           `${logPrefix} — ${progressLabel}: Lance bulk fetch done — ${byId.size} vector(s) present in Lance for requested ids, elapsed=${formatElapsedSec(prefetchStart)}`,
         );
@@ -254,18 +278,25 @@ export async function loadReflectionDedupeCorpusVectors(
     const fp = computeDedupeCorpusFingerprint(sortedIds, modelKey);
     const stateKey = corpusOpts?.checkpoint ? dedupeHydrationStateKey(corpusOpts.checkpoint.kind) : "";
 
-    let nextK = 0;
+    let failedRows: Record<string, DedupeHydrationFailedRow> = {};
+    let doneIds = new Set<string>();
     if (corpusOpts?.checkpoint) {
       const cp = readDedupeHydrationCheckpoint(corpusOpts.checkpoint.factsDb, stateKey);
       if (cp && cp.fp === fp && cp.model === modelKey) {
-        nextK = Math.min(cp.nextNeedIdx, needEmbedIndices.length);
+        failedRows = { ...(cp.failed ?? {}) };
+        doneIds = new Set((cp.doneIds ?? []).map((id) => id.toLowerCase()));
       }
     }
 
-    let checkpointNextIdx = nextK;
+    for (let j = 0; j < facts.length; j++) {
+      if (result[j] !== null) doneIds.add(facts[j]!.id.toLowerCase());
+    }
+
+    let checkpointNextIdx = 0;
     let apiEmbedsThisRun = 0;
     let deferredDueToRateLimit = false;
     let deferredDueToCap = false;
+    let deferredDueToEmbeddingFailure = false;
     let lastEmbedAt = 0;
     let consecutive429 = 0;
     const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
@@ -273,17 +304,40 @@ export async function loadReflectionDedupeCorpusVectors(
     hb.needTotal = needEmbedIndices.length;
 
     const persistCheckpoint = (nextNeedIdx: number) => {
-      checkpointNextIdx = nextNeedIdx;
-      if (!corpusOpts?.checkpoint) return;
+      checkpointNextIdx = Math.max(checkpointNextIdx, nextNeedIdx);
+      if (!corpusOpts?.checkpoint || corpusOpts.persistCheckpoint === false) return;
+      const failed = Object.fromEntries(Object.entries(failedRows).sort(([a], [b]) => a.localeCompare(b)));
       writeDedupeHydrationCheckpoint(corpusOpts.checkpoint.factsDb, stateKey, {
         v: REFLECTION_DEDUPE_CHECKPOINT_VERSION,
         fp,
         model: modelKey,
-        nextNeedIdx,
+        nextNeedIdx: checkpointNextIdx,
+        doneIds: [...doneIds].sort(),
+        failed: Object.keys(failed).length > 0 ? failed : undefined,
       });
     };
 
-    for (let kk = nextK; kk < needEmbedIndices.length; kk++) {
+    const retryDelaySec = (attempts: number) => Math.min(24 * 60 * 60, 60 * 2 ** Math.max(0, attempts - 1));
+    const nowSecForRetry = () => Math.floor(Date.now() / 1000);
+    const markEmbeddingFailure = (factId: string, kk: number) => {
+      const id = factId.toLowerCase();
+      const prev = failedRows[id];
+      const attempts = (prev?.attempts ?? 0) + 1;
+      failedRows[id] = { attempts, nextRetryAt: nowSecForRetry() + retryDelaySec(attempts) };
+      persistCheckpoint(kk + 1);
+    };
+
+    const workKs: number[] = [];
+    const nowRetry = nowSecForRetry();
+    for (let kk = 0; kk < needEmbedIndices.length; kk++) {
+      const f = facts[needEmbedIndices[kk]!]!;
+      const failed = failedRows[f.id.toLowerCase()];
+      const retryDue = !failed || failed.nextRetryAt <= nowRetry;
+      if (doneIds.has(f.id.toLowerCase()) && !failed) continue;
+      if (retryDue) workKs.push(kk);
+    }
+
+    for (const kk of workKs) {
       hb.needK = kk;
       if (policy.maxEmbedsPerRun > 0 && apiEmbedsThisRun >= policy.maxEmbedsPerRun) {
         deferredDueToCap = true;
@@ -302,9 +356,38 @@ export async function loadReflectionDedupeCorpusVectors(
       let done = false;
       while (!done && !deferredDueToRateLimit) {
         try {
-          const vec = await embeddings.embed(f.text);
-          result[j] = normalizeVector(vec);
           apiEmbedsThisRun++;
+          hb.apiEmbeds = apiEmbedsThisRun;
+          const vec = await embeddings.embed(f.text);
+          const normVec = normalizeVector(vec);
+          // If we are going to advance a durable checkpoint, the newly-hydrated vector
+          // must be durable too. Otherwise a later run resumes past this row while Lance
+          // still lacks the vector, permanently forcing lexical fallback for that prefix.
+          if (corpusOpts?.checkpoint && corpusOpts.persistCheckpoint !== false && typeof vdb.store === "function") {
+            try {
+              await vdb.store({
+                id: f.id,
+                text: f.text,
+                vector: normVec,
+                importance: f.importance ?? 0.5,
+                category: f.category,
+              });
+            } catch (storeErr) {
+              const logWarn = logger.warn ?? ((m: string) => logger.info(m));
+              logWarn(
+                `${logPrefix} — ${progressLabel}: vector persistence failed for hydrated backlog item ${kk + 1}/${needEmbedIndices.length} (factId=${f.id}); leaving checkpoint at ${kk} so it can be retried next run: ${storeErr instanceof Error ? storeErr.message : String(storeErr)}`,
+              );
+              result[j] = normVec;
+              consecutive429 = 0;
+              deferredDueToEmbeddingFailure = true;
+              markEmbeddingFailure(f.id, kk);
+              done = true;
+              break;
+            }
+          }
+          result[j] = normVec;
+          doneIds.add(f.id.toLowerCase());
+          delete failedRows[f.id.toLowerCase()];
           consecutive429 = 0;
           lastEmbedAt = Date.now();
           done = true;
@@ -341,8 +424,14 @@ export async function loadReflectionDedupeCorpusVectors(
                 factId: f.id,
               });
             }
+            const logWarn = logger.warn ?? ((m: string) => logger.info(m));
+            logWarn(
+              `${logPrefix} — ${progressLabel}: embedding failed for backlog item ${kk + 1}/${needEmbedIndices.length} (factId=${f.id}); leaving checkpoint at ${kk} so it can be retried next run: ${err instanceof Error ? err.message : String(err)}`,
+            );
             result[j] = null;
             consecutive429 = 0;
+            deferredDueToEmbeddingFailure = true;
+            markEmbeddingFailure(f.id, kk);
             done = true;
           }
         }
@@ -360,15 +449,25 @@ export async function loadReflectionDedupeCorpusVectors(
       }
     }
 
+    if (!deferredDueToRateLimit && !deferredDueToCap) {
+      persistCheckpoint(needEmbedIndices.length);
+    }
+
+    checkpointNextIdx = needEmbedIndices.filter((idx) => doneIds.has(facts[idx]!.id.toLowerCase())).length;
+    const failedRowCount = Object.keys(failedRows).length;
     const nonNull = result.filter((v) => v !== null).length;
-    const complete = !deferredDueToRateLimit && !deferredDueToCap;
+    const complete =
+      !deferredDueToRateLimit &&
+      !deferredDueToCap &&
+      failedRowCount === 0 &&
+      checkpointNextIdx >= needEmbedIndices.length;
     const remainingNeed = Math.max(0, needEmbedIndices.length - checkpointNextIdx);
 
     if (facts.length > 0) {
       logger.info(
-        `${logPrefix} — dedupe corpus: ${lanceHits} vector(s) reused from Lance index, ${apiEmbedsThisRun} via embedding API, ${nonNull}/${facts.length} non-null for cosine check` +
-          (deferredDueToRateLimit || deferredDueToCap
-            ? ` | backlog need_embed_total=${needEmbedIndices.length} remaining=${remainingNeed} checkpoint_nextNeedIdx=${checkpointNextIdx} deferred429=${deferredDueToRateLimit ? 1 : 0} deferredCap=${deferredDueToCap ? 1 : 0} (#1229)`
+        `${logPrefix} — ${progressLabel}: ${lanceHits} vector(s) reused from Lance index, ${apiEmbedsThisRun} via embedding API, ${nonNull}/${facts.length} non-null for cosine check` +
+          (deferredDueToRateLimit || deferredDueToCap || deferredDueToEmbeddingFailure || failedRowCount > 0
+            ? ` | backlog need_embed_total=${needEmbedIndices.length} remaining=${remainingNeed} checkpoint_nextNeedIdx=${checkpointNextIdx} deferred429=${deferredDueToRateLimit ? 1 : 0} deferredCap=${deferredDueToCap ? 1 : 0} failedRows=${failedRowCount} (#1229)`
             : ""),
       );
     }
@@ -585,6 +684,7 @@ export async function runReflection(
         verbose: opts.verbose,
         progressLabel: "reflection dedupe (existing corpus)",
         checkpoint: { factsDb, kind: "pattern" },
+        persistCheckpoint: !opts.dryRun,
         hydrationPolicy: opts.dedupeHydration ?? DEFAULT_REFLECTION_DEDUPE_HYDRATION,
       },
     );
@@ -864,6 +964,7 @@ export async function runReflectionRules(
         verbose: opts.verbose,
         progressLabel: "reflect-rules dedupe (existing corpus)",
         checkpoint: { factsDb, kind: "rule" },
+        persistCheckpoint: !opts.dryRun,
         hydrationPolicy: opts.dedupeHydration ?? DEFAULT_REFLECTION_DEDUPE_HYDRATION,
       },
     );
@@ -1130,6 +1231,7 @@ export async function runReflectionMeta(
         verbose: opts.verbose,
         progressLabel: "reflect-meta dedupe (existing corpus)",
         checkpoint: { factsDb, kind: "meta" },
+        persistCheckpoint: !opts.dryRun,
         hydrationPolicy: opts.dedupeHydration ?? DEFAULT_REFLECTION_DEDUPE_HYDRATION,
       },
     );

--- a/extensions/memory-hybrid/services/reflection.ts
+++ b/extensions/memory-hybrid/services/reflection.ts
@@ -22,6 +22,7 @@ import {
   REFLECTION_TEMPERATURE,
 } from "../utils/constants.js";
 import { getEnv } from "../utils/env-manager.js";
+import { formatElapsedSec, withVerboseHeartbeat } from "../utils/maintenance-progress.js";
 import { fillPrompt, loadPrompt } from "../utils/prompt-loader.js";
 import { LLMRetryError } from "./chat.js";
 import { chatCompleteWithAdaptiveMaintenanceRetry } from "./adaptive-maintenance-llm.js";
@@ -104,6 +105,13 @@ export function dotProductSimilarity(a: number[], b: number[]): number {
   return dot;
 }
 
+export interface ReflectionDedupeCorpusOptions {
+  /** When true, emit Lance chunk lines, embedding batch milestones, and idle heartbeats (#1228). */
+  verbose?: boolean;
+  /** Short label for progress lines (e.g. `reflection dedupe`). */
+  progressLabel?: string;
+}
+
 /**
  * Build normalized dedupe-corpus vectors for existing facts: prefer LanceDB rows (same id as fact),
  * else call the embedding API. Batches API calls (20) with a short pause only when a batch used the API.
@@ -115,68 +123,142 @@ export async function loadReflectionDedupeCorpusVectors(
   logger: { info: (msg: string) => void },
   logPrefix: string,
   captureOperation: string,
+  corpusOpts?: ReflectionDedupeCorpusOptions,
 ): Promise<(number[] | null)[]> {
-  const vdb = vectorDb as VectorDB & {
-    getVectorDim?: () => number;
-    getVectorsByFactIds?: (ids: string[]) => Promise<Map<string, number[]>>;
-  };
-  const dim = typeof vdb.getVectorDim === "function" ? vdb.getVectorDim() : 0;
-  let byId = new Map<string, number[]>();
-  if (typeof vdb.getVectorsByFactIds === "function") {
-    try {
-      byId = await vdb.getVectorsByFactIds(facts.map((f) => f.id));
-    } catch {
-      byId = new Map();
+  const verbose = corpusOpts?.verbose === true;
+  const progressLabel = corpusOpts?.progressLabel ?? "dedupe corpus";
+  const hb = { lanceHits: 0, apiEmbeds: 0, rowEnd: 0 };
+
+  const runBody = async (): Promise<(number[] | null)[]> => {
+    const vdb = vectorDb as VectorDB & {
+      getVectorDim?: () => number;
+      getVectorsByFactIds?: (
+        ids: string[],
+        opts?: { onChunkProgress?: (loaded: number, total: number) => void },
+      ) => Promise<Map<string, number[]>>;
+      isMemoriesVectorSchemaValid?: () => boolean;
+      isLanceAvailable?: () => boolean;
+    };
+    const dim = typeof vdb.getVectorDim === "function" ? vdb.getVectorDim() : 0;
+    let byId = new Map<string, number[]>();
+    const lanceSchemaOk =
+      typeof vdb.isMemoriesVectorSchemaValid === "function" ? vdb.isMemoriesVectorSchemaValid() : true;
+    const lanceUp = typeof vdb.isLanceAvailable === "function" ? vdb.isLanceAvailable() : true;
+
+    if (verbose && facts.length > 0) {
+      logger.info(
+        `${logPrefix} — ${progressLabel}: starting (${facts.length} row(s); Lance available=${lanceUp}, memories vector schema valid=${lanceSchemaOk}, embedModel=${embeddings.modelName ?? "unknown"})`,
+      );
     }
-  }
 
-  const result: (number[] | null)[] = new Array(facts.length);
-  let lanceHits = 0;
-  let apiEmbeds = 0;
+    const prefetchStart = Date.now();
+    if (typeof vdb.getVectorsByFactIds === "function") {
+      try {
+        if (verbose) {
+          logger.info(
+            `${logPrefix} — ${progressLabel}: Lance bulk fetch for ${facts.length} fact id(s) (indexed id IN queries, chunked)`,
+          );
+        }
+        byId = await vdb.getVectorsByFactIds(
+          facts.map((f) => f.id),
+          verbose
+            ? {
+                onChunkProgress: (loaded, total) => {
+                  logger.info(
+                    `${logPrefix} — ${progressLabel}: Lance id scan ${loaded}/${total}, elapsed=${formatElapsedSec(prefetchStart)}`,
+                  );
+                },
+              }
+            : undefined,
+        );
+      } catch {
+        byId = new Map();
+      }
+      if (verbose) {
+        logger.info(
+          `${logPrefix} — ${progressLabel}: Lance bulk fetch done — ${byId.size} vector(s) present in Lance for requested ids, elapsed=${formatElapsedSec(prefetchStart)}`,
+        );
+      }
+    } else if (verbose) {
+      logger.info(
+        `${logPrefix} — ${progressLabel}: no getVectorsByFactIds on backend — per-row embedding API on cache miss`,
+      );
+    }
 
-  for (let i = 0; i < facts.length; i += 20) {
-    const end = Math.min(i + 20, facts.length);
-    let hadApiEmbed = false;
-    for (let j = i; j < end; j++) {
-      const f = facts[j]!;
-      const cached = byId.get(f.id.toLowerCase());
-      const modelOk =
-        f.embeddingModel != null && embeddings.modelName != null && f.embeddingModel === embeddings.modelName;
-      const useCache = dim > 0 && cached != null && cached.length === dim && modelOk;
-      if (useCache) {
-        result[j] = normalizeVector(cached);
-        lanceHits++;
-      } else {
-        try {
-          const vec = await embeddings.embed(f.text);
-          result[j] = normalizeVector(vec);
-          apiEmbeds++;
-          hadApiEmbed = true;
-        } catch (err) {
-          if (!shouldSuppressEmbeddingError(err)) {
-            capturePluginError(err instanceof Error ? err : new Error(String(err)), {
-              operation: captureOperation,
-              subsystem: "embeddings",
-              factId: f.id,
-            });
+    const result: (number[] | null)[] = new Array(facts.length);
+    let lanceHits = 0;
+    let apiEmbeds = 0;
+    const embedPhaseStart = Date.now();
+    const batchSize = 20;
+    const totalBatches = Math.max(1, Math.ceil(facts.length / batchSize));
+
+    for (let i = 0; i < facts.length; i += batchSize) {
+      const end = Math.min(i + batchSize, facts.length);
+      let hadApiEmbed = false;
+      for (let j = i; j < end; j++) {
+        const f = facts[j]!;
+        const cached = byId.get(f.id.toLowerCase());
+        const modelOk =
+          f.embeddingModel != null && embeddings.modelName != null && f.embeddingModel === embeddings.modelName;
+        const useCache = dim > 0 && cached != null && cached.length === dim && modelOk;
+        if (useCache) {
+          result[j] = normalizeVector(cached);
+          lanceHits++;
+        } else {
+          try {
+            const vec = await embeddings.embed(f.text);
+            result[j] = normalizeVector(vec);
+            apiEmbeds++;
+            hadApiEmbed = true;
+          } catch (err) {
+            if (!shouldSuppressEmbeddingError(err)) {
+              capturePluginError(err instanceof Error ? err : new Error(String(err)), {
+                operation: captureOperation,
+                subsystem: "embeddings",
+                factId: f.id,
+              });
+            }
+            result[j] = null;
+            hadApiEmbed = true;
           }
-          result[j] = null;
-          hadApiEmbed = true;
         }
       }
+      hb.lanceHits = lanceHits;
+      hb.apiEmbeds = apiEmbeds;
+      hb.rowEnd = end;
+      if (verbose) {
+        const batchNum = Math.floor(i / batchSize) + 1;
+        const logThisBatch = facts.length <= 100 || batchNum === 1 || batchNum === totalBatches || batchNum % 25 === 0;
+        if (logThisBatch) {
+          logger.info(
+            `${logPrefix} — ${progressLabel}: embedding batch ${batchNum}/${totalBatches} rows ${end}/${facts.length} lanceHits=${lanceHits} apiEmbeds=${apiEmbeds} elapsed=${formatElapsedSec(embedPhaseStart)}`,
+          );
+        }
+      }
+      if (hadApiEmbed && end < facts.length) {
+        await new Promise((r) => setTimeout(r, 200));
+      }
     }
-    if (hadApiEmbed && end < facts.length) {
-      await new Promise((r) => setTimeout(r, 200));
-    }
-  }
 
-  if (facts.length > 0) {
-    const ok = result.filter((v) => v !== null).length;
-    logger.info(
-      `${logPrefix} — dedupe corpus: ${lanceHits} vector(s) reused from Lance index, ${apiEmbeds} via embedding API, ${ok}/${facts.length} non-null for cosine check`,
-    );
+    if (facts.length > 0) {
+      const ok = result.filter((v) => v !== null).length;
+      logger.info(
+        `${logPrefix} — dedupe corpus: ${lanceHits} vector(s) reused from Lance index, ${apiEmbeds} via embedding API, ${ok}/${facts.length} non-null for cosine check`,
+      );
+    }
+    return result;
+  };
+
+  if (!verbose) {
+    return runBody();
   }
-  return result;
+  return withVerboseHeartbeat({
+    verbose: true,
+    log: (m) => logger.info(m),
+    prefix: `${logPrefix} — ${progressLabel}`,
+    detail: () => `rows=${hb.rowEnd}/${facts.length} lanceHits=${hb.lanceHits} apiEmbeds=${hb.apiEmbeds}`,
+    fn: runBody,
+  });
 }
 
 /**
@@ -335,6 +417,7 @@ export async function runReflection(
   }
 
   let existingVectors: (number[] | null)[] = [];
+  const corpusLoadStarted = Date.now();
   if (existingPatternFacts.length > 0) {
     logger.info(
       `memory-hybrid: reflection — loading ${existingPatternFacts.length} existing pattern row(s) for dedupe (Lance vectors + embedding API when index or model is missing)`,
@@ -346,9 +429,15 @@ export async function runReflection(
       logger,
       "memory-hybrid: reflection",
       "reflection-embed-existing",
+      { verbose: opts.verbose, progressLabel: "reflection dedupe (existing corpus)" },
     );
   } else {
     logger.info("memory-hybrid: reflection — no existing pattern facts for dedupe; embedding new candidates only");
+  }
+  if (opts.verbose && existingPatternFacts.length > 0) {
+    logger.info(
+      `memory-hybrid: reflection — existing corpus vectors ready: ${existingVectors.length} slot(s), elapsed=${formatElapsedSec(corpusLoadStarted)}`,
+    );
   }
 
   logger.info(
@@ -359,7 +448,10 @@ export async function runReflection(
   let duplicatesSkipped = 0;
   let newPatternEmbedFailures = 0;
   const reflectionRunId = provenanceService ? randomUUID() : null;
+  const newCandidatePhaseStart = Date.now();
+  let candIndex = 0;
   for (const patternText of uniqueNewPatterns) {
+    candIndex++;
     let vec: number[];
     try {
       vec = await embeddings.embed(patternText);
@@ -373,6 +465,11 @@ export async function runReflection(
           subsystem: "reflection",
         });
       }
+      if (opts.verbose) {
+        logger.info(
+          `memory-hybrid: reflection — dedupe candidate ${candIndex}/${uniqueNewPatterns.length}: embed failed, skipped | elapsed=${formatElapsedSec(newCandidatePhaseStart)}`,
+        );
+      }
       continue; // Skip this pattern on embed failure
     }
     const normVec = normalizeVector(vec);
@@ -383,6 +480,11 @@ export async function runReflection(
         isDuplicate = true;
         break;
       }
+    }
+    if (opts.verbose) {
+      logger.info(
+        `memory-hybrid: reflection — dedupe candidate ${candIndex}/${uniqueNewPatterns.length}: cosine check done, duplicate=${isDuplicate} | elapsed=${formatElapsedSec(newCandidatePhaseStart)}`,
+      );
     }
     if (isDuplicate) {
       duplicatesSkipped++;
@@ -457,7 +559,8 @@ export async function runReflection(
     factsDb.setMaintenanceState("reflection_input_hash", inputHash);
   }
   logger.info(
-    `memory-hybrid: reflection — finished: ${stored} pattern(s) stored in DB + vector index, ${duplicatesSkipped} skipped as near-duplicate(s), ${newPatternEmbedFailures} new-pattern embed failure(s), ${uniqueNewPatterns.length} candidate(s) total`,
+    `memory-hybrid: reflection — finished: ${stored} pattern(s) stored in DB + vector index, ${duplicatesSkipped} skipped as near-duplicate(s), ${newPatternEmbedFailures} new-pattern embed failure(s), ${uniqueNewPatterns.length} candidate(s) total` +
+      (opts.verbose ? ` | new-candidate phase elapsed=${formatElapsedSec(newCandidatePhaseStart)}` : ""),
   );
 
   return {
@@ -579,6 +682,7 @@ export async function runReflectionRules(
       logger,
       "memory-hybrid: reflect-rules",
       "reflection-rules-embed-existing",
+      { verbose: opts.verbose, progressLabel: "reflect-rules dedupe (existing corpus)" },
     );
   } else {
     logger.info("memory-hybrid: reflect-rules — no existing rule facts for dedupe; embedding new candidates only");
@@ -592,7 +696,10 @@ export async function runReflectionRules(
   let rulesDuplicatesSkipped = 0;
   let newRuleEmbedFailures = 0;
   const reflectionRunId = provenanceService ? randomUUID() : null;
+  const rulesCandidatePhaseStart = Date.now();
+  let ruleCandIndex = 0;
   for (const ruleText of uniqueRules) {
+    ruleCandIndex++;
     let vec: number[];
     try {
       vec = await embeddings.embed(ruleText);
@@ -606,6 +713,11 @@ export async function runReflectionRules(
           subsystem: "reflection",
         });
       }
+      if (opts.verbose) {
+        logger.info(
+          `memory-hybrid: reflect-rules — dedupe candidate ${ruleCandIndex}/${uniqueRules.length}: embed failed, skipped | elapsed=${formatElapsedSec(rulesCandidatePhaseStart)}`,
+        );
+      }
       continue; // Skip this rule on embed failure
     }
     const normVec = normalizeVector(vec);
@@ -616,6 +728,11 @@ export async function runReflectionRules(
         isDuplicate = true;
         break;
       }
+    }
+    if (opts.verbose) {
+      logger.info(
+        `memory-hybrid: reflect-rules — dedupe candidate ${ruleCandIndex}/${uniqueRules.length}: duplicate=${isDuplicate} | elapsed=${formatElapsedSec(rulesCandidatePhaseStart)}`,
+      );
     }
     if (isDuplicate) {
       rulesDuplicatesSkipped++;
@@ -685,7 +802,8 @@ export async function runReflectionRules(
   }
 
   logger.info(
-    `memory-hybrid: reflect-rules — finished: ${stored} rule(s) stored, ${rulesDuplicatesSkipped} skipped as near-duplicate(s), ${newRuleEmbedFailures} new-rule embed failure(s), ${uniqueRules.length} candidate(s) total`,
+    `memory-hybrid: reflect-rules — finished: ${stored} rule(s) stored, ${rulesDuplicatesSkipped} skipped as near-duplicate(s), ${newRuleEmbedFailures} new-rule embed failure(s), ${uniqueRules.length} candidate(s) total` +
+      (opts.verbose ? ` | new-candidate phase elapsed=${formatElapsedSec(rulesCandidatePhaseStart)}` : ""),
   );
 
   return { rulesExtracted: rules.length, rulesStored: stored };
@@ -804,6 +922,7 @@ export async function runReflectionMeta(
       logger,
       "memory-hybrid: reflect-meta",
       "reflection-meta-embed-existing",
+      { verbose: opts.verbose, progressLabel: "reflect-meta dedupe (existing corpus)" },
     );
   } else {
     logger.info("memory-hybrid: reflect-meta — no existing meta-patterns for dedupe; embedding new candidates only");
@@ -817,7 +936,10 @@ export async function runReflectionMeta(
   let metaDuplicatesSkipped = 0;
   let newMetaEmbedFailures = 0;
   const reflectionRunId = provenanceService ? randomUUID() : null;
+  const metaCandidatePhaseStart = Date.now();
+  let metaCandIndex = 0;
   for (const metaText of uniqueMetas) {
+    metaCandIndex++;
     let vec: number[];
     try {
       vec = await embeddings.embed(metaText);
@@ -831,6 +953,11 @@ export async function runReflectionMeta(
           subsystem: "reflection",
         });
       }
+      if (opts.verbose) {
+        logger.info(
+          `memory-hybrid: reflect-meta — dedupe candidate ${metaCandIndex}/${uniqueMetas.length}: embed failed, skipped | elapsed=${formatElapsedSec(metaCandidatePhaseStart)}`,
+        );
+      }
       continue; // Skip this meta-pattern on embed failure
     }
     const normVec = normalizeVector(vec);
@@ -841,6 +968,11 @@ export async function runReflectionMeta(
         isDuplicate = true;
         break;
       }
+    }
+    if (opts.verbose) {
+      logger.info(
+        `memory-hybrid: reflect-meta — dedupe candidate ${metaCandIndex}/${uniqueMetas.length}: duplicate=${isDuplicate} | elapsed=${formatElapsedSec(metaCandidatePhaseStart)}`,
+      );
     }
     if (isDuplicate) {
       metaDuplicatesSkipped++;
@@ -910,7 +1042,8 @@ export async function runReflectionMeta(
   }
 
   logger.info(
-    `memory-hybrid: reflect-meta — finished: ${stored} meta-pattern(s) stored, ${metaDuplicatesSkipped} skipped as near-duplicate(s), ${newMetaEmbedFailures} embed failure(s), ${uniqueMetas.length} candidate(s) total`,
+    `memory-hybrid: reflect-meta — finished: ${stored} meta-pattern(s) stored, ${metaDuplicatesSkipped} skipped as near-duplicate(s), ${newMetaEmbedFailures} embed failure(s), ${uniqueMetas.length} candidate(s) total` +
+      (opts.verbose ? ` | new-candidate phase elapsed=${formatElapsedSec(metaCandidatePhaseStart)}` : ""),
   );
 
   return { metaExtracted: metas.length, metaStored: stored };

--- a/extensions/memory-hybrid/services/reflection.ts
+++ b/extensions/memory-hybrid/services/reflection.ts
@@ -24,13 +24,26 @@ import {
 import { getEnv } from "../utils/env-manager.js";
 import { formatElapsedSec, withVerboseHeartbeat } from "../utils/maintenance-progress.js";
 import { fillPrompt, loadPrompt } from "../utils/prompt-loader.js";
-import { LLMRetryError } from "./chat.js";
+import { LLMRetryError, parseRetryAfterMs } from "./chat.js";
 import { chatCompleteWithAdaptiveMaintenanceRetry } from "./adaptive-maintenance-llm.js";
 import { CostFeature } from "./cost-feature-labels.js";
 import type { EmbeddingProvider } from "./embeddings.js";
 import { shouldSuppressEmbeddingError } from "./embeddings.js";
 import { capturePluginError } from "./error-reporter.js";
 import type { ProvenanceService } from "./provenance.js";
+import {
+  computeDedupeCorpusFingerprint,
+  CONSOLIDATE_REFLECTION_DEDUPE_HYDRATION,
+  DEFAULT_REFLECTION_DEDUPE_HYDRATION,
+  dedupeHydrationStateKey,
+  isEmbeddingRateLimitError,
+  readDedupeHydrationCheckpoint,
+  REFLECTION_DEDUPE_CHECKPOINT_VERSION,
+  reflectionLexicalNearDuplicateAgainstFact,
+  writeDedupeHydrationCheckpoint,
+  type DedupeCorpusCheckpointKind,
+  type ReflectionDedupeHydrationResolved,
+} from "./reflection-dedupe-hydration.js";
 
 const REFLECTION_PATTERN_MIN_CHARS = 20;
 const REFLECTION_RULE_MIN_CHARS = 10;
@@ -61,6 +74,8 @@ interface ReflectionOptions {
   fallbackModels?: string[];
   modelSource?: string;
   adaptiveStatePath?: string;
+  /** Resolved hydration throttle + cap (#1229). When omitted, defaults for consolidate-style paths. */
+  dedupeHydration?: ReflectionDedupeHydrationResolved;
 }
 
 interface ReflectionResult {
@@ -105,31 +120,61 @@ export function dotProductSimilarity(a: number[], b: number[]): number {
   return dot;
 }
 
+export interface ReflectionDedupeCorpusCheckpointOpts {
+  factsDb: FactsDB;
+  kind: DedupeCorpusCheckpointKind;
+}
+
 export interface ReflectionDedupeCorpusOptions {
   /** When true, emit Lance chunk lines, embedding batch milestones, and idle heartbeats (#1228). */
   verbose?: boolean;
   /** Short label for progress lines (e.g. `reflection dedupe`). */
   progressLabel?: string;
+  /** When set, persist/resume hydration cursor across runs (#1229). */
+  checkpoint?: ReflectionDedupeCorpusCheckpointOpts;
+  /** Throttle + cap; default depends on checkpoint (dream-cycle vs consolidate). */
+  hydrationPolicy?: ReflectionDedupeHydrationResolved;
+}
+
+export interface ReflectionDedupeCorpusResult {
+  vectors: (number[] | null)[];
+  hydration: {
+    complete: boolean;
+    totalRows: number;
+    needEmbedTotal: number;
+    /** Next index into the sorted need-embed list for resume (see maintenance_state). */
+    checkpointNextNeedIdx: number;
+    deferredDueToRateLimit: boolean;
+    deferredDueToCap: boolean;
+    apiEmbedsThisRun: number;
+    lanceHits: number;
+    vectorsNonNull: number;
+    /** False when some rows still lack vectors — use lexical fallback for those slots (#1229). */
+    vectorsCompleteForCosine: boolean;
+  };
 }
 
 /**
- * Build normalized dedupe-corpus vectors for existing facts: prefer LanceDB rows (same id as fact),
- * else call the embedding API. Batches API calls (20) with a short pause only when a batch used the API.
+ * Build normalized dedupe-corpus vectors: Lance first, then throttled embedding with
+ * checkpoints, 429 backpressure, per-run caps, and resumable backlog (#1229).
  */
 export async function loadReflectionDedupeCorpusVectors(
   facts: MemoryEntry[],
   embeddings: EmbeddingProvider,
   vectorDb: VectorDB,
-  logger: { info: (msg: string) => void },
+  logger: { info: (msg: string) => void; warn?: (msg: string) => void },
   logPrefix: string,
   captureOperation: string,
   corpusOpts?: ReflectionDedupeCorpusOptions,
-): Promise<(number[] | null)[]> {
+): Promise<ReflectionDedupeCorpusResult> {
   const verbose = corpusOpts?.verbose === true;
   const progressLabel = corpusOpts?.progressLabel ?? "dedupe corpus";
-  const hb = { lanceHits: 0, apiEmbeds: 0, rowEnd: 0 };
+  const policy =
+    corpusOpts?.hydrationPolicy ??
+    (corpusOpts?.checkpoint ? DEFAULT_REFLECTION_DEDUPE_HYDRATION : CONSOLIDATE_REFLECTION_DEDUPE_HYDRATION);
+  const hb = { lanceHits: 0, apiEmbeds: 0, rowEnd: 0, needK: 0, needTotal: 0 };
 
-  const runBody = async (): Promise<(number[] | null)[]> => {
+  const runBody = async (): Promise<ReflectionDedupeCorpusResult> => {
     const vdb = vectorDb as VectorDB & {
       getVectorDim?: () => number;
       getVectorsByFactIds?: (
@@ -147,7 +192,7 @@ export async function loadReflectionDedupeCorpusVectors(
 
     if (verbose && facts.length > 0) {
       logger.info(
-        `${logPrefix} — ${progressLabel}: starting (${facts.length} row(s); Lance available=${lanceUp}, memories vector schema valid=${lanceSchemaOk}, embedModel=${embeddings.modelName ?? "unknown"})`,
+        `${logPrefix} — ${progressLabel}: starting (${facts.length} row(s); Lance available=${lanceUp}, memories vector schema valid=${lanceSchemaOk}, embedModel=${embeddings.modelName ?? "unknown"}; maxEmbedsPerRun=${policy.maxEmbedsPerRun || "∞"}, minIntervalMs=${policy.minIntervalMsBetweenEmbeds})`,
       );
     }
 
@@ -185,32 +230,110 @@ export async function loadReflectionDedupeCorpusVectors(
       );
     }
 
-    const result: (number[] | null)[] = new Array(facts.length);
+    const result: (number[] | null)[] = new Array(facts.length).fill(null);
     let lanceHits = 0;
-    let apiEmbeds = 0;
-    const embedPhaseStart = Date.now();
-    const batchSize = 20;
-    const totalBatches = Math.max(1, Math.ceil(facts.length / batchSize));
+    const modelKey = embeddings.modelName ?? "";
+    for (let j = 0; j < facts.length; j++) {
+      const f = facts[j]!;
+      const cached = byId.get(f.id.toLowerCase());
+      const modelOk =
+        f.embeddingModel != null && embeddings.modelName != null && f.embeddingModel === embeddings.modelName;
+      const useCache = dim > 0 && cached != null && cached.length === dim && modelOk;
+      if (useCache) {
+        result[j] = normalizeVector(cached);
+        lanceHits++;
+      }
+    }
 
-    for (let i = 0; i < facts.length; i += batchSize) {
-      const end = Math.min(i + batchSize, facts.length);
-      let hadApiEmbed = false;
-      for (let j = i; j < end; j++) {
-        const f = facts[j]!;
-        const cached = byId.get(f.id.toLowerCase());
-        const modelOk =
-          f.embeddingModel != null && embeddings.modelName != null && f.embeddingModel === embeddings.modelName;
-        const useCache = dim > 0 && cached != null && cached.length === dim && modelOk;
-        if (useCache) {
-          result[j] = normalizeVector(cached);
-          lanceHits++;
-        } else {
-          try {
-            const vec = await embeddings.embed(f.text);
-            result[j] = normalizeVector(vec);
-            apiEmbeds++;
-            hadApiEmbed = true;
-          } catch (err) {
+    const needEmbedIndices: number[] = [];
+    for (let j = 0; j < facts.length; j++) {
+      if (result[j] === null) needEmbedIndices.push(j);
+    }
+    needEmbedIndices.sort((a, b) => facts[a]!.id.toLowerCase().localeCompare(facts[b]!.id.toLowerCase()));
+    const sortedIds = [...facts.map((f) => f.id)].map((id) => id.toLowerCase()).sort();
+    const fp = computeDedupeCorpusFingerprint(sortedIds, modelKey);
+    const stateKey = corpusOpts?.checkpoint ? dedupeHydrationStateKey(corpusOpts.checkpoint.kind) : "";
+
+    let nextK = 0;
+    if (corpusOpts?.checkpoint) {
+      const cp = readDedupeHydrationCheckpoint(corpusOpts.checkpoint.factsDb, stateKey);
+      if (cp && cp.fp === fp && cp.model === modelKey) {
+        nextK = Math.min(cp.nextNeedIdx, needEmbedIndices.length);
+      }
+    }
+
+    let checkpointNextIdx = nextK;
+    let apiEmbedsThisRun = 0;
+    let deferredDueToRateLimit = false;
+    let deferredDueToCap = false;
+    let lastEmbedAt = 0;
+    let consecutive429 = 0;
+    const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+    const embedPhaseStart = Date.now();
+    hb.needTotal = needEmbedIndices.length;
+
+    const persistCheckpoint = (nextNeedIdx: number) => {
+      checkpointNextIdx = nextNeedIdx;
+      if (!corpusOpts?.checkpoint) return;
+      writeDedupeHydrationCheckpoint(corpusOpts.checkpoint.factsDb, stateKey, {
+        v: REFLECTION_DEDUPE_CHECKPOINT_VERSION,
+        fp,
+        model: modelKey,
+        nextNeedIdx,
+      });
+    };
+
+    for (let kk = nextK; kk < needEmbedIndices.length; kk++) {
+      hb.needK = kk;
+      if (policy.maxEmbedsPerRun > 0 && apiEmbedsThisRun >= policy.maxEmbedsPerRun) {
+        deferredDueToCap = true;
+        persistCheckpoint(kk);
+        logger.info(
+          `${logPrefix} — ${progressLabel}: hydration cap — processed=${kk}/${needEmbedIndices.length} embed API calls this run=${apiEmbedsThisRun} cap=${policy.maxEmbedsPerRun} remaining=${needEmbedIndices.length - kk} checkpoint nextNeedIdx=${kk} (#1229)`,
+        );
+        break;
+      }
+
+      const j = needEmbedIndices[kk]!;
+      const f = facts[j]!;
+      const gap = lastEmbedAt + policy.minIntervalMsBetweenEmbeds - Date.now();
+      if (gap > 0) await sleep(gap);
+
+      let done = false;
+      while (!done && !deferredDueToRateLimit) {
+        try {
+          const vec = await embeddings.embed(f.text);
+          result[j] = normalizeVector(vec);
+          apiEmbedsThisRun++;
+          consecutive429 = 0;
+          lastEmbedAt = Date.now();
+          done = true;
+          hb.rowEnd = j + 1;
+          hb.lanceHits = lanceHits;
+          hb.apiEmbeds = apiEmbedsThisRun;
+          if (corpusOpts?.checkpoint && (apiEmbedsThisRun % 8 === 0 || kk === needEmbedIndices.length - 1)) {
+            persistCheckpoint(kk + 1);
+          }
+        } catch (err) {
+          if (isEmbeddingRateLimitError(err)) {
+            consecutive429++;
+            const e = err instanceof Error ? err : new Error(String(err));
+            const ra = parseRetryAfterMs(e);
+            const exp = policy.baseBackoffMsAfter429 * 2 ** Math.max(0, consecutive429 - 1);
+            const backMs = Math.min(180_000, Math.max(ra ?? 0, exp));
+            const logWarn = logger.warn ?? ((m: string) => logger.info(m));
+            logWarn(
+              `${logPrefix} — ${progressLabel}: embedding rate-limited — backing off ${backMs}ms (consecutive=${consecutive429}/${policy.maxConsecutive429BeforeDefer}, backlog kk=${kk}/${needEmbedIndices.length}) (#1229)`,
+            );
+            await sleep(backMs);
+            if (consecutive429 >= policy.maxConsecutive429BeforeDefer) {
+              deferredDueToRateLimit = true;
+              persistCheckpoint(kk);
+              logger.info(
+                `${logPrefix} — ${progressLabel}: deferring hydration — processed=${kk}/${needEmbedIndices.length} remaining=${needEmbedIndices.length - kk} deferred_due_to_rate_limit=1 checkpoint nextNeedIdx=${kk} vectors_created_this_run=${apiEmbedsThisRun} (#1229)`,
+              );
+            }
+          } else {
             if (!shouldSuppressEmbeddingError(err)) {
               capturePluginError(err instanceof Error ? err : new Error(String(err)), {
                 operation: captureOperation,
@@ -219,34 +342,55 @@ export async function loadReflectionDedupeCorpusVectors(
               });
             }
             result[j] = null;
-            hadApiEmbed = true;
+            done = true;
           }
         }
       }
-      hb.lanceHits = lanceHits;
-      hb.apiEmbeds = apiEmbeds;
-      hb.rowEnd = end;
+      if (deferredDueToRateLimit) break;
+
       if (verbose) {
-        const batchNum = Math.floor(i / batchSize) + 1;
-        const logThisBatch = facts.length <= 100 || batchNum === 1 || batchNum === totalBatches || batchNum % 25 === 0;
-        if (logThisBatch) {
+        const logEvery =
+          needEmbedIndices.length <= 80 || kk === 0 || kk === needEmbedIndices.length - 1 || kk % 40 === 0;
+        if (logEvery) {
           logger.info(
-            `${logPrefix} — ${progressLabel}: embedding batch ${batchNum}/${totalBatches} rows ${end}/${facts.length} lanceHits=${lanceHits} apiEmbeds=${apiEmbeds} elapsed=${formatElapsedSec(embedPhaseStart)}`,
+            `${logPrefix} — ${progressLabel}: embed progress kk=${kk + 1}/${needEmbedIndices.length} apiEmbeds=${apiEmbedsThisRun} lanceHits=${lanceHits} elapsed=${formatElapsedSec(embedPhaseStart)}`,
           );
         }
       }
-      if (hadApiEmbed && end < facts.length) {
-        await new Promise((r) => setTimeout(r, 200));
-      }
     }
 
+    if (!deferredDueToRateLimit && !deferredDueToCap && corpusOpts?.checkpoint) {
+      persistCheckpoint(needEmbedIndices.length);
+    }
+
+    const nonNull = result.filter((v) => v !== null).length;
+    const complete = !deferredDueToRateLimit && !deferredDueToCap;
+    const remainingNeed = Math.max(0, needEmbedIndices.length - checkpointNextIdx);
+
     if (facts.length > 0) {
-      const ok = result.filter((v) => v !== null).length;
       logger.info(
-        `${logPrefix} — dedupe corpus: ${lanceHits} vector(s) reused from Lance index, ${apiEmbeds} via embedding API, ${ok}/${facts.length} non-null for cosine check`,
+        `${logPrefix} — dedupe corpus: ${lanceHits} vector(s) reused from Lance index, ${apiEmbedsThisRun} via embedding API, ${nonNull}/${facts.length} non-null for cosine check` +
+          (deferredDueToRateLimit || deferredDueToCap
+            ? ` | backlog need_embed_total=${needEmbedIndices.length} remaining=${remainingNeed} checkpoint_nextNeedIdx=${checkpointNextIdx} deferred429=${deferredDueToRateLimit ? 1 : 0} deferredCap=${deferredDueToCap ? 1 : 0} (#1229)`
+            : ""),
       );
     }
-    return result;
+
+    return {
+      vectors: result,
+      hydration: {
+        complete,
+        totalRows: facts.length,
+        needEmbedTotal: needEmbedIndices.length,
+        checkpointNextNeedIdx: checkpointNextIdx,
+        deferredDueToRateLimit,
+        deferredDueToCap,
+        apiEmbedsThisRun,
+        lanceHits,
+        vectorsNonNull: nonNull,
+        vectorsCompleteForCosine: facts.length === 0 || nonNull === facts.length,
+      },
+    };
   };
 
   if (!verbose) {
@@ -256,7 +400,8 @@ export async function loadReflectionDedupeCorpusVectors(
     verbose: true,
     log: (m) => logger.info(m),
     prefix: `${logPrefix} — ${progressLabel}`,
-    detail: () => `rows=${hb.rowEnd}/${facts.length} lanceHits=${hb.lanceHits} apiEmbeds=${hb.apiEmbeds}`,
+    detail: () =>
+      `rows=${hb.rowEnd}/${facts.length} lanceHits=${hb.lanceHits} apiEmbeds=${hb.apiEmbeds} needEmbed=${hb.needK}/${hb.needTotal}`,
     fn: runBody,
   });
 }
@@ -417,20 +562,42 @@ export async function runReflection(
   }
 
   let existingVectors: (number[] | null)[] = [];
+  let patternCorpusHydration = {
+    vectorsCompleteForCosine: true,
+    complete: true,
+    needEmbedTotal: 0,
+    checkpointNextNeedIdx: 0,
+    deferredDueToRateLimit: false,
+    deferredDueToCap: false,
+    apiEmbedsThisRun: 0,
+    vectorsNonNull: 0,
+  };
   const corpusLoadStarted = Date.now();
   if (existingPatternFacts.length > 0) {
     logger.info(
       `memory-hybrid: reflection — loading ${existingPatternFacts.length} existing pattern row(s) for dedupe (Lance vectors + embedding API when index or model is missing)`,
     );
-    existingVectors = await loadReflectionDedupeCorpusVectors(
+    const corpusRes = await loadReflectionDedupeCorpusVectors(
       existingPatternFacts,
       embeddings,
       vectorDb,
       logger,
       "memory-hybrid: reflection",
       "reflection-embed-existing",
-      { verbose: opts.verbose, progressLabel: "reflection dedupe (existing corpus)" },
+      {
+        verbose: opts.verbose,
+        progressLabel: "reflection dedupe (existing corpus)",
+        checkpoint: { factsDb, kind: "pattern" },
+        hydrationPolicy: opts.dedupeHydration ?? DEFAULT_REFLECTION_DEDUPE_HYDRATION,
+      },
     );
+    existingVectors = corpusRes.vectors;
+    patternCorpusHydration = corpusRes.hydration;
+    if (!corpusRes.hydration.vectorsCompleteForCosine) {
+      logger.info(
+        `memory-hybrid: reflection — dedupe corpus hydration partial: vectors_non_null=${corpusRes.hydration.vectorsNonNull}/${corpusRes.hydration.totalRows} need_embed_total=${corpusRes.hydration.needEmbedTotal} remaining_next_idx=${corpusRes.hydration.checkpointNextNeedIdx} — lexical fallback for rows without vectors (#1229)`,
+      );
+    }
   } else {
     logger.info("memory-hybrid: reflection — no existing pattern facts for dedupe; embedding new candidates only");
   }
@@ -474,16 +641,24 @@ export async function runReflection(
     }
     const normVec = normalizeVector(vec);
     let isDuplicate = false;
-    for (const ev of existingVectors) {
-      if (ev === null || ev.length === 0) continue;
-      if (dotProductSimilarity(normVec, ev) >= REFLECTION_DEDUPE_THRESHOLD) {
-        isDuplicate = true;
-        break;
+    for (let ei = 0; ei < existingVectors.length; ei++) {
+      const ev = existingVectors[ei];
+      if (ev !== null && ev.length > 0) {
+        if (dotProductSimilarity(normVec, ev) >= REFLECTION_DEDUPE_THRESHOLD) {
+          isDuplicate = true;
+          break;
+        }
+      } else if (!patternCorpusHydration.vectorsCompleteForCosine) {
+        const prior = existingPatternFacts[ei];
+        if (prior && reflectionLexicalNearDuplicateAgainstFact(patternText, prior.text)) {
+          isDuplicate = true;
+          break;
+        }
       }
     }
     if (opts.verbose) {
       logger.info(
-        `memory-hybrid: reflection — dedupe candidate ${candIndex}/${uniqueNewPatterns.length}: cosine check done, duplicate=${isDuplicate} | elapsed=${formatElapsedSec(newCandidatePhaseStart)}`,
+        `memory-hybrid: reflection — dedupe candidate ${candIndex}/${uniqueNewPatterns.length}: cosine/lexical check done, duplicate=${isDuplicate} | elapsed=${formatElapsedSec(newCandidatePhaseStart)}`,
       );
     }
     if (isDuplicate) {
@@ -586,6 +761,7 @@ export async function runReflectionRules(
     fallbackModels?: string[];
     modelSource?: string;
     adaptiveStatePath?: string;
+    dedupeHydration?: ReflectionDedupeHydrationResolved;
   },
   logger: { info: (msg: string) => void; warn: (msg: string) => void },
   provenanceService?: ProvenanceService | null,
@@ -671,19 +847,40 @@ export async function runReflectionRules(
     .getByCategory("rule")
     .filter((f) => !f.supersededAt && (f.expiresAt === null || f.expiresAt > nowSec));
   let existingVectors: (number[] | null)[] = [];
+  let rulesCorpusHydration = {
+    vectorsCompleteForCosine: true,
+    vectorsNonNull: 0,
+    totalRows: 0,
+  };
   if (existingRuleFacts.length > 0) {
     logger.info(
       `memory-hybrid: reflect-rules — loading ${existingRuleFacts.length} existing rule row(s) for dedupe (Lance vectors + embedding API when index or model is missing)`,
     );
-    existingVectors = await loadReflectionDedupeCorpusVectors(
+    const corpusRes = await loadReflectionDedupeCorpusVectors(
       existingRuleFacts,
       embeddings,
       vectorDb,
       logger,
       "memory-hybrid: reflect-rules",
       "reflection-rules-embed-existing",
-      { verbose: opts.verbose, progressLabel: "reflect-rules dedupe (existing corpus)" },
+      {
+        verbose: opts.verbose,
+        progressLabel: "reflect-rules dedupe (existing corpus)",
+        checkpoint: { factsDb, kind: "rule" },
+        hydrationPolicy: opts.dedupeHydration ?? DEFAULT_REFLECTION_DEDUPE_HYDRATION,
+      },
     );
+    existingVectors = corpusRes.vectors;
+    rulesCorpusHydration = {
+      vectorsCompleteForCosine: corpusRes.hydration.vectorsCompleteForCosine,
+      vectorsNonNull: corpusRes.hydration.vectorsNonNull,
+      totalRows: corpusRes.hydration.totalRows,
+    };
+    if (!corpusRes.hydration.vectorsCompleteForCosine) {
+      logger.info(
+        `memory-hybrid: reflect-rules — dedupe corpus hydration partial (${corpusRes.hydration.vectorsNonNull}/${corpusRes.hydration.totalRows}); lexical fallback for null-vector rows (#1229)`,
+      );
+    }
   } else {
     logger.info("memory-hybrid: reflect-rules — no existing rule facts for dedupe; embedding new candidates only");
   }
@@ -722,11 +919,19 @@ export async function runReflectionRules(
     }
     const normVec = normalizeVector(vec);
     let isDuplicate = false;
-    for (const ev of existingVectors) {
-      if (ev === null || ev.length === 0) continue;
-      if (dotProductSimilarity(normVec, ev) >= REFLECTION_DEDUPE_THRESHOLD) {
-        isDuplicate = true;
-        break;
+    for (let ei = 0; ei < existingVectors.length; ei++) {
+      const ev = existingVectors[ei];
+      if (ev !== null && ev.length > 0) {
+        if (dotProductSimilarity(normVec, ev) >= REFLECTION_DEDUPE_THRESHOLD) {
+          isDuplicate = true;
+          break;
+        }
+      } else if (!rulesCorpusHydration.vectorsCompleteForCosine) {
+        const prior = existingRuleFacts[ei];
+        if (prior && reflectionLexicalNearDuplicateAgainstFact(ruleText, prior.text)) {
+          isDuplicate = true;
+          break;
+        }
       }
     }
     if (opts.verbose) {
@@ -824,6 +1029,7 @@ export async function runReflectionMeta(
     fallbackModels?: string[];
     modelSource?: string;
     adaptiveStatePath?: string;
+    dedupeHydration?: ReflectionDedupeHydrationResolved;
   },
   logger: { info: (msg: string) => void; warn: (msg: string) => void },
   provenanceService?: ProvenanceService | null,
@@ -911,19 +1117,32 @@ export async function runReflectionMeta(
       (f) => !f.supersededAt && (f.expiresAt === null || f.expiresAt > nowSec) && f.tags?.includes("meta") === true,
     );
   let existingVectors: (number[] | null)[] = [];
+  let metaCorpusHydration = { vectorsCompleteForCosine: true };
   if (existingMetaFacts.length > 0) {
     logger.info(
       `memory-hybrid: reflect-meta — loading ${existingMetaFacts.length} existing meta-pattern row(s) for dedupe (Lance vectors + embedding API when index or model is missing)`,
     );
-    existingVectors = await loadReflectionDedupeCorpusVectors(
+    const corpusRes = await loadReflectionDedupeCorpusVectors(
       existingMetaFacts,
       embeddings,
       vectorDb,
       logger,
       "memory-hybrid: reflect-meta",
       "reflection-meta-embed-existing",
-      { verbose: opts.verbose, progressLabel: "reflect-meta dedupe (existing corpus)" },
+      {
+        verbose: opts.verbose,
+        progressLabel: "reflect-meta dedupe (existing corpus)",
+        checkpoint: { factsDb, kind: "meta" },
+        hydrationPolicy: opts.dedupeHydration ?? DEFAULT_REFLECTION_DEDUPE_HYDRATION,
+      },
     );
+    existingVectors = corpusRes.vectors;
+    metaCorpusHydration = { vectorsCompleteForCosine: corpusRes.hydration.vectorsCompleteForCosine };
+    if (!corpusRes.hydration.vectorsCompleteForCosine) {
+      logger.info(
+        `memory-hybrid: reflect-meta — dedupe corpus hydration partial; lexical fallback for null-vector rows (#1229)`,
+      );
+    }
   } else {
     logger.info("memory-hybrid: reflect-meta — no existing meta-patterns for dedupe; embedding new candidates only");
   }
@@ -962,11 +1181,19 @@ export async function runReflectionMeta(
     }
     const normVec = normalizeVector(vec);
     let isDuplicate = false;
-    for (const ev of existingVectors) {
-      if (ev === null || ev.length === 0) continue;
-      if (dotProductSimilarity(normVec, ev) >= REFLECTION_DEDUPE_THRESHOLD) {
-        isDuplicate = true;
-        break;
+    for (let ei = 0; ei < existingVectors.length; ei++) {
+      const ev = existingVectors[ei];
+      if (ev !== null && ev.length > 0) {
+        if (dotProductSimilarity(normVec, ev) >= REFLECTION_DEDUPE_THRESHOLD) {
+          isDuplicate = true;
+          break;
+        }
+      } else if (!metaCorpusHydration.vectorsCompleteForCosine) {
+        const prior = existingMetaFacts[ei];
+        if (prior && reflectionLexicalNearDuplicateAgainstFact(metaText, prior.text)) {
+          isDuplicate = true;
+          break;
+        }
       }
     }
     if (opts.verbose) {

--- a/extensions/memory-hybrid/setup/cli-context.ts
+++ b/extensions/memory-hybrid/setup/cli-context.ts
@@ -176,6 +176,7 @@ interface CliContextServices {
     threshold: number;
     includeStructured: boolean;
     limit: number;
+    verbose?: boolean;
   }) => Promise<FindDuplicatesResult>;
   runConsolidate: (opts: {
     threshold: number;
@@ -183,6 +184,7 @@ interface CliContextServices {
     dryRun: boolean;
     limit: number;
     model: string;
+    verbose?: boolean;
   }) => Promise<{ clustersFound: number; merged: number; deleted: number }>;
   runReflection: (opts: { window: number; dryRun: boolean; model: string; verbose?: boolean }) => Promise<{
     factsAnalyzed: number;

--- a/extensions/memory-hybrid/setup/cli-context.ts
+++ b/extensions/memory-hybrid/setup/cli-context.ts
@@ -37,6 +37,7 @@ import { runFindDuplicates } from "../services/find-duplicates.js";
 import { runBuildLanguageKeywords } from "../services/language-keywords-build.js";
 import { mergeResults } from "../services/merge-results.js";
 import { runPreConsolidationFlush } from "../services/pre-consolidation-flush.js";
+import { resolveReflectionDedupeHydration } from "../services/reflection-dedupe-hydration.js";
 import { runReflection, runReflectionMeta, runReflectionRules } from "../services/reflection.js";
 import { insertRulesUnderSection } from "../services/tools-md-section.js";
 import { parseSourceDate } from "../utils/dates.js";
@@ -334,6 +335,7 @@ function buildCliContextServices(ctx: HybridMemCliRegistrationContext, api: Claw
           modelSource,
           fallbackModels,
           adaptiveStatePath: adaptiveMaintenanceStatePath,
+          dedupeHydration: resolveReflectionDedupeHydration(cfg.reflection.dedupeHydration ?? null),
         },
         logSink,
         provenanceService,
@@ -369,6 +371,7 @@ function buildCliContextServices(ctx: HybridMemCliRegistrationContext, api: Claw
           modelSource,
           fallbackModels,
           adaptiveStatePath: adaptiveMaintenanceStatePath,
+          dedupeHydration: resolveReflectionDedupeHydration(cfg.reflection.dedupeHydration ?? null),
         },
         logSink,
         provenanceService,
@@ -393,6 +396,7 @@ function buildCliContextServices(ctx: HybridMemCliRegistrationContext, api: Claw
           modelSource,
           fallbackModels,
           adaptiveStatePath: adaptiveMaintenanceStatePath,
+          dedupeHydration: resolveReflectionDedupeHydration(cfg.reflection.dedupeHydration ?? null),
         },
         logSink,
         provenanceService,
@@ -518,6 +522,7 @@ function buildCliContextServices(ctx: HybridMemCliRegistrationContext, api: Claw
             allow: cfg.nightlyCycle.consolidationEventTypeAllow,
             deny: cfg.nightlyCycle.consolidationEventTypeDeny,
           },
+          reflectionDedupeHydration: resolveReflectionDedupeHydration(cfg.reflection.dedupeHydration ?? null),
         },
         logSink,
         provenanceService,

--- a/extensions/memory-hybrid/setup/plugin-service.ts
+++ b/extensions/memory-hybrid/setup/plugin-service.ts
@@ -23,6 +23,7 @@ import type { DashboardServer } from "../routes/dashboard-server.js";
 import { reconcileActiveTaskInProgressSessions } from "../services/active-task.js";
 import { runAutoClassify } from "../services/auto-classifier.js";
 import { syncCronLastRunFromGuards } from "../services/cron-guard.js";
+import { reconcileHybridMemCronMaintenanceOutcomes } from "../services/cron-maintenance-reconciler.js";
 import type { EmbeddingRegistry } from "../services/embedding-registry.js";
 import {
   capturePluginError,
@@ -444,6 +445,14 @@ export function createPluginService(ctx: PluginServiceContext) {
       } catch (err) {
         api.logger.warn?.(`memory-hybrid: cron guard sync failed (non-fatal): ${err}`);
       }
+      // Issue #1233: reconcile hybrid-mem maintenance validation back into OpenClaw
+      // cron state/run ledgers. The OpenClaw scheduler owns isolated agent-turn status,
+      // so plugin-managed jobs repair false OK rows after validation artifacts exist.
+      try {
+        reconcileHybridMemCronMaintenanceOutcomes(api.logger);
+      } catch (err) {
+        api.logger.warn?.(`memory-hybrid: cron maintenance outcome reconciliation failed (non-fatal): ${err}`);
+      }
 
       // Issue #309: Mission Control dashboard HTTP server
       if (cfg.dashboard.enabled) {
@@ -668,6 +677,15 @@ export function createPluginService(ctx: PluginServiceContext) {
       // Task queue watchdog: periodically detect stale/broken autonomous queue runs and self-heal
       const WATCHDOG_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
       const watchdogRun = async () => {
+        // Issue #1233: OpenClaw writes isolated cron run state after the agent turn
+        // finishes, so startup-only repair is not enough. Re-run the idempotent
+        // reconciler from the watchdog so false-OK maintenance rows are corrected
+        // shortly after they land and failure counters/alerts can observe error state.
+        try {
+          reconcileHybridMemCronMaintenanceOutcomes(api.logger);
+        } catch (err) {
+          api.logger.warn?.(`memory-hybrid: cron maintenance outcome reconciliation failed (non-fatal): ${err}`);
+        }
         try {
           await runTaskQueueWatchdog({ repoDir: getEnv("OPENCLAW_WORKSPACE") ?? process.cwd() }, api.logger);
         } catch (err) {

--- a/extensions/memory-hybrid/tests/cron-maintenance-reconciler-1233.test.ts
+++ b/extensions/memory-hybrid/tests/cron-maintenance-reconciler-1233.test.ts
@@ -115,6 +115,54 @@ describe("cron maintenance outcome reconciler (#1233)", () => {
     expect(readJson(join(cronDir, "jobs.json")).jobs[0].state.consecutiveErrors).toBe(3);
   });
 
+  it("patches duplicate-timestamp run records by tail position, not by timestamp key", () => {
+    const openclawDir = mkdtempSync(join(tmpdir(), "hm-cron-reconcile-"));
+    const cronDir = join(openclawDir, "cron");
+    const runsDir = join(cronDir, "runs");
+    mkdirSync(runsDir, { recursive: true });
+    const runAtMs = Date.now();
+    writeFileSync(
+      join(cronDir, "jobs.json"),
+      JSON.stringify({
+        jobs: [{ id: "hybrid-mem:nightly-dream-cycle", state: { lastRunAtMs: runAtMs, consecutiveErrors: 0 } }],
+      }),
+      "utf-8",
+    );
+    const goodSummary = "SUCCESS";
+    const badSummary = `1. **FAILED**
+
+\`\`\`json
+${JSON.stringify({ maintenanceStatus: "failed", error: "Missing steps: dream-cycle", missingSteps: ["dream-cycle"] })}
+\`\`\``;
+    const runPath = join(runsDir, "hybrid-mem:nightly-dream-cycle.jsonl");
+    writeFileSync(
+      runPath,
+      [
+        JSON.stringify({
+          ts: runAtMs,
+          jobId: "hybrid-mem:nightly-dream-cycle",
+          status: "ok",
+          summary: goodSummary,
+          runAtMs,
+        }),
+        JSON.stringify({
+          ts: runAtMs,
+          jobId: "hybrid-mem:nightly-dream-cycle",
+          status: "ok",
+          summary: badSummary,
+          runAtMs,
+        }),
+      ].join("\n") + "\n",
+      "utf-8",
+    );
+
+    const result = reconcileHybridMemCronMaintenanceOutcomes({}, { openclawDir, nowMs: runAtMs + 1000 });
+    const [first, second] = readJsonl(runPath);
+    expect(result.runsCorrected).toBe(1);
+    expect(first.status).toBe("ok");
+    expect(second.status).toBe("error");
+  });
+
   it("leaves successful ok runs unchanged", () => {
     const openclawDir = mkdtempSync(join(tmpdir(), "hm-cron-reconcile-"));
     const cronDir = join(openclawDir, "cron");

--- a/extensions/memory-hybrid/tests/cron-maintenance-reconciler-1233.test.ts
+++ b/extensions/memory-hybrid/tests/cron-maintenance-reconciler-1233.test.ts
@@ -98,7 +98,9 @@ describe("cron maintenance outcome reconciler (#1233)", () => {
     writeFileSync(logPath, "ok so far\n", "utf-8");
     writeFileSync(
       join(cronDir, "jobs.json"),
-      JSON.stringify({ jobs: [{ id: "hybrid-mem:nightly-distill", state: { lastRunAtMs: runAtMs, consecutiveErrors: 2 } }] }),
+      JSON.stringify({
+        jobs: [{ id: "hybrid-mem:nightly-distill", state: { lastRunAtMs: runAtMs, consecutiveErrors: 2 } }],
+      }),
       "utf-8",
     );
     writeFileSync(
@@ -119,7 +121,13 @@ describe("cron maintenance outcome reconciler (#1233)", () => {
     const runsDir = join(cronDir, "runs");
     mkdirSync(runsDir, { recursive: true });
     const runAtMs = Date.now();
-    writeFileSync(join(cronDir, "jobs.json"), JSON.stringify({ jobs: [{ id: "hybrid-mem:weekly-deep-maintenance", state: { lastRunAtMs: runAtMs, consecutiveErrors: 0 } }] }), "utf-8");
+    writeFileSync(
+      join(cronDir, "jobs.json"),
+      JSON.stringify({
+        jobs: [{ id: "hybrid-mem:weekly-deep-maintenance", state: { lastRunAtMs: runAtMs, consecutiveErrors: 0 } }],
+      }),
+      "utf-8",
+    );
     writeFileSync(
       join(runsDir, "hybrid-mem:weekly-deep-maintenance.jsonl"),
       `${JSON.stringify({ ts: runAtMs, jobId: "hybrid-mem:weekly-deep-maintenance", status: "ok", summary: "SUCCESS", runAtMs })}\n`,

--- a/extensions/memory-hybrid/tests/cron-maintenance-reconciler-1233.test.ts
+++ b/extensions/memory-hybrid/tests/cron-maintenance-reconciler-1233.test.ts
@@ -1,0 +1,133 @@
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { reconcileHybridMemCronMaintenanceOutcomes } from "../services/cron-maintenance-reconciler.js";
+
+function readJson(path: string) {
+  return JSON.parse(readFileSync(path, "utf-8"));
+}
+
+function readJsonl(path: string) {
+  return readFileSync(path, "utf-8")
+    .trim()
+    .split("\n")
+    .map((line) => JSON.parse(line));
+}
+
+describe("cron maintenance outcome reconciler (#1233)", () => {
+  it("rewrites false-ok hybrid-mem run records with failed maintenanceStatus to error and increments job consecutiveErrors", () => {
+    const openclawDir = mkdtempSync(join(tmpdir(), "hm-cron-reconcile-"));
+    const cronDir = join(openclawDir, "cron");
+    const runsDir = join(cronDir, "runs");
+    mkdirSync(runsDir, { recursive: true });
+
+    const runAtMs = 1778296560189;
+    const exitPath = join(openclawDir, "logs", "cron-hybrid-mem", "nightly-dream-cycle.exit.txt");
+    const logPath = join(openclawDir, "logs", "cron-hybrid-mem", "nightly-dream-cycle.log");
+    mkdirSync(join(openclawDir, "logs", "cron-hybrid-mem"), { recursive: true });
+    writeFileSync(exitPath, "", "utf-8");
+    writeFileSync(logPath, "reflection — loading 10687 existing pattern row(s) for dedupe\n", "utf-8");
+
+    writeFileSync(
+      join(cronDir, "jobs.json"),
+      JSON.stringify(
+        {
+          jobs: [
+            {
+              id: "hybrid-mem:nightly-dream-cycle",
+              pluginJobId: "hybrid-mem:nightly-dream-cycle",
+              name: "nightly-dream-cycle",
+              state: { lastRunAtMs: runAtMs, lastStatus: "ok", lastRunStatus: "ok", consecutiveErrors: 0 },
+            },
+          ],
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+
+    const summary = `1. **FAILED**\n\nManual validation output:\n\n\`\`\`json\n${JSON.stringify(
+      {
+        maintenanceStatus: "failed",
+        missingSteps: ["dream-cycle"],
+        failedSteps: [],
+        guardUpdated: false,
+        logPath,
+        exitPath,
+        error: "Missing steps: dream-cycle",
+      },
+      null,
+      2,
+    )}\n\`\`\``;
+    writeFileSync(
+      join(runsDir, "hybrid-mem:nightly-dream-cycle.jsonl"),
+      `${JSON.stringify({ ts: runAtMs + 100, jobId: "hybrid-mem:nightly-dream-cycle", action: "finished", status: "ok", summary, runAtMs })}\n`,
+      "utf-8",
+    );
+
+    const result = reconcileHybridMemCronMaintenanceOutcomes({}, { openclawDir, nowMs: runAtMs + 60_000 });
+    expect(result.runsCorrected).toBe(1);
+    expect(result.jobsCorrected).toBe(1);
+
+    const [run] = readJsonl(join(runsDir, "hybrid-mem:nightly-dream-cycle.jsonl"));
+    expect(run.status).toBe("error");
+    expect(run.error).toBe("Missing steps: dream-cycle");
+    expect(run.diagnostics.maintenanceStatus).toBe("failed");
+
+    const store = readJson(join(cronDir, "jobs.json"));
+    const jobState = store.jobs[0].state;
+    expect(jobState.lastStatus).toBe("error");
+    expect(jobState.lastRunStatus).toBe("error");
+    expect(jobState.consecutiveErrors).toBe(1);
+    expect(jobState.lastError).toBe("Missing steps: dream-cycle");
+  });
+
+  it("validates HM_EXIT/HM_LOG paths from summary when structured JSON is absent", () => {
+    const openclawDir = mkdtempSync(join(tmpdir(), "hm-cron-reconcile-"));
+    const cronDir = join(openclawDir, "cron");
+    const runsDir = join(cronDir, "runs");
+    const logDir = join(openclawDir, "logs", "cron-hybrid-mem");
+    mkdirSync(runsDir, { recursive: true });
+    mkdirSync(logDir, { recursive: true });
+    const runAtMs = Date.now();
+    const exitPath = join(logDir, "nightly-memory-sweep.exit.txt");
+    const logPath = join(logDir, "nightly-memory-sweep.log");
+    writeFileSync(exitPath, `${new Date(runAtMs).toISOString().replace(/\.\d{3}Z$/, "Z")} prune exit=0\n`, "utf-8");
+    writeFileSync(logPath, "ok so far\n", "utf-8");
+    writeFileSync(
+      join(cronDir, "jobs.json"),
+      JSON.stringify({ jobs: [{ id: "hybrid-mem:nightly-distill", state: { lastRunAtMs: runAtMs, consecutiveErrors: 2 } }] }),
+      "utf-8",
+    );
+    writeFileSync(
+      join(runsDir, "hybrid-mem:nightly-distill.jsonl"),
+      `${JSON.stringify({ ts: runAtMs, jobId: "hybrid-mem:nightly-distill", status: "ok", summary: `HM_EXIT path:\n${exitPath}\nHM_LOG path:\n${logPath}`, runAtMs })}\n`,
+      "utf-8",
+    );
+
+    const result = reconcileHybridMemCronMaintenanceOutcomes({}, { openclawDir, nowMs: runAtMs + 1000 });
+    expect(result.runsCorrected).toBe(1);
+    expect(readJsonl(join(runsDir, "hybrid-mem:nightly-distill.jsonl"))[0].status).toBe("error");
+    expect(readJson(join(cronDir, "jobs.json")).jobs[0].state.consecutiveErrors).toBe(3);
+  });
+
+  it("leaves successful ok runs unchanged", () => {
+    const openclawDir = mkdtempSync(join(tmpdir(), "hm-cron-reconcile-"));
+    const cronDir = join(openclawDir, "cron");
+    const runsDir = join(cronDir, "runs");
+    mkdirSync(runsDir, { recursive: true });
+    const runAtMs = Date.now();
+    writeFileSync(join(cronDir, "jobs.json"), JSON.stringify({ jobs: [{ id: "hybrid-mem:weekly-deep-maintenance", state: { lastRunAtMs: runAtMs, consecutiveErrors: 0 } }] }), "utf-8");
+    writeFileSync(
+      join(runsDir, "hybrid-mem:weekly-deep-maintenance.jsonl"),
+      `${JSON.stringify({ ts: runAtMs, jobId: "hybrid-mem:weekly-deep-maintenance", status: "ok", summary: "SUCCESS", runAtMs })}\n`,
+      "utf-8",
+    );
+
+    const result = reconcileHybridMemCronMaintenanceOutcomes({}, { openclawDir, nowMs: runAtMs + 1000 });
+    expect(result.runsCorrected).toBe(0);
+    expect(readJsonl(join(runsDir, "hybrid-mem:weekly-deep-maintenance.jsonl"))[0].status).toBe("ok");
+  });
+});

--- a/extensions/memory-hybrid/tests/json-cli-stdout-1234.test.ts
+++ b/extensions/memory-hybrid/tests/json-cli-stdout-1234.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { isHybridMemJsonCliInvocation } from "../index.js";
+import { createJsonCliStderrLogger, pluginLogger, restoreDefaultLogger, initPluginLogger } from "../utils/logger.js";
+
+describe("JSON CLI stdout hygiene (#1234)", () => {
+  afterEach(() => {
+    restoreDefaultLogger();
+    vi.restoreAllMocks();
+  });
+
+  it("detects hybrid-mem JSON invocations before command parsing", () => {
+    expect(isHybridMemJsonCliInvocation(["openclaw", "hybrid-mem", "config", "--json"])).toBe(true);
+    expect(isHybridMemJsonCliInvocation(["openclaw", "hybrid-mem", "config", "--format", "json"])).toBe(true);
+    expect(isHybridMemJsonCliInvocation(["openclaw", "hybrid-mem", "config", "--format=json"])).toBe(true);
+    expect(isHybridMemJsonCliInvocation(["openclaw", "hybrid-mem", "config", "--format", "text"])).toBe(false);
+    expect(isHybridMemJsonCliInvocation(["openclaw", "hybrid-mem", "store", "--", "--json"])).toBe(false);
+  });
+
+  it("routes plugin telemetry to stderr and keeps stdout untouched for JSON CLI mode", () => {
+    const stdoutInfo = vi.spyOn(console, "info").mockImplementation(() => undefined);
+    const stdoutLog = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const stderr = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    const jsonLogger = createJsonCliStderrLogger();
+    initPluginLogger(jsonLogger);
+    jsonLogger.warn("memory-hybrid: direct api.logger warning");
+    pluginLogger.info("memory-hybrid: registered");
+    pluginLogger.warn("memory-hybrid: credentials vault enabled plaintext");
+    pluginLogger.debug("memory-hybrid: debug line");
+
+    expect(stdoutInfo).not.toHaveBeenCalled();
+    expect(stdoutLog).not.toHaveBeenCalled();
+    expect(stderr).toHaveBeenCalledWith("memory-hybrid: direct api.logger warning");
+    expect(stderr).toHaveBeenCalledWith("memory-hybrid: registered");
+    expect(stderr).toHaveBeenCalledWith("memory-hybrid: credentials vault enabled plaintext");
+    expect(stderr).toHaveBeenCalledWith("memory-hybrid: debug line");
+  });
+});

--- a/extensions/memory-hybrid/tests/maintenance-progress.test.ts
+++ b/extensions/memory-hybrid/tests/maintenance-progress.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from "vitest";
+import { withVerboseHeartbeat } from "../utils/maintenance-progress.js";
+
+describe("withVerboseHeartbeat", () => {
+  it("does not let heartbeat detail/log exceptions crash the wrapped task", async () => {
+    vi.useFakeTimers();
+    try {
+      const promise = withVerboseHeartbeat({
+        verbose: true,
+        intervalMs: 10,
+        prefix: "test",
+        log: () => {
+          throw new Error("log failed");
+        },
+        detail: () => {
+          throw new Error("detail failed");
+        },
+        fn: async () => {
+          await new Promise((resolve) => setTimeout(resolve, 25));
+          return "ok";
+        },
+      });
+
+      await vi.advanceTimersByTimeAsync(30);
+      await expect(promise).resolves.toBe("ok");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/extensions/memory-hybrid/tests/reflection-dedupe-hydration.test.ts
+++ b/extensions/memory-hybrid/tests/reflection-dedupe-hydration.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import {
+  computeDedupeCorpusFingerprint,
+  reflectionLexicalNearDuplicateAgainstFact,
+  resolveReflectionDedupeHydration,
+} from "../services/reflection-dedupe-hydration.js";
+
+describe("resolveReflectionDedupeHydration", () => {
+  it("applies defaults when partial is null", () => {
+    const r = resolveReflectionDedupeHydration(null);
+    expect(r.maxEmbedsPerRun).toBeGreaterThan(0);
+    expect(r.minIntervalMsBetweenEmbeds).toBeGreaterThan(0);
+  });
+
+  it("honors maxEmbedsPerRun 0 as unlimited", () => {
+    const r = resolveReflectionDedupeHydration({ maxEmbedsPerRun: 0 });
+    expect(r.maxEmbedsPerRun).toBe(0);
+  });
+});
+
+describe("computeDedupeCorpusFingerprint", () => {
+  it("changes when id set changes", () => {
+    const a = computeDedupeCorpusFingerprint(["b", "a"], "m1");
+    const b = computeDedupeCorpusFingerprint(["a", "b", "c"], "m1");
+    expect(a).not.toBe(b);
+  });
+
+  it("is stable for same sorted ids and model", () => {
+    const fp1 = computeDedupeCorpusFingerprint(["x", "y"], "m");
+    const fp2 = computeDedupeCorpusFingerprint(["x", "y"], "m");
+    expect(fp1).toBe(fp2);
+  });
+});
+
+describe("reflectionLexicalNearDuplicateAgainstFact", () => {
+  it("detects normalized equality", () => {
+    expect(reflectionLexicalNearDuplicateAgainstFact("User prefers TypeScript", "user  prefers   typescript")).toBe(
+      true,
+    );
+  });
+
+  it("detects high token overlap when threshold is relaxed", () => {
+    const a = "The user consistently values small focused functions under twenty lines";
+    const b = "User values small focused functions under twenty lines for readability";
+    expect(reflectionLexicalNearDuplicateAgainstFact(a, b, 0.65)).toBe(true);
+  });
+
+  it("returns false for unrelated short strings", () => {
+    expect(reflectionLexicalNearDuplicateAgainstFact("alpha beta gamma delta", "one two three four five")).toBe(false);
+  });
+});

--- a/extensions/memory-hybrid/tests/reflection-dedupe-hydration.test.ts
+++ b/extensions/memory-hybrid/tests/reflection-dedupe-hydration.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from "vitest";
 import {
   computeDedupeCorpusFingerprint,
+  dedupeHydrationStateKey,
   reflectionLexicalNearDuplicateAgainstFact,
   resolveReflectionDedupeHydration,
 } from "../services/reflection-dedupe-hydration.js";
+import { loadReflectionDedupeCorpusVectors } from "../services/reflection.js";
+import type { MemoryEntry } from "../types/memory.js";
 
 describe("resolveReflectionDedupeHydration", () => {
   it("applies defaults when partial is null", () => {
@@ -47,5 +50,293 @@ describe("reflectionLexicalNearDuplicateAgainstFact", () => {
 
   it("returns false for unrelated short strings", () => {
     expect(reflectionLexicalNearDuplicateAgainstFact("alpha beta gamma delta", "one two three four five")).toBe(false);
+  });
+});
+
+describe("loadReflectionDedupeCorpusVectors checkpoint semantics", () => {
+  function fact(id: string, text = `text ${id}`): MemoryEntry {
+    return {
+      id,
+      text,
+      category: "pattern",
+      timestamp: 1,
+      confidence: 1,
+      source: "test",
+      embedding: null,
+      embeddingModel: null,
+      expiresAt: null,
+      supersededAt: null,
+      metadata: {},
+      importance: 0.5,
+      entity: null,
+      key: null,
+      value: null,
+      decayClass: "normal",
+      sourceSession: null,
+      scope: "global",
+      createdAt: 1,
+      lastConfirmedAt: 1,
+    } as MemoryEntry;
+  }
+
+  function factsDbStub() {
+    const state = new Map<string, string>();
+    return {
+      getMaintenanceState: (key: string) => state.get(key) ?? null,
+      setMaintenanceState: (key: string, value: string) => state.set(key, value),
+      state,
+    };
+  }
+
+  function vectorDbStub(overrides: Record<string, unknown> = {}) {
+    return {
+      getVectorDim: () => 3,
+      isMemoriesVectorSchemaValid: () => true,
+      isLanceDbAvailable: () => true,
+      getVectorsByFactIds: async () => new Map<string, number[]>(),
+      ...overrides,
+    };
+  }
+
+  it("counts failed embed attempts toward maxEmbedsPerRun", async () => {
+    const factsDb = factsDbStub();
+    let calls = 0;
+    const embeddings = {
+      modelName: "m",
+      embed: async () => {
+        calls++;
+        throw new Error("permanent embed failure");
+      },
+    };
+
+    const res = await loadReflectionDedupeCorpusVectors(
+      [fact("00000000-0000-4000-8000-000000000001"), fact("00000000-0000-4000-8000-000000000002")],
+      embeddings as never,
+      vectorDbStub() as never,
+      { info: () => undefined, warn: () => undefined },
+      "test",
+      "test-op",
+      {
+        checkpoint: { factsDb: factsDb as never, kind: "pattern" },
+        hydrationPolicy: {
+          maxEmbedsPerRun: 1,
+          minIntervalMsBetweenEmbeds: 0,
+          maxConsecutive429BeforeDefer: 1,
+          baseBackoffMsAfter429: 500,
+        },
+      },
+    );
+
+    expect(calls).toBe(1);
+    expect(res.hydration.apiEmbedsThisRun).toBe(1);
+    expect(res.hydration.deferredDueToCap).toBe(true);
+  });
+
+  it("uses doneIds rather than positional checkpoint when need-embed rows shift", async () => {
+    const factsDb = factsDbStub();
+    const id1 = "00000000-0000-4000-8000-000000000001";
+    const id2 = "00000000-0000-4000-8000-000000000002";
+    const id3 = "00000000-0000-4000-8000-000000000003";
+    const rows = [fact(id1), fact(id2), fact(id3)];
+    let storedVectors = new Map<string, number[]>();
+    const embeddings = {
+      modelName: "m",
+      embed: async (text: string) => (text.includes(id1) ? [1, 0, 0] : text.includes(id2) ? [0, 1, 0] : [0, 0, 1]),
+    };
+
+    await loadReflectionDedupeCorpusVectors(
+      rows,
+      embeddings as never,
+      vectorDbStub({
+        store: async (entry: { id: string; vector: number[] }) => {
+          storedVectors.set(entry.id.toLowerCase(), entry.vector);
+          return entry.id;
+        },
+      }) as never,
+      { info: () => undefined, warn: () => undefined },
+      "test",
+      "test-op",
+      {
+        checkpoint: { factsDb: factsDb as never, kind: "pattern" },
+        hydrationPolicy: {
+          maxEmbedsPerRun: 1,
+          minIntervalMsBetweenEmbeds: 0,
+          maxConsecutive429BeforeDefer: 1,
+          baseBackoffMsAfter429: 500,
+        },
+      },
+    );
+
+    const firstCp = JSON.parse(factsDb.state.get(dedupeHydrationStateKey("pattern")) ?? "{}");
+    expect(firstCp.doneIds).toEqual([id1]);
+
+    const second = await loadReflectionDedupeCorpusVectors(
+      rows,
+      embeddings as never,
+      vectorDbStub({
+        getVectorsByFactIds: async () => new Map([[id1, storedVectors.get(id1)!]]),
+        store: async (entry: { id: string; vector: number[] }) => {
+          storedVectors.set(entry.id.toLowerCase(), entry.vector);
+          return entry.id;
+        },
+      }) as never,
+      { info: () => undefined, warn: () => undefined },
+      "test",
+      "test-op",
+      {
+        checkpoint: { factsDb: factsDb as never, kind: "pattern" },
+        hydrationPolicy: {
+          maxEmbedsPerRun: 10,
+          minIntervalMsBetweenEmbeds: 0,
+          maxConsecutive429BeforeDefer: 1,
+          baseBackoffMsAfter429: 500,
+        },
+      },
+    );
+
+    const secondCp = JSON.parse(factsDb.state.get(dedupeHydrationStateKey("pattern")) ?? "{}");
+    expect(second.hydration.complete).toBe(true);
+    expect(secondCp.doneIds).toEqual([id1, id2, id3]);
+    expect(storedVectors.has(id2)).toBe(true);
+    expect(storedVectors.has(id3)).toBe(true);
+  });
+
+  it("does not persist hydration checkpoint during dry-run-style corpus loads", async () => {
+    const factsDb = factsDbStub();
+    const embeddings = { modelName: "m", embed: async () => [1, 0, 0] };
+
+    await loadReflectionDedupeCorpusVectors(
+      [fact("00000000-0000-4000-8000-000000000001")],
+      embeddings as never,
+      vectorDbStub() as never,
+      { info: () => undefined, warn: () => undefined },
+      "test",
+      "test-op",
+      {
+        checkpoint: { factsDb: factsDb as never, kind: "pattern" },
+        persistCheckpoint: false,
+        hydrationPolicy: {
+          maxEmbedsPerRun: 10,
+          minIntervalMsBetweenEmbeds: 0,
+          maxConsecutive429BeforeDefer: 1,
+          baseBackoffMsAfter429: 500,
+        },
+      },
+    );
+
+    expect(factsDb.state.has(dedupeHydrationStateKey("pattern"))).toBe(false);
+  });
+
+  it("persists hydrated checkpoint vectors before advancing the checkpoint", async () => {
+    const factsDb = factsDbStub();
+    const stored: Array<{ id: string; vector: number[] }> = [];
+    const embeddings = { modelName: "m", embed: async () => [1, 0, 0] };
+
+    const res = await loadReflectionDedupeCorpusVectors(
+      [fact("00000000-0000-4000-8000-000000000001"), fact("00000000-0000-4000-8000-000000000002")],
+      embeddings as never,
+      vectorDbStub({
+        store: async (entry: { id: string; vector: number[] }) => {
+          stored.push(entry);
+          return entry.id;
+        },
+      }) as never,
+      { info: () => undefined, warn: () => undefined },
+      "test",
+      "test-op",
+      {
+        checkpoint: { factsDb: factsDb as never, kind: "pattern" },
+        hydrationPolicy: {
+          maxEmbedsPerRun: 10,
+          minIntervalMsBetweenEmbeds: 0,
+          maxConsecutive429BeforeDefer: 1,
+          baseBackoffMsAfter429: 500,
+        },
+      },
+    );
+
+    const cp = JSON.parse(factsDb.state.get(dedupeHydrationStateKey("pattern")) ?? "{}");
+    expect(res.hydration.complete).toBe(true);
+    expect(cp.nextNeedIdx).toBe(2);
+    expect(stored.map((s) => s.id)).toEqual([
+      "00000000-0000-4000-8000-000000000001",
+      "00000000-0000-4000-8000-000000000002",
+    ]);
+  });
+
+  it("does not advance checkpoint past a vector persistence failure", async () => {
+    const factsDb = factsDbStub();
+    let stores = 0;
+    const embeddings = { modelName: "m", embed: async () => [1, 0, 0] };
+
+    const res = await loadReflectionDedupeCorpusVectors(
+      [fact("00000000-0000-4000-8000-000000000001"), fact("00000000-0000-4000-8000-000000000002")],
+      embeddings as never,
+      vectorDbStub({
+        store: async () => {
+          stores++;
+          if (stores === 2) throw new Error("store failed");
+          return "ok";
+        },
+      }) as never,
+      { info: () => undefined, warn: () => undefined },
+      "test",
+      "test-op",
+      {
+        checkpoint: { factsDb: factsDb as never, kind: "pattern" },
+        hydrationPolicy: {
+          maxEmbedsPerRun: 10,
+          minIntervalMsBetweenEmbeds: 0,
+          maxConsecutive429BeforeDefer: 1,
+          baseBackoffMsAfter429: 500,
+        },
+      },
+    );
+
+    const cp = JSON.parse(factsDb.state.get(dedupeHydrationStateKey("pattern")) ?? "{}");
+    expect(res.hydration.complete).toBe(false);
+    expect(cp.nextNeedIdx).toBe(2);
+    expect(Object.keys(cp.failed)).toEqual(["00000000-0000-4000-8000-000000000002"]);
+  });
+
+  it("quarantines a non-rate-limit embed error while continuing later rows", async () => {
+    const factsDb = factsDbStub();
+    let calls = 0;
+    const embeddings = {
+      modelName: "m",
+      embed: async () => {
+        calls++;
+        if (calls === 2) throw new Error("boom");
+        return [1, 0, 0];
+      },
+    };
+
+    const res = await loadReflectionDedupeCorpusVectors(
+      [
+        fact("00000000-0000-4000-8000-000000000001"),
+        fact("00000000-0000-4000-8000-000000000002"),
+        fact("00000000-0000-4000-8000-000000000003"),
+      ],
+      embeddings as never,
+      vectorDbStub() as never,
+      { info: () => undefined, warn: () => undefined },
+      "test",
+      "test-op",
+      {
+        checkpoint: { factsDb: factsDb as never, kind: "pattern" },
+        hydrationPolicy: {
+          maxEmbedsPerRun: 10,
+          minIntervalMsBetweenEmbeds: 0,
+          maxConsecutive429BeforeDefer: 1,
+          baseBackoffMsAfter429: 500,
+        },
+      },
+    );
+
+    const cp = JSON.parse(factsDb.state.get(dedupeHydrationStateKey("pattern")) ?? "{}");
+    expect(res.hydration.complete).toBe(false);
+    expect(cp.nextNeedIdx).toBe(3);
+    expect(Object.keys(cp.failed)).toEqual(["00000000-0000-4000-8000-000000000002"]);
+    expect(calls).toBe(3);
   });
 });

--- a/extensions/memory-hybrid/tools/utility-tools.ts
+++ b/extensions/memory-hybrid/tools/utility-tools.ts
@@ -12,6 +12,8 @@ import type { EmbeddingProvider } from "../services/embeddings.js";
 import { capturePluginError } from "../services/error-reporter.js";
 import { analyzeKnowledgeGaps } from "../services/knowledge-gaps.js";
 import type { ProvenanceService } from "../services/provenance.js";
+import type { ReflectionDedupeHydrationResolved } from "../services/reflection-dedupe-hydration.js";
+import { resolveReflectionDedupeHydration } from "../services/reflection-dedupe-hydration.js";
 import { detectClusters } from "../services/topic-clusters.js";
 
 export interface PluginContext {
@@ -32,7 +34,13 @@ export type RunReflectionFn = (
   embeddings: EmbeddingProvider,
   openai: OpenAI,
   config: { defaultWindow: number; minObservations: number; enabled?: boolean },
-  opts: { window: number; dryRun: boolean; model: string; fallbackModels?: string[] },
+  opts: {
+    window: number;
+    dryRun: boolean;
+    model: string;
+    fallbackModels?: string[];
+    dedupeHydration?: ReflectionDedupeHydrationResolved;
+  },
   logger: { info: (msg: string) => void; warn: (msg: string) => void },
   provenanceService?: ProvenanceService | null,
 ) => Promise<{ factsAnalyzed: number; patternsExtracted: number; patternsStored: number; window: number }>;
@@ -244,7 +252,13 @@ export function registerUtilityTools(
             embeddings,
             openai,
             { defaultWindow: reflectionCfg.defaultWindow, minObservations: reflectionCfg.minObservations },
-            { window, dryRun: false, model: defaultModel, fallbackModels },
+            {
+              window,
+              dryRun: false,
+              model: defaultModel,
+              fallbackModels,
+              dedupeHydration: resolveReflectionDedupeHydration(reflectionCfg.dedupeHydration ?? null),
+            },
             api.logger,
             provenanceService,
           );

--- a/extensions/memory-hybrid/utils/logger.ts
+++ b/extensions/memory-hybrid/utils/logger.ts
@@ -85,10 +85,6 @@ export function createJsonCliStderrLogger(): Required<PluginLoggerApi> {
   };
 }
 
-export function initPluginLoggerForJsonCli(): void {
-  activeLogger = createJsonCliStderrLogger();
-}
-
 /**
  * Reset the plugin logger to the silent no-op.
  * Used in unit tests to isolate logging side effects.

--- a/extensions/memory-hybrid/utils/logger.ts
+++ b/extensions/memory-hybrid/utils/logger.ts
@@ -70,6 +70,25 @@ export function initPluginLogger(apiLogger: PluginLoggerApi): void {
   };
 }
 
+/** Logger implementation for machine-readable CLI commands.
+ *
+ * OpenClaw's normal plugin logger may render `[plugins] ...` lines on stdout during
+ * standalone CLI execution. For `hybrid-mem ... --json` commands stdout must be valid
+ * JSON from byte 0, so route runtime telemetry to stderr while preserving visibility.
+ */
+export function createJsonCliStderrLogger(): Required<PluginLoggerApi> {
+  return {
+    info: (msg: string) => console.error(msg),
+    warn: (msg: string) => console.error(msg),
+    error: (msg: string) => console.error(msg),
+    debug: (msg: string) => console.error(msg),
+  };
+}
+
+export function initPluginLoggerForJsonCli(): void {
+  activeLogger = createJsonCliStderrLogger();
+}
+
 /**
  * Reset the plugin logger to the silent no-op.
  * Used in unit tests to isolate logging side effects.

--- a/extensions/memory-hybrid/utils/maintenance-progress.ts
+++ b/extensions/memory-hybrid/utils/maintenance-progress.ts
@@ -1,0 +1,37 @@
+/**
+ * Helpers for verbose maintenance / dream-cycle progress logging (#1228).
+ */
+
+/** Default interval for heartbeat lines when a substep has no finer-grained progress events. */
+export const MAINTENANCE_VERBOSE_HEARTBEAT_MS = 15_000;
+
+export function formatElapsedSec(sinceMs: number): string {
+  return `${Math.max(0, Math.round((Date.now() - sinceMs) / 1000))}s`;
+}
+
+/**
+ * Runs `fn` while emitting periodic heartbeat logs if `verbose` and work takes longer than `intervalMs`.
+ * The heartbeat includes `detail()` output (live counters).
+ */
+export async function withVerboseHeartbeat<T>(opts: {
+  verbose: boolean;
+  log: (msg: string) => void;
+  prefix: string;
+  intervalMs?: number;
+  detail: () => string;
+  fn: () => Promise<T>;
+}): Promise<T> {
+  if (!opts.verbose) {
+    return opts.fn();
+  }
+  const intervalMs = opts.intervalMs ?? MAINTENANCE_VERBOSE_HEARTBEAT_MS;
+  const phaseStart = Date.now();
+  const id = setInterval(() => {
+    opts.log(`${opts.prefix} — heartbeat elapsed=${formatElapsedSec(phaseStart)} | ${opts.detail()}`);
+  }, intervalMs);
+  try {
+    return await opts.fn();
+  } finally {
+    clearInterval(id);
+  }
+}

--- a/extensions/memory-hybrid/utils/maintenance-progress.ts
+++ b/extensions/memory-hybrid/utils/maintenance-progress.ts
@@ -27,7 +27,12 @@ export async function withVerboseHeartbeat<T>(opts: {
   const intervalMs = opts.intervalMs ?? MAINTENANCE_VERBOSE_HEARTBEAT_MS;
   const phaseStart = Date.now();
   const id = setInterval(() => {
-    opts.log(`${opts.prefix} — heartbeat elapsed=${formatElapsedSec(phaseStart)} | ${opts.detail()}`);
+    try {
+      opts.log(`${opts.prefix} — heartbeat elapsed=${formatElapsedSec(phaseStart)} | ${opts.detail()}`);
+    } catch {
+      // Heartbeats are best-effort observability only; never let a logging/detail
+      // failure crash the maintenance task that the heartbeat is observing.
+    }
   }, intervalMs);
   try {
     return await opts.fn();


### PR DESCRIPTION
## Summary
This PR implements:
- [Issue #1228](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/1228): actionable **verbose** logging during long reflection dedupe, Lance work, embedding batches, and other dream-cycle maintenance steps.
- [Issue #1229](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/1229): **throttling, 429 backpressure, resumable checkpoints**, per-run embed caps, and **lexical dedupe fallback** when vector hydration is partial.

## #1228 — Verbose progress
- Reflection / reflect-rules / reflect-meta: Lance chunk progress, embedding batch milestones, 15s heartbeats, per-candidate dedupe lines, elapsed times.
- VectorDB: `setMaintenanceVerbose`, `getVectorsByFactIds` chunk callbacks, init/reconnect milestones.
- Dream-cycle: episodic group progress, decay/FTS/VACUUM timing when verbose; safe `setMaintenanceVerbose` for stubs.
- MEMORY_INDEX: snapshot + LLM synthesis timing when verbose.
- find-duplicates / consolidate: `-v` for embed + Lance scan progress.
- New: `extensions/memory-hybrid/utils/maintenance-progress.ts`.

## #1229 — Hydration throttle + checkpoints
- New: `extensions/memory-hybrid/services/reflection-dedupe-hydration.ts` — defaults, rate-limit detection, checkpoint read/write, lexical near-duplicate helper.
- `loadReflectionDedupeCorpusVectors` returns `{ vectors, hydration }`: Lance prefetch all IDs, then **sorted** embedding backlog with **min interval between embeds**, **max embeds per run**, **Retry-After + exponential backoff** on 429, **defer** after consecutive 429s; persists `maintenance_state` keys `reflection_dedupe_hydration_{pattern,rule,meta}` with corpus fingerprint + model.
- **Lexical fallback** for duplicate detection on rows still missing vectors when hydration incomplete.
- Config: optional `reflection.dedupeHydration` (`maxEmbedsPerRun`, `minIntervalMsBetweenEmbeds`, `maxConsecutive429BeforeDefer`, `baseBackoffMsAfter429`). Dream-cycle passes resolved policy via `reflectionDedupeHydration`.
- Consolidate path keeps **unlimited** embed count but still uses interval + 429 handling.

## Testing
- `npx tsc --noEmit` passes under `extensions/memory-hybrid`.
- `vitest run tests/reflection-dedupe-hydration.test.ts` passes.
- Full suite: CI on this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk: changes core reflection dedupe hydration to persist checkpoints and throttle embedding calls with new fallback paths, which could affect maintenance throughput and duplicate detection behavior. Also adds cron ledger mutation and CLI logging routing that could impact operational observability/output expectations.
> 
> **Overview**
> Adds **verbose, time-stamped progress logging** across long-running maintenance paths (VectorDB init/reconnect/table setup, dream-cycle steps, reflection dedupe loads, find-duplicates/consolidate, and memory-index synthesis), including a reusable `withVerboseHeartbeat` helper and new CLI `--verbose` flags.
> 
> Reworks reflection dedupe corpus hydration to be **throttled and resumable**: `loadReflectionDedupeCorpusVectors` now returns `{ vectors, hydration }`, bulk-prefetches Lance vectors with chunk callbacks, applies per-run embed caps + min-interval pacing, handles 429/403 rate limits with backoff/deferral, persists per-corpus checkpoints in `maintenance_state`, and falls back to **lexical near-duplicate checks** when vectors remain missing.
> 
> Introduces an idempotent **cron maintenance outcome reconciler** that scans recent `hybrid-mem:*` cron run ledgers and job state, rewriting false `ok` runs to `error` when summaries/exit artifacts indicate failed/partial maintenance, and wires it into startup + watchdog. Also ensures `--json` CLI mode keeps stdout clean by routing plugin telemetry to stderr via `createJsonCliStderrLogger`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6275064f8f3bdb085d18e1b19671cf85a0bec6a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->