### PR TITLE
fix(memory-hybrid): clear stale hydration failure markers

### DIFF
--- a/extensions/memory-hybrid/openclaw.plugin.json
+++ b/extensions/memory-hybrid/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "openclaw-hybrid-memory",
   "kind": "memory",
-  "version": "2026.5.81",
+  "version": "2026.5.91",
   "contracts": {
     "tools": [
       "active_task_propose_goal",

--- a/extensions/memory-hybrid/package-lock.json
+++ b/extensions/memory-hybrid/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openclaw-hybrid-memory",
-  "version": "2026.5.81",
+  "version": "2026.5.91",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openclaw-hybrid-memory",
-      "version": "2026.5.81",
+      "version": "2026.5.91",
       "hasInstallScript": true,
       "dependencies": {
         "@lancedb/lancedb": "^0.27.1",

--- a/extensions/memory-hybrid/package.json
+++ b/extensions/memory-hybrid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-hybrid-memory",
-  "version": "2026.5.81",
+  "version": "2026.5.91",
   "type": "module",
   "description": "Give your OpenClaw agent lasting memory: structured facts, semantic search, auto-capture & recall, decay, optional credential vault. Part of Hybrid Memory v3.",
   "files": [

--- a/extensions/memory-hybrid/services/reflection.ts
+++ b/extensions/memory-hybrid/services/reflection.ts
@@ -289,7 +289,11 @@ export async function loadReflectionDedupeCorpusVectors(
     }
 
     for (let j = 0; j < facts.length; j++) {
-      if (result[j] !== null) doneIds.add(facts[j]!.id.toLowerCase());
+      if (result[j] !== null) {
+        const id = facts[j]!.id.toLowerCase();
+        doneIds.add(id);
+        delete failedRows[id];
+      }
     }
 
     let checkpointNextIdx = 0;

--- a/extensions/memory-hybrid/services/reflection.ts
+++ b/extensions/memory-hybrid/services/reflection.ts
@@ -289,10 +289,16 @@ export async function loadReflectionDedupeCorpusVectors(
     }
 
     for (let j = 0; j < facts.length; j++) {
+      const id = facts[j]!.id.toLowerCase();
       if (result[j] !== null) {
-        const id = facts[j]!.id.toLowerCase();
-        doneIds.add(id);
+        // Lance already has a usable vector. Clear stale failure quarantine, but do
+        // not add a cache hit to doneIds: if Lance later loses that vector, the row
+        // must be eligible for rehydration instead of being permanently skipped.
         delete failedRows[id];
+      } else {
+        // If an older checkpoint marked this id as done but Lance no longer has the
+        // vector, discard the stale marker and rehydrate normally.
+        doneIds.delete(id);
       }
     }
 
@@ -337,7 +343,6 @@ export async function loadReflectionDedupeCorpusVectors(
       const f = facts[needEmbedIndices[kk]!]!;
       const failed = failedRows[f.id.toLowerCase()];
       const retryDue = !failed || failed.nextRetryAt <= nowRetry;
-      if (doneIds.has(f.id.toLowerCase()) && !failed) continue;
       if (retryDue) workKs.push(kk);
     }
 

--- a/extensions/memory-hybrid/tests/reflection-dedupe-hydration.test.ts
+++ b/extensions/memory-hybrid/tests/reflection-dedupe-hydration.test.ts
@@ -98,6 +98,55 @@ describe("loadReflectionDedupeCorpusVectors checkpoint semantics", () => {
     };
   }
 
+  it("clears stale failed row markers when Lance already has the vector", async () => {
+    const factsDb = factsDbStub();
+    const id1 = "00000000-0000-4000-8000-000000000001";
+    const stateKey = dedupeHydrationStateKey("pattern");
+    const fp = computeDedupeCorpusFingerprint([id1], "m");
+    factsDb.state.set(
+      stateKey,
+      JSON.stringify({
+        v: 1,
+        fp,
+        model: "m",
+        nextNeedIdx: 0,
+        failed: { [id1]: { attempts: 2, nextRetryAt: 0 } },
+        updatedAt: 1,
+      }),
+    );
+
+    const hydratedFact = fact(id1, "already hydrated");
+    hydratedFact.embeddingModel = "m";
+
+    const res = await loadReflectionDedupeCorpusVectors(
+      [hydratedFact],
+      {
+        modelName: "m",
+        embed: async () => {
+          throw new Error("should not embed");
+        },
+      } as never,
+      vectorDbStub({ getVectorsByFactIds: async () => new Map([[id1, [1, 0, 0]]]) }) as never,
+      { info: () => undefined, warn: () => undefined },
+      "test",
+      "test-op",
+      {
+        checkpoint: { factsDb: factsDb as never, kind: "pattern" },
+        hydrationPolicy: {
+          maxEmbedsPerRun: 10,
+          minIntervalMsBetweenEmbeds: 0,
+          maxConsecutive429BeforeDefer: 1,
+          baseBackoffMsAfter429: 500,
+        },
+      },
+    );
+
+    const cp = JSON.parse(factsDb.state.get(stateKey) ?? "{}");
+    expect(res.hydration.complete).toBe(true);
+    expect(cp.failed).toBeUndefined();
+    expect(cp.doneIds).toEqual([id1]);
+  });
+
   it("counts failed embed attempts toward maxEmbedsPerRun", async () => {
     const factsDb = factsDbStub();
     let calls = 0;

--- a/extensions/memory-hybrid/tests/reflection-dedupe-hydration.test.ts
+++ b/extensions/memory-hybrid/tests/reflection-dedupe-hydration.test.ts
@@ -144,7 +144,55 @@ describe("loadReflectionDedupeCorpusVectors checkpoint semantics", () => {
     const cp = JSON.parse(factsDb.state.get(stateKey) ?? "{}");
     expect(res.hydration.complete).toBe(true);
     expect(cp.failed).toBeUndefined();
-    expect(cp.doneIds).toEqual([id1]);
+    expect(cp.doneIds ?? []).toEqual([]);
+  });
+
+  it("rehydrates a row when a stale doneId exists but Lance no longer has the vector", async () => {
+    const factsDb = factsDbStub();
+    const id1 = "00000000-0000-4000-8000-000000000001";
+    const stateKey = dedupeHydrationStateKey("pattern");
+    const fp = computeDedupeCorpusFingerprint([id1], "m");
+    factsDb.state.set(
+      stateKey,
+      JSON.stringify({
+        v: 1,
+        fp,
+        model: "m",
+        nextNeedIdx: 1,
+        doneIds: [id1],
+        updatedAt: 1,
+      }),
+    );
+    let embedCalls = 0;
+
+    await loadReflectionDedupeCorpusVectors(
+      [fact(id1, "lost vector")],
+      {
+        modelName: "m",
+        embed: async () => {
+          embedCalls++;
+          return [1, 0, 0];
+        },
+      } as never,
+      vectorDbStub({
+        getVectorsByFactIds: async () => new Map<string, number[]>(),
+        store: async (entry: { id: string }) => entry.id,
+      }) as never,
+      { info: () => undefined, warn: () => undefined },
+      "test",
+      "test-op",
+      {
+        checkpoint: { factsDb: factsDb as never, kind: "pattern" },
+        hydrationPolicy: {
+          maxEmbedsPerRun: 10,
+          minIntervalMsBetweenEmbeds: 0,
+          maxConsecutive429BeforeDefer: 1,
+          baseBackoffMsAfter429: 500,
+        },
+      },
+    );
+
+    expect(embedCalls).toBe(1);
   });
 
   it("counts failed embed attempts toward maxEmbedsPerRun", async () => {


### PR DESCRIPTION
## Summary
Follow-up to merged PR #1230. The original PR merged while final post-push bot feedback was still being addressed, so this PR carries the remaining fixes that did **not** make it into merge commit `28d99f3`.

Fixes included here:
- Clear stale hydration `failedRows` when Lance already has a valid vector for that fact.
- Preserve the regression test proving stale failed markers are cleared and hydration can complete.

The earlier PR #1230 branch already included the broader review-feedback fixes before merge; this follow-up is intentionally small and only contains the remaining post-merge delta.

## Verification
- `npm test -- --run tests/reflection-dedupe-hydration.test.ts tests/cron-maintenance-reconciler-1233.test.ts` ✅
- `npx tsc --noEmit` ✅
- `npm run format:check` ✅

## Notes
PR #1230 is already merged, so these final review-feedback fixes cannot be pushed to that source branch anymore.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts checkpointing behavior in reflection dedupe vector hydration, which can change which facts get re-embedded and when; errors could cause extra embed calls or skipped rehydration. Scope is small and covered by new targeted tests.
> 
> **Overview**
> Fixes reflection dedupe-corpus hydration checkpoint handling so **stale checkpoint state can’t block progress**.
> 
> When Lance already has a valid vector, the code now clears any lingering `failed` quarantine for that fact; and when a checkpoint claims an id is `done` but Lance no longer has the vector, it drops that stale `doneId` so the row gets rehydrated.
> 
> Bumps the extension version to `2026.5.91` and adds regression tests covering both stale-`failed` cleanup and stale-`doneId` rehydration behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0dc705e1b9307998f4240a4e22c10e5b1bb09483. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->