### PR TITLE
fix: checkpoint reflection dedupe hydration

### DIFF
--- a/extensions/memory-hybrid/index.ts
+++ b/extensions/memory-hybrid/index.ts
@@ -161,6 +161,7 @@ import {
   dotProductSimilarity,
   normalizeVector,
   parsePatternsFromReflectionResponse,
+  loadReflectionDedupeCorpusVectors,
   runReflection,
   runReflectionMeta,
   runReflectionRules,
@@ -907,6 +908,7 @@ export const _testing = {
   findSimilarByEmbedding,
   // Reflection parsing (for tests) - re-exported from service
   parsePatternsFromReflectionResponse,
+  loadReflectionDedupeCorpusVectors,
   normalizeVector,
   dotProductSimilarity,
   // FTS5 search service (Issue #151)

--- a/extensions/memory-hybrid/services/consolidation.ts
+++ b/extensions/memory-hybrid/services/consolidation.ts
@@ -153,6 +153,8 @@ export async function runConsolidate(
     logger,
     "memory-hybrid: consolidate",
     "consolidate-embed",
+    undefined,
+    opts.dryRun,
   );
   const vectors = vectorResults.map((v) => (v === null ? [] : v));
 

--- a/extensions/memory-hybrid/services/reflection.ts
+++ b/extensions/memory-hybrid/services/reflection.ts
@@ -151,11 +151,12 @@ export async function loadReflectionDedupeCorpusVectors(
     let lanceHits = 0;
     let lanceModelOkHits = 0;
     let lanceModelMissingHits = 0;
-    let lanceModelMismatchHits = 0;
+    let lanceModelMismatchSkips = 0;
     let apiEmbeds = 0;
     let apiPersisted = 0;
     let apiPersistFailures = 0;
     let embedFailures = 0;
+    let nonNullSoFar = 0;
     const startedAt = Date.now();
     let lastProgressAt = startedAt;
 
@@ -170,7 +171,9 @@ export async function loadReflectionDedupeCorpusVectors(
       let batchLance = 0;
       let batchApi = 0;
       let batchPersisted = 0;
-      let batchFailures = 0;
+      let batchPersistFailures = 0;
+      let batchEmbedFailures = 0;
+      let batchMismatchSkips = 0;
 
       for (let j = i; j < end; j++) {
         const f = facts[j]!;
@@ -180,6 +183,7 @@ export async function loadReflectionDedupeCorpusVectors(
         const useCache = dim > 0 && cached != null && cached.length === dim && (!modelKnown || modelOk);
         if (useCache) {
           result[j] = normalizeVector(cached);
+          nonNullSoFar++;
           lanceHits++;
           batchLance++;
           if (modelOk) lanceModelOkHits++;
@@ -194,11 +198,16 @@ export async function loadReflectionDedupeCorpusVectors(
                 );
               }
             }
-          } else lanceModelMismatchHits++;
+          }
         } else {
+          if (dim > 0 && cached != null && cached.length === dim && modelKnown && !modelOk) {
+            lanceModelMismatchSkips++;
+            batchMismatchSkips++;
+          }
           try {
             const vec = await embeddings.embed(f.text);
             result[j] = normalizeVector(vec);
+            nonNullSoFar++;
             apiEmbeds++;
             batchApi++;
             hadApiEmbed = true;
@@ -219,6 +228,7 @@ export async function loadReflectionDedupeCorpusVectors(
                 batchPersisted++;
               } catch (storeErr) {
                 apiPersistFailures++;
+                batchPersistFailures++;
                 logger.info(
                   `${logPrefix} — dedupe corpus: failed to persist hydrated vector for fact ${f.id}: ${storeErr}`,
                 );
@@ -226,7 +236,7 @@ export async function loadReflectionDedupeCorpusVectors(
             }
           } catch (err) {
             embedFailures++;
-            batchFailures++;
+            batchEmbedFailures++;
             if (!shouldSuppressEmbeddingError(err)) {
               capturePluginError(err instanceof Error ? err : new Error(String(err)), {
                 operation: captureOperation,
@@ -244,7 +254,7 @@ export async function loadReflectionDedupeCorpusVectors(
       const batchMs = Date.now() - batchStartedAt;
       const processed = end;
       const remaining = facts.length - end;
-      const ok = result.slice(0, end).filter((v) => v !== null).length;
+      const ok = nonNullSoFar;
       const shouldLog =
         facts.length > 1000 ||
         batchApi > 0 ||
@@ -255,7 +265,7 @@ export async function loadReflectionDedupeCorpusVectors(
       if (shouldLog) {
         lastProgressAt = Date.now();
         logger.info(
-          `${logPrefix} — dedupe corpus progress: ${processed}/${facts.length} processed, ${remaining} remaining; batch=${batchMs}ms (Lance ${batchLance}, API ${batchApi}, persisted ${batchPersisted}, failures ${batchFailures}); totals: Lance ${lanceHits} (model-ok ${lanceModelOkHits}, missing ${lanceModelMissingHits}, mismatch ${lanceModelMismatchHits}), API ${apiEmbeds}, persisted ${apiPersisted}, persistFailures ${apiPersistFailures}, embedFailures ${embedFailures}, non-null ${ok}; elapsed=${elapsedMs}ms`,
+          `${logPrefix} — dedupe corpus progress: ${processed}/${facts.length} processed, ${remaining} remaining; batch=${batchMs}ms (Lance ${batchLance}, API ${batchApi}, persisted ${batchPersisted}, persistFailures ${batchPersistFailures}, embedFailures ${batchEmbedFailures}, mismatchSkips ${batchMismatchSkips}); totals: Lance ${lanceHits} (model-ok ${lanceModelOkHits}, missing ${lanceModelMissingHits}, mismatch-skips ${lanceModelMismatchSkips}), API ${apiEmbeds}, persisted ${apiPersisted}, persistFailures ${apiPersistFailures}, embedFailures ${embedFailures}, non-null ${ok}; elapsed=${elapsedMs}ms`,
         );
       }
 
@@ -267,7 +277,7 @@ export async function loadReflectionDedupeCorpusVectors(
     if (facts.length > 0) {
       const ok = result.filter((v) => v !== null).length;
       logger.info(
-        `${logPrefix} — dedupe corpus: ${lanceHits} vector(s) reused from Lance index (model-ok ${lanceModelOkHits}, missing ${lanceModelMissingHits}, mismatch ${lanceModelMismatchHits}), ${apiEmbeds} row(s) hydrated via embedding API, ${apiPersisted} persisted to Lance (${apiPersistFailures} persist failure(s)), ${embedFailures} embed failure(s), ${ok}/${facts.length} non-null for cosine check`,
+        `${logPrefix} — dedupe corpus: ${lanceHits} vector(s) reused from Lance index (model-ok ${lanceModelOkHits}, missing ${lanceModelMissingHits}, mismatch-skips ${lanceModelMismatchSkips}), ${apiEmbeds} row(s) hydrated via embedding API, ${apiPersisted} persisted to Lance (${apiPersistFailures} persist failure(s)), ${embedFailures} embed failure(s), ${ok}/${facts.length} non-null for cosine check`,
       );
     }
     return result;

--- a/extensions/memory-hybrid/services/reflection.ts
+++ b/extensions/memory-hybrid/services/reflection.ts
@@ -118,11 +118,19 @@ export async function loadReflectionDedupeCorpusVectors(
   logger: { info: (msg: string) => void },
   logPrefix: string,
   captureOperation: string,
+  markEmbeddingModel?: (factId: string, model: string) => void,
 ): Promise<(number[] | null)[]> {
   const loadWithTimeout = async (): Promise<(number[] | null)[]> => {
     const vdb = vectorDb as VectorDB & {
       getVectorDim?: () => number;
       getVectorsByFactIds?: (ids: string[]) => Promise<Map<string, number[]>>;
+      store?: (entry: {
+        text: string;
+        vector: number[];
+        importance: number;
+        category: string;
+        id?: string;
+      }) => Promise<string>;
     };
     const dim = typeof vdb.getVectorDim === "function" ? vdb.getVectorDim() : 0;
     let byId = new Map<string, number[]>();
@@ -141,30 +149,84 @@ export async function loadReflectionDedupeCorpusVectors(
 
     const result: (number[] | null)[] = new Array(facts.length);
     let lanceHits = 0;
+    let lanceModelOkHits = 0;
+    let lanceModelMissingHits = 0;
+    let lanceModelMismatchHits = 0;
     let apiEmbeds = 0;
-    let embedAttemptsThisRun = 0;
+    let apiPersisted = 0;
+    let apiPersistFailures = 0;
+    let embedFailures = 0;
+    const startedAt = Date.now();
+    let lastProgressAt = startedAt;
 
-    logger.info(`${logPrefix} — dedupe corpus: processing ${facts.length} facts in batches of 20...`);
+    logger.info(
+      `${logPrefix} — dedupe corpus: processing ${facts.length} facts in batches of 20 (checkpointing API-hydrated vectors)`,
+    );
 
     for (let i = 0; i < facts.length; i += 20) {
+      const batchStartedAt = Date.now();
       const end = Math.min(i + 20, facts.length);
       let hadApiEmbed = false;
+      let batchLance = 0;
+      let batchApi = 0;
+      let batchPersisted = 0;
+      let batchFailures = 0;
+
       for (let j = i; j < end; j++) {
         const f = facts[j]!;
-        const cached = byId.get(f.id.toLowerCase());
-        const modelOk =
-          f.embeddingModel != null && embeddings.modelName != null && f.embeddingModel === embeddings.modelName;
-        const useCache = dim > 0 && cached != null && cached.length === dim && modelOk;
+        const cached = byId.get(f.id.toLowerCase()) ?? byId.get(f.id);
+        const modelKnown = f.embeddingModel != null && embeddings.modelName != null;
+        const modelOk = modelKnown && f.embeddingModel === embeddings.modelName;
+        const useCache = dim > 0 && cached != null && cached.length === dim && (!modelKnown || modelOk);
         if (useCache) {
           result[j] = normalizeVector(cached);
           lanceHits++;
+          batchLance++;
+          if (modelOk) lanceModelOkHits++;
+          else if (!f.embeddingModel) {
+            lanceModelMissingHits++;
+            if (embeddings.modelName && markEmbeddingModel) {
+              try {
+                markEmbeddingModel(f.id, embeddings.modelName);
+              } catch (markErr) {
+                logger.info(
+                  `${logPrefix} — dedupe corpus: failed to mark embedding model for cached fact ${f.id}: ${markErr}`,
+                );
+              }
+            }
+          } else lanceModelMismatchHits++;
         } else {
           try {
             const vec = await embeddings.embed(f.text);
             result[j] = normalizeVector(vec);
             apiEmbeds++;
+            batchApi++;
             hadApiEmbed = true;
+
+            if (typeof vdb.store === "function") {
+              try {
+                await vdb.store({
+                  text: f.text,
+                  vector: vec,
+                  importance: typeof f.importance === "number" ? f.importance : REFLECTION_IMPORTANCE,
+                  category: f.category,
+                  id: f.id,
+                });
+                if (embeddings.modelName && markEmbeddingModel) {
+                  markEmbeddingModel(f.id, embeddings.modelName);
+                }
+                apiPersisted++;
+                batchPersisted++;
+              } catch (storeErr) {
+                apiPersistFailures++;
+                logger.info(
+                  `${logPrefix} — dedupe corpus: failed to persist hydrated vector for fact ${f.id}: ${storeErr}`,
+                );
+              }
+            }
           } catch (err) {
+            embedFailures++;
+            batchFailures++;
             if (!shouldSuppressEmbeddingError(err)) {
               capturePluginError(err instanceof Error ? err : new Error(String(err)), {
                 operation: captureOperation,
@@ -178,11 +240,22 @@ export async function loadReflectionDedupeCorpusVectors(
         }
       }
 
-      // Log progress for large batches (every 500 facts or at the end)
-      if (facts.length > 1000 && (end % 500 === 0 || end === facts.length)) {
-        const ok = result.slice(0, end).filter((v) => v !== null).length;
+      const elapsedMs = Date.now() - startedAt;
+      const batchMs = Date.now() - batchStartedAt;
+      const processed = end;
+      const remaining = facts.length - end;
+      const ok = result.slice(0, end).filter((v) => v !== null).length;
+      const shouldLog =
+        facts.length > 1000 ||
+        batchApi > 0 ||
+        batchMs >= 5000 ||
+        Date.now() - lastProgressAt >= 10_000 ||
+        end === facts.length;
+
+      if (shouldLog) {
+        lastProgressAt = Date.now();
         logger.info(
-          `${logPrefix} — dedupe corpus progress: ${end}/${facts.length} facts processed (${lanceHits} from Lance, ${apiEmbeds} via API, ${ok} non-null)`,
+          `${logPrefix} — dedupe corpus progress: ${processed}/${facts.length} processed, ${remaining} remaining; batch=${batchMs}ms (Lance ${batchLance}, API ${batchApi}, persisted ${batchPersisted}, failures ${batchFailures}); totals: Lance ${lanceHits} (model-ok ${lanceModelOkHits}, missing ${lanceModelMissingHits}, mismatch ${lanceModelMismatchHits}), API ${apiEmbeds}, persisted ${apiPersisted}, persistFailures ${apiPersistFailures}, embedFailures ${embedFailures}, non-null ${ok}; elapsed=${elapsedMs}ms`,
         );
       }
 
@@ -194,7 +267,7 @@ export async function loadReflectionDedupeCorpusVectors(
     if (facts.length > 0) {
       const ok = result.filter((v) => v !== null).length;
       logger.info(
-        `${logPrefix} — dedupe corpus: ${lanceHits} vector(s) reused from Lance index, ${apiEmbeds} row(s) hydrated via embedding API (${embedAttemptsThisRun} attempt(s)), ${ok}/${facts.length} non-null for cosine check`,
+        `${logPrefix} — dedupe corpus: ${lanceHits} vector(s) reused from Lance index (model-ok ${lanceModelOkHits}, missing ${lanceModelMissingHits}, mismatch ${lanceModelMismatchHits}), ${apiEmbeds} row(s) hydrated via embedding API, ${apiPersisted} persisted to Lance (${apiPersistFailures} persist failure(s)), ${embedFailures} embed failure(s), ${ok}/${facts.length} non-null for cosine check`,
       );
     }
     return result;
@@ -380,6 +453,7 @@ export async function runReflection(
       logger,
       "memory-hybrid: reflection",
       "reflection-embed-existing",
+      (factId, model) => factsDb.setEmbeddingModel(factId, model),
     );
   } else {
     logger.info("memory-hybrid: reflection — no existing pattern facts for dedupe; embedding new candidates only");
@@ -613,6 +687,7 @@ export async function runReflectionRules(
       logger,
       "memory-hybrid: reflect-rules",
       "reflection-rules-embed-existing",
+      (factId, model) => factsDb.setEmbeddingModel(factId, model),
     );
   } else {
     logger.info("memory-hybrid: reflect-rules — no existing rule facts for dedupe; embedding new candidates only");
@@ -838,6 +913,7 @@ export async function runReflectionMeta(
       logger,
       "memory-hybrid: reflect-meta",
       "reflection-meta-embed-existing",
+      (factId, model) => factsDb.setEmbeddingModel(factId, model),
     );
   } else {
     logger.info("memory-hybrid: reflect-meta — no existing meta-patterns for dedupe; embedding new candidates only");

--- a/extensions/memory-hybrid/services/reflection.ts
+++ b/extensions/memory-hybrid/services/reflection.ts
@@ -221,11 +221,17 @@ export async function loadReflectionDedupeCorpusVectors(
                   category: f.category,
                   id: f.id,
                 });
-                if (embeddings.modelName && markEmbeddingModel) {
-                  markEmbeddingModel(f.id, embeddings.modelName);
-                }
                 apiPersisted++;
                 batchPersisted++;
+                if (embeddings.modelName && markEmbeddingModel) {
+                  try {
+                    markEmbeddingModel(f.id, embeddings.modelName);
+                  } catch (markErr) {
+                    logger.info(
+                      `${logPrefix} — dedupe corpus: failed to mark embedding model for persisted fact ${f.id}: ${markErr}`,
+                    );
+                  }
+                }
               } catch (storeErr) {
                 apiPersistFailures++;
                 batchPersistFailures++;

--- a/extensions/memory-hybrid/services/reflection.ts
+++ b/extensions/memory-hybrid/services/reflection.ts
@@ -119,6 +119,7 @@ export async function loadReflectionDedupeCorpusVectors(
   logPrefix: string,
   captureOperation: string,
   markEmbeddingModel?: (factId: string, model: string) => void,
+  dryRun = false,
 ): Promise<(number[] | null)[]> {
   const loadWithTimeout = async (): Promise<(number[] | null)[]> => {
     const vdb = vectorDb as VectorDB & {
@@ -161,7 +162,7 @@ export async function loadReflectionDedupeCorpusVectors(
     let lastProgressAt = startedAt;
 
     logger.info(
-      `${logPrefix} — dedupe corpus: processing ${facts.length} facts in batches of 20 (checkpointing API-hydrated vectors)`,
+      `${logPrefix} — dedupe corpus: processing ${facts.length} facts in batches of 20 (${dryRun ? "dry-run: no Lance checkpoint / metadata writes" : "checkpointing API-hydrated vectors"})`,
     );
 
     for (let i = 0; i < facts.length; i += 20) {
@@ -189,7 +190,7 @@ export async function loadReflectionDedupeCorpusVectors(
           if (modelOk) lanceModelOkHits++;
           else if (!f.embeddingModel) {
             lanceModelMissingHits++;
-            if (embeddings.modelName && markEmbeddingModel) {
+            if (!dryRun && embeddings.modelName && markEmbeddingModel) {
               try {
                 markEmbeddingModel(f.id, embeddings.modelName);
               } catch (markErr) {
@@ -212,7 +213,7 @@ export async function loadReflectionDedupeCorpusVectors(
             batchApi++;
             hadApiEmbed = true;
 
-            if (typeof vdb.store === "function") {
+            if (!dryRun && typeof vdb.store === "function") {
               try {
                 await vdb.store({
                   text: f.text,
@@ -470,6 +471,7 @@ export async function runReflection(
       "memory-hybrid: reflection",
       "reflection-embed-existing",
       (factId, model) => factsDb.setEmbeddingModel(factId, model),
+      opts.dryRun,
     );
   } else {
     logger.info("memory-hybrid: reflection — no existing pattern facts for dedupe; embedding new candidates only");
@@ -704,6 +706,7 @@ export async function runReflectionRules(
       "memory-hybrid: reflect-rules",
       "reflection-rules-embed-existing",
       (factId, model) => factsDb.setEmbeddingModel(factId, model),
+      opts.dryRun,
     );
   } else {
     logger.info("memory-hybrid: reflect-rules — no existing rule facts for dedupe; embedding new candidates only");
@@ -930,6 +933,7 @@ export async function runReflectionMeta(
       "memory-hybrid: reflect-meta",
       "reflection-meta-embed-existing",
       (factId, model) => factsDb.setEmbeddingModel(factId, model),
+      opts.dryRun,
     );
   } else {
     logger.info("memory-hybrid: reflect-meta — no existing meta-patterns for dedupe; embedding new candidates only");

--- a/extensions/memory-hybrid/tests/reflection-dedupe-corpus.test.ts
+++ b/extensions/memory-hybrid/tests/reflection-dedupe-corpus.test.ts
@@ -101,6 +101,35 @@ describe("loadReflectionDedupeCorpusVectors", () => {
     expect(logger.info.mock.calls.some(([msg]) => msg.includes("API 1, persisted 1"))).toBe(true);
   });
 
+  it("skips Lance checkpoint and metadata writes in dry-run", async () => {
+    const facts = [makeFact({ id: "fact-dry", text: "Dry run hydrate", embeddingModel: "old-model" })];
+    const embeddings = makeEmbeddings(vi.fn<(_: string) => Promise<number[]>>().mockResolvedValue([1, 0]));
+    const vectorDb = {
+      getVectorDim: () => 2,
+      getVectorsByFactIds: vi.fn().mockResolvedValue(new Map()),
+      store: vi.fn().mockResolvedValue("fact-dry"),
+    };
+    const logger = makeLogger();
+    const markEmbeddingModel = vi.fn<(_: string, __: string) => void>();
+
+    const vectors = await loadReflectionDedupeCorpusVectors(
+      facts,
+      embeddings,
+      vectorDb as never,
+      logger,
+      "memory-hybrid: reflection",
+      "test-dedupe",
+      markEmbeddingModel,
+      true,
+    );
+
+    expect(embeddings.embed).toHaveBeenCalled();
+    expect(vectorDb.store).not.toHaveBeenCalled();
+    expect(markEmbeddingModel).not.toHaveBeenCalled();
+    expect(vectors[0]).toEqual([1, 0]);
+    expect(logger.info.mock.calls.some(([msg]) => msg.includes("dry-run: no Lance checkpoint"))).toBe(true);
+  });
+
   it("logs and continues when persisting a hydrated vector fails", async () => {
     const facts = [makeFact({ id: "fact-c", text: "Hydrate but persist fails" })];
     const embeddings = makeEmbeddings(vi.fn<(_: string) => Promise<number[]>>().mockResolvedValue([1, 0]));

--- a/extensions/memory-hybrid/tests/reflection-dedupe-corpus.test.ts
+++ b/extensions/memory-hybrid/tests/reflection-dedupe-corpus.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it, vi } from "vitest";
+import { _testing } from "../index.js";
+import type { MemoryEntry } from "../types/memory.js";
+
+const { loadReflectionDedupeCorpusVectors } = _testing;
+
+function makeFact(overrides: Partial<MemoryEntry> = {}): MemoryEntry {
+  return {
+    id: overrides.id ?? "00000000-0000-4000-8000-000000000001",
+    text: overrides.text ?? "A reflection pattern long enough to embed for testing.",
+    category: overrides.category ?? "pattern",
+    importance: overrides.importance ?? 0.7,
+    entity: overrides.entity ?? null,
+    key: overrides.key ?? null,
+    value: overrides.value ?? null,
+    source: overrides.source ?? "reflection",
+    createdAt: overrides.createdAt ?? 1,
+    decayClass: overrides.decayClass ?? "permanent",
+    expiresAt: overrides.expiresAt ?? null,
+    lastConfirmedAt: overrides.lastConfirmedAt ?? 1,
+    confidence: overrides.confidence ?? 0.8,
+    ...overrides,
+  };
+}
+
+function makeLogger() {
+  return { info: vi.fn<(msg: string) => void>() };
+}
+
+describe("loadReflectionDedupeCorpusVectors", () => {
+  it("reuses Lance vectors when embeddingModel is missing but dimensions match", async () => {
+    const facts = [makeFact({ id: "fact-a", embeddingModel: null })];
+    const embeddings = {
+      modelName: "text-embedding-3-large",
+      embed: vi.fn<(_: string) => Promise<number[]>>().mockResolvedValue([0, 1]),
+    };
+    const vectorDb = {
+      getVectorDim: () => 2,
+      getVectorsByFactIds: vi.fn().mockResolvedValue(new Map([["fact-a", [3, 4]]])),
+      store: vi.fn(),
+    };
+    const logger = makeLogger();
+    const markEmbeddingModel = vi.fn<(_: string, __: string) => void>();
+
+    const vectors = await loadReflectionDedupeCorpusVectors(
+      facts,
+      embeddings,
+      vectorDb as never,
+      logger,
+      "memory-hybrid: reflection",
+      "test-dedupe",
+      markEmbeddingModel,
+    );
+
+    expect(embeddings.embed).not.toHaveBeenCalled();
+    expect(vectorDb.store).not.toHaveBeenCalled();
+    expect(markEmbeddingModel).toHaveBeenCalledWith("fact-a", "text-embedding-3-large");
+    expect(vectors[0]?.[0]).toBeCloseTo(0.6);
+    expect(vectors[0]?.[1]).toBeCloseTo(0.8);
+    expect(logger.info.mock.calls.some(([msg]) => msg.includes("model-ok 0, missing 1"))).toBe(true);
+  });
+
+  it("persists API-hydrated dedupe vectors back to Lance with the original fact id", async () => {
+    const facts = [makeFact({ id: "fact-b", text: "Needs API hydration", embeddingModel: "old-model" })];
+    const embeddings = {
+      modelName: "text-embedding-3-large",
+      embed: vi.fn<(_: string) => Promise<number[]>>().mockResolvedValue([0, 5]),
+    };
+    const vectorDb = {
+      getVectorDim: () => 2,
+      getVectorsByFactIds: vi.fn().mockResolvedValue(new Map()),
+      store: vi.fn().mockResolvedValue("fact-b"),
+    };
+    const logger = makeLogger();
+    const markEmbeddingModel = vi.fn<(_: string, __: string) => void>();
+
+    const vectors = await loadReflectionDedupeCorpusVectors(
+      facts,
+      embeddings,
+      vectorDb as never,
+      logger,
+      "memory-hybrid: reflection",
+      "test-dedupe",
+      markEmbeddingModel,
+    );
+
+    expect(embeddings.embed).toHaveBeenCalledWith("Needs API hydration");
+    expect(vectorDb.store).toHaveBeenCalledWith({
+      text: "Needs API hydration",
+      vector: [0, 5],
+      importance: 0.7,
+      category: "pattern",
+      id: "fact-b",
+    });
+    expect(markEmbeddingModel).toHaveBeenCalledWith("fact-b", "text-embedding-3-large");
+    expect(vectors[0]).toEqual([0, 1]);
+    expect(logger.info.mock.calls.some(([msg]) => msg.includes("API 1, persisted 1"))).toBe(true);
+  });
+
+  it("logs and continues when persisting a hydrated vector fails", async () => {
+    const facts = [makeFact({ id: "fact-c", text: "Hydrate but persist fails" })];
+    const embeddings = {
+      modelName: "text-embedding-3-large",
+      embed: vi.fn<(_: string) => Promise<number[]>>().mockResolvedValue([1, 0]),
+    };
+    const vectorDb = {
+      getVectorDim: () => 2,
+      getVectorsByFactIds: vi.fn().mockResolvedValue(new Map()),
+      store: vi.fn().mockRejectedValue(new Error("lance write unavailable")),
+    };
+    const logger = makeLogger();
+
+    const vectors = await loadReflectionDedupeCorpusVectors(
+      facts,
+      embeddings,
+      vectorDb as never,
+      logger,
+      "memory-hybrid: reflection",
+      "test-dedupe",
+    );
+
+    expect(vectors[0]).toEqual([1, 0]);
+    expect(
+      logger.info.mock.calls.some(([msg]) => msg.includes("failed to persist hydrated vector for fact fact-c")),
+    ).toBe(true);
+    expect(logger.info.mock.calls.some(([msg]) => msg.includes("persistFailures 1"))).toBe(true);
+  });
+
+  it("logs per-batch progress with processed and remaining counts", async () => {
+    const facts = Array.from({ length: 25 }, (_, i) => makeFact({ id: `fact-${i}`, text: `Fact ${i}` }));
+    const embeddings = {
+      modelName: "text-embedding-3-large",
+      embed: vi.fn<(_: string) => Promise<number[]>>().mockResolvedValue([1, 0]),
+    };
+    const vectorDb = {
+      getVectorDim: () => 2,
+      getVectorsByFactIds: vi.fn().mockResolvedValue(new Map()),
+      store: vi.fn().mockResolvedValue("ok"),
+    };
+    const logger = makeLogger();
+
+    await loadReflectionDedupeCorpusVectors(
+      facts,
+      embeddings,
+      vectorDb as never,
+      logger,
+      "memory-hybrid: reflection",
+      "test-dedupe",
+    );
+
+    const messages = logger.info.mock.calls.map(([msg]) => msg);
+    expect(messages.some((msg) => msg.includes("20/25 processed, 5 remaining"))).toBe(true);
+    expect(messages.some((msg) => msg.includes("25/25 processed, 0 remaining"))).toBe(true);
+  });
+});

--- a/extensions/memory-hybrid/tests/reflection-dedupe-corpus.test.ts
+++ b/extensions/memory-hybrid/tests/reflection-dedupe-corpus.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { _testing } from "../index.js";
+import type { EmbeddingProvider } from "../services/embeddings.js";
 import type { MemoryEntry } from "../types/memory.js";
 
 const { loadReflectionDedupeCorpusVectors } = _testing;
@@ -27,13 +28,19 @@ function makeLogger() {
   return { info: vi.fn<(msg: string) => void>() };
 }
 
+function makeEmbeddings(embed: EmbeddingProvider["embed"]): EmbeddingProvider {
+  return {
+    modelName: "text-embedding-3-large",
+    dimensions: 2,
+    embed,
+    embedBatch: vi.fn((texts: string[]) => Promise.all(texts.map((t) => embed(t)))),
+  };
+}
+
 describe("loadReflectionDedupeCorpusVectors", () => {
   it("reuses Lance vectors when embeddingModel is missing but dimensions match", async () => {
     const facts = [makeFact({ id: "fact-a", embeddingModel: null })];
-    const embeddings = {
-      modelName: "text-embedding-3-large",
-      embed: vi.fn<(_: string) => Promise<number[]>>().mockResolvedValue([0, 1]),
-    };
+    const embeddings = makeEmbeddings(vi.fn<(_: string) => Promise<number[]>>().mockResolvedValue([0, 1]));
     const vectorDb = {
       getVectorDim: () => 2,
       getVectorsByFactIds: vi.fn().mockResolvedValue(new Map([["fact-a", [3, 4]]])),
@@ -62,10 +69,7 @@ describe("loadReflectionDedupeCorpusVectors", () => {
 
   it("persists API-hydrated dedupe vectors back to Lance with the original fact id", async () => {
     const facts = [makeFact({ id: "fact-b", text: "Needs API hydration", embeddingModel: "old-model" })];
-    const embeddings = {
-      modelName: "text-embedding-3-large",
-      embed: vi.fn<(_: string) => Promise<number[]>>().mockResolvedValue([0, 5]),
-    };
+    const embeddings = makeEmbeddings(vi.fn<(_: string) => Promise<number[]>>().mockResolvedValue([0, 5]));
     const vectorDb = {
       getVectorDim: () => 2,
       getVectorsByFactIds: vi.fn().mockResolvedValue(new Map()),
@@ -99,10 +103,7 @@ describe("loadReflectionDedupeCorpusVectors", () => {
 
   it("logs and continues when persisting a hydrated vector fails", async () => {
     const facts = [makeFact({ id: "fact-c", text: "Hydrate but persist fails" })];
-    const embeddings = {
-      modelName: "text-embedding-3-large",
-      embed: vi.fn<(_: string) => Promise<number[]>>().mockResolvedValue([1, 0]),
-    };
+    const embeddings = makeEmbeddings(vi.fn<(_: string) => Promise<number[]>>().mockResolvedValue([1, 0]));
     const vectorDb = {
       getVectorDim: () => 2,
       getVectorsByFactIds: vi.fn().mockResolvedValue(new Map()),
@@ -128,10 +129,7 @@ describe("loadReflectionDedupeCorpusVectors", () => {
 
   it("logs per-batch progress with processed and remaining counts", async () => {
     const facts = Array.from({ length: 25 }, (_, i) => makeFact({ id: `fact-${i}`, text: `Fact ${i}` }));
-    const embeddings = {
-      modelName: "text-embedding-3-large",
-      embed: vi.fn<(_: string) => Promise<number[]>>().mockResolvedValue([1, 0]),
-    };
+    const embeddings = makeEmbeddings(vi.fn<(_: string) => Promise<number[]>>().mockResolvedValue([1, 0]));
     const vectorDb = {
       getVectorDim: () => 2,
       getVectorsByFactIds: vi.fn().mockResolvedValue(new Map()),


### PR DESCRIPTION
## Summary
- adds per-batch progress logging for reflection dedupe corpus hydration
- checkpoints API-hydrated existing fact vectors back into LanceDB using the original fact id
- reuses dimension-matching Lance vectors when `embeddingModel` metadata is missing
- keeps dedupe non-fatal when Lance persistence fails

Fixes #1237.

## Verification
- `npm test -- --run tests/reflection-dedupe-corpus.test.ts`
- `npm run format:check`
- `npm run lint`
- `npm run build`

## Local evidence
A local v2026.5.92 hotfix run with equivalent behavior showed the dedupe backlog shrinking:
- previous comparable point: `33 Lance / 467 API` at 500 processed
- hotfix comparable point: `99 Lance / 401 API` at 500 processed
- later hotfix run: `2942` API-hydrated vectors persisted to Lance with `0` persist failures and `0` embed failures

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes reflection/consolidation dedupe vector hydration to reuse more cached vectors and to persist newly embedded vectors back into LanceDB, which can affect dedupe behavior and vector DB write patterns. Failures are handled non-fatally, but the added persistence/logging paths may surface new runtime edge cases in production Lance environments.
> 
> **Overview**
> Fixes reflection dedupe corpus hydration to **reduce repeated embedding API calls** and improve observability.
> 
> `loadReflectionDedupeCorpusVectors` now reuses dimension-matching Lance vectors even when `embeddingModel` metadata is missing (and optionally backfills that metadata), **persists API-hydrated vectors back into LanceDB using the original fact id**, and adds richer per-batch progress/error counters with a `dryRun` mode that skips persistence/metadata writes. Reflection (`runReflection*`) and consolidation now pass through the new options, and a new Vitest suite covers cache reuse, persistence, dry-run behavior, and persistence-failure handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d27e8fbe7f061310e3c6f00caf2e84bc1d0f6e6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->