### PR TITLE
fix: add dream-cycle follow-up progress logging

### DIFF
--- a/extensions/memory-hybrid/cli/commands/manage/register-corrections-and-pipeline.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/register-corrections-and-pipeline.ts
@@ -17,6 +17,10 @@ import type {
 } from "../../types.js";
 import type { ManageBindings } from "./bindings.js";
 
+function formatFollowUpError(err: unknown): string {
+  return err instanceof Error ? (err.stack ?? err.message) : String(err);
+}
+
 async function runVerboseFollowUp<T>(label: string, verbose: boolean, fn: () => Promise<T> | T): Promise<T> {
   const started = Date.now();
   let heartbeat: ReturnType<typeof setInterval> | undefined;
@@ -38,7 +42,7 @@ async function runVerboseFollowUp<T>(label: string, verbose: boolean, fn: () => 
   } catch (err) {
     if (verbose) {
       const elapsedSec = Math.floor((Date.now() - started) / 1000);
-      console.log(`[dream-cycle] ${label} — failed after ${elapsedSec}s: ${err}`);
+      console.error(`[dream-cycle] ${label} — failed after ${elapsedSec}s: ${formatFollowUpError(err)}`);
     }
     throw err;
   } finally {

--- a/extensions/memory-hybrid/cli/commands/manage/register-corrections-and-pipeline.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/register-corrections-and-pipeline.ts
@@ -17,6 +17,35 @@ import type {
 } from "../../types.js";
 import type { ManageBindings } from "./bindings.js";
 
+async function runVerboseFollowUp<T>(label: string, verbose: boolean, fn: () => Promise<T> | T): Promise<T> {
+  const started = Date.now();
+  let heartbeat: ReturnType<typeof setInterval> | undefined;
+  if (verbose) {
+    console.log(`[dream-cycle] ${label} — start`);
+    heartbeat = setInterval(() => {
+      const elapsedSec = Math.floor((Date.now() - started) / 1000);
+      console.log(`[dream-cycle] ${label} — still running after ${elapsedSec}s`);
+    }, 60_000);
+    heartbeat.unref?.();
+  }
+  try {
+    const result = await fn();
+    if (verbose) {
+      const elapsedSec = Math.floor((Date.now() - started) / 1000);
+      console.log(`[dream-cycle] ${label} — complete in ${elapsedSec}s`);
+    }
+    return result;
+  } catch (err) {
+    if (verbose) {
+      const elapsedSec = Math.floor((Date.now() - started) / 1000);
+      console.log(`[dream-cycle] ${label} — failed after ${elapsedSec}s: ${err}`);
+    }
+    throw err;
+  } finally {
+    if (heartbeat) clearInterval(heartbeat);
+  }
+}
+
 export function registerManageCorrectionsAndPipeline(mem: Chainable, b: ManageBindings): void {
   const {
     factsDb,
@@ -744,12 +773,11 @@ export function registerManageCorrectionsAndPipeline(mem: Chainable, b: ManageBi
             cfg.verification.enabled &&
             cfg.verification.continuousVerification
           ) {
-            if (verbose) {
-              console.log("[dream-cycle] Continuous verification (plugin logs show per-fact progress when --verbose)…");
-            }
             let verificationRes;
             try {
-              verificationRes = await runContinuousVerification(verbose ? { verbose: true } : undefined);
+              verificationRes = await runVerboseFollowUp("continuous verification", verbose, () =>
+                runContinuousVerification(verbose ? { verbose: true } : undefined),
+              );
             } catch (err) {
               capturePluginError(err instanceof Error ? err : new Error(String(err)), {
                 subsystem: "cli",
@@ -767,16 +795,15 @@ export function registerManageCorrectionsAndPipeline(mem: Chainable, b: ManageBi
 
           // Extract implicit feedback signals as part of nightly cycle
           if (!res.skipped && runExtractImplicitFeedback && cfg.implicitFeedback?.enabled !== false) {
-            if (verbose) {
-              console.log("[dream-cycle] Extract implicit feedback…");
-            }
             try {
-              const implRes = await runExtractImplicitFeedback({
-                days: 3,
-                dryRun: false,
-                includeClosedLoop: false,
-                verbose,
-              });
+              const implRes = await runVerboseFollowUp("extract implicit feedback", verbose, () =>
+                runExtractImplicitFeedback({
+                  days: 3,
+                  dryRun: false,
+                  includeClosedLoop: false,
+                  verbose,
+                }),
+              );
               console.log(
                 `Extract-implicit: ${implRes.signalsExtracted} signals (${implRes.positiveCount}+/${implRes.negativeCount}-) from ${implRes.sessionsScanned} sessions.`,
               );
@@ -790,11 +817,13 @@ export function registerManageCorrectionsAndPipeline(mem: Chainable, b: ManageBi
 
           // Closed-loop effectiveness analysis
           if (!res.skipped && cfg.closedLoop?.enabled !== false && cfg.closedLoop?.runInNightlyCycle !== false) {
-            if (verbose) {
-              console.log("[dream-cycle] Closed-loop effectiveness (local analysis, no LLM)…");
-            }
             try {
-              const clReport = runClosedLoopAnalysis(factsDb, cfg.closedLoop ?? { enabled: true });
+              const clReport = await runVerboseFollowUp("closed-loop effectiveness", verbose, () =>
+                runClosedLoopAnalysis(factsDb, cfg.closedLoop ?? { enabled: true }, {
+                  verbose,
+                  logger: (msg) => console.log(msg),
+                }),
+              );
               console.log(
                 `Closed-loop analysis: ${clReport.rulesAnalyzed} rules measured, ${clReport.deprecated} deprecated, ${clReport.boosted} boosted.`,
               );
@@ -817,11 +846,10 @@ export function registerManageCorrectionsAndPipeline(mem: Chainable, b: ManageBi
             cfg.crossAgentLearning?.enabled &&
             cfg.crossAgentLearning?.runInNightlyCycle !== false
           ) {
-            if (verbose) {
-              console.log("[dream-cycle] Cross-agent learning…");
-            }
             try {
-              const caRes = await runCrossAgentLearning(verbose ? { verbose: true } : undefined);
+              const caRes = await runVerboseFollowUp("cross-agent learning", verbose, () =>
+                runCrossAgentLearning(verbose ? { verbose: true } : undefined),
+              );
               console.log(
                 `Cross-agent learning: ${caRes.generalisedStored} generalised patterns stored from ${caRes.agentsScanned} agents.`,
               );
@@ -841,7 +869,9 @@ export function registerManageCorrectionsAndPipeline(mem: Chainable, b: ManageBi
             cfg.toolEffectiveness?.runInNightlyCycle !== false
           ) {
             try {
-              const teOutput = await runToolEffectiveness({ verbose });
+              const teOutput = await runVerboseFollowUp("tool effectiveness", verbose, () =>
+                runToolEffectiveness({ verbose }),
+              );
               if (teOutput && !teOutput.startsWith("No tool")) {
                 console.log(`Tool effectiveness: ${teOutput.split("\n")[0]}`);
               }
@@ -859,11 +889,10 @@ export function registerManageCorrectionsAndPipeline(mem: Chainable, b: ManageBi
             cfg.costTracking?.enabled !== false &&
             cfg.costTracking?.pruneInNightlyCycle !== false
           ) {
-            if (verbose) {
-              console.log("[dream-cycle] Prune old cost log rows…");
-            }
             try {
-              const pruned = pruneCostLog(cfg.costTracking?.retainDays);
+              const pruned = await runVerboseFollowUp("cost log prune", verbose, () =>
+                pruneCostLog(cfg.costTracking?.retainDays),
+              );
               if (pruned > 0) console.log(`Cost log: pruned ${pruned} old entries.`);
             } catch (err) {
               capturePluginError(err instanceof Error ? err : new Error(String(err)), {

--- a/extensions/memory-hybrid/services/feedback-effectiveness.ts
+++ b/extensions/memory-hybrid/services/feedback-effectiveness.ts
@@ -35,6 +35,12 @@ interface ClosedLoopReport {
   measurements: FeedbackEffectiveness[];
 }
 
+interface ClosedLoopRunOptions {
+  verbose?: boolean;
+  logger?: (message: string) => void;
+  progressEvery?: number;
+}
+
 /**
  * Count feedback events (corrections/praise/implicit) in a time window.
  * Uses the reinforcement_log for praise, self_correction_log equivalent for corrections,
@@ -181,7 +187,11 @@ export function measureRuleEffectiveness(
 /**
  * Run closed-loop analysis across all relevant rules/patterns created in last 30 days.
  */
-export function runClosedLoopAnalysis(factsDb: FactsDB, config: Partial<ClosedLoopConfig>): ClosedLoopReport {
+export function runClosedLoopAnalysis(
+  factsDb: FactsDB,
+  config: Partial<ClosedLoopConfig>,
+  options: ClosedLoopRunOptions = {},
+): ClosedLoopReport {
   const report: ClosedLoopReport = {
     measuredAt: Math.floor(Date.now() / 1000),
     rulesAnalyzed: 0,
@@ -198,6 +208,10 @@ export function runClosedLoopAnalysis(factsDb: FactsDB, config: Partial<ClosedLo
   const windowDays = config.measurementWindowDays ?? 7;
   const lookbackSec = 30 * 24 * 60 * 60;
   const cutoff = Math.floor(Date.now() / 1000) - lookbackSec;
+  const progressEvery = Math.max(1, options.progressEvery ?? 500);
+  const log = (message: string) => {
+    if (options.verbose) options.logger?.(message);
+  };
 
   try {
     // Find rules/patterns created in last 30 days
@@ -210,15 +224,32 @@ export function runClosedLoopAnalysis(factsDb: FactsDB, config: Partial<ClosedLo
       )
       .all(cutoff) as Array<{ id: string }>;
 
+    log(`memory-hybrid: closed-loop — ${rows.length} candidate rule/pattern fact(s) to measure`);
+
+    let processed = 0;
+    let tooYoung = 0;
+    let belowSample = 0;
     for (const row of rows) {
+      processed++;
+      if (processed === 1 || processed % progressEvery === 0 || processed === rows.length) {
+        log(
+          `memory-hybrid: closed-loop — progress ${processed}/${rows.length} candidates; measured=${report.rulesAnalyzed}, tooYoung=${tooYoung}, belowSample=${belowSample}, deprecated=${report.deprecated}, boosted=${report.boosted}`,
+        );
+      }
       const m = measureRuleEffectiveness(row.id, factsDb, config);
       if (!m) continue;
 
       // Only act on rules with enough age (at least windowDays old)
       const ageSec = report.measuredAt - m.createdAt;
       const minAgeSec = windowDays * 24 * 60 * 60;
-      if (ageSec < minAgeSec) continue;
-      if (m.sampleSize < minSampleSize) continue;
+      if (ageSec < minAgeSec) {
+        tooYoung++;
+        continue;
+      }
+      if (m.sampleSize < minSampleSize) {
+        belowSample++;
+        continue;
+      }
 
       report.rulesAnalyzed++;
       report.measurements.push(m);
@@ -287,12 +318,16 @@ export function runClosedLoopAnalysis(factsDb: FactsDB, config: Partial<ClosedLo
         // table may not exist yet, skip silently
       }
     }
+    log(
+      `memory-hybrid: closed-loop — finished: processed=${rows.length}, measured=${report.rulesAnalyzed}, deprecated=${report.deprecated}, boosted=${report.boosted}, measurements=${report.measurements.length}`,
+    );
   } catch (err) {
     capturePluginError(err instanceof Error ? err : new Error(String(err)), {
       operation: "runClosedLoopAnalysis",
       severity: "warning",
       subsystem: "feedback-effectiveness",
     });
+    log(`memory-hybrid: closed-loop — failed: ${err}`);
   }
 
   return report;

--- a/extensions/memory-hybrid/services/feedback-effectiveness.ts
+++ b/extensions/memory-hybrid/services/feedback-effectiveness.ts
@@ -184,6 +184,10 @@ export function measureRuleEffectiveness(
   }
 }
 
+function formatErrorForLog(err: unknown): string {
+  return err instanceof Error ? (err.stack ?? err.message) : String(err);
+}
+
 /**
  * Run closed-loop analysis across all relevant rules/patterns created in last 30 days.
  */
@@ -231,62 +235,58 @@ export function runClosedLoopAnalysis(
     let belowSample = 0;
     for (const row of rows) {
       processed++;
-      if (processed === 1 || processed % progressEvery === 0 || processed === rows.length) {
-        log(
-          `memory-hybrid: closed-loop — progress ${processed}/${rows.length} candidates; measured=${report.rulesAnalyzed}, tooYoung=${tooYoung}, belowSample=${belowSample}, deprecated=${report.deprecated}, boosted=${report.boosted}`,
-        );
-      }
-      const m = measureRuleEffectiveness(row.id, factsDb, config);
-      if (!m) continue;
-
-      // Only act on rules with enough age (at least windowDays old)
-      const ageSec = report.measuredAt - m.createdAt;
-      const minAgeSec = windowDays * 24 * 60 * 60;
-      if (ageSec < minAgeSec) {
-        tooYoung++;
-        continue;
-      }
-      if (m.sampleSize < minSampleSize) {
-        belowSample++;
-        continue;
-      }
-
-      report.rulesAnalyzed++;
-      report.measurements.push(m);
-
-      // Auto-deprecate harmful rules
-      if (m.effectScore < deprecateThreshold) {
-        try {
-          // Lower confidence to 0.1 to effectively deprecate the rule
-          db.prepare("UPDATE facts SET importance = 0.1 WHERE id = ?").run(row.id);
-          report.deprecated++;
-        } catch (err) {
-          capturePluginError(err instanceof Error ? err : new Error(String(err)), {
-            operation: "runClosedLoopAnalysis:deprecate",
-            severity: "warning",
-            subsystem: "feedback-effectiveness",
-          });
-        }
-      }
-
-      // Auto-boost proven rules
-      if (m.effectScore > boostThreshold) {
-        try {
-          db.prepare("UPDATE facts SET importance = MIN(1.0, importance + 0.2) WHERE id = ?").run(row.id);
-          report.boosted++;
-        } catch (err) {
-          capturePluginError(err instanceof Error ? err : new Error(String(err)), {
-            operation: "runClosedLoopAnalysis:boost",
-            severity: "warning",
-            subsystem: "feedback-effectiveness",
-          });
-        }
-      }
-
-      // Persist measurement
       try {
-        db.prepare(
-          `
+        const m = measureRuleEffectiveness(row.id, factsDb, config);
+        if (!m) continue;
+
+        // Only act on rules with enough age (at least windowDays old)
+        const ageSec = report.measuredAt - m.createdAt;
+        const minAgeSec = windowDays * 24 * 60 * 60;
+        if (ageSec < minAgeSec) {
+          tooYoung++;
+          continue;
+        }
+        if (m.sampleSize < minSampleSize) {
+          belowSample++;
+          continue;
+        }
+
+        report.rulesAnalyzed++;
+        report.measurements.push(m);
+
+        // Auto-deprecate harmful rules
+        if (m.effectScore < deprecateThreshold) {
+          try {
+            // Lower confidence to 0.1 to effectively deprecate the rule
+            db.prepare("UPDATE facts SET importance = 0.1 WHERE id = ?").run(row.id);
+            report.deprecated++;
+          } catch (err) {
+            capturePluginError(err instanceof Error ? err : new Error(String(err)), {
+              operation: "runClosedLoopAnalysis:deprecate",
+              severity: "warning",
+              subsystem: "feedback-effectiveness",
+            });
+          }
+        }
+
+        // Auto-boost proven rules
+        if (m.effectScore > boostThreshold) {
+          try {
+            db.prepare("UPDATE facts SET importance = MIN(1.0, importance + 0.2) WHERE id = ?").run(row.id);
+            report.boosted++;
+          } catch (err) {
+            capturePluginError(err instanceof Error ? err : new Error(String(err)), {
+              operation: "runClosedLoopAnalysis:boost",
+              severity: "warning",
+              subsystem: "feedback-effectiveness",
+            });
+          }
+        }
+
+        // Persist measurement
+        try {
+          db.prepare(
+            `
           INSERT OR REPLACE INTO feedback_effectiveness (
             rule_id, rule_text, created_at, window_start, window_end,
             corrections_before, corrections_after, praise_before, praise_after,
@@ -295,27 +295,34 @@ export function runClosedLoopAnalysis(
             effect_score, confidence, sample_size, measured_at
           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         `,
-        ).run(
-          m.ruleId,
-          m.ruleText,
-          m.createdAt,
-          m.windowStart,
-          m.windowEnd,
-          m.correctionsBeforeRule,
-          m.correctionsAfterRule,
-          m.praiseBeforeRule,
-          m.praiseAfterRule,
-          m.implicitPositiveBefore,
-          m.implicitPositiveAfter,
-          m.implicitNegativeBefore,
-          m.implicitNegativeAfter,
-          m.effectScore,
-          m.confidence,
-          m.sampleSize,
-          report.measuredAt,
-        );
-      } catch {
-        // table may not exist yet, skip silently
+          ).run(
+            m.ruleId,
+            m.ruleText,
+            m.createdAt,
+            m.windowStart,
+            m.windowEnd,
+            m.correctionsBeforeRule,
+            m.correctionsAfterRule,
+            m.praiseBeforeRule,
+            m.praiseAfterRule,
+            m.implicitPositiveBefore,
+            m.implicitPositiveAfter,
+            m.implicitNegativeBefore,
+            m.implicitNegativeAfter,
+            m.effectScore,
+            m.confidence,
+            m.sampleSize,
+            report.measuredAt,
+          );
+        } catch {
+          // table may not exist yet, skip silently
+        }
+      } finally {
+        if (processed === 1 || processed % progressEvery === 0 || processed === rows.length) {
+          log(
+            `memory-hybrid: closed-loop — progress ${processed}/${rows.length} candidates; measured=${report.rulesAnalyzed}, tooYoung=${tooYoung}, belowSample=${belowSample}, deprecated=${report.deprecated}, boosted=${report.boosted}`,
+          );
+        }
       }
     }
     log(
@@ -327,7 +334,7 @@ export function runClosedLoopAnalysis(
       severity: "warning",
       subsystem: "feedback-effectiveness",
     });
-    log(`memory-hybrid: closed-loop — failed: ${err}`);
+    log(`memory-hybrid: closed-loop — failed: ${formatErrorForLog(err)}`);
   }
 
   return report;


### PR DESCRIPTION
## Summary
- add verbose start/finish/failure logging around post-dream-cycle follow-up phases
- emit 60-second heartbeat logs while follow-up phases are still running
- add closed-loop progress counters so long analyses show processed/total and hold-up categories

## Verification
- npm test -- --run tests/feedback-effectiveness.test.ts tests/tool-effectiveness.test.ts tests/reflection-dedupe-corpus.test.ts
- npm run format:check
- npm run build

Follow-up split from merged PR #1238 because the observability patch landed after that PR was already closed/merged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are primarily additional verbose/heartbeat logging and progress counters, with only a backward-compatible optional parameter added to `runClosedLoopAnalysis`. Main risk is noisier logs or slight runtime overhead during long-running follow-up steps.
> 
> **Overview**
> Adds a shared `runVerboseFollowUp` wrapper to the `dream-cycle` command to emit **start/finish/failure** messages plus a 60s heartbeat while long-running post-cycle follow-up steps execute (continuous verification, implicit feedback extraction, closed-loop analysis, cross-agent learning, tool effectiveness, and cost-log pruning).
> 
> Extends `runClosedLoopAnalysis` with optional `verbose` logging and periodic progress counters (processed/total, too-young, below-sample, deprecated/boosted) so long closed-loop runs report ongoing progress and include failure details when verbose is enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac178d1483b586099cbe335131cd3f58bc61df9c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->