### PR TITLE
fix: add json output for goals config

### DIFF
--- a/extensions/memory-hybrid/cli/goals.ts
+++ b/extensions/memory-hybrid/cli/goals.ts
@@ -30,8 +30,41 @@ export function registerGoalCommands(mem: Chainable, ctx: { cfg: HybridMemoryCon
 
   g.command("config")
     .description("Show goal stewardship settings from plugin config (same keys as openclaw.json)")
-    .action(() => {
-      for (const line of formatGoalStewardshipConfigLines(ctx.cfg.goalStewardship)) {
+    .option("--json", "output raw JSON config snapshot")
+    .action((opts: { json?: boolean }) => {
+      const gs = ctx.cfg.goalStewardship;
+      if (opts.json) {
+        console.log(
+          JSON.stringify(
+            {
+              enabled: gs.enabled,
+              goalsDir: gs.goalsDir,
+              resolvedGoalsDir: goalsDir(ctx.cfg),
+              workspaceRoot: workspaceRoot(),
+              model: gs.model,
+              heartbeatStewardship: gs.heartbeatStewardship,
+              watchdogHealthCheck: gs.watchdogHealthCheck,
+              heartbeatRefreshActiveTask: gs.heartbeatRefreshActiveTask,
+              llmTriageOnHeartbeat: gs.llmTriageOnHeartbeat,
+              heartbeatPatterns: gs.heartbeatPatterns,
+              attentionWeights: gs.attentionWeights,
+              multiGoalMaxChars: gs.multiGoalMaxChars,
+              multiGoalMaxGoals: gs.multiGoalMaxGoals,
+              confirmationPolicy: gs.confirmationPolicy,
+              circuitBreaker: gs.circuitBreaker,
+              escalationPolicy: gs.escalationPolicy,
+              allowCommandVerification: gs.allowCommandVerification,
+              allowPrVerification: gs.allowPrVerification,
+              globalLimits: gs.globalLimits,
+              defaults: gs.defaults,
+            },
+            null,
+            2,
+          ),
+        );
+        return;
+      }
+      for (const line of formatGoalStewardshipConfigLines(gs)) {
         console.log(line);
       }
     });

--- a/extensions/memory-hybrid/cli/goals.ts
+++ b/extensions/memory-hybrid/cli/goals.ts
@@ -46,6 +46,7 @@ export function registerGoalCommands(mem: Chainable, ctx: { cfg: HybridMemoryCon
               watchdogHealthCheck: gs.watchdogHealthCheck,
               heartbeatRefreshActiveTask: gs.heartbeatRefreshActiveTask,
               llmTriageOnHeartbeat: gs.llmTriageOnHeartbeat,
+              triageSuggestHeavyDirective: gs.triageSuggestHeavyDirective,
               heartbeatPatterns: gs.heartbeatPatterns,
               attentionWeights: gs.attentionWeights,
               multiGoalMaxChars: gs.multiGoalMaxChars,

--- a/extensions/memory-hybrid/tests/goals-config-cli.test.ts
+++ b/extensions/memory-hybrid/tests/goals-config-cli.test.ts
@@ -1,0 +1,60 @@
+import { Command } from "commander";
+import { describe, expect, it, vi } from "vitest";
+import { hybridConfigSchema } from "../config.js";
+import { registerGoalCommands } from "../cli/goals.js";
+import { setEnv } from "../utils/env-manager.js";
+
+function makeCfg() {
+  return hybridConfigSchema.parse({
+    embedding: {
+      apiKey: "sk-test-key-that-is-long-enough-to-pass",
+      model: "text-embedding-3-small",
+    },
+    goalStewardship: {
+      enabled: true,
+      goalsDir: "state/goals-test",
+      heartbeatPatterns: ["^cron heartbeat"],
+      heartbeatStewardship: true,
+      watchdogHealthCheck: true,
+    },
+  });
+}
+
+describe("goals config CLI", () => {
+  it("prints human-readable config by default", async () => {
+    const program = new Command("hybrid-mem");
+    program.exitOverride();
+    registerGoalCommands(program, { cfg: makeCfg() });
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    try {
+      await program.parseAsync(["goals", "config"], { from: "user" });
+      expect(log.mock.calls.map((c) => String(c[0])).join("\n")).toContain("Goal stewardship — enabled");
+    } finally {
+      log.mockRestore();
+    }
+  });
+
+  it("supports --json for automation", async () => {
+    const prevWorkspace = process.env.OPENCLAW_WORKSPACE;
+    setEnv("OPENCLAW_WORKSPACE", "/tmp/openclaw-goals-config-test");
+    const program = new Command("hybrid-mem");
+    program.exitOverride();
+    registerGoalCommands(program, { cfg: makeCfg() });
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    try {
+      await program.parseAsync(["goals", "config", "--json"], { from: "user" });
+      expect(log).toHaveBeenCalledOnce();
+      const parsed = JSON.parse(String(log.mock.calls[0]?.[0]));
+      expect(parsed.enabled).toBe(true);
+      expect(parsed.goalsDir).toBe("state/goals-test");
+      expect(parsed.resolvedGoalsDir).toBe("/tmp/openclaw-goals-config-test/state/goals-test");
+      expect(parsed.heartbeatPatterns).toEqual(["^cron heartbeat"]);
+      expect(parsed.heartbeatStewardship).toBe(true);
+      expect(parsed.globalLimits.maxActiveGoals).toBeGreaterThan(0);
+      expect(parsed.defaults.maxDispatches).toBeGreaterThan(0);
+    } finally {
+      log.mockRestore();
+      setEnv("OPENCLAW_WORKSPACE", prevWorkspace);
+    }
+  });
+});

--- a/extensions/memory-hybrid/tests/goals-config-cli.test.ts
+++ b/extensions/memory-hybrid/tests/goals-config-cli.test.ts
@@ -1,7 +1,7 @@
 import { Command } from "commander";
 import { describe, expect, it, vi } from "vitest";
-import { hybridConfigSchema } from "../config.js";
 import { registerGoalCommands } from "../cli/goals.js";
+import { hybridConfigSchema } from "../config.js";
 import { setEnv } from "../utils/env-manager.js";
 
 function makeCfg() {
@@ -50,6 +50,7 @@ describe("goals config CLI", () => {
       expect(parsed.resolvedGoalsDir).toBe("/tmp/openclaw-goals-config-test/state/goals-test");
       expect(parsed.heartbeatPatterns).toEqual(["^cron heartbeat"]);
       expect(parsed.heartbeatStewardship).toBe(true);
+      expect(parsed.triageSuggestHeavyDirective).toBe(true);
       expect(parsed.globalLimits.maxActiveGoals).toBeGreaterThan(0);
       expect(parsed.defaults.maxDispatches).toBeGreaterThan(0);
     } finally {


### PR DESCRIPTION
## Summary

Fixes #1268 by adding documented JSON output support to:

```bash
openclaw hybrid-mem goals config --json
```

## Details

The operator/skill docs referenced `goals config --json`, but the CLI rejected the flag. This adds a machine-readable configuration snapshot containing:

- enabled state
- configured and resolved goals directory
- workspace root
- heartbeat stewardship flags/patterns
- LLM triage settings
- limits/defaults
- circuit breaker and escalation policy
- command/PR verification toggles

Human-readable output remains unchanged when `--json` is omitted.

## Verification

```bash
npm test -- tests/goals-config-cli.test.ts tests/goal-stewardship-heartbeat.test.ts tests/goal-stewardship-health.test.ts
npx tsc --noEmit --pretty false
npm run build
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds an optional `--json` output mode to an existing CLI command and a focused test; no changes to goal state, persistence, or runtime stewardship logic.
> 
> **Overview**
> `hybrid-mem goals config` now accepts `--json`, emitting a structured configuration snapshot (including resolved goals directory, workspace root, and goal-stewardship limits/policies) for automation while keeping the existing human-readable output as the default.
> 
> Adds a Vitest CLI test covering both the default text output and the new JSON output (including workspace-root-dependent path resolution via `OPENCLAW_WORKSPACE`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84f459becfd437805301f7ef82d3faf5e0b386dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->