### PR TITLE
fix: add verify --fix heartbeat cron installer for goal stewardship

### DIFF
--- a/extensions/memory-hybrid/cli/cmd-install.ts
+++ b/extensions/memory-hybrid/cli/cmd-install.ts
@@ -309,7 +309,34 @@ function selectGoalStewardshipHeartbeatMessage(heartbeatPatterns: string[]): str
   for (const hint of extractPlainHeartbeatPatternHints(heartbeatPatterns)) {
     const candidate = `cron heartbeat ${hint}`.replace(/\s+/g, " ").trim();
     if (!candidates.includes(candidate)) candidates.push(candidate);
+    if (!candidates.includes(hint)) candidates.push(hint);
   }
+  return candidates.find((candidate) => matchers.some((re) => re.test(candidate))) ?? null;
+}
+
+function collectHeartbeatMessageCandidatesFromJob(job: Record<string, unknown>): string[] {
+  const out: string[] = [];
+  const payload =
+    typeof job.payload === "object" && job.payload !== null && !Array.isArray(job.payload)
+      ? (job.payload as Record<string, unknown>)
+      : undefined;
+  const candidates = [payload?.text, payload?.message, job.text, job.message];
+  for (const raw of candidates) {
+    if (typeof raw !== "string") continue;
+    const normalized = raw.trim();
+    if (!normalized || out.includes(normalized)) continue;
+    out.push(normalized);
+  }
+  return out;
+}
+
+function selectExistingGoalStewardshipHeartbeatMessage(
+  existing: Record<string, unknown> | undefined,
+  heartbeatPatterns: string[],
+): string | null {
+  if (!existing) return null;
+  const matchers = compileHeartbeatMatchers(heartbeatPatterns);
+  const candidates = collectHeartbeatMessageCandidatesFromJob(existing);
   return candidates.find((candidate) => matchers.some((re) => re.test(candidate))) ?? null;
 }
 
@@ -324,15 +351,6 @@ export function ensureGoalStewardshipHeartbeatCronJob(
   const cronDir = join(openclawDir, "cron");
   const cronStorePath = join(cronDir, "jobs.json");
   mkdirSync(cronDir, { recursive: true });
-  const desiredMessage = selectGoalStewardshipHeartbeatMessage(options.heartbeatPatterns);
-  if (!desiredMessage) {
-    return {
-      added: false,
-      normalized: false,
-      skippedReason: "could not synthesize a 'cron heartbeat …' message that matches goalStewardship.heartbeatPatterns",
-    };
-  }
-
   const store: { jobs?: unknown[] } = existsSync(cronStorePath)
     ? (JSON.parse(readFileSync(cronStorePath, "utf-8")) as { jobs?: unknown[] })
     : {};
@@ -345,6 +363,16 @@ export function ensureGoalStewardshipHeartbeatCronJob(
         j.id === GOAL_STEWARDSHIP_HEARTBEAT_JOB_ID ||
         j.name === GOAL_STEWARDSHIP_HEARTBEAT_JOB_ID),
   );
+  const desiredMessage =
+    selectGoalStewardshipHeartbeatMessage(options.heartbeatPatterns) ??
+    selectExistingGoalStewardshipHeartbeatMessage(existing, options.heartbeatPatterns);
+  if (!desiredMessage) {
+    return {
+      added: false,
+      normalized: false,
+      skippedReason: "could not synthesize a 'cron heartbeat …' message that matches goalStewardship.heartbeatPatterns",
+    };
+  }
 
   if (!existing) {
     jobsArr.push({
@@ -356,8 +384,8 @@ export function ensureGoalStewardshipHeartbeatCronJob(
       sessionTarget: "main",
       delivery: { mode: "none" },
       payload: {
-        kind: "agentTurn",
-        message: desiredMessage,
+        kind: "systemEvent",
+        text: desiredMessage,
       },
     });
     const payload = JSON.stringify(store, null, 2);
@@ -415,8 +443,8 @@ export function ensureGoalStewardshipHeartbeatCronJob(
     existing.payload = payload;
     changed = true;
   }
-  if (payload.kind !== "agentTurn") {
-    payload.kind = "agentTurn";
+  if (payload.kind !== "systemEvent") {
+    payload.kind = "systemEvent";
     changed = true;
   }
   if (payload.sessionTarget !== undefined) {
@@ -427,12 +455,12 @@ export function ensureGoalStewardshipHeartbeatCronJob(
     payload.isolated = undefined;
     changed = true;
   }
-  if (payload.text !== undefined) {
-    payload.text = undefined;
+  if (payload.message !== undefined) {
+    payload.message = undefined;
     changed = true;
   }
-  if (payload.message !== desiredMessage) {
-    payload.message = desiredMessage;
+  if (payload.text !== desiredMessage) {
+    payload.text = desiredMessage;
     changed = true;
   }
 

--- a/extensions/memory-hybrid/cli/cmd-install.ts
+++ b/extensions/memory-hybrid/cli/cmd-install.ts
@@ -356,8 +356,8 @@ export function ensureGoalStewardshipHeartbeatCronJob(
       sessionTarget: "main",
       delivery: { mode: "none" },
       payload: {
-        kind: "systemEvent",
-        text: desiredMessage,
+        kind: "agentTurn",
+        message: desiredMessage,
       },
     });
     const payload = JSON.stringify(store, null, 2);
@@ -415,8 +415,8 @@ export function ensureGoalStewardshipHeartbeatCronJob(
     existing.payload = payload;
     changed = true;
   }
-  if (payload.kind !== "systemEvent") {
-    payload.kind = "systemEvent";
+  if (payload.kind !== "agentTurn") {
+    payload.kind = "agentTurn";
     changed = true;
   }
   if (payload.sessionTarget !== undefined) {
@@ -427,12 +427,12 @@ export function ensureGoalStewardshipHeartbeatCronJob(
     payload.isolated = undefined;
     changed = true;
   }
-  if (payload.message !== undefined) {
-    payload.message = undefined;
+  if (payload.text !== undefined) {
+    payload.text = undefined;
     changed = true;
   }
-  if (payload.text !== desiredMessage) {
-    payload.text = desiredMessage;
+  if (payload.message !== desiredMessage) {
+    payload.message = desiredMessage;
     changed = true;
   }
 

--- a/extensions/memory-hybrid/cli/cmd-install.ts
+++ b/extensions/memory-hybrid/cli/cmd-install.ts
@@ -356,9 +356,8 @@ export function ensureGoalStewardshipHeartbeatCronJob(
       sessionTarget: "main",
       delivery: { mode: "none" },
       payload: {
-        kind: "agentTurn",
-        sessionTarget: "main",
-        message: desiredMessage,
+        kind: "systemEvent",
+        text: desiredMessage,
       },
     });
     const payload = JSON.stringify(store, null, 2);
@@ -409,27 +408,31 @@ export function ensureGoalStewardshipHeartbeatCronJob(
     changed = true;
   }
   const payload =
-    typeof existing.payload === "object" && existing.payload !== null
+    typeof existing.payload === "object" && existing.payload !== null && !Array.isArray(existing.payload)
       ? (existing.payload as Record<string, unknown>)
       : {};
   if (existing.payload !== payload) {
     existing.payload = payload;
     changed = true;
   }
-  if (payload.kind !== "agentTurn") {
-    payload.kind = "agentTurn";
+  if (payload.kind !== "systemEvent") {
+    payload.kind = "systemEvent";
     changed = true;
   }
-  if (payload.sessionTarget !== "main") {
-    payload.sessionTarget = "main";
+  if (payload.sessionTarget !== undefined) {
+    payload.sessionTarget = undefined;
     changed = true;
   }
   if (payload.isolated !== undefined) {
     payload.isolated = undefined;
     changed = true;
   }
-  if (payload.message !== desiredMessage) {
-    payload.message = desiredMessage;
+  if (payload.message !== undefined) {
+    payload.message = undefined;
+    changed = true;
+  }
+  if (payload.text !== desiredMessage) {
+    payload.text = desiredMessage;
     changed = true;
   }
 

--- a/extensions/memory-hybrid/cli/cmd-install.ts
+++ b/extensions/memory-hybrid/cli/cmd-install.ts
@@ -32,6 +32,7 @@ import {
 } from "../services/cron-job-bash-harness.js";
 import { findDeprecatedHybridMemCronTokens } from "../services/deprecated-cron-commands.js";
 import { capturePluginError } from "../services/error-reporter.js";
+import { compileHeartbeatMatchers } from "../services/goal-stewardship-heartbeat.js";
 import { type PreFilterConfig, preFilterSessions } from "../services/session-pre-filter.js";
 import { resetAllBackoff } from "../utils/auth-failover.js";
 import { PLUGIN_ID } from "../utils/constants.js";
@@ -278,6 +279,168 @@ export function buildPreFilterConfig(cfg: HybridMemoryConfig): PreFilterConfig {
 // modelTier: "default" = standard LLM, "heavy" = larger context; resolved via getDefaultCronModel at install/verify time.
 // Order: daily 02:00 → daily 02:30 → Sun 03:00 → Sun 04:00 → Sat 04:00 → Sun 10:00 → 1st 05:00.
 const PLUGIN_JOB_ID_PREFIX = "hybrid-mem:";
+const GOAL_STEWARDSHIP_HEARTBEAT_JOB_ID = "goal-stewardship-heartbeat";
+const GOAL_STEWARDSHIP_HEARTBEAT_CRON_EXPR = "*/30 * * * *";
+
+function extractPlainHeartbeatPatternHints(patterns: string[]): string[] {
+  const out: string[] = [];
+  for (const rawPattern of patterns) {
+    const raw = rawPattern.trim();
+    if (!raw) continue;
+    let hint: string | null = null;
+    if (raw.startsWith("/") && raw.lastIndexOf("/") > 0) {
+      const last = raw.lastIndexOf("/");
+      const body = raw.slice(1, last).trim().replace(/^\^/, "").replace(/\$$/, "").trim();
+      if (/^[\w -]+$/.test(body)) hint = body;
+    } else if (/^[\w -]+$/.test(raw)) {
+      hint = raw;
+    }
+    if (!hint) continue;
+    const normalized = hint.replace(/\s+/g, " ").trim();
+    if (!normalized) continue;
+    if (!out.includes(normalized)) out.push(normalized);
+  }
+  return out;
+}
+
+function selectGoalStewardshipHeartbeatMessage(heartbeatPatterns: string[]): string | null {
+  const matchers = compileHeartbeatMatchers(heartbeatPatterns);
+  const candidates = ["cron heartbeat"];
+  for (const hint of extractPlainHeartbeatPatternHints(heartbeatPatterns)) {
+    const candidate = `cron heartbeat ${hint}`.replace(/\s+/g, " ").trim();
+    if (!candidates.includes(candidate)) candidates.push(candidate);
+  }
+  return candidates.find((candidate) => matchers.some((re) => re.test(candidate))) ?? null;
+}
+
+/**
+ * Ensure there is one enabled, heartbeat-shaped cron job for goal stewardship.
+ * The job is intentionally simple and should be safe to run continuously.
+ */
+export function ensureGoalStewardshipHeartbeatCronJob(
+  openclawDir: string,
+  options: { heartbeatPatterns: string[] },
+): { added: boolean; normalized: boolean; skippedReason?: string } {
+  const cronDir = join(openclawDir, "cron");
+  const cronStorePath = join(cronDir, "jobs.json");
+  mkdirSync(cronDir, { recursive: true });
+  const desiredMessage = selectGoalStewardshipHeartbeatMessage(options.heartbeatPatterns);
+  if (!desiredMessage) {
+    return {
+      added: false,
+      normalized: false,
+      skippedReason: "could not synthesize a 'cron heartbeat …' message that matches goalStewardship.heartbeatPatterns",
+    };
+  }
+
+  const store: { jobs?: unknown[] } = existsSync(cronStorePath)
+    ? (JSON.parse(readFileSync(cronStorePath, "utf-8")) as { jobs?: unknown[] })
+    : {};
+  if (!Array.isArray(store.jobs)) store.jobs = [];
+  const jobsArr = store.jobs as Array<Record<string, unknown>>;
+  const existing = jobsArr.find(
+    (j) =>
+      j &&
+      (j.pluginJobId === GOAL_STEWARDSHIP_HEARTBEAT_JOB_ID ||
+        j.id === GOAL_STEWARDSHIP_HEARTBEAT_JOB_ID ||
+        j.name === GOAL_STEWARDSHIP_HEARTBEAT_JOB_ID),
+  );
+
+  if (!existing) {
+    jobsArr.push({
+      pluginJobId: GOAL_STEWARDSHIP_HEARTBEAT_JOB_ID,
+      id: GOAL_STEWARDSHIP_HEARTBEAT_JOB_ID,
+      name: GOAL_STEWARDSHIP_HEARTBEAT_JOB_ID,
+      schedule: { kind: "cron", expr: GOAL_STEWARDSHIP_HEARTBEAT_CRON_EXPR },
+      enabled: true,
+      sessionTarget: "main",
+      delivery: { mode: "none" },
+      payload: {
+        kind: "agentTurn",
+        sessionTarget: "main",
+        message: desiredMessage,
+      },
+    });
+    const payload = JSON.stringify(store, null, 2);
+    const tmpPath = `${cronStorePath}.${process.pid}.${Date.now()}.tmp`;
+    writeFileSync(tmpPath, payload, "utf-8");
+    renameSync(tmpPath, cronStorePath);
+    return { added: true, normalized: false };
+  }
+
+  let changed = false;
+  if (existing.pluginJobId !== GOAL_STEWARDSHIP_HEARTBEAT_JOB_ID) {
+    existing.pluginJobId = GOAL_STEWARDSHIP_HEARTBEAT_JOB_ID;
+    changed = true;
+  }
+  if (existing.id !== GOAL_STEWARDSHIP_HEARTBEAT_JOB_ID) {
+    existing.id = GOAL_STEWARDSHIP_HEARTBEAT_JOB_ID;
+    changed = true;
+  }
+  if (existing.name !== GOAL_STEWARDSHIP_HEARTBEAT_JOB_ID) {
+    existing.name = GOAL_STEWARDSHIP_HEARTBEAT_JOB_ID;
+    changed = true;
+  }
+  const currentSchedule = existing.schedule as { kind?: unknown; expr?: unknown } | undefined;
+  if (
+    typeof currentSchedule !== "object" ||
+    currentSchedule === null ||
+    currentSchedule.kind !== "cron" ||
+    currentSchedule.expr !== GOAL_STEWARDSHIP_HEARTBEAT_CRON_EXPR
+  ) {
+    existing.schedule = { kind: "cron", expr: GOAL_STEWARDSHIP_HEARTBEAT_CRON_EXPR };
+    changed = true;
+  }
+  if (existing.enabled !== true) {
+    existing.enabled = true;
+    changed = true;
+  }
+  if (existing.sessionTarget !== "main") {
+    existing.sessionTarget = "main";
+    changed = true;
+  }
+  if (existing.isolated !== undefined) {
+    existing.isolated = undefined;
+    changed = true;
+  }
+  const currentDelivery = existing.delivery as { mode?: unknown } | undefined;
+  if (typeof currentDelivery !== "object" || currentDelivery === null || currentDelivery.mode !== "none") {
+    existing.delivery = { mode: "none" };
+    changed = true;
+  }
+  const payload =
+    typeof existing.payload === "object" && existing.payload !== null
+      ? (existing.payload as Record<string, unknown>)
+      : {};
+  if (existing.payload !== payload) {
+    existing.payload = payload;
+    changed = true;
+  }
+  if (payload.kind !== "agentTurn") {
+    payload.kind = "agentTurn";
+    changed = true;
+  }
+  if (payload.sessionTarget !== "main") {
+    payload.sessionTarget = "main";
+    changed = true;
+  }
+  if (payload.isolated !== undefined) {
+    payload.isolated = undefined;
+    changed = true;
+  }
+  if (payload.message !== desiredMessage) {
+    payload.message = desiredMessage;
+    changed = true;
+  }
+
+  if (!changed) return { added: false, normalized: false };
+
+  const nextPayload = JSON.stringify(store, null, 2);
+  const tmpPath = `${cronStorePath}.${process.pid}.${Date.now()}.tmp`;
+  writeFileSync(tmpPath, nextPayload, "utf-8");
+  renameSync(tmpPath, cronStorePath);
+  return { added: false, normalized: true };
+}
 
 /**
  * Minimum run interval guard (in milliseconds) for each job frequency tier.

--- a/extensions/memory-hybrid/cli/cmd-verify.ts
+++ b/extensions/memory-hybrid/cli/cmd-verify.ts
@@ -63,7 +63,11 @@ import {
   extractCronStoreJobModel,
   readEffectiveAgentChatPrimaryFromOpenclawJsonRoot,
 } from "../utils/openclaw-agent-defaults.js";
-import { ensureMaintenanceCronJobs, getPluginConfigFromFile } from "./cmd-install.js";
+import {
+  ensureGoalStewardshipHeartbeatCronJob,
+  ensureMaintenanceCronJobs,
+  getPluginConfigFromFile,
+} from "./cmd-install.js";
 import { approxIntervalMs, relativeTime } from "./shared.js";
 import { applyAzureFoundryVerifyDirectClientAuth } from "./verify-llm-azure-auth.js";
 
@@ -1969,6 +1973,21 @@ export async function runVerifyForCli(
           });
           added.forEach((name) => applied.push(`Added ${name} job to ${cronStorePath}`));
           normalized.forEach((name) => applied.push(`Normalized ${name} job (schedule/pluginJobId)`));
+          if (cfg.goalStewardship.enabled && cfg.goalStewardship.heartbeatStewardship) {
+            const heartbeat = ensureGoalStewardshipHeartbeatCronJob(openclawDir, {
+              heartbeatPatterns: cfg.goalStewardship.heartbeatPatterns,
+            });
+            if (heartbeat.added) {
+              applied.push(`Added goal-stewardship-heartbeat job to ${cronStorePath}`);
+            }
+            if (heartbeat.normalized) {
+              applied.push("Normalized goal-stewardship-heartbeat job (schedule/sessionTarget/delivery/payload)");
+            }
+            if (heartbeat.skippedReason) {
+              const WARN = noEmoji ? "[WARN]" : "⚠️";
+              log(`${WARN} Goal stewardship heartbeat installer skipped: ${heartbeat.skippedReason}`);
+            }
+          }
         } catch (e) {
           log(`Could not add optional jobs to cron store: ${String(e)}`);
           capturePluginError(e as Error, { subsystem: "cli", operation: "runVerifyForCli:add-cron-jobs" });

--- a/extensions/memory-hybrid/services/goal-stewardship-verify-cron.ts
+++ b/extensions/memory-hybrid/services/goal-stewardship-verify-cron.ts
@@ -8,7 +8,7 @@ import { getCachedMatchers } from "./goal-stewardship-heartbeat.js";
 
 export type CronJobMessageEntry = { id: string; text: string; enabled: boolean };
 
-/** Parse cron store JSON; extract per-job message text (payload.message or top-level message). */
+/** Parse cron store JSON; extract per-job message text from common cron payload fields. */
 export function extractCronJobMessageEntries(store: { jobs?: unknown[] } | null | undefined): CronJobMessageEntry[] {
   const out: CronJobMessageEntry[] = [];
   const rawJobs = store?.jobs;
@@ -18,7 +18,7 @@ export function extractCronJobMessageEntries(store: { jobs?: unknown[] } | null 
     const job = j as Record<string, unknown>;
     const id = String(job.pluginJobId ?? job.id ?? job.name ?? "unnamed");
     const payload = job.payload as Record<string, unknown> | undefined;
-    const raw = payload?.message ?? job.message;
+    const raw = payload?.message ?? payload?.text ?? job.message ?? job.text;
     const text = typeof raw === "string" ? raw.trim() : "";
     const enabled = typeof job.enabled === "boolean" ? job.enabled : true;
     out.push({ id, text, enabled });

--- a/extensions/memory-hybrid/tests/goal-stewardship-heartbeat-cron-installer.test.ts
+++ b/extensions/memory-hybrid/tests/goal-stewardship-heartbeat-cron-installer.test.ts
@@ -33,9 +33,9 @@ describe("ensureGoalStewardshipHeartbeatCronJob", () => {
       expect(job?.schedule).toEqual({ kind: "cron", expr: "*/30 * * * *" });
 
       const payload = job?.payload as Record<string, unknown> | undefined;
-      expect(payload?.kind).toBe("systemEvent");
+      expect(payload?.kind).toBe("agentTurn");
       expect(payload?.sessionTarget).toBeUndefined();
-      const message = String(payload?.text ?? "");
+      const message = String(payload?.message ?? "");
       expect(message.startsWith("cron heartbeat")).toBe(true);
       const matchers = compileHeartbeatMatchers([]);
       expect(matchers.some((re) => re.test(message))).toBe(true);
@@ -93,10 +93,10 @@ describe("ensureGoalStewardshipHeartbeatCronJob", () => {
       expect(job?.isolated).toBeUndefined();
 
       const payload = job?.payload as Record<string, unknown> | undefined;
-      expect(payload?.kind).toBe("systemEvent");
+      expect(payload?.kind).toBe("agentTurn");
       expect(payload?.sessionTarget).toBeUndefined();
-      expect(payload?.message).toBeUndefined();
-      const message = String(payload?.text ?? "");
+      expect(payload?.text).toBeUndefined();
+      const message = String(payload?.message ?? "");
       expect(message.startsWith("cron heartbeat")).toBe(true);
       const matchers = compileHeartbeatMatchers(["steward pulse"]);
       expect(matchers.some((re) => re.test(message))).toBe(true);
@@ -132,7 +132,7 @@ describe("ensureGoalStewardshipHeartbeatCronJob", () => {
       const store = readCronStore(openclawDir);
       const job = store.jobs.find((j) => j.pluginJobId === "goal-stewardship-heartbeat");
       expect(Array.isArray(job?.payload)).toBe(false);
-      expect(job?.payload).toMatchObject({ kind: "systemEvent", text: "cron heartbeat" });
+      expect(job?.payload).toMatchObject({ kind: "agentTurn", message: "cron heartbeat" });
     } finally {
       rmSync(openclawDir, { recursive: true, force: true });
     }

--- a/extensions/memory-hybrid/tests/goal-stewardship-heartbeat-cron-installer.test.ts
+++ b/extensions/memory-hybrid/tests/goal-stewardship-heartbeat-cron-installer.test.ts
@@ -33,9 +33,9 @@ describe("ensureGoalStewardshipHeartbeatCronJob", () => {
       expect(job?.schedule).toEqual({ kind: "cron", expr: "*/30 * * * *" });
 
       const payload = job?.payload as Record<string, unknown> | undefined;
-      expect(payload?.kind).toBe("agentTurn");
-      expect(payload?.sessionTarget).toBe("main");
-      const message = String(payload?.message ?? "");
+      expect(payload?.kind).toBe("systemEvent");
+      expect(payload?.sessionTarget).toBeUndefined();
+      const message = String(payload?.text ?? "");
       expect(message.startsWith("cron heartbeat")).toBe(true);
       const matchers = compileHeartbeatMatchers([]);
       expect(matchers.some((re) => re.test(message))).toBe(true);
@@ -93,12 +93,63 @@ describe("ensureGoalStewardshipHeartbeatCronJob", () => {
       expect(job?.isolated).toBeUndefined();
 
       const payload = job?.payload as Record<string, unknown> | undefined;
-      expect(payload?.kind).toBe("agentTurn");
-      expect(payload?.sessionTarget).toBe("main");
-      const message = String(payload?.message ?? "");
+      expect(payload?.kind).toBe("systemEvent");
+      expect(payload?.sessionTarget).toBeUndefined();
+      expect(payload?.message).toBeUndefined();
+      const message = String(payload?.text ?? "");
       expect(message.startsWith("cron heartbeat")).toBe(true);
       const matchers = compileHeartbeatMatchers(["steward pulse"]);
       expect(matchers.some((re) => re.test(message))).toBe(true);
+    } finally {
+      rmSync(openclawDir, { recursive: true, force: true });
+    }
+  });
+
+  it("replaces non-plain payloads while normalizing existing jobs", () => {
+    const openclawDir = mkdtempSync(join(tmpdir(), "hm-heartbeat-array-payload-"));
+    try {
+      mkdirSync(join(openclawDir, "cron"), { recursive: true });
+      writeFileSync(
+        join(openclawDir, "cron", "jobs.json"),
+        JSON.stringify(
+          {
+            jobs: [
+              {
+                pluginJobId: "goal-stewardship-heartbeat",
+                payload: ["not", "a", "plain", "object"],
+              },
+            ],
+          },
+          null,
+          2,
+        ),
+        "utf-8",
+      );
+
+      const result = ensureGoalStewardshipHeartbeatCronJob(openclawDir, { heartbeatPatterns: [] });
+      expect(result).toEqual({ added: false, normalized: true });
+
+      const store = readCronStore(openclawDir);
+      const job = store.jobs.find((j) => j.pluginJobId === "goal-stewardship-heartbeat");
+      expect(Array.isArray(job?.payload)).toBe(false);
+      expect(job?.payload).toMatchObject({ kind: "systemEvent", text: "cron heartbeat" });
+    } finally {
+      rmSync(openclawDir, { recursive: true, force: true });
+    }
+  });
+
+  it("skips installation when heartbeat patterns cannot match synthesized candidates", () => {
+    const openclawDir = mkdtempSync(join(tmpdir(), "hm-heartbeat-skip-"));
+    try {
+      const result = ensureGoalStewardshipHeartbeatCronJob(openclawDir, {
+        heartbeatPatterns: ["^definitely-not-a-heartbeat$"],
+      });
+      expect(result).toEqual({
+        added: false,
+        normalized: false,
+        skippedReason:
+          "could not synthesize a 'cron heartbeat …' message that matches goalStewardship.heartbeatPatterns",
+      });
     } finally {
       rmSync(openclawDir, { recursive: true, force: true });
     }

--- a/extensions/memory-hybrid/tests/goal-stewardship-heartbeat-cron-installer.test.ts
+++ b/extensions/memory-hybrid/tests/goal-stewardship-heartbeat-cron-installer.test.ts
@@ -33,9 +33,9 @@ describe("ensureGoalStewardshipHeartbeatCronJob", () => {
       expect(job?.schedule).toEqual({ kind: "cron", expr: "*/30 * * * *" });
 
       const payload = job?.payload as Record<string, unknown> | undefined;
-      expect(payload?.kind).toBe("agentTurn");
+      expect(payload?.kind).toBe("systemEvent");
       expect(payload?.sessionTarget).toBeUndefined();
-      const message = String(payload?.message ?? "");
+      const message = String(payload?.text ?? "");
       expect(message.startsWith("cron heartbeat")).toBe(true);
       const matchers = compileHeartbeatMatchers([]);
       expect(matchers.some((re) => re.test(message))).toBe(true);
@@ -93,10 +93,10 @@ describe("ensureGoalStewardshipHeartbeatCronJob", () => {
       expect(job?.isolated).toBeUndefined();
 
       const payload = job?.payload as Record<string, unknown> | undefined;
-      expect(payload?.kind).toBe("agentTurn");
+      expect(payload?.kind).toBe("systemEvent");
       expect(payload?.sessionTarget).toBeUndefined();
-      expect(payload?.text).toBeUndefined();
-      const message = String(payload?.message ?? "");
+      expect(payload?.message).toBeUndefined();
+      const message = String(payload?.text ?? "");
       expect(message.startsWith("cron heartbeat")).toBe(true);
       const matchers = compileHeartbeatMatchers(["steward pulse"]);
       expect(matchers.some((re) => re.test(message))).toBe(true);
@@ -132,7 +132,67 @@ describe("ensureGoalStewardshipHeartbeatCronJob", () => {
       const store = readCronStore(openclawDir);
       const job = store.jobs.find((j) => j.pluginJobId === "goal-stewardship-heartbeat");
       expect(Array.isArray(job?.payload)).toBe(false);
-      expect(job?.payload).toMatchObject({ kind: "agentTurn", message: "cron heartbeat" });
+      expect(job?.payload).toMatchObject({ kind: "systemEvent", text: "cron heartbeat" });
+    } finally {
+      rmSync(openclawDir, { recursive: true, force: true });
+    }
+  });
+
+  it("can synthesize strict non-prefixed heartbeat phrases from plain hints", () => {
+    const openclawDir = mkdtempSync(join(tmpdir(), "hm-heartbeat-hints-"));
+    try {
+      mkdirSync(join(openclawDir, "cron"), { recursive: true });
+      writeFileSync(join(openclawDir, "cron", "jobs.json"), JSON.stringify({ jobs: [] }, null, 2), "utf-8");
+
+      const result = ensureGoalStewardshipHeartbeatCronJob(openclawDir, { heartbeatPatterns: ["/^scheduled ping$/"] });
+      expect(result).toEqual({ added: true, normalized: false });
+
+      const store = readCronStore(openclawDir);
+      const job = store.jobs.find((j) => j.pluginJobId === "goal-stewardship-heartbeat");
+      expect(job?.payload).toMatchObject({ kind: "systemEvent", text: "scheduled ping" });
+    } finally {
+      rmSync(openclawDir, { recursive: true, force: true });
+    }
+  });
+
+  it("normalizes existing heartbeat jobs even when synthesis fallback uses existing message", () => {
+    const openclawDir = mkdtempSync(join(tmpdir(), "hm-heartbeat-existing-msg-"));
+    try {
+      mkdirSync(join(openclawDir, "cron"), { recursive: true });
+      writeFileSync(
+        join(openclawDir, "cron", "jobs.json"),
+        JSON.stringify(
+          {
+            jobs: [
+              {
+                pluginJobId: "goal-stewardship-heartbeat",
+                id: "legacy-id",
+                name: "legacy-name",
+                enabled: false,
+                sessionTarget: "isolated",
+                schedule: { kind: "cron", expr: "0 * * * *" },
+                payload: { kind: "agentTurn", message: "GOAL_PULSE_V1" },
+              },
+            ],
+          },
+          null,
+          2,
+        ),
+        "utf-8",
+      );
+
+      const result = ensureGoalStewardshipHeartbeatCronJob(openclawDir, { heartbeatPatterns: ["/^GOAL_PULSE_V1$/"] });
+      expect(result).toEqual({ added: false, normalized: true });
+
+      const store = readCronStore(openclawDir);
+      const job = store.jobs.find((j) => j.pluginJobId === "goal-stewardship-heartbeat");
+      expect(job?.id).toBe("goal-stewardship-heartbeat");
+      expect(job?.name).toBe("goal-stewardship-heartbeat");
+      expect(job?.enabled).toBe(true);
+      expect(job?.sessionTarget).toBe("main");
+      expect(job?.schedule).toEqual({ kind: "cron", expr: "*/30 * * * *" });
+      expect(job?.delivery).toEqual({ mode: "none" });
+      expect(job?.payload).toMatchObject({ kind: "systemEvent", text: "GOAL_PULSE_V1" });
     } finally {
       rmSync(openclawDir, { recursive: true, force: true });
     }

--- a/extensions/memory-hybrid/tests/goal-stewardship-heartbeat-cron-installer.test.ts
+++ b/extensions/memory-hybrid/tests/goal-stewardship-heartbeat-cron-installer.test.ts
@@ -1,0 +1,106 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { ensureGoalStewardshipHeartbeatCronJob } from "../cli/cmd-install.js";
+import { compileHeartbeatMatchers } from "../services/goal-stewardship-heartbeat.js";
+
+function readCronStore(openclawDir: string): { jobs: Array<Record<string, unknown>> } {
+  const raw = readFileSync(join(openclawDir, "cron", "jobs.json"), "utf-8");
+  return JSON.parse(raw) as { jobs: Array<Record<string, unknown>> };
+}
+
+describe("ensureGoalStewardshipHeartbeatCronJob", () => {
+  it("adds a canonical heartbeat job when missing", () => {
+    const openclawDir = mkdtempSync(join(tmpdir(), "hm-heartbeat-install-"));
+    try {
+      mkdirSync(join(openclawDir, "cron"), { recursive: true });
+      writeFileSync(join(openclawDir, "cron", "jobs.json"), JSON.stringify({ jobs: [] }, null, 2), "utf-8");
+
+      const result = ensureGoalStewardshipHeartbeatCronJob(openclawDir, { heartbeatPatterns: [] });
+      expect(result).toEqual({ added: true, normalized: false });
+
+      const store = readCronStore(openclawDir);
+      const job = store.jobs.find((j) => j.pluginJobId === "goal-stewardship-heartbeat");
+      expect(job).toBeTruthy();
+      expect(job?.id).toBe("goal-stewardship-heartbeat");
+      expect(job?.name).toBe("goal-stewardship-heartbeat");
+      expect(job?.enabled).toBe(true);
+      expect(job?.sessionTarget).toBe("main");
+      expect(job?.delivery).toEqual({ mode: "none" });
+      expect(job?.schedule).toEqual({ kind: "cron", expr: "*/30 * * * *" });
+
+      const payload = job?.payload as Record<string, unknown> | undefined;
+      expect(payload?.kind).toBe("agentTurn");
+      expect(payload?.sessionTarget).toBe("main");
+      const message = String(payload?.message ?? "");
+      expect(message.startsWith("cron heartbeat")).toBe(true);
+      const matchers = compileHeartbeatMatchers([]);
+      expect(matchers.some((re) => re.test(message))).toBe(true);
+    } finally {
+      rmSync(openclawDir, { recursive: true, force: true });
+    }
+  });
+
+  it("normalizes an existing malformed heartbeat job", () => {
+    const openclawDir = mkdtempSync(join(tmpdir(), "hm-heartbeat-normalize-"));
+    try {
+      mkdirSync(join(openclawDir, "cron"), { recursive: true });
+      writeFileSync(
+        join(openclawDir, "cron", "jobs.json"),
+        JSON.stringify(
+          {
+            jobs: [
+              {
+                pluginJobId: "goal-stewardship-heartbeat",
+                id: "legacy-id",
+                name: "legacy-name",
+                enabled: false,
+                isolated: true,
+                sessionTarget: "isolated",
+                delivery: { mode: "announce", channel: "system" },
+                schedule: { kind: "cron", expr: "0 * * * *" },
+                payload: {
+                  kind: "system",
+                  sessionTarget: "isolated",
+                  message: "not a heartbeat",
+                },
+              },
+            ],
+          },
+          null,
+          2,
+        ),
+        "utf-8",
+      );
+
+      const result = ensureGoalStewardshipHeartbeatCronJob(openclawDir, {
+        heartbeatPatterns: ["steward pulse"],
+      });
+      expect(result).toEqual({ added: false, normalized: true });
+
+      const store = readCronStore(openclawDir);
+      const job = store.jobs.find((j) => j.pluginJobId === "goal-stewardship-heartbeat");
+      expect(job).toBeTruthy();
+      expect(job?.id).toBe("goal-stewardship-heartbeat");
+      expect(job?.name).toBe("goal-stewardship-heartbeat");
+      expect(job?.enabled).toBe(true);
+      expect(job?.sessionTarget).toBe("main");
+      expect(job?.delivery).toEqual({ mode: "none" });
+      expect(job?.schedule).toEqual({ kind: "cron", expr: "*/30 * * * *" });
+      expect(job?.isolated).toBeUndefined();
+
+      const payload = job?.payload as Record<string, unknown> | undefined;
+      expect(payload?.kind).toBe("agentTurn");
+      expect(payload?.sessionTarget).toBe("main");
+      const message = String(payload?.message ?? "");
+      expect(message.startsWith("cron heartbeat")).toBe(true);
+      const matchers = compileHeartbeatMatchers(["steward pulse"]);
+      expect(matchers.some((re) => re.test(message))).toBe(true);
+    } finally {
+      rmSync(openclawDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/extensions/memory-hybrid/tests/goal-stewardship-verify-cron.test.ts
+++ b/extensions/memory-hybrid/tests/goal-stewardship-verify-cron.test.ts
@@ -8,19 +8,21 @@ import {
 } from "../services/goal-stewardship-verify-cron.js";
 
 describe("goal-stewardship-verify-cron", () => {
-  it("extractCronJobMessageEntries reads payload.message and top-level message", () => {
+  it("extractCronJobMessageEntries reads payload.message/text and top-level message/text", () => {
     const store = {
       jobs: [
         { pluginJobId: "a", payload: { message: "cron heartbeat" } },
-        { id: "b", message: "scheduled ping" },
-        { name: "c" },
+        { id: "b", payload: { text: "scheduled ping" } },
+        { name: "c", text: "fallback text" },
+        { name: "d" },
       ],
     };
     const e = extractCronJobMessageEntries(store);
     expect(e).toEqual([
       { id: "a", text: "cron heartbeat", enabled: true },
       { id: "b", text: "scheduled ping", enabled: true },
-      { id: "c", text: "", enabled: true },
+      { id: "c", text: "fallback text", enabled: true },
+      { id: "d", text: "", enabled: true },
     ]);
   });
 


### PR DESCRIPTION
## Summary
- add a dedicated heartbeat cron installer/normalizer for goal stewardship (`goal-stewardship-heartbeat`)
- wire the installer into `openclaw hybrid-mem verify --fix` when goal stewardship heartbeat mode is enabled
- add focused tests covering add + normalize behavior and matcher compliance

## Details
- installs/repairs canonical heartbeat job shape:
  - name/pluginJobId/id: `goal-stewardship-heartbeat`
  - schedule: `*/30 * * * *`
  - payload.kind: `agentTurn`
  - payload.message starts with `cron heartbeat`
  - sessionTarget: `main`
  - delivery.mode: `none`
- message selection is validated against effective heartbeat matchers before write

Closes #1269

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new behavior to `verify --fix` that mutates `~/.openclaw/cron/jobs.json` by creating/rewriting a heartbeat job; misconfiguration of heartbeat patterns could cause the installer to skip or adjust an operator’s existing job message shape.
> 
> **Overview**
> Adds a dedicated goal stewardship heartbeat cron installer/normalizer that ensures a single `goal-stewardship-heartbeat` job exists with a canonical schedule (`*/30 * * * *`), delivery disabled, and a `systemEvent` payload whose message is validated against the configured heartbeat matchers.
> 
> Wires this installer into `openclaw hybrid-mem verify --fix` when goal stewardship heartbeat mode is enabled, and updates the heartbeat verification helper to also consider `payload.text`/`job.text` when scanning cron jobs. Includes new unit tests covering add/normalize/skip behavior and matcher compliance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0887d908e417ce1280d0acd0dae77e0756bc29f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->