### PR TITLE
fix: key-aware duplicate suppression for project facts (#1276)

### DIFF
--- a/extensions/memory-hybrid/backends/facts-db/crud.ts
+++ b/extensions/memory-hybrid/backends/facts-db/crud.ts
@@ -164,8 +164,8 @@ export function storeFact(ctx: StoreFactContext, entry: StoreFactInput): MemoryE
 
   const importance = entry.importance ?? 0.5;
   const why = entry.why ?? null;
-  const entity = entry.entity ?? null;
-  const key = entry.key ?? null;
+  const entity = entry.entity?.trim() || null;
+  const key = entry.key?.trim() || null;
   const value = entry.value ?? null;
   const source = entry.source ?? "conversation";
   const category = entry.category ?? "other";

--- a/extensions/memory-hybrid/backends/facts-db/crud.ts
+++ b/extensions/memory-hybrid/backends/facts-db/crud.ts
@@ -168,7 +168,7 @@ export function storeFact(ctx: StoreFactContext, entry: StoreFactInput): MemoryE
   const key = entry.key?.trim() || null;
   const value = entry.value ?? null;
   const source = entry.source ?? "conversation";
-  const category = (entry.category ?? "other").toLowerCase();
+  const category = (entry.category?.trim() || "other").toLowerCase();
   const decayClass =
     entry.decayClass || classifyDecay(entity, key, value, entry.text, { source, category, importance });
   const expiresAt = entry.expiresAt !== undefined ? entry.expiresAt : calculateExpiry(decayClass, nowSec);

--- a/extensions/memory-hybrid/backends/facts-db/crud.ts
+++ b/extensions/memory-hybrid/backends/facts-db/crud.ts
@@ -168,7 +168,7 @@ export function storeFact(ctx: StoreFactContext, entry: StoreFactInput): MemoryE
   const key = entry.key?.trim() || null;
   const value = entry.value ?? null;
   const source = entry.source ?? "conversation";
-  const category = entry.category ?? "other";
+  const category = (entry.category ?? "other").toLowerCase();
   const decayClass =
     entry.decayClass || classifyDecay(entity, key, value, entry.text, { source, category, importance });
   const expiresAt = entry.expiresAt !== undefined ? entry.expiresAt : calculateExpiry(decayClass, nowSec);

--- a/extensions/memory-hybrid/backends/facts-db/crud.ts
+++ b/extensions/memory-hybrid/backends/facts-db/crud.ts
@@ -92,7 +92,14 @@ export function storeFact(ctx: StoreFactContext, entry: StoreFactInput): MemoryE
   // Normalized-hash + lexical Jaccard dedupe (per-source profiles) before daily quota.
   const dedupe = applyDedupe(
     profile,
-    { text: entry.text, source: sourceForPolicy },
+    {
+      text: entry.text,
+      source: sourceForPolicy,
+      category: entry.category ?? null,
+      entity: entry.entity ?? null,
+      key: entry.key ?? null,
+      value: entry.value ?? null,
+    },
     {
       db: ctx.db,
       nowSec,
@@ -387,13 +394,25 @@ export function hasDuplicateText(
   text: string,
   storeConfig?: StoreConfig,
   source?: string,
+  structured?: { category?: MemoryCategory | null; entity?: string | null; key?: string | null; value?: string | null },
 ): boolean {
   const nowSec = Math.floor(Date.now() / 1000);
   if (source === undefined) {
     return hasGlobalDuplicateProbe(db, text, { nowSec, fuzzyDedupe, storeConfig });
   }
   const profile = resolveDedupeProfile(source, storeConfig ?? { fuzzyDedupe });
-  const r = applyDedupe(profile, { text, source }, { db, nowSec, fuzzyDedupe });
+  const r = applyDedupe(
+    profile,
+    {
+      text,
+      source,
+      category: structured?.category ?? null,
+      entity: structured?.entity ?? null,
+      key: structured?.key ?? null,
+      value: structured?.value ?? null,
+    },
+    { db, nowSec, fuzzyDedupe },
+  );
   return r.action !== "store";
 }
 

--- a/extensions/memory-hybrid/backends/facts-db/facts-db-layer1.ts
+++ b/extensions/memory-hybrid/backends/facts-db/facts-db-layer1.ts
@@ -455,8 +455,12 @@ export class FactsDBLayer1 extends BaseSqliteStore {
   }
 
   /** Exact match or dedupe policy would block a new insert (per-source if `source` set; global probe if omitted, #1202). */
-  hasDuplicate(text: string, source?: string): boolean {
-    return hasDuplicateText(this.liveDb, this.fuzzyDedupe, text, this.storeConfig, source);
+  hasDuplicate(
+    text: string,
+    source?: string,
+    structured?: { category?: string | null; entity?: string | null; key?: string | null; value?: string | null },
+  ): boolean {
+    return hasDuplicateText(this.liveDb, this.fuzzyDedupe, text, this.storeConfig, source, structured);
   }
 
   /** Mark a fact as superseded by a new fact. Sets superseded_at, superseded_by, and valid_until (bi-temporal). */

--- a/extensions/memory-hybrid/services/dedupe-policy.ts
+++ b/extensions/memory-hybrid/services/dedupe-policy.ts
@@ -185,17 +185,18 @@ export function applyDedupe(
   const entity = candidate.entity?.trim();
   const key = candidate.key?.trim();
   if (category === "project" && entity && key) {
-    const existing = candidate.value != null
-      ? (ctx.db
-          .prepare(
-            "SELECT id FROM facts WHERE category = 'project' AND entity = ? AND key = ? AND value = ? AND superseded_at IS NULL LIMIT 1",
-          )
-          .get(entity, key, candidate.value) as { id: string } | undefined)
-      : (ctx.db
-          .prepare(
-            "SELECT id FROM facts WHERE category = 'project' AND entity = ? AND key = ? AND text = ? AND superseded_at IS NULL LIMIT 1",
-          )
-          .get(entity, key, candidate.text) as { id: string } | undefined);
+    const existing =
+      candidate.value != null
+        ? (ctx.db
+            .prepare(
+              "SELECT id FROM facts WHERE category = 'project' AND entity = ? AND key = ? AND value = ? AND superseded_at IS NULL LIMIT 1",
+            )
+            .get(entity, key, candidate.value) as { id: string } | undefined)
+        : (ctx.db
+            .prepare(
+              "SELECT id FROM facts WHERE category = 'project' AND entity = ? AND key = ? AND text = ? AND superseded_at IS NULL LIMIT 1",
+            )
+            .get(entity, key, candidate.text) as { id: string } | undefined);
     if (existing) {
       return mapOnDuplicate(profile, existing.id, "exact");
     }

--- a/extensions/memory-hybrid/services/dedupe-policy.ts
+++ b/extensions/memory-hybrid/services/dedupe-policy.ts
@@ -108,6 +108,10 @@ export function shouldReportVectorDedupeFallback(input: {
 export type DedupeCandidate = {
   text: string;
   source: string;
+  category?: string | null;
+  entity?: string | null;
+  key?: string | null;
+  value?: string | null;
 };
 
 export type ApplyDedupeContext = {
@@ -173,6 +177,31 @@ export function applyDedupe(
   candidate: DedupeCandidate,
   ctx: ApplyDedupeContext,
 ): ApplyDedupeResult {
+  // Issue #1276: project-task facts rely on explicit keys (title/status/next/...)
+  // for ACTIVE-TASKS projection. For category=project with entity+key, treat
+  // (category, entity, key) as the identity boundary and only dedupe on the same
+  // key/value pair, not semantic/text similarity across different keys.
+  const category = candidate.category?.trim().toLowerCase();
+  const entity = candidate.entity?.trim();
+  const key = candidate.key?.trim();
+  if (category === "project" && entity && key) {
+    const existing = candidate.value != null
+      ? (ctx.db
+          .prepare(
+            "SELECT id FROM facts WHERE category = 'project' AND entity = ? AND key = ? AND value = ? AND superseded_at IS NULL LIMIT 1",
+          )
+          .get(entity, key, candidate.value) as { id: string } | undefined)
+      : (ctx.db
+          .prepare(
+            "SELECT id FROM facts WHERE category = 'project' AND entity = ? AND key = ? AND text = ? AND superseded_at IS NULL LIMIT 1",
+          )
+          .get(entity, key, candidate.text) as { id: string } | undefined);
+    if (existing) {
+      return mapOnDuplicate(profile, existing.id, "exact");
+    }
+    return { action: "store" };
+  }
+
   const exact = ctx.db
     .prepare("SELECT id FROM facts WHERE text = ? AND source = ? AND superseded_at IS NULL LIMIT 1")
     .get(candidate.text, candidate.source) as { id: string } | undefined;

--- a/extensions/memory-hybrid/services/dedupe-policy.ts
+++ b/extensions/memory-hybrid/services/dedupe-policy.ts
@@ -189,14 +189,14 @@ export function applyDedupe(
       candidate.value != null
         ? (ctx.db
             .prepare(
-              "SELECT id FROM facts WHERE category = 'project' AND entity = ? AND key = ? AND value = ? AND superseded_at IS NULL LIMIT 1",
+              "SELECT id FROM facts WHERE category = 'project' AND entity = ? AND key = ? AND value = ? AND source = ? AND superseded_at IS NULL LIMIT 1",
             )
-            .get(entity, key, candidate.value) as { id: string } | undefined)
+            .get(entity, key, candidate.value, candidate.source) as { id: string } | undefined)
         : (ctx.db
             .prepare(
-              "SELECT id FROM facts WHERE category = 'project' AND entity = ? AND key = ? AND text = ? AND superseded_at IS NULL LIMIT 1",
+              "SELECT id FROM facts WHERE category = 'project' AND entity = ? AND key = ? AND text = ? AND source = ? AND superseded_at IS NULL LIMIT 1",
             )
-            .get(entity, key, candidate.text) as { id: string } | undefined);
+            .get(entity, key, candidate.text, candidate.source) as { id: string } | undefined);
     if (existing) {
       return mapOnDuplicate(profile, existing.id, "exact");
     }

--- a/extensions/memory-hybrid/tests/facts-db.test.ts
+++ b/extensions/memory-hybrid/tests/facts-db.test.ts
@@ -1027,6 +1027,33 @@ describe("FactsDB fuzzy deduplication", () => {
     expect(new Set(rows.map((f) => f.key))).toEqual(new Set(["progress", "title"]));
   });
 
+  it("store does not dedupe project facts across different sources", () => {
+    const entity = "stewardship-reliability-reset";
+    const value = "Stewardship reliability reset and hardening";
+    const first = dedupeDb.store({
+      text: `Task [${entity}] title: ${value}`,
+      category: "project",
+      importance: 0.8,
+      entity,
+      key: "title",
+      value,
+      source: "conversation",
+    });
+    const second = dedupeDb.store({
+      text: `Task [${entity}] title: ${value}`,
+      category: "project",
+      importance: 0.8,
+      entity,
+      key: "title",
+      value,
+      source: "auto-capture",
+    });
+    expect(second.id).not.toBe(first.id);
+    expect(
+      dedupeDb.listFactsByCategory("project", 20).filter((f) => f.entity === entity && f.key === "title"),
+    ).toHaveLength(2);
+  });
+
   it("store keeps duplicate suppression for same project entity/key/value", () => {
     const entity = "stewardship-reliability-reset";
     const value = "Stewardship reliability reset and hardening";

--- a/extensions/memory-hybrid/tests/facts-db.test.ts
+++ b/extensions/memory-hybrid/tests/facts-db.test.ts
@@ -1049,9 +1049,9 @@ describe("FactsDB fuzzy deduplication", () => {
       source: "conversation",
     });
     expect(second.id).toBe(first.id);
-    expect(dedupeDb.listFactsByCategory("project", 20).filter((f) => f.entity === entity && f.key === "title")).toHaveLength(
-      1,
-    );
+    expect(
+      dedupeDb.listFactsByCategory("project", 20).filter((f) => f.entity === entity && f.key === "title"),
+    ).toHaveLength(1);
   });
 });
 

--- a/extensions/memory-hybrid/tests/facts-db.test.ts
+++ b/extensions/memory-hybrid/tests/facts-db.test.ts
@@ -1000,6 +1000,59 @@ describe("FactsDB fuzzy deduplication", () => {
     });
     expect(dedupeDb.count()).toBe(2);
   });
+
+  it("store does not dedupe project facts across different keys", () => {
+    const entity = "stewardship-reliability-reset";
+    const sameText = "Stewardship reliability reset and hardening";
+    dedupeDb.store({
+      text: sameText,
+      category: "project",
+      importance: 0.8,
+      entity,
+      key: "progress",
+      value: sameText,
+      source: "conversation",
+    });
+    dedupeDb.store({
+      text: sameText,
+      category: "project",
+      importance: 0.8,
+      entity,
+      key: "title",
+      value: sameText,
+      source: "conversation",
+    });
+    const rows = dedupeDb.listFactsByCategory("project", 20).filter((f) => f.entity === entity);
+    expect(rows).toHaveLength(2);
+    expect(new Set(rows.map((f) => f.key))).toEqual(new Set(["progress", "title"]));
+  });
+
+  it("store keeps duplicate suppression for same project entity/key/value", () => {
+    const entity = "stewardship-reliability-reset";
+    const value = "Stewardship reliability reset and hardening";
+    const first = dedupeDb.store({
+      text: `Task [${entity}] title: ${value}`,
+      category: "project",
+      importance: 0.8,
+      entity,
+      key: "title",
+      value,
+      source: "conversation",
+    });
+    const second = dedupeDb.store({
+      text: `Task [${entity}] title field value ${value}`,
+      category: "project",
+      importance: 0.8,
+      entity,
+      key: "title",
+      value,
+      source: "conversation",
+    });
+    expect(second.id).toBe(first.id);
+    expect(dedupeDb.listFactsByCategory("project", 20).filter((f) => f.entity === entity && f.key === "title")).toHaveLength(
+      1,
+    );
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/extensions/memory-hybrid/tests/plugin-e2e.test.ts
+++ b/extensions/memory-hybrid/tests/plugin-e2e.test.ts
@@ -13,9 +13,10 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { IssueStore } from "../backends/issue-store.js";
-import { hybridConfigSchema } from "../config.js";
+import { type ActiveTaskProjectionConfig, hybridConfigSchema } from "../config.js";
 import memoryHybridPlugin from "../index.js";
 import { _testing } from "../index.js";
+import { applyActiveTaskProjectionFilters, loadTaskLedgerFromFacts } from "../services/task-ledger-facts.js";
 import { closeOldDatabases, initializeDatabases } from "../setup/init-databases.js";
 import { registerTools } from "../setup/register-tools.js";
 
@@ -593,6 +594,83 @@ describe("Core and common flows e2e", () => {
     };
     expect(secondResult.details?.action).toBe("duplicate");
     expect(secondResult.content?.[0]?.text?.toLowerCase()).toMatch(/similar|already exists|duplicate/);
+  });
+
+  it("memory_store keeps project title writes key-aware for facts projection (Issue #1276)", async () => {
+    factsDb.close();
+    const cfgDedup = getMinimalConfig({
+      sqlitePath: join(tmpDir, "facts.db"),
+      lanceDbPath: join(tmpDir, "lancedb"),
+      store: { fuzzyDedupe: true, classifyBeforeWrite: false },
+    });
+    factsDb = new FactsDB(join(tmpDir, "facts.db"), { fuzzyDedupe: true });
+    registerTools(buildE2EContext({ tmpDir, factsDb, vectorDb, cfg: cfgDedup, api }) as never, api as never);
+
+    const storeTool = api.getTool("memory_store");
+    const entity = "stewardship-reliability-reset";
+    const title = "Stewardship reliability reset and hardening";
+    const projection: ActiveTaskProjectionConfig = {
+      mode: "readable",
+      excludeGenericTitle: true,
+      titleMinChars: 0,
+      dedupeBy: "none",
+      sectioned: true,
+    };
+
+    await storeTool?.execute("call-1", {
+      text: "Task status in progress",
+      category: "project",
+      entity,
+      key: "status",
+      value: "in_progress",
+      importance: 0.8,
+    });
+    await storeTool?.execute("call-2", {
+      text: "Next: harden replay and recovery paths",
+      category: "project",
+      entity,
+      key: "next",
+      value: "harden replay and recovery paths",
+      importance: 0.8,
+    });
+    await storeTool?.execute("call-3", {
+      text: title,
+      category: "project",
+      entity,
+      key: "progress",
+      value: title,
+      importance: 0.8,
+    });
+    await storeTool?.execute("call-4", {
+      text: "session-forge-1276",
+      category: "project",
+      entity,
+      key: "related_session",
+      value: "session-forge-1276",
+      importance: 0.8,
+    });
+
+    const beforeTitle = applyActiveTaskProjectionFilters(loadTaskLedgerFromFacts(factsDb).active, projection);
+    expect(beforeTitle).toHaveLength(0);
+
+    const titleResult = (await storeTool?.execute("call-5", {
+      text: title,
+      category: "project",
+      entity,
+      key: "title",
+      value: title,
+      importance: 0.8,
+    })) as {
+      details?: { action?: string; id?: string };
+    };
+
+    expect(titleResult.details?.action).not.toBe("duplicate");
+    expect(titleResult.details?.id).toBeDefined();
+
+    const afterTitle = applyActiveTaskProjectionFilters(loadTaskLedgerFromFacts(factsDb).active, projection);
+    expect(afterTitle).toHaveLength(1);
+    expect(afterTitle[0].label).toBe(entity);
+    expect(afterTitle[0].description).toBe(title);
   });
 });
 

--- a/extensions/memory-hybrid/tools/memory-tools.ts
+++ b/extensions/memory-hybrid/tools/memory-tools.ts
@@ -1611,17 +1611,17 @@ export function registerMemoryTools(
             }
           };
 
-          if (factsDb.hasDuplicate(textToStore, "conversation")) {
+          const extracted = extractStructuredFields(textToStore, category as MemoryCategory);
+          const entity = paramEntity || extracted.entity;
+          const key = paramKey || extracted.key;
+          const value = paramValue || extracted.value;
+
+          if (factsDb.hasDuplicate(textToStore, "conversation", { category, entity, key, value })) {
             return {
               content: [{ type: "text", text: "Similar memory already exists." }],
               details: { action: "duplicate" },
             };
           }
-
-          const extracted = extractStructuredFields(textToStore, category as MemoryCategory);
-          const entity = paramEntity || extracted.entity;
-          const key = paramKey || extracted.key;
-          const value = paramValue || extracted.value;
 
           // FR-006: Compute scope early so it's available for classify-before-write UPDATE path; normal path may overwrite with multiAgent logic below
           let scope: "global" | "user" | "agent" | "session" = paramScope ?? "global";


### PR DESCRIPTION
## Summary
- make duplicate suppression key-aware for `category=project` facts by using `(category, entity, key)` as the identity boundary
- keep duplicate suppression for exact same project `(entity, key, value)` writes
- pass structured context into the `memory_store` pre-check so project key writes are not rejected by unrelated project facts
- add regression tests for the missing-title active-task projection path and for key-aware project dedupe semantics

## Testing
- npm test -- tests/facts-db.test.ts tests/plugin-e2e.test.ts
- npm run build

Fixes #1276

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes write-time dedupe behavior for `category=project` facts (and the `memory_store` duplicate pre-check), which can alter what gets persisted vs. suppressed and may affect downstream task projections. Scope is contained to dedupe/CRUD paths and is covered by new unit + e2e regression tests.
> 
> **Overview**
> Fixes project-task memory writes being incorrectly rejected as duplicates by making dedupe **key-aware** for `category=project` facts: `applyDedupe` now treats `(category, entity, key)` as the identity boundary and only suppresses duplicates for the same key/value (or key/text when value is missing), while still deduping per-source.
> 
> Plumbs structured fields through `storeFact`/`hasDuplicateText`/`FactsDB.hasDuplicate` and updates `memory_store` to pass `{ category, entity, key, value }` into the duplicate pre-check. Adds unit and e2e regression tests to ensure different project keys/sources don’t collapse, and that active-task projection paths accept title writes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea4b969a55da563eeebeb3d5964bc1c3f107b357. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->