### PR TITLE
fix: add active-task hygiene dedupe for stale project entities (#1273)

### DIFF
--- a/docs/ACTIVE-TASKS-PROJECTION.md
+++ b/docs/ACTIVE-TASKS-PROJECTION.md
@@ -35,7 +35,8 @@ Empty sections are **omitted** (no blank headings), except the all-empty case wh
 
 1. **Close or update work** via `memory_store` / facts (set status to `done`, `failed`, etc., or update `task_updated` and narrative keys).
 2. Run **`hybrid-mem active-tasks reconcile`** when subagent **Session:** references point at missing transcripts—rows can be completed automatically.
-3. Run **`hybrid-mem active-tasks render`** to refresh the markdown.
+3. Run **`hybrid-mem active-tasks hygiene --dry-run`** to detect stale failed rows and duplicate normalized entities; use `--apply` to mark stale/superseded rows without deleting history.
+4. Run **`hybrid-mem active-tasks render`** to refresh the markdown.
 
 See also [TASK-HYGIENE.md](TASK-HYGIENE.md) for heartbeat nudges and `active_task_propose_goal`.
 

--- a/docs/CLI-REFERENCE.md
+++ b/docs/CLI-REFERENCE.md
@@ -32,7 +32,7 @@ CLI output is controlled by the config `verbosity` setting (`silent`, `quiet`, `
 | **Export & config** | `export`, `config`, `config-mode <mode>`, `config-set <key> <value>` |
 | **Credentials & scope** | `credentials migrate-to-vault`, `scope list|stats|prune|promote` |
 | **Plugin lifecycle** | `upgrade [version]`, `uninstall` |
-| **Goals & working memory** | `goals …`, `goals config`, `active-tasks`, `active-tasks config`, `active-tasks complete <label>`, `active-tasks stale`, `active-tasks reconcile`, `active-tasks add <label> <desc>`, `active-tasks render`, `task-queue-status`, `task-queue-touch` |
+| **Goals & working memory** | `goals …`, `goals config`, `active-tasks`, `active-tasks config`, `active-tasks complete <label>`, `active-tasks stale`, `active-tasks reconcile`, `active-tasks hygiene [--dry-run|--apply] [--older-than <duration>]`, `active-tasks add <label> <desc>`, `active-tasks render`, `task-queue-status`, `task-queue-touch` |
 
 ---
 
@@ -107,6 +107,7 @@ CLI output is controlled by the config `verbosity` setting (`silent`, `quiet`, `
 | `active-tasks complete <label>` | Mark task Done and flush to memory log. |
 | `active-tasks stale` | Show tasks not updated within staleThreshold. |
 | `active-tasks reconcile` | Move in-progress tasks whose OpenClaw session transcript is missing to Completed (issues #978, #981). |
+| `active-tasks hygiene [--dry-run|--apply] [--older-than <duration>]` | Detect duplicate normalized task entities and stale rows (failed tasks, dead-session in-progress tasks). `--dry-run` reports findings; `--apply` marks rows as abandoned/superseded (history kept) and writes an audit fact. |
 | `active-tasks add <label> <desc>` | Add or update a task entry (markdown file or project facts). |
 | `active-tasks render` | Write `ACTIVE-TASKS.md` as a projection from the facts ledger (use with `activeTask.ledger: facts`). |
 | `task-queue-status` | Print `state/task-queue/current.json` as JSON (or a structured missing-file object for cron). Adds `recognized: true/false` when the file is valid JSON. Use `--with-active-tasks` to merge a summary of `ACTIVE-TASKS.md` (same paths as `active-tasks`). |

--- a/docs/TASK-HYGIENE.md
+++ b/docs/TASK-HYGIENE.md
@@ -39,6 +39,7 @@ Requires **`activeTask.enabled`**. The tool is registered with the plugin regard
 ## Operations
 
 - **CLI:** `openclaw hybrid-mem active-tasks reconcile` — keeps subagent bookkeeping honest before you trust **`ACTIVE-TASKS.md`** for heartbeats or audits.
+- **CLI:** `openclaw hybrid-mem active-tasks hygiene --dry-run` (or `--apply`) — reports and cleans stale failed/dead-session rows plus duplicate normalized entities while preserving history.
 - **Goals mirror:** When **`goalStewardship.heartbeatRefreshActiveTask`** is on, heartbeat also refreshes the **`## Active Goals`** mirror in **`ACTIVE-TASKS.md`** (do not edit that section by hand).
 
 ## Related docs

--- a/extensions/memory-hybrid/cli/active-tasks.ts
+++ b/extensions/memory-hybrid/cli/active-tasks.ts
@@ -22,18 +22,21 @@ import {
 } from "../services/active-task.js";
 import type { EmbeddingProvider } from "../services/embeddings.js";
 import {
+  applyActiveTaskHygieneFacts,
   loadTaskLedgerFromFacts,
+  planActiveTaskHygiene,
   readActiveTaskRowsFromFacts,
   reconcileActiveTaskInProgressSessionsFacts,
   renderActiveTaskMarkdownFile,
   syncActiveTaskEntryToFacts,
 } from "../services/task-ledger-facts.js";
-import { formatDuration } from "../utils/duration.js";
+import { formatDuration, parseDuration } from "../utils/duration.js";
 import { formatActiveTaskConfigLines } from "./config-feature-summaries.js";
 import type { Chainable } from "./shared.js";
 import type {
   ActiveTaskAddResult,
   ActiveTaskCompleteResult,
+  ActiveTaskHygieneResult,
   ActiveTaskListResult,
   ActiveTaskStaleResult,
 } from "./types.js";
@@ -320,6 +323,109 @@ export async function runActiveTaskAdd(
   return { ok: true, label: opts.label, upserted: wasExisting };
 }
 
+/** Detect/apply active-task hygiene: duplicates, stale failed tasks, dead-session in-progress tasks. */
+export async function runActiveTaskHygiene(
+  ctx: ActiveTaskContext,
+  opts: {
+    apply?: boolean;
+    olderThanMinutes?: number;
+    openclawHome?: string;
+  } = {},
+): Promise<ActiveTaskHygieneResult> {
+  const olderThanMinutes = Math.max(1, Math.floor(opts.olderThanMinutes ?? ctx.staleMinutes));
+  const apply = opts.apply === true;
+  if (ctx.ledger === "facts") {
+    const { factsDb, vectorDb, embeddings } = requireFacts(ctx);
+    const { active } = loadTaskLedgerFromFacts(factsDb);
+    const plan = await planActiveTaskHygiene(active, {
+      olderThanMinutes,
+      openclawHome: opts.openclawHome,
+    });
+    if (!apply || plan.actions.length === 0) {
+      return {
+        ledger: "facts",
+        dryRun: !apply,
+        olderThanMinutes,
+        duplicates: plan.duplicates,
+        stale: plan.stale,
+        actions: plan.actions,
+        appliedCount: 0,
+      };
+    }
+    const applied = await applyActiveTaskHygieneFacts(factsDb, vectorDb, embeddings, plan, {
+      flushOnComplete: ctx.flushOnComplete,
+      memoryDir: ctx.memoryDir,
+    });
+    await renderActiveTaskMarkdownFile(factsDb, ctx.staleMinutes, ctx.activeTaskFilePath, ctx.projection);
+    return {
+      ledger: "facts",
+      dryRun: false,
+      olderThanMinutes,
+      duplicates: plan.duplicates,
+      stale: plan.stale,
+      actions: plan.actions,
+      appliedCount: applied.appliedCount,
+      auditFactId: applied.auditFactId,
+    };
+  }
+
+  const taskFile = await readActiveTaskFile(ctx.activeTaskFilePath, ctx.staleMinutes);
+  const active = taskFile?.active ?? [];
+  const completed = taskFile?.completed ?? [];
+  const plan = await planActiveTaskHygiene(active, {
+    olderThanMinutes,
+    openclawHome: opts.openclawHome,
+  });
+  if (!apply || !taskFile || plan.actions.length === 0) {
+    return {
+      ledger: "markdown",
+      dryRun: !apply,
+      olderThanMinutes,
+      duplicates: plan.duplicates,
+      stale: plan.stale,
+      actions: plan.actions,
+      appliedCount: 0,
+    };
+  }
+
+  const actionByLabel = new Map(plan.actions.map((action) => [action.label, action] as const));
+  const newActive: ActiveTaskEntry[] = [];
+  const newCompleted: ActiveTaskEntry[] = [...completed];
+  const now = new Date().toISOString();
+  const toFlush: ActiveTaskEntry[] = [];
+  for (const task of active) {
+    const action = actionByLabel.get(task.label);
+    if (!action) {
+      newActive.push(task);
+      continue;
+    }
+    const completedEntry: ActiveTaskEntry = {
+      ...task,
+      status: "Done",
+      updated: now,
+      next: action.reason,
+      subagent: action.kind === "dead-session" ? undefined : task.subagent,
+    };
+    newCompleted.push(completedEntry);
+    toFlush.push(completedEntry);
+  }
+  await writeActiveTaskFile(ctx.activeTaskFilePath, newActive, newCompleted);
+  if (ctx.flushOnComplete) {
+    for (const entry of toFlush) {
+      await flushCompletedTaskToMemory(entry, ctx.memoryDir).catch(() => {});
+    }
+  }
+  return {
+    ledger: "markdown",
+    dryRun: false,
+    olderThanMinutes,
+    duplicates: plan.duplicates,
+    stale: plan.stale,
+    actions: plan.actions,
+    appliedCount: toFlush.length,
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Display helpers
 // ---------------------------------------------------------------------------
@@ -354,6 +460,42 @@ function printActiveTaskList(result: ActiveTaskListResult): void {
   }
 }
 
+function printActiveTaskHygiene(result: ActiveTaskHygieneResult): void {
+  console.log(
+    `Active-task hygiene report [${result.ledger}] (older than ${formatDuration(result.olderThanMinutes)}):`,
+  );
+  console.log(`  Duplicate groups: ${result.duplicates.length}`);
+  console.log(`  Stale candidates: ${result.stale.length}`);
+  console.log(`  Actions: ${result.actions.length}`);
+
+  if (result.duplicates.length > 0) {
+    console.log("\nDuplicate groups:");
+    for (const group of result.duplicates) {
+      const variants = group.labels.filter((label) => label !== group.canonicalLabel);
+      console.log(`  Canonical: [${group.canonicalLabel}] (normalized: ${group.normalized})`);
+      if (variants.length > 0) {
+        console.log(`    Variants: ${variants.map((label) => `[${label}]`).join(", ")}`);
+      }
+    }
+  }
+
+  if (result.stale.length > 0) {
+    console.log("\nStale candidates:");
+    for (const row of result.stale) {
+      console.log(`  [${row.label}] ${row.status} — updated ${row.updated} (${row.hoursStale}h)`);
+      console.log(`    ${row.reason}`);
+    }
+  }
+
+  if (result.actions.length > 0) {
+    console.log("\nPlanned actions:");
+    for (const action of result.actions) {
+      const canonical = action.canonicalLabel ? ` -> [${action.canonicalLabel}]` : "";
+      console.log(`  [${action.label}] ${action.kind} => ${action.toStatus}${canonical}`);
+    }
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Commander registration
 // ---------------------------------------------------------------------------
@@ -370,7 +512,7 @@ export function registerActiveTaskCommands(
     .command("active-tasks")
     .description(
       ctx
-        ? `Working memory: active tasks (${ctx.ledger} ledger). Subcommands: list, complete, stale, reconcile, add, render, config`
+        ? `Working memory: active tasks (${ctx.ledger} ledger). Subcommands: list, complete, stale, reconcile, hygiene, add, render, config`
         : "Active tasks disabled (activeTask.enabled: false). Subcommand: config. Enable: openclaw hybrid-mem config-set activeTask enabled",
     )
     .action(async () => {
@@ -488,6 +630,49 @@ export function registerActiveTaskCommands(
       }
       console.log(`✅ Reconciled ${result.reconciledLabels.length} task(s) (moved to Completed):`);
       for (const l of result.reconciledLabels) console.log(`  - [${l}]`);
+    });
+
+  activeTasks
+    .command("hygiene")
+    .description(
+      "Detect and optionally clean stale/duplicate task entities (dead sessions, stale failures, superseded variants)",
+    )
+    .option("--dry-run", "Report hygiene findings and planned actions (default)")
+    .option("--apply", "Apply hygiene actions and persist audit trail")
+    .option("--older-than <duration>", `Age threshold, e.g. 24h or 2d (default: ${formatDuration(ctx.staleMinutes)})`)
+    .action(async (opts: { dryRun?: boolean; apply?: boolean; olderThan?: string }) => {
+      if (opts.apply && opts.dryRun) {
+        console.error("Error: --dry-run and --apply are mutually exclusive.");
+        process.exitCode = 1;
+        return;
+      }
+      let olderThanMinutes = ctx.staleMinutes;
+      if (opts.olderThan?.trim()) {
+        try {
+          olderThanMinutes = parseDuration(opts.olderThan.trim());
+        } catch (err) {
+          console.error(`Error: invalid --older-than value "${opts.olderThan}": ${String(err)}`);
+          process.exitCode = 1;
+          return;
+        }
+      }
+      const apply = opts.apply === true;
+      const result = await runActiveTaskHygiene(ctx, {
+        apply,
+        olderThanMinutes,
+      });
+      printActiveTaskHygiene(result);
+      if (!apply) {
+        console.log("\nDry run only. Re-run with --apply to persist hygiene actions.");
+        return;
+      }
+      console.log(`\nApplied ${result.appliedCount} action(s).`);
+      if (result.auditFactId) {
+        console.log(`Audit fact: ${result.auditFactId}`);
+      }
+      if (result.ledger === "facts") {
+        console.log(`Projection refreshed: ${ctx.activeTaskFilePath}`);
+      }
     });
 
   activeTasks

--- a/extensions/memory-hybrid/cli/active-tasks.ts
+++ b/extensions/memory-hybrid/cli/active-tasks.ts
@@ -461,9 +461,7 @@ function printActiveTaskList(result: ActiveTaskListResult): void {
 }
 
 function printActiveTaskHygiene(result: ActiveTaskHygieneResult): void {
-  console.log(
-    `Active-task hygiene report [${result.ledger}] (older than ${formatDuration(result.olderThanMinutes)}):`,
-  );
+  console.log(`Active-task hygiene report [${result.ledger}] (older than ${formatDuration(result.olderThanMinutes)}):`);
   console.log(`  Duplicate groups: ${result.duplicates.length}`);
   console.log(`  Stale candidates: ${result.stale.length}`);
   console.log(`  Actions: ${result.actions.length}`);

--- a/extensions/memory-hybrid/cli/active-tasks.ts
+++ b/extensions/memory-hybrid/cli/active-tasks.ts
@@ -376,7 +376,19 @@ export async function runActiveTaskHygiene(
     olderThanMinutes,
     openclawHome: opts.openclawHome,
   });
-  if (!apply || !taskFile || plan.actions.length === 0) {
+  if (apply && !taskFile) {
+    return {
+      ledger: "markdown",
+      dryRun: true,
+      cannotApplyReason: `Cannot apply hygiene: ${ctx.activeTaskFilePath} does not exist.`,
+      olderThanMinutes,
+      duplicates: plan.duplicates,
+      stale: plan.stale,
+      actions: plan.actions,
+      appliedCount: 0,
+    };
+  }
+  if (!apply || plan.actions.length === 0) {
     return {
       ledger: "markdown",
       dryRun: !apply,
@@ -462,6 +474,9 @@ function printActiveTaskList(result: ActiveTaskListResult): void {
 
 function printActiveTaskHygiene(result: ActiveTaskHygieneResult): void {
   console.log(`Active-task hygiene report [${result.ledger}] (older than ${formatDuration(result.olderThanMinutes)}):`);
+  if (result.cannotApplyReason) {
+    console.log(`  Apply blocked: ${result.cannotApplyReason}`);
+  }
   console.log(`  Duplicate groups: ${result.duplicates.length}`);
   console.log(`  Stale candidates: ${result.stale.length}`);
   console.log(`  Actions: ${result.actions.length}`);
@@ -636,7 +651,7 @@ export function registerActiveTaskCommands(
       "Detect and optionally clean stale/duplicate task entities (dead sessions, stale failures, superseded variants)",
     )
     .option("--dry-run", "Report hygiene findings and planned actions (default)")
-    .option("--apply", "Apply hygiene actions and persist audit trail")
+    .option("--apply", "Apply hygiene actions and persist audit fact (facts ledger only)")
     .option("--older-than <duration>", `Age threshold, e.g. 24h or 2d (default: ${formatDuration(ctx.staleMinutes)})`)
     .action(async (opts: { dryRun?: boolean; apply?: boolean; olderThan?: string }) => {
       if (opts.apply && opts.dryRun) {
@@ -660,6 +675,11 @@ export function registerActiveTaskCommands(
         olderThanMinutes,
       });
       printActiveTaskHygiene(result);
+      if (apply && result.cannotApplyReason) {
+        console.error(`Error: ${result.cannotApplyReason}`);
+        process.exitCode = 1;
+        return;
+      }
       if (!apply) {
         console.log("\nDry run only. Re-run with --apply to persist hygiene actions.");
         return;

--- a/extensions/memory-hybrid/cli/types.ts
+++ b/extensions/memory-hybrid/cli/types.ts
@@ -215,3 +215,30 @@ export type ActiveTaskStaleResult = {
 };
 
 export type ActiveTaskAddResult = { ok: true; label: string; upserted: boolean } | { ok: false; error: string };
+
+export type ActiveTaskHygieneResult = {
+  ledger: "markdown" | "facts";
+  dryRun: boolean;
+  olderThanMinutes: number;
+  duplicates: Array<{
+    normalized: string;
+    canonicalLabel: string;
+    labels: string[];
+  }>;
+  stale: Array<{
+    label: string;
+    status: string;
+    updated: string;
+    hoursStale: number | "?";
+    reason: string;
+  }>;
+  actions: Array<{
+    label: string;
+    kind: "dead-session" | "stale-failed" | "superseded-duplicate";
+    toStatus: "abandoned" | "superseded";
+    reason: string;
+    canonicalLabel?: string;
+  }>;
+  appliedCount: number;
+  auditFactId?: string;
+};

--- a/extensions/memory-hybrid/cli/types.ts
+++ b/extensions/memory-hybrid/cli/types.ts
@@ -219,6 +219,7 @@ export type ActiveTaskAddResult = { ok: true; label: string; upserted: boolean }
 export type ActiveTaskHygieneResult = {
   ledger: "markdown" | "facts";
   dryRun: boolean;
+  cannotApplyReason?: string;
   olderThanMinutes: number;
   duplicates: Array<{
     normalized: string;

--- a/extensions/memory-hybrid/services/task-ledger-facts.ts
+++ b/extensions/memory-hybrid/services/task-ledger-facts.ts
@@ -30,7 +30,7 @@ import { isOpenClawSessionLikelyPresent, looksLikeOpenClawSessionRef } from "./o
 
 export const TASK_LEDGER_CATEGORY = "project" as MemoryCategory;
 
-const TERMINAL = new Set(["done", "completed", "cancelled", "closed", "abandoned"]);
+const TERMINAL = new Set(["done", "completed", "cancelled", "closed", "abandoned", "superseded"]);
 
 /** Latest value per entity+key from non-superseded project facts */
 export function groupProjectFactsByEntity(facts: MemoryEntry[]): Map<string, Map<string, MemoryEntry>> {
@@ -244,6 +244,249 @@ export function applyActiveTaskProjectionFilters(
   return result;
 }
 
+export interface ActiveTaskHygieneDuplicateGroup {
+  normalized: string;
+  canonicalLabel: string;
+  labels: string[];
+}
+
+export interface ActiveTaskHygieneStaleCandidate {
+  label: string;
+  status: ActiveTaskStatus;
+  updated: string;
+  hoursStale: number | "?";
+  reason: string;
+}
+
+export type ActiveTaskHygieneActionKind = "dead-session" | "stale-failed" | "superseded-duplicate";
+
+export interface ActiveTaskHygieneAction {
+  label: string;
+  kind: ActiveTaskHygieneActionKind;
+  toStatus: "abandoned" | "superseded";
+  reason: string;
+  canonicalLabel?: string;
+}
+
+export interface ActiveTaskHygienePlan {
+  olderThanMinutes: number;
+  duplicates: ActiveTaskHygieneDuplicateGroup[];
+  stale: ActiveTaskHygieneStaleCandidate[];
+  actions: ActiveTaskHygieneAction[];
+}
+
+function parseTaskUpdatedMs(updated: string): number | null {
+  if (!updated || updated === UNKNOWN_ACTIVE_TASK_TIME) return null;
+  const ms = Date.parse(updated);
+  if (Number.isNaN(ms)) return null;
+  return ms;
+}
+
+function normalizeTaskString(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[_\-.:/]+/g, " ")
+    .replace(/[^a-z0-9\s]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function staleHoursFromUpdated(updated: string, nowMs: number): number | "?" {
+  const ms = parseTaskUpdatedMs(updated);
+  if (ms == null) return "?";
+  return Math.floor((nowMs - ms) / (60 * 60 * 1000));
+}
+
+function statusRankForCanonical(status: ActiveTaskStatus): number {
+  switch (status) {
+    case "In progress":
+      return 0;
+    case "Waiting":
+      return 1;
+    case "Stalled":
+      return 2;
+    case "Failed":
+      return 3;
+    default:
+      return 4;
+  }
+}
+
+function buildDuplicateComponents(tasks: ActiveTaskEntry[]): number[][] {
+  const byLabel = new Map<string, number[]>();
+  const byTitle = new Map<string, number[]>();
+  for (let i = 0; i < tasks.length; i++) {
+    const labelKey = normalizeTaskString(tasks[i].label);
+    const titleKey = normalizeTaskString(tasks[i].description);
+    if (labelKey) {
+      const arr = byLabel.get(labelKey) ?? [];
+      arr.push(i);
+      byLabel.set(labelKey, arr);
+    }
+    if (titleKey) {
+      const arr = byTitle.get(titleKey) ?? [];
+      arr.push(i);
+      byTitle.set(titleKey, arr);
+    }
+  }
+
+  const edges = new Map<number, Set<number>>();
+  const linkGroup = (indices: number[]): void => {
+    if (indices.length < 2) return;
+    const root = indices[0];
+    let rootSet = edges.get(root);
+    if (!rootSet) {
+      rootSet = new Set<number>();
+      edges.set(root, rootSet);
+    }
+    for (let i = 1; i < indices.length; i++) {
+      const idx = indices[i];
+      rootSet.add(idx);
+      let setI = edges.get(idx);
+      if (!setI) {
+        setI = new Set<number>();
+        edges.set(idx, setI);
+      }
+      setI.add(root);
+    }
+  };
+
+  for (const indices of byLabel.values()) linkGroup(indices);
+  for (const indices of byTitle.values()) linkGroup(indices);
+
+  const components: number[][] = [];
+  const seen = new Set<number>();
+  for (const idx of edges.keys()) {
+    if (seen.has(idx)) continue;
+    const stack = [idx];
+    const comp: number[] = [];
+    while (stack.length > 0) {
+      const cur = stack.pop() as number;
+      if (seen.has(cur)) continue;
+      seen.add(cur);
+      comp.push(cur);
+      for (const n of edges.get(cur) ?? []) {
+        if (!seen.has(n)) stack.push(n);
+      }
+    }
+    if (comp.length > 1) components.push(comp);
+  }
+  return components;
+}
+
+export async function planActiveTaskHygiene(
+  tasks: ActiveTaskEntry[],
+  opts: {
+    olderThanMinutes: number;
+    nowMs?: number;
+    openclawHome?: string;
+    checkSessionPresent?: (sessionRef: string) => Promise<boolean>;
+  },
+): Promise<ActiveTaskHygienePlan> {
+  const nowMs = opts.nowMs ?? Date.now();
+  const olderThanMinutes = Math.max(1, Math.floor(opts.olderThanMinutes));
+  const olderThanMs = olderThanMinutes * 60 * 1000;
+  const isOlderThan = (task: ActiveTaskEntry): boolean => {
+    const updatedMs = parseTaskUpdatedMs(task.updated);
+    return updatedMs == null || nowMs - updatedMs > olderThanMs;
+  };
+  const checkSessionPresent =
+    opts.checkSessionPresent ??
+    ((sessionRef: string): Promise<boolean> => isOpenClawSessionLikelyPresent(sessionRef, opts.openclawHome));
+
+  const stale: ActiveTaskHygieneStaleCandidate[] = [];
+  const actionsByLabel = new Map<string, ActiveTaskHygieneAction>();
+
+  for (const task of tasks) {
+    if (task.status !== "Failed") continue;
+    if (!isOlderThan(task)) continue;
+    const reason = `Failed task older than ${olderThanMinutes}m; marking abandoned.`;
+    stale.push({
+      label: task.label,
+      status: task.status,
+      updated: task.updated,
+      hoursStale: staleHoursFromUpdated(task.updated, nowMs),
+      reason,
+    });
+    actionsByLabel.set(task.label, {
+      label: task.label,
+      kind: "stale-failed",
+      toStatus: "abandoned",
+      reason,
+    });
+  }
+
+  for (const task of tasks) {
+    if (task.status !== "In progress") continue;
+    const sessionRef = task.subagent?.trim();
+    if (!sessionRef || !looksLikeOpenClawSessionRef(sessionRef)) continue;
+    if (!isOlderThan(task)) continue;
+    const present = await checkSessionPresent(sessionRef);
+    if (present) continue;
+    const reason = `In-progress task has missing session transcript (${sessionRef}) and is older than ${olderThanMinutes}m; marking abandoned.`;
+    stale.push({
+      label: task.label,
+      status: task.status,
+      updated: task.updated,
+      hoursStale: staleHoursFromUpdated(task.updated, nowMs),
+      reason,
+    });
+    actionsByLabel.set(task.label, {
+      label: task.label,
+      kind: "dead-session",
+      toStatus: "abandoned",
+      reason,
+    });
+  }
+
+  const duplicates: ActiveTaskHygieneDuplicateGroup[] = [];
+  const components = buildDuplicateComponents(tasks);
+  for (const comp of components) {
+    const members = comp.map((idx) => tasks[idx]);
+    const ranked = [...members].sort((a, b) => {
+      const actionA = actionsByLabel.has(a.label) ? 1 : 0;
+      const actionB = actionsByLabel.has(b.label) ? 1 : 0;
+      if (actionA !== actionB) return actionA - actionB;
+      const rankDiff = statusRankForCanonical(a.status) - statusRankForCanonical(b.status);
+      if (rankDiff !== 0) return rankDiff;
+      const updA = parseTaskUpdatedMs(a.updated) ?? Number.NEGATIVE_INFINITY;
+      const updB = parseTaskUpdatedMs(b.updated) ?? Number.NEGATIVE_INFINITY;
+      if (updA !== updB) return updB - updA;
+      if (a.label.length !== b.label.length) return a.label.length - b.label.length;
+      return a.label.localeCompare(b.label);
+    });
+    const canonical = ranked[0];
+    const normalized = normalizeTaskString(canonical.description) || normalizeTaskString(canonical.label);
+    const labels = ranked.map((m) => m.label);
+    duplicates.push({
+      normalized,
+      canonicalLabel: canonical.label,
+      labels,
+    });
+    for (const row of ranked.slice(1)) {
+      if (actionsByLabel.has(row.label)) continue;
+      actionsByLabel.set(row.label, {
+        label: row.label,
+        kind: "superseded-duplicate",
+        toStatus: "superseded",
+        canonicalLabel: canonical.label,
+        reason: `Superseded duplicate of [${canonical.label}] after normalization.`,
+      });
+    }
+  }
+
+  stale.sort((a, b) => a.label.localeCompare(b.label));
+  duplicates.sort((a, b) => a.canonicalLabel.localeCompare(b.canonicalLabel));
+  const actions = [...actionsByLabel.values()].sort((a, b) => a.label.localeCompare(b.label));
+  return {
+    olderThanMinutes,
+    duplicates,
+    stale,
+    actions,
+  };
+}
+
 function capRows<T extends ActiveTaskEntry>(rows: T[], max?: number): { rows: T[]; omitted: number } {
   if (max === undefined || rows.length <= max) return { rows, omitted: 0 };
   return { rows: rows.slice(0, max), omitted: rows.length - max };
@@ -368,10 +611,14 @@ export async function syncActiveTaskEntryToFacts(
   embeddings: EmbeddingProvider,
   entry: ActiveTaskEntry,
   log?: { warn?: (m: string) => void },
+  opts?: {
+    statusOverride?: string;
+  },
 ): Promise<void> {
   const entity = entry.label;
   await upsertProjectTaskKey(factsDb, vectorDb, embeddings, entity, "title", entry.description, log);
-  await upsertProjectTaskKey(factsDb, vectorDb, embeddings, entity, "status", displayStatusToFact(entry.status), log);
+  const statusValue = opts?.statusOverride?.trim() || displayStatusToFact(entry.status);
+  await upsertProjectTaskKey(factsDb, vectorDb, embeddings, entity, "status", statusValue, log);
   await upsertProjectTaskKey(factsDb, vectorDb, embeddings, entity, "next", entry.next?.trim() || "", log);
   await upsertProjectTaskKey(
     factsDb,
@@ -403,6 +650,81 @@ export async function syncActiveTaskEntryToFacts(
     entry.handoff ? JSON.stringify(entry.handoff) : "",
     log,
   );
+}
+
+export interface ActiveTaskHygieneApplyResult {
+  appliedCount: number;
+  auditFactId?: string;
+}
+
+export async function applyActiveTaskHygieneFacts(
+  factsDb: FactsDB,
+  vectorDb: VectorDB,
+  embeddings: EmbeddingProvider,
+  plan: ActiveTaskHygienePlan,
+  opts: {
+    flushOnComplete?: boolean;
+    memoryDir?: string;
+    log?: { warn?: (m: string) => void };
+  } = {},
+): Promise<ActiveTaskHygieneApplyResult> {
+  if (plan.actions.length === 0) {
+    return { appliedCount: 0 };
+  }
+
+  const runAt = new Date().toISOString();
+  const audit = {
+    runAt,
+    olderThanMinutes: plan.olderThanMinutes,
+    duplicates: plan.duplicates,
+    stale: plan.stale,
+    actions: plan.actions,
+  };
+  const auditFact = factsDb.store({
+    text: `Active-task hygiene audit ${runAt}: ${plan.actions.length} action(s), ${plan.duplicates.length} duplicate group(s).`,
+    category: "episode",
+    importance: CLI_STORE_IMPORTANCE,
+    source: "active-task-hygiene",
+    decayClass: "permanent",
+    entity: `active-task-hygiene:${runAt}`,
+    key: "report",
+    value: JSON.stringify(audit),
+  });
+
+  const { active } = loadTaskLedgerFromFacts(factsDb);
+  const byLabel = new Map(active.map((task) => [task.label, task] as const));
+  let appliedCount = 0;
+  for (const action of plan.actions) {
+    const task = byLabel.get(action.label);
+    if (!task) continue;
+    const doneEntry: ActiveTaskEntry = {
+      ...task,
+      status: "Done",
+      updated: runAt,
+      next: action.reason,
+      subagent: action.kind === "dead-session" ? undefined : task.subagent,
+    };
+    await syncActiveTaskEntryToFacts(factsDb, vectorDb, embeddings, doneEntry, opts.log, {
+      statusOverride: action.toStatus,
+    });
+    if (action.kind === "superseded-duplicate" && action.canonicalLabel) {
+      await upsertProjectTaskKey(
+        factsDb,
+        vectorDb,
+        embeddings,
+        doneEntry.label,
+        "superseded_by",
+        action.canonicalLabel,
+        opts.log,
+      );
+    }
+    if (opts.flushOnComplete && opts.memoryDir) {
+      await flushCompletedTaskToMemory(doneEntry, opts.memoryDir).catch(() => {});
+    }
+    appliedCount++;
+  }
+
+  return { appliedCount, auditFactId: auditFact.id };
 }
 
 export async function renderActiveTaskMarkdownFile(

--- a/extensions/memory-hybrid/services/task-ledger-facts.ts
+++ b/extensions/memory-hybrid/services/task-ledger-facts.ts
@@ -31,6 +31,7 @@ import { isOpenClawSessionLikelyPresent, looksLikeOpenClawSessionRef } from "./o
 export const TASK_LEDGER_CATEGORY = "project" as MemoryCategory;
 
 const TERMINAL = new Set(["done", "completed", "cancelled", "closed", "abandoned", "superseded"]);
+const GENERIC_TASK_TITLE_NORMALIZED = new Set(["project task", "task", "active task"]);
 
 /** Latest value per entity+key from non-superseded project facts */
 export function groupProjectFactsByEntity(facts: MemoryEntry[]): Map<string, Map<string, MemoryEntry>> {
@@ -292,6 +293,12 @@ function normalizeTaskString(value: string): string {
     .trim();
 }
 
+function isGenericTaskTitle(value: string): boolean {
+  const normalized = normalizeTaskString(value);
+  if (!normalized) return true;
+  return GENERIC_TASK_TITLE_NORMALIZED.has(normalized);
+}
+
 function staleHoursFromUpdated(updated: string, nowMs: number): number | "?" {
   const ms = parseTaskUpdatedMs(updated);
   if (ms == null) return "?";
@@ -324,7 +331,7 @@ function buildDuplicateComponents(tasks: ActiveTaskEntry[]): number[][] {
       arr.push(i);
       byLabel.set(labelKey, arr);
     }
-    if (titleKey) {
+    if (titleKey && !isGenericTaskTitle(tasks[i].description)) {
       const arr = byTitle.get(titleKey) ?? [];
       arr.push(i);
       byTitle.set(titleKey, arr);
@@ -387,9 +394,23 @@ export async function planActiveTaskHygiene(
   const nowMs = opts.nowMs ?? Date.now();
   const olderThanMinutes = Math.max(1, Math.floor(opts.olderThanMinutes));
   const olderThanMs = olderThanMinutes * 60 * 1000;
-  const isOlderThan = (task: ActiveTaskEntry): boolean => {
+  const classifyAge = (
+    task: ActiveTaskEntry,
+  ): {
+    stale: boolean;
+    reasonQualifier: string;
+  } => {
     const updatedMs = parseTaskUpdatedMs(task.updated);
-    return updatedMs == null || nowMs - updatedMs > olderThanMs;
+    if (updatedMs == null) {
+      return {
+        stale: true,
+        reasonQualifier: "missing/unknown updated timestamp",
+      };
+    }
+    return {
+      stale: nowMs - updatedMs > olderThanMs,
+      reasonQualifier: `older than ${olderThanMinutes}m`,
+    };
   };
   const checkSessionPresent =
     opts.checkSessionPresent ??
@@ -400,8 +421,9 @@ export async function planActiveTaskHygiene(
 
   for (const task of tasks) {
     if (task.status !== "Failed") continue;
-    if (!isOlderThan(task)) continue;
-    const reason = `Failed task older than ${olderThanMinutes}m; marking abandoned.`;
+    const age = classifyAge(task);
+    if (!age.stale) continue;
+    const reason = `Failed task ${age.reasonQualifier}; marking abandoned.`;
     stale.push({
       label: task.label,
       status: task.status,
@@ -417,14 +439,24 @@ export async function planActiveTaskHygiene(
     });
   }
 
-  for (const task of tasks) {
-    if (task.status !== "In progress") continue;
-    const sessionRef = task.subagent?.trim();
-    if (!sessionRef || !looksLikeOpenClawSessionRef(sessionRef)) continue;
-    if (!isOlderThan(task)) continue;
-    const present = await checkSessionPresent(sessionRef);
+  const staleSessionCandidates = tasks
+    .filter((task) => task.status === "In progress")
+    .map((task) => ({ task, sessionRef: task.subagent?.trim() ?? "" }))
+    .filter(({ sessionRef }) => sessionRef.length > 0 && looksLikeOpenClawSessionRef(sessionRef))
+    .map(({ task, sessionRef }) => ({ task, sessionRef, age: classifyAge(task) }))
+    .filter(({ age }) => age.stale);
+  const uniqueSessionRefs = [...new Set(staleSessionCandidates.map((c) => c.sessionRef))];
+  const sessionPresentByRef = new Map<string, boolean>();
+  await Promise.all(
+    uniqueSessionRefs.map(async (sessionRef) => {
+      const present = await checkSessionPresent(sessionRef);
+      sessionPresentByRef.set(sessionRef, present);
+    }),
+  );
+  for (const { task, sessionRef, age } of staleSessionCandidates) {
+    const present = sessionPresentByRef.get(sessionRef) ?? false;
     if (present) continue;
-    const reason = `In-progress task has missing session transcript (${sessionRef}) and is older than ${olderThanMinutes}m; marking abandoned.`;
+    const reason = `In-progress task has missing session transcript (${sessionRef}) and is ${age.reasonQualifier}; marking abandoned.`;
     stale.push({
       label: task.label,
       status: task.status,
@@ -560,6 +592,10 @@ export function buildFactsSectionedMarkdownBody(
   return parts.join("\n");
 }
 
+function taskEntityKey(entity: string, key: string): string {
+  return `${entity}\u0000${key}`;
+}
+
 export async function upsertProjectTaskKey(
   factsDb: FactsDB,
   vectorDb: VectorDB,
@@ -568,11 +604,18 @@ export async function upsertProjectTaskKey(
   key: string,
   value: string,
   log?: { warn?: (m: string) => void },
+  opts?: { latestByEntityKey?: Map<string, MemoryEntry> },
 ): Promise<void> {
-  const facts = factsDb.listFactsByCategory(TASK_LEDGER_CATEGORY, 8000);
-  const same = facts.filter((f) => f.entity === entity && (f.key ?? "") === key);
-  same.sort((a, b) => b.createdAt - a.createdAt);
-  const previous = same[0];
+  const cacheKey = taskEntityKey(entity, key);
+  let previous: MemoryEntry | undefined;
+  if (opts?.latestByEntityKey) {
+    previous = opts.latestByEntityKey.get(cacheKey);
+  } else {
+    const facts = factsDb.listFactsByCategory(TASK_LEDGER_CATEGORY, 8000);
+    const same = facts.filter((f) => f.entity === entity && (f.key ?? "") === key);
+    same.sort((a, b) => b.createdAt - a.createdAt);
+    previous = same[0];
+  }
   const text = `Task [${entity}] ${key}: ${value}`;
   const entry = factsDb.store({
     text,
@@ -587,6 +630,7 @@ export async function upsertProjectTaskKey(
   if (previous) {
     factsDb.supersede(previous.id, entry.id);
   }
+  opts?.latestByEntityKey?.set(cacheKey, entry);
   try {
     const vector = await embeddings.embed(text);
     factsDb.setEmbeddingModel(entry.id, embeddings.modelName);
@@ -613,13 +657,15 @@ export async function syncActiveTaskEntryToFacts(
   log?: { warn?: (m: string) => void },
   opts?: {
     statusOverride?: string;
+    latestByEntityKey?: Map<string, MemoryEntry>;
   },
 ): Promise<void> {
   const entity = entry.label;
-  await upsertProjectTaskKey(factsDb, vectorDb, embeddings, entity, "title", entry.description, log);
+  const upsertOpts = { latestByEntityKey: opts?.latestByEntityKey };
+  await upsertProjectTaskKey(factsDb, vectorDb, embeddings, entity, "title", entry.description, log, upsertOpts);
   const statusValue = opts?.statusOverride?.trim() || displayStatusToFact(entry.status);
-  await upsertProjectTaskKey(factsDb, vectorDb, embeddings, entity, "status", statusValue, log);
-  await upsertProjectTaskKey(factsDb, vectorDb, embeddings, entity, "next", entry.next?.trim() || "", log);
+  await upsertProjectTaskKey(factsDb, vectorDb, embeddings, entity, "status", statusValue, log, upsertOpts);
+  await upsertProjectTaskKey(factsDb, vectorDb, embeddings, entity, "next", entry.next?.trim() || "", log, upsertOpts);
   await upsertProjectTaskKey(
     factsDb,
     vectorDb,
@@ -628,10 +674,11 @@ export async function syncActiveTaskEntryToFacts(
     "related_session",
     entry.subagent?.trim() || "",
     log,
+    upsertOpts,
   );
-  await upsertProjectTaskKey(factsDb, vectorDb, embeddings, entity, "task_updated", entry.updated, log);
-  await upsertProjectTaskKey(factsDb, vectorDb, embeddings, entity, "started", entry.started, log);
-  await upsertProjectTaskKey(factsDb, vectorDb, embeddings, entity, "branch", entry.branch?.trim() || "", log);
+  await upsertProjectTaskKey(factsDb, vectorDb, embeddings, entity, "task_updated", entry.updated, log, upsertOpts);
+  await upsertProjectTaskKey(factsDb, vectorDb, embeddings, entity, "started", entry.started, log, upsertOpts);
+  await upsertProjectTaskKey(factsDb, vectorDb, embeddings, entity, "branch", entry.branch?.trim() || "", log, upsertOpts);
   await upsertProjectTaskKey(
     factsDb,
     vectorDb,
@@ -640,6 +687,7 @@ export async function syncActiveTaskEntryToFacts(
     "stash_commit",
     entry.stashCommit?.trim() || "",
     log,
+    upsertOpts,
   );
   await upsertProjectTaskKey(
     factsDb,
@@ -649,6 +697,7 @@ export async function syncActiveTaskEntryToFacts(
     "handoff",
     entry.handoff ? JSON.stringify(entry.handoff) : "",
     log,
+    upsertOpts,
   );
 }
 
@@ -673,26 +722,19 @@ export async function applyActiveTaskHygieneFacts(
   }
 
   const runAt = new Date().toISOString();
-  const audit = {
-    runAt,
-    olderThanMinutes: plan.olderThanMinutes,
-    duplicates: plan.duplicates,
-    stale: plan.stale,
-    actions: plan.actions,
-  };
-  const auditFact = factsDb.store({
-    text: `Active-task hygiene audit ${runAt}: ${plan.actions.length} action(s), ${plan.duplicates.length} duplicate group(s).`,
-    category: "episode",
-    importance: CLI_STORE_IMPORTANCE,
-    source: "active-task-hygiene",
-    decayClass: "permanent",
-    entity: `active-task-hygiene:${runAt}`,
-    key: "report",
-    value: JSON.stringify(audit),
-  });
-
   const { active } = loadTaskLedgerFromFacts(factsDb);
   const byLabel = new Map(active.map((task) => [task.label, task] as const));
+  const latestByEntityKey = new Map<string, MemoryEntry>();
+  for (const fact of factsDb.listFactsByCategory(TASK_LEDGER_CATEGORY, 8000)) {
+    const entity = fact.entity?.trim();
+    if (!entity) continue;
+    const key = (fact.key ?? "").trim();
+    const cacheKey = taskEntityKey(entity, key);
+    const prev = latestByEntityKey.get(cacheKey);
+    if (!prev || fact.createdAt > prev.createdAt) {
+      latestByEntityKey.set(cacheKey, fact);
+    }
+  }
   let appliedCount = 0;
   for (const action of plan.actions) {
     const task = byLabel.get(action.label);
@@ -706,6 +748,7 @@ export async function applyActiveTaskHygieneFacts(
     };
     await syncActiveTaskEntryToFacts(factsDb, vectorDb, embeddings, doneEntry, opts.log, {
       statusOverride: action.toStatus,
+      latestByEntityKey,
     });
     if (action.kind === "superseded-duplicate" && action.canonicalLabel) {
       await upsertProjectTaskKey(
@@ -716,6 +759,7 @@ export async function applyActiveTaskHygieneFacts(
         "superseded_by",
         action.canonicalLabel,
         opts.log,
+        { latestByEntityKey },
       );
     }
     if (opts.flushOnComplete && opts.memoryDir) {
@@ -723,6 +767,25 @@ export async function applyActiveTaskHygieneFacts(
     }
     appliedCount++;
   }
+
+  const audit = {
+    runAt,
+    olderThanMinutes: plan.olderThanMinutes,
+    duplicates: plan.duplicates,
+    stale: plan.stale,
+    actions: plan.actions,
+    appliedCount,
+  };
+  const auditFact = factsDb.store({
+    text: `Active-task hygiene audit ${runAt}: ${plan.actions.length} action(s), ${plan.duplicates.length} duplicate group(s), ${appliedCount} applied.`,
+    category: "episode",
+    importance: CLI_STORE_IMPORTANCE,
+    source: "active-task-hygiene",
+    decayClass: "permanent",
+    entity: `active-task-hygiene:${runAt}`,
+    key: "report",
+    value: JSON.stringify(audit),
+  });
 
   return { appliedCount, auditFactId: auditFact.id };
 }

--- a/extensions/memory-hybrid/tests/active-task.test.ts
+++ b/extensions/memory-hybrid/tests/active-task.test.ts
@@ -11,6 +11,7 @@ import {
   type ActiveTaskContext,
   runActiveTaskAdd,
   runActiveTaskComplete,
+  runActiveTaskHygiene,
   runActiveTaskList,
   runActiveTaskStale,
 } from "../cli/active-tasks.js";
@@ -1013,6 +1014,108 @@ describe("runActiveTaskAdd", () => {
   });
 });
 
+describe("runActiveTaskHygiene", () => {
+  let tmpDir: string;
+  let ctx: ActiveTaskContext;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "active-task-hygiene-"));
+    ctx = {
+      activeTaskFilePath: join(tmpDir, "ACTIVE-TASKS.md"),
+      staleMinutes: 1440,
+      flushOnComplete: false,
+      memoryDir: join(tmpDir, "memory"),
+      ledger: "markdown",
+      projection: {
+        mode: "readable",
+        excludeGenericTitle: true,
+        titleMinChars: 0,
+        dedupeBy: "none",
+        sectioned: true,
+      },
+    };
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("dry-run reports duplicates, dead sessions, and stale failed tasks", async () => {
+    const staleIso = new Date(Date.now() - 72 * 60 * 60 * 1000).toISOString();
+    const freshIso = new Date(Date.now() - 5 * 60 * 1000).toISOString();
+    await writeActiveTaskFile(
+      ctx.activeTaskFilePath,
+      [
+        makeEntry({ label: "dup-a", description: "Issue 1273 hygiene", status: "Waiting", updated: freshIso }),
+        makeEntry({
+          label: "dup_a_copy",
+          description: "Issue 1273 hygiene",
+          status: "Waiting",
+          updated: freshIso,
+        }),
+        makeEntry({
+          label: "dead-subagent",
+          status: "In progress",
+          subagent: "agent:forge:subagent:dead-test-session",
+          updated: staleIso,
+        }),
+        makeEntry({ label: "failed-stale", status: "Failed", updated: staleIso }),
+      ],
+      [],
+    );
+
+    const report = await runActiveTaskHygiene(ctx, {
+      olderThanMinutes: 60,
+      openclawHome: join(tmpDir, "missing-openclaw-home"),
+    });
+    expect(report.dryRun).toBe(true);
+    expect(report.duplicates.length).toBeGreaterThanOrEqual(1);
+    expect(report.actions.some((a) => a.kind === "dead-session" && a.label === "dead-subagent")).toBe(true);
+    expect(report.actions.some((a) => a.kind === "stale-failed" && a.label === "failed-stale")).toBe(true);
+    expect(report.actions.some((a) => a.kind === "superseded-duplicate" && a.label === "dup_a_copy")).toBe(true);
+  });
+
+  it("apply marks stale/superseded rows done without deleting history", async () => {
+    const staleIso = new Date(Date.now() - 72 * 60 * 60 * 1000).toISOString();
+    const freshIso = new Date(Date.now() - 5 * 60 * 1000).toISOString();
+    await writeActiveTaskFile(
+      ctx.activeTaskFilePath,
+      [
+        makeEntry({ label: "dup-a", description: "Issue 1273 hygiene", status: "Waiting", updated: freshIso }),
+        makeEntry({
+          label: "dup_a_copy",
+          description: "Issue 1273 hygiene",
+          status: "Waiting",
+          updated: freshIso,
+        }),
+        makeEntry({
+          label: "dead-subagent",
+          status: "In progress",
+          subagent: "agent:forge:subagent:dead-test-session",
+          updated: staleIso,
+        }),
+        makeEntry({ label: "failed-stale", status: "Failed", updated: staleIso }),
+      ],
+      [],
+    );
+
+    const report = await runActiveTaskHygiene(ctx, {
+      apply: true,
+      olderThanMinutes: 60,
+      openclawHome: join(tmpDir, "missing-openclaw-home"),
+    });
+    expect(report.dryRun).toBe(false);
+    expect(report.appliedCount).toBeGreaterThanOrEqual(3);
+
+    const file = await readActiveTaskFile(ctx.activeTaskFilePath, 1440);
+    expect(file?.active.some((t) => t.label === "dup-a")).toBe(true);
+    expect(file?.active.some((t) => t.label === "dup_a_copy")).toBe(false);
+    expect(file?.completed.some((t) => t.label === "dup_a_copy")).toBe(true);
+    expect(file?.completed.some((t) => t.label === "dead-subagent")).toBe(true);
+    expect(file?.completed.some((t) => t.label === "failed-stale")).toBe(true);
+  });
+});
+
 // ---------------------------------------------------------------------------
 // Config injection tests
 // ---------------------------------------------------------------------------
@@ -1643,5 +1746,7 @@ describe("registerActiveTaskCommands", () => {
     const listCmd = activeTasksCmd?.commands.find((c) => c.name() === "list");
     expect(listCmd).toBeDefined();
     expect(listCmd?.description()).toContain("List active tasks");
+    const hygieneCmd = activeTasksCmd?.commands.find((c) => c.name() === "hygiene");
+    expect(hygieneCmd).toBeDefined();
   });
 });

--- a/extensions/memory-hybrid/tests/active-task.test.ts
+++ b/extensions/memory-hybrid/tests/active-task.test.ts
@@ -1075,6 +1075,17 @@ describe("runActiveTaskHygiene", () => {
     expect(report.actions.some((a) => a.kind === "superseded-duplicate" && a.label === "dup_a_copy")).toBe(true);
   });
 
+  it("apply reports a blocking error when ACTIVE-TASKS.md is missing in markdown mode", async () => {
+    const report = await runActiveTaskHygiene(ctx, {
+      apply: true,
+      olderThanMinutes: 60,
+      openclawHome: join(tmpDir, "missing-openclaw-home"),
+    });
+    expect(report.dryRun).toBe(true);
+    expect(report.cannotApplyReason).toContain("Cannot apply hygiene");
+    expect(report.appliedCount).toBe(0);
+  });
+
   it("apply marks stale/superseded rows done without deleting history", async () => {
     const staleIso = new Date(Date.now() - 72 * 60 * 60 * 1000).toISOString();
     const freshIso = new Date(Date.now() - 5 * 60 * 1000).toISOString();

--- a/extensions/memory-hybrid/tests/task-ledger-facts.test.ts
+++ b/extensions/memory-hybrid/tests/task-ledger-facts.test.ts
@@ -1,13 +1,22 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
+import { FactsDB } from "../backends/facts-db.js";
+import type { VectorDB } from "../backends/vector-db.js";
 import type { ActiveTaskProjectionConfig } from "../config.js";
 import { type ActiveTaskEntry, UNKNOWN_ACTIVE_TASK_TIME } from "../services/active-task.js";
+import type { EmbeddingProvider } from "../services/embeddings.js";
 import {
+  applyActiveTaskHygieneFacts,
   applyActiveTaskProjectionFilters,
   buildFactsSectionedMarkdownBody,
   buildTaskEntriesFromGroupedFacts,
   displayStatusToFact,
   factStatusToDisplay,
   groupProjectFactsByEntity,
+  loadTaskLedgerFromFacts,
+  planActiveTaskHygiene,
 } from "../services/task-ledger-facts.js";
 import type { MemoryEntry } from "../types/memory.js";
 
@@ -147,5 +156,125 @@ describe("task-ledger-facts", () => {
     expect(md).toContain("## Stale — revisit");
     expect(md).toContain("[fresh]");
     expect(md).toContain("[old]");
+  });
+
+  it("planActiveTaskHygiene detects duplicate variants, dead sessions, and stale failed tasks", async () => {
+    const now = Date.now();
+    const staleIso = new Date(now - 3 * 24 * 60 * 60 * 1000).toISOString();
+    const freshIso = new Date(now - 20 * 60 * 1000).toISOString();
+    const tasks: ActiveTaskEntry[] = [
+      {
+        label: "proj-1273",
+        description: "Issue 1273 active task hygiene",
+        status: "In progress",
+        subagent: "agent:forge:subagent:dead-aaa",
+        started: staleIso,
+        updated: staleIso,
+      },
+      {
+        label: "proj 1273",
+        description: "Issue 1273 Active Task Hygiene",
+        status: "Waiting",
+        started: freshIso,
+        updated: freshIso,
+      },
+      {
+        label: "proj_1273_copy",
+        description: "Issue 1273 active task hygiene",
+        status: "Waiting",
+        started: freshIso,
+        updated: freshIso,
+      },
+      {
+        label: "stale-failure",
+        description: "Previous run failed",
+        status: "Failed",
+        started: staleIso,
+        updated: staleIso,
+      },
+    ];
+
+    const plan = await planActiveTaskHygiene(tasks, {
+      olderThanMinutes: 60,
+      checkSessionPresent: async () => false,
+    });
+
+    expect(plan.duplicates.length).toBeGreaterThanOrEqual(1);
+    expect(plan.actions.some((a) => a.label === "proj-1273" && a.kind === "dead-session")).toBe(true);
+    expect(plan.actions.some((a) => a.label === "stale-failure" && a.kind === "stale-failed")).toBe(true);
+    expect(plan.actions.some((a) => a.label === "proj_1273_copy" && a.kind === "superseded-duplicate")).toBe(true);
+  });
+
+  it("applyActiveTaskHygieneFacts marks rows as terminal and keeps an audit trail fact", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "task-hygiene-facts-"));
+    const db = new FactsDB(join(dir, "facts.db"));
+    const vectorDb = {
+      hasDuplicate: async () => true,
+      store: async () => {},
+    } as unknown as VectorDB;
+    const embeddings = {
+      modelName: "test-model",
+      embed: async () => new Float32Array([0.1, 0.2, 0.3]),
+    } as unknown as EmbeddingProvider;
+    const staleIso = new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString();
+    const freshIso = new Date(Date.now() - 10 * 60 * 1000).toISOString();
+    const storeTask = (entity: string, title: string, status: string, updated: string, relatedSession?: string): void => {
+      const base = {
+        category: "project",
+        importance: 0.7,
+        source: "test",
+        decayClass: "permanent" as const,
+        entity,
+      };
+      db.store({ ...base, key: "title", value: title, text: `Task [${entity}] title: ${title}` });
+      db.store({ ...base, key: "status", value: status, text: `Task [${entity}] status: ${status}` });
+      db.store({ ...base, key: "started", value: staleIso, text: `Task [${entity}] started: ${staleIso}` });
+      db.store({ ...base, key: "task_updated", value: updated, text: `Task [${entity}] updated: ${updated}` });
+      if (relatedSession) {
+        db.store({
+          ...base,
+          key: "related_session",
+          value: relatedSession,
+          text: `Task [${entity}] session: ${relatedSession}`,
+        });
+      }
+    };
+
+    try {
+      storeTask(
+        "proj-1273-a",
+        "Issue 1273 active task hygiene",
+        "in_progress",
+        staleIso,
+        "agent:forge:subagent:dead-zzz",
+      );
+      storeTask("proj-1273-b", "Issue 1273 Active Task Hygiene", "waiting", freshIso);
+      storeTask("proj-1273-copy", "Issue 1273 active task hygiene", "waiting", freshIso);
+      storeTask("stale-failure", "Failed run", "failed", staleIso);
+
+      const plan = await planActiveTaskHygiene(loadTaskLedgerFromFacts(db).active, {
+        olderThanMinutes: 60,
+        checkSessionPresent: async () => false,
+      });
+      const applied = await applyActiveTaskHygieneFacts(db, vectorDb, embeddings, plan);
+      expect(applied.appliedCount).toBeGreaterThanOrEqual(3);
+
+      const { active, completed } = loadTaskLedgerFromFacts(db);
+      expect(active.some((t) => t.label === "proj-1273-b")).toBe(true);
+      expect(active.some((t) => t.label === "proj-1273-copy")).toBe(false);
+      expect(completed.some((t) => t.label === "proj-1273-copy")).toBe(true);
+      expect(completed.some((t) => t.label === "stale-failure")).toBe(true);
+
+      const projectRows = groupProjectFactsByEntity(db.listFactsByCategory("project", 1000));
+      expect(projectRows.get("proj-1273-copy")?.get("status")?.value).toBe("superseded");
+      expect(projectRows.get("stale-failure")?.get("status")?.value).toBe("abandoned");
+      expect(projectRows.get("proj-1273-copy")?.get("superseded_by")?.value).toBe("proj-1273-b");
+
+      const audits = db.listFactsByCategory("episode", 1000).filter((row) => row.source === "active-task-hygiene");
+      expect(audits.length).toBeGreaterThanOrEqual(1);
+    } finally {
+      db.close();
+      await rm(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/extensions/memory-hybrid/tests/task-ledger-facts.test.ts
+++ b/extensions/memory-hybrid/tests/task-ledger-facts.test.ts
@@ -205,6 +205,45 @@ describe("task-ledger-facts", () => {
     expect(plan.actions.some((a) => a.label === "proj_1273_copy" && a.kind === "superseded-duplicate")).toBe(true);
   });
 
+  it("planActiveTaskHygiene does not group generic fallback titles as duplicates", async () => {
+    const now = Date.now();
+    const freshIso = new Date(now - 5 * 60 * 1000).toISOString();
+    const tasks: ActiveTaskEntry[] = [
+      {
+        label: "task-alpha",
+        description: "Project task",
+        status: "In progress",
+        started: freshIso,
+        updated: freshIso,
+      },
+      {
+        label: "task-beta",
+        description: "Project task",
+        status: "In progress",
+        started: freshIso,
+        updated: freshIso,
+      },
+    ];
+    const plan = await planActiveTaskHygiene(tasks, { olderThanMinutes: 60 });
+    expect(plan.duplicates).toHaveLength(0);
+    expect(plan.actions.some((a) => a.kind === "superseded-duplicate")).toBe(false);
+  });
+
+  it("planActiveTaskHygiene explains unknown updated timestamps in stale reasons", async () => {
+    const tasks: ActiveTaskEntry[] = [
+      {
+        label: "failed-unknown-updated",
+        description: "Unknown update timestamp",
+        status: "Failed",
+        started: "2026-01-01T00:00:00.000Z",
+        updated: UNKNOWN_ACTIVE_TASK_TIME,
+      },
+    ];
+    const plan = await planActiveTaskHygiene(tasks, { olderThanMinutes: 60 });
+    expect(plan.actions).toHaveLength(1);
+    expect(plan.actions[0].reason).toContain("missing/unknown updated timestamp");
+  });
+
   it("applyActiveTaskHygieneFacts marks rows as terminal and keeps an audit trail fact", async () => {
     const dir = await mkdtemp(join(tmpdir(), "task-hygiene-facts-"));
     const db = new FactsDB(join(dir, "facts.db"));
@@ -224,6 +263,7 @@ describe("task-ledger-facts", () => {
       status: string,
       updated: string,
       relatedSession?: string,
+      started?: string,
     ): void => {
       const base = {
         category: "project",
@@ -234,7 +274,8 @@ describe("task-ledger-facts", () => {
       };
       db.store({ ...base, key: "title", value: title, text: `Task [${entity}] title: ${title}` });
       db.store({ ...base, key: "status", value: status, text: `Task [${entity}] status: ${status}` });
-      db.store({ ...base, key: "started", value: staleIso, text: `Task [${entity}] started: ${staleIso}` });
+      const startedIso = started ?? updated;
+      db.store({ ...base, key: "started", value: startedIso, text: `Task [${entity}] started: ${startedIso}` });
       db.store({ ...base, key: "task_updated", value: updated, text: `Task [${entity}] updated: ${updated}` });
       if (relatedSession) {
         db.store({

--- a/extensions/memory-hybrid/tests/task-ledger-facts.test.ts
+++ b/extensions/memory-hybrid/tests/task-ledger-facts.test.ts
@@ -218,7 +218,13 @@ describe("task-ledger-facts", () => {
     } as unknown as EmbeddingProvider;
     const staleIso = new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString();
     const freshIso = new Date(Date.now() - 10 * 60 * 1000).toISOString();
-    const storeTask = (entity: string, title: string, status: string, updated: string, relatedSession?: string): void => {
+    const storeTask = (
+      entity: string,
+      title: string,
+      status: string,
+      updated: string,
+      relatedSession?: string,
+    ): void => {
       const base = {
         category: "project",
         importance: 0.7,


### PR DESCRIPTION
## Summary
- add `active-tasks hygiene` with `--dry-run`, `--apply`, and `--older-than`
- detect duplicate normalized task entities and stale rows (dead subagent sessions + stale failed tasks)
- on apply, mark rows as abandoned/superseded (no history deletion), persist an audit episode fact, and refresh ACTIVE-TASKS.md projection for facts ledger
- add tests for duplicate labels, dead subagent sessions, and stale failed tasks
- update active-task hygiene/projection CLI docs

Fixes #1273

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new command that can automatically mark project-task facts/rows as `abandoned`/`superseded` and write audit facts, so incorrect detection or configuration could change task state unexpectedly. Scope is limited to active-task ledger maintenance and is covered by new unit tests plus dry-run mode.
> 
> **Overview**
> Adds a new `active-tasks hygiene` CLI command (with `--dry-run`, `--apply`, and `--older-than`) to identify **duplicate normalized task entities** and **stale candidates** (failed tasks and in-progress tasks whose subagent session transcript is missing).
> 
> When applied, it marks affected rows as terminal (`abandoned`/`superseded`), optionally clears dead-session `subagent` refs, writes an **audit `episode` fact** in the facts ledger, and refreshes the `ACTIVE-TASKS.md` projection for `activeTask.ledger: facts` (markdown ledger moves rows to Completed without deleting history). Docs and tests are updated to cover the new workflow and status handling (including `superseded` as terminal).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a6e37949f57ba70ee8a01dce85167d82e40c35b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->