### PR TITLE
fix: pre-finalization guard for unfinished external workflows (#1271)

### DIFF
--- a/docs/TASK-HYGIENE.md
+++ b/docs/TASK-HYGIENE.md
@@ -40,6 +40,11 @@ Requires **`activeTask.enabled`**. The tool is registered with the plugin regard
 
 - **CLI:** `openclaw hybrid-mem active-tasks reconcile` — keeps subagent bookkeeping honest before you trust **`ACTIVE-TASKS.md`** for heartbeats or audits.
 - **Goals mirror:** When **`goalStewardship.heartbeatRefreshActiveTask`** is on, heartbeat also refreshes the **`## Active Goals`** mirror in **`ACTIVE-TASKS.md`** (do not edit that section by hand).
+- **Pre-finalization guard (#1271):** On `agent_end`, unfinished external-workflow signals (e.g. CI pending, background command still running, scheduled recheck) can trigger a guard that warns or blocks finalization until checkpoint evidence exists.
+  Satisfy by:
+  1. Calling `active_task_checkpoint` (when available), or
+  2. Writing project facts (`category:project`) with `status` (`in_progress`/`waiting`/`blocked`), `next`, fresh `task_updated`, and `related_session` (`waiting` also needs a wake link; goal-backed rows also need `goal_assess` in the turn).
+  False positives can be bypassed explicitly by adding `CHECKPOINT_GUARD_BYPASS: <short reason>` in the final assistant message.
 
 ## Related docs
 

--- a/docs/TASK-HYGIENE.md
+++ b/docs/TASK-HYGIENE.md
@@ -43,7 +43,7 @@ Requires **`activeTask.enabled`**. The tool is registered with the plugin regard
 - **Pre-finalization guard (#1271):** On `agent_end`, unfinished external-workflow signals (e.g. CI pending, background command still running, scheduled recheck) can trigger a guard that warns or blocks finalization until checkpoint evidence exists.
   Satisfy by:
   1. Calling `active_task_checkpoint` (when available), or
-  2. Writing project facts (`category:project`) with `status` (`in_progress`/`waiting`/`blocked`), `next`, fresh `task_updated`, and `related_session` (`waiting` also needs a wake link; goal-backed rows also need `goal_assess` in the turn).
+  2. Writing project facts (`category:project`) with `status` (`in_progress`/`waiting`/`blocked`), `next`, fresh `task_updated` (default freshness window: **2 hours**), and `related_session` bound to the current session (`waiting` also needs a persisted wake link; goal-backed rows also need `goal_assess` in the turn).
   False positives can be bypassed explicitly by adding `CHECKPOINT_GUARD_BYPASS: <short reason>` in the final assistant message.
 
 ## Related docs

--- a/extensions/memory-hybrid/lifecycle/hooks.ts
+++ b/extensions/memory-hybrid/lifecycle/hooks.ts
@@ -122,7 +122,8 @@ export function createLifecycleHooks(ctx: LifecycleContext) {
             ctx.auditStore?.append({
               agentId: ctx.currentAgentIdRef.value ?? "unknown",
               action: "cleanup:pre-finalization-guard-blocked",
-              details: {
+              outcome: "failed",
+              context: {
                 missingFields: guard.checkpoint.missingFields,
                 signals: guard.signals,
               },

--- a/extensions/memory-hybrid/lifecycle/hooks.ts
+++ b/extensions/memory-hybrid/lifecycle/hooks.ts
@@ -26,6 +26,8 @@ import { registerGoalSubagentHandlers } from "./stage-goal-subagent.js";
 import { runInjectionStage } from "./stage-injection.js";
 import { runRecallStage } from "./stage-recall.js";
 import { runSetupStage } from "./stage-setup.js";
+import { formatPreFinalizationGuardMessage, evaluatePreFinalizationGuard } from "../services/pre-finalization-guard.js";
+import { TASK_LEDGER_CATEGORY } from "../services/task-ledger-facts.js";
 import type { LifecycleContext, SessionState } from "./types.js";
 
 export type { LifecycleContext } from "./types.js";
@@ -104,11 +106,41 @@ export function createLifecycleHooks(ctx: LifecycleContext) {
     // Same typed-hook shape as before_agent_start (#1005).
     api.on("agent_end", async (event: unknown, hookCtx: unknown) => {
       const rApi = withHookResolutionApi(api, hookCtx);
+      const ev = event as { messages?: unknown[]; success?: boolean };
+
+      if (ev?.success !== false) {
+        try {
+          const projectFacts = ctx.factsDb.listFactsByCategory(TASK_LEDGER_CATEGORY, 8000);
+          const guard = evaluatePreFinalizationGuard(ev?.messages ?? [], { projectFacts });
+          const guardMessage = formatPreFinalizationGuardMessage(guard);
+          if (guard.reason === "explicit_bypass" || guard.reason === "checkpoint_present") {
+            api.logger.info?.(`memory-hybrid: ${guardMessage}`);
+          } else if (guard.action === "warn") {
+            api.logger.warn?.(`memory-hybrid: ${guardMessage}`);
+          } else if (guard.action === "block") {
+            api.logger.warn?.(`memory-hybrid: ${guardMessage}`);
+            ctx.auditStore?.append({
+              agentId: ctx.currentAgentIdRef.value ?? "unknown",
+              action: "cleanup:pre-finalization-guard-blocked",
+              details: {
+                missingFields: guard.checkpoint.missingFields,
+                signals: guard.signals,
+              },
+            });
+            throw new Error(`memory-hybrid: ${guardMessage}`);
+          }
+        } catch (err) {
+          if (err instanceof Error && err.message.startsWith("memory-hybrid: pre-finalization guard: blocking")) {
+            throw err;
+          }
+          api.logger.debug?.(`memory-hybrid: pre-finalization guard skipped (non-fatal): ${String(err)}`);
+        }
+      }
+
       // Issue #742: extract tool names from messages and record via WorkflowTracker
       // so crystallization can detect patterns from the traces table.
       if (ctx.workflowTracker && ctx.cfg.workflowTracking?.enabled) {
         try {
-          const ev = event as { messages?: unknown[]; success?: boolean };
           const messages = ev?.messages ?? [];
           const sessionId = sessionState.resolveSessionKey(event, rApi) ?? ctx.currentAgentIdRef.value ?? "default";
 

--- a/extensions/memory-hybrid/lifecycle/hooks.ts
+++ b/extensions/memory-hybrid/lifecycle/hooks.ts
@@ -231,8 +231,14 @@ export function createLifecycleHooks(ctx: LifecycleContext) {
 
       if (ev?.success !== false) {
         try {
-          const projectFacts = ctx.factsDb.listFactsByCategory(TASK_LEDGER_CATEGORY, 8000);
-          const guard = evaluatePreFinalizationGuard(ev?.messages ?? [], { projectFacts });
+          const messages = ev?.messages ?? [];
+          let guard = evaluatePreFinalizationGuard(messages, { sessionKey: sessionId });
+          const requiresProjectFacts =
+            guard.reason === "missing_checkpoint_block" || guard.reason === "missing_checkpoint_warn";
+          if (requiresProjectFacts) {
+            const projectFacts = ctx.factsDb.listFactsByCategory(TASK_LEDGER_CATEGORY, 8000);
+            guard = evaluatePreFinalizationGuard(messages, { projectFacts, sessionKey: sessionId });
+          }
           const guardMessage = formatPreFinalizationGuardMessage(guard);
           if (guard.reason === "explicit_bypass" || guard.reason === "checkpoint_present") {
             api.logger.info?.(`memory-hybrid: ${guardMessage}`);

--- a/extensions/memory-hybrid/lifecycle/hooks.ts
+++ b/extensions/memory-hybrid/lifecycle/hooks.ts
@@ -112,40 +112,6 @@ export function createLifecycleHooks(ctx: LifecycleContext) {
       const rApi = withHookResolutionApi(api, hookCtx);
       const ev = event as { messages?: unknown[]; success?: boolean };
 
-      if (ev?.success !== false) {
-        try {
-          const projectFacts = ctx.factsDb.listFactsByCategory(TASK_LEDGER_CATEGORY, 8000);
-          const guard = evaluatePreFinalizationGuard(ev?.messages ?? [], { projectFacts });
-          const guardMessage = formatPreFinalizationGuardMessage(guard);
-          if (guard.reason === "explicit_bypass" || guard.reason === "checkpoint_present") {
-            api.logger.info?.(`memory-hybrid: ${guardMessage}`);
-          } else if (guard.action === "warn") {
-            api.logger.warn?.(`memory-hybrid: ${guardMessage}`);
-          } else if (guard.action === "block") {
-            api.logger.warn?.(`memory-hybrid: ${guardMessage}`);
-            try {
-              ctx.auditStore?.append({
-                agentId: ctx.currentAgentIdRef.value ?? "unknown",
-                action: "cleanup:pre-finalization-guard-blocked",
-                outcome: "failed",
-                context: {
-                  missingFields: guard.checkpoint.missingFields,
-                  signals: guard.signals,
-                },
-              });
-            } catch (auditErr) {
-              api.logger.debug?.(`memory-hybrid: audit store append failed (non-fatal): ${String(auditErr)}`);
-            }
-            throw new PreFinalizationGuardBlockingError(`memory-hybrid: ${guardMessage}`);
-          }
-        } catch (err) {
-          if (err instanceof PreFinalizationGuardBlockingError) {
-            throw err;
-          }
-          api.logger.debug?.(`memory-hybrid: pre-finalization guard skipped (non-fatal): ${String(err)}`);
-        }
-      }
-
       // Issue #742: extract tool names from messages and record via WorkflowTracker
       // so crystallization can detect patterns from the traces table.
       if (ctx.workflowTracker && ctx.cfg.workflowTracking?.enabled) {
@@ -260,6 +226,40 @@ export function createLifecycleHooks(ctx: LifecycleContext) {
           api.logger.info?.(`memory-hybrid: session narrative skipped (LLM unavailable or aborted): ${detail}`);
         } else {
           api.logger.warn(`memory-hybrid: session narrative build failed: ${String(err)}`);
+        }
+      }
+
+      if (ev?.success !== false) {
+        try {
+          const projectFacts = ctx.factsDb.listFactsByCategory(TASK_LEDGER_CATEGORY, 8000);
+          const guard = evaluatePreFinalizationGuard(ev?.messages ?? [], { projectFacts });
+          const guardMessage = formatPreFinalizationGuardMessage(guard);
+          if (guard.reason === "explicit_bypass" || guard.reason === "checkpoint_present") {
+            api.logger.info?.(`memory-hybrid: ${guardMessage}`);
+          } else if (guard.action === "warn") {
+            api.logger.warn?.(`memory-hybrid: ${guardMessage}`);
+          } else if (guard.action === "block") {
+            api.logger.warn?.(`memory-hybrid: ${guardMessage}`);
+            try {
+              ctx.auditStore?.append({
+                agentId: ctx.currentAgentIdRef.value ?? "unknown",
+                action: "cleanup:pre-finalization-guard-blocked",
+                outcome: "failed",
+                context: {
+                  missingFields: guard.checkpoint.missingFields,
+                  signals: guard.signals,
+                },
+              });
+            } catch (auditErr) {
+              api.logger.debug?.(`memory-hybrid: audit store append failed (non-fatal): ${String(auditErr)}`);
+            }
+            throw new PreFinalizationGuardBlockingError(`memory-hybrid: ${guardMessage}`);
+          }
+        } catch (err) {
+          if (err instanceof PreFinalizationGuardBlockingError) {
+            throw err;
+          }
+          api.logger.debug?.(`memory-hybrid: pre-finalization guard skipped (non-fatal): ${String(err)}`);
         }
       }
     });

--- a/extensions/memory-hybrid/lifecycle/hooks.ts
+++ b/extensions/memory-hybrid/lifecycle/hooks.ts
@@ -123,15 +123,19 @@ export function createLifecycleHooks(ctx: LifecycleContext) {
             api.logger.warn?.(`memory-hybrid: ${guardMessage}`);
           } else if (guard.action === "block") {
             api.logger.warn?.(`memory-hybrid: ${guardMessage}`);
-            ctx.auditStore?.append({
-              agentId: ctx.currentAgentIdRef.value ?? "unknown",
-              action: "cleanup:pre-finalization-guard-blocked",
-              outcome: "failed",
-              context: {
-                missingFields: guard.checkpoint.missingFields,
-                signals: guard.signals,
-              },
-            });
+            try {
+              ctx.auditStore?.append({
+                agentId: ctx.currentAgentIdRef.value ?? "unknown",
+                action: "cleanup:pre-finalization-guard-blocked",
+                outcome: "failed",
+                context: {
+                  missingFields: guard.checkpoint.missingFields,
+                  signals: guard.signals,
+                },
+              });
+            } catch (auditErr) {
+              api.logger.debug?.(`memory-hybrid: audit store append failed (non-fatal): ${String(auditErr)}`);
+            }
             throw new PreFinalizationGuardBlockingError(`memory-hybrid: ${guardMessage}`);
           }
         } catch (err) {

--- a/extensions/memory-hybrid/lifecycle/hooks.ts
+++ b/extensions/memory-hybrid/lifecycle/hooks.ts
@@ -26,7 +26,11 @@ import { registerGoalSubagentHandlers } from "./stage-goal-subagent.js";
 import { runInjectionStage } from "./stage-injection.js";
 import { runRecallStage } from "./stage-recall.js";
 import { runSetupStage } from "./stage-setup.js";
-import { formatPreFinalizationGuardMessage, evaluatePreFinalizationGuard } from "../services/pre-finalization-guard.js";
+import {
+  formatPreFinalizationGuardMessage,
+  evaluatePreFinalizationGuard,
+  PreFinalizationGuardBlockingError,
+} from "../services/pre-finalization-guard.js";
 import { TASK_LEDGER_CATEGORY } from "../services/task-ledger-facts.js";
 import type { LifecycleContext, SessionState } from "./types.js";
 
@@ -128,10 +132,10 @@ export function createLifecycleHooks(ctx: LifecycleContext) {
                 signals: guard.signals,
               },
             });
-            throw new Error(`memory-hybrid: ${guardMessage}`);
+            throw new PreFinalizationGuardBlockingError(`memory-hybrid: ${guardMessage}`);
           }
         } catch (err) {
-          if (err instanceof Error && err.message.startsWith("memory-hybrid: pre-finalization guard: blocking")) {
+          if (err instanceof PreFinalizationGuardBlockingError) {
             throw err;
           }
           api.logger.debug?.(`memory-hybrid: pre-finalization guard skipped (non-fatal): ${String(err)}`);

--- a/extensions/memory-hybrid/services/pre-finalization-guard.ts
+++ b/extensions/memory-hybrid/services/pre-finalization-guard.ts
@@ -23,6 +23,10 @@ const NEGATED_WAITING_OR_PENDING_RE =
   /\b(?:no longer|not|nothing|without|never)\b[\s\S]{0,24}\b(?:pending|waiting|awaiting)\b/i;
 const CLEARED_WAITING_OR_PENDING_RE =
   /\b(?:pending|waiting|awaiting)\b[\s\S]{0,24}\b(?:cleared|resolved|finished|complete|completed|done|over)\b/i;
+const NEGATED_EXTERNAL_STATUS_RE =
+  /\b(?:no longer|not|nothing|without|never)\b[\s\S]{0,24}\b(?:pending|running|in progress|queued|awaiting|blocked)\b/i;
+const CLEARED_EXTERNAL_STATUS_RE =
+  /\b(?:pending|running|in progress|queued|awaiting|blocked)\b[\s\S]{0,24}\b(?:cleared|resolved|finished|complete|completed|done|over)\b/i;
 const CRON_WAKE_RE =
   /\b(?:cron wake|scheduled?\s+(?:a\s+)?(?:wake|wake-?up|recheck)|wake(?:\s|-)?at|resume(?:\s+at|\s+on)|next\s+(?:wake|check))\b/i;
 const BACKGROUND_TEXT_RE =
@@ -260,8 +264,8 @@ function hasAffirmativeWaitingOrPending(text: string): boolean {
 
 function hasUnresolvedExternalMention(text: string): boolean {
   if (!UNRESOLVED_EXTERNAL_RE.test(text)) return false;
-  if (NEGATED_WAITING_OR_PENDING_RE.test(text)) return false;
-  if (CLEARED_WAITING_OR_PENDING_RE.test(text)) return false;
+  if (NEGATED_EXTERNAL_STATUS_RE.test(text)) return false;
+  if (CLEARED_EXTERNAL_STATUS_RE.test(text)) return false;
   return true;
 }
 

--- a/extensions/memory-hybrid/services/pre-finalization-guard.ts
+++ b/extensions/memory-hybrid/services/pre-finalization-guard.ts
@@ -18,7 +18,7 @@ export class PreFinalizationGuardBlockingError extends Error {
 }
 
 const WAITING_OR_PENDING_RE =
-  /\b(wait(?:ing)?|pending|recheck|check back|continue (?:later|after|tomorrow)|follow up(?: later)?|await(?:ing)?)\b/i;
+  /\b(waiting\s+(?:for|on|to)|still\s+waiting|pending|recheck|check back|continue (?:later|after|tomorrow)|follow up(?: later)?|awaiting)\b/i;
 const CRON_WAKE_RE =
   /\b(?:cron wake|scheduled?\s+(?:a\s+)?(?:wake|wake-?up|recheck)|wake(?:\s|-)?at|resume(?:\s+at|\s+on)|next\s+(?:wake|check))\b/i;
 const BACKGROUND_TEXT_RE =

--- a/extensions/memory-hybrid/services/pre-finalization-guard.ts
+++ b/extensions/memory-hybrid/services/pre-finalization-guard.ts
@@ -24,9 +24,11 @@ const NEGATED_WAITING_OR_PENDING_RE =
 const CLEARED_WAITING_OR_PENDING_RE =
   /\b(?:pending|waiting|awaiting)\b[\s\S]{0,24}\b(?:cleared|resolved|finished|complete|completed|done|over)\b/i;
 const NEGATED_EXTERNAL_STATUS_RE =
-  /\b(?:no longer|not|nothing|without|never)\b[\s\S]{0,24}\b(?:pending|running|in progress|queued|awaiting|blocked)\b/i;
+  /\b(?:no longer|not|nothing|without|never)\b[\s\S]{0,32}\b(?:pending|running|still running|in progress|queued|awaiting|blocked)\b/i;
 const CLEARED_EXTERNAL_STATUS_RE =
-  /\b(?:pending|running|in progress|queued|awaiting|blocked)\b[\s\S]{0,24}\b(?:cleared|resolved|finished|complete|completed|done|over)\b/i;
+  /\b(?:pending|running|still running|in progress|queued|awaiting|blocked)\b[\s\S]{0,32}\b(?:cleared|resolved|finished|complete|completed|done|over|stopped|succeeded)\b/i;
+const EXTERNAL_STATUS_FINISHED_RE =
+  /\b(?:finished|complete(?:d)?|done|resolved|cleared|stopped|succeeded)\b[\s\S]{0,24}\b(?:running|still running|pending|queued|awaiting|blocked|in progress)\b/i;
 const CRON_WAKE_RE =
   /\b(?:cron wake|scheduled?\s+(?:a\s+)?(?:wake|wake-?up|recheck)|wake(?:\s|-)?at|resume(?:\s+at|\s+on)|next\s+(?:wake|check))\b/i;
 const BACKGROUND_TEXT_RE =
@@ -64,6 +66,11 @@ interface ToolCallSnapshot {
   name: string;
   rawArguments: string;
   parsedArgs: Record<string, unknown> | null;
+}
+
+interface GoalAssessEvidence {
+  called: boolean;
+  assessedGoalIds: Set<string>;
 }
 
 interface ProjectCheckpointEvaluation {
@@ -166,10 +173,11 @@ function collectToolCalls(messages: unknown[]): ToolCallSnapshot[] {
       for (const block of content) {
         if (!block || typeof block !== "object") continue;
         const b = block as Record<string, unknown>;
-        if (b.type !== "tool_use") continue;
-        const name = b.name;
+        const blockType = typeof b.type === "string" ? b.type : "";
+        if (blockType !== "tool_use" && blockType !== "toolCall") continue;
+        const name = typeof b.name === "string" ? b.name : typeof b.toolName === "string" ? b.toolName : null;
         if (typeof name !== "string" || !name.trim()) continue;
-        const input = b.input;
+        const input = b.input ?? b.arguments;
         let rawArguments = "";
         let parsedArgs: Record<string, unknown> | null = null;
         if (typeof input === "string") {
@@ -255,6 +263,30 @@ function extractCommandCandidates(call: ToolCallSnapshot): string[] {
   return candidates;
 }
 
+function normalizeGoalId(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim().toLowerCase();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function collectGoalAssessEvidence(toolCalls: ToolCallSnapshot[]): GoalAssessEvidence {
+  const assessedGoalIds = new Set<string>();
+  let called = false;
+  for (const call of toolCalls) {
+    if (call.name.toLowerCase() !== "goal_assess") continue;
+    called = true;
+    const parsedId =
+      normalizeGoalId(call.parsedArgs?.goal_id) ??
+      normalizeGoalId(call.parsedArgs?.goalId) ??
+      normalizeGoalId(call.parsedArgs?.related_goal) ??
+      normalizeGoalId(call.parsedArgs?.goal);
+    if (parsedId) {
+      assessedGoalIds.add(parsedId);
+    }
+  }
+  return { called, assessedGoalIds };
+}
+
 function hasAffirmativeWaitingOrPending(text: string): boolean {
   if (!WAITING_OR_PENDING_RE.test(text)) return false;
   if (NEGATED_WAITING_OR_PENDING_RE.test(text)) return false;
@@ -266,6 +298,7 @@ function hasUnresolvedExternalMention(text: string): boolean {
   if (!UNRESOLVED_EXTERNAL_RE.test(text)) return false;
   if (NEGATED_EXTERNAL_STATUS_RE.test(text)) return false;
   if (CLEARED_EXTERNAL_STATUS_RE.test(text)) return false;
+  if (EXTERNAL_STATUS_FINISHED_RE.test(text)) return false;
   return true;
 }
 
@@ -301,7 +334,7 @@ function evaluateProjectCheckpoint(
   projectFacts: MemoryEntry[],
   nowMs: number,
   taskUpdatedFreshnessMs: number,
-  goalAssessCalled: boolean,
+  goalAssess: GoalAssessEvidence,
   currentSessionKey?: string,
 ): ProjectCheckpointEvaluation {
   if (projectFacts.length === 0) return { satisfied: false, missingFields: ["status"] };
@@ -338,7 +371,17 @@ function evaluateProjectCheckpoint(
     if (!updatedFresh) missingFields.push("task_updated");
     if (!relatedSessionMatches) missingFields.push("related_session");
     if (!wakeLinked) missingFields.push("wake_link");
-    if (relatedGoal && !goalAssessCalled) missingFields.push("goal_assess");
+    const normalizedRelatedGoal = relatedGoal.trim().toLowerCase();
+    if (normalizedRelatedGoal) {
+      if (!goalAssess.called) {
+        missingFields.push("goal_assess");
+      } else if (
+        goalAssess.assessedGoalIds.size > 0 &&
+        !goalAssess.assessedGoalIds.has(normalizedRelatedGoal)
+      ) {
+        missingFields.push("goal_assess");
+      }
+    }
 
     if (missingFields.length === 0) {
       return { satisfied: true, candidateEntity: entity, missingFields: [] };
@@ -368,10 +411,11 @@ function extractBypassReason(text: string): string | null {
   return reason.length >= 3 && reason.length <= 160 ? reason : null;
 }
 
-function detectSignals(finalAssistantText: string, toolCalls: ToolCallSnapshot[]): PreFinalizationGuardSignals {
+function detectSignals(assistantTexts: string[], toolCalls: ToolCallSnapshot[]): PreFinalizationGuardSignals {
+  const fullAssistantText = assistantTexts.join("\n");
   let gitOrGithubMutation = false;
-  let backgroundProcessRunning = BACKGROUND_TEXT_RE.test(finalAssistantText);
-  let cronWakeScheduled = CRON_WAKE_RE.test(finalAssistantText);
+  let backgroundProcessRunning = BACKGROUND_TEXT_RE.test(fullAssistantText);
+  let cronWakeScheduled = CRON_WAKE_RE.test(fullAssistantText);
 
   for (const call of toolCalls) {
     const commands = extractCommandCandidates(call);
@@ -393,11 +437,11 @@ function detectSignals(finalAssistantText: string, toolCalls: ToolCallSnapshot[]
   }
 
   return {
-    waitingOrPending: hasAffirmativeWaitingOrPending(finalAssistantText),
+    waitingOrPending: assistantTexts.some((text) => hasAffirmativeWaitingOrPending(text)),
     cronWakeScheduled,
     backgroundProcessRunning,
     gitOrGithubMutation,
-    unresolvedExternalMention: hasUnresolvedExternalMention(finalAssistantText),
+    unresolvedExternalMention: assistantTexts.some((text) => hasUnresolvedExternalMention(text)),
   };
 }
 
@@ -414,8 +458,8 @@ export function evaluatePreFinalizationGuard(
   const bypassReason = extractBypassReason(finalAssistantText);
 
   const activeTaskCheckpointCalled = toolCalls.some((c) => c.name.toLowerCase() === "active_task_checkpoint");
-  const goalAssessCalled = toolCalls.some((c) => c.name.toLowerCase() === "goal_assess");
-  const signals = detectSignals(finalAssistantText, toolCalls);
+  const goalAssess = collectGoalAssessEvidence(toolCalls);
+  const signals = detectSignals(assistantTexts, toolCalls);
   const strongSignals =
     signals.waitingOrPending ||
     signals.cronWakeScheduled ||
@@ -431,7 +475,7 @@ export function evaluatePreFinalizationGuard(
       signals,
       checkpoint: {
         activeTaskCheckpointCalled,
-        goalAssessCalled,
+        goalAssessCalled: goalAssess.called,
         projectFactsSatisfied: false,
         missingFields: [],
       },
@@ -444,7 +488,7 @@ export function evaluatePreFinalizationGuard(
     allProjectFacts,
     nowMs,
     taskUpdatedFreshnessMs,
-    goalAssessCalled,
+    goalAssess,
     options.sessionKey,
   );
   const checkpointSatisfied = activeTaskCheckpointCalled || projectCheckpoint.satisfied;
@@ -456,7 +500,7 @@ export function evaluatePreFinalizationGuard(
       signals,
       checkpoint: {
         activeTaskCheckpointCalled,
-        goalAssessCalled,
+        goalAssessCalled: goalAssess.called,
         projectFactsSatisfied: projectCheckpoint.satisfied,
         projectCheckpointEntity: projectCheckpoint.candidateEntity,
         missingFields: projectCheckpoint.missingFields,
@@ -472,7 +516,7 @@ export function evaluatePreFinalizationGuard(
       signals,
       checkpoint: {
         activeTaskCheckpointCalled,
-        goalAssessCalled,
+        goalAssessCalled: goalAssess.called,
         projectFactsSatisfied: projectCheckpoint.satisfied,
         projectCheckpointEntity: projectCheckpoint.candidateEntity,
         missingFields: projectCheckpoint.missingFields,
@@ -487,7 +531,7 @@ export function evaluatePreFinalizationGuard(
     signals,
     checkpoint: {
       activeTaskCheckpointCalled,
-      goalAssessCalled,
+      goalAssessCalled: goalAssess.called,
       projectFactsSatisfied: false,
       projectCheckpointEntity: projectCheckpoint.candidateEntity,
       missingFields: projectCheckpoint.missingFields,

--- a/extensions/memory-hybrid/services/pre-finalization-guard.ts
+++ b/extensions/memory-hybrid/services/pre-finalization-guard.ts
@@ -10,6 +10,13 @@
 import type { MemoryEntry } from "../types/memory.js";
 import { TASK_LEDGER_CATEGORY, groupProjectFactsByEntity } from "./task-ledger-facts.js";
 
+export class PreFinalizationGuardBlockingError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "PreFinalizationGuardBlockingError";
+  }
+}
+
 const WAITING_OR_PENDING_RE =
   /\b(wait(?:ing)?|pending|recheck|check back|continue (?:later|after|tomorrow)|follow up(?: later)?|await(?:ing)?)\b/i;
 const CRON_WAKE_RE =

--- a/extensions/memory-hybrid/services/pre-finalization-guard.ts
+++ b/extensions/memory-hybrid/services/pre-finalization-guard.ts
@@ -18,7 +18,7 @@ export class PreFinalizationGuardBlockingError extends Error {
 }
 
 const WAITING_OR_PENDING_RE =
-  /\b(waiting\s+(?:for|on|to)|still\s+waiting|pending|recheck|check back|continue (?:later|after|tomorrow)|follow up(?: later)?|awaiting)\b/i;
+  /\b(waiting\s+(?:for|on|to)|still\s+waiting|pending|will\s+recheck|recheck\s+(?:later|tomorrow|again|soon|after|in|at|once)|check back(?:\s+(?:later|tomorrow|soon|after|in|at|once))?|continue (?:later|after|tomorrow)|follow up(?: later)?|awaiting)\b/i;
 const NEGATED_WAITING_OR_PENDING_RE =
   /\b(?:no longer|not|nothing|without|never)\b[\s\S]{0,24}\b(?:pending|waiting|awaiting)\b/i;
 const CLEARED_WAITING_OR_PENDING_RE =

--- a/extensions/memory-hybrid/services/pre-finalization-guard.ts
+++ b/extensions/memory-hybrid/services/pre-finalization-guard.ts
@@ -217,10 +217,12 @@ function collectAssistantTexts(messages: unknown[]): string[] {
 
 function extractCommandCandidates(call: ToolCallSnapshot): string[] {
   const candidates: string[] = [];
-  if (call.rawArguments.trim()) candidates.push(call.rawArguments);
-
+  
   const parsed = call.parsedArgs;
-  if (!parsed) return candidates;
+  if (!parsed) {
+    if (call.rawArguments.trim()) candidates.push(call.rawArguments);
+    return candidates;
+  }
 
   const preferredKeys = ["cmd", "command", "script", "bash", "input", "query", "args"];
   for (const key of preferredKeys) {

--- a/extensions/memory-hybrid/services/pre-finalization-guard.ts
+++ b/extensions/memory-hybrid/services/pre-finalization-guard.ts
@@ -1,0 +1,466 @@
+/**
+ * Pre-finalization guard for unfinished external workflows (#1271).
+ *
+ * Evaluates the current turn right before finalization and decides whether to:
+ * - allow finalization,
+ * - warn (non-blocking), or
+ * - block finalization until checkpoint requirements are met.
+ */
+
+import type { MemoryEntry } from "../types/memory.js";
+import { TASK_LEDGER_CATEGORY, groupProjectFactsByEntity } from "./task-ledger-facts.js";
+
+const WAITING_OR_PENDING_RE =
+  /\b(wait(?:ing)?|pending|recheck|check back|continue (?:later|after|tomorrow)|follow up(?: later)?|await(?:ing)?)\b/i;
+const CRON_WAKE_RE =
+  /\b(?:cron wake|scheduled?\s+(?:a\s+)?(?:wake|wake-?up|recheck)|wake(?:\s|-)?at|resume(?:\s+at|\s+on)|next\s+(?:wake|check))\b/i;
+const BACKGROUND_TEXT_RE =
+  /\b(?:in the background|background process|still running in background|running in the background|daemonized)\b/i;
+const UNRESOLVED_EXTERNAL_RE =
+  /\b(?:ci|checks?|workflow|mergeabilit(?:y|ies)|review|approval|deploy(?:ment)?|job|pipeline)\b[^\n.]{0,80}\b(?:pending|running|in progress|queued|awaiting|blocked|not (?:done|complete)|still running)\b/i;
+const BACKGROUND_COMMAND_RE = /(?:\s&\s*$)|(?:\s&$)|\b(?:nohup|disown|bg|screen\s+-dm|tmux\s+new-session\s+-d)\b/i;
+const GIT_MUTATION_RE =
+  /\bgit\s+(?:add|commit|push|merge|rebase|cherry-pick|revert|tag|branch|switch|checkout|stash|pull|mv|rm|reset\s+--soft)\b/i;
+const GH_MUTATION_RE =
+  /\bgh\s+(?:pr\s+(?:create|merge|ready|review|edit)|issue\s+(?:create|edit)|workflow\s+run|api\s+repos\/[^\s]+\/pulls\/\d+)\b/i;
+
+const WAITING_WAKE_FIELDS = [
+  "wake",
+  "wake_at",
+  "wakeat",
+  "next_wake",
+  "next_check",
+  "next_check_at",
+  "resume_at",
+  "resumeat",
+  "cron_wake",
+  "scheduled_wake",
+  "wake_link",
+] as const;
+
+const ACTIVE_PROJECT_STATUSES = new Set(["in_progress", "waiting", "blocked"]);
+
+export const CHECKPOINT_GUARD_BYPASS_PREFIX = "CHECKPOINT_GUARD_BYPASS:";
+const BYPASS_REASON_RE = /(?:CHECKPOINT_GUARD_BYPASS:|checkpoint[-_ ]guard[-_ ]bypass\s*:)\s*([^\n]{3,160})/i;
+
+const DEFAULT_TASK_UPDATED_FRESHNESS_MS = 2 * 60 * 60 * 1000;
+
+interface ToolCallSnapshot {
+  name: string;
+  rawArguments: string;
+  parsedArgs: Record<string, unknown> | null;
+}
+
+interface ProjectCheckpointEvaluation {
+  satisfied: boolean;
+  candidateEntity?: string;
+  missingFields: string[];
+}
+
+export interface PreFinalizationGuardSignals {
+  waitingOrPending: boolean;
+  cronWakeScheduled: boolean;
+  backgroundProcessRunning: boolean;
+  gitOrGithubMutation: boolean;
+  unresolvedExternalMention: boolean;
+}
+
+export interface PreFinalizationGuardCheckpointEvidence {
+  activeTaskCheckpointCalled: boolean;
+  goalAssessCalled: boolean;
+  projectFactsSatisfied: boolean;
+  projectCheckpointEntity?: string;
+  missingFields: string[];
+}
+
+export interface PreFinalizationGuardResult {
+  action: "allow" | "warn" | "block";
+  reason:
+    | "no_external_signal"
+    | "checkpoint_present"
+    | "explicit_bypass"
+    | "missing_checkpoint_block"
+    | "missing_checkpoint_warn";
+  signals: PreFinalizationGuardSignals;
+  checkpoint: PreFinalizationGuardCheckpointEvidence;
+  bypassReason: string | null;
+}
+
+export interface EvaluatePreFinalizationGuardOptions {
+  projectFacts?: MemoryEntry[];
+  nowMs?: number;
+  taskUpdatedFreshnessMs?: number;
+}
+
+function extractTextBlocks(content: unknown): string[] {
+  if (typeof content === "string") {
+    return content.trim() ? [content] : [];
+  }
+  if (!Array.isArray(content)) return [];
+  const texts: string[] = [];
+  for (const block of content) {
+    if (!block || typeof block !== "object") continue;
+    const b = block as Record<string, unknown>;
+    if (b.type === "text" && typeof b.text === "string" && b.text.trim()) {
+      texts.push(b.text);
+    }
+  }
+  return texts;
+}
+
+function parseJsonRecord(raw: string): Record<string, unknown> | null {
+  if (!raw.trim()) return null;
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+    return parsed as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+function collectToolCalls(messages: unknown[]): ToolCallSnapshot[] {
+  const out: ToolCallSnapshot[] = [];
+
+  for (const msg of messages) {
+    if (!msg || typeof msg !== "object") continue;
+    const m = msg as Record<string, unknown>;
+    if (m.role !== "assistant") continue;
+
+    const toolCalls = m.tool_calls;
+    if (Array.isArray(toolCalls)) {
+      for (const tc of toolCalls) {
+        if (!tc || typeof tc !== "object") continue;
+        const fn = (tc as { function?: unknown }).function;
+        if (!fn || typeof fn !== "object") continue;
+        const name = (fn as { name?: unknown }).name;
+        if (typeof name !== "string" || !name.trim()) continue;
+        const argsRaw = (fn as { arguments?: unknown }).arguments;
+        const rawArguments = typeof argsRaw === "string" ? argsRaw : "";
+        out.push({
+          name: name.trim(),
+          rawArguments,
+          parsedArgs: parseJsonRecord(rawArguments),
+        });
+      }
+    }
+
+    const content = m.content;
+    if (Array.isArray(content)) {
+      for (const block of content) {
+        if (!block || typeof block !== "object") continue;
+        const b = block as Record<string, unknown>;
+        if (b.type !== "tool_use") continue;
+        const name = b.name;
+        if (typeof name !== "string" || !name.trim()) continue;
+        const input = b.input;
+        let rawArguments = "";
+        let parsedArgs: Record<string, unknown> | null = null;
+        if (typeof input === "string") {
+          rawArguments = input;
+          parsedArgs = parseJsonRecord(input);
+        } else if (input && typeof input === "object" && !Array.isArray(input)) {
+          parsedArgs = input as Record<string, unknown>;
+          try {
+            rawArguments = JSON.stringify(input);
+          } catch {
+            rawArguments = "";
+          }
+        }
+        out.push({ name: name.trim(), rawArguments, parsedArgs });
+      }
+    }
+
+    const legacyToolCalls = m.toolCalls;
+    if (Array.isArray(legacyToolCalls)) {
+      for (const name of legacyToolCalls) {
+        if (typeof name !== "string" || !name.trim()) continue;
+        out.push({ name: name.trim(), rawArguments: "", parsedArgs: null });
+      }
+    }
+  }
+
+  return out;
+}
+
+function currentTurnSlice(messages: unknown[]): unknown[] {
+  let lastUserIndex = -1;
+  for (let i = 0; i < messages.length; i++) {
+    const msg = messages[i];
+    if (!msg || typeof msg !== "object") continue;
+    const role = (msg as { role?: unknown }).role;
+    if (role === "user") {
+      lastUserIndex = i;
+    }
+  }
+  if (lastUserIndex < 0) return messages;
+  return messages.slice(lastUserIndex);
+}
+
+function collectAssistantTexts(messages: unknown[]): string[] {
+  const texts: string[] = [];
+  for (const msg of messages) {
+    if (!msg || typeof msg !== "object") continue;
+    const m = msg as Record<string, unknown>;
+    if (m.role !== "assistant") continue;
+    texts.push(...extractTextBlocks(m.content));
+  }
+  return texts;
+}
+
+function extractCommandCandidates(call: ToolCallSnapshot): string[] {
+  const candidates: string[] = [];
+  if (call.rawArguments.trim()) candidates.push(call.rawArguments);
+
+  const parsed = call.parsedArgs;
+  if (!parsed) return candidates;
+
+  const preferredKeys = ["cmd", "command", "script", "bash", "input", "query", "args"];
+  for (const key of preferredKeys) {
+    const v = parsed[key];
+    if (typeof v === "string" && v.trim()) {
+      candidates.push(v);
+    }
+  }
+
+  for (const value of Object.values(parsed)) {
+    if (typeof value === "string" && value.trim()) {
+      candidates.push(value);
+    }
+  }
+
+  return candidates;
+}
+
+function normalizeProjectStatus(raw: string | undefined): string | null {
+  if (!raw?.trim()) return null;
+  const s = raw.trim().toLowerCase();
+  if (s === "open" || s === "in progress" || s === "in_progress") return "in_progress";
+  if (s === "pending" || s === "waiting") return "waiting";
+  if (s === "blocked" || s === "stalled" || s.startsWith("blocked")) return "blocked";
+  return null;
+}
+
+function chooseLatestText(entry: MemoryEntry | undefined): string {
+  if (!entry) return "";
+  return (entry.value ?? entry.text ?? "").trim();
+}
+
+function evaluateProjectCheckpoint(
+  projectFacts: MemoryEntry[],
+  nowMs: number,
+  taskUpdatedFreshnessMs: number,
+  goalAssessCalled: boolean,
+  cronWakeScheduled: boolean,
+): ProjectCheckpointEvaluation {
+  if (projectFacts.length === 0) return { satisfied: false, missingFields: ["status"] };
+
+  const grouped = groupProjectFactsByEntity(projectFacts);
+  let bestUnsatisfied: { entity: string; updatedMs: number; missingFields: string[] } | null = null;
+
+  for (const [entity, keyMap] of grouped.entries()) {
+    const status = normalizeProjectStatus(chooseLatestText(keyMap.get("status")));
+    if (!status || !ACTIVE_PROJECT_STATUSES.has(status)) continue;
+
+    const next = chooseLatestText(keyMap.get("next"));
+    const relatedSession = chooseLatestText(keyMap.get("related_session"));
+    const relatedGoal = chooseLatestText(keyMap.get("related_goal")) || chooseLatestText(keyMap.get("goal_id"));
+    const updatedRaw =
+      chooseLatestText(keyMap.get("task_updated")) ||
+      chooseLatestText(keyMap.get("updated")) ||
+      chooseLatestText(keyMap.get("updated_at"));
+    const updatedMs = updatedRaw ? Date.parse(updatedRaw) : Number.NaN;
+    const updatedFresh = Number.isFinite(updatedMs) && nowMs - updatedMs <= taskUpdatedFreshnessMs;
+
+    const wakeLinked =
+      status !== "waiting" ||
+      cronWakeScheduled ||
+      WAITING_WAKE_FIELDS.some((k) => {
+        const raw = chooseLatestText(keyMap.get(k));
+        return raw.length > 0;
+      });
+
+    const missingFields: string[] = [];
+    if (!next) missingFields.push("next");
+    if (!updatedFresh) missingFields.push("task_updated");
+    if (!relatedSession) missingFields.push("related_session");
+    if (!wakeLinked) missingFields.push("wake_link");
+    if (relatedGoal && !goalAssessCalled) missingFields.push("goal_assess");
+
+    if (missingFields.length === 0) {
+      return { satisfied: true, candidateEntity: entity, missingFields: [] };
+    }
+
+    const rankMs = Number.isFinite(updatedMs) ? updatedMs : 0;
+    if (!bestUnsatisfied || rankMs > bestUnsatisfied.updatedMs) {
+      bestUnsatisfied = { entity, updatedMs: rankMs, missingFields };
+    }
+  }
+
+  if (bestUnsatisfied) {
+    return {
+      satisfied: false,
+      candidateEntity: bestUnsatisfied.entity,
+      missingFields: bestUnsatisfied.missingFields,
+    };
+  }
+
+  return { satisfied: false, missingFields: ["status"] };
+}
+
+function extractBypassReason(text: string): string | null {
+  const match = text.match(BYPASS_REASON_RE);
+  if (!match) return null;
+  const reason = match[1]?.trim() ?? "";
+  return reason.length >= 3 && reason.length <= 160 ? reason : null;
+}
+
+function detectSignals(finalAssistantText: string, toolCalls: ToolCallSnapshot[]): PreFinalizationGuardSignals {
+  let gitOrGithubMutation = false;
+  let backgroundProcessRunning = BACKGROUND_TEXT_RE.test(finalAssistantText);
+  let cronWakeScheduled = CRON_WAKE_RE.test(finalAssistantText);
+
+  for (const call of toolCalls) {
+    const commands = extractCommandCandidates(call);
+    const nameLower = call.name.toLowerCase();
+    if (nameLower.includes("active_task_checkpoint")) {
+      continue;
+    }
+    for (const cmd of commands) {
+      if (GIT_MUTATION_RE.test(cmd) || GH_MUTATION_RE.test(cmd)) {
+        gitOrGithubMutation = true;
+      }
+      if (BACKGROUND_COMMAND_RE.test(cmd)) {
+        backgroundProcessRunning = true;
+      }
+      if (CRON_WAKE_RE.test(cmd)) {
+        cronWakeScheduled = true;
+      }
+    }
+  }
+
+  return {
+    waitingOrPending: WAITING_OR_PENDING_RE.test(finalAssistantText),
+    cronWakeScheduled,
+    backgroundProcessRunning,
+    gitOrGithubMutation,
+    unresolvedExternalMention: UNRESOLVED_EXTERNAL_RE.test(finalAssistantText),
+  };
+}
+
+export function evaluatePreFinalizationGuard(
+  messages: unknown[],
+  options: EvaluatePreFinalizationGuardOptions = {},
+): PreFinalizationGuardResult {
+  const nowMs = options.nowMs ?? Date.now();
+  const taskUpdatedFreshnessMs = options.taskUpdatedFreshnessMs ?? DEFAULT_TASK_UPDATED_FRESHNESS_MS;
+  const turnMessages = currentTurnSlice(messages);
+  const assistantTexts = collectAssistantTexts(turnMessages);
+  const finalAssistantText = assistantTexts[assistantTexts.length - 1] ?? "";
+  const toolCalls = collectToolCalls(turnMessages);
+  const bypassReason = extractBypassReason(finalAssistantText);
+
+  const activeTaskCheckpointCalled = toolCalls.some((c) => c.name.toLowerCase() === "active_task_checkpoint");
+  const goalAssessCalled = toolCalls.some((c) => c.name.toLowerCase() === "goal_assess");
+  const signals = detectSignals(finalAssistantText, toolCalls);
+  const strongSignals =
+    signals.waitingOrPending ||
+    signals.cronWakeScheduled ||
+    signals.backgroundProcessRunning ||
+    signals.unresolvedExternalMention;
+  const weakSignals = signals.gitOrGithubMutation;
+  const shouldGuard = strongSignals || weakSignals;
+
+  if (!shouldGuard) {
+    return {
+      action: "allow",
+      reason: "no_external_signal",
+      signals,
+      checkpoint: {
+        activeTaskCheckpointCalled,
+        goalAssessCalled,
+        projectFactsSatisfied: false,
+        missingFields: [],
+      },
+      bypassReason: null,
+    };
+  }
+
+  const allProjectFacts = (options.projectFacts ?? []).filter((f) => f.category === TASK_LEDGER_CATEGORY);
+  const projectCheckpoint = evaluateProjectCheckpoint(
+    allProjectFacts,
+    nowMs,
+    taskUpdatedFreshnessMs,
+    goalAssessCalled,
+    signals.cronWakeScheduled,
+  );
+  const checkpointSatisfied = activeTaskCheckpointCalled || projectCheckpoint.satisfied;
+
+  if (bypassReason) {
+    return {
+      action: "allow",
+      reason: "explicit_bypass",
+      signals,
+      checkpoint: {
+        activeTaskCheckpointCalled,
+        goalAssessCalled,
+        projectFactsSatisfied: projectCheckpoint.satisfied,
+        projectCheckpointEntity: projectCheckpoint.candidateEntity,
+        missingFields: projectCheckpoint.missingFields,
+      },
+      bypassReason,
+    };
+  }
+
+  if (checkpointSatisfied) {
+    return {
+      action: "allow",
+      reason: "checkpoint_present",
+      signals,
+      checkpoint: {
+        activeTaskCheckpointCalled,
+        goalAssessCalled,
+        projectFactsSatisfied: projectCheckpoint.satisfied,
+        projectCheckpointEntity: projectCheckpoint.candidateEntity,
+        missingFields: projectCheckpoint.missingFields,
+      },
+      bypassReason: null,
+    };
+  }
+
+  return {
+    action: strongSignals ? "block" : "warn",
+    reason: strongSignals ? "missing_checkpoint_block" : "missing_checkpoint_warn",
+    signals,
+    checkpoint: {
+      activeTaskCheckpointCalled,
+      goalAssessCalled,
+      projectFactsSatisfied: false,
+      projectCheckpointEntity: projectCheckpoint.candidateEntity,
+      missingFields: projectCheckpoint.missingFields,
+    },
+    bypassReason: null,
+  };
+}
+
+export function formatPreFinalizationGuardMessage(result: PreFinalizationGuardResult): string {
+  if (result.reason === "no_external_signal") {
+    return "pre-finalization guard: no unfinished external-workflow signals detected.";
+  }
+  if (result.reason === "checkpoint_present") {
+    const source = result.checkpoint.activeTaskCheckpointCalled ? "active_task_checkpoint tool call" : "project facts";
+    return `pre-finalization guard: checkpoint satisfied via ${source}.`;
+  }
+  if (result.reason === "explicit_bypass") {
+    return `pre-finalization guard: bypass accepted (${result.bypassReason ?? "no reason"}).`;
+  }
+
+  const missing =
+    result.checkpoint.missingFields.length > 0 ? result.checkpoint.missingFields.join(", ") : "project checkpoint";
+  const mode = result.action === "block" ? "blocking" : "warning";
+  return [
+    `pre-finalization guard: ${mode} finalization due to unfinished external workflow and missing checkpoint fields: ${missing}.`,
+    "Satisfy with active_task_checkpoint (if available) or project facts keys [status(in_progress|waiting|blocked), next, task_updated, related_session].",
+    `False positive override: include '${CHECKPOINT_GUARD_BYPASS_PREFIX} <short reason>' in the final assistant message.`,
+  ].join(" ");
+}

--- a/extensions/memory-hybrid/services/pre-finalization-guard.ts
+++ b/extensions/memory-hybrid/services/pre-finalization-guard.ts
@@ -19,6 +19,10 @@ export class PreFinalizationGuardBlockingError extends Error {
 
 const WAITING_OR_PENDING_RE =
   /\b(waiting\s+(?:for|on|to)|still\s+waiting|pending|recheck|check back|continue (?:later|after|tomorrow)|follow up(?: later)?|awaiting)\b/i;
+const NEGATED_WAITING_OR_PENDING_RE =
+  /\b(?:no longer|not|nothing|without|never)\b[\s\S]{0,24}\b(?:pending|waiting|awaiting)\b/i;
+const CLEARED_WAITING_OR_PENDING_RE =
+  /\b(?:pending|waiting|awaiting)\b[\s\S]{0,24}\b(?:cleared|resolved|finished|complete|completed|done|over)\b/i;
 const CRON_WAKE_RE =
   /\b(?:cron wake|scheduled?\s+(?:a\s+)?(?:wake|wake-?up|recheck)|wake(?:\s|-)?at|resume(?:\s+at|\s+on)|next\s+(?:wake|check))\b/i;
 const BACKGROUND_TEXT_RE =
@@ -97,6 +101,7 @@ export interface EvaluatePreFinalizationGuardOptions {
   projectFacts?: MemoryEntry[];
   nowMs?: number;
   taskUpdatedFreshnessMs?: number;
+  sessionKey?: string;
 }
 
 function extractTextBlocks(content: unknown): string[] {
@@ -215,28 +220,62 @@ function collectAssistantTexts(messages: unknown[]): string[] {
   return texts;
 }
 
+function isCommandExecutionTool(name: string): boolean {
+  return /\b(exec|bash|shell|terminal|command|script|run[_-]?command|subprocess|spawn|process)\b/i.test(name);
+}
+
 function extractCommandCandidates(call: ToolCallSnapshot): string[] {
   const candidates: string[] = [];
-  if (call.rawArguments.trim()) candidates.push(call.rawArguments);
+  if (isCommandExecutionTool(call.name) && call.rawArguments.trim()) candidates.push(call.rawArguments);
 
   const parsed = call.parsedArgs;
   if (!parsed) return candidates;
 
-  const preferredKeys = ["cmd", "command", "script", "bash", "input", "query", "args"];
+  const preferredKeys = ["cmd", "command", "script", "bash", "args"];
   for (const key of preferredKeys) {
     const v = parsed[key];
     if (typeof v === "string" && v.trim()) {
       candidates.push(v);
+      continue;
     }
-  }
-
-  for (const value of Object.values(parsed)) {
-    if (typeof value === "string" && value.trim()) {
-      candidates.push(value);
+    if (key === "args" && Array.isArray(v)) {
+      for (const item of v) {
+        if (typeof item === "string" && item.trim()) {
+          candidates.push(item);
+        }
+      }
     }
   }
 
   return candidates;
+}
+
+function hasAffirmativeWaitingOrPending(text: string): boolean {
+  if (!WAITING_OR_PENDING_RE.test(text)) return false;
+  if (NEGATED_WAITING_OR_PENDING_RE.test(text)) return false;
+  if (CLEARED_WAITING_OR_PENDING_RE.test(text)) return false;
+  return true;
+}
+
+function hasUnresolvedExternalMention(text: string): boolean {
+  if (!UNRESOLVED_EXTERNAL_RE.test(text)) return false;
+  if (NEGATED_WAITING_OR_PENDING_RE.test(text)) return false;
+  if (CLEARED_WAITING_OR_PENDING_RE.test(text)) return false;
+  return true;
+}
+
+function normalizeSessionRef(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function sessionRefMatches(relatedSession: string, currentSession: string): boolean {
+  const related = normalizeSessionRef(relatedSession);
+  const current = normalizeSessionRef(currentSession);
+  if (!related || !current) return false;
+  if (related === current) return true;
+  if ((related === "main" || related === "private") && current.startsWith(`agent:${related}:`)) return true;
+  if ((current === "main" || current === "private") && related.startsWith(`agent:${current}:`)) return true;
+  return false;
 }
 
 function normalizeProjectStatus(raw: string | undefined): string | null {
@@ -258,7 +297,7 @@ function evaluateProjectCheckpoint(
   nowMs: number,
   taskUpdatedFreshnessMs: number,
   goalAssessCalled: boolean,
-  cronWakeScheduled: boolean,
+  currentSessionKey?: string,
 ): ProjectCheckpointEvaluation {
   if (projectFacts.length === 0) return { satisfied: false, missingFields: ["status"] };
 
@@ -281,16 +320,18 @@ function evaluateProjectCheckpoint(
 
     const wakeLinked =
       status !== "waiting" ||
-      cronWakeScheduled ||
       WAITING_WAKE_FIELDS.some((k) => {
         const raw = chooseLatestText(keyMap.get(k));
         return raw.length > 0;
       });
+    const relatedSessionMatches = currentSessionKey
+      ? sessionRefMatches(relatedSession, currentSessionKey)
+      : relatedSession.length > 0;
 
     const missingFields: string[] = [];
     if (!next) missingFields.push("next");
     if (!updatedFresh) missingFields.push("task_updated");
-    if (!relatedSession) missingFields.push("related_session");
+    if (!relatedSessionMatches) missingFields.push("related_session");
     if (!wakeLinked) missingFields.push("wake_link");
     if (relatedGoal && !goalAssessCalled) missingFields.push("goal_assess");
 
@@ -347,11 +388,11 @@ function detectSignals(finalAssistantText: string, toolCalls: ToolCallSnapshot[]
   }
 
   return {
-    waitingOrPending: WAITING_OR_PENDING_RE.test(finalAssistantText),
+    waitingOrPending: hasAffirmativeWaitingOrPending(finalAssistantText),
     cronWakeScheduled,
     backgroundProcessRunning,
     gitOrGithubMutation,
-    unresolvedExternalMention: UNRESOLVED_EXTERNAL_RE.test(finalAssistantText),
+    unresolvedExternalMention: hasUnresolvedExternalMention(finalAssistantText),
   };
 }
 
@@ -399,7 +440,7 @@ export function evaluatePreFinalizationGuard(
     nowMs,
     taskUpdatedFreshnessMs,
     goalAssessCalled,
-    signals.cronWakeScheduled,
+    options.sessionKey,
   );
   const checkpointSatisfied = activeTaskCheckpointCalled || projectCheckpoint.satisfied;
 
@@ -465,9 +506,17 @@ export function formatPreFinalizationGuardMessage(result: PreFinalizationGuardRe
   const missing =
     result.checkpoint.missingFields.length > 0 ? result.checkpoint.missingFields.join(", ") : "project checkpoint";
   const mode = result.action === "block" ? "blocking" : "warning";
+  const conditionalHints: string[] = [];
+  if (result.checkpoint.missingFields.includes("wake_link")) {
+    conditionalHints.push("For waiting tasks, persist a wake field in project facts (e.g. wake_link/wake_at/resume_at).");
+  }
+  if (result.checkpoint.missingFields.includes("goal_assess")) {
+    conditionalHints.push("If the task is goal-backed (related_goal/goal_id), call goal_assess in this turn.");
+  }
   return [
     `pre-finalization guard: ${mode} finalization due to unfinished external workflow and missing checkpoint fields: ${missing}.`,
     "Satisfy with active_task_checkpoint (if available) or project facts keys [status(in_progress|waiting|blocked), next, task_updated, related_session].",
+    ...conditionalHints,
     `False positive override: include '${CHECKPOINT_GUARD_BYPASS_PREFIX} <short reason>' in the final assistant message.`,
   ].join(" ");
 }

--- a/extensions/memory-hybrid/tests/pre-finalization-guard.test.ts
+++ b/extensions/memory-hybrid/tests/pre-finalization-guard.test.ts
@@ -1,8 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-  CHECKPOINT_GUARD_BYPASS_PREFIX,
-  evaluatePreFinalizationGuard,
-} from "../services/pre-finalization-guard.js";
+import { CHECKPOINT_GUARD_BYPASS_PREFIX, evaluatePreFinalizationGuard } from "../services/pre-finalization-guard.js";
 import type { MemoryEntry } from "../types/memory.js";
 
 const NOW_ISO = "2026-05-10T08:31:00.000Z";
@@ -119,7 +116,10 @@ describe("pre-finalization guard", () => {
   it("allows explicit bypass with a short reason", () => {
     const messages: unknown[] = [
       { role: "user", content: "Quick status only." },
-      { role: "assistant", content: `CI is still pending. ${CHECKPOINT_GUARD_BYPASS_PREFIX} user requested quick one-off.` },
+      {
+        role: "assistant",
+        content: `CI is still pending. ${CHECKPOINT_GUARD_BYPASS_PREFIX} user requested quick one-off.`,
+      },
     ];
 
     const result = evaluatePreFinalizationGuard(messages, { nowMs: NOW_MS, projectFacts: [] });

--- a/extensions/memory-hybrid/tests/pre-finalization-guard.test.ts
+++ b/extensions/memory-hybrid/tests/pre-finalization-guard.test.ts
@@ -230,6 +230,16 @@ describe("pre-finalization guard", () => {
     expect(result.signals.unresolvedExternalMention).toBe(false);
   });
 
+  it("does not treat past-tense recheck language as pending work", () => {
+    const messages: unknown[] = [
+      { role: "user", content: "Status?" },
+      { role: "assistant", content: "I rechecked CI and it passed; no follow-up needed." },
+    ];
+    const result = evaluatePreFinalizationGuard(messages, { nowMs: NOW_MS, projectFacts: [] });
+    expect(result.signals.waitingOrPending).toBe(false);
+    expect(result.action).toBe("allow");
+  });
+
   it("does not infer command mutations from non-command tool payload text", () => {
     const messages: unknown[] = [
       { role: "user", content: "Assess progress." },

--- a/extensions/memory-hybrid/tests/pre-finalization-guard.test.ts
+++ b/extensions/memory-hybrid/tests/pre-finalization-guard.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from "vitest";
+import {
+  CHECKPOINT_GUARD_BYPASS_PREFIX,
+  evaluatePreFinalizationGuard,
+} from "../services/pre-finalization-guard.js";
+import type { MemoryEntry } from "../types/memory.js";
+
+const NOW_ISO = "2026-05-10T08:31:00.000Z";
+const NOW_MS = Date.parse(NOW_ISO);
+
+function projectFact(params: {
+  id: string;
+  entity: string;
+  key: string;
+  value: string;
+  createdAt?: number;
+}): MemoryEntry {
+  return {
+    id: params.id,
+    text: `Task [${params.entity}] ${params.key}: ${params.value}`,
+    category: "project",
+    importance: 0.7,
+    entity: params.entity,
+    key: params.key,
+    value: params.value,
+    source: "test",
+    createdAt: params.createdAt ?? Math.floor(NOW_MS / 1000),
+    decayClass: "permanent",
+    expiresAt: null,
+    lastConfirmedAt: Math.floor(NOW_MS / 1000),
+    confidence: 1,
+  };
+}
+
+describe("pre-finalization guard", () => {
+  it("blocks CI-wait finalization when checkpoint is missing", () => {
+    const messages: unknown[] = [
+      { role: "user", content: "Push and watch CI." },
+      {
+        role: "assistant",
+        tool_calls: [
+          {
+            function: {
+              name: "exec",
+              arguments: JSON.stringify({ cmd: "git push origin fix/1271-pre-finalization-guard" }),
+            },
+          },
+        ],
+      },
+      {
+        role: "assistant",
+        content: "Branch pushed. CI checks are still pending, I will recheck later.",
+      },
+    ];
+
+    const result = evaluatePreFinalizationGuard(messages, { nowMs: NOW_MS, projectFacts: [] });
+    expect(result.action).toBe("block");
+    expect(result.signals.waitingOrPending).toBe(true);
+    expect(result.signals.unresolvedExternalMention).toBe(true);
+    expect(result.signals.gitOrGithubMutation).toBe(true);
+    expect(result.checkpoint.projectFactsSatisfied).toBe(false);
+  });
+
+  it("blocks when a background process is still running without checkpoint", () => {
+    const messages: unknown[] = [
+      { role: "user", content: "Start tests and report back." },
+      {
+        role: "assistant",
+        content: [{ type: "tool_use", name: "exec", input: { cmd: "npm run test > /tmp/test.log 2>&1 &" } }],
+      },
+      {
+        role: "assistant",
+        content: "I started the test job in the background and it is still running.",
+      },
+    ];
+
+    const result = evaluatePreFinalizationGuard(messages, { nowMs: NOW_MS, projectFacts: [] });
+    expect(result.action).toBe("block");
+    expect(result.signals.backgroundProcessRunning).toBe(true);
+    expect(result.checkpoint.projectFactsSatisfied).toBe(false);
+  });
+
+  it("allows CI-wait when project-fact checkpoint requirements are satisfied", () => {
+    const facts: MemoryEntry[] = [
+      projectFact({ id: "1", entity: "issue-1271-ci", key: "status", value: "waiting" }),
+      projectFact({ id: "2", entity: "issue-1271-ci", key: "next", value: "Recheck CI in 10 minutes." }),
+      projectFact({ id: "3", entity: "issue-1271-ci", key: "task_updated", value: NOW_ISO }),
+      projectFact({ id: "4", entity: "issue-1271-ci", key: "related_session", value: "agent:main:main" }),
+      projectFact({ id: "5", entity: "issue-1271-ci", key: "wake_at", value: "2026-05-10T08:41:00.000Z" }),
+      projectFact({ id: "6", entity: "issue-1271-ci", key: "related_goal", value: "goal-1271" }),
+    ];
+    const messages: unknown[] = [
+      { role: "user", content: "Status?" },
+      {
+        role: "assistant",
+        tool_calls: [
+          {
+            function: {
+              name: "goal_assess",
+              arguments: JSON.stringify({
+                goal_id: "goal-1271",
+                assessment: "CI still pending.",
+                next_action: "Recheck after wake window.",
+              }),
+            },
+          },
+        ],
+      },
+      { role: "assistant", content: "CI is pending; recheck is scheduled." },
+    ];
+
+    const result = evaluatePreFinalizationGuard(messages, { nowMs: NOW_MS, projectFacts: facts });
+    expect(result.action).toBe("allow");
+    expect(result.reason).toBe("checkpoint_present");
+    expect(result.checkpoint.projectFactsSatisfied).toBe(true);
+    expect(result.checkpoint.projectCheckpointEntity).toBe("issue-1271-ci");
+  });
+
+  it("allows explicit bypass with a short reason", () => {
+    const messages: unknown[] = [
+      { role: "user", content: "Quick status only." },
+      { role: "assistant", content: `CI is still pending. ${CHECKPOINT_GUARD_BYPASS_PREFIX} user requested quick one-off.` },
+    ];
+
+    const result = evaluatePreFinalizationGuard(messages, { nowMs: NOW_MS, projectFacts: [] });
+    expect(result.action).toBe("allow");
+    expect(result.reason).toBe("explicit_bypass");
+    expect(result.bypassReason).toContain("quick one-off");
+  });
+
+  it("warns on git/github mutation-only turns without unfinished-wait signals", () => {
+    const messages: unknown[] = [
+      { role: "user", content: "Commit the changes." },
+      {
+        role: "assistant",
+        tool_calls: [
+          {
+            function: {
+              name: "exec",
+              arguments: JSON.stringify({ cmd: "git commit -m 'fix: issue 1271'" }),
+            },
+          },
+        ],
+      },
+      { role: "assistant", content: "Changes committed." },
+    ];
+
+    const result = evaluatePreFinalizationGuard(messages, { nowMs: NOW_MS, projectFacts: [] });
+    expect(result.action).toBe("warn");
+    expect(result.reason).toBe("missing_checkpoint_warn");
+    expect(result.signals.gitOrGithubMutation).toBe(true);
+    expect(result.signals.waitingOrPending).toBe(false);
+  });
+
+  it("allows hypothetical active_task_checkpoint tool as direct satisfaction path", () => {
+    const messages: unknown[] = [
+      { role: "user", content: "Pause and continue later." },
+      {
+        role: "assistant",
+        tool_calls: [
+          {
+            function: {
+              name: "active_task_checkpoint",
+              arguments: JSON.stringify({ label: "issue-1271", status: "waiting", next: "Recheck CI" }),
+            },
+          },
+        ],
+      },
+      { role: "assistant", content: "Still waiting for CI, I will continue later." },
+    ];
+
+    const result = evaluatePreFinalizationGuard(messages, { nowMs: NOW_MS, projectFacts: [] });
+    expect(result.action).toBe("allow");
+    expect(result.reason).toBe("checkpoint_present");
+    expect(result.checkpoint.activeTaskCheckpointCalled).toBe(true);
+  });
+});

--- a/extensions/memory-hybrid/tests/pre-finalization-guard.test.ts
+++ b/extensions/memory-hybrid/tests/pre-finalization-guard.test.ts
@@ -3,6 +3,7 @@ import {
   CHECKPOINT_GUARD_BYPASS_PREFIX,
   evaluatePreFinalizationGuard,
   formatPreFinalizationGuardMessage,
+  type PreFinalizationGuardResult,
 } from "../services/pre-finalization-guard.js";
 import type { MemoryEntry } from "../types/memory.js";
 
@@ -121,6 +122,42 @@ describe("pre-finalization guard", () => {
     expect(result.checkpoint.projectCheckpointEntity).toBe("issue-1271-ci");
   });
 
+  it("requires goal_assess to match the related goal id on active project rows", () => {
+    const facts: MemoryEntry[] = [
+      projectFact({ id: "1", entity: "issue-1271-ci", key: "status", value: "waiting" }),
+      projectFact({ id: "2", entity: "issue-1271-ci", key: "next", value: "Recheck CI in 10 minutes." }),
+      projectFact({ id: "3", entity: "issue-1271-ci", key: "task_updated", value: NOW_ISO }),
+      projectFact({ id: "4", entity: "issue-1271-ci", key: "related_session", value: "agent:main:main" }),
+      projectFact({ id: "5", entity: "issue-1271-ci", key: "wake_at", value: "2026-05-10T08:41:00.000Z" }),
+      projectFact({ id: "6", entity: "issue-1271-ci", key: "related_goal", value: "goal-1271-a" }),
+    ];
+    const messages: unknown[] = [
+      { role: "user", content: "Status?" },
+      {
+        role: "assistant",
+        tool_calls: [
+          {
+            function: {
+              name: "goal_assess",
+              arguments: JSON.stringify({
+                goal_id: "goal-1271-b",
+                assessment: "Different goal was assessed.",
+              }),
+            },
+          },
+        ],
+      },
+      { role: "assistant", content: "CI is pending; recheck is scheduled." },
+    ];
+    const result = evaluatePreFinalizationGuard(messages, {
+      nowMs: NOW_MS,
+      projectFacts: facts,
+      sessionKey: "agent:main:main",
+    });
+    expect(result.action).toBe("block");
+    expect(result.checkpoint.missingFields).toContain("goal_assess");
+  });
+
   it("allows explicit bypass with a short reason", () => {
     const messages: unknown[] = [
       { role: "user", content: "Quick status only." },
@@ -160,6 +197,18 @@ describe("pre-finalization guard", () => {
     expect(result.signals.waitingOrPending).toBe(false);
   });
 
+  it("detects unfinished-work signals from earlier assistant messages in the same turn", () => {
+    const messages: unknown[] = [
+      { role: "user", content: "Status update?" },
+      { role: "assistant", content: "CI is still pending and checks are running." },
+      { role: "assistant", content: "Noted." },
+    ];
+    const result = evaluatePreFinalizationGuard(messages, { nowMs: NOW_MS, projectFacts: [] });
+    expect(result.action).toBe("block");
+    expect(result.signals.waitingOrPending).toBe(true);
+    expect(result.signals.unresolvedExternalMention).toBe(true);
+  });
+
   it("does not treat negated pending/waiting phrases as unfinished workflow signals", () => {
     const messages: unknown[] = [
       { role: "user", content: "Status?" },
@@ -169,6 +218,16 @@ describe("pre-finalization guard", () => {
     expect(result.action).toBe("allow");
     expect(result.reason).toBe("no_external_signal");
     expect(result.signals.waitingOrPending).toBe(false);
+  });
+
+  it("does not treat negated/cleared running phrases as unresolved external signals", () => {
+    const messages: unknown[] = [
+      { role: "user", content: "Status?" },
+      { role: "assistant", content: "CI is no longer running; checks finished running successfully." },
+    ];
+    const result = evaluatePreFinalizationGuard(messages, { nowMs: NOW_MS, projectFacts: [] });
+    expect(result.action).toBe("allow");
+    expect(result.signals.unresolvedExternalMention).toBe(false);
   });
 
   it("does not infer command mutations from non-command tool payload text", () => {
@@ -247,7 +306,7 @@ describe("pre-finalization guard", () => {
   });
 
   it("formats conditional wake/goal requirements in the guard message", () => {
-    const result = {
+    const result: PreFinalizationGuardResult = {
       action: "block",
       reason: "missing_checkpoint_block",
       signals: {
@@ -264,7 +323,7 @@ describe("pre-finalization guard", () => {
         missingFields: ["wake_link", "goal_assess"],
       },
       bypassReason: null,
-    } as const;
+    };
     const message = formatPreFinalizationGuardMessage(result);
     expect(message).toContain("wake");
     expect(message).toContain("goal_assess");
@@ -287,6 +346,27 @@ describe("pre-finalization guard", () => {
       { role: "assistant", content: "Still waiting for CI, I will continue later." },
     ];
 
+    const result = evaluatePreFinalizationGuard(messages, { nowMs: NOW_MS, projectFacts: [] });
+    expect(result.action).toBe("allow");
+    expect(result.reason).toBe("checkpoint_present");
+    expect(result.checkpoint.activeTaskCheckpointCalled).toBe(true);
+  });
+
+  it("detects OpenClaw toolCall content blocks as tool evidence", () => {
+    const messages: unknown[] = [
+      { role: "user", content: "Pause and continue later." },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            name: "active_task_checkpoint",
+            arguments: { entity: "issue-1271", status: "waiting", next: "Recheck CI" },
+          },
+        ],
+      },
+      { role: "assistant", content: "Still waiting for CI, I will continue later." },
+    ];
     const result = evaluatePreFinalizationGuard(messages, { nowMs: NOW_MS, projectFacts: [] });
     expect(result.action).toBe("allow");
     expect(result.reason).toBe("checkpoint_present");

--- a/extensions/memory-hybrid/tests/pre-finalization-guard.test.ts
+++ b/extensions/memory-hybrid/tests/pre-finalization-guard.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { CHECKPOINT_GUARD_BYPASS_PREFIX, evaluatePreFinalizationGuard } from "../services/pre-finalization-guard.js";
+import {
+  CHECKPOINT_GUARD_BYPASS_PREFIX,
+  evaluatePreFinalizationGuard,
+  formatPreFinalizationGuardMessage,
+} from "../services/pre-finalization-guard.js";
 import type { MemoryEntry } from "../types/memory.js";
 
 const NOW_ISO = "2026-05-10T08:31:00.000Z";
@@ -106,7 +110,11 @@ describe("pre-finalization guard", () => {
       { role: "assistant", content: "CI is pending; recheck is scheduled." },
     ];
 
-    const result = evaluatePreFinalizationGuard(messages, { nowMs: NOW_MS, projectFacts: facts });
+    const result = evaluatePreFinalizationGuard(messages, {
+      nowMs: NOW_MS,
+      projectFacts: facts,
+      sessionKey: "agent:main:main",
+    });
     expect(result.action).toBe("allow");
     expect(result.reason).toBe("checkpoint_present");
     expect(result.checkpoint.projectFactsSatisfied).toBe(true);
@@ -150,6 +158,116 @@ describe("pre-finalization guard", () => {
     expect(result.reason).toBe("missing_checkpoint_warn");
     expect(result.signals.gitOrGithubMutation).toBe(true);
     expect(result.signals.waitingOrPending).toBe(false);
+  });
+
+  it("does not treat negated pending/waiting phrases as unfinished workflow signals", () => {
+    const messages: unknown[] = [
+      { role: "user", content: "Status?" },
+      { role: "assistant", content: "CI is no longer pending and nothing is waiting." },
+    ];
+    const result = evaluatePreFinalizationGuard(messages, { nowMs: NOW_MS, projectFacts: [] });
+    expect(result.action).toBe("allow");
+    expect(result.reason).toBe("no_external_signal");
+    expect(result.signals.waitingOrPending).toBe(false);
+  });
+
+  it("does not infer command mutations from non-command tool payload text", () => {
+    const messages: unknown[] = [
+      { role: "user", content: "Assess progress." },
+      {
+        role: "assistant",
+        tool_calls: [
+          {
+            function: {
+              name: "goal_assess",
+              arguments: JSON.stringify({
+                goal_id: "goal-1",
+                assessment: "Need to run git push after CI passes",
+              }),
+            },
+          },
+        ],
+      },
+      { role: "assistant", content: "Assessment captured." },
+    ];
+    const result = evaluatePreFinalizationGuard(messages, { nowMs: NOW_MS, projectFacts: [] });
+    expect(result.signals.gitOrGithubMutation).toBe(false);
+  });
+
+  it("requires waiting wake link to be persisted in facts (cron wording alone is not enough)", () => {
+    const facts: MemoryEntry[] = [
+      projectFact({ id: "1", entity: "issue-1271-ci", key: "status", value: "waiting" }),
+      projectFact({ id: "2", entity: "issue-1271-ci", key: "next", value: "Recheck CI in 10 minutes." }),
+      projectFact({ id: "3", entity: "issue-1271-ci", key: "task_updated", value: NOW_ISO }),
+      projectFact({ id: "4", entity: "issue-1271-ci", key: "related_session", value: "agent:main:main" }),
+      projectFact({ id: "5", entity: "issue-1271-ci", key: "related_goal", value: "goal-1271" }),
+    ];
+    const messages: unknown[] = [
+      { role: "user", content: "Status?" },
+      {
+        role: "assistant",
+        tool_calls: [
+          {
+            function: {
+              name: "goal_assess",
+              arguments: JSON.stringify({ goal_id: "goal-1271", assessment: "Pending CI" }),
+            },
+          },
+        ],
+      },
+      { role: "assistant", content: "CI is pending and recheck is scheduled." },
+    ];
+    const result = evaluatePreFinalizationGuard(messages, {
+      nowMs: NOW_MS,
+      projectFacts: facts,
+      sessionKey: "agent:main:main",
+    });
+    expect(result.action).toBe("block");
+    expect(result.checkpoint.missingFields).toContain("wake_link");
+  });
+
+  it("requires project checkpoint related_session to match the active session", () => {
+    const facts: MemoryEntry[] = [
+      projectFact({ id: "1", entity: "issue-1271-ci", key: "status", value: "in_progress" }),
+      projectFact({ id: "2", entity: "issue-1271-ci", key: "next", value: "Continue processing." }),
+      projectFact({ id: "3", entity: "issue-1271-ci", key: "task_updated", value: NOW_ISO }),
+      projectFact({ id: "4", entity: "issue-1271-ci", key: "related_session", value: "agent:main:other-session" }),
+    ];
+    const messages: unknown[] = [
+      { role: "user", content: "Status?" },
+      { role: "assistant", content: "Still waiting for CI." },
+    ];
+    const result = evaluatePreFinalizationGuard(messages, {
+      nowMs: NOW_MS,
+      projectFacts: facts,
+      sessionKey: "agent:main:current-session",
+    });
+    expect(result.action).toBe("block");
+    expect(result.checkpoint.missingFields).toContain("related_session");
+  });
+
+  it("formats conditional wake/goal requirements in the guard message", () => {
+    const result = {
+      action: "block",
+      reason: "missing_checkpoint_block",
+      signals: {
+        waitingOrPending: true,
+        cronWakeScheduled: false,
+        backgroundProcessRunning: false,
+        gitOrGithubMutation: false,
+        unresolvedExternalMention: true,
+      },
+      checkpoint: {
+        activeTaskCheckpointCalled: false,
+        goalAssessCalled: false,
+        projectFactsSatisfied: false,
+        missingFields: ["wake_link", "goal_assess"],
+      },
+      bypassReason: null,
+    } as const;
+    const message = formatPreFinalizationGuardMessage(result);
+    expect(message).toContain("wake");
+    expect(message).toContain("goal_assess");
   });
 
   it("allows hypothetical active_task_checkpoint tool as direct satisfaction path", () => {


### PR DESCRIPTION
## Summary
- add a runtime pre-finalization guard that inspects current-turn assistant/tool signals for unfinished external workflows
- require checkpoint evidence (active task checkpoint tool call or project-fact pathway) before allowing strong-signal finalization
- support explicit short bypass via `CHECKPOINT_GUARD_BYPASS: <reason>`
- wire guard into `agent_end` and add dedicated tests for CI-wait and background-process scenarios
- document guard behavior in task hygiene docs

## Validation
- npm test -- tests/pre-finalization-guard.test.ts
- npm test -- tests/verbosity.test.ts
- npm run build

Fixes #1271

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new `agent_end` blocking behavior based on heuristic signal detection and fact/tool evidence; incorrect detection could prevent session finalization or produce noisy warnings.
> 
> **Overview**
> Adds a **pre-finalization guard** that inspects current-turn assistant text/tool calls for signals of unfinished external work (e.g. CI pending, background commands, scheduled rechecks, git/GitHub mutations) and then **warns or blocks `agent_end` finalization** until checkpoint evidence is present.
> 
> Checkpoint evidence can come from an `active_task_checkpoint` tool call or from persisted `category:project` facts (status/next/task_updated/related_session, plus wake link for `waiting` and `goal_assess` for goal-backed rows); an explicit `CHECKPOINT_GUARD_BYPASS: <reason>` in the final message overrides false positives. Includes focused unit tests and updates `TASK-HYGIENE.md` to document the guard and requirements.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc542be7271556a2e287080604dd6222b32c1e3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->