### PR TITLE
fix: add active_task_checkpoint for reliable resume (#1270)

### DIFF
--- a/extensions/memory-hybrid/contracts/agent-tool-names.ts
+++ b/extensions/memory-hybrid/contracts/agent-tool-names.ts
@@ -3,6 +3,7 @@
  * Must match `openclaw.plugin.json` → `contracts.tools` (see contract test).
  */
 export const AGENT_TOOL_CONTRACT_NAMES = [
+  "active_task_checkpoint",
   "active_task_propose_goal",
   "apitap_capture",
   "apitap_list",

--- a/extensions/memory-hybrid/openclaw.plugin.json
+++ b/extensions/memory-hybrid/openclaw.plugin.json
@@ -4,6 +4,7 @@
   "version": "2026.5.94",
   "contracts": {
     "tools": [
+      "active_task_checkpoint",
       "active_task_propose_goal",
       "apitap_capture",
       "apitap_list",

--- a/extensions/memory-hybrid/services/active-task-checkpoint.ts
+++ b/extensions/memory-hybrid/services/active-task-checkpoint.ts
@@ -680,7 +680,7 @@ export async function runActiveTaskCheckpoint(
   }
 
   const ok = errors.length === 0;
-  const partial = !ok;
+  const partial = !ok && updatedKeys.length > 0;
 
   const summaryBits: string[] = [
     `entity=${checkpoint.entity}`,

--- a/extensions/memory-hybrid/services/active-task-checkpoint.ts
+++ b/extensions/memory-hybrid/services/active-task-checkpoint.ts
@@ -1,13 +1,15 @@
+import { createHash } from "node:crypto";
 import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { isAbsolute, join } from "node:path";
 import type { FactsDB } from "../backends/facts-db.js";
 import type { VectorDB } from "../backends/vector-db.js";
 import { type HybridMemoryConfig, getCronModelConfig, getDefaultCronModel, getLLMModelPreference } from "../config.js";
-import type { EpisodeOutcome, ScopeFilter } from "../types/memory.js";
+import type { EpisodeOutcome, MemoryEntry, ScopeFilter } from "../types/memory.js";
 import { parseDuration } from "../utils/duration.js";
 import { getEnv } from "../utils/env-manager.js";
 import { renderActiveTaskMarkdownFile, upsertProjectTaskKey } from "./task-ledger-facts.js";
+import { buildGuardPrefix } from "./cron-guard.js";
 import type { EmbeddingProvider } from "./embeddings.js";
 
 const ACTIVE_TASK_WAKE_JOB_PREFIX = "hybrid-mem:active-task-wake:";
@@ -43,10 +45,10 @@ export interface ActiveTaskCheckpointDeps {
 
 interface NormalizedCheckpointInput {
   entity: string;
-  status: string;
-  owner: string;
-  next: string;
-  relatedSession: string;
+  status?: string;
+  owner?: string;
+  next?: string;
+  relatedSession?: string;
   title?: string;
   resumeAtIso?: string;
   resumeAtDate?: Date;
@@ -150,7 +152,8 @@ function trimToString(value: unknown): string | undefined {
 }
 
 function normalizeStatus(raw?: string): string | null {
-  if (!raw?.trim()) return "in_progress";
+  if (raw === undefined) return null;
+  if (!raw.trim()) return "in_progress";
   const value = raw.trim().toLowerCase();
   if (value === "open" || value === "in_progress" || value === "in progress" || value === "working") {
     return "in_progress";
@@ -186,7 +189,7 @@ function normalizeCheckpointInput(
   }
 
   const status = normalizeStatus(input.status);
-  if (!status) {
+  if (input.status !== undefined && !status) {
     errors.push({
       step: "validation",
       message:
@@ -195,9 +198,9 @@ function normalizeCheckpointInput(
   }
 
   const title = trimToString(input.title);
-  const owner = trimToString(input.owner) ?? "";
-  const next = trimToString(input.next) ?? "";
-  const relatedSession = trimToString(input.relatedSession) ?? "";
+  const owner = input.owner !== undefined ? trimToString(input.owner) ?? "" : undefined;
+  const next = input.next !== undefined ? trimToString(input.next) ?? "" : undefined;
+  const relatedSession = input.relatedSession !== undefined ? trimToString(input.relatedSession) ?? "" : undefined;
 
   let resumeAtIso: string | undefined;
   let resumeAtDate: Date | undefined;
@@ -222,7 +225,7 @@ function normalizeCheckpointInput(
     errors.push({ step: "validation", message: "state must be an object when provided" });
   }
 
-  if (errors.length > 0 || !entity || !status) {
+  if (errors.length > 0 || !entity) {
     return { errors };
   }
 
@@ -251,6 +254,40 @@ function slugify(input: string): string {
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/^-+|-+$/g, "")
     .slice(0, 64);
+}
+
+function projectFactCacheKey(entity: string, key: string): string {
+  return `${entity}\u0000${key}`;
+}
+
+function buildLatestProjectFactCache(factsDb: FactsDB): Map<string, MemoryEntry> {
+  const cache = new Map<string, MemoryEntry>();
+  for (const row of factsDb.listFactsByCategory("project", 8000)) {
+    const entity = trimToString(row.entity);
+    if (!entity) continue;
+    const key = (row.key ?? "").trim();
+    const cacheKey = projectFactCacheKey(entity, key);
+    const prev = cache.get(cacheKey);
+    if (!prev || row.createdAt > prev.createdAt) {
+      cache.set(cacheKey, row);
+    }
+  }
+  return cache;
+}
+
+function getLatestProjectValue(
+  cache: Map<string, MemoryEntry>,
+  entity: string,
+  key: string,
+): string | undefined {
+  const row = cache.get(projectFactCacheKey(entity, key));
+  return trimToString(row?.value) ?? trimToString(row?.text) ?? undefined;
+}
+
+function wakeEntityKey(entity: string): string {
+  const slug = slugify(entity).slice(0, 40) || "task";
+  const digest = createHash("sha1").update(entity).digest("hex").slice(0, 12);
+  return `${slug}-${digest}`;
 }
 
 function resolveOpenclawDir(override?: string): string {
@@ -342,12 +379,13 @@ export async function scheduleActiveTaskWakeReminder(
 
   const jobs = store.jobs as Array<Record<string, unknown>>;
   const entitySlug = slugify(input.entity) || "task";
+  const entityKey = wakeEntityKey(input.entity);
   const resumeAtIso = input.resumeAt.toISOString();
   const resumeEpochSec = Math.floor(input.resumeAt.getTime() / 1000);
-  const jobId = `${ACTIVE_TASK_WAKE_JOB_PREFIX}${entitySlug}:${resumeEpochSec}`;
+  const jobId = `${ACTIVE_TASK_WAKE_JOB_PREFIX}${entityKey}:${resumeEpochSec}`;
 
   let disabledPreviousJobs = 0;
-  const entityPrefix = `${ACTIVE_TASK_WAKE_JOB_PREFIX}${entitySlug}:`;
+  const entityPrefix = `${ACTIVE_TASK_WAKE_JOB_PREFIX}${entityKey}:`;
   for (const row of jobs) {
     const pluginJobId = typeof row.pluginJobId === "string" ? row.pluginJobId : undefined;
     if (!pluginJobId || pluginJobId === jobId) continue;
@@ -361,13 +399,8 @@ export async function scheduleActiveTaskWakeReminder(
   const cronExpr = scheduleToCronExpr(input.resumeAt);
   const model = resolveCronModel(input.cfg);
   const minIntervalMs = ACTIVE_TASK_WAKE_GUARD_YEARS * 365 * 24 * 60 * 60 * 1000;
-  const guardFile = join(openclawDir, "cron", "guard", `active-task-wake-${entitySlug}.ms`);
-  const guardPrefix = [
-    `GUARD CHECK: Before continuing, read \"${guardFile}\" if it exists.`,
-    `If current epoch ms minus the stored value is less than ${minIntervalMs}, reply only \"Skipped: active-task wake already delivered recently\" and stop.`,
-    `After a successful reminder, write the current epoch ms back to \"${guardFile}\".`,
-    "",
-  ].join("\n");
+  const guardJobName = `active-task-wake-${entityKey}-${resumeEpochSec}`;
+  const guardPrefix = buildGuardPrefix(guardJobName, minIntervalMs);
 
   const job: Record<string, unknown> = {
     id: jobId,
@@ -522,6 +555,17 @@ export async function runActiveTaskCheckpoint(
   }
 
   const checkpoint = validation.normalized;
+  const latestProjectFacts = buildLatestProjectFactCache(deps.factsDb);
+  const resolvedStatus =
+    checkpoint.status ??
+    normalizeStatus(getLatestProjectValue(latestProjectFacts, checkpoint.entity, "status")) ??
+    "in_progress";
+  const resolvedOwner = checkpoint.owner ?? getLatestProjectValue(latestProjectFacts, checkpoint.entity, "owner") ?? "";
+  const resolvedNext = checkpoint.next ?? getLatestProjectValue(latestProjectFacts, checkpoint.entity, "next") ?? "";
+  const resolvedRelatedSession =
+    checkpoint.relatedSession ??
+    getLatestProjectValue(latestProjectFacts, checkpoint.entity, "related_session") ??
+    "";
   const taskUpdated = now.toISOString();
   const errors: ActiveTaskCheckpointError[] = [];
   const updatedKeys: string[] = [];
@@ -534,12 +578,7 @@ export async function runActiveTaskCheckpoint(
     if (effectiveTitle) {
       titleSource = "provided";
     } else {
-      const existingTitleHit = deps.factsDb.lookup(checkpoint.entity, "title", undefined, {
-        includeSuperseded: false,
-        limit: 1,
-      })[0];
-      const existingTitle =
-        trimToString(existingTitleHit?.entry?.value) ?? trimToString(existingTitleHit?.entry?.text) ?? undefined;
+      const existingTitle = getLatestProjectValue(latestProjectFacts, checkpoint.entity, "title");
       if (existingTitle) {
         effectiveTitle = existingTitle;
         titleSource = "existing";
@@ -555,10 +594,10 @@ export async function runActiveTaskCheckpoint(
   }
 
   const updates: Array<{ key: string; value: string }> = [
-    { key: "status", value: checkpoint.status },
-    { key: "next", value: checkpoint.next },
-    { key: "owner", value: checkpoint.owner },
-    { key: "related_session", value: checkpoint.relatedSession },
+    { key: "status", value: resolvedStatus },
+    { key: "next", value: resolvedNext },
+    { key: "owner", value: resolvedOwner },
+    { key: "related_session", value: resolvedRelatedSession },
     { key: "task_updated", value: taskUpdated },
   ];
 
@@ -584,6 +623,7 @@ export async function runActiveTaskCheckpoint(
         update.key,
         update.value,
         deps.logger,
+        { latestByEntityKey: latestProjectFacts },
       );
       updatedKeys.push(update.key);
     } catch (err) {
@@ -603,10 +643,10 @@ export async function runActiveTaskCheckpoint(
       const scope = scopeFromFilter(deps.episodeScopeFilter);
       const contextLines: string[] = [
         `entity=${checkpoint.entity}`,
-        `status=${checkpoint.status}`,
-        `owner=${checkpoint.owner || "n/a"}`,
-        `next=${checkpoint.next || "n/a"}`,
-        `relatedSession=${checkpoint.relatedSession || "n/a"}`,
+        `status=${resolvedStatus}`,
+        `owner=${resolvedOwner || "n/a"}`,
+        `next=${resolvedNext || "n/a"}`,
+        `relatedSession=${resolvedRelatedSession || "n/a"}`,
         `taskUpdated=${taskUpdated}`,
       ];
       if (checkpoint.resumeAtIso) contextLines.push(`resumeAt=${checkpoint.resumeAtIso}`);
@@ -614,9 +654,9 @@ export async function runActiveTaskCheckpoint(
 
       const ep = deps.factsDb.recordEpisode({
         event: `Active task checkpoint: ${checkpoint.entity}`,
-        outcome: outcomeFromStatus(checkpoint.status),
+        outcome: outcomeFromStatus(resolvedStatus),
         context: contextLines.join("\n"),
-        importance: checkpoint.status === "failed" ? 0.8 : 0.6,
+        importance: resolvedStatus === "failed" ? 0.8 : 0.6,
         tags: ["active-task", "checkpoint", slugify(checkpoint.entity)],
         scope: scope.scope,
         scopeTarget: scope.scopeTarget,
@@ -638,17 +678,19 @@ export async function runActiveTaskCheckpoint(
   let wakeSkippedReason: string | undefined;
   let wakeResult: ActiveTaskWakeScheduleResult | undefined;
 
-  if (checkpoint.resumeAtIso && checkpoint.resumeAtDate && checkpoint.scheduleWake) {
+  if (failedKeys.length > 0) {
+    wakeSkippedReason = "facts_write_failed";
+  } else if (checkpoint.resumeAtIso && checkpoint.resumeAtDate && checkpoint.scheduleWake) {
     wakeAttempted = true;
     try {
       const scheduleWake = deps.scheduleWakeFn ?? scheduleActiveTaskWakeReminder;
       wakeResult = await scheduleWake({
         cfg: deps.cfg,
         entity: checkpoint.entity,
-        status: checkpoint.status,
-        owner: checkpoint.owner || undefined,
-        next: checkpoint.next || undefined,
-        relatedSession: checkpoint.relatedSession || undefined,
+        status: resolvedStatus,
+        owner: resolvedOwner || undefined,
+        next: resolvedNext || undefined,
+        relatedSession: resolvedRelatedSession || undefined,
         title: effectiveTitle,
         resumeAt: checkpoint.resumeAtDate,
         state: checkpoint.state,
@@ -686,7 +728,7 @@ export async function runActiveTaskCheckpoint(
 
   const summaryBits: string[] = [
     `entity=${checkpoint.entity}`,
-    `status=${checkpoint.status}`,
+    `status=${resolvedStatus}`,
     `facts=${updatedKeys.length}/${updates.length}`,
     checkpoint.recordEpisode ? `episode=${episodeOk ? "recorded" : "failed"}` : "episode=skipped",
   ];
@@ -711,10 +753,10 @@ export async function runActiveTaskCheckpoint(
     message,
     checkpoint: {
       entity: checkpoint.entity,
-      status: checkpoint.status,
-      owner: checkpoint.owner,
-      next: checkpoint.next,
-      relatedSession: checkpoint.relatedSession,
+      status: resolvedStatus,
+      owner: resolvedOwner,
+      next: resolvedNext,
+      relatedSession: resolvedRelatedSession,
       title: effectiveTitle,
       resumeAt: checkpoint.resumeAtIso,
       taskUpdated,

--- a/extensions/memory-hybrid/services/active-task-checkpoint.ts
+++ b/extensions/memory-hybrid/services/active-task-checkpoint.ts
@@ -160,15 +160,11 @@ function normalizeStatus(raw?: string): string | undefined {
   }
   if (value === "blocked" || value === "stalled") return "blocked";
   if (value === "waiting" || value === "on_hold" || value === "on hold") return "waiting";
-  if (
-    value === "done" ||
-    value === "completed" ||
-    value === "closed" ||
-    value === "cancelled" ||
-    value === "canceled" ||
-    value === "abandoned"
-  ) {
+  if (value === "done" || value === "completed" || value === "closed") {
     return "done";
+  }
+  if (value === "cancelled" || value === "canceled" || value === "abandoned") {
+    return "cancelled";
   }
   if (value === "failed" || value === "error") return "failed";
   return undefined;
@@ -193,7 +189,7 @@ function normalizeCheckpointInput(
     errors.push({
       step: "validation",
       message:
-        "status must be one of: open, in_progress, blocked, waiting, done/completed/closed/cancelled/abandoned, failed",
+        "status must be one of: open, in_progress, blocked, waiting, done/completed/closed, cancelled/canceled/abandoned, failed",
     });
   }
 
@@ -292,7 +288,7 @@ function resolveOpenclawDir(override?: string): string {
   return join(homedir(), ".openclaw");
 }
 
-function resolveWorkspaceRoot(cfg: HybridMemoryConfig, override?: string): string {
+function resolveWorkspaceRoot(override?: string): string {
   if (override?.trim()) return override.trim();
   const env = getEnv("OPENCLAW_WORKSPACE")?.trim();
   if (env) return env;
@@ -464,7 +460,7 @@ async function refreshActiveTaskProjectionFromFacts(
     return { attempted: true, refreshed: false, reason: "active_task_ledger_not_facts" };
   }
 
-  const workspaceRoot = resolveWorkspaceRoot(input.cfg, input.workspaceRoot);
+  const workspaceRoot = resolveWorkspaceRoot(input.workspaceRoot);
   const activeTaskPath = isAbsolute(input.cfg.activeTask.filePath)
     ? input.cfg.activeTask.filePath
     : join(workspaceRoot, input.cfg.activeTask.filePath);
@@ -481,6 +477,7 @@ function stepError(step: ActiveTaskCheckpointStep, err: unknown): ActiveTaskChec
 function outcomeFromStatus(status: string): EpisodeOutcome {
   if (status === "done") return "success";
   if (status === "failed") return "failure";
+  if (status === "cancelled") return "partial";
   if (status === "blocked" || status === "waiting") return "partial";
   return "unknown";
 }

--- a/extensions/memory-hybrid/services/active-task-checkpoint.ts
+++ b/extensions/memory-hybrid/services/active-task-checkpoint.ts
@@ -175,10 +175,10 @@ function normalizeStatus(raw?: string): string | undefined {
 function normalizeExistingStatus(raw?: string): string | undefined {
   const value = trimToString(raw);
   if (value === undefined) return undefined;
-  const normalized = normalizeStatus(value);
-  if (normalized) return normalized;
   const lower = value.toLowerCase();
   if (lower === "abandoned" || lower === "superseded") return lower;
+  const normalized = normalizeStatus(value);
+  if (normalized) return normalized;
   return lower;
 }
 

--- a/extensions/memory-hybrid/services/active-task-checkpoint.ts
+++ b/extensions/memory-hybrid/services/active-task-checkpoint.ts
@@ -3,12 +3,7 @@ import { homedir } from "node:os";
 import { isAbsolute, join } from "node:path";
 import type { FactsDB } from "../backends/facts-db.js";
 import type { VectorDB } from "../backends/vector-db.js";
-import {
-  type HybridMemoryConfig,
-  getCronModelConfig,
-  getDefaultCronModel,
-  getLLMModelPreference,
-} from "../config.js";
+import { type HybridMemoryConfig, getCronModelConfig, getDefaultCronModel, getLLMModelPreference } from "../config.js";
 import type { EpisodeOutcome, ScopeFilter } from "../types/memory.js";
 import { parseDuration } from "../utils/duration.js";
 import { getEnv } from "../utils/env-manager.js";
@@ -176,7 +171,10 @@ function normalizeStatus(raw?: string): string | null {
   return null;
 }
 
-function normalizeCheckpointInput(input: ActiveTaskCheckpointInput, now: Date): {
+function normalizeCheckpointInput(
+  input: ActiveTaskCheckpointInput,
+  now: Date,
+): {
   normalized?: NormalizedCheckpointInput;
   errors: ActiveTaskCheckpointError[];
 } {
@@ -283,7 +281,7 @@ function safeJson(value: unknown): string {
   try {
     return JSON.stringify(value);
   } catch {
-    return "{\"error\":\"unserializable\"}";
+    return '{"error":"unserializable"}';
   }
 }
 
@@ -664,7 +662,11 @@ export async function runActiveTaskCheckpoint(
     wakeSkippedReason = checkpoint.resumeAtIso ? "schedule_wake_disabled" : "resumeAt_not_provided";
   }
 
-  let projection = { attempted: false, refreshed: false, reason: "refresh_not_requested" } as ActiveTaskProjectionRefreshResult;
+  let projection = {
+    attempted: false,
+    refreshed: false,
+    reason: "refresh_not_requested",
+  } as ActiveTaskProjectionRefreshResult;
   if (checkpoint.refreshProjection) {
     try {
       const refreshFn = deps.refreshProjectionFn ?? refreshActiveTaskProjectionFromFacts;

--- a/extensions/memory-hybrid/services/active-task-checkpoint.ts
+++ b/extensions/memory-hybrid/services/active-task-checkpoint.ts
@@ -8,7 +8,7 @@ import { type HybridMemoryConfig, getCronModelConfig, getDefaultCronModel, getLL
 import type { EpisodeOutcome, MemoryEntry, ScopeFilter } from "../types/memory.js";
 import { parseDuration } from "../utils/duration.js";
 import { getEnv } from "../utils/env-manager.js";
-import { groupProjectFactsByEntity, renderActiveTaskMarkdownFile, upsertProjectTaskKey } from "./task-ledger-facts.js";
+import { renderActiveTaskMarkdownFile, taskEntityKey, upsertProjectTaskKey } from "./task-ledger-facts.js";
 import { buildGuardPrefix } from "./cron-guard.js";
 import type { EmbeddingProvider } from "./embeddings.js";
 
@@ -264,10 +264,6 @@ function slugify(input: string): string {
     .slice(0, 64);
 }
 
-function projectFactCacheKey(entity: string, key: string): string {
-  return `${entity}\u0000${key}`;
-}
-
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
@@ -283,21 +279,26 @@ function extractProjectValueFromText(text: string, key: string): string | undefi
   return trimToString(trimmedText);
 }
 
-function buildLatestProjectFactCache(factsDb: FactsDB): Map<string, MemoryEntry> {
-  const facts = factsDb.listFactsByCategory("project", Number.MAX_SAFE_INTEGER);
-  const grouped = groupProjectFactsByEntity(facts);
-  const cache = new Map<string, MemoryEntry>();
-  for (const [entity, keyMap] of grouped) {
-    for (const [key, entry] of keyMap) {
-      const actualKey = key === "_body" ? "" : key;
-      cache.set(projectFactCacheKey(entity, actualKey), entry);
-    }
+function primeLatestProjectFactCacheForEntityKeys(
+  factsDb: FactsDB,
+  cache: Map<string, MemoryEntry>,
+  entity: string,
+  keys: readonly string[],
+): void {
+  for (const key of keys) {
+    const normalizedKey = key.trim();
+    if (!normalizedKey) continue;
+    const cacheKey = taskEntityKey(entity, normalizedKey);
+    if (cache.has(cacheKey)) continue;
+    const hit = factsDb.lookup(entity, normalizedKey, undefined, { includeSuperseded: false, limit: 1 })[0]?.entry;
+    if (!hit) continue;
+    if ((hit.category ?? "").trim() !== "project") continue;
+    cache.set(cacheKey, hit);
   }
-  return cache;
 }
 
 function getLatestProjectValue(cache: Map<string, MemoryEntry>, entity: string, key: string): string | undefined {
-  const row = cache.get(projectFactCacheKey(entity, key));
+  const row = cache.get(taskEntityKey(entity, key));
   if (!row) return undefined;
   if (typeof row.value === "string") return row.value.trim();
   if (typeof row.text === "string") {
@@ -311,6 +312,64 @@ function wakeEntityKey(entity: string): string {
   const digest = createHash("sha1").update(entity).digest("hex").slice(0, 12);
   return `${slug}-${digest}`;
 }
+
+function disableActiveTaskWakeJobs(
+  jobs: Array<Record<string, unknown>>,
+  entity: string,
+  opts?: { excludeJobId?: string },
+): number {
+  const entityPrefix = `${ACTIVE_TASK_WAKE_JOB_PREFIX}${wakeEntityKey(entity)}:`;
+  let disabled = 0;
+  for (const row of jobs) {
+    const pluginJobId = typeof row.pluginJobId === "string" ? row.pluginJobId : "";
+    const id = typeof row.id === "string" ? row.id : "";
+    const rowId = pluginJobId || id;
+    if (!rowId) continue;
+    if (opts?.excludeJobId && (pluginJobId === opts.excludeJobId || id === opts.excludeJobId)) continue;
+    if (!rowId.startsWith(entityPrefix)) continue;
+    if (row.enabled !== false) {
+      row.enabled = false;
+      disabled += 1;
+    }
+  }
+  return disabled;
+}
+
+function disableActiveTaskWakeJobsForEntity(
+  entity: string,
+  openclawDirOverride?: string,
+): { jobsPath: string; disabled: number } {
+  const openclawDir = resolveOpenclawDir(openclawDirOverride);
+  const cronDir = join(openclawDir, "cron");
+  const jobsPath = join(cronDir, "jobs.json");
+  if (!existsSync(jobsPath)) {
+    return { jobsPath, disabled: 0 };
+  }
+
+  let store: { jobs?: unknown[] };
+  try {
+    store = JSON.parse(readFileSync(jobsPath, "utf-8")) as { jobs?: unknown[] };
+  } catch (err) {
+    throw new Error(`failed to parse ${jobsPath}: ${String(err)}`);
+  }
+
+  if (!Array.isArray(store.jobs)) {
+    return { jobsPath, disabled: 0 };
+  }
+
+  const jobs = store.jobs as Array<Record<string, unknown>>;
+  const disabled = disableActiveTaskWakeJobs(jobs, entity);
+  if (disabled <= 0) {
+    return { jobsPath, disabled: 0 };
+  }
+
+  const payload = JSON.stringify(store, null, 2);
+  const tmpPath = `${jobsPath}.${process.pid}.${Date.now()}.tmp`;
+  writeFileSync(tmpPath, payload, "utf-8");
+  renameSync(tmpPath, jobsPath);
+  return { jobsPath, disabled };
+}
+
 function resolveOpenclawDir(override?: string): string {
   if (override?.trim()) return override.trim();
   const env = getEnv("OPENCLAW_HOME")?.trim();
@@ -401,17 +460,7 @@ async function scheduleActiveTaskWakeReminder(
   const resumeEpochSec = Math.floor(input.resumeAt.getTime() / 1000);
   const jobId = `${ACTIVE_TASK_WAKE_JOB_PREFIX}${entityKey}:${resumeEpochSec}`;
 
-  let disabledPreviousJobs = 0;
-  const entityPrefix = `${ACTIVE_TASK_WAKE_JOB_PREFIX}${entityKey}:`;
-  for (const row of jobs) {
-    const pluginJobId = typeof row.pluginJobId === "string" ? row.pluginJobId : undefined;
-    if (!pluginJobId || pluginJobId === jobId) continue;
-    if (!pluginJobId.startsWith(entityPrefix)) continue;
-    if (row.enabled !== false) {
-      row.enabled = false;
-      disabledPreviousJobs += 1;
-    }
-  }
+  const disabledPreviousJobs = disableActiveTaskWakeJobs(jobs, input.entity, { excludeJobId: jobId });
 
   const model = resolveCronModel(input.cfg);
   const minIntervalMs = ACTIVE_TASK_WAKE_GUARD_YEARS * 365 * 24 * 60 * 60 * 1000;
@@ -576,7 +625,14 @@ export async function runActiveTaskCheckpoint(
   }
 
   const checkpoint = validation.normalized;
-  const latestProjectFacts = buildLatestProjectFactCache(deps.factsDb);
+  const latestProjectFacts = new Map<string, MemoryEntry>();
+  primeLatestProjectFactCacheForEntityKeys(deps.factsDb, latestProjectFacts, checkpoint.entity, [
+    "status",
+    "owner",
+    "next",
+    "related_session",
+    "title",
+  ]);
   const existingStatus = getLatestProjectValue(latestProjectFacts, checkpoint.entity, "status");
   const resolvedStatus = checkpoint.status ?? normalizeExistingStatus(existingStatus) ?? "in_progress";
   const resolvedOwner = checkpoint.owner ?? getLatestProjectValue(latestProjectFacts, checkpoint.entity, "owner") ?? "";
@@ -629,6 +685,13 @@ export async function runActiveTaskCheckpoint(
   if (checkpoint.resumeAtIso) {
     updates.push({ key: "resume_at", value: checkpoint.resumeAtIso });
   }
+
+  primeLatestProjectFactCacheForEntityKeys(
+    deps.factsDb,
+    latestProjectFacts,
+    checkpoint.entity,
+    updates.map((u) => u.key),
+  );
 
   for (const update of updates) {
     try {
@@ -694,6 +757,8 @@ export async function runActiveTaskCheckpoint(
   let wakeScheduled = false;
   let wakeSkippedReason: string | undefined;
   let wakeResult: ActiveTaskWakeScheduleResult | undefined;
+  let wakeJobsPath: string | undefined;
+  let wakeDisabledPreviousJobs: number | undefined;
 
   if (failedKeys.length > 0) {
     wakeSkippedReason = "facts_write_failed";
@@ -714,11 +779,20 @@ export async function runActiveTaskCheckpoint(
         openclawDir: deps.openclawDir,
       });
       wakeScheduled = wakeResult.scheduled;
+      wakeJobsPath = wakeResult.jobsPath;
+      wakeDisabledPreviousJobs = wakeResult.disabledPreviousJobs;
     } catch (err) {
       errors.push(stepError("schedule", err));
     }
   } else {
     wakeSkippedReason = checkpoint.resumeAtIso ? "schedule_wake_disabled" : "resumeAt_not_provided";
+    try {
+      const cleanup = disableActiveTaskWakeJobsForEntity(checkpoint.entity, deps.openclawDir);
+      wakeJobsPath = cleanup.jobsPath;
+      wakeDisabledPreviousJobs = cleanup.disabled;
+    } catch (err) {
+      errors.push(stepError("schedule", err));
+    }
   }
 
   let projection = {
@@ -798,8 +872,8 @@ export async function runActiveTaskCheckpoint(
         jobId: wakeResult?.jobId,
         scheduleKind: wakeResult?.scheduleKind,
         scheduleAt: wakeResult?.scheduleAt,
-        jobsPath: wakeResult?.jobsPath,
-        disabledPreviousJobs: wakeResult?.disabledPreviousJobs,
+        jobsPath: wakeJobsPath,
+        disabledPreviousJobs: wakeDisabledPreviousJobs,
         skippedReason: wakeSkippedReason,
       },
       projection,

--- a/extensions/memory-hybrid/services/active-task-checkpoint.ts
+++ b/extensions/memory-hybrid/services/active-task-checkpoint.ts
@@ -9,6 +9,7 @@ import { parseDuration } from "../utils/duration.js";
 import { getEnv } from "../utils/env-manager.js";
 import { renderActiveTaskMarkdownFile, upsertProjectTaskKey } from "./task-ledger-facts.js";
 import type { EmbeddingProvider } from "./embeddings.js";
+import { slugify } from "./credential-scanner.js";
 
 const ACTIVE_TASK_WAKE_JOB_PREFIX = "hybrid-mem:active-task-wake:";
 const ACTIVE_TASK_WAKE_GUARD_YEARS = 10;
@@ -243,14 +244,6 @@ function normalizeCheckpointInput(
     },
     errors,
   };
-}
-
-function slugify(input: string): string {
-  return input
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "")
-    .slice(0, 64);
 }
 
 function resolveOpenclawDir(override?: string): string {

--- a/extensions/memory-hybrid/services/active-task-checkpoint.ts
+++ b/extensions/memory-hybrid/services/active-task-checkpoint.ts
@@ -199,9 +199,9 @@ function normalizeCheckpointInput(
   }
 
   const title = trimToString(input.title);
-  const owner = input.owner !== undefined ? trimToString(input.owner) ?? "" : undefined;
-  const next = input.next !== undefined ? trimToString(input.next) ?? "" : undefined;
-  const relatedSession = input.relatedSession !== undefined ? trimToString(input.relatedSession) ?? "" : undefined;
+  const owner = input.owner !== undefined ? (trimToString(input.owner) ?? "") : undefined;
+  const next = input.next !== undefined ? (trimToString(input.next) ?? "") : undefined;
+  const relatedSession = input.relatedSession !== undefined ? (trimToString(input.relatedSession) ?? "") : undefined;
 
   let resumeAtIso: string | undefined;
   let resumeAtDate: Date | undefined;
@@ -276,11 +276,7 @@ function buildLatestProjectFactCache(factsDb: FactsDB): Map<string, MemoryEntry>
   return cache;
 }
 
-function getLatestProjectValue(
-  cache: Map<string, MemoryEntry>,
-  entity: string,
-  key: string,
-): string | undefined {
+function getLatestProjectValue(cache: Map<string, MemoryEntry>, entity: string, key: string): string | undefined {
   const row = cache.get(projectFactCacheKey(entity, key));
   return trimToString(row?.value) ?? trimToString(row?.text) ?? undefined;
 }
@@ -563,9 +559,7 @@ export async function runActiveTaskCheckpoint(
   const resolvedOwner = checkpoint.owner ?? getLatestProjectValue(latestProjectFacts, checkpoint.entity, "owner") ?? "";
   const resolvedNext = checkpoint.next ?? getLatestProjectValue(latestProjectFacts, checkpoint.entity, "next") ?? "";
   const resolvedRelatedSession =
-    checkpoint.relatedSession ??
-    getLatestProjectValue(latestProjectFacts, checkpoint.entity, "related_session") ??
-    "";
+    checkpoint.relatedSession ?? getLatestProjectValue(latestProjectFacts, checkpoint.entity, "related_session") ?? "";
   const taskUpdated = now.toISOString();
   const errors: ActiveTaskCheckpointError[] = [];
   const updatedKeys: string[] = [];

--- a/extensions/memory-hybrid/services/active-task-checkpoint.ts
+++ b/extensions/memory-hybrid/services/active-task-checkpoint.ts
@@ -699,7 +699,9 @@ export async function runActiveTaskCheckpoint(
 
   const message = ok
     ? `active_task_checkpoint completed (${summaryBits.join(", ")}).`
-    : `active_task_checkpoint completed with partial failures (${summaryBits.join(", ")}).`;
+    : partial
+      ? `active_task_checkpoint completed with partial failures (${summaryBits.join(", ")}).`
+      : `active_task_checkpoint failed (${summaryBits.join(", ")}).`;
 
   return {
     ok,

--- a/extensions/memory-hybrid/services/active-task-checkpoint.ts
+++ b/extensions/memory-hybrid/services/active-task-checkpoint.ts
@@ -296,7 +296,7 @@ function resolveWorkspaceRoot(override?: string): string {
 }
 
 function scheduleToCronExpr(resumeAt: Date): string {
-  return `${resumeAt.getUTCMinutes()} ${resumeAt.getUTCHours()} ${resumeAt.getUTCDate()} ${resumeAt.getUTCMonth() + 1} *`;
+  return `${resumeAt.getUTCMinutes()} ${resumeAt.getUTCHours()} ${resumeAt.getUTCDate()} ${resumeAt.getUTCMonth() + 1} * ${resumeAt.getUTCFullYear()}`;
 }
 
 function resolveCronModel(cfg: HybridMemoryConfig): string {

--- a/extensions/memory-hybrid/services/active-task-checkpoint.ts
+++ b/extensions/memory-hybrid/services/active-task-checkpoint.ts
@@ -8,7 +8,7 @@ import { type HybridMemoryConfig, getCronModelConfig, getDefaultCronModel, getLL
 import type { EpisodeOutcome, MemoryEntry, ScopeFilter } from "../types/memory.js";
 import { parseDuration } from "../utils/duration.js";
 import { getEnv } from "../utils/env-manager.js";
-import { renderActiveTaskMarkdownFile, upsertProjectTaskKey } from "./task-ledger-facts.js";
+import { groupProjectFactsByEntity, renderActiveTaskMarkdownFile, upsertProjectTaskKey } from "./task-ledger-facts.js";
 import { buildGuardPrefix } from "./cron-guard.js";
 import type { EmbeddingProvider } from "./embeddings.js";
 
@@ -257,15 +257,13 @@ function projectFactCacheKey(entity: string, key: string): string {
 }
 
 function buildLatestProjectFactCache(factsDb: FactsDB): Map<string, MemoryEntry> {
+  const facts = factsDb.listFactsByCategory("project", Number.MAX_SAFE_INTEGER);
+  const grouped = groupProjectFactsByEntity(facts);
   const cache = new Map<string, MemoryEntry>();
-  for (const row of factsDb.listFactsByCategory("project", Number.MAX_SAFE_INTEGER)) {
-    const entity = trimToString(row.entity);
-    if (!entity) continue;
-    const key = (row.key ?? "").trim();
-    const cacheKey = projectFactCacheKey(entity, key);
-    const prev = cache.get(cacheKey);
-    if (!prev || row.createdAt > prev.createdAt) {
-      cache.set(cacheKey, row);
+  for (const [entity, keyMap] of grouped) {
+    for (const [key, entry] of keyMap) {
+      const actualKey = key === "_body" ? "" : key;
+      cache.set(projectFactCacheKey(entity, actualKey), entry);
     }
   }
   return cache;
@@ -296,7 +294,7 @@ function resolveWorkspaceRoot(override?: string): string {
 }
 
 function scheduleToCronExpr(resumeAt: Date): string {
-  return `${resumeAt.getUTCMinutes()} ${resumeAt.getUTCHours()} ${resumeAt.getUTCDate()} ${resumeAt.getUTCMonth() + 1} * ${resumeAt.getUTCFullYear()}`;
+  return `${resumeAt.getUTCMinutes()} ${resumeAt.getUTCHours()} ${resumeAt.getUTCDate()} ${resumeAt.getUTCMonth() + 1} *`;
 }
 
 function resolveCronModel(cfg: HybridMemoryConfig): string {

--- a/extensions/memory-hybrid/services/active-task-checkpoint.ts
+++ b/extensions/memory-hybrid/services/active-task-checkpoint.ts
@@ -262,8 +262,7 @@ function projectFactCacheKey(entity: string, key: string): string {
 
 function buildLatestProjectFactCache(factsDb: FactsDB): Map<string, MemoryEntry> {
   const cache = new Map<string, MemoryEntry>();
-  for (const row of factsDb.getAll({ includeSuperseded: false })) {
-    if (row.category !== "project") continue;
+  for (const row of factsDb.listFactsByCategory("project", Number.MAX_SAFE_INTEGER)) {
     const entity = trimToString(row.entity);
     if (!entity) continue;
     const key = (row.key ?? "").trim();
@@ -352,7 +351,7 @@ function buildWakeMessage(args: {
   return lines.join("\n");
 }
 
-export async function scheduleActiveTaskWakeReminder(
+async function scheduleActiveTaskWakeReminder(
   input: ActiveTaskWakeScheduleInput,
 ): Promise<ActiveTaskWakeScheduleResult> {
   const openclawDir = resolveOpenclawDir(input.openclawDir);
@@ -455,7 +454,7 @@ export async function scheduleActiveTaskWakeReminder(
   };
 }
 
-export async function refreshActiveTaskProjectionFromFacts(
+async function refreshActiveTaskProjectionFromFacts(
   input: ActiveTaskProjectionRefreshInput,
 ): Promise<ActiveTaskProjectionRefreshResult> {
   if (!input.cfg.activeTask.enabled) {

--- a/extensions/memory-hybrid/services/active-task-checkpoint.ts
+++ b/extensions/memory-hybrid/services/active-task-checkpoint.ts
@@ -1,0 +1,745 @@
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { isAbsolute, join } from "node:path";
+import type { FactsDB } from "../backends/facts-db.js";
+import type { VectorDB } from "../backends/vector-db.js";
+import {
+  type HybridMemoryConfig,
+  getCronModelConfig,
+  getDefaultCronModel,
+  getLLMModelPreference,
+} from "../config.js";
+import type { EpisodeOutcome, ScopeFilter } from "../types/memory.js";
+import { parseDuration } from "../utils/duration.js";
+import { getEnv } from "../utils/env-manager.js";
+import { renderActiveTaskMarkdownFile, upsertProjectTaskKey } from "./task-ledger-facts.js";
+import type { EmbeddingProvider } from "./embeddings.js";
+
+const ACTIVE_TASK_WAKE_JOB_PREFIX = "hybrid-mem:active-task-wake:";
+const ACTIVE_TASK_WAKE_GUARD_YEARS = 10;
+
+export interface ActiveTaskCheckpointInput {
+  entity?: string;
+  status?: string;
+  owner?: string;
+  next?: string;
+  relatedSession?: string;
+  title?: string;
+  resumeAt?: string;
+  state?: Record<string, unknown>;
+  scheduleWake?: boolean;
+  refreshProjection?: boolean;
+  recordEpisode?: boolean;
+}
+
+export interface ActiveTaskCheckpointDeps {
+  factsDb: FactsDB;
+  vectorDb: VectorDB;
+  embeddings: EmbeddingProvider;
+  cfg: HybridMemoryConfig;
+  logger?: { warn?: (msg: string) => void; info?: (msg: string) => void };
+  openclawDir?: string;
+  workspaceRoot?: string;
+  now?: () => Date;
+  episodeScopeFilter?: ScopeFilter | null;
+  scheduleWakeFn?: (args: ActiveTaskWakeScheduleInput) => Promise<ActiveTaskWakeScheduleResult>;
+  refreshProjectionFn?: (args: ActiveTaskProjectionRefreshInput) => Promise<ActiveTaskProjectionRefreshResult>;
+}
+
+interface NormalizedCheckpointInput {
+  entity: string;
+  status: string;
+  owner: string;
+  next: string;
+  relatedSession: string;
+  title?: string;
+  resumeAtIso?: string;
+  resumeAtDate?: Date;
+  state?: Record<string, unknown>;
+  scheduleWake: boolean;
+  refreshProjection: boolean;
+  recordEpisode: boolean;
+}
+
+export type ActiveTaskCheckpointStep = "validation" | "facts" | "episode" | "schedule" | "projection";
+
+export interface ActiveTaskCheckpointError {
+  step: ActiveTaskCheckpointStep;
+  message: string;
+}
+
+export interface ActiveTaskWakeScheduleInput {
+  cfg: HybridMemoryConfig;
+  entity: string;
+  status: string;
+  owner?: string;
+  next?: string;
+  relatedSession?: string;
+  title?: string;
+  resumeAt: Date;
+  state?: Record<string, unknown>;
+  openclawDir?: string;
+}
+
+export interface ActiveTaskWakeScheduleResult {
+  scheduled: boolean;
+  jobId: string;
+  cronExpr: string;
+  jobsPath: string;
+  disabledPreviousJobs: number;
+}
+
+export interface ActiveTaskProjectionRefreshInput {
+  cfg: HybridMemoryConfig;
+  factsDb: FactsDB;
+  workspaceRoot?: string;
+}
+
+export interface ActiveTaskProjectionRefreshResult {
+  attempted: boolean;
+  refreshed: boolean;
+  path?: string;
+  reason?: string;
+}
+
+export interface ActiveTaskCheckpointResult {
+  ok: boolean;
+  partial: boolean;
+  message: string;
+  checkpoint?: {
+    entity: string;
+    status: string;
+    owner: string;
+    next: string;
+    relatedSession: string;
+    title?: string;
+    resumeAt?: string;
+    taskUpdated: string;
+    state?: Record<string, unknown>;
+  };
+  steps: {
+    facts: {
+      ok: boolean;
+      updatedKeys: string[];
+      failedKeys: string[];
+      titleSource?: "provided" | "existing" | "defaulted";
+    };
+    episode: {
+      attempted: boolean;
+      ok: boolean;
+      episodeId?: string;
+      skippedReason?: string;
+    };
+    schedule: {
+      attempted: boolean;
+      scheduled: boolean;
+      jobId?: string;
+      cronExpr?: string;
+      jobsPath?: string;
+      disabledPreviousJobs?: number;
+      skippedReason?: string;
+    };
+    projection: ActiveTaskProjectionRefreshResult;
+  };
+  errors: ActiveTaskCheckpointError[];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function trimToString(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function normalizeStatus(raw?: string): string | null {
+  if (!raw?.trim()) return "in_progress";
+  const value = raw.trim().toLowerCase();
+  if (value === "open" || value === "in_progress" || value === "in progress" || value === "working") {
+    return "in_progress";
+  }
+  if (value === "blocked" || value === "stalled") return "blocked";
+  if (value === "waiting" || value === "on_hold" || value === "on hold") return "waiting";
+  if (
+    value === "done" ||
+    value === "completed" ||
+    value === "closed" ||
+    value === "cancelled" ||
+    value === "canceled" ||
+    value === "abandoned"
+  ) {
+    return "done";
+  }
+  if (value === "failed" || value === "error") return "failed";
+  return null;
+}
+
+function normalizeCheckpointInput(input: ActiveTaskCheckpointInput, now: Date): {
+  normalized?: NormalizedCheckpointInput;
+  errors: ActiveTaskCheckpointError[];
+} {
+  const errors: ActiveTaskCheckpointError[] = [];
+
+  const entity = trimToString(input.entity);
+  if (!entity) {
+    errors.push({ step: "validation", message: "entity is required" });
+  }
+
+  const status = normalizeStatus(input.status);
+  if (!status) {
+    errors.push({
+      step: "validation",
+      message:
+        "status must be one of: open, in_progress, blocked, waiting, done/completed/closed/cancelled/abandoned, failed",
+    });
+  }
+
+  const title = trimToString(input.title);
+  const owner = trimToString(input.owner) ?? "";
+  const next = trimToString(input.next) ?? "";
+  const relatedSession = trimToString(input.relatedSession) ?? "";
+
+  let resumeAtIso: string | undefined;
+  let resumeAtDate: Date | undefined;
+  if (input.resumeAt !== undefined) {
+    const rawResumeAt = trimToString(input.resumeAt);
+    if (!rawResumeAt) {
+      errors.push({ step: "validation", message: "resumeAt must be a non-empty ISO timestamp" });
+    } else {
+      const parsed = new Date(rawResumeAt);
+      if (Number.isNaN(parsed.getTime())) {
+        errors.push({ step: "validation", message: "resumeAt must be a valid ISO timestamp" });
+      } else if (parsed.getTime() <= now.getTime()) {
+        errors.push({ step: "validation", message: "resumeAt must be in the future" });
+      } else {
+        resumeAtDate = parsed;
+        resumeAtIso = parsed.toISOString();
+      }
+    }
+  }
+
+  if (input.state !== undefined && !isRecord(input.state)) {
+    errors.push({ step: "validation", message: "state must be an object when provided" });
+  }
+
+  if (errors.length > 0 || !entity || !status) {
+    return { errors };
+  }
+
+  return {
+    normalized: {
+      entity,
+      status,
+      owner,
+      next,
+      relatedSession,
+      title,
+      resumeAtIso,
+      resumeAtDate,
+      state: input.state,
+      scheduleWake: input.scheduleWake !== false,
+      refreshProjection: input.refreshProjection === true,
+      recordEpisode: input.recordEpisode !== false,
+    },
+    errors,
+  };
+}
+
+function slugify(input: string): string {
+  return input
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 64);
+}
+
+function resolveOpenclawDir(override?: string): string {
+  if (override?.trim()) return override.trim();
+  const env = getEnv("OPENCLAW_HOME")?.trim();
+  if (env) return env;
+  return join(homedir(), ".openclaw");
+}
+
+function resolveWorkspaceRoot(cfg: HybridMemoryConfig, override?: string): string {
+  if (override?.trim()) return override.trim();
+  const env = getEnv("OPENCLAW_WORKSPACE")?.trim();
+  if (env) return env;
+  return join(resolveOpenclawDir(), "workspace");
+}
+
+function scheduleToCronExpr(resumeAt: Date): string {
+  return `${resumeAt.getUTCMinutes()} ${resumeAt.getUTCHours()} ${resumeAt.getUTCDate()} ${resumeAt.getUTCMonth() + 1} *`;
+}
+
+function resolveCronModel(cfg: HybridMemoryConfig): string {
+  const cronCfg = getCronModelConfig(cfg);
+  const pref = getLLMModelPreference(cronCfg, "nano");
+  return pref[0] ?? getDefaultCronModel(cronCfg, "nano");
+}
+
+function safeJson(value: unknown): string {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return "{\"error\":\"unserializable\"}";
+  }
+}
+
+function buildWakeMessage(args: {
+  entity: string;
+  status: string;
+  owner?: string;
+  next?: string;
+  relatedSession?: string;
+  title?: string;
+  resumeAtIso: string;
+  state?: Record<string, unknown>;
+  guardYears: number;
+}): string {
+  const lines: string[] = [
+    `Active-task wake reminder for \"${args.entity}\".`,
+    `Scheduled resume time (UTC): ${args.resumeAtIso}`,
+    `Status: ${args.status}`,
+  ];
+
+  if (args.title) lines.push(`Title: ${args.title}`);
+  if (args.owner) lines.push(`Owner: ${args.owner}`);
+  if (args.relatedSession) lines.push(`Related session: ${args.relatedSession}`);
+  if (args.next) lines.push(`Next: ${args.next}`);
+  if (args.state) {
+    const json = safeJson(args.state);
+    lines.push(`Checkpoint state JSON: ${json.length > 1500 ? `${json.slice(0, 1500)}...` : json}`);
+  }
+
+  lines.push(
+    `This reminder is guarded to avoid duplicate reruns for approximately ${args.guardYears} year(s).`,
+    "If work is still relevant, continue execution and update task state with active_task_checkpoint.",
+  );
+
+  return lines.join("\n");
+}
+
+export async function scheduleActiveTaskWakeReminder(
+  input: ActiveTaskWakeScheduleInput,
+): Promise<ActiveTaskWakeScheduleResult> {
+  const openclawDir = resolveOpenclawDir(input.openclawDir);
+  const cronDir = join(openclawDir, "cron");
+  const jobsPath = join(cronDir, "jobs.json");
+  mkdirSync(cronDir, { recursive: true });
+
+  let store: { jobs?: unknown[] } = {};
+  if (existsSync(jobsPath)) {
+    try {
+      store = JSON.parse(readFileSync(jobsPath, "utf-8")) as { jobs?: unknown[] };
+    } catch (err) {
+      throw new Error(`failed to parse ${jobsPath}: ${String(err)}`);
+    }
+  }
+
+  if (!Array.isArray(store.jobs)) {
+    store.jobs = [];
+  }
+
+  const jobs = store.jobs as Array<Record<string, unknown>>;
+  const entitySlug = slugify(input.entity) || "task";
+  const resumeAtIso = input.resumeAt.toISOString();
+  const resumeEpochSec = Math.floor(input.resumeAt.getTime() / 1000);
+  const jobId = `${ACTIVE_TASK_WAKE_JOB_PREFIX}${entitySlug}:${resumeEpochSec}`;
+
+  let disabledPreviousJobs = 0;
+  const entityPrefix = `${ACTIVE_TASK_WAKE_JOB_PREFIX}${entitySlug}:`;
+  for (const row of jobs) {
+    const pluginJobId = typeof row.pluginJobId === "string" ? row.pluginJobId : undefined;
+    if (!pluginJobId || pluginJobId === jobId) continue;
+    if (!pluginJobId.startsWith(entityPrefix)) continue;
+    if (row.enabled !== false) {
+      row.enabled = false;
+      disabledPreviousJobs += 1;
+    }
+  }
+
+  const cronExpr = scheduleToCronExpr(input.resumeAt);
+  const model = resolveCronModel(input.cfg);
+  const minIntervalMs = ACTIVE_TASK_WAKE_GUARD_YEARS * 365 * 24 * 60 * 60 * 1000;
+  const guardFile = join(openclawDir, "cron", "guard", `active-task-wake-${entitySlug}.ms`);
+  const guardPrefix = [
+    `GUARD CHECK: Before continuing, read \"${guardFile}\" if it exists.`,
+    `If current epoch ms minus the stored value is less than ${minIntervalMs}, reply only \"Skipped: active-task wake already delivered recently\" and stop.`,
+    `After a successful reminder, write the current epoch ms back to \"${guardFile}\".`,
+    "",
+  ].join("\n");
+
+  const job: Record<string, unknown> = {
+    id: jobId,
+    pluginJobId: jobId,
+    name: `active-task-wake-${entitySlug}`,
+    sessionTarget: "isolated",
+    schedule: { kind: "cron", expr: cronExpr },
+    channel: "system",
+    message:
+      guardPrefix +
+      buildWakeMessage({
+        entity: input.entity,
+        status: input.status,
+        owner: input.owner,
+        next: input.next,
+        relatedSession: input.relatedSession,
+        title: input.title,
+        resumeAtIso,
+        state: input.state,
+        guardYears: ACTIVE_TASK_WAKE_GUARD_YEARS,
+      }),
+    model,
+    delivery: { mode: "announce" },
+    enabled: true,
+    metadata: {
+      source: "active_task_checkpoint",
+      entity: input.entity,
+      resumeAt: resumeAtIso,
+      createdAt: new Date().toISOString(),
+    },
+  };
+
+  const existingIdx = jobs.findIndex((row) => {
+    const pluginJobId = typeof row.pluginJobId === "string" ? row.pluginJobId : "";
+    const id = typeof row.id === "string" ? row.id : "";
+    return pluginJobId === jobId || id === jobId;
+  });
+
+  if (existingIdx >= 0) {
+    jobs[existingIdx] = { ...(jobs[existingIdx] ?? {}), ...job };
+  } else {
+    jobs.push(job);
+  }
+
+  const payload = JSON.stringify(store, null, 2);
+  const tmpPath = `${jobsPath}.${process.pid}.${Date.now()}.tmp`;
+  writeFileSync(tmpPath, payload, "utf-8");
+  renameSync(tmpPath, jobsPath);
+
+  return {
+    scheduled: true,
+    jobId,
+    cronExpr,
+    jobsPath,
+    disabledPreviousJobs,
+  };
+}
+
+export async function refreshActiveTaskProjectionFromFacts(
+  input: ActiveTaskProjectionRefreshInput,
+): Promise<ActiveTaskProjectionRefreshResult> {
+  if (!input.cfg.activeTask.enabled) {
+    return { attempted: true, refreshed: false, reason: "active_task_disabled" };
+  }
+  if (input.cfg.activeTask.ledger !== "facts") {
+    return { attempted: true, refreshed: false, reason: "active_task_ledger_not_facts" };
+  }
+
+  const workspaceRoot = resolveWorkspaceRoot(input.cfg, input.workspaceRoot);
+  const activeTaskPath = isAbsolute(input.cfg.activeTask.filePath)
+    ? input.cfg.activeTask.filePath
+    : join(workspaceRoot, input.cfg.activeTask.filePath);
+  const staleMinutes = parseDuration(input.cfg.activeTask.staleThreshold);
+
+  await renderActiveTaskMarkdownFile(input.factsDb, staleMinutes, activeTaskPath, input.cfg.activeTask.projection);
+  return { attempted: true, refreshed: true, path: activeTaskPath };
+}
+
+function stepError(step: ActiveTaskCheckpointStep, err: unknown): ActiveTaskCheckpointError {
+  return { step, message: err instanceof Error ? err.message : String(err) };
+}
+
+function outcomeFromStatus(status: string): EpisodeOutcome {
+  if (status === "done") return "success";
+  if (status === "failed") return "failure";
+  if (status === "blocked" || status === "waiting") return "partial";
+  return "unknown";
+}
+
+function scopeFromFilter(filter?: ScopeFilter | null): {
+  scope: "global" | "user" | "agent" | "session";
+  scopeTarget: string | null;
+  agentId?: string;
+  userId?: string;
+  sessionId?: string;
+} {
+  if (filter?.sessionId?.trim()) {
+    return {
+      scope: "session",
+      scopeTarget: filter.sessionId,
+      agentId: filter.agentId ?? undefined,
+      userId: filter.userId ?? undefined,
+      sessionId: filter.sessionId,
+    };
+  }
+  if (filter?.userId?.trim()) {
+    return {
+      scope: "user",
+      scopeTarget: filter.userId,
+      agentId: filter.agentId ?? undefined,
+      userId: filter.userId,
+      sessionId: filter.sessionId ?? undefined,
+    };
+  }
+  if (filter?.agentId?.trim()) {
+    return {
+      scope: "agent",
+      scopeTarget: filter.agentId,
+      agentId: filter.agentId,
+      userId: filter.userId ?? undefined,
+      sessionId: filter.sessionId ?? undefined,
+    };
+  }
+  return {
+    scope: "global",
+    scopeTarget: null,
+    agentId: filter?.agentId ?? undefined,
+    userId: filter?.userId ?? undefined,
+    sessionId: filter?.sessionId ?? undefined,
+  };
+}
+
+export async function runActiveTaskCheckpoint(
+  deps: ActiveTaskCheckpointDeps,
+  input: ActiveTaskCheckpointInput,
+): Promise<ActiveTaskCheckpointResult> {
+  const now = deps.now?.() ?? new Date();
+  const validation = normalizeCheckpointInput(input, now);
+  if (!validation.normalized) {
+    return {
+      ok: false,
+      partial: false,
+      message: `active_task_checkpoint validation failed: ${validation.errors.map((e) => e.message).join("; ")}`,
+      steps: {
+        facts: { ok: false, updatedKeys: [], failedKeys: [] },
+        episode: { attempted: false, ok: false, skippedReason: "validation_failed" },
+        schedule: { attempted: false, scheduled: false, skippedReason: "validation_failed" },
+        projection: { attempted: false, refreshed: false, reason: "validation_failed" },
+      },
+      errors: validation.errors,
+    };
+  }
+
+  const checkpoint = validation.normalized;
+  const taskUpdated = now.toISOString();
+  const errors: ActiveTaskCheckpointError[] = [];
+  const updatedKeys: string[] = [];
+  const failedKeys: string[] = [];
+
+  let titleSource: "provided" | "existing" | "defaulted" | undefined;
+  let effectiveTitle = checkpoint.title;
+
+  try {
+    if (effectiveTitle) {
+      titleSource = "provided";
+    } else {
+      const existingTitleHit = deps.factsDb.lookup(checkpoint.entity, "title", undefined, {
+        includeSuperseded: false,
+        limit: 1,
+      })[0];
+      const existingTitle =
+        trimToString(existingTitleHit?.entry?.value) ?? trimToString(existingTitleHit?.entry?.text) ?? undefined;
+      if (existingTitle) {
+        effectiveTitle = existingTitle;
+        titleSource = "existing";
+      } else {
+        effectiveTitle = "Project task";
+        titleSource = "defaulted";
+      }
+    }
+  } catch (err) {
+    deps.logger?.warn?.(`memory-hybrid: active-task checkpoint title lookup failed: ${String(err)}`);
+    effectiveTitle = checkpoint.title ?? "Project task";
+    titleSource = checkpoint.title ? "provided" : "defaulted";
+  }
+
+  const updates: Array<{ key: string; value: string }> = [
+    { key: "status", value: checkpoint.status },
+    { key: "next", value: checkpoint.next },
+    { key: "owner", value: checkpoint.owner },
+    { key: "related_session", value: checkpoint.relatedSession },
+    { key: "task_updated", value: taskUpdated },
+  ];
+
+  if (effectiveTitle) {
+    updates.push({ key: "title", value: effectiveTitle });
+  }
+
+  if (checkpoint.state) {
+    updates.push({ key: "checkpoint_state", value: safeJson(checkpoint.state) });
+  }
+
+  if (checkpoint.resumeAtIso) {
+    updates.push({ key: "resume_at", value: checkpoint.resumeAtIso });
+  }
+
+  for (const update of updates) {
+    try {
+      await upsertProjectTaskKey(
+        deps.factsDb,
+        deps.vectorDb,
+        deps.embeddings,
+        checkpoint.entity,
+        update.key,
+        update.value,
+        deps.logger,
+      );
+      updatedKeys.push(update.key);
+    } catch (err) {
+      failedKeys.push(update.key);
+      errors.push(stepError("facts", new Error(`${update.key}: ${String(err)}`)));
+    }
+  }
+
+  let episodeId: string | undefined;
+  let episodeAttempted = false;
+  let episodeOk = false;
+  let episodeSkippedReason: string | undefined;
+
+  if (checkpoint.recordEpisode) {
+    episodeAttempted = true;
+    try {
+      const scope = scopeFromFilter(deps.episodeScopeFilter);
+      const contextLines: string[] = [
+        `entity=${checkpoint.entity}`,
+        `status=${checkpoint.status}`,
+        `owner=${checkpoint.owner || "n/a"}`,
+        `next=${checkpoint.next || "n/a"}`,
+        `relatedSession=${checkpoint.relatedSession || "n/a"}`,
+        `taskUpdated=${taskUpdated}`,
+      ];
+      if (checkpoint.resumeAtIso) contextLines.push(`resumeAt=${checkpoint.resumeAtIso}`);
+      if (checkpoint.state) contextLines.push(`state=${safeJson(checkpoint.state)}`);
+
+      const ep = deps.factsDb.recordEpisode({
+        event: `Active task checkpoint: ${checkpoint.entity}`,
+        outcome: outcomeFromStatus(checkpoint.status),
+        context: contextLines.join("\n"),
+        importance: checkpoint.status === "failed" ? 0.8 : 0.6,
+        tags: ["active-task", "checkpoint", slugify(checkpoint.entity)],
+        scope: scope.scope,
+        scopeTarget: scope.scopeTarget,
+        agentId: scope.agentId,
+        userId: scope.userId,
+        sessionId: scope.sessionId,
+      });
+      episodeId = ep.id;
+      episodeOk = true;
+    } catch (err) {
+      errors.push(stepError("episode", err));
+    }
+  } else {
+    episodeSkippedReason = "record_episode_disabled";
+  }
+
+  let wakeAttempted = false;
+  let wakeScheduled = false;
+  let wakeSkippedReason: string | undefined;
+  let wakeResult: ActiveTaskWakeScheduleResult | undefined;
+
+  if (checkpoint.resumeAtIso && checkpoint.resumeAtDate && checkpoint.scheduleWake) {
+    wakeAttempted = true;
+    try {
+      const scheduleWake = deps.scheduleWakeFn ?? scheduleActiveTaskWakeReminder;
+      wakeResult = await scheduleWake({
+        cfg: deps.cfg,
+        entity: checkpoint.entity,
+        status: checkpoint.status,
+        owner: checkpoint.owner || undefined,
+        next: checkpoint.next || undefined,
+        relatedSession: checkpoint.relatedSession || undefined,
+        title: effectiveTitle,
+        resumeAt: checkpoint.resumeAtDate,
+        state: checkpoint.state,
+        openclawDir: deps.openclawDir,
+      });
+      wakeScheduled = wakeResult.scheduled;
+    } catch (err) {
+      errors.push(stepError("schedule", err));
+    }
+  } else {
+    wakeSkippedReason = checkpoint.resumeAtIso ? "schedule_wake_disabled" : "resumeAt_not_provided";
+  }
+
+  let projection = { attempted: false, refreshed: false, reason: "refresh_not_requested" } as ActiveTaskProjectionRefreshResult;
+  if (checkpoint.refreshProjection) {
+    try {
+      const refreshFn = deps.refreshProjectionFn ?? refreshActiveTaskProjectionFromFacts;
+      projection = await refreshFn({
+        cfg: deps.cfg,
+        factsDb: deps.factsDb,
+        workspaceRoot: deps.workspaceRoot,
+      });
+    } catch (err) {
+      projection = { attempted: true, refreshed: false, reason: String(err) };
+      errors.push(stepError("projection", err));
+    }
+  }
+
+  const ok = errors.length === 0;
+  const partial = !ok;
+
+  const summaryBits: string[] = [
+    `entity=${checkpoint.entity}`,
+    `status=${checkpoint.status}`,
+    `facts=${updatedKeys.length}/${updates.length}`,
+    checkpoint.recordEpisode ? `episode=${episodeOk ? "recorded" : "failed"}` : "episode=skipped",
+  ];
+  if (wakeAttempted) {
+    summaryBits.push(`wake=${wakeScheduled ? "scheduled" : "failed"}`);
+  } else if (wakeSkippedReason) {
+    summaryBits.push(`wake=skipped(${wakeSkippedReason})`);
+  }
+  if (checkpoint.refreshProjection) {
+    summaryBits.push(`projection=${projection.refreshed ? "refreshed" : "not_refreshed"}`);
+  }
+
+  const message = ok
+    ? `active_task_checkpoint completed (${summaryBits.join(", ")}).`
+    : `active_task_checkpoint completed with partial failures (${summaryBits.join(", ")}).`;
+
+  return {
+    ok,
+    partial,
+    message,
+    checkpoint: {
+      entity: checkpoint.entity,
+      status: checkpoint.status,
+      owner: checkpoint.owner,
+      next: checkpoint.next,
+      relatedSession: checkpoint.relatedSession,
+      title: effectiveTitle,
+      resumeAt: checkpoint.resumeAtIso,
+      taskUpdated,
+      state: checkpoint.state,
+    },
+    steps: {
+      facts: {
+        ok: failedKeys.length === 0,
+        updatedKeys,
+        failedKeys,
+        titleSource,
+      },
+      episode: {
+        attempted: episodeAttempted,
+        ok: episodeOk,
+        episodeId,
+        skippedReason: episodeSkippedReason,
+      },
+      schedule: {
+        attempted: wakeAttempted,
+        scheduled: wakeScheduled,
+        jobId: wakeResult?.jobId,
+        cronExpr: wakeResult?.cronExpr,
+        jobsPath: wakeResult?.jobsPath,
+        disabledPreviousJobs: wakeResult?.disabledPreviousJobs,
+        skippedReason: wakeSkippedReason,
+      },
+      projection,
+    },
+    errors,
+  };
+}

--- a/extensions/memory-hybrid/services/active-task-checkpoint.ts
+++ b/extensions/memory-hybrid/services/active-task-checkpoint.ts
@@ -81,7 +81,8 @@ export interface ActiveTaskWakeScheduleInput {
 export interface ActiveTaskWakeScheduleResult {
   scheduled: boolean;
   jobId: string;
-  cronExpr: string;
+  scheduleKind: "at";
+  scheduleAt: string;
   jobsPath: string;
   disabledPreviousJobs: number;
 }
@@ -131,7 +132,8 @@ export interface ActiveTaskCheckpointResult {
       attempted: boolean;
       scheduled: boolean;
       jobId?: string;
-      cronExpr?: string;
+      scheduleKind?: "at";
+      scheduleAt?: string;
       jobsPath?: string;
       disabledPreviousJobs?: number;
       skippedReason?: string;
@@ -168,6 +170,16 @@ function normalizeStatus(raw?: string): string | undefined {
   }
   if (value === "failed" || value === "error") return "failed";
   return undefined;
+}
+
+function normalizeExistingStatus(raw?: string): string | undefined {
+  const value = trimToString(raw);
+  if (value === undefined) return undefined;
+  const normalized = normalizeStatus(value);
+  if (normalized) return normalized;
+  const lower = value.toLowerCase();
+  if (lower === "abandoned" || lower === "superseded") return lower;
+  return lower;
 }
 
 function normalizeCheckpointInput(
@@ -256,6 +268,21 @@ function projectFactCacheKey(entity: string, key: string): string {
   return `${entity}\u0000${key}`;
 }
 
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function extractProjectValueFromText(text: string, key: string): string | undefined {
+  const trimmedText = text.trim();
+  if (!trimmedText) return undefined;
+  const keyPattern = escapeRegExp(key);
+  const match = trimmedText.match(new RegExp(`^Task \\[[^\\]]+\\] ${keyPattern}:\\s*(.*)$`));
+  if (match) {
+    return (match[1] ?? "").trim();
+  }
+  return trimToString(trimmedText);
+}
+
 function buildLatestProjectFactCache(factsDb: FactsDB): Map<string, MemoryEntry> {
   const facts = factsDb.listFactsByCategory("project", Number.MAX_SAFE_INTEGER);
   const grouped = groupProjectFactsByEntity(facts);
@@ -271,7 +298,12 @@ function buildLatestProjectFactCache(factsDb: FactsDB): Map<string, MemoryEntry>
 
 function getLatestProjectValue(cache: Map<string, MemoryEntry>, entity: string, key: string): string | undefined {
   const row = cache.get(projectFactCacheKey(entity, key));
-  return trimToString(row?.value) ?? trimToString(row?.text) ?? undefined;
+  if (!row) return undefined;
+  if (typeof row.value === "string") return row.value.trim();
+  if (typeof row.text === "string") {
+    return extractProjectValueFromText(row.text, key);
+  }
+  return trimToString(row.value) ?? undefined;
 }
 
 function wakeEntityKey(entity: string): string {
@@ -291,10 +323,6 @@ function resolveWorkspaceRoot(override?: string): string {
   const env = getEnv("OPENCLAW_WORKSPACE")?.trim();
   if (env) return env;
   return join(resolveOpenclawDir(), "workspace");
-}
-
-function scheduleToCronExpr(resumeAt: Date): string {
-  return `${resumeAt.getUTCMinutes()} ${resumeAt.getUTCHours()} ${resumeAt.getUTCDate()} ${resumeAt.getUTCMonth() + 1} *`;
 }
 
 function resolveCronModel(cfg: HybridMemoryConfig): string {
@@ -385,33 +413,35 @@ async function scheduleActiveTaskWakeReminder(
     }
   }
 
-  const cronExpr = scheduleToCronExpr(input.resumeAt);
   const model = resolveCronModel(input.cfg);
   const minIntervalMs = ACTIVE_TASK_WAKE_GUARD_YEARS * 365 * 24 * 60 * 60 * 1000;
   const guardJobName = `active-task-wake-${entityKey}-${resumeEpochSec}`;
-  const guardPrefix = buildGuardPrefix(guardJobName, minIntervalMs);
+  const guardPrefix = buildGuardPrefix(guardJobName, minIntervalMs, openclawDir);
 
   const job: Record<string, unknown> = {
     id: jobId,
     pluginJobId: jobId,
     name: `active-task-wake-${entitySlug}`,
     sessionTarget: "isolated",
-    schedule: { kind: "cron", expr: cronExpr },
-    channel: "system",
-    message:
-      guardPrefix +
-      buildWakeMessage({
-        entity: input.entity,
-        status: input.status,
-        owner: input.owner,
-        next: input.next,
-        relatedSession: input.relatedSession,
-        title: input.title,
-        resumeAtIso,
-        state: input.state,
-        guardYears: ACTIVE_TASK_WAKE_GUARD_YEARS,
-      }),
-    model,
+    schedule: { kind: "at", at: resumeAtIso },
+    deleteAfterRun: true,
+    payload: {
+      kind: "agentTurn",
+      message:
+        guardPrefix +
+        buildWakeMessage({
+          entity: input.entity,
+          status: input.status,
+          owner: input.owner,
+          next: input.next,
+          relatedSession: input.relatedSession,
+          title: input.title,
+          resumeAtIso,
+          state: input.state,
+          guardYears: ACTIVE_TASK_WAKE_GUARD_YEARS,
+        }),
+      model,
+    },
     delivery: { mode: "announce" },
     enabled: true,
     metadata: {
@@ -442,7 +472,8 @@ async function scheduleActiveTaskWakeReminder(
   return {
     scheduled: true,
     jobId,
-    cronExpr,
+    scheduleKind: "at",
+    scheduleAt: resumeAtIso,
     jobsPath,
     disabledPreviousJobs,
   };
@@ -475,7 +506,7 @@ function stepError(step: ActiveTaskCheckpointStep, err: unknown): ActiveTaskChec
 function outcomeFromStatus(status: string): EpisodeOutcome {
   if (status === "done") return "success";
   if (status === "failed") return "failure";
-  if (status === "cancelled") return "partial";
+  if (status === "cancelled" || status === "abandoned" || status === "superseded") return "partial";
   if (status === "blocked" || status === "waiting") return "partial";
   return "unknown";
 }
@@ -546,10 +577,8 @@ export async function runActiveTaskCheckpoint(
 
   const checkpoint = validation.normalized;
   const latestProjectFacts = buildLatestProjectFactCache(deps.factsDb);
-  const resolvedStatus =
-    checkpoint.status ??
-    normalizeStatus(getLatestProjectValue(latestProjectFacts, checkpoint.entity, "status")) ??
-    "in_progress";
+  const existingStatus = getLatestProjectValue(latestProjectFacts, checkpoint.entity, "status");
+  const resolvedStatus = checkpoint.status ?? normalizeExistingStatus(existingStatus) ?? "in_progress";
   const resolvedOwner = checkpoint.owner ?? getLatestProjectValue(latestProjectFacts, checkpoint.entity, "owner") ?? "";
   const resolvedNext = checkpoint.next ?? getLatestProjectValue(latestProjectFacts, checkpoint.entity, "next") ?? "";
   const resolvedRelatedSession =
@@ -767,7 +796,8 @@ export async function runActiveTaskCheckpoint(
         attempted: wakeAttempted,
         scheduled: wakeScheduled,
         jobId: wakeResult?.jobId,
-        cronExpr: wakeResult?.cronExpr,
+        scheduleKind: wakeResult?.scheduleKind,
+        scheduleAt: wakeResult?.scheduleAt,
         jobsPath: wakeResult?.jobsPath,
         disabledPreviousJobs: wakeResult?.disabledPreviousJobs,
         skippedReason: wakeSkippedReason,

--- a/extensions/memory-hybrid/services/cron-guard.ts
+++ b/extensions/memory-hybrid/services/cron-guard.ts
@@ -66,10 +66,10 @@ export function readGuardTimestampMs(jobName: string, openclawDir?: string): num
  * The persistent path (~/.openclaw/cron/guard/) survives system reboots,
  * unlike the old /tmp/ files used by issue #304.
  */
-export function buildGuardPrefix(jobName: string, minIntervalMs: number): string {
+export function buildGuardPrefix(jobName: string, minIntervalMs: number, openclawDir?: string): string {
   const hours = Math.round(minIntervalMs / (60 * 60 * 1000));
-  const guardFile = getGuardFilePath(jobName);
-  const guardDir = getGuardDir();
+  const guardFile = getGuardFilePath(jobName, openclawDir);
+  const guardDir = getGuardDir(openclawDir);
   return `GUARD CHECK (issue #305): Before running, read the last-run guard file: cat "${guardFile}" 2>/dev/null. If the file contains a number T (Unix epoch ms) where (current epoch ms − T) < ${minIntervalMs} (${hours}h guard window), reply ONLY 'Skipped: ${jobName} — ran within ${hours}h guard window' and stop. Otherwise proceed with the task below. AFTER successful completion: mkdir -p "${guardDir}" and write the current Unix epoch ms to "${guardFile}".\n\n`;
 }
 

--- a/extensions/memory-hybrid/services/task-ledger-facts.ts
+++ b/extensions/memory-hybrid/services/task-ledger-facts.ts
@@ -325,8 +325,7 @@ export async function getActiveTaskProjectionStatus(
 ): Promise<ActiveTaskProjectionStatus> {
   const markerPath = getActiveTaskProjectionStaleMarkerPath(filePath);
   const marker = await readActiveTaskProjectionStaleMarker(filePath);
-  const latestProjectFactSec =
-    opts.latestProjectFactSec ?? getLatestProjectFactCreatedAtSec(factsDb, opts.scopeFilter);
+  const latestProjectFactSec = opts.latestProjectFactSec ?? getLatestProjectFactCreatedAtSec(factsDb, opts.scopeFilter);
   const latestProjectFactAt = toIsoOrNull(latestProjectFactSec);
 
   let exists = false;
@@ -861,7 +860,16 @@ export async function syncActiveTaskEntryToFacts(
   );
   await upsertProjectTaskKey(factsDb, vectorDb, embeddings, entity, "task_updated", entry.updated, log, upsertOpts);
   await upsertProjectTaskKey(factsDb, vectorDb, embeddings, entity, "started", entry.started, log, upsertOpts);
-  await upsertProjectTaskKey(factsDb, vectorDb, embeddings, entity, "branch", entry.branch?.trim() || "", log, upsertOpts);
+  await upsertProjectTaskKey(
+    factsDb,
+    vectorDb,
+    embeddings,
+    entity,
+    "branch",
+    entry.branch?.trim() || "",
+    log,
+    upsertOpts,
+  );
   await upsertProjectTaskKey(
     factsDb,
     vectorDb,

--- a/extensions/memory-hybrid/services/task-ledger-facts.ts
+++ b/extensions/memory-hybrid/services/task-ledger-facts.ts
@@ -325,8 +325,11 @@ export async function upsertProjectTaskKey(
   key: string,
   value: string,
   log?: { warn?: (m: string) => void },
+  cache?: { latestByEntityKey: Map<string, MemoryEntry> },
 ): Promise<void> {
-  const facts = factsDb.listFactsByCategory(TASK_LEDGER_CATEGORY, 8000);
+  const facts = cache?.latestByEntityKey
+    ? Array.from(cache.latestByEntityKey.values())
+    : factsDb.listFactsByCategory(TASK_LEDGER_CATEGORY, 8000);
   const same = facts.filter((f) => f.entity === entity && (f.key ?? "") === key);
   same.sort((a, b) => b.createdAt - a.createdAt);
   const previous = same[0];

--- a/extensions/memory-hybrid/services/task-ledger-facts.ts
+++ b/extensions/memory-hybrid/services/task-ledger-facts.ts
@@ -774,7 +774,7 @@ export function buildFactsSectionedMarkdownBody(
   return parts.join("\n");
 }
 
-function taskEntityKey(entity: string, key: string): string {
+export function taskEntityKey(entity: string, key: string): string {
   return `${entity}\u0000${key}`;
 }
 

--- a/extensions/memory-hybrid/skills/hybrid-memory/SKILL.md
+++ b/extensions/memory-hybrid/skills/hybrid-memory/SKILL.md
@@ -54,6 +54,7 @@ When goal stewardship is enabled, use these tools for long-running, multi-sessio
 | `goal_update` | Goal description, criteria, or priority needs updating as context evolves |
 | `goal_complete` | ALL acceptance criteria are verifiably met — include a clear verification summary |
 | `goal_abandon` | Goal is no longer relevant (user changed their mind) |
+| `active_task_checkpoint` | Atomically checkpoint active work (project facts + episode audit + optional wake schedule + optional ACTIVE-TASKS projection refresh) |
 | `active_task_propose_goal` | Draft a `goal_register` payload from an `ACTIVE-TASKS.md` row (task hygiene) |
 
 **Subagent naming convention for automatic goal linkage:**

--- a/extensions/memory-hybrid/tests/active-task-checkpoint.test.ts
+++ b/extensions/memory-hybrid/tests/active-task-checkpoint.test.ts
@@ -241,7 +241,9 @@ describe("active-task-checkpoint", () => {
     expect(followup.checkpoint?.owner).toBe("agent:forge");
     expect(followup.checkpoint?.next).toBe("Wait for dependency");
     expect(followup.checkpoint?.relatedSession).toBe("agent:main:session-a");
-    expect(followup.steps.facts.updatedKeys).toEqual(expect.arrayContaining(["status", "owner", "next", "related_session"]));
+    expect(followup.steps.facts.updatedKeys).toEqual(
+      expect.arrayContaining(["status", "owner", "next", "related_session"]),
+    );
 
     factsDb.close();
   });

--- a/extensions/memory-hybrid/tests/active-task-checkpoint.test.ts
+++ b/extensions/memory-hybrid/tests/active-task-checkpoint.test.ts
@@ -217,6 +217,50 @@ describe("active-task-checkpoint", () => {
     factsDb.close();
   });
 
+  it("disables stale wake reminder when a follow-up checkpoint omits resumeAt", async () => {
+    const { cfg, factsDb, vectorDb, embeddings, openclawDir } = setup();
+    const resumeAtDate = new Date(Date.now() + 2 * 60 * 60 * 1000);
+
+    const first = await runActiveTaskCheckpoint(
+      { cfg, factsDb, vectorDb, embeddings, openclawDir },
+      {
+        entity: "task-1270-wake-cleanup",
+        status: "waiting",
+        next: "Resume later",
+        resumeAt: resumeAtDate.toISOString(),
+      },
+    );
+    expect(first.ok).toBe(true);
+    expect(first.steps.schedule.scheduled).toBe(true);
+    expect(first.steps.schedule.jobId).toBeTruthy();
+
+    const second = await runActiveTaskCheckpoint(
+      { cfg, factsDb, vectorDb, embeddings, openclawDir },
+      {
+        entity: "task-1270-wake-cleanup",
+        status: "done",
+      },
+    );
+    expect(second.ok).toBe(true);
+    expect(second.steps.schedule.attempted).toBe(false);
+    expect(second.steps.schedule.scheduled).toBe(false);
+    expect(second.steps.schedule.skippedReason).toBe("resumeAt_not_provided");
+    expect(second.steps.schedule.disabledPreviousJobs).toBe(1);
+
+    const jobsPath = second.steps.schedule.jobsPath;
+    expect(jobsPath).toBeTruthy();
+    const raw = readFileSync(jobsPath as string, "utf-8");
+    const store = JSON.parse(raw) as { jobs?: Array<Record<string, unknown>> };
+    const wakeJobs = (store.jobs ?? []).filter((j) => {
+      const pluginJobId = typeof j.pluginJobId === "string" ? j.pluginJobId : "";
+      return pluginJobId.startsWith("hybrid-mem:active-task-wake:");
+    });
+    expect(wakeJobs.length).toBeGreaterThan(0);
+    expect(wakeJobs.filter((j) => j.enabled !== false).length).toBe(0);
+
+    factsDb.close();
+  });
+
   it("preserves existing status/owner/next/related_session when optional fields are omitted", async () => {
     const { cfg, factsDb, vectorDb, embeddings, openclawDir } = setup();
 

--- a/extensions/memory-hybrid/tests/active-task-checkpoint.test.ts
+++ b/extensions/memory-hybrid/tests/active-task-checkpoint.test.ts
@@ -113,7 +113,7 @@ describe("active-task-checkpoint", () => {
     expect(latestProjectValue(factsDb, "task-1270", "related_session")).toBe("agent:forge:subagent:1");
     expect(latestProjectValue(factsDb, "task-1270", "title")).toBe("Implement checkpoint tool");
     expect(latestProjectValue(factsDb, "task-1270", "task_updated")).toBeTruthy();
-    expect(latestProjectValue(factsDb, "task-1270", "checkpoint_state")).toContain("\"phase\":\"coding\"");
+    expect(latestProjectValue(factsDb, "task-1270", "checkpoint_state")).toContain('"phase":"coding"');
 
     expect(factsDb.episodesCount()).toBe(1);
 

--- a/extensions/memory-hybrid/tests/active-task-checkpoint.test.ts
+++ b/extensions/memory-hybrid/tests/active-task-checkpoint.test.ts
@@ -198,6 +198,8 @@ describe("active-task-checkpoint", () => {
     expect(result.steps.schedule.attempted).toBe(true);
     expect(result.steps.schedule.scheduled).toBe(true);
     expect(result.steps.schedule.jobId).toMatch(/^hybrid-mem:active-task-wake:[a-z0-9-]+:\d+$/);
+    expect(result.steps.schedule.scheduleKind).toBe("at");
+    expect(result.steps.schedule.scheduleAt).toBe(resumeAtDate.toISOString());
     expect(result.steps.schedule.jobsPath).toBeTruthy();
 
     const jobsPath = result.steps.schedule.jobsPath!;
@@ -205,10 +207,12 @@ describe("active-task-checkpoint", () => {
     const store = JSON.parse(raw) as { jobs?: Array<Record<string, unknown>> };
     const job = (store.jobs ?? []).find((j) => j.pluginJobId === result.steps.schedule.jobId);
     expect(job).toBeTruthy();
-    const schedule = job?.schedule as { kind?: string; expr?: string } | undefined;
-    expect(schedule?.kind).toBe("cron");
-    expect(schedule?.expr).toBe(result.steps.schedule.cronExpr);
-    expect(String(job?.message ?? "")).toContain("mkdir -p");
+    const schedule = job?.schedule as { kind?: string; at?: string } | undefined;
+    expect(schedule?.kind).toBe("at");
+    expect(schedule?.at).toBe(result.steps.schedule.scheduleAt);
+    const payload = job?.payload as { kind?: string; message?: string } | undefined;
+    expect(payload?.kind).toBe("agentTurn");
+    expect(String(payload?.message ?? "")).toContain("mkdir -p");
 
     factsDb.close();
   });
@@ -289,6 +293,75 @@ describe("active-task-checkpoint", () => {
     expect(followup.checkpoint?.owner).toBe("agent:forge");
     expect(followup.checkpoint?.next).toBe("Wait for dependency");
     expect(followup.checkpoint?.relatedSession).toBe("agent:main:session-a");
+
+    factsDb.close();
+  });
+
+  it("preserves explicitly cleared owner/next fields on follow-up checkpoints", async () => {
+    const { cfg, factsDb, vectorDb, embeddings, openclawDir } = setup();
+
+    const baseline = await runActiveTaskCheckpoint(
+      { cfg, factsDb, vectorDb, embeddings, openclawDir },
+      {
+        entity: "task-1270-clear-fields",
+        status: "in_progress",
+        owner: "agent:forge",
+        next: "Initial next step",
+      },
+    );
+    expect(baseline.ok).toBe(true);
+
+    const clearFields = await runActiveTaskCheckpoint(
+      { cfg, factsDb, vectorDb, embeddings, openclawDir },
+      {
+        entity: "task-1270-clear-fields",
+        owner: "",
+        next: "",
+      },
+    );
+    expect(clearFields.ok).toBe(true);
+    expect(clearFields.checkpoint?.owner).toBe("");
+    expect(clearFields.checkpoint?.next).toBe("");
+
+    const followup = await runActiveTaskCheckpoint(
+      { cfg, factsDb, vectorDb, embeddings, openclawDir },
+      {
+        entity: "task-1270-clear-fields",
+        title: "Touch checkpoint",
+      },
+    );
+    expect(followup.ok).toBe(true);
+    expect(followup.checkpoint?.owner).toBe("");
+    expect(followup.checkpoint?.next).toBe("");
+
+    factsDb.close();
+  });
+
+  it("preserves terminal statuses from existing facts when status is omitted", async () => {
+    const { cfg, factsDb, vectorDb, embeddings, openclawDir } = setup();
+
+    factsDb.store({
+      text: "Task task-1270-terminal status: superseded",
+      category: "project",
+      importance: 0.3,
+      entity: "task-1270-terminal",
+      key: "status",
+      value: "superseded",
+      source: "conversation",
+    });
+
+    const result = await runActiveTaskCheckpoint(
+      { cfg, factsDb, vectorDb, embeddings, openclawDir },
+      {
+        entity: "task-1270-terminal",
+        title: "Metadata only checkpoint",
+        scheduleWake: false,
+      },
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.checkpoint?.status).toBe("superseded");
+    expect(latestProjectValue(factsDb, "task-1270-terminal", "status")).toBe("superseded");
 
     factsDb.close();
   });

--- a/extensions/memory-hybrid/tests/active-task-checkpoint.test.ts
+++ b/extensions/memory-hybrid/tests/active-task-checkpoint.test.ts
@@ -349,6 +349,15 @@ describe("active-task-checkpoint", () => {
       value: "superseded",
       source: "conversation",
     });
+    factsDb.store({
+      text: "Task task-1270-terminal-abandoned status: abandoned",
+      category: "project",
+      importance: 0.3,
+      entity: "task-1270-terminal-abandoned",
+      key: "status",
+      value: "abandoned",
+      source: "conversation",
+    });
 
     const result = await runActiveTaskCheckpoint(
       { cfg, factsDb, vectorDb, embeddings, openclawDir },
@@ -362,6 +371,18 @@ describe("active-task-checkpoint", () => {
     expect(result.ok).toBe(true);
     expect(result.checkpoint?.status).toBe("superseded");
     expect(latestProjectValue(factsDb, "task-1270-terminal", "status")).toBe("superseded");
+
+    const abandonedResult = await runActiveTaskCheckpoint(
+      { cfg, factsDb, vectorDb, embeddings, openclawDir },
+      {
+        entity: "task-1270-terminal-abandoned",
+        title: "Metadata only checkpoint",
+        scheduleWake: false,
+      },
+    );
+    expect(abandonedResult.ok).toBe(true);
+    expect(abandonedResult.checkpoint?.status).toBe("abandoned");
+    expect(latestProjectValue(factsDb, "task-1270-terminal-abandoned", "status")).toBe("abandoned");
 
     factsDb.close();
   });

--- a/extensions/memory-hybrid/tests/active-task-checkpoint.test.ts
+++ b/extensions/memory-hybrid/tests/active-task-checkpoint.test.ts
@@ -387,6 +387,35 @@ describe("active-task-checkpoint", () => {
     factsDb.close();
   });
 
+  it("preserves abandoned status from existing facts when status is omitted", async () => {
+    const { cfg, factsDb, vectorDb, embeddings, openclawDir } = setup();
+
+    factsDb.store({
+      text: "Task task-1270-abandoned status: abandoned",
+      category: "project",
+      importance: 0.3,
+      entity: "task-1270-abandoned",
+      key: "status",
+      value: "abandoned",
+      source: "conversation",
+    });
+
+    const result = await runActiveTaskCheckpoint(
+      { cfg, factsDb, vectorDb, embeddings, openclawDir },
+      {
+        entity: "task-1270-abandoned",
+        title: "Metadata only checkpoint",
+        scheduleWake: false,
+      },
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.checkpoint?.status).toBe("abandoned");
+    expect(latestProjectValue(factsDb, "task-1270-abandoned", "status")).toBe("abandoned");
+
+    factsDb.close();
+  });
+
   it("keeps wake jobs isolated for long similar entity names", async () => {
     const { cfg, factsDb, vectorDb, embeddings, openclawDir } = setup();
     const base = "task-with-a-very-long-entity-name-that-shares-a-prefix-between-two-different-items-";

--- a/extensions/memory-hybrid/tests/active-task-checkpoint.test.ts
+++ b/extensions/memory-hybrid/tests/active-task-checkpoint.test.ts
@@ -7,6 +7,7 @@ import type { VectorDB } from "../backends/vector-db.js";
 import { hybridConfigSchema, type HybridMemoryConfig } from "../config.js";
 import type { EmbeddingProvider } from "../services/embeddings.js";
 import { runActiveTaskCheckpoint } from "../services/active-task-checkpoint.js";
+import * as taskLedgerFacts from "../services/task-ledger-facts.js";
 
 function makeConfig(root: string): HybridMemoryConfig {
   return hybridConfigSchema.parse({
@@ -55,11 +56,10 @@ function makeVectorDb(): VectorDB {
 }
 
 function latestProjectValue(factsDb: FactsDB, entity: string, key: string): string | undefined {
-  const rows = factsDb
-    .listFactsByCategory("project", 5000)
-    .filter((f) => f.entity === entity && (f.key ?? "") === key)
-    .sort((a, b) => b.createdAt - a.createdAt);
-  const hit = rows[0];
+  const hit = factsDb.lookup(entity, key, undefined, {
+    includeSuperseded: false,
+    limit: 1,
+  })[0]?.entry;
   if (!hit) return undefined;
   return hit.value ?? hit.text;
 }
@@ -197,7 +197,7 @@ describe("active-task-checkpoint", () => {
     expect(result.ok).toBe(true);
     expect(result.steps.schedule.attempted).toBe(true);
     expect(result.steps.schedule.scheduled).toBe(true);
-    expect(result.steps.schedule.jobId).toContain("hybrid-mem:active-task-wake:task-1270-wake:");
+    expect(result.steps.schedule.jobId).toMatch(/^hybrid-mem:active-task-wake:[a-z0-9-]+:\d+$/);
     expect(result.steps.schedule.jobsPath).toBeTruthy();
 
     const jobsPath = result.steps.schedule.jobsPath!;
@@ -208,7 +208,105 @@ describe("active-task-checkpoint", () => {
     const schedule = job?.schedule as { kind?: string; expr?: string } | undefined;
     expect(schedule?.kind).toBe("cron");
     expect(schedule?.expr).toBe(result.steps.schedule.cronExpr);
+    expect(String(job?.message ?? "")).toContain("mkdir -p");
 
     factsDb.close();
+  });
+
+  it("preserves existing status/owner/next/related_session when optional fields are omitted", async () => {
+    const { cfg, factsDb, vectorDb, embeddings, openclawDir } = setup();
+
+    const baseline = await runActiveTaskCheckpoint(
+      { cfg, factsDb, vectorDb, embeddings, openclawDir },
+      {
+        entity: "task-1270-preserve",
+        status: "blocked",
+        owner: "agent:forge",
+        next: "Wait for dependency",
+        relatedSession: "agent:main:session-a",
+      },
+    );
+    expect(baseline.ok).toBe(true);
+
+    const followup = await runActiveTaskCheckpoint(
+      { cfg, factsDb, vectorDb, embeddings, openclawDir },
+      {
+        entity: "task-1270-preserve",
+        title: "Updated title only",
+        scheduleWake: false,
+      },
+    );
+    expect(followup.ok).toBe(true);
+    expect(followup.checkpoint?.status).toBe("blocked");
+    expect(followup.checkpoint?.owner).toBe("agent:forge");
+    expect(followup.checkpoint?.next).toBe("Wait for dependency");
+    expect(followup.checkpoint?.relatedSession).toBe("agent:main:session-a");
+    expect(followup.steps.facts.updatedKeys).toEqual(expect.arrayContaining(["status", "owner", "next", "related_session"]));
+
+    factsDb.close();
+  });
+
+  it("keeps wake jobs isolated for long similar entity names", async () => {
+    const { cfg, factsDb, vectorDb, embeddings, openclawDir } = setup();
+    const base = "task-with-a-very-long-entity-name-that-shares-a-prefix-between-two-different-items-";
+    const resumeA = new Date(Date.now() + 2 * 60 * 60 * 1000).toISOString();
+    const resumeB = new Date(Date.now() + 3 * 60 * 60 * 1000).toISOString();
+
+    const first = await runActiveTaskCheckpoint(
+      { cfg, factsDb, vectorDb, embeddings, openclawDir },
+      {
+        entity: `${base}alpha`,
+        status: "waiting",
+        next: "resume alpha",
+        resumeAt: resumeA,
+      },
+    );
+    const second = await runActiveTaskCheckpoint(
+      { cfg, factsDb, vectorDb, embeddings, openclawDir },
+      {
+        entity: `${base}beta`,
+        status: "waiting",
+        next: "resume beta",
+        resumeAt: resumeB,
+      },
+    );
+
+    expect(first.ok).toBe(true);
+    expect(second.ok).toBe(true);
+    expect(second.steps.schedule.disabledPreviousJobs).toBe(0);
+
+    const jobsPath = second.steps.schedule.jobsPath!;
+    const raw = readFileSync(jobsPath, "utf-8");
+    const store = JSON.parse(raw) as { jobs?: Array<Record<string, unknown>> };
+    const activeWakeJobs = (store.jobs ?? []).filter(
+      (j) => typeof j.pluginJobId === "string" && j.pluginJobId.startsWith("hybrid-mem:active-task-wake:"),
+    );
+    expect(activeWakeJobs.filter((j) => j.enabled !== false).length).toBeGreaterThanOrEqual(2);
+
+    factsDb.close();
+  });
+
+  it("skips wake scheduling when fact writes fail", async () => {
+    const { cfg, factsDb, vectorDb, embeddings, openclawDir } = setup();
+    const spy = vi.spyOn(taskLedgerFacts, "upsertProjectTaskKey").mockRejectedValue(new Error("write failed"));
+    const resumeAt = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+
+    try {
+      const result = await runActiveTaskCheckpoint(
+        { cfg, factsDb, vectorDb, embeddings, openclawDir },
+        {
+          entity: "task-1270-fail-facts",
+          status: "waiting",
+          next: "recheck",
+          resumeAt,
+        },
+      );
+      expect(result.steps.facts.ok).toBe(false);
+      expect(result.steps.schedule.attempted).toBe(false);
+      expect(result.steps.schedule.skippedReason).toBe("facts_write_failed");
+    } finally {
+      spy.mockRestore();
+      factsDb.close();
+    }
   });
 });

--- a/extensions/memory-hybrid/tests/active-task-checkpoint.test.ts
+++ b/extensions/memory-hybrid/tests/active-task-checkpoint.test.ts
@@ -1,0 +1,214 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { FactsDB } from "../backends/facts-db.js";
+import type { VectorDB } from "../backends/vector-db.js";
+import { hybridConfigSchema, type HybridMemoryConfig } from "../config.js";
+import type { EmbeddingProvider } from "../services/embeddings.js";
+import { runActiveTaskCheckpoint } from "../services/active-task-checkpoint.js";
+
+function makeConfig(root: string): HybridMemoryConfig {
+  return hybridConfigSchema.parse({
+    embedding: { apiKey: "sk-test-key-long-enough", model: "text-embedding-3-small" },
+    sqlitePath: join(root, "facts.db"),
+    lanceDbPath: join(root, "lancedb"),
+    activeTask: {
+      enabled: true,
+      ledger: "facts",
+      filePath: "ACTIVE-TASKS.md",
+      staleThreshold: "24h",
+      projection: {
+        mode: "readable",
+        excludeGenericTitle: true,
+        titleMinChars: 0,
+        dedupeBy: "none",
+        sectioned: true,
+      },
+      staleWarning: { enabled: true },
+      autoCheckpoint: true,
+      flushOnComplete: true,
+      injectionBudget: 500,
+      taskHygiene: {
+        heartbeatEscalation: true,
+        suggestGoalAfterTaskAgeDays: 0,
+        heartbeatNudgeMaxChars: 2500,
+      },
+    },
+  });
+}
+
+function makeEmbeddings(): EmbeddingProvider {
+  return {
+    modelName: "text-embedding-3-small",
+    dimensions: 4,
+    embed: vi.fn().mockResolvedValue([0.1, 0.2, 0.3, 0.4]),
+    embedBatch: vi.fn().mockResolvedValue([[0.1, 0.2, 0.3, 0.4]]),
+  };
+}
+
+function makeVectorDb(): VectorDB {
+  return {
+    hasDuplicate: vi.fn().mockResolvedValue(true),
+    store: vi.fn().mockResolvedValue(undefined),
+  } as unknown as VectorDB;
+}
+
+function latestProjectValue(factsDb: FactsDB, entity: string, key: string): string | undefined {
+  const rows = factsDb
+    .listFactsByCategory("project", 5000)
+    .filter((f) => f.entity === entity && (f.key ?? "") === key)
+    .sort((a, b) => b.createdAt - a.createdAt);
+  const hit = rows[0];
+  if (!hit) return undefined;
+  return hit.value ?? hit.text;
+}
+
+describe("active-task-checkpoint", () => {
+  const dirs: string[] = [];
+
+  afterEach(() => {
+    while (dirs.length > 0) {
+      const dir = dirs.pop();
+      if (dir) rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  function setup() {
+    const root = mkdtempSync(join(tmpdir(), "hm-active-task-checkpoint-"));
+    dirs.push(root);
+    const cfg = makeConfig(root);
+    const factsDb = new FactsDB(cfg.sqlitePath);
+    const vectorDb = makeVectorDb();
+    const embeddings = makeEmbeddings();
+    const openclawDir = join(root, "openclaw");
+    return { root, cfg, factsDb, vectorDb, embeddings, openclawDir };
+  }
+
+  it("updates project facts and records an episode on success", async () => {
+    const { cfg, factsDb, vectorDb, embeddings, openclawDir } = setup();
+
+    const result = await runActiveTaskCheckpoint(
+      { cfg, factsDb, vectorDb, embeddings, openclawDir },
+      {
+        entity: "task-1270",
+        status: "in_progress",
+        owner: "agent:forge",
+        next: "Implement tests",
+        relatedSession: "agent:forge:subagent:1",
+        title: "Implement checkpoint tool",
+        state: { phase: "coding", files: ["a.ts", "b.ts"] },
+      },
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.partial).toBe(false);
+    expect(result.steps.facts.ok).toBe(true);
+    expect(result.steps.episode.ok).toBe(true);
+    expect(result.steps.schedule.attempted).toBe(false);
+
+    expect(latestProjectValue(factsDb, "task-1270", "status")).toBe("in_progress");
+    expect(latestProjectValue(factsDb, "task-1270", "next")).toBe("Implement tests");
+    expect(latestProjectValue(factsDb, "task-1270", "owner")).toBe("agent:forge");
+    expect(latestProjectValue(factsDb, "task-1270", "related_session")).toBe("agent:forge:subagent:1");
+    expect(latestProjectValue(factsDb, "task-1270", "title")).toBe("Implement checkpoint tool");
+    expect(latestProjectValue(factsDb, "task-1270", "task_updated")).toBeTruthy();
+    expect(latestProjectValue(factsDb, "task-1270", "checkpoint_state")).toContain("\"phase\":\"coding\"");
+
+    expect(factsDb.episodesCount()).toBe(1);
+
+    factsDb.close();
+  });
+
+  it("returns validation errors for invalid payload", async () => {
+    const { cfg, factsDb, vectorDb, embeddings, openclawDir } = setup();
+
+    const result = await runActiveTaskCheckpoint(
+      { cfg, factsDb, vectorDb, embeddings, openclawDir },
+      {
+        entity: "   ",
+        status: "bogus",
+        resumeAt: "not-a-date",
+      },
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.partial).toBe(false);
+    expect(result.errors.some((e) => e.step === "validation")).toBe(true);
+    expect(factsDb.listFactsByCategory("project", 100).length).toBe(0);
+    expect(factsDb.episodesCount()).toBe(0);
+
+    factsDb.close();
+  });
+
+  it("reports partial failure when wake scheduling fails but keeps checkpoint evidence", async () => {
+    const { cfg, factsDb, vectorDb, embeddings, openclawDir } = setup();
+    const resumeAt = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+
+    const result = await runActiveTaskCheckpoint(
+      {
+        cfg,
+        factsDb,
+        vectorDb,
+        embeddings,
+        openclawDir,
+        scheduleWakeFn: async () => {
+          throw new Error("cron store unavailable");
+        },
+      },
+      {
+        entity: "task-1270-partial",
+        status: "blocked",
+        owner: "agent:forge",
+        next: "Wait for credentials",
+        resumeAt,
+      },
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.partial).toBe(true);
+    expect(result.steps.facts.ok).toBe(true);
+    expect(result.steps.episode.ok).toBe(true);
+    expect(result.steps.schedule.attempted).toBe(true);
+    expect(result.steps.schedule.scheduled).toBe(false);
+    expect(result.errors.some((e) => e.step === "schedule")).toBe(true);
+
+    expect(latestProjectValue(factsDb, "task-1270-partial", "status")).toBe("blocked");
+    expect(latestProjectValue(factsDb, "task-1270-partial", "owner")).toBe("agent:forge");
+    expect(factsDb.episodesCount()).toBe(1);
+
+    factsDb.close();
+  });
+
+  it("schedules wake reminder when resumeAt is provided", async () => {
+    const { cfg, factsDb, vectorDb, embeddings, openclawDir } = setup();
+    const resumeAtDate = new Date(Date.now() + 2 * 60 * 60 * 1000);
+
+    const result = await runActiveTaskCheckpoint(
+      { cfg, factsDb, vectorDb, embeddings, openclawDir },
+      {
+        entity: "task-1270-wake",
+        status: "waiting",
+        next: "Resume after dependency maintenance",
+        resumeAt: resumeAtDate.toISOString(),
+      },
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.steps.schedule.attempted).toBe(true);
+    expect(result.steps.schedule.scheduled).toBe(true);
+    expect(result.steps.schedule.jobId).toContain("hybrid-mem:active-task-wake:task-1270-wake:");
+    expect(result.steps.schedule.jobsPath).toBeTruthy();
+
+    const jobsPath = result.steps.schedule.jobsPath!;
+    const raw = readFileSync(jobsPath, "utf-8");
+    const store = JSON.parse(raw) as { jobs?: Array<Record<string, unknown>> };
+    const job = (store.jobs ?? []).find((j) => j.pluginJobId === result.steps.schedule.jobId);
+    expect(job).toBeTruthy();
+    const schedule = job?.schedule as { kind?: string; expr?: string } | undefined;
+    expect(schedule?.kind).toBe("cron");
+    expect(schedule?.expr).toBe(result.steps.schedule.cronExpr);
+
+    factsDb.close();
+  });
+});

--- a/extensions/memory-hybrid/tests/memory-tools-embedding-registry.test.ts
+++ b/extensions/memory-hybrid/tests/memory-tools-embedding-registry.test.ts
@@ -140,6 +140,7 @@ describe("memory tools embedding registry wiring", () => {
     );
 
     const names = api.getToolNames();
+    expect(names).toContain("active_task_checkpoint");
     expect(names).toContain("memory_directory");
     expect(names).toContain("memory_record_episode");
     expect(names).toContain("memory_search_episodes");

--- a/extensions/memory-hybrid/tests/public-api-routes.test.ts
+++ b/extensions/memory-hybrid/tests/public-api-routes.test.ts
@@ -470,7 +470,10 @@ describe("registerPublicApiRoutes", () => {
     );
 
     const activeTasksRoute = routes.find((r) => r.path === `${PUBLIC_API_PREFIX}${PUBLIC_API_PATHS.activeTasks}`)!;
-    const res = await invokeNodeHttpRoute(activeTasksRoute.handler, fakeReq(`${PUBLIC_API_PREFIX}${PUBLIC_API_PATHS.activeTasks}`));
+    const res = await invokeNodeHttpRoute(
+      activeTasksRoute.handler,
+      fakeReq(`${PUBLIC_API_PREFIX}${PUBLIC_API_PATHS.activeTasks}`),
+    );
     expect(res.status).toBe(404);
     expect(JSON.parse(res.body).error).toBe("active_tasks_disabled");
   });

--- a/extensions/memory-hybrid/tools/memory-tools.ts
+++ b/extensions/memory-hybrid/tools/memory-tools.ts
@@ -2738,7 +2738,9 @@ export function registerMemoryTools(
       owner: Type.Optional(Type.String({ description: "Task owner (free-form, e.g. subagent/session/role)." })),
       next: Type.Optional(Type.String({ description: "Next concrete action for safe resume." })),
       relatedSession: Type.Optional(Type.String({ description: "Related OpenClaw session key/id." })),
-      title: Type.Optional(Type.String({ description: "Human-readable task title (defaults to existing or Project task)." })),
+      title: Type.Optional(
+        Type.String({ description: "Human-readable task title (defaults to existing or Project task)." }),
+      ),
       resumeAt: Type.Optional(
         Type.String({
           description: "Optional future ISO timestamp for wake/reminder scheduling via cron jobs store.",
@@ -2754,8 +2756,7 @@ export function registerMemoryTools(
       ),
       refreshProjection: Type.Optional(
         Type.Boolean({
-          description:
-            "When true, best-effort refresh ACTIVE-TASKS.md projection (activeTask.ledger=facts only).",
+          description: "When true, best-effort refresh ACTIVE-TASKS.md projection (activeTask.ledger=facts only).",
         }),
       ),
       recordEpisode: Type.Optional(

--- a/extensions/memory-hybrid/tools/memory-tools.ts
+++ b/extensions/memory-hybrid/tools/memory-tools.ts
@@ -65,6 +65,7 @@ import { embedCallWithTimeoutAndRetry } from "../utils/embed-call.js";
 import { getEnv } from "../utils/env-manager.js";
 import { extractTags } from "../utils/tags.js";
 import { truncateForStorage } from "../utils/text.js";
+import { runActiveTaskCheckpoint } from "../services/active-task-checkpoint.js";
 
 export type BoundWalWriteFn = (
   operation: "store" | "update",
@@ -2720,6 +2721,106 @@ export function registerMemoryTools(
     },
     { name: "memory_forget" },
   );
+
+  // ---------------------------------------------------------------------------
+  // Active-task checkpoint tool (#1270)
+  // ---------------------------------------------------------------------------
+
+  {
+    const _activeTaskCheckpointParams = Type.Object({
+      entity: Type.String({ description: "Stable task entity/label (category:project row key)." }),
+      status: Type.Optional(
+        Type.String({
+          description:
+            "Task status: open|in_progress|blocked|waiting|done|completed|closed|cancelled|abandoned|failed.",
+        }),
+      ),
+      owner: Type.Optional(Type.String({ description: "Task owner (free-form, e.g. subagent/session/role)." })),
+      next: Type.Optional(Type.String({ description: "Next concrete action for safe resume." })),
+      relatedSession: Type.Optional(Type.String({ description: "Related OpenClaw session key/id." })),
+      title: Type.Optional(Type.String({ description: "Human-readable task title (defaults to existing or Project task)." })),
+      resumeAt: Type.Optional(
+        Type.String({
+          description: "Optional future ISO timestamp for wake/reminder scheduling via cron jobs store.",
+        }),
+      ),
+      state: Type.Optional(
+        Type.Record(Type.String(), Type.Unknown(), {
+          description: "Structured checkpoint state object (serialized into facts + episode context).",
+        }),
+      ),
+      scheduleWake: Type.Optional(
+        Type.Boolean({ description: "When true (default), schedule wake job when resumeAt is supplied." }),
+      ),
+      refreshProjection: Type.Optional(
+        Type.Boolean({
+          description:
+            "When true, best-effort refresh ACTIVE-TASKS.md projection (activeTask.ledger=facts only).",
+        }),
+      ),
+      recordEpisode: Type.Optional(
+        Type.Boolean({ description: "When true (default), record an episode audit trail for the checkpoint." }),
+      ),
+    });
+    const _activeTaskCheckpointDesc =
+      "Atomically checkpoint active task state for reliable resume. One call updates project facts (status/next/owner/related_session/task_updated/title), records an episode audit trail, optionally schedules wake/reminder from resumeAt, and optionally refreshes ACTIVE-TASKS.md projection. Returns structured partial-failure details when later steps fail.";
+    const _execActiveTaskCheckpoint = async (_toolCallId: string, params: Record<string, unknown>) => {
+      const scopeFilter = buildToolScopeFilter({}, currentAgentIdRef.value, cfg);
+      try {
+        const result = await runActiveTaskCheckpoint(
+          {
+            factsDb,
+            vectorDb,
+            embeddings,
+            cfg,
+            logger: api.logger,
+            episodeScopeFilter: scopeFilter,
+          },
+          params as {
+            entity?: string;
+            status?: string;
+            owner?: string;
+            next?: string;
+            relatedSession?: string;
+            title?: string;
+            resumeAt?: string;
+            state?: Record<string, unknown>;
+            scheduleWake?: boolean;
+            refreshProjection?: boolean;
+            recordEpisode?: boolean;
+          },
+        );
+
+        return {
+          content: [{ type: "text", text: result.message }],
+          details: result,
+        };
+      } catch (err) {
+        capturePluginError(err instanceof Error ? err : new Error(String(err)), {
+          subsystem: "memory",
+          operation: "active_task_checkpoint",
+          phase: "runtime",
+        });
+        return {
+          content: [{ type: "text", text: `active_task_checkpoint failed: ${String(err)}` }],
+          details: {
+            ok: false,
+            partial: false,
+            error: String(err),
+          },
+        };
+      }
+    };
+    api.registerTool(
+      {
+        name: "active_task_checkpoint",
+        description: _activeTaskCheckpointDesc,
+        parameters: _activeTaskCheckpointParams,
+        execute: _execActiveTaskCheckpoint,
+      },
+      { name: "active_task_checkpoint" },
+    );
+  }
 
   // ---------------------------------------------------------------------------
   // Episodic Memory tools (#781)

--- a/extensions/memory-hybrid/tools/memory-tools.ts
+++ b/extensions/memory-hybrid/tools/memory-tools.ts
@@ -2764,7 +2764,7 @@ export function registerMemoryTools(
       ),
     });
     const _activeTaskCheckpointDesc =
-      "Atomically checkpoint active task state for reliable resume. One call updates project facts (status/next/owner/related_session/task_updated/title), records an episode audit trail, optionally schedules wake/reminder from resumeAt, and optionally refreshes ACTIVE-TASKS.md projection. Returns structured partial-failure details when later steps fail.";
+      "Best-effort checkpoint active task state for reliable resume. One call updates project facts (status/next/owner/related_session/task_updated/title), records an episode audit trail, optionally schedules wake/reminder from resumeAt, and optionally refreshes ACTIVE-TASKS.md projection. Returns structured partial-failure details when later steps fail.";
     const _execActiveTaskCheckpoint = async (_toolCallId: string, params: Record<string, unknown>) => {
       const scopeFilter = buildToolScopeFilter({}, currentAgentIdRef.value, cfg);
       try {

--- a/extensions/memory-hybrid/workspace-snippets/TOOLS-hybrid-memory-body.md
+++ b/extensions/memory-hybrid/workspace-snippets/TOOLS-hybrid-memory-body.md
@@ -13,6 +13,7 @@
 | `goal_update` | Goal description, criteria, or priority needs updating |
 | `goal_complete` | ALL acceptance criteria are verifiably met |
 | `goal_abandon` | Goal is no longer relevant (user decision) |
+| `active_task_checkpoint` | Atomically checkpoint active work (facts + episode + optional wake schedule/projection refresh) |
 | `active_task_propose_goal` | Draft a `goal_register` payload from an `ACTIVE-TASKS.md` row |
 
 **Subagent naming:** Use the goal label as a prefix for subagents that work toward it. Example: goal `deploy-api` -> subagents `deploy-api-run-tests`, `deploy-api-create-pr`. CLI: `openclaw hybrid-mem goals list|status|cancel|budget|reset-budget|stewardship-run|audit`. See [Goal stewardship design](https://github.com/markus-lassfolk/openclaw-hybrid-memory/blob/main/docs/GOAL-STEWARDSHIP-DESIGN.md), [Operator guide](https://github.com/markus-lassfolk/openclaw-hybrid-memory/blob/main/docs/GOAL-STEWARDSHIP-OPERATOR.md), and [Task hygiene](https://github.com/markus-lassfolk/openclaw-hybrid-memory/blob/main/docs/TASK-HYGIENE.md).


### PR DESCRIPTION
Fixes #1270

## Summary
- add a first-class `active_task_checkpoint` tool that performs a best-effort atomic checkpoint flow
- update project task facts in one call (`status`, `next`, `owner`, `related_session`, `task_updated`, and `title` fallback behavior)
- record checkpoint audit trail as an episode with structured state context
- optionally schedule wake reminders from `resumeAt` through cron jobs store
- optionally refresh facts-backed ACTIVE-TASKS projection
- return structured partial-failure details when later steps fail after facts are written

## Tests
- `npm test -- --run tests/active-task-checkpoint.test.ts tests/agent-tool-contracts.test.ts tests/memory-tools-embedding-registry.test.ts`
- `npm run build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new first-class tool that writes to the facts DB and modifies the user’s `~/.openclaw/cron/jobs.json` for wake reminders; mistakes could impact task state consistency or cron job execution.
> 
> **Overview**
> **Adds a new `active_task_checkpoint` agent tool** and registers it in the plugin contracts, docs, and embedding-registry test coverage.
> 
> The tool performs a best-effort checkpoint flow: upserts a bundle of project task facts (with title fallback and optional JSON `state`/`resume_at`), records an episode audit entry, optionally refreshes the facts-backed `ACTIVE-TASKS.md` projection, and optionally schedules (or cleans up) an isolated cron wake job by writing/disabling entries in `~/.openclaw/cron/jobs.json`.
> 
> Also extends `buildGuardPrefix` to accept an optional `openclawDir` so scheduled wake jobs can write persistent guard files under a configurable OpenClaw home.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40e50e1d5f879ea1af681317674db03ddd0ff918. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->