### PR TITLE
fix: lightweight active-task snapshot/render for #1272

### DIFF
--- a/docs/ACTIVE-TASKS-PROJECTION.md
+++ b/docs/ACTIVE-TASKS-PROJECTION.md
@@ -10,6 +10,16 @@ openclaw hybrid-mem active-tasks render
 
 Requires `activeTask.ledger: facts`. With the default `markdown` ledger, the file **is** the ledger—no render step.
 
+## Fast snapshot/render via gateway
+
+The public gateway route `/plugins/memory-public/active-tasks` returns a DB-backed snapshot directly from
+`category:project` facts (no CLI cold start).
+
+- `GET /plugins/memory-public/active-tasks` returns active rows + projection status (`stale`, reasons, timestamps).
+- `GET /plugins/memory-public/active-tasks?render=1` does a best-effort projection refresh before returning.
+- `memory_store` writes to `category:project` also trigger a best-effort `ACTIVE-TASKS.md` refresh when
+  `activeTask.ledger: facts`; failures mark the projection stale.
+
 ## Timestamp semantics
 
 The projection must not invent “when work started” or “last touch” from the render clock.

--- a/extensions/memory-hybrid/backends/facts-db/fact-read-queries.ts
+++ b/extensions/memory-hybrid/backends/facts-db/fact-read-queries.ts
@@ -387,6 +387,18 @@ export function listDirectives(db: DatabaseSync, limit = 100): MemoryEntry[] {
   return rows.map((row) => rowToMemoryEntry(row));
 }
 
+export function getMaxCreatedAtByCategory(db: DatabaseSync, category: string): number | null {
+  const row = db
+    .prepare("SELECT MAX(created_at) as max_created_at FROM facts WHERE category = ? AND (superseded_at IS NULL)")
+    .get(category) as Record<string, unknown> | undefined;
+  if (!row) return null;
+  const maxCreatedAt = row.max_created_at;
+  if (typeof maxCreatedAt === "number" && Number.isFinite(maxCreatedAt)) {
+    return maxCreatedAt;
+  }
+  return null;
+}
+
 export function updateCategory(db: DatabaseSync, id: string, category: string): boolean {
   const result = db.prepare("UPDATE facts SET category = ? WHERE id = ?").run(category, id);
   return result.changes > 0;

--- a/extensions/memory-hybrid/backends/facts-db/facts-db-layer2.ts
+++ b/extensions/memory-hybrid/backends/facts-db/facts-db-layer2.ts
@@ -11,6 +11,7 @@ import {
   getBatch as getBatchImpl,
   getByCategory as getByCategoryImpl,
   getCount as getCountImpl,
+  getMaxCreatedAtByCategory as getMaxCreatedAtByCategoryImpl,
   getRecentFacts as getRecentFactsImpl,
   getUnattemptedOtherFacts as getUnattemptedOtherFactsImpl,
   listDirectives as listDirectivesImpl,
@@ -448,6 +449,11 @@ export class FactsDBLayer2 extends FactsDBLayer1 {
   /** List directive facts (source LIKE 'directive:%'), non-superseded, by created_at DESC. */
   listDirectives(limit = 100): MemoryEntry[] {
     return listDirectivesImpl(this.liveDb, limit);
+  }
+
+  /** Get maximum created_at timestamp for non-superseded facts in a category. */
+  getMaxCreatedAtByCategory(category: string): number | null {
+    return getMaxCreatedAtByCategoryImpl(this.liveDb, category);
   }
 
   updateCategory(id: string, category: string): boolean {

--- a/extensions/memory-hybrid/services/task-ledger-facts.ts
+++ b/extensions/memory-hybrid/services/task-ledger-facts.ts
@@ -356,13 +356,15 @@ export async function refreshActiveTaskProjectionBestEffort(opts: {
     return { rendered: true, staleMarked: false };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
+    let staleMarked = false;
     try {
       await markActiveTaskProjectionStale(opts.filePath, opts.reason, { source: opts.source, factId: opts.factId });
+      staleMarked = true;
     } catch {
       // Ignore stale marker write failures (best-effort)
     }
     opts.logger?.warn?.(`memory-hybrid: active-task projection refresh failed: ${message}`);
-    return { rendered: false, staleMarked: true, error: message };
+    return { rendered: false, staleMarked, error: message };
   }
 }
 

--- a/extensions/memory-hybrid/services/task-ledger-facts.ts
+++ b/extensions/memory-hybrid/services/task-ledger-facts.ts
@@ -287,14 +287,7 @@ export async function clearActiveTaskProjectionStale(filePath: string): Promise<
 }
 
 export function getLatestProjectFactCreatedAtSec(factsDb: FactsDB, factLimit = 8000): number | null {
-  const facts = factsDb.listFactsByCategory(TASK_LEDGER_CATEGORY, factLimit);
-  let maxSec: number | null = null;
-  for (const fact of facts) {
-    const createdAt = fact.createdAt;
-    if (typeof createdAt !== "number" || !Number.isFinite(createdAt)) continue;
-    maxSec = maxSec === null ? createdAt : Math.max(maxSec, createdAt);
-  }
-  return maxSec;
+  return factsDb.getMaxCreatedAtByCategory(TASK_LEDGER_CATEGORY);
 }
 
 function toIsoOrNull(unixSeconds: number | null): string | null {

--- a/extensions/memory-hybrid/services/task-ledger-facts.ts
+++ b/extensions/memory-hybrid/services/task-ledger-facts.ts
@@ -3,7 +3,7 @@
  * Aligns hybrid-mem active-tasks with memory_store / memory_recall workflows.
  */
 
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdir, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import type { FactsDB } from "../backends/facts-db.js";
 import type { VectorDB } from "../backends/vector-db.js";
@@ -31,6 +31,25 @@ import { isOpenClawSessionLikelyPresent, looksLikeOpenClawSessionRef } from "./o
 export const TASK_LEDGER_CATEGORY = "project" as MemoryCategory;
 
 const TERMINAL = new Set(["done", "completed", "cancelled", "closed", "abandoned"]);
+const PROJECTION_STALE_MARKER_SUFFIX = ".stale.json";
+
+type ActiveTaskProjectionStaleMarker = {
+  staleAt: string;
+  reason: string;
+  source?: string;
+  factId?: string;
+};
+
+export type ActiveTaskProjectionStatus = {
+  filePath: string;
+  markerPath: string;
+  exists: boolean;
+  stale: boolean;
+  staleReasons: string[];
+  latestProjectFactAt: string | null;
+  renderedAt: string | null;
+  marker: ActiveTaskProjectionStaleMarker | null;
+};
 
 /** Latest value per entity+key from non-superseded project facts */
 export function groupProjectFactsByEntity(facts: MemoryEntry[]): Map<string, Map<string, MemoryEntry>> {
@@ -207,6 +226,148 @@ export function readActiveTaskRowsFromFacts(
   const { active, completed } = loadTaskLedgerFromFacts(factsDb);
   const staleActive = detectStaleTasks(active, staleMinutes);
   return { active: staleActive, completed };
+}
+
+export function getActiveTaskProjectionStaleMarkerPath(filePath: string): string {
+  return `${filePath}${PROJECTION_STALE_MARKER_SUFFIX}`;
+}
+
+function parseProjectionMarker(raw: string): ActiveTaskProjectionStaleMarker | null {
+  try {
+    const parsed = JSON.parse(raw) as Partial<ActiveTaskProjectionStaleMarker>;
+    if (
+      typeof parsed === "object" &&
+      parsed !== null &&
+      typeof parsed.staleAt === "string" &&
+      parsed.staleAt.trim().length > 0 &&
+      typeof parsed.reason === "string" &&
+      parsed.reason.trim().length > 0
+    ) {
+      return {
+        staleAt: parsed.staleAt.trim(),
+        reason: parsed.reason.trim(),
+        ...(typeof parsed.source === "string" && parsed.source.trim().length > 0 ? { source: parsed.source } : {}),
+        ...(typeof parsed.factId === "string" && parsed.factId.trim().length > 0 ? { factId: parsed.factId } : {}),
+      };
+    }
+  } catch {
+    // ignore malformed marker JSON
+  }
+  return null;
+}
+
+async function readActiveTaskProjectionStaleMarker(filePath: string): Promise<ActiveTaskProjectionStaleMarker | null> {
+  const markerPath = getActiveTaskProjectionStaleMarkerPath(filePath);
+  try {
+    const raw = await readFile(markerPath, "utf-8");
+    return parseProjectionMarker(raw);
+  } catch {
+    return null;
+  }
+}
+
+export async function markActiveTaskProjectionStale(
+  filePath: string,
+  reason: string,
+  meta: { source?: string; factId?: string } = {},
+): Promise<void> {
+  const markerPath = getActiveTaskProjectionStaleMarkerPath(filePath);
+  const marker: ActiveTaskProjectionStaleMarker = {
+    staleAt: new Date().toISOString(),
+    reason: reason.trim().length > 0 ? reason.trim() : "projection marked stale",
+    ...(meta.source ? { source: meta.source } : {}),
+    ...(meta.factId ? { factId: meta.factId } : {}),
+  };
+  await mkdir(dirname(markerPath), { recursive: true });
+  await writeFile(markerPath, `${JSON.stringify(marker, null, 2)}\n`, "utf-8");
+}
+
+export async function clearActiveTaskProjectionStale(filePath: string): Promise<void> {
+  await rm(getActiveTaskProjectionStaleMarkerPath(filePath), { force: true });
+}
+
+export function getLatestProjectFactCreatedAtSec(factsDb: FactsDB, factLimit = 8000): number | null {
+  const facts = factsDb.listFactsByCategory(TASK_LEDGER_CATEGORY, factLimit);
+  let maxSec: number | null = null;
+  for (const fact of facts) {
+    const createdAt = fact.createdAt;
+    if (typeof createdAt !== "number" || !Number.isFinite(createdAt)) continue;
+    maxSec = maxSec === null ? createdAt : Math.max(maxSec, createdAt);
+  }
+  return maxSec;
+}
+
+function toIsoOrNull(unixSeconds: number | null): string | null {
+  if (unixSeconds === null) return null;
+  return new Date(unixSeconds * 1000).toISOString();
+}
+
+export async function getActiveTaskProjectionStatus(
+  factsDb: FactsDB,
+  filePath: string,
+  factLimit = 8000,
+): Promise<ActiveTaskProjectionStatus> {
+  const markerPath = getActiveTaskProjectionStaleMarkerPath(filePath);
+  const marker = await readActiveTaskProjectionStaleMarker(filePath);
+  const latestProjectFactSec = getLatestProjectFactCreatedAtSec(factsDb, factLimit);
+  const latestProjectFactAt = toIsoOrNull(latestProjectFactSec);
+
+  let exists = false;
+  let renderedAt: string | null = null;
+  let renderedMs: number | null = null;
+  try {
+    const fileStat = await stat(filePath);
+    exists = fileStat.isFile();
+    if (exists) {
+      renderedMs = fileStat.mtimeMs;
+      renderedAt = new Date(fileStat.mtimeMs).toISOString();
+    }
+  } catch {
+    // no projection file
+  }
+
+  const staleReasons = new Set<string>();
+  if (latestProjectFactSec !== null && !exists) {
+    staleReasons.add("projection_missing");
+  }
+  if (latestProjectFactSec !== null && renderedMs !== null && latestProjectFactSec * 1000 > renderedMs + 1000) {
+    staleReasons.add("project_facts_newer_than_projection");
+  }
+  if (marker) {
+    staleReasons.add("projection_marked_stale");
+  }
+
+  return {
+    filePath,
+    markerPath,
+    exists,
+    stale: staleReasons.size > 0,
+    staleReasons: [...staleReasons],
+    latestProjectFactAt,
+    renderedAt,
+    marker,
+  };
+}
+
+export async function refreshActiveTaskProjectionBestEffort(opts: {
+  factsDb: FactsDB;
+  staleMinutes: number;
+  filePath: string;
+  projection: ActiveTaskProjectionConfig;
+  reason: string;
+  source?: string;
+  factId?: string;
+  logger?: { warn?: (m: string) => void };
+}): Promise<{ rendered: boolean; staleMarked: boolean; error?: string }> {
+  try {
+    await renderActiveTaskMarkdownFile(opts.factsDb, opts.staleMinutes, opts.filePath, opts.projection);
+    return { rendered: true, staleMarked: false };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    await markActiveTaskProjectionStale(opts.filePath, opts.reason, { source: opts.source, factId: opts.factId });
+    opts.logger?.warn?.(`memory-hybrid: active-task projection refresh failed: ${message}`);
+    return { rendered: false, staleMarked: true, error: message };
+  }
 }
 
 /** Normalize description for `dedupeBy: normalizedTitle`. */
@@ -460,6 +621,7 @@ export async function renderActiveTaskMarkdownFile(
   );
   await mkdir(dirname(filePath), { recursive: true });
   await writeFile(filePath, lines.join("\n"), "utf-8");
+  await clearActiveTaskProjectionStale(filePath);
 }
 
 /**

--- a/extensions/memory-hybrid/services/task-ledger-facts.ts
+++ b/extensions/memory-hybrid/services/task-ledger-facts.ts
@@ -246,8 +246,8 @@ function parseProjectionMarker(raw: string): ActiveTaskProjectionStaleMarker | n
       return {
         staleAt: parsed.staleAt.trim(),
         reason: parsed.reason.trim(),
-        ...(typeof parsed.source === "string" && parsed.source.trim().length > 0 ? { source: parsed.source } : {}),
-        ...(typeof parsed.factId === "string" && parsed.factId.trim().length > 0 ? { factId: parsed.factId } : {}),
+        ...(typeof parsed.source === "string" && parsed.source.trim().length > 0 ? { source: parsed.source.trim() } : {}),
+        ...(typeof parsed.factId === "string" && parsed.factId.trim().length > 0 ? { factId: parsed.factId.trim() } : {}),
       };
     }
   } catch {

--- a/extensions/memory-hybrid/services/task-ledger-facts.ts
+++ b/extensions/memory-hybrid/services/task-ledger-facts.ts
@@ -286,7 +286,7 @@ export async function clearActiveTaskProjectionStale(filePath: string): Promise<
   await rm(getActiveTaskProjectionStaleMarkerPath(filePath), { force: true });
 }
 
-export function getLatestProjectFactCreatedAtSec(factsDb: FactsDB, factLimit = 8000): number | null {
+export function getLatestProjectFactCreatedAtSec(factsDb: FactsDB): number | null {
   return factsDb.getMaxCreatedAtByCategory(TASK_LEDGER_CATEGORY);
 }
 
@@ -298,11 +298,10 @@ function toIsoOrNull(unixSeconds: number | null): string | null {
 export async function getActiveTaskProjectionStatus(
   factsDb: FactsDB,
   filePath: string,
-  factLimit = 8000,
 ): Promise<ActiveTaskProjectionStatus> {
   const markerPath = getActiveTaskProjectionStaleMarkerPath(filePath);
   const marker = await readActiveTaskProjectionStaleMarker(filePath);
-  const latestProjectFactSec = getLatestProjectFactCreatedAtSec(factsDb, factLimit);
+  const latestProjectFactSec = getLatestProjectFactCreatedAtSec(factsDb);
   const latestProjectFactAt = toIsoOrNull(latestProjectFactSec);
 
   let exists = false;

--- a/extensions/memory-hybrid/services/task-ledger-facts.ts
+++ b/extensions/memory-hybrid/services/task-ledger-facts.ts
@@ -246,8 +246,12 @@ function parseProjectionMarker(raw: string): ActiveTaskProjectionStaleMarker | n
       return {
         staleAt: parsed.staleAt.trim(),
         reason: parsed.reason.trim(),
-        ...(typeof parsed.source === "string" && parsed.source.trim().length > 0 ? { source: parsed.source.trim() } : {}),
-        ...(typeof parsed.factId === "string" && parsed.factId.trim().length > 0 ? { factId: parsed.factId.trim() } : {}),
+        ...(typeof parsed.source === "string" && parsed.source.trim().length > 0
+          ? { source: parsed.source.trim() }
+          : {}),
+        ...(typeof parsed.factId === "string" && parsed.factId.trim().length > 0
+          ? { factId: parsed.factId.trim() }
+          : {}),
       };
     }
   } catch {

--- a/extensions/memory-hybrid/services/task-ledger-facts.ts
+++ b/extensions/memory-hybrid/services/task-ledger-facts.ts
@@ -364,7 +364,11 @@ export async function refreshActiveTaskProjectionBestEffort(opts: {
     return { rendered: true, staleMarked: false };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    await markActiveTaskProjectionStale(opts.filePath, opts.reason, { source: opts.source, factId: opts.factId });
+    try {
+      await markActiveTaskProjectionStale(opts.filePath, opts.reason, { source: opts.source, factId: opts.factId });
+    } catch {
+      // Ignore stale marker write failures (best-effort)
+    }
     opts.logger?.warn?.(`memory-hybrid: active-task projection refresh failed: ${message}`);
     return { rendered: false, staleMarked: true, error: message };
   }

--- a/extensions/memory-hybrid/tests/memory-tools-embedding-registry.test.ts
+++ b/extensions/memory-hybrid/tests/memory-tools-embedding-registry.test.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import { mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -390,5 +390,59 @@ describe("memory tools embedding registry wiring", () => {
     const stored = factsDb.getEmbeddings(id!);
     const models = stored.map((r) => r.model).sort();
     expect(models).toEqual(["nomic-embed-text", "text-embedding-3-small"]);
+  });
+
+  it("refreshes ACTIVE-TASKS.md projection on project memory_store writes when ledger=facts", async () => {
+    vi.stubEnv("OPENCLAW_WORKSPACE", tmpDir);
+    const api = makeMockApi();
+    const embeddings = makeMockEmbeddings();
+    const embeddingRegistry = buildEmbeddingRegistry(embeddings, embeddings.modelName, []);
+    const cfg = makeCfg({
+      activeTask: {
+        enabled: true,
+        ledger: "facts",
+        filePath: "ACTIVE-TASKS.md",
+      },
+    });
+    const vectorDb = makeMockVectorDb();
+
+    registerMemoryTools(
+      {
+        factsDb,
+        vectorDb,
+        cfg,
+        embeddings,
+        embeddingRegistry,
+        openai: {} as never,
+        wal: null,
+        credentialsDb: null,
+        eventLog: null,
+        lastProgressiveIndexIds: [],
+        currentAgentIdRef: { value: null },
+        pendingLLMWarnings: createPendingLLMWarnings(),
+      },
+      api as never,
+      noopScopeFilter as never,
+      walWrite,
+      walRemove,
+      findSimilarByEmbedding as never,
+    );
+
+    const tool = api.getTool("memory_store");
+    expect(tool).toBeTruthy();
+    await tool?.execute("tool-call", {
+      text: "Task title: ship lightweight active-task snapshot",
+      category: "project",
+      entity: "task-1272",
+      key: "title",
+      value: "Ship lightweight active-task snapshot",
+      importance: 0.9,
+    });
+
+    const renderedPath = join(tmpDir, "ACTIVE-TASKS.md");
+    expect(existsSync(renderedPath)).toBe(true);
+    const projection = readFileSync(renderedPath, "utf-8");
+    expect(projection).toContain("[task-1272]");
+    expect(projection).toContain("**Projection** of hybrid-memory `category:project` facts");
   });
 });

--- a/extensions/memory-hybrid/tests/public-api-routes.test.ts
+++ b/extensions/memory-hybrid/tests/public-api-routes.test.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck
 
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, utimesSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { ClawdbotPluginApi } from "openclaw/plugin-sdk/core";
@@ -26,14 +26,19 @@ describe("registerPublicApiRoutes", () => {
   let tmp: string;
   let factsDb: FactsDB;
   let narrativesDb: NarrativesDB;
+  let prevWorkspace: string | undefined;
 
   beforeEach(() => {
+    prevWorkspace = process.env.OPENCLAW_WORKSPACE;
     tmp = mkdtempSync(join(tmpdir(), "public-api-routes-"));
+    process.env.OPENCLAW_WORKSPACE = tmp;
     factsDb = new FactsDB(join(tmp, "facts.db"));
     narrativesDb = new NarrativesDB(join(tmp, "narratives.db"));
   });
 
   afterEach(() => {
+    if (prevWorkspace === undefined) delete process.env.OPENCLAW_WORKSPACE;
+    else process.env.OPENCLAW_WORKSPACE = prevWorkspace;
     rmSync(tmp, { recursive: true, force: true });
   });
 
@@ -56,11 +61,32 @@ describe("registerPublicApiRoutes", () => {
     return { method: "GET", url, headers: {} };
   }
 
+  function makeCfg(
+    authenticated: boolean,
+    overrides: Partial<{
+      ledger: "markdown" | "facts";
+      filePath: string;
+      staleThreshold: string;
+      projection: Record<string, unknown>;
+    }> = {},
+  ) {
+    return {
+      health: { enabled: true, authenticated },
+      activeTask: {
+        enabled: true,
+        ledger: overrides.ledger ?? "markdown",
+        filePath: overrides.filePath ?? "ACTIVE-TASKS.md",
+        staleThreshold: overrides.staleThreshold ?? "24h",
+        projection: overrides.projection ?? { sectioned: true },
+      },
+    };
+  }
+
   it("registers all public surface routes", () => {
     const { api, routes } = makeApi();
     registerPublicApiRoutes(
       {
-        cfg: { health: { enabled: true, authenticated: true } },
+        cfg: makeCfg(true),
         factsDb,
         narrativesDb,
       },
@@ -118,7 +144,7 @@ describe("registerPublicApiRoutes", () => {
     const { api, routes } = makeApi();
     registerPublicApiRoutes(
       {
-        cfg: { health: { enabled: true, authenticated: false } },
+        cfg: makeCfg(false),
         factsDb,
         narrativesDb,
       },
@@ -215,7 +241,7 @@ describe("registerPublicApiRoutes", () => {
     const { api, routes } = makeApi();
     registerPublicApiRoutes(
       {
-        cfg: { health: { enabled: true, authenticated: true } },
+        cfg: makeCfg(true),
         factsDb,
         narrativesDb,
       },
@@ -273,11 +299,88 @@ describe("registerPublicApiRoutes", () => {
     expect(deniedFact.status).toBe(404);
   });
 
+  it("active-tasks endpoint reports stale projection and can render on request", async () => {
+    factsDb.store({
+      text: "Task title: Ship active-task endpoint",
+      category: "project",
+      importance: 0.9,
+      entity: "task-1272",
+      key: "title",
+      value: "Ship active-task endpoint",
+      source: "conversation",
+    });
+    factsDb.store({
+      text: "Task status: in progress",
+      category: "project",
+      importance: 0.9,
+      entity: "task-1272",
+      key: "status",
+      value: "in_progress",
+      source: "conversation",
+    });
+
+    const { api, routes } = makeApi();
+    registerPublicApiRoutes(
+      {
+        cfg: makeCfg(true, { ledger: "facts", staleThreshold: "4h", filePath: "ACTIVE-TASKS.md" }),
+        factsDb,
+        narrativesDb,
+      },
+      api,
+    );
+
+    const activeTasksRoute = routes.find((r) => r.path === `${PUBLIC_API_PREFIX}${PUBLIC_API_PATHS.activeTasks}`)!;
+    const firstRes = await invokeNodeHttpRoute(
+      activeTasksRoute.handler,
+      fakeReq(`${PUBLIC_API_PREFIX}${PUBLIC_API_PATHS.activeTasks}`),
+    );
+    expect(firstRes.status).toBe(200);
+    const firstBody = JSON.parse(firstRes.body);
+    expect(firstBody.activeCount).toBe(1);
+    expect(firstBody.projection.stale).toBe(true);
+    expect(firstBody.projection.staleReasons).toContain("projection_missing");
+
+    const renderRes = await invokeNodeHttpRoute(
+      activeTasksRoute.handler,
+      fakeReq(`${PUBLIC_API_PREFIX}${PUBLIC_API_PATHS.activeTasks}?render=1&includeCompleted=1`),
+    );
+    expect(renderRes.status).toBe(200);
+    const renderBody = JSON.parse(renderRes.body);
+    expect(renderBody.render.applied).toBe(true);
+    expect(renderBody.projection.stale).toBe(false);
+    expect(renderBody.completedCount).toBe(0);
+
+    const projectionPath = join(tmp, "ACTIVE-TASKS.md");
+    const projectionText = readFileSync(projectionPath, "utf-8");
+    expect(projectionText).toContain("**Projection** of hybrid-memory `category:project` facts");
+
+    const staleTime = new Date(Date.now() - 2 * 60 * 1000);
+    utimesSync(projectionPath, staleTime, staleTime);
+    factsDb.store({
+      text: "Task next: wire tests",
+      category: "project",
+      importance: 0.8,
+      entity: "task-1272",
+      key: "next",
+      value: "Wire tests",
+      source: "conversation",
+    });
+
+    const staleAgainRes = await invokeNodeHttpRoute(
+      activeTasksRoute.handler,
+      fakeReq(`${PUBLIC_API_PREFIX}${PUBLIC_API_PATHS.activeTasks}`),
+    );
+    expect(staleAgainRes.status).toBe(200);
+    const staleAgain = JSON.parse(staleAgainRes.body);
+    expect(staleAgain.projection.stale).toBe(true);
+    expect(staleAgain.projection.staleReasons).toContain("project_facts_newer_than_projection");
+  });
+
   it("does not register routes when health is disabled", () => {
     const { api, routes } = makeApi();
     registerPublicApiRoutes(
       {
-        cfg: { health: { enabled: false, authenticated: true } },
+        cfg: { ...makeCfg(true), health: { enabled: false, authenticated: true } },
         factsDb,
         narrativesDb,
       },

--- a/extensions/memory-hybrid/tools/memory-tools.ts
+++ b/extensions/memory-hybrid/tools/memory-tools.ts
@@ -1972,7 +1972,7 @@ export function registerMemoryTools(
                   }
 
                   await walRemove(walEntryId, api.logger);
-                  await maybeRefreshProjectActiveTaskProjection(newEntry.category, newEntry.id);
+                  void maybeRefreshProjectActiveTaskProjection(newEntry.category, newEntry.id);
 
                   // Issue #159: enqueue contextual variant generation (non-blocking)
                   if (variantQueue) {
@@ -2156,7 +2156,7 @@ export function registerMemoryTools(
           }
 
           await walRemove(walEntryId, api.logger);
-          await maybeRefreshProjectActiveTaskProjection(entry.category, entry.id);
+          void maybeRefreshProjectActiveTaskProjection(entry.category, entry.id);
 
           // Issue #150: write event to episodic event log
           if (eventLog) {

--- a/extensions/memory-hybrid/tools/memory-tools.ts
+++ b/extensions/memory-hybrid/tools/memory-tools.ts
@@ -303,23 +303,26 @@ export function registerMemoryTools(
     }
   }
 
-  const activeTaskProjectionPath = resolveWorkspacePath(cfg.activeTask.filePath);
+  const activeTaskCfg = cfg.activeTask;
+  const activeTaskProjectionPath = activeTaskCfg ? resolveWorkspacePath(activeTaskCfg.filePath) : null;
   const activeTaskStaleMinutes = (() => {
+    if (!activeTaskCfg) return parseDuration("24h");
     try {
-      return parseDuration(cfg.activeTask.staleThreshold);
+      return parseDuration(activeTaskCfg.staleThreshold);
     } catch {
       return parseDuration("24h");
     }
   })();
 
   const maybeRefreshProjectActiveTaskProjection = async (factCategory: string, factId: string): Promise<void> => {
-    if (!cfg.activeTask.enabled || cfg.activeTask.ledger !== "facts") return;
+    if (!activeTaskCfg || !activeTaskCfg.enabled || activeTaskCfg.ledger !== "facts" || !activeTaskProjectionPath)
+      return;
     if (factCategory !== TASK_LEDGER_CATEGORY) return;
     await refreshActiveTaskProjectionBestEffort({
       factsDb,
       staleMinutes: activeTaskStaleMinutes,
       filePath: activeTaskProjectionPath,
-      projection: cfg.activeTask.projection,
+      projection: activeTaskCfg.projection,
       reason: "memory_store_project_fact_write",
       source: "memory_store",
       factId,

--- a/extensions/memory-hybrid/tools/memory-tools.ts
+++ b/extensions/memory-hybrid/tools/memory-tools.ts
@@ -1972,7 +1972,7 @@ export function registerMemoryTools(
                   }
 
                   await walRemove(walEntryId, api.logger);
-                  void maybeRefreshProjectActiveTaskProjection(newEntry.category, newEntry.id);
+                  await maybeRefreshProjectActiveTaskProjection(newEntry.category, newEntry.id);
 
                   // Issue #159: enqueue contextual variant generation (non-blocking)
                   if (variantQueue) {
@@ -2156,7 +2156,7 @@ export function registerMemoryTools(
           }
 
           await walRemove(walEntryId, api.logger);
-          void maybeRefreshProjectActiveTaskProjection(entry.category, entry.id);
+          await maybeRefreshProjectActiveTaskProjection(entry.category, entry.id);
 
           // Issue #150: write event to episodic event log
           if (eventLog) {

--- a/extensions/memory-hybrid/tools/memory-tools.ts
+++ b/extensions/memory-hybrid/tools/memory-tools.ts
@@ -65,7 +65,7 @@ import { parseSourceDate } from "../utils/dates.js";
 import { parseDuration } from "../utils/duration.js";
 import { embedCallWithTimeoutAndRetry } from "../utils/embed-call.js";
 import { getEnv } from "../utils/env-manager.js";
-import { resolveWorkspaceRoot, resolveWorkspacePath } from "../utils/path.js";
+import { resolveWorkspacePath } from "../utils/path.js";
 import { extractTags } from "../utils/tags.js";
 import { truncateForStorage } from "../utils/text.js";
 
@@ -303,7 +303,6 @@ export function registerMemoryTools(
     }
   }
 
-  const workspaceRoot = resolveWorkspaceRoot();
   const activeTaskProjectionPath = resolveWorkspacePath(cfg.activeTask.filePath);
   const activeTaskStaleMinutes = (() => {
     try {

--- a/extensions/memory-hybrid/tools/memory-tools.ts
+++ b/extensions/memory-hybrid/tools/memory-tools.ts
@@ -5,6 +5,8 @@
  * Extracted from index.ts for better modularity.
  */
 
+import { homedir } from "node:os";
+import { isAbsolute, join as pathJoin } from "node:path";
 import { Type } from "@sinclair/typebox";
 import type OpenAI from "openai";
 import type { ClawdbotPluginApi } from "openclaw/plugin-sdk/core";
@@ -54,6 +56,7 @@ import {
   type ExplicitDeepRetrievalPolicy,
 } from "../services/retrieval-mode-policy.js";
 import { buildExplicitSemanticQueryVector, runExplicitDeepRetrieval } from "../services/retrieval-orchestrator.js";
+import { TASK_LEDGER_CATEGORY, refreshActiveTaskProjectionBestEffort } from "../services/task-ledger-facts.js";
 import type { VerificationStore } from "../services/verification-store.js";
 import { shouldAutoVerify } from "../services/verification-store.js";
 import type { Episode, EpisodeOutcome, MemoryEntry, ScopeFilter, SearchResult } from "../types/memory.js";
@@ -61,6 +64,7 @@ import { MEMORY_SCOPES } from "../types/memory.js";
 import { UUID_REGEX, getSessionLogFileSuffix } from "../utils/constants.js";
 import { detectFutureDate } from "../utils/date-detector.js";
 import { parseSourceDate } from "../utils/dates.js";
+import { parseDuration } from "../utils/duration.js";
 import { embedCallWithTimeoutAndRetry } from "../utils/embed-call.js";
 import { getEnv } from "../utils/env-manager.js";
 import { extractTags } from "../utils/tags.js";
@@ -299,6 +303,33 @@ export function registerMemoryTools(
       /* non-fatal */
     }
   }
+
+  const workspaceRoot = getEnv("OPENCLAW_WORKSPACE") ?? pathJoin(homedir(), ".openclaw", "workspace");
+  const activeTaskProjectionPath = isAbsolute(cfg.activeTask.filePath)
+    ? cfg.activeTask.filePath
+    : pathJoin(workspaceRoot, cfg.activeTask.filePath);
+  const activeTaskStaleMinutes = (() => {
+    try {
+      return parseDuration(cfg.activeTask.staleThreshold);
+    } catch {
+      return parseDuration("24h");
+    }
+  })();
+
+  const maybeRefreshProjectActiveTaskProjection = async (factCategory: string, factId: string): Promise<void> => {
+    if (!cfg.activeTask.enabled || cfg.activeTask.ledger !== "facts") return;
+    if (factCategory !== TASK_LEDGER_CATEGORY) return;
+    await refreshActiveTaskProjectionBestEffort({
+      factsDb,
+      staleMinutes: activeTaskStaleMinutes,
+      filePath: activeTaskProjectionPath,
+      projection: cfg.activeTask.projection,
+      reason: "memory_store_project_fact_write",
+      source: "memory_store",
+      factId,
+      logger: api.logger,
+    });
+  };
 
   api.registerTool(
     {
@@ -1942,6 +1973,7 @@ export function registerMemoryTools(
                   }
 
                   await walRemove(walEntryId, api.logger);
+                  await maybeRefreshProjectActiveTaskProjection(newEntry.category, newEntry.id);
 
                   // Issue #159: enqueue contextual variant generation (non-blocking)
                   if (variantQueue) {
@@ -2125,6 +2157,7 @@ export function registerMemoryTools(
           }
 
           await walRemove(walEntryId, api.logger);
+          await maybeRefreshProjectActiveTaskProjection(entry.category, entry.id);
 
           // Issue #150: write event to episodic event log
           if (eventLog) {

--- a/extensions/memory-hybrid/tools/memory-tools.ts
+++ b/extensions/memory-hybrid/tools/memory-tools.ts
@@ -5,8 +5,6 @@
  * Extracted from index.ts for better modularity.
  */
 
-import { homedir } from "node:os";
-import { isAbsolute, join as pathJoin } from "node:path";
 import { Type } from "@sinclair/typebox";
 import type OpenAI from "openai";
 import type { ClawdbotPluginApi } from "openclaw/plugin-sdk/core";
@@ -67,6 +65,7 @@ import { parseSourceDate } from "../utils/dates.js";
 import { parseDuration } from "../utils/duration.js";
 import { embedCallWithTimeoutAndRetry } from "../utils/embed-call.js";
 import { getEnv } from "../utils/env-manager.js";
+import { resolveWorkspaceRoot, resolveWorkspacePath } from "../utils/path.js";
 import { extractTags } from "../utils/tags.js";
 import { truncateForStorage } from "../utils/text.js";
 
@@ -304,10 +303,8 @@ export function registerMemoryTools(
     }
   }
 
-  const workspaceRoot = getEnv("OPENCLAW_WORKSPACE") ?? pathJoin(homedir(), ".openclaw", "workspace");
-  const activeTaskProjectionPath = isAbsolute(cfg.activeTask.filePath)
-    ? cfg.activeTask.filePath
-    : pathJoin(workspaceRoot, cfg.activeTask.filePath);
+  const workspaceRoot = resolveWorkspaceRoot();
+  const activeTaskProjectionPath = resolveWorkspacePath(cfg.activeTask.filePath);
   const activeTaskStaleMinutes = (() => {
     try {
       return parseDuration(cfg.activeTask.staleThreshold);

--- a/extensions/memory-hybrid/tools/public-api-routes.ts
+++ b/extensions/memory-hybrid/tools/public-api-routes.ts
@@ -1,5 +1,3 @@
-import { homedir } from "node:os";
-import { isAbsolute, join as pathJoin } from "node:path";
 import type { ClawdbotPluginApi } from "openclaw/plugin-sdk/core";
 import type { AuditStore } from "../backends/audit-store.js";
 import type { EventLog } from "../backends/event-log.js";
@@ -14,7 +12,7 @@ import {
 } from "../services/task-ledger-facts.js";
 import type { ScopeFilter } from "../types/memory.js";
 import { parseDuration } from "../utils/duration.js";
-import { getEnv } from "../utils/env-manager.js";
+import { resolveWorkspacePath } from "../utils/path.js";
 import { versionInfo } from "../versionInfo.js";
 import type { HttpRequestHandler, HttpRouteOptions } from "./http-route-types.js";
 import { type SafeRouteLogger, createSafeRegisterHttpRoute } from "./safe-register-http-route.js";
@@ -103,14 +101,6 @@ function resolveActiveTaskConfig(cfg: PublicApiConfig): ActiveTaskConfigSubset {
   };
 }
 
-function resolveWorkspaceRoot(): string {
-  return getEnv("OPENCLAW_WORKSPACE") ?? pathJoin(homedir(), ".openclaw", "workspace");
-}
-
-function resolveActiveTaskFilePath(filePath: string): string {
-  return isAbsolute(filePath) ? filePath : pathJoin(resolveWorkspaceRoot(), filePath);
-}
-
 function extractFactId(url: URL): string | null {
   const byQuery = url.searchParams.get("id")?.trim();
   if (byQuery) return byQuery;
@@ -174,7 +164,7 @@ export function registerPublicApiRoutes(ctx: PublicApiRoutesContext, api: Clawdb
   const register = createSafeRegisterHttpRoute(api, logger, "memory-public");
   const makeRoute = (path: string, handler: HttpRequestHandler) => register(path, handler, routeOpts);
   const activeTaskCfg = resolveActiveTaskConfig(ctx.cfg);
-  const activeTaskFilePath = resolveActiveTaskFilePath(activeTaskCfg.filePath);
+  const activeTaskFilePath = resolveWorkspacePath(activeTaskCfg.filePath);
   const staleMinutes = (() => {
     try {
       return parseDuration(activeTaskCfg.staleThreshold);

--- a/extensions/memory-hybrid/tools/public-api-routes.ts
+++ b/extensions/memory-hybrid/tools/public-api-routes.ts
@@ -91,9 +91,12 @@ function resolveActiveTaskConfig(cfg: PublicApiConfig): ActiveTaskConfigSubset {
   return {
     enabled: raw.enabled !== false,
     ledger: raw.ledger === "facts" ? "facts" : "markdown",
-    filePath: typeof raw.filePath === "string" && raw.filePath.trim().length > 0 ? raw.filePath.trim() : "ACTIVE-TASKS.md",
+    filePath:
+      typeof raw.filePath === "string" && raw.filePath.trim().length > 0 ? raw.filePath.trim() : "ACTIVE-TASKS.md",
     staleThreshold:
-      typeof raw.staleThreshold === "string" && raw.staleThreshold.trim().length > 0 ? raw.staleThreshold.trim() : "24h",
+      typeof raw.staleThreshold === "string" && raw.staleThreshold.trim().length > 0
+        ? raw.staleThreshold.trim()
+        : "24h",
     projection:
       raw.projection && typeof raw.projection === "object"
         ? { ...DEFAULT_ACTIVE_TASK_PROJECTION, ...raw.projection }

--- a/extensions/memory-hybrid/tools/public-api-routes.ts
+++ b/extensions/memory-hybrid/tools/public-api-routes.ts
@@ -1,21 +1,42 @@
+import { homedir } from "node:os";
+import { isAbsolute, join as pathJoin } from "node:path";
 import type { ClawdbotPluginApi } from "openclaw/plugin-sdk/core";
 import type { AuditStore } from "../backends/audit-store.js";
 import type { EventLog } from "../backends/event-log.js";
 import type { FactsDB } from "../backends/facts-db.js";
 import type { NarrativesDB } from "../backends/narratives-db.js";
+import type { ActiveTaskProjectionConfig } from "../config.js";
 import { buildPublicExportBundle } from "../services/public-export-bundle.js";
+import {
+  getActiveTaskProjectionStatus,
+  readActiveTaskRowsFromFacts,
+  refreshActiveTaskProjectionBestEffort,
+} from "../services/task-ledger-facts.js";
 import type { ScopeFilter } from "../types/memory.js";
+import { parseDuration } from "../utils/duration.js";
+import { getEnv } from "../utils/env-manager.js";
 import { versionInfo } from "../versionInfo.js";
 import type { HttpRequestHandler, HttpRouteOptions } from "./http-route-types.js";
 import { type SafeRouteLogger, createSafeRegisterHttpRoute } from "./safe-register-http-route.js";
 
-export interface PublicApiRoutesContext {
-  cfg: {
-    health: {
-      enabled: boolean;
-      authenticated: boolean;
-    };
+type ActiveTaskConfigSubset = {
+  enabled: boolean;
+  ledger: "markdown" | "facts";
+  filePath: string;
+  staleThreshold: string;
+  projection: ActiveTaskProjectionConfig;
+};
+
+type PublicApiConfig = {
+  health: {
+    enabled: boolean;
+    authenticated: boolean;
   };
+  activeTask?: Partial<ActiveTaskConfigSubset>;
+};
+
+export interface PublicApiRoutesContext {
+  cfg: PublicApiConfig;
   factsDb: FactsDB;
   narrativesDb: NarrativesDB | null;
   auditStore?: AuditStore | null;
@@ -33,10 +54,18 @@ export const PUBLIC_API_PATHS = {
   export: "/export",
   fact: "/fact",
   session: "/session",
+  activeTasks: "/active-tasks",
 } as const;
 
 const JSON_HEADERS = { "Content-Type": "application/json" } as const;
 const DEFAULT_PUBLIC_SCOPE_SENTINEL = "__public_api_unscoped__";
+const DEFAULT_ACTIVE_TASK_PROJECTION: ActiveTaskProjectionConfig = {
+  mode: "readable",
+  excludeGenericTitle: true,
+  titleMinChars: 0,
+  dedupeBy: "none",
+  sectioned: true,
+};
 
 function toJson(status: number, body: unknown): { status: number; headers: Record<string, string>; body: string } {
   return { status, headers: { ...JSON_HEADERS }, body: JSON.stringify(body) };
@@ -51,6 +80,35 @@ function parseLimitParam(raw: string | null, fallback = 20, max = 200): number {
   const parsed = Number.parseInt(raw, 10);
   if (!Number.isFinite(parsed) || parsed < 1) return fallback;
   return Math.min(parsed, max);
+}
+
+function parseBooleanParam(raw: string | null): boolean {
+  if (!raw) return false;
+  const normalized = raw.trim().toLowerCase();
+  return normalized === "1" || normalized === "true" || normalized === "yes" || normalized === "on";
+}
+
+function resolveActiveTaskConfig(cfg: PublicApiConfig): ActiveTaskConfigSubset {
+  const raw = cfg.activeTask ?? {};
+  return {
+    enabled: raw.enabled !== false,
+    ledger: raw.ledger === "facts" ? "facts" : "markdown",
+    filePath: typeof raw.filePath === "string" && raw.filePath.trim().length > 0 ? raw.filePath.trim() : "ACTIVE-TASKS.md",
+    staleThreshold:
+      typeof raw.staleThreshold === "string" && raw.staleThreshold.trim().length > 0 ? raw.staleThreshold.trim() : "24h",
+    projection:
+      raw.projection && typeof raw.projection === "object"
+        ? { ...DEFAULT_ACTIVE_TASK_PROJECTION, ...raw.projection }
+        : { ...DEFAULT_ACTIVE_TASK_PROJECTION },
+  };
+}
+
+function resolveWorkspaceRoot(): string {
+  return getEnv("OPENCLAW_WORKSPACE") ?? pathJoin(homedir(), ".openclaw", "workspace");
+}
+
+function resolveActiveTaskFilePath(filePath: string): string {
+  return isAbsolute(filePath) ? filePath : pathJoin(resolveWorkspaceRoot(), filePath);
 }
 
 function extractFactId(url: URL): string | null {
@@ -115,6 +173,15 @@ export function registerPublicApiRoutes(ctx: PublicApiRoutesContext, api: Clawdb
   const logger = (api.logger ?? { warn: () => {} }) as SafeRouteLogger;
   const register = createSafeRegisterHttpRoute(api, logger, "memory-public");
   const makeRoute = (path: string, handler: HttpRequestHandler) => register(path, handler, routeOpts);
+  const activeTaskCfg = resolveActiveTaskConfig(ctx.cfg);
+  const activeTaskFilePath = resolveActiveTaskFilePath(activeTaskCfg.filePath);
+  const staleMinutes = (() => {
+    try {
+      return parseDuration(activeTaskCfg.staleThreshold);
+    } catch {
+      return parseDuration("24h");
+    }
+  })();
 
   makeRoute(`${PUBLIC_API_PREFIX}${PUBLIC_API_PATHS.health}`, async () =>
     toJson(200, {
@@ -276,6 +343,60 @@ export function registerPublicApiRoutes(ctx: PublicApiRoutesContext, api: Clawdb
         outgoing: filteredOutgoingLinks,
         incoming: filteredIncomingLinks,
       },
+    });
+  });
+
+  makeRoute(`${PUBLIC_API_PREFIX}${PUBLIC_API_PATHS.activeTasks}`, async (req) => {
+    const url = parseReqUrl(req.url);
+    const renderRequested = parseBooleanParam(url.searchParams.get("render"));
+    const includeCompleted = parseBooleanParam(url.searchParams.get("includeCompleted"));
+
+    let renderApplied = false;
+    let renderError: string | null = null;
+    if (renderRequested) {
+      if (activeTaskCfg.ledger !== "facts") {
+        renderError = "render_requested_but_activeTask_ledger_is_not_facts";
+      } else {
+        const result = await refreshActiveTaskProjectionBestEffort({
+          factsDb: ctx.factsDb,
+          staleMinutes,
+          filePath: activeTaskFilePath,
+          projection: activeTaskCfg.projection,
+          reason: "public_api_active_tasks_render",
+          source: "public_api",
+          logger: api.logger,
+        });
+        renderApplied = result.rendered;
+        renderError = result.error ?? null;
+      }
+    }
+
+    const rows = readActiveTaskRowsFromFacts(ctx.factsDb, staleMinutes);
+    const projection = await getActiveTaskProjectionStatus(ctx.factsDb, activeTaskFilePath);
+    const warnings: string[] = [];
+    if (activeTaskCfg.ledger !== "facts") {
+      warnings.push("activeTask.ledger is markdown; DB snapshot may diverge from markdown ledger.");
+    }
+    if (projection.stale) {
+      warnings.push(`ACTIVE-TASKS.md projection is stale (${projection.staleReasons.join(", ")}).`);
+    }
+
+    return toJson(200, {
+      generatedAt: new Date().toISOString(),
+      source: "category:project",
+      staleThresholdMinutes: staleMinutes,
+      ledger: activeTaskCfg.ledger,
+      active: rows.active,
+      activeCount: rows.active.length,
+      staleCount: rows.active.filter((row) => row.stale).length,
+      ...(includeCompleted ? { completed: rows.completed, completedCount: rows.completed.length } : {}),
+      projection,
+      render: {
+        requested: renderRequested,
+        applied: renderApplied,
+        error: renderError,
+      },
+      warnings,
     });
   });
 

--- a/extensions/memory-hybrid/tools/public-api-routes.ts
+++ b/extensions/memory-hybrid/tools/public-api-routes.ts
@@ -347,7 +347,9 @@ export function registerPublicApiRoutes(ctx: PublicApiRoutesContext, api: Clawdb
     let renderApplied = false;
     let renderError: string | null = null;
     if (renderRequested) {
-      if (activeTaskCfg.ledger !== "facts") {
+      if (!activeTaskCfg.enabled) {
+        renderError = "render_requested_but_activeTask_is_disabled";
+      } else if (activeTaskCfg.ledger !== "facts") {
         renderError = "render_requested_but_activeTask_ledger_is_not_facts";
       } else {
         const result = await refreshActiveTaskProjectionBestEffort({

--- a/extensions/memory-hybrid/utils/path.ts
+++ b/extensions/memory-hybrid/utils/path.ts
@@ -4,7 +4,7 @@ import { getEnv } from "./env-manager.js";
  */
 
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { isAbsolute, join } from "node:path";
 
 /**
  * Expand tilde (~) in path to user's home directory.
@@ -28,4 +28,21 @@ export function expandHomePlaceholders(p: string): string {
     return home + p.slice("$HOME".length);
   }
   return expandTilde(p);
+}
+
+/**
+ * Resolve the OpenClaw workspace root directory.
+ * Defaults to ~/.openclaw/workspace if OPENCLAW_WORKSPACE is not set.
+ */
+export function resolveWorkspaceRoot(): string {
+  return getEnv("OPENCLAW_WORKSPACE") ?? join(homedir(), ".openclaw", "workspace");
+}
+
+/**
+ * Resolve a potentially-relative file path against the workspace root.
+ * If the path is absolute, returns it as-is.
+ * If the path is relative, joins it with the workspace root.
+ */
+export function resolveWorkspacePath(filePath: string): string {
+  return isAbsolute(filePath) ? filePath : join(resolveWorkspaceRoot(), filePath);
 }


### PR DESCRIPTION
## Summary
- add fast gateway endpoint `/plugins/memory-public/active-tasks` backed by facts DB
- support optional `?render=1` projection refresh without CLI cold start
- add projection stale marker/status detection and best-effort refresh helper
- trigger best-effort ACTIVE-TASKS.md refresh after `memory_store` writes to `category:project` when `activeTask.ledger=facts`
- add tests for projection stale detection and write-triggered refresh

Fixes #1272

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new public gateway endpoint and introduces automatic, best-effort writes to `ACTIVE-TASKS.md` with stale-marker tracking; bugs here could expose incorrect task snapshots or cause unexpected filesystem churn.
> 
> **Overview**
> Adds a new public gateway endpoint, `GET /plugins/memory-public/active-tasks`, that returns a DB-backed snapshot of `category:project` tasks with scope filtering, optional completed-task inclusion, and projection status reporting.
> 
> When `activeTask.ledger: facts`, the endpoint can optionally run a best-effort projection refresh via `?render=1`, and `memory_store` writes to global `project` facts now trigger a best-effort `ACTIVE-TASKS.md` refresh; failures are recorded via a `.stale.json` marker and surfaced as stale reasons.
> 
> Extends the facts DB read layer with `getMaxCreatedAtByCategory`, adds workspace-relative path resolution helpers, updates docs, and adds tests covering refresh-on-write, stale detection, render-on-request, scope behavior, and disabled-config handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed13050c8ec51e84d4b9f0f438b3d04648e6afde. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->