### PR TITLE
fix: prevent stale active-task wake reminders on terminal/no-schedule transitions

### DIFF
--- a/extensions/memory-hybrid/services/active-task-checkpoint.ts
+++ b/extensions/memory-hybrid/services/active-task-checkpoint.ts
@@ -182,6 +182,12 @@ function normalizeExistingStatus(raw?: string): string | undefined {
   return lower;
 }
 
+const TERMINAL_CHECKPOINT_STATUSES = new Set(["done", "failed", "cancelled", "abandoned", "superseded"]);
+
+function isTerminalCheckpointStatus(status: string): boolean {
+  return TERMINAL_CHECKPOINT_STATUSES.has(status);
+}
+
 function normalizeCheckpointInput(
   input: ActiveTaskCheckpointInput,
   now: Date,
@@ -632,6 +638,7 @@ export async function runActiveTaskCheckpoint(
     "next",
     "related_session",
     "title",
+    "resume_at",
   ]);
   const existingStatus = getLatestProjectValue(latestProjectFacts, checkpoint.entity, "status");
   const resolvedStatus = checkpoint.status ?? normalizeExistingStatus(existingStatus) ?? "in_progress";
@@ -639,6 +646,8 @@ export async function runActiveTaskCheckpoint(
   const resolvedNext = checkpoint.next ?? getLatestProjectValue(latestProjectFacts, checkpoint.entity, "next") ?? "";
   const resolvedRelatedSession =
     checkpoint.relatedSession ?? getLatestProjectValue(latestProjectFacts, checkpoint.entity, "related_session") ?? "";
+  const existingResumeAt = getLatestProjectValue(latestProjectFacts, checkpoint.entity, "resume_at");
+  const terminalStatus = isTerminalCheckpointStatus(resolvedStatus);
   const taskUpdated = now.toISOString();
   const errors: ActiveTaskCheckpointError[] = [];
   const updatedKeys: string[] = [];
@@ -682,8 +691,12 @@ export async function runActiveTaskCheckpoint(
     updates.push({ key: "checkpoint_state", value: safeJson(checkpoint.state) });
   }
 
-  if (checkpoint.resumeAtIso) {
-    updates.push({ key: "resume_at", value: checkpoint.resumeAtIso });
+  const shouldPersistResumeAt = !terminalStatus && !!checkpoint.resumeAtIso;
+  const shouldClearResumeAt = !checkpoint.resumeAtIso || terminalStatus;
+  if (shouldPersistResumeAt) {
+    updates.push({ key: "resume_at", value: checkpoint.resumeAtIso as string });
+  } else if (shouldClearResumeAt && existingResumeAt !== undefined) {
+    updates.push({ key: "resume_at", value: "" });
   }
 
   primeLatestProjectFactCacheForEntityKeys(
@@ -762,7 +775,7 @@ export async function runActiveTaskCheckpoint(
 
   if (failedKeys.length > 0) {
     wakeSkippedReason = "facts_write_failed";
-  } else if (checkpoint.resumeAtIso && checkpoint.resumeAtDate && checkpoint.scheduleWake) {
+  } else if (checkpoint.resumeAtIso && checkpoint.resumeAtDate && checkpoint.scheduleWake && !terminalStatus) {
     wakeAttempted = true;
     try {
       const scheduleWake = deps.scheduleWakeFn ?? scheduleActiveTaskWakeReminder;
@@ -785,7 +798,11 @@ export async function runActiveTaskCheckpoint(
       errors.push(stepError("schedule", err));
     }
   } else {
-    wakeSkippedReason = checkpoint.resumeAtIso ? "schedule_wake_disabled" : "resumeAt_not_provided";
+    wakeSkippedReason = terminalStatus
+      ? "terminal_status_no_wake"
+      : checkpoint.resumeAtIso
+        ? "schedule_wake_disabled"
+        : "resumeAt_not_provided";
     try {
       const cleanup = disableActiveTaskWakeJobsForEntity(checkpoint.entity, deps.openclawDir);
       wakeJobsPath = cleanup.jobsPath;

--- a/extensions/memory-hybrid/services/active-task-checkpoint.ts
+++ b/extensions/memory-hybrid/services/active-task-checkpoint.ts
@@ -226,9 +226,8 @@ function normalizeCheckpointInput(
       const parsed = new Date(rawResumeAt);
       if (Number.isNaN(parsed.getTime())) {
         errors.push({ step: "validation", message: "resumeAt must be a valid ISO timestamp" });
-      } else if (parsed.getTime() <= now.getTime()) {
-        errors.push({ step: "validation", message: "resumeAt must be in the future" });
       } else {
+        // Accept past timestamps so missed reminders can be caught up by the cron scanner.
         resumeAtDate = parsed;
         resumeAtIso = parsed.toISOString();
       }

--- a/extensions/memory-hybrid/tests/active-task-checkpoint.test.ts
+++ b/extensions/memory-hybrid/tests/active-task-checkpoint.test.ts
@@ -217,7 +217,95 @@ describe("active-task-checkpoint", () => {
     factsDb.close();
   });
 
-  it("disables stale wake reminder when a follow-up checkpoint omits resumeAt", async () => {
+  it("schedules an overdue catch-up wake when resumeAt is already in the past", async () => {
+    const { cfg, factsDb, vectorDb, embeddings, openclawDir } = setup();
+    const now = new Date("2026-05-10T12:00:00.000Z");
+    const overdueResumeAt = "2026-05-10T11:45:00.000Z";
+
+    const result = await runActiveTaskCheckpoint(
+      {
+        cfg,
+        factsDb,
+        vectorDb,
+        embeddings,
+        openclawDir,
+        now: () => now,
+      },
+      {
+        entity: "task-1270-overdue-catchup",
+        status: "waiting",
+        next: "Resume immediately on recovery",
+        resumeAt: overdueResumeAt,
+      },
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.partial).toBe(false);
+    expect(result.steps.schedule.attempted).toBe(true);
+    expect(result.steps.schedule.scheduled).toBe(true);
+    expect(result.steps.schedule.scheduleAt).toBe(overdueResumeAt);
+    expect(latestProjectValue(factsDb, "task-1270-overdue-catchup", "resume_at")).toBe(overdueResumeAt);
+
+    const jobsPath = result.steps.schedule.jobsPath as string;
+    const raw = readFileSync(jobsPath, "utf-8");
+    const store = JSON.parse(raw) as { jobs?: Array<Record<string, unknown>> };
+    const job = (store.jobs ?? []).find((j) => j.pluginJobId === result.steps.schedule.jobId);
+    expect(job).toBeTruthy();
+    const schedule = job?.schedule as { kind?: string; at?: string } | undefined;
+    expect(schedule?.kind).toBe("at");
+    expect(schedule?.at).toBe(overdueResumeAt);
+
+    factsDb.close();
+  });
+
+  it("disables stale wake reminder when task resumes early and no longer includes resumeAt", async () => {
+    const { cfg, factsDb, vectorDb, embeddings, openclawDir } = setup();
+    const resumeAtDate = new Date(Date.now() + 2 * 60 * 60 * 1000);
+
+    const first = await runActiveTaskCheckpoint(
+      { cfg, factsDb, vectorDb, embeddings, openclawDir },
+      {
+        entity: "task-1270-resume-early",
+        status: "waiting",
+        next: "Resume later",
+        resumeAt: resumeAtDate.toISOString(),
+      },
+    );
+    expect(first.ok).toBe(true);
+    expect(first.steps.schedule.scheduled).toBe(true);
+    expect(first.steps.schedule.jobId).toBeTruthy();
+
+    const second = await runActiveTaskCheckpoint(
+      { cfg, factsDb, vectorDb, embeddings, openclawDir },
+      {
+        entity: "task-1270-resume-early",
+        status: "in_progress",
+        next: "Resumed ahead of schedule",
+      },
+    );
+    expect(second.ok).toBe(true);
+    expect(second.steps.schedule.attempted).toBe(false);
+    expect(second.steps.schedule.scheduled).toBe(false);
+    expect(second.steps.schedule.skippedReason).toBe("resumeAt_not_provided");
+    expect(second.steps.schedule.disabledPreviousJobs).toBe(1);
+    const clearedResumeAt = latestProjectValue(factsDb, "task-1270-resume-early", "resume_at") ?? "";
+    expect(clearedResumeAt).not.toContain(resumeAtDate.toISOString());
+
+    const jobsPath = second.steps.schedule.jobsPath;
+    expect(jobsPath).toBeTruthy();
+    const raw = readFileSync(jobsPath as string, "utf-8");
+    const store = JSON.parse(raw) as { jobs?: Array<Record<string, unknown>> };
+    const wakeJobs = (store.jobs ?? []).filter((j) => {
+      const pluginJobId = typeof j.pluginJobId === "string" ? j.pluginJobId : "";
+      return pluginJobId.startsWith("hybrid-mem:active-task-wake:");
+    });
+    expect(wakeJobs.length).toBeGreaterThan(0);
+    expect(wakeJobs.filter((j) => j.enabled !== false).length).toBe(0);
+
+    factsDb.close();
+  });
+
+  it("disables stale wake reminder when a terminal follow-up checkpoint omits resumeAt", async () => {
     const { cfg, factsDb, vectorDb, embeddings, openclawDir } = setup();
     const resumeAtDate = new Date(Date.now() + 2 * 60 * 60 * 1000);
 

--- a/extensions/memory-hybrid/tests/active-task-checkpoint.test.ts
+++ b/extensions/memory-hybrid/tests/active-task-checkpoint.test.ts
@@ -202,7 +202,7 @@ describe("active-task-checkpoint", () => {
     expect(result.steps.schedule.scheduleAt).toBe(resumeAtDate.toISOString());
     expect(result.steps.schedule.jobsPath).toBeTruthy();
 
-    const jobsPath = result.steps.schedule.jobsPath!;
+    const jobsPath = result.steps.schedule.jobsPath as string;
     const raw = readFileSync(jobsPath, "utf-8");
     const store = JSON.parse(raw) as { jobs?: Array<Record<string, unknown>> };
     const job = (store.jobs ?? []).find((j) => j.pluginJobId === result.steps.schedule.jobId);
@@ -244,8 +244,59 @@ describe("active-task-checkpoint", () => {
     expect(second.ok).toBe(true);
     expect(second.steps.schedule.attempted).toBe(false);
     expect(second.steps.schedule.scheduled).toBe(false);
-    expect(second.steps.schedule.skippedReason).toBe("resumeAt_not_provided");
+    expect(second.steps.schedule.skippedReason).toBe("terminal_status_no_wake");
     expect(second.steps.schedule.disabledPreviousJobs).toBe(1);
+    const clearedResumeAt = latestProjectValue(factsDb, "task-1270-wake-cleanup", "resume_at") ?? "";
+    expect(clearedResumeAt).not.toContain(resumeAtDate.toISOString());
+
+    const jobsPath = second.steps.schedule.jobsPath;
+    expect(jobsPath).toBeTruthy();
+    const raw = readFileSync(jobsPath as string, "utf-8");
+    const store = JSON.parse(raw) as { jobs?: Array<Record<string, unknown>> };
+    const wakeJobs = (store.jobs ?? []).filter((j) => {
+      const pluginJobId = typeof j.pluginJobId === "string" ? j.pluginJobId : "";
+      return pluginJobId.startsWith("hybrid-mem:active-task-wake:");
+    });
+    expect(wakeJobs.length).toBeGreaterThan(0);
+    expect(wakeJobs.filter((j) => j.enabled !== false).length).toBe(0);
+
+    factsDb.close();
+  });
+
+  it("does not schedule a wake when terminal status includes resumeAt and clears stale wake metadata", async () => {
+    const { cfg, factsDb, vectorDb, embeddings, openclawDir } = setup();
+    const firstResumeAt = new Date(Date.now() + 2 * 60 * 60 * 1000);
+    const staleResumeAt = new Date(Date.now() + 3 * 60 * 60 * 1000).toISOString();
+
+    const first = await runActiveTaskCheckpoint(
+      { cfg, factsDb, vectorDb, embeddings, openclawDir },
+      {
+        entity: "task-1270-terminal-stale-wake",
+        status: "waiting",
+        next: "Resume later",
+        resumeAt: firstResumeAt.toISOString(),
+      },
+    );
+    expect(first.ok).toBe(true);
+    expect(first.steps.schedule.scheduled).toBe(true);
+
+    const second = await runActiveTaskCheckpoint(
+      { cfg, factsDb, vectorDb, embeddings, openclawDir },
+      {
+        entity: "task-1270-terminal-stale-wake",
+        status: "done",
+        resumeAt: staleResumeAt,
+      },
+    );
+
+    expect(second.ok).toBe(true);
+    expect(second.steps.schedule.attempted).toBe(false);
+    expect(second.steps.schedule.scheduled).toBe(false);
+    expect(second.steps.schedule.skippedReason).toBe("terminal_status_no_wake");
+    expect(second.steps.schedule.disabledPreviousJobs).toBe(1);
+    const clearedResumeAt = latestProjectValue(factsDb, "task-1270-terminal-stale-wake", "resume_at") ?? "";
+    expect(clearedResumeAt).not.toContain(firstResumeAt.toISOString());
+    expect(clearedResumeAt).not.toContain(staleResumeAt);
 
     const jobsPath = second.steps.schedule.jobsPath;
     expect(jobsPath).toBeTruthy();
@@ -489,7 +540,7 @@ describe("active-task-checkpoint", () => {
     expect(second.ok).toBe(true);
     expect(second.steps.schedule.disabledPreviousJobs).toBe(0);
 
-    const jobsPath = second.steps.schedule.jobsPath!;
+    const jobsPath = second.steps.schedule.jobsPath as string;
     const raw = readFileSync(jobsPath, "utf-8");
     const store = JSON.parse(raw) as { jobs?: Array<Record<string, unknown>> };
     const activeWakeJobs = (store.jobs ?? []).filter(


### PR DESCRIPTION
## Summary
Follow-up lifecycle hardening for the bug class discussed in PR #1283 review comments: stale wake/reminder artifacts after task-state transitions.

## Root Cause
`active_task_checkpoint` handled wake scheduling/cleanup around `resumeAt`, but catch-up semantics for missed schedules were incomplete and stale reminder cleanup needed explicit coverage for resumed-early transitions.

## Fix
- Keep terminal-state behavior: never schedule wake jobs for terminal statuses.
- Keep stale cleanup behavior: when no new schedule applies, clear `resume_at` and disable prior `hybrid-mem:active-task-wake:*` jobs.
- Allow past `resumeAt` timestamps so missed one-shot reminders are retained as overdue `at` jobs and can run on next cron scan/recovery.

## Missed schedule / catch-up semantics
### Execute due work (catch-up)
- If `resumeAt` is already in the past and the task is still non-terminal/waiting-applicable, checkpoint now accepts it and writes an `at` schedule for that timestamp.
- This preserves idempotent job identity (`pluginJobId` derived from entity + scheduled epoch), so repeated writes for the same missed occurrence update/dedupe instead of multiplying reminders.

### Cancel stale reminder
- If the task is no longer waiting/applicable (for example resumed early, terminal, or `resumeAt` omitted), checkpoint does not schedule and disables previous wake jobs for that task entity.
- `resume_at` fact metadata is cleared so stale wake state does not linger across restarts/scans.

### Recurring policy note
- Active-task wake jobs here are one-shot (`schedule.kind = at`, `deleteAfterRun = true`), not recurring cron expressions.
- Recurring missed-run policy remains governed by the core cron scheduler; this PR makes one-shot wake semantics explicit and non-stale.

## Tests
- `active-task-checkpoint.test.ts`: `schedules an overdue catch-up wake when resumeAt is already in the past` (execute-due-work path).
- `active-task-checkpoint.test.ts`: `disables stale wake reminder when task resumes early and no longer includes resumeAt` (cancel-stale-reminder path).
- Existing terminal/no-schedule cleanup regressions remain and continue to pass.

## Validation
- `npm --prefix extensions/memory-hybrid test -- tests/active-task-checkpoint.test.ts`
- `npm --prefix extensions/memory-hybrid exec -- biome lint extensions/memory-hybrid/services/active-task-checkpoint.ts extensions/memory-hybrid/tests/active-task-checkpoint.test.ts`
- `cd extensions/memory-hybrid && npx tsc -p tsconfig.json --noEmit --pretty false`
- `git diff --check`
