### PR TITLE
fix: stop hybrid-mem CLI hangs by clearing service timers

### DIFF
--- a/extensions/memory-hybrid/api/plugin-runtime.ts
+++ b/extensions/memory-hybrid/api/plugin-runtime.ts
@@ -136,3 +136,46 @@ export function createTimers(): PluginRuntime["timers"] {
     watchdogTimer: { value: null },
   };
 }
+
+/**
+ * Clear all runtime timer handles and reset refs.
+ * Shared by CLI teardown and hot-reload cleanup paths.
+ */
+export function clearRuntimeTimers(timers: PluginRuntime["timers"]): void {
+  if (timers.pruneTimer.value) {
+    clearInterval(timers.pruneTimer.value);
+    timers.pruneTimer.value = null;
+  }
+  if (timers.classifyTimer.value) {
+    clearInterval(timers.classifyTimer.value);
+    timers.classifyTimer.value = null;
+  }
+  if (timers.classifyStartupTimeout.value) {
+    clearTimeout(timers.classifyStartupTimeout.value);
+    timers.classifyStartupTimeout.value = null;
+  }
+  if (timers.proposalsPruneTimer.value) {
+    clearInterval(timers.proposalsPruneTimer.value);
+    timers.proposalsPruneTimer.value = null;
+  }
+  if (timers.languageKeywordsTimer.value) {
+    clearInterval(timers.languageKeywordsTimer.value);
+    timers.languageKeywordsTimer.value = null;
+  }
+  if (timers.languageKeywordsStartupTimeout.value) {
+    clearTimeout(timers.languageKeywordsStartupTimeout.value);
+    timers.languageKeywordsStartupTimeout.value = null;
+  }
+  if (timers.postUpgradeTimeout.value) {
+    clearTimeout(timers.postUpgradeTimeout.value);
+    timers.postUpgradeTimeout.value = null;
+  }
+  if (timers.passiveObserverTimer.value) {
+    clearInterval(timers.passiveObserverTimer.value);
+    timers.passiveObserverTimer.value = null;
+  }
+  if (timers.watchdogTimer.value) {
+    clearInterval(timers.watchdogTimer.value);
+    timers.watchdogTimer.value = null;
+  }
+}

--- a/extensions/memory-hybrid/index.ts
+++ b/extensions/memory-hybrid/index.ts
@@ -118,7 +118,7 @@ export type {
   ClusterFactLookup,
 } from "./services/topic-clusters.js";
 import type { MemoryPluginAPI } from "./api/memory-plugin-api.js";
-import { type PluginRuntime, createTimers } from "./api/plugin-runtime.js";
+import { type PluginRuntime, clearRuntimeTimers, createTimers } from "./api/plugin-runtime.js";
 import {
   type AuthFailurePattern,
   DEFAULT_AUTH_FAILURE_PATTERNS,
@@ -324,11 +324,15 @@ const runtimeRef: { value: PluginRuntime | null } = { value: null };
 async function performHybridMemCliTeardown(): Promise<void> {
   const r = runtimeRef.value;
   if (!r) return;
+  // Stop long-lived service timers first so one-shot CLI commands can exit promptly.
+  clearRuntimeTimers(r.timers);
   try {
     await r.bootstrapAsyncInit;
   } catch {
     /* embedding/vault init may fail; still close handles */
   }
+  // Startup can race with command completion; clear again after async init settles.
+  clearRuntimeTimers(r.timers);
   try {
     r.lifecycleHooksHandle?.dispose();
   } catch (err) {
@@ -442,16 +446,8 @@ function runMemoryHybridRegister(api: ClawdbotPluginApi): void {
   }
 
   if (old) {
-    // Clear old timer handles to prevent leaks
-    if (old.timers.pruneTimer.value) clearInterval(old.timers.pruneTimer.value);
-    if (old.timers.classifyTimer.value) clearInterval(old.timers.classifyTimer.value);
-    if (old.timers.classifyStartupTimeout.value) clearTimeout(old.timers.classifyStartupTimeout.value);
-    if (old.timers.proposalsPruneTimer.value) clearInterval(old.timers.proposalsPruneTimer.value);
-    if (old.timers.languageKeywordsTimer.value) clearInterval(old.timers.languageKeywordsTimer.value);
-    if (old.timers.languageKeywordsStartupTimeout.value) clearTimeout(old.timers.languageKeywordsStartupTimeout.value);
-    if (old.timers.postUpgradeTimeout.value) clearTimeout(old.timers.postUpgradeTimeout.value);
-    if (old.timers.passiveObserverTimer.value) clearInterval(old.timers.passiveObserverTimer.value);
-    if (old.timers.watchdogTimer.value) clearInterval(old.timers.watchdogTimer.value);
+    // Clear old timer handles to prevent leaks.
+    clearRuntimeTimers(old.timers);
     // Issue #463: Dispose lifecycle hooks (stale session sweep timer, per-session state)
     old.lifecycleHooksHandle?.dispose();
     // Close SQLite/Lance and related stores before opening new connections (issue #802 — same paths must not be double-opened).

--- a/extensions/memory-hybrid/setup/plugin-service.ts
+++ b/extensions/memory-hybrid/setup/plugin-service.ts
@@ -4,6 +4,7 @@ import { dirname, isAbsolute, join } from "node:path";
 import { findPluginRoot } from "../utils/plugin-root.js";
 import type OpenAI from "openai";
 import type { ClawdbotPluginApi } from "openclaw/plugin-sdk/core";
+import { clearRuntimeTimers } from "../api/plugin-runtime.js";
 import type { CredentialsDB } from "../backends/credentials-db.js";
 import type { EdictStore } from "../backends/edict-store.js";
 import type { FactsDB } from "../backends/facts-db.js";
@@ -929,42 +930,7 @@ export function createPluginService(ctx: PluginServiceContext) {
       if (isErrorReporterActive()) {
         flushErrorReporter(2000).catch(() => {});
       }
-      if (timers.pruneTimer.value) {
-        clearInterval(timers.pruneTimer.value);
-        timers.pruneTimer.value = null;
-      }
-      if (timers.classifyStartupTimeout.value) {
-        clearTimeout(timers.classifyStartupTimeout.value);
-        timers.classifyStartupTimeout.value = null;
-      }
-      if (timers.classifyTimer.value) {
-        clearInterval(timers.classifyTimer.value);
-        timers.classifyTimer.value = null;
-      }
-      if (timers.proposalsPruneTimer.value) {
-        clearInterval(timers.proposalsPruneTimer.value);
-        timers.proposalsPruneTimer.value = null;
-      }
-      if (timers.languageKeywordsStartupTimeout.value) {
-        clearTimeout(timers.languageKeywordsStartupTimeout.value);
-        timers.languageKeywordsStartupTimeout.value = null;
-      }
-      if (timers.languageKeywordsTimer.value) {
-        clearInterval(timers.languageKeywordsTimer.value);
-        timers.languageKeywordsTimer.value = null;
-      }
-      if (timers.passiveObserverTimer.value) {
-        clearInterval(timers.passiveObserverTimer.value);
-        timers.passiveObserverTimer.value = null;
-      }
-      if (timers.postUpgradeTimeout.value) {
-        clearTimeout(timers.postUpgradeTimeout.value);
-        timers.postUpgradeTimeout.value = null;
-      }
-      if (timers.watchdogTimer.value) {
-        clearInterval(timers.watchdogTimer.value);
-        timers.watchdogTimer.value = null;
-      }
+      clearRuntimeTimers(timers);
       if (dashboardServer) {
         try {
           dashboardServer.close();

--- a/extensions/memory-hybrid/tests/hybrid-mem-cli-teardown.test.ts
+++ b/extensions/memory-hybrid/tests/hybrid-mem-cli-teardown.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync } from "node:fs";
+import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Command } from "commander";
@@ -100,14 +100,16 @@ async function expectCommandCompletesAndRunsTeardown(argv: string[]): Promise<vo
 
   try {
     await program.parseAsync(argv, { from: "user" });
+    const ticksAfterCompletion = ticks;
     await new Promise((resolve) => setTimeout(resolve, 180));
     expect(onComplete).toHaveBeenCalledTimes(1);
-    expect(ticks).toBe(0);
+    expect(ticks).toBe(ticksAfterCompletion);
     expect(log).toHaveBeenCalled();
   } finally {
     clearInterval(sentinel);
     log.mockRestore();
     setEnv("OPENCLAW_WORKSPACE", prevWorkspace);
+    rmSync(workspace, { recursive: true, force: true });
   }
 }
 

--- a/extensions/memory-hybrid/tests/hybrid-mem-cli-teardown.test.ts
+++ b/extensions/memory-hybrid/tests/hybrid-mem-cli-teardown.test.ts
@@ -1,0 +1,122 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Command } from "commander";
+import type { ClawdbotPluginApi } from "openclaw/plugin-sdk/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { hybridConfigSchema } from "../config.js";
+import { registerHybridMemCliWithApi, type HybridMemCliRegistrationContext } from "../setup/cli-context.js";
+import { setEnv } from "../utils/env-manager.js";
+
+function makeCfg(goalsDir: string) {
+  return hybridConfigSchema.parse({
+    embedding: {
+      apiKey: "sk-test-key-that-is-long-enough-to-pass",
+      model: "text-embedding-3-small",
+    },
+    goalStewardship: {
+      enabled: true,
+      goalsDir,
+      heartbeatPatterns: ["^cron heartbeat"],
+      heartbeatStewardship: true,
+      watchdogHealthCheck: true,
+    },
+  });
+}
+
+function makeCliRegistrationContext(workspace: string): HybridMemCliRegistrationContext {
+  const stub = {} as unknown;
+  return {
+    factsDb: stub as HybridMemCliRegistrationContext["factsDb"],
+    vectorDb: stub as HybridMemCliRegistrationContext["vectorDb"],
+    embeddings: stub as HybridMemCliRegistrationContext["embeddings"],
+    openai: stub as HybridMemCliRegistrationContext["openai"],
+    cfg: makeCfg("state/goals-test"),
+    credentialsDb: null,
+    aliasDb: null,
+    wal: null,
+    proposalsDb: null,
+    identityReflectionStore: null,
+    personaStateStore: null,
+    verificationStore: null,
+    provenanceService: null,
+    resolvedSqlitePath: join(workspace, "memory", "facts.db"),
+    resolvedLancePath: join(workspace, "memory", "lancedb"),
+    pluginId: "openclaw-hybrid-memory",
+    detectCategory: (() => "fact") as HybridMemCliRegistrationContext["detectCategory"],
+    eventLog: null,
+    costTracker: null,
+    eventBus: null,
+    auditStore: null,
+    agentHealthStore: null,
+  };
+}
+
+function makeMockApi(registerCapture: {
+  callback: ((opts: { program: Command }) => void) | null;
+}): ClawdbotPluginApi {
+  return {
+    logger: {
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+      debug: () => {},
+    },
+    resolvePath: (p: string) => p,
+    registerCli: (callback: (opts: { program: Command }) => void) => {
+      registerCapture.callback = callback;
+    },
+  } as unknown as ClawdbotPluginApi;
+}
+
+async function expectCommandCompletesAndRunsTeardown(argv: string[]): Promise<void> {
+  const prevWorkspace = process.env.OPENCLAW_WORKSPACE;
+  const workspace = mkdtempSync(join(tmpdir(), "hm-cli-teardown-"));
+  setEnv("OPENCLAW_WORKSPACE", workspace);
+
+  // Sentinel handle: if teardown is skipped this interval keeps ticking.
+  let ticks = 0;
+  const sentinel = setInterval(() => {
+    ticks += 1;
+  }, 75);
+
+  const onComplete = vi.fn(async () => {
+    clearInterval(sentinel);
+  });
+
+  const capture: { callback: ((opts: { program: Command }) => void) | null } = {
+    callback: null,
+  };
+  const api = makeMockApi(capture);
+  const ctx = makeCliRegistrationContext(workspace);
+  registerHybridMemCliWithApi(api, ctx, { onHybridMemCliComplete: onComplete });
+  expect(capture.callback).not.toBeNull();
+
+  const program = new Command("openclaw");
+  program.exitOverride();
+  capture.callback?.({ program });
+
+  const log = vi.spyOn(console, "log").mockImplementation(() => {});
+
+  try {
+    await program.parseAsync(argv, { from: "user" });
+    await new Promise((resolve) => setTimeout(resolve, 180));
+    expect(onComplete).toHaveBeenCalledTimes(1);
+    expect(ticks).toBe(0);
+    expect(log).toHaveBeenCalled();
+  } finally {
+    clearInterval(sentinel);
+    log.mockRestore();
+    setEnv("OPENCLAW_WORKSPACE", prevWorkspace);
+  }
+}
+
+describe("hybrid-mem CLI teardown", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("runs completion teardown for goals list --json so one-shot CLI does not hang", async () => {
+    await expectCommandCompletesAndRunsTeardown(["hybrid-mem", "goals", "list", "--json"]);
+  });
+});

--- a/extensions/memory-hybrid/tests/runtime-timer-cleanup.test.ts
+++ b/extensions/memory-hybrid/tests/runtime-timer-cleanup.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { clearRuntimeTimers, createTimers } from "../api/plugin-runtime.js";
+
+describe("clearRuntimeTimers", () => {
+  it("clears all interval/timeout refs and prevents queued callbacks from firing", async () => {
+    const timers = createTimers();
+    let fired = 0;
+
+    timers.pruneTimer.value = setInterval(() => {
+      fired += 1;
+    }, 100);
+    timers.classifyTimer.value = setInterval(() => {
+      fired += 1;
+    }, 100);
+    timers.classifyStartupTimeout.value = setTimeout(() => {
+      fired += 1;
+    }, 100);
+    timers.proposalsPruneTimer.value = setInterval(() => {
+      fired += 1;
+    }, 100);
+    timers.languageKeywordsTimer.value = setInterval(() => {
+      fired += 1;
+    }, 100);
+    timers.languageKeywordsStartupTimeout.value = setTimeout(() => {
+      fired += 1;
+    }, 100);
+    timers.postUpgradeTimeout.value = setTimeout(() => {
+      fired += 1;
+    }, 100);
+    timers.passiveObserverTimer.value = setInterval(() => {
+      fired += 1;
+    }, 100);
+    timers.watchdogTimer.value = setInterval(() => {
+      fired += 1;
+    }, 100);
+
+    clearRuntimeTimers(timers);
+    await new Promise((resolve) => setTimeout(resolve, 160));
+
+    expect(fired).toBe(0);
+    expect(timers.pruneTimer.value).toBeNull();
+    expect(timers.classifyTimer.value).toBeNull();
+    expect(timers.classifyStartupTimeout.value).toBeNull();
+    expect(timers.proposalsPruneTimer.value).toBeNull();
+    expect(timers.languageKeywordsTimer.value).toBeNull();
+    expect(timers.languageKeywordsStartupTimeout.value).toBeNull();
+    expect(timers.postUpgradeTimeout.value).toBeNull();
+    expect(timers.passiveObserverTimer.value).toBeNull();
+    expect(timers.watchdogTimer.value).toBeNull();
+  });
+
+  it("is safe when all timer refs are already null", () => {
+    const timers = createTimers();
+    expect(() => clearRuntimeTimers(timers)).not.toThrow();
+  });
+});

--- a/extensions/memory-hybrid/tests/runtime-timer-cleanup.test.ts
+++ b/extensions/memory-hybrid/tests/runtime-timer-cleanup.test.ts
@@ -1,7 +1,15 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { clearRuntimeTimers, createTimers } from "../api/plugin-runtime.js";
 
 describe("clearRuntimeTimers", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("clears all interval/timeout refs and prevents queued callbacks from firing", async () => {
     const timers = createTimers();
     let fired = 0;
@@ -35,7 +43,7 @@ describe("clearRuntimeTimers", () => {
     }, 100);
 
     clearRuntimeTimers(timers);
-    await new Promise((resolve) => setTimeout(resolve, 160));
+    await vi.advanceTimersByTimeAsync(160);
 
     expect(fired).toBe(0);
     expect(timers.pruneTimer.value).toBeNull();


### PR DESCRIPTION
## Summary
- fix CLI hang after successful `hybrid-mem` command completion by clearing all runtime service timers during CLI teardown
- reuse the same centralized timer cleanup in both CLI teardown and hot-reload cleanup paths
- add regression tests to ensure:
  - `hybrid-mem goals list --json` executes completion teardown hook
  - centralized runtime timer cleanup clears all known interval/timeout refs

## Root Cause
`performHybridMemCliTeardown()` closed DB/hooks but did not clear timers started by plugin service startup (`prune`, `watchdog`, `post-upgrade`, etc.).
For one-shot CLI invocations this left active handles in the event loop, so commands like `openclaw hybrid-mem goals list --json` could print JSON but not exit promptly.

## Validation
- `npm --prefix extensions/memory-hybrid test -- tests/runtime-timer-cleanup.test.ts tests/hybrid-mem-cli-teardown.test.ts tests/goals-config-cli.test.ts`
- `npm --prefix extensions/memory-hybrid run format:check`
- `npm --prefix extensions/memory-hybrid run build`
- `npm --prefix extensions/memory-hybrid run lint` (repo has pre-existing warnings; no new lint errors introduced)

## Notes
- reproduced locally before fix: `timeout 30 env -u OPENCLAW_SKIP_HYBRID_MEMORY_CLI openclaw hybrid-mem goals list --json` -> `exit 124` (hung after JSON output)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches plugin lifecycle teardown paths (CLI completion, service stop, hot-reload) and could inadvertently stop timers needed for long-running service mode if mis-invoked, but changes are localized and covered by new tests.
> 
> **Overview**
> Fixes one-shot `hybrid-mem` CLI commands hanging after completion by **centralizing runtime timer cleanup** and running it during CLI teardown.
> 
> Adds `clearRuntimeTimers()` in `api/plugin-runtime.ts` and reuses it in both hot-reload/registration cleanup and `plugin-service` shutdown, with a double-clear in `performHybridMemCliTeardown()` to handle async startup races.
> 
> Adds regression tests ensuring CLI completion teardown runs (e.g. `hybrid-mem goals list --json`) and that `clearRuntimeTimers()` nulls all timer refs and prevents queued callbacks from firing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d17b59de6048396f696243a630fccbff51065e9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->