### PR TITLE
fix(recall): add probe logging for hybrid-memory stalls

### DIFF
--- a/extensions/memory-hybrid/lifecycle/stage-recall.ts
+++ b/extensions/memory-hybrid/lifecycle/stage-recall.ts
@@ -832,10 +832,10 @@ async function runRecall(
     );
     throw err;
   } finally {
+    ctx.recallInFlightRef.value--;
     clearRecallProbeWatchdog();
     api.logger.debug?.(
       `memory-hybrid: recall-probe id=${recallProbeId} exit elapsedMs=${Date.now() - recallStartMs} phase=${recallProbePhase} completed=${recallStageCompleted}`,
     );
-    ctx.recallInFlightRef.value--;
   }
 }

--- a/extensions/memory-hybrid/lifecycle/stage-recall.ts
+++ b/extensions/memory-hybrid/lifecycle/stage-recall.ts
@@ -81,9 +81,31 @@ async function runRecall(
   if (!e.prompt || e.prompt.length < 5) {
     return { kind: "empty", prependContext: undefined };
   }
+  const promptText = e.prompt;
 
   ctx.recallInFlightRef.value++;
   const recallStartMs = Date.now();
+  const recallProbeId = `recall-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+  let recallProbePhase = "start";
+  let recallProbeWatchdog: ReturnType<typeof setTimeout> | undefined;
+  const setRecallProbePhase = (phase: string): void => {
+    recallProbePhase = phase;
+    scheduleRecallProbeWatchdog();
+  };
+  const clearRecallProbeWatchdog = (): void => {
+    if (recallProbeWatchdog !== undefined) clearTimeout(recallProbeWatchdog);
+  };
+  const scheduleRecallProbeWatchdog = (): void => {
+    clearRecallProbeWatchdog();
+    recallProbeWatchdog = setTimeout(() => {
+      const elapsedMs = Date.now() - recallStartMs;
+      api.logger.warn?.(
+        `memory-hybrid: recall-probe id=${recallProbeId} still-running elapsedMs=${elapsedMs} phase=${recallProbePhase} inFlight=${ctx.recallInFlightRef.value} promptChars=${promptText.length}`,
+      );
+    }, 5_000);
+    recallProbeWatchdog.unref?.();
+  };
+  scheduleRecallProbeWatchdog();
   const recallTiming = createRecallTimingLogger({
     logger: api.logger,
     mode: ctx.cfg.autoRecall.recallTiming ?? "off",
@@ -94,6 +116,7 @@ async function runRecall(
   let recallStageCompleted = false;
   let recallStageFields: Record<string, string | number | boolean> | undefined;
   const completeStage = (result: RecallStageResult): RecallStageResult => {
+    setRecallProbePhase(`complete:${result.kind}`);
     recallStageFields = {
       result_kind: result.kind,
       candidate_count: result.kind === "full" ? result.result.candidates.length : 0,
@@ -112,6 +135,9 @@ async function runRecall(
       sessionState;
 
     api.logger.debug?.(`memory-hybrid: auto-recall start (prompt length ${e.prompt.length})`);
+    api.logger.debug?.(
+      `memory-hybrid: recall-probe id=${recallProbeId} enter promptChars=${promptText.length} inFlight=${ctx.recallInFlightRef.value}`,
+    );
 
     if (e.prompt.length >= 5 && ctx.lastAutoRecallPromptRef) {
       ctx.lastAutoRecallPromptRef.value = e.prompt.trim().slice(0, 12_000);
@@ -162,6 +188,7 @@ async function runRecall(
     const forceDegraded = degradationQueueDepth > 0 && ctx.recallInFlightRef.value > degradationQueueDepth;
 
     if (forceDegraded) {
+      setRecallProbePhase("degraded_fts_only");
       const recallOpts = {
         tierFilter: ctx.cfg.memoryTiering.enabled ? ("warm" as const) : ("all" as const),
         scopeFilter,
@@ -219,6 +246,7 @@ async function runRecall(
     }
 
     // Procedural memory (skip expensive FTS when injection budget is zero — issue #863)
+    setRecallProbePhase("procedures_block");
     const proceduresStartedAt = recallTiming.phaseStarted("procedures_block");
     let procedureBlock = "";
     const procMaxTokens = ctx.cfg.procedures.maxInjectionTokens ?? 0;
@@ -286,6 +314,7 @@ async function runRecall(
     const withProcedures = (s: string) => (procedureBlock ? `${procedureBlock}\n${s}` : s);
 
     // HOT block
+    setRecallProbePhase("hot_facts_block");
     const hotFactsStartedAt = recallTiming.phaseStarted("hot_facts_block");
     let hotBlock = "";
     if (ctx.cfg.memoryTiering.enabled && ctx.cfg.memoryTiering.hotMaxTokens > 0) {
@@ -350,6 +379,7 @@ async function runRecall(
     if (recallAborted(signal)) return completeStage(emptyRecallStage());
 
     let promptEmbedding: number[] | null = null;
+    setRecallProbePhase("prompt_embedding");
     if (
       interactivePolicy.allowAmbientMultiQuery &&
       ambientCfg.enabled &&
@@ -365,8 +395,10 @@ async function runRecall(
 
     if (recallAborted(signal)) return completeStage(emptyRecallStage());
 
+    setRecallProbePhase("main_pipeline");
     const mainPipelineStartedAt = recallTiming.phaseStarted("main_pipeline");
     let candidates = await runRecallPipelineQuery(e.prompt, limit, pipelineDeps, hydeUsedRef, {
+      probeId: `${recallProbeId}:main`,
       hydeLabel: "HyDE",
       errorPrefix: "auto-recall-",
       precomputedVector: promptEmbedding ?? undefined,
@@ -379,6 +411,7 @@ async function runRecall(
     if (recallAborted(signal)) return completeStage(emptyRecallStage());
 
     if (interactivePolicy.allowAmbientMultiQuery && ambientCfg.enabled && ambientCfg.multiQuery) {
+      setRecallProbePhase("ambient_multi_query");
       const ambientStartedAt = recallTiming.phaseStarted("ambient_multi_query");
       let ambientQueriesRun = 0;
       try {
@@ -410,6 +443,7 @@ async function runRecall(
             await yieldEventLoop();
             try {
               const qResults = await runRecallPipelineQuery(q.text, Math.ceil(limit / 2), pipelineDeps, hydeUsedRef, {
+                probeId: `${recallProbeId}:ambient:${q.type}:${ambientQueriesRun + 1}`,
                 entity: q.type === "entity" ? q.entity : undefined,
                 hydeLabel: "HyDE",
                 errorPrefix: `ambient-${q.type}-`,
@@ -451,6 +485,7 @@ async function runRecall(
 
     let issueBlock = "";
     let narrativeBlock = "";
+    setRecallProbePhase("issues_block");
     const issuesStartedAt = recallTiming.phaseStarted("issues_block");
     if (ambientCfg.enabled && ctx.issueStore) {
       try {
@@ -483,6 +518,7 @@ async function runRecall(
     }
     recallTiming.phaseCompleted("issues_block", issuesStartedAt, { injected: issueBlock.length > 0 });
 
+    setRecallProbePhase("narrative_block");
     const narrativeStartedAt = recallTiming.phaseStarted("narrative_block");
     if (ctx.narrativesDb || ctx.eventLog) {
       try {
@@ -512,6 +548,7 @@ async function runRecall(
 
     const promptLower = e.prompt.toLowerCase();
     const { entityLookup } = ctx.cfg.autoRecall;
+    setRecallProbePhase("entity_lookup");
     const entityLookupStartedAt = recallTiming.phaseStarted("entity_lookup");
     let entityLookupHits = 0;
     if (entityLookup.enabled) {
@@ -570,6 +607,7 @@ async function runRecall(
       return directiveCalls < maxDirectiveCalls && candidates.length < maxDirectiveCandidates;
     }
 
+    setRecallProbePhase("directives_loop");
     const directivesStartedAt = recallTiming.phaseStarted("directives_loop");
     const abortDirectives = () => {
       recallTiming.phaseCompleted("directives_loop", directivesStartedAt, {
@@ -596,6 +634,7 @@ async function runRecall(
               if (!promptLower.includes(entity.toLowerCase())) continue;
               if (!canRunDirective()) break;
               const results = await runRecallPipelineQuery(entity, directiveLimit, pipelineDeps, hydeUsedRef, {
+                probeId: `${recallProbeId}:directive:entity:${entity}`,
                 entity,
                 hydeLabel: "HyDE",
                 errorPrefix: "directive-",
@@ -617,6 +656,7 @@ async function runRecall(
             if (!promptLower.includes(keyword.toLowerCase())) continue;
             if (!canRunDirective()) break;
             const results = await runRecallPipelineQuery(keyword, directiveLimit, pipelineDeps, hydeUsedRef, {
+              probeId: `${recallProbeId}:directive:keyword:${keyword}`,
               hydeLabel: "HyDE",
               errorPrefix: "directive-",
               limitHydeOnce: true,
@@ -635,6 +675,7 @@ async function runRecall(
           const hit = triggers.some((t) => promptLower.includes(t.toLowerCase()));
           if (!hit || !canRunDirective()) continue;
           const results = await runRecallPipelineQuery(taskType, directiveLimit, pipelineDeps, hydeUsedRef, {
+            probeId: `${recallProbeId}:directive:task:${taskType}`,
             hydeLabel: "HyDE",
             errorPrefix: "directive-",
             limitHydeOnce: true,
@@ -651,6 +692,7 @@ async function runRecall(
           }
           if (!sessionStartSeen.has(sessionKey) && canRunDirective()) {
             const results = await runRecallPipelineQuery("session start", directiveLimit, pipelineDeps, hydeUsedRef, {
+              probeId: `${recallProbeId}:directive:session-start`,
               hydeLabel: "HyDE",
               errorPrefix: "directive-",
               limitHydeOnce: true,
@@ -748,6 +790,7 @@ async function runRecall(
         `memory-hybrid: fixed blocks (${fixedBlocksTokens} tokens) exhausted total budget (${totalBudget} tokens); recall suppressed`,
       );
     }
+    setRecallProbePhase("finalize");
     const indexCap = Math.min(progressiveIndexMaxTokens ?? maxTokens, maxTokens);
     const groupByCategory = progressiveGroupByCategory === true;
     const pinnedRecallThreshold = progressivePinnedRecallCount ?? 3;
@@ -784,8 +827,15 @@ async function runRecall(
       });
       recallStageCompleted = true;
     }
+    api.logger.warn?.(
+      `memory-hybrid: recall-probe id=${recallProbeId} error elapsedMs=${Date.now() - recallStartMs} phase=${recallProbePhase} error=${err instanceof Error ? err.message : String(err)}`,
+    );
     throw err;
   } finally {
+    clearRecallProbeWatchdog();
+    api.logger.debug?.(
+      `memory-hybrid: recall-probe id=${recallProbeId} exit elapsedMs=${Date.now() - recallStartMs} phase=${recallProbePhase} completed=${recallStageCompleted}`,
+    );
     ctx.recallInFlightRef.value--;
   }
 }

--- a/extensions/memory-hybrid/services/auto-capture.ts
+++ b/extensions/memory-hybrid/services/auto-capture.ts
@@ -67,7 +67,10 @@ export function extractCredentialMatch(text: string): { type: string; secretValu
   for (const { regex, type } of CREDENTIAL_PATTERNS) {
     const match = regex.exec(text);
     if (match) {
-      const secretValue = match[0].replace(/^Bearer\s+/i, "").trim().slice(0, MAX_SECRET_VALUE_LENGTH);
+      const secretValue = match[0]
+        .replace(/^Bearer\s+/i, "")
+        .trim()
+        .slice(0, MAX_SECRET_VALUE_LENGTH);
       if (secretValue.length >= 8) return { type, secretValue };
     }
   }

--- a/extensions/memory-hybrid/services/recall-pipeline.ts
+++ b/extensions/memory-hybrid/services/recall-pipeline.ts
@@ -108,6 +108,7 @@ export async function runRecallPipelineQuery(
   hydeUsedRef: { value: boolean },
   opts?: {
     entity?: string;
+    probeId?: string;
     hydeLabel?: string;
     errorPrefix?: string;
     limitHydeOnce?: boolean;
@@ -131,14 +132,38 @@ export async function runRecallPipelineQuery(
     span: opts?.timingSpan ?? createRecallSpan("recall"),
     op: opts?.timingOp ?? `${opts?.errorPrefix ?? policy.mode}-pipeline`,
   });
+  const stageMs = { fts: 0, embed: 0, vector: 0, merge: 0 };
   const pipelineWallT0 = Date.now();
+  const probeId = opts?.probeId;
+  let probeStage = useSemantic ? "semantic_setup" : "fts_only_setup";
+  let vectorStepStatus = useSemantic ? "pending" : "fts-only";
+  let pipelineProbeWatchdog: ReturnType<typeof setTimeout> | undefined;
+  const clearPipelineProbeWatchdog = (): void => {
+    if (pipelineProbeWatchdog !== undefined) clearTimeout(pipelineProbeWatchdog);
+  };
+  const probeDebug = (message: string): void => {
+    if (probeId) logger.debug?.(message);
+  };
+  const probeWarn = (message: string): void => {
+    if (probeId) logger.warn?.(message);
+  };
+  if (probeId) {
+    pipelineProbeWatchdog = setTimeout(() => {
+      const elapsedMs = Date.now() - pipelineWallT0;
+      logger.warn?.(
+        `memory-hybrid: recall-probe id=${probeId} pipeline-still-running elapsedMs=${elapsedMs} stage=${probeStage} semantic=${useSemantic} ftsMs=${stageMs.fts} embedMs=${stageMs.embed} vectorMs=${stageMs.vector} mergeMs=${stageMs.merge}`,
+      );
+    }, 5_000);
+    pipelineProbeWatchdog.unref?.();
+    probeDebug(
+      `memory-hybrid: recall-probe id=${probeId} pipeline-enter semantic=${useSemantic} mode=${policy.mode} queryChars=${trimmed.length} limit=${limitNum}`,
+    );
+  }
   const runStartedAt = recallTiming.phaseStarted("pipeline_run", {
     query_chars: trimmed.length,
     limit: limitNum,
     semantic_enabled: useSemantic,
   });
-
-  const stageMs = { fts: 0, embed: 0, vector: 0, merge: 0 };
 
   let sqliteResults: SearchResult[] = [];
   let lanceResults: SearchResult[] = [];
@@ -172,264 +197,343 @@ export async function runRecallPipelineQuery(
     };
   };
 
-  if (!useSemantic) {
-    const ftsStartedAt = recallTiming.phaseStarted("fts_search", { limit: limitNum });
-    const t0 = Date.now();
-    const ftsOut = runFtsSearchSync();
-    stageMs.fts = Date.now() - t0;
-    sqliteResults = ftsOut.sqliteResults;
-    ftsRowCount = ftsOut.ftsRowCount;
-    recallTiming.phaseCompleted("fts_search", ftsStartedAt, {
-      fts_rows: ftsOut.ftsRowCount,
-      entity_lookup_rows: ftsOut.entityLookupRows,
-      sqlite_rows: ftsOut.sqliteResults.length,
-    });
-    await yieldEventLoop();
-  } else {
-    const vectorStepStartedAt = recallTiming.phaseStarted("vector_step");
-    let vectorStepStatus = "ok";
-    const directiveAbort = new AbortController();
-
-    // --- Phase 1: Kick off async I/O (HyDE / embed) BEFORE scheduling FTS ---
-    // FTS runs synchronously inside setImmediate and can block the event loop for
-    // tens of seconds on large fact stores (13k+ rows).  If the vector-step timeout
-    // (setTimeout) is registered before FTS, the timer fires after FTS unblocks but
-    // the vector step has not had any CPU time — producing a spurious timeout.
-    //
-    // Fix (#42): initiate the network-bound embed call first so the HTTP request is
-    // in-flight while FTS occupies the CPU, then schedule FTS on the next macrotask.
-    // The timeout is armed only after FTS yields, so it measures actual vector-step
-    // execution time rather than event-loop starvation from FTS.
-
-    let textToEmbed = trimmed;
-    const allowHyde = policy.allowHyde && cfg.queryExpansion.enabled && (!opts?.limitHydeOnce || !hydeUsedRef.value);
-
-    if (allowHyde) {
-      if (opts?.limitHydeOnce) hydeUsedRef.value = true;
-      if (!directiveAbort.signal.aborted) {
-        const hydeStartedAt = recallTiming.phaseStarted("hyde_generation");
-        textToEmbed = await expandQueryWithHyde({
-          query: trimmed,
-          rawCfg: cfg.rawCfg,
-          model: cfg.queryExpansion.model,
-          timeoutMs: cfg.queryExpansion.timeoutMs,
-          openai,
-          label: opts?.hydeLabel ?? "HyDE",
-          signal: directiveAbort.signal,
-          pendingWarnings: pendingLLMWarnings,
-          logger,
-          subsystem: "auto-recall",
-          operation: `${opts?.errorPrefix ?? ""}hyde-generation`,
-        });
-        recallTiming.phaseCompleted("hyde_generation", hydeStartedAt, {
-          input_chars: trimmed.length,
-          output_chars: textToEmbed.length,
-        });
-      }
-    }
-
-    const _precomputedVector = opts?.precomputedVector;
-    const usePrecomputedVector = Boolean(_precomputedVector) && textToEmbed === trimmed;
-
-    // Kick off the embed HTTP request NOW (before FTS blocks the loop).
-    // The returned promise will resolve once the network response arrives — which
-    // can happen while FTS is occupying the CPU on the next macrotask.
-    // Wall-clock for `stageMs.embed` / telemetry: HyDE + FTS must not be counted as "embed" time.
-    const embedT0 = Date.now();
-    const embedPromise = usePrecomputedVector
-      ? Promise.resolve(_precomputedVector as number[])
-      : embeddings.embed(textToEmbed);
-
-    // --- Phase 2: Run FTS synchronously on the next macrotask ---
-    const ftsPromise = new Promise<SearchResult[]>((resolve, reject) => {
-      setImmediate(() => {
-        try {
-          const ftsStartedAt = recallTiming.phaseStarted("fts_search", { limit: limitNum });
-          const t0 = Date.now();
-          const ftsOut = runFtsSearchSync();
-          stageMs.fts = Date.now() - t0;
-          ftsRowCount = ftsOut.ftsRowCount;
-          recallTiming.phaseCompleted("fts_search", ftsStartedAt, {
-            fts_rows: ftsOut.ftsRowCount,
-            entity_lookup_rows: ftsOut.entityLookupRows,
-            sqlite_rows: ftsOut.sqliteResults.length,
-          });
-          resolve(ftsOut.sqliteResults);
-        } catch (err) {
-          reject(err instanceof Error ? err : new Error(String(err)));
-        }
+  try {
+    if (!useSemantic) {
+      probeStage = "fts_search";
+      probeDebug(`memory-hybrid: recall-probe id=${probeId} stage=fts_search start semantic=false`);
+      const ftsStartedAt = recallTiming.phaseStarted("fts_search", { limit: limitNum });
+      const t0 = Date.now();
+      const ftsOut = runFtsSearchSync();
+      stageMs.fts = Date.now() - t0;
+      sqliteResults = ftsOut.sqliteResults;
+      ftsRowCount = ftsOut.ftsRowCount;
+      recallTiming.phaseCompleted("fts_search", ftsStartedAt, {
+        fts_rows: ftsOut.ftsRowCount,
+        entity_lookup_rows: ftsOut.entityLookupRows,
+        sqlite_rows: ftsOut.sqliteResults.length,
       });
-    });
-
-    // --- Phase 3: Await FTS first, then arm timeout and run vector step ---
-    // By awaiting ftsPromise here we guarantee the timeout is only armed AFTER FTS
-    // has finished and the event loop is free.  This prevents FTS event-loop
-    // starvation from eating into the vector-step budget.
-    let ftsRows: SearchResult[];
-    try {
-      ftsRows = await ftsPromise;
-    } catch (ftsErr) {
-      // Embed was started before FTS; if FTS fails first, fire-and-forget the
-      // embed promise so a fast network rejection cannot surface as an unhandled
-      // rejection, without blocking the error path on embed settling.
-      embedPromise.catch(() => {
-        /* intentionally ignored */
-      });
-      throw ftsErr;
-    }
-
-    const vectorStepPromise = (async (): Promise<SearchResult[]> => {
-      if (directiveAbort.signal.aborted) {
-        const abortError = new Error(`recall pipeline timed out after ${policy.vectorStepTimeoutMs}ms`);
-        abortError.name = "AbortError";
-        throw abortError;
-      }
-
-      const embedStartedAt = recallTiming.phaseStarted("embed_query", {
-        precomputed_vector: usePrecomputedVector,
-      });
-      const vector = usePrecomputedVector
-        ? (_precomputedVector as number[])
-        : await embedWithAbortRace(
-            embedPromise.then((v) => {
-              stageMs.embed = Date.now() - embedT0;
-              return v;
-            }),
-            directiveAbort.signal,
-            `recall pipeline timed out after ${policy.vectorStepTimeoutMs}ms`,
-          );
-      if (usePrecomputedVector) {
-        stageMs.embed = Date.now() - embedT0;
-      }
-      recallTiming.phaseCompleted("embed_query", embedStartedAt, {
-        precomputed_vector: usePrecomputedVector,
-        input_chars: textToEmbed.length,
-      });
-
-      const vectorStartedAt = recallTiming.phaseStarted("lancedb_search", {
-        limit: limitNum * 2,
-        min_score: minScore,
-      });
-      const vecT0 = Date.now();
-      const rawResults = await vectorDb.search(vector, limitNum * 2, minScore);
-      stageMs.vector = Date.now() - vecT0;
-      const nowSec = Math.floor(Date.now() / 1000);
-      let results = filterByScope(
-        rawResults,
-        (id, o) => {
-          const entry = factsDb.getById(id, o);
-          if (!entry) return null;
-          if (entry.supersededAt != null) return null;
-          if (entry.expiresAt != null && entry.expiresAt <= nowSec) return null;
-          return entry;
-        },
-        recallOpts.scopeFilter,
+      probeDebug(
+        `memory-hybrid: recall-probe id=${probeId} stage=fts_search end elapsedMs=${stageMs.fts} rows=${ftsOut.sqliteResults.length}`,
       );
-      results = results
-        .map((r) => {
-          const fullEntry = factsDb.getById(r.entry.id);
-          if (
-            fullEntry &&
-            fullEntry.supersededAt == null &&
-            (fullEntry.expiresAt == null || fullEntry.expiresAt > nowSec)
-          ) {
-            const salienceScore = computeDynamicSalience(r.score, fullEntry);
-            const controlledScore = applyConsolidationRetrievalControls(salienceScore, fullEntry);
-            return { ...r, entry: fullEntry, score: controlledScore };
-          }
-          return null;
-        })
-        .filter((r): r is SearchResult => r !== null);
-      recallTiming.phaseCompleted("lancedb_search", vectorStartedAt, {
-        raw_hits: rawResults.length,
-        hits: results.length,
-      });
-      return results;
-    })();
-
-    let timeoutId: NodeJS.Timeout | undefined;
-    const timeoutPromise = new Promise<never>((_, reject) => {
-      timeoutId = setTimeout(() => {
-        directiveAbort.abort();
-        reject(new Error(`${policy.mode} timed out after ${policy.vectorStepTimeoutMs}ms`));
-      }, policy.vectorStepTimeoutMs);
-    });
-
-    const vectorRacePromise = Promise.race([vectorStepPromise, timeoutPromise])
-      .catch((err: unknown) => {
-        const isTimeout = err instanceof Error && err.message.includes("timed out");
-        vectorStepStatus = isTimeout ? "timeout" : "error";
-        if (isTimeout) logger.warn(`memory-hybrid: ${String(err)}, using FTS-only recall`);
-        else {
-          if (!shouldSuppressEmbeddingError(err)) {
-            capturePluginError(err instanceof Error ? err : new Error(String(err)), {
-              operation: `${opts?.errorPrefix ?? ""}vector-recall`,
-              subsystem: "auto-recall",
-              backend: "lancedb",
-            });
-          }
-          logger.warn(`memory-hybrid: ${opts?.errorPrefix ?? ""}vector recall failed: ${err}`);
-        }
-        return [] as SearchResult[];
-      })
-      .finally(() => {
-        if (timeoutId !== undefined) clearTimeout(timeoutId);
-      });
-
-    sqliteResults = ftsRows;
-    lanceResults = await vectorRacePromise;
-    recallTiming.phaseCompleted("vector_step", vectorStepStartedAt, {
-      status: vectorStepStatus,
-      hits: lanceResults.length,
-    });
-
-    vectorStepPromise.catch((err) => {
-      if (!directiveAbort.signal.aborted && !shouldSuppressEmbeddingError(err)) {
-        capturePluginError(err instanceof Error ? err : new Error(String(err)), {
-          operation: `${opts?.errorPrefix ?? ""}vector-recall-post-timeout`,
-          subsystem: "auto-recall",
-        });
+      if (stageMs.fts >= 2_000) {
+        probeWarn(
+          `memory-hybrid: recall-probe id=${probeId} stage=fts_search slow elapsedMs=${stageMs.fts} rows=${ftsOut.sqliteResults.length}`,
+        );
       }
-    });
+      await yieldEventLoop();
+    } else {
+      const vectorStepStartedAt = recallTiming.phaseStarted("vector_step");
+      vectorStepStatus = "ok";
+      const directiveAbort = new AbortController();
+
+      // --- Phase 1: Kick off async I/O (HyDE / embed) BEFORE scheduling FTS ---
+      // FTS runs synchronously inside setImmediate and can block the event loop for
+      // tens of seconds on large fact stores (13k+ rows).  If the vector-step timeout
+      // (setTimeout) is registered before FTS, the timer fires after FTS unblocks but
+      // the vector step has not had any CPU time — producing a spurious timeout.
+      //
+      // Fix (#42): initiate the network-bound embed call first so the HTTP request is
+      // in-flight while FTS occupies the CPU, then schedule FTS on the next macrotask.
+      // The timeout is armed only after FTS yields, so it measures actual vector-step
+      // execution time rather than event-loop starvation from FTS.
+
+      let textToEmbed = trimmed;
+      const allowHyde = policy.allowHyde && cfg.queryExpansion.enabled && (!opts?.limitHydeOnce || !hydeUsedRef.value);
+
+      if (allowHyde) {
+        if (opts?.limitHydeOnce) hydeUsedRef.value = true;
+        if (!directiveAbort.signal.aborted) {
+          probeStage = "hyde_generation";
+          probeDebug(`memory-hybrid: recall-probe id=${probeId} stage=hyde_generation start`);
+          const hydeStartedAt = recallTiming.phaseStarted("hyde_generation");
+          textToEmbed = await expandQueryWithHyde({
+            query: trimmed,
+            rawCfg: cfg.rawCfg,
+            model: cfg.queryExpansion.model,
+            timeoutMs: cfg.queryExpansion.timeoutMs,
+            openai,
+            label: opts?.hydeLabel ?? "HyDE",
+            signal: directiveAbort.signal,
+            pendingWarnings: pendingLLMWarnings,
+            logger,
+            subsystem: "auto-recall",
+            operation: `${opts?.errorPrefix ?? ""}hyde-generation`,
+          });
+          recallTiming.phaseCompleted("hyde_generation", hydeStartedAt, {
+            input_chars: trimmed.length,
+            output_chars: textToEmbed.length,
+          });
+          probeDebug(
+            `memory-hybrid: recall-probe id=${probeId} stage=hyde_generation end outputChars=${textToEmbed.length}`,
+          );
+        }
+      }
+
+      const _precomputedVector = opts?.precomputedVector;
+      const usePrecomputedVector = Boolean(_precomputedVector) && textToEmbed === trimmed;
+
+      // Kick off the embed HTTP request NOW (before FTS blocks the loop).
+      // The returned promise will resolve once the network response arrives — which
+      // can happen while FTS is occupying the CPU on the next macrotask.
+      // Wall-clock for `stageMs.embed` / telemetry: HyDE + FTS must not be counted as "embed" time.
+      const embedT0 = Date.now();
+      const embedPromise = usePrecomputedVector
+        ? Promise.resolve(_precomputedVector as number[])
+        : embeddings.embed(textToEmbed);
+
+      // --- Phase 2: Run FTS synchronously on the next macrotask ---
+      const ftsPromise = new Promise<SearchResult[]>((resolve, reject) => {
+        setImmediate(() => {
+          try {
+            probeStage = "semantic_fts_search";
+            probeDebug(`memory-hybrid: recall-probe id=${probeId} stage=semantic_fts_search start`);
+            const ftsStartedAt = recallTiming.phaseStarted("fts_search", { limit: limitNum });
+            const t0 = Date.now();
+            const ftsOut = runFtsSearchSync();
+            stageMs.fts = Date.now() - t0;
+            ftsRowCount = ftsOut.ftsRowCount;
+            recallTiming.phaseCompleted("fts_search", ftsStartedAt, {
+              fts_rows: ftsOut.ftsRowCount,
+              entity_lookup_rows: ftsOut.entityLookupRows,
+              sqlite_rows: ftsOut.sqliteResults.length,
+            });
+            probeDebug(
+              `memory-hybrid: recall-probe id=${probeId} stage=semantic_fts_search end elapsedMs=${stageMs.fts} rows=${ftsOut.sqliteResults.length}`,
+            );
+            if (stageMs.fts >= 2_000) {
+              probeWarn(
+                `memory-hybrid: recall-probe id=${probeId} stage=semantic_fts_search slow elapsedMs=${stageMs.fts} rows=${ftsOut.sqliteResults.length}`,
+              );
+            }
+            resolve(ftsOut.sqliteResults);
+          } catch (err) {
+            reject(err instanceof Error ? err : new Error(String(err)));
+          }
+        });
+      });
+
+      // --- Phase 3: Await FTS first, then arm timeout and run vector step ---
+      // By awaiting ftsPromise here we guarantee the timeout is only armed AFTER FTS
+      // has finished and the event loop is free.  This prevents FTS event-loop
+      // starvation from eating into the vector-step budget.
+      let ftsRows: SearchResult[];
+      try {
+        ftsRows = await ftsPromise;
+      } catch (ftsErr) {
+        // Embed was started before FTS; if FTS fails first, fire-and-forget the
+        // embed promise so a fast network rejection cannot surface as an unhandled
+        // rejection, without blocking the error path on embed settling.
+        embedPromise.catch(() => {
+          /* intentionally ignored */
+        });
+        throw ftsErr;
+      }
+
+      const vectorStepPromise = (async (): Promise<SearchResult[]> => {
+        if (directiveAbort.signal.aborted) {
+          const abortError = new Error(`recall pipeline timed out after ${policy.vectorStepTimeoutMs}ms`);
+          abortError.name = "AbortError";
+          throw abortError;
+        }
+
+        probeStage = "embed_query";
+        probeDebug(
+          `memory-hybrid: recall-probe id=${probeId} stage=embed_query start precomputed=${usePrecomputedVector}`,
+        );
+        const embedStartedAt = recallTiming.phaseStarted("embed_query", {
+          precomputed_vector: usePrecomputedVector,
+        });
+        const vector = usePrecomputedVector
+          ? (_precomputedVector as number[])
+          : await embedWithAbortRace(
+              embedPromise.then((v) => {
+                stageMs.embed = Date.now() - embedT0;
+                return v;
+              }),
+              directiveAbort.signal,
+              `recall pipeline timed out after ${policy.vectorStepTimeoutMs}ms`,
+            );
+        if (usePrecomputedVector) {
+          stageMs.embed = Date.now() - embedT0;
+        }
+        recallTiming.phaseCompleted("embed_query", embedStartedAt, {
+          precomputed_vector: usePrecomputedVector,
+          input_chars: textToEmbed.length,
+        });
+        probeDebug(
+          `memory-hybrid: recall-probe id=${probeId} stage=embed_query end elapsedMs=${stageMs.embed} inputChars=${textToEmbed.length}`,
+        );
+        if (stageMs.embed >= 2_000) {
+          probeWarn(
+            `memory-hybrid: recall-probe id=${probeId} stage=embed_query slow elapsedMs=${stageMs.embed} inputChars=${textToEmbed.length}`,
+          );
+        }
+
+        probeStage = "lancedb_search";
+        probeDebug(
+          `memory-hybrid: recall-probe id=${probeId} stage=lancedb_search start limit=${limitNum * 2} minScore=${minScore}`,
+        );
+        const vectorStartedAt = recallTiming.phaseStarted("lancedb_search", {
+          limit: limitNum * 2,
+          min_score: minScore,
+        });
+        const vecT0 = Date.now();
+        const rawResults = await vectorDb.search(vector, limitNum * 2, minScore);
+        stageMs.vector = Date.now() - vecT0;
+        const nowSec = Math.floor(Date.now() / 1000);
+        let results = filterByScope(
+          rawResults,
+          (id, o) => {
+            const entry = factsDb.getById(id, o);
+            if (!entry) return null;
+            if (entry.supersededAt != null) return null;
+            if (entry.expiresAt != null && entry.expiresAt <= nowSec) return null;
+            return entry;
+          },
+          recallOpts.scopeFilter,
+        );
+        results = results
+          .map((r) => {
+            const fullEntry = factsDb.getById(r.entry.id);
+            if (
+              fullEntry &&
+              fullEntry.supersededAt == null &&
+              (fullEntry.expiresAt == null || fullEntry.expiresAt > nowSec)
+            ) {
+              const salienceScore = computeDynamicSalience(r.score, fullEntry);
+              const controlledScore = applyConsolidationRetrievalControls(salienceScore, fullEntry);
+              return { ...r, entry: fullEntry, score: controlledScore };
+            }
+            return null;
+          })
+          .filter((r): r is SearchResult => r !== null);
+        recallTiming.phaseCompleted("lancedb_search", vectorStartedAt, {
+          raw_hits: rawResults.length,
+          hits: results.length,
+        });
+        probeDebug(
+          `memory-hybrid: recall-probe id=${probeId} stage=lancedb_search end elapsedMs=${stageMs.vector} rawHits=${rawResults.length} hits=${results.length}`,
+        );
+        if (stageMs.vector >= 2_000) {
+          probeWarn(
+            `memory-hybrid: recall-probe id=${probeId} stage=lancedb_search slow elapsedMs=${stageMs.vector} rawHits=${rawResults.length} hits=${results.length}`,
+          );
+        }
+        return results;
+      })();
+
+      let timeoutId: NodeJS.Timeout | undefined;
+      const timeoutPromise = new Promise<never>((_, reject) => {
+        timeoutId = setTimeout(() => {
+          probeWarn(
+            `memory-hybrid: recall-probe id=${probeId} stage=vector_timeout fired elapsedMs=${Date.now() - pipelineWallT0} configuredMs=${policy.vectorStepTimeoutMs} probeStage=${probeStage}`,
+          );
+          directiveAbort.abort();
+          reject(new Error(`${policy.mode} timed out after ${policy.vectorStepTimeoutMs}ms`));
+        }, policy.vectorStepTimeoutMs);
+        timeoutId.unref?.();
+      });
+
+      const vectorRacePromise = Promise.race([vectorStepPromise, timeoutPromise])
+        .catch((err: unknown) => {
+          const isTimeout = err instanceof Error && err.message.includes("timed out");
+          vectorStepStatus = isTimeout ? "timeout" : "error";
+          if (isTimeout) logger.warn(`memory-hybrid: ${String(err)}, using FTS-only recall`);
+          else {
+            if (!shouldSuppressEmbeddingError(err)) {
+              capturePluginError(err instanceof Error ? err : new Error(String(err)), {
+                operation: `${opts?.errorPrefix ?? ""}vector-recall`,
+                subsystem: "auto-recall",
+                backend: "lancedb",
+              });
+            }
+            logger.warn(`memory-hybrid: ${opts?.errorPrefix ?? ""}vector recall failed: ${err}`);
+          }
+          return [] as SearchResult[];
+        })
+        .finally(() => {
+          if (timeoutId !== undefined) clearTimeout(timeoutId);
+        });
+
+      sqliteResults = ftsRows;
+      lanceResults = await vectorRacePromise;
+      recallTiming.phaseCompleted("vector_step", vectorStepStartedAt, {
+        status: vectorStepStatus,
+        hits: lanceResults.length,
+      });
+
+      vectorStepPromise.catch((err) => {
+        if (!directiveAbort.signal.aborted && !shouldSuppressEmbeddingError(err)) {
+          capturePluginError(err instanceof Error ? err : new Error(String(err)), {
+            operation: `${opts?.errorPrefix ?? ""}vector-recall-post-timeout`,
+            subsystem: "auto-recall",
+          });
+        }
+      });
+
+      await yieldEventLoop();
+    }
 
     await yieldEventLoop();
+
+    probeStage = "merge_results";
+    const mergeStartedAt = recallTiming.phaseStarted("merge_results");
+    const mergeT0 = Date.now();
+    let results = mergeResults(sqliteResults, lanceResults, limitNum, factsDb);
+    stageMs.merge = Date.now() - mergeT0;
+    recallTiming.phaseCompleted("merge_results", mergeStartedAt, {
+      sqlite_rows: sqliteResults.length,
+      vector_hits: lanceResults.length,
+      merged_rows: results.length,
+    });
+    probeDebug(
+      `memory-hybrid: recall-probe id=${probeId} stage=merge_results end elapsedMs=${stageMs.merge} mergedRows=${results.length}`,
+    );
+    if (stageMs.merge >= 2_000) {
+      probeWarn(
+        `memory-hybrid: recall-probe id=${probeId} stage=merge_results slow elapsedMs=${stageMs.merge} mergedRows=${results.length}`,
+      );
+    }
+
+    if (cfg.memoryTieringEnabled && results.length > 0) {
+      results = results
+        .filter((r) => {
+          const full = factsDb.getById(r.entry.id);
+          return full && full.tier !== "cold";
+        })
+        .slice(0, limitNum);
+    }
+
+    const wallClockMs = Date.now() - pipelineWallT0;
+    logger.debug?.(
+      `memory-hybrid: ${policy.mode} timing (ms) — FTS: ${stageMs.fts}, embed: ${stageMs.embed}, vector: ${stageMs.vector}, merge: ${stageMs.merge}, wall: ${wallClockMs}`,
+    );
+    probeDebug(
+      `memory-hybrid: recall-probe id=${probeId} pipeline-exit elapsedMs=${wallClockMs} semantic=${useSemantic} status=${vectorStepStatus} mergedRows=${results.length}`,
+    );
+    if (wallClockMs >= 5_000) {
+      probeWarn(
+        `memory-hybrid: recall-probe id=${probeId} pipeline-slow elapsedMs=${wallClockMs} semantic=${useSemantic} status=${vectorStepStatus} ftsMs=${stageMs.fts} embedMs=${stageMs.embed} vectorMs=${stageMs.vector} mergeMs=${stageMs.merge}`,
+      );
+    }
+    recallTiming.phaseCompleted("pipeline_run", runStartedAt, {
+      fts_ms: stageMs.fts,
+      embed_ms: stageMs.embed,
+      vector_ms: stageMs.vector,
+      merge_ms: stageMs.merge,
+      wall_ms: wallClockMs,
+      fts_rows: ftsRowCount,
+      vector_hits: lanceResults.length,
+      merged_rows: results.length,
+    });
+
+    return results;
+  } catch (err) {
+    probeWarn(
+      `memory-hybrid: recall-probe id=${probeId} pipeline-error elapsedMs=${Date.now() - pipelineWallT0} stage=${probeStage} semantic=${useSemantic} error=${err instanceof Error ? err.message : String(err)}`,
+    );
+    throw err;
+  } finally {
+    clearPipelineProbeWatchdog();
   }
-
-  await yieldEventLoop();
-
-  const mergeStartedAt = recallTiming.phaseStarted("merge_results");
-  const mergeT0 = Date.now();
-  let results = mergeResults(sqliteResults, lanceResults, limitNum, factsDb);
-  stageMs.merge = Date.now() - mergeT0;
-  recallTiming.phaseCompleted("merge_results", mergeStartedAt, {
-    sqlite_rows: sqliteResults.length,
-    vector_hits: lanceResults.length,
-    merged_rows: results.length,
-  });
-
-  if (cfg.memoryTieringEnabled && results.length > 0) {
-    results = results
-      .filter((r) => {
-        const full = factsDb.getById(r.entry.id);
-        return full && full.tier !== "cold";
-      })
-      .slice(0, limitNum);
-  }
-
-  const wallClockMs = Date.now() - pipelineWallT0;
-  logger.debug?.(
-    `memory-hybrid: ${policy.mode} timing (ms) — FTS: ${stageMs.fts}, embed: ${stageMs.embed}, vector: ${stageMs.vector}, merge: ${stageMs.merge}, wall: ${wallClockMs}`,
-  );
-  recallTiming.phaseCompleted("pipeline_run", runStartedAt, {
-    fts_ms: stageMs.fts,
-    embed_ms: stageMs.embed,
-    vector_ms: stageMs.vector,
-    merge_ms: stageMs.merge,
-    wall_ms: wallClockMs,
-    fts_rows: ftsRowCount,
-    vector_hits: lanceResults.length,
-    merged_rows: results.length,
-  });
-
-  return results;
 }

--- a/extensions/memory-hybrid/services/recall-pipeline.ts
+++ b/extensions/memory-hybrid/services/recall-pipeline.ts
@@ -431,7 +431,6 @@ export async function runRecallPipelineQuery(
           directiveAbort.abort();
           reject(new Error(`${policy.mode} timed out after ${policy.vectorStepTimeoutMs}ms`));
         }, policy.vectorStepTimeoutMs);
-        timeoutId.unref?.();
       });
 
       const vectorRacePromise = Promise.race([vectorStepPromise, timeoutPromise])

--- a/extensions/memory-hybrid/services/recall-pipeline.ts
+++ b/extensions/memory-hybrid/services/recall-pipeline.ts
@@ -469,7 +469,6 @@ export async function runRecallPipelineQuery(
           });
         }
       });
-
     }
 
     await yieldEventLoop();

--- a/extensions/memory-hybrid/services/recall-pipeline.ts
+++ b/extensions/memory-hybrid/services/recall-pipeline.ts
@@ -470,7 +470,6 @@ export async function runRecallPipelineQuery(
         }
       });
 
-      await yieldEventLoop();
     }
 
     await yieldEventLoop();

--- a/extensions/memory-hybrid/tests/recall-pipeline.test.ts
+++ b/extensions/memory-hybrid/tests/recall-pipeline.test.ts
@@ -920,3 +920,62 @@ describe("runRecallPipelineQuery — stale vector hit filtering", () => {
     expect(result.map((r) => r.entry.id)).toEqual(["active"]);
   });
 });
+
+describe("runRecallPipelineQuery — probe logs", () => {
+  it("does not emit probe logs or watchdogs when probeId is omitted", async () => {
+    const deps = makeDeps({
+      cfg: {
+        queryExpansion: {
+          enabled: false,
+          maxVariants: 4,
+          cacheSize: 100,
+          timeoutMs: 15_000,
+          skipForInteractiveTurns: true,
+        },
+        retrievalStrategies: ["semantic", "fts5"],
+        memoryTieringEnabled: false,
+        rawCfg: { llm: undefined } as unknown as RecallPipelineDeps["cfg"]["rawCfg"],
+      },
+    });
+    (deps.factsDb.search as ReturnType<typeof vi.fn>).mockReturnValue([makeSearchResult("fts-1")]);
+    (deps.vectorDb.search as ReturnType<typeof vi.fn>).mockResolvedValue([makeSearchResult("vec-1")]);
+    (deps.factsDb.getById as ReturnType<typeof vi.fn>).mockImplementation((id: string) => makeEntry(id));
+
+    await runRecallPipelineQuery("probe me", 5, deps, { value: false });
+
+    const debugCalls = vi.mocked(deps.logger.debug).mock.calls.map(([line]) => String(line));
+    const warnCalls = vi.mocked(deps.logger.warn).mock.calls.map(([line]) => String(line));
+    expect(debugCalls.some((line) => line.includes("recall-probe"))).toBe(false);
+    expect(warnCalls.some((line) => line.includes("recall-probe"))).toBe(false);
+  });
+
+  it("emits probe stage markers when probeId is provided", async () => {
+    const deps = makeDeps({
+      cfg: {
+        queryExpansion: {
+          enabled: false,
+          maxVariants: 4,
+          cacheSize: 100,
+          timeoutMs: 15_000,
+          skipForInteractiveTurns: true,
+        },
+        retrievalStrategies: ["semantic", "fts5"],
+        memoryTieringEnabled: false,
+        rawCfg: { llm: undefined } as unknown as RecallPipelineDeps["cfg"]["rawCfg"],
+      },
+    });
+    (deps.factsDb.search as ReturnType<typeof vi.fn>).mockReturnValue([makeSearchResult("fts-1")]);
+    (deps.vectorDb.search as ReturnType<typeof vi.fn>).mockResolvedValue([makeSearchResult("vec-1")]);
+    (deps.factsDb.getById as ReturnType<typeof vi.fn>).mockImplementation((id: string) => makeEntry(id));
+
+    await runRecallPipelineQuery("probe me", 5, deps, { value: false }, { probeId: "probe-123" });
+
+    const debugCalls = vi.mocked(deps.logger.debug).mock.calls.map(([line]) => String(line));
+    expect(debugCalls.some((line) => line.includes("recall-probe id=probe-123 pipeline-enter"))).toBe(true);
+    expect(debugCalls.some((line) => line.includes("recall-probe id=probe-123 stage=semantic_fts_search start"))).toBe(
+      true,
+    );
+    expect(debugCalls.some((line) => line.includes("recall-probe id=probe-123 stage=lancedb_search start"))).toBe(true);
+    expect(debugCalls.some((line) => line.includes("recall-probe id=probe-123 pipeline-exit"))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add correlated `recall-probe` IDs and watchdog logs around the top-level auto-recall flow so hangs can be tied to the exact recall branch that stopped making progress
- thread probe IDs through main, ambient, and directive recall pipeline calls and log stage-level entry/exit, slow-path, timeout, and error details for FTS, embedding, LanceDB, and merge work
- add a focused regression test that verifies probe stage markers are emitted when a pipeline call receives a `probeId`

## Test plan
- [x] `cd extensions/memory-hybrid && ./node_modules/.bin/vitest run tests/recall-pipeline.test.ts -t "emits probe stage markers when probeId is provided"`
- [ ] `cd extensions/memory-hybrid && ./node_modules/.bin/vitest run tests/recall-pipeline.test.ts` (currently hits an existing `hydeUsedRef` timeout in this environment)
- [ ] `cd extensions/memory-hybrid && npm run build` (currently blocked here by a missing `rolldown` native binding under Node 20)


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are primarily additive diagnostics (correlated probe IDs, stage markers, watchdog warnings) and should not alter recall results, though it does touch hot-path recall code and could increase log volume slightly.
> 
> **Overview**
> Adds correlated `recall-probe` instrumentation across the auto-recall stage and underlying `runRecallPipelineQuery` to pinpoint where hybrid-memory recall stalls.
> 
> The recall stage now generates a per-invocation probe ID, tracks high-level phases (degraded path, procedures/hot blocks, embeddings, main/ambient/directive pipelines, finalize), and emits 5s watchdog + enter/exit/error logs.
> 
> The pipeline query function accepts an optional `probeId` and, when set, logs stage entry/exit, slow-path warnings, watchdog warnings, timeout context, and pipeline-level timing; new tests assert probe logs are only emitted when `probeId` is provided.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98d4d6f055727562b74748031b9fe68ab53c7477. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->