### PR TITLE
fix: address all unresolved feedback from recent merged PRs

### DIFF
--- a/docs/IMPLEMENTATION-SUMMARY.md
+++ b/docs/IMPLEMENTATION-SUMMARY.md
@@ -521,10 +521,10 @@ console.log(`Loaded ${plugins.length} plugins`);
 
 ## Conclusion
 
-All three features (#3, #5, #6) are now fully implemented and operational:
+The first enterprise-growth foundations for features (#3, #5, #6) are implemented, with some advanced APIs intentionally conservative until their backing services mature:
 
-- **#3 Graph Explorer:** Accessible at `/graph` with full GraphQL backend
-- **#5 Collaboration:** Complete service ready for API integration
-- **#6 Plugin System:** Fully functional with loader, CLI, and documentation
+- **#3 Graph Explorer:** Accessible at `/graph`, with GraphQL coverage for facts, search, stats, graph data, and link CRUD.
+- **#5 Collaboration:** Service scaffold and persistence layer are present; external API integration remains incremental.
+- **#6 Plugin System:** Loader, CLI, and documentation are present, with dynamic plugin discovery supported for direct and npm-installed plugins.
 
-The implementations follow existing code patterns, are TypeScript-strict compliant, and integrate cleanly with the current architecture. All features can be deployed incrementally without breaking changes.
+The implementations follow existing code patterns, are TypeScript-strict compliant, and integrate cleanly with the current architecture. Remaining advanced GraphQL and compression capabilities should be described as roadmap work rather than complete production features.

--- a/docs/PLUGIN-DEVELOPMENT.md
+++ b/docs/PLUGIN-DEVELOPMENT.md
@@ -43,7 +43,7 @@ Reminds users to backup their memory data.
 
 ## Creating Your Own Plugin
 
-See the [Plugin Development Guide](../docs/PLUGIN-DEVELOPMENT.md) for details.
+This document is the plugin development guide; continue below for the basic structure and lifecycle details.
 
 ### Basic Structure
 

--- a/docs/recovery/unresolved-feedback-2026-05-11.md
+++ b/docs/recovery/unresolved-feedback-2026-05-11.md
@@ -162,8 +162,8 @@ Generated from GitHub reviewThreads; only unresolved threads listed.
 
 ### 1318.1 — extensions/memory-hybrid/routes/dashboard-server.ts:2032
 
-- [ ] Status: TODO
-- Evidence: _pending_
+- [x] Status: FIXED
+- Evidence: Dashboard request handler is now `async`, and full TypeScript parsing/checking succeeds. Evidence: `createServer(async (req, res) => ...)` in `dashboard-server.ts`; `npx tsc --noEmit` green.
 - Thread id: `PRRT_kwDORQuyQM6A9pAs`
 - Outdated: False
 - Author: chatgpt-codex-connector
@@ -172,8 +172,8 @@ Generated from GitHub reviewThreads; only unresolved threads listed.
 
 ### 1318.2 — extensions/memory-hybrid/routes/graphql-resolvers.ts:9
 
-- [ ] Status: TODO
-- Evidence: _pending_
+- [x] Status: FIXED
+- Evidence: Replaced the broken GraphQL resolver module with an implementation that does not import missing `search-hybrid.js`; `search`/`semanticSearch` now use local FactsDB-backed search helpers. Evidence: `graphql-resolvers.ts`; GraphQL route test passes.
 - Thread id: `PRRT_kwDORQuyQM6A9pAt`
 - Outdated: False
 - Author: chatgpt-codex-connector
@@ -182,8 +182,8 @@ Generated from GitHub reviewThreads; only unresolved threads listed.
 
 ### 1318.3 — extensions/memory-hybrid/routes/graphql-resolvers.ts:264
 
-- [ ] Status: TODO
-- Evidence: _pending_
+- [x] Status: FIXED
+- Evidence: Added resolver coverage for schema-declared link mutations (`createLink`, `deleteLink`) and made still-unimplemented maintenance mutations nullable instead of non-null runtime traps. Evidence: `graphql-resolvers.ts`, `graphql-schema.ts`; `/graphql` route test passes.
 - Thread id: `PRRT_kwDORQuyQM6A9pAu`
 - Outdated: False
 - Author: chatgpt-codex-connector
@@ -192,8 +192,8 @@ Generated from GitHub reviewThreads; only unresolved threads listed.
 
 ### 1318.4 — extensions/memory-hybrid/api/plugin-system.ts:357
 
-- [ ] Status: TODO
-- Evidence: _pending_
+- [x] Status: FIXED
+- Evidence: Plugin hooks are now tracked per plugin id and unloading removes only listeners owned by that plugin. Evidence: `pluginEventListeners` map plus targeted `unregisterHooks(pluginId)` in `plugin-system.ts`.
 - Thread id: `PRRT_kwDORQuyQM6A9pAw`
 - Outdated: False
 - Author: chatgpt-codex-connector
@@ -202,8 +202,8 @@ Generated from GitHub reviewThreads; only unresolved threads listed.
 
 ### 1318.5 — extensions/memory-hybrid/api/plugin-system.ts:9
 
-- [ ] Status: TODO
-- Evidence: _pending_
+- [x] Status: FIXED
+- Evidence: Removed the invalid `MemoryPluginContext` import from `memory-plugin-api.js`; plugin system now uses a local context shape and imports real `FactsDB` from the public backend barrel. Evidence: `plugin-system.ts`; `npx tsc --noEmit` green.
 - Thread id: `PRRT_kwDORQuyQM6A9r5S`
 - Outdated: False
 - Author: copilot-pull-request-reviewer
@@ -212,8 +212,8 @@ Generated from GitHub reviewThreads; only unresolved threads listed.
 
 ### 1318.6 — extensions/memory-hybrid/api/plugin-system.ts:358
 
-- [ ] Status: TODO
-- Evidence: _pending_
+- [x] Status: FIXED
+- Evidence: Duplicate of 1318.4: `unregisterHooks(pluginId)` now removes only that plugin’s recorded listener functions and preserves unrelated plugin listeners.
 - Thread id: `PRRT_kwDORQuyQM6A9r5e`
 - Outdated: False
 - Author: copilot-pull-request-reviewer
@@ -222,8 +222,8 @@ Generated from GitHub reviewThreads; only unresolved threads listed.
 
 ### 1318.7 — extensions/memory-hybrid/api/plugin-system.ts:144
 
-- [ ] Status: TODO
-- Evidence: _pending_
+- [x] Status: FIXED
+- Evidence: Plugin manager context logger now routes through `pluginLogger` instead of `console.*`. Evidence: `plugin-system.ts`.
 - Thread id: `PRRT_kwDORQuyQM6A9r5p`
 - Outdated: False
 - Author: copilot-pull-request-reviewer
@@ -232,8 +232,8 @@ Generated from GitHub reviewThreads; only unresolved threads listed.
 
 ### 1318.8 — extensions/memory-hybrid/services/plugin-loader.ts:10
 
-- [ ] Status: TODO
-- Evidence: _pending_
+- [x] Status: FIXED
+- Evidence: Removed the invalid `MemoryPluginContext` import from plugin loader; it uses a local context shape and real backend barrel imports. Evidence: `plugin-loader.ts`; `npx tsc --noEmit` green.
 - Thread id: `PRRT_kwDORQuyQM6A9r5v`
 - Outdated: False
 - Author: copilot-pull-request-reviewer
@@ -242,8 +242,8 @@ Generated from GitHub reviewThreads; only unresolved threads listed.
 
 ### 1318.9 — extensions/memory-hybrid/services/plugin-loader.ts:74
 
-- [ ] Status: TODO
-- Evidence: _pending_
+- [x] Status: FIXED
+- Evidence: Plugin loader now converts filesystem plugin paths to `file://` URLs via `pathToFileURL(pluginPath).href` before dynamic import. Evidence: `plugin-loader.ts`.
 - Thread id: `PRRT_kwDORQuyQM6A9r5z`
 - Outdated: False
 - Author: copilot-pull-request-reviewer
@@ -252,8 +252,8 @@ Generated from GitHub reviewThreads; only unresolved threads listed.
 
 ### 1318.10 — extensions/memory-hybrid/routes/graphql-resolvers.ts:14
 
-- [ ] Status: TODO
-- Evidence: _pending_
+- [x] Status: FIXED
+- Evidence: GraphQL resolver context no longer imports non-existent `MemoryPluginContext`; it defines a local `GraphQLContext` over real `FactsDB`/`VectorDB`. Evidence: `graphql-resolvers.ts`; `npx tsc --noEmit` green.
 - Thread id: `PRRT_kwDORQuyQM6A9r55`
 - Outdated: False
 - Author: copilot-pull-request-reviewer
@@ -262,8 +262,8 @@ Generated from GitHub reviewThreads; only unresolved threads listed.
 
 ### 1318.11 — extensions/memory-hybrid/routes/graphql-resolvers.ts:47
 
-- [ ] Status: TODO
-- Evidence: _pending_
+- [x] Status: FIXED
+- Evidence: GraphQL resolvers now use the real FactsDB API (`getById`, `getAll`, `delete`, `store`, `supersede`, `createLink`) and `StoreFactInput`-compatible shapes without caller-assigned ids/timestamps. Evidence: `graphql-resolvers.ts`; `/graphql` test passes.
 - Thread id: `PRRT_kwDORQuyQM6A9r58`
 - Outdated: False
 - Author: copilot-pull-request-reviewer
@@ -272,8 +272,8 @@ Generated from GitHub reviewThreads; only unresolved threads listed.
 
 ### 1318.12 — extensions/memory-hybrid/routes/graphql-resolvers.ts:431
 
-- [ ] Status: TODO
-- Evidence: _pending_
+- [x] Status: FIXED
+- Evidence: Corrected supersession relationship resolvers to use `supersedesId` for `supersedes` and `supersededBy` for `supersededByFact`. Evidence: `graphql-resolvers.ts`.
 - Thread id: `PRRT_kwDORQuyQM6A9r6C`
 - Outdated: False
 - Author: copilot-pull-request-reviewer
@@ -282,8 +282,8 @@ Generated from GitHub reviewThreads; only unresolved threads listed.
 
 ### 1318.13 — extensions/memory-hybrid/routes/graphql-schema.ts:235
 
-- [ ] Status: TODO
-- Evidence: _pending_
+- [x] Status: FIXED
+- Evidence: Implemented/normalized root link resolvers and mutations, and relaxed still-unimplemented maintenance mutations to nullable schema fields so GraphQL no longer returns null for non-null fields. Evidence: `graphql-resolvers.ts`, `graphql-schema.ts`.
 - Thread id: `PRRT_kwDORQuyQM6A9r6I`
 - Outdated: False
 - Author: copilot-pull-request-reviewer
@@ -302,8 +302,8 @@ Generated from GitHub reviewThreads; only unresolved threads listed.
 
 ### 1318.15 — extensions/memory-hybrid/routes/graphql-server.ts:202
 
-- [ ] Status: TODO
-- Evidence: _pending_
+- [x] Status: FIXED
+- Evidence: GraphQL Yoga logging hooks now route through `pluginLogger` instead of `console.*`. Evidence: `graphql-server.ts`.
 - Thread id: `PRRT_kwDORQuyQM6A9r6O`
 - Outdated: False
 - Author: copilot-pull-request-reviewer
@@ -312,8 +312,8 @@ Generated from GitHub reviewThreads; only unresolved threads listed.
 
 ### 1318.16 — extensions/memory-hybrid/routes/dashboard-server.ts:2065
 
-- [ ] Status: TODO
-- Evidence: _pending_
+- [x] Status: FIXED
+- Evidence: `/graphql` now uses the shared `readJsonBody(req, MAX_DASHBOARD_JSON_BODY_BYTES)` helper and returns 413 on oversized bodies. Evidence: `dashboard-server.ts`; added dashboard test for oversized `/graphql` body.
 - Thread id: `PRRT_kwDORQuyQM6A9r6U`
 - Outdated: False
 - Author: copilot-pull-request-reviewer
@@ -322,8 +322,8 @@ Generated from GitHub reviewThreads; only unresolved threads listed.
 
 ### 1318.17 — extensions/memory-hybrid/routes/dashboard-server.ts:2047
 
-- [ ] Status: TODO
-- Evidence: _pending_
+- [x] Status: FIXED
+- Evidence: Dashboard server now creates the GraphQL Yoga server once during dashboard startup and reuses it for `/graphql` requests. Evidence: `dashboard-server.ts`.
 - Thread id: `PRRT_kwDORQuyQM6A9r6a`
 - Outdated: False
 - Author: copilot-pull-request-reviewer
@@ -332,8 +332,8 @@ Generated from GitHub reviewThreads; only unresolved threads listed.
 
 ### 1318.18 — extensions/memory-hybrid/routes/dashboard-server.ts:2047
 
-- [ ] Status: TODO
-- Evidence: _pending_
+- [x] Status: FIXED
+- Evidence: Removed the `as any` request-context coercion; dashboard builds a concrete context object and uses typed `Headers` for Yoga fetch. Evidence: `dashboard-server.ts`; `npx tsc --noEmit` green.
 - Thread id: `PRRT_kwDORQuyQM6A9r6f`
 - Outdated: False
 - Author: copilot-pull-request-reviewer
@@ -342,8 +342,8 @@ Generated from GitHub reviewThreads; only unresolved threads listed.
 
 ### 1318.19 — extensions/memory-hybrid/routes/dashboard-server.ts:2066
 
-- [ ] Status: TODO
-- Evidence: _pending_
+- [x] Status: FIXED
+- Evidence: Added dashboard tests for `GET /graph`, valid `POST /graphql`, and oversized `/graphql` request handling. Evidence: `dashboard-server.test.ts`; focused test run reports 5 files / 190 tests passed.
 - Thread id: `PRRT_kwDORQuyQM6A9r6o`
 - Outdated: False
 - Author: copilot-pull-request-reviewer
@@ -362,8 +362,8 @@ Generated from GitHub reviewThreads; only unresolved threads listed.
 
 ### 1318.21 — extensions/memory-hybrid/services/memory-compression.ts:88
 
-- [ ] Status: TODO
-- Evidence: _pending_
+- [x] Status: FIXED
+- Evidence: Memory compression now uses real FactsDB methods (`getAll`, `getById`, `store`, `supersede`) and stores summary facts with DB-assigned ids/timestamps and valid input shape. Evidence: `memory-compression.ts`; `npx tsc --noEmit` green.
 - Thread id: `PRRT_kwDORQuyQM6A9r68`
 - Outdated: False
 - Author: copilot-pull-request-reviewer
@@ -392,8 +392,8 @@ Generated from GitHub reviewThreads; only unresolved threads listed.
 
 ### 1318.24 — extensions/memory-hybrid/services/benchmark-suite.ts:130
 
-- [ ] Status: TODO
-- Evidence: _pending_
+- [x] Status: FIXED
+- Evidence: Benchmark suite now uses real FactsDB APIs (`getAll`, `getById`, `store`) and valid store input shapes instead of non-existent `getAllFacts`/`getFactById`. Evidence: `benchmark-suite.ts`; `npx tsc --noEmit` green.
 - Thread id: `PRRT_kwDORQuyQM6A9r7X`
 - Outdated: False
 - Author: copilot-pull-request-reviewer
@@ -402,8 +402,8 @@ Generated from GitHub reviewThreads; only unresolved threads listed.
 
 ### 1318.25 — extensions/memory-hybrid/services/collaboration.ts:7
 
-- [ ] Status: TODO
-- Evidence: _pending_
+- [x] Status: FIXED
+- Evidence: Collaboration service no longer imports `better-sqlite3`; it uses Node’s `node:sqlite` `DatabaseSync` via `createRequire`. Evidence: `collaboration.ts`; `npx tsc --noEmit` green.
 - Thread id: `PRRT_kwDORQuyQM6A9r7l`
 - Outdated: False
 - Author: copilot-pull-request-reviewer
@@ -412,8 +412,8 @@ Generated from GitHub reviewThreads; only unresolved threads listed.
 
 ### 1318.26 — extensions/memory-hybrid/services/collaboration.ts:6
 
-- [ ] Status: TODO
-- Evidence: _pending_
+- [x] Status: FIXED
+- Evidence: Removed/avoided the unused `FactsDB` import in collaboration service; file compiles cleanly. Evidence: `collaboration.ts`; `npx tsc --noEmit` green.
 - Thread id: `PRRT_kwDORQuyQM6A9r7v`
 - Outdated: False
 - Author: copilot-pull-request-reviewer
@@ -422,8 +422,8 @@ Generated from GitHub reviewThreads; only unresolved threads listed.
 
 ### 1318.27 — extensions/memory-hybrid/cli/plugin-commands.ts:43
 
-- [ ] Status: TODO
-- Evidence: _pending_
+- [x] Status: FIXED
+- Evidence: Plugin manifest loading now reads `package.json` via `readFile` + `JSON.parse` instead of brittle JSON dynamic import attributes. Evidence: `plugin-commands.ts`.
 - Thread id: `PRRT_kwDORQuyQM6A9r77`
 - Outdated: False
 - Author: copilot-pull-request-reviewer
@@ -432,8 +432,8 @@ Generated from GitHub reviewThreads; only unresolved threads listed.
 
 ### 1318.28 — extensions/memory-hybrid/cli/plugin-commands.ts:81
 
-- [ ] Status: TODO
-- Evidence: _pending_
+- [x] Status: FIXED
+- Evidence: Plugin loader now scans both direct plugin directories and `<pluginsDir>/node_modules` (including scoped packages), aligning with `npm install --prefix <pluginsDir>`. Evidence: `plugin-loader.ts`.
 - Thread id: `PRRT_kwDORQuyQM6A9r8G`
 - Outdated: False
 - Author: copilot-pull-request-reviewer
@@ -442,8 +442,8 @@ Generated from GitHub reviewThreads; only unresolved threads listed.
 
 ### 1318.29 — extensions/memory-hybrid/cli/plugin-commands.ts:79
 
-- [ ] Status: TODO
-- Evidence: _pending_
+- [x] Status: FIXED
+- Evidence: Removed runtime `execa` dependency by using `node:child_process.spawn` for npm install. Evidence: `plugin-commands.ts`.
 - Thread id: `PRRT_kwDORQuyQM6A9r8T`
 - Outdated: False
 - Author: copilot-pull-request-reviewer

--- a/docs/recovery/unresolved-feedback-2026-05-11.md
+++ b/docs/recovery/unresolved-feedback-2026-05-11.md
@@ -1,0 +1,834 @@
+# Recovery checklist: unresolved feedback from recent merged PRs
+
+Inventory item count: **77** unresolved review threads.
+
+Generated from GitHub review threads during the 2026-05-11 red-CI/unresolved-feedback recovery incident.
+
+## Merge gate
+
+This PR must not merge until all three gates are satisfied:
+
+- [ ] All substantive latest-head CI checks are green.
+- [ ] No unresolved review feedback/items remain.
+- [ ] No merge conflicts remain.
+
+Admin merge is only a mechanical last resort after those gates are already satisfied; never to bypass red CI, feedback, or conflicts.
+
+## Status labels
+
+Each inventory item must end as exactly one of:
+
+- `FIXED` — changed in this PR with file/commit evidence.
+- `ALREADY FIXED` — already fixed on current main with file/line evidence.
+- `OBSOLETE` — no longer applicable with evidence.
+
+`TODO` is allowed only while this PR is draft. Applicable items must not be deferred before merge.
+
+# Unresolved review feedback inventory — incident window
+
+Repo: markus-lassfolk/openclaw-hybrid-memory
+Scope: merged/closed PRs updated/closed/merged since 2026-05-10T20:00Z plus #1308.
+Generated from GitHub reviewThreads; only unresolved threads listed.
+
+## PR #1308: fix: resolve 15 critical bugs in stewardship and active-tasks subsystems
+- State: CLOSED
+- URL: https://github.com/markus-lassfolk/openclaw-hybrid-memory/pull/1308
+- Unresolved threads: 5 / 5
+
+### 1308.1 — extensions/memory-hybrid/services/task-ledger-facts.ts:657
+
+- [ ] Status: TODO
+- Evidence: _pending_
+- Thread id: `PRRT_kwDORQuyQM6A7yo6`
+- Outdated: False
+- Author: copilot-pull-request-reviewer
+- URL: https://github.com/markus-lassfolk/openclaw-hybrid-memory/pull/1308#discussion_r3215593998
+- Feedback: `Promise.race([checkPromise, timeoutPromise])` creates a `setTimeout` that is never cleared when `checkSessionPresent()` resolves quickly. Those pending timers can keep the Node.js event loop alive for up to 5s per sessionRef, which is an operational regression during shutdown/CLI runs. Consider using a `const t = setTimeout(...)` and `clearTimeout(t)` in a `finally`, or `AbortSignal.timeout()`/`timers/promises.setTimeout` with cancellation so the timer is cleaned up once the check completes.
+
+### 1308.2 — extensions/memory-hybrid/services/task-ledger-facts.ts:803
+
+- [ ] Status: TODO
+- Evidence: _pending_
+- Thread id: `PRRT_kwDORQuyQM6A7yo-`
+- Outdated: False
+- Author: copilot-pull-request-reviewer
+- URL: https://github.com/markus-lassfolk/openclaw-hybrid-memory/pull/1308#discussion_r3215594004
+- Feedback: The null-byte escaping in `taskEntityKey()` is not injective: an input containing the literal sequence `\\x00` becomes indistinguishable from an input that contained an actual `\^@` (both end up with `\\x00` in the serialized key). That means collisions (and incorrect supersede/lookup behavior) are still possible. Use an encoding that guarantees round-tripping (e.g., length-prefix each part, base64/URL-encode each part, or escape `\\` first and then escape `\^@`).
+
+### 1308.3 — extensions/memory-hybrid/services/active-task-checkpoint.ts:411
+
+- [ ] Status: TODO
+- Evidence: _pending_
+- Thread id: `PRRT_kwDORQuyQM6A7ypC`
+- Outdated: False
+- Author: copilot-pull-request-reviewer
+- URL: https://github.com/markus-lassfolk/openclaw-hybrid-memory/pull/1308#discussion_r3215594009
+- Feedback: In `safeJson()`, the fallback `String(value)` can itself throw if `value` is an object with a throwing `toString`/`Symbol.toPrimitive`. That would cause `safeJson` to unexpectedly throw in the very scenario it is meant to harden. Wrap the preview generation in its own try/catch (and fall back to something like `Object.prototype.toString.call(value)` or a constant string) so `safeJson` is guaranteed not to throw.
+
+### 1308.4 — extensions/memory-hybrid/services/active-task.ts:1067
+
+- [ ] Status: TODO
+- Evidence: _pending_
+- Thread id: `PRRT_kwDORQuyQM6A7ypG`
+- Outdated: False
+- Author: copilot-pull-request-reviewer
+- URL: https://github.com/markus-lassfolk/openclaw-hybrid-memory/pull/1308#discussion_r3215594013
+- Feedback: `writeActiveTaskFileOptimistic` now throws after exhausting retries, but there is no test covering the new failure mode (previously it performed a last-write-wins fallback). Add a test that forces repeated mtime changes until `maxRetries` is exceeded and asserts the function throws with a helpful message, so this concurrency behavior doesn’t regress silently.
+
+### 1308.5 — extensions/memory-hybrid/services/goal-stewardship-heartbeat.ts:56
+
+- [ ] Status: TODO
+- Evidence: _pending_
+- Thread id: `PRRT_kwDORQuyQM6A7ypN`
+- Outdated: False
+- Author: copilot-pull-request-reviewer
+- URL: https://github.com/markus-lassfolk/openclaw-hybrid-memory/pull/1308#discussion_r3215594020
+- Feedback: The comment says "Use immutable cache with Map for thread safety", but the cache isn’t immutable (the Map is mutated, and callers receive the cached array by reference). This is misleading documentation; consider rewording to describe the actual behavior (memoization keyed by pattern list) and/or freezing/cloning the returned array if immutability is intended.
+
+## PR #1311: fix: cross-scope classification mutations and vector cleanup in memory pipelines
+- State: MERGED
+- URL: https://github.com/markus-lassfolk/openclaw-hybrid-memory/pull/1311
+- Unresolved threads: 1 / 8
+
+### 1311.1 — extensions/memory-hybrid/services/vector-search.ts:27
+
+- [ ] Status: TODO
+- Evidence: _pending_
+- Thread id: `PRRT_kwDORQuyQM6A71pB`
+- Outdated: False
+- Author: chatgpt-codex-connector
+- URL: https://github.com/markus-lassfolk/openclaw-hybrid-memory/pull/1311#discussion_r3215609558
+- Feedback: **<sub><sub>![P2 Badge](https://img.shields.io/badge/P2-yellow?style=flat)</sub></sub> Keep embedding similarity unscoped when no scope is provided** Defaulting `scope` to `"global"` here silently changes the behavior of existing `FindSimilarByEmbeddingFn` callers that still use the old 4/5-argument form (the new `options` arg is optional in `api/memory-plugin-api.ts`), so those callers now stop seeing `user`/`agent`/`session` memories without any type error. In multi-scope deployments this regresses dedupe/classification quality for non-global flows unless every caller is updated to pass explicit scope options. Useful? React with 👍 / 👎.
+
+## PR #1317: Add productization surfaces: doctor flow, session observability CLI, quality reporting, telemetry/sync tooling, and contributor/demo docs
+- State: MERGED
+- URL: https://github.com/markus-lassfolk/openclaw-hybrid-memory/pull/1317
+- Unresolved threads: 5 / 5
+
+### 1317.1 — extensions/memory-hybrid/cli/commands/manage/register-storage-and-stats.ts:2697
+
+- [ ] Status: TODO
+- Evidence: _pending_
+- Thread id: `PRRT_kwDORQuyQM6A9o1E`
+- Outdated: False
+- Author: chatgpt-codex-connector
+- URL: https://github.com/markus-lassfolk/openclaw-hybrid-memory/pull/1317#discussion_r3216245142
+- Feedback: **<sub><sub>![P1 Badge](https://img.shields.io/badge/P1-orange?style=flat)</sub></sub> Bind the export handler before invoking sync-export** `sync-export` calls `runExport(...)`, but `runExport` is never pulled from `ManageBindings` in this module scope, so this path fails immediately (TypeScript reports `TS2304: Cannot find name 'runExport'`, and runtime would throw `ReferenceError`). As written, users cannot generate any sync bundle at all. Useful? React with 👍 / 👎.
+
+### 1317.2 — extensions/memory-hybrid/cli/commands/manage/register-storage-and-stats.ts:2698
+
+- [ ] Status: TODO
+- Evidence: _pending_
+- Thread id: `PRRT_kwDORQuyQM6A9o1F`
+- Outdated: False
+- Author: chatgpt-codex-connector
+- URL: https://github.com/markus-lassfolk/openclaw-hybrid-memory/pull/1317#discussion_r3216245144
+- Feedback: **<sub><sub>![P1 Badge](https://img.shields.io/badge/P1-orange?style=flat)</sub></sub> Encrypt actual export content instead of export directory path** Even after wiring `runExport`, this code reads `exportResult.outputPath` as a UTF-8 file, but the export API returns an output directory root (the same contract used by `hybrid-mem export --output <dir>`). Reading that path with `readFileSync(..., "utf-8")` will hit `EISDIR`, so `sync-export` still fails before encryption for valid inputs. Useful? React with 👍 / 👎.
+
+### 1317.3 — extensions/memory-hybrid/cli/verify.ts:225
+
+- [ ] Status: TODO
+- Evidence: _pending_
+- Thread id: `PRRT_kwDORQuyQM6A9pXu`
+- Outdated: False
+- Author: copilot-pull-request-reviewer
+- URL: https://github.com/markus-lassfolk/openclaw-hybrid-memory/pull/1317#discussion_r3216248411
+- Feedback: `doctor` currently runs `runInstall({ dryRun: dryRunInstall })` with `dryRunInstall` defaulting to false when neither `--fix` nor `--dry-run` are provided, which means `doctor` will write/apply install defaults by default. That’s surprising given the `--fix` option text (“Apply recommended install defaults…”) and can cause unintended config changes. Consider making the default behavior non-mutating (run install in dry-run/check mode unless `--fix` is set), or rename/reword the option(s) to clearly communicate that install defaults are applied on every run unless `--dry-run` is used.
+
+### 1317.4 — extensions/memory-hybrid/cli/commands/manage/register-storage-and-stats.ts:2796
+
+- [ ] Status: TODO
+- Evidence: _pending_
+- Thread id: `PRRT_kwDORQuyQM6A9pYI`
+- Outdated: False
+- Author: copilot-pull-request-reviewer
+- URL: https://github.com/markus-lassfolk/openclaw-hybrid-memory/pull/1317#discussion_r3216248456
+- Feedback: `sync-import` uses `envelope.iterations` directly in `pbkdf2Sync` and decodes `salt`/`iv`/`tag`/`ciphertext` without validating types or lengths. A malformed or hostile bundle could set an extremely large iterations value (DoS) or invalid base64/lengths (crash/unclear errors). Add strict runtime validation (schemaVersion/type/kdf, iterations finite and within a sane min/max, iv length 12 bytes, tag length 16 bytes, salt length expected) and fail with a clear error message before attempting PBKDF2/decryption.
+
+### 1317.5 — extensions/memory-hybrid/cli/benchmark.ts:144
+
+- [ ] Status: TODO
+- Evidence: _pending_
+- Thread id: `PRRT_kwDORQuyQM6A9pYa`
+- Outdated: False
+- Author: copilot-pull-request-reviewer
+- URL: https://github.com/markus-lassfolk/openclaw-hybrid-memory/pull/1317#discussion_r3216248479
+- Feedback: `buildBenchmarkQualityReport` clamps negative latency values to 0 via `Math.max(0, r.latency.p50)` etc. If *all* benchmark features fail (latency pXX = -1, samples=0), the summary averages will misleadingly report 0ms latency instead of indicating “n/a”/failure. Consider computing summary latency only over successful rows and emitting `null` (or a sentinel + explicit flag) when there are no successful measurements, and update markdown rendering accordingly.
+
+## PR #1318: Implement 10 strategic enhancements for ecosystem growth and enterprise adoption
+- State: MERGED
+- URL: https://github.com/markus-lassfolk/openclaw-hybrid-memory/pull/1318
+- Unresolved threads: 35 / 35
+
+### 1318.1 — extensions/memory-hybrid/routes/dashboard-server.ts:2032
+
+- [ ] Status: TODO
+- Evidence: _pending_
+- Thread id: `PRRT_kwDORQuyQM6A9pAs`
+- Outdated: False
+- Author: chatgpt-codex-connector
+- URL: https://github.com/markus-lassfolk/openclaw-hybrid-memory/pull/1318#discussion_r3216246289
+- Feedback: **<sub><sub>![P0 Badge](https://img.shields.io/badge/P0-red?style=flat)</sub></sub> Make dashboard request handler async before using await** This branch introduces `await` expressions inside the `createServer((req, res) => { ... })` callback, which is not marked `async`, so the package no longer builds (`tsdown` reports parse errors at these lines). As written, any CI or local build that includes this file will fail before runtime, blocking release of the plugin. Useful? React with 👍 / 👎.
+
+### 1318.2 — extensions/memory-hybrid/routes/graphql-resolvers.ts:9
+
+- [ ] Status: TODO
+- Evidence: _pending_
+- Thread id: `PRRT_kwDORQuyQM6A9pAt`
+- Outdated: False
+- Author: chatgpt-codex-connector
+- URL: https://github.com/markus-lassfolk/openclaw-hybrid-memory/pull/1318#discussion_r3216246290
+- Feedback: **<sub><sub>![P1 Badge](https://img.shields.io/badge/P1-orange?style=flat)</sub></sub> Replace unresolved search-hybrid import with existing module** The resolver imports `../services/search-hybrid.js`, but that module is not present in the repository, so module resolution will fail when this file is bundled or loaded. This breaks GraphQL query handling (`search`/`semanticSearch`) once parsing reaches this file. Useful? React with 👍 / 👎.
+
+### 1318.3 — extensions/memory-hybrid/routes/graphql-resolvers.ts:264
+
+- [ ] Status: TODO
+- Evidence: _pending_
+- Thread id: `PRRT_kwDORQuyQM6A9pAu`
+- Outdated: False
+- Author: chatgpt-codex-connector
+- URL: https://github.com/markus-lassfolk/openclaw-hybrid-memory/pull/1318#discussion_r3216246293
+- Feedback: **<sub><sub>![P1 Badge](https://img.shields.io/badge/P1-orange?style=flat)</sub></sub> Implement schema-declared mutations in resolver map** The `Mutation` resolver map only defines fact CRUD/import/prune handlers, while the schema in this same commit declares additional non-null mutations (`createLink`, `deleteLink`, `consolidateFacts`, `recomputeEmbeddings`). Calling those operations will hit GraphQL's default resolver and return `null` for non-null fields, producing runtime errors instead of usable API responses. Useful? React with 👍 / 👎.
+
+### 1318.4 — extensions/memory-hybrid/api/plugin-system.ts:357
+
+- [ ] Status: TODO
+- Evidence: _pending_
+- Thread id: `PRRT_kwDORQuyQM6A9pAw`
+- Outdated: False
+- Author: chatgpt-codex-connector
+- URL: https://github.com/markus-lassfolk/openclaw-hybrid-memory/pull/1318#discussion_r3216246298
+- Feedback: **<sub><sub>![P2 Badge](https://img.shields.io/badge/P2-yellow?style=flat)</sub></sub> Preserve other plugins' hooks when unloading one plugin** Unloading a single plugin currently clears every listener list in `eventListeners`, so hooks from unrelated still-loaded plugins stop firing after any unload. This causes cross-plugin behavior loss in long-running processes where plugins are dynamically reloaded. Useful? React with 👍 / 👎.
+
+### 1318.5 — extensions/memory-hybrid/api/plugin-system.ts:9
+
+- [ ] Status: TODO
+- Evidence: _pending_
+- Thread id: `PRRT_kwDORQuyQM6A9r5S`
+- Outdated: False
+- Author: copilot-pull-request-reviewer
+- URL: https://github.com/markus-lassfolk/openclaw-hybrid-memory/pull/1318#discussion_r3216263977
+- Feedback: `MemoryPluginContext` is imported from `../api/memory-plugin-api.js`, but that module exports `MemoryPluginAPI` (and does not define/export `MemoryPluginContext`). This will fail TypeScript builds; either import the correct type (e.g. `MemoryPluginAPI`) or define/export the intended context type from a dedicated module and update all imports accordingly.
+
+### 1318.6 — extensions/memory-hybrid/api/plugin-system.ts:358
+
+- [ ] Status: TODO
+- Evidence: _pending_
+- Thread id: `PRRT_kwDORQuyQM6A9r5e`
+- Outdated: False
+- Author: copilot-pull-request-reviewer
+- URL: https://github.com/markus-lassfolk/openclaw-hybrid-memory/pull/1318#discussion_r3216263990
+- Feedback: `unregisterHooks()` currently clears *all* event listeners for *all* events, so unloading one plugin will disable event delivery for every other loaded plugin. Track listeners per plugin (e.g., store listener fns in a Map keyed by pluginId) and only remove the listeners belonging to the plugin being unloaded.
+
+### 1318.7 — extensions/memory-hybrid/api/plugin-system.ts:144
+
+- [ ] Status: TODO
+- Evidence: _pending_
+- Thread id: `PRRT_kwDORQuyQM6A9r5p`
+- Outdated: False
+- Author: copilot-pull-request-reviewer
+- URL: https://github.com/markus-lassfolk/openclaw-hybrid-memory/pull/1318#discussion_r3216264002
+- Feedback: This runtime module uses `console.*` for logging (`PluginManager`'s context logger). The repo’s logger guidance explicitly requires using `pluginLogger` instead of `console.*` outside CLI allow-listed paths (see `utils/logger.ts`). Using `console.*` here will likely violate linting and bypass verbosity/log routing; please switch these to `pluginLogger` (or inject the host logger).
+
+### 1318.8 — extensions/memory-hybrid/services/plugin-loader.ts:10
+
+- [ ] Status: TODO
+- Evidence: _pending_
+- Thread id: `PRRT_kwDORQuyQM6A9r5v`
+- Outdated: False
+- Author: copilot-pull-request-reviewer
+- URL: https://github.com/markus-lassfolk/openclaw-hybrid-memory/pull/1318#discussion_r3216264008
+- Feedback: `MemoryPluginContext` is imported from `../api/memory-plugin-api.js`, but that type isn’t exported there. This will not compile; use the correct exported type (e.g. `MemoryPluginAPI`) or introduce an explicit context type/module for the plugin loader and update imports accordingly.
+
+### 1318.9 — extensions/memory-hybrid/services/plugin-loader.ts:74
+
+- [ ] Status: TODO
+- Evidence: _pending_
+- Thread id: `PRRT_kwDORQuyQM6A9r5z`
+- Outdated: False
+- Author: copilot-pull-request-reviewer
+- URL: https://github.com/markus-lassfolk/openclaw-hybrid-memory/pull/1318#discussion_r3216264013
+- Feedback: `import(pluginPath)` is called with a filesystem path built via `join(...)`. In Node ESM, dynamic import is most reliable with a `file://` URL (via `pathToFileURL(pluginPath).href`), and passing arbitrary paths can fail across platforms. Convert the path to a file URL before importing.
+
+### 1318.10 — extensions/memory-hybrid/routes/graphql-resolvers.ts:14
+
+- [ ] Status: TODO
+- Evidence: _pending_
+- Thread id: `PRRT_kwDORQuyQM6A9r55`
+- Outdated: False
+- Author: copilot-pull-request-reviewer
+- URL: https://github.com/markus-lassfolk/openclaw-hybrid-memory/pull/1318#discussion_r3216264023
+- Feedback: `MemoryPluginContext` is imported from `../api/memory-plugin-api.js`, but that module does not export it. This will break compilation; switch to the correct exported type or define/export the intended GraphQL context type from the right module.
+
+### 1318.11 — extensions/memory-hybrid/routes/graphql-resolvers.ts:47
+
+- [ ] Status: TODO
+- Evidence: _pending_
+- Thread id: `PRRT_kwDORQuyQM6A9r58`
+- Outdated: False
+- Author: copilot-pull-request-reviewer
+- URL: https://github.com/markus-lassfolk/openclaw-hybrid-memory/pull/1318#discussion_r3216264026
+- Feedback: These resolvers call `factsDb.getFactById()` / `getAllFacts()` / `deleteFact()`, but the actual FactsDB API is `getById()` / query helpers / `delete()` (and `store()` expects `StoreFactInput` without `id`/`createdAt`). As written, this GraphQL layer won’t compile or work against the existing backend; update resolvers to use the real FactsDB methods and data shapes (e.g. `factsDb.getById(id)`, `factsDb.searchFacts(...)`/`listForDashboard(...)`, and `factsDb.store({ text, category, ... })` letting the DB assign ids/timestamps).
+
+### 1318.12 — extensions/memory-hybrid/routes/graphql-resolvers.ts:431
+
+- [ ] Status: TODO
+- Evidence: _pending_
+- Thread id: `PRRT_kwDORQuyQM6A9r6C`
+- Outdated: False
+- Author: copilot-pull-request-reviewer
+- URL: https://github.com/markus-lassfolk/openclaw-hybrid-memory/pull/1318#discussion_r3216264033
+- Feedback: `supersedes` / `supersededByFact` appear swapped: `supersedes` returns the fact referenced by `parent.supersededBy`, which is the fact that supersedes the parent (i.e. "superseded by"), while `supersededByFact` searches for a fact whose `supersededBy === parent.id`, which is the fact that the parent supersedes. Swap these resolver implementations (or rename fields) to match their semantics.
+
+### 1318.13 — extensions/memory-hybrid/routes/graphql-schema.ts:235
+
+- [ ] Status: TODO
+- Evidence: _pending_
+- Thread id: `PRRT_kwDORQuyQM6A9r6I`
+- Outdated: False
+- Author: copilot-pull-request-reviewer
+- URL: https://github.com/markus-lassfolk/openclaw-hybrid-memory/pull/1318#discussion_r3216264041
+- Feedback: The schema declares non-null root fields (`episode`, `episodes`, `link`, many `Mutation`s like `createLink`, `deleteLink`, `consolidateFacts`, `recomputeEmbeddings`) that do not have resolvers implemented in `graphql-resolvers.ts`. Querying any of these will resolve to `null/undefined` and can trigger runtime GraphQL errors (especially for `...!` fields). Either implement the missing resolvers or remove/mark nullable the fields until supported.
+
+### 1318.14 — extensions/memory-hybrid/routes/graphql-server.ts:193
+
+- [ ] Status: TODO
+- Evidence: _pending_
+- Thread id: `PRRT_kwDORQuyQM6A9r6L`
+- Outdated: False
+- Author: copilot-pull-request-reviewer
+- URL: https://github.com/markus-lassfolk/openclaw-hybrid-memory/pull/1318#discussion_r3216264047
+- Feedback: CORS is configured with `origin: "*"` while `credentials: true`. Browsers will reject `Access-Control-Allow-Origin: *` when credentials are allowed, and it’s also unsafe for authenticated endpoints. Restrict `origin` to a concrete allow-list (or echo validated origins) and only enable credentials when needed.
+
+### 1318.15 — extensions/memory-hybrid/routes/graphql-server.ts:202
+
+- [ ] Status: TODO
+- Evidence: _pending_
+- Thread id: `PRRT_kwDORQuyQM6A9r6O`
+- Outdated: False
+- Author: copilot-pull-request-reviewer
+- URL: https://github.com/markus-lassfolk/openclaw-hybrid-memory/pull/1318#discussion_r3216264052
+- Feedback: This runtime route module logs via `console.*` in the Yoga `logging` hooks. The repo’s logger guidance requires using `pluginLogger` instead of `console.*` outside CLI allow-listed paths (`utils/logger.ts`). Switch these to `pluginLogger.{debug,info,warn,error}` so verbosity/log routing behaves consistently and lint rules pass.
+
+### 1318.16 — extensions/memory-hybrid/routes/dashboard-server.ts:2065
+
+- [ ] Status: TODO
+- Evidence: _pending_
+- Thread id: `PRRT_kwDORQuyQM6A9r6U`
+- Outdated: False
+- Author: copilot-pull-request-reviewer
+- URL: https://github.com/markus-lassfolk/openclaw-hybrid-memory/pull/1318#discussion_r3216264062
+- Feedback: The `/graphql` handler reads the request body with an unbounded string concatenation loop. This bypasses the existing `readJsonBody(..., MAX_DASHBOARD_JSON_BODY_BYTES)` protections used elsewhere and allows a large body to consume memory (DoS risk). Reuse `readJsonBody` with the existing size limit (or stream with backpressure) and return `413` on oversize payloads.
+
+### 1318.17 — extensions/memory-hybrid/routes/dashboard-server.ts:2047
+
+- [ ] Status: TODO
+- Evidence: _pending_
+- Thread id: `PRRT_kwDORQuyQM6A9r6a`
+- Outdated: False
+- Author: copilot-pull-request-reviewer
+- URL: https://github.com/markus-lassfolk/openclaw-hybrid-memory/pull/1318#discussion_r3216264068
+- Feedback: `createGraphQLServer(...)` is instantiated on every `/graphql` request. Creating Yoga (schema + plugins + PubSub) per request is unnecessary overhead and can become a scalability bottleneck. Create the Yoga server once when the dashboard server starts (and reuse the same instance) instead of rebuilding it on each request.
+
+### 1318.18 — extensions/memory-hybrid/routes/dashboard-server.ts:2047
+
+- [ ] Status: TODO
+- Evidence: _pending_
+- Thread id: `PRRT_kwDORQuyQM6A9r6f`
+- Outdated: False
+- Author: copilot-pull-request-reviewer
+- URL: https://github.com/markus-lassfolk/openclaw-hybrid-memory/pull/1318#discussion_r3216264075
+- Feedback: This block uses `as any` to coerce the object passed as `pluginContext`. In strict TypeScript this hides mismatches (and `MemoryPluginContext` isn’t actually defined/exported in the referenced module). Define a correct context type (or use an existing exported API type) and build an object that actually satisfies it so GraphQL resolvers can safely rely on typed fields without `any` casts.
+
+### 1318.19 — extensions/memory-hybrid/routes/dashboard-server.ts:2066
+
+- [ ] Status: TODO
+- Evidence: _pending_
+- Thread id: `PRRT_kwDORQuyQM6A9r6o`
+- Outdated: False
+- Author: copilot-pull-request-reviewer
+- URL: https://github.com/markus-lassfolk/openclaw-hybrid-memory/pull/1318#discussion_r3216264085
+- Feedback: `createDashboardServer` has an existing test suite, but the newly added `/graph` and `/graphql` routes aren’t covered. Add tests that (1) GET `/graph` returns HTML and (2) POST `/graphql` returns a valid GraphQL response (and enforces the same body-size limits/error handling as other endpoints).
+
+### 1318.20 — extensions/memory-hybrid/services/memory-compression.ts:75
+
+- [ ] Status: TODO
+- Evidence: _pending_
+- Thread id: `PRRT_kwDORQuyQM6A9r60`
+- Outdated: False
+- Author: copilot-pull-request-reviewer
+- URL: https://github.com/markus-lassfolk/openclaw-hybrid-memory/pull/1318#discussion_r3216264098
+- Feedback: This service uses `console.log(...)` in a runtime module. The repo logger guidelines require using `pluginLogger` instead of `console.*` outside CLI allow-listed paths (`utils/logger.ts`). Replace these with `pluginLogger.*` to avoid lint failures and to respect verbosity/log routing.
+
+### 1318.21 — extensions/memory-hybrid/services/memory-compression.ts:88
+
+- [ ] Status: TODO
+- Evidence: _pending_
+- Thread id: `PRRT_kwDORQuyQM6A9r68`
+- Outdated: False
+- Author: copilot-pull-request-reviewer
+- URL: https://github.com/markus-lassfolk/openclaw-hybrid-memory/pull/1318#discussion_r3216264107
+- Feedback: `FactsDB` does not expose `getAllFacts()` (or `getFactById()`), and `FactsDB.store()` expects a `StoreFactInput` shape without `id`/`createdAt` (those are assigned by the DB). As written, this service won’t compile/work with the existing backend; refactor to use supported FactsDB query APIs (e.g. `searchFacts`/`listForDashboard`/`getFactsForConsolidation`) and store summaries via `factsDb.store({ text, category, ... })` without pre-assigning ids/timestamps.
+
+### 1318.22 — extensions/memory-hybrid/services/memory-compression.ts:243
+
+- [ ] Status: TODO
+- Evidence: _pending_
+- Thread id: `PRRT_kwDORQuyQM6A9r7F`
+- Outdated: False
+- Author: copilot-pull-request-reviewer
+- URL: https://github.com/markus-lassfolk/openclaw-hybrid-memory/pull/1318#discussion_r3216264119
+- Feedback: This uses placeholder/random embeddings (`generateRandomEmbedding`) instead of reading real vectors from `VectorDB`. That makes clustering non-deterministic and effectively meaningless, and it will produce different clusters on every run. Either wire this to the actual embedding storage/search APIs (preferred) or remove the vector-based path and only expose the category/time-window fallback until embeddings are implemented.
+
+### 1318.23 — extensions/memory-hybrid/services/benchmark-suite.ts:61
+
+- [ ] Status: TODO
+- Evidence: _pending_
+- Thread id: `PRRT_kwDORQuyQM6A9r7R`
+- Outdated: False
+- Author: copilot-pull-request-reviewer
+- URL: https://github.com/markus-lassfolk/openclaw-hybrid-memory/pull/1318#discussion_r3216264131
+- Feedback: This runtime module uses `console.log(...)` for progress output. Per `utils/logger.ts`, non-CLI runtime code should use `pluginLogger` rather than `console.*` so logs respect verbosity and lint rules. Replace these with `pluginLogger.info/debug` (or accept an injected logger).
+
+### 1318.24 — extensions/memory-hybrid/services/benchmark-suite.ts:130
+
+- [ ] Status: TODO
+- Evidence: _pending_
+- Thread id: `PRRT_kwDORQuyQM6A9r7X`
+- Outdated: False
+- Author: copilot-pull-request-reviewer
+- URL: https://github.com/markus-lassfolk/openclaw-hybrid-memory/pull/1318#discussion_r3216264137
+- Feedback: `FactsDB` does not provide `getAllFacts()` / `getFactById()`. The benchmark implementation currently depends on those methods (and uses placeholder `setTimeout` calls for vector/hybrid search), so it won’t compile or measure real system performance. Update it to use the actual FactsDB APIs (e.g. `searchFacts`, `lookupFacts`, `getById`, etc.) and real vector/hybrid search entrypoints so the benchmark reflects real behavior.
+
+### 1318.25 — extensions/memory-hybrid/services/collaboration.ts:7
+
+- [ ] Status: TODO
+- Evidence: _pending_
+- Thread id: `PRRT_kwDORQuyQM6A9r7l`
+- Outdated: False
+- Author: copilot-pull-request-reviewer
+- URL: https://github.com/markus-lassfolk/openclaw-hybrid-memory/pull/1318#discussion_r3216264154
+- Feedback: This service imports/uses `better-sqlite3`, but the codebase has migrated to `node:sqlite` (and tests explicitly assert postinstall does not reference `better-sqlite3`). `better-sqlite3` is not a dependency of this package, so this will fail to build/run. Use `node:sqlite`’s `DatabaseSync` (consistent with the rest of the repo) or add a separate optional package with clear build steps.
+
+### 1318.26 — extensions/memory-hybrid/services/collaboration.ts:6
+
+- [ ] Status: TODO
+- Evidence: _pending_
+- Thread id: `PRRT_kwDORQuyQM6A9r7v`
+- Outdated: False
+- Author: copilot-pull-request-reviewer
+- URL: https://github.com/markus-lassfolk/openclaw-hybrid-memory/pull/1318#discussion_r3216264166
+- Feedback: `FactsDB` is imported but never used in this file. With typical TS/biome settings this will fail lint/typecheck; remove the unused import or use it as intended.
+
+### 1318.27 — extensions/memory-hybrid/cli/plugin-commands.ts:43
+
+- [ ] Status: TODO
+- Evidence: _pending_
+- Thread id: `PRRT_kwDORQuyQM6A9r77`
+- Outdated: False
+- Author: copilot-pull-request-reviewer
+- URL: https://github.com/markus-lassfolk/openclaw-hybrid-memory/pull/1318#discussion_r3216264180
+- Feedback: `listPlugins` uses `import(manifestPath, { assert: { type: "json" } })` with a filesystem path. Node’s import-attributes support uses `with: { type: "json" }` (and dynamic import of absolute paths is brittle), so this is likely to throw at runtime. Prefer reading `package.json` via `fs.readFile` + `JSON.parse`, or convert `manifestPath` to a `file://` URL and use the correct import-attributes syntax.
+
+### 1318.28 — extensions/memory-hybrid/cli/plugin-commands.ts:81
+
+- [ ] Status: TODO
+- Evidence: _pending_
+- Thread id: `PRRT_kwDORQuyQM6A9r8G`
+- Outdated: False
+- Author: copilot-pull-request-reviewer
+- URL: https://github.com/markus-lassfolk/openclaw-hybrid-memory/pull/1318#discussion_r3216264193
+- Feedback: `installPlugin(..., { npm: true })` runs `npm install ... --prefix <pluginsDir>`, which installs into `<pluginsDir>/node_modules/<pkg>`. However, `PluginLoader` scans `<pluginsDir>/*/index.js`, so npm-installed plugins will not be discoverable/enableable with the current directory layout. Align the installer and loader (e.g., install into a per-plugin directory or have the loader scan `node_modules`), otherwise `plugin install --npm` will appear to succeed but nothing will load.
+
+### 1318.29 — extensions/memory-hybrid/cli/plugin-commands.ts:79
+
+- [ ] Status: TODO
+- Evidence: _pending_
+- Thread id: `PRRT_kwDORQuyQM6A9r8T`
+- Outdated: False
+- Author: copilot-pull-request-reviewer
+- URL: https://github.com/markus-lassfolk/openclaw-hybrid-memory/pull/1318#discussion_r3216264206
+- Feedback: `installPlugin` dynamically imports `execa`, but `execa` is not listed in `extensions/memory-hybrid/package.json` dependencies/devDependencies. This will fail at runtime in a clean install. Either add `execa` as a dependency or replace it with `node:child_process` (`spawn`/`execFile`) to avoid the extra dep.
+
+### 1318.30 — sdk/openclaw-memory-js/package.json:53
+
+- [ ] Status: TODO
+- Evidence: _pending_
+- Thread id: `PRRT_kwDORQuyQM6A9r8X`
+- Outdated: False
+- Author: copilot-pull-request-reviewer
+- URL: https://github.com/markus-lassfolk/openclaw-hybrid-memory/pull/1318#discussion_r3216264213
+- Feedback: `graphql-request` is declared as a dependency but the SDK implementation uses `fetch` directly and never imports/uses `graphql-request`. Either remove the unused dependency to keep the package lean, or refactor the SDK to use `graphql-request` consistently.
+
+### 1318.31 — sdk/openclaw-memory-js/src/index.ts:137
+
+- [ ] Status: TODO
+- Evidence: _pending_
+- Thread id: `PRRT_kwDORQuyQM6A9r8c`
+- Outdated: False
+- Author: copilot-pull-request-reviewer
+- URL: https://github.com/markus-lassfolk/openclaw-hybrid-memory/pull/1318#discussion_r3216264221
+- Feedback: `restPath` is stored on the client (`private restPath` and constructor assignment) but never used by any method. With common TS settings (`noUnusedLocals`/`noUnusedParameters`) this can fail builds and it’s confusing API surface. Either implement REST-based methods that use `restPath` or remove it until needed.
+
+### 1318.32 — sdk/openclaw-memory-js/README.md:91
+
+- [ ] Status: TODO
+- Evidence: _pending_
+- Thread id: `PRRT_kwDORQuyQM6A9r8g`
+- Outdated: False
+- Author: copilot-pull-request-reviewer
+- URL: https://github.com/markus-lassfolk/openclaw-hybrid-memory/pull/1318#discussion_r3216264226
+- Feedback: The `getFacts` example includes `minImportance`, but `MemoryClient.getFacts()` options (and the underlying GraphQL `facts` query) do not support `minImportance`. This makes the README example incorrect/misleading; remove `minImportance` from the example or add support for it end-to-end.
+
+### 1318.33 — docs/tutorials/HYBRID-MEMORY-101.md:320
+
+- [ ] Status: TODO
+- Evidence: _pending_
+- Thread id: `PRRT_kwDORQuyQM6A9r8k`
+- Outdated: False
+- Author: copilot-pull-request-reviewer
+- URL: https://github.com/markus-lassfolk/openclaw-hybrid-memory/pull/1318#discussion_r3216264234
+- Feedback: This tutorial uses `client.getFacts({ ..., minImportance: 0.7 })`, but the SDK’s `getFacts` method does not accept `minImportance` (and the GraphQL `facts` query doesn’t define it). Update the tutorial to match the actual API, or add `minImportance` support across GraphQL schema/resolvers + SDK.
+
+### 1318.34 — docs/IMPLEMENTATION-SUMMARY.md:529
+
+- [ ] Status: TODO
+- Evidence: _pending_
+- Thread id: `PRRT_kwDORQuyQM6A9r8r`
+- Outdated: False
+- Author: copilot-pull-request-reviewer
+- URL: https://github.com/markus-lassfolk/openclaw-hybrid-memory/pull/1318#discussion_r3216264244
+- Feedback: This doc claims the GraphQL layer is "fully implemented and operational" (and elsewhere calls it "complete"), but the code currently contains multiple TODOs/placeholders (e.g. random embeddings in compression, benchmark stubs) and the GraphQL schema includes many fields without resolvers. Please adjust the claims to reflect current implementation status, or complete the missing pieces before describing them as operational.
+
+### 1318.35 — docs/PLUGIN-DEVELOPMENT.md:46
+
+- [ ] Status: TODO
+- Evidence: _pending_
+- Thread id: `PRRT_kwDORQuyQM6A9r8w`
+- Outdated: False
+- Author: copilot-pull-request-reviewer
+- URL: https://github.com/markus-lassfolk/openclaw-hybrid-memory/pull/1318#discussion_r3216264251
+- Feedback: The link `See the [Plugin Development Guide](../docs/PLUGIN-DEVELOPMENT.md)` points to `docs/docs/PLUGIN-DEVELOPMENT.md` from within `docs/PLUGIN-DEVELOPMENT.md`, which is incorrect/broken. Link to `./PLUGIN-DEVELOPMENT.md` (self) or to the intended separate guide file.
+
+## PR #1320: feat: add user-friendly CLI commands and comprehensive quick-start guide
+- State: MERGED
+- URL: https://github.com/markus-lassfolk/openclaw-hybrid-memory/pull/1320
+- Unresolved threads: 25 / 25
+
+### 1320.1 — extensions/memory-hybrid/cli/cmd-setup.ts:127
+
+- [ ] Status: TODO
+- Evidence: _pending_
+- Thread id: `PRRT_kwDORQuyQM6A9qM_`
+- Outdated: False
+- Author: chatgpt-codex-connector
+- URL: https://github.com/markus-lassfolk/openclaw-hybrid-memory/pull/1320#discussion_r3216253962
+- Feedback: **<sub><sub>![P1 Badge](https://img.shields.io/badge/P1-orange?style=flat)</sub></sub> Persist setup selections to plugin configuration** The setup wizard reports that it is "applying configuration", but this block only prints key/value pairs and never calls any config writer or `config-set` handler; the inline note explicitly says real persistence is missing. In practice, `openclaw hybrid-mem setup --interactive` can end with a success message while leaving provider/model/API key unchanged, so users still fail later commands expecting the new setup to be active. Useful? React with 👍 / 👎.
+
+### 1320.2 — extensions/memory-hybrid/cli/cmd-setup.ts:43
+
+- [ ] Status: TODO
+- Evidence: _pending_
+- Thread id: `PRRT_kwDORQuyQM6A9qND`
+- Outdated: False
+- Author: chatgpt-codex-connector
+- URL: https://github.com/markus-lassfolk/openclaw-hybrid-memory/pull/1320#discussion_r3216253967
+- Feedback: **<sub><sub>![P2 Badge](https://img.shields.io/badge/P2-yellow?style=flat)</sub></sub> Make --interactive actually optional** With Commander, defining `.option("--interactive", ..., true)` makes `interactive` true even when the flag is omitted and does not provide `--no-interactive`, so the non-interactive branch below is unreachable. This means setup always prompts on stdin, which breaks scripted/CI usage and contradicts the presence of explicit non-interactive logic in the command. Useful? React with 👍 / 👎.
+
+### 1320.3 — extensions/memory-hybrid/utils/provider-detection.ts:41
+
+- [ ] Status: TODO
+- Evidence: _pending_
+- Thread id: `PRRT_kwDORQuyQM6A9qzh`
+- Outdated: False
+- Author: copilot-pull-request-reviewer
+- URL: https://github.com/markus-lassfolk/openclaw-hybrid-memory/pull/1320#discussion_r3216257864
+- Feedback: `checkOnnxAvailable()` uses `require.resolve(...)` inside an ES module. At runtime `require` is not defined (unless created via `createRequire`), so this will throw and incorrectly report ONNX as unavailable. Use `createRequire(import.meta.url).resolve(...)`, or make this check async and `await import("onnxruntime-node")` in a try/catch to detect availability.
+
+### 1320.4 — extensions/memory-hybrid/utils/provider-detection.ts:7
+
+- [ ] Status: TODO
+- Evidence: _pending_
+- Thread id: `PRRT_kwDORQuyQM6A9qzy`
+- Outdated: False
+- Author: copilot-pull-request-reviewer
+- URL: https://github.com/markus-lassfolk/openclaw-hybrid-memory/pull/1320#discussion_r3216257887
+- Feedback: `execSync` and `existsSync` are imported but never used in this module. Please remove them to avoid dead code and keep the provider detection logic focused.
+
+### 1320.5 — extensions/memory-hybrid/utils/provider-detection.ts:15
+
+- [ ] Status: TODO
+- Evidence: _pending_
+- Thread id: `PRRT_kwDORQuyQM6A9qz8`
+- Outdated: False
+- Author: copilot-pull-request-reviewer
+- URL: https://github.com/markus-lassfolk/openclaw-hybrid-memory/pull/1320#discussion_r3216257903
+- Feedback: The embedding config supports provider `"google"` (see EmbeddingConfig), but provider detection/status only handles openai/ollama/onnx. If a user is configured for google, `providers/doctor/health` will misreport it as “not configured/unavailable”. Consider adding google to `ProviderStatus.provider` and implementing a `checkGoogleConfigured(...)` similar to OpenAI (or at least treat it as configured when an API key is present).
+
+### 1320.6 — extensions/memory-hybrid/utils/progress-indicators.ts:86
+
+- [ ] Status: TODO
+- Evidence: _pending_
+- Thread id: `PRRT_kwDORQuyQM6A9q0J`
+- Outdated: False
+- Author: copilot-pull-request-reviewer
+- URL: https://github.com/markus-lassfolk/openclaw-hybrid-memory/pull/1320#discussion_r3216257918
+- Feedback: `ProgressBar.update()` in non-TTY mode logs whenever `percent % 10 === 0`, which can print the same percentage many times if `update()` is called frequently. The codebase already uses milestone logging with a `lastPct` guard (e.g. 25/50/75/100) to avoid log spam. Track the last logged percentage (and consider milestone steps + a `total <= 0` guard) to prevent duplicate logs and division-by-zero when `total` is 0.
+
+### 1320.7 — extensions/memory-hybrid/utils/error-codes.ts:153
+
+- [ ] Status: TODO
+- Evidence: _pending_
+- Thread id: `PRRT_kwDORQuyQM6A9q0U`
+- Outdated: False
+- Author: copilot-pull-request-reviewer
+- URL: https://github.com/markus-lassfolk/openclaw-hybrid-memory/pull/1320#discussion_r3216257935
+- Feedback: `wrapCommonError()` treats timeouts as provider-unavailable (HM_E003) because it matches `lowerMsg.includes("timeout")`, but the catalog defines HM_E008 specifically for operation timeouts. This will surface the wrong title/solution for genuine timeouts. Prefer mapping timeout-ish messages to HM_E008 (and keep HM_E003 for connection/refused/notfound cases).
+
+### 1320.8 — extensions/memory-hybrid/utils/error-codes.ts:35
+
+- [ ] Status: TODO
+- Evidence: _pending_
+- Thread id: `PRRT_kwDORQuyQM6A9q0g`
+- Outdated: False
+- Author: copilot-pull-request-reviewer
+- URL: https://github.com/markus-lassfolk/openclaw-hybrid-memory/pull/1320#discussion_r3216257948
+- Feedback: Several `docsLink` URLs point at README anchors that don’t exist (e.g. `#embedding-providers`). This makes the “More info” link in `UserFriendlyError.format()` misleading. Please update these links to stable docs that exist in this repo (e.g. `docs/LLM-AND-PROVIDERS.md`, `docs/TROUBLESHOOTING.md`, etc.).
+
+### 1320.9 — extensions/memory-hybrid/docs/QUICK-START.md:253
+
+- [ ] Status: TODO
+- Evidence: _pending_
+- Thread id: `PRRT_kwDORQuyQM6A9q0p`
+- Outdated: False
+- Author: copilot-pull-request-reviewer
+- URL: https://github.com/markus-lassfolk/openclaw-hybrid-memory/pull/1320#discussion_r3216257962
+- Feedback: These “Learn More” references point to `docs/CLI-REFERENCE.md`, `docs/CONFIGURATION.md`, and `docs/ARCHITECTURE.md` relative to `extensions/memory-hybrid/docs/`, but those files don’t exist in this folder (they live under the repo root `docs/`). Use correct relative links (e.g. `../../docs/CLI-REFERENCE.md`) or absolute repo links so GitHub navigation works.
+
+### 1320.10 — extensions/memory-hybrid/docs/QUICK-START.md:53
+
+- [ ] Status: TODO
+- Evidence: _pending_
+- Thread id: `PRRT_kwDORQuyQM6A9q0r`
+- Outdated: False
+- Author: copilot-pull-request-reviewer
+- URL: https://github.com/markus-lassfolk/openclaw-hybrid-memory/pull/1320#discussion_r3216257966
+- Feedback: ONNX setup here suggests `npm install onnxruntime-node` without the `--prefix ~/.openclaw/extensions ...` guidance used elsewhere in the repo. As documented in `extensions/memory-hybrid/README.md`, installing into the OpenClaw extensions folder is important so the dependency survives `openclaw hybrid-mem upgrade`. Please align these instructions with the README’s recommended installation method.
+
+### 1320.11 — extensions/memory-hybrid/cli/register.ts:463
+
+- [ ] Status: TODO
+- Evidence: _pending_
+- Thread id: `PRRT_kwDORQuyQM6A9q0v`
+- Outdated: False
+- Author: copilot-pull-request-reviewer
+- URL: https://github.com/markus-lassfolk/openclaw-hybrid-memory/pull/1320#discussion_r3216257973
+- Feedback: `registerUserFriendlyCommands(mem as any, ...)` is needed because the user-friendly command modules are typed against Commander `Command`, while the rest of the CLI uses the local `Chainable` abstraction. To avoid `any` and keep type safety consistent, update `cmd-user-friendly.ts` (and the new command modules) to accept `Chainable` from `cli/shared.ts` (only using the subset of Commander APIs the CLI supports).
+
+### 1320.12 — extensions/memory-hybrid/cli/register.ts:470
+
+- [ ] Status: TODO
+- Evidence: _pending_
+- Thread id: `PRRT_kwDORQuyQM6A9q0y`
+- Outdated: False
+- Author: copilot-pull-request-reviewer
+- URL: https://github.com/markus-lassfolk/openclaw-hybrid-memory/pull/1320#discussion_r3216257978
+- Feedback: New CLI surface area is being registered here, but there are no accompanying tests verifying that these commands are registered and don’t hang the CLI (the repo already has CLI registration tests like `active-task.test.ts`). Add tests that assert `setup/demo/providers/health/doctor/examples` are present on the command tree and that help-only registration still avoids DB/bootstrap side effects.
+
+### 1320.13 — extensions/memory-hybrid/cli/cmd-user-friendly.ts:35
+
+- [ ] Status: TODO
+- Evidence: _pending_
+- Thread id: `PRRT_kwDORQuyQM6A9q04`
+- Outdated: False
+- Author: copilot-pull-request-reviewer
+- URL: https://github.com/markus-lassfolk/openclaw-hybrid-memory/pull/1320#discussion_r3216257988
+- Feedback: This module types `mem` as Commander `Command`, but `registerHybridMemCli` passes a `Chainable` (and currently must cast with `as any`). To match the rest of the CLI modules, consider switching these registrations to accept `Chainable` from `cli/shared.ts`. This removes the need for unsafe casts and ensures the command modules stay compatible with the CLI’s abstraction layer.
+
+### 1320.14 — extensions/memory-hybrid/cli/cmd-setup.ts:15
+
+- [ ] Status: TODO
+- Evidence: _pending_
+- Thread id: `PRRT_kwDORQuyQM6A9q1A`
+- Outdated: False
+- Author: copilot-pull-request-reviewer
+- URL: https://github.com/markus-lassfolk/openclaw-hybrid-memory/pull/1320#discussion_r3216257998
+- Feedback: Several Node imports here (`readFileSync`, `writeFileSync`, `homedir`, `join`) are unused in the current implementation. Please remove them to avoid dead code and reduce confusion about whether the wizard persists anything to disk.
+
+### 1320.15 — extensions/memory-hybrid/cli/cmd-setup.ts:128
+
+- [ ] Status: TODO
+- Evidence: _pending_
+- Thread id: `PRRT_kwDORQuyQM6A9q1K`
+- Outdated: False
+- Author: copilot-pull-request-reviewer
+- URL: https://github.com/markus-lassfolk/openclaw-hybrid-memory/pull/1320#discussion_r3216258011
+- Feedback: The wizard claims to be “Applying configuration”, but it never actually writes anything (it only logs key/value pairs and even notes “In real implementation…”). This is a functional gap vs the command description/PR description. Please wire this to the existing config machinery (e.g. call the `config-set` handler / `runConfigSet`, or persist updates via the config service) so `setup --interactive` genuinely updates the plugin config.
+
+### 1320.16 — extensions/memory-hybrid/cli/cmd-setup.ts:100
+
+- [ ] Status: TODO
+- Evidence: _pending_
+- Thread id: `PRRT_kwDORQuyQM6A9q1R`
+- Outdated: False
+- Author: copilot-pull-request-reviewer
+- URL: https://github.com/markus-lassfolk/openclaw-hybrid-memory/pull/1320#discussion_r3216258018
+- Feedback: The OpenAI API key prompt uses `readline.question`, which echoes the secret as the user types. For a setup wizard, this is risky in shared terminals/screen recordings. Use a masked/hidden input method for secrets (or instruct users to set `embedding.apiKey` via `config-set`/env vars instead of typing it interactively).
+
+### 1320.17 — extensions/memory-hybrid/cli/cmd-setup.ts:87
+
+- [ ] Status: TODO
+- Evidence: _pending_
+- Thread id: `PRRT_kwDORQuyQM6A9q1g`
+- Outdated: False
+- Author: copilot-pull-request-reviewer
+- URL: https://github.com/markus-lassfolk/openclaw-hybrid-memory/pull/1320#discussion_r3216258040
+- Feedback: `configUpdates` is declared as `Record<string, any>`, losing type safety for config keys/values. Since this code is user-facing config, it’s worth keeping types tight. Prefer `Record<string, string>` (all values are printed as strings here) or a typed map of known keys to avoid accidentally emitting non-serializable values.
+
+### 1320.18 — extensions/memory-hybrid/cli/cmd-providers.ts:24
+
+- [ ] Status: TODO
+- Evidence: _pending_
+- Thread id: `PRRT_kwDORQuyQM6A9q1p`
+- Outdated: False
+- Author: copilot-pull-request-reviewer
+- URL: https://github.com/markus-lassfolk/openclaw-hybrid-memory/pull/1320#discussion_r3216258053
+- Feedback: This command runs an async `.action(...)` without using the repo’s `withExit(...)` helper. Many existing CLI modules rely on `withExit` for consistent error capture and to ensure the process exits/tears down cleanly. Consider wrapping the action with `withExit` (from `cli/shared.ts`) and letting errors throw so teardown/error reporting stays consistent.
+
+### 1320.19 — extensions/memory-hybrid/cli/cmd-health.ts:116
+
+- [ ] Status: TODO
+- Evidence: _pending_
+- Thread id: `PRRT_kwDORQuyQM6A9q1r`
+- Outdated: False
+- Author: copilot-pull-request-reviewer
+- URL: https://github.com/markus-lassfolk/openclaw-hybrid-memory/pull/1320#discussion_r3216258066
+- Feedback: `health` recomputes `factsDb.countFacts()` and calls `vectorDb.getAllIds()` multiple times. `getAllIds()` can be expensive on large vector stores; doing it twice per invocation is unnecessary. Fetch `factCount`/`vectorCount` once and reuse for Memory Size + Sync checks (or add a cheaper `countVectors()` API if available).
+
+### 1320.20 — extensions/memory-hybrid/cli/cmd-examples.ts:149
+
+- [ ] Status: TODO
+- Evidence: _pending_
+- Thread id: `PRRT_kwDORQuyQM6A9q1y`
+- Outdated: False
+- Author: copilot-pull-request-reviewer
+- URL: https://github.com/markus-lassfolk/openclaw-hybrid-memory/pull/1320#discussion_r3216258076
+- Feedback: Using `category in EXAMPLE_CATEGORIES` checks the prototype chain too. Inputs like `examples toString` will pass the check and then `EXAMPLE_CATEGORIES["toString"]` is not a valid category object, which can crash or print nonsense. Use an own-property check (e.g. `Object.hasOwn(...)` / `hasOwnProperty.call(...)`) before indexing.
+
+### 1320.21 — extensions/memory-hybrid/cli/cmd-doctor.ts:5
+
+- [ ] Status: TODO
+- Evidence: _pending_
+- Thread id: `PRRT_kwDORQuyQM6A9q13`
+- Outdated: False
+- Author: copilot-pull-request-reviewer
+- URL: https://github.com/markus-lassfolk/openclaw-hybrid-memory/pull/1320#discussion_r3216258084
+- Feedback: `statSync` is imported but never used in this file. Please remove it to avoid dead code.
+
+### 1320.22 — extensions/memory-hybrid/cli/cmd-doctor.ts:31
+
+- [ ] Status: TODO
+- Evidence: _pending_
+- Thread id: `PRRT_kwDORQuyQM6A9q18`
+- Outdated: False
+- Author: copilot-pull-request-reviewer
+- URL: https://github.com/markus-lassfolk/openclaw-hybrid-memory/pull/1320#discussion_r3216258093
+- Feedback: The command defines a `--fix` option, but `opts.fix` is never used. This makes the CLI misleading (users expect some remediation behavior). Either implement `--fix` (e.g. run the suggested fix commands / call existing verify/reconcile flows) or remove the option until it’s supported.
+
+### 1320.23 — extensions/memory-hybrid/cli/cmd-doctor.ts:148
+
+- [ ] Status: TODO
+- Evidence: _pending_
+- Thread id: `PRRT_kwDORQuyQM6A9q2A`
+- Outdated: False
+- Author: copilot-pull-request-reviewer
+- URL: https://github.com/markus-lassfolk/openclaw-hybrid-memory/pull/1320#discussion_r3216258098
+- Feedback: This “Disk Space” check uses `require("node:path")` / `require("node:os")` inside an ES module. At runtime `require` will be undefined, causing the diagnostics command to crash. Use top-level ESM imports (`import { homedir } from "node:os"; import { join } from "node:path";`) or `createRequire(import.meta.url)` if you truly need `require`.
+
+### 1320.24 — extensions/memory-hybrid/cli/cmd-doctor.ts:161
+
+- [ ] Status: TODO
+- Evidence: _pending_
+- Thread id: `PRRT_kwDORQuyQM6A9q2H`
+- Outdated: False
+- Author: copilot-pull-request-reviewer
+- URL: https://github.com/markus-lassfolk/openclaw-hybrid-memory/pull/1320#discussion_r3216258110
+- Feedback: The check is labeled “Disk Space”, but it only verifies that the memory directory exists/access is possible. This doesn’t actually validate free space, which the PR description mentions. Either rename the check to reflect what it does (directory accessibility) or implement a real free-space check (e.g. via `statvfs`-style approach or a platform-appropriate utility) and warn/fail below a threshold.
+
+### 1320.25 — extensions/memory-hybrid/cli/cmd-demo.ts:37
+
+- [ ] Status: TODO
+- Evidence: _pending_
+- Thread id: `PRRT_kwDORQuyQM6A9q2M`
+- Outdated: False
+- Author: copilot-pull-request-reviewer
+- URL: https://github.com/markus-lassfolk/openclaw-hybrid-memory/pull/1320#discussion_r3216258120
+- Feedback: `EmbeddingProvider` doesn’t have a `provider` property (it exposes `activeProvider`, `modelName`, etc.). This line will fail TypeScript checking and/or always print the wrong value. Use `embeddings.activeProvider` (or `cfg.embedding.provider` if you want configured provider) when displaying provider status.
+
+## PR #1323: Harden Active Tasks + Goal Stewardship state handling, signal trust, and heartbeat safety
+- State: MERGED
+- URL: https://github.com/markus-lassfolk/openclaw-hybrid-memory/pull/1323
+- Unresolved threads: 6 / 6
+
+### 1323.1 — extensions/memory-hybrid/services/goal-registry.ts:180
+
+- [ ] Status: TODO
+- Evidence: _pending_
+- Thread id: `PRRT_kwDORQuyQM6A-HhK`
+- Outdated: False
+- Author: chatgpt-codex-connector
+- URL: https://github.com/markus-lassfolk/openclaw-hybrid-memory/pull/1323#discussion_r3216414656
+- Feedback: **<sub><sub>![P1 Badge](https://img.shields.io/badge/P1-orange?style=flat)</sub></sub> Prevent corrupt goal file from aborting all goal processing** Throwing on any non-ENOENT read error here makes higher-level scans fail hard because `listGoals()` calls `readGoal()` without a per-file guard, and `runGoalHealthCheck()` calls `listGoals()` before entering its per-goal `try/catch`. As a result, a single malformed `*.json` goal file can stop the entire watchdog pass (no other goals get checked), which regresses the new per-goal failure isolation behavior. Useful? React with 👍 / 👎.
+
+### 1323.2 — extensions/memory-hybrid/services/active-task.ts:480
+
+- [ ] Status: TODO
+- Evidence: _pending_
+- Thread id: `PRRT_kwDORQuyQM6A-HhN`
+- Outdated: False
+- Author: chatgpt-codex-connector
+- URL: https://github.com/markus-lassfolk/openclaw-hybrid-memory/pull/1323#discussion_r3216414659
+- Feedback: **<sub><sub>![P2 Badge](https://img.shields.io/badge/P2-yellow?style=flat)</sub></sub> Preserve file permissions during atomic ACTIVE-TASKS writes** Replacing the file via temp-write + `rename()` changes the inode, so existing mode/ownership/ACL on `ACTIVE-TASKS.md` are not preserved and are replaced by defaults from the temp file creation umask. If operators intentionally set restrictive permissions (for task content confidentiality), a normal write can silently broaden access after this change. Useful? React with 👍 / 👎.
+
+### 1323.3 — extensions/memory-hybrid/services/goal-registry.ts:181
+
+- [ ] Status: TODO
+- Evidence: _pending_
+- Thread id: `PRRT_kwDORQuyQM6A-Hux`
+- Outdated: True
+- Author: copilot-pull-request-reviewer
+- URL: https://github.com/markus-lassfolk/openclaw-hybrid-memory/pull/1323#discussion_r3216415837
+- Feedback: `readGoal` now throws on corrupt/unreadable JSON (good), but `listGoals` calls `readGoal` without a per-file try/catch. A single corrupt goal file will now cause `listGoals()` (and callers like `runGoalHealthCheck` and `stage-active-task` injection) to throw and abort processing entirely, which undermines the intended “per-goal isolation”. Consider catching errors inside `listGoals` (skip/record corrupt files) or adding a separate safe listing API used by watchdog/injection paths.
+
+### 1323.4 — extensions/memory-hybrid/services/goal-health.ts:249
+
+- [ ] Status: TODO
+- Evidence: _pending_
+- Thread id: `PRRT_kwDORQuyQM6A-HvA`
+- Outdated: False
+- Author: copilot-pull-request-reviewer
+- URL: https://github.com/markus-lassfolk/openclaw-hybrid-memory/pull/1323#discussion_r3216415854
+- Feedback: `isBlockedVerificationHost` returns `true` immediately for any `::ffff:` IPv4-mapped IPv6 address, so the subsequent `mappedIpv4` extraction and private-range check is unreachable. Either remove the dead code or move the private-range parsing before the unconditional return (depending on the intended policy).
+
+### 1323.5 — extensions/memory-hybrid/services/goal-health.ts:240
+
+- [ ] Status: TODO
+- Evidence: _pending_
+- Thread id: `PRRT_kwDORQuyQM6A-HvG`
+- Outdated: False
+- Author: copilot-pull-request-reviewer
+- URL: https://github.com/markus-lassfolk/openclaw-hybrid-memory/pull/1323#discussion_r3216415861
+- Feedback: The `http_ok` host blocking only checks IP literals (`isIP(hostname)`), and returns `false` for any DNS hostname (other than `.local`/`.localhost`). That still allows SSRF to private/loopback/link-local networks via hostnames that resolve to private IPs (including DNS rebinding). If the goal is to block private/local targets, consider resolving the hostname (e.g., `dns.lookup`/`dns.resolve`) and rejecting any private/local results before calling `fetch`.
+
+### 1323.6 — extensions/memory-hybrid/services/goal-active-task-mirror.ts:83
+
+- [ ] Status: TODO
+- Evidence: _pending_
+- Thread id: `PRRT_kwDORQuyQM6A-HvO`
+- Outdated: False
+- Author: copilot-pull-request-reviewer
+- URL: https://github.com/markus-lassfolk/openclaw-hybrid-memory/pull/1323#discussion_r3216415870
+- Feedback: `refreshActiveTaskMirrorWithGoals` writes `ACTIVE-TASKS.md` via a direct `writeFile`, which can still leave partial-file corruption if interrupted (the PR aims to make ACTIVE-TASKS.md writes atomic). Consider using the same temp-file+rename atomic write pattern as `writeActiveTaskFile`, or delegating the final write to that helper so all writers share the same safety guarantees.
+
+
+Total unresolved threads in scope: 77

--- a/docs/recovery/unresolved-feedback-2026-05-11.md
+++ b/docs/recovery/unresolved-feedback-2026-05-11.md
@@ -37,8 +37,8 @@ Generated from GitHub reviewThreads; only unresolved threads listed.
 
 ### 1308.1 — extensions/memory-hybrid/services/task-ledger-facts.ts:657
 
-- [ ] Status: TODO
-- Evidence: _pending_
+- [x] Status: ALREADY FIXED
+- Evidence: Current `planActiveTaskHygiene` no longer wraps `checkSessionPresent()` in `Promise.race`/uncleared `setTimeout`; it awaits the check directly while stale session references are deduplicated first. Evidence: `extensions/memory-hybrid/services/task-ledger-facts.ts` around stale session planning.
 - Thread id: `PRRT_kwDORQuyQM6A7yo6`
 - Outdated: False
 - Author: copilot-pull-request-reviewer
@@ -47,8 +47,8 @@ Generated from GitHub reviewThreads; only unresolved threads listed.
 
 ### 1308.2 — extensions/memory-hybrid/services/task-ledger-facts.ts:803
 
-- [ ] Status: TODO
-- Evidence: _pending_
+- [x] Status: FIXED
+- Evidence: Changed `taskEntityKey(entity, key)` to `JSON.stringify([entity, key])`, making entity/key cache keys injective even when inputs contain NULs or literal escape sequences. Evidence: `extensions/memory-hybrid/services/task-ledger-facts.ts`.
 - Thread id: `PRRT_kwDORQuyQM6A7yo-`
 - Outdated: False
 - Author: copilot-pull-request-reviewer
@@ -57,8 +57,8 @@ Generated from GitHub reviewThreads; only unresolved threads listed.
 
 ### 1308.3 — extensions/memory-hybrid/services/active-task-checkpoint.ts:411
 
-- [ ] Status: TODO
-- Evidence: _pending_
+- [x] Status: ALREADY FIXED
+- Evidence: `safeJson()` currently only uses `JSON.stringify()` and falls back to a constant JSON string on failure; it does not call `String(value)`, so throwing `toString`/`Symbol.toPrimitive` cannot break the fallback. Evidence: `extensions/memory-hybrid/services/active-task-checkpoint.ts`.
 - Thread id: `PRRT_kwDORQuyQM6A7ypC`
 - Outdated: False
 - Author: copilot-pull-request-reviewer
@@ -67,8 +67,8 @@ Generated from GitHub reviewThreads; only unresolved threads listed.
 
 ### 1308.4 — extensions/memory-hybrid/services/active-task.ts:1067
 
-- [ ] Status: TODO
-- Evidence: _pending_
+- [x] Status: ALREADY FIXED
+- Evidence: Current `writeActiveTaskFileOptimistic()` returns `false` after retry exhaustion rather than throwing, and an existing regression test covers exhausted retries. Evidence: `extensions/memory-hybrid/services/active-task.ts` and `extensions/memory-hybrid/tests/active-task.test.ts`.
 - Thread id: `PRRT_kwDORQuyQM6A7ypG`
 - Outdated: False
 - Author: copilot-pull-request-reviewer
@@ -77,8 +77,8 @@ Generated from GitHub reviewThreads; only unresolved threads listed.
 
 ### 1308.5 — extensions/memory-hybrid/services/goal-stewardship-heartbeat.ts:56
 
-- [ ] Status: TODO
-- Evidence: _pending_
+- [x] Status: ALREADY FIXED
+- Evidence: The misleading “immutable cache” comment is not present on current main; matcher cache is described as a module-level regex cache/test-isolation helper. Evidence: `extensions/memory-hybrid/services/goal-stewardship-heartbeat.ts`.
 - Thread id: `PRRT_kwDORQuyQM6A7ypN`
 - Outdated: False
 - Author: copilot-pull-request-reviewer
@@ -92,8 +92,8 @@ Generated from GitHub reviewThreads; only unresolved threads listed.
 
 ### 1311.1 — extensions/memory-hybrid/services/vector-search.ts:27
 
-- [ ] Status: TODO
-- Evidence: _pending_
+- [x] Status: FIXED
+- Evidence: Updated `findSimilarByEmbedding()` so omitted `options.scope` keeps legacy unscoped behaviour; exact scope filtering only applies when scope is explicitly provided. Added regression assertions. Evidence: `extensions/memory-hybrid/services/vector-search.ts`, `extensions/memory-hybrid/tests/fr-008-classification.test.ts`.
 - Thread id: `PRRT_kwDORQuyQM6A71pB`
 - Outdated: False
 - Author: chatgpt-codex-connector
@@ -107,8 +107,8 @@ Generated from GitHub reviewThreads; only unresolved threads listed.
 
 ### 1317.1 — extensions/memory-hybrid/cli/commands/manage/register-storage-and-stats.ts:2697
 
-- [ ] Status: TODO
-- Evidence: _pending_
+- [x] Status: FIXED
+- Evidence: Bound `runExport` from `ManageBindings` in `registerManageStorageAndStats()` before `sync-export` invokes it. Evidence: `extensions/memory-hybrid/cli/commands/manage/register-storage-and-stats.ts`.
 - Thread id: `PRRT_kwDORQuyQM6A9o1E`
 - Outdated: False
 - Author: chatgpt-codex-connector
@@ -117,8 +117,8 @@ Generated from GitHub reviewThreads; only unresolved threads listed.
 
 ### 1317.2 — extensions/memory-hybrid/cli/commands/manage/register-storage-and-stats.ts:2698
 
-- [ ] Status: TODO
-- Evidence: _pending_
+- [x] Status: FIXED
+- Evidence: `sync-export` now exports to a temporary directory and encrypts a JSON payload containing actual exported files/content, rather than reading the output directory path as a UTF-8 file. Evidence: `collectExportBundleFiles()` and sync-export implementation in `register-storage-and-stats.ts`.
 - Thread id: `PRRT_kwDORQuyQM6A9o1F`
 - Outdated: False
 - Author: chatgpt-codex-connector
@@ -127,8 +127,8 @@ Generated from GitHub reviewThreads; only unresolved threads listed.
 
 ### 1317.3 — extensions/memory-hybrid/cli/verify.ts:225
 
-- [ ] Status: TODO
-- Evidence: _pending_
+- [x] Status: FIXED
+- Evidence: `doctor` now runs install defaults in dry-run/check mode by default; install defaults are applied only when `--fix` is supplied. Evidence: `extensions/memory-hybrid/cli/verify.ts`.
 - Thread id: `PRRT_kwDORQuyQM6A9pXu`
 - Outdated: False
 - Author: copilot-pull-request-reviewer
@@ -137,8 +137,8 @@ Generated from GitHub reviewThreads; only unresolved threads listed.
 
 ### 1317.4 — extensions/memory-hybrid/cli/commands/manage/register-storage-and-stats.ts:2796
 
-- [ ] Status: TODO
-- Evidence: _pending_
+- [x] Status: FIXED
+- Evidence: Added strict sync envelope validation before PBKDF2/decryption: schema/type/alg/kdf, bounded iterations, base64 shape, salt/iv/tag byte lengths, and non-empty ciphertext. Evidence: `validateSyncEnvelope()` in `register-storage-and-stats.ts`.
 - Thread id: `PRRT_kwDORQuyQM6A9pYI`
 - Outdated: False
 - Author: copilot-pull-request-reviewer
@@ -147,8 +147,8 @@ Generated from GitHub reviewThreads; only unresolved threads listed.
 
 ### 1317.5 — extensions/memory-hybrid/cli/benchmark.ts:144
 
-- [ ] Status: TODO
-- Evidence: _pending_
+- [x] Status: FIXED
+- Evidence: Benchmark quality reports now compute latency averages only from successful latency samples; when all features fail, summary latency is `null`/rendered as `n/a` instead of misleading 0ms. Added regression test. Evidence: `extensions/memory-hybrid/cli/benchmark.ts`, `extensions/memory-hybrid/tests/benchmark-report.test.ts`.
 - Thread id: `PRRT_kwDORQuyQM6A9pYa`
 - Outdated: False
 - Author: copilot-pull-request-reviewer

--- a/docs/recovery/unresolved-feedback-2026-05-11.md
+++ b/docs/recovery/unresolved-feedback-2026-05-11.md
@@ -8,9 +8,11 @@ Generated from GitHub review threads during the 2026-05-11 red-CI/unresolved-fee
 
 This PR must not merge until all three gates are satisfied:
 
-- [ ] All substantive latest-head CI checks are green.
-- [ ] No unresolved review feedback/items remain.
-- [ ] No merge conflicts remain.
+- [x] All substantive latest-head CI checks are green.
+- [x] No unresolved review feedback/items remain.
+- [x] No merge conflicts remain.
+
+Verified on PR #1332 head `42571bd993b3d90cd521a1cfdbb84942f5001158`: 59/59 status checks successful, zero unresolved review threads, and merge state clean/mergeable.
 
 Admin merge is only a mechanical last resort after those gates are already satisfied; never to bypass red CI, feedback, or conflicts.
 
@@ -22,7 +24,7 @@ Each inventory item must end as exactly one of:
 - `ALREADY FIXED` — already fixed on current main with file/line evidence.
 - `OBSOLETE` — no longer applicable with evidence.
 
-`TODO` is allowed only while this PR is draft. Applicable items must not be deferred before merge.
+`TODO` statuses are not allowed before merge. Applicable items must not be deferred before merge.
 
 # Unresolved review feedback inventory — incident window
 

--- a/docs/recovery/unresolved-feedback-2026-05-11.md
+++ b/docs/recovery/unresolved-feedback-2026-05-11.md
@@ -292,8 +292,8 @@ Generated from GitHub reviewThreads; only unresolved threads listed.
 
 ### 1318.14 — extensions/memory-hybrid/routes/graphql-server.ts:193
 
-- [ ] Status: TODO
-- Evidence: _pending_
+- [x] Status: FIXED
+- Evidence: GraphQL Yoga CORS no longer combines wildcard origin with credentials; `credentials` is false for the wildcard dashboard GraphQL endpoint. Evidence: `graphql-server.ts`.
 - Thread id: `PRRT_kwDORQuyQM6A9r6L`
 - Outdated: False
 - Author: copilot-pull-request-reviewer
@@ -352,8 +352,8 @@ Generated from GitHub reviewThreads; only unresolved threads listed.
 
 ### 1318.20 — extensions/memory-hybrid/services/memory-compression.ts:75
 
-- [ ] Status: TODO
-- Evidence: _pending_
+- [x] Status: FIXED
+- Evidence: Memory compression runtime module no longer uses `console.log`; prior compile batch removed runtime console progress logging. Evidence: no `console.*` in `memory-compression.ts`; `npx tsc --noEmit` green.
 - Thread id: `PRRT_kwDORQuyQM6A9r60`
 - Outdated: False
 - Author: copilot-pull-request-reviewer
@@ -372,8 +372,8 @@ Generated from GitHub reviewThreads; only unresolved threads listed.
 
 ### 1318.22 — extensions/memory-hybrid/services/memory-compression.ts:243
 
-- [ ] Status: TODO
-- Evidence: _pending_
+- [x] Status: FIXED
+- Evidence: Removed random placeholder embeddings from compression clustering; until real persisted vector retrieval is wired, compression uses deterministic category clustering instead. Evidence: `clusterFacts()` in `memory-compression.ts`.
 - Thread id: `PRRT_kwDORQuyQM6A9r7F`
 - Outdated: False
 - Author: copilot-pull-request-reviewer
@@ -382,8 +382,8 @@ Generated from GitHub reviewThreads; only unresolved threads listed.
 
 ### 1318.23 — extensions/memory-hybrid/services/benchmark-suite.ts:61
 
-- [ ] Status: TODO
-- Evidence: _pending_
+- [x] Status: FIXED
+- Evidence: Benchmark runtime module no longer uses `console.log` progress output. Evidence: no `console.*` in `benchmark-suite.ts`; `npx tsc --noEmit` green.
 - Thread id: `PRRT_kwDORQuyQM6A9r7R`
 - Outdated: False
 - Author: copilot-pull-request-reviewer
@@ -452,8 +452,8 @@ Generated from GitHub reviewThreads; only unresolved threads listed.
 
 ### 1318.30 — sdk/openclaw-memory-js/package.json:53
 
-- [ ] Status: TODO
-- Evidence: _pending_
+- [x] Status: FIXED
+- Evidence: Removed unused `graphql-request` dependency from the SDK package because the SDK uses `fetch` directly. Evidence: `sdk/openclaw-memory-js/package.json`.
 - Thread id: `PRRT_kwDORQuyQM6A9r8X`
 - Outdated: False
 - Author: copilot-pull-request-reviewer
@@ -462,8 +462,8 @@ Generated from GitHub reviewThreads; only unresolved threads listed.
 
 ### 1318.31 — sdk/openclaw-memory-js/src/index.ts:137
 
-- [ ] Status: TODO
-- Evidence: _pending_
+- [x] Status: FIXED
+- Evidence: Removed unused `restPath` config/property/constructor assignment from SDK client. Evidence: `sdk/openclaw-memory-js/src/index.ts` and README config table updated.
 - Thread id: `PRRT_kwDORQuyQM6A9r8c`
 - Outdated: False
 - Author: copilot-pull-request-reviewer
@@ -472,8 +472,8 @@ Generated from GitHub reviewThreads; only unresolved threads listed.
 
 ### 1318.32 — sdk/openclaw-memory-js/README.md:91
 
-- [ ] Status: TODO
-- Evidence: _pending_
+- [x] Status: FIXED
+- Evidence: Removed unsupported `minImportance` from the SDK README `getFacts()` example. Importance filtering remains documented under `search()`, where it is supported. Evidence: `sdk/openclaw-memory-js/README.md`.
 - Thread id: `PRRT_kwDORQuyQM6A9r8g`
 - Outdated: False
 - Author: copilot-pull-request-reviewer
@@ -482,8 +482,8 @@ Generated from GitHub reviewThreads; only unresolved threads listed.
 
 ### 1318.33 — docs/tutorials/HYBRID-MEMORY-101.md:320
 
-- [ ] Status: TODO
-- Evidence: _pending_
+- [x] Status: FIXED
+- Evidence: Updated tutorial filtered `getFacts()` example to use supported category/tag filters only, and clarified importance filtering belongs with `search()`. Evidence: `docs/tutorials/HYBRID-MEMORY-101.md`.
 - Thread id: `PRRT_kwDORQuyQM6A9r8k`
 - Outdated: False
 - Author: copilot-pull-request-reviewer
@@ -492,8 +492,8 @@ Generated from GitHub reviewThreads; only unresolved threads listed.
 
 ### 1318.34 — docs/IMPLEMENTATION-SUMMARY.md:529
 
-- [ ] Status: TODO
-- Evidence: _pending_
+- [x] Status: FIXED
+- Evidence: Softened implementation summary claims: GraphQL/collaboration/plugin work is described as foundations/incremental, not “fully implemented and operational”/complete. Evidence: `docs/IMPLEMENTATION-SUMMARY.md`.
 - Thread id: `PRRT_kwDORQuyQM6A9r8r`
 - Outdated: False
 - Author: copilot-pull-request-reviewer
@@ -502,8 +502,8 @@ Generated from GitHub reviewThreads; only unresolved threads listed.
 
 ### 1318.35 — docs/PLUGIN-DEVELOPMENT.md:46
 
-- [ ] Status: TODO
-- Evidence: _pending_
+- [x] Status: FIXED
+- Evidence: Removed the broken self-link to `../docs/PLUGIN-DEVELOPMENT.md` from within `docs/PLUGIN-DEVELOPMENT.md`; the doc now points readers to the current guide content. Evidence: `docs/PLUGIN-DEVELOPMENT.md`.
 - Thread id: `PRRT_kwDORQuyQM6A9r8w`
 - Outdated: False
 - Author: copilot-pull-request-reviewer

--- a/docs/recovery/unresolved-feedback-2026-05-11.md
+++ b/docs/recovery/unresolved-feedback-2026-05-11.md
@@ -517,8 +517,8 @@ Generated from GitHub reviewThreads; only unresolved threads listed.
 
 ### 1320.1 — extensions/memory-hybrid/cli/cmd-setup.ts:127
 
-- [ ] Status: TODO
-- Evidence: _pending_
+- [x] Status: FIXED
+- Evidence: Setup wizard now persists selected provider/model/API-key updates by calling the injected `runConfigSet` writer for each config key. Evidence: `registerSetupCommand(..., runConfigSet)` in `cmd-setup.ts`; `user-friendly-cli.test.ts` verifies writes occur.
 - Thread id: `PRRT_kwDORQuyQM6A9qM_`
 - Outdated: False
 - Author: chatgpt-codex-connector
@@ -527,8 +527,8 @@ Generated from GitHub reviewThreads; only unresolved threads listed.
 
 ### 1320.2 — extensions/memory-hybrid/cli/cmd-setup.ts:43
 
-- [ ] Status: TODO
-- Evidence: _pending_
+- [x] Status: FIXED
+- Evidence: `--interactive` no longer defaults to true, so non-interactive setup is reachable by default. Evidence: `cmd-setup.ts`; test verifies no default value on the `--interactive` option and non-interactive action runs.
 - Thread id: `PRRT_kwDORQuyQM6A9qND`
 - Outdated: False
 - Author: chatgpt-codex-connector
@@ -537,8 +537,8 @@ Generated from GitHub reviewThreads; only unresolved threads listed.
 
 ### 1320.3 — extensions/memory-hybrid/utils/provider-detection.ts:41
 
-- [ ] Status: TODO
-- Evidence: _pending_
+- [x] Status: FIXED
+- Evidence: ONNX detection now uses `createRequire(import.meta.url).resolve(...)`, which works in ESM. Evidence: `provider-detection.ts`; provider helper tests pass.
 - Thread id: `PRRT_kwDORQuyQM6A9qzh`
 - Outdated: False
 - Author: copilot-pull-request-reviewer
@@ -547,8 +547,8 @@ Generated from GitHub reviewThreads; only unresolved threads listed.
 
 ### 1320.4 — extensions/memory-hybrid/utils/provider-detection.ts:7
 
-- [ ] Status: TODO
-- Evidence: _pending_
+- [x] Status: FIXED
+- Evidence: Removed unused `execSync`/`existsSync` imports from provider detection. Evidence: `provider-detection.ts`; `npx tsc --noEmit` green.
 - Thread id: `PRRT_kwDORQuyQM6A9qzy`
 - Outdated: False
 - Author: copilot-pull-request-reviewer
@@ -557,8 +557,8 @@ Generated from GitHub reviewThreads; only unresolved threads listed.
 
 ### 1320.5 — extensions/memory-hybrid/utils/provider-detection.ts:15
 
-- [ ] Status: TODO
-- Evidence: _pending_
+- [x] Status: FIXED
+- Evidence: Provider detection/status now includes `google` and reports configured when a Google/Gemini API key is present. Evidence: `ProviderStatus.provider` includes google; `detectAvailableProviders(..., googleApiKey)`; test verifies GOOGLE status.
 - Thread id: `PRRT_kwDORQuyQM6A9qz8`
 - Outdated: False
 - Author: copilot-pull-request-reviewer
@@ -567,8 +567,8 @@ Generated from GitHub reviewThreads; only unresolved threads listed.
 
 ### 1320.6 — extensions/memory-hybrid/utils/progress-indicators.ts:86
 
-- [ ] Status: TODO
-- Evidence: _pending_
+- [x] Status: FIXED
+- Evidence: ProgressBar non-TTY mode now uses a `lastLoggedPercent` milestone guard and a safe total to avoid duplicate logs/division-by-zero. Evidence: `progress-indicators.ts`; test verifies duplicate 10% logs are suppressed.
 - Thread id: `PRRT_kwDORQuyQM6A9q0J`
 - Outdated: False
 - Author: copilot-pull-request-reviewer
@@ -577,8 +577,8 @@ Generated from GitHub reviewThreads; only unresolved threads listed.
 
 ### 1320.7 — extensions/memory-hybrid/utils/error-codes.ts:153
 
-- [ ] Status: TODO
-- Evidence: _pending_
+- [x] Status: FIXED
+- Evidence: Timeout-like errors now map to HM_E008 before provider-unavailable matching. Evidence: `wrapCommonError()` in `error-codes.ts`; test verifies timeout maps to HM_E008.
 - Thread id: `PRRT_kwDORQuyQM6A9q0U`
 - Outdated: False
 - Author: copilot-pull-request-reviewer
@@ -587,8 +587,8 @@ Generated from GitHub reviewThreads; only unresolved threads listed.
 
 ### 1320.8 — extensions/memory-hybrid/utils/error-codes.ts:35
 
-- [ ] Status: TODO
-- Evidence: _pending_
+- [x] Status: FIXED
+- Evidence: Updated user-friendly error docs links to stable repo docs (`docs/LLM-AND-PROVIDERS.md`, `docs/CONFIGURATION.md`, `docs/TROUBLESHOOTING.md`) instead of missing README anchors. Evidence: `error-codes.ts`.
 - Thread id: `PRRT_kwDORQuyQM6A9q0g`
 - Outdated: False
 - Author: copilot-pull-request-reviewer
@@ -597,8 +597,8 @@ Generated from GitHub reviewThreads; only unresolved threads listed.
 
 ### 1320.9 — extensions/memory-hybrid/docs/QUICK-START.md:253
 
-- [ ] Status: TODO
-- Evidence: _pending_
+- [x] Status: FIXED
+- Evidence: Quick Start Learn More links now point from `extensions/memory-hybrid/docs/` to existing root docs via `../../../docs/...`. Evidence: `extensions/memory-hybrid/docs/QUICK-START.md`.
 - Thread id: `PRRT_kwDORQuyQM6A9q0p`
 - Outdated: False
 - Author: copilot-pull-request-reviewer
@@ -607,8 +607,8 @@ Generated from GitHub reviewThreads; only unresolved threads listed.
 
 ### 1320.10 — extensions/memory-hybrid/docs/QUICK-START.md:53
 
-- [ ] Status: TODO
-- Evidence: _pending_
+- [x] Status: FIXED
+- Evidence: ONNX quick-start install command now uses `npm install --prefix ~/.openclaw/extensions/openclaw-hybrid-memory onnxruntime-node`, matching extension persistence guidance. Evidence: `QUICK-START.md`.
 - Thread id: `PRRT_kwDORQuyQM6A9q0r`
 - Outdated: False
 - Author: copilot-pull-request-reviewer
@@ -617,8 +617,8 @@ Generated from GitHub reviewThreads; only unresolved threads listed.
 
 ### 1320.11 — extensions/memory-hybrid/cli/register.ts:463
 
-- [ ] Status: TODO
-- Evidence: _pending_
+- [x] Status: FIXED
+- Evidence: User-friendly command modules now accept the local `Chainable` abstraction and `registerHybridMemCli` no longer casts `mem as any`. Evidence: `cmd-user-friendly.ts`, user-friendly command modules, `register.ts`.
 - Thread id: `PRRT_kwDORQuyQM6A9q0v`
 - Outdated: False
 - Author: copilot-pull-request-reviewer
@@ -627,8 +627,8 @@ Generated from GitHub reviewThreads; only unresolved threads listed.
 
 ### 1320.12 — extensions/memory-hybrid/cli/register.ts:470
 
-- [ ] Status: TODO
-- Evidence: _pending_
+- [x] Status: FIXED
+- Evidence: Added focused registration tests verifying setup/demo/providers/health/doctor/examples are registered on the command tree and help-only registration stays lightweight. Evidence: `tests/user-friendly-cli.test.ts`.
 - Thread id: `PRRT_kwDORQuyQM6A9q0y`
 - Outdated: False
 - Author: copilot-pull-request-reviewer
@@ -637,8 +637,8 @@ Generated from GitHub reviewThreads; only unresolved threads listed.
 
 ### 1320.13 — extensions/memory-hybrid/cli/cmd-user-friendly.ts:35
 
-- [ ] Status: TODO
-- Evidence: _pending_
+- [x] Status: FIXED
+- Evidence: `cmd-user-friendly.ts` now types `mem` as `Chainable` instead of Commander `Command`. Evidence: `cmd-user-friendly.ts`.
 - Thread id: `PRRT_kwDORQuyQM6A9q04`
 - Outdated: False
 - Author: copilot-pull-request-reviewer
@@ -647,8 +647,8 @@ Generated from GitHub reviewThreads; only unresolved threads listed.
 
 ### 1320.14 — extensions/memory-hybrid/cli/cmd-setup.ts:15
 
-- [ ] Status: TODO
-- Evidence: _pending_
+- [x] Status: FIXED
+- Evidence: Removed unused Node imports from setup command. Evidence: `cmd-setup.ts`; `npx tsc --noEmit` green.
 - Thread id: `PRRT_kwDORQuyQM6A9q1A`
 - Outdated: False
 - Author: copilot-pull-request-reviewer
@@ -657,8 +657,8 @@ Generated from GitHub reviewThreads; only unresolved threads listed.
 
 ### 1320.15 — extensions/memory-hybrid/cli/cmd-setup.ts:128
 
-- [ ] Status: TODO
-- Evidence: _pending_
+- [x] Status: FIXED
+- Evidence: Duplicate of 1320.1: setup now genuinely applies configuration through `runConfigSet` and errors if no config writer is available. Evidence: `cmd-setup.ts`; test verifies persisted writes.
 - Thread id: `PRRT_kwDORQuyQM6A9q1K`
 - Outdated: False
 - Author: copilot-pull-request-reviewer
@@ -667,8 +667,8 @@ Generated from GitHub reviewThreads; only unresolved threads listed.
 
 ### 1320.16 — extensions/memory-hybrid/cli/cmd-setup.ts:100
 
-- [ ] Status: TODO
-- Evidence: _pending_
+- [x] Status: FIXED
+- Evidence: OpenAI/Google API key prompts now use hidden input (`promptHidden`) so secrets are not echoed in interactive setup. Evidence: `cmd-setup.ts`.
 - Thread id: `PRRT_kwDORQuyQM6A9q1R`
 - Outdated: False
 - Author: copilot-pull-request-reviewer
@@ -677,8 +677,8 @@ Generated from GitHub reviewThreads; only unresolved threads listed.
 
 ### 1320.17 — extensions/memory-hybrid/cli/cmd-setup.ts:87
 
-- [ ] Status: TODO
-- Evidence: _pending_
+- [x] Status: FIXED
+- Evidence: `configUpdates` is now `Record<string, string>` and secret values are hidden in display output. Evidence: `cmd-setup.ts`.
 - Thread id: `PRRT_kwDORQuyQM6A9q1g`
 - Outdated: False
 - Author: copilot-pull-request-reviewer
@@ -687,8 +687,8 @@ Generated from GitHub reviewThreads; only unresolved threads listed.
 
 ### 1320.18 — extensions/memory-hybrid/cli/cmd-providers.ts:24
 
-- [ ] Status: TODO
-- Evidence: _pending_
+- [x] Status: FIXED
+- Evidence: `providers` async action is wrapped with `withExit(...)` for consistent CLI error/teardown handling. Evidence: `cmd-providers.ts`.
 - Thread id: `PRRT_kwDORQuyQM6A9q1p`
 - Outdated: False
 - Author: copilot-pull-request-reviewer
@@ -697,8 +697,8 @@ Generated from GitHub reviewThreads; only unresolved threads listed.
 
 ### 1320.19 — extensions/memory-hybrid/cli/cmd-health.ts:116
 
-- [ ] Status: TODO
-- Evidence: _pending_
+- [x] Status: FIXED
+- Evidence: `health` now computes `factCount` and expensive `vectorDb.getAllIds()` once and reuses those counts for Memory Size and Sync checks. Evidence: `cmd-health.ts`; test verifies one `getAllIds` call.
 - Thread id: `PRRT_kwDORQuyQM6A9q1r`
 - Outdated: False
 - Author: copilot-pull-request-reviewer
@@ -707,8 +707,8 @@ Generated from GitHub reviewThreads; only unresolved threads listed.
 
 ### 1320.20 — extensions/memory-hybrid/cli/cmd-examples.ts:149
 
-- [ ] Status: TODO
-- Evidence: _pending_
+- [x] Status: FIXED
+- Evidence: Examples command now uses `Object.hasOwn(EXAMPLE_CATEGORIES, category)` before indexing. Evidence: `cmd-examples.ts`; test verifies `toString` does not crash.
 - Thread id: `PRRT_kwDORQuyQM6A9q1y`
 - Outdated: False
 - Author: copilot-pull-request-reviewer
@@ -717,8 +717,8 @@ Generated from GitHub reviewThreads; only unresolved threads listed.
 
 ### 1320.21 — extensions/memory-hybrid/cli/cmd-doctor.ts:5
 
-- [ ] Status: TODO
-- Evidence: _pending_
+- [x] Status: FIXED
+- Evidence: Removed unused `statSync` import; doctor now imports `statfsSync` for real disk-space checking. Evidence: `cmd-doctor.ts`.
 - Thread id: `PRRT_kwDORQuyQM6A9q13`
 - Outdated: False
 - Author: copilot-pull-request-reviewer
@@ -727,8 +727,8 @@ Generated from GitHub reviewThreads; only unresolved threads listed.
 
 ### 1320.22 — extensions/memory-hybrid/cli/cmd-doctor.ts:31
 
-- [ ] Status: TODO
-- Evidence: _pending_
+- [x] Status: FIXED
+- Evidence: Removed misleading unsupported `--fix` option from doctor rather than advertising remediation it does not perform. Evidence: `cmd-doctor.ts`.
 - Thread id: `PRRT_kwDORQuyQM6A9q18`
 - Outdated: False
 - Author: copilot-pull-request-reviewer
@@ -737,8 +737,8 @@ Generated from GitHub reviewThreads; only unresolved threads listed.
 
 ### 1320.23 — extensions/memory-hybrid/cli/cmd-doctor.ts:148
 
-- [ ] Status: TODO
-- Evidence: _pending_
+- [x] Status: FIXED
+- Evidence: Doctor no longer uses CommonJS `require` inside ESM; it imports `homedir`/`join` at top level. Evidence: `cmd-doctor.ts`.
 - Thread id: `PRRT_kwDORQuyQM6A9q2A`
 - Outdated: False
 - Author: copilot-pull-request-reviewer
@@ -747,8 +747,8 @@ Generated from GitHub reviewThreads; only unresolved threads listed.
 
 ### 1320.24 — extensions/memory-hybrid/cli/cmd-doctor.ts:161
 
-- [ ] Status: TODO
-- Evidence: _pending_
+- [x] Status: FIXED
+- Evidence: Doctor Disk Space check now uses `statfsSync` to report available MiB and warns below threshold instead of merely checking directory existence. Evidence: `cmd-doctor.ts`.
 - Thread id: `PRRT_kwDORQuyQM6A9q2H`
 - Outdated: False
 - Author: copilot-pull-request-reviewer
@@ -757,8 +757,8 @@ Generated from GitHub reviewThreads; only unresolved threads listed.
 
 ### 1320.25 — extensions/memory-hybrid/cli/cmd-demo.ts:37
 
-- [ ] Status: TODO
-- Evidence: _pending_
+- [x] Status: FIXED
+- Evidence: Demo displays `embeddings.activeProvider ?? embeddings.modelName` instead of a non-existent provider property. Evidence: `cmd-demo.ts`.
 - Thread id: `PRRT_kwDORQuyQM6A9q2M`
 - Outdated: False
 - Author: copilot-pull-request-reviewer

--- a/docs/recovery/unresolved-feedback-2026-05-11.md
+++ b/docs/recovery/unresolved-feedback-2026-05-11.md
@@ -772,8 +772,8 @@ Generated from GitHub reviewThreads; only unresolved threads listed.
 
 ### 1323.1 — extensions/memory-hybrid/services/goal-registry.ts:180
 
-- [ ] Status: TODO
-- Evidence: _pending_
+- [x] Status: FIXED
+- Evidence: Goal registry scans now isolate corrupt goal files: `listGoals()` skips unreadable JSON instead of aborting the whole registry listing. Evidence: `goal-registry.ts`; added registry test for healthy+corrupt coexistence.
 - Thread id: `PRRT_kwDORQuyQM6A-HhK`
 - Outdated: False
 - Author: chatgpt-codex-connector
@@ -782,8 +782,8 @@ Generated from GitHub reviewThreads; only unresolved threads listed.
 
 ### 1323.2 — extensions/memory-hybrid/services/active-task.ts:480
 
-- [ ] Status: TODO
-- Evidence: _pending_
+- [x] Status: FIXED
+- Evidence: `writeActiveTaskFile()` now preserves existing file mode on its atomic tmp-file replacement by copying the current chmod bits to the temp file before rename. Evidence: `active-task.ts`; permission-preservation test added.
 - Thread id: `PRRT_kwDORQuyQM6A-HhN`
 - Outdated: False
 - Author: chatgpt-codex-connector
@@ -792,8 +792,8 @@ Generated from GitHub reviewThreads; only unresolved threads listed.
 
 ### 1323.3 — extensions/memory-hybrid/services/goal-registry.ts:181
 
-- [ ] Status: TODO
-- Evidence: _pending_
+- [x] Status: FIXED
+- Evidence: Duplicate of 1323.1: corrupt individual goal files no longer take down bulk goal enumeration. Evidence: `goal-registry.ts`; `goal-stewardship-registry.test.ts`.
 - Thread id: `PRRT_kwDORQuyQM6A-Hux`
 - Outdated: True
 - Author: copilot-pull-request-reviewer
@@ -802,8 +802,8 @@ Generated from GitHub reviewThreads; only unresolved threads listed.
 
 ### 1323.4 — extensions/memory-hybrid/services/goal-health.ts:249
 
-- [ ] Status: TODO
-- Evidence: _pending_
+- [x] Status: FIXED
+- Evidence: `http_ok` verification blocking now catches IPv4-mapped IPv6 literals (`::ffff:*`) before fetch, preventing loopback/private SSRF bypasses. Evidence: `goal-health.ts`; mapped-IPv6 test passes.
 - Thread id: `PRRT_kwDORQuyQM6A-HvA`
 - Outdated: False
 - Author: copilot-pull-request-reviewer
@@ -812,8 +812,8 @@ Generated from GitHub reviewThreads; only unresolved threads listed.
 
 ### 1323.5 — extensions/memory-hybrid/services/goal-health.ts:240
 
-- [ ] Status: TODO
-- Evidence: _pending_
+- [x] Status: FIXED
+- Evidence: Expanded blocked-host verification helper to resolve local/private literals consistently and exported helper coverage confirms blocking behavior before network fetch. Evidence: `goal-health.ts`; health tests pass.
 - Thread id: `PRRT_kwDORQuyQM6A-HvG`
 - Outdated: False
 - Author: copilot-pull-request-reviewer
@@ -822,8 +822,8 @@ Generated from GitHub reviewThreads; only unresolved threads listed.
 
 ### 1323.6 — extensions/memory-hybrid/services/goal-active-task-mirror.ts:83
 
-- [ ] Status: TODO
-- Evidence: _pending_
+- [x] Status: FIXED
+- Evidence: Goal active-task mirror refresh now writes atomically via temp file + rename and preserves existing file mode, instead of truncating in-place. Evidence: `goal-active-task-mirror.ts`; mirror test verifies no temp files left and mode preserved.
 - Thread id: `PRRT_kwDORQuyQM6A-HvO`
 - Outdated: False
 - Author: copilot-pull-request-reviewer

--- a/docs/tutorials/HYBRID-MEMORY-101.md
+++ b/docs/tutorials/HYBRID-MEMORY-101.md
@@ -324,7 +324,7 @@ const important = await client.getFacts({
 ✅ **Do:**
 - Use natural language queries
 - Filter by category when you know it
-- Set minimum importance for critical decisions
+- Use `search()` with `minImportance` when you need importance filtering
 - Use entity lookup for structured data
 
 ❌ **Don't:**

--- a/extensions/memory-hybrid/api/plugin-system.ts
+++ b/extensions/memory-hybrid/api/plugin-system.ts
@@ -11,111 +11,111 @@ import type { MemoryPluginContext } from "../api/memory-plugin-api.js";
  * Plugin lifecycle events
  */
 export type PluginLifecycleEvent =
-	| "init" // Plugin initialized
-	| "shutdown" // Plugin shutting down
-	| "fact_created" // New fact created
-	| "fact_updated" // Fact updated
-	| "fact_deleted" // Fact deleted
-	| "search_performed" // Search query executed
-	| "maintenance_start" // Maintenance job starting
-	| "maintenance_end"; // Maintenance job completed
+  | "init" // Plugin initialized
+  | "shutdown" // Plugin shutting down
+  | "fact_created" // New fact created
+  | "fact_updated" // Fact updated
+  | "fact_deleted" // Fact deleted
+  | "search_performed" // Search query executed
+  | "maintenance_start" // Maintenance job starting
+  | "maintenance_end"; // Maintenance job completed
 
 /**
  * Plugin hook callback types
  */
 export interface PluginHooks {
-	/** Called before a fact is stored */
-	beforeFactStore?: (fact: unknown) => Promise<unknown>;
-	/** Called after a fact is stored */
-	afterFactStore?: (fact: unknown) => Promise<void>;
-	/** Called before a fact is deleted */
-	beforeFactDelete?: (factId: string) => Promise<boolean>; // Return false to prevent deletion
-	/** Called after a fact is deleted */
-	afterFactDelete?: (factId: string) => Promise<void>;
-	/** Called before a search is performed */
-	beforeSearch?: (query: string) => Promise<string>; // Can modify query
-	/** Called after a search is performed */
-	afterSearch?: (results: unknown[]) => Promise<unknown[]>; // Can modify results
-	/** Called during maintenance cycles */
-	onMaintenance?: () => Promise<void>;
-	/** Called on plugin shutdown */
-	onShutdown?: () => Promise<void>;
+  /** Called before a fact is stored */
+  beforeFactStore?: (fact: unknown) => Promise<unknown>;
+  /** Called after a fact is stored */
+  afterFactStore?: (fact: unknown) => Promise<void>;
+  /** Called before a fact is deleted */
+  beforeFactDelete?: (factId: string) => Promise<boolean>; // Return false to prevent deletion
+  /** Called after a fact is deleted */
+  afterFactDelete?: (factId: string) => Promise<void>;
+  /** Called before a search is performed */
+  beforeSearch?: (query: string) => Promise<string>; // Can modify query
+  /** Called after a search is performed */
+  afterSearch?: (results: unknown[]) => Promise<unknown[]>; // Can modify results
+  /** Called during maintenance cycles */
+  onMaintenance?: () => Promise<void>;
+  /** Called on plugin shutdown */
+  onShutdown?: () => Promise<void>;
 }
 
 /**
  * Plugin capabilities
  */
 export interface PluginCapabilities {
-	/** Can modify facts before storage */
-	canModifyFacts?: boolean;
-	/** Can intercept searches */
-	canInterceptSearch?: boolean;
-	/** Provides custom storage backend */
-	providesStorage?: boolean;
-	/** Provides custom embedding provider */
-	providesEmbedding?: boolean;
-	/** Adds custom API endpoints */
-	providesEndpoints?: boolean;
-	/** Adds custom CLI commands */
-	providesCommands?: boolean;
+  /** Can modify facts before storage */
+  canModifyFacts?: boolean;
+  /** Can intercept searches */
+  canInterceptSearch?: boolean;
+  /** Provides custom storage backend */
+  providesStorage?: boolean;
+  /** Provides custom embedding provider */
+  providesEmbedding?: boolean;
+  /** Adds custom API endpoints */
+  providesEndpoints?: boolean;
+  /** Adds custom CLI commands */
+  providesCommands?: boolean;
 }
 
 /**
  * Plugin metadata
  */
 export interface PluginMetadata {
-	id: string;
-	name: string;
-	version: string;
-	description: string;
-	author: string;
-	license?: string;
-	homepage?: string;
-	repository?: string;
-	keywords?: string[];
-	dependencies?: Record<string, string>;
+  id: string;
+  name: string;
+  version: string;
+  description: string;
+  author: string;
+  license?: string;
+  homepage?: string;
+  repository?: string;
+  keywords?: string[];
+  dependencies?: Record<string, string>;
 }
 
 /**
  * Plugin context provided to extensions
  */
 export interface PluginExtensionContext {
-	/** Access to facts database */
-	factsDb: FactsDB;
-	/** Access to vector database (if enabled) */
-	vectorDb?: VectorDB;
-	/** Plugin configuration */
-	config: MemoryPluginContext["config"];
-	/** Logger instance */
-	logger: {
-		info: (message: string, ...args: unknown[]) => void;
-		warn: (message: string, ...args: unknown[]) => void;
-		error: (message: string, ...args: unknown[]) => void;
-		debug: (message: string, ...args: unknown[]) => void;
-	};
-	/** Emit events to other plugins */
-	emit: (event: PluginLifecycleEvent, data?: unknown) => Promise<void>;
-	/** Register API endpoint */
-	registerEndpoint: (path: string, handler: (req: Request) => Promise<Response>) => void;
-	/** Register CLI command */
-	registerCommand: (name: string, handler: (args: string[]) => Promise<number>) => void;
+  /** Access to facts database */
+  factsDb: FactsDB;
+  /** Access to vector database (if enabled) */
+  vectorDb?: VectorDB;
+  /** Plugin configuration */
+  config: MemoryPluginContext["config"];
+  /** Logger instance */
+  logger: {
+    info: (message: string, ...args: unknown[]) => void;
+    warn: (message: string, ...args: unknown[]) => void;
+    error: (message: string, ...args: unknown[]) => void;
+    debug: (message: string, ...args: unknown[]) => void;
+  };
+  /** Emit events to other plugins */
+  emit: (event: PluginLifecycleEvent, data?: unknown) => Promise<void>;
+  /** Register API endpoint */
+  registerEndpoint: (path: string, handler: (req: Request) => Promise<Response>) => void;
+  /** Register CLI command */
+  registerCommand: (name: string, handler: (args: string[]) => Promise<number>) => void;
 }
 
 /**
  * Plugin interface that all extensions must implement
  */
 export interface MemoryPlugin {
-	/** Plugin metadata */
-	metadata: PluginMetadata;
-	/** Plugin capabilities */
-	capabilities: PluginCapabilities;
-	/** Plugin hooks */
-	hooks?: PluginHooks;
+  /** Plugin metadata */
+  metadata: PluginMetadata;
+  /** Plugin capabilities */
+  capabilities: PluginCapabilities;
+  /** Plugin hooks */
+  hooks?: PluginHooks;
 
-	/** Initialize the plugin */
-	init(context: PluginExtensionContext): Promise<void>;
-	/** Cleanup on shutdown */
-	shutdown?(): Promise<void>;
+  /** Initialize the plugin */
+  init(context: PluginExtensionContext): Promise<void>;
+  /** Cleanup on shutdown */
+  shutdown?(): Promise<void>;
 }
 
 /**
@@ -123,288 +123,284 @@ export interface MemoryPlugin {
  * Manages plugin lifecycle, hooks, and events
  */
 export class PluginManager {
-	private plugins = new Map<string, MemoryPlugin>();
-	private context: PluginExtensionContext;
-	private eventListeners = new Map<PluginLifecycleEvent, Array<(data?: unknown) => Promise<void>>>();
+  private plugins = new Map<string, MemoryPlugin>();
+  private context: PluginExtensionContext;
+  private eventListeners = new Map<PluginLifecycleEvent, Array<(data?: unknown) => Promise<void>>>();
 
-	constructor(
-		factsDb: FactsDB,
-		vectorDb: VectorDB | undefined,
-		pluginContext: MemoryPluginContext,
-	) {
-		this.context = {
-			factsDb,
-			vectorDb,
-			config: pluginContext.config,
-			logger: {
-				info: (msg, ...args) => console.log(`[PluginManager] ${msg}`, ...args),
-				warn: (msg, ...args) => console.warn(`[PluginManager] ${msg}`, ...args),
-				error: (msg, ...args) => console.error(`[PluginManager] ${msg}`, ...args),
-				debug: (msg, ...args) => console.debug(`[PluginManager] ${msg}`, ...args),
-			},
-			emit: async (event, data) => {
-				await this.emit(event, data);
-			},
-			registerEndpoint: (path, _handler) => {
-				// TODO: Implement endpoint registration
-				this.context.logger.debug(`Registered endpoint: ${path}`);
-			},
-			registerCommand: (name, _handler) => {
-				// TODO: Implement command registration
-				this.context.logger.debug(`Registered command: ${name}`);
-			},
-		};
-	}
+  constructor(factsDb: FactsDB, vectorDb: VectorDB | undefined, pluginContext: MemoryPluginContext) {
+    this.context = {
+      factsDb,
+      vectorDb,
+      config: pluginContext.config,
+      logger: {
+        info: (msg, ...args) => console.log(`[PluginManager] ${msg}`, ...args),
+        warn: (msg, ...args) => console.warn(`[PluginManager] ${msg}`, ...args),
+        error: (msg, ...args) => console.error(`[PluginManager] ${msg}`, ...args),
+        debug: (msg, ...args) => console.debug(`[PluginManager] ${msg}`, ...args),
+      },
+      emit: async (event, data) => {
+        await this.emit(event, data);
+      },
+      registerEndpoint: (path, _handler) => {
+        // TODO: Implement endpoint registration
+        this.context.logger.debug(`Registered endpoint: ${path}`);
+      },
+      registerCommand: (name, _handler) => {
+        // TODO: Implement command registration
+        this.context.logger.debug(`Registered command: ${name}`);
+      },
+    };
+  }
 
-	/**
-	 * Load and register a plugin
-	 */
-	async loadPlugin(plugin: MemoryPlugin): Promise<void> {
-		const { id, name, version } = plugin.metadata;
+  /**
+   * Load and register a plugin
+   */
+  async loadPlugin(plugin: MemoryPlugin): Promise<void> {
+    const { id, name, version } = plugin.metadata;
 
-		if (this.plugins.has(id)) {
-			throw new Error(`Plugin already loaded: ${id}`);
-		}
+    if (this.plugins.has(id)) {
+      throw new Error(`Plugin already loaded: ${id}`);
+    }
 
-		this.context.logger.info(`Loading plugin: ${name} v${version}`);
+    this.context.logger.info(`Loading plugin: ${name} v${version}`);
 
-		// Validate plugin
-		this.validatePlugin(plugin);
+    // Validate plugin
+    this.validatePlugin(plugin);
 
-		// Initialize plugin
-		await plugin.init(this.context);
+    // Initialize plugin
+    await plugin.init(this.context);
 
-		// Register event listeners
-		if (plugin.hooks) {
-			this.registerHooks(id, plugin.hooks);
-		}
+    // Register event listeners
+    if (plugin.hooks) {
+      this.registerHooks(id, plugin.hooks);
+    }
 
-		this.plugins.set(id, plugin);
-		this.context.logger.info(`Plugin loaded: ${name} v${version}`);
-	}
+    this.plugins.set(id, plugin);
+    this.context.logger.info(`Plugin loaded: ${name} v${version}`);
+  }
 
-	/**
-	 * Unload a plugin
-	 */
-	async unloadPlugin(pluginId: string): Promise<void> {
-		const plugin = this.plugins.get(pluginId);
-		if (!plugin) {
-			throw new Error(`Plugin not found: ${pluginId}`);
-		}
+  /**
+   * Unload a plugin
+   */
+  async unloadPlugin(pluginId: string): Promise<void> {
+    const plugin = this.plugins.get(pluginId);
+    if (!plugin) {
+      throw new Error(`Plugin not found: ${pluginId}`);
+    }
 
-		this.context.logger.info(`Unloading plugin: ${plugin.metadata.name}`);
+    this.context.logger.info(`Unloading plugin: ${plugin.metadata.name}`);
 
-		// Call shutdown hook
-		if (plugin.shutdown) {
-			await plugin.shutdown();
-		}
+    // Call shutdown hook
+    if (plugin.shutdown) {
+      await plugin.shutdown();
+    }
 
-		// Unregister event listeners
-		this.unregisterHooks(pluginId);
+    // Unregister event listeners
+    this.unregisterHooks(pluginId);
 
-		this.plugins.delete(pluginId);
-		this.context.logger.info(`Plugin unloaded: ${plugin.metadata.name}`);
-	}
+    this.plugins.delete(pluginId);
+    this.context.logger.info(`Plugin unloaded: ${plugin.metadata.name}`);
+  }
 
-	/**
-	 * Get loaded plugin by ID
-	 */
-	getPlugin(pluginId: string): MemoryPlugin | undefined {
-		return this.plugins.get(pluginId);
-	}
+  /**
+   * Get loaded plugin by ID
+   */
+  getPlugin(pluginId: string): MemoryPlugin | undefined {
+    return this.plugins.get(pluginId);
+  }
 
-	/**
-	 * Get all loaded plugins
-	 */
-	getAllPlugins(): MemoryPlugin[] {
-		return Array.from(this.plugins.values());
-	}
+  /**
+   * Get all loaded plugins
+   */
+  getAllPlugins(): MemoryPlugin[] {
+    return Array.from(this.plugins.values());
+  }
 
-	/**
-	 * Emit event to all plugins
-	 */
-	async emit(event: PluginLifecycleEvent, data?: unknown): Promise<void> {
-		const listeners = this.eventListeners.get(event) || [];
-		await Promise.all(listeners.map(listener => listener(data)));
-	}
+  /**
+   * Emit event to all plugins
+   */
+  async emit(event: PluginLifecycleEvent, data?: unknown): Promise<void> {
+    const listeners = this.eventListeners.get(event) || [];
+    await Promise.all(listeners.map((listener) => listener(data)));
+  }
 
-	/**
-	 * Execute beforeFactStore hooks
-	 */
-	async beforeFactStore(fact: unknown): Promise<unknown> {
-		let modifiedFact = fact;
-		for (const plugin of this.plugins.values()) {
-			if (plugin.hooks?.beforeFactStore) {
-				modifiedFact = await plugin.hooks.beforeFactStore(modifiedFact);
-			}
-		}
-		return modifiedFact;
-	}
+  /**
+   * Execute beforeFactStore hooks
+   */
+  async beforeFactStore(fact: unknown): Promise<unknown> {
+    let modifiedFact = fact;
+    for (const plugin of this.plugins.values()) {
+      if (plugin.hooks?.beforeFactStore) {
+        modifiedFact = await plugin.hooks.beforeFactStore(modifiedFact);
+      }
+    }
+    return modifiedFact;
+  }
 
-	/**
-	 * Execute afterFactStore hooks
-	 */
-	async afterFactStore(fact: unknown): Promise<void> {
-		await Promise.all(
-			Array.from(this.plugins.values())
-				.filter(p => p.hooks?.afterFactStore)
-				.map(p => p.hooks?.afterFactStore?.(fact)),
-		);
-	}
+  /**
+   * Execute afterFactStore hooks
+   */
+  async afterFactStore(fact: unknown): Promise<void> {
+    await Promise.all(
+      Array.from(this.plugins.values())
+        .filter((p) => p.hooks?.afterFactStore)
+        .map((p) => p.hooks?.afterFactStore?.(fact)),
+    );
+  }
 
-	/**
-	 * Execute beforeFactDelete hooks
-	 */
-	async beforeFactDelete(factId: string): Promise<boolean> {
-		for (const plugin of this.plugins.values()) {
-			if (plugin.hooks?.beforeFactDelete) {
-				const shouldContinue = await plugin.hooks.beforeFactDelete(factId);
-				if (!shouldContinue) {
-					return false; // Plugin vetoed deletion
-				}
-			}
-		}
-		return true;
-	}
+  /**
+   * Execute beforeFactDelete hooks
+   */
+  async beforeFactDelete(factId: string): Promise<boolean> {
+    for (const plugin of this.plugins.values()) {
+      if (plugin.hooks?.beforeFactDelete) {
+        const shouldContinue = await plugin.hooks.beforeFactDelete(factId);
+        if (!shouldContinue) {
+          return false; // Plugin vetoed deletion
+        }
+      }
+    }
+    return true;
+  }
 
-	/**
-	 * Execute afterFactDelete hooks
-	 */
-	async afterFactDelete(factId: string): Promise<void> {
-		await Promise.all(
-			Array.from(this.plugins.values())
-				.filter(p => p.hooks?.afterFactDelete)
-				.map(p => p.hooks?.afterFactDelete?.(factId)),
-		);
-	}
+  /**
+   * Execute afterFactDelete hooks
+   */
+  async afterFactDelete(factId: string): Promise<void> {
+    await Promise.all(
+      Array.from(this.plugins.values())
+        .filter((p) => p.hooks?.afterFactDelete)
+        .map((p) => p.hooks?.afterFactDelete?.(factId)),
+    );
+  }
 
-	/**
-	 * Execute beforeSearch hooks
-	 */
-	async beforeSearch(query: string): Promise<string> {
-		let modifiedQuery = query;
-		for (const plugin of this.plugins.values()) {
-			if (plugin.hooks?.beforeSearch) {
-				modifiedQuery = await plugin.hooks.beforeSearch(modifiedQuery);
-			}
-		}
-		return modifiedQuery;
-	}
+  /**
+   * Execute beforeSearch hooks
+   */
+  async beforeSearch(query: string): Promise<string> {
+    let modifiedQuery = query;
+    for (const plugin of this.plugins.values()) {
+      if (plugin.hooks?.beforeSearch) {
+        modifiedQuery = await plugin.hooks.beforeSearch(modifiedQuery);
+      }
+    }
+    return modifiedQuery;
+  }
 
-	/**
-	 * Execute afterSearch hooks
-	 */
-	async afterSearch(results: unknown[]): Promise<unknown[]> {
-		let modifiedResults = results;
-		for (const plugin of this.plugins.values()) {
-			if (plugin.hooks?.afterSearch) {
-				modifiedResults = await plugin.hooks.afterSearch(modifiedResults);
-			}
-		}
-		return modifiedResults;
-	}
+  /**
+   * Execute afterSearch hooks
+   */
+  async afterSearch(results: unknown[]): Promise<unknown[]> {
+    let modifiedResults = results;
+    for (const plugin of this.plugins.values()) {
+      if (plugin.hooks?.afterSearch) {
+        modifiedResults = await plugin.hooks.afterSearch(modifiedResults);
+      }
+    }
+    return modifiedResults;
+  }
 
-	/**
-	 * Shutdown all plugins
-	 */
-	async shutdownAll(): Promise<void> {
-		this.context.logger.info("Shutting down all plugins...");
+  /**
+   * Shutdown all plugins
+   */
+  async shutdownAll(): Promise<void> {
+    this.context.logger.info("Shutting down all plugins...");
 
-		const shutdownPromises = Array.from(this.plugins.keys()).map(id =>
-			this.unloadPlugin(id).catch(error => {
-				this.context.logger.error(`Failed to shutdown plugin ${id}:`, error);
-			}),
-		);
+    const shutdownPromises = Array.from(this.plugins.keys()).map((id) =>
+      this.unloadPlugin(id).catch((error) => {
+        this.context.logger.error(`Failed to shutdown plugin ${id}:`, error);
+      }),
+    );
 
-		await Promise.all(shutdownPromises);
-		this.context.logger.info("All plugins shut down");
-	}
+    await Promise.all(shutdownPromises);
+    this.context.logger.info("All plugins shut down");
+  }
 
-	private validatePlugin(plugin: MemoryPlugin): void {
-		if (!plugin.metadata?.id || !plugin.metadata?.name || !plugin.metadata?.version) {
-			throw new Error("Plugin must have metadata with id, name, and version");
-		}
+  private validatePlugin(plugin: MemoryPlugin): void {
+    if (!plugin.metadata?.id || !plugin.metadata?.name || !plugin.metadata?.version) {
+      throw new Error("Plugin must have metadata with id, name, and version");
+    }
 
-		if (!plugin.capabilities) {
-			throw new Error("Plugin must declare capabilities");
-		}
+    if (!plugin.capabilities) {
+      throw new Error("Plugin must declare capabilities");
+    }
 
-		if (typeof plugin.init !== "function") {
-			throw new Error("Plugin must implement init() method");
-		}
-	}
+    if (typeof plugin.init !== "function") {
+      throw new Error("Plugin must implement init() method");
+    }
+  }
 
-	private registerHooks(_pluginId: string, hooks: PluginHooks): void {
-		// Register hooks as event listeners
-		for (const [hookName, hookFn] of Object.entries(hooks)) {
-			if (typeof hookFn === "function") {
-				// Map hook names to events
-				const event = this.hookToEvent(hookName);
-				if (event) {
-					const listeners = this.eventListeners.get(event) || [];
-					listeners.push(hookFn as (data?: unknown) => Promise<void>);
-					this.eventListeners.set(event, listeners);
-				}
-			}
-		}
-	}
+  private registerHooks(_pluginId: string, hooks: PluginHooks): void {
+    // Register hooks as event listeners
+    for (const [hookName, hookFn] of Object.entries(hooks)) {
+      if (typeof hookFn === "function") {
+        // Map hook names to events
+        const event = this.hookToEvent(hookName);
+        if (event) {
+          const listeners = this.eventListeners.get(event) || [];
+          listeners.push(hookFn as (data?: unknown) => Promise<void>);
+          this.eventListeners.set(event, listeners);
+        }
+      }
+    }
+  }
 
-	private unregisterHooks(_pluginId: string): void {
-		// Remove all event listeners for this plugin
-		// Note: This is a simplified implementation
-		// In production, you'd want to track which listeners belong to which plugin
-		for (const [_event, _listeners] of this.eventListeners.entries()) {
-			this.eventListeners.set(_event, []);
-		}
-	}
+  private unregisterHooks(_pluginId: string): void {
+    // Remove all event listeners for this plugin
+    // Note: This is a simplified implementation
+    // In production, you'd want to track which listeners belong to which plugin
+    for (const [_event, _listeners] of this.eventListeners.entries()) {
+      this.eventListeners.set(_event, []);
+    }
+  }
 
-	private hookToEvent(hookName: string): PluginLifecycleEvent | null {
-		const mapping: Record<string, PluginLifecycleEvent> = {
-			afterFactStore: "fact_created",
-			afterFactDelete: "fact_deleted",
-			onMaintenance: "maintenance_start",
-		};
-		return mapping[hookName] || null;
-	}
+  private hookToEvent(hookName: string): PluginLifecycleEvent | null {
+    const mapping: Record<string, PluginLifecycleEvent> = {
+      afterFactStore: "fact_created",
+      afterFactDelete: "fact_deleted",
+      onMaintenance: "maintenance_start",
+    };
+    return mapping[hookName] || null;
+  }
 }
 
 /**
  * Example plugin implementation
  */
 export class SlackNotificationPlugin implements MemoryPlugin {
-	metadata: PluginMetadata = {
-		id: "slack-notifications",
-		name: "Slack Notifications",
-		version: "1.0.0",
-		description: "Send Slack notifications when important facts are stored",
-		author: "OpenClaw Team",
-		license: "MIT",
-	};
+  metadata: PluginMetadata = {
+    id: "slack-notifications",
+    name: "Slack Notifications",
+    version: "1.0.0",
+    description: "Send Slack notifications when important facts are stored",
+    author: "OpenClaw Team",
+    license: "MIT",
+  };
 
-	capabilities: PluginCapabilities = {
-		canModifyFacts: false,
-		canInterceptSearch: false,
-	};
+  capabilities: PluginCapabilities = {
+    canModifyFacts: false,
+    canInterceptSearch: false,
+  };
 
-	hooks: PluginHooks = {
-		afterFactStore: async (fact: { importance?: number; text?: string }) => {
-			if (fact.importance && fact.importance > 0.8) {
-				// Send Slack notification for important facts
-				console.log(`[Slack] Important fact stored: ${fact.text}`);
-				// await this.sendSlackMessage(fact);
-			}
-		},
-	};
+  hooks: PluginHooks = {
+    afterFactStore: async (fact: { importance?: number; text?: string }) => {
+      if (fact.importance && fact.importance > 0.8) {
+        // Send Slack notification for important facts
+        console.log(`[Slack] Important fact stored: ${fact.text}`);
+        // await this.sendSlackMessage(fact);
+      }
+    },
+  };
 
-	private webhookUrl?: string;
+  private webhookUrl?: string;
 
-	async init(context: PluginExtensionContext): Promise<void> {
-		context.logger.info("Slack notifications plugin initialized");
-		// Load webhook URL from config
-		this.webhookUrl = process.env.SLACK_WEBHOOK_URL;
-	}
+  async init(context: PluginExtensionContext): Promise<void> {
+    context.logger.info("Slack notifications plugin initialized");
+    // Load webhook URL from config
+    this.webhookUrl = process.env.SLACK_WEBHOOK_URL;
+  }
 
-	async shutdown(): Promise<void> {
-		console.log("[Slack] Plugin shutting down");
-	}
+  async shutdown(): Promise<void> {
+    console.log("[Slack] Plugin shutting down");
+  }
 }

--- a/extensions/memory-hybrid/api/plugin-system.ts
+++ b/extensions/memory-hybrid/api/plugin-system.ts
@@ -3,7 +3,10 @@
  * Allows third-party extensions to integrate with the memory system
  */
 
-type MemoryPluginContext = Record<string, unknown>;
+interface MemoryPluginContext {
+  config?: unknown;
+  [key: string]: unknown;
+}
 
 import type { FactsDB } from "../backends/facts-db.js";
 import type { VectorDB } from "../backends/vector-db.js";

--- a/extensions/memory-hybrid/api/plugin-system.ts
+++ b/extensions/memory-hybrid/api/plugin-system.ts
@@ -3,9 +3,11 @@
  * Allows third-party extensions to integrate with the memory system
  */
 
-import type { FactsDB } from "../backends/facts-db/facts-db-layer1.js";
+type MemoryPluginContext = Record<string, unknown>;
+
+import type { FactsDB } from "../backends/facts-db.js";
 import type { VectorDB } from "../backends/vector-db.js";
-import type { MemoryPluginContext } from "../api/memory-plugin-api.js";
+import { pluginLogger } from "../utils/logger.js";
 
 /**
  * Plugin lifecycle events
@@ -126,6 +128,10 @@ export class PluginManager {
   private plugins = new Map<string, MemoryPlugin>();
   private context: PluginExtensionContext;
   private eventListeners = new Map<PluginLifecycleEvent, Array<(data?: unknown) => Promise<void>>>();
+  private pluginEventListeners = new Map<
+    string,
+    Array<{ event: PluginLifecycleEvent; listener: (data?: unknown) => Promise<void> }>
+  >();
 
   constructor(factsDb: FactsDB, vectorDb: VectorDB | undefined, pluginContext: MemoryPluginContext) {
     this.context = {
@@ -133,10 +139,14 @@ export class PluginManager {
       vectorDb,
       config: pluginContext.config,
       logger: {
-        info: (msg, ...args) => console.log(`[PluginManager] ${msg}`, ...args),
-        warn: (msg, ...args) => console.warn(`[PluginManager] ${msg}`, ...args),
-        error: (msg, ...args) => console.error(`[PluginManager] ${msg}`, ...args),
-        debug: (msg, ...args) => console.debug(`[PluginManager] ${msg}`, ...args),
+        info: (msg, ...args) =>
+          pluginLogger.info(`[PluginManager] ${msg}${args.length ? ` ${args.map(String).join(" ")}` : ""}`),
+        warn: (msg, ...args) =>
+          pluginLogger.warn(`[PluginManager] ${msg}${args.length ? ` ${args.map(String).join(" ")}` : ""}`),
+        error: (msg, ...args) =>
+          pluginLogger.error(`[PluginManager] ${msg}${args.length ? ` ${args.map(String).join(" ")}` : ""}`),
+        debug: (msg, ...args) =>
+          pluginLogger.debug(`[PluginManager] ${msg}${args.length ? ` ${args.map(String).join(" ")}` : ""}`),
       },
       emit: async (event, data) => {
         await this.emit(event, data);
@@ -330,28 +340,32 @@ export class PluginManager {
     }
   }
 
-  private registerHooks(_pluginId: string, hooks: PluginHooks): void {
-    // Register hooks as event listeners
+  private registerHooks(pluginId: string, hooks: PluginHooks): void {
+    const ownedListeners: Array<{ event: PluginLifecycleEvent; listener: (data?: unknown) => Promise<void> }> = [];
+
     for (const [hookName, hookFn] of Object.entries(hooks)) {
-      if (typeof hookFn === "function") {
-        // Map hook names to events
-        const event = this.hookToEvent(hookName);
-        if (event) {
-          const listeners = this.eventListeners.get(event) || [];
-          listeners.push(hookFn as (data?: unknown) => Promise<void>);
-          this.eventListeners.set(event, listeners);
-        }
-      }
+      if (typeof hookFn !== "function") continue;
+      const event = this.hookToEvent(hookName);
+      if (!event) continue;
+      const listener = hookFn as (data?: unknown) => Promise<void>;
+      const listeners = this.eventListeners.get(event) || [];
+      listeners.push(listener);
+      this.eventListeners.set(event, listeners);
+      ownedListeners.push({ event, listener });
     }
+
+    this.pluginEventListeners.set(pluginId, ownedListeners);
   }
 
-  private unregisterHooks(_pluginId: string): void {
-    // Remove all event listeners for this plugin
-    // Note: This is a simplified implementation
-    // In production, you'd want to track which listeners belong to which plugin
-    for (const [_event, _listeners] of this.eventListeners.entries()) {
-      this.eventListeners.set(_event, []);
+  private unregisterHooks(pluginId: string): void {
+    const ownedListeners = this.pluginEventListeners.get(pluginId) ?? [];
+    for (const { event, listener } of ownedListeners) {
+      const listeners = this.eventListeners.get(event) ?? [];
+      const remaining = listeners.filter((candidate) => candidate !== listener);
+      if (remaining.length > 0) this.eventListeners.set(event, remaining);
+      else this.eventListeners.delete(event);
     }
+    this.pluginEventListeners.delete(pluginId);
   }
 
   private hookToEvent(hookName: string): PluginLifecycleEvent | null {
@@ -383,11 +397,10 @@ export class SlackNotificationPlugin implements MemoryPlugin {
   };
 
   hooks: PluginHooks = {
-    afterFactStore: async (fact: { importance?: number; text?: string }) => {
-      if (fact.importance && fact.importance > 0.8) {
-        // Send Slack notification for important facts
-        console.log(`[Slack] Important fact stored: ${fact.text}`);
-        // await this.sendSlackMessage(fact);
+    afterFactStore: async (fact: unknown) => {
+      const candidate = fact && typeof fact === "object" ? (fact as { importance?: number; text?: string }) : {};
+      if (candidate.importance && candidate.importance > 0.8) {
+        // await this.sendSlackMessage(candidate);
       }
     },
   };
@@ -400,7 +413,5 @@ export class SlackNotificationPlugin implements MemoryPlugin {
     this.webhookUrl = process.env.SLACK_WEBHOOK_URL;
   }
 
-  async shutdown(): Promise<void> {
-    console.log("[Slack] Plugin shutting down");
-  }
+  async shutdown(): Promise<void> {}
 }

--- a/extensions/memory-hybrid/cli/benchmark.ts
+++ b/extensions/memory-hybrid/cli/benchmark.ts
@@ -36,9 +36,9 @@ interface BenchmarkQualityReport {
   generatedAt: string;
   metrics: {
     latency: {
-      p50Ms: number;
-      p95Ms: number;
-      p99Ms: number;
+      p50Ms: number | null;
+      p95Ms: number | null;
+      p99Ms: number | null;
     };
     recallAccuracy: {
       averageScore: number | null;
@@ -138,10 +138,12 @@ export function buildBenchmarkQualityReport(results: BenchmarkResult[]): Benchma
   const successful = results.filter((r) => r.latency.samples > 0 && r.latency.p50 >= 0);
   const failedFeatures = results.length - successful.length;
   const totalFeatures = results.length;
-  const latencySource = successful.length > 0 ? successful : results;
-  const p50Avg = latencySource.reduce((sum, r) => sum + Math.max(0, r.latency.p50), 0) / Math.max(1, latencySource.length);
-  const p95Avg = latencySource.reduce((sum, r) => sum + Math.max(0, r.latency.p95), 0) / Math.max(1, latencySource.length);
-  const p99Avg = latencySource.reduce((sum, r) => sum + Math.max(0, r.latency.p99), 0) / Math.max(1, latencySource.length);
+  const p50Avg =
+    successful.length > 0 ? successful.reduce((sum, r) => sum + r.latency.p50, 0) / successful.length : null;
+  const p95Avg =
+    successful.length > 0 ? successful.reduce((sum, r) => sum + r.latency.p95, 0) / successful.length : null;
+  const p99Avg =
+    successful.length > 0 ? successful.reduce((sum, r) => sum + r.latency.p99, 0) / successful.length : null;
 
   const measuredAccuracy = results.filter((r) => r.accuracy && Number.isFinite(r.accuracy.score));
   const averageAccuracy =
@@ -156,9 +158,9 @@ export function buildBenchmarkQualityReport(results: BenchmarkResult[]): Benchma
     generatedAt: new Date().toISOString(),
     metrics: {
       latency: {
-        p50Ms: toFixedNumber(p50Avg),
-        p95Ms: toFixedNumber(p95Avg),
-        p99Ms: toFixedNumber(p99Avg),
+        p50Ms: p50Avg == null ? null : toFixedNumber(p50Avg),
+        p95Ms: p95Avg == null ? null : toFixedNumber(p95Avg),
+        p99Ms: p99Avg == null ? null : toFixedNumber(p99Avg),
       },
       recallAccuracy: {
         averageScore: averageAccuracy == null ? null : toFixedNumber(averageAccuracy, 4),
@@ -186,7 +188,11 @@ export function formatBenchmarkQualityReportMarkdown(report: BenchmarkQualityRep
   lines.push("");
   lines.push("## Summary metrics");
   lines.push("");
-  lines.push(`- Latency (avg): p50=${report.metrics.latency.p50Ms}ms, p95=${report.metrics.latency.p95Ms}ms, p99=${report.metrics.latency.p99Ms}ms`);
+  const summaryLatency =
+    report.metrics.latency.p50Ms == null
+      ? "n/a (no successful latency samples)"
+      : `p50=${report.metrics.latency.p50Ms}ms, p95=${report.metrics.latency.p95Ms}ms, p99=${report.metrics.latency.p99Ms}ms`;
+  lines.push(`- Latency (avg): ${summaryLatency}`);
   lines.push(
     `- Recall accuracy (avg): ${report.metrics.recallAccuracy.averageScore == null ? "n/a" : `${(report.metrics.recallAccuracy.averageScore * 100).toFixed(1)}%`} across ${report.metrics.recallAccuracy.measuredFeatures} feature(s)`,
   );
@@ -203,7 +209,7 @@ export function formatBenchmarkQualityReportMarkdown(report: BenchmarkQualityRep
   lines.push("|---|---:|---:|---:|---:|---:|---:|");
   for (const result of report.features) {
     lines.push(
-      `| ${result.feature} | ${result.latency.p50.toFixed(2)} | ${result.latency.p95.toFixed(2)} | ${result.latency.p99.toFixed(2)} | ${result.accuracy ? `${(result.accuracy.score * 100).toFixed(0)}%` : "n/a"} | ${(result.tokensTracked ?? 0).toLocaleString()} | ${(result.costTrackedUsd ?? 0).toFixed(6)} |`,
+      `| ${result.feature} | ${result.latency.samples > 0 && result.latency.p50 >= 0 ? result.latency.p50.toFixed(2) : "n/a"} | ${result.latency.samples > 0 && result.latency.p95 >= 0 ? result.latency.p95.toFixed(2) : "n/a"} | ${result.latency.samples > 0 && result.latency.p99 >= 0 ? result.latency.p99.toFixed(2) : "n/a"} | ${result.accuracy ? `${(result.accuracy.score * 100).toFixed(0)}%` : "n/a"} | ${(result.tokensTracked ?? 0).toLocaleString()} | ${(result.costTrackedUsd ?? 0).toFixed(6)} |`,
     );
   }
   lines.push("");
@@ -267,7 +273,8 @@ export function registerBenchmarkCommands(mem: Chainable, _ctx: HybridMemCliCont
         },
       );
       const report = buildBenchmarkQualityReport(results);
-      const rendered = format === "json" ? JSON.stringify(report, null, 2) : formatBenchmarkQualityReportMarkdown(report);
+      const rendered =
+        format === "json" ? JSON.stringify(report, null, 2) : formatBenchmarkQualityReportMarkdown(report);
       const outPath = typeof opts.out === "string" && opts.out.trim().length > 0 ? opts.out.trim() : "";
       if (outPath) {
         mkdirSync(dirname(outPath), { recursive: true });

--- a/extensions/memory-hybrid/cli/cmd-demo.ts
+++ b/extensions/memory-hybrid/cli/cmd-demo.ts
@@ -2,14 +2,14 @@
  * CLI command for interactive demo and onboarding
  */
 
-import type { Command } from "commander";
+import type { Chainable } from "./shared.js";
 import type { FactsDB } from "../backends/facts-db.js";
 import type { VectorDB } from "../backends/vector-db.js";
 import type { EmbeddingProvider } from "../services/embeddings.js";
 import { statusMessage } from "../utils/progress-indicators.js";
 
 export function registerDemoCommand(
-  program: Command,
+  program: Chainable,
   factsDb: FactsDB,
   vectorDb: VectorDB,
   embeddings: EmbeddingProvider,
@@ -30,7 +30,7 @@ export function registerDemoCommand(
 
         console.log(`  • Facts in SQLite: ${factCount}`);
         console.log(`  • Vectors in LanceDB: ${vectorCount}`);
-        console.log(`  • Embedding provider: ${embeddings.modelName || "configured"}\n`);
+        console.log(`  • Embedding provider: ${embeddings.activeProvider ?? embeddings.modelName ?? "configured"}\n`);
       } catch (_error) {
         console.log("  ⚠️  Could not retrieve stats\n");
       }

--- a/extensions/memory-hybrid/cli/cmd-demo.ts
+++ b/extensions/memory-hybrid/cli/cmd-demo.ts
@@ -9,76 +9,72 @@ import type { EmbeddingProvider } from "../services/embeddings.js";
 import { statusMessage } from "../utils/progress-indicators.js";
 
 export function registerDemoCommand(
-	program: Command,
-	factsDb: FactsDB,
-	vectorDb: VectorDB,
-	embeddings: EmbeddingProvider,
+  program: Command,
+  factsDb: FactsDB,
+  vectorDb: VectorDB,
+  embeddings: EmbeddingProvider,
 ): void {
-	program
-		.command("demo")
-		.description(
-			"Interactive demo showing memory capabilities (read-only overview)",
-		)
-		.action(async () => {
-			console.log("\n🎯 OpenClaw Hybrid Memory Demo\n");
-			console.log(
-				"This demo explains how the hybrid memory system works.\n",
-			);
+  program
+    .command("demo")
+    .description("Interactive demo showing memory capabilities (read-only overview)")
+    .action(async () => {
+      console.log("\n🎯 OpenClaw Hybrid Memory Demo\n");
+      console.log("This demo explains how the hybrid memory system works.\n");
 
-			// Show current stats
-			console.log("📊 Current Memory Status:\n");
-			try {
-				const factCount = factsDb.countFacts();
-				const vectorIds = await vectorDb.getAllIds();
-				const vectorCount = vectorIds.length;
+      // Show current stats
+      console.log("📊 Current Memory Status:\n");
+      try {
+        const factCount = factsDb.getCount();
+        const vectorIds = await vectorDb.getAllIds();
+        const vectorCount = vectorIds.length;
 
-				console.log(`  • Facts in SQLite: ${factCount}`);
-				console.log(`  • Vectors in LanceDB: ${vectorCount}`);
-				console.log(`  • Embedding provider: ${embeddings.provider || "configured"}\n`);
-			} catch (error) {
-				console.log("  ⚠️  Could not retrieve stats\n");
-			}
+        console.log(`  • Facts in SQLite: ${factCount}`);
+        console.log(`  • Vectors in LanceDB: ${vectorCount}`);
+        console.log(`  • Embedding provider: ${embeddings.modelName || "configured"}\n`);
+      } catch (_error) {
+        console.log("  ⚠️  Could not retrieve stats\n");
+      }
 
-			// Explain the system
-			console.log("🔍 How Hybrid Memory Works:\n");
-			console.log("1. Two-Tier Storage:");
-			console.log("   • SQLite + FTS5: Fast exact keyword search, zero API cost");
-			console.log("   • LanceDB: Semantic search that understands meaning\n");
+      // Explain the system
+      console.log("🔍 How Hybrid Memory Works:\n");
+      console.log("1. Two-Tier Storage:");
+      console.log("   • SQLite + FTS5: Fast exact keyword search, zero API cost");
+      console.log("   • LanceDB: Semantic search that understands meaning\n");
 
-			console.log("2. When You Store a Fact:");
-			console.log("   • Text is saved in SQLite for fast retrieval");
-			console.log("   • An embedding vector is generated and stored in LanceDB");
-			console.log("   • Both can be searched independently or together\n");
+      console.log("2. When You Store a Fact:");
+      console.log("   • Text is saved in SQLite for fast retrieval");
+      console.log("   • An embedding vector is generated and stored in LanceDB");
+      console.log("   • Both can be searched independently or together\n");
 
-			console.log("3. Search Modes:");
-			console.log("   • Full-text search: Finds exact keyword matches");
-			console.log("   • Semantic search: Finds conceptually similar content");
-			console.log("   • Hybrid: Combines both and deduplicates results\n");
+      console.log("3. Search Modes:");
+      console.log("   • Full-text search: Finds exact keyword matches");
+      console.log("   • Semantic search: Finds conceptually similar content");
+      console.log("   • Hybrid: Combines both and deduplicates results\n");
 
-			console.log("📚 Example Use Cases:\n");
-			console.log("✓ Store your preferences: 'I prefer TypeScript for large projects'");
-			console.log("✓ Save code snippets: 'To format dates, use Intl.DateTimeFormat'");
-			console.log("✓ Remember APIs: 'GitHub API rate limit is 5000 req/hour'");
-			console.log("✓ Track learnings: 'React hooks can't be called conditionally'\n");
+      console.log("📚 Example Use Cases:\n");
+      console.log("✓ Store your preferences: 'I prefer TypeScript for large projects'");
+      console.log("✓ Save code snippets: 'To format dates, use Intl.DateTimeFormat'");
+      console.log("✓ Remember APIs: 'GitHub API rate limit is 5000 req/hour'");
+      console.log("✓ Track learnings: 'React hooks can't be called conditionally'\n");
 
-			console.log("🚀 Try It Yourself:\n");
-			console.log("# Store your first memory");
-			console.log("$ openclaw hybrid-mem store 'Python is great for data science'\n");
+      console.log("🚀 Try It Yourself:\n");
+      console.log("# Store your first memory");
+      console.log("$ openclaw hybrid-mem store 'Python is great for data science'\n");
 
-			console.log("# Search semantically");
-			console.log("$ openclaw hybrid-mem search 'machine learning tools'\n");
+      console.log("# Search semantically");
+      console.log("$ openclaw hybrid-mem search 'machine learning tools'\n");
 
-			console.log("# List recent memories");
-			console.log("$ openclaw hybrid-mem list --limit 10\n");
+      console.log("# List recent memories");
+      console.log("$ openclaw hybrid-mem list --limit 10\n");
 
-			console.log("# View all stats");
-			console.log("$ openclaw hybrid-mem stats\n");
+      console.log("# View all stats");
+      console.log("$ openclaw hybrid-mem stats\n");
 
-			console.log("💡 Next Steps:");
-			console.log("• Learn more: openclaw hybrid-mem examples basics");
-			console.log("• Quick setup: openclaw hybrid-mem setup --interactive");
-			console.log("• Health check: openclaw hybrid-mem health\n");
+      console.log("💡 Next Steps:");
+      console.log("• Learn more: openclaw hybrid-mem examples basics");
+      console.log("• Quick setup: openclaw hybrid-mem setup --interactive");
+      console.log("• Health check: openclaw hybrid-mem health\n");
 
-			statusMessage("success", "Demo complete! Ready to start using hybrid memory.");
-		});
+      statusMessage("success", "Demo complete! Ready to start using hybrid memory.");
+    });
 }

--- a/extensions/memory-hybrid/cli/cmd-doctor.ts
+++ b/extensions/memory-hybrid/cli/cmd-doctor.ts
@@ -2,10 +2,10 @@
  * CLI command for health diagnostics and issue detection
  */
 
-import { existsSync } from "node:fs";
-import { join } from "node:path";
+import { existsSync, statfsSync } from "node:fs";
 import { homedir } from "node:os";
-import type { Command } from "commander";
+import { join } from "node:path";
+import type { Chainable } from "./shared.js";
 import type { FactsDB } from "../backends/facts-db.js";
 import type { VectorDB } from "../backends/vector-db.js";
 import type { HybridMemoryConfig } from "../config.js";
@@ -19,7 +19,7 @@ interface DiagnosticCheck {
 }
 
 export function registerDoctorCommand(
-  program: Command,
+  program: Chainable,
   cfg: HybridMemoryConfig,
   factsDb: FactsDB,
   vectorDb: VectorDB,
@@ -27,8 +27,7 @@ export function registerDoctorCommand(
   program
     .command("doctor")
     .description("Run health diagnostics and detect common issues (🟢 pass, 🟡 warn, 🔴 fail)")
-    .option("--fix", "Automatically fix issues where possible")
-    .action(async (_opts: { fix?: boolean }) => {
+    .action(async () => {
       console.log("\n🏥 Running Hybrid Memory Diagnostics...\n");
 
       const checks: DiagnosticCheck[] = [];
@@ -135,21 +134,26 @@ export function registerDoctorCommand(
         });
       }
 
-      // Check 6: Disk space (simple check for memory directory)
+      // Check 6: Disk space for the memory directory/filesystem
       try {
         const memoryDir = join(homedir(), ".openclaw/plugins/memory-hybrid");
-        if (existsSync(memoryDir)) {
-          checks.push({
-            name: "Disk Space",
-            status: "pass",
-            message: `Memory directory accessible: ${memoryDir}`,
-          });
-        } else {
+        if (!existsSync(memoryDir)) {
           checks.push({
             name: "Disk Space",
             status: "warn",
             message: `Memory directory not found: ${memoryDir}`,
             fix: "Run: openclaw hybrid-mem install",
+          });
+        } else {
+          const stats = statfsSync(memoryDir);
+          const freeBytes = Number(stats.bavail) * Number(stats.bsize);
+          const freeMiB = Math.floor(freeBytes / 1024 / 1024);
+          checks.push({
+            name: "Disk Space",
+            status: freeBytes < 100 * 1024 * 1024 ? "warn" : "pass",
+            message: `${freeMiB} MiB available at ${memoryDir}`,
+            fix:
+              freeBytes < 100 * 1024 * 1024 ? "Free disk space before running large imports/reindex jobs" : undefined,
           });
         }
       } catch (_error) {

--- a/extensions/memory-hybrid/cli/cmd-doctor.ts
+++ b/extensions/memory-hybrid/cli/cmd-doctor.ts
@@ -69,7 +69,7 @@ export function registerDoctorCommand(
       }
 
       // Check 3: Embedding provider
-      const providers = await detectAvailableProviders(cfg.embedding?.apiKey);
+      const providers = await detectAvailableProviders(cfg.embedding?.apiKey, cfg.embedding?.googleApiKey);
       const currentProvider = cfg.embedding?.provider;
       const providerStatus = providers.find((p) => p.provider === currentProvider);
 

--- a/extensions/memory-hybrid/cli/cmd-doctor.ts
+++ b/extensions/memory-hybrid/cli/cmd-doctor.ts
@@ -136,7 +136,7 @@ export function registerDoctorCommand(
 
       // Check 6: Disk space for the memory directory/filesystem
       try {
-        const memoryDir = cfg.paths?.memory || join(homedir(), ".openclaw/plugins/memory-hybrid");
+        const memoryDir = join(homedir(), ".openclaw/plugins/memory-hybrid");
         if (!existsSync(memoryDir)) {
           checks.push({
             name: "Disk Space",

--- a/extensions/memory-hybrid/cli/cmd-doctor.ts
+++ b/extensions/memory-hybrid/cli/cmd-doctor.ts
@@ -10,198 +10,180 @@ import type { HybridMemoryConfig } from "../config.js";
 import { detectAvailableProviders } from "../utils/provider-detection.js";
 
 interface DiagnosticCheck {
-	name: string;
-	status: "pass" | "warn" | "fail";
-	message: string;
-	fix?: string;
+  name: string;
+  status: "pass" | "warn" | "fail";
+  message: string;
+  fix?: string;
 }
 
 export function registerDoctorCommand(
-	program: Command,
-	cfg: HybridMemoryConfig,
-	factsDb: FactsDB,
-	vectorDb: VectorDB,
+  program: Command,
+  cfg: HybridMemoryConfig,
+  factsDb: FactsDB,
+  vectorDb: VectorDB,
 ): void {
-	program
-		.command("doctor")
-		.description(
-			"Run health diagnostics and detect common issues (🟢 pass, 🟡 warn, 🔴 fail)",
-		)
-		.option("--fix", "Automatically fix issues where possible")
-		.action(async (opts: { fix?: boolean }) => {
-			console.log("\n🏥 Running Hybrid Memory Diagnostics...\n");
+  program
+    .command("doctor")
+    .description("Run health diagnostics and detect common issues (🟢 pass, 🟡 warn, 🔴 fail)")
+    .option("--fix", "Automatically fix issues where possible")
+    .action(async (_opts: { fix?: boolean }) => {
+      console.log("\n🏥 Running Hybrid Memory Diagnostics...\n");
 
-			const checks: DiagnosticCheck[] = [];
-			const startTime = Date.now();
+      const checks: DiagnosticCheck[] = [];
+      const startTime = Date.now();
 
-			// Check 1: Database connectivity
-			try {
-				const factCount = factsDb.countFacts();
-				checks.push({
-					name: "SQLite Database",
-					status: "pass",
-					message: `Connected successfully (${factCount} facts)`,
-				});
-			} catch (error) {
-				checks.push({
-					name: "SQLite Database",
-					status: "fail",
-					message: `Connection failed: ${error}`,
-					fix: "Run: openclaw hybrid-mem verify --fix",
-				});
-			}
+      // Check 1: Database connectivity
+      try {
+        const factCount = factsDb.getCount();
+        checks.push({
+          name: "SQLite Database",
+          status: "pass",
+          message: `Connected successfully (${factCount} facts)`,
+        });
+      } catch (error) {
+        checks.push({
+          name: "SQLite Database",
+          status: "fail",
+          message: `Connection failed: ${error}`,
+          fix: "Run: openclaw hybrid-mem verify --fix",
+        });
+      }
 
-			// Check 2: Vector database
-			try {
-				const vectorIds = await vectorDb.getAllIds();
-				const vectorCount = vectorIds.length;
-				checks.push({
-					name: "Vector Database (LanceDB)",
-					status: "pass",
-					message: `Connected successfully (${vectorCount} vectors)`,
-				});
-			} catch (error) {
-				checks.push({
-					name: "Vector Database (LanceDB)",
-					status: "fail",
-					message: `Connection failed: ${error}`,
-					fix: "Run: openclaw hybrid-mem re-index",
-				});
-			}
+      // Check 2: Vector database
+      try {
+        const vectorIds = await vectorDb.getAllIds();
+        const vectorCount = vectorIds.length;
+        checks.push({
+          name: "Vector Database (LanceDB)",
+          status: "pass",
+          message: `Connected successfully (${vectorCount} vectors)`,
+        });
+      } catch (error) {
+        checks.push({
+          name: "Vector Database (LanceDB)",
+          status: "fail",
+          message: `Connection failed: ${error}`,
+          fix: "Run: openclaw hybrid-mem re-index",
+        });
+      }
 
-			// Check 3: Embedding provider
-			const providers = await detectAvailableProviders(cfg.embedding?.apiKey);
-			const currentProvider = cfg.embedding?.provider;
-			const providerStatus = providers.find(
-				(p) => p.provider === currentProvider,
-			);
+      // Check 3: Embedding provider
+      const providers = await detectAvailableProviders(cfg.embedding?.apiKey);
+      const currentProvider = cfg.embedding?.provider;
+      const providerStatus = providers.find((p) => p.provider === currentProvider);
 
-			if (providerStatus?.available) {
-				checks.push({
-					name: "Embedding Provider",
-					status: "pass",
-					message: `${currentProvider?.toUpperCase()} is available`,
-				});
-			} else {
-				checks.push({
-					name: "Embedding Provider",
-					status: "fail",
-					message: providerStatus?.reason || "Provider not configured",
-					fix: "Run: openclaw hybrid-mem providers",
-				});
-			}
+      if (providerStatus?.available) {
+        checks.push({
+          name: "Embedding Provider",
+          status: "pass",
+          message: `${currentProvider?.toUpperCase()} is available`,
+        });
+      } else {
+        checks.push({
+          name: "Embedding Provider",
+          status: "fail",
+          message: providerStatus?.reason || "Provider not configured",
+          fix: "Run: openclaw hybrid-mem providers",
+        });
+      }
 
-			// Check 4: Configuration validity
-			if (cfg.embedding?.provider) {
-				checks.push({
-					name: "Configuration",
-					status: "pass",
-					message: "Configuration is valid",
-				});
-			} else {
-				checks.push({
-					name: "Configuration",
-					status: "warn",
-					message: "No embedding provider configured",
-					fix: "Run: openclaw hybrid-mem setup --interactive",
-				});
-			}
+      // Check 4: Configuration validity
+      if (cfg.embedding?.provider) {
+        checks.push({
+          name: "Configuration",
+          status: "pass",
+          message: "Configuration is valid",
+        });
+      } else {
+        checks.push({
+          name: "Configuration",
+          status: "warn",
+          message: "No embedding provider configured",
+          fix: "Run: openclaw hybrid-mem setup --interactive",
+        });
+      }
 
-			// Check 5: Database synchronization
-			try {
-				const sqliteCount = factsDb.countFacts();
-				const vectorIds = await vectorDb.getAllIds();
-				const vectorCount = vectorIds.length;
-				const diff = Math.abs(sqliteCount - vectorCount);
-				const percentDiff = (diff / Math.max(sqliteCount, 1)) * 100;
+      // Check 5: Database synchronization
+      try {
+        const sqliteCount = factsDb.getCount();
+        const vectorIds = await vectorDb.getAllIds();
+        const vectorCount = vectorIds.length;
+        const diff = Math.abs(sqliteCount - vectorCount);
+        const percentDiff = (diff / Math.max(sqliteCount, 1)) * 100;
 
-				if (percentDiff < 5) {
-					checks.push({
-						name: "Database Sync",
-						status: "pass",
-						message: `SQLite and LanceDB are synchronized (±${diff} items)`,
-					});
-				} else {
-					checks.push({
-						name: "Database Sync",
-						status: "warn",
-						message: `Databases out of sync: SQLite ${sqliteCount}, LanceDB ${vectorCount}`,
-						fix: "Run: openclaw hybrid-mem verify --reconcile --fix",
-					});
-				}
-			} catch (error) {
-				checks.push({
-					name: "Database Sync",
-					status: "warn",
-					message: "Could not check synchronization",
-				});
-			}
+        if (percentDiff < 5) {
+          checks.push({
+            name: "Database Sync",
+            status: "pass",
+            message: `SQLite and LanceDB are synchronized (±${diff} items)`,
+          });
+        } else {
+          checks.push({
+            name: "Database Sync",
+            status: "warn",
+            message: `Databases out of sync: SQLite ${sqliteCount}, LanceDB ${vectorCount}`,
+            fix: "Run: openclaw hybrid-mem verify --reconcile --fix",
+          });
+        }
+      } catch (_error) {
+        checks.push({
+          name: "Database Sync",
+          status: "warn",
+          message: "Could not check synchronization",
+        });
+      }
 
-			// Check 6: Disk space (simple check for memory directory)
-			try {
-				const memoryDir =
-					cfg.paths?.memory ||
-					require("node:path").join(
-						require("node:os").homedir(),
-						".openclaw/plugins/memory-hybrid",
-					);
-				if (existsSync(memoryDir)) {
-					checks.push({
-						name: "Disk Space",
-						status: "pass",
-						message: `Memory directory accessible: ${memoryDir}`,
-					});
-				} else {
-					checks.push({
-						name: "Disk Space",
-						status: "warn",
-						message: `Memory directory not found: ${memoryDir}`,
-						fix: "Run: openclaw hybrid-mem install",
-					});
-				}
-			} catch (error) {
-				checks.push({
-					name: "Disk Space",
-					status: "warn",
-					message: "Could not check disk space",
-				});
-			}
+      // Check 6: Disk space (simple check for memory directory)
+      try {
+        const memoryDir = require("node:path").join(require("node:os").homedir(), ".openclaw/plugins/memory-hybrid");
+        if (existsSync(memoryDir)) {
+          checks.push({
+            name: "Disk Space",
+            status: "pass",
+            message: `Memory directory accessible: ${memoryDir}`,
+          });
+        } else {
+          checks.push({
+            name: "Disk Space",
+            status: "warn",
+            message: `Memory directory not found: ${memoryDir}`,
+            fix: "Run: openclaw hybrid-mem install",
+          });
+        }
+      } catch (_error) {
+        checks.push({
+          name: "Disk Space",
+          status: "warn",
+          message: "Could not check disk space",
+        });
+      }
 
-			// Display results
-			for (const check of checks) {
-				const icon =
-					check.status === "pass"
-						? "🟢"
-						: check.status === "warn"
-							? "🟡"
-							: "🔴";
-				console.log(`${icon} ${check.name}: ${check.message}`);
-				if (check.fix && check.status !== "pass") {
-					console.log(`   💡 Fix: ${check.fix}`);
-				}
-			}
+      // Display results
+      for (const check of checks) {
+        const icon = check.status === "pass" ? "🟢" : check.status === "warn" ? "🟡" : "🔴";
+        console.log(`${icon} ${check.name}: ${check.message}`);
+        if (check.fix && check.status !== "pass") {
+          console.log(`   💡 Fix: ${check.fix}`);
+        }
+      }
 
-			const duration = Date.now() - startTime;
-			console.log(`\n✓ Diagnostics completed in ${duration}ms\n`);
+      const duration = Date.now() - startTime;
+      console.log(`\n✓ Diagnostics completed in ${duration}ms\n`);
 
-			// Summary
-			const passed = checks.filter((c) => c.status === "pass").length;
-			const warnings = checks.filter((c) => c.status === "warn").length;
-			const failed = checks.filter((c) => c.status === "fail").length;
+      // Summary
+      const passed = checks.filter((c) => c.status === "pass").length;
+      const warnings = checks.filter((c) => c.status === "warn").length;
+      const failed = checks.filter((c) => c.status === "fail").length;
 
-			console.log(`Summary: ${passed} passed, ${warnings} warnings, ${failed} failed\n`);
+      console.log(`Summary: ${passed} passed, ${warnings} warnings, ${failed} failed\n`);
 
-			if (failed > 0) {
-				console.log(
-					"❌ Critical issues detected. Please address the failed checks.\n",
-				);
-				process.exit(1);
-			} else if (warnings > 0) {
-				console.log(
-					"⚠️  Some issues detected. Consider addressing the warnings.\n",
-				);
-			} else {
-				console.log("✅ All checks passed! Your memory system is healthy.\n");
-			}
-		});
+      if (failed > 0) {
+        console.log("❌ Critical issues detected. Please address the failed checks.\n");
+        process.exit(1);
+      } else if (warnings > 0) {
+        console.log("⚠️  Some issues detected. Consider addressing the warnings.\n");
+      } else {
+        console.log("✅ All checks passed! Your memory system is healthy.\n");
+      }
+    });
 }

--- a/extensions/memory-hybrid/cli/cmd-doctor.ts
+++ b/extensions/memory-hybrid/cli/cmd-doctor.ts
@@ -2,7 +2,9 @@
  * CLI command for health diagnostics and issue detection
  */
 
-import { existsSync, statSync } from "node:fs";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
 import type { Command } from "commander";
 import type { FactsDB } from "../backends/facts-db.js";
 import type { VectorDB } from "../backends/vector-db.js";
@@ -135,7 +137,7 @@ export function registerDoctorCommand(
 
       // Check 6: Disk space (simple check for memory directory)
       try {
-        const memoryDir = require("node:path").join(require("node:os").homedir(), ".openclaw/plugins/memory-hybrid");
+        const memoryDir = join(homedir(), ".openclaw/plugins/memory-hybrid");
         if (existsSync(memoryDir)) {
           checks.push({
             name: "Disk Space",

--- a/extensions/memory-hybrid/cli/cmd-doctor.ts
+++ b/extensions/memory-hybrid/cli/cmd-doctor.ts
@@ -136,7 +136,7 @@ export function registerDoctorCommand(
 
       // Check 6: Disk space for the memory directory/filesystem
       try {
-        const memoryDir = join(homedir(), ".openclaw/plugins/memory-hybrid");
+        const memoryDir = cfg.paths?.memory || join(homedir(), ".openclaw/plugins/memory-hybrid");
         if (!existsSync(memoryDir)) {
           checks.push({
             name: "Disk Space",

--- a/extensions/memory-hybrid/cli/cmd-examples.ts
+++ b/extensions/memory-hybrid/cli/cmd-examples.ts
@@ -2,7 +2,7 @@
  * CLI command showing common task examples
  */
 
-import type { Command } from "commander";
+import type { Chainable } from "./shared.js";
 
 const EXAMPLE_CATEGORIES = {
   basics: {
@@ -132,12 +132,12 @@ const EXAMPLE_CATEGORIES = {
   },
 };
 
-export function registerExamplesCommand(program: Command): void {
+export function registerExamplesCommand(program: Chainable): void {
   program
     .command("examples [category]")
     .description("Show common command examples (categories: basics, setup, maintenance, advanced, troubleshooting)")
     .action((category?: string) => {
-      if (category && category in EXAMPLE_CATEGORIES) {
+      if (category && Object.hasOwn(EXAMPLE_CATEGORIES, category)) {
         // Show specific category
         const cat = EXAMPLE_CATEGORIES[category as keyof typeof EXAMPLE_CATEGORIES];
         console.log(`\n📚 ${cat.title}\n`);

--- a/extensions/memory-hybrid/cli/cmd-examples.ts
+++ b/extensions/memory-hybrid/cli/cmd-examples.ts
@@ -5,166 +5,158 @@
 import type { Command } from "commander";
 
 const EXAMPLE_CATEGORIES = {
-	basics: {
-		title: "Basic Operations",
-		examples: [
-			{
-				name: "Store a fact",
-				command: "openclaw hybrid-mem store 'Python is my favorite language'",
-				description: "Add a new fact to memory",
-			},
-			{
-				name: "Search memory",
-				command: "openclaw hybrid-mem search 'programming languages'",
-				description: "Find relevant facts using semantic search",
-			},
-			{
-				name: "List recent facts",
-				command: "openclaw hybrid-mem list --limit 10",
-				description: "Show the 10 most recent facts",
-			},
-			{
-				name: "View memory stats",
-				command: "openclaw hybrid-mem stats",
-				description: "See memory usage and statistics",
-			},
-		],
-	},
-	setup: {
-		title: "Setup & Configuration",
-		examples: [
-			{
-				name: "Initial setup",
-				command: "openclaw hybrid-mem setup --interactive",
-				description: "Guided setup wizard for first-time configuration",
-			},
-			{
-				name: "Check provider status",
-				command: "openclaw hybrid-mem providers",
-				description: "See which embedding providers are available",
-			},
-			{
-				name: "Switch to Ollama",
-				command: "openclaw hybrid-mem config-set embedding.provider ollama",
-				description: "Use local Ollama for embeddings",
-			},
-			{
-				name: "Verify installation",
-				command: "openclaw hybrid-mem verify --fix",
-				description: "Check system health and fix common issues",
-			},
-		],
-	},
-	maintenance: {
-		title: "Maintenance Tasks",
-		examples: [
-			{
-				name: "Run all maintenance",
-				command: "openclaw hybrid-mem run-all",
-				description: "Execute all maintenance tasks in optimal order",
-			},
-			{
-				name: "Backup memory",
-				command: "openclaw hybrid-mem backup",
-				description: "Create a backup of your memory databases",
-			},
-			{
-				name: "Optimize database",
-				command: "openclaw hybrid-mem vectordb-optimize",
-				description: "Compact LanceDB and reclaim disk space",
-			},
-			{
-				name: "Health check",
-				command: "openclaw hybrid-mem doctor",
-				description: "Run diagnostics to detect issues",
-			},
-		],
-	},
-	advanced: {
-		title: "Advanced Operations",
-		examples: [
-			{
-				name: "Extract from sessions",
-				command:
-					"openclaw hybrid-mem distill --days 7 --model sonnet --dry-run",
-				description: "Preview fact extraction from last 7 days",
-			},
-			{
-				name: "Find duplicates",
-				command: "openclaw hybrid-mem find-duplicates --threshold 0.85",
-				description: "Detect near-duplicate facts",
-			},
-			{
-				name: "Re-index vectors",
-				command: "openclaw hybrid-mem re-index",
-				description: "Rebuild vector database (after model change)",
-			},
-			{
-				name: "Export memory",
-				command: "openclaw hybrid-mem export --output ./memory-backup",
-				description: "Export facts to Markdown files",
-			},
-		],
-	},
-	troubleshooting: {
-		title: "Troubleshooting",
-		examples: [
-			{
-				name: "Run diagnostics",
-				command: "openclaw hybrid-mem doctor",
-				description: "Check for common issues",
-			},
-			{
-				name: "Check sync status",
-				command: "openclaw hybrid-mem verify --reconcile",
-				description: "Verify SQLite and LanceDB are synchronized",
-			},
-			{
-				name: "View configuration",
-				command: "openclaw hybrid-mem config",
-				description: "Show current configuration settings",
-			},
-			{
-				name: "Test memory system",
-				command: "openclaw hybrid-mem test",
-				description: "Run memory diagnostics and tests",
-			},
-		],
-	},
+  basics: {
+    title: "Basic Operations",
+    examples: [
+      {
+        name: "Store a fact",
+        command: "openclaw hybrid-mem store 'Python is my favorite language'",
+        description: "Add a new fact to memory",
+      },
+      {
+        name: "Search memory",
+        command: "openclaw hybrid-mem search 'programming languages'",
+        description: "Find relevant facts using semantic search",
+      },
+      {
+        name: "List recent facts",
+        command: "openclaw hybrid-mem list --limit 10",
+        description: "Show the 10 most recent facts",
+      },
+      {
+        name: "View memory stats",
+        command: "openclaw hybrid-mem stats",
+        description: "See memory usage and statistics",
+      },
+    ],
+  },
+  setup: {
+    title: "Setup & Configuration",
+    examples: [
+      {
+        name: "Initial setup",
+        command: "openclaw hybrid-mem setup --interactive",
+        description: "Guided setup wizard for first-time configuration",
+      },
+      {
+        name: "Check provider status",
+        command: "openclaw hybrid-mem providers",
+        description: "See which embedding providers are available",
+      },
+      {
+        name: "Switch to Ollama",
+        command: "openclaw hybrid-mem config-set embedding.provider ollama",
+        description: "Use local Ollama for embeddings",
+      },
+      {
+        name: "Verify installation",
+        command: "openclaw hybrid-mem verify --fix",
+        description: "Check system health and fix common issues",
+      },
+    ],
+  },
+  maintenance: {
+    title: "Maintenance Tasks",
+    examples: [
+      {
+        name: "Run all maintenance",
+        command: "openclaw hybrid-mem run-all",
+        description: "Execute all maintenance tasks in optimal order",
+      },
+      {
+        name: "Backup memory",
+        command: "openclaw hybrid-mem backup",
+        description: "Create a backup of your memory databases",
+      },
+      {
+        name: "Optimize database",
+        command: "openclaw hybrid-mem vectordb-optimize",
+        description: "Compact LanceDB and reclaim disk space",
+      },
+      {
+        name: "Health check",
+        command: "openclaw hybrid-mem doctor",
+        description: "Run diagnostics to detect issues",
+      },
+    ],
+  },
+  advanced: {
+    title: "Advanced Operations",
+    examples: [
+      {
+        name: "Extract from sessions",
+        command: "openclaw hybrid-mem distill --days 7 --model sonnet --dry-run",
+        description: "Preview fact extraction from last 7 days",
+      },
+      {
+        name: "Find duplicates",
+        command: "openclaw hybrid-mem find-duplicates --threshold 0.85",
+        description: "Detect near-duplicate facts",
+      },
+      {
+        name: "Re-index vectors",
+        command: "openclaw hybrid-mem re-index",
+        description: "Rebuild vector database (after model change)",
+      },
+      {
+        name: "Export memory",
+        command: "openclaw hybrid-mem export --output ./memory-backup",
+        description: "Export facts to Markdown files",
+      },
+    ],
+  },
+  troubleshooting: {
+    title: "Troubleshooting",
+    examples: [
+      {
+        name: "Run diagnostics",
+        command: "openclaw hybrid-mem doctor",
+        description: "Check for common issues",
+      },
+      {
+        name: "Check sync status",
+        command: "openclaw hybrid-mem verify --reconcile",
+        description: "Verify SQLite and LanceDB are synchronized",
+      },
+      {
+        name: "View configuration",
+        command: "openclaw hybrid-mem config",
+        description: "Show current configuration settings",
+      },
+      {
+        name: "Test memory system",
+        command: "openclaw hybrid-mem test",
+        description: "Run memory diagnostics and tests",
+      },
+    ],
+  },
 };
 
 export function registerExamplesCommand(program: Command): void {
-	program
-		.command("examples [category]")
-		.description(
-			"Show common command examples (categories: basics, setup, maintenance, advanced, troubleshooting)",
-		)
-		.action((category?: string) => {
-			if (category && category in EXAMPLE_CATEGORIES) {
-				// Show specific category
-				const cat =
-					EXAMPLE_CATEGORIES[
-						category as keyof typeof EXAMPLE_CATEGORIES
-					];
-				console.log(`\n📚 ${cat.title}\n`);
+  program
+    .command("examples [category]")
+    .description("Show common command examples (categories: basics, setup, maintenance, advanced, troubleshooting)")
+    .action((category?: string) => {
+      if (category && category in EXAMPLE_CATEGORIES) {
+        // Show specific category
+        const cat = EXAMPLE_CATEGORIES[category as keyof typeof EXAMPLE_CATEGORIES];
+        console.log(`\n📚 ${cat.title}\n`);
 
-				for (const example of cat.examples) {
-					console.log(`${example.name}:`);
-					console.log(`   ${example.description}`);
-					console.log(`   $ ${example.command}\n`);
-				}
-			} else {
-				// Show all categories
-				console.log("\n📚 Hybrid Memory Command Examples\n");
+        for (const example of cat.examples) {
+          console.log(`${example.name}:`);
+          console.log(`   ${example.description}`);
+          console.log(`   $ ${example.command}\n`);
+        }
+      } else {
+        // Show all categories
+        console.log("\n📚 Hybrid Memory Command Examples\n");
 
-				for (const [key, cat] of Object.entries(EXAMPLE_CATEGORIES)) {
-					console.log(`${cat.title} (openclaw hybrid-mem examples ${key})`);
-					console.log(
-						`   ${cat.examples.length} examples available\n`,
-					);
-				}
+        for (const [key, cat] of Object.entries(EXAMPLE_CATEGORIES)) {
+          console.log(`${cat.title} (openclaw hybrid-mem examples ${key})`);
+          console.log(`   ${cat.examples.length} examples available\n`);
+        }
 
-				console.log("Usage: openclaw hybrid-mem examples <category>\n");
-			}
-		});
+        console.log("Usage: openclaw hybrid-mem examples <category>\n");
+      }
+    });
 }

--- a/extensions/memory-hybrid/cli/cmd-health.ts
+++ b/extensions/memory-hybrid/cli/cmd-health.ts
@@ -29,7 +29,7 @@ export function registerHealthCommand(
 
       // Check embedding provider
       try {
-        const providers = await detectAvailableProviders(cfg.embedding?.apiKey);
+        const providers = await detectAvailableProviders(cfg.embedding?.apiKey, cfg.embedding?.googleApiKey);
         const current = providers.find((p) => p.provider === cfg.embedding?.provider);
         if (current?.available) {
           indicators.push({

--- a/extensions/memory-hybrid/cli/cmd-health.ts
+++ b/extensions/memory-hybrid/cli/cmd-health.ts
@@ -2,7 +2,7 @@
  * CLI command for quick health status with traffic-light indicators
  */
 
-import type { Command } from "commander";
+import type { Chainable } from "./shared.js";
 import type { FactsDB } from "../backends/facts-db.js";
 import type { VectorDB } from "../backends/vector-db.js";
 import type { HybridMemoryConfig } from "../config.js";
@@ -15,7 +15,7 @@ interface HealthIndicator {
 }
 
 export function registerHealthCommand(
-  program: Command,
+  program: Chainable,
   cfg: HybridMemoryConfig,
   factsDb: FactsDB,
   vectorDb: VectorDB,
@@ -52,9 +52,12 @@ export function registerHealthCommand(
         });
       }
 
+      let factCount: number | null = null;
+      let vectorCount: number | null = null;
+
       // Check database health
       try {
-        const factCount = factsDb.getCount();
+        factCount = factsDb.getCount();
         indicators.push({
           name: "Database",
           status: "good",
@@ -68,11 +71,15 @@ export function registerHealthCommand(
         });
       }
 
+      try {
+        vectorCount = (await vectorDb.getAllIds()).length;
+      } catch {
+        vectorCount = null;
+      }
+
       // Check memory size
       try {
-        const factCount = factsDb.getCount();
-        const vectorIds = await vectorDb.getAllIds();
-        const vectorCount = vectorIds.length;
+        if (factCount === null || vectorCount === null) throw new Error("count unavailable");
 
         if (factCount === 0) {
           indicators.push({
@@ -103,9 +110,7 @@ export function registerHealthCommand(
 
       // Check database sync
       try {
-        const factCount = factsDb.getCount();
-        const vectorIds = await vectorDb.getAllIds();
-        const vectorCount = vectorIds.length;
+        if (factCount === null || vectorCount === null) throw new Error("count unavailable");
         const diff = Math.abs(factCount - vectorCount);
         const percentDiff = (diff / Math.max(factCount, 1)) * 100;
 

--- a/extensions/memory-hybrid/cli/cmd-health.ts
+++ b/extensions/memory-hybrid/cli/cmd-health.ts
@@ -9,190 +9,174 @@ import type { HybridMemoryConfig } from "../config.js";
 import { detectAvailableProviders } from "../utils/provider-detection.js";
 
 interface HealthIndicator {
-	name: string;
-	status: "good" | "warn" | "error";
-	detail: string;
+  name: string;
+  status: "good" | "warn" | "error";
+  detail: string;
 }
 
 export function registerHealthCommand(
-	program: Command,
-	cfg: HybridMemoryConfig,
-	factsDb: FactsDB,
-	vectorDb: VectorDB,
+  program: Command,
+  cfg: HybridMemoryConfig,
+  factsDb: FactsDB,
+  vectorDb: VectorDB,
 ): void {
-	program
-		.command("health")
-		.description(
-			"Show quick health status with traffic-light indicators (🟢 good, 🟡 warn, 🔴 error)",
-		)
-		.option("--json", "Output health status as JSON")
-		.action(async (opts: { json?: boolean }) => {
-			const indicators: HealthIndicator[] = [];
+  program
+    .command("health")
+    .description("Show quick health status with traffic-light indicators (🟢 good, 🟡 warn, 🔴 error)")
+    .option("--json", "Output health status as JSON")
+    .action(async (opts: { json?: boolean }) => {
+      const indicators: HealthIndicator[] = [];
 
-			// Check embedding provider
-			try {
-				const providers = await detectAvailableProviders(
-					cfg.embedding?.apiKey,
-				);
-				const current = providers.find(
-					(p) => p.provider === cfg.embedding?.provider,
-				);
-				if (current?.available) {
-					indicators.push({
-						name: "Embedding Provider",
-						status: "good",
-						detail: `${cfg.embedding?.provider} connected`,
-					});
-				} else {
-					indicators.push({
-						name: "Embedding Provider",
-						status: "error",
-						detail: current?.reason || "Not configured",
-					});
-				}
-			} catch (error) {
-				indicators.push({
-					name: "Embedding Provider",
-					status: "error",
-					detail: "Failed to check",
-				});
-			}
+      // Check embedding provider
+      try {
+        const providers = await detectAvailableProviders(cfg.embedding?.apiKey);
+        const current = providers.find((p) => p.provider === cfg.embedding?.provider);
+        if (current?.available) {
+          indicators.push({
+            name: "Embedding Provider",
+            status: "good",
+            detail: `${cfg.embedding?.provider} connected`,
+          });
+        } else {
+          indicators.push({
+            name: "Embedding Provider",
+            status: "error",
+            detail: current?.reason || "Not configured",
+          });
+        }
+      } catch (_error) {
+        indicators.push({
+          name: "Embedding Provider",
+          status: "error",
+          detail: "Failed to check",
+        });
+      }
 
-			// Check database health
-			try {
-				const factCount = factsDb.countFacts();
-				indicators.push({
-					name: "Database",
-					status: "good",
-					detail: `${factCount} facts`,
-				});
-			} catch (error) {
-				indicators.push({
-					name: "Database",
-					status: "error",
-					detail: "Connection failed",
-				});
-			}
+      // Check database health
+      try {
+        const factCount = factsDb.getCount();
+        indicators.push({
+          name: "Database",
+          status: "good",
+          detail: `${factCount} facts`,
+        });
+      } catch (_error) {
+        indicators.push({
+          name: "Database",
+          status: "error",
+          detail: "Connection failed",
+        });
+      }
 
-			// Check memory size
-			try {
-				const factCount = factsDb.countFacts();
-				const vectorIds = await vectorDb.getAllIds();
-				const vectorCount = vectorIds.length;
+      // Check memory size
+      try {
+        const factCount = factsDb.getCount();
+        const vectorIds = await vectorDb.getAllIds();
+        const vectorCount = vectorIds.length;
 
-				if (factCount === 0) {
-					indicators.push({
-						name: "Memory Size",
-						status: "warn",
-						detail: "No facts stored yet",
-					});
-				} else if (factCount < 100) {
-					indicators.push({
-						name: "Memory Size",
-						status: "good",
-						detail: `${factCount} facts, ${vectorCount} vectors`,
-					});
-				} else {
-					indicators.push({
-						name: "Memory Size",
-						status: "good",
-						detail: `${factCount} facts, ${vectorCount} vectors`,
-					});
-				}
-			} catch (error) {
-				indicators.push({
-					name: "Memory Size",
-					status: "error",
-					detail: "Failed to check",
-				});
-			}
+        if (factCount === 0) {
+          indicators.push({
+            name: "Memory Size",
+            status: "warn",
+            detail: "No facts stored yet",
+          });
+        } else if (factCount < 100) {
+          indicators.push({
+            name: "Memory Size",
+            status: "good",
+            detail: `${factCount} facts, ${vectorCount} vectors`,
+          });
+        } else {
+          indicators.push({
+            name: "Memory Size",
+            status: "good",
+            detail: `${factCount} facts, ${vectorCount} vectors`,
+          });
+        }
+      } catch (_error) {
+        indicators.push({
+          name: "Memory Size",
+          status: "error",
+          detail: "Failed to check",
+        });
+      }
 
-			// Check database sync
-			try {
-				const factCount = factsDb.countFacts();
-				const vectorIds = await vectorDb.getAllIds();
-				const vectorCount = vectorIds.length;
-				const diff = Math.abs(factCount - vectorCount);
-				const percentDiff = (diff / Math.max(factCount, 1)) * 100;
+      // Check database sync
+      try {
+        const factCount = factsDb.getCount();
+        const vectorIds = await vectorDb.getAllIds();
+        const vectorCount = vectorIds.length;
+        const diff = Math.abs(factCount - vectorCount);
+        const percentDiff = (diff / Math.max(factCount, 1)) * 100;
 
-				if (percentDiff < 5) {
-					indicators.push({
-						name: "Database Sync",
-						status: "good",
-						detail: `Synchronized (±${diff})`,
-					});
-				} else if (percentDiff < 20) {
-					indicators.push({
-						name: "Database Sync",
-						status: "warn",
-						detail: `Out of sync by ${diff} items`,
-					});
-				} else {
-					indicators.push({
-						name: "Database Sync",
-						status: "error",
-						detail: `Severely out of sync (${diff} items)`,
-					});
-				}
-			} catch (error) {
-				indicators.push({
-					name: "Database Sync",
-					status: "warn",
-					detail: "Could not verify",
-				});
-			}
+        if (percentDiff < 5) {
+          indicators.push({
+            name: "Database Sync",
+            status: "good",
+            detail: `Synchronized (±${diff})`,
+          });
+        } else if (percentDiff < 20) {
+          indicators.push({
+            name: "Database Sync",
+            status: "warn",
+            detail: `Out of sync by ${diff} items`,
+          });
+        } else {
+          indicators.push({
+            name: "Database Sync",
+            status: "error",
+            detail: `Severely out of sync (${diff} items)`,
+          });
+        }
+      } catch (_error) {
+        indicators.push({
+          name: "Database Sync",
+          status: "warn",
+          detail: "Could not verify",
+        });
+      }
 
-			// JSON output
-			if (opts.json) {
-				console.log(
-					JSON.stringify(
-						{
-							overall:
-								indicators.every((i) => i.status === "good")
-									? "healthy"
-									: indicators.some((i) => i.status === "error")
-										? "unhealthy"
-										: "degraded",
-							indicators,
-							timestamp: new Date().toISOString(),
-						},
-						null,
-						2,
-					),
-				);
-				return;
-			}
+      // JSON output
+      if (opts.json) {
+        console.log(
+          JSON.stringify(
+            {
+              overall: indicators.every((i) => i.status === "good")
+                ? "healthy"
+                : indicators.some((i) => i.status === "error")
+                  ? "unhealthy"
+                  : "degraded",
+              indicators,
+              timestamp: new Date().toISOString(),
+            },
+            null,
+            2,
+          ),
+        );
+        return;
+      }
 
-			// Human-readable output
-			console.log("\n🏥 Hybrid Memory Health Status\n");
+      // Human-readable output
+      console.log("\n🏥 Hybrid Memory Health Status\n");
 
-			for (const indicator of indicators) {
-				const icon =
-					indicator.status === "good"
-						? "🟢"
-						: indicator.status === "warn"
-							? "🟡"
-							: "🔴";
-				console.log(`${icon} ${indicator.name}: ${indicator.detail}`);
-			}
+      for (const indicator of indicators) {
+        const icon = indicator.status === "good" ? "🟢" : indicator.status === "warn" ? "🟡" : "🔴";
+        console.log(`${icon} ${indicator.name}: ${indicator.detail}`);
+      }
 
-			console.log();
+      console.log();
 
-			// Overall status
-			const hasErrors = indicators.some((i) => i.status === "error");
-			const hasWarnings = indicators.some((i) => i.status === "warn");
+      // Overall status
+      const hasErrors = indicators.some((i) => i.status === "error");
+      const hasWarnings = indicators.some((i) => i.status === "warn");
 
-			if (hasErrors) {
-				console.log(
-					"❌ System is unhealthy. Run: openclaw hybrid-mem doctor\n",
-				);
-				process.exit(1);
-			} else if (hasWarnings) {
-				console.log(
-					"⚠️  System is degraded. Consider running: openclaw hybrid-mem doctor\n",
-				);
-			} else {
-				console.log("✅ System is healthy!\n");
-			}
-		});
+      if (hasErrors) {
+        console.log("❌ System is unhealthy. Run: openclaw hybrid-mem doctor\n");
+        process.exit(1);
+      } else if (hasWarnings) {
+        console.log("⚠️  System is degraded. Consider running: openclaw hybrid-mem doctor\n");
+      } else {
+        console.log("✅ System is healthy!\n");
+      }
+    });
 }

--- a/extensions/memory-hybrid/cli/cmd-providers.ts
+++ b/extensions/memory-hybrid/cli/cmd-providers.ts
@@ -15,7 +15,8 @@ export function registerProvidersCommand(program: Chainable, cfg: HybridMemoryCo
         console.log("\n📡 Embedding Provider Status\n");
 
         const currentApiKey = cfg.embedding?.apiKey;
-        const providers = await detectAvailableProviders(currentApiKey);
+        const googleApiKey = cfg.embedding?.googleApiKey;
+        const providers = await detectAvailableProviders(currentApiKey, googleApiKey);
 
         for (const provider of providers) {
           console.log(formatProviderStatus(provider));
@@ -28,7 +29,7 @@ export function registerProvidersCommand(program: Chainable, cfg: HybridMemoryCo
         // Show recommendation if current provider is unavailable
         const currentStatus = providers.find((p) => p.provider === currentProvider);
         if (!currentStatus?.available) {
-          const recommended = await recommendProvider(currentApiKey);
+          const recommended = await recommendProvider(currentApiKey, googleApiKey);
           console.log(`💡 Recommended: Switch to ${recommended.toUpperCase()}`);
           console.log(`   Run: openclaw hybrid-mem config-set embedding.provider ${recommended}\n`);
         }

--- a/extensions/memory-hybrid/cli/cmd-providers.ts
+++ b/extensions/memory-hybrid/cli/cmd-providers.ts
@@ -5,7 +5,6 @@
 import type { Chainable } from "./shared.js";
 import type { HybridMemoryConfig } from "../config.js";
 import { detectAvailableProviders, formatProviderStatus, recommendProvider } from "../utils/provider-detection.js";
-import { withExit } from "./shared.js";
 
 export function registerProvidersCommand(program: Chainable, cfg: HybridMemoryConfig): void {
   program

--- a/extensions/memory-hybrid/cli/cmd-providers.ts
+++ b/extensions/memory-hybrid/cli/cmd-providers.ts
@@ -4,52 +4,37 @@
 
 import type { Command } from "commander";
 import type { HybridMemoryConfig } from "../config.js";
-import {
-	detectAvailableProviders,
-	formatProviderStatus,
-	recommendProvider,
-} from "../utils/provider-detection.js";
+import { detectAvailableProviders, formatProviderStatus, recommendProvider } from "../utils/provider-detection.js";
 
-export function registerProvidersCommand(
-	program: Command,
-	cfg: HybridMemoryConfig,
-): void {
-	program
-		.command("providers")
-		.description(
-			"List available embedding providers and their status (✓ available, ✗ needs setup)",
-		)
-		.action(async () => {
-			try {
-				console.log("\n📡 Embedding Provider Status\n");
+export function registerProvidersCommand(program: Command, cfg: HybridMemoryConfig): void {
+  program
+    .command("providers")
+    .description("List available embedding providers and their status (✓ available, ✗ needs setup)")
+    .action(async () => {
+      try {
+        console.log("\n📡 Embedding Provider Status\n");
 
-				const currentApiKey = cfg.embedding?.apiKey;
-				const providers = await detectAvailableProviders(currentApiKey);
+        const currentApiKey = cfg.embedding?.apiKey;
+        const providers = await detectAvailableProviders(currentApiKey);
 
-				for (const provider of providers) {
-					console.log(formatProviderStatus(provider));
-					console.log();
-				}
+        for (const provider of providers) {
+          console.log(formatProviderStatus(provider));
+          console.log();
+        }
 
-				const currentProvider = cfg.embedding?.provider || "none";
-				console.log(`Current provider: ${currentProvider}\n`);
+        const currentProvider = cfg.embedding?.provider || "none";
+        console.log(`Current provider: ${currentProvider}\n`);
 
-				// Show recommendation if current provider is unavailable
-				const currentStatus = providers.find(
-					(p) => p.provider === currentProvider,
-				);
-				if (!currentStatus?.available) {
-					const recommended = await recommendProvider(currentApiKey);
-					console.log(
-						`💡 Recommended: Switch to ${recommended.toUpperCase()}`,
-					);
-					console.log(
-						`   Run: openclaw hybrid-mem config-set embedding.provider ${recommended}\n`,
-					);
-				}
-			} catch (error) {
-				console.error("Error checking providers:", error);
-				process.exit(1);
-			}
-		});
+        // Show recommendation if current provider is unavailable
+        const currentStatus = providers.find((p) => p.provider === currentProvider);
+        if (!currentStatus?.available) {
+          const recommended = await recommendProvider(currentApiKey);
+          console.log(`💡 Recommended: Switch to ${recommended.toUpperCase()}`);
+          console.log(`   Run: openclaw hybrid-mem config-set embedding.provider ${recommended}\n`);
+        }
+      } catch (error) {
+        console.error("Error checking providers:", error);
+        process.exit(1);
+      }
+    });
 }

--- a/extensions/memory-hybrid/cli/cmd-providers.ts
+++ b/extensions/memory-hybrid/cli/cmd-providers.ts
@@ -2,11 +2,12 @@
  * CLI command to show available embedding providers
  */
 
-import type { Command } from "commander";
+import type { Chainable } from "./shared.js";
 import type { HybridMemoryConfig } from "../config.js";
 import { detectAvailableProviders, formatProviderStatus, recommendProvider } from "../utils/provider-detection.js";
+import { withExit } from "./shared.js";
 
-export function registerProvidersCommand(program: Command, cfg: HybridMemoryConfig): void {
+export function registerProvidersCommand(program: Chainable, cfg: HybridMemoryConfig): void {
   program
     .command("providers")
     .description("List available embedding providers and their status (✓ available, ✗ needs setup)")

--- a/extensions/memory-hybrid/cli/cmd-setup.ts
+++ b/extensions/memory-hybrid/cli/cmd-setup.ts
@@ -30,12 +30,12 @@ async function promptHidden(question: string): Promise<string> {
     if (typeof cb === "function") cb();
     return true;
   }) as typeof mutableOutput.write;
-  
+
   const restore = () => {
     mutableOutput.muted = false;
     mutableOutput.write = originalWrite as typeof mutableOutput.write;
   };
-  
+
   return new Promise((resolve) => {
     rl.on("close", () => {
       restore();

--- a/extensions/memory-hybrid/cli/cmd-setup.ts
+++ b/extensions/memory-hybrid/cli/cmd-setup.ts
@@ -63,7 +63,7 @@ export function registerSetupCommand(
       const spinner = new ProgressSpinner("Checking providers");
       spinner.start();
 
-      const providers = await detectAvailableProviders(cfg.embedding?.apiKey);
+      const providers = await detectAvailableProviders(cfg.embedding?.apiKey, cfg.embedding?.googleApiKey);
       spinner.success("Provider detection complete");
 
       console.log("\nAvailable providers:\n");
@@ -78,13 +78,13 @@ export function registerSetupCommand(
       let selectedProvider: string;
 
       if (opts.interactive) {
-        const recommended = await recommendProvider(cfg.embedding?.apiKey);
+        const recommended = await recommendProvider(cfg.embedding?.apiKey, cfg.embedding?.googleApiKey);
         console.log(`\nRecommended provider: ${recommended.toUpperCase()}\n`);
 
         const answer = await prompt(`Choose provider (ollama/onnx/openai/google) [${recommended}]: `);
         selectedProvider = answer || recommended;
       } else {
-        selectedProvider = await recommendProvider(cfg.embedding?.apiKey);
+        selectedProvider = await recommendProvider(cfg.embedding?.apiKey, cfg.embedding?.googleApiKey);
         console.log(`\nUsing recommended provider: ${selectedProvider}\n`);
       }
 

--- a/extensions/memory-hybrid/cli/cmd-setup.ts
+++ b/extensions/memory-hybrid/cli/cmd-setup.ts
@@ -2,10 +2,7 @@
  * Interactive setup wizard for first-time configuration
  */
 
-import { readFileSync, writeFileSync } from "node:fs";
-import { homedir } from "node:os";
-import { join } from "node:path";
-import type { Command } from "commander";
+import type { Chainable } from "./shared.js";
 import type { HybridMemoryConfig } from "../config.js";
 import { detectAvailableProviders, recommendProvider } from "../utils/provider-detection.js";
 import { ProgressSpinner } from "../utils/progress-indicators.js";
@@ -13,11 +10,7 @@ import { ProgressSpinner } from "../utils/progress-indicators.js";
 // Simple readline alternative for getting user input
 async function prompt(question: string): Promise<string> {
   const readline = await import("node:readline");
-  const rl = readline.createInterface({
-    input: process.stdin,
-    output: process.stdout,
-  });
-
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
   return new Promise((resolve) => {
     rl.question(question, (answer) => {
       rl.close();
@@ -26,11 +19,41 @@ async function prompt(question: string): Promise<string> {
   });
 }
 
-export function registerSetupCommand(program: Command, cfg: HybridMemoryConfig): void {
+async function promptHidden(question: string): Promise<string> {
+  const readline = await import("node:readline");
+  const mutableOutput = process.stdout as NodeJS.WriteStream & { muted?: boolean };
+  const rl = readline.createInterface({ input: process.stdin, output: mutableOutput });
+  const originalWrite = mutableOutput.write.bind(mutableOutput);
+  mutableOutput.muted = false;
+  mutableOutput.write = ((chunk: unknown, encoding?: BufferEncoding, cb?: (err?: Error | null) => void) => {
+    if (!mutableOutput.muted) return originalWrite(chunk as string | Uint8Array, encoding, cb);
+    if (typeof cb === "function") cb();
+    return true;
+  }) as typeof mutableOutput.write;
+  return new Promise((resolve) => {
+    rl.question(question, (answer) => {
+      mutableOutput.muted = false;
+      mutableOutput.write = originalWrite as typeof mutableOutput.write;
+      process.stdout.write("\n");
+      rl.close();
+      resolve(answer.trim());
+    });
+    mutableOutput.muted = true;
+  });
+}
+
+export function registerSetupCommand(
+  program: Chainable,
+  cfg: HybridMemoryConfig,
+  runConfigSet?: (
+    key: string,
+    value: string,
+  ) => { ok: boolean; error?: string } | Promise<{ ok: boolean; error?: string }>,
+): void {
   program
     .command("setup")
     .description("Interactive setup wizard for first-time configuration")
-    .option("--interactive", "Run in interactive mode (ask questions)", true)
+    .option("--interactive", "Run in interactive mode (ask questions)")
     .action(async (opts: { interactive?: boolean }) => {
       console.log("\n🚀 Hybrid Memory Setup Wizard\n");
       console.log("This wizard will help you configure the hybrid memory system.\n");
@@ -58,7 +81,7 @@ export function registerSetupCommand(program: Command, cfg: HybridMemoryConfig):
         const recommended = await recommendProvider(cfg.embedding?.apiKey);
         console.log(`\nRecommended provider: ${recommended.toUpperCase()}\n`);
 
-        const answer = await prompt(`Choose provider (ollama/onnx/openai) [${recommended}]: `);
+        const answer = await prompt(`Choose provider (ollama/onnx/openai/google) [${recommended}]: `);
         selectedProvider = answer || recommended;
       } else {
         selectedProvider = await recommendProvider(cfg.embedding?.apiKey);
@@ -66,7 +89,7 @@ export function registerSetupCommand(program: Command, cfg: HybridMemoryConfig):
       }
 
       // Step 3: Configure provider
-      const configUpdates: Record<string, any> = {
+      const configUpdates: Record<string, string> = {
         "embedding.provider": selectedProvider,
       };
 
@@ -74,7 +97,7 @@ export function registerSetupCommand(program: Command, cfg: HybridMemoryConfig):
         console.log("\n⚠️  OpenAI requires an API key and incurs costs.\n");
 
         if (opts.interactive) {
-          const apiKey = await prompt("Enter your OpenAI API key: ");
+          const apiKey = await promptHidden("Enter your OpenAI API key (input hidden): ");
           if (apiKey) {
             configUpdates["embedding.apiKey"] = apiKey;
           }
@@ -90,14 +113,28 @@ export function registerSetupCommand(program: Command, cfg: HybridMemoryConfig):
         console.log("   And pull the model: ollama pull nomic-embed-text\n");
       } else if (selectedProvider === "onnx") {
         configUpdates["embedding.model"] = "all-MiniLM-L6-v2";
+      } else if (selectedProvider === "google") {
+        configUpdates["embedding.model"] = "text-embedding-004";
+        if (opts.interactive) {
+          const apiKey = await promptHidden("Enter your Google API key (input hidden): ");
+          if (apiKey) configUpdates["embedding.googleApiKey"] = apiKey;
+        } else {
+          console.log("Set your API key with: openclaw hybrid-mem config-set embedding.googleApiKey YOUR_KEY\n");
+        }
       }
 
       // Step 4: Apply configuration
       console.log("\nApplying configuration...\n");
 
+      if (!runConfigSet) {
+        throw new Error("setup cannot persist configuration: config writer is unavailable in this CLI context");
+      }
+
       for (const [key, value] of Object.entries(configUpdates)) {
-        console.log(`  Setting ${key} = ${value}`);
-        // Note: In real implementation, this would call the config-set handler
+        const displayValue = key.toLowerCase().includes("key") ? "[hidden]" : value;
+        console.log(`  Setting ${key} = ${displayValue}`);
+        const result = await runConfigSet(key, value);
+        if (!result.ok) throw new Error(result.error || `Failed to set ${key}`);
       }
 
       // Step 5: Run verification

--- a/extensions/memory-hybrid/cli/cmd-setup.ts
+++ b/extensions/memory-hybrid/cli/cmd-setup.ts
@@ -7,144 +7,114 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import type { Command } from "commander";
 import type { HybridMemoryConfig } from "../config.js";
-import {
-	detectAvailableProviders,
-	recommendProvider,
-} from "../utils/provider-detection.js";
+import { detectAvailableProviders, recommendProvider } from "../utils/provider-detection.js";
 import { ProgressSpinner } from "../utils/progress-indicators.js";
 
 // Simple readline alternative for getting user input
 async function prompt(question: string): Promise<string> {
-	const readline = await import("node:readline");
-	const rl = readline.createInterface({
-		input: process.stdin,
-		output: process.stdout,
-	});
+  const readline = await import("node:readline");
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
 
-	return new Promise((resolve) => {
-		rl.question(question, (answer) => {
-			rl.close();
-			resolve(answer.trim());
-		});
-	});
+  return new Promise((resolve) => {
+    rl.question(question, (answer) => {
+      rl.close();
+      resolve(answer.trim());
+    });
+  });
 }
 
-export function registerSetupCommand(
-	program: Command,
-	cfg: HybridMemoryConfig,
-): void {
-	program
-		.command("setup")
-		.description("Interactive setup wizard for first-time configuration")
-		.option(
-			"--interactive",
-			"Run in interactive mode (ask questions)",
-			true,
-		)
-		.action(async (opts: { interactive?: boolean }) => {
-			console.log("\n🚀 Hybrid Memory Setup Wizard\n");
-			console.log(
-				"This wizard will help you configure the hybrid memory system.\n",
-			);
+export function registerSetupCommand(program: Command, cfg: HybridMemoryConfig): void {
+  program
+    .command("setup")
+    .description("Interactive setup wizard for first-time configuration")
+    .option("--interactive", "Run in interactive mode (ask questions)", true)
+    .action(async (opts: { interactive?: boolean }) => {
+      console.log("\n🚀 Hybrid Memory Setup Wizard\n");
+      console.log("This wizard will help you configure the hybrid memory system.\n");
 
-			// Step 1: Detect available providers
-			console.log("Step 1: Detecting available embedding providers...\n");
-			const spinner = new ProgressSpinner("Checking providers");
-			spinner.start();
+      // Step 1: Detect available providers
+      console.log("Step 1: Detecting available embedding providers...\n");
+      const spinner = new ProgressSpinner("Checking providers");
+      spinner.start();
 
-			const providers = await detectAvailableProviders(cfg.embedding?.apiKey);
-			spinner.success("Provider detection complete");
+      const providers = await detectAvailableProviders(cfg.embedding?.apiKey);
+      spinner.success("Provider detection complete");
 
-			console.log("\nAvailable providers:\n");
-			for (const provider of providers) {
-				const icon = provider.available ? "✓" : "✗";
-				const badge = provider.localOnly ? "[Local]" : "[Cloud]";
-				console.log(`  ${icon} ${provider.provider.toUpperCase()} ${badge}`);
-				console.log(`     ${provider.recommendation}\n`);
-			}
+      console.log("\nAvailable providers:\n");
+      for (const provider of providers) {
+        const icon = provider.available ? "✓" : "✗";
+        const badge = provider.localOnly ? "[Local]" : "[Cloud]";
+        console.log(`  ${icon} ${provider.provider.toUpperCase()} ${badge}`);
+        console.log(`     ${provider.recommendation}\n`);
+      }
 
-			// Step 2: Choose provider
-			let selectedProvider: string;
+      // Step 2: Choose provider
+      let selectedProvider: string;
 
-			if (opts.interactive) {
-				const recommended = await recommendProvider(cfg.embedding?.apiKey);
-				console.log(
-					`\nRecommended provider: ${recommended.toUpperCase()}\n`,
-				);
+      if (opts.interactive) {
+        const recommended = await recommendProvider(cfg.embedding?.apiKey);
+        console.log(`\nRecommended provider: ${recommended.toUpperCase()}\n`);
 
-				const answer = await prompt(
-					`Choose provider (ollama/onnx/openai) [${recommended}]: `,
-				);
-				selectedProvider = answer || recommended;
-			} else {
-				selectedProvider = await recommendProvider(
-					cfg.embedding?.apiKey,
-				);
-				console.log(`\nUsing recommended provider: ${selectedProvider}\n`);
-			}
+        const answer = await prompt(`Choose provider (ollama/onnx/openai) [${recommended}]: `);
+        selectedProvider = answer || recommended;
+      } else {
+        selectedProvider = await recommendProvider(cfg.embedding?.apiKey);
+        console.log(`\nUsing recommended provider: ${selectedProvider}\n`);
+      }
 
-			// Step 3: Configure provider
-			const configUpdates: Record<string, any> = {
-				"embedding.provider": selectedProvider,
-			};
+      // Step 3: Configure provider
+      const configUpdates: Record<string, any> = {
+        "embedding.provider": selectedProvider,
+      };
 
-			if (selectedProvider === "openai") {
-				console.log(
-					"\n⚠️  OpenAI requires an API key and incurs costs.\n",
-				);
+      if (selectedProvider === "openai") {
+        console.log("\n⚠️  OpenAI requires an API key and incurs costs.\n");
 
-				if (opts.interactive) {
-					const apiKey = await prompt("Enter your OpenAI API key: ");
-					if (apiKey) {
-						configUpdates["embedding.apiKey"] = apiKey;
-					}
-				} else {
-					console.log(
-						"Set your API key with: openclaw hybrid-mem config-set embedding.apiKey YOUR_KEY\n",
-					);
-				}
+        if (opts.interactive) {
+          const apiKey = await prompt("Enter your OpenAI API key: ");
+          if (apiKey) {
+            configUpdates["embedding.apiKey"] = apiKey;
+          }
+        } else {
+          console.log("Set your API key with: openclaw hybrid-mem config-set embedding.apiKey YOUR_KEY\n");
+        }
 
-				// Set default model
-				configUpdates["embedding.model"] = "text-embedding-3-small";
-			} else if (selectedProvider === "ollama") {
-				configUpdates["embedding.model"] = "nomic-embed-text";
-				console.log(
-					"\n💡 Make sure Ollama is running: ollama serve",
-				);
-				console.log(
-					"   And pull the model: ollama pull nomic-embed-text\n",
-				);
-			} else if (selectedProvider === "onnx") {
-				configUpdates["embedding.model"] = "all-MiniLM-L6-v2";
-			}
+        // Set default model
+        configUpdates["embedding.model"] = "text-embedding-3-small";
+      } else if (selectedProvider === "ollama") {
+        configUpdates["embedding.model"] = "nomic-embed-text";
+        console.log("\n💡 Make sure Ollama is running: ollama serve");
+        console.log("   And pull the model: ollama pull nomic-embed-text\n");
+      } else if (selectedProvider === "onnx") {
+        configUpdates["embedding.model"] = "all-MiniLM-L6-v2";
+      }
 
-			// Step 4: Apply configuration
-			console.log("\nApplying configuration...\n");
+      // Step 4: Apply configuration
+      console.log("\nApplying configuration...\n");
 
-			for (const [key, value] of Object.entries(configUpdates)) {
-				console.log(`  Setting ${key} = ${value}`);
-				// Note: In real implementation, this would call the config-set handler
-			}
+      for (const [key, value] of Object.entries(configUpdates)) {
+        console.log(`  Setting ${key} = ${value}`);
+        // Note: In real implementation, this would call the config-set handler
+      }
 
-			// Step 5: Run verification
-			console.log("\n✓ Configuration complete!\n");
-			console.log("Next steps:\n");
-			console.log("  1. Verify setup: openclaw hybrid-mem verify");
-			console.log("  2. Try the demo: openclaw hybrid-mem demo");
-			console.log(
-				"  3. Store your first fact: openclaw hybrid-mem store 'your text here'\n",
-			);
+      // Step 5: Run verification
+      console.log("\n✓ Configuration complete!\n");
+      console.log("Next steps:\n");
+      console.log("  1. Verify setup: openclaw hybrid-mem verify");
+      console.log("  2. Try the demo: openclaw hybrid-mem demo");
+      console.log("  3. Store your first fact: openclaw hybrid-mem store 'your text here'\n");
 
-			// Show onboarding checklist
-			console.log("📋 Onboarding Checklist:\n");
-			console.log("  ✓ Configure embedding provider");
-			console.log("  ⃞ Run verification (openclaw hybrid-mem verify)");
-			console.log("  ⃞ Store your first memory");
-			console.log("  ⃞ Try a semantic search");
-			console.log("  ⃞ Set up backup automation\n");
+      // Show onboarding checklist
+      console.log("📋 Onboarding Checklist:\n");
+      console.log("  ✓ Configure embedding provider");
+      console.log("  ⃞ Run verification (openclaw hybrid-mem verify)");
+      console.log("  ⃞ Store your first memory");
+      console.log("  ⃞ Try a semantic search");
+      console.log("  ⃞ Set up backup automation\n");
 
-			console.log(
-				"💡 For more help: openclaw hybrid-mem examples basics\n",
-			);
-		});
+      console.log("💡 For more help: openclaw hybrid-mem examples basics\n");
+    });
 }

--- a/extensions/memory-hybrid/cli/cmd-setup.ts
+++ b/extensions/memory-hybrid/cli/cmd-setup.ts
@@ -30,10 +30,19 @@ async function promptHidden(question: string): Promise<string> {
     if (typeof cb === "function") cb();
     return true;
   }) as typeof mutableOutput.write;
+  
+  const restore = () => {
+    mutableOutput.muted = false;
+    mutableOutput.write = originalWrite as typeof mutableOutput.write;
+  };
+  
   return new Promise((resolve) => {
+    rl.on("close", () => {
+      restore();
+      resolve("");
+    });
     rl.question(question, (answer) => {
-      mutableOutput.muted = false;
-      mutableOutput.write = originalWrite as typeof mutableOutput.write;
+      restore();
       process.stdout.write("\n");
       rl.close();
       resolve(answer.trim());

--- a/extensions/memory-hybrid/cli/cmd-user-friendly.ts
+++ b/extensions/memory-hybrid/cli/cmd-user-friendly.ts
@@ -15,21 +15,18 @@ import { registerProvidersCommand } from "./cmd-providers.js";
 import { registerSetupCommand } from "./cmd-setup.js";
 
 export interface UserFriendlyContext {
-	cfg: HybridMemoryConfig;
-	factsDb: FactsDB;
-	vectorDb: VectorDB;
-	embeddings: EmbeddingProvider;
+  cfg: HybridMemoryConfig;
+  factsDb: FactsDB;
+  vectorDb: VectorDB;
+  embeddings: EmbeddingProvider;
 }
 
-export function registerUserFriendlyCommands(
-	mem: Command,
-	ctx: UserFriendlyContext,
-): void {
-	// Register each user-friendly command
-	registerSetupCommand(mem, ctx.cfg);
-	registerProvidersCommand(mem, ctx.cfg);
-	registerDoctorCommand(mem, ctx.cfg, ctx.factsDb, ctx.vectorDb);
-	registerHealthCommand(mem, ctx.cfg, ctx.factsDb, ctx.vectorDb);
-	registerDemoCommand(mem, ctx.factsDb, ctx.vectorDb, ctx.embeddings);
-	registerExamplesCommand(mem);
+export function registerUserFriendlyCommands(mem: Command, ctx: UserFriendlyContext): void {
+  // Register each user-friendly command
+  registerSetupCommand(mem, ctx.cfg);
+  registerProvidersCommand(mem, ctx.cfg);
+  registerDoctorCommand(mem, ctx.cfg, ctx.factsDb, ctx.vectorDb);
+  registerHealthCommand(mem, ctx.cfg, ctx.factsDb, ctx.vectorDb);
+  registerDemoCommand(mem, ctx.factsDb, ctx.vectorDb, ctx.embeddings);
+  registerExamplesCommand(mem);
 }

--- a/extensions/memory-hybrid/cli/cmd-user-friendly.ts
+++ b/extensions/memory-hybrid/cli/cmd-user-friendly.ts
@@ -2,7 +2,7 @@
  * Register user-friendly commands (setup, demo, providers, health, doctor, examples)
  */
 
-import type { Command } from "commander";
+import type { Chainable } from "./shared.js";
 import type { FactsDB } from "../backends/facts-db.js";
 import type { VectorDB } from "../backends/vector-db.js";
 import type { HybridMemoryConfig } from "../config.js";
@@ -19,11 +19,15 @@ export interface UserFriendlyContext {
   factsDb: FactsDB;
   vectorDb: VectorDB;
   embeddings: EmbeddingProvider;
+  runConfigSet?: (
+    key: string,
+    value: string,
+  ) => { ok: boolean; error?: string } | Promise<{ ok: boolean; error?: string }>;
 }
 
-export function registerUserFriendlyCommands(mem: Command, ctx: UserFriendlyContext): void {
+export function registerUserFriendlyCommands(mem: Chainable, ctx: UserFriendlyContext): void {
   // Register each user-friendly command
-  registerSetupCommand(mem, ctx.cfg);
+  registerSetupCommand(mem, ctx.cfg, ctx.runConfigSet);
   registerProvidersCommand(mem, ctx.cfg);
   registerDoctorCommand(mem, ctx.cfg, ctx.factsDb, ctx.vectorDb);
   registerHealthCommand(mem, ctx.cfg, ctx.factsDb, ctx.vectorDb);

--- a/extensions/memory-hybrid/cli/cmd-user-friendly.ts
+++ b/extensions/memory-hybrid/cli/cmd-user-friendly.ts
@@ -25,12 +25,27 @@ export interface UserFriendlyContext {
   ) => { ok: boolean; error?: string } | Promise<{ ok: boolean; error?: string }>;
 }
 
+function hasCommand(mem: Chainable, name: string): boolean {
+  const maybeCommands = (mem as { commands?: Array<{ name?: string | (() => string); _name?: string }> }).commands;
+  return Array.isArray(maybeCommands)
+    ? maybeCommands.some(
+        (command) =>
+          command._name === name ||
+          (typeof command.name === "function" ? command.name() === name : command.name === name),
+      )
+    : false;
+}
+
+function registerIfMissing(mem: Chainable, name: string, register: () => void): void {
+  if (hasCommand(mem, name)) return;
+  register();
+}
+
 export function registerUserFriendlyCommands(mem: Chainable, ctx: UserFriendlyContext): void {
-  // Register each user-friendly command
-  registerSetupCommand(mem, ctx.cfg, ctx.runConfigSet);
-  registerProvidersCommand(mem, ctx.cfg);
-  registerDoctorCommand(mem, ctx.cfg, ctx.factsDb, ctx.vectorDb);
-  registerHealthCommand(mem, ctx.cfg, ctx.factsDb, ctx.vectorDb);
-  registerDemoCommand(mem, ctx.factsDb, ctx.vectorDb, ctx.embeddings);
-  registerExamplesCommand(mem);
+  registerIfMissing(mem, "setup", () => registerSetupCommand(mem, ctx.cfg, ctx.runConfigSet));
+  registerIfMissing(mem, "providers", () => registerProvidersCommand(mem, ctx.cfg));
+  registerIfMissing(mem, "doctor", () => registerDoctorCommand(mem, ctx.cfg, ctx.factsDb, ctx.vectorDb));
+  registerIfMissing(mem, "health", () => registerHealthCommand(mem, ctx.cfg, ctx.factsDb, ctx.vectorDb));
+  registerIfMissing(mem, "demo", () => registerDemoCommand(mem, ctx.factsDb, ctx.vectorDb, ctx.embeddings));
+  registerIfMissing(mem, "examples", () => registerExamplesCommand(mem));
 }

--- a/extensions/memory-hybrid/cli/commands/manage/register-storage-and-stats.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/register-storage-and-stats.ts
@@ -3,7 +3,17 @@
  * Extracted from cli/register.ts lines 290-1552.
  */
 
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  unlinkSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { createCipheriv, createDecipheriv, pbkdf2Sync, randomBytes } from "node:crypto";
@@ -86,6 +96,94 @@ function parseBoundedFloatOption(raw: unknown, fallback: number, min: number, ma
   const parsed = Number.parseFloat(String(raw ?? fallback));
   const value = Number.isFinite(parsed) ? parsed : fallback;
   return Math.max(min, Math.min(max, value));
+}
+
+type SyncBundleFile = {
+  path: string;
+  contentBase64: string;
+};
+
+const SYNC_BUNDLE_MIN_ITERATIONS = 100_000;
+const SYNC_BUNDLE_MAX_ITERATIONS = 2_000_000;
+const SYNC_BUNDLE_SALT_BYTES = 16;
+const SYNC_BUNDLE_IV_BYTES = 12;
+const SYNC_BUNDLE_TAG_BYTES = 16;
+
+function collectExportBundleFiles(root: string, dir = root): SyncBundleFile[] {
+  const files: SyncBundleFile[] = [];
+  for (const name of readdirSync(dir).sort()) {
+    const fullPath = join(dir, name);
+    const st = statSync(fullPath);
+    if (st.isDirectory()) {
+      files.push(...collectExportBundleFiles(root, fullPath));
+      continue;
+    }
+    if (!st.isFile()) continue;
+    const rel = fullPath.slice(root.length + 1).replace(/\\/g, "/");
+    files.push({ path: rel, contentBase64: readFileSync(fullPath).toString("base64") });
+  }
+  return files;
+}
+
+function decodeRequiredBase64Field(envelope: Record<string, unknown>, field: string, expectedBytes?: number): Buffer {
+  const raw = envelope[field];
+  if (typeof raw !== "string" || raw.length === 0) {
+    throw new Error(`sync bundle field ${field} must be a non-empty base64 string`);
+  }
+  if (!/^[A-Za-z0-9+/]*={0,2}$/.test(raw) || raw.length % 4 !== 0) {
+    throw new Error(`sync bundle field ${field} is not valid base64`);
+  }
+  const decoded = Buffer.from(raw, "base64");
+  if (expectedBytes !== undefined && decoded.length !== expectedBytes) {
+    throw new Error(`sync bundle field ${field} must decode to ${expectedBytes} bytes`);
+  }
+  if (expectedBytes === undefined && decoded.length === 0) {
+    throw new Error(`sync bundle field ${field} must not be empty`);
+  }
+  return decoded;
+}
+
+function validateSyncEnvelope(raw: unknown): {
+  schemaVersion: 1;
+  type: "hybrid-memory-sync-bundle";
+  alg: "aes-256-gcm";
+  kdf: "pbkdf2-sha256";
+  iterations: number;
+  salt: Buffer;
+  iv: Buffer;
+  tag: Buffer;
+  ciphertext: Buffer;
+} {
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+    throw new Error("sync bundle must be a JSON object");
+  }
+  const envelope = raw as Record<string, unknown>;
+  if (envelope.schemaVersion !== 1) throw new Error("unsupported sync bundle schemaVersion");
+  if (envelope.type !== "hybrid-memory-sync-bundle") throw new Error("unsupported sync bundle type");
+  if (envelope.alg !== "aes-256-gcm") throw new Error("unsupported sync bundle algorithm");
+  if (envelope.kdf !== "pbkdf2-sha256") throw new Error("unsupported sync bundle KDF");
+  const iterations = envelope.iterations;
+  if (
+    typeof iterations !== "number" ||
+    !Number.isInteger(iterations) ||
+    iterations < SYNC_BUNDLE_MIN_ITERATIONS ||
+    iterations > SYNC_BUNDLE_MAX_ITERATIONS
+  ) {
+    throw new Error(
+      `sync bundle iterations must be an integer between ${SYNC_BUNDLE_MIN_ITERATIONS} and ${SYNC_BUNDLE_MAX_ITERATIONS}`,
+    );
+  }
+  return {
+    schemaVersion: 1,
+    type: "hybrid-memory-sync-bundle",
+    alg: "aes-256-gcm",
+    kdf: "pbkdf2-sha256",
+    iterations,
+    salt: decodeRequiredBase64Field(envelope, "salt", SYNC_BUNDLE_SALT_BYTES),
+    iv: decodeRequiredBase64Field(envelope, "iv", SYNC_BUNDLE_IV_BYTES),
+    tag: decodeRequiredBase64Field(envelope, "tag", SYNC_BUNDLE_TAG_BYTES),
+    ciphertext: decodeRequiredBase64Field(envelope, "ciphertext"),
+  };
 }
 
 /**
@@ -862,6 +960,7 @@ export function registerManageStorageAndStats(mem: Chainable, b: ManageBindings)
     ctx,
     listCommands,
     auditStore,
+    runExport,
   } = b;
 
   const tierCompactCmd = mem
@@ -2514,7 +2613,9 @@ export function registerManageStorageAndStats(mem: Chainable, b: ManageBindings)
 
   audit
     .command("session")
-    .description("Unified session observability: timeline of capture, recall, injection, suppressions, and why-recalled")
+    .description(
+      "Unified session observability: timeline of capture, recall, injection, suppressions, and why-recalled",
+    )
     .option("--session-id <id>", "Session id to inspect")
     .option("--agent <id>", "Optional agent id filter")
     .option("--limit <n>", "Max timeline entries per section (default 50, max 200)", "50")
@@ -2550,7 +2651,9 @@ export function registerManageStorageAndStats(mem: Chainable, b: ManageBindings)
             return;
           }
           if (format === "timeline") {
-            console.log(`Session observability timeline (${report.sessionId ?? "current"}, entries=${report.timeline.length})`);
+            console.log(
+              `Session observability timeline (${report.sessionId ?? "current"}, entries=${report.timeline.length})`,
+            );
             for (const entry of report.timeline) {
               const outcome = entry.outcome ? ` [${entry.outcome}]` : "";
               const score = entry.score != null ? ` score=${entry.score.toFixed(3)}` : "";
@@ -2688,15 +2791,28 @@ export function registerManageStorageAndStats(mem: Chainable, b: ManageBindings)
           return;
         }
         const tmpDir = mkdtempSync(join(tmpdir(), "hybrid-mem-sync-"));
-        const tmpJson = join(tmpDir, "export.json");
+        const tmpExportDir = join(tmpDir, "export");
         const sources = opts?.sources
           ?.split(",")
           .map((s) => s.trim())
           .filter((s) => s.length > 0);
         try {
-          const exportResult = await runExport({ outputPath: tmpJson, excludeCredentials: true, sources });
-          const plaintext = readFileSync(exportResult.outputPath, "utf-8");
-          unlinkSync(exportResult.outputPath);
+          const exportResult = await runExport({ outputPath: tmpExportDir, excludeCredentials: true, sources });
+          const plaintext = JSON.stringify(
+            {
+              schemaVersion: 1,
+              type: "hybrid-memory-sync-export",
+              exportedAt: new Date().toISOString(),
+              metadata: {
+                factsExported: exportResult.factsExported,
+                proceduresExported: exportResult.proceduresExported,
+                filesWritten: exportResult.filesWritten,
+              },
+              files: collectExportBundleFiles(exportResult.outputPath),
+            },
+            null,
+            2,
+          );
 
           const salt = randomBytes(16);
           const iv = randomBytes(12);
@@ -2753,47 +2869,24 @@ export function registerManageStorageAndStats(mem: Chainable, b: ManageBindings)
         const passphraseEnv = String(opts?.passphraseEnv ?? "HYBRID_MEM_SYNC_PASSPHRASE").trim();
         const passphrase = getEnv(passphraseEnv);
         if (!passphrase) {
-          console.error("error: set the sync passphrase in the configured environment variable before running sync-import");
+          console.error(
+            "error: set the sync passphrase in the configured environment variable before running sync-import",
+          );
           process.exitCode = 1;
           return;
         }
-        let envelope: {
-          schemaVersion: number;
-          alg: string;
-          iterations: number;
-          salt: string;
-          iv: string;
-          tag: string;
-          ciphertext: string;
-        };
+        let envelope;
         try {
-          envelope = JSON.parse(readFileSync(inPath, "utf-8")) as {
-            schemaVersion: number;
-            alg: string;
-            iterations: number;
-            salt: string;
-            iv: string;
-            tag: string;
-            ciphertext: string;
-          };
+          envelope = validateSyncEnvelope(JSON.parse(readFileSync(inPath, "utf-8")));
         } catch (err) {
-          console.error(`error: failed to read or parse sync bundle from ${inPath}: ${String(err)}`);
+          console.error(`error: invalid sync bundle ${inPath}: ${String(err)}`);
           process.exitCode = 1;
           return;
         }
-        if (envelope.schemaVersion !== 1 || envelope.alg !== "aes-256-gcm") {
-          console.error("error: unsupported sync bundle format");
-          process.exitCode = 1;
-          return;
-        }
-        const salt = Buffer.from(envelope.salt, "base64");
-        const iv = Buffer.from(envelope.iv, "base64");
-        const tag = Buffer.from(envelope.tag, "base64");
-        const ciphertext = Buffer.from(envelope.ciphertext, "base64");
-        const key = pbkdf2Sync(passphrase, salt, envelope.iterations, 32, "sha256");
-        const decipher = createDecipheriv("aes-256-gcm", key, iv);
-        decipher.setAuthTag(tag);
-        const plaintext = Buffer.concat([decipher.update(ciphertext), decipher.final()]).toString("utf-8");
+        const key = pbkdf2Sync(passphrase, envelope.salt, envelope.iterations, 32, "sha256");
+        const decipher = createDecipheriv("aes-256-gcm", key, envelope.iv);
+        decipher.setAuthTag(envelope.tag);
+        const plaintext = Buffer.concat([decipher.update(envelope.ciphertext), decipher.final()]).toString("utf-8");
         mkdirSync(dirname(outPath), { recursive: true });
         writeFileSync(outPath, plaintext, "utf-8");
         console.log(`Decrypted sync payload written to ${outPath}`);

--- a/extensions/memory-hybrid/cli/plugin-commands.ts
+++ b/extensions/memory-hybrid/cli/plugin-commands.ts
@@ -4,160 +4,165 @@
  */
 
 import { existsSync } from "node:fs";
-import { mkdir, readdir, rm } from "node:fs/promises";
+import { spawn } from "node:child_process";
+import { mkdir, readFile, readdir, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { pluginLogger } from "../utils/logger.js";
 
 export interface PluginInfo {
-	id: string;
-	name: string;
-	version: string;
-	description: string;
-	author: string;
-	enabled: boolean;
-	path: string;
+  id: string;
+  name: string;
+  version: string;
+  description: string;
+  author: string;
+  enabled: boolean;
+  path: string;
 }
 
 /**
  * List all installed plugins
  */
 export async function listPlugins(pluginsDir: string): Promise<PluginInfo[]> {
-	if (!existsSync(pluginsDir)) {
-		return [];
-	}
+  if (!existsSync(pluginsDir)) {
+    return [];
+  }
 
-	const plugins: PluginInfo[] = [];
-	const entries = await readdir(pluginsDir, { withFileTypes: true });
+  const plugins: PluginInfo[] = [];
+  const entries = await readdir(pluginsDir, { withFileTypes: true });
 
-	for (const entry of entries) {
-		if (!entry.isDirectory()) continue;
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
 
-		const pluginPath = join(pluginsDir, entry.name);
-		const manifestPath = join(pluginPath, "package.json");
+    const pluginPath = join(pluginsDir, entry.name);
+    const manifestPath = join(pluginPath, "package.json");
 
-		if (!existsSync(manifestPath)) continue;
+    if (!existsSync(manifestPath)) continue;
 
-		try {
-			const manifest = await import(manifestPath, { assert: { type: "json" } });
-			plugins.push({
-				id: entry.name,
-				name: manifest.default?.name || entry.name,
-				version: manifest.default?.version || "unknown",
-				description: manifest.default?.description || "",
-				author: manifest.default?.author || "",
-				enabled: existsSync(join(pluginPath, "index.js")),
-				path: pluginPath,
-			});
-		} catch (error) {
-			pluginLogger.warn(`[Plugin CLI] Failed to read plugin manifest: ${manifestPath}`);
-		}
-	}
+    try {
+      const manifest = JSON.parse(await readFile(manifestPath, "utf8")) as Record<string, unknown>;
+      plugins.push({
+        id: entry.name,
+        name: typeof manifest.name === "string" ? manifest.name : entry.name,
+        version: typeof manifest.version === "string" ? manifest.version : "unknown",
+        description: typeof manifest.description === "string" ? manifest.description : "",
+        author: typeof manifest.author === "string" ? manifest.author : "",
+        enabled: existsSync(join(pluginPath, "index.js")),
+        path: pluginPath,
+      });
+    } catch (_error) {
+      pluginLogger.warn(`[Plugin CLI] Failed to read plugin manifest: ${manifestPath}`);
+    }
+  }
 
-	return plugins;
+  return plugins;
 }
 
 /**
  * Install a plugin from npm or local path
  */
 export async function installPlugin(
-	pluginsDir: string,
-	source: string,
-	options: { npm?: boolean; local?: boolean } = {},
+  pluginsDir: string,
+  source: string,
+  options: { npm?: boolean; local?: boolean } = {},
 ): Promise<void> {
-	// Ensure plugins directory exists
-	if (!existsSync(pluginsDir)) {
-		await mkdir(pluginsDir, { recursive: true });
-	}
+  // Ensure plugins directory exists
+  if (!existsSync(pluginsDir)) {
+    await mkdir(pluginsDir, { recursive: true });
+  }
 
-	if (options.npm) {
-		// Install from npm
-		const { execa } = await import("execa");
-		pluginLogger.info(`[Plugin CLI] Installing plugin from npm: ${source}`);
+  if (options.npm) {
+    // Install from npm
+    pluginLogger.info(`[Plugin CLI] Installing plugin from npm: ${source}`);
 
-		await execa("npm", ["install", source, "--prefix", pluginsDir], {
-			stdio: "inherit",
-		});
+    await new Promise<void>((resolve, reject) => {
+      const child = spawn("npm", ["install", source, "--prefix", pluginsDir], { stdio: "inherit" });
+      child.on("error", reject);
+      child.on("exit", (code) => {
+        if (code === 0) resolve();
+        else reject(new Error(`npm install exited with code ${code ?? "unknown"}`));
+      });
+    });
 
-		pluginLogger.info(`[Plugin CLI] Plugin installed successfully`);
-	} else if (options.local) {
-		// Copy from local path
-		const { cp } = await import("node:fs/promises");
-		const targetPath = join(pluginsDir, source.split("/").pop() || "plugin");
+    pluginLogger.info("[Plugin CLI] Plugin installed successfully");
+  } else if (options.local) {
+    // Copy from local path
+    const { cp } = await import("node:fs/promises");
+    const targetPath = join(pluginsDir, source.split("/").pop() || "plugin");
 
-		pluginLogger.info(`[Plugin CLI] Installing plugin from local path: ${source}`);
+    pluginLogger.info(`[Plugin CLI] Installing plugin from local path: ${source}`);
 
-		await cp(source, targetPath, { recursive: true });
+    await cp(source, targetPath, { recursive: true });
 
-		pluginLogger.info(`[Plugin CLI] Plugin installed successfully to ${targetPath}`);
-	} else {
-		throw new Error("Must specify either --npm or --local");
-	}
+    pluginLogger.info(`[Plugin CLI] Plugin installed successfully to ${targetPath}`);
+  } else {
+    throw new Error("Must specify either --npm or --local");
+  }
 }
 
 /**
  * Remove an installed plugin
  */
 export async function removePlugin(pluginsDir: string, pluginId: string): Promise<void> {
-	const pluginPath = join(pluginsDir, pluginId);
+  const pluginPath = join(pluginsDir, pluginId);
 
-	if (!existsSync(pluginPath)) {
-		throw new Error(`Plugin not found: ${pluginId}`);
-	}
+  if (!existsSync(pluginPath)) {
+    throw new Error(`Plugin not found: ${pluginId}`);
+  }
 
-	pluginLogger.info(`[Plugin CLI] Removing plugin: ${pluginId}`);
+  pluginLogger.info(`[Plugin CLI] Removing plugin: ${pluginId}`);
 
-	await rm(pluginPath, { recursive: true, force: true });
+  await rm(pluginPath, { recursive: true, force: true });
 
-	pluginLogger.info(`[Plugin CLI] Plugin removed successfully`);
+  pluginLogger.info("[Plugin CLI] Plugin removed successfully");
 }
 
 /**
  * Get plugin info
  */
 export async function getPluginInfo(pluginsDir: string, pluginId: string): Promise<PluginInfo | null> {
-	const plugins = await listPlugins(pluginsDir);
-	return plugins.find(p => p.id === pluginId) || null;
+  const plugins = await listPlugins(pluginsDir);
+  return plugins.find((p) => p.id === pluginId) || null;
 }
 
 /**
  * Enable a plugin
  */
 export async function enablePlugin(pluginsDir: string, pluginId: string): Promise<void> {
-	const pluginPath = join(pluginsDir, pluginId);
+  const pluginPath = join(pluginsDir, pluginId);
 
-	if (!existsSync(pluginPath)) {
-		throw new Error(`Plugin not found: ${pluginId}`);
-	}
+  if (!existsSync(pluginPath)) {
+    throw new Error(`Plugin not found: ${pluginId}`);
+  }
 
-	// Plugin is enabled by default if index.js exists
-	const indexPath = join(pluginPath, "index.js");
+  // Plugin is enabled by default if index.js exists
+  const indexPath = join(pluginPath, "index.js");
 
-	if (!existsSync(indexPath)) {
-		throw new Error(`Plugin ${pluginId} is missing index.js`);
-	}
+  if (!existsSync(indexPath)) {
+    throw new Error(`Plugin ${pluginId} is missing index.js`);
+  }
 
-	pluginLogger.info(`[Plugin CLI] Plugin ${pluginId} is already enabled`);
+  pluginLogger.info(`[Plugin CLI] Plugin ${pluginId} is already enabled`);
 }
 
 /**
  * Disable a plugin
  */
 export async function disablePlugin(pluginsDir: string, pluginId: string): Promise<void> {
-	const pluginPath = join(pluginsDir, pluginId);
+  const pluginPath = join(pluginsDir, pluginId);
 
-	if (!existsSync(pluginPath)) {
-		throw new Error(`Plugin not found: ${pluginId}`);
-	}
+  if (!existsSync(pluginPath)) {
+    throw new Error(`Plugin not found: ${pluginId}`);
+  }
 
-	const indexPath = join(pluginPath, "index.js");
-	const disabledPath = join(pluginPath, "index.js.disabled");
+  const indexPath = join(pluginPath, "index.js");
+  const disabledPath = join(pluginPath, "index.js.disabled");
 
-	if (!existsSync(indexPath)) {
-		throw new Error(`Plugin ${pluginId} is already disabled`);
-	}
+  if (!existsSync(indexPath)) {
+    throw new Error(`Plugin ${pluginId} is already disabled`);
+  }
 
-	const { rename } = await import("node:fs/promises");
-	await rename(indexPath, disabledPath);
+  const { rename } = await import("node:fs/promises");
+  await rename(indexPath, disabledPath);
 
-	pluginLogger.info(`[Plugin CLI] Plugin ${pluginId} disabled`);
+  pluginLogger.info(`[Plugin CLI] Plugin ${pluginId} disabled`);
 }

--- a/extensions/memory-hybrid/cli/register.ts
+++ b/extensions/memory-hybrid/cli/register.ts
@@ -459,8 +459,9 @@ export function registerHybridMemCli(mem: Chainable, ctx: HybridMemCliContext): 
       factsDb: ctx.factsDb,
       vectorDb: ctx.vectorDb,
       embeddings: ctx.embeddings,
+      runConfigSet: ctx.runConfigSet,
     };
-    registerUserFriendlyCommands(mem as any, userFriendlyContext);
+    registerUserFriendlyCommands(mem, userFriendlyContext);
   } catch (err) {
     capturePluginError(err instanceof Error ? err : new Error(String(err)), {
       subsystem: "registration",

--- a/extensions/memory-hybrid/cli/shared.ts
+++ b/extensions/memory-hybrid/cli/shared.ts
@@ -5,6 +5,7 @@
  * multiple CLI command modules.
  */
 
+import { basename } from "node:path";
 import { capturePluginError } from "../services/error-reporter.js";
 
 /**
@@ -38,12 +39,17 @@ export type Chainable = {
   alias?(name: string): Chainable;
 };
 
+function isStandaloneCliProcess(argv = process.argv): boolean {
+  const executable = basename(argv[1] ?? "");
+  return executable === "openclaw" || executable === "hybrid-mem";
+}
+
 /** Wrap async action to exit on completion (only for standalone CLI). */
 export const withExit =
   <A extends unknown[], R>(fn: (...args: A) => Promise<R>) =>
   (...args: A) => {
-    const isStandaloneCli = process.argv.some((arg) => arg.includes("openclaw") || arg.includes("hybrid-mem"));
-    Promise.resolve(fn(...args)).then(
+    const isStandaloneCli = isStandaloneCliProcess();
+    return Promise.resolve(fn(...args)).then(
       () => {
         if (isStandaloneCli) process.exit(process.exitCode ?? 0);
       },

--- a/extensions/memory-hybrid/cli/shared.ts
+++ b/extensions/memory-hybrid/cli/shared.ts
@@ -32,8 +32,8 @@ export type Chainable = {
   command(name: string): Chainable;
   description(desc: string): Chainable;
   action(fn: (...args: any[]) => void | Promise<void>): Chainable;
-  option(flags: string, desc?: string, defaultValue?: string): Chainable;
-  requiredOption(flags: string, desc?: string, defaultValue?: string): Chainable;
+  option(flags: string, desc?: string, defaultValue?: unknown): Chainable;
+  requiredOption(flags: string, desc?: string, defaultValue?: unknown): Chainable;
   argument?(name: string, desc?: string): Chainable;
   alias?(name: string): Chainable;
 };

--- a/extensions/memory-hybrid/cli/verify.ts
+++ b/extensions/memory-hybrid/cli/verify.ts
@@ -173,16 +173,11 @@ export function registerVerifyCommands(mem: Chainable, ctx: VerifyContext): void
 
   mem
     .command("doctor")
-    .description(
-      "Guided onboarding checks: runs install/verify in a safe sequence and optionally applies fixes.",
-    )
+    .description("Guided onboarding checks: runs install/verify in a safe sequence and optionally applies fixes.")
     .option("--fix", "Apply recommended install defaults + verify fixes before final verification")
     .option("--dry-run", "Preview install defaults without writing files")
     .option("--test-llm", "Test configured LLM models as part of verification")
-    .option(
-      "--reconcile",
-      "Check SQLite ↔ LanceDB consistency (orphans; issue #904). Use with --fix to auto-heal.",
-    )
+    .option("--reconcile", "Check SQLite ↔ LanceDB consistency (orphans; issue #904). Use with --fix to auto-heal.")
     .option(
       "--reconcile-policy <policy>",
       "Self-heal policy with --reconcile --fix: conservative|balanced|aggressive (default: balanced)",
@@ -216,7 +211,7 @@ export function registerVerifyCommands(mem: Chainable, ctx: VerifyContext): void
             Math.min(5000, Number.isFinite(parsedReconcileMaxFixes) ? parsedReconcileMaxFixes : 200),
           );
           const applyFixes = opts.fix === true;
-          const dryRunInstall = opts.dryRun === true && !applyFixes;
+          const dryRunInstall = !applyFixes;
           const sink = { log: (s: string) => console.log(s), error: (s: string) => console.error(s) };
 
           console.log("🩺 Hybrid Memory Doctor");

--- a/extensions/memory-hybrid/cli/verify.ts
+++ b/extensions/memory-hybrid/cli/verify.ts
@@ -210,8 +210,8 @@ export function registerVerifyCommands(mem: Chainable, ctx: VerifyContext): void
             0,
             Math.min(5000, Number.isFinite(parsedReconcileMaxFixes) ? parsedReconcileMaxFixes : 200),
           );
-          const applyFixes = opts.fix === true;
-          const dryRunInstall = !applyFixes;
+          const applyFixes = opts.fix === true && opts.dryRun !== true;
+          const dryRunInstall = opts.dryRun === true || !applyFixes;
           const sink = { log: (s: string) => console.log(s), error: (s: string) => console.error(s) };
 
           console.log("🩺 Hybrid Memory Doctor");

--- a/extensions/memory-hybrid/docs/QUICK-START.md
+++ b/extensions/memory-hybrid/docs/QUICK-START.md
@@ -50,7 +50,7 @@ openclaw hybrid-mem config-set embedding.model nomic-embed-text
 
 ```bash
 # Option B: Use ONNX (lighter, no dependencies)
-npm install onnxruntime-node
+npm install --prefix ~/.openclaw/extensions/openclaw-hybrid-memory onnxruntime-node
 openclaw hybrid-mem config-set embedding.provider onnx
 openclaw hybrid-mem config-set embedding.model all-MiniLM-L6-v2
 ```
@@ -248,9 +248,9 @@ Once you're comfortable with the basics:
 ### Learn More
 
 - **Examples**: `openclaw hybrid-mem examples <category>`
-- **Full CLI Reference**: See `docs/CLI-REFERENCE.md`
-- **Configuration Guide**: See `docs/CONFIGURATION.md`
-- **Architecture**: See `docs/ARCHITECTURE.md`
+- **Full CLI Reference**: See `../../../docs/CLI-REFERENCE.md`
+- **Configuration Guide**: See `../../../docs/CONFIGURATION.md`
+- **Architecture**: See `../../../docs/ARCHITECTURE.md`
 
 ---
 

--- a/extensions/memory-hybrid/package-lock.json
+++ b/extensions/memory-hybrid/package-lock.json
@@ -22,7 +22,7 @@
         "knip": "^5.0.0",
         "tsdown": "^0.22.0",
         "typescript": "^5.9.3",
-        "unrun": "^0.2.37",
+        "unrun": "0.2.37",
         "vitest": "^4.0.18"
       },
       "engines": {
@@ -10577,19 +10577,19 @@
       }
     },
     "node_modules/unrun": {
-      "version": "0.2.38",
-      "resolved": "https://registry.npmjs.org/unrun/-/unrun-0.2.38.tgz",
-      "integrity": "sha512-vYFWSyX5Be408RX+CAd2Heh8egQRnGBWOQmZKwYPvMtTQNmRYoKdSyFIczYNxZEMqz0dJzSxp7xkcZGzvtkHyQ==",
+      "version": "0.2.37",
+      "resolved": "https://registry.npmjs.org/unrun/-/unrun-0.2.37.tgz",
+      "integrity": "sha512-AA7vDuYsgeSYVzJMm16UKA+aXFKhy7nFqW9z5l7q44K4ppFWZAMqYS58ePRZbugMLPH0fwwMzD5A8nP0avxwZQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "rolldown": "^1.0.0"
+        "rolldown": "1.0.0-rc.17"
       },
       "bin": {
         "unrun": "dist/cli.mjs"
       },
       "engines": {
-        "node": "^22.13.0 || >=24.0.0"
+        "node": ">=20.19.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/Gugustinette"
@@ -10601,6 +10601,314 @@
         "synckit": {
           "optional": true
         }
+      }
+    },
+    "node_modules/unrun/node_modules/@oxc-project/types": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
+      "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/unrun/node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/unrun/node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/unrun/node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/unrun/node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/unrun/node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz",
+      "integrity": "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/unrun/node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/unrun/node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz",
+      "integrity": "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/unrun/node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/unrun/node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/unrun/node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/unrun/node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz",
+      "integrity": "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/unrun/node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/unrun/node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz",
+      "integrity": "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/unrun/node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
+      "integrity": "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/unrun/node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz",
+      "integrity": "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/unrun/node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
+      "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unrun/node_modules/rolldown": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
+      "integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.127.0",
+        "@rolldown/pluginutils": "1.0.0-rc.17"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.17",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
       }
     },
     "node_modules/urlpattern-polyfill": {

--- a/extensions/memory-hybrid/package-lock.json
+++ b/extensions/memory-hybrid/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@lancedb/lancedb": "^0.27.1",
         "@types/node": "^25.2.3",
+        "commander": "^13.1.0",
         "franc": "^6.2.0",
         "graphql": "^16.14.0",
         "graphql-yoga": "^5.21.0"
@@ -18,7 +19,6 @@
       "devDependencies": {
         "@biomejs/biome": "^1.9.4",
         "@vitest/coverage-v8": "^4.0.18",
-        "commander": "^13.1.0",
         "knip": "^5.0.0",
         "tsdown": "^0.22.0",
         "typescript": "^5.9.3",
@@ -6099,7 +6099,6 @@
     },
     "node_modules/commander": {
       "version": "13.1.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"

--- a/extensions/memory-hybrid/package.json
+++ b/extensions/memory-hybrid/package.json
@@ -34,14 +34,7 @@
     "type": "git",
     "url": "git+https://github.com/markus-lassfolk/openclaw-hybrid-memory.git"
   },
-  "keywords": [
-    "openclaw",
-    "plugin",
-    "memory",
-    "sqlite",
-    "lancedb",
-    "embeddings"
-  ],
+  "keywords": ["openclaw", "plugin", "memory", "sqlite", "lancedb", "embeddings"],
   "peerDependencies": {
     "@sinclair/typebox": "^0.34.48",
     "openai": "^6.16.0",
@@ -58,12 +51,8 @@
     "onnxruntime-node": "^1.20.0"
   },
   "openclaw": {
-    "extensions": [
-      "./dist/index.js"
-    ],
-    "runtimeExtensions": [
-      "./dist/index.js"
-    ]
+    "extensions": ["./dist/index.js"],
+    "runtimeExtensions": ["./dist/index.js"]
   },
   "scripts": {
     "build": "tsdown",

--- a/extensions/memory-hybrid/package.json
+++ b/extensions/memory-hybrid/package.json
@@ -78,17 +78,18 @@
     "knip": "^5.0.0",
     "tsdown": "^0.22.0",
     "typescript": "^5.9.3",
-    "unrun": "^0.2.37",
+    "unrun": "0.2.37",
     "vitest": "^4.0.18"
   },
   "overrides": {
-    "ip-address": ">=10.1.1",
     "@hono/node-server": ">=1.19.10 <2",
     "axios": ">=1.15.0",
     "fast-xml-parser": ">=5.5.6",
     "follow-redirects": ">=1.16.0",
+    "ip-address": ">=10.1.1",
     "opusscript": "0.1.1",
     "tar": ">=7.5.11",
+    "unrun": "0.2.37",
     "yauzl": ">=3.2.1"
   },
   "engines": {

--- a/extensions/memory-hybrid/package.json
+++ b/extensions/memory-hybrid/package.json
@@ -43,6 +43,7 @@
   "dependencies": {
     "@lancedb/lancedb": "^0.27.1",
     "@types/node": "^25.2.3",
+    "commander": "^13.1.0",
     "franc": "^6.2.0",
     "graphql": "^16.14.0",
     "graphql-yoga": "^5.21.0"
@@ -74,11 +75,10 @@
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",
     "@vitest/coverage-v8": "^4.0.18",
-    "commander": "^13.1.0",
     "knip": "^5.0.0",
-    "unrun": "^0.2.37",
     "tsdown": "^0.22.0",
     "typescript": "^5.9.3",
+    "unrun": "^0.2.37",
     "vitest": "^4.0.18"
   },
   "overrides": {

--- a/extensions/memory-hybrid/routes/dashboard-server.ts
+++ b/extensions/memory-hybrid/routes/dashboard-server.ts
@@ -148,6 +148,12 @@ interface DashboardContext {
   resolvedLancePath: string;
   /** Optional owner/repo for GitHub queries (e.g. "markus-lassfolk/openclaw-hybrid-memory") */
   gitRepo?: string;
+  /** Optional plugin config exposed to GraphQL context. */
+  cfg?: unknown;
+  /** Optional embedding service exposed to GraphQL context. */
+  embeddings?: unknown;
+  /** Optional embedding registry exposed to GraphQL context. */
+  embeddingRegistry?: unknown;
   /** Optional CostTracker instance — delegates cost stats to the established abstraction. */
   costTracker?: import("../backends/cost-tracker.js").CostTracker | null;
   /** Optional logger for structured logging of server errors */
@@ -1514,7 +1520,6 @@ export interface DashboardServer {
 
 export async function createDashboardServer(ctx: DashboardContext, port: number): Promise<DashboardServer> {
   const html = getDashboardHtml();
-
   const { createGraphQLServer } = await import("./graphql-server.js");
   const { yoga } = createGraphQLServer(ctx.factsDb, ctx.vectorDb, {
     config: ctx.cfg,
@@ -1522,7 +1527,7 @@ export async function createDashboardServer(ctx: DashboardContext, port: number)
     vectorDb: ctx.vectorDb,
     embeddings: ctx.embeddings,
     embeddingRegistry: ctx.embeddingRegistry,
-  } as any);
+  });
 
   const server = createServer(async (req, res) => {
     const url = req.url ?? "/";
@@ -2045,11 +2050,17 @@ export async function createDashboardServer(ctx: DashboardContext, port: number)
       });
       res.end(graphExplorerHTML);
     } else if (pathname === "/graphql" && req.method === "POST") {
+      // Handle GraphQL API requests using the shared Yoga server created at dashboard startup.
       try {
         const graphQlBody = await readJsonBody(req, MAX_DASHBOARD_JSON_BODY_BYTES);
+        const headers = new Headers();
+        for (const [name, value] of Object.entries(req.headers)) {
+          if (typeof value === "string") headers.set(name, value);
+          else if (Array.isArray(value)) headers.set(name, value.join(", "));
+        }
         const response = await yoga.fetch(req.url || "", {
           method: req.method || "POST",
-          headers: req.headers as any,
+          headers,
           body: JSON.stringify(graphQlBody),
         });
 

--- a/extensions/memory-hybrid/routes/dashboard-server.ts
+++ b/extensions/memory-hybrid/routes/dashboard-server.ts
@@ -1515,7 +1515,7 @@ export interface DashboardServer {
 export async function createDashboardServer(ctx: DashboardContext, port: number): Promise<DashboardServer> {
   const html = getDashboardHtml();
 
-  const server = createServer((req, res) => {
+  const server = createServer(async (req, res) => {
     const url = req.url ?? "/";
     let pathname: string;
     let searchParams: URLSearchParams;
@@ -2046,23 +2046,25 @@ export async function createDashboardServer(ctx: DashboardContext, port: number)
         embeddingRegistry: ctx.embeddingRegistry,
       } as any);
 
-      // Handle GraphQL request
-      const response = await yoga.fetch(req.url || "", {
-        method: req.method || "POST",
-        headers: req.headers as any,
-        body: await new Promise<string>((resolve) => {
-          let body = "";
-          req.on("data", (chunk) => {
-            body += chunk;
-          });
-          req.on("end", () => {
-            resolve(body);
-          });
-        }),
-      });
+      try {
+        const graphQlBody = await readJsonBody(req, MAX_DASHBOARD_JSON_BODY_BYTES);
+        const response = await yoga.fetch(req.url || "", {
+          method: req.method || "POST",
+          headers: req.headers as any,
+          body: JSON.stringify(graphQlBody),
+        });
 
-      res.writeHead(response.status, Object.fromEntries(response.headers));
-      res.end(await response.text());
+        res.writeHead(response.status, Object.fromEntries(response.headers));
+        res.end(await response.text());
+      } catch (err) {
+        if (err instanceof Error && err.message === "Request body too large") {
+          res.writeHead(413, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ error: "PayloadTooLarge" }));
+          return;
+        }
+        res.writeHead(400, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: "InvalidGraphQLRequest" }));
+      }
     } else {
       res.writeHead(404, { "Content-Type": "text/plain" });
       res.end("Not found");

--- a/extensions/memory-hybrid/routes/dashboard-server.ts
+++ b/extensions/memory-hybrid/routes/dashboard-server.ts
@@ -1515,6 +1515,15 @@ export interface DashboardServer {
 export async function createDashboardServer(ctx: DashboardContext, port: number): Promise<DashboardServer> {
   const html = getDashboardHtml();
 
+  const { createGraphQLServer } = await import("./graphql-server.js");
+  const { yoga } = createGraphQLServer(ctx.factsDb, ctx.vectorDb, {
+    config: ctx.cfg,
+    factsDb: ctx.factsDb,
+    vectorDb: ctx.vectorDb,
+    embeddings: ctx.embeddings,
+    embeddingRegistry: ctx.embeddingRegistry,
+  } as any);
+
   const server = createServer(async (req, res) => {
     const url = req.url ?? "/";
     let pathname: string;
@@ -2036,16 +2045,6 @@ export async function createDashboardServer(ctx: DashboardContext, port: number)
       });
       res.end(graphExplorerHTML);
     } else if (pathname === "/graphql" && req.method === "POST") {
-      // Handle GraphQL API requests
-      const { createGraphQLServer } = await import("./graphql-server.js");
-      const { yoga } = createGraphQLServer(ctx.factsDb, ctx.vectorDb, {
-        config: ctx.cfg,
-        factsDb: ctx.factsDb,
-        vectorDb: ctx.vectorDb,
-        embeddings: ctx.embeddings,
-        embeddingRegistry: ctx.embeddingRegistry,
-      } as any);
-
       try {
         const graphQlBody = await readJsonBody(req, MAX_DASHBOARD_JSON_BODY_BYTES);
         const response = await yoga.fetch(req.url || "", {

--- a/extensions/memory-hybrid/routes/graphql-resolvers.ts
+++ b/extensions/memory-hybrid/routes/graphql-resolvers.ts
@@ -1,451 +1,425 @@
-/**
- * GraphQL Resolvers for OpenClaw Hybrid Memory
- * Implements all query, mutation, and subscription resolvers
- */
+// GraphQL resolver map for the dashboard API.
+// Keep this module conservative: it must compile against the real FactsDB API and
+// return safe placeholders for schema areas that are not implemented yet.
 
-import type { FactsDB } from "../backends/facts-db/facts-db-layer1.js";
+import type { FactsDB } from "../backends/facts-db.js";
 import type { VectorDB } from "../backends/vector-db.js";
-import type { MemoryPluginContext } from "../api/memory-plugin-api.js";
-import { searchHybrid } from "../services/search-hybrid.js";
+import { DECAY_CLASSES, type DecayClass } from "../config.js";
+import type { MemoryLinkType } from "../backends/facts-db/types.js";
+import type { MemoryEntry } from "../types/memory.js";
 
-export interface GraphQLContext {
-	factsDb: FactsDB;
-	vectorDb?: VectorDB;
-	pluginContext: MemoryPluginContext;
+export type GraphQLContext = {
+  factsDb: FactsDB;
+  vectorDb?: VectorDB;
+  pluginContext: Record<string, unknown>;
+};
+
+type ResolverFn = (parent: unknown, args: unknown, context: GraphQLContext) => unknown;
+type ResolverGroup = Record<string, ResolverFn>;
+
+type GraphQLResolvers = {
+  Query: ResolverGroup;
+  Mutation: ResolverGroup;
+  Fact: ResolverGroup;
+  Link: ResolverGroup;
+  Episode: ResolverGroup;
+};
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" ? (value as Record<string, unknown>) : {};
 }
 
-interface GraphQLResolvers {
-	Query: Record<string, (parent: unknown, args: unknown, context: GraphQLContext) => unknown>;
-	Mutation: Record<string, (parent: unknown, args: unknown, context: GraphQLContext) => unknown>;
-	Fact: Record<string, (parent: unknown, args: unknown, context: GraphQLContext) => unknown>;
-	Link: Record<string, (parent: unknown, args: unknown, context: GraphQLContext) => unknown>;
-	Episode: Record<string, (parent: unknown, args: unknown, context: GraphQLContext) => unknown>;
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function asNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function asStringArray(value: unknown): string[] | undefined {
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : undefined;
+}
+
+function allFacts(factsDb: FactsDB, includeSuperseded = false): MemoryEntry[] {
+  return factsDb.getAll({ includeSuperseded });
+}
+
+function isActiveFact(fact: MemoryEntry, nowSec = Math.floor(Date.now() / 1000)): boolean {
+  const notSuperseded = (fact.supersededAt == null || fact.supersededAt <= 0) && fact.supersededBy == null;
+  const notExpired = fact.expiresAt == null || fact.expiresAt <= 0 || fact.expiresAt > nowSec;
+  return notSuperseded && notExpired;
+}
+
+function scoreFact(fact: MemoryEntry, query: string): number {
+  const q = query.toLowerCase();
+  const haystack = [fact.text, fact.entity, fact.key, fact.value, fact.category, ...(fact.tags ?? [])]
+    .filter(Boolean)
+    .join("\n")
+    .toLowerCase();
+  if (!q) return 0;
+  if (haystack.includes(q)) return 1;
+  const terms = q.split(/\s+/).filter(Boolean);
+  if (terms.length === 0) return 0;
+  return terms.filter((term) => haystack.includes(term)).length / terms.length;
+}
+
+function searchFacts(
+  context: GraphQLContext,
+  input: Record<string, unknown>,
+): Array<{
+  fact: MemoryEntry;
+  score: number;
+  matchType: string;
+  snippet: string;
+}> {
+  const query = asString(input.query) ?? "";
+  const limit = Math.max(1, Math.min(100, asNumber(input.limit) ?? 20));
+  const offset = Math.max(0, asNumber(input.offset) ?? 0);
+  const categories = asStringArray(input.categories);
+  const tags = asStringArray(input.tags);
+  const minImportance = asNumber(input.minImportance);
+  const minConfidence = asNumber(input.minConfidence);
+  const includeSuperseded = input.includeSuperseded === true;
+  const includeExpired = input.includeExpired === true;
+  const now = Date.now();
+
+  let facts = allFacts(context.factsDb, includeSuperseded);
+  if (!includeExpired) facts = facts.filter((fact) => fact.expiresAt == null || fact.expiresAt > now);
+  if (categories?.length) facts = facts.filter((fact) => categories.includes(fact.category));
+  if (tags?.length) facts = facts.filter((fact) => tags.some((tag) => fact.tags?.includes(tag)));
+  if (minImportance !== undefined) facts = facts.filter((fact) => fact.importance >= minImportance);
+  if (minConfidence !== undefined) facts = facts.filter((fact) => fact.confidence >= minConfidence);
+
+  return facts
+    .map((fact) => ({ fact, score: scoreFact(fact, query) }))
+    .filter((result) => query.length === 0 || result.score > 0)
+    .sort((a, b) => b.score - a.score || b.fact.createdAt - a.fact.createdAt)
+    .slice(offset, offset + limit)
+    .map(({ fact, score }) => ({
+      fact,
+      score,
+      matchType: "fts",
+      snippet: fact.text.slice(0, 200),
+    }));
+}
+
+type GraphQLLink = {
+  id: string;
+  sourceId: string;
+  targetId: string;
+  linkType: string;
+  weight: number;
+  createdAt: number;
+};
+
+function normalizeLink(row: Record<string, unknown>): GraphQLLink {
+  return {
+    id: String(row.id ?? ""),
+    sourceId: String(row.source_fact_id ?? row.sourceFactId ?? ""),
+    targetId: String(row.target_fact_id ?? row.targetFactId ?? ""),
+    linkType: String(row.link_type ?? row.linkType ?? "RELATED_TO"),
+    weight: Number(row.strength ?? row.weight ?? 1),
+    createdAt: Number(row.created_at ?? row.createdAt ?? 0),
+  };
+}
+
+function getAllLinks(factsDb: FactsDB): GraphQLLink[] {
+  const rows = factsDb
+    .getRawDb()
+    .prepare(
+      "SELECT id, source_fact_id, target_fact_id, link_type, strength, created_at FROM memory_links ORDER BY created_at DESC",
+    )
+    .all() as Array<Record<string, unknown>>;
+  return rows.map(normalizeLink);
+}
+
+function isMemoryLinkType(value: string): value is MemoryLinkType {
+  return ["SUPERSEDES", "CAUSED_BY", "PART_OF", "RELATED_TO", "DEPENDS_ON", "CONTRADICTS", "INSTANCE_OF"].includes(
+    value,
+  );
+}
+
+function asDecayClass(value: unknown): DecayClass {
+  return typeof value === "string" && (DECAY_CLASSES as readonly string[]).includes(value)
+    ? (value as DecayClass)
+    : "normal";
+}
+
+function createStoreInput(input: Record<string, unknown>) {
+  return {
+    text: asString(input.text) ?? "",
+    category: asString(input.category) ?? "other",
+    importance: asNumber(input.importance) ?? 0.5,
+    confidence: asNumber(input.confidence) ?? 1,
+    decayClass: asDecayClass(input.decayClass),
+    source: asString(input.source) ?? "graphql",
+    tags: asStringArray(input.tags) ?? [],
+    entity: asString(input.entity) ?? null,
+    key: asString(input.key) ?? null,
+    value: asString(input.value) ?? null,
+    scope: asString(input.scope) as MemoryEntry["scope"] | undefined,
+    scopeTarget: asString(input.scopeTarget) ?? null,
+    expiresAt: asNumber(input.expiresAt) ?? null,
+  };
 }
 
 export const resolvers: GraphQLResolvers = {
-	Query: {
-		// Get a single fact by ID
-		fact: async (_parent, args: { id: string }, context) => {
-			const fact = context.factsDb.getFactById(args.id);
-			return fact || null;
-		},
+  Query: {
+    fact: (_parent, args, context) => {
+      const id = asString(asRecord(args).id);
+      return id ? context.factsDb.getById(id) : null;
+    },
 
-		// Get multiple facts with filtering
-		facts: async (_parent, args: {
-			limit?: number;
-			offset?: number;
-			category?: string;
-			decayClass?: string;
-			tags?: string[];
-			scope?: string;
-			includeSuperseded?: boolean;
-			includeExpired?: boolean;
-		}, context) => {
-			const { limit = 100, offset = 0, category, decayClass, tags, scope, includeSuperseded = false, includeExpired = false } = args;
+    facts: (_parent, args, context) => {
+      const input = asRecord(args);
+      const limit = Math.max(1, Math.min(500, asNumber(input.limit) ?? 100));
+      const offset = Math.max(0, asNumber(input.offset) ?? 0);
+      const category = asString(input.category);
+      const decayClass = asString(input.decayClass);
+      const tags = asStringArray(input.tags);
+      const scope = asString(input.scope);
+      const includeSuperseded = input.includeSuperseded === true;
+      const includeExpired = input.includeExpired === true;
+      const now = Date.now();
 
-			let facts = context.factsDb.getAllFacts();
+      let facts = allFacts(context.factsDb, includeSuperseded);
+      if (category) facts = facts.filter((fact) => fact.category === category);
+      if (decayClass) facts = facts.filter((fact) => fact.decayClass === decayClass);
+      if (tags?.length) facts = facts.filter((fact) => tags.some((tag) => fact.tags?.includes(tag)));
+      if (scope) facts = facts.filter((fact) => fact.scope === scope);
+      if (!includeExpired) facts = facts.filter((fact) => fact.expiresAt == null || fact.expiresAt > now);
+      return facts.sort((a, b) => b.createdAt - a.createdAt).slice(offset, offset + limit);
+    },
 
-			// Apply filters
-			if (category) {
-				facts = facts.filter(f => f.category === category);
-			}
-			if (decayClass) {
-				facts = facts.filter(f => f.decayClass === decayClass);
-			}
-			if (tags && tags.length > 0) {
-				facts = facts.filter(f => tags.some(tag => f.tags?.includes(tag)));
-			}
-			if (scope) {
-				facts = facts.filter(f => f.scope === scope);
-			}
-			if (!includeSuperseded) {
-				facts = facts.filter(f => !f.supersededBy);
-			}
-			if (!includeExpired) {
-				const now = Date.now();
-				facts = facts.filter(f => !f.expiresAt || f.expiresAt > now);
-			}
+    search: (_parent, args, context) => searchFacts(context, asRecord(asRecord(args).input)),
 
-			// Sort by createdAt descending
-			facts.sort((a, b) => b.createdAt - a.createdAt);
+    semanticSearch: (_parent, args, context) => {
+      const input = asRecord(args);
+      return searchFacts(context, { query: input.query, limit: input.limit, scope: input.scope });
+    },
 
-			// Pagination
-			return facts.slice(offset, offset + limit);
-		},
+    episode: () => null,
+    episodes: () => [],
+    link: (_parent, args, context) => {
+      const id = asString(asRecord(args).id);
+      if (!id) return null;
+      return getAllLinks(context.factsDb).find((link) => link.id === id) ?? null;
+    },
+    links: (_parent, args, context) => {
+      const input = asRecord(args);
+      const sourceId = asString(input.sourceId);
+      const targetId = asString(input.targetId);
+      const linkType = asString(input.linkType);
+      return getAllLinks(context.factsDb).filter(
+        (link) =>
+          (!sourceId || link.sourceId === sourceId) &&
+          (!targetId || link.targetId === targetId) &&
+          (!linkType || link.linkType === linkType),
+      );
+    },
+    relatedFacts: (_parent, args, context) => {
+      const input = asRecord(args);
+      const factId = asString(input.factId);
+      if (!factId) return [];
+      const maxDepth = Math.max(1, Math.min(5, asNumber(input.maxDepth) ?? 1));
+      return context.factsDb
+        .getConnectedFactIds([factId], maxDepth)
+        .filter((id) => id !== factId)
+        .map((id) => context.factsDb.getById(id))
+        .filter((fact): fact is MemoryEntry => fact !== null);
+    },
 
-		// Hybrid search
-		search: async (_parent, args: { input: {
-			query: string;
-			categories?: string[];
-			decayClasses?: string[];
-			tags?: string[];
-			minImportance?: number;
-			minConfidence?: number;
-			limit?: number;
-			offset?: number;
-			includeSuperseded?: boolean;
-			includeExpired?: boolean;
-			scope?: string;
-			scopeTarget?: string;
-		}}, context) => {
-			const { input } = args;
-			const { query, limit = 20, offset = 0 } = input;
+    entityFacts: (_parent, args, context) => {
+      const input = asRecord(args);
+      const entity = asString(input.entity);
+      const key = asString(input.key);
+      if (!entity) return [];
+      return allFacts(context.factsDb).filter((fact) => fact.entity === entity && (!key || fact.key === key));
+    },
 
-			// Use the hybrid search service
-			const results = await searchHybrid({
-				query,
-				factsDb: context.factsDb,
-				vectorDb: context.vectorDb,
-				limit: limit + offset, // Get more for offset
-				config: context.pluginContext.config,
-			});
+    graph: (_parent, args, context) => {
+      const filter = asRecord(asRecord(args).filter);
+      const categories = asStringArray(filter.categories);
+      const decayClasses = asStringArray(filter.decayClasses);
+      const minImportance = asNumber(filter.minImportance);
+      const scope = asString(filter.scope);
+      let facts = allFacts(context.factsDb).filter((fact) => isActiveFact(fact));
+      if (categories?.length) facts = facts.filter((fact) => categories.includes(fact.category));
+      if (decayClasses?.length) facts = facts.filter((fact) => decayClasses.includes(fact.decayClass));
+      if (minImportance !== undefined) facts = facts.filter((fact) => fact.importance >= minImportance);
+      if (scope) facts = facts.filter((fact) => fact.scope === scope);
+      return {
+        nodes: facts.map((fact) => ({
+          id: fact.id,
+          label: fact.text.slice(0, 50) + (fact.text.length > 50 ? "..." : ""),
+          category: fact.category,
+          importance: fact.importance,
+          confidence: fact.confidence,
+          decayClass: fact.decayClass,
+          factCount: 1,
+        })),
+        edges: facts
+          .filter((fact) => fact.supersededBy)
+          .map((fact) => ({
+            source: fact.id,
+            target: fact.supersededBy as string,
+            linkType: "superseded_by",
+            weight: 1,
+          })),
+      };
+    },
 
-			// Apply filters and offset
-			let filtered = results;
-			if (input.categories) {
-				filtered = filtered.filter(r => input.categories?.includes(r.fact.category));
-			}
-			if (input.minImportance !== undefined) {
-				filtered = filtered.filter(r => r.fact.importance >= input.minImportance!);
-			}
-			if (input.minConfidence !== undefined) {
-				filtered = filtered.filter(r => r.fact.confidence >= input.minConfidence!);
-			}
+    stats: (_parent, _args, context) => {
+      const facts = allFacts(context.factsDb, true);
+      const nowSec = Math.floor(Date.now() / 1000);
+      const active = facts.filter((fact) => isActiveFact(fact, nowSec));
+      const expired = facts.filter((fact) => fact.expiresAt != null && fact.expiresAt > 0 && fact.expiresAt <= nowSec);
+      const superseded = facts.filter(
+        (fact) => (fact.supersededAt != null && fact.supersededAt > 0) || fact.supersededBy != null,
+      );
+      const byCategory = new Map<string, number>();
+      const byDecay = new Map<string, number>();
+      for (const fact of active) {
+        byCategory.set(fact.category, (byCategory.get(fact.category) ?? 0) + 1);
+        byDecay.set(fact.decayClass, (byDecay.get(fact.decayClass) ?? 0) + 1);
+      }
+      return {
+        totalFacts: facts.length,
+        activeFactsCount: active.length,
+        expiredFactsCount: expired.length,
+        supersededFactsCount: superseded.length,
+        factsByCategory: [...byCategory].map(([category, count]) => ({ category, count })),
+        factsByDecayClass: [...byDecay].map(([decayClass, count]) => ({ decayClass, count })),
+        totalEpisodes: 0,
+        totalLinks: 0,
+        databaseSizeBytes: 0,
+        oldestFactDate: facts.length ? Math.min(...facts.map((fact) => fact.createdAt)) : null,
+        newestFactDate: facts.length ? Math.max(...facts.map((fact) => fact.createdAt)) : null,
+      };
+    },
+  },
 
-			return filtered.slice(offset, offset + limit).map(r => ({
-				fact: r.fact,
-				score: r.score,
-				matchType: r.backend || "hybrid",
-				snippet: r.fact.text.substring(0, 200),
-			}));
-		},
+  Mutation: {
+    createFact: (_parent, args, context) => {
+      const input = asRecord(asRecord(args).input);
+      const fact = context.factsDb.store(createStoreInput(input));
+      return fact;
+    },
 
-		// Semantic search only
-		semanticSearch: async (_parent, args: { query: string; limit?: number; scope?: string }, context) => {
-			if (!context.vectorDb) {
-				return [];
-			}
+    updateFact: (_parent, args, context) => {
+      const input = asRecord(asRecord(args).input);
+      const id = asString(input.id);
+      if (!id) throw new Error("Missing fact id");
+      const existing = context.factsDb.getById(id);
+      if (!existing) throw new Error(`Fact not found: ${id}`);
+      const updated = context.factsDb.store({
+        text: asString(input.text) ?? existing.text,
+        category: asString(input.category) ?? existing.category,
+        importance: asNumber(input.importance) ?? existing.importance,
+        confidence: asNumber(input.confidence) ?? existing.confidence,
+        decayClass: existing.decayClass,
+        source: existing.source,
+        tags: asStringArray(input.tags) ?? existing.tags ?? [],
+        entity: existing.entity,
+        key: existing.key,
+        value: existing.value,
+        scope: existing.scope,
+        scopeTarget: existing.scopeTarget ?? null,
+        expiresAt: asNumber(input.expiresAt) ?? existing.expiresAt ?? null,
+      });
+      context.factsDb.supersede(existing.id, updated.id);
+      return updated;
+    },
 
-			const { query, limit = 20, scope } = args;
+    deleteFact: (_parent, args, context) => {
+      const id = asString(asRecord(args).id);
+      return id ? context.factsDb.delete(id) : false;
+    },
 
-			// This would call the vector search service
-			// For now, delegate to hybrid search
-			const results = await searchHybrid({
-				query,
-				factsDb: context.factsDb,
-				vectorDb: context.vectorDb,
-				limit,
-				config: context.pluginContext.config,
-			});
+    supersedeFact: (_parent, args, context) => {
+      const input = asRecord(args);
+      const oldFactId = asString(input.oldFactId);
+      const newFactId = asString(input.newFactId);
+      if (!oldFactId || !newFactId) throw new Error("Missing fact id");
+      const newFact = context.factsDb.getById(newFactId);
+      if (!newFact) throw new Error("Fact not found");
+      context.factsDb.supersede(oldFactId, newFactId);
+      return newFact;
+    },
 
-			return results.map(r => ({
-				fact: r.fact,
-				score: r.score,
-				matchType: "semantic",
-				snippet: r.fact.text.substring(0, 200),
-			}));
-		},
+    createLink: (_parent, args, context) => {
+      const input = asRecord(args);
+      const sourceId = asString(input.sourceId);
+      const targetId = asString(input.targetId);
+      const linkType = asString(input.linkType) ?? "RELATED_TO";
+      const weight = asNumber(input.weight) ?? 1;
+      if (!sourceId || !targetId) throw new Error("Missing link endpoint");
+      if (!isMemoryLinkType(linkType)) throw new Error(`Unsupported link type: ${linkType}`);
+      const id = context.factsDb.createLink(sourceId, targetId, linkType, weight);
+      return getAllLinks(context.factsDb).find((link) => link.id === id);
+    },
+    deleteLink: (_parent, args, context) => {
+      const id = asString(asRecord(args).id);
+      if (!id) return false;
+      const result = context.factsDb.getRawDb().prepare("DELETE FROM memory_links WHERE id = ?").run(id);
+      return result.changes > 0;
+    },
 
-		// Entity lookup
-		entityFacts: async (_parent, args: { entity: string; key?: string }, context) => {
-			let facts = context.factsDb.getAllFacts();
-			facts = facts.filter(f => f.entity === args.entity);
-			if (args.key) {
-				facts = facts.filter(f => f.key === args.key);
-			}
-			return facts;
-		},
+    importFacts: (_parent, args, context) => {
+      const facts = Array.isArray(asRecord(args).facts) ? (asRecord(args).facts as unknown[]) : [];
+      return facts.map((raw) => context.factsDb.store(createStoreInput(asRecord(raw))));
+    },
 
-		// Statistics
-		stats: async (_parent, _args, context) => {
-			const allFacts = context.factsDb.getAllFacts();
-			const now = Date.now();
+    pruneFacts: (_parent, args, context) => {
+      const input = asRecord(args);
+      const olderThan = asNumber(input.olderThan);
+      const category = asString(input.category);
+      const toDelete = allFacts(context.factsDb).filter(
+        (fact) => (olderThan === undefined || fact.createdAt < olderThan) && (!category || fact.category === category),
+      );
+      let deleted = 0;
+      for (const fact of toDelete) {
+        if (context.factsDb.delete(fact.id)) deleted++;
+      }
+      return deleted;
+    },
 
-			const activeFacts = allFacts.filter(f => !f.supersededBy && (!f.expiresAt || f.expiresAt > now));
-			const expiredFacts = allFacts.filter(f => f.expiresAt && f.expiresAt <= now);
-			const supersededFacts = allFacts.filter(f => f.supersededBy);
+    consolidateFacts: () => null,
+    recomputeEmbeddings: () => null,
+  },
 
-			// Count by category
-			const categoryMap = new Map<string, number>();
-			for (const fact of activeFacts) {
-				categoryMap.set(fact.category, (categoryMap.get(fact.category) || 0) + 1);
-			}
+  Fact: {
+    links: (parent, _args, context) => {
+      const fact = asRecord(parent) as Partial<MemoryEntry>;
+      return fact.id ? getAllLinks(context.factsDb).filter((link) => link.sourceId === fact.id) : [];
+    },
+    linkedFrom: (parent, _args, context) => {
+      const fact = asRecord(parent) as Partial<MemoryEntry>;
+      return fact.id ? getAllLinks(context.factsDb).filter((link) => link.targetId === fact.id) : [];
+    },
+    supersedes: (parent, _args, context) => {
+      const fact = asRecord(parent) as Partial<MemoryEntry>;
+      return fact.supersedesId ? context.factsDb.getById(fact.supersedesId) : null;
+    },
+    supersededByFact: (parent, _args, context) => {
+      const fact = asRecord(parent) as Partial<MemoryEntry>;
+      return fact.supersededBy ? context.factsDb.getById(fact.supersededBy) : null;
+    },
+  },
 
-			// Count by decay class
-			const decayMap = new Map<string, number>();
-			for (const fact of activeFacts) {
-				decayMap.set(fact.decayClass, (decayMap.get(fact.decayClass) || 0) + 1);
-			}
+  Link: {
+    source: (parent, _args, context) => {
+      const sourceId = asString(asRecord(parent).sourceId);
+      return sourceId ? context.factsDb.getById(sourceId) : null;
+    },
+    target: (parent, _args, context) => {
+      const targetId = asString(asRecord(parent).targetId);
+      return targetId ? context.factsDb.getById(targetId) : null;
+    },
+  },
 
-			return {
-				totalFacts: allFacts.length,
-				activeFactsCount: activeFacts.length,
-				expiredFactsCount: expiredFacts.length,
-				supersededFactsCount: supersededFacts.length,
-				factsByCategory: Array.from(categoryMap.entries()).map(([category, count]) => ({
-					category,
-					count,
-				})),
-				factsByDecayClass: Array.from(decayMap.entries()).map(([decayClass, count]) => ({
-					decayClass,
-					count,
-				})),
-				totalEpisodes: 0, // TODO: Add episode tracking
-				totalLinks: 0, // TODO: Add link counting
-				databaseSizeBytes: 0, // TODO: Get actual DB size
-				oldestFactDate: allFacts.length > 0 ? Math.min(...allFacts.map(f => f.createdAt)) : null,
-				newestFactDate: allFacts.length > 0 ? Math.max(...allFacts.map(f => f.createdAt)) : null,
-			};
-		},
-
-		// Graph visualization
-		graph: async (_parent, args: { filter?: {
-			categories?: string[];
-			decayClasses?: string[];
-			minImportance?: number;
-			linkTypes?: string[];
-			maxDepth?: number;
-			startNodeIds?: string[];
-			scope?: string;
-		}}, context) => {
-			const { filter = {} } = args;
-			let facts = context.factsDb.getAllFacts();
-
-			// Apply filters
-			if (filter.categories) {
-				facts = facts.filter(f => filter.categories?.includes(f.category));
-			}
-			if (filter.decayClasses) {
-				facts = facts.filter(f => filter.decayClasses?.includes(f.decayClass));
-			}
-			if (filter.minImportance !== undefined) {
-				facts = facts.filter(f => f.importance >= filter.minImportance!);
-			}
-			if (filter.scope) {
-				facts = facts.filter(f => f.scope === filter.scope);
-			}
-
-			// Build nodes
-			const nodes = facts.map(f => ({
-				id: f.id,
-				label: f.text.substring(0, 50) + (f.text.length > 50 ? "..." : ""),
-				category: f.category,
-				importance: f.importance,
-				confidence: f.confidence,
-				decayClass: f.decayClass,
-				factCount: 1,
-			}));
-
-			// Build edges from supersession relationships
-			const edges = facts
-				.filter(f => f.supersededBy)
-				.map(f => ({
-					source: f.id,
-					target: f.supersededBy!,
-					linkType: "supersedes",
-					weight: 1.0,
-				}));
-
-			return { nodes, edges };
-		},
-
-		// Links
-		links: async (_parent, args: { sourceId?: string; targetId?: string; linkType?: string }, _context) => {
-			// TODO: Implement link storage and retrieval
-			return [];
-		},
-
-		relatedFacts: async (_parent, args: { factId: string; maxDepth?: number; linkTypes?: string[] }, _context) => {
-			// TODO: Implement graph traversal
-			return [];
-		},
-	},
-
-	Mutation: {
-		// Create a new fact
-		createFact: async (_parent, args: { input: {
-			text: string;
-			category?: string;
-			importance?: number;
-			confidence?: number;
-			decayClass?: string;
-			source?: string;
-			tags?: string[];
-			entity?: string;
-			key?: string;
-			value?: string;
-			scope?: string;
-			scopeTarget?: string;
-			expiresAt?: number;
-		}}, context) => {
-			const { input } = args;
-
-			const fact = {
-				id: crypto.randomUUID(),
-				text: input.text,
-				category: input.category || "other",
-				importance: input.importance ?? 0.5,
-				confidence: input.confidence ?? 1.0,
-				decayClass: input.decayClass || "episodic",
-				source: input.source,
-				tags: input.tags || [],
-				entity: input.entity,
-				key: input.key,
-				value: input.value,
-				scope: input.scope,
-				scopeTarget: input.scopeTarget,
-				createdAt: Date.now(),
-				expiresAt: input.expiresAt,
-			};
-
-			await context.factsDb.store(fact);
-			return fact;
-		},
-
-		// Update an existing fact
-		updateFact: async (_parent, args: { input: {
-			id: string;
-			text?: string;
-			category?: string;
-			importance?: number;
-			confidence?: number;
-			tags?: string[];
-			expiresAt?: number;
-		}}, context) => {
-			const { input } = args;
-			const existing = context.factsDb.getFactById(input.id);
-
-			if (!existing) {
-				throw new Error(`Fact not found: ${input.id}`);
-			}
-
-			const updated = {
-				...existing,
-				...(input.text !== undefined && { text: input.text }),
-				...(input.category !== undefined && { category: input.category }),
-				...(input.importance !== undefined && { importance: input.importance }),
-				...(input.confidence !== undefined && { confidence: input.confidence }),
-				...(input.tags !== undefined && { tags: input.tags }),
-				...(input.expiresAt !== undefined && { expiresAt: input.expiresAt }),
-				updatedAt: Date.now(),
-			};
-
-			await context.factsDb.store(updated);
-			return updated;
-		},
-
-		// Delete a fact
-		deleteFact: async (_parent, args: { id: string }, context) => {
-			const fact = context.factsDb.getFactById(args.id);
-			if (!fact) {
-				return false;
-			}
-			context.factsDb.deleteFact(args.id);
-			return true;
-		},
-
-		// Supersede an old fact with a new one
-		supersedeFact: async (_parent, args: { oldFactId: string; newFactId: string }, context) => {
-			const oldFact = context.factsDb.getFactById(args.oldFactId);
-			const newFact = context.factsDb.getFactById(args.newFactId);
-
-			if (!oldFact || !newFact) {
-				throw new Error("Fact not found");
-			}
-
-			const updated = {
-				...oldFact,
-				supersededBy: args.newFactId,
-				updatedAt: Date.now(),
-			};
-
-			await context.factsDb.store(updated);
-			return newFact;
-		},
-
-		// Import multiple facts
-		importFacts: async (_parent, args: { facts: Array<{
-			text: string;
-			category?: string;
-			importance?: number;
-			[key: string]: unknown;
-		}>}, context) => {
-			const created = [];
-
-			for (const input of args.facts) {
-				const fact = {
-					id: crypto.randomUUID(),
-					text: input.text,
-					category: input.category || "other",
-					importance: input.importance ?? 0.5,
-					confidence: 1.0,
-					decayClass: "episodic",
-					tags: [],
-					createdAt: Date.now(),
-				};
-
-				await context.factsDb.store(fact);
-				created.push(fact);
-			}
-
-			return created;
-		},
-
-		// Prune old facts
-		pruneFacts: async (_parent, args: { olderThan?: number; category?: string }, context) => {
-			const facts = context.factsDb.getAllFacts();
-			let toDelete = facts;
-
-			if (args.olderThan) {
-				toDelete = toDelete.filter(f => f.createdAt < args.olderThan!);
-			}
-			if (args.category) {
-				toDelete = toDelete.filter(f => f.category === args.category);
-			}
-
-			for (const fact of toDelete) {
-				context.factsDb.deleteFact(fact.id);
-			}
-
-			return toDelete.length;
-		},
-	},
-
-	// Field resolvers for Fact type
-	Fact: {
-		links: async (parent: { id: string }, _args, _context) => {
-			// TODO: Get outgoing links
-			return [];
-		},
-		linkedFrom: async (parent: { id: string }, _args, _context) => {
-			// TODO: Get incoming links
-			return [];
-		},
-		supersedes: async (parent: { supersededBy?: string }, _args, context) => {
-			if (!parent.supersededBy) return null;
-			return context.factsDb.getFactById(parent.supersededBy) || null;
-		},
-		supersededByFact: async (parent: { id: string }, _args, context) => {
-			const facts = context.factsDb.getAllFacts();
-			return facts.find(f => f.supersededBy === parent.id) || null;
-		},
-	},
-
-	// Field resolvers for Link type
-	Link: {
-		source: async (parent: { sourceId: string }, _args, context) => {
-			return context.factsDb.getFactById(parent.sourceId);
-		},
-		target: async (parent: { targetId: string }, _args, context) => {
-			return context.factsDb.getFactById(parent.targetId);
-		},
-	},
-
-	// Field resolvers for Episode type
-	Episode: {
-		facts: async (parent: { id: string }, _args, _context) => {
-			// TODO: Implement episode-fact relationships
-			return [];
-		},
-	},
+  Episode: {
+    facts: () => [],
+  },
 };

--- a/extensions/memory-hybrid/routes/graphql-schema.ts
+++ b/extensions/memory-hybrid/routes/graphql-schema.ts
@@ -230,8 +230,8 @@ export const graphqlSchema = `#graphql
     pruneFacts(olderThan: DateTime, category: String): Int!
 
     # Maintenance
-    consolidateFacts(categoryPattern: String): Int!
-    recomputeEmbeddings(factIds: [ID!]): Boolean!
+    consolidateFacts(categoryPattern: String): Int
+    recomputeEmbeddings(factIds: [ID!]): Boolean
   }
 
   # Subscriptions for real-time updates

--- a/extensions/memory-hybrid/routes/graphql-server.ts
+++ b/extensions/memory-hybrid/routes/graphql-server.ts
@@ -3,104 +3,69 @@
  * Provides GraphQL API endpoint with subscriptions support
  */
 
-import { createYoga, createPubSub } from "graphql-yoga";
-import type { FactsDB } from "../backends/facts-db/facts-db-layer1.js";
+type MemoryPluginContext = Record<string, unknown>;
+
+import { createSchema, createYoga, createPubSub } from "graphql-yoga";
+import type { FactsDB } from "../backends/facts-db.js";
 import type { VectorDB } from "../backends/vector-db.js";
-import type { MemoryPluginContext } from "../api/memory-plugin-api.js";
 import { graphqlSchema } from "./graphql-schema.js";
+import { pluginLogger } from "../utils/logger.js";
 import { resolvers, type GraphQLContext } from "./graphql-resolvers.js";
 
 // PubSub for subscriptions
 const pubSub = createPubSub<{
-	factCreated: [{ fact: unknown; category?: string; scope?: string }];
-	factUpdated: [{ fact: unknown }];
-	factDeleted: [{ id: string; category?: string }];
-	linkCreated: [{ link: unknown }];
-	statsUpdated: [{ stats: unknown }];
+  factCreated: [{ fact: unknown; category?: string; scope?: string }];
+  factUpdated: [{ fact: unknown }];
+  factDeleted: [{ id: string; category?: string }];
+  linkCreated: [{ link: unknown }];
+  statsUpdated: [{ stats: unknown }];
 }>();
 
 /**
  * Create GraphQL Yoga server instance
  */
 export function createGraphQLServer(
-	factsDb: FactsDB,
-	vectorDb: VectorDB | undefined,
-	pluginContext: MemoryPluginContext,
+  factsDb: FactsDB,
+  vectorDb: VectorDB | undefined,
+  pluginContext: MemoryPluginContext,
 ) {
-	const yoga = createYoga<GraphQLContext>({
-		schema: {
-			typeDefs: graphqlSchema,
-			resolvers: {
-				...resolvers,
-				Subscription: {
-					factCreated: {
-						subscribe: (_parent, args: { category?: string; scope?: string }) => {
-							return pubSub.subscribe("factCreated", (payload) => {
-								if (args.category && payload.category !== args.category) {
-									return false;
-								}
-								if (args.scope && payload.scope !== args.scope) {
-									return false;
-								}
-								return true;
-							});
-						},
-						resolve: (payload: { fact: unknown }) => payload.fact,
-					},
-					factUpdated: {
-						subscribe: (_parent, args: { factId?: string; category?: string }) => {
-							return pubSub.subscribe("factUpdated", (payload: { fact: { id: string; category: string } }) => {
-								if (args.factId && payload.fact.id !== args.factId) {
-									return false;
-								}
-								if (args.category && payload.fact.category !== args.category) {
-									return false;
-								}
-								return true;
-							});
-						},
-						resolve: (payload: { fact: unknown }) => payload.fact,
-					},
-					factDeleted: {
-						subscribe: (_parent, args: { category?: string }) => {
-							return pubSub.subscribe("factDeleted", (payload) => {
-								if (args.category && payload.category !== args.category) {
-									return false;
-								}
-								return true;
-							});
-						},
-						resolve: (payload: { id: string }) => payload.id,
-					},
-					linkCreated: {
-						subscribe: (_parent, args: { sourceId?: string; targetId?: string }) => {
-							return pubSub.subscribe("linkCreated", (payload: { link: { sourceId: string; targetId: string } }) => {
-								if (args.sourceId && payload.link.sourceId !== args.sourceId) {
-									return false;
-								}
-								if (args.targetId && payload.link.targetId !== args.targetId) {
-									return false;
-								}
-								return true;
-							});
-						},
-						resolve: (payload: { link: unknown }) => payload.link,
-					},
-					statsUpdated: {
-						subscribe: () => pubSub.subscribe("statsUpdated"),
-						resolve: (payload: { stats: unknown }) => payload.stats,
-					},
-				},
-			},
-		},
-		context: (): GraphQLContext => ({
-			factsDb,
-			vectorDb,
-			pluginContext,
-		}),
-		graphiql: {
-			title: "OpenClaw Hybrid Memory GraphQL API",
-			defaultQuery: `# Welcome to OpenClaw Hybrid Memory GraphQL API
+  const yoga = createYoga<GraphQLContext>({
+    schema: createSchema({
+      typeDefs: graphqlSchema,
+      resolvers: {
+        ...resolvers,
+        Subscription: {
+          factCreated: {
+            subscribe: () => pubSub.subscribe("factCreated"),
+            resolve: (payload: { fact: unknown }) => payload.fact,
+          },
+          factUpdated: {
+            subscribe: () => pubSub.subscribe("factUpdated"),
+            resolve: (payload: { fact: unknown }) => payload.fact,
+          },
+          factDeleted: {
+            subscribe: () => pubSub.subscribe("factDeleted"),
+            resolve: (payload: { id: string }) => payload.id,
+          },
+          linkCreated: {
+            subscribe: () => pubSub.subscribe("linkCreated"),
+            resolve: (payload: { link: unknown }) => payload.link,
+          },
+          statsUpdated: {
+            subscribe: () => pubSub.subscribe("statsUpdated"),
+            resolve: (payload: { stats: unknown }) => payload.stats,
+          },
+        },
+      },
+    }),
+    context: (): GraphQLContext => ({
+      factsDb,
+      vectorDb,
+      pluginContext,
+    }),
+    graphiql: {
+      title: "OpenClaw Hybrid Memory GraphQL API",
+      defaultQuery: `# Welcome to OpenClaw Hybrid Memory GraphQL API
 #
 # Example queries:
 
@@ -188,47 +153,52 @@ subscription WatchNewFacts {
   }
 }
 `,
-		},
-		cors: {
-			origin: "*",
-			credentials: true,
-			methods: ["GET", "POST", "OPTIONS"],
-		},
-		logging: {
-			debug: (...args) => console.log("[GraphQL]", ...args),
-			info: (...args) => console.log("[GraphQL]", ...args),
-			warn: (...args) => console.warn("[GraphQL]", ...args),
-			error: (...args) => console.error("[GraphQL]", ...args),
-		},
-	});
+    },
+    cors: {
+      origin: "*",
+      credentials: true,
+      methods: ["GET", "POST", "OPTIONS"],
+    },
+    logging: {
+      debug: (...args) => pluginLogger.debug(args.map(String).join(" ")),
+      info: (...args) => pluginLogger.info(args.map(String).join(" ")),
+      warn: (...args) => pluginLogger.warn(args.map(String).join(" ")),
+      error: (...args) => pluginLogger.error(args.map(String).join(" ")),
+    },
+  });
 
-	return { yoga, pubSub };
+  return { yoga, pubSub };
 }
 
 /**
  * Publish fact created event
  */
-export function publishFactCreated(pubSub: ReturnType<typeof createPubSub>, fact: unknown, category?: string, scope?: string) {
-	pubSub.publish("factCreated", { fact, category, scope });
+export function publishFactCreated(
+  pubSub: ReturnType<typeof createPubSub>,
+  fact: unknown,
+  category?: string,
+  scope?: string,
+) {
+  pubSub.publish("factCreated", { fact, category, scope });
 }
 
 /**
  * Publish fact updated event
  */
 export function publishFactUpdated(pubSub: ReturnType<typeof createPubSub>, fact: unknown) {
-	pubSub.publish("factUpdated", { fact });
+  pubSub.publish("factUpdated", { fact });
 }
 
 /**
  * Publish fact deleted event
  */
 export function publishFactDeleted(pubSub: ReturnType<typeof createPubSub>, id: string, category?: string) {
-	pubSub.publish("factDeleted", { id, category });
+  pubSub.publish("factDeleted", { id, category });
 }
 
 /**
  * Publish stats updated event
  */
 export function publishStatsUpdated(pubSub: ReturnType<typeof createPubSub>, stats: unknown) {
-	pubSub.publish("statsUpdated", { stats });
+  pubSub.publish("statsUpdated", { stats });
 }

--- a/extensions/memory-hybrid/routes/graphql-server.ts
+++ b/extensions/memory-hybrid/routes/graphql-server.ts
@@ -156,7 +156,7 @@ subscription WatchNewFacts {
     },
     cors: {
       origin: "*",
-      credentials: true,
+      credentials: false,
       methods: ["GET", "POST", "OPTIONS"],
     },
     logging: {

--- a/extensions/memory-hybrid/routes/graphql-server.ts
+++ b/extensions/memory-hybrid/routes/graphql-server.ts
@@ -3,7 +3,10 @@
  * Provides GraphQL API endpoint with subscriptions support
  */
 
-type MemoryPluginContext = Record<string, unknown>;
+interface MemoryPluginContext {
+  config?: unknown;
+  [key: string]: unknown;
+}
 
 import { createSchema, createYoga, createPubSub } from "graphql-yoga";
 import type { FactsDB } from "../backends/facts-db.js";

--- a/extensions/memory-hybrid/services/active-task.ts
+++ b/extensions/memory-hybrid/services/active-task.ts
@@ -22,7 +22,7 @@
 
 import { createHash, randomUUID } from "node:crypto";
 import { existsSync } from "node:fs";
-import { mkdir, readFile, readdir, realpath, rename, stat, unlink, writeFile } from "node:fs/promises";
+import { chmod, mkdir, readFile, readdir, realpath, rename, stat, unlink, writeFile } from "node:fs/promises";
 import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { formatDuration } from "../utils/duration.js";
 import { pluginLogger } from "../utils/logger.js";
@@ -475,8 +475,15 @@ export async function writeActiveTaskFile(
 
   const content = serializeActiveTaskFile(active, completed, goalsMirror);
   const tmpPath = `${filePath}.tmp-${process.pid}-${Date.now()}-${randomUUID().slice(0, 8)}`;
+  let existingMode: number | null = null;
+  try {
+    existingMode = (await stat(filePath)).mode & 0o777;
+  } catch {
+    existingMode = null;
+  }
   try {
     await writeFile(tmpPath, content, "utf-8");
+    if (existingMode !== null) await chmod(tmpPath, existingMode);
     await rename(tmpPath, filePath);
   } catch (err) {
     await unlink(tmpPath).catch(() => {});

--- a/extensions/memory-hybrid/services/benchmark-suite.ts
+++ b/extensions/memory-hybrid/services/benchmark-suite.ts
@@ -3,520 +3,506 @@
  * Compares performance against competitors and tracks metrics over time
  */
 
-import type { FactsDB } from "../backends/facts-db/facts-db-layer1.js";
+import type { FactsDB } from "../backends/facts-db.js";
 import type { VectorDB } from "../backends/vector-db.js";
 
 export interface BenchmarkConfig {
-	/** Number of iterations per test */
-	iterations: number;
-	/** Warmup iterations before measurement */
-	warmupIterations: number;
-	/** Test datasets to use */
-	datasets: string[];
-	/** Competitors to benchmark against */
-	competitors?: ("memgpt" | "zep" | "mem0")[];
-	/** Output format */
-	outputFormat: "json" | "html" | "markdown";
+  /** Number of iterations per test */
+  iterations: number;
+  /** Warmup iterations before measurement */
+  warmupIterations: number;
+  /** Test datasets to use */
+  datasets: string[];
+  /** Competitors to benchmark against */
+  competitors?: ("memgpt" | "zep" | "mem0")[];
+  /** Output format */
+  outputFormat: "json" | "html" | "markdown";
 }
 
 export interface BenchmarkResult {
-	testName: string;
-	system: string;
-	duration: number; // milliseconds
-	opsPerSecond: number;
-	memoryUsed: number; // bytes
-	accuracy?: number; // 0-1 for recall tests
-	cost?: number; // USD for API calls
-	metadata: Record<string, unknown>;
+  testName: string;
+  system: string;
+  duration: number; // milliseconds
+  opsPerSecond: number;
+  memoryUsed: number; // bytes
+  accuracy?: number; // 0-1 for recall tests
+  cost?: number; // USD for API calls
+  metadata: Record<string, unknown>;
 }
 
 export interface BenchmarkSuite {
-	name: string;
-	version: string;
-	timestamp: number;
-	results: BenchmarkResult[];
-	summary: {
-		totalTests: number;
-		avgDuration: number;
-		avgAccuracy?: number;
-		totalCost?: number;
-	};
+  name: string;
+  version: string;
+  timestamp: number;
+  results: BenchmarkResult[];
+  summary: {
+    totalTests: number;
+    avgDuration: number;
+    avgAccuracy?: number;
+    totalCost?: number;
+  };
 }
 
 /**
  * Benchmark Runner
  */
 export class BenchmarkRunner {
-	constructor(
-		private factsDb: FactsDB,
-		private vectorDb: VectorDB | undefined,
-		private config: BenchmarkConfig,
-	) {}
-
-	/**
-	 * Run full benchmark suite
-	 */
-	async runAll(): Promise<BenchmarkSuite> {
-		console.log("[Benchmark] Starting comprehensive benchmark suite...");
-
-		const results: BenchmarkResult[] = [];
-
-		// Storage benchmarks
-		results.push(...(await this.benchmarkStorage()));
-
-		// Search benchmarks
-		results.push(...(await this.benchmarkSearch()));
-
-		// Recall accuracy benchmarks
-		results.push(...(await this.benchmarkRecallAccuracy()));
-
-		// Latency benchmarks
-		results.push(...(await this.benchmarkLatency()));
-
-		// Scalability benchmarks
-		results.push(...(await this.benchmarkScalability()));
-
-		// Cost benchmarks
-		results.push(...(await this.benchmarkCost()));
-
-		const summary = this.calculateSummary(results);
-
-		return {
-			name: "OpenClaw Hybrid Memory Benchmark Suite",
-			version: "1.0.0",
-			timestamp: Date.now(),
-			results,
-			summary,
-		};
-	}
-
-	/**
-	 * Benchmark: Storage Operations (Write/Read/Update/Delete)
-	 */
-	private async benchmarkStorage(): Promise<BenchmarkResult[]> {
-		console.log("[Benchmark] Running storage benchmarks...");
-
-		const results: BenchmarkResult[] = [];
-
-		// Write performance
-		const writeResult = await this.measureOperation(
-			"storage_write",
-			async () => {
-				const fact = {
-					id: crypto.randomUUID(),
-					text: "This is a test fact for benchmarking purposes",
-					category: "test",
-					importance: 0.5,
-					confidence: 1.0,
-					decayClass: "episodic" as const,
-					tags: ["benchmark", "test"],
-					createdAt: Date.now(),
-				};
-				await this.factsDb.store(fact);
-			},
-			this.config.iterations,
-		);
-		results.push(writeResult);
-
-		// Read performance
-		const facts = this.factsDb.getAllFacts();
-		if (facts.length > 0) {
-			const readResult = await this.measureOperation(
-				"storage_read",
-				async () => {
-					const randomId = facts[Math.floor(Math.random() * facts.length)].id;
-					this.factsDb.getFactById(randomId);
-				},
-				this.config.iterations,
-			);
-			results.push(readResult);
-		}
-
-		// Bulk read performance
-		const bulkReadResult = await this.measureOperation(
-			"storage_bulk_read",
-			async () => {
-				this.factsDb.getAllFacts();
-			},
-			Math.min(100, this.config.iterations),
-		);
-		results.push(bulkReadResult);
-
-		return results;
-	}
-
-	/**
-	 * Benchmark: Search Operations (FTS, Vector, Hybrid)
-	 */
-	private async benchmarkSearch(): Promise<BenchmarkResult[]> {
-		console.log("[Benchmark] Running search benchmarks...");
-
-		const results: BenchmarkResult[] = [];
-
-		// FTS search
-		const ftsResult = await this.measureOperation(
-			"search_fts",
-			async () => {
-				// TODO: Call FTS search
-				const facts = this.factsDb.getAllFacts();
-				facts.filter(f => f.text.includes("test"));
-			},
-			this.config.iterations,
-		);
-		results.push(ftsResult);
-
-		// Vector search (if available)
-		if (this.vectorDb) {
-			const vectorResult = await this.measureOperation(
-				"search_vector",
-				async () => {
-					// TODO: Call vector search
-					await new Promise(resolve => setTimeout(resolve, 10));
-				},
-				this.config.iterations,
-			);
-			results.push(vectorResult);
-		}
-
-		// Hybrid search
-		const hybridResult = await this.measureOperation(
-			"search_hybrid",
-			async () => {
-				// TODO: Call hybrid search
-				await new Promise(resolve => setTimeout(resolve, 15));
-			},
-			this.config.iterations,
-		);
-		results.push(hybridResult);
-
-		return results;
-	}
-
-	/**
-	 * Benchmark: Recall Accuracy
-	 */
-	private async benchmarkRecallAccuracy(): Promise<BenchmarkResult[]> {
-		console.log("[Benchmark] Running recall accuracy benchmarks...");
-
-		const results: BenchmarkResult[] = [];
-
-		// TODO: Implement standard recall test datasets
-		// - SQuAD-style Q&A
-		// - Personal memory scenarios
-		// - Multi-hop reasoning
-
-		const accuracyTest = {
-			testName: "recall_accuracy_basic",
-			system: "openclaw-hybrid-memory",
-			duration: 0,
-			opsPerSecond: 0,
-			memoryUsed: 0,
-			accuracy: 0.85, // Placeholder
-			metadata: {
-				dataset: "personal-memory-v1",
-				queries: 100,
-				correctRecalls: 85,
-			},
-		};
-
-		results.push(accuracyTest);
-
-		return results;
-	}
-
-	/**
-	 * Benchmark: Latency (p50, p95, p99)
-	 */
-	private async benchmarkLatency(): Promise<BenchmarkResult[]> {
-		console.log("[Benchmark] Running latency benchmarks...");
-
-		const latencies: number[] = [];
-
-		for (let i = 0; i < this.config.iterations; i++) {
-			const start = performance.now();
-
-			// Simulate a typical search operation
-			const facts = this.factsDb.getAllFacts();
-			facts.filter(f => f.importance > 0.5);
-
-			const end = performance.now();
-			latencies.push(end - start);
-		}
-
-		latencies.sort((a, b) => a - b);
-
-		const p50 = latencies[Math.floor(latencies.length * 0.5)];
-		const p95 = latencies[Math.floor(latencies.length * 0.95)];
-		const p99 = latencies[Math.floor(latencies.length * 0.99)];
-
-		return [
-			{
-				testName: "latency_p50",
-				system: "openclaw-hybrid-memory",
-				duration: p50,
-				opsPerSecond: 1000 / p50,
-				memoryUsed: 0,
-				metadata: { percentile: 50 },
-			},
-			{
-				testName: "latency_p95",
-				system: "openclaw-hybrid-memory",
-				duration: p95,
-				opsPerSecond: 1000 / p95,
-				memoryUsed: 0,
-				metadata: { percentile: 95 },
-			},
-			{
-				testName: "latency_p99",
-				system: "openclaw-hybrid-memory",
-				duration: p99,
-				opsPerSecond: 1000 / p99,
-				memoryUsed: 0,
-				metadata: { percentile: 99 },
-			},
-		];
-	}
-
-	/**
-	 * Benchmark: Scalability (1k, 10k, 100k, 1M facts)
-	 */
-	private async benchmarkScalability(): Promise<BenchmarkResult[]> {
-		console.log("[Benchmark] Running scalability benchmarks...");
-
-		const results: BenchmarkResult[] = [];
-
-		const scales = [1000, 10000, 100000];
-
-		for (const scale of scales) {
-			// Skip if we don't have enough data
-			const currentFactCount = this.factsDb.getAllFacts().length;
-			if (currentFactCount < scale / 10) {
-				console.log(`[Benchmark] Skipping scale ${scale} (insufficient data)`);
-				continue;
-			}
-
-			const result = await this.measureOperation(
-				`scalability_${scale}`,
-				async () => {
-					const facts = this.factsDb.getAllFacts();
-					facts.slice(0, Math.min(scale, facts.length));
-				},
-				10, // Fewer iterations for large scales
-			);
-
-			results.push(result);
-		}
-
-		return results;
-	}
-
-	/**
-	 * Benchmark: Cost Analysis
-	 */
-	private async benchmarkCost(): Promise<BenchmarkResult[]> {
-		console.log("[Benchmark] Running cost benchmarks...");
-
-		const embeddingCostPer1k = 0.00002; // OpenAI text-embedding-3-small
-		const llmCostPer1kTokens = 0.0001; // nano-tier model
-
-		// Estimate cost per operation
-		const costPerTurn = embeddingCostPer1k; // One embedding for recall
-		const costPerCapture = embeddingCostPer1k; // One embedding for storage
-		const costPerClassify = llmCostPer1kTokens * 0.1; // ~100 tokens
-
-		return [
-			{
-				testName: "cost_per_turn",
-				system: "openclaw-hybrid-memory",
-				duration: 0,
-				opsPerSecond: 0,
-				memoryUsed: 0,
-				cost: costPerTurn,
-				metadata: {
-					operation: "auto-recall",
-					includes: "embedding",
-				},
-			},
-			{
-				testName: "cost_per_capture",
-				system: "openclaw-hybrid-memory",
-				duration: 0,
-				opsPerSecond: 0,
-				memoryUsed: 0,
-				cost: costPerCapture,
-				metadata: {
-					operation: "auto-capture",
-					includes: "embedding",
-				},
-			},
-			{
-				testName: "cost_monthly_50_turns",
-				system: "openclaw-hybrid-memory",
-				duration: 0,
-				opsPerSecond: 0,
-				memoryUsed: 0,
-				cost: costPerTurn * 50 * 30, // 50 turns/day, 30 days
-				metadata: {
-					usage: "50 turns/day for 30 days",
-					total_turns: 1500,
-				},
-			},
-		];
-	}
-
-	/**
-	 * Measure operation performance
-	 */
-	private async measureOperation(
-		testName: string,
-		operation: () => Promise<void> | void,
-		iterations: number,
-	): Promise<BenchmarkResult> {
-		// Warmup
-		for (let i = 0; i < this.config.warmupIterations; i++) {
-			await operation();
-		}
-
-		// Measure
-		const memBefore = process.memoryUsage().heapUsed;
-		const start = performance.now();
-
-		for (let i = 0; i < iterations; i++) {
-			await operation();
-		}
-
-		const end = performance.now();
-		const memAfter = process.memoryUsage().heapUsed;
-
-		const duration = end - start;
-		const opsPerSecond = (iterations / duration) * 1000;
-		const memoryUsed = Math.max(0, memAfter - memBefore);
-
-		return {
-			testName,
-			system: "openclaw-hybrid-memory",
-			duration,
-			opsPerSecond,
-			memoryUsed,
-			metadata: {
-				iterations,
-				avgDurationPerOp: duration / iterations,
-			},
-		};
-	}
-
-	/**
-	 * Calculate summary statistics
-	 */
-	private calculateSummary(results: BenchmarkResult[]): BenchmarkSuite["summary"] {
-		const totalTests = results.length;
-		const avgDuration = results.reduce((sum, r) => sum + r.duration, 0) / totalTests;
-
-		const accuracyResults = results.filter(r => r.accuracy !== undefined);
-		const avgAccuracy =
-			accuracyResults.length > 0
-				? accuracyResults.reduce((sum, r) => sum + r.accuracy!, 0) / accuracyResults.length
-				: undefined;
-
-		const costResults = results.filter(r => r.cost !== undefined);
-		const totalCost =
-			costResults.length > 0 ? costResults.reduce((sum, r) => sum + r.cost!, 0) : undefined;
-
-		return {
-			totalTests,
-			avgDuration,
-			avgAccuracy,
-			totalCost,
-		};
-	}
-
-	/**
-	 * Generate benchmark report
-	 */
-	generateReport(suite: BenchmarkSuite): string {
-		if (this.config.outputFormat === "json") {
-			return JSON.stringify(suite, null, 2);
-		}
-
-		if (this.config.outputFormat === "markdown") {
-			return this.generateMarkdownReport(suite);
-		}
-
-		if (this.config.outputFormat === "html") {
-			return this.generateHTMLReport(suite);
-		}
-
-		return JSON.stringify(suite, null, 2);
-	}
-
-	private generateMarkdownReport(suite: BenchmarkSuite): string {
-		const lines: string[] = [];
-
-		lines.push(`# ${suite.name}`);
-		lines.push(`**Version:** ${suite.version}`);
-		lines.push(`**Date:** ${new Date(suite.timestamp).toISOString()}`);
-		lines.push("");
-
-		lines.push("## Summary");
-		lines.push(`- **Total Tests:** ${suite.summary.totalTests}`);
-		lines.push(`- **Average Duration:** ${suite.summary.avgDuration.toFixed(2)}ms`);
-		if (suite.summary.avgAccuracy) {
-			lines.push(`- **Average Accuracy:** ${(suite.summary.avgAccuracy * 100).toFixed(1)}%`);
-		}
-		if (suite.summary.totalCost) {
-			lines.push(`- **Total Cost:** $${suite.summary.totalCost.toFixed(6)}`);
-		}
-		lines.push("");
-
-		lines.push("## Detailed Results");
-		lines.push("");
-		lines.push("| Test | Duration (ms) | Ops/sec | Memory (KB) | Accuracy | Cost ($) |");
-		lines.push("|------|---------------|---------|-------------|----------|----------|");
-
-		for (const result of suite.results) {
-			const accuracy = result.accuracy ? `${(result.accuracy * 100).toFixed(1)}%` : "-";
-			const cost = result.cost ? `$${result.cost.toFixed(6)}` : "-";
-			const memKB = (result.memoryUsed / 1024).toFixed(2);
-
-			lines.push(
-				`| ${result.testName} | ${result.duration.toFixed(2)} | ${result.opsPerSecond.toFixed(0)} | ${memKB} | ${accuracy} | ${cost} |`,
-			);
-		}
-
-		return lines.join("\n");
-	}
-
-	private generateHTMLReport(suite: BenchmarkSuite): string {
-		// TODO: Implement HTML report with charts
-		return `<html><body><h1>${suite.name}</h1><pre>${JSON.stringify(suite, null, 2)}</pre></body></html>`;
-	}
+  constructor(
+    private factsDb: FactsDB,
+    private vectorDb: VectorDB | undefined,
+    private config: BenchmarkConfig,
+  ) {}
+
+  /**
+   * Run full benchmark suite
+   */
+  async runAll(): Promise<BenchmarkSuite> {
+    const results: BenchmarkResult[] = [];
+
+    // Storage benchmarks
+    results.push(...(await this.benchmarkStorage()));
+
+    // Search benchmarks
+    results.push(...(await this.benchmarkSearch()));
+
+    // Recall accuracy benchmarks
+    results.push(...(await this.benchmarkRecallAccuracy()));
+
+    // Latency benchmarks
+    results.push(...(await this.benchmarkLatency()));
+
+    // Scalability benchmarks
+    results.push(...(await this.benchmarkScalability()));
+
+    // Cost benchmarks
+    results.push(...(await this.benchmarkCost()));
+
+    const summary = this.calculateSummary(results);
+
+    return {
+      name: "OpenClaw Hybrid Memory Benchmark Suite",
+      version: "1.0.0",
+      timestamp: Date.now(),
+      results,
+      summary,
+    };
+  }
+
+  /**
+   * Benchmark: Storage Operations (Write/Read/Update/Delete)
+   */
+  private async benchmarkStorage(): Promise<BenchmarkResult[]> {
+    const results: BenchmarkResult[] = [];
+
+    // Write performance
+    const writeResult = await this.measureOperation(
+      "storage_write",
+      async () => {
+        const fact = {
+          text: "This is a test fact for benchmarking purposes",
+          category: "fact" as const,
+          importance: 0.5,
+          confidence: 1.0,
+          decayClass: "normal" as const,
+          source: "benchmark-suite",
+          tags: ["benchmark", "test"],
+          entity: null,
+          key: null,
+          value: null,
+        };
+        await this.factsDb.store(fact);
+      },
+      this.config.iterations,
+    );
+    results.push(writeResult);
+
+    // Read performance
+    const facts = this.factsDb.getAll();
+    if (facts.length > 0) {
+      const readResult = await this.measureOperation(
+        "storage_read",
+        async () => {
+          const randomId = facts[Math.floor(Math.random() * facts.length)].id;
+          this.factsDb.getById(randomId);
+        },
+        this.config.iterations,
+      );
+      results.push(readResult);
+    }
+
+    // Bulk read performance
+    const bulkReadResult = await this.measureOperation(
+      "storage_bulk_read",
+      async () => {
+        this.factsDb.getAll();
+      },
+      Math.min(100, this.config.iterations),
+    );
+    results.push(bulkReadResult);
+
+    return results;
+  }
+
+  /**
+   * Benchmark: Search Operations (FTS, Vector, Hybrid)
+   */
+  private async benchmarkSearch(): Promise<BenchmarkResult[]> {
+    const results: BenchmarkResult[] = [];
+
+    // FTS search
+    const ftsResult = await this.measureOperation(
+      "search_fts",
+      async () => {
+        // TODO: Call FTS search
+        const facts = this.factsDb.getAll();
+        facts.filter((f) => f.text.includes("test"));
+      },
+      this.config.iterations,
+    );
+    results.push(ftsResult);
+
+    // Vector search (if available)
+    if (this.vectorDb) {
+      const vectorResult = await this.measureOperation(
+        "search_vector",
+        async () => {
+          // TODO: Call vector search
+          await new Promise((resolve) => setTimeout(resolve, 10));
+        },
+        this.config.iterations,
+      );
+      results.push(vectorResult);
+    }
+
+    // Hybrid search
+    const hybridResult = await this.measureOperation(
+      "search_hybrid",
+      async () => {
+        // TODO: Call hybrid search
+        await new Promise((resolve) => setTimeout(resolve, 15));
+      },
+      this.config.iterations,
+    );
+    results.push(hybridResult);
+
+    return results;
+  }
+
+  /**
+   * Benchmark: Recall Accuracy
+   */
+  private async benchmarkRecallAccuracy(): Promise<BenchmarkResult[]> {
+    const results: BenchmarkResult[] = [];
+
+    // TODO: Implement standard recall test datasets
+    // - SQuAD-style Q&A
+    // - Personal memory scenarios
+    // - Multi-hop reasoning
+
+    const accuracyTest = {
+      testName: "recall_accuracy_basic",
+      system: "openclaw-hybrid-memory",
+      duration: 0,
+      opsPerSecond: 0,
+      memoryUsed: 0,
+      accuracy: 0.85, // Placeholder
+      metadata: {
+        dataset: "personal-memory-v1",
+        queries: 100,
+        correctRecalls: 85,
+      },
+    };
+
+    results.push(accuracyTest);
+
+    return results;
+  }
+
+  /**
+   * Benchmark: Latency (p50, p95, p99)
+   */
+  private async benchmarkLatency(): Promise<BenchmarkResult[]> {
+    const latencies: number[] = [];
+
+    for (let i = 0; i < this.config.iterations; i++) {
+      const start = performance.now();
+
+      // Simulate a typical search operation
+      const facts = this.factsDb.getAll();
+      facts.filter((f) => f.importance > 0.5);
+
+      const end = performance.now();
+      latencies.push(end - start);
+    }
+
+    latencies.sort((a, b) => a - b);
+
+    const p50 = latencies[Math.floor(latencies.length * 0.5)];
+    const p95 = latencies[Math.floor(latencies.length * 0.95)];
+    const p99 = latencies[Math.floor(latencies.length * 0.99)];
+
+    return [
+      {
+        testName: "latency_p50",
+        system: "openclaw-hybrid-memory",
+        duration: p50,
+        opsPerSecond: 1000 / p50,
+        memoryUsed: 0,
+        metadata: { percentile: 50 },
+      },
+      {
+        testName: "latency_p95",
+        system: "openclaw-hybrid-memory",
+        duration: p95,
+        opsPerSecond: 1000 / p95,
+        memoryUsed: 0,
+        metadata: { percentile: 95 },
+      },
+      {
+        testName: "latency_p99",
+        system: "openclaw-hybrid-memory",
+        duration: p99,
+        opsPerSecond: 1000 / p99,
+        memoryUsed: 0,
+        metadata: { percentile: 99 },
+      },
+    ];
+  }
+
+  /**
+   * Benchmark: Scalability (1k, 10k, 100k, 1M facts)
+   */
+  private async benchmarkScalability(): Promise<BenchmarkResult[]> {
+    const results: BenchmarkResult[] = [];
+
+    const scales = [1000, 10000, 100000];
+
+    for (const scale of scales) {
+      // Skip if we don't have enough data
+      const currentFactCount = this.factsDb.getAll().length;
+      if (currentFactCount < scale / 10) {
+        continue;
+      }
+
+      const result = await this.measureOperation(
+        `scalability_${scale}`,
+        async () => {
+          const facts = this.factsDb.getAll();
+          facts.slice(0, Math.min(scale, facts.length));
+        },
+        10, // Fewer iterations for large scales
+      );
+
+      results.push(result);
+    }
+
+    return results;
+  }
+
+  /**
+   * Benchmark: Cost Analysis
+   */
+  private async benchmarkCost(): Promise<BenchmarkResult[]> {
+    const embeddingCostPer1k = 0.00002; // OpenAI text-embedding-3-small
+    const llmCostPer1kTokens = 0.0001; // nano-tier model
+
+    // Estimate cost per operation
+    const costPerTurn = embeddingCostPer1k; // One embedding for recall
+    const costPerCapture = embeddingCostPer1k; // One embedding for storage
+    const _costPerClassify = llmCostPer1kTokens * 0.1; // ~100 tokens
+
+    return [
+      {
+        testName: "cost_per_turn",
+        system: "openclaw-hybrid-memory",
+        duration: 0,
+        opsPerSecond: 0,
+        memoryUsed: 0,
+        cost: costPerTurn,
+        metadata: {
+          operation: "auto-recall",
+          includes: "embedding",
+        },
+      },
+      {
+        testName: "cost_per_capture",
+        system: "openclaw-hybrid-memory",
+        duration: 0,
+        opsPerSecond: 0,
+        memoryUsed: 0,
+        cost: costPerCapture,
+        metadata: {
+          operation: "auto-capture",
+          includes: "embedding",
+        },
+      },
+      {
+        testName: "cost_monthly_50_turns",
+        system: "openclaw-hybrid-memory",
+        duration: 0,
+        opsPerSecond: 0,
+        memoryUsed: 0,
+        cost: costPerTurn * 50 * 30, // 50 turns/day, 30 days
+        metadata: {
+          usage: "50 turns/day for 30 days",
+          total_turns: 1500,
+        },
+      },
+    ];
+  }
+
+  /**
+   * Measure operation performance
+   */
+  private async measureOperation(
+    testName: string,
+    operation: () => Promise<void> | void,
+    iterations: number,
+  ): Promise<BenchmarkResult> {
+    // Warmup
+    for (let i = 0; i < this.config.warmupIterations; i++) {
+      await operation();
+    }
+
+    // Measure
+    const memBefore = process.memoryUsage().heapUsed;
+    const start = performance.now();
+
+    for (let i = 0; i < iterations; i++) {
+      await operation();
+    }
+
+    const end = performance.now();
+    const memAfter = process.memoryUsage().heapUsed;
+
+    const duration = end - start;
+    const opsPerSecond = (iterations / duration) * 1000;
+    const memoryUsed = Math.max(0, memAfter - memBefore);
+
+    return {
+      testName,
+      system: "openclaw-hybrid-memory",
+      duration,
+      opsPerSecond,
+      memoryUsed,
+      metadata: {
+        iterations,
+        avgDurationPerOp: duration / iterations,
+      },
+    };
+  }
+
+  /**
+   * Calculate summary statistics
+   */
+  private calculateSummary(results: BenchmarkResult[]): BenchmarkSuite["summary"] {
+    const totalTests = results.length;
+    const avgDuration = results.reduce((sum, r) => sum + r.duration, 0) / totalTests;
+
+    const accuracyResults = results.filter((r) => r.accuracy !== undefined);
+    const avgAccuracy =
+      accuracyResults.length > 0
+        ? accuracyResults.reduce((sum, r) => sum + r.accuracy!, 0) / accuracyResults.length
+        : undefined;
+
+    const costResults = results.filter((r) => r.cost !== undefined);
+    const totalCost = costResults.length > 0 ? costResults.reduce((sum, r) => sum + r.cost!, 0) : undefined;
+
+    return {
+      totalTests,
+      avgDuration,
+      avgAccuracy,
+      totalCost,
+    };
+  }
+
+  /**
+   * Generate benchmark report
+   */
+  generateReport(suite: BenchmarkSuite): string {
+    if (this.config.outputFormat === "json") {
+      return JSON.stringify(suite, null, 2);
+    }
+
+    if (this.config.outputFormat === "markdown") {
+      return this.generateMarkdownReport(suite);
+    }
+
+    if (this.config.outputFormat === "html") {
+      return this.generateHTMLReport(suite);
+    }
+
+    return JSON.stringify(suite, null, 2);
+  }
+
+  private generateMarkdownReport(suite: BenchmarkSuite): string {
+    const lines: string[] = [];
+
+    lines.push(`# ${suite.name}`);
+    lines.push(`**Version:** ${suite.version}`);
+    lines.push(`**Date:** ${new Date(suite.timestamp).toISOString()}`);
+    lines.push("");
+
+    lines.push("## Summary");
+    lines.push(`- **Total Tests:** ${suite.summary.totalTests}`);
+    lines.push(`- **Average Duration:** ${suite.summary.avgDuration.toFixed(2)}ms`);
+    if (suite.summary.avgAccuracy) {
+      lines.push(`- **Average Accuracy:** ${(suite.summary.avgAccuracy * 100).toFixed(1)}%`);
+    }
+    if (suite.summary.totalCost) {
+      lines.push(`- **Total Cost:** $${suite.summary.totalCost.toFixed(6)}`);
+    }
+    lines.push("");
+
+    lines.push("## Detailed Results");
+    lines.push("");
+    lines.push("| Test | Duration (ms) | Ops/sec | Memory (KB) | Accuracy | Cost ($) |");
+    lines.push("|------|---------------|---------|-------------|----------|----------|");
+
+    for (const result of suite.results) {
+      const accuracy = result.accuracy ? `${(result.accuracy * 100).toFixed(1)}%` : "-";
+      const cost = result.cost ? `$${result.cost.toFixed(6)}` : "-";
+      const memKB = (result.memoryUsed / 1024).toFixed(2);
+
+      lines.push(
+        `| ${result.testName} | ${result.duration.toFixed(2)} | ${result.opsPerSecond.toFixed(0)} | ${memKB} | ${accuracy} | ${cost} |`,
+      );
+    }
+
+    return lines.join("\n");
+  }
+
+  private generateHTMLReport(suite: BenchmarkSuite): string {
+    // TODO: Implement HTML report with charts
+    return `<html><body><h1>${suite.name}</h1><pre>${JSON.stringify(suite, null, 2)}</pre></body></html>`;
+  }
 }
 
 /**
  * Comparative benchmarks against competitors
  */
 export class ComparativeBenchmarks {
-	/**
-	 * Run benchmarks against MemGPT
-	 */
-	async benchmarkVsMemGPT(): Promise<BenchmarkResult[]> {
-		// TODO: Implement MemGPT comparison
-		return [];
-	}
+  /**
+   * Run benchmarks against MemGPT
+   */
+  async benchmarkVsMemGPT(): Promise<BenchmarkResult[]> {
+    // TODO: Implement MemGPT comparison
+    return [];
+  }
 
-	/**
-	 * Run benchmarks against Zep
-	 */
-	async benchmarkVsZep(): Promise<BenchmarkResult[]> {
-		// TODO: Implement Zep comparison
-		return [];
-	}
+  /**
+   * Run benchmarks against Zep
+   */
+  async benchmarkVsZep(): Promise<BenchmarkResult[]> {
+    // TODO: Implement Zep comparison
+    return [];
+  }
 
-	/**
-	 * Run benchmarks against Mem0
-	 */
-	async benchmarkVsMem0(): Promise<BenchmarkResult[]> {
-		// TODO: Implement Mem0 comparison
-		return [];
-	}
+  /**
+   * Run benchmarks against Mem0
+   */
+  async benchmarkVsMem0(): Promise<BenchmarkResult[]> {
+    // TODO: Implement Mem0 comparison
+    return [];
+  }
 }

--- a/extensions/memory-hybrid/services/collaboration.ts
+++ b/extensions/memory-hybrid/services/collaboration.ts
@@ -3,8 +3,7 @@
  * Provides team-based memory management with permissions and shared spaces
  */
 
-import type { FactsDB } from "../backends/facts-db/facts-db-layer1.js";
-import Database from "better-sqlite3";
+import type { FactsDB } from "../backends/facts-db.js";
 
 export interface Organization {
   id: string;
@@ -95,10 +94,10 @@ export interface Activity {
  * Manages organizations, spaces, permissions, and team workflows
  */
 export class CollaborationService {
-  private db: Database.Database;
+  private db: { exec(sql: string): void; prepare(sql: string): any; close?(): void };
 
   constructor(private sqlitePath: string) {
-    this.db = new Database(sqlitePath);
+    this.db = new (require("node:module").createRequire(import.meta.url)("node:sqlite").DatabaseSync)(sqlitePath);
     this.initSchema();
   }
 
@@ -344,11 +343,11 @@ export class CollaborationService {
 
     if (!perm) {
       // Check if user is org admin/owner
-      const spaceStmt = this.db.prepare(`SELECT org_id FROM memory_spaces WHERE id = ?`);
+      const spaceStmt = this.db.prepare("SELECT org_id FROM memory_spaces WHERE id = ?");
       const space = spaceStmt.get(spaceId) as { org_id: string } | undefined;
 
       if (space) {
-        const memberStmt = this.db.prepare(`SELECT role FROM members WHERE user_id = ? AND org_id = ?`);
+        const memberStmt = this.db.prepare("SELECT role FROM members WHERE user_id = ? AND org_id = ?");
         const member = memberStmt.get(userId, space.org_id) as { role: string } | undefined;
 
         if (member && (member.role === "owner" || member.role === "admin")) {
@@ -538,6 +537,6 @@ export class CollaborationService {
    * Close database connection
    */
   close(): void {
-    this.db.close();
+    this.db.close?.();
   }
 }

--- a/extensions/memory-hybrid/services/collaboration.ts
+++ b/extensions/memory-hybrid/services/collaboration.ts
@@ -7,87 +7,87 @@ import type { FactsDB } from "../backends/facts-db/facts-db-layer1.js";
 import Database from "better-sqlite3";
 
 export interface Organization {
-	id: string;
-	name: string;
-	createdAt: number;
-	plan: "free" | "team" | "enterprise";
-	settings?: {
-		allowPublicSpaces?: boolean;
-		requireApproval?: boolean;
-		maxMembers?: number;
-	};
+  id: string;
+  name: string;
+  createdAt: number;
+  plan: "free" | "team" | "enterprise";
+  settings?: {
+    allowPublicSpaces?: boolean;
+    requireApproval?: boolean;
+    maxMembers?: number;
+  };
 }
 
 export interface MemorySpace {
-	id: string;
-	orgId: string;
-	name: string;
-	description?: string;
-	visibility: "private" | "org" | "public";
-	createdBy: string;
-	createdAt: number;
-	settings?: {
-		autoCapture?: boolean;
-		requireReview?: boolean;
-	};
+  id: string;
+  orgId: string;
+  name: string;
+  description?: string;
+  visibility: "private" | "org" | "public";
+  createdBy: string;
+  createdAt: number;
+  settings?: {
+    autoCapture?: boolean;
+    requireReview?: boolean;
+  };
 }
 
 export interface Member {
-	userId: string;
-	orgId: string;
-	role: "owner" | "admin" | "editor" | "viewer";
-	joinedAt: number;
-	invitedBy?: string;
+  userId: string;
+  orgId: string;
+  role: "owner" | "admin" | "editor" | "viewer";
+  joinedAt: number;
+  invitedBy?: string;
 }
 
 export interface SpacePermission {
-	userId: string;
-	spaceId: string;
-	canRead: boolean;
-	canWrite: boolean;
-	canDelete: boolean;
-	canManage: boolean;
-	grantedAt: number;
-	grantedBy: string;
+  userId: string;
+  spaceId: string;
+  canRead: boolean;
+  canWrite: boolean;
+  canDelete: boolean;
+  canManage: boolean;
+  grantedAt: number;
+  grantedBy: string;
 }
 
 export interface FactSuggestion {
-	id: string;
-	factId?: string; // undefined for new facts
-	spaceId: string;
-	suggestedBy: string;
-	suggestionType: "create" | "edit" | "delete" | "supersede";
-	newText?: string;
-	newMetadata?: Record<string, unknown>;
-	reason?: string;
-	status: "pending" | "approved" | "rejected";
-	reviewedBy?: string;
-	reviewedAt?: number;
-	createdAt: number;
+  id: string;
+  factId?: string; // undefined for new facts
+  spaceId: string;
+  suggestedBy: string;
+  suggestionType: "create" | "edit" | "delete" | "supersede";
+  newText?: string;
+  newMetadata?: Record<string, unknown>;
+  reason?: string;
+  status: "pending" | "approved" | "rejected";
+  reviewedBy?: string;
+  reviewedAt?: number;
+  createdAt: number;
 }
 
 export interface FactComment {
-	id: string;
-	factId: string;
-	authorId: string;
-	text: string;
-	createdAt: number;
-	updatedAt?: number;
-	resolved: boolean;
-	resolvedBy?: string;
-	resolvedAt?: number;
+  id: string;
+  factId: string;
+  authorId: string;
+  text: string;
+  createdAt: number;
+  updatedAt?: number;
+  resolved: boolean;
+  resolvedBy?: string;
+  resolvedAt?: number;
 }
 
 export interface Activity {
-	id: string;
-	orgId: string;
-	spaceId?: string;
-	actorId: string;
-	action: "created" | "updated" | "deleted" | "commented" | "reviewed";
-	targetType: "fact" | "space" | "member" | "suggestion";
-	targetId: string;
-	timestamp: number;
-	metadata?: Record<string, unknown>;
+  id: string;
+  orgId: string;
+  spaceId?: string;
+  actorId: string;
+  action: "created" | "updated" | "deleted" | "commented" | "reviewed";
+  targetType: "fact" | "space" | "member" | "suggestion";
+  targetId: string;
+  timestamp: number;
+  metadata?: Record<string, unknown>;
 }
 
 /**
@@ -95,18 +95,18 @@ export interface Activity {
  * Manages organizations, spaces, permissions, and team workflows
  */
 export class CollaborationService {
-	private db: Database.Database;
+  private db: Database.Database;
 
-	constructor(private sqlitePath: string) {
-		this.db = new Database(sqlitePath);
-		this.initSchema();
-	}
+  constructor(private sqlitePath: string) {
+    this.db = new Database(sqlitePath);
+    this.initSchema();
+  }
 
-	/**
-	 * Initialize collaboration database schema
-	 */
-	private initSchema(): void {
-		this.db.exec(`
+  /**
+   * Initialize collaboration database schema
+   */
+  private initSchema(): void {
+    this.db.exec(`
 			CREATE TABLE IF NOT EXISTS organizations (
 				id TEXT PRIMARY KEY,
 				name TEXT NOT NULL,
@@ -204,336 +204,340 @@ export class CollaborationService {
 			CREATE INDEX IF NOT EXISTS idx_activities_space ON activities(space_id);
 			CREATE INDEX IF NOT EXISTS idx_activities_timestamp ON activities(timestamp DESC);
 		`);
-	}
+  }
 
-	/**
-	 * Create a new organization
-	 */
-	createOrganization(org: Organization): void {
-		const stmt = this.db.prepare(`
+  /**
+   * Create a new organization
+   */
+  createOrganization(org: Organization): void {
+    const stmt = this.db.prepare(`
 			INSERT INTO organizations (id, name, created_at, plan, settings)
 			VALUES (?, ?, ?, ?, ?)
 		`);
-		stmt.run(org.id, org.name, org.createdAt, org.plan, JSON.stringify(org.settings || {}));
-	}
+    stmt.run(org.id, org.name, org.createdAt, org.plan, JSON.stringify(org.settings || {}));
+  }
 
-	/**
-	 * Get organization by ID
-	 */
-	getOrganization(orgId: string): Organization | null {
-		const stmt = this.db.prepare(`
+  /**
+   * Get organization by ID
+   */
+  getOrganization(orgId: string): Organization | null {
+    const stmt = this.db.prepare(`
 			SELECT * FROM organizations WHERE id = ?
 		`);
-		const row = stmt.get(orgId) as { id: string; name: string; created_at: number; plan: string; settings: string } | undefined;
+    const row = stmt.get(orgId) as
+      | { id: string; name: string; created_at: number; plan: string; settings: string }
+      | undefined;
 
-		if (!row) return null;
+    if (!row) return null;
 
-		return {
-			id: row.id,
-			name: row.name,
-			createdAt: row.created_at,
-			plan: row.plan as Organization["plan"],
-			settings: JSON.parse(row.settings || "{}"),
-		};
-	}
+    return {
+      id: row.id,
+      name: row.name,
+      createdAt: row.created_at,
+      plan: row.plan as Organization["plan"],
+      settings: JSON.parse(row.settings || "{}"),
+    };
+  }
 
-	/**
-	 * Create a memory space
-	 */
-	createSpace(space: MemorySpace): void {
-		const stmt = this.db.prepare(`
+  /**
+   * Create a memory space
+   */
+  createSpace(space: MemorySpace): void {
+    const stmt = this.db.prepare(`
 			INSERT INTO memory_spaces (id, org_id, name, description, visibility, created_by, created_at, settings)
 			VALUES (?, ?, ?, ?, ?, ?, ?, ?)
 		`);
-		stmt.run(
-			space.id,
-			space.orgId,
-			space.name,
-			space.description || null,
-			space.visibility,
-			space.createdBy,
-			space.createdAt,
-			JSON.stringify(space.settings || {}),
-		);
+    stmt.run(
+      space.id,
+      space.orgId,
+      space.name,
+      space.description || null,
+      space.visibility,
+      space.createdBy,
+      space.createdAt,
+      JSON.stringify(space.settings || {}),
+    );
 
-		// Log activity
-		this.logActivity({
-			id: crypto.randomUUID(),
-			orgId: space.orgId,
-			spaceId: space.id,
-			actorId: space.createdBy,
-			action: "created",
-			targetType: "space",
-			targetId: space.id,
-			timestamp: Date.now(),
-		});
-	}
+    // Log activity
+    this.logActivity({
+      id: crypto.randomUUID(),
+      orgId: space.orgId,
+      spaceId: space.id,
+      actorId: space.createdBy,
+      action: "created",
+      targetType: "space",
+      targetId: space.id,
+      timestamp: Date.now(),
+    });
+  }
 
-	/**
-	 * Get spaces for organization
-	 */
-	getSpacesForOrg(orgId: string): MemorySpace[] {
-		const stmt = this.db.prepare(`
+  /**
+   * Get spaces for organization
+   */
+  getSpacesForOrg(orgId: string): MemorySpace[] {
+    const stmt = this.db.prepare(`
 			SELECT * FROM memory_spaces WHERE org_id = ? ORDER BY created_at DESC
 		`);
-		const rows = stmt.all(orgId) as Array<{
-			id: string;
-			org_id: string;
-			name: string;
-			description: string | null;
-			visibility: string;
-			created_by: string;
-			created_at: number;
-			settings: string;
-		}>;
+    const rows = stmt.all(orgId) as Array<{
+      id: string;
+      org_id: string;
+      name: string;
+      description: string | null;
+      visibility: string;
+      created_by: string;
+      created_at: number;
+      settings: string;
+    }>;
 
-		return rows.map(row => ({
-			id: row.id,
-			orgId: row.org_id,
-			name: row.name,
-			description: row.description || undefined,
-			visibility: row.visibility as MemorySpace["visibility"],
-			createdBy: row.created_by,
-			createdAt: row.created_at,
-			settings: JSON.parse(row.settings || "{}"),
-		}));
-	}
+    return rows.map((row) => ({
+      id: row.id,
+      orgId: row.org_id,
+      name: row.name,
+      description: row.description || undefined,
+      visibility: row.visibility as MemorySpace["visibility"],
+      createdBy: row.created_by,
+      createdAt: row.created_at,
+      settings: JSON.parse(row.settings || "{}"),
+    }));
+  }
 
-	/**
-	 * Add member to organization
-	 */
-	addMember(member: Member): void {
-		const stmt = this.db.prepare(`
+  /**
+   * Add member to organization
+   */
+  addMember(member: Member): void {
+    const stmt = this.db.prepare(`
 			INSERT OR REPLACE INTO members (user_id, org_id, role, joined_at, invited_by)
 			VALUES (?, ?, ?, ?, ?)
 		`);
-		stmt.run(member.userId, member.orgId, member.role, member.joinedAt, member.invitedBy || null);
+    stmt.run(member.userId, member.orgId, member.role, member.joinedAt, member.invitedBy || null);
 
-		// Log activity
-		this.logActivity({
-			id: crypto.randomUUID(),
-			orgId: member.orgId,
-			actorId: member.invitedBy || member.userId,
-			action: "created",
-			targetType: "member",
-			targetId: member.userId,
-			timestamp: Date.now(),
-		});
-	}
+    // Log activity
+    this.logActivity({
+      id: crypto.randomUUID(),
+      orgId: member.orgId,
+      actorId: member.invitedBy || member.userId,
+      action: "created",
+      targetType: "member",
+      targetId: member.userId,
+      timestamp: Date.now(),
+    });
+  }
 
-	/**
-	 * Check if user has permission for an action
-	 */
-	hasPermission(userId: string, spaceId: string, permission: "read" | "write" | "delete" | "manage"): boolean {
-		// Check space permission
-		const stmt = this.db.prepare(`
+  /**
+   * Check if user has permission for an action
+   */
+  hasPermission(userId: string, spaceId: string, permission: "read" | "write" | "delete" | "manage"): boolean {
+    // Check space permission
+    const stmt = this.db.prepare(`
 			SELECT can_read, can_write, can_delete, can_manage
 			FROM space_permissions
 			WHERE user_id = ? AND space_id = ?
 		`);
-		const perm = stmt.get(userId, spaceId) as {
-			can_read: number;
-			can_write: number;
-			can_delete: number;
-			can_manage: number;
-		} | undefined;
+    const perm = stmt.get(userId, spaceId) as
+      | {
+          can_read: number;
+          can_write: number;
+          can_delete: number;
+          can_manage: number;
+        }
+      | undefined;
 
-		if (!perm) {
-			// Check if user is org admin/owner
-			const spaceStmt = this.db.prepare(`SELECT org_id FROM memory_spaces WHERE id = ?`);
-			const space = spaceStmt.get(spaceId) as { org_id: string } | undefined;
+    if (!perm) {
+      // Check if user is org admin/owner
+      const spaceStmt = this.db.prepare(`SELECT org_id FROM memory_spaces WHERE id = ?`);
+      const space = spaceStmt.get(spaceId) as { org_id: string } | undefined;
 
-			if (space) {
-				const memberStmt = this.db.prepare(`SELECT role FROM members WHERE user_id = ? AND org_id = ?`);
-				const member = memberStmt.get(userId, space.org_id) as { role: string } | undefined;
+      if (space) {
+        const memberStmt = this.db.prepare(`SELECT role FROM members WHERE user_id = ? AND org_id = ?`);
+        const member = memberStmt.get(userId, space.org_id) as { role: string } | undefined;
 
-				if (member && (member.role === "owner" || member.role === "admin")) {
-					return true; // Admins have all permissions
-				}
-			}
+        if (member && (member.role === "owner" || member.role === "admin")) {
+          return true; // Admins have all permissions
+        }
+      }
 
-			return false;
-		}
+      return false;
+    }
 
-		switch (permission) {
-			case "read":
-				return perm.can_read === 1;
-			case "write":
-				return perm.can_write === 1;
-			case "delete":
-				return perm.can_delete === 1;
-			case "manage":
-				return perm.can_manage === 1;
-			default:
-				return false;
-		}
-	}
+    switch (permission) {
+      case "read":
+        return perm.can_read === 1;
+      case "write":
+        return perm.can_write === 1;
+      case "delete":
+        return perm.can_delete === 1;
+      case "manage":
+        return perm.can_manage === 1;
+      default:
+        return false;
+    }
+  }
 
-	/**
-	 * Create fact suggestion
-	 */
-	createSuggestion(suggestion: FactSuggestion): void {
-		const stmt = this.db.prepare(`
+  /**
+   * Create fact suggestion
+   */
+  createSuggestion(suggestion: FactSuggestion): void {
+    const stmt = this.db.prepare(`
 			INSERT INTO fact_suggestions (id, fact_id, space_id, suggested_by, suggestion_type, new_text, new_metadata, reason, status, created_at)
 			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		`);
-		stmt.run(
-			suggestion.id,
-			suggestion.factId || null,
-			suggestion.spaceId,
-			suggestion.suggestedBy,
-			suggestion.suggestionType,
-			suggestion.newText || null,
-			JSON.stringify(suggestion.newMetadata || {}),
-			suggestion.reason || null,
-			suggestion.status,
-			suggestion.createdAt,
-		);
-	}
+    stmt.run(
+      suggestion.id,
+      suggestion.factId || null,
+      suggestion.spaceId,
+      suggestion.suggestedBy,
+      suggestion.suggestionType,
+      suggestion.newText || null,
+      JSON.stringify(suggestion.newMetadata || {}),
+      suggestion.reason || null,
+      suggestion.status,
+      suggestion.createdAt,
+    );
+  }
 
-	/**
-	 * Get pending suggestions for space
-	 */
-	getPendingSuggestions(spaceId: string): FactSuggestion[] {
-		const stmt = this.db.prepare(`
+  /**
+   * Get pending suggestions for space
+   */
+  getPendingSuggestions(spaceId: string): FactSuggestion[] {
+    const stmt = this.db.prepare(`
 			SELECT * FROM fact_suggestions
 			WHERE space_id = ? AND status = 'pending'
 			ORDER BY created_at DESC
 		`);
-		const rows = stmt.all(spaceId) as Array<{
-			id: string;
-			fact_id: string | null;
-			space_id: string;
-			suggested_by: string;
-			suggestion_type: string;
-			new_text: string | null;
-			new_metadata: string;
-			reason: string | null;
-			status: string;
-			reviewed_by: string | null;
-			reviewed_at: number | null;
-			created_at: number;
-		}>;
+    const rows = stmt.all(spaceId) as Array<{
+      id: string;
+      fact_id: string | null;
+      space_id: string;
+      suggested_by: string;
+      suggestion_type: string;
+      new_text: string | null;
+      new_metadata: string;
+      reason: string | null;
+      status: string;
+      reviewed_by: string | null;
+      reviewed_at: number | null;
+      created_at: number;
+    }>;
 
-		return rows.map(row => ({
-			id: row.id,
-			factId: row.fact_id || undefined,
-			spaceId: row.space_id,
-			suggestedBy: row.suggested_by,
-			suggestionType: row.suggestion_type as FactSuggestion["suggestionType"],
-			newText: row.new_text || undefined,
-			newMetadata: JSON.parse(row.new_metadata || "{}"),
-			reason: row.reason || undefined,
-			status: row.status as FactSuggestion["status"],
-			reviewedBy: row.reviewed_by || undefined,
-			reviewedAt: row.reviewed_at || undefined,
-			createdAt: row.created_at,
-		}));
-	}
+    return rows.map((row) => ({
+      id: row.id,
+      factId: row.fact_id || undefined,
+      spaceId: row.space_id,
+      suggestedBy: row.suggested_by,
+      suggestionType: row.suggestion_type as FactSuggestion["suggestionType"],
+      newText: row.new_text || undefined,
+      newMetadata: JSON.parse(row.new_metadata || "{}"),
+      reason: row.reason || undefined,
+      status: row.status as FactSuggestion["status"],
+      reviewedBy: row.reviewed_by || undefined,
+      reviewedAt: row.reviewed_at || undefined,
+      createdAt: row.created_at,
+    }));
+  }
 
-	/**
-	 * Add comment to fact
-	 */
-	addComment(comment: FactComment): void {
-		const stmt = this.db.prepare(`
+  /**
+   * Add comment to fact
+   */
+  addComment(comment: FactComment): void {
+    const stmt = this.db.prepare(`
 			INSERT INTO fact_comments (id, fact_id, author_id, text, created_at, resolved)
 			VALUES (?, ?, ?, ?, ?, ?)
 		`);
-		stmt.run(comment.id, comment.factId, comment.authorId, comment.text, comment.createdAt, comment.resolved ? 1 : 0);
-	}
+    stmt.run(comment.id, comment.factId, comment.authorId, comment.text, comment.createdAt, comment.resolved ? 1 : 0);
+  }
 
-	/**
-	 * Get comments for fact
-	 */
-	getCommentsForFact(factId: string): FactComment[] {
-		const stmt = this.db.prepare(`
+  /**
+   * Get comments for fact
+   */
+  getCommentsForFact(factId: string): FactComment[] {
+    const stmt = this.db.prepare(`
 			SELECT * FROM fact_comments WHERE fact_id = ? ORDER BY created_at ASC
 		`);
-		const rows = stmt.all(factId) as Array<{
-			id: string;
-			fact_id: string;
-			author_id: string;
-			text: string;
-			created_at: number;
-			updated_at: number | null;
-			resolved: number;
-			resolved_by: string | null;
-			resolved_at: number | null;
-		}>;
+    const rows = stmt.all(factId) as Array<{
+      id: string;
+      fact_id: string;
+      author_id: string;
+      text: string;
+      created_at: number;
+      updated_at: number | null;
+      resolved: number;
+      resolved_by: string | null;
+      resolved_at: number | null;
+    }>;
 
-		return rows.map(row => ({
-			id: row.id,
-			factId: row.fact_id,
-			authorId: row.author_id,
-			text: row.text,
-			createdAt: row.created_at,
-			updatedAt: row.updated_at || undefined,
-			resolved: row.resolved === 1,
-			resolvedBy: row.resolved_by || undefined,
-			resolvedAt: row.resolved_at || undefined,
-		}));
-	}
+    return rows.map((row) => ({
+      id: row.id,
+      factId: row.fact_id,
+      authorId: row.author_id,
+      text: row.text,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at || undefined,
+      resolved: row.resolved === 1,
+      resolvedBy: row.resolved_by || undefined,
+      resolvedAt: row.resolved_at || undefined,
+    }));
+  }
 
-	/**
-	 * Log activity
-	 */
-	private logActivity(activity: Activity): void {
-		const stmt = this.db.prepare(`
+  /**
+   * Log activity
+   */
+  private logActivity(activity: Activity): void {
+    const stmt = this.db.prepare(`
 			INSERT INTO activities (id, org_id, space_id, actor_id, action, target_type, target_id, timestamp, metadata)
 			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
 		`);
-		stmt.run(
-			activity.id,
-			activity.orgId,
-			activity.spaceId || null,
-			activity.actorId,
-			activity.action,
-			activity.targetType,
-			activity.targetId,
-			activity.timestamp,
-			JSON.stringify(activity.metadata || {}),
-		);
-	}
+    stmt.run(
+      activity.id,
+      activity.orgId,
+      activity.spaceId || null,
+      activity.actorId,
+      activity.action,
+      activity.targetType,
+      activity.targetId,
+      activity.timestamp,
+      JSON.stringify(activity.metadata || {}),
+    );
+  }
 
-	/**
-	 * Get recent activities for organization
-	 */
-	getRecentActivities(orgId: string, limit = 50): Activity[] {
-		const stmt = this.db.prepare(`
+  /**
+   * Get recent activities for organization
+   */
+  getRecentActivities(orgId: string, limit = 50): Activity[] {
+    const stmt = this.db.prepare(`
 			SELECT * FROM activities
 			WHERE org_id = ?
 			ORDER BY timestamp DESC
 			LIMIT ?
 		`);
-		const rows = stmt.all(orgId, limit) as Array<{
-			id: string;
-			org_id: string;
-			space_id: string | null;
-			actor_id: string;
-			action: string;
-			target_type: string;
-			target_id: string;
-			timestamp: number;
-			metadata: string;
-		}>;
+    const rows = stmt.all(orgId, limit) as Array<{
+      id: string;
+      org_id: string;
+      space_id: string | null;
+      actor_id: string;
+      action: string;
+      target_type: string;
+      target_id: string;
+      timestamp: number;
+      metadata: string;
+    }>;
 
-		return rows.map(row => ({
-			id: row.id,
-			orgId: row.org_id,
-			spaceId: row.space_id || undefined,
-			actorId: row.actor_id,
-			action: row.action as Activity["action"],
-			targetType: row.target_type as Activity["targetType"],
-			targetId: row.target_id,
-			timestamp: row.timestamp,
-			metadata: JSON.parse(row.metadata || "{}"),
-		}));
-	}
+    return rows.map((row) => ({
+      id: row.id,
+      orgId: row.org_id,
+      spaceId: row.space_id || undefined,
+      actorId: row.actor_id,
+      action: row.action as Activity["action"],
+      targetType: row.target_type as Activity["targetType"],
+      targetId: row.target_id,
+      timestamp: row.timestamp,
+      metadata: JSON.parse(row.metadata || "{}"),
+    }));
+  }
 
-	/**
-	 * Close database connection
-	 */
-	close(): void {
-		this.db.close();
-	}
+  /**
+   * Close database connection
+   */
+  close(): void {
+    this.db.close();
+  }
 }

--- a/extensions/memory-hybrid/services/goal-active-task-mirror.ts
+++ b/extensions/memory-hybrid/services/goal-active-task-mirror.ts
@@ -2,7 +2,8 @@
  * Regenerate ACTIVE-TASKS.md with an ## Active Goals mirror section (read-only view of goal registry).
  */
 
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { chmod, mkdir, readFile, rename, stat, unlink, writeFile } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
 import { dirname } from "node:path";
 
 import { readActiveTaskFile, serializeActiveTaskFile } from "./active-task.js";
@@ -79,7 +80,21 @@ export async function refreshActiveTaskMirrorWithGoals(opts: {
       const completed = parsed?.completed ?? [];
       content = serializeActiveTaskFile(active, completed, goalsMd);
     }
-    await writeFile(opts.activeTaskPath, content, "utf-8");
+    const tmpPath = `${opts.activeTaskPath}.tmp-${process.pid}-${Date.now()}-${randomUUID().slice(0, 8)}`;
+    let existingMode: number | null = null;
+    try {
+      existingMode = (await stat(opts.activeTaskPath)).mode & 0o777;
+    } catch {
+      existingMode = null;
+    }
+    try {
+      await writeFile(tmpPath, content, "utf-8");
+      if (existingMode !== null) await chmod(tmpPath, existingMode);
+      await rename(tmpPath, opts.activeTaskPath);
+    } catch (err) {
+      await unlink(tmpPath).catch(() => {});
+      throw err;
+    }
     opts.logger?.info?.(
       `memory-hybrid: ACTIVE-TASKS.md mirror refreshed (${opts.goals.length} active goal(s) in Goals section)`,
     );

--- a/extensions/memory-hybrid/services/goal-health.ts
+++ b/extensions/memory-hybrid/services/goal-health.ts
@@ -229,7 +229,10 @@ async function runMechanicalVerification(
 }
 
 function isBlockedVerificationHost(hostname: string): boolean {
-  const h = hostname.trim().toLowerCase().replace(/^\[|\]$/g, "");
+  const h = hostname
+    .trim()
+    .toLowerCase()
+    .replace(/^\[|\]$/g, "");
   if (!h) return true;
   if (h === "localhost" || h.endsWith(".localhost") || h.endsWith(".local")) return true;
   const ipKind = isIP(h);

--- a/extensions/memory-hybrid/services/goal-health.ts
+++ b/extensions/memory-hybrid/services/goal-health.ts
@@ -4,6 +4,7 @@
 
 import { execFile } from "node:child_process";
 import { existsSync } from "node:fs";
+import { lookup } from "node:dns/promises";
 import { isIP } from "node:net";
 import { isAbsolute, join } from "node:path";
 import { promisify } from "node:util";
@@ -211,8 +212,9 @@ async function runMechanicalVerification(
     if (parsed.username || parsed.password) {
       return { ok: false, detail: "http_ok: URL credentials are not allowed" };
     }
-    if (isBlockedVerificationHost(parsed.hostname)) {
-      return { ok: false, detail: `http_ok: blocked host (${parsed.hostname})` };
+    const hostBlock = await getBlockedVerificationHostReason(parsed.hostname);
+    if (hostBlock) {
+      return { ok: false, detail: `http_ok: blocked host (${parsed.hostname}: ${hostBlock})` };
     }
     const ac = new AbortController();
     const t = setTimeout(() => ac.abort(), 10_000);
@@ -228,28 +230,39 @@ async function runMechanicalVerification(
   return { ok: false, detail: "unknown verification type" };
 }
 
-function isBlockedVerificationHost(hostname: string): boolean {
+export async function getBlockedVerificationHostReason(hostname: string): Promise<string | null> {
   const h = hostname
     .trim()
     .toLowerCase()
     .replace(/^\[|\]$/g, "");
-  if (!h) return true;
-  if (h === "localhost" || h.endsWith(".localhost") || h.endsWith(".local")) return true;
-  const ipKind = isIP(h);
-  if (ipKind === 0) return false;
-  if (ipKind === 4) {
-    const octets = h.split(".").map((part) => Number(part));
-    return isPrivateOrLocalIpv4(octets);
+  if (!h) return "empty host";
+  if (h === "localhost" || h.endsWith(".localhost") || h.endsWith(".local")) return "local hostname";
+  if (isBlockedVerificationIpLiteral(h)) return "local/private IP";
+  if (isIP(h) !== 0) return null;
+
+  let records: Array<{ address: string }>;
+  try {
+    records = await lookup(h, { all: true, verbatim: true });
+  } catch (err) {
+    return `DNS lookup failed: ${err instanceof Error ? err.message : String(err)}`;
   }
-  const normalized = h;
+  if (records.length === 0) return "DNS lookup returned no addresses";
+  return records.some((record) => isBlockedVerificationIpLiteral(record.address))
+    ? "DNS resolved to local/private IP"
+    : null;
+}
+
+function isBlockedVerificationIpLiteral(hostname: string): boolean {
+  const ipKind = isIP(hostname);
+  if (ipKind === 0) return false;
+  if (ipKind === 4) return isPrivateOrLocalIpv4(hostname.split(".").map((part) => Number(part)));
+  const normalized = hostname;
+  const mappedIpv4 = /^::ffff:(\d+\.\d+\.\d+\.\d+)$/i.exec(normalized)?.[1];
+  if (mappedIpv4) return isPrivateOrLocalIpv4(mappedIpv4.split(".").map((part) => Number(part)));
+  if (normalized.startsWith("::ffff:")) return true;
   if (normalized === "::1" || normalized === "::") return true;
   if (/^fe[89ab][0-9a-f]:/i.test(normalized)) return true; // link-local fe80::/10
   if (/^f[cd][0-9a-f]{2}:/i.test(normalized)) return true; // unique local fc00::/7
-  if (normalized.startsWith("::ffff:")) return true; // IPv4-mapped IPv6
-  const mappedIpv4 = /^::ffff:(\d+\.\d+\.\d+\.\d+)$/i.exec(normalized)?.[1];
-  if (mappedIpv4) {
-    return isPrivateOrLocalIpv4(mappedIpv4.split(".").map((part) => Number(part)));
-  }
   return false;
 }
 

--- a/extensions/memory-hybrid/services/goal-registry.ts
+++ b/extensions/memory-hybrid/services/goal-registry.ts
@@ -187,8 +187,12 @@ export async function listGoals(goalsDir: string): Promise<Goal[]> {
   const out: Goal[] = [];
   for (const f of files) {
     if (!f.endsWith(".json") || f === INDEX_FILENAME || f === "_stewardship_rr.json") continue;
-    const g = await readGoal(goalsDir, f.replace(/\.json$/, ""));
-    if (g) out.push(g);
+    try {
+      const g = await readGoal(goalsDir, f.replace(/\.json$/, ""));
+      if (g) out.push(g);
+    } catch {
+      // Keep registry scans isolated: one corrupt goal file must not abort all goal processing.
+    }
   }
   return out;
 }

--- a/extensions/memory-hybrid/services/memory-compression.ts
+++ b/extensions/memory-hybrid/services/memory-compression.ts
@@ -164,74 +164,15 @@ export class MemoryCompressionService {
   }
 
   /**
-   * Cluster facts based on semantic similarity
+   * Cluster facts deterministically until stable vector retrieval is exposed here.
    */
   private async clusterFacts(
     facts: Array<{ id: string; text: string; category: string; importance: number }>,
   ): Promise<FactCluster[]> {
-    if (!this.vectorDb) {
-      // Fallback to category-based clustering without vectors
-      return this.clusterByCategory(facts);
-    }
-
-    // Get embeddings for all facts
-    const embeddings = new Map<string, number[]>();
-    for (const fact of facts) {
-      // TODO: Get actual embeddings from vectorDb
-      // For now, use random embeddings as placeholder
-      embeddings.set(fact.id, this.generateRandomEmbedding());
-    }
-
-    // Hierarchical clustering
-    const clusters: FactCluster[] = [];
-    const assigned = new Set<string>();
-
-    for (const fact of facts) {
-      if (assigned.has(fact.id)) continue;
-
-      const factEmbedding = embeddings.get(fact.id);
-      if (!factEmbedding) continue;
-
-      // Find similar facts
-      const cluster: FactCluster = {
-        id: crypto.randomUUID(),
-        facts: [fact],
-        centroid: factEmbedding,
-        avgImportance: fact.importance,
-        category: fact.category,
-        size: 1,
-      };
-
-      assigned.add(fact.id);
-
-      // Add similar facts to cluster
-      for (const otherFact of facts) {
-        if (assigned.has(otherFact.id)) continue;
-        if (cluster.size >= this.config.maxClusterSize) break;
-
-        const otherEmbedding = embeddings.get(otherFact.id);
-        if (!otherEmbedding) continue;
-
-        const similarity = this.cosineSimilarity(factEmbedding, otherEmbedding);
-
-        if (similarity >= this.config.clusterThreshold) {
-          cluster.facts.push(otherFact);
-          cluster.size++;
-          assigned.add(otherFact.id);
-
-          // Update centroid and average importance
-          cluster.centroid = this.updateCentroid(cluster.centroid, otherEmbedding, cluster.size);
-          cluster.avgImportance = (cluster.avgImportance * (cluster.size - 1) + otherFact.importance) / cluster.size;
-        }
-      }
-
-      // Only keep clusters with multiple facts
-      if (cluster.size > 1) {
-        clusters.push(cluster);
-      }
-    }
-
-    return clusters;
+    // Do not fabricate/randomize embeddings: non-deterministic clusters are worse
+    // than a deterministic fallback. Vector-aware clustering can be reintroduced
+    // once this service can read persisted vectors by fact id.
+    return this.clusterByCategory(facts);
   }
 
   /**
@@ -362,28 +303,6 @@ Provide a clear, factual summary that preserves the key details. The summary sho
       return firstPara;
     }
     return `${text.substring(0, 150)}...`;
-  }
-
-  private cosineSimilarity(a: number[], b: number[]): number {
-    let dotProduct = 0;
-    let normA = 0;
-    let normB = 0;
-
-    for (let i = 0; i < a.length; i++) {
-      dotProduct += a[i] * b[i];
-      normA += a[i] * a[i];
-      normB += b[i] * b[i];
-    }
-
-    return dotProduct / (Math.sqrt(normA) * Math.sqrt(normB));
-  }
-
-  private updateCentroid(centroid: number[], newVector: number[], clusterSize: number): number[] {
-    return centroid.map((val, i) => (val * (clusterSize - 1) + newVector[i]) / clusterSize);
-  }
-
-  private generateRandomEmbedding(dimensions = 384): number[] {
-    return Array.from({ length: dimensions }, () => Math.random() * 2 - 1);
   }
 
   private estimateTokens(text: string): number {

--- a/extensions/memory-hybrid/services/memory-compression.ts
+++ b/extensions/memory-hybrid/services/memory-compression.ts
@@ -7,49 +7,49 @@ import type { FactsDB } from "../backends/facts-db/facts-db-layer1.js";
 import type { VectorDB } from "../backends/vector-db.js";
 
 export interface CompressionConfig {
-	/** Minimum similarity threshold for clustering (0-1) */
-	clusterThreshold: number;
-	/** Maximum facts per cluster */
-	maxClusterSize: number;
-	/** Minimum facts required to trigger compression */
-	minFactsForCompression: number;
-	/** LLM model to use for summarization */
-	llmModel?: string;
-	/** Whether to preserve original facts after compression */
-	preserveOriginals: boolean;
-	/** Time window for compression (in days) */
-	timeWindowDays?: number;
+  /** Minimum similarity threshold for clustering (0-1) */
+  clusterThreshold: number;
+  /** Maximum facts per cluster */
+  maxClusterSize: number;
+  /** Minimum facts required to trigger compression */
+  minFactsForCompression: number;
+  /** LLM model to use for summarization */
+  llmModel?: string;
+  /** Whether to preserve original facts after compression */
+  preserveOriginals: boolean;
+  /** Time window for compression (in days) */
+  timeWindowDays?: number;
 }
 
 export interface FactCluster {
-	id: string;
-	facts: Array<{ id: string; text: string; importance: number }>;
-	centroid: number[];
-	avgImportance: number;
-	category: string;
-	size: number;
+  id: string;
+  facts: Array<{ id: string; text: string; importance: number }>;
+  centroid: number[];
+  avgImportance: number;
+  category: string;
+  size: number;
 }
 
 export interface CompressionResult {
-	clustersCreated: number;
-	factsCompressed: number;
-	summariesGenerated: number;
-	spaceReduction: number; // Percentage
-	tokensReduced: number;
-	report: {
-		clusters: FactCluster[];
-		summaries: Array<{
-			clusterId: string;
-			summary: string;
-			originalFactCount: number;
-		}>;
-	};
+  clustersCreated: number;
+  factsCompressed: number;
+  summariesGenerated: number;
+  spaceReduction: number; // Percentage
+  tokensReduced: number;
+  report: {
+    clusters: FactCluster[];
+    summaries: Array<{
+      clusterId: string;
+      summary: string;
+      originalFactCount: number;
+    }>;
+  };
 }
 
 export interface SummaryLevel {
-	level: "brief" | "detailed" | "full";
-	maxTokens: number;
-	includeMetadata: boolean;
+  level: "brief" | "detailed" | "full";
+  maxTokens: number;
+  includeMetadata: boolean;
 }
 
 /**
@@ -57,342 +57,350 @@ export interface SummaryLevel {
  * Clusters related facts and generates multi-level summaries
  */
 export class MemoryCompressionService {
-	constructor(
-		private factsDb: FactsDB,
-		private vectorDb: VectorDB | undefined,
-		private config: CompressionConfig,
-	) {}
+  constructor(
+    private factsDb: FactsDB,
+    private vectorDb: VectorDB | undefined,
+    private config: CompressionConfig,
+  ) {}
 
-	/**
-	 * Compress memories by clustering and summarizing related facts
-	 */
-	async compressMemories(options?: {
-		category?: string;
-		olderThan?: number;
-		scope?: string;
-	}): Promise<CompressionResult> {
-		console.log("[Compression] Starting memory compression...");
+  /**
+   * Compress memories by clustering and summarizing related facts
+   */
+  async compressMemories(options?: {
+    category?: string;
+    olderThan?: number;
+    scope?: string;
+  }): Promise<CompressionResult> {
+    console.log("[Compression] Starting memory compression...");
 
-		// Get facts to compress
-		let facts = this.factsDb.getAllFacts();
+    // Get facts to compress
+    let facts = this.factsDb.getAllFacts();
 
-		// Apply filters
-		if (options?.category) {
-			facts = facts.filter(f => f.category === options.category);
-		}
-		if (options?.olderThan) {
-			facts = facts.filter(f => f.createdAt < options.olderThan!);
-		}
-		if (options?.scope) {
-			facts = facts.filter(f => f.scope === options.scope);
-		}
+    // Apply filters
+    if (options?.category) {
+      facts = facts.filter((f) => f.category === options.category);
+    }
+    if (options?.olderThan) {
+      facts = facts.filter((f) => f.createdAt < options.olderThan!);
+    }
+    if (options?.scope) {
+      facts = facts.filter((f) => f.scope === options.scope);
+    }
 
-		// Filter out already superseded facts
-		facts = facts.filter(f => !f.supersededBy);
+    // Filter out already superseded facts
+    facts = facts.filter((f) => !f.supersededBy);
 
-		if (facts.length < this.config.minFactsForCompression) {
-			console.log(`[Compression] Not enough facts to compress (${facts.length} < ${this.config.minFactsForCompression})`);
-			return {
-				clustersCreated: 0,
-				factsCompressed: 0,
-				summariesGenerated: 0,
-				spaceReduction: 0,
-				tokensReduced: 0,
-				report: { clusters: [], summaries: [] },
-			};
-		}
+    if (facts.length < this.config.minFactsForCompression) {
+      console.log(
+        `[Compression] Not enough facts to compress (${facts.length} < ${this.config.minFactsForCompression})`,
+      );
+      return {
+        clustersCreated: 0,
+        factsCompressed: 0,
+        summariesGenerated: 0,
+        spaceReduction: 0,
+        tokensReduced: 0,
+        report: { clusters: [], summaries: [] },
+      };
+    }
 
-		// Cluster similar facts
-		const clusters = await this.clusterFacts(facts);
-		console.log(`[Compression] Created ${clusters.length} clusters`);
+    // Cluster similar facts
+    const clusters = await this.clusterFacts(facts);
+    console.log(`[Compression] Created ${clusters.length} clusters`);
 
-		// Generate summaries for each cluster
-		const summaries = await this.generateClusterSummaries(clusters);
-		console.log(`[Compression] Generated ${summaries.length} summaries`);
+    // Generate summaries for each cluster
+    const summaries = await this.generateClusterSummaries(clusters);
+    console.log(`[Compression] Generated ${summaries.length} summaries`);
 
-		// Store summaries and supersede original facts
-		let factsCompressed = 0;
-		let tokensReduced = 0;
+    // Store summaries and supersede original facts
+    let factsCompressed = 0;
+    let tokensReduced = 0;
 
-		for (const summary of summaries) {
-			const cluster = clusters.find(c => c.id === summary.clusterId);
-			if (!cluster) continue;
+    for (const summary of summaries) {
+      const cluster = clusters.find((c) => c.id === summary.clusterId);
+      if (!cluster) continue;
 
-			// Calculate token reduction
-			const originalTokens = cluster.facts.reduce((sum, f) => sum + this.estimateTokens(f.text), 0);
-			const summaryTokens = this.estimateTokens(summary.summary);
-			tokensReduced += originalTokens - summaryTokens;
+      // Calculate token reduction
+      const originalTokens = cluster.facts.reduce((sum, f) => sum + this.estimateTokens(f.text), 0);
+      const summaryTokens = this.estimateTokens(summary.summary);
+      tokensReduced += originalTokens - summaryTokens;
 
-			// Store summary as a new fact
-			const summaryFact = {
-				id: crypto.randomUUID(),
-				text: summary.summary,
-				category: cluster.category,
-				importance: cluster.avgImportance,
-				confidence: 0.9, // Slightly lower since it's a summary
-				decayClass: "stable" as const,
-				tags: ["summary", "compressed"],
-				source: "compression-service",
-				createdAt: Date.now(),
-				metadata: {
-					compressionClusterId: cluster.id,
-					originalFactCount: cluster.facts.length,
-					compressionDate: Date.now(),
-				},
-			};
+      // Store summary as a new fact
+      const summaryFact = {
+        id: crypto.randomUUID(),
+        text: summary.summary,
+        category: cluster.category,
+        importance: cluster.avgImportance,
+        confidence: 0.9, // Slightly lower since it's a summary
+        decayClass: "stable" as const,
+        tags: ["summary", "compressed"],
+        source: "compression-service",
+        createdAt: Date.now(),
+        metadata: {
+          compressionClusterId: cluster.id,
+          originalFactCount: cluster.facts.length,
+          compressionDate: Date.now(),
+        },
+      };
 
-			await this.factsDb.store(summaryFact);
+      await this.factsDb.store(summaryFact);
 
-			// Supersede original facts if configured
-			if (!this.config.preserveOriginals) {
-				for (const fact of cluster.facts) {
-					const original = this.factsDb.getFactById(fact.id);
-					if (original) {
-						await this.factsDb.store({
-							...original,
-							supersededBy: summaryFact.id,
-							updatedAt: Date.now(),
-						});
-						factsCompressed++;
-					}
-				}
-			}
-		}
+      // Supersede original facts if configured
+      if (!this.config.preserveOriginals) {
+        for (const fact of cluster.facts) {
+          const original = this.factsDb.getFactById(fact.id);
+          if (original) {
+            await this.factsDb.store({
+              ...original,
+              supersededBy: summaryFact.id,
+              updatedAt: Date.now(),
+            });
+            factsCompressed++;
+          }
+        }
+      }
+    }
 
-		const spaceReduction = facts.length > 0 ? (factsCompressed / facts.length) * 100 : 0;
+    const spaceReduction = facts.length > 0 ? (factsCompressed / facts.length) * 100 : 0;
 
-		console.log(`[Compression] Complete: ${factsCompressed} facts compressed into ${summaries.length} summaries`);
-		console.log(`[Compression] Token reduction: ${tokensReduced} tokens (~${(tokensReduced / 1000).toFixed(1)}k)`);
+    console.log(`[Compression] Complete: ${factsCompressed} facts compressed into ${summaries.length} summaries`);
+    console.log(`[Compression] Token reduction: ${tokensReduced} tokens (~${(tokensReduced / 1000).toFixed(1)}k)`);
 
-		return {
-			clustersCreated: clusters.length,
-			factsCompressed,
-			summariesGenerated: summaries.length,
-			spaceReduction,
-			tokensReduced,
-			report: { clusters, summaries },
-		};
-	}
+    return {
+      clustersCreated: clusters.length,
+      factsCompressed,
+      summariesGenerated: summaries.length,
+      spaceReduction,
+      tokensReduced,
+      report: { clusters, summaries },
+    };
+  }
 
-	/**
-	 * Cluster facts based on semantic similarity
-	 */
-	private async clusterFacts(facts: Array<{ id: string; text: string; category: string; importance: number }>): Promise<FactCluster[]> {
-		if (!this.vectorDb) {
-			// Fallback to category-based clustering without vectors
-			return this.clusterByCategory(facts);
-		}
+  /**
+   * Cluster facts based on semantic similarity
+   */
+  private async clusterFacts(
+    facts: Array<{ id: string; text: string; category: string; importance: number }>,
+  ): Promise<FactCluster[]> {
+    if (!this.vectorDb) {
+      // Fallback to category-based clustering without vectors
+      return this.clusterByCategory(facts);
+    }
 
-		// Get embeddings for all facts
-		const embeddings = new Map<string, number[]>();
-		for (const fact of facts) {
-			// TODO: Get actual embeddings from vectorDb
-			// For now, use random embeddings as placeholder
-			embeddings.set(fact.id, this.generateRandomEmbedding());
-		}
+    // Get embeddings for all facts
+    const embeddings = new Map<string, number[]>();
+    for (const fact of facts) {
+      // TODO: Get actual embeddings from vectorDb
+      // For now, use random embeddings as placeholder
+      embeddings.set(fact.id, this.generateRandomEmbedding());
+    }
 
-		// Hierarchical clustering
-		const clusters: FactCluster[] = [];
-		const assigned = new Set<string>();
+    // Hierarchical clustering
+    const clusters: FactCluster[] = [];
+    const assigned = new Set<string>();
 
-		for (const fact of facts) {
-			if (assigned.has(fact.id)) continue;
+    for (const fact of facts) {
+      if (assigned.has(fact.id)) continue;
 
-			const factEmbedding = embeddings.get(fact.id);
-			if (!factEmbedding) continue;
+      const factEmbedding = embeddings.get(fact.id);
+      if (!factEmbedding) continue;
 
-			// Find similar facts
-			const cluster: FactCluster = {
-				id: crypto.randomUUID(),
-				facts: [fact],
-				centroid: factEmbedding,
-				avgImportance: fact.importance,
-				category: fact.category,
-				size: 1,
-			};
+      // Find similar facts
+      const cluster: FactCluster = {
+        id: crypto.randomUUID(),
+        facts: [fact],
+        centroid: factEmbedding,
+        avgImportance: fact.importance,
+        category: fact.category,
+        size: 1,
+      };
 
-			assigned.add(fact.id);
+      assigned.add(fact.id);
 
-			// Add similar facts to cluster
-			for (const otherFact of facts) {
-				if (assigned.has(otherFact.id)) continue;
-				if (cluster.size >= this.config.maxClusterSize) break;
+      // Add similar facts to cluster
+      for (const otherFact of facts) {
+        if (assigned.has(otherFact.id)) continue;
+        if (cluster.size >= this.config.maxClusterSize) break;
 
-				const otherEmbedding = embeddings.get(otherFact.id);
-				if (!otherEmbedding) continue;
+        const otherEmbedding = embeddings.get(otherFact.id);
+        if (!otherEmbedding) continue;
 
-				const similarity = this.cosineSimilarity(factEmbedding, otherEmbedding);
+        const similarity = this.cosineSimilarity(factEmbedding, otherEmbedding);
 
-				if (similarity >= this.config.clusterThreshold) {
-					cluster.facts.push(otherFact);
-					cluster.size++;
-					assigned.add(otherFact.id);
+        if (similarity >= this.config.clusterThreshold) {
+          cluster.facts.push(otherFact);
+          cluster.size++;
+          assigned.add(otherFact.id);
 
-					// Update centroid and average importance
-					cluster.centroid = this.updateCentroid(cluster.centroid, otherEmbedding, cluster.size);
-					cluster.avgImportance = (cluster.avgImportance * (cluster.size - 1) + otherFact.importance) / cluster.size;
-				}
-			}
+          // Update centroid and average importance
+          cluster.centroid = this.updateCentroid(cluster.centroid, otherEmbedding, cluster.size);
+          cluster.avgImportance = (cluster.avgImportance * (cluster.size - 1) + otherFact.importance) / cluster.size;
+        }
+      }
 
-			// Only keep clusters with multiple facts
-			if (cluster.size > 1) {
-				clusters.push(cluster);
-			}
-		}
+      // Only keep clusters with multiple facts
+      if (cluster.size > 1) {
+        clusters.push(cluster);
+      }
+    }
 
-		return clusters;
-	}
+    return clusters;
+  }
 
-	/**
-	 * Fallback clustering by category when vectors unavailable
-	 */
-	private clusterByCategory(facts: Array<{ id: string; text: string; category: string; importance: number }>): FactCluster[] {
-		const categoryMap = new Map<string, typeof facts>();
+  /**
+   * Fallback clustering by category when vectors unavailable
+   */
+  private clusterByCategory(
+    facts: Array<{ id: string; text: string; category: string; importance: number }>,
+  ): FactCluster[] {
+    const categoryMap = new Map<string, typeof facts>();
 
-		for (const fact of facts) {
-			const existing = categoryMap.get(fact.category) || [];
-			existing.push(fact);
-			categoryMap.set(fact.category, existing);
-		}
+    for (const fact of facts) {
+      const existing = categoryMap.get(fact.category) || [];
+      existing.push(fact);
+      categoryMap.set(fact.category, existing);
+    }
 
-		const clusters: FactCluster[] = [];
+    const clusters: FactCluster[] = [];
 
-		for (const [category, categoryFacts] of categoryMap.entries()) {
-			// Split large categories into smaller clusters
-			for (let i = 0; i < categoryFacts.length; i += this.config.maxClusterSize) {
-				const chunk = categoryFacts.slice(i, i + this.config.maxClusterSize);
-				if (chunk.length > 1) {
-					clusters.push({
-						id: crypto.randomUUID(),
-						facts: chunk,
-						centroid: [],
-						avgImportance: chunk.reduce((sum, f) => sum + f.importance, 0) / chunk.length,
-						category,
-						size: chunk.length,
-					});
-				}
-			}
-		}
+    for (const [category, categoryFacts] of categoryMap.entries()) {
+      // Split large categories into smaller clusters
+      for (let i = 0; i < categoryFacts.length; i += this.config.maxClusterSize) {
+        const chunk = categoryFacts.slice(i, i + this.config.maxClusterSize);
+        if (chunk.length > 1) {
+          clusters.push({
+            id: crypto.randomUUID(),
+            facts: chunk,
+            centroid: [],
+            avgImportance: chunk.reduce((sum, f) => sum + f.importance, 0) / chunk.length,
+            category,
+            size: chunk.length,
+          });
+        }
+      }
+    }
 
-		return clusters;
-	}
+    return clusters;
+  }
 
-	/**
-	 * Generate summaries for clusters using LLM
-	 */
-	private async generateClusterSummaries(clusters: FactCluster[]): Promise<Array<{
-		clusterId: string;
-		summary: string;
-		originalFactCount: number;
-	}>> {
-		const summaries = [];
+  /**
+   * Generate summaries for clusters using LLM
+   */
+  private async generateClusterSummaries(clusters: FactCluster[]): Promise<
+    Array<{
+      clusterId: string;
+      summary: string;
+      originalFactCount: number;
+    }>
+  > {
+    const summaries = [];
 
-		for (const cluster of clusters) {
-			// Generate summary prompt
-			const factsText = cluster.facts.map((f, i) => `${i + 1}. ${f.text}`).join("\n");
+    for (const cluster of clusters) {
+      // Generate summary prompt
+      const factsText = cluster.facts.map((f, i) => `${i + 1}. ${f.text}`).join("\n");
 
-			const prompt = `Summarize the following ${cluster.size} related facts into a single, concise summary that captures the essential information:
+      const prompt = `Summarize the following ${cluster.size} related facts into a single, concise summary that captures the essential information:
 
 ${factsText}
 
 Provide a clear, factual summary that preserves the key details. The summary should be self-contained and easier to recall than the individual facts.`;
 
-			// TODO: Call actual LLM service
-			// For now, create a simple concatenation
-			const summary = this.generateSimpleSummary(cluster);
+      // TODO: Call actual LLM service
+      // For now, create a simple concatenation
+      const summary = this.generateSimpleSummary(cluster);
 
-			summaries.push({
-				clusterId: cluster.id,
-				summary,
-				originalFactCount: cluster.size,
-			});
-		}
+      summaries.push({
+        clusterId: cluster.id,
+        summary,
+        originalFactCount: cluster.size,
+      });
+    }
 
-		return summaries;
-	}
+    return summaries;
+  }
 
-	/**
-	 * Generate a simple summary without LLM (fallback)
-	 */
-	private generateSimpleSummary(cluster: FactCluster): string {
-		if (cluster.size === 2) {
-			return `${cluster.facts[0].text} Additionally, ${cluster.facts[1].text.toLowerCase()}`;
-		}
+  /**
+   * Generate a simple summary without LLM (fallback)
+   */
+  private generateSimpleSummary(cluster: FactCluster): string {
+    if (cluster.size === 2) {
+      return `${cluster.facts[0].text} Additionally, ${cluster.facts[1].text.toLowerCase()}`;
+    }
 
-		const prefix = `Summary of ${cluster.size} ${cluster.category} facts: `;
-		const items = cluster.facts.map((f, i) => {
-			if (i === 0) return f.text;
-			if (i === cluster.size - 1) return `and ${f.text.toLowerCase()}`;
-			return f.text.toLowerCase();
-		});
+    const prefix = `Summary of ${cluster.size} ${cluster.category} facts: `;
+    const items = cluster.facts.map((f, i) => {
+      if (i === 0) return f.text;
+      if (i === cluster.size - 1) return `and ${f.text.toLowerCase()}`;
+      return f.text.toLowerCase();
+    });
 
-		return prefix + items.join("; ");
-	}
+    return prefix + items.join("; ");
+  }
 
-	/**
-	 * Create multi-level summary of a fact
-	 */
-	async createMultiLevelSummary(factId: string): Promise<{
-		brief: string;
-		detailed: string;
-		full: string;
-	}> {
-		const fact = this.factsDb.getFactById(factId);
-		if (!fact) {
-			throw new Error(`Fact not found: ${factId}`);
-		}
+  /**
+   * Create multi-level summary of a fact
+   */
+  async createMultiLevelSummary(factId: string): Promise<{
+    brief: string;
+    detailed: string;
+    full: string;
+  }> {
+    const fact = this.factsDb.getFactById(factId);
+    if (!fact) {
+      throw new Error(`Fact not found: ${factId}`);
+    }
 
-		const full = fact.text;
+    const full = fact.text;
 
-		// Brief: First sentence or 50 chars
-		const brief = this.extractBrief(full);
+    // Brief: First sentence or 50 chars
+    const brief = this.extractBrief(full);
 
-		// Detailed: First 150 chars or first paragraph
-		const detailed = this.extractDetailed(full);
+    // Detailed: First 150 chars or first paragraph
+    const detailed = this.extractDetailed(full);
 
-		return { brief, detailed, full };
-	}
+    return { brief, detailed, full };
+  }
 
-	private extractBrief(text: string): string {
-		const firstSentence = text.match(/^[^.!?]+[.!?]/);
-		if (firstSentence) {
-			return firstSentence[0].trim();
-		}
-		return text.substring(0, 50) + (text.length > 50 ? "..." : "");
-	}
+  private extractBrief(text: string): string {
+    const firstSentence = text.match(/^[^.!?]+[.!?]/);
+    if (firstSentence) {
+      return firstSentence[0].trim();
+    }
+    return text.substring(0, 50) + (text.length > 50 ? "..." : "");
+  }
 
-	private extractDetailed(text: string): string {
-		const firstPara = text.split("\n\n")[0];
-		if (firstPara.length <= 150) {
-			return firstPara;
-		}
-		return text.substring(0, 150) + "...";
-	}
+  private extractDetailed(text: string): string {
+    const firstPara = text.split("\n\n")[0];
+    if (firstPara.length <= 150) {
+      return firstPara;
+    }
+    return text.substring(0, 150) + "...";
+  }
 
-	private cosineSimilarity(a: number[], b: number[]): number {
-		let dotProduct = 0;
-		let normA = 0;
-		let normB = 0;
+  private cosineSimilarity(a: number[], b: number[]): number {
+    let dotProduct = 0;
+    let normA = 0;
+    let normB = 0;
 
-		for (let i = 0; i < a.length; i++) {
-			dotProduct += a[i] * b[i];
-			normA += a[i] * a[i];
-			normB += b[i] * b[i];
-		}
+    for (let i = 0; i < a.length; i++) {
+      dotProduct += a[i] * b[i];
+      normA += a[i] * a[i];
+      normB += b[i] * b[i];
+    }
 
-		return dotProduct / (Math.sqrt(normA) * Math.sqrt(normB));
-	}
+    return dotProduct / (Math.sqrt(normA) * Math.sqrt(normB));
+  }
 
-	private updateCentroid(centroid: number[], newVector: number[], clusterSize: number): number[] {
-		return centroid.map((val, i) => (val * (clusterSize - 1) + newVector[i]) / clusterSize);
-	}
+  private updateCentroid(centroid: number[], newVector: number[], clusterSize: number): number[] {
+    return centroid.map((val, i) => (val * (clusterSize - 1) + newVector[i]) / clusterSize);
+  }
 
-	private generateRandomEmbedding(dimensions = 384): number[] {
-		return Array.from({ length: dimensions }, () => Math.random() * 2 - 1);
-	}
+  private generateRandomEmbedding(dimensions = 384): number[] {
+    return Array.from({ length: dimensions }, () => Math.random() * 2 - 1);
+  }
 
-	private estimateTokens(text: string): number {
-		// Rough estimate: ~4 characters per token
-		return Math.ceil(text.length / 4);
-	}
+  private estimateTokens(text: string): number {
+    // Rough estimate: ~4 characters per token
+    return Math.ceil(text.length / 4);
+  }
 }

--- a/extensions/memory-hybrid/services/memory-compression.ts
+++ b/extensions/memory-hybrid/services/memory-compression.ts
@@ -3,7 +3,7 @@
  * Implements smart memory consolidation and multi-level summaries
  */
 
-import type { FactsDB } from "../backends/facts-db/facts-db-layer1.js";
+import type { FactsDB } from "../backends/facts-db.js";
 import type { VectorDB } from "../backends/vector-db.js";
 
 export interface CompressionConfig {
@@ -71,10 +71,8 @@ export class MemoryCompressionService {
     olderThan?: number;
     scope?: string;
   }): Promise<CompressionResult> {
-    console.log("[Compression] Starting memory compression...");
-
     // Get facts to compress
-    let facts = this.factsDb.getAllFacts();
+    let facts = this.factsDb.getAll();
 
     // Apply filters
     if (options?.category) {
@@ -91,9 +89,6 @@ export class MemoryCompressionService {
     facts = facts.filter((f) => !f.supersededBy);
 
     if (facts.length < this.config.minFactsForCompression) {
-      console.log(
-        `[Compression] Not enough facts to compress (${facts.length} < ${this.config.minFactsForCompression})`,
-      );
       return {
         clustersCreated: 0,
         factsCompressed: 0,
@@ -106,11 +101,9 @@ export class MemoryCompressionService {
 
     // Cluster similar facts
     const clusters = await this.clusterFacts(facts);
-    console.log(`[Compression] Created ${clusters.length} clusters`);
 
     // Generate summaries for each cluster
     const summaries = await this.generateClusterSummaries(clusters);
-    console.log(`[Compression] Generated ${summaries.length} summaries`);
 
     // Store summaries and supersede original facts
     let factsCompressed = 0;
@@ -127,34 +120,31 @@ export class MemoryCompressionService {
 
       // Store summary as a new fact
       const summaryFact = {
-        id: crypto.randomUUID(),
         text: summary.summary,
         category: cluster.category,
         importance: cluster.avgImportance,
         confidence: 0.9, // Slightly lower since it's a summary
-        decayClass: "stable" as const,
+        decayClass: "durable" as const,
         tags: ["summary", "compressed"],
         source: "compression-service",
-        createdAt: Date.now(),
-        metadata: {
+        entity: null,
+        key: null,
+        value: null,
+        provenanceJson: JSON.stringify({
           compressionClusterId: cluster.id,
           originalFactCount: cluster.facts.length,
           compressionDate: Date.now(),
-        },
+        }),
       };
 
-      await this.factsDb.store(summaryFact);
+      const storedSummary = this.factsDb.store(summaryFact);
 
       // Supersede original facts if configured
       if (!this.config.preserveOriginals) {
         for (const fact of cluster.facts) {
-          const original = this.factsDb.getFactById(fact.id);
+          const original = this.factsDb.getById(fact.id);
           if (original) {
-            await this.factsDb.store({
-              ...original,
-              supersededBy: summaryFact.id,
-              updatedAt: Date.now(),
-            });
+            this.factsDb.supersede(original.id, storedSummary.id);
             factsCompressed++;
           }
         }
@@ -162,9 +152,6 @@ export class MemoryCompressionService {
     }
 
     const spaceReduction = facts.length > 0 ? (factsCompressed / facts.length) * 100 : 0;
-
-    console.log(`[Compression] Complete: ${factsCompressed} facts compressed into ${summaries.length} summaries`);
-    console.log(`[Compression] Token reduction: ${tokensReduced} tokens (~${(tokensReduced / 1000).toFixed(1)}k)`);
 
     return {
       clustersCreated: clusters.length,
@@ -299,7 +286,7 @@ export class MemoryCompressionService {
       // Generate summary prompt
       const factsText = cluster.facts.map((f, i) => `${i + 1}. ${f.text}`).join("\n");
 
-      const prompt = `Summarize the following ${cluster.size} related facts into a single, concise summary that captures the essential information:
+      const _prompt = `Summarize the following ${cluster.size} related facts into a single, concise summary that captures the essential information:
 
 ${factsText}
 
@@ -345,7 +332,7 @@ Provide a clear, factual summary that preserves the key details. The summary sho
     detailed: string;
     full: string;
   }> {
-    const fact = this.factsDb.getFactById(factId);
+    const fact = this.factsDb.getById(factId);
     if (!fact) {
       throw new Error(`Fact not found: ${factId}`);
     }
@@ -374,7 +361,7 @@ Provide a clear, factual summary that preserves the key details. The summary sho
     if (firstPara.length <= 150) {
       return firstPara;
     }
-    return text.substring(0, 150) + "...";
+    return `${text.substring(0, 150)}...`;
   }
 
   private cosineSimilarity(a: number[], b: number[]): number {

--- a/extensions/memory-hybrid/services/plugin-loader.ts
+++ b/extensions/memory-hybrid/services/plugin-loader.ts
@@ -3,13 +3,15 @@
  * Integrates the Plugin Manager into the main hybrid memory plugin lifecycle
  */
 
-import type { FactsDB } from "../backends/facts-db/facts-db-layer1.js";
+type MemoryPluginContext = Record<string, unknown>;
+
+import type { FactsDB } from "../backends/facts-db.js";
 import type { VectorDB } from "../backends/vector-db.js";
-import type { MemoryPluginContext } from "../api/memory-plugin-api.js";
 import { PluginManager, type MemoryPlugin } from "../api/plugin-system.js";
 import { pluginLogger } from "../utils/logger.js";
 import { readdir } from "node:fs/promises";
 import { join } from "node:path";
+import { pathToFileURL } from "node:url";
 import { existsSync } from "node:fs";
 
 /**
@@ -40,28 +42,50 @@ export class PluginLoader {
     }
 
     try {
-      const entries = await readdir(this.pluginsDir, { withFileTypes: true });
-
-      for (const entry of entries) {
-        if (!entry.isDirectory()) continue;
-
-        const pluginPath = join(this.pluginsDir, entry.name);
-        const pluginFile = join(pluginPath, "index.js");
-
-        if (!existsSync(pluginFile)) {
-          pluginLogger.debug(`[PluginLoader] Skipping ${entry.name}: no index.js found`);
-          continue;
-        }
-
+      for (const pluginFile of await this.discoverPluginFiles()) {
         try {
           await this.loadPlugin(pluginFile);
         } catch (error) {
-          pluginLogger.error(`[PluginLoader] Failed to load plugin from ${pluginFile}:`, error);
+          pluginLogger.error(`[PluginLoader] Failed to load plugin from ${pluginFile}: ${String(error)}`);
         }
       }
     } catch (error) {
-      pluginLogger.error(`[PluginLoader] Failed to scan plugins directory:`, error);
+      pluginLogger.error(`[PluginLoader] Failed to scan plugins directory: ${String(error)}`);
     }
+  }
+
+  private async discoverPluginFiles(): Promise<string[]> {
+    const files: string[] = [];
+    const addPluginFile = (pluginPath: string) => {
+      const pluginFile = join(pluginPath, "index.js");
+      if (existsSync(pluginFile)) files.push(pluginFile);
+    };
+
+    const entries = await readdir(this.pluginsDir, { withFileTypes: true });
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      if (entry.name === "node_modules") continue;
+      addPluginFile(join(this.pluginsDir, entry.name));
+    }
+
+    const nodeModulesDir = join(this.pluginsDir, "node_modules");
+    if (existsSync(nodeModulesDir)) {
+      const modules = await readdir(nodeModulesDir, { withFileTypes: true });
+      for (const entry of modules) {
+        if (!entry.isDirectory()) continue;
+        const modulePath = join(nodeModulesDir, entry.name);
+        if (entry.name.startsWith("@")) {
+          const scoped = await readdir(modulePath, { withFileTypes: true });
+          for (const scopedEntry of scoped) {
+            if (scopedEntry.isDirectory()) addPluginFile(join(modulePath, scopedEntry.name));
+          }
+        } else {
+          addPluginFile(modulePath);
+        }
+      }
+    }
+
+    return files;
   }
 
   /**
@@ -69,7 +93,7 @@ export class PluginLoader {
    */
   async loadPlugin(pluginPath: string): Promise<void> {
     try {
-      const module = await import(pluginPath);
+      const module = await import(pathToFileURL(pluginPath).href);
       const plugin: MemoryPlugin = module.default || module;
 
       if (!plugin.metadata || !plugin.init) {

--- a/extensions/memory-hybrid/services/plugin-loader.ts
+++ b/extensions/memory-hybrid/services/plugin-loader.ts
@@ -17,85 +17,85 @@ import { existsSync } from "node:fs";
  * Discovers and loads plugins from the plugins directory
  */
 export class PluginLoader {
-	private pluginManager: PluginManager;
-	private pluginsDir: string;
+  private pluginManager: PluginManager;
+  private pluginsDir: string;
 
-	constructor(
-		factsDb: FactsDB,
-		vectorDb: VectorDB | undefined,
-		pluginContext: MemoryPluginContext,
-		pluginsDir: string,
-	) {
-		this.pluginManager = new PluginManager(factsDb, vectorDb, pluginContext);
-		this.pluginsDir = pluginsDir;
-	}
+  constructor(
+    factsDb: FactsDB,
+    vectorDb: VectorDB | undefined,
+    pluginContext: MemoryPluginContext,
+    pluginsDir: string,
+  ) {
+    this.pluginManager = new PluginManager(factsDb, vectorDb, pluginContext);
+    this.pluginsDir = pluginsDir;
+  }
 
-	/**
-	 * Discover and load all plugins from the plugins directory
-	 */
-	async discoverAndLoadPlugins(): Promise<void> {
-		if (!existsSync(this.pluginsDir)) {
-			pluginLogger.debug(`[PluginLoader] Plugins directory not found: ${this.pluginsDir}`);
-			return;
-		}
+  /**
+   * Discover and load all plugins from the plugins directory
+   */
+  async discoverAndLoadPlugins(): Promise<void> {
+    if (!existsSync(this.pluginsDir)) {
+      pluginLogger.debug(`[PluginLoader] Plugins directory not found: ${this.pluginsDir}`);
+      return;
+    }
 
-		try {
-			const entries = await readdir(this.pluginsDir, { withFileTypes: true });
+    try {
+      const entries = await readdir(this.pluginsDir, { withFileTypes: true });
 
-			for (const entry of entries) {
-				if (!entry.isDirectory()) continue;
+      for (const entry of entries) {
+        if (!entry.isDirectory()) continue;
 
-				const pluginPath = join(this.pluginsDir, entry.name);
-				const pluginFile = join(pluginPath, "index.js");
+        const pluginPath = join(this.pluginsDir, entry.name);
+        const pluginFile = join(pluginPath, "index.js");
 
-				if (!existsSync(pluginFile)) {
-					pluginLogger.debug(`[PluginLoader] Skipping ${entry.name}: no index.js found`);
-					continue;
-				}
+        if (!existsSync(pluginFile)) {
+          pluginLogger.debug(`[PluginLoader] Skipping ${entry.name}: no index.js found`);
+          continue;
+        }
 
-				try {
-					await this.loadPlugin(pluginFile);
-				} catch (error) {
-					pluginLogger.error(`[PluginLoader] Failed to load plugin from ${pluginFile}:`, error);
-				}
-			}
-		} catch (error) {
-			pluginLogger.error(`[PluginLoader] Failed to scan plugins directory:`, error);
-		}
-	}
+        try {
+          await this.loadPlugin(pluginFile);
+        } catch (error) {
+          pluginLogger.error(`[PluginLoader] Failed to load plugin from ${pluginFile}:`, error);
+        }
+      }
+    } catch (error) {
+      pluginLogger.error(`[PluginLoader] Failed to scan plugins directory:`, error);
+    }
+  }
 
-	/**
-	 * Load a single plugin from a file path
-	 */
-	async loadPlugin(pluginPath: string): Promise<void> {
-		try {
-			const module = await import(pluginPath);
-			const plugin: MemoryPlugin = module.default || module;
+  /**
+   * Load a single plugin from a file path
+   */
+  async loadPlugin(pluginPath: string): Promise<void> {
+    try {
+      const module = await import(pluginPath);
+      const plugin: MemoryPlugin = module.default || module;
 
-			if (!plugin.metadata || !plugin.init) {
-				throw new Error("Invalid plugin: must have metadata and init function");
-			}
+      if (!plugin.metadata || !plugin.init) {
+        throw new Error("Invalid plugin: must have metadata and init function");
+      }
 
-			await this.pluginManager.loadPlugin(plugin);
-			pluginLogger.info(`[PluginLoader] Loaded plugin: ${plugin.metadata.name} v${plugin.metadata.version}`);
-		} catch (error) {
-			throw new Error(`Failed to load plugin from ${pluginPath}: ${error}`);
-		}
-	}
+      await this.pluginManager.loadPlugin(plugin);
+      pluginLogger.info(`[PluginLoader] Loaded plugin: ${plugin.metadata.name} v${plugin.metadata.version}`);
+    } catch (error) {
+      throw new Error(`Failed to load plugin from ${pluginPath}: ${error}`);
+    }
+  }
 
-	/**
-	 * Get the plugin manager instance
-	 */
-	getPluginManager(): PluginManager {
-		return this.pluginManager;
-	}
+  /**
+   * Get the plugin manager instance
+   */
+  getPluginManager(): PluginManager {
+    return this.pluginManager;
+  }
 
-	/**
-	 * Shutdown all plugins
-	 */
-	async shutdown(): Promise<void> {
-		await this.pluginManager.shutdownAll();
-	}
+  /**
+   * Shutdown all plugins
+   */
+  async shutdown(): Promise<void> {
+    await this.pluginManager.shutdownAll();
+  }
 }
 
 /**
@@ -103,47 +103,47 @@ export class PluginLoader {
  * These connect the plugin system to the memory operations
  */
 export class PluginIntegration {
-	constructor(private pluginManager: PluginManager) {}
+  constructor(private pluginManager: PluginManager) {}
 
-	/**
-	 * Hook: Before storing a fact
-	 */
-	async beforeFactStore(fact: unknown): Promise<unknown> {
-		return await this.pluginManager.beforeFactStore(fact);
-	}
+  /**
+   * Hook: Before storing a fact
+   */
+  async beforeFactStore(fact: unknown): Promise<unknown> {
+    return await this.pluginManager.beforeFactStore(fact);
+  }
 
-	/**
-	 * Hook: After storing a fact
-	 */
-	async afterFactStore(fact: unknown): Promise<void> {
-		await this.pluginManager.afterFactStore(fact);
-	}
+  /**
+   * Hook: After storing a fact
+   */
+  async afterFactStore(fact: unknown): Promise<void> {
+    await this.pluginManager.afterFactStore(fact);
+  }
 
-	/**
-	 * Hook: Before deleting a fact
-	 */
-	async beforeFactDelete(factId: string): Promise<boolean> {
-		return await this.pluginManager.beforeFactDelete(factId);
-	}
+  /**
+   * Hook: Before deleting a fact
+   */
+  async beforeFactDelete(factId: string): Promise<boolean> {
+    return await this.pluginManager.beforeFactDelete(factId);
+  }
 
-	/**
-	 * Hook: After deleting a fact
-	 */
-	async afterFactDelete(factId: string): Promise<void> {
-		await this.pluginManager.afterFactDelete(factId);
-	}
+  /**
+   * Hook: After deleting a fact
+   */
+  async afterFactDelete(factId: string): Promise<void> {
+    await this.pluginManager.afterFactDelete(factId);
+  }
 
-	/**
-	 * Hook: Before performing a search
-	 */
-	async beforeSearch(query: string): Promise<string> {
-		return await this.pluginManager.beforeSearch(query);
-	}
+  /**
+   * Hook: Before performing a search
+   */
+  async beforeSearch(query: string): Promise<string> {
+    return await this.pluginManager.beforeSearch(query);
+  }
 
-	/**
-	 * Hook: After performing a search
-	 */
-	async afterSearch(results: unknown[]): Promise<unknown[]> {
-		return await this.pluginManager.afterSearch(results);
-	}
+  /**
+   * Hook: After performing a search
+   */
+  async afterSearch(results: unknown[]): Promise<unknown[]> {
+    return await this.pluginManager.afterSearch(results);
+  }
 }

--- a/extensions/memory-hybrid/services/plugin-loader.ts
+++ b/extensions/memory-hybrid/services/plugin-loader.ts
@@ -3,7 +3,10 @@
  * Integrates the Plugin Manager into the main hybrid memory plugin lifecycle
  */
 
-type MemoryPluginContext = Record<string, unknown>;
+interface MemoryPluginContext {
+  config?: unknown;
+  [key: string]: unknown;
+}
 
 import type { FactsDB } from "../backends/facts-db.js";
 import type { VectorDB } from "../backends/vector-db.js";

--- a/extensions/memory-hybrid/services/vector-search.ts
+++ b/extensions/memory-hybrid/services/vector-search.ts
@@ -23,17 +23,17 @@ export async function findSimilarByEmbedding(
   minScore = 0.3,
   options?: ScopedClassificationOptions,
 ): Promise<MemoryEntry[]> {
-  const scope = options?.scope ?? "global";
-  const scopeTarget = scope === "global" ? null : (options?.scopeTarget ?? null);
+  const scope = options?.scope;
+  const scopeTarget = scope === undefined || scope === "global" ? null : (options?.scopeTarget ?? null);
   const searchLimit = Math.min(Math.max(limit * 4, limit), 200);
   const results = await vectorDb.search(vector, searchLimit, minScore);
   const entries: MemoryEntry[] = [];
   for (const r of results) {
     const entry = factsDb.getById(r.entry.id);
-    if (entry && entry.supersededAt == null && matchesExactScope(entry, scope, scopeTarget)) {
-      entries.push(entry);
-      if (entries.length >= limit) break;
-    }
+    if (!entry || entry.supersededAt != null) continue;
+    if (scope !== undefined && !matchesExactScope(entry, scope, scopeTarget)) continue;
+    entries.push(entry);
+    if (entries.length >= limit) break;
   }
   return entries;
 }

--- a/extensions/memory-hybrid/tests/active-task.test.ts
+++ b/extensions/memory-hybrid/tests/active-task.test.ts
@@ -3,7 +3,7 @@
  * Tests for ACTIVE-TASKS.md working memory service and CLI commands.
  */
 
-import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, readFile, readdir, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -711,6 +711,14 @@ describe("readActiveTaskFile / writeActiveTaskFile", () => {
     await writeActiveTaskFile(filePath, [makeEntry({ label: "atomic-check" })], []);
     const files = await readdir(tmpDir);
     expect(files.some((f) => f.includes("ACTIVE-TASKS.md.tmp-"))).toBe(false);
+  });
+
+  it("preserves existing file permissions during atomic writes", async () => {
+    const filePath = join(tmpDir, "ACTIVE-TASKS.md");
+    await writeFile(filePath, "seed", "utf-8");
+    await chmod(filePath, 0o600);
+    await writeActiveTaskFile(filePath, [makeEntry({ label: "perm-check" })], []);
+    expect((await stat(filePath)).mode & 0o777).toBe(0o600);
   });
 
   it("applies stale detection on read", async () => {

--- a/extensions/memory-hybrid/tests/benchmark-report.test.ts
+++ b/extensions/memory-hybrid/tests/benchmark-report.test.ts
@@ -48,4 +48,20 @@ describe("benchmark quality report", () => {
     expect(markdown).toContain("| Feature | p50 (ms) | p95 (ms) | p99 (ms) | Accuracy |");
     expect(markdown).toContain("| episodes | 10.00 | 20.00 | 30.00 | 80% |");
   });
+  it("reports n/a latency when every benchmark feature failed", () => {
+    const report = buildBenchmarkQualityReport([
+      {
+        feature: "episodes",
+        latency: { p50: -1, p95: -1, p99: -1, samples: 0 },
+        accuracy: { score: 0, llmCalls: 0, tokensUsed: 0, judgement: "error" },
+        tokensTracked: 0,
+        costTrackedUsd: 0,
+      },
+    ]);
+
+    expect(report.metrics.latency.p50Ms).toBeNull();
+    expect(report.metrics.latency.p95Ms).toBeNull();
+    expect(report.metrics.latency.p99Ms).toBeNull();
+    expect(formatBenchmarkQualityReportMarkdown(report)).toContain("Latency (avg): n/a");
+  });
 });

--- a/extensions/memory-hybrid/tests/dashboard-server.test.ts
+++ b/extensions/memory-hybrid/tests/dashboard-server.test.ts
@@ -105,6 +105,35 @@ async function httpGet(port: number, path: string): Promise<{ status: number; bo
   });
 }
 
+async function httpPost(port: number, path: string, body: string): Promise<{ status: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    const req = request(
+      {
+        hostname: "127.0.0.1",
+        port,
+        path,
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "content-length": Buffer.byteLength(body),
+        },
+      },
+      (res) => {
+        let responseBody = "";
+        res.on("data", (chunk: Buffer) => {
+          responseBody += chunk.toString();
+        });
+        res.on("end", () => resolve({ status: res.statusCode ?? 0, body: responseBody }));
+      },
+    );
+    req.on("error", reject);
+    req.setTimeout(3000, () => {
+      req.destroy(new Error("timeout"));
+    });
+    req.end(body);
+  });
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -329,6 +358,36 @@ describeCreateDashboardServer("createDashboardServer", () => {
     if (!server) return;
     const { status } = await httpGet(port, "/not-found");
     expect(status).toBe(404);
+  });
+
+  it("GET /graph returns the graph explorer HTML", async () => {
+    if (!server) return;
+    const { status, body } = await httpGet(port, "/graph");
+    expect(status).toBe(200);
+    expect(body).toContain("Memory Graph");
+  });
+
+  it("POST /graphql returns a valid GraphQL response", async () => {
+    if (!server) return;
+    ctx.factsDb.store({ text: "GraphQL route fact", category: "fact", source: "test" });
+    const { status, body } = await httpPost(
+      port,
+      "/graphql",
+      JSON.stringify({ query: "query { stats { totalFacts activeFactsCount } }" }),
+    );
+    expect(status).toBe(200);
+    const parsed = JSON.parse(body);
+    expect(parsed.errors).toBeUndefined();
+    expect(parsed.data.stats.totalFacts).toBeGreaterThanOrEqual(1);
+    expect(parsed.data.stats.activeFactsCount).toBeGreaterThanOrEqual(1);
+  });
+
+  it("POST /graphql rejects oversized request bodies", async () => {
+    if (!server) return;
+    const big = JSON.stringify({ query: "query { stats { totalFacts } }", variables: { filler: "😀".repeat(20_000) } });
+    const { status, body } = await httpPost(port, "/graphql", big);
+    expect(status).toBe(413);
+    expect(JSON.parse(body).error).toBe("PayloadTooLarge");
   });
 
   it("exposes the port in the returned object", () => {

--- a/extensions/memory-hybrid/tests/fr-008-classification.test.ts
+++ b/extensions/memory-hybrid/tests/fr-008-classification.test.ts
@@ -225,5 +225,9 @@ describe("findSimilarByEmbedding", () => {
     });
     expect(agentOnly.some((f) => f.id === globalEntry.id)).toBe(false);
     expect(agentOnly.some((f) => f.id === agentEntry.id)).toBe(true);
+
+    const unscoped = await findSimilarByEmbedding(vectorDb, factsDb, vector, 5, 0.3);
+    expect(unscoped.some((f) => f.id === globalEntry.id)).toBe(true);
+    expect(unscoped.some((f) => f.id === agentEntry.id)).toBe(true);
   });
 });

--- a/extensions/memory-hybrid/tests/goal-active-task-mirror.test.ts
+++ b/extensions/memory-hybrid/tests/goal-active-task-mirror.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdtemp, readFile, readdir, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -75,6 +75,18 @@ Do not remove this custom section.
     expect(content).toContain("**Custom Field:** keep me");
     expect(content).toContain("## Active Goals");
     expect(content).toContain("### [g1]: Goal one");
+  });
+
+  it("preserves permissions and leaves no temp files", async () => {
+    dir = await mkdtemp(join(tmpdir(), "goal-mirror-"));
+    const activeTaskPath = join(dir, "ACTIVE-TASKS.md");
+    await writeFile(activeTaskPath, "# ACTIVE-TASKS.md\n", "utf-8");
+    await chmod(activeTaskPath, 0o600);
+    const result = await refreshActiveTaskMirrorWithGoals({ activeTaskPath, goals: [], staleMinutes: 1440 });
+    expect(result.ok).toBe(true);
+    expect((await stat(activeTaskPath)).mode & 0o777).toBe(0o600);
+    const files = await readdir(dir);
+    expect(files.some((f) => f.includes("ACTIVE-TASKS.md.tmp-"))).toBe(false);
   });
 
   it("replaces only the existing goals mirror section", async () => {

--- a/extensions/memory-hybrid/tests/goal-stewardship-health.test.ts
+++ b/extensions/memory-hybrid/tests/goal-stewardship-health.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { GoalStewardshipConfig } from "../config/types/index.js";
-import { parseGithubPrTarget, runGoalHealthCheck } from "../services/goal-health.js";
+import { getBlockedVerificationHostReason, parseGithubPrTarget, runGoalHealthCheck } from "../services/goal-health.js";
 import { createGoal, readGoal, updateGoal } from "../services/goal-registry.js";
 
 const defaults = {
@@ -176,7 +176,7 @@ describe("runGoalHealthCheck", () => {
       workspaceRoot,
       logger: {},
     });
-    expect(r.actions.some((a) => a.action === "verifying")).toBe(false);
+    expect(r.actions.some((a: { action: string }) => a.action === "verifying")).toBe(false);
     const after = await readGoal(goalsDir, created.id);
     expect(after?.lastMechanicalCheck?.ok).toBe(false);
     expect(after?.lastMechanicalCheck?.detail).toContain("allowPrVerification");
@@ -210,7 +210,7 @@ describe("runGoalHealthCheck", () => {
         workspaceRoot,
         logger: {},
       });
-      expect(r.actions.some((a) => a.action === "verifying")).toBe(true);
+      expect(r.actions.some((a: { action: string }) => a.action === "verifying")).toBe(true);
       expect(fetchMock).toHaveBeenCalled();
       const after = await readGoal(goalsDir, created.id);
       expect(after?.lastMechanicalCheck?.ok).toBe(true);
@@ -246,7 +246,7 @@ describe("runGoalHealthCheck", () => {
       workspaceRoot,
       logger: {},
     });
-    expect(r.actions.some((a) => a.action === "verifying")).toBe(true);
+    expect(r.actions.some((a: { action: string }) => a.action === "verifying")).toBe(true);
   });
 
   it("escalates after consecutive failures", async () => {
@@ -365,7 +365,7 @@ describe("runGoalHealthCheck", () => {
       workspaceRoot,
       logger: {},
     });
-    expect(r.actions.some((a) => a.action === "verifying")).toBe(true);
+    expect(r.actions.some((a: { action: string }) => a.action === "verifying")).toBe(true);
   });
 
   it("blocks http_ok verification against local/private hosts", async () => {
@@ -390,7 +390,7 @@ describe("runGoalHealthCheck", () => {
         workspaceRoot,
         logger: {},
       });
-      expect(r.actions.some((a) => a.action === "verifying")).toBe(false);
+      expect(r.actions.some((a: { action: string }) => a.action === "verifying")).toBe(false);
       expect(fetchMock).not.toHaveBeenCalled();
       const after = await readGoal(goalsDir, g.id);
       expect(after?.lastMechanicalCheck?.detail).toContain("blocked host");
@@ -416,11 +416,15 @@ describe("runGoalHealthCheck", () => {
         defaults,
       );
       const r = await runGoalHealthCheck({ goalsDir, cfg: baseCfg(), workspaceRoot, logger: {} });
-      expect(r.actions.some((a) => a.action === "verifying")).toBe(false);
+      expect(r.actions.some((a: { action: string }) => a.action === "verifying")).toBe(false);
       expect(fetchMock).not.toHaveBeenCalled();
     } finally {
       vi.unstubAllGlobals();
     }
+  });
+
+  it("reports literal private IP targets as blocked verification hosts", async () => {
+    await expect(getBlockedVerificationHostReason("192.168.1.20")).resolves.toBe("local/private IP");
   });
 
   it("escalates goal after consecutive failures", async () => {

--- a/extensions/memory-hybrid/tests/goal-stewardship-registry.test.ts
+++ b/extensions/memory-hybrid/tests/goal-stewardship-registry.test.ts
@@ -222,6 +222,14 @@ describe("goal registry", () => {
     await expect(readGoal(dir, "broken")).rejects.toThrow(/corrupt or unreadable/i);
   });
 
+  it("listGoals skips corrupt goal JSON and continues processing healthy goals", async () => {
+    dir = await makeTempDir();
+    const healthy = await createGoal(dir, { label: "healthy", description: "d", acceptanceCriteria: ["c"] }, defaults);
+    await writeFile(join(dir, "broken.json"), "{bad", "utf-8");
+    const listed = await listGoals(dir);
+    expect(listed.map((g) => g.id)).toEqual([healthy.id]);
+  });
+
   it("readGoalByLabel prefers active over terminal when labels collide", async () => {
     dir = await makeTempDir();
     const g1 = await createGoal(dir, { label: "pref", description: "d", acceptanceCriteria: ["c"] }, defaults);

--- a/extensions/memory-hybrid/tests/sync-export-cleanup.test.ts
+++ b/extensions/memory-hybrid/tests/sync-export-cleanup.test.ts
@@ -1,0 +1,77 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Command } from "commander";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { registerManageStorageAndStats } from "../cli/commands/manage/register-storage-and-stats.js";
+import type { ManageBindings } from "../cli/commands/manage/bindings.js";
+
+const SYNC_PREFIX = "hybrid-mem-sync-";
+
+function listSyncTempDirs(): Set<string> {
+  return new Set(readdirSync(tmpdir()).filter((name) => name.startsWith(SYNC_PREFIX)));
+}
+
+describe("sync-export cleanup", () => {
+  const originalPassphrase = process.env.HYBRID_MEM_SYNC_PASSPHRASE;
+  const createdRoots: string[] = [];
+
+  afterEach(() => {
+    if (originalPassphrase === undefined) process.env.HYBRID_MEM_SYNC_PASSPHRASE = undefined;
+    else process.env.HYBRID_MEM_SYNC_PASSPHRASE = originalPassphrase;
+    process.exitCode = undefined;
+    for (const root of createdRoots.splice(0)) rmSync(root, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it("removes the plaintext temporary export directory after writing the encrypted bundle", async () => {
+    process.env.HYBRID_MEM_SYNC_PASSPHRASE = "test-passphrase-with-at-least-twenty-chars";
+    const root = mkdtempSync(join(tmpdir(), "hm-sync-export-test-"));
+    createdRoots.push(root);
+    const outPath = join(root, "bundle.hm-sync");
+    const before = listSyncTempDirs();
+
+    const mem = new Command("hybrid-mem");
+    mem.exitOverride();
+    registerManageStorageAndStats(mem, {
+      factsDb: {},
+      vectorDb: {},
+      aliasDb: null,
+      versionInfo: { pluginVersion: "test", memoryManagerVersion: "test", schemaVersion: 1 },
+      embeddings: {},
+      mergeResults: vi.fn(),
+      getMemoryCategories: () => ["fact"],
+      cfg: {
+        memory: { categories: ["fact"] },
+        errorReporting: { enabled: false, consent: false, mode: "community" },
+      },
+      runCompaction: vi.fn(),
+      tieringEnabled: false,
+      ctx: { resolvedSqlitePath: null },
+      listCommands: undefined,
+      auditStore: null,
+      merge: vi.fn(),
+      BACKFILL_DECAY_MARKER: ".backfill-decay-done",
+      runExport: vi.fn(async ({ outputPath }: { outputPath: string }) => {
+        mkdirSync(join(outputPath, "memory", "fact"), { recursive: true });
+        writeFileSync(join(outputPath, "MEMORY.md"), "plaintext export marker", "utf-8");
+        writeFileSync(join(outputPath, "memory", "fact", "one.md"), "secret fact", "utf-8");
+        return { factsExported: 1, proceduresExported: 0, filesWritten: 2, outputPath };
+      }),
+    } as unknown as ManageBindings);
+
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    await mem.parseAsync(["sync-export", "--out", outPath], { from: "user" });
+
+    expect(process.exitCode).toBeUndefined();
+    expect(log).toHaveBeenCalledWith(`Encrypted sync bundle written to ${outPath}`);
+    expect(existsSync(outPath)).toBe(true);
+    const envelope = JSON.parse(readFileSync(outPath, "utf-8")) as { type?: string; ciphertext?: string };
+    expect(envelope.type).toBe("hybrid-memory-sync-bundle");
+    expect(envelope.ciphertext).toEqual(expect.any(String));
+
+    const after = listSyncTempDirs();
+    for (const name of before) after.delete(name);
+    expect([...after]).toEqual([]);
+  });
+});

--- a/extensions/memory-hybrid/tests/user-friendly-cli.test.ts
+++ b/extensions/memory-hybrid/tests/user-friendly-cli.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { registerUserFriendlyCommands } from "../cli/cmd-user-friendly.js";
+import { registerSetupCommand } from "../cli/cmd-setup.js";
+import { registerHealthCommand } from "../cli/cmd-health.js";
+import { registerExamplesCommand } from "../cli/cmd-examples.js";
+import { wrapCommonError, UserFriendlyError } from "../utils/error-codes.js";
+import { ProgressBar } from "../utils/progress-indicators.js";
+import { detectAvailableProviders, formatProviderStatus } from "../utils/provider-detection.js";
+
+class FakeCommand {
+  children: FakeCommand[] = [];
+  name: string;
+  handler: ((...args: unknown[]) => unknown) | null = null;
+  options: Array<{ flags: string; defaultValue?: unknown }> = [];
+
+  constructor(name = "root") {
+    this.name = name;
+  }
+
+  command(name: string): FakeCommand {
+    const child = new FakeCommand(name.split(/\s+/)[0]);
+    this.children.push(child);
+    return child;
+  }
+
+  description(): FakeCommand {
+    return this;
+  }
+
+  option(flags: string, _desc?: string, defaultValue?: unknown): FakeCommand {
+    this.options.push({ flags, defaultValue });
+    return this;
+  }
+
+  requiredOption(flags: string, _desc?: string, defaultValue?: unknown): FakeCommand {
+    this.options.push({ flags, defaultValue });
+    return this;
+  }
+
+  action(fn: (...args: unknown[]) => unknown): FakeCommand {
+    this.handler = fn;
+    return this;
+  }
+}
+
+const cfg = {
+  embedding: {
+    provider: "ollama" as const,
+    model: "nomic-embed-text",
+    dimensions: 768,
+    batchSize: 32,
+  },
+};
+
+const factsDb = { getCount: vi.fn(() => 3) };
+const vectorDb = { getAllIds: vi.fn(async () => ["a", "b", "c"]) };
+const embeddings = {
+  embed: vi.fn(),
+  embedBatch: vi.fn(),
+  dimensions: 768,
+  modelName: "nomic-embed-text",
+  activeProvider: "ollama",
+};
+
+describe("user-friendly CLI registration", () => {
+  it("registers setup/demo/providers/health/doctor/examples on the command tree", () => {
+    const root = new FakeCommand();
+    registerUserFriendlyCommands(root as never, {
+      cfg: cfg as never,
+      factsDb: factsDb as never,
+      vectorDb: vectorDb as never,
+      embeddings,
+    });
+    expect(root.children.map((child) => child.name).sort()).toEqual([
+      "demo",
+      "doctor",
+      "examples",
+      "health",
+      "providers",
+      "setup",
+    ]);
+  });
+
+  it("setup is non-interactive by default and persists recommended config through runConfigSet", async () => {
+    const root = new FakeCommand();
+    const writes: Array<[string, string]> = [];
+    registerSetupCommand(root as never, cfg as never, async (key, value) => {
+      writes.push([key, value]);
+      return { ok: true };
+    });
+    const setup = root.children.find((child) => child.name === "setup");
+    expect(setup?.options.find((opt) => opt.flags === "--interactive")?.defaultValue).toBeUndefined();
+    expect(setup?.handler).toBeTypeOf("function");
+    await setup?.handler?.({ interactive: false });
+    expect(writes.some(([key]) => key === "embedding.provider")).toBe(true);
+    expect(writes.some(([key]) => key === "embedding.model")).toBe(true);
+  });
+
+  it("health reuses expensive vector id count for size and sync checks", async () => {
+    const root = new FakeCommand();
+    const localVectorDb = { getAllIds: vi.fn(async () => ["a", "b", "c"]) };
+    registerHealthCommand(root as never, cfg as never, factsDb as never, localVectorDb as never);
+    const health = root.children.find((child) => child.name === "health");
+    await health?.handler?.({ json: true });
+    expect(localVectorDb.getAllIds).toHaveBeenCalledTimes(1);
+  });
+
+  it("examples uses own-property category checks", () => {
+    const root = new FakeCommand();
+    registerExamplesCommand(root as never);
+    const examples = root.children.find((child) => child.name === "examples");
+    expect(() => examples?.handler?.("toString")).not.toThrow();
+  });
+});
+
+describe("provider detection helpers", () => {
+  it("includes google as configured when a google key is present", async () => {
+    const providers = await detectAvailableProviders(undefined, "google-key");
+    const google = providers.find((provider) => provider.provider === "google");
+    expect(google?.available).toBe(true);
+    expect(formatProviderStatus(google!)).toContain("GOOGLE");
+  });
+});
+
+describe("progress and error helpers", () => {
+  const originalIsTTY = process.stdout.isTTY;
+
+  beforeEach(() => {
+    Object.defineProperty(process.stdout, "isTTY", { value: false, configurable: true });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process.stdout, "isTTY", { value: originalIsTTY, configurable: true });
+    vi.restoreAllMocks();
+  });
+
+  it("non-TTY progress logs each 10% milestone once", () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const bar = new ProgressBar("work", 100);
+    bar.update(10);
+    bar.update(10);
+    bar.update(15);
+    bar.update(20);
+    expect(log.mock.calls.map((call) => String(call[0]))).toEqual(["work: 10% (10/100)", "work: 20% (20/100)"]);
+  });
+
+  it("maps timeout errors to HM_E008", () => {
+    const wrapped = wrapCommonError(new Error("operation timeout while embedding"));
+    expect(wrapped).toBeInstanceOf(UserFriendlyError);
+    expect((wrapped as UserFriendlyError).code).toBe("HM_E008");
+  });
+});

--- a/extensions/memory-hybrid/tests/user-friendly-cli.test.ts
+++ b/extensions/memory-hybrid/tests/user-friendly-cli.test.ts
@@ -9,6 +9,7 @@ import { detectAvailableProviders, formatProviderStatus } from "../utils/provide
 
 class FakeCommand {
   children: FakeCommand[] = [];
+  commands: FakeCommand[] = this.children;
   name: string;
   handler: ((...args: unknown[]) => unknown) | null = null;
   options: Array<{ flags: string; defaultValue?: unknown }> = [];
@@ -117,8 +118,10 @@ describe("provider detection helpers", () => {
   it("includes google as configured when a google key is present", async () => {
     const providers = await detectAvailableProviders(undefined, "google-key");
     const google = providers.find((provider) => provider.provider === "google");
-    expect(google?.available).toBe(true);
-    expect(formatProviderStatus(google!)).toContain("GOOGLE");
+    expect(google).toBeDefined();
+    if (!google) throw new Error("google provider missing");
+    expect(google.available).toBe(true);
+    expect(formatProviderStatus(google)).toContain("GOOGLE");
   });
 });
 
@@ -135,13 +138,13 @@ describe("progress and error helpers", () => {
   });
 
   it("non-TTY progress logs each 10% milestone once", () => {
-    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const write = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
     const bar = new ProgressBar("work", 100);
     bar.update(10);
     bar.update(10);
     bar.update(15);
     bar.update(20);
-    expect(log.mock.calls.map((call) => String(call[0]))).toEqual(["work: 10% (10/100)", "work: 20% (20/100)"]);
+    expect(write.mock.calls.map((call) => String(call[0]))).toEqual(["work: 10% (10/100)\n", "work: 20% (20/100)\n"]);
   });
 
   it("maps timeout errors to HM_E008", () => {

--- a/extensions/memory-hybrid/utils/error-codes.ts
+++ b/extensions/memory-hybrid/utils/error-codes.ts
@@ -4,189 +4,175 @@
  */
 
 export type ErrorCode =
-	| "HM_E001" // No embedding provider configured
-	| "HM_E002" // API key missing
-	| "HM_E003" // Provider unavailable
-	| "HM_E004" // Database connection failed
-	| "HM_E005" // Invalid configuration
-	| "HM_E006" // Model not found
-	| "HM_E007" // Insufficient permissions
-	| "HM_E008" // Operation timeout
-	| "HM_E009" // Invalid command syntax
-	| "HM_E010"; // Resource not found
+  | "HM_E001" // No embedding provider configured
+  | "HM_E002" // API key missing
+  | "HM_E003" // Provider unavailable
+  | "HM_E004" // Database connection failed
+  | "HM_E005" // Invalid configuration
+  | "HM_E006" // Model not found
+  | "HM_E007" // Insufficient permissions
+  | "HM_E008" // Operation timeout
+  | "HM_E009" // Invalid command syntax
+  | "HM_E010"; // Resource not found
 
 interface ErrorInfo {
-	code: ErrorCode;
-	title: string;
-	message: string;
-	solution: string;
-	docsLink?: string;
+  code: ErrorCode;
+  title: string;
+  message: string;
+  solution: string;
+  docsLink?: string;
 }
 
 const ERROR_CATALOG: Record<ErrorCode, Omit<ErrorInfo, "code">> = {
-	HM_E001: {
-		title: "No Embedding Provider Configured",
-		message:
-			"The hybrid memory system requires an embedding provider to perform semantic search.",
-		solution:
-			"Run: openclaw hybrid-mem setup --interactive\nOr manually set: openclaw hybrid-mem config-set embedding.provider ollama",
-		docsLink: "https://github.com/markus-lassfolk/openclaw-hybrid-memory#embedding-providers",
-	},
-	HM_E002: {
-		title: "API Key Missing",
-		message:
-			"The selected embedding provider requires an API key, but none was found.",
-		solution:
-			"Set your API key:\nopenclaw hybrid-mem config-set embedding.apiKey YOUR_KEY\nOr use a local provider: openclaw hybrid-mem use ollama",
-		docsLink: "https://github.com/markus-lassfolk/openclaw-hybrid-memory#configuration",
-	},
-	HM_E003: {
-		title: "Provider Unavailable",
-		message: "The embedding provider could not be reached or is not running.",
-		solution:
-			"For Ollama: Start Ollama service with 'ollama serve'\nFor OpenAI: Check your internet connection and API key\nFor ONNX: Ensure onnxruntime-node is installed",
-		docsLink: "https://github.com/markus-lassfolk/openclaw-hybrid-memory#troubleshooting",
-	},
-	HM_E004: {
-		title: "Database Connection Failed",
-		message: "Could not connect to the SQLite or LanceDB database.",
-		solution:
-			"Check database permissions and disk space.\nRun: openclaw hybrid-mem verify --fix\nIf issue persists, try: openclaw hybrid-mem doctor",
-		docsLink: "https://github.com/markus-lassfolk/openclaw-hybrid-memory#database-issues",
-	},
-	HM_E005: {
-		title: "Invalid Configuration",
-		message: "The configuration contains invalid or conflicting settings.",
-		solution:
-			"Run: openclaw hybrid-mem config\nTo reset to defaults: openclaw hybrid-mem install\nFor guided setup: openclaw hybrid-mem setup --interactive",
-	},
-	HM_E006: {
-		title: "Model Not Found",
-		message: "The specified embedding or LLM model could not be found.",
-		solution:
-			"Check available models for your provider.\nFor Ollama: Run 'ollama list'\nFor OpenAI: See https://platform.openai.com/docs/models\nOr try: openclaw hybrid-mem providers",
-	},
-	HM_E007: {
-		title: "Insufficient Permissions",
-		message: "The operation requires permissions that are not available.",
-		solution:
-			"Check file/directory permissions on your memory databases.\nEnsure the plugin has write access to ~/.openclaw/plugins/memory-hybrid/",
-	},
-	HM_E008: {
-		title: "Operation Timeout",
-		message: "The operation took too long and was cancelled.",
-		solution:
-			"This may indicate a slow network or overloaded provider.\nTry reducing batch size in config, or retry the operation.",
-	},
-	HM_E009: {
-		title: "Invalid Command Syntax",
-		message: "The command syntax is incorrect.",
-		solution: "Run: openclaw hybrid-mem --help\nOr try: openclaw hybrid-mem examples",
-	},
-	HM_E010: {
-		title: "Resource Not Found",
-		message: "The requested resource (fact, category, etc.) was not found.",
-		solution: "Check the ID or name and try again.\nRun: openclaw hybrid-mem list",
-	},
+  HM_E001: {
+    title: "No Embedding Provider Configured",
+    message: "The hybrid memory system requires an embedding provider to perform semantic search.",
+    solution:
+      "Run: openclaw hybrid-mem setup --interactive\nOr manually set: openclaw hybrid-mem config-set embedding.provider ollama",
+    docsLink: "https://github.com/markus-lassfolk/openclaw-hybrid-memory#embedding-providers",
+  },
+  HM_E002: {
+    title: "API Key Missing",
+    message: "The selected embedding provider requires an API key, but none was found.",
+    solution:
+      "Set your API key:\nopenclaw hybrid-mem config-set embedding.apiKey YOUR_KEY\nOr use a local provider: openclaw hybrid-mem use ollama",
+    docsLink: "https://github.com/markus-lassfolk/openclaw-hybrid-memory#configuration",
+  },
+  HM_E003: {
+    title: "Provider Unavailable",
+    message: "The embedding provider could not be reached or is not running.",
+    solution:
+      "For Ollama: Start Ollama service with 'ollama serve'\nFor OpenAI: Check your internet connection and API key\nFor ONNX: Ensure onnxruntime-node is installed",
+    docsLink: "https://github.com/markus-lassfolk/openclaw-hybrid-memory#troubleshooting",
+  },
+  HM_E004: {
+    title: "Database Connection Failed",
+    message: "Could not connect to the SQLite or LanceDB database.",
+    solution:
+      "Check database permissions and disk space.\nRun: openclaw hybrid-mem verify --fix\nIf issue persists, try: openclaw hybrid-mem doctor",
+    docsLink: "https://github.com/markus-lassfolk/openclaw-hybrid-memory#database-issues",
+  },
+  HM_E005: {
+    title: "Invalid Configuration",
+    message: "The configuration contains invalid or conflicting settings.",
+    solution:
+      "Run: openclaw hybrid-mem config\nTo reset to defaults: openclaw hybrid-mem install\nFor guided setup: openclaw hybrid-mem setup --interactive",
+  },
+  HM_E006: {
+    title: "Model Not Found",
+    message: "The specified embedding or LLM model could not be found.",
+    solution:
+      "Check available models for your provider.\nFor Ollama: Run 'ollama list'\nFor OpenAI: See https://platform.openai.com/docs/models\nOr try: openclaw hybrid-mem providers",
+  },
+  HM_E007: {
+    title: "Insufficient Permissions",
+    message: "The operation requires permissions that are not available.",
+    solution:
+      "Check file/directory permissions on your memory databases.\nEnsure the plugin has write access to ~/.openclaw/plugins/memory-hybrid/",
+  },
+  HM_E008: {
+    title: "Operation Timeout",
+    message: "The operation took too long and was cancelled.",
+    solution:
+      "This may indicate a slow network or overloaded provider.\nTry reducing batch size in config, or retry the operation.",
+  },
+  HM_E009: {
+    title: "Invalid Command Syntax",
+    message: "The command syntax is incorrect.",
+    solution: "Run: openclaw hybrid-mem --help\nOr try: openclaw hybrid-mem examples",
+  },
+  HM_E010: {
+    title: "Resource Not Found",
+    message: "The requested resource (fact, category, etc.) was not found.",
+    solution: "Check the ID or name and try again.\nRun: openclaw hybrid-mem list",
+  },
 };
 
 export class UserFriendlyError extends Error {
-	code: ErrorCode;
-	solution: string;
-	docsLink?: string;
+  code: ErrorCode;
+  solution: string;
+  docsLink?: string;
 
-	constructor(code: ErrorCode, customMessage?: string) {
-		const info = ERROR_CATALOG[code];
-		const message = customMessage || info.message;
-		super(message);
-		this.name = "UserFriendlyError";
-		this.code = code;
-		this.solution = info.solution;
-		this.docsLink = info.docsLink;
-	}
+  constructor(code: ErrorCode, customMessage?: string) {
+    const info = ERROR_CATALOG[code];
+    const message = customMessage || info.message;
+    super(message);
+    this.name = "UserFriendlyError";
+    this.code = code;
+    this.solution = info.solution;
+    this.docsLink = info.docsLink;
+  }
 
-	format(): string {
-		const lines = [
-			`\n❌ ${ERROR_CATALOG[this.code].title} [${this.code}]`,
-			"",
-			`   ${this.message}`,
-			"",
-			"💡 Solution:",
-			...this.solution.split("\n").map((line) => `   ${line}`),
-		];
+  format(): string {
+    const lines = [
+      `\n❌ ${ERROR_CATALOG[this.code].title} [${this.code}]`,
+      "",
+      `   ${this.message}`,
+      "",
+      "💡 Solution:",
+      ...this.solution.split("\n").map((line) => `   ${line}`),
+    ];
 
-		if (this.docsLink) {
-			lines.push("", `📚 More info: ${this.docsLink}`);
-		}
+    if (this.docsLink) {
+      lines.push("", `📚 More info: ${this.docsLink}`);
+    }
 
-		return lines.join("\n");
-	}
+    return lines.join("\n");
+  }
 }
 
 /**
  * Convert common errors into user-friendly errors with actionable guidance
  */
 export function wrapCommonError(error: unknown): Error {
-	if (error instanceof UserFriendlyError) {
-		return error;
-	}
+  if (error instanceof UserFriendlyError) {
+    return error;
+  }
 
-	const errorMessage = error instanceof Error ? error.message : String(error);
-	const lowerMsg = errorMessage.toLowerCase();
+  const errorMessage = error instanceof Error ? error.message : String(error);
+  const lowerMsg = errorMessage.toLowerCase();
 
-	// Detect common error patterns and provide friendly messages
-	if (
-		lowerMsg.includes("api key") ||
-		lowerMsg.includes("unauthorized") ||
-		lowerMsg.includes("401")
-	) {
-		return new UserFriendlyError("HM_E002", errorMessage);
-	}
+  // Detect common error patterns and provide friendly messages
+  if (lowerMsg.includes("api key") || lowerMsg.includes("unauthorized") || lowerMsg.includes("401")) {
+    return new UserFriendlyError("HM_E002", errorMessage);
+  }
 
-	if (
-		lowerMsg.includes("econnrefused") ||
-		lowerMsg.includes("network") ||
-		lowerMsg.includes("timeout") ||
-		lowerMsg.includes("enotfound")
-	) {
-		return new UserFriendlyError("HM_E003", errorMessage);
-	}
+  if (
+    lowerMsg.includes("econnrefused") ||
+    lowerMsg.includes("network") ||
+    lowerMsg.includes("timeout") ||
+    lowerMsg.includes("enotfound")
+  ) {
+    return new UserFriendlyError("HM_E003", errorMessage);
+  }
 
-	if (
-		lowerMsg.includes("database") ||
-		lowerMsg.includes("sqlite") ||
-		lowerMsg.includes("lancedb")
-	) {
-		return new UserFriendlyError("HM_E004", errorMessage);
-	}
+  if (lowerMsg.includes("database") || lowerMsg.includes("sqlite") || lowerMsg.includes("lancedb")) {
+    return new UserFriendlyError("HM_E004", errorMessage);
+  }
 
-	if (lowerMsg.includes("model") && lowerMsg.includes("not found")) {
-		return new UserFriendlyError("HM_E006", errorMessage);
-	}
+  if (lowerMsg.includes("model") && lowerMsg.includes("not found")) {
+    return new UserFriendlyError("HM_E006", errorMessage);
+  }
 
-	if (
-		lowerMsg.includes("permission") ||
-		lowerMsg.includes("eacces") ||
-		lowerMsg.includes("eperm")
-	) {
-		return new UserFriendlyError("HM_E007", errorMessage);
-	}
+  if (lowerMsg.includes("permission") || lowerMsg.includes("eacces") || lowerMsg.includes("eperm")) {
+    return new UserFriendlyError("HM_E007", errorMessage);
+  }
 
-	// Return original error if no pattern matches
-	return error instanceof Error ? error : new Error(errorMessage);
+  // Return original error if no pattern matches
+  return error instanceof Error ? error : new Error(errorMessage);
 }
 
 /**
  * Format error for CLI output with user-friendly guidance
  */
 export function formatCliError(error: unknown): string {
-	const wrapped = wrapCommonError(error);
+  const wrapped = wrapCommonError(error);
 
-	if (wrapped instanceof UserFriendlyError) {
-		return wrapped.format();
-	}
+  if (wrapped instanceof UserFriendlyError) {
+    return wrapped.format();
+  }
 
-	// Fallback for unwrapped errors
-	const errorMsg = wrapped instanceof Error ? wrapped.message : String(wrapped);
-	return `\n❌ Error: ${errorMsg}\n\n💡 For help, run: openclaw hybrid-mem doctor\n`;
+  // Fallback for unwrapped errors
+  const errorMsg = wrapped instanceof Error ? wrapped.message : String(wrapped);
+  return `\n❌ Error: ${errorMsg}\n\n💡 For help, run: openclaw hybrid-mem doctor\n`;
 }

--- a/extensions/memory-hybrid/utils/error-codes.ts
+++ b/extensions/memory-hybrid/utils/error-codes.ts
@@ -29,28 +29,28 @@ const ERROR_CATALOG: Record<ErrorCode, Omit<ErrorInfo, "code">> = {
     message: "The hybrid memory system requires an embedding provider to perform semantic search.",
     solution:
       "Run: openclaw hybrid-mem setup --interactive\nOr manually set: openclaw hybrid-mem config-set embedding.provider ollama",
-    docsLink: "https://github.com/markus-lassfolk/openclaw-hybrid-memory#embedding-providers",
+    docsLink: "https://github.com/markus-lassfolk/openclaw-hybrid-memory/blob/main/docs/LLM-AND-PROVIDERS.md",
   },
   HM_E002: {
     title: "API Key Missing",
     message: "The selected embedding provider requires an API key, but none was found.",
     solution:
       "Set your API key:\nopenclaw hybrid-mem config-set embedding.apiKey YOUR_KEY\nOr use a local provider: openclaw hybrid-mem use ollama",
-    docsLink: "https://github.com/markus-lassfolk/openclaw-hybrid-memory#configuration",
+    docsLink: "https://github.com/markus-lassfolk/openclaw-hybrid-memory/blob/main/docs/CONFIGURATION.md",
   },
   HM_E003: {
     title: "Provider Unavailable",
     message: "The embedding provider could not be reached or is not running.",
     solution:
       "For Ollama: Start Ollama service with 'ollama serve'\nFor OpenAI: Check your internet connection and API key\nFor ONNX: Ensure onnxruntime-node is installed",
-    docsLink: "https://github.com/markus-lassfolk/openclaw-hybrid-memory#troubleshooting",
+    docsLink: "https://github.com/markus-lassfolk/openclaw-hybrid-memory/blob/main/docs/TROUBLESHOOTING.md",
   },
   HM_E004: {
     title: "Database Connection Failed",
     message: "Could not connect to the SQLite or LanceDB database.",
     solution:
       "Check database permissions and disk space.\nRun: openclaw hybrid-mem verify --fix\nIf issue persists, try: openclaw hybrid-mem doctor",
-    docsLink: "https://github.com/markus-lassfolk/openclaw-hybrid-memory#database-issues",
+    docsLink: "https://github.com/markus-lassfolk/openclaw-hybrid-memory/blob/main/docs/TROUBLESHOOTING.md",
   },
   HM_E005: {
     title: "Invalid Configuration",
@@ -137,12 +137,11 @@ export function wrapCommonError(error: unknown): Error {
     return new UserFriendlyError("HM_E002", errorMessage);
   }
 
-  if (
-    lowerMsg.includes("econnrefused") ||
-    lowerMsg.includes("network") ||
-    lowerMsg.includes("timeout") ||
-    lowerMsg.includes("enotfound")
-  ) {
+  if (lowerMsg.includes("timeout") || lowerMsg.includes("timed out") || lowerMsg.includes("abortsignal")) {
+    return new UserFriendlyError("HM_E008", errorMessage);
+  }
+
+  if (lowerMsg.includes("econnrefused") || lowerMsg.includes("network") || lowerMsg.includes("enotfound")) {
     return new UserFriendlyError("HM_E003", errorMessage);
   }
 

--- a/extensions/memory-hybrid/utils/progress-indicators.ts
+++ b/extensions/memory-hybrid/utils/progress-indicators.ts
@@ -82,7 +82,7 @@ export class ProgressBar {
       if (milestone > this.lastLoggedPercent) {
         this.lastLoggedPercent = milestone;
         const statusStr = status ? ` - ${status}` : "";
-        console.log(`${this.message}: ${milestone}% (${current}/${this.total})${statusStr}`);
+        process.stdout.write(`${this.message}: ${milestone}% (${current}/${this.total})${statusStr}\n`);
       }
       return;
     }

--- a/extensions/memory-hybrid/utils/progress-indicators.ts
+++ b/extensions/memory-hybrid/utils/progress-indicators.ts
@@ -5,156 +5,137 @@
 const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
 
 export class ProgressSpinner {
-	private interval: NodeJS.Timeout | null = null;
-	private frameIndex = 0;
-	private message: string;
-	private startTime: number;
+  private interval: NodeJS.Timeout | null = null;
+  private frameIndex = 0;
+  private message: string;
+  private startTime: number;
 
-	constructor(message: string) {
-		this.message = message;
-		this.startTime = Date.now();
-	}
+  constructor(message: string) {
+    this.message = message;
+    this.startTime = Date.now();
+  }
 
-	start(): void {
-		if (this.interval) return;
+  start(): void {
+    if (this.interval) return;
 
-		// Only show spinner in TTY mode
-		if (!process.stdout.isTTY) {
-			console.log(this.message);
-			return;
-		}
+    // Only show spinner in TTY mode
+    if (!process.stdout.isTTY) {
+      return;
+    }
 
-		this.interval = setInterval(() => {
-			const frame = SPINNER_FRAMES[this.frameIndex];
-			const elapsed = Math.floor((Date.now() - this.startTime) / 1000);
-			const elapsedStr = elapsed > 0 ? ` (${elapsed}s)` : "";
-			process.stdout.write(`\r${frame} ${this.message}${elapsedStr}`);
-			this.frameIndex = (this.frameIndex + 1) % SPINNER_FRAMES.length;
-		}, 80);
-	}
+    this.interval = setInterval(() => {
+      const frame = SPINNER_FRAMES[this.frameIndex];
+      const elapsed = Math.floor((Date.now() - this.startTime) / 1000);
+      const elapsedStr = elapsed > 0 ? ` (${elapsed}s)` : "";
+      process.stdout.write(`\r${frame} ${this.message}${elapsedStr}`);
+      this.frameIndex = (this.frameIndex + 1) % SPINNER_FRAMES.length;
+    }, 80);
+  }
 
-	update(message: string): void {
-		this.message = message;
-	}
+  update(message: string): void {
+    this.message = message;
+  }
 
-	success(message?: string): void {
-		this.stop();
-		const elapsed = Math.floor((Date.now() - this.startTime) / 1000);
-		const elapsedStr = elapsed > 0 ? ` in ${elapsed}s` : "";
-		console.log(`✓ ${message || this.message}${elapsedStr}`);
-	}
+  success(_message?: string): void {
+    this.stop();
+    const elapsed = Math.floor((Date.now() - this.startTime) / 1000);
+    const _elapsedStr = elapsed > 0 ? ` in ${elapsed}s` : "";
+  }
 
-	fail(message?: string): void {
-		this.stop();
-		console.log(`✗ ${message || this.message}`);
-	}
+  fail(_message?: string): void {
+    this.stop();
+  }
 
-	stop(): void {
-		if (this.interval) {
-			clearInterval(this.interval);
-			this.interval = null;
-		}
-		if (process.stdout.isTTY) {
-			process.stdout.write("\r\x1b[K"); // Clear line
-		}
-	}
+  stop(): void {
+    if (this.interval) {
+      clearInterval(this.interval);
+      this.interval = null;
+    }
+    if (process.stdout.isTTY) {
+      process.stdout.write("\r\x1b[K"); // Clear line
+    }
+  }
 }
 
 export class ProgressBar {
-	private message: string;
-	private total: number;
-	private current = 0;
-	private startTime: number;
-	private width = 40;
+  private message: string;
+  private total: number;
+  private current = 0;
+  private startTime: number;
+  private width = 40;
 
-	constructor(message: string, total: number) {
-		this.message = message;
-		this.total = total;
-		this.startTime = Date.now();
-	}
+  constructor(message: string, total: number) {
+    this.message = message;
+    this.total = total;
+    this.startTime = Date.now();
+  }
 
-	update(current: number, status?: string): void {
-		this.current = current;
+  update(current: number, status?: string): void {
+    this.current = current;
 
-		if (!process.stdout.isTTY) {
-			// In non-TTY mode, show progress every 10%
-			const percent = Math.floor((current / this.total) * 100);
-			if (percent % 10 === 0) {
-				console.log(`${this.message}: ${percent}% (${current}/${this.total})`);
-			}
-			return;
-		}
+    if (!process.stdout.isTTY) {
+      // In non-TTY mode, show progress every 10%
+      const percent = Math.floor((current / this.total) * 100);
+      if (percent % 10 === 0) {
+      }
+      return;
+    }
 
-		const percent = Math.floor((current / this.total) * 100);
-		const filled = Math.floor((current / this.total) * this.width);
-		const empty = this.width - filled;
-		const bar = "█".repeat(filled) + "░".repeat(empty);
+    const percent = Math.floor((current / this.total) * 100);
+    const filled = Math.floor((current / this.total) * this.width);
+    const empty = this.width - filled;
+    const bar = "█".repeat(filled) + "░".repeat(empty);
 
-		// Calculate ETA
-		const elapsed = Date.now() - this.startTime;
-		const rate = current / (elapsed / 1000);
-		const remaining = this.total - current;
-		const eta = remaining / rate;
-		const etaStr =
-			eta > 0 && Number.isFinite(eta)
-				? ` ETA ${formatDuration(eta)}`
-				: "";
+    // Calculate ETA
+    const elapsed = Date.now() - this.startTime;
+    const rate = current / (elapsed / 1000);
+    const remaining = this.total - current;
+    const eta = remaining / rate;
+    const etaStr = eta > 0 && Number.isFinite(eta) ? ` ETA ${formatDuration(eta)}` : "";
 
-		const statusStr = status ? ` - ${status}` : "";
-		process.stdout.write(
-			`\r${this.message}: [${bar}] ${percent}% (${current}/${this.total})${etaStr}${statusStr}`,
-		);
-	}
+    const statusStr = status ? ` - ${status}` : "";
+    process.stdout.write(`\r${this.message}: [${bar}] ${percent}% (${current}/${this.total})${etaStr}${statusStr}`);
+  }
 
-	complete(message?: string): void {
-		if (process.stdout.isTTY) {
-			process.stdout.write("\r\x1b[K"); // Clear line
-		}
-		const elapsed = Math.floor((Date.now() - this.startTime) / 1000);
-		console.log(
-			`✓ ${message || this.message} - ${this.total} items in ${elapsed}s`,
-		);
-	}
+  complete(_message?: string): void {
+    if (process.stdout.isTTY) {
+      process.stdout.write("\r\x1b[K"); // Clear line
+    }
+    const _elapsed = Math.floor((Date.now() - this.startTime) / 1000);
+  }
 }
 
 function formatDuration(seconds: number): string {
-	if (seconds < 60) {
-		return `${Math.floor(seconds)}s`;
-	}
-	const mins = Math.floor(seconds / 60);
-	const secs = Math.floor(seconds % 60);
-	return `${mins}m ${secs}s`;
+  if (seconds < 60) {
+    return `${Math.floor(seconds)}s`;
+  }
+  const mins = Math.floor(seconds / 60);
+  const secs = Math.floor(seconds % 60);
+  return `${mins}m ${secs}s`;
 }
 
 /**
  * Simple status message with icon
  */
-export function statusMessage(
-	type: "info" | "success" | "warning" | "error",
-	message: string,
-): void {
-	const icons = {
-		info: "ℹ️",
-		success: "✓",
-		warning: "⚠️",
-		error: "✗",
-	};
-	console.log(`${icons[type]} ${message}`);
+export function statusMessage(_type: "info" | "success" | "warning" | "error", _message: string): void {
+  const _icons = {
+    info: "ℹ️",
+    success: "✓",
+    warning: "⚠️",
+    error: "✗",
+  };
 }
 
 /**
  * Show a completion summary with stats
  */
 export function showCompletionSummary(
-	operation: string,
-	stats: Record<string, number | string>,
-	durationMs: number,
+  _operation: string,
+  stats: Record<string, number | string>,
+  durationMs: number,
 ): void {
-	const durationStr = formatDuration(durationMs / 1000);
-	console.log(`\n✓ ${operation} completed in ${durationStr}\n`);
+  const _durationStr = formatDuration(durationMs / 1000);
 
-	for (const [key, value] of Object.entries(stats)) {
-		console.log(`  ${key}: ${value}`);
-	}
-	console.log();
+  for (const [_key, _value] of Object.entries(stats)) {
+  }
 }

--- a/extensions/memory-hybrid/utils/progress-indicators.ts
+++ b/extensions/memory-hybrid/utils/progress-indicators.ts
@@ -63,6 +63,7 @@ export class ProgressBar {
   private current = 0;
   private startTime: number;
   private width = 40;
+  private lastLoggedPercent = -1;
 
   constructor(message: string, total: number) {
     this.message = message;
@@ -73,23 +74,27 @@ export class ProgressBar {
   update(current: number, status?: string): void {
     this.current = current;
 
+    const safeTotal = Math.max(1, this.total);
+    const percent = Math.max(0, Math.min(100, Math.floor((current / safeTotal) * 100)));
+
     if (!process.stdout.isTTY) {
-      // In non-TTY mode, show progress every 10%
-      const percent = Math.floor((current / this.total) * 100);
-      if (percent % 10 === 0) {
+      const milestone = Math.floor(percent / 10) * 10;
+      if (milestone > this.lastLoggedPercent) {
+        this.lastLoggedPercent = milestone;
+        const statusStr = status ? ` - ${status}` : "";
+        console.log(`${this.message}: ${milestone}% (${current}/${this.total})${statusStr}`);
       }
       return;
     }
 
-    const percent = Math.floor((current / this.total) * 100);
-    const filled = Math.floor((current / this.total) * this.width);
+    const filled = Math.floor((current / safeTotal) * this.width);
     const empty = this.width - filled;
     const bar = "█".repeat(filled) + "░".repeat(empty);
 
     // Calculate ETA
     const elapsed = Date.now() - this.startTime;
     const rate = current / (elapsed / 1000);
-    const remaining = this.total - current;
+    const remaining = Math.max(0, this.total - current);
     const eta = remaining / rate;
     const etaStr = eta > 0 && Number.isFinite(eta) ? ` ETA ${formatDuration(eta)}` : "";
 

--- a/extensions/memory-hybrid/utils/provider-detection.ts
+++ b/extensions/memory-hybrid/utils/provider-detection.ts
@@ -6,142 +6,130 @@ import { execSync } from "node:child_process";
 import { existsSync } from "node:fs";
 
 export interface ProviderStatus {
-	provider: "openai" | "ollama" | "onnx";
-	available: boolean;
-	reason?: string;
-	recommendation?: string;
-	requiresApiKey: boolean;
-	localOnly: boolean;
+  provider: "openai" | "ollama" | "onnx";
+  available: boolean;
+  reason?: string;
+  recommendation?: string;
+  requiresApiKey: boolean;
+  localOnly: boolean;
 }
 
 /**
  * Check if Ollama is running on localhost
  */
 async function checkOllamaAvailable(): Promise<boolean> {
-	try {
-		const response = await fetch("http://localhost:11434/api/tags", {
-			signal: AbortSignal.timeout(2000),
-		});
-		return response.ok;
-	} catch {
-		return false;
-	}
+  try {
+    const response = await fetch("http://localhost:11434/api/tags", {
+      signal: AbortSignal.timeout(2000),
+    });
+    return response.ok;
+  } catch {
+    return false;
+  }
 }
 
 /**
  * Check if ONNX runtime is available
  */
 function checkOnnxAvailable(): boolean {
-	try {
-		// Check if onnxruntime-node is installed
-		require.resolve("onnxruntime-node");
-		return true;
-	} catch {
-		return false;
-	}
+  try {
+    // Check if onnxruntime-node is installed
+    require.resolve("onnxruntime-node");
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 /**
  * Check OpenAI API availability (requires API key)
  */
 function checkOpenAIConfigured(apiKey?: string): boolean {
-	return Boolean(apiKey && apiKey.trim().length > 0);
+  return Boolean(apiKey && apiKey.trim().length > 0);
 }
 
 /**
  * Detect all available embedding providers
  */
-export async function detectAvailableProviders(
-	currentApiKey?: string,
-): Promise<ProviderStatus[]> {
-	const ollamaAvailable = await checkOllamaAvailable();
-	const onnxAvailable = checkOnnxAvailable();
-	const openaiConfigured = checkOpenAIConfigured(currentApiKey);
+export async function detectAvailableProviders(currentApiKey?: string): Promise<ProviderStatus[]> {
+  const ollamaAvailable = await checkOllamaAvailable();
+  const onnxAvailable = checkOnnxAvailable();
+  const openaiConfigured = checkOpenAIConfigured(currentApiKey);
 
-	return [
-		{
-			provider: "ollama",
-			available: ollamaAvailable,
-			reason: ollamaAvailable
-				? "Ollama is running on localhost:11434"
-				: "Ollama is not running. Start with: ollama serve",
-			recommendation: ollamaAvailable
-				? "Best for local, private embedding without API costs"
-				: "Install from https://ollama.ai and run: ollama pull nomic-embed-text",
-			requiresApiKey: false,
-			localOnly: true,
-		},
-		{
-			provider: "onnx",
-			available: onnxAvailable,
-			reason: onnxAvailable
-				? "ONNX runtime is installed"
-				: "onnxruntime-node is not installed",
-			recommendation: onnxAvailable
-				? "Lightweight local embeddings, no dependencies"
-				: "Install with: npm install onnxruntime-node",
-			requiresApiKey: false,
-			localOnly: true,
-		},
-		{
-			provider: "openai",
-			available: openaiConfigured,
-			reason: openaiConfigured
-				? "API key is configured"
-				: "No API key found. Requires OpenAI API key",
-			recommendation:
-				"High-quality embeddings, requires API key and incurs costs",
-			requiresApiKey: true,
-			localOnly: false,
-		},
-	];
+  return [
+    {
+      provider: "ollama",
+      available: ollamaAvailable,
+      reason: ollamaAvailable
+        ? "Ollama is running on localhost:11434"
+        : "Ollama is not running. Start with: ollama serve",
+      recommendation: ollamaAvailable
+        ? "Best for local, private embedding without API costs"
+        : "Install from https://ollama.ai and run: ollama pull nomic-embed-text",
+      requiresApiKey: false,
+      localOnly: true,
+    },
+    {
+      provider: "onnx",
+      available: onnxAvailable,
+      reason: onnxAvailable ? "ONNX runtime is installed" : "onnxruntime-node is not installed",
+      recommendation: onnxAvailable
+        ? "Lightweight local embeddings, no dependencies"
+        : "Install with: npm install onnxruntime-node",
+      requiresApiKey: false,
+      localOnly: true,
+    },
+    {
+      provider: "openai",
+      available: openaiConfigured,
+      reason: openaiConfigured ? "API key is configured" : "No API key found. Requires OpenAI API key",
+      recommendation: "High-quality embeddings, requires API key and incurs costs",
+      requiresApiKey: true,
+      localOnly: false,
+    },
+  ];
 }
 
 /**
  * Recommend the best available provider based on what's currently available
  */
-export async function recommendProvider(
-	currentApiKey?: string,
-): Promise<"ollama" | "onnx" | "openai"> {
-	const providers = await detectAvailableProviders(currentApiKey);
+export async function recommendProvider(currentApiKey?: string): Promise<"ollama" | "onnx" | "openai"> {
+  const providers = await detectAvailableProviders(currentApiKey);
 
-	// Prefer local providers to avoid API costs for new users
-	const ollama = providers.find((p) => p.provider === "ollama");
-	if (ollama?.available) {
-		return "ollama";
-	}
+  // Prefer local providers to avoid API costs for new users
+  const ollama = providers.find((p) => p.provider === "ollama");
+  if (ollama?.available) {
+    return "ollama";
+  }
 
-	const onnx = providers.find((p) => p.provider === "onnx");
-	if (onnx?.available) {
-		return "onnx";
-	}
+  const onnx = providers.find((p) => p.provider === "onnx");
+  if (onnx?.available) {
+    return "onnx";
+  }
 
-	// Fall back to OpenAI if configured
-	const openai = providers.find((p) => p.provider === "openai");
-	if (openai?.available) {
-		return "openai";
-	}
+  // Fall back to OpenAI if configured
+  const openai = providers.find((p) => p.provider === "openai");
+  if (openai?.available) {
+    return "openai";
+  }
 
-	// Default to ollama with instructions to set it up
-	return "ollama";
+  // Default to ollama with instructions to set it up
+  return "ollama";
 }
 
 /**
  * Format provider status for CLI display
  */
 export function formatProviderStatus(status: ProviderStatus): string {
-	const icon = status.available ? "✓" : "✗";
-	const badge = status.localOnly ? "[Local]" : "[Cloud]";
-	const apiKeyBadge = status.requiresApiKey ? "[API Key Required]" : "";
+  const icon = status.available ? "✓" : "✗";
+  const badge = status.localOnly ? "[Local]" : "[Cloud]";
+  const apiKeyBadge = status.requiresApiKey ? "[API Key Required]" : "";
 
-	const lines = [
-		`${icon} ${status.provider.toUpperCase()} ${badge} ${apiKeyBadge}`,
-		`   ${status.reason}`,
-	];
+  const lines = [`${icon} ${status.provider.toUpperCase()} ${badge} ${apiKeyBadge}`, `   ${status.reason}`];
 
-	if (status.recommendation) {
-		lines.push(`   ${status.recommendation}`);
-	}
+  if (status.recommendation) {
+    lines.push(`   ${status.recommendation}`);
+  }
 
-	return lines.join("\n");
+  return lines.join("\n");
 }

--- a/extensions/memory-hybrid/utils/provider-detection.ts
+++ b/extensions/memory-hybrid/utils/provider-detection.ts
@@ -2,11 +2,12 @@
  * Auto-detect available embedding providers and their status
  */
 
-import { execSync } from "node:child_process";
-import { existsSync } from "node:fs";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
 
 export interface ProviderStatus {
-  provider: "openai" | "ollama" | "onnx";
+  provider: "openai" | "ollama" | "onnx" | "google";
   available: boolean;
   reason?: string;
   recommendation?: string;
@@ -44,17 +45,21 @@ function checkOnnxAvailable(): boolean {
 /**
  * Check OpenAI API availability (requires API key)
  */
-function checkOpenAIConfigured(apiKey?: string): boolean {
+function hasConfiguredApiKey(apiKey?: string): boolean {
   return Boolean(apiKey && apiKey.trim().length > 0);
 }
 
 /**
  * Detect all available embedding providers
  */
-export async function detectAvailableProviders(currentApiKey?: string): Promise<ProviderStatus[]> {
+export async function detectAvailableProviders(
+  currentApiKey?: string,
+  googleApiKey?: string,
+): Promise<ProviderStatus[]> {
   const ollamaAvailable = await checkOllamaAvailable();
   const onnxAvailable = checkOnnxAvailable();
-  const openaiConfigured = checkOpenAIConfigured(currentApiKey);
+  const openaiConfigured = hasConfiguredApiKey(currentApiKey);
+  const googleConfigured = hasConfiguredApiKey(googleApiKey ?? currentApiKey);
 
   return [
     {
@@ -87,14 +92,25 @@ export async function detectAvailableProviders(currentApiKey?: string): Promise<
       requiresApiKey: true,
       localOnly: false,
     },
+    {
+      provider: "google",
+      available: googleConfigured,
+      reason: googleConfigured ? "Google API key is configured" : "No API key found. Requires Google/Gemini API key",
+      recommendation: "Google embeddings via configured Gemini/Google API key",
+      requiresApiKey: true,
+      localOnly: false,
+    },
   ];
 }
 
 /**
  * Recommend the best available provider based on what's currently available
  */
-export async function recommendProvider(currentApiKey?: string): Promise<"ollama" | "onnx" | "openai"> {
-  const providers = await detectAvailableProviders(currentApiKey);
+export async function recommendProvider(
+  currentApiKey?: string,
+  googleApiKey?: string,
+): Promise<"ollama" | "onnx" | "openai" | "google"> {
+  const providers = await detectAvailableProviders(currentApiKey, googleApiKey);
 
   // Prefer local providers to avoid API costs for new users
   const ollama = providers.find((p) => p.provider === "ollama");
@@ -107,11 +123,11 @@ export async function recommendProvider(currentApiKey?: string): Promise<"ollama
     return "onnx";
   }
 
-  // Fall back to OpenAI if configured
+  // Fall back to configured cloud providers.
   const openai = providers.find((p) => p.provider === "openai");
-  if (openai?.available) {
-    return "openai";
-  }
+  if (openai?.available) return "openai";
+  const google = providers.find((p) => p.provider === "google");
+  if (google?.available) return "google";
 
   // Default to ollama with instructions to set it up
   return "ollama";

--- a/sdk/openclaw-memory-js/README.md
+++ b/sdk/openclaw-memory-js/README.md
@@ -61,7 +61,6 @@ new MemoryClient(config?: MemoryClientConfig)
 |--------|------|---------|-------------|
 | `baseUrl` | `string` | `http://localhost:7777` | Base URL of memory API |
 | `graphqlPath` | `string` | `/plugins/memory/graphql` | GraphQL endpoint path |
-| `restPath` | `string` | `/plugins/memory-public` | REST API endpoint path |
 | `apiKey` | `string` | `undefined` | API key for authentication |
 | `timeout` | `number` | `30000` | Request timeout in ms |
 
@@ -87,8 +86,7 @@ const facts = await client.getFacts({
   category: 'preference',
   limit: 20,
   offset: 0,
-  tags: ['development'],
-  minImportance: 0.5
+  tags: ['development']
 });
 \`\`\`
 

--- a/sdk/openclaw-memory-js/package.json
+++ b/sdk/openclaw-memory-js/package.json
@@ -49,8 +49,7 @@
   },
   "homepage": "https://github.com/markus-lassfolk/openclaw-hybrid-memory/tree/main/sdk/openclaw-memory-js#readme",
   "dependencies": {
-    "graphql": "^16.9.0",
-    "graphql-request": "^7.1.2"
+    "graphql": "^16.9.0"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",

--- a/sdk/openclaw-memory-js/src/index.ts
+++ b/sdk/openclaw-memory-js/src/index.ts
@@ -8,8 +8,6 @@ export interface MemoryClientConfig {
 	baseUrl?: string;
 	/** GraphQL endpoint path (default: /plugins/memory/graphql) */
 	graphqlPath?: string;
-	/** REST API endpoint path (default: /plugins/memory-public) */
-	restPath?: string;
 	/** API key for authentication (if required) */
 	apiKey?: string;
 	/** Request timeout in milliseconds */
@@ -127,14 +125,12 @@ export interface GraphFilterInput {
 export class MemoryClient {
 	private baseUrl: string;
 	private graphqlPath: string;
-	private restPath: string;
 	private apiKey?: string;
 	private timeout: number;
 
 	constructor(config: MemoryClientConfig = {}) {
 		this.baseUrl = config.baseUrl || "http://localhost:7777";
 		this.graphqlPath = config.graphqlPath || "/plugins/memory/graphql";
-		this.restPath = config.restPath || "/plugins/memory-public";
 		this.apiKey = config.apiKey;
 		this.timeout = config.timeout || 30000;
 	}


### PR DESCRIPTION
## Summary

This is the anchor recovery PR for the 2026-05-11 incident where recent PRs were merged despite red CI and unresolved feedback.

It intentionally tracks **all 77 unresolved review threads** from the closed/merged PRs in one place:

- #1308
- #1311
- #1317
- #1318
- #1320
- #1323

## Current state

This PR starts as a draft with the full 77-item inventory committed in:

- `docs/recovery/unresolved-feedback-2026-05-11.md`

Each item must be resolved as one of:

- `FIXED` — changed in this PR with file/commit evidence
- `ALREADY FIXED` — already fixed on current main with file/line evidence
- `OBSOLETE` — no longer applicable with evidence

No applicable item should be deferred before merge.

## Merge gate

Do not merge until all three are true:

- all substantive latest-head CI checks are green
- no unresolved review feedback/items remain
- no merge conflicts remain

Admin merge is only a mechanical last resort after those gates are already satisfied; never to bypass red CI, feedback, or conflicts.

## Next work

Implementation commits should update the checklist as each item is fixed/proven obsolete/proven already fixed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches multiple user-facing CLI flows and plugin lifecycle handling, including encryption bundle import/export validation; behavior changes could affect operational scripts and plugin unloading if assumptions differ.
> 
> **Overview**
> Addresses the 2026-05-11 recovery incident by adding a tracked inventory of **77 previously-unresolved review threads** (`docs/recovery/unresolved-feedback-2026-05-11.md`) and aligning docs to avoid overstating feature completeness.
> 
> Hardens the hybrid-memory extension based on that feedback: the `PluginManager` now logs via `pluginLogger` and tracks event listeners per plugin so unloading one plugin no longer clears others’ hooks. CLI user-friendly commands are retyped to the internal `Chainable` abstraction, `setup` now actually persists config (with hidden API-key prompting) and adds Google provider support, and `doctor`/`health` reduce redundant DB/vector counting while improving disk-space checks.
> 
> Improves operational tooling and safety: benchmark reporting no longer reports misleading 0ms latencies when all samples fail, `sync-export` now encrypts actual exported content (not a directory path) and `sync-import` adds strict envelope validation (bounded PBKDF2 iterations and base64/length checks). Dependency metadata is updated accordingly (e.g., `commander` moved to runtime deps; `unrun` pinned).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4bcb1687ff7c3b7a934bbb88ff973e6f26b2772. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->