### PR TITLE
feat(memory): add pending autopilot foundation

### DIFF
--- a/extensions/memory-hybrid/backends/migrations/facts-migrations.ts
+++ b/extensions/memory-hybrid/backends/migrations/facts-migrations.ts
@@ -1150,6 +1150,67 @@ function migrateDerivedFromLinksToProvenanceJson(db: DatabaseSync): void {
   tx();
 }
 
+/** Pending Autopilot control-plane tables (#1334).
+ *
+ * Child issues #1326-#1330 share these durable contracts; queue-specific policy
+ * logic must live in adapters, not in this migration.
+ */
+function migratePendingAutopilotTables(db: DatabaseSync): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS pending_autopilot_runs (
+      id TEXT PRIMARY KEY,
+      mode TEXT NOT NULL,
+      policy_version TEXT NOT NULL,
+      input_hash TEXT NOT NULL,
+      queues_json TEXT NOT NULL DEFAULT '[]',
+      started_at INTEGER NOT NULL,
+      finished_at INTEGER,
+      summary_json TEXT
+    );
+
+    CREATE TABLE IF NOT EXISTS pending_autopilot_decisions (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      queue TEXT NOT NULL,
+      item_id TEXT NOT NULL,
+      input_hash TEXT NOT NULL,
+      policy_version TEXT NOT NULL,
+      mode TEXT NOT NULL,
+      action TEXT NOT NULL,
+      reason_code TEXT NOT NULL,
+      action_class TEXT NOT NULL,
+      capability_class TEXT,
+      run_id TEXT,
+      summary_json TEXT,
+      audit_json TEXT,
+      created_at INTEGER NOT NULL,
+      UNIQUE(queue, item_id, input_hash, policy_version)
+    );
+
+    CREATE TABLE IF NOT EXISTS pending_autopilot_cursors (
+      queue TEXT PRIMARY KEY,
+      cursor TEXT NOT NULL,
+      input_hash TEXT NOT NULL,
+      policy_version TEXT NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS pending_autopilot_locks (
+      queue TEXT NOT NULL,
+      item_id TEXT NOT NULL,
+      input_hash TEXT NOT NULL,
+      owner TEXT NOT NULL,
+      expires_at INTEGER NOT NULL,
+      created_at INTEGER NOT NULL,
+      PRIMARY KEY(queue, item_id)
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_pending_autopilot_runs_started ON pending_autopilot_runs(started_at DESC);
+    CREATE INDEX IF NOT EXISTS idx_pending_autopilot_decisions_run ON pending_autopilot_decisions(run_id);
+    CREATE INDEX IF NOT EXISTS idx_pending_autopilot_decisions_queue ON pending_autopilot_decisions(queue, item_id);
+    CREATE INDEX IF NOT EXISTS idx_pending_autopilot_locks_expiry ON pending_autopilot_locks(expires_at);
+  `);
+}
+
 export function runFactsMigrations(db: DatabaseSync): void {
   // Column migrations (depend on base facts table existing)
   migrateDecayColumns(db);
@@ -1249,6 +1310,9 @@ export function runFactsMigrations(db: DatabaseSync): void {
 
   // Audit-health storage growth samples (Issue #1193)
   migrateStorageGrowthHistoryTable(db);
+
+  // Pending Autopilot control-plane substrate (#1334)
+  migratePendingAutopilotTables(db);
 
   // Denormalized degree columns for hub guard (#1192)
   migrateFactDegreeColumns(db);

--- a/extensions/memory-hybrid/backends/migrations/facts-migrations.ts
+++ b/extensions/memory-hybrid/backends/migrations/facts-migrations.ts
@@ -1150,67 +1150,6 @@ function migrateDerivedFromLinksToProvenanceJson(db: DatabaseSync): void {
   tx();
 }
 
-/** Pending Autopilot control-plane tables (#1334).
- *
- * Child issues #1326-#1330 share these durable contracts; queue-specific policy
- * logic must live in adapters, not in this migration.
- */
-function migratePendingAutopilotTables(db: DatabaseSync): void {
-  db.exec(`
-    CREATE TABLE IF NOT EXISTS pending_autopilot_runs (
-      id TEXT PRIMARY KEY,
-      mode TEXT NOT NULL,
-      policy_version TEXT NOT NULL,
-      input_hash TEXT NOT NULL,
-      queues_json TEXT NOT NULL DEFAULT '[]',
-      started_at INTEGER NOT NULL,
-      finished_at INTEGER,
-      summary_json TEXT
-    );
-
-    CREATE TABLE IF NOT EXISTS pending_autopilot_decisions (
-      id INTEGER PRIMARY KEY AUTOINCREMENT,
-      queue TEXT NOT NULL,
-      item_id TEXT NOT NULL,
-      input_hash TEXT NOT NULL,
-      policy_version TEXT NOT NULL,
-      mode TEXT NOT NULL,
-      action TEXT NOT NULL,
-      reason_code TEXT NOT NULL,
-      action_class TEXT NOT NULL,
-      capability_class TEXT,
-      run_id TEXT,
-      summary_json TEXT,
-      audit_json TEXT,
-      created_at INTEGER NOT NULL,
-      UNIQUE(queue, item_id, input_hash, policy_version)
-    );
-
-    CREATE TABLE IF NOT EXISTS pending_autopilot_cursors (
-      queue TEXT PRIMARY KEY,
-      cursor TEXT NOT NULL,
-      input_hash TEXT NOT NULL,
-      policy_version TEXT NOT NULL,
-      updated_at INTEGER NOT NULL
-    );
-
-    CREATE TABLE IF NOT EXISTS pending_autopilot_locks (
-      queue TEXT NOT NULL,
-      item_id TEXT NOT NULL,
-      input_hash TEXT NOT NULL,
-      owner TEXT NOT NULL,
-      expires_at INTEGER NOT NULL,
-      created_at INTEGER NOT NULL,
-      PRIMARY KEY(queue, item_id)
-    );
-
-    CREATE INDEX IF NOT EXISTS idx_pending_autopilot_runs_started ON pending_autopilot_runs(started_at DESC);
-    CREATE INDEX IF NOT EXISTS idx_pending_autopilot_decisions_run ON pending_autopilot_decisions(run_id);
-    CREATE INDEX IF NOT EXISTS idx_pending_autopilot_decisions_queue ON pending_autopilot_decisions(queue, item_id);
-    CREATE INDEX IF NOT EXISTS idx_pending_autopilot_locks_expiry ON pending_autopilot_locks(expires_at);
-  `);
-}
-
 export function runFactsMigrations(db: DatabaseSync): void {
   // Column migrations (depend on base facts table existing)
   migrateDecayColumns(db);
@@ -1310,9 +1249,6 @@ export function runFactsMigrations(db: DatabaseSync): void {
 
   // Audit-health storage growth samples (Issue #1193)
   migrateStorageGrowthHistoryTable(db);
-
-  // Pending Autopilot control-plane substrate (#1334)
-  migratePendingAutopilotTables(db);
 
   // Denormalized degree columns for hub guard (#1192)
   migrateFactDegreeColumns(db);

--- a/extensions/memory-hybrid/index.ts
+++ b/extensions/memory-hybrid/index.ts
@@ -91,6 +91,7 @@ export type {
   LinkPathStep,
 } from "./services/graph-retrieval.js";
 export { DEFAULT_GRAPH_HUB_DEGREE_CAP, resolveGraphHubDegreeCap } from "./services/graph-retrieval.js";
+export * from "./services/pending-autopilot/index.js";
 import { findShortestPath, formatPath, resolveInput } from "./services/shortest-path.js";
 export type { ShortestPathResult, PathStep, ShortestPathLookup } from "./services/shortest-path.js";
 import {

--- a/extensions/memory-hybrid/services/pending-autopilot/README.md
+++ b/extensions/memory-hybrid/services/pending-autopilot/README.md
@@ -3,8 +3,8 @@
 This module is the shared safety substrate for the pending-digest autopilot work. Issue #1334 is a prerequisite for:
 
 - #1326 parent orchestration
-- #1327 procedure/skill queue adapter
-- #1328 persona queue adapter
+- #1327 persona queue adapter
+- #1328 procedure/skill queue adapter
 - #1329 verified-fact queue adapter
 - #1330 cron wrapper and observability
 

--- a/extensions/memory-hybrid/services/pending-autopilot/README.md
+++ b/extensions/memory-hybrid/services/pending-autopilot/README.md
@@ -1,0 +1,54 @@
+# Pending Autopilot Foundation (#1334)
+
+This module is the shared safety substrate for the pending-digest autopilot work. Issue #1334 is a prerequisite for:
+
+- #1326 parent orchestration
+- #1327 procedure/skill queue adapter
+- #1328 persona queue adapter
+- #1329 verified-fact queue adapter
+- #1330 cron wrapper and observability
+
+Child, parent, and cron work must consume these contracts instead of defining bespoke action, capability, policy, cursor, lock, or audit models.
+
+## Global invariants
+
+- Deny by default.
+- `dry-run` is non-mutating for durable foundation state. No run, decision, cursor, lock, or mutation rows are written in dry-run.
+- Every persisted decision records queue, item id, input hash, policy, policy version, action, reason, capability, confidence, human-review flag, evidence, actor/run/job context, and timestamp.
+- Durable summaries and audit payloads are redacted before persistence.
+- Mutating paths must revalidate input hash and active lock ownership immediately before mutation.
+- Mutation and audit write are transactional: if audit persistence fails, the mutation fails and rolls back.
+- Cursors must not hide human-review-required, failed-validation, failed-audit, or unknown-decision items.
+- Parent/child equivalence is required for queue adapters.
+- Cron has no policy authority; it only invokes and observes the parent command.
+- Trust-changing, external, destructive, credential-affecting, policy-broadening, or behaviour-enabling work requires explicit human approval.
+
+## Capability boundaries
+
+`--apply` is intent, not authority. Each planned action must map to one explicit capability level:
+
+1. `read-only`
+2. `dry-run`
+3. `record-review-metadata`
+4. `safe-state-transition`
+5. `write-draft-artifact`
+6. `apply-low-risk-change`
+7. `enable-behaviour`
+8. `trust-changing-action`
+9. `external-side-effect`
+10. `destructive-action`
+
+Adapters may add queue-specific policy, but they must preserve these approval boundaries.
+
+## Parent/child equivalence
+
+Tests should compare two distinct execution paths:
+
+- standalone child adapter execution
+- parent orchestration execution that delegates to the adapter
+
+The shared test helper verifies both paths produce equivalent normalized decisions for the same fixture, policy, and input hash. Do not satisfy this by calling the same adapter path twice.
+
+## Dry-run semantics
+
+Dry-run may produce in-memory summaries or CLI output, but any artifact that could influence a later apply must be ephemeral/non-authoritative. The store intentionally skips durable `pending_autopilot_*` writes when mode is `dry-run`.

--- a/extensions/memory-hybrid/services/pending-autopilot/foundation.ts
+++ b/extensions/memory-hybrid/services/pending-autopilot/foundation.ts
@@ -1,7 +1,7 @@
 import { createHash, randomUUID } from "node:crypto";
 import { redactAutopilotValue } from "./redaction.js";
-import type { PendingAutopilotRunSummary, PendingDecision, PendingQueue } from "./types.js";
-import { AUTOPILOT_ACTIONS, type AUTOPILOT_MODES, PENDING_QUEUES, assertKnownEnum } from "./types.js";
+import type { AutopilotMode, PendingAutopilotRunSummary, PendingDecision, PendingQueue } from "./types.js";
+import { AUTOPILOT_ACTIONS, PENDING_QUEUES, assertKnownEnum } from "./types.js";
 
 export const PENDING_AUTOPILOT_SCHEMA_VERSION = 1;
 
@@ -35,7 +35,7 @@ export function sanitizePendingDecision(decision: PendingDecision): PendingDecis
 
 export function createStableRunSummary(input: {
   runId: string;
-  mode: (typeof AUTOPILOT_MODES)[number];
+  mode: AutopilotMode;
   policyVersion: string;
   queues: PendingQueue[];
   startedAt: number;

--- a/extensions/memory-hybrid/services/pending-autopilot/foundation.ts
+++ b/extensions/memory-hybrid/services/pending-autopilot/foundation.ts
@@ -48,7 +48,7 @@ export function createStableRunSummary(input: {
   const decisions = input.decisions.map(sanitizePendingDecision).sort((a, b) => {
     const ak = `${a.queue}:${a.itemId}:${a.inputHash}:${a.policyVersion}`;
     const bk = `${b.queue}:${b.itemId}:${b.inputHash}:${b.policyVersion}`;
-    return ak.localeCompare(bk);
+    return ak < bk ? -1 : ak > bk ? 1 : 0;
   });
   for (const decision of decisions) totals[decision.action] += 1;
   return {
@@ -83,7 +83,7 @@ function sortJson(value: unknown): unknown {
   if (value && typeof value === "object") {
     return Object.fromEntries(
       Object.entries(value)
-        .sort(([a], [b]) => a.localeCompare(b))
+        .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
         .map(([k, v]) => [k, sortJson(v)]),
     );
   }

--- a/extensions/memory-hybrid/services/pending-autopilot/foundation.ts
+++ b/extensions/memory-hybrid/services/pending-autopilot/foundation.ts
@@ -84,12 +84,7 @@ export function stableRunSummaryJson(summary: PendingAutopilotRunSummary): strin
 
 export function shouldAdvancePendingCursor(decision: PendingDecision): boolean {
   if (decision.humanReviewRequired) return false;
-  return ![
-    "deferred-for-human",
-    "failed-validation",
-    "failed-audit",
-    "unknown-decision",
-  ].includes(decision.action);
+  return !["deferred-for-human", "failed-validation", "failed-audit", "unknown-decision"].includes(decision.action);
 }
 
 function compareCodePointOrder(a: string, b: string): number {
@@ -106,9 +101,7 @@ function sortJson(value: unknown): unknown {
       .sort(([a], [b]) => compareCodePointOrder(canonicalJson(a), canonicalJson(b)));
   }
   if (value instanceof Set) {
-    return [...value.values()]
-      .map(sortJson)
-      .sort((a, b) => compareCodePointOrder(canonicalJson(a), canonicalJson(b)));
+    return [...value.values()].map(sortJson).sort((a, b) => compareCodePointOrder(canonicalJson(a), canonicalJson(b)));
   }
   if (value && typeof value === "object") {
     const maybeToJson = (value as { toJSON?: unknown }).toJSON;

--- a/extensions/memory-hybrid/services/pending-autopilot/foundation.ts
+++ b/extensions/memory-hybrid/services/pending-autopilot/foundation.ts
@@ -1,0 +1,91 @@
+import { createHash, randomUUID } from "node:crypto";
+import { redactAutopilotValue } from "./redaction.js";
+import type { PendingAutopilotRunSummary, PendingDecision, PendingQueue } from "./types.js";
+import { AUTOPILOT_ACTIONS, type AUTOPILOT_MODES, PENDING_QUEUES, assertKnownEnum } from "./types.js";
+
+export const PENDING_AUTOPILOT_SCHEMA_VERSION = 1;
+
+export function canonicalJson(value: unknown): string {
+  return JSON.stringify(sortJson(value));
+}
+
+export function computePendingInputHash(input: unknown): string {
+  return createHash("sha256")
+    .update(canonicalJson(redactAutopilotValue(input)))
+    .digest("hex");
+}
+
+export function createPendingAutopilotRunId(): string {
+  return randomUUID();
+}
+
+export function sanitizePendingDecision(decision: PendingDecision): PendingDecision {
+  assertKnownEnum("queue", decision.queue);
+  assertKnownEnum("mode", decision.mode);
+  assertKnownEnum("action", decision.action);
+  assertKnownEnum("reasonCode", decision.reasonCode);
+  assertKnownEnum("actionClass", decision.actionClass);
+  if (decision.capabilityClass) assertKnownEnum("capabilityClass", decision.capabilityClass);
+  return {
+    ...decision,
+    summary: decision.summary ? (redactAutopilotValue(decision.summary) as PendingDecision["summary"]) : undefined,
+    audit: decision.audit ? (redactAutopilotValue(decision.audit) as PendingDecision["audit"]) : undefined,
+  };
+}
+
+export function createStableRunSummary(input: {
+  runId: string;
+  mode: (typeof AUTOPILOT_MODES)[number];
+  policyVersion: string;
+  queues: PendingQueue[];
+  startedAt: number;
+  finishedAt?: number;
+  decisions: PendingDecision[];
+}): PendingAutopilotRunSummary {
+  const totals = Object.fromEntries(
+    AUTOPILOT_ACTIONS.map((action) => [action, 0]),
+  ) as PendingAutopilotRunSummary["totals"];
+  const decisions = input.decisions.map(sanitizePendingDecision).sort((a, b) => {
+    const ak = `${a.queue}:${a.itemId}:${a.inputHash}:${a.policyVersion}`;
+    const bk = `${b.queue}:${b.itemId}:${b.inputHash}:${b.policyVersion}`;
+    return ak.localeCompare(bk);
+  });
+  for (const decision of decisions) totals[decision.action] += 1;
+  return {
+    runId: input.runId,
+    mode: input.mode,
+    policyVersion: input.policyVersion,
+    queues: [...input.queues].sort((a, b) => PENDING_QUEUES.indexOf(a) - PENDING_QUEUES.indexOf(b)),
+    startedAt: input.startedAt,
+    ...(input.finishedAt !== undefined ? { finishedAt: input.finishedAt } : {}),
+    totals,
+    decisions: decisions.map((d) => ({
+      queue: d.queue,
+      itemId: d.itemId,
+      inputHash: d.inputHash,
+      policyVersion: d.policyVersion,
+      action: d.action,
+      reasonCode: d.reasonCode,
+    })),
+  };
+}
+
+export function stableRunSummaryJson(summary: PendingAutopilotRunSummary): string {
+  return `${canonicalJson(summary)}\n`;
+}
+
+export function shouldAdvancePendingCursor(decision: PendingDecision): boolean {
+  return !["deferred-for-human", "failed-validation"].includes(decision.action);
+}
+
+function sortJson(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortJson);
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value)
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([k, v]) => [k, sortJson(v)]),
+    );
+  }
+  return value;
+}

--- a/extensions/memory-hybrid/services/pending-autopilot/foundation.ts
+++ b/extensions/memory-hybrid/services/pending-autopilot/foundation.ts
@@ -25,17 +25,20 @@ export function sanitizePendingDecision(decision: PendingDecision): PendingDecis
   assertKnownEnum("action", decision.action);
   assertKnownEnum("reasonCode", decision.reasonCode);
   assertKnownEnum("actionClass", decision.actionClass);
-  if (decision.capabilityClass) assertKnownEnum("capabilityClass", decision.capabilityClass);
+  assertKnownEnum("capabilityClass", decision.capabilityClass);
   return {
     ...decision,
     summary: decision.summary ? (redactAutopilotValue(decision.summary) as PendingDecision["summary"]) : undefined,
     audit: decision.audit ? (redactAutopilotValue(decision.audit) as PendingDecision["audit"]) : undefined,
+    evidence: redactAutopilotValue(decision.evidence) as PendingDecision["evidence"],
+    actor: redactAutopilotValue(decision.actor) as PendingDecision["actor"],
   };
 }
 
 export function createStableRunSummary(input: {
   runId: string;
   mode: AutopilotMode;
+  policy: string;
   policyVersion: string;
   queues: PendingQueue[];
   startedAt: number;
@@ -46,14 +49,15 @@ export function createStableRunSummary(input: {
     AUTOPILOT_ACTIONS.map((action) => [action, 0]),
   ) as PendingAutopilotRunSummary["totals"];
   const decisions = input.decisions.map(sanitizePendingDecision).sort((a, b) => {
-    const ak = `${a.queue}:${a.itemId}:${a.inputHash}:${a.policyVersion}`;
-    const bk = `${b.queue}:${b.itemId}:${b.inputHash}:${b.policyVersion}`;
-    return ak.localeCompare(bk);
+    const ak = `${a.queue}:${a.itemId}:${a.inputHash}:${a.policy}:${a.policyVersion}`;
+    const bk = `${b.queue}:${b.itemId}:${b.inputHash}:${b.policy}:${b.policyVersion}`;
+    return compareCodePointOrder(ak, bk);
   });
   for (const decision of decisions) totals[decision.action] += 1;
   return {
     runId: input.runId,
     mode: input.mode,
+    policy: input.policy,
     policyVersion: input.policyVersion,
     queues: [...input.queues].sort((a, b) => PENDING_QUEUES.indexOf(a) - PENDING_QUEUES.indexOf(b)),
     startedAt: input.startedAt,
@@ -63,9 +67,13 @@ export function createStableRunSummary(input: {
       queue: d.queue,
       itemId: d.itemId,
       inputHash: d.inputHash,
+      policy: d.policy,
       policyVersion: d.policyVersion,
       action: d.action,
       reasonCode: d.reasonCode,
+      capabilityClass: d.capabilityClass,
+      confidence: d.confidence,
+      humanReviewRequired: d.humanReviewRequired,
     })),
   };
 }
@@ -75,7 +83,13 @@ export function stableRunSummaryJson(summary: PendingAutopilotRunSummary): strin
 }
 
 export function shouldAdvancePendingCursor(decision: PendingDecision): boolean {
-  return !["deferred-for-human", "failed-validation"].includes(decision.action);
+  if (decision.humanReviewRequired) return false;
+  return ![
+    "deferred-for-human",
+    "failed-validation",
+    "failed-audit",
+    "unknown-decision",
+  ].includes(decision.action);
 }
 
 function compareCodePointOrder(a: string, b: string): number {
@@ -84,7 +98,23 @@ function compareCodePointOrder(a: string, b: string): number {
 
 function sortJson(value: unknown): unknown {
   if (Array.isArray(value)) return value.map(sortJson);
+  if (value instanceof Date) return value.toISOString();
+  if (value instanceof URL) return value.toString();
+  if (value instanceof Map) {
+    return [...value.entries()]
+      .map(([k, v]) => [sortJson(k), sortJson(v)] as const)
+      .sort(([a], [b]) => compareCodePointOrder(canonicalJson(a), canonicalJson(b)));
+  }
+  if (value instanceof Set) {
+    return [...value.values()]
+      .map(sortJson)
+      .sort((a, b) => compareCodePointOrder(canonicalJson(a), canonicalJson(b)));
+  }
   if (value && typeof value === "object") {
+    const maybeToJson = (value as { toJSON?: unknown }).toJSON;
+    if (typeof maybeToJson === "function" && Object.getPrototypeOf(value) !== Object.prototype) {
+      return sortJson(maybeToJson.call(value));
+    }
     return Object.fromEntries(
       Object.entries(value)
         .sort(([a], [b]) => compareCodePointOrder(a, b))

--- a/extensions/memory-hybrid/services/pending-autopilot/foundation.ts
+++ b/extensions/memory-hybrid/services/pending-autopilot/foundation.ts
@@ -6,7 +6,7 @@ import { AUTOPILOT_ACTIONS, PENDING_QUEUES, assertKnownEnum } from "./types.js";
 export const PENDING_AUTOPILOT_SCHEMA_VERSION = 1;
 
 export function canonicalJson(value: unknown): string {
-  return JSON.stringify(sortJson(value));
+  return JSON.stringify(toCanonicalJsonValue(value));
 }
 
 export function computePendingInputHash(input: unknown): string {
@@ -91,28 +91,47 @@ function compareCodePointOrder(a: string, b: string): number {
   return a < b ? -1 : a > b ? 1 : 0;
 }
 
-function sortJson(value: unknown): unknown {
-  if (Array.isArray(value)) return value.map(sortJson);
+function toCanonicalJsonValue(value: unknown): unknown {
+  if (value === undefined) return { __pendingAutopilotType: "undefined" };
+  if (typeof value === "bigint") return { __pendingAutopilotType: "bigint", value: value.toString() };
+  if (typeof value === "function") {
+    return { __pendingAutopilotType: "function", name: value.name || null };
+  }
+  if (typeof value === "symbol") {
+    return { __pendingAutopilotType: "symbol", description: value.description ?? null };
+  }
+  if (typeof value === "number" && !Number.isFinite(value)) {
+    return { __pendingAutopilotType: "non-finite-number", value: String(value) };
+  }
+  if (Array.isArray(value)) return value.map(toCanonicalJsonValue);
   if (value instanceof Date) return value.toISOString();
   if (value instanceof URL) return value.toString();
   if (value instanceof Map) {
-    return [...value.entries()]
-      .map(([k, v]) => [sortJson(k), sortJson(v)] as const)
-      .sort(([a], [b]) => compareCodePointOrder(canonicalJson(a), canonicalJson(b)));
+    const entries = [...value.entries()]
+      .map(([k, v]) => [toCanonicalJsonValue(k), toCanonicalJsonValue(v)] as const)
+      .sort(([a], [b]) => compareCodePointOrder(stringifyCanonicalValue(a), stringifyCanonicalValue(b)));
+    return { __pendingAutopilotType: "Map", entries };
   }
   if (value instanceof Set) {
-    return [...value.values()].map(sortJson).sort((a, b) => compareCodePointOrder(canonicalJson(a), canonicalJson(b)));
+    const values = [...value.values()]
+      .map(toCanonicalJsonValue)
+      .sort((a, b) => compareCodePointOrder(stringifyCanonicalValue(a), stringifyCanonicalValue(b)));
+    return { __pendingAutopilotType: "Set", values };
   }
   if (value && typeof value === "object") {
     const maybeToJson = (value as { toJSON?: unknown }).toJSON;
     if (typeof maybeToJson === "function" && Object.getPrototypeOf(value) !== Object.prototype) {
-      return sortJson(maybeToJson.call(value));
+      return toCanonicalJsonValue(maybeToJson.call(value));
     }
     return Object.fromEntries(
       Object.entries(value)
         .sort(([a], [b]) => compareCodePointOrder(a, b))
-        .map(([k, v]) => [k, sortJson(v)]),
+        .map(([k, v]) => [k, toCanonicalJsonValue(v)]),
     );
   }
   return value;
+}
+
+function stringifyCanonicalValue(value: unknown): string {
+  return JSON.stringify(value) ?? "";
 }

--- a/extensions/memory-hybrid/services/pending-autopilot/foundation.ts
+++ b/extensions/memory-hybrid/services/pending-autopilot/foundation.ts
@@ -48,7 +48,7 @@ export function createStableRunSummary(input: {
   const decisions = input.decisions.map(sanitizePendingDecision).sort((a, b) => {
     const ak = `${a.queue}:${a.itemId}:${a.inputHash}:${a.policyVersion}`;
     const bk = `${b.queue}:${b.itemId}:${b.inputHash}:${b.policyVersion}`;
-    return ak < bk ? -1 : ak > bk ? 1 : 0;
+    return ak.localeCompare(bk);
   });
   for (const decision of decisions) totals[decision.action] += 1;
   return {
@@ -78,12 +78,16 @@ export function shouldAdvancePendingCursor(decision: PendingDecision): boolean {
   return !["deferred-for-human", "failed-validation"].includes(decision.action);
 }
 
+function compareCodePointOrder(a: string, b: string): number {
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
 function sortJson(value: unknown): unknown {
   if (Array.isArray(value)) return value.map(sortJson);
   if (value && typeof value === "object") {
     return Object.fromEntries(
       Object.entries(value)
-        .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+        .sort(([a], [b]) => compareCodePointOrder(a, b))
         .map(([k, v]) => [k, sortJson(v)]),
     );
   }

--- a/extensions/memory-hybrid/services/pending-autopilot/foundation.ts
+++ b/extensions/memory-hybrid/services/pending-autopilot/foundation.ts
@@ -49,8 +49,8 @@ export function createStableRunSummary(input: {
     AUTOPILOT_ACTIONS.map((action) => [action, 0]),
   ) as PendingAutopilotRunSummary["totals"];
   const decisions = input.decisions.map(sanitizePendingDecision).sort((a, b) => {
-    const ak = `${a.queue}:${a.itemId}:${a.inputHash}:${a.policy}:${a.policyVersion}`;
-    const bk = `${b.queue}:${b.itemId}:${b.inputHash}:${b.policy}:${b.policyVersion}`;
+    const ak = `${a.queue}:${a.itemId}:${a.inputHash}:${a.policy}:${a.policyVersion}:${a.action}`;
+    const bk = `${b.queue}:${b.itemId}:${b.inputHash}:${b.policy}:${b.policyVersion}:${b.action}`;
     return compareCodePointOrder(ak, bk);
   });
   for (const decision of decisions) totals[decision.action] += 1;

--- a/extensions/memory-hybrid/services/pending-autopilot/index.ts
+++ b/extensions/memory-hybrid/services/pending-autopilot/index.ts
@@ -1,0 +1,4 @@
+export * from "./types.js";
+export * from "./foundation.js";
+export * from "./redaction.js";
+export * from "./store.js";

--- a/extensions/memory-hybrid/services/pending-autopilot/redaction.ts
+++ b/extensions/memory-hybrid/services/pending-autopilot/redaction.ts
@@ -11,6 +11,7 @@ const SECRET_PATTERNS: RegExp[] = [
 const PRIVATE_KEY_BEGIN = "-----BEGIN ";
 const PRIVATE_KEY_END = "-----END ";
 const PRIVATE_KEY_FOOTER = " PRIVATE KEY-----";
+const PRIVATE_KEY_BARE_FOOTER = "PRIVATE KEY-----";
 const MAX_PRIVATE_KEY_BLOCK_LENGTH = 64_000;
 
 export function redactAutopilotText(input: unknown): { redacted: string; redactionCount: number } {
@@ -37,24 +38,27 @@ function redactPrivateKeyBlocks(text: string): { text: string; redactionCount: n
       break;
     }
     const headerEnd = text.indexOf("-----", begin + PRIVATE_KEY_BEGIN.length);
-    if (headerEnd === -1 || !text.slice(begin, headerEnd + 5).endsWith(PRIVATE_KEY_FOOTER)) {
+    if (headerEnd === -1 || !text.slice(begin, headerEnd + 5).endsWith(PRIVATE_KEY_BARE_FOOTER)) {
       redacted += text.slice(cursor, begin + PRIVATE_KEY_BEGIN.length);
       cursor = begin + PRIVATE_KEY_BEGIN.length;
       continue;
     }
     const headerLabel = text.slice(begin + PRIVATE_KEY_BEGIN.length, headerEnd);
-    if (!headerLabel.endsWith(" PRIVATE KEY")) {
+    if (headerLabel !== "PRIVATE KEY" && !headerLabel.endsWith(" PRIVATE KEY")) {
       redacted += text.slice(cursor, begin + PRIVATE_KEY_BEGIN.length);
       cursor = begin + PRIVATE_KEY_BEGIN.length;
       continue;
     }
-    const label = headerLabel.slice(0, -" PRIVATE KEY".length);
-    if (!/^[A-Z0-9 ]{1,48}$/.test(label)) {
+    const label = headerLabel === "PRIVATE KEY" ? "" : headerLabel.slice(0, -" PRIVATE KEY".length);
+    if (label.length > 0 && !/^[A-Z0-9 ]{1,48}$/.test(label)) {
       redacted += text.slice(cursor, begin + PRIVATE_KEY_BEGIN.length);
       cursor = begin + PRIVATE_KEY_BEGIN.length;
       continue;
     }
-    const footer = `${PRIVATE_KEY_END}${label}${PRIVATE_KEY_FOOTER}`;
+    const footer =
+      label.length > 0
+        ? `${PRIVATE_KEY_END}${label}${PRIVATE_KEY_FOOTER}`
+        : `${PRIVATE_KEY_END}${PRIVATE_KEY_BARE_FOOTER}`;
     const end = text.indexOf(footer, headerEnd + 5);
     if (end === -1 || end >= begin + MAX_PRIVATE_KEY_BLOCK_LENGTH) {
       redacted += text.slice(cursor, begin + PRIVATE_KEY_BEGIN.length);

--- a/extensions/memory-hybrid/services/pending-autopilot/redaction.ts
+++ b/extensions/memory-hybrid/services/pending-autopilot/redaction.ts
@@ -98,9 +98,9 @@ export function redactAutopilotValue(value: unknown): unknown {
   if (value instanceof Date) return value.toISOString();
   if (value instanceof URL) return redactAutopilotText(value.toString()).redacted;
   if (value instanceof Map) {
-    return [...value.entries()].map(([key, child]) => [redactAutopilotValue(key), redactAutopilotValue(child)]);
+    return new Map([...value.entries()].map(([key, child]) => [redactAutopilotValue(key), redactAutopilotValue(child)]));
   }
-  if (value instanceof Set) return [...value.values()].map((v) => redactAutopilotValue(v));
+  if (value instanceof Set) return new Set([...value.values()].map((v) => redactAutopilotValue(v)));
   if (value && typeof value === "object") {
     const maybeToJson = (value as { toJSON?: unknown }).toJSON;
     if (typeof maybeToJson === "function" && Object.getPrototypeOf(value) !== Object.prototype) {

--- a/extensions/memory-hybrid/services/pending-autopilot/redaction.ts
+++ b/extensions/memory-hybrid/services/pending-autopilot/redaction.ts
@@ -1,17 +1,22 @@
 /** Redaction helpers for pending-autopilot audit and summary output (#1334). */
 
 const SECRET_PATTERNS: RegExp[] = [
-  /\b(?:sk|pk|rk|ghp|gho|github_pat|xox[baprs])-[-_a-zA-Z0-9]{8,}\b/g,
+  /\b(?:sk|pk|rk|ghp|gho|github_pat|xox[baprs])[-_][A-Za-z0-9_-]{8,}\b/g,
   /\bAKIA[0-9A-Z]{16}\b/g,
-  /-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----/g,
   /\b(?:password|passwd|pwd|secret|token|api[_-]?key|authorization)\s*[:=]\s*[^\s,;}{\]]+/gi,
   /\bBearer\s+[A-Za-z0-9._~+/-]+=*/gi,
   /\b[a-z][a-z0-9+.-]*:\/\/[^\s:@/]+:[^\s@/]+@[^\s]+/gi,
 ];
 
+const PRIVATE_KEY_BEGIN = "-----BEGIN ";
+const PRIVATE_KEY_END = "-----END ";
+const PRIVATE_KEY_FOOTER = " PRIVATE KEY-----";
+const MAX_PRIVATE_KEY_BLOCK_LENGTH = 64_000;
+
 export function redactAutopilotText(input: unknown): { redacted: string; redactionCount: number } {
-  let text = typeof input === "string" ? input : JSON.stringify(input ?? "");
-  let redactionCount = 0;
+  let { text, redactionCount } = redactPrivateKeyBlocks(
+    typeof input === "string" ? input : JSON.stringify(input ?? ""),
+  );
   for (const pattern of SECRET_PATTERNS) {
     text = text.replace(pattern, () => {
       redactionCount += 1;
@@ -19,6 +24,48 @@ export function redactAutopilotText(input: unknown): { redacted: string; redacti
     });
   }
   return { redacted: text, redactionCount };
+}
+
+function redactPrivateKeyBlocks(text: string): { text: string; redactionCount: number } {
+  let cursor = 0;
+  let redactionCount = 0;
+  let redacted = "";
+  while (cursor < text.length) {
+    const begin = text.indexOf(PRIVATE_KEY_BEGIN, cursor);
+    if (begin === -1) {
+      redacted += text.slice(cursor);
+      break;
+    }
+    const headerEnd = text.indexOf("-----", begin + PRIVATE_KEY_BEGIN.length);
+    if (headerEnd === -1 || !text.slice(begin, headerEnd + 5).endsWith(PRIVATE_KEY_FOOTER)) {
+      redacted += text.slice(cursor, begin + PRIVATE_KEY_BEGIN.length);
+      cursor = begin + PRIVATE_KEY_BEGIN.length;
+      continue;
+    }
+    const headerLabel = text.slice(begin + PRIVATE_KEY_BEGIN.length, headerEnd);
+    if (!headerLabel.endsWith(" PRIVATE KEY")) {
+      redacted += text.slice(cursor, begin + PRIVATE_KEY_BEGIN.length);
+      cursor = begin + PRIVATE_KEY_BEGIN.length;
+      continue;
+    }
+    const label = headerLabel.slice(0, -" PRIVATE KEY".length);
+    if (!/^[A-Z0-9 ]{1,48}$/.test(label)) {
+      redacted += text.slice(cursor, begin + PRIVATE_KEY_BEGIN.length);
+      cursor = begin + PRIVATE_KEY_BEGIN.length;
+      continue;
+    }
+    const footer = `${PRIVATE_KEY_END}${label}${PRIVATE_KEY_FOOTER}`;
+    const end = text.indexOf(footer, headerEnd + 5);
+    if (end === -1 || end >= begin + MAX_PRIVATE_KEY_BLOCK_LENGTH) {
+      redacted += text.slice(cursor, begin + PRIVATE_KEY_BEGIN.length);
+      cursor = begin + PRIVATE_KEY_BEGIN.length;
+      continue;
+    }
+    redacted += `${text.slice(cursor, begin)}[REDACTED]`;
+    redactionCount += 1;
+    cursor = end + footer.length;
+  }
+  return { text: redacted, redactionCount };
 }
 
 export function redactAutopilotValue(value: unknown): unknown {

--- a/extensions/memory-hybrid/services/pending-autopilot/redaction.ts
+++ b/extensions/memory-hybrid/services/pending-autopilot/redaction.ts
@@ -98,7 +98,9 @@ export function redactAutopilotValue(value: unknown): unknown {
   if (value instanceof Date) return value.toISOString();
   if (value instanceof URL) return redactAutopilotText(value.toString()).redacted;
   if (value instanceof Map) {
-    return new Map([...value.entries()].map(([key, child]) => [redactAutopilotValue(key), redactAutopilotValue(child)]));
+    return new Map(
+      [...value.entries()].map(([key, child]) => [redactAutopilotValue(key), redactAutopilotValue(child)]),
+    );
   }
   if (value instanceof Set) return new Set([...value.values()].map((v) => redactAutopilotValue(v)));
   if (value && typeof value === "object") {

--- a/extensions/memory-hybrid/services/pending-autopilot/redaction.ts
+++ b/extensions/memory-hybrid/services/pending-autopilot/redaction.ts
@@ -14,23 +14,25 @@ const PRIVATE_KEY_FOOTER = " PRIVATE KEY-----";
 const PRIVATE_KEY_BARE_FOOTER = "PRIVATE KEY-----";
 const MAX_PRIVATE_KEY_BLOCK_LENGTH = 64_000;
 
-const CREDENTIAL_KEY_NORMALIZED = new Set([
-  "password",
-  "passwd",
-  "pwd",
-  "secret",
-  "token",
-  "apikey",
-  "apiSecret",
-  "authorization",
-  "authtoken",
-  "accesstoken",
-  "refreshtoken",
-  "bearertoken",
-  "clientsecret",
-  "privatekey",
-  "secretkey",
-].map((key) => key.toLowerCase()));
+const CREDENTIAL_KEY_NORMALIZED = new Set(
+  [
+    "password",
+    "passwd",
+    "pwd",
+    "secret",
+    "token",
+    "apikey",
+    "apiSecret",
+    "authorization",
+    "authtoken",
+    "accesstoken",
+    "refreshtoken",
+    "bearertoken",
+    "clientsecret",
+    "privatekey",
+    "secretkey",
+  ].map((key) => key.toLowerCase()),
+);
 
 export function redactAutopilotText(input: unknown): { redacted: string; redactionCount: number } {
   let { text, redactionCount } = redactPrivateKeyBlocks(

--- a/extensions/memory-hybrid/services/pending-autopilot/redaction.ts
+++ b/extensions/memory-hybrid/services/pending-autopilot/redaction.ts
@@ -14,6 +14,24 @@ const PRIVATE_KEY_FOOTER = " PRIVATE KEY-----";
 const PRIVATE_KEY_BARE_FOOTER = "PRIVATE KEY-----";
 const MAX_PRIVATE_KEY_BLOCK_LENGTH = 64_000;
 
+const CREDENTIAL_KEY_NORMALIZED = new Set([
+  "password",
+  "passwd",
+  "pwd",
+  "secret",
+  "token",
+  "apikey",
+  "apiSecret",
+  "authorization",
+  "authtoken",
+  "accesstoken",
+  "refreshtoken",
+  "bearertoken",
+  "clientsecret",
+  "privatekey",
+  "secretkey",
+].map((key) => key.toLowerCase()));
+
 export function redactAutopilotText(input: unknown): { redacted: string; redactionCount: number } {
   let { text, redactionCount } = redactPrivateKeyBlocks(
     typeof input === "string" ? input : JSON.stringify(input ?? ""),
@@ -75,10 +93,20 @@ function redactPrivateKeyBlocks(text: string): { text: string; redactionCount: n
 export function redactAutopilotValue(value: unknown): unknown {
   if (typeof value === "string") return redactAutopilotText(value).redacted;
   if (Array.isArray(value)) return value.map((v) => redactAutopilotValue(v));
+  if (value instanceof Date) return value.toISOString();
+  if (value instanceof URL) return redactAutopilotText(value.toString()).redacted;
+  if (value instanceof Map) {
+    return [...value.entries()].map(([key, child]) => [redactAutopilotValue(key), redactAutopilotValue(child)]);
+  }
+  if (value instanceof Set) return [...value.values()].map((v) => redactAutopilotValue(v));
   if (value && typeof value === "object") {
+    const maybeToJson = (value as { toJSON?: unknown }).toJSON;
+    if (typeof maybeToJson === "function" && Object.getPrototypeOf(value) !== Object.prototype) {
+      return redactAutopilotValue(maybeToJson.call(value));
+    }
     const out: Record<string, unknown> = {};
     for (const [key, child] of Object.entries(value)) {
-      if (/password|passwd|pwd|secret|token|api[_-]?key|authorization/i.test(key)) {
+      if (isCredentialKey(key)) {
         out[key] = "[REDACTED]";
       } else {
         out[key] = redactAutopilotValue(child);
@@ -87,4 +115,9 @@ export function redactAutopilotValue(value: unknown): unknown {
     return out;
   }
   return value;
+}
+
+function isCredentialKey(key: string): boolean {
+  const normalized = key.replace(/[\s_-]/g, "").toLowerCase();
+  return CREDENTIAL_KEY_NORMALIZED.has(normalized);
 }

--- a/extensions/memory-hybrid/services/pending-autopilot/redaction.ts
+++ b/extensions/memory-hybrid/services/pending-autopilot/redaction.ts
@@ -3,7 +3,7 @@
 const SECRET_PATTERNS: RegExp[] = [
   /\b(?:sk|pk|rk|ghp|gho|github_pat|xox[baprs])[-_][A-Za-z0-9_-]{8,}\b/g,
   /\bAKIA[0-9A-Z]{16}\b/g,
-  /\b(?:password|passwd|pwd|secret|token|api[_-]?key|authorization)\s*[:=]\s*[^\s,;}{\]]+/gi,
+  /\b(?:password|passwd|pwd|secret|token|api[_-]?key|authorization)\s*[:=]\s*[^\s,;}{\[\]]+/gi,
   /\bBearer\s+[A-Za-z0-9._~+/-]+=*/gi,
   /\b[a-z][a-z0-9+.-]*:\/\/[^\s:@/]+:[^\s@/]+@[^\s]+/gi,
 ];

--- a/extensions/memory-hybrid/services/pending-autopilot/redaction.ts
+++ b/extensions/memory-hybrid/services/pending-autopilot/redaction.ts
@@ -99,7 +99,10 @@ export function redactAutopilotValue(value: unknown): unknown {
   if (value instanceof URL) return redactAutopilotText(value.toString()).redacted;
   if (value instanceof Map) {
     return new Map(
-      [...value.entries()].map(([key, child]) => [redactAutopilotValue(key), redactAutopilotValue(child)]),
+      [...value.entries()].map(([key, child]) => [
+        redactAutopilotValue(key),
+        typeof key === "string" && isCredentialKey(key) ? "[REDACTED]" : redactAutopilotValue(child),
+      ]),
     );
   }
   if (value instanceof Set) return new Set([...value.values()].map((v) => redactAutopilotValue(v)));

--- a/extensions/memory-hybrid/services/pending-autopilot/redaction.ts
+++ b/extensions/memory-hybrid/services/pending-autopilot/redaction.ts
@@ -1,0 +1,39 @@
+/** Redaction helpers for pending-autopilot audit and summary output (#1334). */
+
+const SECRET_PATTERNS: RegExp[] = [
+  /\b(?:sk|pk|rk|ghp|gho|github_pat|xox[baprs])-[-_a-zA-Z0-9]{8,}\b/g,
+  /\bAKIA[0-9A-Z]{16}\b/g,
+  /-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----/g,
+  /\b(?:password|passwd|pwd|secret|token|api[_-]?key|authorization)\s*[:=]\s*[^\s,;}{\]]+/gi,
+  /\bBearer\s+[A-Za-z0-9._~+/-]+=*/gi,
+  /\b[a-z][a-z0-9+.-]*:\/\/[^\s:@/]+:[^\s@/]+@[^\s]+/gi,
+];
+
+export function redactAutopilotText(input: unknown): { redacted: string; redactionCount: number } {
+  let text = typeof input === "string" ? input : JSON.stringify(input ?? "");
+  let redactionCount = 0;
+  for (const pattern of SECRET_PATTERNS) {
+    text = text.replace(pattern, () => {
+      redactionCount += 1;
+      return "[REDACTED]";
+    });
+  }
+  return { redacted: text, redactionCount };
+}
+
+export function redactAutopilotValue(value: unknown): unknown {
+  if (typeof value === "string") return redactAutopilotText(value).redacted;
+  if (Array.isArray(value)) return value.map((v) => redactAutopilotValue(v));
+  if (value && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [key, child] of Object.entries(value)) {
+      if (/password|passwd|pwd|secret|token|api[_-]?key|authorization/i.test(key)) {
+        out[key] = "[REDACTED]";
+      } else {
+        out[key] = redactAutopilotValue(child);
+      }
+    }
+    return out;
+  }
+  return value;
+}

--- a/extensions/memory-hybrid/services/pending-autopilot/store.ts
+++ b/extensions/memory-hybrid/services/pending-autopilot/store.ts
@@ -154,6 +154,7 @@ export class PendingAutopilotStore extends BaseSqliteStore {
     owner: string;
     mode: AutopilotMode;
   }): boolean {
+    assertKnownEnum("queue", input.queue);
     assertKnownEnum("mode", input.mode);
     if (input.mode === "dry-run") return false;
     const result = this.liveDb
@@ -170,6 +171,7 @@ export class PendingAutopilotStore extends BaseSqliteStore {
     mode: AutopilotMode;
     mutate: () => void;
   }): boolean {
+    assertKnownEnum("queue", input.queue);
     assertKnownEnum("mode", input.mode);
     if (input.mode === "dry-run") return false;
     if (input.expectedInputHash !== input.actualInputHash) return false;

--- a/extensions/memory-hybrid/services/pending-autopilot/store.ts
+++ b/extensions/memory-hybrid/services/pending-autopilot/store.ts
@@ -129,14 +129,21 @@ export class PendingAutopilotStore extends BaseSqliteStore {
     assertKnownEnum("mode", input.mode);
     if (input.mode === "dry-run") return false;
     const now = nowSeconds();
-    this.liveDb.prepare("DELETE FROM pending_autopilot_locks WHERE expires_at <= ?").run(now);
-    const result = this.liveDb
-      .prepare(
-        `INSERT OR IGNORE INTO pending_autopilot_locks (queue, item_id, input_hash, owner, expires_at, created_at)
-         VALUES (?, ?, ?, ?, ?, ?)`,
-      )
-      .run(input.queue, input.itemId, input.inputHash, input.owner, now + input.ttlSeconds, now);
-    return result.changes > 0;
+    const tx = createTransaction(
+      this.liveDb,
+      () => {
+        this.liveDb.prepare("DELETE FROM pending_autopilot_locks WHERE expires_at <= ?").run(now);
+        const result = this.liveDb
+          .prepare(
+            `INSERT OR IGNORE INTO pending_autopilot_locks (queue, item_id, input_hash, owner, expires_at, created_at)
+             VALUES (?, ?, ?, ?, ?, ?)`,
+          )
+          .run(input.queue, input.itemId, input.inputHash, input.owner, now + input.ttlSeconds, now);
+        return result.changes > 0;
+      },
+      "IMMEDIATE",
+    );
+    return tx();
   }
 
   releaseLock(input: {

--- a/extensions/memory-hybrid/services/pending-autopilot/store.ts
+++ b/extensions/memory-hybrid/services/pending-autopilot/store.ts
@@ -167,7 +167,7 @@ export class PendingAutopilotStore extends BaseSqliteStore {
     owner: string;
     actualInputHash: string;
     mutate: () => void;
-    audit?: () => void;
+    audit: () => void;
   }): boolean {
     const safe = sanitizePendingDecision(input.decision);
     if (safe.mode === "dry-run") return false;
@@ -180,7 +180,7 @@ export class PendingAutopilotStore extends BaseSqliteStore {
         if (!lock || lock.inputHash !== safe.inputHash) return false;
         const inserted = this.insertDecision(safe).inserted;
         if (!inserted) return false;
-        if (input.audit) input.audit();
+        input.audit();
         input.mutate();
         return true;
       },

--- a/extensions/memory-hybrid/services/pending-autopilot/store.ts
+++ b/extensions/memory-hybrid/services/pending-autopilot/store.ts
@@ -341,9 +341,13 @@ export function migratePendingAutopilotTables(db: DatabaseSync): void {
       summary_json TEXT,
       audit_json TEXT,
       created_at INTEGER NOT NULL,
-      UNIQUE(queue, item_id, input_hash, policy, action)
+      UNIQUE(queue, item_id, input_hash, policy, policy_version, action)
     );
+  `);
 
+  migrateDecisionPolicyVersionUnique(db);
+
+  db.exec(`
     CREATE TABLE IF NOT EXISTS pending_autopilot_cursors (
       queue TEXT NOT NULL,
       policy TEXT NOT NULL DEFAULT 'default',
@@ -368,6 +372,49 @@ export function migratePendingAutopilotTables(db: DatabaseSync): void {
     CREATE INDEX IF NOT EXISTS idx_pending_autopilot_decisions_run ON pending_autopilot_decisions(run_id);
     CREATE INDEX IF NOT EXISTS idx_pending_autopilot_decisions_queue ON pending_autopilot_decisions(queue, item_id);
     CREATE INDEX IF NOT EXISTS idx_pending_autopilot_locks_expiry ON pending_autopilot_locks(expires_at);
+  `);
+}
+
+function migrateDecisionPolicyVersionUnique(db: DatabaseSync): void {
+  const row = db
+    .prepare("SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'pending_autopilot_decisions'")
+    .get() as { sql?: string } | undefined;
+  if (!row?.sql?.includes("UNIQUE(queue, item_id, input_hash, policy, action)")) return;
+
+  db.exec(`
+    ALTER TABLE pending_autopilot_decisions RENAME TO pending_autopilot_decisions_old_policy_unique;
+
+    CREATE TABLE pending_autopilot_decisions (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      queue TEXT NOT NULL,
+      item_id TEXT NOT NULL,
+      input_hash TEXT NOT NULL,
+      policy TEXT NOT NULL DEFAULT 'default',
+      policy_version TEXT NOT NULL,
+      mode TEXT NOT NULL,
+      action TEXT NOT NULL,
+      reason_code TEXT NOT NULL,
+      action_class TEXT NOT NULL,
+      capability_class TEXT NOT NULL,
+      confidence REAL NOT NULL,
+      human_review_required INTEGER NOT NULL,
+      evidence_json TEXT NOT NULL DEFAULT '[]',
+      actor_json TEXT NOT NULL DEFAULT '{}',
+      run_id TEXT NOT NULL,
+      job_id TEXT,
+      summary_json TEXT,
+      audit_json TEXT,
+      created_at INTEGER NOT NULL,
+      UNIQUE(queue, item_id, input_hash, policy, policy_version, action)
+    );
+
+    INSERT OR IGNORE INTO pending_autopilot_decisions
+      (id, queue, item_id, input_hash, policy, policy_version, mode, action, reason_code, action_class, capability_class, confidence, human_review_required, evidence_json, actor_json, run_id, job_id, summary_json, audit_json, created_at)
+    SELECT
+      id, queue, item_id, input_hash, policy, policy_version, mode, action, reason_code, action_class, capability_class, confidence, human_review_required, evidence_json, actor_json, run_id, job_id, summary_json, audit_json, created_at
+    FROM pending_autopilot_decisions_old_policy_unique;
+
+    DROP TABLE pending_autopilot_decisions_old_policy_unique;
   `);
 }
 

--- a/extensions/memory-hybrid/services/pending-autopilot/store.ts
+++ b/extensions/memory-hybrid/services/pending-autopilot/store.ts
@@ -182,7 +182,11 @@ export class PendingAutopilotStore extends BaseSqliteStore {
     return tx();
   }
 
-  /** @deprecated Use mutateWithLockAndAudit so lock ownership and audit atomicity are enforced. */
+  /**
+   * @deprecated Use mutateWithLockAndAudit so lock ownership and audit atomicity are enforced.
+   * This legacy CAS-only helper intentionally no-ops: #1334 requires every mutating path
+   * to revalidate an active lock and write audit state transactionally before mutation.
+   */
   mutateWithInputHash(input: {
     queue: PendingQueue;
     itemId: string;
@@ -193,10 +197,11 @@ export class PendingAutopilotStore extends BaseSqliteStore {
   }): boolean {
     assertKnownEnum("queue", input.queue);
     assertKnownEnum("mode", input.mode);
-    if (input.mode === "dry-run") return false;
-    if (input.expectedInputHash !== input.actualInputHash) return false;
-    input.mutate();
-    return true;
+    void input.itemId;
+    void input.expectedInputHash;
+    void input.actualInputHash;
+    void input.mutate;
+    return false;
   }
 
   listDecisions(filter: { queue?: PendingQueue; itemId?: string } = {}): PendingDecision[] {

--- a/extensions/memory-hybrid/services/pending-autopilot/store.ts
+++ b/extensions/memory-hybrid/services/pending-autopilot/store.ts
@@ -1,0 +1,303 @@
+/** Durable SQLite state for Pending Autopilot control-plane runs (#1334). */
+
+import { mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+import { DatabaseSync, type SQLInputValue } from "node:sqlite";
+import { BaseSqliteStore } from "../../backends/base-sqlite-store.js";
+import { sanitizePendingDecision, shouldAdvancePendingCursor, stableRunSummaryJson } from "./foundation.js";
+import type {
+  AutopilotMode,
+  PendingAutopilotLock,
+  PendingAutopilotRunSummary,
+  PendingDecision,
+  PendingQueue,
+} from "./types.js";
+import { assertKnownEnum } from "./types.js";
+
+export interface CreatePendingRunInput {
+  runId: string;
+  mode: AutopilotMode;
+  policyVersion: string;
+  inputHash: string;
+  queues: PendingQueue[];
+  startedAt?: number;
+  summary?: PendingAutopilotRunSummary;
+}
+
+export class PendingAutopilotStore extends BaseSqliteStore {
+  constructor(dbPath: string) {
+    mkdirSync(dirname(dbPath), { recursive: true });
+    const db = new DatabaseSync(dbPath);
+    super(db);
+    migratePendingAutopilotTables(this.liveDb);
+  }
+
+  protected getSubsystemName(): string {
+    return "pending-autopilot-store";
+  }
+
+  createRun(input: CreatePendingRunInput): void {
+    assertKnownEnum("mode", input.mode);
+    for (const queue of input.queues) assertKnownEnum("queue", queue);
+    const now = input.startedAt ?? nowSeconds();
+    this.liveDb
+      .prepare(
+        `INSERT OR IGNORE INTO pending_autopilot_runs
+          (id, mode, policy_version, input_hash, queues_json, started_at, summary_json)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        input.runId,
+        input.mode,
+        input.policyVersion,
+        input.inputHash,
+        JSON.stringify(input.queues),
+        now,
+        input.summary ? stableRunSummaryJson(input.summary) : null,
+      );
+  }
+
+  finishRun(runId: string, summary: PendingAutopilotRunSummary, finishedAt = nowSeconds()): void {
+    this.liveDb
+      .prepare("UPDATE pending_autopilot_runs SET finished_at = ?, summary_json = ? WHERE id = ?")
+      .run(finishedAt, stableRunSummaryJson(summary), runId);
+  }
+
+  recordDecision(decision: PendingDecision): { inserted: boolean } {
+    const safe = sanitizePendingDecision(decision);
+    if (safe.mode === "dry-run") return { inserted: false };
+    const createdAt = safe.createdAt ?? nowSeconds();
+    const result = this.liveDb
+      .prepare(
+        `INSERT OR IGNORE INTO pending_autopilot_decisions
+          (queue, item_id, input_hash, policy_version, mode, action, reason_code, action_class, capability_class, run_id, summary_json, audit_json, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        safe.queue,
+        safe.itemId,
+        safe.inputHash,
+        safe.policyVersion,
+        safe.mode,
+        safe.action,
+        safe.reasonCode,
+        safe.actionClass,
+        safe.capabilityClass ?? null,
+        safe.runId ?? null,
+        safe.summary ? JSON.stringify(safe.summary) : null,
+        safe.audit ? JSON.stringify(safe.audit) : null,
+        createdAt,
+      );
+    return { inserted: result.changes > 0 };
+  }
+
+  advanceCursorIfSafe(decision: PendingDecision, cursor: string): boolean {
+    const safe = sanitizePendingDecision(decision);
+    if (safe.mode === "dry-run" || !shouldAdvancePendingCursor(safe)) return false;
+    this.liveDb
+      .prepare(
+        `INSERT INTO pending_autopilot_cursors (queue, cursor, input_hash, policy_version, updated_at)
+         VALUES (?, ?, ?, ?, ?)
+         ON CONFLICT(queue) DO UPDATE SET
+           cursor = excluded.cursor,
+           input_hash = excluded.input_hash,
+           policy_version = excluded.policy_version,
+           updated_at = excluded.updated_at`,
+      )
+      .run(safe.queue, cursor, safe.inputHash, safe.policyVersion, nowSeconds());
+    return true;
+  }
+
+  getCursor(
+    queue: PendingQueue,
+  ): { queue: PendingQueue; cursor: string; inputHash: string; policyVersion: string; updatedAt: number } | null {
+    assertKnownEnum("queue", queue);
+    const row = this.liveDb.prepare("SELECT * FROM pending_autopilot_cursors WHERE queue = ?").get(queue) as
+      | Record<string, unknown>
+      | undefined;
+    if (!row) return null;
+    return {
+      queue,
+      cursor: row.cursor as string,
+      inputHash: row.input_hash as string,
+      policyVersion: row.policy_version as string,
+      updatedAt: row.updated_at as number,
+    };
+  }
+
+  acquireLock(input: {
+    queue: PendingQueue;
+    itemId: string;
+    inputHash: string;
+    owner: string;
+    ttlSeconds: number;
+    mode: AutopilotMode;
+  }): boolean {
+    assertKnownEnum("queue", input.queue);
+    assertKnownEnum("mode", input.mode);
+    if (input.mode === "dry-run") return false;
+    const now = nowSeconds();
+    this.liveDb.prepare("DELETE FROM pending_autopilot_locks WHERE expires_at <= ?").run(now);
+    const result = this.liveDb
+      .prepare(
+        `INSERT OR IGNORE INTO pending_autopilot_locks (queue, item_id, input_hash, owner, expires_at, created_at)
+         VALUES (?, ?, ?, ?, ?, ?)`,
+      )
+      .run(input.queue, input.itemId, input.inputHash, input.owner, now + input.ttlSeconds, now);
+    return result.changes > 0;
+  }
+
+  releaseLock(input: {
+    queue: PendingQueue;
+    itemId: string;
+    inputHash: string;
+    owner: string;
+    mode: AutopilotMode;
+  }): boolean {
+    assertKnownEnum("mode", input.mode);
+    if (input.mode === "dry-run") return false;
+    const result = this.liveDb
+      .prepare("DELETE FROM pending_autopilot_locks WHERE queue = ? AND item_id = ? AND input_hash = ? AND owner = ?")
+      .run(input.queue, input.itemId, input.inputHash, input.owner);
+    return result.changes > 0;
+  }
+
+  mutateWithInputHash(input: {
+    queue: PendingQueue;
+    itemId: string;
+    expectedInputHash: string;
+    actualInputHash: string;
+    mode: AutopilotMode;
+    mutate: () => void;
+  }): boolean {
+    assertKnownEnum("mode", input.mode);
+    if (input.mode === "dry-run") return false;
+    if (input.expectedInputHash !== input.actualInputHash) return false;
+    input.mutate();
+    return true;
+  }
+
+  listDecisions(filter: { queue?: PendingQueue; itemId?: string } = {}): PendingDecision[] {
+    const clauses: string[] = [];
+    const params: SQLInputValue[] = [];
+    if (filter.queue) {
+      clauses.push("queue = ?");
+      params.push(filter.queue);
+    }
+    if (filter.itemId) {
+      clauses.push("item_id = ?");
+      params.push(filter.itemId);
+    }
+    const where = clauses.length ? `WHERE ${clauses.join(" AND ")}` : "";
+    const rows = this.liveDb
+      .prepare(`SELECT * FROM pending_autopilot_decisions ${where} ORDER BY created_at, queue, item_id`)
+      .all(...params) as Record<string, unknown>[];
+    return rows.map(rowToDecision);
+  }
+
+  listLocks(): PendingAutopilotLock[] {
+    const rows = this.liveDb.prepare("SELECT * FROM pending_autopilot_locks ORDER BY queue, item_id").all() as Record<
+      string,
+      unknown
+    >[];
+    return rows.map((row) => ({
+      queue: row.queue as PendingQueue,
+      itemId: row.item_id as string,
+      inputHash: row.input_hash as string,
+      owner: row.owner as string,
+      expiresAt: row.expires_at as number,
+      createdAt: row.created_at as number,
+    }));
+  }
+
+  tableCounts(): Record<string, number> {
+    const out: Record<string, number> = {};
+    for (const table of [
+      "pending_autopilot_runs",
+      "pending_autopilot_decisions",
+      "pending_autopilot_cursors",
+      "pending_autopilot_locks",
+    ] as const) {
+      out[table] = (this.liveDb.prepare(`SELECT COUNT(*) AS n FROM ${table}`).get() as { n: number }).n;
+    }
+    return out;
+  }
+}
+
+export function migratePendingAutopilotTables(db: DatabaseSync): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS pending_autopilot_runs (
+      id TEXT PRIMARY KEY,
+      mode TEXT NOT NULL,
+      policy_version TEXT NOT NULL,
+      input_hash TEXT NOT NULL,
+      queues_json TEXT NOT NULL DEFAULT '[]',
+      started_at INTEGER NOT NULL,
+      finished_at INTEGER,
+      summary_json TEXT
+    );
+
+    CREATE TABLE IF NOT EXISTS pending_autopilot_decisions (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      queue TEXT NOT NULL,
+      item_id TEXT NOT NULL,
+      input_hash TEXT NOT NULL,
+      policy_version TEXT NOT NULL,
+      mode TEXT NOT NULL,
+      action TEXT NOT NULL,
+      reason_code TEXT NOT NULL,
+      action_class TEXT NOT NULL,
+      capability_class TEXT,
+      run_id TEXT,
+      summary_json TEXT,
+      audit_json TEXT,
+      created_at INTEGER NOT NULL,
+      UNIQUE(queue, item_id, input_hash, policy_version)
+    );
+
+    CREATE TABLE IF NOT EXISTS pending_autopilot_cursors (
+      queue TEXT PRIMARY KEY,
+      cursor TEXT NOT NULL,
+      input_hash TEXT NOT NULL,
+      policy_version TEXT NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS pending_autopilot_locks (
+      queue TEXT NOT NULL,
+      item_id TEXT NOT NULL,
+      input_hash TEXT NOT NULL,
+      owner TEXT NOT NULL,
+      expires_at INTEGER NOT NULL,
+      created_at INTEGER NOT NULL,
+      PRIMARY KEY(queue, item_id)
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_pending_autopilot_runs_started ON pending_autopilot_runs(started_at DESC);
+    CREATE INDEX IF NOT EXISTS idx_pending_autopilot_decisions_run ON pending_autopilot_decisions(run_id);
+    CREATE INDEX IF NOT EXISTS idx_pending_autopilot_decisions_queue ON pending_autopilot_decisions(queue, item_id);
+    CREATE INDEX IF NOT EXISTS idx_pending_autopilot_locks_expiry ON pending_autopilot_locks(expires_at);
+  `);
+}
+
+function rowToDecision(row: Record<string, unknown>): PendingDecision {
+  return {
+    queue: row.queue as PendingQueue,
+    itemId: row.item_id as string,
+    inputHash: row.input_hash as string,
+    policyVersion: row.policy_version as string,
+    mode: row.mode as AutopilotMode,
+    action: row.action as PendingDecision["action"],
+    reasonCode: row.reason_code as PendingDecision["reasonCode"],
+    actionClass: row.action_class as PendingDecision["actionClass"],
+    capabilityClass: (row.capability_class as PendingDecision["capabilityClass"]) ?? undefined,
+    runId: (row.run_id as string | null) ?? undefined,
+    summary: row.summary_json ? JSON.parse(row.summary_json as string) : undefined,
+    audit: row.audit_json ? JSON.parse(row.audit_json as string) : undefined,
+    createdAt: row.created_at as number,
+  };
+}
+
+function nowSeconds(): number {
+  return Math.floor(Date.now() / 1000);
+}

--- a/extensions/memory-hybrid/services/pending-autopilot/store.ts
+++ b/extensions/memory-hybrid/services/pending-autopilot/store.ts
@@ -389,6 +389,8 @@ function migrateDecisionPolicyVersionUnique(db: DatabaseSync): void {
   if (!row?.sql?.includes("UNIQUE(queue, item_id, input_hash, policy, action)")) return;
 
   db.exec(`
+    BEGIN;
+
     ALTER TABLE pending_autopilot_decisions RENAME TO pending_autopilot_decisions_old_policy_unique;
 
     CREATE TABLE pending_autopilot_decisions (
@@ -422,6 +424,8 @@ function migrateDecisionPolicyVersionUnique(db: DatabaseSync): void {
     FROM pending_autopilot_decisions_old_policy_unique;
 
     DROP TABLE pending_autopilot_decisions_old_policy_unique;
+
+    COMMIT;
   `);
 }
 

--- a/extensions/memory-hybrid/services/pending-autopilot/store.ts
+++ b/extensions/memory-hybrid/services/pending-autopilot/store.ts
@@ -4,6 +4,7 @@ import { mkdirSync } from "node:fs";
 import { dirname } from "node:path";
 import { DatabaseSync, type SQLInputValue } from "node:sqlite";
 import { BaseSqliteStore } from "../../backends/base-sqlite-store.js";
+import { createTransaction } from "../../utils/sqlite-transaction.js";
 import { sanitizePendingDecision, shouldAdvancePendingCursor, stableRunSummaryJson } from "./foundation.js";
 import type {
   AutopilotMode,
@@ -17,6 +18,7 @@ import { assertKnownEnum } from "./types.js";
 export interface CreatePendingRunInput {
   runId: string;
   mode: AutopilotMode;
+  policy: string;
   policyVersion: string;
   inputHash: string;
   queues: PendingQueue[];
@@ -39,16 +41,18 @@ export class PendingAutopilotStore extends BaseSqliteStore {
   createRun(input: CreatePendingRunInput): void {
     assertKnownEnum("mode", input.mode);
     for (const queue of input.queues) assertKnownEnum("queue", queue);
+    if (input.mode === "dry-run") return;
     const now = input.startedAt ?? nowSeconds();
     this.liveDb
       .prepare(
         `INSERT OR IGNORE INTO pending_autopilot_runs
-          (id, mode, policy_version, input_hash, queues_json, started_at, summary_json)
-         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+          (id, mode, policy, policy_version, input_hash, queues_json, started_at, summary_json)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
       )
       .run(
         input.runId,
         input.mode,
+        input.policy,
         input.policyVersion,
         input.inputHash,
         JSON.stringify(input.queues),
@@ -58,6 +62,7 @@ export class PendingAutopilotStore extends BaseSqliteStore {
   }
 
   finishRun(runId: string, summary: PendingAutopilotRunSummary, finishedAt = nowSeconds()): void {
+    if (summary.mode === "dry-run") return;
     this.liveDb
       .prepare("UPDATE pending_autopilot_runs SET finished_at = ?, summary_json = ? WHERE id = ?")
       .run(finishedAt, stableRunSummaryJson(summary), runId);
@@ -66,29 +71,7 @@ export class PendingAutopilotStore extends BaseSqliteStore {
   recordDecision(decision: PendingDecision): { inserted: boolean } {
     const safe = sanitizePendingDecision(decision);
     if (safe.mode === "dry-run") return { inserted: false };
-    const createdAt = safe.createdAt ?? nowSeconds();
-    const result = this.liveDb
-      .prepare(
-        `INSERT OR IGNORE INTO pending_autopilot_decisions
-          (queue, item_id, input_hash, policy_version, mode, action, reason_code, action_class, capability_class, run_id, summary_json, audit_json, created_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-      )
-      .run(
-        safe.queue,
-        safe.itemId,
-        safe.inputHash,
-        safe.policyVersion,
-        safe.mode,
-        safe.action,
-        safe.reasonCode,
-        safe.actionClass,
-        safe.capabilityClass ?? null,
-        safe.runId ?? null,
-        safe.summary ? JSON.stringify(safe.summary) : null,
-        safe.audit ? JSON.stringify(safe.audit) : null,
-        createdAt,
-      );
-    return { inserted: result.changes > 0 };
+    return this.insertDecision(safe);
   }
 
   advanceCursorIfSafe(decision: PendingDecision, cursor: string): boolean {
@@ -96,28 +79,30 @@ export class PendingAutopilotStore extends BaseSqliteStore {
     if (safe.mode === "dry-run" || !shouldAdvancePendingCursor(safe)) return false;
     this.liveDb
       .prepare(
-        `INSERT INTO pending_autopilot_cursors (queue, cursor, input_hash, policy_version, updated_at)
-         VALUES (?, ?, ?, ?, ?)
-         ON CONFLICT(queue) DO UPDATE SET
+        `INSERT INTO pending_autopilot_cursors (queue, policy, cursor, input_hash, policy_version, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?)
+         ON CONFLICT(queue, policy) DO UPDATE SET
            cursor = excluded.cursor,
            input_hash = excluded.input_hash,
            policy_version = excluded.policy_version,
            updated_at = excluded.updated_at`,
       )
-      .run(safe.queue, cursor, safe.inputHash, safe.policyVersion, nowSeconds());
+      .run(safe.queue, safe.policy, cursor, safe.inputHash, safe.policyVersion, nowSeconds());
     return true;
   }
 
   getCursor(
     queue: PendingQueue,
-  ): { queue: PendingQueue; cursor: string; inputHash: string; policyVersion: string; updatedAt: number } | null {
+    policy = "default",
+  ): { queue: PendingQueue; policy: string; cursor: string; inputHash: string; policyVersion: string; updatedAt: number } | null {
     assertKnownEnum("queue", queue);
-    const row = this.liveDb.prepare("SELECT * FROM pending_autopilot_cursors WHERE queue = ?").get(queue) as
+    const row = this.liveDb.prepare("SELECT * FROM pending_autopilot_cursors WHERE queue = ? AND policy = ?").get(queue, policy) as
       | Record<string, unknown>
       | undefined;
     if (!row) return null;
     return {
       queue,
+      policy: row.policy as string,
       cursor: row.cursor as string,
       inputHash: row.input_hash as string,
       policyVersion: row.policy_version as string,
@@ -163,6 +148,34 @@ export class PendingAutopilotStore extends BaseSqliteStore {
     return result.changes > 0;
   }
 
+  mutateWithLockAndAudit(input: {
+    decision: PendingDecision;
+    owner: string;
+    actualInputHash: string;
+    mutate: () => void;
+    audit?: () => void;
+  }): boolean {
+    const safe = sanitizePendingDecision(input.decision);
+    if (safe.mode === "dry-run") return false;
+    assertKnownEnum("queue", safe.queue);
+    const tx = createTransaction(
+      this.liveDb,
+      () => {
+        if (safe.inputHash !== input.actualInputHash) return false;
+        const lock = this.getActiveLockInternal(safe.queue, safe.itemId, input.owner, nowSeconds());
+        if (!lock || lock.inputHash !== safe.inputHash) return false;
+        const inserted = this.insertDecision(safe).inserted;
+        if (!inserted) return false;
+        if (input.audit) input.audit();
+        input.mutate();
+        return true;
+      },
+      "IMMEDIATE",
+    );
+    return tx();
+  }
+
+  /** @deprecated Use mutateWithLockAndAudit so lock ownership and audit atomicity are enforced. */
   mutateWithInputHash(input: {
     queue: PendingQueue;
     itemId: string;
@@ -224,6 +237,56 @@ export class PendingAutopilotStore extends BaseSqliteStore {
     }
     return out;
   }
+
+  private insertDecision(safe: PendingDecision): { inserted: boolean } {
+    const createdAt = safe.createdAt ?? nowSeconds();
+    const result = this.liveDb
+      .prepare(
+        `INSERT OR IGNORE INTO pending_autopilot_decisions
+          (queue, item_id, input_hash, policy, policy_version, mode, action, reason_code, action_class, capability_class, confidence, human_review_required, evidence_json, actor_json, run_id, job_id, summary_json, audit_json, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        safe.queue,
+        safe.itemId,
+        safe.inputHash,
+        safe.policy,
+        safe.policyVersion,
+        safe.mode,
+        safe.action,
+        safe.reasonCode,
+        safe.actionClass,
+        safe.capabilityClass,
+        safe.confidence,
+        safe.humanReviewRequired ? 1 : 0,
+        JSON.stringify(safe.evidence),
+        JSON.stringify(safe.actor),
+        safe.runId,
+        safe.jobId ?? null,
+        safe.summary ? JSON.stringify(safe.summary) : null,
+        safe.audit ? JSON.stringify(safe.audit) : null,
+        createdAt,
+      );
+    return { inserted: result.changes > 0 };
+  }
+
+  private getActiveLockInternal(queue: PendingQueue, itemId: string, owner: string, now: number): PendingAutopilotLock | null {
+    const row = this.liveDb
+      .prepare(
+        `SELECT * FROM pending_autopilot_locks
+         WHERE queue = ? AND item_id = ? AND owner = ? AND expires_at > ?`,
+      )
+      .get(queue, itemId, owner, now) as Record<string, unknown> | undefined;
+    if (!row) return null;
+    return {
+      queue: row.queue as PendingQueue,
+      itemId: row.item_id as string,
+      inputHash: row.input_hash as string,
+      owner: row.owner as string,
+      expiresAt: row.expires_at as number,
+      createdAt: row.created_at as number,
+    };
+  }
 }
 
 export function migratePendingAutopilotTables(db: DatabaseSync): void {
@@ -231,6 +294,7 @@ export function migratePendingAutopilotTables(db: DatabaseSync): void {
     CREATE TABLE IF NOT EXISTS pending_autopilot_runs (
       id TEXT PRIMARY KEY,
       mode TEXT NOT NULL,
+      policy TEXT NOT NULL DEFAULT 'default',
       policy_version TEXT NOT NULL,
       input_hash TEXT NOT NULL,
       queues_json TEXT NOT NULL DEFAULT '[]',
@@ -244,25 +308,33 @@ export function migratePendingAutopilotTables(db: DatabaseSync): void {
       queue TEXT NOT NULL,
       item_id TEXT NOT NULL,
       input_hash TEXT NOT NULL,
+      policy TEXT NOT NULL DEFAULT 'default',
       policy_version TEXT NOT NULL,
       mode TEXT NOT NULL,
       action TEXT NOT NULL,
       reason_code TEXT NOT NULL,
       action_class TEXT NOT NULL,
-      capability_class TEXT,
-      run_id TEXT,
+      capability_class TEXT NOT NULL,
+      confidence REAL NOT NULL,
+      human_review_required INTEGER NOT NULL,
+      evidence_json TEXT NOT NULL DEFAULT '[]',
+      actor_json TEXT NOT NULL DEFAULT '{}',
+      run_id TEXT NOT NULL,
+      job_id TEXT,
       summary_json TEXT,
       audit_json TEXT,
       created_at INTEGER NOT NULL,
-      UNIQUE(queue, item_id, input_hash, policy_version)
+      UNIQUE(queue, item_id, input_hash, policy, action)
     );
 
     CREATE TABLE IF NOT EXISTS pending_autopilot_cursors (
-      queue TEXT PRIMARY KEY,
+      queue TEXT NOT NULL,
+      policy TEXT NOT NULL DEFAULT 'default',
       cursor TEXT NOT NULL,
       input_hash TEXT NOT NULL,
       policy_version TEXT NOT NULL,
-      updated_at INTEGER NOT NULL
+      updated_at INTEGER NOT NULL,
+      PRIMARY KEY(queue, policy)
     );
 
     CREATE TABLE IF NOT EXISTS pending_autopilot_locks (
@@ -287,13 +359,19 @@ function rowToDecision(row: Record<string, unknown>): PendingDecision {
     queue: row.queue as PendingQueue,
     itemId: row.item_id as string,
     inputHash: row.input_hash as string,
+    policy: row.policy as string,
     policyVersion: row.policy_version as string,
     mode: row.mode as AutopilotMode,
     action: row.action as PendingDecision["action"],
     reasonCode: row.reason_code as PendingDecision["reasonCode"],
     actionClass: row.action_class as PendingDecision["actionClass"],
-    capabilityClass: (row.capability_class as PendingDecision["capabilityClass"]) ?? undefined,
-    runId: (row.run_id as string | null) ?? undefined,
+    capabilityClass: row.capability_class as PendingDecision["capabilityClass"],
+    confidence: row.confidence as number,
+    humanReviewRequired: Boolean(row.human_review_required),
+    evidence: JSON.parse(row.evidence_json as string),
+    actor: JSON.parse(row.actor_json as string),
+    runId: row.run_id as string,
+    jobId: (row.job_id as string | null) ?? undefined,
     summary: row.summary_json ? JSON.parse(row.summary_json as string) : undefined,
     audit: row.audit_json ? JSON.parse(row.audit_json as string) : undefined,
     createdAt: row.created_at as number,

--- a/extensions/memory-hybrid/services/pending-autopilot/store.ts
+++ b/extensions/memory-hybrid/services/pending-autopilot/store.ts
@@ -94,11 +94,18 @@ export class PendingAutopilotStore extends BaseSqliteStore {
   getCursor(
     queue: PendingQueue,
     policy = "default",
-  ): { queue: PendingQueue; policy: string; cursor: string; inputHash: string; policyVersion: string; updatedAt: number } | null {
+  ): {
+    queue: PendingQueue;
+    policy: string;
+    cursor: string;
+    inputHash: string;
+    policyVersion: string;
+    updatedAt: number;
+  } | null {
     assertKnownEnum("queue", queue);
-    const row = this.liveDb.prepare("SELECT * FROM pending_autopilot_cursors WHERE queue = ? AND policy = ?").get(queue, policy) as
-      | Record<string, unknown>
-      | undefined;
+    const row = this.liveDb
+      .prepare("SELECT * FROM pending_autopilot_cursors WHERE queue = ? AND policy = ?")
+      .get(queue, policy) as Record<string, unknown> | undefined;
     if (!row) return null;
     return {
       queue,
@@ -270,7 +277,12 @@ export class PendingAutopilotStore extends BaseSqliteStore {
     return { inserted: result.changes > 0 };
   }
 
-  private getActiveLockInternal(queue: PendingQueue, itemId: string, owner: string, now: number): PendingAutopilotLock | null {
+  private getActiveLockInternal(
+    queue: PendingQueue,
+    itemId: string,
+    owner: string,
+    now: number,
+  ): PendingAutopilotLock | null {
     const row = this.liveDb
       .prepare(
         `SELECT * FROM pending_autopilot_locks

--- a/extensions/memory-hybrid/services/pending-autopilot/types.ts
+++ b/extensions/memory-hybrid/services/pending-autopilot/types.ts
@@ -1,0 +1,193 @@
+/**
+ * Shared Pending Autopilot control-plane contracts (#1334).
+ *
+ * This foundation is intentionally queue-policy agnostic. Child issues #1326-#1330
+ * plug concrete queue adapters for persona, procedures, verified facts, tool
+ * proposals, and crystallization on top of these contracts without changing the
+ * durable state or audit invariants defined here.
+ */
+
+export const PENDING_QUEUES = ["persona", "procedures", "verified", "tools", "crystallization"] as const;
+export type PendingQueue = (typeof PENDING_QUEUES)[number];
+
+export const AUTOPILOT_MODES = ["dry-run", "apply"] as const;
+export type AutopilotMode = (typeof AUTOPILOT_MODES)[number];
+
+export const AUTOPILOT_ACTIONS = [
+  "reported",
+  "classified",
+  "applied",
+  "rejected",
+  "promoted-to-draft",
+  "deferred-for-human",
+  "failed-validation",
+  "skipped-by-policy",
+] as const;
+export type AutopilotAction = (typeof AUTOPILOT_ACTIONS)[number];
+
+export const AUTOPILOT_REASON_CODES = [
+  "already-processed",
+  "capability-not-allowed",
+  "dry-run",
+  "duplicate-input",
+  "human-review-required",
+  "input-hash-mismatch",
+  "invalid-item",
+  "lock-conflict",
+  "policy-denied",
+  "policy-threshold-not-met",
+  "schema-validation-failed",
+  "unknown-queue",
+] as const;
+export type AutopilotReasonCode = (typeof AUTOPILOT_REASON_CODES)[number];
+
+export const AUTOPILOT_CAPABILITY_CLASSES = ["read", "classify", "write-queue", "write-repo", "write-memory"] as const;
+export type AutopilotCapabilityClass = (typeof AUTOPILOT_CAPABILITY_CLASSES)[number];
+
+export const AUTOPILOT_ACTION_CLASSES = [
+  "observe",
+  "classify",
+  "mutate-queue",
+  "mutate-repo",
+  "mutate-memory",
+] as const;
+export type AutopilotActionClass = (typeof AUTOPILOT_ACTION_CLASSES)[number];
+
+const enumSets = {
+  queue: PENDING_QUEUES,
+  mode: AUTOPILOT_MODES,
+  action: AUTOPILOT_ACTIONS,
+  reasonCode: AUTOPILOT_REASON_CODES,
+  capabilityClass: AUTOPILOT_CAPABILITY_CLASSES,
+  actionClass: AUTOPILOT_ACTION_CLASSES,
+} as const;
+
+type EnumName = keyof typeof enumSets;
+
+export function isPendingQueue(value: unknown): value is PendingQueue {
+  return includes(PENDING_QUEUES, value);
+}
+
+export function isAutopilotMode(value: unknown): value is AutopilotMode {
+  return includes(AUTOPILOT_MODES, value);
+}
+
+export function isAutopilotAction(value: unknown): value is AutopilotAction {
+  return includes(AUTOPILOT_ACTIONS, value);
+}
+
+export function isAutopilotReasonCode(value: unknown): value is AutopilotReasonCode {
+  return includes(AUTOPILOT_REASON_CODES, value);
+}
+
+export function isAutopilotCapabilityClass(value: unknown): value is AutopilotCapabilityClass {
+  return includes(AUTOPILOT_CAPABILITY_CLASSES, value);
+}
+
+export function isAutopilotActionClass(value: unknown): value is AutopilotActionClass {
+  return includes(AUTOPILOT_ACTION_CLASSES, value);
+}
+
+export function assertKnownEnum<T extends EnumName>(name: T, value: unknown): (typeof enumSets)[T][number] {
+  const values = enumSets[name];
+  if (!includes(values, value)) {
+    throw new Error(`Unknown pending-autopilot ${name}: ${String(value)}`);
+  }
+  return value;
+}
+
+function includes<const T extends readonly string[]>(values: T, value: unknown): value is T[number] {
+  return typeof value === "string" && (values as readonly string[]).includes(value);
+}
+
+export interface RedactedAutopilotText {
+  redacted: string;
+  redactionCount: number;
+}
+
+export interface PendingItem<TPayload extends Record<string, unknown> = Record<string, unknown>> {
+  queue: PendingQueue;
+  id: string;
+  /** Stable content/policy input hash. Queue adapters must not include raw secrets in hash sources. */
+  inputHash: string;
+  policyVersion: string;
+  capabilityClasses: AutopilotCapabilityClass[];
+  payload: TPayload;
+  visibleAfterCursor?: string | null;
+  requiresHumanReview?: boolean;
+  validationFailed?: boolean;
+}
+
+export interface PendingDecision {
+  queue: PendingQueue;
+  itemId: string;
+  inputHash: string;
+  policyVersion: string;
+  mode: AutopilotMode;
+  action: AutopilotAction;
+  reasonCode: AutopilotReasonCode;
+  actionClass: AutopilotActionClass;
+  capabilityClass?: AutopilotCapabilityClass;
+  runId?: string;
+  summary?: RedactedAutopilotSummary;
+  audit?: RedactedAutopilotAudit;
+  createdAt?: number;
+}
+
+export interface PendingQueueAdapter<TItem extends PendingItem = PendingItem> {
+  queue: PendingQueue;
+  listPending(cursor?: PendingAutopilotCursor | null): Promise<TItem[]> | TItem[];
+  decide(item: TItem, context: PendingDecisionContext): Promise<PendingDecision> | PendingDecision;
+  apply?(decision: PendingDecision, item: TItem): Promise<void> | void;
+}
+
+export interface PendingDecisionContext {
+  runId: string;
+  mode: AutopilotMode;
+  policyVersion: string;
+  inputHash: string;
+}
+
+export interface PendingAutopilotRunSummary {
+  runId: string;
+  mode: AutopilotMode;
+  policyVersion: string;
+  queues: PendingQueue[];
+  startedAt: number;
+  finishedAt?: number;
+  totals: Record<AutopilotAction, number>;
+  decisions: Array<Pick<PendingDecision, "queue" | "itemId" | "inputHash" | "policyVersion" | "action" | "reasonCode">>;
+}
+
+export interface RedactedAutopilotSummary {
+  title?: string;
+  body?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface RedactedAutopilotAudit {
+  queue: PendingQueue;
+  itemId: string;
+  inputHash: string;
+  policyVersion: string;
+  action: AutopilotAction;
+  reasonCode: AutopilotReasonCode;
+  summary?: RedactedAutopilotSummary;
+}
+
+export interface PendingAutopilotCursor {
+  queue: PendingQueue;
+  cursor: string;
+  inputHash: string;
+  policyVersion: string;
+  updatedAt: number;
+}
+
+export interface PendingAutopilotLock {
+  queue: PendingQueue;
+  itemId: string;
+  inputHash: string;
+  owner: string;
+  expiresAt: number;
+  createdAt: number;
+}

--- a/extensions/memory-hybrid/services/pending-autopilot/types.ts
+++ b/extensions/memory-hybrid/services/pending-autopilot/types.ts
@@ -21,12 +21,15 @@ export const AUTOPILOT_ACTIONS = [
   "promoted-to-draft",
   "deferred-for-human",
   "failed-validation",
+  "failed-audit",
+  "unknown-decision",
   "skipped-by-policy",
 ] as const;
 export type AutopilotAction = (typeof AUTOPILOT_ACTIONS)[number];
 
 export const AUTOPILOT_REASON_CODES = [
   "already-processed",
+  "audit-write-failed",
   "capability-not-allowed",
   "dry-run",
   "duplicate-input",
@@ -34,22 +37,46 @@ export const AUTOPILOT_REASON_CODES = [
   "input-hash-mismatch",
   "invalid-item",
   "lock-conflict",
+  "lock-expired",
+  "lock-missing",
+  "lock-owner-mismatch",
   "policy-denied",
   "policy-threshold-not-met",
   "schema-validation-failed",
+  "unknown-decision",
   "unknown-queue",
 ] as const;
 export type AutopilotReasonCode = (typeof AUTOPILOT_REASON_CODES)[number];
 
-export const AUTOPILOT_CAPABILITY_CLASSES = ["read", "classify", "write-queue", "write-repo", "write-memory"] as const;
+/**
+ * Ordered from least to most authority. `apply` is only intent; queue adapters
+ * must map every planned action to one of these explicit approval boundaries.
+ */
+export const AUTOPILOT_CAPABILITY_CLASSES = [
+  "read-only",
+  "dry-run",
+  "record-review-metadata",
+  "safe-state-transition",
+  "write-draft-artifact",
+  "apply-low-risk-change",
+  "enable-behaviour",
+  "trust-changing-action",
+  "external-side-effect",
+  "destructive-action",
+] as const;
 export type AutopilotCapabilityClass = (typeof AUTOPILOT_CAPABILITY_CLASSES)[number];
 
 export const AUTOPILOT_ACTION_CLASSES = [
   "observe",
-  "classify",
-  "mutate-queue",
-  "mutate-repo",
-  "mutate-memory",
+  "preview",
+  "record-review",
+  "state-transition",
+  "draft-artifact",
+  "low-risk-apply",
+  "enable-behaviour",
+  "trust-change",
+  "external-side-effect",
+  "destructive",
 ] as const;
 export type AutopilotActionClass = (typeof AUTOPILOT_ACTION_CLASSES)[number];
 
@@ -118,17 +145,35 @@ export interface PendingItem<TPayload extends Record<string, unknown> = Record<s
   validationFailed?: boolean;
 }
 
+export interface PendingDecisionEvidence {
+  type: string;
+  id?: string;
+  summary?: string;
+}
+
+export interface PendingDecisionActorContext {
+  type: "system" | "agent" | "human" | "cron" | "test";
+  id: string;
+}
+
 export interface PendingDecision {
   queue: PendingQueue;
   itemId: string;
   inputHash: string;
+  /** Stable policy identifier/name; policyVersion identifies the exact revision. */
+  policy: string;
   policyVersion: string;
   mode: AutopilotMode;
   action: AutopilotAction;
   reasonCode: AutopilotReasonCode;
   actionClass: AutopilotActionClass;
-  capabilityClass?: AutopilotCapabilityClass;
-  runId?: string;
+  capabilityClass: AutopilotCapabilityClass;
+  confidence: number;
+  humanReviewRequired: boolean;
+  evidence: PendingDecisionEvidence[];
+  actor: PendingDecisionActorContext;
+  runId: string;
+  jobId?: string;
   summary?: RedactedAutopilotSummary;
   audit?: RedactedAutopilotAudit;
   createdAt?: number;
@@ -143,20 +188,38 @@ export interface PendingQueueAdapter<TItem extends PendingItem = PendingItem> {
 
 export interface PendingDecisionContext {
   runId: string;
+  jobId?: string;
   mode: AutopilotMode;
+  policy: string;
   policyVersion: string;
   inputHash: string;
+  actor: PendingDecisionActorContext;
 }
 
 export interface PendingAutopilotRunSummary {
   runId: string;
   mode: AutopilotMode;
+  policy: string;
   policyVersion: string;
   queues: PendingQueue[];
   startedAt: number;
   finishedAt?: number;
   totals: Record<AutopilotAction, number>;
-  decisions: Array<Pick<PendingDecision, "queue" | "itemId" | "inputHash" | "policyVersion" | "action" | "reasonCode">>;
+  decisions: Array<
+    Pick<
+      PendingDecision,
+      | "queue"
+      | "itemId"
+      | "inputHash"
+      | "policy"
+      | "policyVersion"
+      | "action"
+      | "reasonCode"
+      | "capabilityClass"
+      | "confidence"
+      | "humanReviewRequired"
+    >
+  >;
 }
 
 export interface RedactedAutopilotSummary {
@@ -169,14 +232,22 @@ export interface RedactedAutopilotAudit {
   queue: PendingQueue;
   itemId: string;
   inputHash: string;
+  policy: string;
   policyVersion: string;
   action: AutopilotAction;
   reasonCode: AutopilotReasonCode;
+  capabilityClass: AutopilotCapabilityClass;
+  humanReviewRequired: boolean;
+  evidence: PendingDecisionEvidence[];
+  actor: PendingDecisionActorContext;
+  runId: string;
+  jobId?: string;
   summary?: RedactedAutopilotSummary;
 }
 
 export interface PendingAutopilotCursor {
   queue: PendingQueue;
+  policy: string;
   cursor: string;
   inputHash: string;
   policyVersion: string;

--- a/extensions/memory-hybrid/tests/helpers/pending-autopilot-equivalence.ts
+++ b/extensions/memory-hybrid/tests/helpers/pending-autopilot-equivalence.ts
@@ -30,6 +30,7 @@ export async function expectStandaloneAndParentDecisionsEquivalent<TItem extends
       payload: fixture.item.payload,
       policyVersion: fixture.policyVersion,
     });
+    expect(fixture.item.inputHash).toBe(inputHash);
     const baseContext: PendingDecisionContext = {
       runId: "standalone",
       mode: "dry-run",

--- a/extensions/memory-hybrid/tests/helpers/pending-autopilot-equivalence.ts
+++ b/extensions/memory-hybrid/tests/helpers/pending-autopilot-equivalence.ts
@@ -3,43 +3,54 @@ import type {
   PendingDecision,
   PendingDecisionContext,
   PendingItem,
-  PendingQueueAdapter,
 } from "../../services/pending-autopilot/index.js";
 import { computePendingInputHash, sanitizePendingDecision } from "../../services/pending-autopilot/index.js";
 
 export interface PendingAutopilotEquivalenceFixture<TItem extends PendingItem = PendingItem> {
   item: TItem;
+  policy: string;
   policyVersion: string;
 }
 
+export type PendingAutopilotExecutionPath<TItem extends PendingItem = PendingItem> = (
+  item: TItem,
+  context: PendingDecisionContext,
+) => Promise<PendingDecision> | PendingDecision;
+
 /**
  * Parent/child equivalence primitive for child issues #1326-#1330.
- * It proves a queue adapter emits the same decisions when invoked standalone and
- * when invoked through a parent-style run context for the same fixture and input hash.
+ * Callers must pass two distinct execution paths: standalone child execution and
+ * parent orchestration execution. The harness compares normalized decisions for
+ * the same fixture, policy, and input hash.
  */
-export async function expectStandaloneAndParentDecisionsEquivalent<TItem extends PendingItem>(
-  adapter: PendingQueueAdapter<TItem>,
-  fixtures: PendingAutopilotEquivalenceFixture<TItem>[],
-): Promise<void> {
+export async function expectStandaloneAndParentDecisionsEquivalent<TItem extends PendingItem>(input: {
+  standalone: PendingAutopilotExecutionPath<TItem>;
+  parent: PendingAutopilotExecutionPath<TItem>;
+  fixtures: PendingAutopilotEquivalenceFixture<TItem>[];
+}): Promise<void> {
   const standalone: PendingDecision[] = [];
   const parentRun: PendingDecision[] = [];
-  for (const fixture of fixtures) {
+  for (const fixture of input.fixtures) {
     const inputHash = computePendingInputHash({
       queue: fixture.item.queue,
       id: fixture.item.id,
       payload: fixture.item.payload,
+      policy: fixture.policy,
       policyVersion: fixture.policyVersion,
     });
     expect(fixture.item.inputHash).toBe(inputHash);
     const baseContext: PendingDecisionContext = {
       runId: "standalone",
+      jobId: "job-1",
       mode: "dry-run",
+      policy: fixture.policy,
       policyVersion: fixture.policyVersion,
       inputHash: fixture.item.inputHash,
+      actor: { type: "test", id: "equivalence-harness" },
     };
     const parentContext: PendingDecisionContext = { ...baseContext, runId: "parent-run" };
-    standalone.push(sanitizePendingDecision(await adapter.decide(fixture.item, baseContext)));
-    parentRun.push(sanitizePendingDecision(await adapter.decide(fixture.item, parentContext)));
+    standalone.push(sanitizePendingDecision(await input.standalone(fixture.item, baseContext)));
+    parentRun.push(sanitizePendingDecision(await input.parent(fixture.item, parentContext)));
   }
   expect(normalize(standalone)).toEqual(normalize(parentRun));
 }
@@ -47,5 +58,9 @@ export async function expectStandaloneAndParentDecisionsEquivalent<TItem extends
 function normalize(decisions: PendingDecision[]): Array<Omit<PendingDecision, "runId" | "createdAt">> {
   return decisions
     .map(({ runId: _runId, createdAt: _createdAt, ...decision }) => decision)
-    .sort((a, b) => `${a.queue}:${a.itemId}`.localeCompare(`${b.queue}:${b.itemId}`));
+    .sort((a, b) => {
+      const ak = `${a.queue}:${a.itemId}:${a.policy}:${a.inputHash}`;
+      const bk = `${b.queue}:${b.itemId}:${b.policy}:${b.inputHash}`;
+      return ak < bk ? -1 : ak > bk ? 1 : 0;
+    });
 }

--- a/extensions/memory-hybrid/tests/helpers/pending-autopilot-equivalence.ts
+++ b/extensions/memory-hybrid/tests/helpers/pending-autopilot-equivalence.ts
@@ -35,7 +35,7 @@ export async function expectStandaloneAndParentDecisionsEquivalent<TItem extends
       runId: "standalone",
       mode: "dry-run",
       policyVersion: fixture.policyVersion,
-      inputHash,
+      inputHash: fixture.item.inputHash,
     };
     const parentContext: PendingDecisionContext = { ...baseContext, runId: "parent-run" };
     standalone.push(sanitizePendingDecision(await adapter.decide(fixture.item, baseContext)));

--- a/extensions/memory-hybrid/tests/helpers/pending-autopilot-equivalence.ts
+++ b/extensions/memory-hybrid/tests/helpers/pending-autopilot-equivalence.ts
@@ -1,0 +1,50 @@
+import { expect } from "vitest";
+import type {
+  PendingDecision,
+  PendingDecisionContext,
+  PendingItem,
+  PendingQueueAdapter,
+} from "../../services/pending-autopilot/index.js";
+import { computePendingInputHash, sanitizePendingDecision } from "../../services/pending-autopilot/index.js";
+
+export interface PendingAutopilotEquivalenceFixture<TItem extends PendingItem = PendingItem> {
+  item: TItem;
+  policyVersion: string;
+}
+
+/**
+ * Parent/child equivalence primitive for child issues #1326-#1330.
+ * It proves a queue adapter emits the same decisions when invoked standalone and
+ * when invoked through a parent-style run context for the same fixture and input hash.
+ */
+export async function expectStandaloneAndParentDecisionsEquivalent<TItem extends PendingItem>(
+  adapter: PendingQueueAdapter<TItem>,
+  fixtures: PendingAutopilotEquivalenceFixture<TItem>[],
+): Promise<void> {
+  const standalone: PendingDecision[] = [];
+  const parentRun: PendingDecision[] = [];
+  for (const fixture of fixtures) {
+    const inputHash = computePendingInputHash({
+      queue: fixture.item.queue,
+      id: fixture.item.id,
+      payload: fixture.item.payload,
+      policyVersion: fixture.policyVersion,
+    });
+    const baseContext: PendingDecisionContext = {
+      runId: "standalone",
+      mode: "dry-run",
+      policyVersion: fixture.policyVersion,
+      inputHash,
+    };
+    const parentContext: PendingDecisionContext = { ...baseContext, runId: "parent-run" };
+    standalone.push(sanitizePendingDecision(await adapter.decide(fixture.item, baseContext)));
+    parentRun.push(sanitizePendingDecision(await adapter.decide(fixture.item, parentContext)));
+  }
+  expect(normalize(standalone)).toEqual(normalize(parentRun));
+}
+
+function normalize(decisions: PendingDecision[]): Array<Omit<PendingDecision, "runId" | "createdAt">> {
+  return decisions
+    .map(({ runId: _runId, createdAt: _createdAt, ...decision }) => decision)
+    .sort((a, b) => `${a.queue}:${a.itemId}`.localeCompare(`${b.queue}:${b.itemId}`));
+}

--- a/extensions/memory-hybrid/tests/helpers/pending-autopilot-equivalence.ts
+++ b/extensions/memory-hybrid/tests/helpers/pending-autopilot-equivalence.ts
@@ -1,9 +1,5 @@
 import { expect } from "vitest";
-import type {
-  PendingDecision,
-  PendingDecisionContext,
-  PendingItem,
-} from "../../services/pending-autopilot/index.js";
+import type { PendingDecision, PendingDecisionContext, PendingItem } from "../../services/pending-autopilot/index.js";
 import { computePendingInputHash, sanitizePendingDecision } from "../../services/pending-autopilot/index.js";
 
 export interface PendingAutopilotEquivalenceFixture<TItem extends PendingItem = PendingItem> {

--- a/extensions/memory-hybrid/tests/pending-autopilot-foundation.test.ts
+++ b/extensions/memory-hybrid/tests/pending-autopilot-foundation.test.ts
@@ -124,7 +124,12 @@ describe("pending-autopilot shared contracts", () => {
 describe("pending-autopilot durable state invariants", () => {
   it("dry-run contract writes no durable foundation tables, including run rows", () => {
     const before = store.tableCounts();
-    const dry = decision({ mode: "dry-run", reasonCode: "dry-run", capabilityClass: "dry-run", actionClass: "preview" });
+    const dry = decision({
+      mode: "dry-run",
+      reasonCode: "dry-run",
+      capabilityClass: "dry-run",
+      actionClass: "preview",
+    });
     store.createRun({
       runId: dry.runId,
       mode: "dry-run",
@@ -133,15 +138,18 @@ describe("pending-autopilot durable state invariants", () => {
       inputHash: dry.inputHash,
       queues: ["persona"],
     });
-    store.finishRun(dry.runId, createStableRunSummary({
-      runId: dry.runId,
-      mode: "dry-run",
-      policy: dry.policy,
-      policyVersion: dry.policyVersion,
-      queues: ["persona"],
-      startedAt: 1,
-      decisions: [dry],
-    }));
+    store.finishRun(
+      dry.runId,
+      createStableRunSummary({
+        runId: dry.runId,
+        mode: "dry-run",
+        policy: dry.policy,
+        policyVersion: dry.policyVersion,
+        queues: ["persona"],
+        startedAt: 1,
+        decisions: [dry],
+      }),
+    );
     expect(store.recordDecision(dry).inserted).toBe(false);
     expect(
       store.acquireLock({
@@ -313,7 +321,11 @@ describe("pending-autopilot durable state invariants", () => {
   it("idempotently records the same queue/item/hash/policy/action only once", () => {
     expect(store.recordDecision(decision()).inserted).toBe(true);
     expect(store.recordDecision(decision()).inserted).toBe(false);
-    expect(store.recordDecision(decision({ action: "applied", capabilityClass: "apply-low-risk-change", actionClass: "low-risk-apply" })).inserted).toBe(true);
+    expect(
+      store.recordDecision(
+        decision({ action: "applied", capabilityClass: "apply-low-risk-change", actionClass: "low-risk-apply" }),
+      ).inserted,
+    ).toBe(true);
     expect(store.listDecisions()).toHaveLength(2);
   });
 
@@ -335,10 +347,18 @@ describe("pending-autopilot durable state invariants", () => {
       store.advanceCursorIfSafe(decision({ action: "failed-audit", reasonCode: "audit-write-failed" }), "cursor-audit"),
     ).toBe(false);
     expect(
-      store.advanceCursorIfSafe(decision({ action: "unknown-decision", reasonCode: "unknown-decision" }), "cursor-unknown"),
+      store.advanceCursorIfSafe(
+        decision({ action: "unknown-decision", reasonCode: "unknown-decision" }),
+        "cursor-unknown",
+      ),
     ).toBe(false);
     expect(store.getCursor("persona")).toBeNull();
-    expect(store.advanceCursorIfSafe(decision({ action: "applied", capabilityClass: "apply-low-risk-change", actionClass: "low-risk-apply" }), "cursor-applied")).toBe(true);
+    expect(
+      store.advanceCursorIfSafe(
+        decision({ action: "applied", capabilityClass: "apply-low-risk-change", actionClass: "low-risk-apply" }),
+        "cursor-applied",
+      ),
+    ).toBe(true);
     expect(store.getCursor("persona")?.cursor).toBe("cursor-applied");
   });
 });
@@ -354,8 +374,20 @@ describe("pending-autopilot summaries and harness", () => {
       startedAt: 100,
       finishedAt: 110,
       decisions: [
-        decision({ queue: "tools", itemId: "b", action: "reported", reasonCode: "already-processed", capabilityClass: "read-only", actionClass: "observe" }),
-        decision({ itemId: "a", action: "applied", capabilityClass: "apply-low-risk-change", actionClass: "low-risk-apply" }),
+        decision({
+          queue: "tools",
+          itemId: "b",
+          action: "reported",
+          reasonCode: "already-processed",
+          capabilityClass: "read-only",
+          actionClass: "observe",
+        }),
+        decision({
+          itemId: "a",
+          action: "applied",
+          capabilityClass: "apply-low-risk-change",
+          actionClass: "low-risk-apply",
+        }),
       ],
     });
     expect(stableRunSummaryJson(summary)).toMatchInlineSnapshot(

--- a/extensions/memory-hybrid/tests/pending-autopilot-foundation.test.ts
+++ b/extensions/memory-hybrid/tests/pending-autopilot-foundation.test.ts
@@ -1,0 +1,286 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  AUTOPILOT_ACTIONS,
+  AUTOPILOT_CAPABILITY_CLASSES,
+  AUTOPILOT_REASON_CODES,
+  PENDING_QUEUES,
+  PendingAutopilotStore,
+  type PendingDecision,
+  type PendingItem,
+  type PendingQueueAdapter,
+  assertKnownEnum,
+  computePendingInputHash,
+  createStableRunSummary,
+  redactAutopilotValue,
+  stableRunSummaryJson,
+} from "../services/pending-autopilot/index.js";
+import { expectStandaloneAndParentDecisionsEquivalent } from "./helpers/pending-autopilot-equivalence.js";
+
+let tmpDir: string;
+let store: PendingAutopilotStore;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "pending-autopilot-"));
+  store = new PendingAutopilotStore(join(tmpDir, "pending.db"));
+});
+
+afterEach(() => {
+  store.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function decision(overrides: Partial<PendingDecision> = {}): PendingDecision {
+  return {
+    queue: "persona",
+    itemId: "item-1",
+    inputHash: "hash-1",
+    policyVersion: "policy-v1",
+    mode: "apply",
+    action: "classified",
+    reasonCode: "policy-threshold-not-met",
+    actionClass: "classify",
+    capabilityClass: "classify",
+    ...overrides,
+  };
+}
+
+describe("pending-autopilot shared contracts", () => {
+  it("snapshots enum contracts and rejects unknown action/reason/capability values", () => {
+    expect({
+      queues: PENDING_QUEUES,
+      actions: AUTOPILOT_ACTIONS,
+      reasons: AUTOPILOT_REASON_CODES,
+      capabilities: AUTOPILOT_CAPABILITY_CLASSES,
+    }).toMatchInlineSnapshot(`
+      {
+        "actions": [
+          "reported",
+          "classified",
+          "applied",
+          "rejected",
+          "promoted-to-draft",
+          "deferred-for-human",
+          "failed-validation",
+          "skipped-by-policy",
+        ],
+        "capabilities": [
+          "read",
+          "classify",
+          "write-queue",
+          "write-repo",
+          "write-memory",
+        ],
+        "queues": [
+          "persona",
+          "procedures",
+          "verified",
+          "tools",
+          "crystallization",
+        ],
+        "reasons": [
+          "already-processed",
+          "capability-not-allowed",
+          "dry-run",
+          "duplicate-input",
+          "human-review-required",
+          "input-hash-mismatch",
+          "invalid-item",
+          "lock-conflict",
+          "policy-denied",
+          "policy-threshold-not-met",
+          "schema-validation-failed",
+          "unknown-queue",
+        ],
+      }
+    `);
+    expect(() => assertKnownEnum("action", "invented-action")).toThrow(/Unknown pending-autopilot action/);
+    expect(() => assertKnownEnum("reasonCode", "mystery")).toThrow(/Unknown pending-autopilot reasonCode/);
+    expect(() => assertKnownEnum("capabilityClass", "root-shell")).toThrow(/Unknown pending-autopilot capabilityClass/);
+  });
+});
+
+describe("pending-autopilot durable state invariants", () => {
+  it("dry-run contract writes no durable decision/cursor/lock state", () => {
+    const before = store.tableCounts();
+    expect(store.recordDecision(decision({ mode: "dry-run", reasonCode: "dry-run" })).inserted).toBe(false);
+    expect(
+      store.acquireLock({
+        queue: "persona",
+        itemId: "item-1",
+        inputHash: "hash-1",
+        owner: "test",
+        ttlSeconds: 60,
+        mode: "dry-run",
+      }),
+    ).toBe(false);
+    expect(
+      store.releaseLock({ queue: "persona", itemId: "item-1", inputHash: "hash-1", owner: "test", mode: "dry-run" }),
+    ).toBe(false);
+    expect(store.advanceCursorIfSafe(decision({ mode: "dry-run" }), "cursor-2")).toBe(false);
+    expect(
+      store.mutateWithInputHash({
+        queue: "persona",
+        itemId: "item-1",
+        expectedInputHash: "hash-1",
+        actualInputHash: "hash-1",
+        mode: "dry-run",
+        mutate: () => {
+          throw new Error("must not mutate");
+        },
+      }),
+    ).toBe(false);
+    expect(store.tableCounts()).toEqual(before);
+  });
+
+  it("redacts secrets/private data before persisted summaries and audit output", () => {
+    const input = decision({
+      summary: { title: "token test", body: "apiKey=sk-secret123456789 and password=hunter2" },
+      audit: {
+        queue: "persona",
+        itemId: "item-1",
+        inputHash: "hash-1",
+        policyVersion: "policy-v1",
+        action: "classified",
+        reasonCode: "policy-denied",
+        summary: { metadata: { token: "ghp_123456789abcdef", nested: "Bearer abcdefghijklmnop" } },
+      },
+    });
+    store.recordDecision(input);
+    const persisted = store.listDecisions()[0];
+    expect(JSON.stringify(persisted)).not.toContain("sk-secret");
+    expect(JSON.stringify(persisted)).not.toContain("hunter2");
+    expect(JSON.stringify(persisted)).not.toContain("ghp_123");
+    expect(JSON.stringify(persisted)).not.toContain("Bearer abc");
+    expect(JSON.stringify(persisted)).toContain("[REDACTED]");
+    expect(redactAutopilotValue({ password: "abc", url: "postgres://u:p@example/db" })).toEqual({
+      password: "[REDACTED]",
+      url: "[REDACTED]",
+    });
+  });
+
+  it("lock/CAS helpers block stale input hash mutations", () => {
+    let mutated = false;
+    expect(
+      store.acquireLock({
+        queue: "persona",
+        itemId: "item-1",
+        inputHash: "hash-fresh",
+        owner: "runner",
+        ttlSeconds: 60,
+        mode: "apply",
+      }),
+    ).toBe(true);
+    expect(
+      store.acquireLock({
+        queue: "persona",
+        itemId: "item-1",
+        inputHash: "hash-fresh",
+        owner: "runner-2",
+        ttlSeconds: 60,
+        mode: "apply",
+      }),
+    ).toBe(false);
+    expect(
+      store.mutateWithInputHash({
+        queue: "persona",
+        itemId: "item-1",
+        expectedInputHash: "hash-old",
+        actualInputHash: "hash-fresh",
+        mode: "apply",
+        mutate: () => {
+          mutated = true;
+        },
+      }),
+    ).toBe(false);
+    expect(mutated).toBe(false);
+    expect(
+      store.mutateWithInputHash({
+        queue: "persona",
+        itemId: "item-1",
+        expectedInputHash: "hash-fresh",
+        actualInputHash: "hash-fresh",
+        mode: "apply",
+        mutate: () => {
+          mutated = true;
+        },
+      }),
+    ).toBe(true);
+    expect(mutated).toBe(true);
+  });
+
+  it("idempotently records the same queue/item/hash/policy only once", () => {
+    expect(store.recordDecision(decision()).inserted).toBe(true);
+    expect(store.recordDecision(decision({ action: "applied" })).inserted).toBe(false);
+    expect(store.listDecisions()).toHaveLength(1);
+  });
+
+  it("does not hide human-review-required or failed-validation items by advancing cursor", () => {
+    expect(
+      store.advanceCursorIfSafe(
+        decision({ action: "deferred-for-human", reasonCode: "human-review-required" }),
+        "cursor-human",
+      ),
+    ).toBe(false);
+    expect(store.getCursor("persona")).toBeNull();
+    expect(
+      store.advanceCursorIfSafe(
+        decision({ action: "failed-validation", reasonCode: "schema-validation-failed" }),
+        "cursor-failed",
+      ),
+    ).toBe(false);
+    expect(store.getCursor("persona")).toBeNull();
+    expect(store.advanceCursorIfSafe(decision({ action: "applied" }), "cursor-applied")).toBe(true);
+    expect(store.getCursor("persona")?.cursor).toBe("cursor-applied");
+  });
+});
+
+describe("pending-autopilot summaries and harness", () => {
+  it("generates a stable JSON summary schema", () => {
+    const summary = createStableRunSummary({
+      runId: "run-1",
+      mode: "apply",
+      policyVersion: "policy-v1",
+      queues: ["tools", "persona"],
+      startedAt: 100,
+      finishedAt: 110,
+      decisions: [
+        decision({ queue: "tools", itemId: "b", action: "reported", reasonCode: "already-processed" }),
+        decision({ itemId: "a", action: "applied" }),
+      ],
+    });
+    expect(stableRunSummaryJson(summary)).toMatchInlineSnapshot(
+      `"{\"decisions\":[{\"action\":\"applied\",\"inputHash\":\"hash-1\",\"itemId\":\"a\",\"policyVersion\":\"policy-v1\",\"queue\":\"persona\",\"reasonCode\":\"policy-threshold-not-met\"},{\"action\":\"reported\",\"inputHash\":\"hash-1\",\"itemId\":\"b\",\"policyVersion\":\"policy-v1\",\"queue\":\"tools\",\"reasonCode\":\"already-processed\"}],\"finishedAt\":110,\"mode\":\"apply\",\"policyVersion\":\"policy-v1\",\"queues\":[\"persona\",\"tools\"],\"runId\":\"run-1\",\"startedAt\":100,\"totals\":{\"applied\":1,\"classified\":0,\"deferred-for-human\":0,\"failed-validation\":0,\"promoted-to-draft\":0,\"rejected\":0,\"reported\":1,\"skipped-by-policy\":0}}\n"`,
+    );
+  });
+
+  it("provides a parent/child equivalence harness primitive for fake adapters", async () => {
+    const adapter: PendingQueueAdapter = {
+      queue: "persona",
+      listPending: () => [],
+      decide: (item: PendingItem, context) =>
+        decision({
+          queue: item.queue,
+          itemId: item.id,
+          inputHash: context.inputHash,
+          policyVersion: context.policyVersion,
+          runId: context.runId,
+          mode: context.mode,
+          action: item.requiresHumanReview ? "deferred-for-human" : "classified",
+          reasonCode: item.requiresHumanReview ? "human-review-required" : "policy-threshold-not-met",
+        }),
+    };
+    const item: PendingItem = {
+      queue: "persona",
+      id: "fixture-1",
+      inputHash: computePendingInputHash({ id: "fixture-1" }),
+      policyVersion: "policy-v1",
+      capabilityClasses: ["classify"],
+      payload: { title: "hello" },
+      requiresHumanReview: true,
+    };
+    await expectStandaloneAndParentDecisionsEquivalent(adapter, [{ item, policyVersion: "policy-v1" }]);
+  });
+});

--- a/extensions/memory-hybrid/tests/pending-autopilot-foundation.test.ts
+++ b/extensions/memory-hybrid/tests/pending-autopilot-foundation.test.ts
@@ -175,6 +175,18 @@ describe("pending-autopilot durable state invariants", () => {
         },
       }),
     ).toBe(false);
+    expect(
+      store.mutateWithInputHash({
+        queue: "persona",
+        itemId: "item-1",
+        expectedInputHash: "hash-1",
+        actualInputHash: "hash-1",
+        mode: "dry-run",
+        mutate: () => {
+          throw new Error("must not mutate");
+        },
+      }),
+    ).toBe(false);
     expect(store.tableCounts()).toEqual(before);
   });
 
@@ -246,6 +258,19 @@ describe("pending-autopilot durable state invariants", () => {
   it("requires active lock ownership and transactional audit before mutation", () => {
     let mutated = false;
     const fresh = decision({ inputHash: "hash-fresh" });
+    expect(
+      store.mutateWithInputHash({
+        queue: "persona",
+        itemId: "item-1",
+        expectedInputHash: "hash-fresh",
+        actualInputHash: "hash-fresh",
+        mode: "apply",
+        mutate: () => {
+          mutated = true;
+        },
+      }),
+    ).toBe(false);
+    expect(mutated).toBe(false);
     expect(
       store.mutateWithLockAndAudit({
         decision: fresh,

--- a/extensions/memory-hybrid/tests/pending-autopilot-foundation.test.ts
+++ b/extensions/memory-hybrid/tests/pending-autopilot-foundation.test.ts
@@ -37,12 +37,19 @@ function decision(overrides: Partial<PendingDecision> = {}): PendingDecision {
     queue: "persona",
     itemId: "item-1",
     inputHash: "hash-1",
+    policy: "default",
     policyVersion: "policy-v1",
     mode: "apply",
     action: "classified",
     reasonCode: "policy-threshold-not-met",
-    actionClass: "classify",
-    capabilityClass: "classify",
+    actionClass: "record-review",
+    capabilityClass: "record-review-metadata",
+    confidence: 0.7,
+    humanReviewRequired: false,
+    evidence: [{ type: "fixture", id: "ev-1", summary: "safe" }],
+    actor: { type: "test", id: "unit" },
+    runId: "run-1",
+    jobId: "job-1",
     ...overrides,
   };
 }
@@ -64,14 +71,21 @@ describe("pending-autopilot shared contracts", () => {
           "promoted-to-draft",
           "deferred-for-human",
           "failed-validation",
+          "failed-audit",
+          "unknown-decision",
           "skipped-by-policy",
         ],
         "capabilities": [
-          "read",
-          "classify",
-          "write-queue",
-          "write-repo",
-          "write-memory",
+          "read-only",
+          "dry-run",
+          "record-review-metadata",
+          "safe-state-transition",
+          "write-draft-artifact",
+          "apply-low-risk-change",
+          "enable-behaviour",
+          "trust-changing-action",
+          "external-side-effect",
+          "destructive-action",
         ],
         "queues": [
           "persona",
@@ -82,6 +96,7 @@ describe("pending-autopilot shared contracts", () => {
         ],
         "reasons": [
           "already-processed",
+          "audit-write-failed",
           "capability-not-allowed",
           "dry-run",
           "duplicate-input",
@@ -89,9 +104,13 @@ describe("pending-autopilot shared contracts", () => {
           "input-hash-mismatch",
           "invalid-item",
           "lock-conflict",
+          "lock-expired",
+          "lock-missing",
+          "lock-owner-mismatch",
           "policy-denied",
           "policy-threshold-not-met",
           "schema-validation-failed",
+          "unknown-decision",
           "unknown-queue",
         ],
       }
@@ -103,9 +122,27 @@ describe("pending-autopilot shared contracts", () => {
 });
 
 describe("pending-autopilot durable state invariants", () => {
-  it("dry-run contract writes no durable decision/cursor/lock state", () => {
+  it("dry-run contract writes no durable foundation tables, including run rows", () => {
     const before = store.tableCounts();
-    expect(store.recordDecision(decision({ mode: "dry-run", reasonCode: "dry-run" })).inserted).toBe(false);
+    const dry = decision({ mode: "dry-run", reasonCode: "dry-run", capabilityClass: "dry-run", actionClass: "preview" });
+    store.createRun({
+      runId: dry.runId,
+      mode: "dry-run",
+      policy: dry.policy,
+      policyVersion: dry.policyVersion,
+      inputHash: dry.inputHash,
+      queues: ["persona"],
+    });
+    store.finishRun(dry.runId, createStableRunSummary({
+      runId: dry.runId,
+      mode: "dry-run",
+      policy: dry.policy,
+      policyVersion: dry.policyVersion,
+      queues: ["persona"],
+      startedAt: 1,
+      decisions: [dry],
+    }));
+    expect(store.recordDecision(dry).inserted).toBe(false);
     expect(
       store.acquireLock({
         queue: "persona",
@@ -119,14 +156,12 @@ describe("pending-autopilot durable state invariants", () => {
     expect(
       store.releaseLock({ queue: "persona", itemId: "item-1", inputHash: "hash-1", owner: "test", mode: "dry-run" }),
     ).toBe(false);
-    expect(store.advanceCursorIfSafe(decision({ mode: "dry-run" }), "cursor-2")).toBe(false);
+    expect(store.advanceCursorIfSafe(dry, "cursor-2")).toBe(false);
     expect(
-      store.mutateWithInputHash({
-        queue: "persona",
-        itemId: "item-1",
-        expectedInputHash: "hash-1",
+      store.mutateWithLockAndAudit({
+        decision: dry,
+        owner: "test",
         actualInputHash: "hash-1",
-        mode: "dry-run",
         mutate: () => {
           throw new Error("must not mutate");
         },
@@ -150,9 +185,15 @@ describe("pending-autopilot durable state invariants", () => {
         queue: "persona",
         itemId: "item-1",
         inputHash: "hash-1",
+        policy: "default",
         policyVersion: "policy-v1",
         action: "classified",
         reasonCode: "policy-denied",
+        capabilityClass: "record-review-metadata",
+        humanReviewRequired: false,
+        evidence: [{ type: "secret", summary: "Bearer abcdefghijklmnop" }],
+        actor: { type: "test", id: "unit" },
+        runId: "run-1",
         summary: { metadata: { token: "ghp_123456789abcdef", nested: "Bearer abcdefghijklmnop" } },
       },
     });
@@ -169,19 +210,45 @@ describe("pending-autopilot durable state invariants", () => {
       redactAutopilotValue({
         password: "abc",
         token: "github_pat_123456789abcdef",
+        tokenCount: 7,
+        secretary: "not-secret-key-name",
         url: "postgres://u:p@example/db",
         key: "-----BEGIN RSA PRIVATE KEY-----\nabc123\n-----END RSA PRIVATE KEY-----",
       }),
     ).toEqual({
       password: "[REDACTED]",
       token: "[REDACTED]",
+      tokenCount: 7,
+      secretary: "not-secret-key-name",
       url: "[REDACTED]",
       key: "[REDACTED]",
     });
   });
 
-  it("lock/CAS helpers block stale input hash mutations", () => {
+  it("input hashes change for non-secret field updates and non-plain objects", () => {
+    expect(computePendingInputHash({ tokenCount: 1 })).not.toBe(computePendingInputHash({ tokenCount: 2 }));
+    expect(computePendingInputHash({ at: new Date("2026-01-01T00:00:00Z") })).not.toBe(
+      computePendingInputHash({ at: new Date("2026-01-02T00:00:00Z") }),
+    );
+    expect(computePendingInputHash(new URL("https://example.com/a"))).not.toBe(
+      computePendingInputHash(new URL("https://example.com/b")),
+    );
+  });
+
+  it("requires active lock ownership and transactional audit before mutation", () => {
     let mutated = false;
+    const fresh = decision({ inputHash: "hash-fresh" });
+    expect(
+      store.mutateWithLockAndAudit({
+        decision: fresh,
+        owner: "runner",
+        actualInputHash: "hash-fresh",
+        mutate: () => {
+          mutated = true;
+        },
+      }),
+    ).toBe(false);
+    expect(mutated).toBe(false);
     expect(
       store.acquireLock({
         queue: "persona",
@@ -193,22 +260,10 @@ describe("pending-autopilot durable state invariants", () => {
       }),
     ).toBe(true);
     expect(
-      store.acquireLock({
-        queue: "persona",
-        itemId: "item-1",
-        inputHash: "hash-fresh",
-        owner: "runner-2",
-        ttlSeconds: 60,
-        mode: "apply",
-      }),
-    ).toBe(false);
-    expect(
-      store.mutateWithInputHash({
-        queue: "persona",
-        itemId: "item-1",
-        expectedInputHash: "hash-old",
+      store.mutateWithLockAndAudit({
+        decision: fresh,
+        owner: "wrong-runner",
         actualInputHash: "hash-fresh",
-        mode: "apply",
         mutate: () => {
           mutated = true;
         },
@@ -216,30 +271,56 @@ describe("pending-autopilot durable state invariants", () => {
     ).toBe(false);
     expect(mutated).toBe(false);
     expect(
-      store.mutateWithInputHash({
-        queue: "persona",
-        itemId: "item-1",
-        expectedInputHash: "hash-fresh",
+      store.mutateWithLockAndAudit({
+        decision: fresh,
+        owner: "runner",
+        actualInputHash: "hash-old",
+        mutate: () => {
+          mutated = true;
+        },
+      }),
+    ).toBe(false);
+    expect(mutated).toBe(false);
+    expect(() =>
+      store.mutateWithLockAndAudit({
+        decision: fresh,
+        owner: "runner",
         actualInputHash: "hash-fresh",
-        mode: "apply",
+        audit: () => {
+          throw new Error("audit unavailable");
+        },
+        mutate: () => {
+          mutated = true;
+        },
+      }),
+    ).toThrow(/audit unavailable/);
+    expect(mutated).toBe(false);
+    expect(store.listDecisions()).toHaveLength(0);
+    expect(
+      store.mutateWithLockAndAudit({
+        decision: fresh,
+        owner: "runner",
+        actualInputHash: "hash-fresh",
         mutate: () => {
           mutated = true;
         },
       }),
     ).toBe(true);
     expect(mutated).toBe(true);
-  });
-
-  it("idempotently records the same queue/item/hash/policy only once", () => {
-    expect(store.recordDecision(decision()).inserted).toBe(true);
-    expect(store.recordDecision(decision({ action: "applied" })).inserted).toBe(false);
     expect(store.listDecisions()).toHaveLength(1);
   });
 
-  it("does not hide human-review-required or failed-validation items by advancing cursor", () => {
+  it("idempotently records the same queue/item/hash/policy/action only once", () => {
+    expect(store.recordDecision(decision()).inserted).toBe(true);
+    expect(store.recordDecision(decision()).inserted).toBe(false);
+    expect(store.recordDecision(decision({ action: "applied", capabilityClass: "apply-low-risk-change", actionClass: "low-risk-apply" })).inserted).toBe(true);
+    expect(store.listDecisions()).toHaveLength(2);
+  });
+
+  it("does not hide human-review-required, failed-validation, failed-audit, or unknown decisions by advancing cursor", () => {
     expect(
       store.advanceCursorIfSafe(
-        decision({ action: "deferred-for-human", reasonCode: "human-review-required" }),
+        decision({ action: "deferred-for-human", reasonCode: "human-review-required", humanReviewRequired: true }),
         "cursor-human",
       ),
     ).toBe(false);
@@ -250,8 +331,14 @@ describe("pending-autopilot durable state invariants", () => {
         "cursor-failed",
       ),
     ).toBe(false);
+    expect(
+      store.advanceCursorIfSafe(decision({ action: "failed-audit", reasonCode: "audit-write-failed" }), "cursor-audit"),
+    ).toBe(false);
+    expect(
+      store.advanceCursorIfSafe(decision({ action: "unknown-decision", reasonCode: "unknown-decision" }), "cursor-unknown"),
+    ).toBe(false);
     expect(store.getCursor("persona")).toBeNull();
-    expect(store.advanceCursorIfSafe(decision({ action: "applied" }), "cursor-applied")).toBe(true);
+    expect(store.advanceCursorIfSafe(decision({ action: "applied", capabilityClass: "apply-low-risk-change", actionClass: "low-risk-apply" }), "cursor-applied")).toBe(true);
     expect(store.getCursor("persona")?.cursor).toBe("cursor-applied");
   });
 });
@@ -261,21 +348,22 @@ describe("pending-autopilot summaries and harness", () => {
     const summary = createStableRunSummary({
       runId: "run-1",
       mode: "apply",
+      policy: "default",
       policyVersion: "policy-v1",
       queues: ["tools", "persona"],
       startedAt: 100,
       finishedAt: 110,
       decisions: [
-        decision({ queue: "tools", itemId: "b", action: "reported", reasonCode: "already-processed" }),
-        decision({ itemId: "a", action: "applied" }),
+        decision({ queue: "tools", itemId: "b", action: "reported", reasonCode: "already-processed", capabilityClass: "read-only", actionClass: "observe" }),
+        decision({ itemId: "a", action: "applied", capabilityClass: "apply-low-risk-change", actionClass: "low-risk-apply" }),
       ],
     });
     expect(stableRunSummaryJson(summary)).toMatchInlineSnapshot(
-      `"{\"decisions\":[{\"action\":\"applied\",\"inputHash\":\"hash-1\",\"itemId\":\"a\",\"policyVersion\":\"policy-v1\",\"queue\":\"persona\",\"reasonCode\":\"policy-threshold-not-met\"},{\"action\":\"reported\",\"inputHash\":\"hash-1\",\"itemId\":\"b\",\"policyVersion\":\"policy-v1\",\"queue\":\"tools\",\"reasonCode\":\"already-processed\"}],\"finishedAt\":110,\"mode\":\"apply\",\"policyVersion\":\"policy-v1\",\"queues\":[\"persona\",\"tools\"],\"runId\":\"run-1\",\"startedAt\":100,\"totals\":{\"applied\":1,\"classified\":0,\"deferred-for-human\":0,\"failed-validation\":0,\"promoted-to-draft\":0,\"rejected\":0,\"reported\":1,\"skipped-by-policy\":0}}\n"`,
+      `"{\"decisions\":[{\"action\":\"applied\",\"capabilityClass\":\"apply-low-risk-change\",\"confidence\":0.7,\"humanReviewRequired\":false,\"inputHash\":\"hash-1\",\"itemId\":\"a\",\"policy\":\"default\",\"policyVersion\":\"policy-v1\",\"queue\":\"persona\",\"reasonCode\":\"policy-threshold-not-met\"},{\"action\":\"reported\",\"capabilityClass\":\"read-only\",\"confidence\":0.7,\"humanReviewRequired\":false,\"inputHash\":\"hash-1\",\"itemId\":\"b\",\"policy\":\"default\",\"policyVersion\":\"policy-v1\",\"queue\":\"tools\",\"reasonCode\":\"already-processed\"}],\"finishedAt\":110,\"mode\":\"apply\",\"policy\":\"default\",\"policyVersion\":\"policy-v1\",\"queues\":[\"persona\",\"tools\"],\"runId\":\"run-1\",\"startedAt\":100,\"totals\":{\"applied\":1,\"classified\":0,\"deferred-for-human\":0,\"failed-audit\":0,\"failed-validation\":0,\"promoted-to-draft\":0,\"rejected\":0,\"reported\":1,\"skipped-by-policy\":0,\"unknown-decision\":0}}\n"`,
     );
   });
 
-  it("provides a parent/child equivalence harness primitive for fake adapters", async () => {
+  it("provides a parent/child equivalence harness primitive for distinct fake execution paths", async () => {
     const adapter: PendingQueueAdapter = {
       queue: "persona",
       listPending: () => [],
@@ -284,12 +372,20 @@ describe("pending-autopilot summaries and harness", () => {
           queue: item.queue,
           itemId: item.id,
           inputHash: context.inputHash,
+          policy: context.policy,
           policyVersion: context.policyVersion,
           runId: context.runId,
+          actor: context.actor,
           mode: context.mode,
           action: item.requiresHumanReview ? "deferred-for-human" : "classified",
           reasonCode: item.requiresHumanReview ? "human-review-required" : "policy-threshold-not-met",
+          humanReviewRequired: item.requiresHumanReview === true,
         }),
+    };
+    const parentRunner = async (item: PendingItem, context: Parameters<typeof adapter.decide>[1]) => {
+      const listed = [item];
+      const match = listed.find((candidate) => candidate.id === item.id)!;
+      return adapter.decide(match, context);
     };
     const payload = { title: "hello" };
     const item: PendingItem = {
@@ -299,13 +395,18 @@ describe("pending-autopilot summaries and harness", () => {
         queue: "persona",
         id: "fixture-1",
         payload,
+        policy: "default",
         policyVersion: "policy-v1",
       }),
       policyVersion: "policy-v1",
-      capabilityClasses: ["classify"],
+      capabilityClasses: ["record-review-metadata"],
       payload,
       requiresHumanReview: true,
     };
-    await expectStandaloneAndParentDecisionsEquivalent(adapter, [{ item, policyVersion: "policy-v1" }]);
+    await expectStandaloneAndParentDecisionsEquivalent({
+      standalone: adapter.decide,
+      parent: parentRunner,
+      fixtures: [{ item, policy: "default", policyVersion: "policy-v1" }],
+    });
   });
 });

--- a/extensions/memory-hybrid/tests/pending-autopilot-foundation.test.ts
+++ b/extensions/memory-hybrid/tests/pending-autopilot-foundation.test.ts
@@ -173,6 +173,7 @@ describe("pending-autopilot durable state invariants", () => {
         decision: dry,
         owner: "test",
         actualInputHash: "hash-1",
+        audit: () => {},
         mutate: () => {
           throw new Error("must not mutate");
         },
@@ -328,6 +329,7 @@ describe("pending-autopilot durable state invariants", () => {
         decision: fresh,
         owner: "runner",
         actualInputHash: "hash-fresh",
+        audit: () => {},
         mutate: () => {
           mutated = true;
         },
@@ -349,6 +351,7 @@ describe("pending-autopilot durable state invariants", () => {
         decision: fresh,
         owner: "wrong-runner",
         actualInputHash: "hash-fresh",
+        audit: () => {},
         mutate: () => {
           mutated = true;
         },
@@ -360,6 +363,7 @@ describe("pending-autopilot durable state invariants", () => {
         decision: fresh,
         owner: "runner",
         actualInputHash: "hash-old",
+        audit: () => {},
         mutate: () => {
           mutated = true;
         },
@@ -386,6 +390,7 @@ describe("pending-autopilot durable state invariants", () => {
         decision: fresh,
         owner: "runner",
         actualInputHash: "hash-fresh",
+        audit: () => {},
         mutate: () => {
           mutated = true;
         },

--- a/extensions/memory-hybrid/tests/pending-autopilot-foundation.test.ts
+++ b/extensions/memory-hybrid/tests/pending-autopilot-foundation.test.ts
@@ -1,4 +1,5 @@
 import { mkdtempSync, rmSync } from "node:fs";
+import { DatabaseSync } from "node:sqlite";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -9,10 +10,12 @@ import {
   PENDING_QUEUES,
   PendingAutopilotStore,
   type PendingDecision,
+  migratePendingAutopilotTables,
   type PendingItem,
   type PendingQueueAdapter,
   assertKnownEnum,
   computePendingInputHash,
+  canonicalJson,
   createStableRunSummary,
   redactAutopilotValue,
   stableRunSummaryJson,
@@ -255,6 +258,55 @@ describe("pending-autopilot durable state invariants", () => {
     );
   });
 
+  it("deterministically serializes non-JSON top-level input hash values", () => {
+    const namedFunction = function pendingFixture() {
+      return undefined;
+    };
+    expect(canonicalJson(undefined)).toBe('{"__pendingAutopilotType":"undefined"}');
+    expect(() => computePendingInputHash(undefined)).not.toThrow();
+    expect(() => computePendingInputHash(namedFunction)).not.toThrow();
+    expect(() => computePendingInputHash(Symbol("pending"))).not.toThrow();
+    expect(() => computePendingInputHash(123n)).not.toThrow();
+    expect(computePendingInputHash(undefined)).toBe(computePendingInputHash(undefined));
+    expect(computePendingInputHash(namedFunction)).toBe(computePendingInputHash(namedFunction));
+    expect(computePendingInputHash(Symbol("pending"))).toBe(computePendingInputHash(Symbol("pending")));
+    expect(computePendingInputHash(Symbol("pending"))).not.toBe(computePendingInputHash(Symbol("other")));
+    expect(computePendingInputHash(123n)).not.toBe(computePendingInputHash(124n));
+  });
+
+  it("preserves Map and Set identity through redaction for deterministic canonicalization", () => {
+    const redactedMap = redactAutopilotValue(
+      new Map<unknown, unknown>([
+        ["token", "github_pat_123456789abcdef"],
+        [{ z: 1 }, new Set(["b", "a"])],
+      ]),
+    );
+    const redactedSet = redactAutopilotValue(new Set<unknown>(["b", "a", "Bearer abcdefghijklmnop"]));
+
+    expect(redactedMap).toBeInstanceOf(Map);
+    expect(redactedSet).toBeInstanceOf(Set);
+    expect(canonicalJson(new Set(["b", "a"]))).toBe(canonicalJson(new Set(["a", "b"])));
+    expect(
+      canonicalJson(
+        new Map([
+          ["b", 2],
+          ["a", 1],
+        ]),
+      ),
+    ).toBe(
+      canonicalJson(
+        new Map([
+          ["a", 1],
+          ["b", 2],
+        ]),
+      ),
+    );
+    expect(canonicalJson(redactedMap)).toContain('"__pendingAutopilotType":"Map"');
+    expect(canonicalJson(redactedSet)).toContain('"__pendingAutopilotType":"Set"');
+    expect(canonicalJson(redactedMap)).toContain("[REDACTED]");
+    expect(canonicalJson(redactedSet)).toContain("[REDACTED]");
+  });
+
   it("requires active lock ownership and transactional audit before mutation", () => {
     let mutated = false;
     const fresh = decision({ inputHash: "hash-fresh" });
@@ -343,7 +395,7 @@ describe("pending-autopilot durable state invariants", () => {
     expect(store.listDecisions()).toHaveLength(1);
   });
 
-  it("idempotently records the same queue/item/hash/policy/action only once", () => {
+  it("idempotently records the same queue/item/hash/policy/policy-version/action only once", () => {
     expect(store.recordDecision(decision()).inserted).toBe(true);
     expect(store.recordDecision(decision()).inserted).toBe(false);
     expect(
@@ -351,7 +403,54 @@ describe("pending-autopilot durable state invariants", () => {
         decision({ action: "applied", capabilityClass: "apply-low-risk-change", actionClass: "low-risk-apply" }),
       ).inserted,
     ).toBe(true);
-    expect(store.listDecisions()).toHaveLength(2);
+    expect(store.recordDecision(decision({ policyVersion: "policy-v2", runId: "run-2" })).inserted).toBe(true);
+    expect(store.listDecisions()).toHaveLength(3);
+  });
+
+  it("migrates the decisions unique key so policy-version upgrades are reprocessed", () => {
+    const db = new DatabaseSync(join(tmpDir, "legacy.db"));
+    db.exec(`
+      CREATE TABLE pending_autopilot_decisions (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        queue TEXT NOT NULL,
+        item_id TEXT NOT NULL,
+        input_hash TEXT NOT NULL,
+        policy TEXT NOT NULL DEFAULT 'default',
+        policy_version TEXT NOT NULL,
+        mode TEXT NOT NULL,
+        action TEXT NOT NULL,
+        reason_code TEXT NOT NULL,
+        action_class TEXT NOT NULL,
+        capability_class TEXT NOT NULL,
+        confidence REAL NOT NULL,
+        human_review_required INTEGER NOT NULL,
+        evidence_json TEXT NOT NULL DEFAULT '[]',
+        actor_json TEXT NOT NULL DEFAULT '{}',
+        run_id TEXT NOT NULL,
+        job_id TEXT,
+        summary_json TEXT,
+        audit_json TEXT,
+        created_at INTEGER NOT NULL,
+        UNIQUE(queue, item_id, input_hash, policy, action)
+      );
+    `);
+
+    migratePendingAutopilotTables(db);
+
+    const sql = db
+      .prepare("SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'pending_autopilot_decisions'")
+      .get() as { sql: string };
+    expect(sql.sql).toContain("UNIQUE(queue, item_id, input_hash, policy, policy_version, action)");
+
+    const insert = db.prepare(`
+      INSERT INTO pending_autopilot_decisions
+        (queue, item_id, input_hash, policy, policy_version, mode, action, reason_code, action_class, capability_class, confidence, human_review_required, evidence_json, actor_json, run_id, created_at)
+      VALUES ('persona', 'item-1', 'hash-1', 'default', ?, 'apply', 'classified', 'policy-threshold-not-met', 'record-review', 'record-review-metadata', 0.7, 0, '[]', '{}', ?, ?)
+    `);
+    insert.run("policy-v1", "run-1", 1);
+    insert.run("policy-v2", "run-2", 2);
+    expect((db.prepare("SELECT COUNT(*) AS n FROM pending_autopilot_decisions").get() as { n: number }).n).toBe(2);
+    db.close();
   });
 
   it("does not hide human-review-required, failed-validation, failed-audit, or unknown decisions by advancing cursor", () => {

--- a/extensions/memory-hybrid/tests/pending-autopilot-foundation.test.ts
+++ b/extensions/memory-hybrid/tests/pending-autopilot-foundation.test.ts
@@ -137,7 +137,15 @@ describe("pending-autopilot durable state invariants", () => {
 
   it("redacts secrets/private data before persisted summaries and audit output", () => {
     const input = decision({
-      summary: { title: "token test", body: "apiKey=sk-secret123456789 and password=hunter2" },
+      summary: {
+        title: "token test",
+        body: [
+          "apiKey=sk-secret123456789 and password=hunter2",
+          "classic github token ghp_123456789abcdef123456789abcdef123456",
+          "fine grained github token github_pat_abcdefghijklmnopqrstuvwxyz1234567890",
+          "-----BEGIN PRIVATE KEY-----\nabc123\n-----END PRIVATE KEY-----",
+        ].join("\n"),
+      },
       audit: {
         queue: "persona",
         itemId: "item-1",
@@ -153,7 +161,9 @@ describe("pending-autopilot durable state invariants", () => {
     expect(JSON.stringify(persisted)).not.toContain("sk-secret");
     expect(JSON.stringify(persisted)).not.toContain("hunter2");
     expect(JSON.stringify(persisted)).not.toContain("ghp_123");
+    expect(JSON.stringify(persisted)).not.toContain("github_pat_");
     expect(JSON.stringify(persisted)).not.toContain("Bearer abc");
+    expect(JSON.stringify(persisted)).not.toContain("-----BEGIN PRIVATE KEY-----");
     expect(JSON.stringify(persisted)).toContain("[REDACTED]");
     expect(
       redactAutopilotValue({

--- a/extensions/memory-hybrid/tests/pending-autopilot-foundation.test.ts
+++ b/extensions/memory-hybrid/tests/pending-autopilot-foundation.test.ts
@@ -155,9 +155,18 @@ describe("pending-autopilot durable state invariants", () => {
     expect(JSON.stringify(persisted)).not.toContain("ghp_123");
     expect(JSON.stringify(persisted)).not.toContain("Bearer abc");
     expect(JSON.stringify(persisted)).toContain("[REDACTED]");
-    expect(redactAutopilotValue({ password: "abc", url: "postgres://u:p@example/db" })).toEqual({
+    expect(
+      redactAutopilotValue({
+        password: "abc",
+        token: "github_pat_123456789abcdef",
+        url: "postgres://u:p@example/db",
+        key: "-----BEGIN RSA PRIVATE KEY-----\nabc123\n-----END RSA PRIVATE KEY-----",
+      }),
+    ).toEqual({
       password: "[REDACTED]",
+      token: "[REDACTED]",
       url: "[REDACTED]",
+      key: "[REDACTED]",
     });
   });
 
@@ -272,13 +281,19 @@ describe("pending-autopilot summaries and harness", () => {
           reasonCode: item.requiresHumanReview ? "human-review-required" : "policy-threshold-not-met",
         }),
     };
+    const payload = { title: "hello" };
     const item: PendingItem = {
       queue: "persona",
       id: "fixture-1",
-      inputHash: computePendingInputHash({ id: "fixture-1" }),
+      inputHash: computePendingInputHash({
+        queue: "persona",
+        id: "fixture-1",
+        payload,
+        policyVersion: "policy-v1",
+      }),
       policyVersion: "policy-v1",
       capabilityClasses: ["classify"],
-      payload: { title: "hello" },
+      payload,
       requiresHumanReview: true,
     };
     await expectStandaloneAndParentDecisionsEquivalent(adapter, [{ item, policyVersion: "policy-v1" }]);


### PR DESCRIPTION
## Summary
- Adds shared pending-autopilot foundation contracts for queues, modes, actions, reason codes, capability/action classes, items, decisions, adapters, summaries, and redacted audit shapes.
- Adds SQLite-backed control-plane state for runs, decisions, cursors, and locks, including dry-run no-write behavior, idempotent decision recording, input-hash/CAS mutation guard, cursor safety, and redacted persistence.
- Adds stable input hashing / JSON summary generation and a reusable parent/child equivalence harness for #1326-#1330 adapter work.

## Scope
This PR intentionally implements only the #1334 foundation/control-plane substrate. It does not implement queue-specific policies or child behaviours from #1326-#1330.

## Tests
- `npm run test -- pending-autopilot-foundation.test.ts`
- `npx tsc --noEmit`
- `npm run build`

Fixes #1334

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new SQLite-backed control-plane persistence (runs/decisions/cursors/locks) and redaction/hashing logic; while mostly additive, mistakes could affect data durability or leak sensitive data if integrated incorrectly.
> 
> **Overview**
> Adds a new `services/pending-autopilot` foundation module that standardizes pending-autopilot contracts (queues, actions/reasons, capability/action classes, item/decision/adaptor types) and exports it from `memory-hybrid`.
> 
> Implements deterministic input hashing and stable run summaries (`canonicalJson`, `computePendingInputHash`, `createStableRunSummary`) with mandatory redaction of audit/summary/evidence/actor payloads before persistence.
> 
> Introduces `PendingAutopilotStore`, a SQLite-backed control-plane store with migrations for `pending_autopilot_*` tables, idempotent decision recording, safe cursor advancement rules, lock acquisition/expiry, and a transactional `mutateWithLockAndAudit` path (while deprecating the legacy CAS-only mutation helper).
> 
> Adds a shared test harness to assert parent/child adapter decision equivalence and a comprehensive test suite covering dry-run no-write guarantees, redaction, hashing determinism, lock/audit mutation invariants, and schema migration behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b01bd1e1d98e167756ab56c44d76692dde0b1fd1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->