### PR TITLE
feat(memory): add digest autopilot parent skeleton

### DIFF
--- a/extensions/memory-hybrid/cli/commands/manage/register-digest.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/register-digest.ts
@@ -6,116 +6,182 @@
  */
 
 import {
-  type PendingDigestAutopilotMaxima,
-  type PendingDigestAutopilotPolicies,
-  runPendingDigestAutopilot,
-  stablePendingDigestAutopilotJson,
+	type PendingDigestAutopilotMaxima,
+	type PendingDigestAutopilotPolicies,
+	runPendingDigestAutopilot,
+	stablePendingDigestAutopilotJson,
 } from "../../../services/pending-digest-autopilot.js";
 import {
-  buildPendingReviewDigestReport,
-  writePendingReviewDigestOutput,
+	buildPendingReviewDigestReport,
+	writePendingReviewDigestOutput,
 } from "../../../services/pending-review-digest.js";
 import { type Chainable, withExit } from "../../shared.js";
 import type { ManageBindings } from "./bindings.js";
 
 export function registerManageDigest(mem: Chainable, b: ManageBindings): void {
-  const digest = mem
-    .command("digest")
-    .description("Surface pending review backlogs across proposals/procedures/tools/crystallization stores.");
+	const digest = mem
+		.command("digest")
+		.description(
+			"Surface pending review backlogs across proposals/procedures/tools/crystallization stores.",
+		);
 
-  digest
-    .command("pending")
-    .description(
-      "Show pending backlogs: persona proposals, procedure promotions, tool proposals, crystallization, verified facts.",
-    )
-    .option("--since <duration>", "Lookback window, e.g. 7d, 24h, 2w (default: 7d)")
-    .option("--format <fmt>", "Output format: md or json (default: md)")
-    .option("--out <path>", "Output file path, or '-' for stdout (default: -)")
-    .action(
-      withExit(async (opts?: { since?: string; format?: string; out?: string }) => {
-        const rawFormat = String(opts?.format ?? "md").toLowerCase();
-        const format = rawFormat === "json" ? "json" : "md";
-        const outPath = opts?.out ?? "-";
-        const report = buildPendingReviewDigestReport({ cfg: b.cfg, factsDb: b.factsDb, since: opts?.since });
-        writePendingReviewDigestOutput({ report, format, outPath });
-      }),
-    );
+	digest
+		.command("pending")
+		.description(
+			"Show pending backlogs: persona proposals, procedure promotions, tool proposals, crystallization, verified facts.",
+		)
+		.option(
+			"--since <duration>",
+			"Lookback window, e.g. 7d, 24h, 2w (default: 7d)",
+		)
+		.option("--format <fmt>", "Output format: md or json (default: md)")
+		.option("--out <path>", "Output file path, or '-' for stdout (default: -)")
+		.action(
+			withExit(
+				async (opts?: { since?: string; format?: string; out?: string }) => {
+					const rawFormat = String(opts?.format ?? "md").toLowerCase();
+					const format = rawFormat === "json" ? "json" : "md";
+					const outPath = opts?.out ?? "-";
+					const report = buildPendingReviewDigestReport({
+						cfg: b.cfg,
+						factsDb: b.factsDb,
+						since: opts?.since,
+					});
+					writePendingReviewDigestOutput({ report, format, outPath });
+				},
+			),
+		);
 
-  digest
-    .command("autopilot")
-    .description(
-      "Read-only parent pending-digest autopilot (#1326). Uses #1334 foundation and delegates to queue adapters; apply records decisions only.",
-    )
-    .option("--dry-run", "Preview only; default and non-mutating")
-    .option("--apply", "Record allowed parent classify decisions through #1334 state; no queue mutations in Phase 1")
-    .option("--json", "Emit stable structured JSON instead of the concise human summary")
-    .option("--state-db <path>", "Optional pending-autopilot state DB for apply-mode decision records")
-    .option("--persona-policy <policy>", "disabled|report-only|cautious|apply-safe")
-    .option("--procedure-policy <policy>", "disabled|report-only|dry-run-skills|auto-safe")
-    .option("--verified-policy <policy>", "disabled|report-only|classify|apply-obvious")
-    .option("--tool-policy <policy>", "disabled|report-only|classify")
-    .option("--crystallization-policy <policy>", "disabled|report-only|classify")
-    .option("--max-persona <n>", "Maximum persona proposals to inspect (default: 20)")
-    .option("--max-procedures <n>", "Maximum procedures to inspect (default: 50)")
-    .option("--max-verified <n>", "Maximum verified review placeholders to inspect (default: 100)")
-    .option("--max-tools <n>", "Maximum tool proposals to inspect (default: 50)")
-    .option("--max-crystallization <n>", "Maximum crystallization proposals to inspect (default: 50)")
-    .action(
-      withExit(async (opts?: DigestAutopilotCliOptions) => {
-        if (opts?.apply && opts?.dryRun) {
-          throw new Error("--dry-run and --apply are mutually exclusive for digest autopilot");
-        }
-        if (opts?.apply && !opts?.stateDb) {
-          throw new Error("--apply requires --state-db so parent classification decisions are recorded durably");
-        }
-        const mode = opts?.apply ? "apply" : "dry-run";
-        const policies: Partial<PendingDigestAutopilotPolicies> = {
-          persona: opts?.personaPolicy as PendingDigestAutopilotPolicies["persona"] | undefined,
-          procedures: opts?.procedurePolicy as PendingDigestAutopilotPolicies["procedures"] | undefined,
-          verified: opts?.verifiedPolicy as PendingDigestAutopilotPolicies["verified"] | undefined,
-          tools: opts?.toolPolicy as PendingDigestAutopilotPolicies["tools"] | undefined,
-          crystallization: opts?.crystallizationPolicy as PendingDigestAutopilotPolicies["crystallization"] | undefined,
-        };
-        const max: Partial<PendingDigestAutopilotMaxima> = {
-          persona: parseOptionalInt(opts?.maxPersona),
-          procedures: parseOptionalInt(opts?.maxProcedures),
-          verified: parseOptionalInt(opts?.maxVerified),
-          tools: parseOptionalInt(opts?.maxTools),
-          crystallization: parseOptionalInt(opts?.maxCrystallization),
-        };
-        const result = await runPendingDigestAutopilot({
-          cfg: b.cfg,
-          factsDb: b.factsDb,
-          mode,
-          policies,
-          max,
-          stateDbPath: opts?.stateDb,
-        });
-        process.stdout.write(opts?.json ? stablePendingDigestAutopilotJson(result) : `${result.humanSummary}\n`);
-      }),
-    );
+	digest
+		.command("autopilot")
+		.description(
+			"Read-only parent pending-digest autopilot (#1326). Uses #1334 foundation and delegates to queue adapters; apply records decisions only.",
+		)
+		.option("--dry-run", "Preview only; default and non-mutating")
+		.option(
+			"--apply",
+			"Record allowed parent classify decisions through #1334 state; no queue mutations in Phase 1",
+		)
+		.option(
+			"--json",
+			"Emit stable structured JSON instead of the concise human summary",
+		)
+		.option(
+			"--state-db <path>",
+			"Optional pending-autopilot state DB for apply-mode decision records",
+		)
+		.option(
+			"--persona-policy <policy>",
+			"disabled|report-only|cautious|apply-safe",
+		)
+		.option(
+			"--procedure-policy <policy>",
+			"disabled|report-only|dry-run-skills|auto-safe",
+		)
+		.option(
+			"--verified-policy <policy>",
+			"disabled|report-only|classify|apply-obvious",
+		)
+		.option("--tool-policy <policy>", "disabled|report-only|classify")
+		.option(
+			"--crystallization-policy <policy>",
+			"disabled|report-only|classify",
+		)
+		.option(
+			"--max-persona <n>",
+			"Maximum persona proposals to inspect (default: 20)",
+		)
+		.option(
+			"--max-procedures <n>",
+			"Maximum procedures to inspect (default: 50)",
+		)
+		.option(
+			"--max-verified <n>",
+			"Maximum verified review placeholders to inspect (default: 100)",
+		)
+		.option(
+			"--max-tools <n>",
+			"Maximum tool proposals to inspect (default: 50)",
+		)
+		.option(
+			"--max-crystallization <n>",
+			"Maximum crystallization proposals to inspect (default: 50)",
+		)
+		.action(
+			withExit(async (opts?: DigestAutopilotCliOptions) => {
+				if (opts?.apply && opts?.dryRun) {
+					throw new Error(
+						"--dry-run and --apply are mutually exclusive for digest autopilot",
+					);
+				}
+				if (opts?.apply && !opts?.stateDb) {
+					throw new Error(
+						"--apply requires --state-db so parent classification decisions are recorded durably",
+					);
+				}
+				const mode = opts?.apply ? "apply" : "dry-run";
+				const policies: Partial<PendingDigestAutopilotPolicies> = {
+					persona: opts?.personaPolicy as
+						| PendingDigestAutopilotPolicies["persona"]
+						| undefined,
+					procedures: opts?.procedurePolicy as
+						| PendingDigestAutopilotPolicies["procedures"]
+						| undefined,
+					verified: opts?.verifiedPolicy as
+						| PendingDigestAutopilotPolicies["verified"]
+						| undefined,
+					tools: opts?.toolPolicy as
+						| PendingDigestAutopilotPolicies["tools"]
+						| undefined,
+					crystallization: opts?.crystallizationPolicy as
+						| PendingDigestAutopilotPolicies["crystallization"]
+						| undefined,
+				};
+				const max: Partial<PendingDigestAutopilotMaxima> = {
+					persona: parseOptionalInt(opts?.maxPersona),
+					procedures: parseOptionalInt(opts?.maxProcedures),
+					verified: parseOptionalInt(opts?.maxVerified),
+					tools: parseOptionalInt(opts?.maxTools),
+					crystallization: parseOptionalInt(opts?.maxCrystallization),
+				};
+				const result = await runPendingDigestAutopilot({
+					cfg: b.cfg,
+					factsDb: b.factsDb,
+					mode,
+					policies,
+					max,
+					stateDbPath: opts?.stateDb,
+				});
+				process.stdout.write(
+					opts?.json
+						? stablePendingDigestAutopilotJson(result)
+						: `${result.humanSummary}\n`,
+				);
+			}),
+		);
 }
 
 type DigestAutopilotCliOptions = {
-  dryRun?: boolean;
-  apply?: boolean;
-  json?: boolean;
-  stateDb?: string;
-  personaPolicy?: string;
-  procedurePolicy?: string;
-  verifiedPolicy?: string;
-  toolPolicy?: string;
-  crystallizationPolicy?: string;
-  maxPersona?: string;
-  maxProcedures?: string;
-  maxVerified?: string;
-  maxTools?: string;
-  maxCrystallization?: string;
+	dryRun?: boolean;
+	apply?: boolean;
+	json?: boolean;
+	stateDb?: string;
+	personaPolicy?: string;
+	procedurePolicy?: string;
+	verifiedPolicy?: string;
+	toolPolicy?: string;
+	crystallizationPolicy?: string;
+	maxPersona?: string;
+	maxProcedures?: string;
+	maxVerified?: string;
+	maxTools?: string;
+	maxCrystallization?: string;
 };
 
 function parseOptionalInt(value: string | undefined): number | undefined {
-  if (value === undefined) return undefined;
-  const parsed = Number.parseInt(value, 10);
-  if (!Number.isFinite(parsed)) throw new Error(`Invalid numeric option: ${value}`);
-  return parsed;
+	if (value === undefined) return undefined;
+	const normalized = value.trim();
+	if (!/^[0-9]+$/.test(normalized))
+		throw new Error(`Invalid numeric option: ${value}`);
+	return Number.parseInt(normalized, 10);
 }

--- a/extensions/memory-hybrid/cli/commands/manage/register-digest.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/register-digest.ts
@@ -6,6 +6,12 @@
  */
 
 import {
+  type PendingDigestAutopilotMaxima,
+  type PendingDigestAutopilotPolicies,
+  runPendingDigestAutopilot,
+  stablePendingDigestAutopilotJson,
+} from "../../../services/pending-digest-autopilot.js";
+import {
   buildPendingReviewDigestReport,
   writePendingReviewDigestOutput,
 } from "../../../services/pending-review-digest.js";
@@ -34,4 +40,76 @@ export function registerManageDigest(mem: Chainable, b: ManageBindings): void {
         writePendingReviewDigestOutput({ report, format, outPath });
       }),
     );
+
+  digest
+    .command("autopilot")
+    .description(
+      "Read-only parent pending-digest autopilot (#1326). Uses #1334 foundation and delegates to queue adapters; apply records decisions only.",
+    )
+    .option("--dry-run", "Preview only; default and non-mutating")
+    .option("--apply", "Record allowed parent classify decisions through #1334 state; no queue mutations in Phase 1")
+    .option("--json", "Emit stable structured JSON instead of the concise human summary")
+    .option("--state-db <path>", "Optional pending-autopilot state DB for apply-mode decision records")
+    .option("--persona-policy <policy>", "disabled|report-only|cautious|apply-safe")
+    .option("--procedure-policy <policy>", "disabled|report-only|dry-run-skills|auto-safe")
+    .option("--verified-policy <policy>", "disabled|report-only|classify|apply-obvious")
+    .option("--tool-policy <policy>", "disabled|report-only|classify")
+    .option("--crystallization-policy <policy>", "disabled|report-only|classify")
+    .option("--max-persona <n>", "Maximum persona proposals to inspect (default: 20)")
+    .option("--max-procedures <n>", "Maximum procedures to inspect (default: 50)")
+    .option("--max-verified <n>", "Maximum verified review placeholders to inspect (default: 100)")
+    .option("--max-tools <n>", "Maximum tool proposals to inspect (default: 50)")
+    .option("--max-crystallization <n>", "Maximum crystallization proposals to inspect (default: 50)")
+    .action(
+      withExit(async (opts?: DigestAutopilotCliOptions) => {
+        const mode = opts?.apply ? "apply" : "dry-run";
+        const policies: Partial<PendingDigestAutopilotPolicies> = {
+          persona: opts?.personaPolicy as PendingDigestAutopilotPolicies["persona"] | undefined,
+          procedures: opts?.procedurePolicy as PendingDigestAutopilotPolicies["procedures"] | undefined,
+          verified: opts?.verifiedPolicy as PendingDigestAutopilotPolicies["verified"] | undefined,
+          tools: opts?.toolPolicy as PendingDigestAutopilotPolicies["tools"] | undefined,
+          crystallization: opts?.crystallizationPolicy as PendingDigestAutopilotPolicies["crystallization"] | undefined,
+        };
+        const max: Partial<PendingDigestAutopilotMaxima> = {
+          persona: parseOptionalInt(opts?.maxPersona),
+          procedures: parseOptionalInt(opts?.maxProcedures),
+          verified: parseOptionalInt(opts?.maxVerified),
+          tools: parseOptionalInt(opts?.maxTools),
+          crystallization: parseOptionalInt(opts?.maxCrystallization),
+        };
+        const result = await runPendingDigestAutopilot({
+          cfg: b.cfg,
+          factsDb: b.factsDb,
+          mode,
+          policies,
+          max,
+          stateDbPath: opts?.stateDb,
+        });
+        process.stdout.write(opts?.json ? stablePendingDigestAutopilotJson(result) : `${result.humanSummary}\n`);
+      }),
+    );
+}
+
+type DigestAutopilotCliOptions = {
+  dryRun?: boolean;
+  apply?: boolean;
+  json?: boolean;
+  stateDb?: string;
+  personaPolicy?: string;
+  procedurePolicy?: string;
+  verifiedPolicy?: string;
+  toolPolicy?: string;
+  crystallizationPolicy?: string;
+  maxPersona?: string;
+  maxProcedures?: string;
+  maxVerified?: string;
+  maxTools?: string;
+  maxCrystallization?: string;
+};
+
+function parseOptionalInt(value: string | undefined): number | undefined {
+  if (value === undefined) return undefined;
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed)) throw new Error(`Invalid numeric option: ${value}`);
+  return parsed;
 }

--- a/extensions/memory-hybrid/cli/commands/manage/register-digest.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/register-digest.ts
@@ -6,182 +6,120 @@
  */
 
 import {
-	type PendingDigestAutopilotMaxima,
-	type PendingDigestAutopilotPolicies,
-	runPendingDigestAutopilot,
-	stablePendingDigestAutopilotJson,
+  type PendingDigestAutopilotMaxima,
+  type PendingDigestAutopilotPolicies,
+  runPendingDigestAutopilot,
+  stablePendingDigestAutopilotJson,
 } from "../../../services/pending-digest-autopilot.js";
 import {
-	buildPendingReviewDigestReport,
-	writePendingReviewDigestOutput,
+  buildPendingReviewDigestReport,
+  writePendingReviewDigestOutput,
 } from "../../../services/pending-review-digest.js";
 import { type Chainable, withExit } from "../../shared.js";
 import type { ManageBindings } from "./bindings.js";
 
 export function registerManageDigest(mem: Chainable, b: ManageBindings): void {
-	const digest = mem
-		.command("digest")
-		.description(
-			"Surface pending review backlogs across proposals/procedures/tools/crystallization stores.",
-		);
+  const digest = mem
+    .command("digest")
+    .description("Surface pending review backlogs across proposals/procedures/tools/crystallization stores.");
 
-	digest
-		.command("pending")
-		.description(
-			"Show pending backlogs: persona proposals, procedure promotions, tool proposals, crystallization, verified facts.",
-		)
-		.option(
-			"--since <duration>",
-			"Lookback window, e.g. 7d, 24h, 2w (default: 7d)",
-		)
-		.option("--format <fmt>", "Output format: md or json (default: md)")
-		.option("--out <path>", "Output file path, or '-' for stdout (default: -)")
-		.action(
-			withExit(
-				async (opts?: { since?: string; format?: string; out?: string }) => {
-					const rawFormat = String(opts?.format ?? "md").toLowerCase();
-					const format = rawFormat === "json" ? "json" : "md";
-					const outPath = opts?.out ?? "-";
-					const report = buildPendingReviewDigestReport({
-						cfg: b.cfg,
-						factsDb: b.factsDb,
-						since: opts?.since,
-					});
-					writePendingReviewDigestOutput({ report, format, outPath });
-				},
-			),
-		);
+  digest
+    .command("pending")
+    .description(
+      "Show pending backlogs: persona proposals, procedure promotions, tool proposals, crystallization, verified facts.",
+    )
+    .option("--since <duration>", "Lookback window, e.g. 7d, 24h, 2w (default: 7d)")
+    .option("--format <fmt>", "Output format: md or json (default: md)")
+    .option("--out <path>", "Output file path, or '-' for stdout (default: -)")
+    .action(
+      withExit(async (opts?: { since?: string; format?: string; out?: string }) => {
+        const rawFormat = String(opts?.format ?? "md").toLowerCase();
+        const format = rawFormat === "json" ? "json" : "md";
+        const outPath = opts?.out ?? "-";
+        const report = buildPendingReviewDigestReport({
+          cfg: b.cfg,
+          factsDb: b.factsDb,
+          since: opts?.since,
+        });
+        writePendingReviewDigestOutput({ report, format, outPath });
+      }),
+    );
 
-	digest
-		.command("autopilot")
-		.description(
-			"Read-only parent pending-digest autopilot (#1326). Uses #1334 foundation and delegates to queue adapters; apply records decisions only.",
-		)
-		.option("--dry-run", "Preview only; default and non-mutating")
-		.option(
-			"--apply",
-			"Record allowed parent classify decisions through #1334 state; no queue mutations in Phase 1",
-		)
-		.option(
-			"--json",
-			"Emit stable structured JSON instead of the concise human summary",
-		)
-		.option(
-			"--state-db <path>",
-			"Optional pending-autopilot state DB for apply-mode decision records",
-		)
-		.option(
-			"--persona-policy <policy>",
-			"disabled|report-only|cautious|apply-safe",
-		)
-		.option(
-			"--procedure-policy <policy>",
-			"disabled|report-only|dry-run-skills|auto-safe",
-		)
-		.option(
-			"--verified-policy <policy>",
-			"disabled|report-only|classify|apply-obvious",
-		)
-		.option("--tool-policy <policy>", "disabled|report-only|classify")
-		.option(
-			"--crystallization-policy <policy>",
-			"disabled|report-only|classify",
-		)
-		.option(
-			"--max-persona <n>",
-			"Maximum persona proposals to inspect (default: 20)",
-		)
-		.option(
-			"--max-procedures <n>",
-			"Maximum procedures to inspect (default: 50)",
-		)
-		.option(
-			"--max-verified <n>",
-			"Maximum verified review placeholders to inspect (default: 100)",
-		)
-		.option(
-			"--max-tools <n>",
-			"Maximum tool proposals to inspect (default: 50)",
-		)
-		.option(
-			"--max-crystallization <n>",
-			"Maximum crystallization proposals to inspect (default: 50)",
-		)
-		.action(
-			withExit(async (opts?: DigestAutopilotCliOptions) => {
-				if (opts?.apply && opts?.dryRun) {
-					throw new Error(
-						"--dry-run and --apply are mutually exclusive for digest autopilot",
-					);
-				}
-				if (opts?.apply && !opts?.stateDb) {
-					throw new Error(
-						"--apply requires --state-db so parent classification decisions are recorded durably",
-					);
-				}
-				const mode = opts?.apply ? "apply" : "dry-run";
-				const policies: Partial<PendingDigestAutopilotPolicies> = {
-					persona: opts?.personaPolicy as
-						| PendingDigestAutopilotPolicies["persona"]
-						| undefined,
-					procedures: opts?.procedurePolicy as
-						| PendingDigestAutopilotPolicies["procedures"]
-						| undefined,
-					verified: opts?.verifiedPolicy as
-						| PendingDigestAutopilotPolicies["verified"]
-						| undefined,
-					tools: opts?.toolPolicy as
-						| PendingDigestAutopilotPolicies["tools"]
-						| undefined,
-					crystallization: opts?.crystallizationPolicy as
-						| PendingDigestAutopilotPolicies["crystallization"]
-						| undefined,
-				};
-				const max: Partial<PendingDigestAutopilotMaxima> = {
-					persona: parseOptionalInt(opts?.maxPersona),
-					procedures: parseOptionalInt(opts?.maxProcedures),
-					verified: parseOptionalInt(opts?.maxVerified),
-					tools: parseOptionalInt(opts?.maxTools),
-					crystallization: parseOptionalInt(opts?.maxCrystallization),
-				};
-				const result = await runPendingDigestAutopilot({
-					cfg: b.cfg,
-					factsDb: b.factsDb,
-					mode,
-					policies,
-					max,
-					stateDbPath: opts?.stateDb,
-				});
-				process.stdout.write(
-					opts?.json
-						? stablePendingDigestAutopilotJson(result)
-						: `${result.humanSummary}\n`,
-				);
-			}),
-		);
+  digest
+    .command("autopilot")
+    .description(
+      "Read-only parent pending-digest autopilot (#1326). Uses #1334 foundation and delegates to queue adapters; apply records decisions only.",
+    )
+    .option("--dry-run", "Preview only; default and non-mutating")
+    .option("--apply", "Record allowed parent classify decisions through #1334 state; no queue mutations in Phase 1")
+    .option("--json", "Emit stable structured JSON instead of the concise human summary")
+    .option("--state-db <path>", "Optional pending-autopilot state DB for apply-mode decision records")
+    .option("--persona-policy <policy>", "disabled|report-only|cautious|apply-safe")
+    .option("--procedure-policy <policy>", "disabled|report-only|dry-run-skills|auto-safe")
+    .option("--verified-policy <policy>", "disabled|report-only|classify|apply-obvious")
+    .option("--tool-policy <policy>", "disabled|report-only|classify")
+    .option("--crystallization-policy <policy>", "disabled|report-only|classify")
+    .option("--max-persona <n>", "Maximum persona proposals to inspect (default: 20)")
+    .option("--max-procedures <n>", "Maximum procedures to inspect (default: 50)")
+    .option("--max-verified <n>", "Maximum verified review placeholders to inspect (default: 100)")
+    .option("--max-tools <n>", "Maximum tool proposals to inspect (default: 50)")
+    .option("--max-crystallization <n>", "Maximum crystallization proposals to inspect (default: 50)")
+    .action(
+      withExit(async (opts?: DigestAutopilotCliOptions) => {
+        if (opts?.apply && opts?.dryRun) {
+          throw new Error("--dry-run and --apply are mutually exclusive for digest autopilot");
+        }
+        if (opts?.apply && !opts?.stateDb) {
+          throw new Error("--apply requires --state-db so parent classification decisions are recorded durably");
+        }
+        const mode = opts?.apply ? "apply" : "dry-run";
+        const policies: Partial<PendingDigestAutopilotPolicies> = {
+          persona: opts?.personaPolicy as PendingDigestAutopilotPolicies["persona"] | undefined,
+          procedures: opts?.procedurePolicy as PendingDigestAutopilotPolicies["procedures"] | undefined,
+          verified: opts?.verifiedPolicy as PendingDigestAutopilotPolicies["verified"] | undefined,
+          tools: opts?.toolPolicy as PendingDigestAutopilotPolicies["tools"] | undefined,
+          crystallization: opts?.crystallizationPolicy as PendingDigestAutopilotPolicies["crystallization"] | undefined,
+        };
+        const max: Partial<PendingDigestAutopilotMaxima> = {
+          persona: parseOptionalInt(opts?.maxPersona),
+          procedures: parseOptionalInt(opts?.maxProcedures),
+          verified: parseOptionalInt(opts?.maxVerified),
+          tools: parseOptionalInt(opts?.maxTools),
+          crystallization: parseOptionalInt(opts?.maxCrystallization),
+        };
+        const result = await runPendingDigestAutopilot({
+          cfg: b.cfg,
+          factsDb: b.factsDb,
+          mode,
+          policies,
+          max,
+          stateDbPath: opts?.stateDb,
+        });
+        process.stdout.write(opts?.json ? stablePendingDigestAutopilotJson(result) : `${result.humanSummary}\n`);
+      }),
+    );
 }
 
 type DigestAutopilotCliOptions = {
-	dryRun?: boolean;
-	apply?: boolean;
-	json?: boolean;
-	stateDb?: string;
-	personaPolicy?: string;
-	procedurePolicy?: string;
-	verifiedPolicy?: string;
-	toolPolicy?: string;
-	crystallizationPolicy?: string;
-	maxPersona?: string;
-	maxProcedures?: string;
-	maxVerified?: string;
-	maxTools?: string;
-	maxCrystallization?: string;
+  dryRun?: boolean;
+  apply?: boolean;
+  json?: boolean;
+  stateDb?: string;
+  personaPolicy?: string;
+  procedurePolicy?: string;
+  verifiedPolicy?: string;
+  toolPolicy?: string;
+  crystallizationPolicy?: string;
+  maxPersona?: string;
+  maxProcedures?: string;
+  maxVerified?: string;
+  maxTools?: string;
+  maxCrystallization?: string;
 };
 
 function parseOptionalInt(value: string | undefined): number | undefined {
-	if (value === undefined) return undefined;
-	const normalized = value.trim();
-	if (!/^[0-9]+$/.test(normalized))
-		throw new Error(`Invalid numeric option: ${value}`);
-	return Number.parseInt(normalized, 10);
+  if (value === undefined) return undefined;
+  const normalized = value.trim();
+  if (!/^[0-9]+$/.test(normalized)) throw new Error(`Invalid numeric option: ${value}`);
+  return Number.parseInt(normalized, 10);
 }

--- a/extensions/memory-hybrid/cli/commands/manage/register-digest.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/register-digest.ts
@@ -62,6 +62,12 @@ export function registerManageDigest(mem: Chainable, b: ManageBindings): void {
     .option("--max-crystallization <n>", "Maximum crystallization proposals to inspect (default: 50)")
     .action(
       withExit(async (opts?: DigestAutopilotCliOptions) => {
+        if (opts?.apply && opts?.dryRun) {
+          throw new Error("--dry-run and --apply are mutually exclusive for digest autopilot");
+        }
+        if (opts?.apply && !opts?.stateDb) {
+          throw new Error("--apply requires --state-db so parent classification decisions are recorded durably");
+        }
         const mode = opts?.apply ? "apply" : "dry-run";
         const policies: Partial<PendingDigestAutopilotPolicies> = {
           persona: opts?.personaPolicy as PendingDigestAutopilotPolicies["persona"] | undefined,

--- a/extensions/memory-hybrid/services/pending-autopilot/README.md
+++ b/extensions/memory-hybrid/services/pending-autopilot/README.md
@@ -2,7 +2,7 @@
 
 This module is the shared safety substrate for the pending-digest autopilot work. Issue #1334 is a prerequisite for:
 
-- #1326 parent orchestration
+- #1326 parent orchestration — `openclaw hybrid-mem digest autopilot`
 - #1327 persona queue adapter
 - #1328 procedure/skill queue adapter
 - #1329 verified-fact queue adapter
@@ -39,6 +39,12 @@ Child, parent, and cron work must consume these contracts instead of defining be
 10. `destructive-action`
 
 Adapters may add queue-specific policy, but they must preserve these approval boundaries.
+
+## Parent command (#1326)
+
+`openclaw hybrid-mem digest autopilot` is the Phase 1 parent skeleton. Default mode is `--dry-run` and non-mutating. `--apply` is intentionally limited to recording allowed parent classification decisions in the shared #1334 state DB when `--state-db` is supplied; it does **not** mutate persona proposals, procedures, verified facts, tool proposals, crystallization proposals, or generated skills.
+
+Supported parent flags include `--dry-run`, `--apply`, `--json`, per-queue policies (`--persona-policy`, `--procedure-policy`, `--verified-policy`, `--tool-policy`, `--crystallization-policy`), and per-queue maxes. Queue policy modules/adapters own queue-specific safety logic in #1327/#1328/#1329; tool and crystallization queues are read-only/classify only in #1326.
 
 ## Parent/child equivalence
 

--- a/extensions/memory-hybrid/services/pending-digest-autopilot.ts
+++ b/extensions/memory-hybrid/services/pending-digest-autopilot.ts
@@ -234,7 +234,8 @@ export async function runPendingDigestAutopilot(
         const listed = await adapter.listPending(store?.getCursor(queue, policy) ?? null);
         const items = listed.slice(0, normalized.max[queue]);
         queueResult.inspected = items.length;
-        for (const item of items) {
+        for (let i = 0; i < items.length; i++) {
+          const item = items[i];
           const context: PendingDecisionContext = {
             runId,
             jobId: opts.jobId,
@@ -251,6 +252,7 @@ export async function runPendingDigestAutopilot(
           if (inserted) store?.advanceCursorIfSafe(decision, item.visibleAfterCursor ?? item.id);
         }
       } catch (err) {
+        queueResult.inspected = queueResult.decisions.length;
         const decision = makeFailureDecision({
           queue,
           policy,
@@ -602,8 +604,7 @@ function makeFailureDecision(input: {
 
 function summarizeCounts(decisions: PendingDecision[]): PendingDigestAutopilotResult["counts"] {
   return {
-    inspected: decisions.filter((d) => !d.itemId.endsWith(":skipped") && !d.itemId.endsWith(":inventory-failed"))
-      .length,
+    inspected: decisions.filter((d) => d.action !== "skipped-by-policy" && d.action !== "failed-validation").length,
     classified: decisions.filter((d) => d.action === "classified" || d.action === "reported").length,
     applied: decisions.filter((d) => d.action === "applied").length,
     deferred: decisions.filter((d) => d.action === "deferred-for-human").length,

--- a/extensions/memory-hybrid/services/pending-digest-autopilot.ts
+++ b/extensions/memory-hybrid/services/pending-digest-autopilot.ts
@@ -10,640 +10,812 @@
 
 import type { DatabaseSync } from "node:sqlite";
 import { CrystallizationStore } from "../backends/crystallization-store.js";
-import type { ProcedureTriageReport, ProcedureTriageRow } from "../backends/facts-db/procedures.js";
+import type {
+	ProcedureTriageReport,
+	ProcedureTriageRow,
+} from "../backends/facts-db/procedures.js";
 import { type ProposalEntry, ProposalsDB } from "../backends/proposals-db.js";
-import { type ToolProposal, ToolProposalStore } from "../backends/tool-proposal-store.js";
+import {
+	type ToolProposal,
+	ToolProposalStore,
+} from "../backends/tool-proposal-store.js";
 import type { HybridMemoryConfig } from "../config.js";
 import {
-  type AutopilotMode,
-  PENDING_QUEUES,
-  type PendingAutopilotRunSummary,
-  PendingAutopilotStore,
-  canonicalJson,
-  redactAutopilotValue,
-  type PendingDecision,
-  type PendingDecisionContext,
-  type PendingItem,
-  type PendingQueue,
-  type PendingQueueAdapter,
-  computePendingInputHash,
-  createPendingAutopilotRunId,
-  createStableRunSummary,
+	type AutopilotMode,
+	PENDING_QUEUES,
+	type PendingAutopilotRunSummary,
+	PendingAutopilotStore,
+	canonicalJson,
+	redactAutopilotValue,
+	type PendingDecision,
+	type PendingDecisionContext,
+	type PendingItem,
+	type PendingQueue,
+	type PendingQueueAdapter,
+	computePendingInputHash,
+	createPendingAutopilotRunId,
+	createStableRunSummary,
 } from "./pending-autopilot/index.js";
-import { buildPendingReviewDigestReport, pendingStorePaths } from "./pending-review-digest.js";
+import {
+	buildPendingReviewDigestReport,
+	pendingStorePaths,
+} from "./pending-review-digest.js";
 
 export const PENDING_DIGEST_AUTOPILOT_POLICY_VERSION = "parent-skeleton-v1";
 
-export type PersonaAutopilotPolicy = "disabled" | "report-only" | "cautious" | "apply-safe";
-export type ProcedureAutopilotPolicy = "disabled" | "report-only" | "dry-run-skills" | "auto-safe";
-export type VerifiedAutopilotPolicy = "disabled" | "report-only" | "classify" | "apply-obvious";
+export type PersonaAutopilotPolicy =
+	| "disabled"
+	| "report-only"
+	| "cautious"
+	| "apply-safe";
+export type ProcedureAutopilotPolicy =
+	| "disabled"
+	| "report-only"
+	| "dry-run-skills"
+	| "auto-safe";
+export type VerifiedAutopilotPolicy =
+	| "disabled"
+	| "report-only"
+	| "classify"
+	| "apply-obvious";
 export type ReadOnlyClassifyPolicy = "disabled" | "report-only" | "classify";
 export type PendingDigestAutopilotPolicy =
-  | PersonaAutopilotPolicy
-  | ProcedureAutopilotPolicy
-  | VerifiedAutopilotPolicy
-  | ReadOnlyClassifyPolicy;
+	| PersonaAutopilotPolicy
+	| ProcedureAutopilotPolicy
+	| VerifiedAutopilotPolicy
+	| ReadOnlyClassifyPolicy;
 
 export interface PendingDigestAutopilotPolicies {
-  persona: PersonaAutopilotPolicy;
-  procedures: ProcedureAutopilotPolicy;
-  verified: VerifiedAutopilotPolicy;
-  tools: ReadOnlyClassifyPolicy;
-  crystallization: ReadOnlyClassifyPolicy;
+	persona: PersonaAutopilotPolicy;
+	procedures: ProcedureAutopilotPolicy;
+	verified: VerifiedAutopilotPolicy;
+	tools: ReadOnlyClassifyPolicy;
+	crystallization: ReadOnlyClassifyPolicy;
 }
 
 export interface PendingDigestAutopilotMaxima {
-  persona: number;
-  procedures: number;
-  verified: number;
-  tools: number;
-  crystallization: number;
+	persona: number;
+	procedures: number;
+	verified: number;
+	tools: number;
+	crystallization: number;
 }
 
 export interface PendingDigestAutopilotOptions {
-  cfg: HybridMemoryConfig;
-  factsDb: PendingDigestFactsDb;
-  mode?: AutopilotMode;
-  policies?: Partial<PendingDigestAutopilotPolicies>;
-  max?: Partial<PendingDigestAutopilotMaxima>;
-  runId?: string;
-  jobId?: string;
-  actorId?: string;
-  now?: Date;
-  stateDbPath?: string;
-  adapters?: Partial<Record<PendingQueue, PendingQueueAdapter>>;
+	cfg: HybridMemoryConfig;
+	factsDb: PendingDigestFactsDb;
+	mode?: AutopilotMode;
+	policies?: Partial<PendingDigestAutopilotPolicies>;
+	max?: Partial<PendingDigestAutopilotMaxima>;
+	runId?: string;
+	jobId?: string;
+	actorId?: string;
+	now?: Date;
+	stateDbPath?: string;
+	adapters?: Partial<Record<PendingQueue, PendingQueueAdapter>>;
 }
 
 export interface PendingDigestFactsDb {
-  proceduresCount(): number;
-  proceduresValidatedCount(): number;
-  proceduresPromotedCount(): number;
-  countVerifiedFacts(): number;
-  proceduresValidatedSince?(sinceSec: number): number;
-  getRawDb?(): DatabaseSync | undefined | null;
-  triageProcedures?(options?: {
-    status?: "validated" | "all";
-    notPromoted?: boolean;
-    limit?: number;
-    validationThreshold?: number;
-  }): ProcedureTriageReport;
+	proceduresCount(): number;
+	proceduresValidatedCount(): number;
+	proceduresPromotedCount(): number;
+	countVerifiedFacts(): number;
+	proceduresValidatedSince?(sinceSec: number): number;
+	getRawDb?(): DatabaseSync | undefined | null;
+	triageProcedures?(options?: {
+		status?: "validated" | "all";
+		notPromoted?: boolean;
+		limit?: number;
+		validationThreshold?: number;
+	}): ProcedureTriageReport;
 }
 
 export interface PendingDigestAutopilotResult {
-  schemaVersion: 1;
-  runId: string;
-  mode: AutopilotMode;
-  policyVersion: string;
-  applyBehavior: "record-decisions-only" | "non-mutating-dry-run";
-  policies: PendingDigestAutopilotPolicies;
-  max: PendingDigestAutopilotMaxima;
-  counts: {
-    inspected: number;
-    classified: number;
-    applied: number;
-    deferred: number;
-    rejected: number;
-    failedValidation: number;
-    skipped: number;
-    humanReviewRequired: number;
-  };
-  queues: Record<PendingQueue, PendingDigestQueueResult>;
-  foundationSummary: PendingAutopilotRunSummary;
-  digestContext: ReturnType<typeof buildPendingReviewDigestReport>["pendingReview"];
-  humanSummary: string;
+	schemaVersion: 1;
+	runId: string;
+	mode: AutopilotMode;
+	policyVersion: string;
+	applyBehavior: "record-decisions-only" | "non-mutating-dry-run";
+	policies: PendingDigestAutopilotPolicies;
+	max: PendingDigestAutopilotMaxima;
+	counts: {
+		inspected: number;
+		classified: number;
+		applied: number;
+		deferred: number;
+		rejected: number;
+		failedValidation: number;
+		skipped: number;
+		humanReviewRequired: number;
+	};
+	queues: Record<PendingQueue, PendingDigestQueueResult>;
+	foundationSummary: PendingAutopilotRunSummary;
+	digestContext: ReturnType<
+		typeof buildPendingReviewDigestReport
+	>["pendingReview"];
+	humanSummary: string;
 }
 
 export interface PendingDigestQueueResult {
-  policy: PendingDigestAutopilotPolicy;
-  inspected: number;
-  skipped: boolean;
-  skipReason?: "queue-disabled-by-policy" | "adapter-unavailable" | "inventory-failed";
-  decisions: PendingDecision[];
+	policy: PendingDigestAutopilotPolicy;
+	inspected: number;
+	skipped: boolean;
+	skipReason?:
+		| "queue-disabled-by-policy"
+		| "adapter-unavailable"
+		| "inventory-failed";
+	decisions: PendingDecision[];
 }
 
 type QueuePayload = Record<string, unknown>;
 type QueueItem = PendingItem<QueuePayload>;
 
 const DEFAULT_POLICIES: PendingDigestAutopilotPolicies = {
-  persona: "cautious",
-  procedures: "auto-safe",
-  verified: "classify",
-  tools: "classify",
-  crystallization: "classify",
+	persona: "cautious",
+	procedures: "auto-safe",
+	verified: "classify",
+	tools: "classify",
+	crystallization: "classify",
 };
 
 const DEFAULT_MAX: PendingDigestAutopilotMaxima = {
-  persona: 20,
-  procedures: 50,
-  verified: 100,
-  tools: 50,
-  crystallization: 50,
+	persona: 20,
+	procedures: 50,
+	verified: 100,
+	tools: 50,
+	crystallization: 50,
 };
 
 export function normalizePendingDigestAutopilotOptions(input: {
-  mode?: AutopilotMode;
-  policies?: Partial<PendingDigestAutopilotPolicies>;
-  max?: Partial<PendingDigestAutopilotMaxima>;
-}): { mode: AutopilotMode; policies: PendingDigestAutopilotPolicies; max: PendingDigestAutopilotMaxima } {
-  const mode = input.mode ?? "dry-run";
-  if (mode !== "dry-run" && mode !== "apply") throw new Error(`Unsupported pending autopilot mode: ${mode}`);
-  const policies: PendingDigestAutopilotPolicies = { ...DEFAULT_POLICIES };
-  const policyInput = input.policies ?? {};
-  if (policyInput.persona !== undefined) policies.persona = policyInput.persona;
-  if (policyInput.procedures !== undefined) policies.procedures = policyInput.procedures;
-  if (policyInput.verified !== undefined) policies.verified = policyInput.verified;
-  if (policyInput.tools !== undefined) policies.tools = policyInput.tools;
-  if (policyInput.crystallization !== undefined) policies.crystallization = policyInput.crystallization;
-  validatePolicies(policies);
-  const max: PendingDigestAutopilotMaxima = { ...DEFAULT_MAX };
-  for (const [queue, value] of Object.entries(input.max ?? {})) {
-    if (value !== undefined) max[queue as PendingQueue] = value;
-  }
-  for (const [queue, value] of Object.entries(max)) {
-    if (!Number.isFinite(value) || value < 0) throw new Error(`Invalid max for ${queue}: ${value}`);
-    max[queue as PendingQueue] = Math.floor(value);
-  }
-  return { mode, policies, max };
+	mode?: AutopilotMode;
+	policies?: Partial<PendingDigestAutopilotPolicies>;
+	max?: Partial<PendingDigestAutopilotMaxima>;
+}): {
+	mode: AutopilotMode;
+	policies: PendingDigestAutopilotPolicies;
+	max: PendingDigestAutopilotMaxima;
+} {
+	const mode = input.mode ?? "dry-run";
+	if (mode !== "dry-run" && mode !== "apply")
+		throw new Error(`Unsupported pending autopilot mode: ${mode}`);
+	const policies: PendingDigestAutopilotPolicies = { ...DEFAULT_POLICIES };
+	const policyInput = input.policies ?? {};
+	if (policyInput.persona !== undefined) policies.persona = policyInput.persona;
+	if (policyInput.procedures !== undefined)
+		policies.procedures = policyInput.procedures;
+	if (policyInput.verified !== undefined)
+		policies.verified = policyInput.verified;
+	if (policyInput.tools !== undefined) policies.tools = policyInput.tools;
+	if (policyInput.crystallization !== undefined)
+		policies.crystallization = policyInput.crystallization;
+	validatePolicies(policies);
+	const max: PendingDigestAutopilotMaxima = { ...DEFAULT_MAX };
+	for (const [queue, value] of Object.entries(input.max ?? {})) {
+		if (value !== undefined) max[queue as PendingQueue] = value;
+	}
+	for (const [queue, value] of Object.entries(max)) {
+		if (!Number.isFinite(value) || value < 0)
+			throw new Error(`Invalid max for ${queue}: ${value}`);
+		max[queue as PendingQueue] = Math.floor(value);
+	}
+	return { mode, policies, max };
 }
 
 export async function runPendingDigestAutopilot(
-  opts: PendingDigestAutopilotOptions,
+	opts: PendingDigestAutopilotOptions,
 ): Promise<PendingDigestAutopilotResult> {
-  const normalized = normalizePendingDigestAutopilotOptions(opts);
-  const runId = opts.runId ?? createPendingAutopilotRunId();
-  const startedAt = Math.floor((opts.now ?? new Date()).getTime() / 1000);
-  const actor = { type: "agent" as const, id: opts.actorId ?? "pending-digest-autopilot" };
-  const digest = buildPendingReviewDigestReport({ cfg: opts.cfg, factsDb: opts.factsDb, now: opts.now });
-  const adapters = { ...createDefaultPendingDigestAdapters(opts), ...(opts.adapters ?? {}) };
-  if (normalized.mode === "apply" && !opts.stateDbPath) {
-    throw new Error("--apply requires --state-db so parent classification decisions are recorded durably");
-  }
-  const store = normalized.mode === "apply" ? new PendingAutopilotStore(opts.stateDbPath as string) : null;
-  const decisions: PendingDecision[] = [];
-  const queues = Object.fromEntries(
-    PENDING_QUEUES.map((queue) => [
-      queue,
-      { policy: normalized.policies[queue], inspected: 0, skipped: false, decisions: [] as PendingDecision[] },
-    ]),
-  ) as Record<PendingQueue, PendingDigestQueueResult>;
+	const normalized = normalizePendingDigestAutopilotOptions(opts);
+	const runId = opts.runId ?? createPendingAutopilotRunId();
+	const startedAt = Math.floor((opts.now ?? new Date()).getTime() / 1000);
+	const actor = {
+		type: "agent" as const,
+		id: opts.actorId ?? "pending-digest-autopilot",
+	};
+	const digest = buildPendingReviewDigestReport({
+		cfg: opts.cfg,
+		factsDb: opts.factsDb,
+		now: opts.now,
+	});
+	const adapters = {
+		...createDefaultPendingDigestAdapters(opts),
+		...(opts.adapters ?? {}),
+	};
+	if (normalized.mode === "apply" && !opts.stateDbPath) {
+		throw new Error(
+			"--apply requires --state-db so parent classification decisions are recorded durably",
+		);
+	}
+	const store =
+		normalized.mode === "apply"
+			? new PendingAutopilotStore(opts.stateDbPath as string)
+			: null;
+	const decisions: PendingDecision[] = [];
+	const queues = Object.fromEntries(
+		PENDING_QUEUES.map((queue) => [
+			queue,
+			{
+				policy: normalized.policies[queue],
+				inspected: 0,
+				skipped: false,
+				decisions: [] as PendingDecision[],
+			},
+		]),
+	) as Record<PendingQueue, PendingDigestQueueResult>;
 
-  const inputHash = computePendingInputHash({
-    command: "digest-autopilot",
-    policies: normalized.policies,
-    max: normalized.max,
-    digest: digest.pendingReview,
-    policyVersion: PENDING_DIGEST_AUTOPILOT_POLICY_VERSION,
-  });
+	const inputHash = computePendingInputHash({
+		command: "digest-autopilot",
+		policies: normalized.policies,
+		max: normalized.max,
+		digest: digest.pendingReview,
+		policyVersion: PENDING_DIGEST_AUTOPILOT_POLICY_VERSION,
+	});
 
-  try {
-    store?.createRun({
-      runId,
-      mode: normalized.mode,
-      policy: "parent",
-      policyVersion: PENDING_DIGEST_AUTOPILOT_POLICY_VERSION,
-      inputHash,
-      queues: [...PENDING_QUEUES],
-      startedAt,
-    });
+	try {
+		store?.createRun({
+			runId,
+			mode: normalized.mode,
+			policy: "parent",
+			policyVersion: PENDING_DIGEST_AUTOPILOT_POLICY_VERSION,
+			inputHash,
+			queues: [...PENDING_QUEUES],
+			startedAt,
+		});
 
-    for (const queue of PENDING_QUEUES) {
-      const policy = normalized.policies[queue];
-      const adapter = adapters[queue];
-      const queueResult = queues[queue];
-      if (policy === "disabled") {
-        const decision = makeSkippedDecision({ queue, policy, mode: normalized.mode, runId, jobId: opts.jobId, actor });
-        decisions.push(decision);
-        queueResult.decisions.push(decision);
-        queueResult.inspected = 0;
-        queueResult.skipped = true;
-        queueResult.skipReason = "queue-disabled-by-policy";
-        store?.recordDecision(decision);
-        continue;
-      }
-      if (!adapter) {
-        const decision = makeSkippedDecision({ queue, policy, mode: normalized.mode, runId, jobId: opts.jobId, actor });
-        decisions.push(decision);
-        queueResult.decisions.push(decision);
-        queueResult.skipped = true;
-        queueResult.skipReason = "adapter-unavailable";
-        store?.recordDecision(decision);
-        continue;
-      }
+		for (const queue of PENDING_QUEUES) {
+			const policy = normalized.policies[queue];
+			const adapter = adapters[queue];
+			const queueResult = queues[queue];
+			if (policy === "disabled") {
+				const decision = makeSkippedDecision({
+					queue,
+					policy,
+					mode: normalized.mode,
+					runId,
+					jobId: opts.jobId,
+					actor,
+				});
+				decisions.push(decision);
+				queueResult.decisions.push(decision);
+				queueResult.inspected = 0;
+				queueResult.skipped = true;
+				queueResult.skipReason = "queue-disabled-by-policy";
+				store?.recordDecision(decision);
+				continue;
+			}
+			if (!adapter) {
+				const decision = makeSkippedDecision({
+					queue,
+					policy,
+					mode: normalized.mode,
+					runId,
+					jobId: opts.jobId,
+					actor,
+				});
+				decisions.push(decision);
+				queueResult.decisions.push(decision);
+				queueResult.skipped = true;
+				queueResult.skipReason = "adapter-unavailable";
+				store?.recordDecision(decision);
+				continue;
+			}
 
-      try {
-        const listed = await adapter.listPending(store?.getCursor(queue, policy) ?? null);
-        const items = listed.slice(0, normalized.max[queue]);
-        queueResult.inspected = items.length;
-        for (let i = 0; i < items.length; i++) {
-          const item = items[i];
-          const context: PendingDecisionContext = {
-            runId,
-            jobId: opts.jobId,
-            mode: normalized.mode,
-            policy,
-            policyVersion: PENDING_DIGEST_AUTOPILOT_POLICY_VERSION,
-            inputHash: item.inputHash,
-            actor,
-          };
-          const decision = await adapter.decide(item, context);
-          decisions.push(decision);
-          queueResult.decisions.push(decision);
-          const inserted = store?.recordDecision(decision).inserted ?? false;
-          if (inserted) store?.advanceCursorIfSafe(decision, item.visibleAfterCursor ?? item.id);
-        }
-      } catch (err) {
-        queueResult.inspected = queueResult.decisions.length;
-        const decision = makeFailureDecision({
-          queue,
-          policy,
-          mode: normalized.mode,
-          runId,
-          jobId: opts.jobId,
-          actor,
-          error: err,
-        });
-        decisions.push(decision);
-        queueResult.decisions.push(decision);
-        queueResult.skipped = true;
-        queueResult.skipReason = "inventory-failed";
-        store?.recordDecision(decision);
-      }
-    }
+			try {
+				const listed = await adapter.listPending(
+					store?.getCursor(queue, policy) ?? null,
+				);
+				const items = listed.slice(0, normalized.max[queue]);
+				queueResult.inspected = items.length;
+				for (let i = 0; i < items.length; i++) {
+					const item = items[i];
+					const context: PendingDecisionContext = {
+						runId,
+						jobId: opts.jobId,
+						mode: normalized.mode,
+						policy,
+						policyVersion: PENDING_DIGEST_AUTOPILOT_POLICY_VERSION,
+						inputHash: item.inputHash,
+						actor,
+					};
+					const decision = await adapter.decide(item, context);
+					decisions.push(decision);
+					queueResult.decisions.push(decision);
+					const inserted = store?.recordDecision(decision).inserted ?? false;
+					if (inserted)
+						store?.advanceCursorIfSafe(
+							decision,
+							item.visibleAfterCursor ?? item.id,
+						);
+				}
+			} catch (err) {
+				queueResult.inspected = queueResult.decisions.length;
+				const decision = makeFailureDecision({
+					queue,
+					policy,
+					mode: normalized.mode,
+					runId,
+					jobId: opts.jobId,
+					actor,
+					error: err,
+				});
+				decisions.push(decision);
+				queueResult.decisions.push(decision);
+				queueResult.skipped = true;
+				queueResult.skipReason = "inventory-failed";
+				store?.recordDecision(decision);
+			}
+		}
 
-    const foundationSummary = createStableRunSummary({
-      runId,
-      mode: normalized.mode,
-      policy: "parent",
-      policyVersion: PENDING_DIGEST_AUTOPILOT_POLICY_VERSION,
-      queues: [...PENDING_QUEUES],
-      startedAt,
-      finishedAt: Math.floor((opts.now ?? new Date()).getTime() / 1000),
-      decisions,
-    });
-    store?.finishRun(runId, foundationSummary);
+		const foundationSummary = createStableRunSummary({
+			runId,
+			mode: normalized.mode,
+			policy: "parent",
+			policyVersion: PENDING_DIGEST_AUTOPILOT_POLICY_VERSION,
+			queues: [...PENDING_QUEUES],
+			startedAt,
+			finishedAt: Math.floor((opts.now ?? new Date()).getTime() / 1000),
+			decisions,
+		});
+		store?.finishRun(runId, foundationSummary);
 
-    const result: PendingDigestAutopilotResult = {
-      schemaVersion: 1,
-      runId,
-      mode: normalized.mode,
-      policyVersion: PENDING_DIGEST_AUTOPILOT_POLICY_VERSION,
-      applyBehavior: normalized.mode === "apply" ? "record-decisions-only" : "non-mutating-dry-run",
-      policies: normalized.policies,
-      max: normalized.max,
-      counts: summarizeCounts(decisions),
-      queues,
-      foundationSummary,
-      digestContext: digest.pendingReview,
-      humanSummary: "",
-    };
-    result.humanSummary = renderPendingDigestAutopilotHumanSummary(result);
-    return result;
-  } finally {
-    store?.close();
-  }
+		const result: PendingDigestAutopilotResult = {
+			schemaVersion: 1,
+			runId,
+			mode: normalized.mode,
+			policyVersion: PENDING_DIGEST_AUTOPILOT_POLICY_VERSION,
+			applyBehavior:
+				normalized.mode === "apply"
+					? "record-decisions-only"
+					: "non-mutating-dry-run",
+			policies: normalized.policies,
+			max: normalized.max,
+			counts: summarizeCounts(decisions),
+			queues,
+			foundationSummary,
+			digestContext: digest.pendingReview,
+			humanSummary: "",
+		};
+		result.humanSummary = renderPendingDigestAutopilotHumanSummary(result);
+		return result;
+	} finally {
+		store?.close();
+	}
 }
 
-export function renderPendingDigestAutopilotHumanSummary(result: PendingDigestAutopilotResult): string {
-  const lines = [
-    `Pending digest autopilot ${result.runId} (${result.mode})`,
-    `Apply behavior: ${result.applyBehavior}. Queue stores are not mutated by the #1326 parent skeleton.`,
-    `Inspected ${result.counts.inspected}; classified ${result.counts.classified}; deferred ${result.counts.deferred}; skipped ${result.counts.skipped}; failed validation ${result.counts.failedValidation}.`,
-    "Queues:",
-  ];
-  for (const queue of PENDING_QUEUES) {
-    const q = result.queues[queue];
-    const human = q.decisions.filter((d) => d.humanReviewRequired).length;
-    const suffix = q.skipped ? ` skipped (${q.skipReason ?? "unknown"})` : ` ${q.inspected} inspected`;
-    lines.push(`- ${queue}: policy=${q.policy};${suffix}; humanReview=${human}`);
-  }
-  if (result.counts.humanReviewRequired > 0) {
-    lines.push(
-      "Next: review deferred human-review items; child adapters #1327/#1328/#1329 own queue-specific apply gates.",
-    );
-  } else {
-    lines.push(
-      "Next: no parent-applied queue mutations. Use child adapters for queue-specific review/apply when implemented.",
-    );
-  }
-  return lines.join("\n");
+export function renderPendingDigestAutopilotHumanSummary(
+	result: PendingDigestAutopilotResult,
+): string {
+	const lines = [
+		`Pending digest autopilot ${result.runId} (${result.mode})`,
+		`Apply behavior: ${result.applyBehavior}. Queue stores are not mutated by the #1326 parent skeleton.`,
+		`Inspected ${result.counts.inspected}; classified ${result.counts.classified}; deferred ${result.counts.deferred}; skipped ${result.counts.skipped}; failed validation ${result.counts.failedValidation}.`,
+		"Queues:",
+	];
+	for (const queue of PENDING_QUEUES) {
+		const q = result.queues[queue];
+		const human = q.decisions.filter((d) => d.humanReviewRequired).length;
+		const suffix = q.skipped
+			? ` skipped (${q.skipReason ?? "unknown"})`
+			: ` ${q.inspected} inspected`;
+		lines.push(
+			`- ${queue}: policy=${q.policy};${suffix}; humanReview=${human}`,
+		);
+	}
+	if (result.counts.humanReviewRequired > 0) {
+		lines.push(
+			"Next: review deferred human-review items; child adapters #1327/#1328/#1329 own queue-specific apply gates.",
+		);
+	} else {
+		lines.push(
+			"Next: no parent-applied queue mutations. Use child adapters for queue-specific review/apply when implemented.",
+		);
+	}
+	return lines.join("\n");
 }
 
 export function createDefaultPendingDigestAdapters(
-  opts: Pick<PendingDigestAutopilotOptions, "cfg" | "factsDb">,
+	opts: Pick<PendingDigestAutopilotOptions, "cfg" | "factsDb">,
 ): Record<PendingQueue, PendingQueueAdapter> {
-  const paths = pendingStorePaths(opts.cfg.sqlitePath);
-  return {
-    persona: createPersonaReadOnlyAdapter({ cfg: opts.cfg, dbPath: paths.proposals }),
-    procedures: createProcedureReadOnlyAdapter(opts.factsDb),
-    verified: createVerifiedReadOnlyAdapter(opts.factsDb),
-    tools: createToolProposalReadOnlyAdapter(paths.toolProposals),
-    crystallization: createCrystallizationReadOnlyAdapter(paths.crystallization),
-  };
+	const paths = pendingStorePaths(opts.cfg.sqlitePath);
+	return {
+		persona: createPersonaReadOnlyAdapter({
+			cfg: opts.cfg,
+			dbPath: paths.proposals,
+		}),
+		procedures: createProcedureReadOnlyAdapter(opts.factsDb),
+		verified: createVerifiedReadOnlyAdapter(opts.factsDb),
+		tools: createToolProposalReadOnlyAdapter(paths.toolProposals),
+		crystallization: createCrystallizationReadOnlyAdapter(
+			paths.crystallization,
+		),
+	};
 }
 
 export function createPersonaReadOnlyAdapter(input: {
-  cfg: HybridMemoryConfig;
-  dbPath: string;
+	cfg: HybridMemoryConfig;
+	dbPath: string;
 }): PendingQueueAdapter<QueueItem> {
-  return {
-    queue: "persona",
-    listPending: () => {
-      if (!input.cfg.personaProposals.enabled) return [];
-      return withCloseable(
-        () => new ProposalsDB(input.dbPath),
-        (store) => store.list({ status: "pending" }).map(personaProposalToItem),
-      );
-    },
-    decide: decideReadOnlyItem,
-  };
+	return {
+		queue: "persona",
+		listPending: () => {
+			if (!input.cfg.personaProposals.enabled) return [];
+			return withCloseable(
+				() => new ProposalsDB(input.dbPath),
+				(store) => store.list({ status: "pending" }).map(personaProposalToItem),
+			);
+		},
+		decide: decideReadOnlyItem,
+	};
 }
 
-export function createProcedureReadOnlyAdapter(factsDb: PendingDigestFactsDb): PendingQueueAdapter<QueueItem> {
-  return {
-    queue: "procedures",
-    listPending: () => {
-      if (!factsDb.triageProcedures) return [];
-      const report = factsDb.triageProcedures({ status: "validated", notPromoted: true, limit: 10_000 });
-      return report.rows.map(procedureRowToItem);
-    },
-    decide: decideReadOnlyItem,
-  };
+export function createProcedureReadOnlyAdapter(
+	factsDb: PendingDigestFactsDb,
+): PendingQueueAdapter<QueueItem> {
+	return {
+		queue: "procedures",
+		listPending: () => {
+			if (!factsDb.triageProcedures) return [];
+			const report = factsDb.triageProcedures({
+				status: "validated",
+				notPromoted: true,
+				limit: 10_000,
+			});
+			return report.rows.map(procedureRowToItem);
+		},
+		decide: decideReadOnlyItem,
+	};
 }
 
-export function createVerifiedReadOnlyAdapter(factsDb: PendingDigestFactsDb): PendingQueueAdapter<QueueItem> {
-  return {
-    queue: "verified",
-    listPending: () => {
-      const count = Math.max(0, factsDb.countVerifiedFacts());
-      return Array.from({ length: count }, (_, index) => verifiedPlaceholderToItem(index + 1));
-    },
-    decide: decideReadOnlyItem,
-  };
+export function createVerifiedReadOnlyAdapter(
+	factsDb: PendingDigestFactsDb,
+): PendingQueueAdapter<QueueItem> {
+	return {
+		queue: "verified",
+		listPending: () => {
+			const count = Math.max(0, factsDb.countVerifiedFacts());
+			return Array.from({ length: count }, (_, index) =>
+				verifiedPlaceholderToItem(index + 1),
+			);
+		},
+		decide: decideReadOnlyItem,
+	};
 }
 
-export function createToolProposalReadOnlyAdapter(dbPath: string): PendingQueueAdapter<QueueItem> {
-  return {
-    queue: "tools",
-    listPending: () =>
-      withCloseable(
-        () => new ToolProposalStore(dbPath),
-        (store) => store.list({ status: "proposed" }).map(toolProposalToItem),
-      ),
-    decide: decideReadOnlyItem,
-  };
+export function createToolProposalReadOnlyAdapter(
+	dbPath: string,
+): PendingQueueAdapter<QueueItem> {
+	return {
+		queue: "tools",
+		listPending: () =>
+			withCloseable(
+				() => new ToolProposalStore(dbPath),
+				(store) => store.list({ status: "proposed" }).map(toolProposalToItem),
+			),
+		decide: decideReadOnlyItem,
+	};
 }
 
-export function createCrystallizationReadOnlyAdapter(dbPath: string): PendingQueueAdapter<QueueItem> {
-  return {
-    queue: "crystallization",
-    listPending: () =>
-      withCloseable(
-        () => new CrystallizationStore(dbPath),
-        (store) => store.list({ status: "pending" }).map(crystallizationProposalToItem),
-      ),
-    decide: decideReadOnlyItem,
-  };
+export function createCrystallizationReadOnlyAdapter(
+	dbPath: string,
+): PendingQueueAdapter<QueueItem> {
+	return {
+		queue: "crystallization",
+		listPending: () =>
+			withCloseable(
+				() => new CrystallizationStore(dbPath),
+				(store) =>
+					store.list({ status: "pending" }).map(crystallizationProposalToItem),
+			),
+		decide: decideReadOnlyItem,
+	};
 }
 
-export function decideReadOnlyItem(item: QueueItem, context: PendingDecisionContext): PendingDecision {
-  if (context.policy === "disabled") {
-    return makeSkippedDecision({
-      queue: item.queue,
-      policy: context.policy,
-      mode: context.mode,
-      runId: context.runId,
-      jobId: context.jobId,
-      actor: context.actor,
-    });
-  }
-  const reportOnly = context.policy === "report-only";
-  const requiresHuman = item.requiresHumanReview === true || reportOnly;
-  return {
-    queue: item.queue,
-    itemId: item.id,
-    inputHash: item.inputHash,
-    policy: context.policy,
-    policyVersion: context.policyVersion,
-    mode: context.mode,
-    action: reportOnly ? "reported" : requiresHuman ? "deferred-for-human" : "classified",
-    reasonCode: reportOnly ? "policy-denied" : requiresHuman ? "human-review-required" : "dry-run",
-    actionClass: reportOnly ? "observe" : "preview",
-    capabilityClass: context.mode === "dry-run" ? "dry-run" : "read-only",
-    confidence: typeof item.payload.confidence === "number" ? item.payload.confidence : 0.5,
-    humanReviewRequired: requiresHuman,
-    evidence: [{ type: "pending-item", id: item.id, summary: String(item.payload.title ?? item.id) }],
-    actor: context.actor,
-    runId: context.runId,
-    jobId: context.jobId,
-    summary: {
-      title: String(item.payload.title ?? item.id),
-      body: String(item.payload.summary ?? "read-only pending digest classification"),
-      metadata: { queue: item.queue, source: item.payload.source ?? "live-inventory" },
-    },
-  };
+export function decideReadOnlyItem(
+	item: QueueItem,
+	context: PendingDecisionContext,
+): PendingDecision {
+	if (context.policy === "disabled") {
+		return makeSkippedDecision({
+			queue: item.queue,
+			policy: context.policy,
+			mode: context.mode,
+			runId: context.runId,
+			jobId: context.jobId,
+			actor: context.actor,
+		});
+	}
+	const reportOnly = context.policy === "report-only";
+	const requiresHuman = item.requiresHumanReview === true || reportOnly;
+	return {
+		queue: item.queue,
+		itemId: item.id,
+		inputHash: item.inputHash,
+		policy: context.policy,
+		policyVersion: context.policyVersion,
+		mode: context.mode,
+		action: reportOnly
+			? "reported"
+			: requiresHuman
+				? "deferred-for-human"
+				: "classified",
+		reasonCode: reportOnly
+			? "policy-denied"
+			: requiresHuman
+				? "human-review-required"
+				: context.mode === "dry-run"
+					? "dry-run"
+					: "read-only",
+		actionClass: reportOnly ? "observe" : "preview",
+		capabilityClass: context.mode === "dry-run" ? "dry-run" : "read-only",
+		confidence:
+			typeof item.payload.confidence === "number"
+				? item.payload.confidence
+				: 0.5,
+		humanReviewRequired: requiresHuman,
+		evidence: [
+			{
+				type: "pending-item",
+				id: item.id,
+				summary: String(item.payload.title ?? item.id),
+			},
+		],
+		actor: context.actor,
+		runId: context.runId,
+		jobId: context.jobId,
+		summary: {
+			title: String(item.payload.title ?? item.id),
+			body: String(
+				item.payload.summary ?? "read-only pending digest classification",
+			),
+			metadata: {
+				queue: item.queue,
+				source: item.payload.source ?? "live-inventory",
+			},
+		},
+	};
 }
 
 function personaProposalToItem(p: ProposalEntry): QueueItem {
-  const payload = {
-    source: "persona-proposals",
-    title: p.title,
-    targetFile: p.targetFile,
-    confidence: p.confidence,
-    createdAt: p.createdAt,
-    evidenceSessions: p.evidenceSessions,
-    summary: `Pending persona proposal for ${p.targetFile}`,
-  };
-  return makeItem("persona", p.id, payload, true);
+	const payload = {
+		source: "persona-proposals",
+		title: p.title,
+		targetFile: p.targetFile,
+		confidence: p.confidence,
+		createdAt: p.createdAt,
+		evidenceSessions: p.evidenceSessions,
+		summary: `Pending persona proposal for ${p.targetFile}`,
+	};
+	return makeItem("persona", p.id, payload, true);
 }
 
 function procedureRowToItem(p: ProcedureTriageRow): QueueItem {
-  const payload = {
-    source: "procedures-triage",
-    title: p.title,
-    validatedAt: p.validatedAt,
-    promotionBlockReason: p.promotionBlockReason,
-    successCount: p.successCount,
-    confidence: p.confidence,
-    skillPath: p.skillPath,
-    summary: `Procedure promotion candidate blocked by ${p.promotionBlockReason}`,
-  };
-  return makeItem("procedures", p.id, payload, true);
+	const payload = {
+		source: "procedures-triage",
+		title: p.title,
+		validatedAt: p.validatedAt,
+		promotionBlockReason: p.promotionBlockReason,
+		successCount: p.successCount,
+		confidence: p.confidence,
+		skillPath: p.skillPath,
+		summary: `Procedure promotion candidate blocked by ${p.promotionBlockReason}`,
+	};
+	return makeItem("procedures", p.id, payload, true);
 }
 
 function verifiedPlaceholderToItem(index: number): QueueItem {
-  const id = `verified-review-${index}`;
-  return makeItem(
-    "verified",
-    id,
-    {
-      source: "verified-facts-count",
-      title: `Verified fact review placeholder ${index}`,
-      summary:
-        "#1329 must define the exact verified-fact review queue. Parent #1326 only reports/classifies the current digest count.",
-    },
-    true,
-  );
+	const id = `verified-review-${index}`;
+	return makeItem(
+		"verified",
+		id,
+		{
+			source: "verified-facts-count",
+			title: `Verified fact review placeholder ${index}`,
+			summary:
+				"#1329 must define the exact verified-fact review queue. Parent #1326 only reports/classifies the current digest count.",
+		},
+		true,
+	);
 }
 
 function toolProposalToItem(p: ToolProposal): QueueItem {
-  return makeItem(
-    "tools",
-    p.id,
-    {
-      source: "tool-proposals",
-      title: p.name,
-      summary: p.description,
-      createdAt: p.createdAt,
-      updatedAt: p.updatedAt,
-    },
-    false,
-  );
+	return makeItem(
+		"tools",
+		p.id,
+		{
+			source: "tool-proposals",
+			title: p.name,
+			summary: p.description,
+			createdAt: p.createdAt,
+			updatedAt: p.updatedAt,
+		},
+		false,
+	);
 }
 
 function crystallizationProposalToItem(p: {
-  id: string;
-  skillName: string;
-  createdAt: string;
-  updatedAt: string;
+	id: string;
+	skillName: string;
+	createdAt: string;
+	updatedAt: string;
 }): QueueItem {
-  return makeItem(
-    "crystallization",
-    p.id,
-    {
-      source: "crystallization-proposals",
-      title: p.skillName,
-      summary: "Pending crystallization proposal; #1326 parent only classifies/read-only reports.",
-      createdAt: p.createdAt,
-      updatedAt: p.updatedAt,
-    },
-    false,
-  );
+	return makeItem(
+		"crystallization",
+		p.id,
+		{
+			source: "crystallization-proposals",
+			title: p.skillName,
+			summary:
+				"Pending crystallization proposal; #1326 parent only classifies/read-only reports.",
+			createdAt: p.createdAt,
+			updatedAt: p.updatedAt,
+		},
+		false,
+	);
 }
 
-function makeItem(queue: PendingQueue, id: string, payload: QueuePayload, requiresHumanReview: boolean): QueueItem {
-  return {
-    queue,
-    id,
-    inputHash: computePendingInputHash({
-      queue,
-      id,
-      payload,
-      policy: "default",
-      policyVersion: PENDING_DIGEST_AUTOPILOT_POLICY_VERSION,
-    }),
-    policyVersion: PENDING_DIGEST_AUTOPILOT_POLICY_VERSION,
-    capabilityClasses: ["read-only"],
-    payload,
-    visibleAfterCursor: id,
-    requiresHumanReview,
-  };
+function makeItem(
+	queue: PendingQueue,
+	id: string,
+	payload: QueuePayload,
+	requiresHumanReview: boolean,
+): QueueItem {
+	return {
+		queue,
+		id,
+		inputHash: computePendingInputHash({
+			queue,
+			id,
+			payload,
+			policy: "default",
+			policyVersion: PENDING_DIGEST_AUTOPILOT_POLICY_VERSION,
+		}),
+		policyVersion: PENDING_DIGEST_AUTOPILOT_POLICY_VERSION,
+		capabilityClasses: ["read-only"],
+		payload,
+		visibleAfterCursor: id,
+		requiresHumanReview,
+	};
 }
 
 function makeSkippedDecision(input: {
-  queue: PendingQueue;
-  policy: string;
-  mode: AutopilotMode;
-  runId: string;
-  jobId?: string;
-  actor: PendingDecision["actor"];
+	queue: PendingQueue;
+	policy: string;
+	mode: AutopilotMode;
+	runId: string;
+	jobId?: string;
+	actor: PendingDecision["actor"];
 }): PendingDecision {
-  const itemId = `${input.queue}:skipped`;
-  const inputHash = computePendingInputHash({ queue: input.queue, itemId, policy: input.policy, reason: "disabled" });
-  return {
-    queue: input.queue,
-    itemId,
-    inputHash,
-    policy: input.policy,
-    policyVersion: PENDING_DIGEST_AUTOPILOT_POLICY_VERSION,
-    mode: input.mode,
-    action: "skipped-by-policy",
-    reasonCode: "policy-denied",
-    actionClass: "observe",
-    capabilityClass: input.mode === "dry-run" ? "dry-run" : "read-only",
-    confidence: 1,
-    humanReviewRequired: false,
-    evidence: [{ type: "policy", id: input.policy, summary: "queue disabled or unavailable" }],
-    actor: input.actor,
-    runId: input.runId,
-    jobId: input.jobId,
-    summary: { title: `${input.queue} skipped`, body: "Queue skipped by parent orchestration policy." },
-  };
+	const itemId = `${input.queue}:skipped`;
+	const inputHash = computePendingInputHash({
+		queue: input.queue,
+		itemId,
+		policy: input.policy,
+		reason: "disabled",
+	});
+	return {
+		queue: input.queue,
+		itemId,
+		inputHash,
+		policy: input.policy,
+		policyVersion: PENDING_DIGEST_AUTOPILOT_POLICY_VERSION,
+		mode: input.mode,
+		action: "skipped-by-policy",
+		reasonCode: "policy-denied",
+		actionClass: "observe",
+		capabilityClass: input.mode === "dry-run" ? "dry-run" : "read-only",
+		confidence: 1,
+		humanReviewRequired: false,
+		evidence: [
+			{
+				type: "policy",
+				id: input.policy,
+				summary: "queue disabled or unavailable",
+			},
+		],
+		actor: input.actor,
+		runId: input.runId,
+		jobId: input.jobId,
+		summary: {
+			title: `${input.queue} skipped`,
+			body: "Queue skipped by parent orchestration policy.",
+		},
+	};
 }
 
 function makeFailureDecision(input: {
-  queue: PendingQueue;
-  policy: string;
-  mode: AutopilotMode;
-  runId: string;
-  jobId?: string;
-  actor: PendingDecision["actor"];
-  error: unknown;
+	queue: PendingQueue;
+	policy: string;
+	mode: AutopilotMode;
+	runId: string;
+	jobId?: string;
+	actor: PendingDecision["actor"];
+	error: unknown;
 }): PendingDecision {
-  const itemId = `${input.queue}:inventory-failed`;
-  const message = input.error instanceof Error ? input.error.message : String(input.error);
-  return {
-    queue: input.queue,
-    itemId,
-    inputHash: computePendingInputHash({ queue: input.queue, itemId, policy: input.policy, message }),
-    policy: input.policy,
-    policyVersion: PENDING_DIGEST_AUTOPILOT_POLICY_VERSION,
-    mode: input.mode,
-    action: "failed-validation",
-    reasonCode: "schema-validation-failed",
-    actionClass: "observe",
-    capabilityClass: input.mode === "dry-run" ? "dry-run" : "read-only",
-    confidence: 0,
-    humanReviewRequired: true,
-    evidence: [{ type: "error", summary: message }],
-    actor: input.actor,
-    runId: input.runId,
-    jobId: input.jobId,
-    summary: { title: `${input.queue} inventory failed`, body: message },
-  };
+	const itemId = `${input.queue}:inventory-failed`;
+	const message =
+		input.error instanceof Error ? input.error.message : String(input.error);
+	return {
+		queue: input.queue,
+		itemId,
+		inputHash: computePendingInputHash({
+			queue: input.queue,
+			itemId,
+			policy: input.policy,
+			message,
+		}),
+		policy: input.policy,
+		policyVersion: PENDING_DIGEST_AUTOPILOT_POLICY_VERSION,
+		mode: input.mode,
+		action: "failed-validation",
+		reasonCode: "schema-validation-failed",
+		actionClass: "observe",
+		capabilityClass: input.mode === "dry-run" ? "dry-run" : "read-only",
+		confidence: 0,
+		humanReviewRequired: true,
+		evidence: [{ type: "error", summary: message }],
+		actor: input.actor,
+		runId: input.runId,
+		jobId: input.jobId,
+		summary: { title: `${input.queue} inventory failed`, body: message },
+	};
 }
 
-function summarizeCounts(decisions: PendingDecision[]): PendingDigestAutopilotResult["counts"] {
-  return {
-    inspected: decisions.filter((d) => d.action !== "skipped-by-policy" && d.action !== "failed-validation").length,
-    classified: decisions.filter((d) => d.action === "classified" || d.action === "reported").length,
-    applied: decisions.filter((d) => d.action === "applied").length,
-    deferred: decisions.filter((d) => d.action === "deferred-for-human").length,
-    rejected: decisions.filter((d) => d.action === "rejected").length,
-    failedValidation: decisions.filter((d) => d.action === "failed-validation").length,
-    skipped: decisions.filter((d) => d.action === "skipped-by-policy").length,
-    humanReviewRequired: decisions.filter((d) => d.humanReviewRequired).length,
-  };
+function summarizeCounts(
+	decisions: PendingDecision[],
+): PendingDigestAutopilotResult["counts"] {
+	return {
+		inspected: decisions.filter(
+			(d) =>
+				d.action !== "skipped-by-policy" && d.action !== "failed-validation",
+		).length,
+		classified: decisions.filter(
+			(d) => d.action === "classified" || d.action === "reported",
+		).length,
+		applied: decisions.filter((d) => d.action === "applied").length,
+		deferred: decisions.filter((d) => d.action === "deferred-for-human").length,
+		rejected: decisions.filter((d) => d.action === "rejected").length,
+		failedValidation: decisions.filter((d) => d.action === "failed-validation")
+			.length,
+		skipped: decisions.filter((d) => d.action === "skipped-by-policy").length,
+		humanReviewRequired: decisions.filter((d) => d.humanReviewRequired).length,
+	};
 }
 
 function validatePolicies(policies: PendingDigestAutopilotPolicies): void {
-  const allowed: Record<PendingQueue, readonly string[]> = {
-    persona: ["disabled", "report-only", "cautious", "apply-safe"],
-    procedures: ["disabled", "report-only", "dry-run-skills", "auto-safe"],
-    verified: ["disabled", "report-only", "classify", "apply-obvious"],
-    tools: ["disabled", "report-only", "classify"],
-    crystallization: ["disabled", "report-only", "classify"],
-  };
-  for (const queue of PENDING_QUEUES) {
-    if (!allowed[queue].includes(policies[queue])) {
-      throw new Error(`Unsupported ${queue} pending autopilot policy: ${policies[queue]}`);
-    }
-  }
+	const allowed: Record<PendingQueue, readonly string[]> = {
+		persona: ["disabled", "report-only", "cautious", "apply-safe"],
+		procedures: ["disabled", "report-only", "dry-run-skills", "auto-safe"],
+		verified: ["disabled", "report-only", "classify", "apply-obvious"],
+		tools: ["disabled", "report-only", "classify"],
+		crystallization: ["disabled", "report-only", "classify"],
+	};
+	for (const queue of PENDING_QUEUES) {
+		if (!allowed[queue].includes(policies[queue])) {
+			throw new Error(
+				`Unsupported ${queue} pending autopilot policy: ${policies[queue]}`,
+			);
+		}
+	}
 }
 
-function withCloseable<TStore extends { close?: () => void }, T>(factory: () => TStore, fn: (store: TStore) => T): T {
-  let store: TStore | null = null;
-  try {
-    store = factory();
-    return fn(store);
-  } finally {
-    try {
-      store?.close?.();
-    } catch {
-      // Best-effort close for inventory readers.
-    }
-  }
+function withCloseable<TStore extends { close?: () => void }, T>(
+	factory: () => TStore,
+	fn: (store: TStore) => T,
+): T {
+	let store: TStore | null = null;
+	try {
+		store = factory();
+		return fn(store);
+	} finally {
+		try {
+			store?.close?.();
+		} catch {
+			// Best-effort close for inventory readers.
+		}
+	}
 }
 
-export function stablePendingDigestAutopilotJson(result: PendingDigestAutopilotResult): string {
-  return `${canonicalJson(redactAutopilotValue(result))}\n`;
+export function stablePendingDigestAutopilotJson(
+	result: PendingDigestAutopilotResult,
+): string {
+	return `${canonicalJson(redactAutopilotValue(result))}\n`;
 }

--- a/extensions/memory-hybrid/services/pending-digest-autopilot.ts
+++ b/extensions/memory-hybrid/services/pending-digest-autopilot.ts
@@ -651,7 +651,3 @@ function withCloseable<TStore extends { close?: () => void }, T>(
 export function stablePendingDigestAutopilotJson(result: PendingDigestAutopilotResult): string {
   return `${JSON.stringify(result, null, 2)}\n`;
 }
-
-export function foundationSummaryJson(result: PendingDigestAutopilotResult): string {
-  return stableRunSummaryJson(result.foundationSummary);
-}

--- a/extensions/memory-hybrid/services/pending-digest-autopilot.ts
+++ b/extensions/memory-hybrid/services/pending-digest-autopilot.ts
@@ -299,7 +299,11 @@ export async function runPendingDigestAutopilot(
         queueResult.decisions.push(decision);
         queueResult.skipped = true;
         queueResult.skipReason = "inventory-failed";
-        store?.recordDecision(decision);
+        try {
+          store?.recordDecision(decision);
+        } catch {
+          // Best-effort record for inventory failure; do not cascade store errors.
+        }
       }
     }
 
@@ -415,7 +419,22 @@ export function createVerifiedReadOnlyAdapter(factsDb: PendingDigestFactsDb): Pe
     queue: "verified",
     listPending: () => {
       const count = Math.max(0, factsDb.countVerifiedFacts());
-      return Array.from({ length: count }, (_, index) => verifiedPlaceholderToItem(index + 1));
+      return {
+        length: count,
+        *[Symbol.iterator]() {
+          for (let index = 1; index <= count; index++) {
+            yield verifiedPlaceholderToItem(index);
+          }
+        },
+        slice(start: number, end?: number) {
+          const sliceEnd = end ?? count;
+          const result: QueueItem[] = [];
+          for (let index = start + 1; index <= Math.min(sliceEnd, count); index++) {
+            result.push(verifiedPlaceholderToItem(index));
+          }
+          return result;
+        },
+      } as QueueItem[];
     },
     decide: decideReadOnlyItem,
   };

--- a/extensions/memory-hybrid/services/pending-digest-autopilot.ts
+++ b/extensions/memory-hybrid/services/pending-digest-autopilot.ts
@@ -629,10 +629,7 @@ function validatePolicies(policies: PendingDigestAutopilotPolicies): void {
   }
 }
 
-function withCloseable<TStore extends { close?: () => void }, T>(
-  factory: () => TStore,
-  fn: (store: TStore) => T,
-): T {
+function withCloseable<TStore extends { close?: () => void }, T>(factory: () => TStore, fn: (store: TStore) => T): T {
   let store: TStore | null = null;
   try {
     store = factory();

--- a/extensions/memory-hybrid/services/pending-digest-autopilot.ts
+++ b/extensions/memory-hybrid/services/pending-digest-autopilot.ts
@@ -19,6 +19,8 @@ import {
   PENDING_QUEUES,
   type PendingAutopilotRunSummary,
   PendingAutopilotStore,
+  canonicalJson,
+  redactAutopilotValue,
   type PendingDecision,
   type PendingDecisionContext,
   type PendingItem,
@@ -27,7 +29,6 @@ import {
   computePendingInputHash,
   createPendingAutopilotRunId,
   createStableRunSummary,
-  stableRunSummaryJson,
 } from "./pending-autopilot/index.js";
 import { buildPendingReviewDigestReport, pendingStorePaths } from "./pending-review-digest.js";
 
@@ -174,7 +175,10 @@ export async function runPendingDigestAutopilot(
   const actor = { type: "agent" as const, id: opts.actorId ?? "pending-digest-autopilot" };
   const digest = buildPendingReviewDigestReport({ cfg: opts.cfg, factsDb: opts.factsDb, now: opts.now });
   const adapters = { ...createDefaultPendingDigestAdapters(opts), ...(opts.adapters ?? {}) };
-  const store = opts.stateDbPath ? new PendingAutopilotStore(opts.stateDbPath) : null;
+  if (normalized.mode === "apply" && !opts.stateDbPath) {
+    throw new Error("--apply requires --state-db so parent classification decisions are recorded durably");
+  }
+  const store = normalized.mode === "apply" ? new PendingAutopilotStore(opts.stateDbPath as string) : null;
   const decisions: PendingDecision[] = [];
   const queues = Object.fromEntries(
     PENDING_QUEUES.map((queue) => [
@@ -243,8 +247,8 @@ export async function runPendingDigestAutopilot(
           const decision = await adapter.decide(item, context);
           decisions.push(decision);
           queueResult.decisions.push(decision);
-          store?.recordDecision(decision);
-          store?.advanceCursorIfSafe(decision, item.visibleAfterCursor ?? item.id);
+          const inserted = store?.recordDecision(decision).inserted ?? false;
+          if (inserted) store?.advanceCursorIfSafe(decision, item.visibleAfterCursor ?? item.id);
         }
       } catch (err) {
         const decision = makeFailureDecision({
@@ -346,7 +350,6 @@ export function createPersonaReadOnlyAdapter(input: {
       return withCloseable(
         () => new ProposalsDB(input.dbPath),
         (store) => store.list({ status: "pending" }).map(personaProposalToItem),
-        [],
       );
     },
     decide: decideReadOnlyItem,
@@ -383,7 +386,6 @@ export function createToolProposalReadOnlyAdapter(dbPath: string): PendingQueueA
       withCloseable(
         () => new ToolProposalStore(dbPath),
         (store) => store.list({ status: "proposed" }).map(toolProposalToItem),
-        [],
       ),
     decide: decideReadOnlyItem,
   };
@@ -396,7 +398,6 @@ export function createCrystallizationReadOnlyAdapter(dbPath: string): PendingQue
       withCloseable(
         () => new CrystallizationStore(dbPath),
         (store) => store.list({ status: "pending" }).map(crystallizationProposalToItem),
-        [],
       ),
     decide: decideReadOnlyItem,
   };
@@ -414,7 +415,7 @@ export function decideReadOnlyItem(item: QueueItem, context: PendingDecisionCont
     });
   }
   const reportOnly = context.policy === "report-only";
-  const requiresHuman = item.requiresHumanReview === true || reportOnly || context.mode === "apply";
+  const requiresHuman = item.requiresHumanReview === true || reportOnly;
   return {
     queue: item.queue,
     itemId: item.id,
@@ -631,14 +632,11 @@ function validatePolicies(policies: PendingDigestAutopilotPolicies): void {
 function withCloseable<TStore extends { close?: () => void }, T>(
   factory: () => TStore,
   fn: (store: TStore) => T,
-  fallback: T,
 ): T {
   let store: TStore | null = null;
   try {
     store = factory();
     return fn(store);
-  } catch {
-    return fallback;
   } finally {
     try {
       store?.close?.();
@@ -649,5 +647,5 @@ function withCloseable<TStore extends { close?: () => void }, T>(
 }
 
 export function stablePendingDigestAutopilotJson(result: PendingDigestAutopilotResult): string {
-  return `${JSON.stringify(result, null, 2)}\n`;
+  return `${canonicalJson(redactAutopilotValue(result))}\n`;
 }

--- a/extensions/memory-hybrid/services/pending-digest-autopilot.ts
+++ b/extensions/memory-hybrid/services/pending-digest-autopilot.ts
@@ -192,29 +192,30 @@ export async function runPendingDigestAutopilot(
   if (normalized.mode === "apply" && !opts.stateDbPath) {
     throw new Error("--apply requires --state-db so parent classification decisions are recorded durably");
   }
-  const store = normalized.mode === "apply" ? new PendingAutopilotStore(opts.stateDbPath as string) : null;
-  const decisions: PendingDecision[] = [];
-  const queues = Object.fromEntries(
-    PENDING_QUEUES.map((queue) => [
-      queue,
-      {
-        policy: normalized.policies[queue],
-        inspected: 0,
-        skipped: false,
-        decisions: [] as PendingDecision[],
-      },
-    ]),
-  ) as Record<PendingQueue, PendingDigestQueueResult>;
 
-  const inputHash = computePendingInputHash({
-    command: "digest-autopilot",
-    policies: normalized.policies,
-    max: normalized.max,
-    digest: digest.pendingReview,
-    policyVersion: PENDING_DIGEST_AUTOPILOT_POLICY_VERSION,
-  });
-
+  let store: PendingAutopilotStore | null = null;
   try {
+    store = normalized.mode === "apply" ? new PendingAutopilotStore(opts.stateDbPath as string) : null;
+    const decisions: PendingDecision[] = [];
+    const queues = Object.fromEntries(
+      PENDING_QUEUES.map((queue) => [
+        queue,
+        {
+          policy: normalized.policies[queue],
+          inspected: 0,
+          skipped: false,
+          decisions: [] as PendingDecision[],
+        },
+      ]),
+    ) as Record<PendingQueue, PendingDigestQueueResult>;
+
+    const inputHash = computePendingInputHash({
+      command: "digest-autopilot",
+      policies: normalized.policies,
+      max: normalized.max,
+      digest: digest.pendingReview,
+      policyVersion: PENDING_DIGEST_AUTOPILOT_POLICY_VERSION,
+    });
     store?.createRun({
       runId,
       mode: normalized.mode,
@@ -419,22 +420,7 @@ export function createVerifiedReadOnlyAdapter(factsDb: PendingDigestFactsDb): Pe
     queue: "verified",
     listPending: () => {
       const count = Math.max(0, factsDb.countVerifiedFacts());
-      return {
-        length: count,
-        *[Symbol.iterator]() {
-          for (let index = 1; index <= count; index++) {
-            yield verifiedPlaceholderToItem(index);
-          }
-        },
-        slice(start: number, end?: number) {
-          const sliceEnd = end ?? count;
-          const result: QueueItem[] = [];
-          for (let index = start + 1; index <= Math.min(sliceEnd, count); index++) {
-            result.push(verifiedPlaceholderToItem(index));
-          }
-          return result;
-        },
-      } as QueueItem[];
+      return Array.from({ length: count }, (_, i) => verifiedPlaceholderToItem(i + 1));
     },
     decide: decideReadOnlyItem,
   };

--- a/extensions/memory-hybrid/services/pending-digest-autopilot.ts
+++ b/extensions/memory-hybrid/services/pending-digest-autopilot.ts
@@ -10,812 +10,714 @@
 
 import type { DatabaseSync } from "node:sqlite";
 import { CrystallizationStore } from "../backends/crystallization-store.js";
-import type {
-	ProcedureTriageReport,
-	ProcedureTriageRow,
-} from "../backends/facts-db/procedures.js";
+import type { ProcedureTriageReport, ProcedureTriageRow } from "../backends/facts-db/procedures.js";
 import { type ProposalEntry, ProposalsDB } from "../backends/proposals-db.js";
-import {
-	type ToolProposal,
-	ToolProposalStore,
-} from "../backends/tool-proposal-store.js";
+import { type ToolProposal, ToolProposalStore } from "../backends/tool-proposal-store.js";
 import type { HybridMemoryConfig } from "../config.js";
 import {
-	type AutopilotMode,
-	PENDING_QUEUES,
-	type PendingAutopilotRunSummary,
-	PendingAutopilotStore,
-	canonicalJson,
-	redactAutopilotValue,
-	type PendingDecision,
-	type PendingDecisionContext,
-	type PendingItem,
-	type PendingQueue,
-	type PendingQueueAdapter,
-	computePendingInputHash,
-	createPendingAutopilotRunId,
-	createStableRunSummary,
+  type AutopilotMode,
+  PENDING_QUEUES,
+  type PendingAutopilotRunSummary,
+  PendingAutopilotStore,
+  canonicalJson,
+  redactAutopilotValue,
+  type PendingDecision,
+  type PendingDecisionContext,
+  type PendingItem,
+  type PendingQueue,
+  type PendingQueueAdapter,
+  computePendingInputHash,
+  createPendingAutopilotRunId,
+  createStableRunSummary,
 } from "./pending-autopilot/index.js";
-import {
-	buildPendingReviewDigestReport,
-	pendingStorePaths,
-} from "./pending-review-digest.js";
+import { buildPendingReviewDigestReport, pendingStorePaths } from "./pending-review-digest.js";
 
 export const PENDING_DIGEST_AUTOPILOT_POLICY_VERSION = "parent-skeleton-v1";
 
-export type PersonaAutopilotPolicy =
-	| "disabled"
-	| "report-only"
-	| "cautious"
-	| "apply-safe";
-export type ProcedureAutopilotPolicy =
-	| "disabled"
-	| "report-only"
-	| "dry-run-skills"
-	| "auto-safe";
-export type VerifiedAutopilotPolicy =
-	| "disabled"
-	| "report-only"
-	| "classify"
-	| "apply-obvious";
+export type PersonaAutopilotPolicy = "disabled" | "report-only" | "cautious" | "apply-safe";
+export type ProcedureAutopilotPolicy = "disabled" | "report-only" | "dry-run-skills" | "auto-safe";
+export type VerifiedAutopilotPolicy = "disabled" | "report-only" | "classify" | "apply-obvious";
 export type ReadOnlyClassifyPolicy = "disabled" | "report-only" | "classify";
 export type PendingDigestAutopilotPolicy =
-	| PersonaAutopilotPolicy
-	| ProcedureAutopilotPolicy
-	| VerifiedAutopilotPolicy
-	| ReadOnlyClassifyPolicy;
+  | PersonaAutopilotPolicy
+  | ProcedureAutopilotPolicy
+  | VerifiedAutopilotPolicy
+  | ReadOnlyClassifyPolicy;
 
 export interface PendingDigestAutopilotPolicies {
-	persona: PersonaAutopilotPolicy;
-	procedures: ProcedureAutopilotPolicy;
-	verified: VerifiedAutopilotPolicy;
-	tools: ReadOnlyClassifyPolicy;
-	crystallization: ReadOnlyClassifyPolicy;
+  persona: PersonaAutopilotPolicy;
+  procedures: ProcedureAutopilotPolicy;
+  verified: VerifiedAutopilotPolicy;
+  tools: ReadOnlyClassifyPolicy;
+  crystallization: ReadOnlyClassifyPolicy;
 }
 
 export interface PendingDigestAutopilotMaxima {
-	persona: number;
-	procedures: number;
-	verified: number;
-	tools: number;
-	crystallization: number;
+  persona: number;
+  procedures: number;
+  verified: number;
+  tools: number;
+  crystallization: number;
 }
 
 export interface PendingDigestAutopilotOptions {
-	cfg: HybridMemoryConfig;
-	factsDb: PendingDigestFactsDb;
-	mode?: AutopilotMode;
-	policies?: Partial<PendingDigestAutopilotPolicies>;
-	max?: Partial<PendingDigestAutopilotMaxima>;
-	runId?: string;
-	jobId?: string;
-	actorId?: string;
-	now?: Date;
-	stateDbPath?: string;
-	adapters?: Partial<Record<PendingQueue, PendingQueueAdapter>>;
+  cfg: HybridMemoryConfig;
+  factsDb: PendingDigestFactsDb;
+  mode?: AutopilotMode;
+  policies?: Partial<PendingDigestAutopilotPolicies>;
+  max?: Partial<PendingDigestAutopilotMaxima>;
+  runId?: string;
+  jobId?: string;
+  actorId?: string;
+  now?: Date;
+  stateDbPath?: string;
+  adapters?: Partial<Record<PendingQueue, PendingQueueAdapter>>;
 }
 
 export interface PendingDigestFactsDb {
-	proceduresCount(): number;
-	proceduresValidatedCount(): number;
-	proceduresPromotedCount(): number;
-	countVerifiedFacts(): number;
-	proceduresValidatedSince?(sinceSec: number): number;
-	getRawDb?(): DatabaseSync | undefined | null;
-	triageProcedures?(options?: {
-		status?: "validated" | "all";
-		notPromoted?: boolean;
-		limit?: number;
-		validationThreshold?: number;
-	}): ProcedureTriageReport;
+  proceduresCount(): number;
+  proceduresValidatedCount(): number;
+  proceduresPromotedCount(): number;
+  countVerifiedFacts(): number;
+  proceduresValidatedSince?(sinceSec: number): number;
+  getRawDb?(): DatabaseSync | undefined | null;
+  triageProcedures?(options?: {
+    status?: "validated" | "all";
+    notPromoted?: boolean;
+    limit?: number;
+    validationThreshold?: number;
+  }): ProcedureTriageReport;
 }
 
 export interface PendingDigestAutopilotResult {
-	schemaVersion: 1;
-	runId: string;
-	mode: AutopilotMode;
-	policyVersion: string;
-	applyBehavior: "record-decisions-only" | "non-mutating-dry-run";
-	policies: PendingDigestAutopilotPolicies;
-	max: PendingDigestAutopilotMaxima;
-	counts: {
-		inspected: number;
-		classified: number;
-		applied: number;
-		deferred: number;
-		rejected: number;
-		failedValidation: number;
-		skipped: number;
-		humanReviewRequired: number;
-	};
-	queues: Record<PendingQueue, PendingDigestQueueResult>;
-	foundationSummary: PendingAutopilotRunSummary;
-	digestContext: ReturnType<
-		typeof buildPendingReviewDigestReport
-	>["pendingReview"];
-	humanSummary: string;
+  schemaVersion: 1;
+  runId: string;
+  mode: AutopilotMode;
+  policyVersion: string;
+  applyBehavior: "record-decisions-only" | "non-mutating-dry-run";
+  policies: PendingDigestAutopilotPolicies;
+  max: PendingDigestAutopilotMaxima;
+  counts: {
+    inspected: number;
+    classified: number;
+    applied: number;
+    deferred: number;
+    rejected: number;
+    failedValidation: number;
+    skipped: number;
+    humanReviewRequired: number;
+  };
+  queues: Record<PendingQueue, PendingDigestQueueResult>;
+  foundationSummary: PendingAutopilotRunSummary;
+  digestContext: ReturnType<typeof buildPendingReviewDigestReport>["pendingReview"];
+  humanSummary: string;
 }
 
 export interface PendingDigestQueueResult {
-	policy: PendingDigestAutopilotPolicy;
-	inspected: number;
-	skipped: boolean;
-	skipReason?:
-		| "queue-disabled-by-policy"
-		| "adapter-unavailable"
-		| "inventory-failed";
-	decisions: PendingDecision[];
+  policy: PendingDigestAutopilotPolicy;
+  inspected: number;
+  skipped: boolean;
+  skipReason?: "queue-disabled-by-policy" | "adapter-unavailable" | "inventory-failed";
+  decisions: PendingDecision[];
 }
 
 type QueuePayload = Record<string, unknown>;
 type QueueItem = PendingItem<QueuePayload>;
 
 const DEFAULT_POLICIES: PendingDigestAutopilotPolicies = {
-	persona: "cautious",
-	procedures: "auto-safe",
-	verified: "classify",
-	tools: "classify",
-	crystallization: "classify",
+  persona: "cautious",
+  procedures: "auto-safe",
+  verified: "classify",
+  tools: "classify",
+  crystallization: "classify",
 };
 
 const DEFAULT_MAX: PendingDigestAutopilotMaxima = {
-	persona: 20,
-	procedures: 50,
-	verified: 100,
-	tools: 50,
-	crystallization: 50,
+  persona: 20,
+  procedures: 50,
+  verified: 100,
+  tools: 50,
+  crystallization: 50,
 };
 
 export function normalizePendingDigestAutopilotOptions(input: {
-	mode?: AutopilotMode;
-	policies?: Partial<PendingDigestAutopilotPolicies>;
-	max?: Partial<PendingDigestAutopilotMaxima>;
+  mode?: AutopilotMode;
+  policies?: Partial<PendingDigestAutopilotPolicies>;
+  max?: Partial<PendingDigestAutopilotMaxima>;
 }): {
-	mode: AutopilotMode;
-	policies: PendingDigestAutopilotPolicies;
-	max: PendingDigestAutopilotMaxima;
+  mode: AutopilotMode;
+  policies: PendingDigestAutopilotPolicies;
+  max: PendingDigestAutopilotMaxima;
 } {
-	const mode = input.mode ?? "dry-run";
-	if (mode !== "dry-run" && mode !== "apply")
-		throw new Error(`Unsupported pending autopilot mode: ${mode}`);
-	const policies: PendingDigestAutopilotPolicies = { ...DEFAULT_POLICIES };
-	const policyInput = input.policies ?? {};
-	if (policyInput.persona !== undefined) policies.persona = policyInput.persona;
-	if (policyInput.procedures !== undefined)
-		policies.procedures = policyInput.procedures;
-	if (policyInput.verified !== undefined)
-		policies.verified = policyInput.verified;
-	if (policyInput.tools !== undefined) policies.tools = policyInput.tools;
-	if (policyInput.crystallization !== undefined)
-		policies.crystallization = policyInput.crystallization;
-	validatePolicies(policies);
-	const max: PendingDigestAutopilotMaxima = { ...DEFAULT_MAX };
-	for (const [queue, value] of Object.entries(input.max ?? {})) {
-		if (value !== undefined) max[queue as PendingQueue] = value;
-	}
-	for (const [queue, value] of Object.entries(max)) {
-		if (!Number.isFinite(value) || value < 0)
-			throw new Error(`Invalid max for ${queue}: ${value}`);
-		max[queue as PendingQueue] = Math.floor(value);
-	}
-	return { mode, policies, max };
+  const mode = input.mode ?? "dry-run";
+  if (mode !== "dry-run" && mode !== "apply") throw new Error(`Unsupported pending autopilot mode: ${mode}`);
+  const policies: PendingDigestAutopilotPolicies = { ...DEFAULT_POLICIES };
+  const policyInput = input.policies ?? {};
+  if (policyInput.persona !== undefined) policies.persona = policyInput.persona;
+  if (policyInput.procedures !== undefined) policies.procedures = policyInput.procedures;
+  if (policyInput.verified !== undefined) policies.verified = policyInput.verified;
+  if (policyInput.tools !== undefined) policies.tools = policyInput.tools;
+  if (policyInput.crystallization !== undefined) policies.crystallization = policyInput.crystallization;
+  validatePolicies(policies);
+  const max: PendingDigestAutopilotMaxima = { ...DEFAULT_MAX };
+  for (const [queue, value] of Object.entries(input.max ?? {})) {
+    if (value !== undefined) max[queue as PendingQueue] = value;
+  }
+  for (const [queue, value] of Object.entries(max)) {
+    if (!Number.isFinite(value) || value < 0) throw new Error(`Invalid max for ${queue}: ${value}`);
+    max[queue as PendingQueue] = Math.floor(value);
+  }
+  return { mode, policies, max };
 }
 
 export async function runPendingDigestAutopilot(
-	opts: PendingDigestAutopilotOptions,
+  opts: PendingDigestAutopilotOptions,
 ): Promise<PendingDigestAutopilotResult> {
-	const normalized = normalizePendingDigestAutopilotOptions(opts);
-	const runId = opts.runId ?? createPendingAutopilotRunId();
-	const startedAt = Math.floor((opts.now ?? new Date()).getTime() / 1000);
-	const actor = {
-		type: "agent" as const,
-		id: opts.actorId ?? "pending-digest-autopilot",
-	};
-	const digest = buildPendingReviewDigestReport({
-		cfg: opts.cfg,
-		factsDb: opts.factsDb,
-		now: opts.now,
-	});
-	const adapters = {
-		...createDefaultPendingDigestAdapters(opts),
-		...(opts.adapters ?? {}),
-	};
-	if (normalized.mode === "apply" && !opts.stateDbPath) {
-		throw new Error(
-			"--apply requires --state-db so parent classification decisions are recorded durably",
-		);
-	}
-	const store =
-		normalized.mode === "apply"
-			? new PendingAutopilotStore(opts.stateDbPath as string)
-			: null;
-	const decisions: PendingDecision[] = [];
-	const queues = Object.fromEntries(
-		PENDING_QUEUES.map((queue) => [
-			queue,
-			{
-				policy: normalized.policies[queue],
-				inspected: 0,
-				skipped: false,
-				decisions: [] as PendingDecision[],
-			},
-		]),
-	) as Record<PendingQueue, PendingDigestQueueResult>;
+  const normalized = normalizePendingDigestAutopilotOptions(opts);
+  const runId = opts.runId ?? createPendingAutopilotRunId();
+  const startedAt = Math.floor((opts.now ?? new Date()).getTime() / 1000);
+  const actor = {
+    type: "agent" as const,
+    id: opts.actorId ?? "pending-digest-autopilot",
+  };
+  const digest = buildPendingReviewDigestReport({
+    cfg: opts.cfg,
+    factsDb: opts.factsDb,
+    now: opts.now,
+  });
+  const adapters = {
+    ...createDefaultPendingDigestAdapters(opts),
+    ...(opts.adapters ?? {}),
+  };
+  if (normalized.mode === "apply" && !opts.stateDbPath) {
+    throw new Error("--apply requires --state-db so parent classification decisions are recorded durably");
+  }
+  const store = normalized.mode === "apply" ? new PendingAutopilotStore(opts.stateDbPath as string) : null;
+  const decisions: PendingDecision[] = [];
+  const queues = Object.fromEntries(
+    PENDING_QUEUES.map((queue) => [
+      queue,
+      {
+        policy: normalized.policies[queue],
+        inspected: 0,
+        skipped: false,
+        decisions: [] as PendingDecision[],
+      },
+    ]),
+  ) as Record<PendingQueue, PendingDigestQueueResult>;
 
-	const inputHash = computePendingInputHash({
-		command: "digest-autopilot",
-		policies: normalized.policies,
-		max: normalized.max,
-		digest: digest.pendingReview,
-		policyVersion: PENDING_DIGEST_AUTOPILOT_POLICY_VERSION,
-	});
+  const inputHash = computePendingInputHash({
+    command: "digest-autopilot",
+    policies: normalized.policies,
+    max: normalized.max,
+    digest: digest.pendingReview,
+    policyVersion: PENDING_DIGEST_AUTOPILOT_POLICY_VERSION,
+  });
 
-	try {
-		store?.createRun({
-			runId,
-			mode: normalized.mode,
-			policy: "parent",
-			policyVersion: PENDING_DIGEST_AUTOPILOT_POLICY_VERSION,
-			inputHash,
-			queues: [...PENDING_QUEUES],
-			startedAt,
-		});
+  try {
+    store?.createRun({
+      runId,
+      mode: normalized.mode,
+      policy: "parent",
+      policyVersion: PENDING_DIGEST_AUTOPILOT_POLICY_VERSION,
+      inputHash,
+      queues: [...PENDING_QUEUES],
+      startedAt,
+    });
 
-		for (const queue of PENDING_QUEUES) {
-			const policy = normalized.policies[queue];
-			const adapter = adapters[queue];
-			const queueResult = queues[queue];
-			if (policy === "disabled") {
-				const decision = makeSkippedDecision({
-					queue,
-					policy,
-					mode: normalized.mode,
-					runId,
-					jobId: opts.jobId,
-					actor,
-				});
-				decisions.push(decision);
-				queueResult.decisions.push(decision);
-				queueResult.inspected = 0;
-				queueResult.skipped = true;
-				queueResult.skipReason = "queue-disabled-by-policy";
-				store?.recordDecision(decision);
-				continue;
-			}
-			if (!adapter) {
-				const decision = makeSkippedDecision({
-					queue,
-					policy,
-					mode: normalized.mode,
-					runId,
-					jobId: opts.jobId,
-					actor,
-				});
-				decisions.push(decision);
-				queueResult.decisions.push(decision);
-				queueResult.skipped = true;
-				queueResult.skipReason = "adapter-unavailable";
-				store?.recordDecision(decision);
-				continue;
-			}
+    for (const queue of PENDING_QUEUES) {
+      const policy = normalized.policies[queue];
+      const adapter = adapters[queue];
+      const queueResult = queues[queue];
+      if (policy === "disabled") {
+        const decision = makeSkippedDecision({
+          queue,
+          policy,
+          mode: normalized.mode,
+          runId,
+          jobId: opts.jobId,
+          actor,
+        });
+        decisions.push(decision);
+        queueResult.decisions.push(decision);
+        queueResult.inspected = 0;
+        queueResult.skipped = true;
+        queueResult.skipReason = "queue-disabled-by-policy";
+        store?.recordDecision(decision);
+        continue;
+      }
+      if (!adapter) {
+        const decision = makeSkippedDecision({
+          queue,
+          policy,
+          mode: normalized.mode,
+          runId,
+          jobId: opts.jobId,
+          actor,
+        });
+        decisions.push(decision);
+        queueResult.decisions.push(decision);
+        queueResult.skipped = true;
+        queueResult.skipReason = "adapter-unavailable";
+        store?.recordDecision(decision);
+        continue;
+      }
 
-			try {
-				const listed = await adapter.listPending(
-					store?.getCursor(queue, policy) ?? null,
-				);
-				const items = listed.slice(0, normalized.max[queue]);
-				queueResult.inspected = items.length;
-				for (let i = 0; i < items.length; i++) {
-					const item = items[i];
-					const context: PendingDecisionContext = {
-						runId,
-						jobId: opts.jobId,
-						mode: normalized.mode,
-						policy,
-						policyVersion: PENDING_DIGEST_AUTOPILOT_POLICY_VERSION,
-						inputHash: item.inputHash,
-						actor,
-					};
-					const decision = await adapter.decide(item, context);
-					decisions.push(decision);
-					queueResult.decisions.push(decision);
-					const inserted = store?.recordDecision(decision).inserted ?? false;
-					if (inserted)
-						store?.advanceCursorIfSafe(
-							decision,
-							item.visibleAfterCursor ?? item.id,
-						);
-				}
-			} catch (err) {
-				queueResult.inspected = queueResult.decisions.length;
-				const decision = makeFailureDecision({
-					queue,
-					policy,
-					mode: normalized.mode,
-					runId,
-					jobId: opts.jobId,
-					actor,
-					error: err,
-				});
-				decisions.push(decision);
-				queueResult.decisions.push(decision);
-				queueResult.skipped = true;
-				queueResult.skipReason = "inventory-failed";
-				store?.recordDecision(decision);
-			}
-		}
+      try {
+        const listed = await adapter.listPending(store?.getCursor(queue, policy) ?? null);
+        const items = listed.slice(0, normalized.max[queue]);
+        queueResult.inspected = items.length;
+        for (let i = 0; i < items.length; i++) {
+          const item = items[i];
+          const context: PendingDecisionContext = {
+            runId,
+            jobId: opts.jobId,
+            mode: normalized.mode,
+            policy,
+            policyVersion: PENDING_DIGEST_AUTOPILOT_POLICY_VERSION,
+            inputHash: item.inputHash,
+            actor,
+          };
+          const decision = await adapter.decide(item, context);
+          decisions.push(decision);
+          queueResult.decisions.push(decision);
+          const inserted = store?.recordDecision(decision).inserted ?? false;
+          if (inserted) store?.advanceCursorIfSafe(decision, item.visibleAfterCursor ?? item.id);
+        }
+      } catch (err) {
+        queueResult.inspected = queueResult.decisions.length;
+        const decision = makeFailureDecision({
+          queue,
+          policy,
+          mode: normalized.mode,
+          runId,
+          jobId: opts.jobId,
+          actor,
+          error: err,
+        });
+        decisions.push(decision);
+        queueResult.decisions.push(decision);
+        queueResult.skipped = true;
+        queueResult.skipReason = "inventory-failed";
+        store?.recordDecision(decision);
+      }
+    }
 
-		const foundationSummary = createStableRunSummary({
-			runId,
-			mode: normalized.mode,
-			policy: "parent",
-			policyVersion: PENDING_DIGEST_AUTOPILOT_POLICY_VERSION,
-			queues: [...PENDING_QUEUES],
-			startedAt,
-			finishedAt: Math.floor((opts.now ?? new Date()).getTime() / 1000),
-			decisions,
-		});
-		store?.finishRun(runId, foundationSummary);
+    const foundationSummary = createStableRunSummary({
+      runId,
+      mode: normalized.mode,
+      policy: "parent",
+      policyVersion: PENDING_DIGEST_AUTOPILOT_POLICY_VERSION,
+      queues: [...PENDING_QUEUES],
+      startedAt,
+      finishedAt: Math.floor((opts.now ?? new Date()).getTime() / 1000),
+      decisions,
+    });
+    store?.finishRun(runId, foundationSummary);
 
-		const result: PendingDigestAutopilotResult = {
-			schemaVersion: 1,
-			runId,
-			mode: normalized.mode,
-			policyVersion: PENDING_DIGEST_AUTOPILOT_POLICY_VERSION,
-			applyBehavior:
-				normalized.mode === "apply"
-					? "record-decisions-only"
-					: "non-mutating-dry-run",
-			policies: normalized.policies,
-			max: normalized.max,
-			counts: summarizeCounts(decisions),
-			queues,
-			foundationSummary,
-			digestContext: digest.pendingReview,
-			humanSummary: "",
-		};
-		result.humanSummary = renderPendingDigestAutopilotHumanSummary(result);
-		return result;
-	} finally {
-		store?.close();
-	}
+    const result: PendingDigestAutopilotResult = {
+      schemaVersion: 1,
+      runId,
+      mode: normalized.mode,
+      policyVersion: PENDING_DIGEST_AUTOPILOT_POLICY_VERSION,
+      applyBehavior: normalized.mode === "apply" ? "record-decisions-only" : "non-mutating-dry-run",
+      policies: normalized.policies,
+      max: normalized.max,
+      counts: summarizeCounts(decisions),
+      queues,
+      foundationSummary,
+      digestContext: digest.pendingReview,
+      humanSummary: "",
+    };
+    result.humanSummary = renderPendingDigestAutopilotHumanSummary(result);
+    return result;
+  } finally {
+    store?.close();
+  }
 }
 
-export function renderPendingDigestAutopilotHumanSummary(
-	result: PendingDigestAutopilotResult,
-): string {
-	const lines = [
-		`Pending digest autopilot ${result.runId} (${result.mode})`,
-		`Apply behavior: ${result.applyBehavior}. Queue stores are not mutated by the #1326 parent skeleton.`,
-		`Inspected ${result.counts.inspected}; classified ${result.counts.classified}; deferred ${result.counts.deferred}; skipped ${result.counts.skipped}; failed validation ${result.counts.failedValidation}.`,
-		"Queues:",
-	];
-	for (const queue of PENDING_QUEUES) {
-		const q = result.queues[queue];
-		const human = q.decisions.filter((d) => d.humanReviewRequired).length;
-		const suffix = q.skipped
-			? ` skipped (${q.skipReason ?? "unknown"})`
-			: ` ${q.inspected} inspected`;
-		lines.push(
-			`- ${queue}: policy=${q.policy};${suffix}; humanReview=${human}`,
-		);
-	}
-	if (result.counts.humanReviewRequired > 0) {
-		lines.push(
-			"Next: review deferred human-review items; child adapters #1327/#1328/#1329 own queue-specific apply gates.",
-		);
-	} else {
-		lines.push(
-			"Next: no parent-applied queue mutations. Use child adapters for queue-specific review/apply when implemented.",
-		);
-	}
-	return lines.join("\n");
+export function renderPendingDigestAutopilotHumanSummary(result: PendingDigestAutopilotResult): string {
+  const lines = [
+    `Pending digest autopilot ${result.runId} (${result.mode})`,
+    `Apply behavior: ${result.applyBehavior}. Queue stores are not mutated by the #1326 parent skeleton.`,
+    `Inspected ${result.counts.inspected}; classified ${result.counts.classified}; deferred ${result.counts.deferred}; skipped ${result.counts.skipped}; failed validation ${result.counts.failedValidation}.`,
+    "Queues:",
+  ];
+  for (const queue of PENDING_QUEUES) {
+    const q = result.queues[queue];
+    const human = q.decisions.filter((d) => d.humanReviewRequired).length;
+    const suffix = q.skipped ? ` skipped (${q.skipReason ?? "unknown"})` : ` ${q.inspected} inspected`;
+    lines.push(`- ${queue}: policy=${q.policy};${suffix}; humanReview=${human}`);
+  }
+  if (result.counts.humanReviewRequired > 0) {
+    lines.push(
+      "Next: review deferred human-review items; child adapters #1327/#1328/#1329 own queue-specific apply gates.",
+    );
+  } else {
+    lines.push(
+      "Next: no parent-applied queue mutations. Use child adapters for queue-specific review/apply when implemented.",
+    );
+  }
+  return lines.join("\n");
 }
 
 export function createDefaultPendingDigestAdapters(
-	opts: Pick<PendingDigestAutopilotOptions, "cfg" | "factsDb">,
+  opts: Pick<PendingDigestAutopilotOptions, "cfg" | "factsDb">,
 ): Record<PendingQueue, PendingQueueAdapter> {
-	const paths = pendingStorePaths(opts.cfg.sqlitePath);
-	return {
-		persona: createPersonaReadOnlyAdapter({
-			cfg: opts.cfg,
-			dbPath: paths.proposals,
-		}),
-		procedures: createProcedureReadOnlyAdapter(opts.factsDb),
-		verified: createVerifiedReadOnlyAdapter(opts.factsDb),
-		tools: createToolProposalReadOnlyAdapter(paths.toolProposals),
-		crystallization: createCrystallizationReadOnlyAdapter(
-			paths.crystallization,
-		),
-	};
+  const paths = pendingStorePaths(opts.cfg.sqlitePath);
+  return {
+    persona: createPersonaReadOnlyAdapter({
+      cfg: opts.cfg,
+      dbPath: paths.proposals,
+    }),
+    procedures: createProcedureReadOnlyAdapter(opts.factsDb),
+    verified: createVerifiedReadOnlyAdapter(opts.factsDb),
+    tools: createToolProposalReadOnlyAdapter(paths.toolProposals),
+    crystallization: createCrystallizationReadOnlyAdapter(paths.crystallization),
+  };
 }
 
 export function createPersonaReadOnlyAdapter(input: {
-	cfg: HybridMemoryConfig;
-	dbPath: string;
+  cfg: HybridMemoryConfig;
+  dbPath: string;
 }): PendingQueueAdapter<QueueItem> {
-	return {
-		queue: "persona",
-		listPending: () => {
-			if (!input.cfg.personaProposals.enabled) return [];
-			return withCloseable(
-				() => new ProposalsDB(input.dbPath),
-				(store) => store.list({ status: "pending" }).map(personaProposalToItem),
-			);
-		},
-		decide: decideReadOnlyItem,
-	};
+  return {
+    queue: "persona",
+    listPending: () => {
+      if (!input.cfg.personaProposals.enabled) return [];
+      return withCloseable(
+        () => new ProposalsDB(input.dbPath),
+        (store) => store.list({ status: "pending" }).map(personaProposalToItem),
+      );
+    },
+    decide: decideReadOnlyItem,
+  };
 }
 
-export function createProcedureReadOnlyAdapter(
-	factsDb: PendingDigestFactsDb,
-): PendingQueueAdapter<QueueItem> {
-	return {
-		queue: "procedures",
-		listPending: () => {
-			if (!factsDb.triageProcedures) return [];
-			const report = factsDb.triageProcedures({
-				status: "validated",
-				notPromoted: true,
-				limit: 10_000,
-			});
-			return report.rows.map(procedureRowToItem);
-		},
-		decide: decideReadOnlyItem,
-	};
+export function createProcedureReadOnlyAdapter(factsDb: PendingDigestFactsDb): PendingQueueAdapter<QueueItem> {
+  return {
+    queue: "procedures",
+    listPending: () => {
+      if (!factsDb.triageProcedures) return [];
+      const report = factsDb.triageProcedures({
+        status: "validated",
+        notPromoted: true,
+        limit: 10_000,
+      });
+      return report.rows.map(procedureRowToItem);
+    },
+    decide: decideReadOnlyItem,
+  };
 }
 
-export function createVerifiedReadOnlyAdapter(
-	factsDb: PendingDigestFactsDb,
-): PendingQueueAdapter<QueueItem> {
-	return {
-		queue: "verified",
-		listPending: () => {
-			const count = Math.max(0, factsDb.countVerifiedFacts());
-			return Array.from({ length: count }, (_, index) =>
-				verifiedPlaceholderToItem(index + 1),
-			);
-		},
-		decide: decideReadOnlyItem,
-	};
+export function createVerifiedReadOnlyAdapter(factsDb: PendingDigestFactsDb): PendingQueueAdapter<QueueItem> {
+  return {
+    queue: "verified",
+    listPending: () => {
+      const count = Math.max(0, factsDb.countVerifiedFacts());
+      return Array.from({ length: count }, (_, index) => verifiedPlaceholderToItem(index + 1));
+    },
+    decide: decideReadOnlyItem,
+  };
 }
 
-export function createToolProposalReadOnlyAdapter(
-	dbPath: string,
-): PendingQueueAdapter<QueueItem> {
-	return {
-		queue: "tools",
-		listPending: () =>
-			withCloseable(
-				() => new ToolProposalStore(dbPath),
-				(store) => store.list({ status: "proposed" }).map(toolProposalToItem),
-			),
-		decide: decideReadOnlyItem,
-	};
+export function createToolProposalReadOnlyAdapter(dbPath: string): PendingQueueAdapter<QueueItem> {
+  return {
+    queue: "tools",
+    listPending: () =>
+      withCloseable(
+        () => new ToolProposalStore(dbPath),
+        (store) => store.list({ status: "proposed" }).map(toolProposalToItem),
+      ),
+    decide: decideReadOnlyItem,
+  };
 }
 
-export function createCrystallizationReadOnlyAdapter(
-	dbPath: string,
-): PendingQueueAdapter<QueueItem> {
-	return {
-		queue: "crystallization",
-		listPending: () =>
-			withCloseable(
-				() => new CrystallizationStore(dbPath),
-				(store) =>
-					store.list({ status: "pending" }).map(crystallizationProposalToItem),
-			),
-		decide: decideReadOnlyItem,
-	};
+export function createCrystallizationReadOnlyAdapter(dbPath: string): PendingQueueAdapter<QueueItem> {
+  return {
+    queue: "crystallization",
+    listPending: () =>
+      withCloseable(
+        () => new CrystallizationStore(dbPath),
+        (store) => store.list({ status: "pending" }).map(crystallizationProposalToItem),
+      ),
+    decide: decideReadOnlyItem,
+  };
 }
 
-export function decideReadOnlyItem(
-	item: QueueItem,
-	context: PendingDecisionContext,
-): PendingDecision {
-	if (context.policy === "disabled") {
-		return makeSkippedDecision({
-			queue: item.queue,
-			policy: context.policy,
-			mode: context.mode,
-			runId: context.runId,
-			jobId: context.jobId,
-			actor: context.actor,
-		});
-	}
-	const reportOnly = context.policy === "report-only";
-	const requiresHuman = item.requiresHumanReview === true || reportOnly;
-	return {
-		queue: item.queue,
-		itemId: item.id,
-		inputHash: item.inputHash,
-		policy: context.policy,
-		policyVersion: context.policyVersion,
-		mode: context.mode,
-		action: reportOnly
-			? "reported"
-			: requiresHuman
-				? "deferred-for-human"
-				: "classified",
-		reasonCode: reportOnly
-			? "policy-denied"
-			: requiresHuman
-				? "human-review-required"
-				: context.mode === "dry-run"
-					? "dry-run"
-					: "read-only",
-		actionClass: reportOnly ? "observe" : "preview",
-		capabilityClass: context.mode === "dry-run" ? "dry-run" : "read-only",
-		confidence:
-			typeof item.payload.confidence === "number"
-				? item.payload.confidence
-				: 0.5,
-		humanReviewRequired: requiresHuman,
-		evidence: [
-			{
-				type: "pending-item",
-				id: item.id,
-				summary: String(item.payload.title ?? item.id),
-			},
-		],
-		actor: context.actor,
-		runId: context.runId,
-		jobId: context.jobId,
-		summary: {
-			title: String(item.payload.title ?? item.id),
-			body: String(
-				item.payload.summary ?? "read-only pending digest classification",
-			),
-			metadata: {
-				queue: item.queue,
-				source: item.payload.source ?? "live-inventory",
-			},
-		},
-	};
+export function decideReadOnlyItem(item: QueueItem, context: PendingDecisionContext): PendingDecision {
+  if (context.policy === "disabled") {
+    return makeSkippedDecision({
+      queue: item.queue,
+      policy: context.policy,
+      mode: context.mode,
+      runId: context.runId,
+      jobId: context.jobId,
+      actor: context.actor,
+    });
+  }
+  const reportOnly = context.policy === "report-only";
+  const requiresHuman = item.requiresHumanReview === true || reportOnly;
+  return {
+    queue: item.queue,
+    itemId: item.id,
+    inputHash: item.inputHash,
+    policy: context.policy,
+    policyVersion: context.policyVersion,
+    mode: context.mode,
+    action: reportOnly ? "reported" : requiresHuman ? "deferred-for-human" : "classified",
+    reasonCode: reportOnly
+      ? "policy-denied"
+      : requiresHuman
+        ? "human-review-required"
+        : context.mode === "dry-run"
+          ? "dry-run"
+          : "policy-threshold-not-met",
+    actionClass: reportOnly ? "observe" : "preview",
+    capabilityClass: context.mode === "dry-run" ? "dry-run" : "read-only",
+    confidence: typeof item.payload.confidence === "number" ? item.payload.confidence : 0.5,
+    humanReviewRequired: requiresHuman,
+    evidence: [
+      {
+        type: "pending-item",
+        id: item.id,
+        summary: String(item.payload.title ?? item.id),
+      },
+    ],
+    actor: context.actor,
+    runId: context.runId,
+    jobId: context.jobId,
+    summary: {
+      title: String(item.payload.title ?? item.id),
+      body: String(item.payload.summary ?? "read-only pending digest classification"),
+      metadata: {
+        queue: item.queue,
+        source: item.payload.source ?? "live-inventory",
+      },
+    },
+  };
 }
 
 function personaProposalToItem(p: ProposalEntry): QueueItem {
-	const payload = {
-		source: "persona-proposals",
-		title: p.title,
-		targetFile: p.targetFile,
-		confidence: p.confidence,
-		createdAt: p.createdAt,
-		evidenceSessions: p.evidenceSessions,
-		summary: `Pending persona proposal for ${p.targetFile}`,
-	};
-	return makeItem("persona", p.id, payload, true);
+  const payload = {
+    source: "persona-proposals",
+    title: p.title,
+    targetFile: p.targetFile,
+    confidence: p.confidence,
+    createdAt: p.createdAt,
+    evidenceSessions: p.evidenceSessions,
+    summary: `Pending persona proposal for ${p.targetFile}`,
+  };
+  return makeItem("persona", p.id, payload, true);
 }
 
 function procedureRowToItem(p: ProcedureTriageRow): QueueItem {
-	const payload = {
-		source: "procedures-triage",
-		title: p.title,
-		validatedAt: p.validatedAt,
-		promotionBlockReason: p.promotionBlockReason,
-		successCount: p.successCount,
-		confidence: p.confidence,
-		skillPath: p.skillPath,
-		summary: `Procedure promotion candidate blocked by ${p.promotionBlockReason}`,
-	};
-	return makeItem("procedures", p.id, payload, true);
+  const payload = {
+    source: "procedures-triage",
+    title: p.title,
+    validatedAt: p.validatedAt,
+    promotionBlockReason: p.promotionBlockReason,
+    successCount: p.successCount,
+    confidence: p.confidence,
+    skillPath: p.skillPath,
+    summary: `Procedure promotion candidate blocked by ${p.promotionBlockReason}`,
+  };
+  return makeItem("procedures", p.id, payload, true);
 }
 
 function verifiedPlaceholderToItem(index: number): QueueItem {
-	const id = `verified-review-${index}`;
-	return makeItem(
-		"verified",
-		id,
-		{
-			source: "verified-facts-count",
-			title: `Verified fact review placeholder ${index}`,
-			summary:
-				"#1329 must define the exact verified-fact review queue. Parent #1326 only reports/classifies the current digest count.",
-		},
-		true,
-	);
+  const id = `verified-review-${index}`;
+  return makeItem(
+    "verified",
+    id,
+    {
+      source: "verified-facts-count",
+      title: `Verified fact review placeholder ${index}`,
+      summary:
+        "#1329 must define the exact verified-fact review queue. Parent #1326 only reports/classifies the current digest count.",
+    },
+    true,
+  );
 }
 
 function toolProposalToItem(p: ToolProposal): QueueItem {
-	return makeItem(
-		"tools",
-		p.id,
-		{
-			source: "tool-proposals",
-			title: p.name,
-			summary: p.description,
-			createdAt: p.createdAt,
-			updatedAt: p.updatedAt,
-		},
-		false,
-	);
+  return makeItem(
+    "tools",
+    p.id,
+    {
+      source: "tool-proposals",
+      title: p.name,
+      summary: p.description,
+      createdAt: p.createdAt,
+      updatedAt: p.updatedAt,
+    },
+    false,
+  );
 }
 
 function crystallizationProposalToItem(p: {
-	id: string;
-	skillName: string;
-	createdAt: string;
-	updatedAt: string;
+  id: string;
+  skillName: string;
+  createdAt: string;
+  updatedAt: string;
 }): QueueItem {
-	return makeItem(
-		"crystallization",
-		p.id,
-		{
-			source: "crystallization-proposals",
-			title: p.skillName,
-			summary:
-				"Pending crystallization proposal; #1326 parent only classifies/read-only reports.",
-			createdAt: p.createdAt,
-			updatedAt: p.updatedAt,
-		},
-		false,
-	);
+  return makeItem(
+    "crystallization",
+    p.id,
+    {
+      source: "crystallization-proposals",
+      title: p.skillName,
+      summary: "Pending crystallization proposal; #1326 parent only classifies/read-only reports.",
+      createdAt: p.createdAt,
+      updatedAt: p.updatedAt,
+    },
+    false,
+  );
 }
 
-function makeItem(
-	queue: PendingQueue,
-	id: string,
-	payload: QueuePayload,
-	requiresHumanReview: boolean,
-): QueueItem {
-	return {
-		queue,
-		id,
-		inputHash: computePendingInputHash({
-			queue,
-			id,
-			payload,
-			policy: "default",
-			policyVersion: PENDING_DIGEST_AUTOPILOT_POLICY_VERSION,
-		}),
-		policyVersion: PENDING_DIGEST_AUTOPILOT_POLICY_VERSION,
-		capabilityClasses: ["read-only"],
-		payload,
-		visibleAfterCursor: id,
-		requiresHumanReview,
-	};
+function makeItem(queue: PendingQueue, id: string, payload: QueuePayload, requiresHumanReview: boolean): QueueItem {
+  return {
+    queue,
+    id,
+    inputHash: computePendingInputHash({
+      queue,
+      id,
+      payload,
+      policy: "default",
+      policyVersion: PENDING_DIGEST_AUTOPILOT_POLICY_VERSION,
+    }),
+    policyVersion: PENDING_DIGEST_AUTOPILOT_POLICY_VERSION,
+    capabilityClasses: ["read-only"],
+    payload,
+    visibleAfterCursor: id,
+    requiresHumanReview,
+  };
 }
 
 function makeSkippedDecision(input: {
-	queue: PendingQueue;
-	policy: string;
-	mode: AutopilotMode;
-	runId: string;
-	jobId?: string;
-	actor: PendingDecision["actor"];
+  queue: PendingQueue;
+  policy: string;
+  mode: AutopilotMode;
+  runId: string;
+  jobId?: string;
+  actor: PendingDecision["actor"];
 }): PendingDecision {
-	const itemId = `${input.queue}:skipped`;
-	const inputHash = computePendingInputHash({
-		queue: input.queue,
-		itemId,
-		policy: input.policy,
-		reason: "disabled",
-	});
-	return {
-		queue: input.queue,
-		itemId,
-		inputHash,
-		policy: input.policy,
-		policyVersion: PENDING_DIGEST_AUTOPILOT_POLICY_VERSION,
-		mode: input.mode,
-		action: "skipped-by-policy",
-		reasonCode: "policy-denied",
-		actionClass: "observe",
-		capabilityClass: input.mode === "dry-run" ? "dry-run" : "read-only",
-		confidence: 1,
-		humanReviewRequired: false,
-		evidence: [
-			{
-				type: "policy",
-				id: input.policy,
-				summary: "queue disabled or unavailable",
-			},
-		],
-		actor: input.actor,
-		runId: input.runId,
-		jobId: input.jobId,
-		summary: {
-			title: `${input.queue} skipped`,
-			body: "Queue skipped by parent orchestration policy.",
-		},
-	};
+  const itemId = `${input.queue}:skipped`;
+  const inputHash = computePendingInputHash({
+    queue: input.queue,
+    itemId,
+    policy: input.policy,
+    reason: "disabled",
+  });
+  return {
+    queue: input.queue,
+    itemId,
+    inputHash,
+    policy: input.policy,
+    policyVersion: PENDING_DIGEST_AUTOPILOT_POLICY_VERSION,
+    mode: input.mode,
+    action: "skipped-by-policy",
+    reasonCode: "policy-denied",
+    actionClass: "observe",
+    capabilityClass: input.mode === "dry-run" ? "dry-run" : "read-only",
+    confidence: 1,
+    humanReviewRequired: false,
+    evidence: [
+      {
+        type: "policy",
+        id: input.policy,
+        summary: "queue disabled or unavailable",
+      },
+    ],
+    actor: input.actor,
+    runId: input.runId,
+    jobId: input.jobId,
+    summary: {
+      title: `${input.queue} skipped`,
+      body: "Queue skipped by parent orchestration policy.",
+    },
+  };
 }
 
 function makeFailureDecision(input: {
-	queue: PendingQueue;
-	policy: string;
-	mode: AutopilotMode;
-	runId: string;
-	jobId?: string;
-	actor: PendingDecision["actor"];
-	error: unknown;
+  queue: PendingQueue;
+  policy: string;
+  mode: AutopilotMode;
+  runId: string;
+  jobId?: string;
+  actor: PendingDecision["actor"];
+  error: unknown;
 }): PendingDecision {
-	const itemId = `${input.queue}:inventory-failed`;
-	const message =
-		input.error instanceof Error ? input.error.message : String(input.error);
-	return {
-		queue: input.queue,
-		itemId,
-		inputHash: computePendingInputHash({
-			queue: input.queue,
-			itemId,
-			policy: input.policy,
-			message,
-		}),
-		policy: input.policy,
-		policyVersion: PENDING_DIGEST_AUTOPILOT_POLICY_VERSION,
-		mode: input.mode,
-		action: "failed-validation",
-		reasonCode: "schema-validation-failed",
-		actionClass: "observe",
-		capabilityClass: input.mode === "dry-run" ? "dry-run" : "read-only",
-		confidence: 0,
-		humanReviewRequired: true,
-		evidence: [{ type: "error", summary: message }],
-		actor: input.actor,
-		runId: input.runId,
-		jobId: input.jobId,
-		summary: { title: `${input.queue} inventory failed`, body: message },
-	};
+  const itemId = `${input.queue}:inventory-failed`;
+  const message = input.error instanceof Error ? input.error.message : String(input.error);
+  return {
+    queue: input.queue,
+    itemId,
+    inputHash: computePendingInputHash({
+      queue: input.queue,
+      itemId,
+      policy: input.policy,
+      message,
+    }),
+    policy: input.policy,
+    policyVersion: PENDING_DIGEST_AUTOPILOT_POLICY_VERSION,
+    mode: input.mode,
+    action: "failed-validation",
+    reasonCode: "schema-validation-failed",
+    actionClass: "observe",
+    capabilityClass: input.mode === "dry-run" ? "dry-run" : "read-only",
+    confidence: 0,
+    humanReviewRequired: true,
+    evidence: [{ type: "error", summary: message }],
+    actor: input.actor,
+    runId: input.runId,
+    jobId: input.jobId,
+    summary: { title: `${input.queue} inventory failed`, body: message },
+  };
 }
 
-function summarizeCounts(
-	decisions: PendingDecision[],
-): PendingDigestAutopilotResult["counts"] {
-	return {
-		inspected: decisions.filter(
-			(d) =>
-				d.action !== "skipped-by-policy" && d.action !== "failed-validation",
-		).length,
-		classified: decisions.filter(
-			(d) => d.action === "classified" || d.action === "reported",
-		).length,
-		applied: decisions.filter((d) => d.action === "applied").length,
-		deferred: decisions.filter((d) => d.action === "deferred-for-human").length,
-		rejected: decisions.filter((d) => d.action === "rejected").length,
-		failedValidation: decisions.filter((d) => d.action === "failed-validation")
-			.length,
-		skipped: decisions.filter((d) => d.action === "skipped-by-policy").length,
-		humanReviewRequired: decisions.filter((d) => d.humanReviewRequired).length,
-	};
+function summarizeCounts(decisions: PendingDecision[]): PendingDigestAutopilotResult["counts"] {
+  return {
+    inspected: decisions.filter((d) => d.action !== "skipped-by-policy" && d.action !== "failed-validation").length,
+    classified: decisions.filter((d) => d.action === "classified" || d.action === "reported").length,
+    applied: decisions.filter((d) => d.action === "applied").length,
+    deferred: decisions.filter((d) => d.action === "deferred-for-human").length,
+    rejected: decisions.filter((d) => d.action === "rejected").length,
+    failedValidation: decisions.filter((d) => d.action === "failed-validation").length,
+    skipped: decisions.filter((d) => d.action === "skipped-by-policy").length,
+    humanReviewRequired: decisions.filter((d) => d.humanReviewRequired).length,
+  };
 }
 
 function validatePolicies(policies: PendingDigestAutopilotPolicies): void {
-	const allowed: Record<PendingQueue, readonly string[]> = {
-		persona: ["disabled", "report-only", "cautious", "apply-safe"],
-		procedures: ["disabled", "report-only", "dry-run-skills", "auto-safe"],
-		verified: ["disabled", "report-only", "classify", "apply-obvious"],
-		tools: ["disabled", "report-only", "classify"],
-		crystallization: ["disabled", "report-only", "classify"],
-	};
-	for (const queue of PENDING_QUEUES) {
-		if (!allowed[queue].includes(policies[queue])) {
-			throw new Error(
-				`Unsupported ${queue} pending autopilot policy: ${policies[queue]}`,
-			);
-		}
-	}
+  const allowed: Record<PendingQueue, readonly string[]> = {
+    persona: ["disabled", "report-only", "cautious", "apply-safe"],
+    procedures: ["disabled", "report-only", "dry-run-skills", "auto-safe"],
+    verified: ["disabled", "report-only", "classify", "apply-obvious"],
+    tools: ["disabled", "report-only", "classify"],
+    crystallization: ["disabled", "report-only", "classify"],
+  };
+  for (const queue of PENDING_QUEUES) {
+    if (!allowed[queue].includes(policies[queue])) {
+      throw new Error(`Unsupported ${queue} pending autopilot policy: ${policies[queue]}`);
+    }
+  }
 }
 
-function withCloseable<TStore extends { close?: () => void }, T>(
-	factory: () => TStore,
-	fn: (store: TStore) => T,
-): T {
-	let store: TStore | null = null;
-	try {
-		store = factory();
-		return fn(store);
-	} finally {
-		try {
-			store?.close?.();
-		} catch {
-			// Best-effort close for inventory readers.
-		}
-	}
+function withCloseable<TStore extends { close?: () => void }, T>(factory: () => TStore, fn: (store: TStore) => T): T {
+  let store: TStore | null = null;
+  try {
+    store = factory();
+    return fn(store);
+  } finally {
+    try {
+      store?.close?.();
+    } catch {
+      // Best-effort close for inventory readers.
+    }
+  }
 }
 
-export function stablePendingDigestAutopilotJson(
-	result: PendingDigestAutopilotResult,
-): string {
-	return `${canonicalJson(redactAutopilotValue(result))}\n`;
+export function stablePendingDigestAutopilotJson(result: PendingDigestAutopilotResult): string {
+  return `${canonicalJson(redactAutopilotValue(result))}\n`;
 }

--- a/extensions/memory-hybrid/services/pending-digest-autopilot.ts
+++ b/extensions/memory-hybrid/services/pending-digest-autopilot.ts
@@ -1,0 +1,657 @@
+/**
+ * Parent pending-digest autopilot orchestration (#1326).
+ *
+ * This service is intentionally a read-only/classification skeleton. It consumes
+ * the shared pending-autopilot foundation (#1334), builds live queue inventory
+ * from the same sources as `digest pending`, and delegates decisions to queue
+ * adapters. Child issues #1327/#1328/#1329 own deep persona/procedure/verified
+ * policy and mutation semantics; this parent must not duplicate them.
+ */
+
+import type { DatabaseSync } from "node:sqlite";
+import { CrystallizationStore } from "../backends/crystallization-store.js";
+import type { ProcedureTriageReport, ProcedureTriageRow } from "../backends/facts-db/procedures.js";
+import { type ProposalEntry, ProposalsDB } from "../backends/proposals-db.js";
+import { type ToolProposal, ToolProposalStore } from "../backends/tool-proposal-store.js";
+import type { HybridMemoryConfig } from "../config.js";
+import {
+  type AutopilotMode,
+  PENDING_QUEUES,
+  type PendingAutopilotRunSummary,
+  PendingAutopilotStore,
+  type PendingDecision,
+  type PendingDecisionContext,
+  type PendingItem,
+  type PendingQueue,
+  type PendingQueueAdapter,
+  computePendingInputHash,
+  createPendingAutopilotRunId,
+  createStableRunSummary,
+  stableRunSummaryJson,
+} from "./pending-autopilot/index.js";
+import { buildPendingReviewDigestReport, pendingStorePaths } from "./pending-review-digest.js";
+
+export const PENDING_DIGEST_AUTOPILOT_POLICY_VERSION = "parent-skeleton-v1";
+
+export type PersonaAutopilotPolicy = "disabled" | "report-only" | "cautious" | "apply-safe";
+export type ProcedureAutopilotPolicy = "disabled" | "report-only" | "dry-run-skills" | "auto-safe";
+export type VerifiedAutopilotPolicy = "disabled" | "report-only" | "classify" | "apply-obvious";
+export type ReadOnlyClassifyPolicy = "disabled" | "report-only" | "classify";
+export type PendingDigestAutopilotPolicy =
+  | PersonaAutopilotPolicy
+  | ProcedureAutopilotPolicy
+  | VerifiedAutopilotPolicy
+  | ReadOnlyClassifyPolicy;
+
+export interface PendingDigestAutopilotPolicies {
+  persona: PersonaAutopilotPolicy;
+  procedures: ProcedureAutopilotPolicy;
+  verified: VerifiedAutopilotPolicy;
+  tools: ReadOnlyClassifyPolicy;
+  crystallization: ReadOnlyClassifyPolicy;
+}
+
+export interface PendingDigestAutopilotMaxima {
+  persona: number;
+  procedures: number;
+  verified: number;
+  tools: number;
+  crystallization: number;
+}
+
+export interface PendingDigestAutopilotOptions {
+  cfg: HybridMemoryConfig;
+  factsDb: PendingDigestFactsDb;
+  mode?: AutopilotMode;
+  policies?: Partial<PendingDigestAutopilotPolicies>;
+  max?: Partial<PendingDigestAutopilotMaxima>;
+  runId?: string;
+  jobId?: string;
+  actorId?: string;
+  now?: Date;
+  stateDbPath?: string;
+  adapters?: Partial<Record<PendingQueue, PendingQueueAdapter>>;
+}
+
+export interface PendingDigestFactsDb {
+  proceduresCount(): number;
+  proceduresValidatedCount(): number;
+  proceduresPromotedCount(): number;
+  countVerifiedFacts(): number;
+  proceduresValidatedSince?(sinceSec: number): number;
+  getRawDb?(): DatabaseSync | undefined | null;
+  triageProcedures?(options?: {
+    status?: "validated" | "all";
+    notPromoted?: boolean;
+    limit?: number;
+    validationThreshold?: number;
+  }): ProcedureTriageReport;
+}
+
+export interface PendingDigestAutopilotResult {
+  schemaVersion: 1;
+  runId: string;
+  mode: AutopilotMode;
+  policyVersion: string;
+  applyBehavior: "record-decisions-only" | "non-mutating-dry-run";
+  policies: PendingDigestAutopilotPolicies;
+  max: PendingDigestAutopilotMaxima;
+  counts: {
+    inspected: number;
+    classified: number;
+    applied: number;
+    deferred: number;
+    rejected: number;
+    failedValidation: number;
+    skipped: number;
+    humanReviewRequired: number;
+  };
+  queues: Record<PendingQueue, PendingDigestQueueResult>;
+  foundationSummary: PendingAutopilotRunSummary;
+  digestContext: ReturnType<typeof buildPendingReviewDigestReport>["pendingReview"];
+  humanSummary: string;
+}
+
+export interface PendingDigestQueueResult {
+  policy: PendingDigestAutopilotPolicy;
+  inspected: number;
+  skipped: boolean;
+  skipReason?: "queue-disabled-by-policy" | "adapter-unavailable" | "inventory-failed";
+  decisions: PendingDecision[];
+}
+
+type QueuePayload = Record<string, unknown>;
+type QueueItem = PendingItem<QueuePayload>;
+
+const DEFAULT_POLICIES: PendingDigestAutopilotPolicies = {
+  persona: "cautious",
+  procedures: "auto-safe",
+  verified: "classify",
+  tools: "classify",
+  crystallization: "classify",
+};
+
+const DEFAULT_MAX: PendingDigestAutopilotMaxima = {
+  persona: 20,
+  procedures: 50,
+  verified: 100,
+  tools: 50,
+  crystallization: 50,
+};
+
+export function normalizePendingDigestAutopilotOptions(input: {
+  mode?: AutopilotMode;
+  policies?: Partial<PendingDigestAutopilotPolicies>;
+  max?: Partial<PendingDigestAutopilotMaxima>;
+}): { mode: AutopilotMode; policies: PendingDigestAutopilotPolicies; max: PendingDigestAutopilotMaxima } {
+  const mode = input.mode ?? "dry-run";
+  if (mode !== "dry-run" && mode !== "apply") throw new Error(`Unsupported pending autopilot mode: ${mode}`);
+  const policies: PendingDigestAutopilotPolicies = { ...DEFAULT_POLICIES };
+  const policyInput = input.policies ?? {};
+  if (policyInput.persona !== undefined) policies.persona = policyInput.persona;
+  if (policyInput.procedures !== undefined) policies.procedures = policyInput.procedures;
+  if (policyInput.verified !== undefined) policies.verified = policyInput.verified;
+  if (policyInput.tools !== undefined) policies.tools = policyInput.tools;
+  if (policyInput.crystallization !== undefined) policies.crystallization = policyInput.crystallization;
+  validatePolicies(policies);
+  const max: PendingDigestAutopilotMaxima = { ...DEFAULT_MAX };
+  for (const [queue, value] of Object.entries(input.max ?? {})) {
+    if (value !== undefined) max[queue as PendingQueue] = value;
+  }
+  for (const [queue, value] of Object.entries(max)) {
+    if (!Number.isFinite(value) || value < 0) throw new Error(`Invalid max for ${queue}: ${value}`);
+    max[queue as PendingQueue] = Math.floor(value);
+  }
+  return { mode, policies, max };
+}
+
+export async function runPendingDigestAutopilot(
+  opts: PendingDigestAutopilotOptions,
+): Promise<PendingDigestAutopilotResult> {
+  const normalized = normalizePendingDigestAutopilotOptions(opts);
+  const runId = opts.runId ?? createPendingAutopilotRunId();
+  const startedAt = Math.floor((opts.now ?? new Date()).getTime() / 1000);
+  const actor = { type: "agent" as const, id: opts.actorId ?? "pending-digest-autopilot" };
+  const digest = buildPendingReviewDigestReport({ cfg: opts.cfg, factsDb: opts.factsDb, now: opts.now });
+  const adapters = { ...createDefaultPendingDigestAdapters(opts), ...(opts.adapters ?? {}) };
+  const store = opts.stateDbPath ? new PendingAutopilotStore(opts.stateDbPath) : null;
+  const decisions: PendingDecision[] = [];
+  const queues = Object.fromEntries(
+    PENDING_QUEUES.map((queue) => [
+      queue,
+      { policy: normalized.policies[queue], inspected: 0, skipped: false, decisions: [] as PendingDecision[] },
+    ]),
+  ) as Record<PendingQueue, PendingDigestQueueResult>;
+
+  const inputHash = computePendingInputHash({
+    command: "digest-autopilot",
+    policies: normalized.policies,
+    max: normalized.max,
+    digest: digest.pendingReview,
+    policyVersion: PENDING_DIGEST_AUTOPILOT_POLICY_VERSION,
+  });
+
+  try {
+    store?.createRun({
+      runId,
+      mode: normalized.mode,
+      policy: "parent",
+      policyVersion: PENDING_DIGEST_AUTOPILOT_POLICY_VERSION,
+      inputHash,
+      queues: [...PENDING_QUEUES],
+      startedAt,
+    });
+
+    for (const queue of PENDING_QUEUES) {
+      const policy = normalized.policies[queue];
+      const adapter = adapters[queue];
+      const queueResult = queues[queue];
+      if (policy === "disabled") {
+        const decision = makeSkippedDecision({ queue, policy, mode: normalized.mode, runId, jobId: opts.jobId, actor });
+        decisions.push(decision);
+        queueResult.decisions.push(decision);
+        queueResult.inspected = 0;
+        queueResult.skipped = true;
+        queueResult.skipReason = "queue-disabled-by-policy";
+        store?.recordDecision(decision);
+        continue;
+      }
+      if (!adapter) {
+        const decision = makeSkippedDecision({ queue, policy, mode: normalized.mode, runId, jobId: opts.jobId, actor });
+        decisions.push(decision);
+        queueResult.decisions.push(decision);
+        queueResult.skipped = true;
+        queueResult.skipReason = "adapter-unavailable";
+        store?.recordDecision(decision);
+        continue;
+      }
+
+      try {
+        const listed = await adapter.listPending(store?.getCursor(queue, policy) ?? null);
+        const items = listed.slice(0, normalized.max[queue]);
+        queueResult.inspected = items.length;
+        for (const item of items) {
+          const context: PendingDecisionContext = {
+            runId,
+            jobId: opts.jobId,
+            mode: normalized.mode,
+            policy,
+            policyVersion: PENDING_DIGEST_AUTOPILOT_POLICY_VERSION,
+            inputHash: item.inputHash,
+            actor,
+          };
+          const decision = await adapter.decide(item, context);
+          decisions.push(decision);
+          queueResult.decisions.push(decision);
+          store?.recordDecision(decision);
+          store?.advanceCursorIfSafe(decision, item.visibleAfterCursor ?? item.id);
+        }
+      } catch (err) {
+        const decision = makeFailureDecision({
+          queue,
+          policy,
+          mode: normalized.mode,
+          runId,
+          jobId: opts.jobId,
+          actor,
+          error: err,
+        });
+        decisions.push(decision);
+        queueResult.decisions.push(decision);
+        queueResult.skipped = true;
+        queueResult.skipReason = "inventory-failed";
+        store?.recordDecision(decision);
+      }
+    }
+
+    const foundationSummary = createStableRunSummary({
+      runId,
+      mode: normalized.mode,
+      policy: "parent",
+      policyVersion: PENDING_DIGEST_AUTOPILOT_POLICY_VERSION,
+      queues: [...PENDING_QUEUES],
+      startedAt,
+      finishedAt: Math.floor((opts.now ?? new Date()).getTime() / 1000),
+      decisions,
+    });
+    store?.finishRun(runId, foundationSummary);
+
+    const result: PendingDigestAutopilotResult = {
+      schemaVersion: 1,
+      runId,
+      mode: normalized.mode,
+      policyVersion: PENDING_DIGEST_AUTOPILOT_POLICY_VERSION,
+      applyBehavior: normalized.mode === "apply" ? "record-decisions-only" : "non-mutating-dry-run",
+      policies: normalized.policies,
+      max: normalized.max,
+      counts: summarizeCounts(decisions),
+      queues,
+      foundationSummary,
+      digestContext: digest.pendingReview,
+      humanSummary: "",
+    };
+    result.humanSummary = renderPendingDigestAutopilotHumanSummary(result);
+    return result;
+  } finally {
+    store?.close();
+  }
+}
+
+export function renderPendingDigestAutopilotHumanSummary(result: PendingDigestAutopilotResult): string {
+  const lines = [
+    `Pending digest autopilot ${result.runId} (${result.mode})`,
+    `Apply behavior: ${result.applyBehavior}. Queue stores are not mutated by the #1326 parent skeleton.`,
+    `Inspected ${result.counts.inspected}; classified ${result.counts.classified}; deferred ${result.counts.deferred}; skipped ${result.counts.skipped}; failed validation ${result.counts.failedValidation}.`,
+    "Queues:",
+  ];
+  for (const queue of PENDING_QUEUES) {
+    const q = result.queues[queue];
+    const human = q.decisions.filter((d) => d.humanReviewRequired).length;
+    const suffix = q.skipped ? ` skipped (${q.skipReason ?? "unknown"})` : ` ${q.inspected} inspected`;
+    lines.push(`- ${queue}: policy=${q.policy};${suffix}; humanReview=${human}`);
+  }
+  if (result.counts.humanReviewRequired > 0) {
+    lines.push(
+      "Next: review deferred human-review items; child adapters #1327/#1328/#1329 own queue-specific apply gates.",
+    );
+  } else {
+    lines.push(
+      "Next: no parent-applied queue mutations. Use child adapters for queue-specific review/apply when implemented.",
+    );
+  }
+  return lines.join("\n");
+}
+
+export function createDefaultPendingDigestAdapters(
+  opts: Pick<PendingDigestAutopilotOptions, "cfg" | "factsDb">,
+): Record<PendingQueue, PendingQueueAdapter> {
+  const paths = pendingStorePaths(opts.cfg.sqlitePath);
+  return {
+    persona: createPersonaReadOnlyAdapter({ cfg: opts.cfg, dbPath: paths.proposals }),
+    procedures: createProcedureReadOnlyAdapter(opts.factsDb),
+    verified: createVerifiedReadOnlyAdapter(opts.factsDb),
+    tools: createToolProposalReadOnlyAdapter(paths.toolProposals),
+    crystallization: createCrystallizationReadOnlyAdapter(paths.crystallization),
+  };
+}
+
+export function createPersonaReadOnlyAdapter(input: {
+  cfg: HybridMemoryConfig;
+  dbPath: string;
+}): PendingQueueAdapter<QueueItem> {
+  return {
+    queue: "persona",
+    listPending: () => {
+      if (!input.cfg.personaProposals.enabled) return [];
+      return withCloseable(
+        () => new ProposalsDB(input.dbPath),
+        (store) => store.list({ status: "pending" }).map(personaProposalToItem),
+        [],
+      );
+    },
+    decide: decideReadOnlyItem,
+  };
+}
+
+export function createProcedureReadOnlyAdapter(factsDb: PendingDigestFactsDb): PendingQueueAdapter<QueueItem> {
+  return {
+    queue: "procedures",
+    listPending: () => {
+      if (!factsDb.triageProcedures) return [];
+      const report = factsDb.triageProcedures({ status: "validated", notPromoted: true, limit: 10_000 });
+      return report.rows.map(procedureRowToItem);
+    },
+    decide: decideReadOnlyItem,
+  };
+}
+
+export function createVerifiedReadOnlyAdapter(factsDb: PendingDigestFactsDb): PendingQueueAdapter<QueueItem> {
+  return {
+    queue: "verified",
+    listPending: () => {
+      const count = Math.max(0, factsDb.countVerifiedFacts());
+      return Array.from({ length: count }, (_, index) => verifiedPlaceholderToItem(index + 1));
+    },
+    decide: decideReadOnlyItem,
+  };
+}
+
+export function createToolProposalReadOnlyAdapter(dbPath: string): PendingQueueAdapter<QueueItem> {
+  return {
+    queue: "tools",
+    listPending: () =>
+      withCloseable(
+        () => new ToolProposalStore(dbPath),
+        (store) => store.list({ status: "proposed" }).map(toolProposalToItem),
+        [],
+      ),
+    decide: decideReadOnlyItem,
+  };
+}
+
+export function createCrystallizationReadOnlyAdapter(dbPath: string): PendingQueueAdapter<QueueItem> {
+  return {
+    queue: "crystallization",
+    listPending: () =>
+      withCloseable(
+        () => new CrystallizationStore(dbPath),
+        (store) => store.list({ status: "pending" }).map(crystallizationProposalToItem),
+        [],
+      ),
+    decide: decideReadOnlyItem,
+  };
+}
+
+export function decideReadOnlyItem(item: QueueItem, context: PendingDecisionContext): PendingDecision {
+  if (context.policy === "disabled") {
+    return makeSkippedDecision({
+      queue: item.queue,
+      policy: context.policy,
+      mode: context.mode,
+      runId: context.runId,
+      jobId: context.jobId,
+      actor: context.actor,
+    });
+  }
+  const reportOnly = context.policy === "report-only";
+  const requiresHuman = item.requiresHumanReview === true || reportOnly || context.mode === "apply";
+  return {
+    queue: item.queue,
+    itemId: item.id,
+    inputHash: item.inputHash,
+    policy: context.policy,
+    policyVersion: context.policyVersion,
+    mode: context.mode,
+    action: reportOnly ? "reported" : requiresHuman ? "deferred-for-human" : "classified",
+    reasonCode: reportOnly ? "policy-denied" : requiresHuman ? "human-review-required" : "dry-run",
+    actionClass: reportOnly ? "observe" : "preview",
+    capabilityClass: context.mode === "dry-run" ? "dry-run" : "read-only",
+    confidence: typeof item.payload.confidence === "number" ? item.payload.confidence : 0.5,
+    humanReviewRequired: requiresHuman,
+    evidence: [{ type: "pending-item", id: item.id, summary: String(item.payload.title ?? item.id) }],
+    actor: context.actor,
+    runId: context.runId,
+    jobId: context.jobId,
+    summary: {
+      title: String(item.payload.title ?? item.id),
+      body: String(item.payload.summary ?? "read-only pending digest classification"),
+      metadata: { queue: item.queue, source: item.payload.source ?? "live-inventory" },
+    },
+  };
+}
+
+function personaProposalToItem(p: ProposalEntry): QueueItem {
+  const payload = {
+    source: "persona-proposals",
+    title: p.title,
+    targetFile: p.targetFile,
+    confidence: p.confidence,
+    createdAt: p.createdAt,
+    evidenceSessions: p.evidenceSessions,
+    summary: `Pending persona proposal for ${p.targetFile}`,
+  };
+  return makeItem("persona", p.id, payload, true);
+}
+
+function procedureRowToItem(p: ProcedureTriageRow): QueueItem {
+  const payload = {
+    source: "procedures-triage",
+    title: p.title,
+    validatedAt: p.validatedAt,
+    promotionBlockReason: p.promotionBlockReason,
+    successCount: p.successCount,
+    confidence: p.confidence,
+    skillPath: p.skillPath,
+    summary: `Procedure promotion candidate blocked by ${p.promotionBlockReason}`,
+  };
+  return makeItem("procedures", p.id, payload, true);
+}
+
+function verifiedPlaceholderToItem(index: number): QueueItem {
+  const id = `verified-review-${index}`;
+  return makeItem(
+    "verified",
+    id,
+    {
+      source: "verified-facts-count",
+      title: `Verified fact review placeholder ${index}`,
+      summary:
+        "#1329 must define the exact verified-fact review queue. Parent #1326 only reports/classifies the current digest count.",
+    },
+    true,
+  );
+}
+
+function toolProposalToItem(p: ToolProposal): QueueItem {
+  return makeItem(
+    "tools",
+    p.id,
+    {
+      source: "tool-proposals",
+      title: p.name,
+      summary: p.description,
+      createdAt: p.createdAt,
+      updatedAt: p.updatedAt,
+    },
+    false,
+  );
+}
+
+function crystallizationProposalToItem(p: {
+  id: string;
+  skillName: string;
+  createdAt: string;
+  updatedAt: string;
+}): QueueItem {
+  return makeItem(
+    "crystallization",
+    p.id,
+    {
+      source: "crystallization-proposals",
+      title: p.skillName,
+      summary: "Pending crystallization proposal; #1326 parent only classifies/read-only reports.",
+      createdAt: p.createdAt,
+      updatedAt: p.updatedAt,
+    },
+    false,
+  );
+}
+
+function makeItem(queue: PendingQueue, id: string, payload: QueuePayload, requiresHumanReview: boolean): QueueItem {
+  return {
+    queue,
+    id,
+    inputHash: computePendingInputHash({
+      queue,
+      id,
+      payload,
+      policy: "default",
+      policyVersion: PENDING_DIGEST_AUTOPILOT_POLICY_VERSION,
+    }),
+    policyVersion: PENDING_DIGEST_AUTOPILOT_POLICY_VERSION,
+    capabilityClasses: ["read-only"],
+    payload,
+    visibleAfterCursor: id,
+    requiresHumanReview,
+  };
+}
+
+function makeSkippedDecision(input: {
+  queue: PendingQueue;
+  policy: string;
+  mode: AutopilotMode;
+  runId: string;
+  jobId?: string;
+  actor: PendingDecision["actor"];
+}): PendingDecision {
+  const itemId = `${input.queue}:skipped`;
+  const inputHash = computePendingInputHash({ queue: input.queue, itemId, policy: input.policy, reason: "disabled" });
+  return {
+    queue: input.queue,
+    itemId,
+    inputHash,
+    policy: input.policy,
+    policyVersion: PENDING_DIGEST_AUTOPILOT_POLICY_VERSION,
+    mode: input.mode,
+    action: "skipped-by-policy",
+    reasonCode: "policy-denied",
+    actionClass: "observe",
+    capabilityClass: input.mode === "dry-run" ? "dry-run" : "read-only",
+    confidence: 1,
+    humanReviewRequired: false,
+    evidence: [{ type: "policy", id: input.policy, summary: "queue disabled or unavailable" }],
+    actor: input.actor,
+    runId: input.runId,
+    jobId: input.jobId,
+    summary: { title: `${input.queue} skipped`, body: "Queue skipped by parent orchestration policy." },
+  };
+}
+
+function makeFailureDecision(input: {
+  queue: PendingQueue;
+  policy: string;
+  mode: AutopilotMode;
+  runId: string;
+  jobId?: string;
+  actor: PendingDecision["actor"];
+  error: unknown;
+}): PendingDecision {
+  const itemId = `${input.queue}:inventory-failed`;
+  const message = input.error instanceof Error ? input.error.message : String(input.error);
+  return {
+    queue: input.queue,
+    itemId,
+    inputHash: computePendingInputHash({ queue: input.queue, itemId, policy: input.policy, message }),
+    policy: input.policy,
+    policyVersion: PENDING_DIGEST_AUTOPILOT_POLICY_VERSION,
+    mode: input.mode,
+    action: "failed-validation",
+    reasonCode: "schema-validation-failed",
+    actionClass: "observe",
+    capabilityClass: input.mode === "dry-run" ? "dry-run" : "read-only",
+    confidence: 0,
+    humanReviewRequired: true,
+    evidence: [{ type: "error", summary: message }],
+    actor: input.actor,
+    runId: input.runId,
+    jobId: input.jobId,
+    summary: { title: `${input.queue} inventory failed`, body: message },
+  };
+}
+
+function summarizeCounts(decisions: PendingDecision[]): PendingDigestAutopilotResult["counts"] {
+  return {
+    inspected: decisions.filter((d) => !d.itemId.endsWith(":skipped") && !d.itemId.endsWith(":inventory-failed"))
+      .length,
+    classified: decisions.filter((d) => d.action === "classified" || d.action === "reported").length,
+    applied: decisions.filter((d) => d.action === "applied").length,
+    deferred: decisions.filter((d) => d.action === "deferred-for-human").length,
+    rejected: decisions.filter((d) => d.action === "rejected").length,
+    failedValidation: decisions.filter((d) => d.action === "failed-validation").length,
+    skipped: decisions.filter((d) => d.action === "skipped-by-policy").length,
+    humanReviewRequired: decisions.filter((d) => d.humanReviewRequired).length,
+  };
+}
+
+function validatePolicies(policies: PendingDigestAutopilotPolicies): void {
+  const allowed: Record<PendingQueue, readonly string[]> = {
+    persona: ["disabled", "report-only", "cautious", "apply-safe"],
+    procedures: ["disabled", "report-only", "dry-run-skills", "auto-safe"],
+    verified: ["disabled", "report-only", "classify", "apply-obvious"],
+    tools: ["disabled", "report-only", "classify"],
+    crystallization: ["disabled", "report-only", "classify"],
+  };
+  for (const queue of PENDING_QUEUES) {
+    if (!allowed[queue].includes(policies[queue])) {
+      throw new Error(`Unsupported ${queue} pending autopilot policy: ${policies[queue]}`);
+    }
+  }
+}
+
+function withCloseable<TStore extends { close?: () => void }, T>(
+  factory: () => TStore,
+  fn: (store: TStore) => T,
+  fallback: T,
+): T {
+  let store: TStore | null = null;
+  try {
+    store = factory();
+    return fn(store);
+  } catch {
+    return fallback;
+  } finally {
+    try {
+      store?.close?.();
+    } catch {
+      // Best-effort close for inventory readers.
+    }
+  }
+}
+
+export function stablePendingDigestAutopilotJson(result: PendingDigestAutopilotResult): string {
+  return `${JSON.stringify(result, null, 2)}\n`;
+}
+
+export function foundationSummaryJson(result: PendingDigestAutopilotResult): string {
+  return stableRunSummaryJson(result.foundationSummary);
+}

--- a/extensions/memory-hybrid/tests/pending-digest-autopilot.test.ts
+++ b/extensions/memory-hybrid/tests/pending-digest-autopilot.test.ts
@@ -11,17 +11,17 @@ import type { ManageBindings } from "../cli/commands/manage/bindings.js";
 import { registerManageDigest } from "../cli/commands/manage/register-digest.js";
 import { type HybridMemoryConfig, hybridConfigSchema } from "../config.js";
 import {
-  PendingAutopilotStore,
-  type PendingItem,
-  computePendingInputHash,
+	PendingAutopilotStore,
+	type PendingItem,
+	computePendingInputHash,
 } from "../services/pending-autopilot/index.js";
 import {
-  PENDING_DIGEST_AUTOPILOT_POLICY_VERSION,
-  type PendingDigestFactsDb,
-  createDefaultPendingDigestAdapters,
-  decideReadOnlyItem,
-  runPendingDigestAutopilot,
-  stablePendingDigestAutopilotJson,
+	PENDING_DIGEST_AUTOPILOT_POLICY_VERSION,
+	type PendingDigestFactsDb,
+	createDefaultPendingDigestAdapters,
+	decideReadOnlyItem,
+	runPendingDigestAutopilot,
+	stablePendingDigestAutopilotJson,
 } from "../services/pending-digest-autopilot.js";
 import { pendingStorePaths } from "../services/pending-review-digest.js";
 import { expectStandaloneAndParentDecisionsEquivalent } from "./helpers/pending-autopilot-equivalence.js";
@@ -29,392 +29,458 @@ import { expectStandaloneAndParentDecisionsEquivalent } from "./helpers/pending-
 const dirs: string[] = [];
 
 afterEach(() => {
-  vi.restoreAllMocks();
-  while (dirs.length > 0) {
-    const dir = dirs.pop();
-    if (dir) rmSync(dir, { recursive: true, force: true });
-  }
+	vi.restoreAllMocks();
+	while (dirs.length > 0) {
+		const dir = dirs.pop();
+		if (dir) rmSync(dir, { recursive: true, force: true });
+	}
 });
 
 function newDir(): string {
-  const dir = mkdtempSync(join(tmpdir(), "pending-digest-autopilot-"));
-  dirs.push(dir);
-  return dir;
+	const dir = mkdtempSync(join(tmpdir(), "pending-digest-autopilot-"));
+	dirs.push(dir);
+	return dir;
 }
 
 function configFor(sqlitePath: string): HybridMemoryConfig {
-  return hybridConfigSchema.parse({
-    embedding: { apiKey: "sk-test-embed-key-that-is-long-enough", model: "text-embedding-3-small" },
-    sqlitePath,
-    lanceDbPath: join(dirname(sqlitePath), "lancedb"),
-    credentials: { enabled: false },
-    wal: { enabled: false },
-    personaProposals: { enabled: true },
-    verification: { enabled: false },
-    provenance: { enabled: false },
-    nightlyCycle: { enabled: false },
-  });
+	return hybridConfigSchema.parse({
+		embedding: {
+			apiKey: "sk-test-embed-key-that-is-long-enough",
+			model: "text-embedding-3-small",
+		},
+		sqlitePath,
+		lanceDbPath: join(dirname(sqlitePath), "lancedb"),
+		credentials: { enabled: false },
+		wal: { enabled: false },
+		personaProposals: { enabled: true },
+		verification: { enabled: false },
+		provenance: { enabled: false },
+		nightlyCycle: { enabled: false },
+	});
 }
 
 function factsDb(): PendingDigestFactsDb {
-  return {
-    proceduresCount: () => 2,
-    proceduresValidatedCount: () => 2,
-    proceduresPromotedCount: () => 0,
-    countVerifiedFacts: () => 2,
-    proceduresValidatedSince: () => 1,
-    triageProcedures: ({ limit = 10_000 } = {}): ProcedureTriageReport => ({
-      rows: [
-        {
-          id: "proc-1",
-          title: "Review repeatable procedure",
-          validatedAt: 1,
-          promotionBlockReason: "awaiting_approval" as const,
-          lastRecall: 1,
-          successCount: 5,
-          confidence: 0.9,
-          skillPath: null,
-        },
-        {
-          id: "proc-2",
-          title: "Missing recipe anchor",
-          validatedAt: 1,
-          promotionBlockReason: "missing_anchor" as const,
-          lastRecall: 1,
-          successCount: 3,
-          confidence: 0.6,
-          skillPath: null,
-        },
-      ].slice(0, limit),
-      summary: {
-        total: 2,
-        byReason: { awaiting_approval: 1, missing_anchor: 1, unknown: 0, duplicate_skill: 0, low_recall: 0 },
-        topReason: "awaiting_approval",
-      },
-    }),
-  };
+	return {
+		proceduresCount: () => 2,
+		proceduresValidatedCount: () => 2,
+		proceduresPromotedCount: () => 0,
+		countVerifiedFacts: () => 2,
+		proceduresValidatedSince: () => 1,
+		triageProcedures: ({ limit = 10_000 } = {}): ProcedureTriageReport => ({
+			rows: [
+				{
+					id: "proc-1",
+					title: "Review repeatable procedure",
+					validatedAt: 1,
+					promotionBlockReason: "awaiting_approval" as const,
+					lastRecall: 1,
+					successCount: 5,
+					confidence: 0.9,
+					skillPath: null,
+				},
+				{
+					id: "proc-2",
+					title: "Missing recipe anchor",
+					validatedAt: 1,
+					promotionBlockReason: "missing_anchor" as const,
+					lastRecall: 1,
+					successCount: 3,
+					confidence: 0.6,
+					skillPath: null,
+				},
+			].slice(0, limit),
+			summary: {
+				total: 2,
+				byReason: {
+					awaiting_approval: 1,
+					missing_anchor: 1,
+					unknown: 0,
+					duplicate_skill: 0,
+					low_recall: 0,
+				},
+				topReason: "awaiting_approval",
+			},
+		}),
+	};
 }
 
 function seedQueues(cfg: HybridMemoryConfig): void {
-  const paths = pendingStorePaths(cfg.sqlitePath);
-  const persona = new ProposalsDB(paths.proposals);
-  const tools = new ToolProposalStore(paths.toolProposals);
-  const crystal = new CrystallizationStore(paths.crystallization);
-  persona.create({
-    targetFile: "SOUL.md",
-    title: "Change identity guidance",
-    observation: "Sensitive persona change.",
-    suggestedChange: "Rewrite identity.",
-    confidence: 0.91,
-    evidenceSessions: ["session-a"],
-  });
-  tools.create({
-    name: "safe_reporter",
-    description: "Draft read-only reports",
-    parameters: "{}",
-    rationale: "Useful reporting helper",
-    sourcePatterns: "[]",
-    implementationHint: "No external writes",
-  });
-  crystal.create({
-    patternId: "pattern-1",
-    skillName: "review-backlog",
-    skillContent: "# Skill",
-    patternSnapshot: "{}",
-  });
-  persona.close();
-  tools.close();
-  crystal.close();
+	const paths = pendingStorePaths(cfg.sqlitePath);
+	const persona = new ProposalsDB(paths.proposals);
+	const tools = new ToolProposalStore(paths.toolProposals);
+	const crystal = new CrystallizationStore(paths.crystallization);
+	persona.create({
+		targetFile: "SOUL.md",
+		title: "Change identity guidance",
+		observation: "Sensitive persona change.",
+		suggestedChange: "Rewrite identity.",
+		confidence: 0.91,
+		evidenceSessions: ["session-a"],
+	});
+	tools.create({
+		name: "safe_reporter",
+		description: "Draft read-only reports",
+		parameters: "{}",
+		rationale: "Useful reporting helper",
+		sourcePatterns: "[]",
+		implementationHint: "No external writes",
+	});
+	crystal.create({
+		patternId: "pattern-1",
+		skillName: "review-backlog",
+		skillContent: "# Skill",
+		patternSnapshot: "{}",
+	});
+	persona.close();
+	tools.close();
+	crystal.close();
 }
 
 describe("pending digest autopilot parent (#1326)", () => {
-  it("defaults to dry-run, inspects live pending queues, emits stable structured JSON, and does not open durable state", async () => {
-    const dir = newDir();
-    const cfg = configFor(join(dir, "facts.db"));
-    seedQueues(cfg);
-    const stateDb = join(dir, "autopilot.db");
+	it("defaults to dry-run, inspects live pending queues, emits stable structured JSON, and does not open durable state", async () => {
+		const dir = newDir();
+		const cfg = configFor(join(dir, "facts.db"));
+		seedQueues(cfg);
+		const stateDb = join(dir, "autopilot.db");
 
-    const result = await runPendingDigestAutopilot({
-      cfg,
-      factsDb: factsDb(),
-      stateDbPath: stateDb,
-      runId: "run-dry",
-      now: new Date("2026-05-12T00:00:00.000Z"),
-    });
+		const result = await runPendingDigestAutopilot({
+			cfg,
+			factsDb: factsDb(),
+			stateDbPath: stateDb,
+			runId: "run-dry",
+			now: new Date("2026-05-12T00:00:00.000Z"),
+		});
 
-    expect(result.mode).toBe("dry-run");
-    expect(result.applyBehavior).toBe("non-mutating-dry-run");
-    expect(result.digestContext).toMatchObject({
-      persona: 1,
-      procedures: 2,
-      tools: 1,
-      crystallization: 1,
-      verified: 2,
-    });
-    expect(result.counts.inspected).toBe(7);
-    expect(result.queues.persona.decisions[0]).toMatchObject({
-      action: "deferred-for-human",
-      reasonCode: "human-review-required",
-    });
-    expect(result.queues.tools.decisions[0]).toMatchObject({ action: "classified", reasonCode: "dry-run" });
-    expect(JSON.parse(JSON.stringify(result))).toMatchObject({
-      schemaVersion: 1,
-      runId: "run-dry",
-      policies: { persona: "cautious", procedures: "auto-safe", verified: "classify", tools: "classify" },
-      counts: { inspected: 7, applied: 0 },
-    });
+		expect(result.mode).toBe("dry-run");
+		expect(result.applyBehavior).toBe("non-mutating-dry-run");
+		expect(result.digestContext).toMatchObject({
+			persona: 1,
+			procedures: 2,
+			tools: 1,
+			crystallization: 1,
+			verified: 2,
+		});
+		expect(result.counts.inspected).toBe(7);
+		expect(result.queues.persona.decisions[0]).toMatchObject({
+			action: "deferred-for-human",
+			reasonCode: "human-review-required",
+		});
+		expect(result.queues.tools.decisions[0]).toMatchObject({
+			action: "classified",
+			reasonCode: "dry-run",
+		});
+		expect(JSON.parse(JSON.stringify(result))).toMatchObject({
+			schemaVersion: 1,
+			runId: "run-dry",
+			policies: {
+				persona: "cautious",
+				procedures: "auto-safe",
+				verified: "classify",
+				tools: "classify",
+			},
+			counts: { inspected: 7, applied: 0 },
+		});
 
-    expect(existsSync(stateDb)).toBe(false);
-  });
+		expect(existsSync(stateDb)).toBe(false);
+	});
 
-  it("apply mode records only foundation decisions and remains idempotent without queue mutations", async () => {
-    const dir = newDir();
-    const cfg = configFor(join(dir, "facts.db"));
-    seedQueues(cfg);
-    const stateDb = join(dir, "autopilot.db");
+	it("apply mode records only foundation decisions and remains idempotent without queue mutations", async () => {
+		const dir = newDir();
+		const cfg = configFor(join(dir, "facts.db"));
+		seedQueues(cfg);
+		const stateDb = join(dir, "autopilot.db");
 
-    const first = await runPendingDigestAutopilot({
-      cfg,
-      factsDb: factsDb(),
-      stateDbPath: stateDb,
-      mode: "apply",
-      runId: "run-apply-1",
-    });
-    const second = await runPendingDigestAutopilot({
-      cfg,
-      factsDb: factsDb(),
-      stateDbPath: stateDb,
-      mode: "apply",
-      runId: "run-apply-2",
-    });
+		const first = await runPendingDigestAutopilot({
+			cfg,
+			factsDb: factsDb(),
+			stateDbPath: stateDb,
+			mode: "apply",
+			runId: "run-apply-1",
+		});
+		const second = await runPendingDigestAutopilot({
+			cfg,
+			factsDb: factsDb(),
+			stateDbPath: stateDb,
+			mode: "apply",
+			runId: "run-apply-2",
+		});
 
-    expect(first.applyBehavior).toBe("record-decisions-only");
-    expect(first.queues.tools.decisions[0]).toMatchObject({ action: "classified", humanReviewRequired: false });
-    expect(second.counts).toEqual(first.counts);
-    const paths = pendingStorePaths(cfg.sqlitePath);
-    const persona = new ProposalsDB(paths.proposals);
-    expect(persona.list({ status: "pending" })).toHaveLength(1);
-    persona.close();
-    const store = new PendingAutopilotStore(stateDb);
-    expect(store.listDecisions()).toHaveLength(7);
-    expect(store.tableCounts().pending_autopilot_runs).toBe(2);
-    expect(store.tableCounts().pending_autopilot_locks).toBe(0);
-    store.close();
-  });
+		expect(first.applyBehavior).toBe("record-decisions-only");
+		expect(first.queues.tools.decisions[0]).toMatchObject({
+			action: "classified",
+			humanReviewRequired: false,
+			reasonCode: "read-only",
+			capabilityClass: "read-only",
+		});
+		expect(second.counts).toEqual(first.counts);
+		const paths = pendingStorePaths(cfg.sqlitePath);
+		const persona = new ProposalsDB(paths.proposals);
+		expect(persona.list({ status: "pending" })).toHaveLength(1);
+		persona.close();
+		const store = new PendingAutopilotStore(stateDb);
+		expect(store.listDecisions()).toHaveLength(7);
+		expect(store.tableCounts().pending_autopilot_runs).toBe(2);
+		expect(store.tableCounts().pending_autopilot_locks).toBe(0);
+		store.close();
+	});
 
-  it("supports disabled per-queue policies with stable skipped reason codes and max batch sizes", async () => {
-    const dir = newDir();
-    const cfg = configFor(join(dir, "facts.db"));
-    seedQueues(cfg);
-    const result = await runPendingDigestAutopilot({
-      cfg,
-      factsDb: factsDb(),
-      runId: "run-disabled",
-      policies: { tools: "disabled", crystallization: "report-only" },
-      max: { procedures: 1, verified: 1 },
-    });
+	it("supports disabled per-queue policies with stable skipped reason codes and max batch sizes", async () => {
+		const dir = newDir();
+		const cfg = configFor(join(dir, "facts.db"));
+		seedQueues(cfg);
+		const result = await runPendingDigestAutopilot({
+			cfg,
+			factsDb: factsDb(),
+			runId: "run-disabled",
+			policies: { tools: "disabled", crystallization: "report-only" },
+			max: { procedures: 1, verified: 1 },
+		});
 
-    expect(result.queues.tools).toMatchObject({ skipped: true, skipReason: "queue-disabled-by-policy", inspected: 0 });
-    expect(result.queues.tools.decisions[0]).toMatchObject({
-      action: "skipped-by-policy",
-      reasonCode: "policy-denied",
-    });
-    expect(result.queues.procedures.inspected).toBe(1);
-    expect(result.queues.verified.inspected).toBe(1);
-    expect(result.queues.crystallization.decisions[0]).toMatchObject({
-      action: "reported",
-      reasonCode: "policy-denied",
-    });
-  });
+		expect(result.queues.tools).toMatchObject({
+			skipped: true,
+			skipReason: "queue-disabled-by-policy",
+			inspected: 0,
+		});
+		expect(result.queues.tools.decisions[0]).toMatchObject({
+			action: "skipped-by-policy",
+			reasonCode: "policy-denied",
+		});
+		expect(result.queues.procedures.inspected).toBe(1);
+		expect(result.queues.verified.inspected).toBe(1);
+		expect(result.queues.crystallization.decisions[0]).toMatchObject({
+			action: "reported",
+			reasonCode: "policy-denied",
+		});
+	});
 
-  it("requires a state DB before apply mode can record parent decisions", async () => {
-    const dir = newDir();
-    const cfg = configFor(join(dir, "facts.db"));
-    seedQueues(cfg);
+	it("requires a state DB before apply mode can record parent decisions", async () => {
+		const dir = newDir();
+		const cfg = configFor(join(dir, "facts.db"));
+		seedQueues(cfg);
 
-    await expect(
-      runPendingDigestAutopilot({
-        cfg,
-        factsDb: factsDb(),
-        mode: "apply",
-        runId: "run-apply-no-state",
-      }),
-    ).rejects.toThrow("--apply requires --state-db");
-  });
+		await expect(
+			runPendingDigestAutopilot({
+				cfg,
+				factsDb: factsDb(),
+				mode: "apply",
+				runId: "run-apply-no-state",
+			}),
+		).rejects.toThrow("--apply requires --state-db");
+	});
 
-  it("captures adapter/list failures as visible failed-validation decisions", async () => {
-    const dir = newDir();
-    const cfg = configFor(join(dir, "facts.db"));
-    const result = await runPendingDigestAutopilot({
-      cfg,
-      factsDb: factsDb(),
-      runId: "run-failure",
-      adapters: {
-        tools: {
-          queue: "tools",
-          listPending: () => {
-            throw new Error("backend down");
-          },
-          decide: decideReadOnlyItem,
-        },
-      },
-    });
+	it("captures adapter/list failures as visible failed-validation decisions", async () => {
+		const dir = newDir();
+		const cfg = configFor(join(dir, "facts.db"));
+		const result = await runPendingDigestAutopilot({
+			cfg,
+			factsDb: factsDb(),
+			runId: "run-failure",
+			adapters: {
+				tools: {
+					queue: "tools",
+					listPending: () => {
+						throw new Error("backend down");
+					},
+					decide: decideReadOnlyItem,
+				},
+			},
+		});
 
-    expect(result.queues.tools).toMatchObject({ skipped: true, skipReason: "inventory-failed" });
-    expect(result.queues.tools.decisions[0]).toMatchObject({
-      action: "failed-validation",
-      reasonCode: "schema-validation-failed",
-      humanReviewRequired: true,
-    });
-    expect(result.humanSummary).toContain("failed validation 1");
-  });
+		expect(result.queues.tools).toMatchObject({
+			skipped: true,
+			skipReason: "inventory-failed",
+		});
+		expect(result.queues.tools.decisions[0]).toMatchObject({
+			action: "failed-validation",
+			reasonCode: "schema-validation-failed",
+			humanReviewRequired: true,
+		});
+		expect(result.humanSummary).toContain("failed validation 1");
+	});
 
-  it("parent route delegates to the same adapter decision path as standalone child route", async () => {
-    const dir = newDir();
-    const cfg = configFor(join(dir, "facts.db"));
-    seedQueues(cfg);
-    const adapters = createDefaultPendingDigestAdapters({ cfg, factsDb: factsDb() });
-    const listed = (await adapters.persona.listPending(null)) as PendingItem[];
-    const fixture = listed[0];
+	it("parent route delegates to the same adapter decision path as standalone child route", async () => {
+		const dir = newDir();
+		const cfg = configFor(join(dir, "facts.db"));
+		seedQueues(cfg);
+		const adapters = createDefaultPendingDigestAdapters({
+			cfg,
+			factsDb: factsDb(),
+		});
+		const listed = (await adapters.persona.listPending(null)) as PendingItem[];
+		const fixture = listed[0];
 
-    await expectStandaloneAndParentDecisionsEquivalent({
-      standalone: adapters.persona.decide,
-      parent: async (item, context) => {
-        const parentListed = (await adapters.persona.listPending(null)) as PendingItem[];
-        const matched = parentListed.find((candidate) => candidate.id === item.id);
-        if (!matched) throw new Error("fixture missing from parent inventory");
-        return adapters.persona.decide(matched, context);
-      },
-      fixtures: [{ item: fixture, policy: "default", policyVersion: PENDING_DIGEST_AUTOPILOT_POLICY_VERSION }],
-    });
-  });
+		await expectStandaloneAndParentDecisionsEquivalent({
+			standalone: adapters.persona.decide,
+			parent: async (item, context) => {
+				const parentListed = (await adapters.persona.listPending(
+					null,
+				)) as PendingItem[];
+				const matched = parentListed.find(
+					(candidate) => candidate.id === item.id,
+				);
+				if (!matched) throw new Error("fixture missing from parent inventory");
+				return adapters.persona.decide(matched, context);
+			},
+			fixtures: [
+				{
+					item: fixture,
+					policy: "default",
+					policyVersion: PENDING_DIGEST_AUTOPILOT_POLICY_VERSION,
+				},
+			],
+		});
+	});
 
-  it("propagates default inventory store failures as inventory-failed decisions", async () => {
-    const dir = newDir();
-    const cfg = configFor(join(dir, "facts.db"));
-    vi.spyOn(ProposalsDB.prototype, "list").mockImplementation(() => {
-      throw new Error("persona sqlite read failed");
-    });
+	it("propagates default inventory store failures as inventory-failed decisions", async () => {
+		const dir = newDir();
+		const cfg = configFor(join(dir, "facts.db"));
+		vi.spyOn(ProposalsDB.prototype, "list").mockImplementation(() => {
+			throw new Error("persona sqlite read failed");
+		});
 
-    const result = await runPendingDigestAutopilot({
-      cfg,
-      factsDb: factsDb(),
-      runId: "run-default-store-failure",
-    });
+		const result = await runPendingDigestAutopilot({
+			cfg,
+			factsDb: factsDb(),
+			runId: "run-default-store-failure",
+		});
 
-    expect(result.queues.persona).toMatchObject({ skipped: true, skipReason: "inventory-failed" });
-    expect(result.queues.persona.decisions[0]).toMatchObject({
-      action: "failed-validation",
-      summary: { body: "persona sqlite read failed" },
-    });
-  });
+		expect(result.queues.persona).toMatchObject({
+			skipped: true,
+			skipReason: "inventory-failed",
+		});
+		expect(result.queues.persona.decisions[0]).toMatchObject({
+			action: "failed-validation",
+			summary: { body: "persona sqlite read failed" },
+		});
+	});
 
-  it("registers digest autopilot CLI and emits JSON helpfully", async () => {
-    const dir = newDir();
-    const cfg = configFor(join(dir, "facts.db"));
-    seedQueues(cfg);
-    const program = new Command("hybrid-mem");
-    program.exitOverride();
-    registerManageDigest(program as never, { cfg, factsDb: factsDb() } as ManageBindings);
-    const out = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+	it("registers digest autopilot CLI and emits JSON helpfully", async () => {
+		const dir = newDir();
+		const cfg = configFor(join(dir, "facts.db"));
+		seedQueues(cfg);
+		const program = new Command("hybrid-mem");
+		program.exitOverride();
+		registerManageDigest(
+			program as never,
+			{ cfg, factsDb: factsDb() } as ManageBindings,
+		);
+		const out = vi
+			.spyOn(process.stdout, "write")
+			.mockImplementation(() => true);
 
-    await program.parseAsync(["digest", "autopilot", "--dry-run", "--json", "--max-verified", "1"], { from: "user" });
+		await program.parseAsync(
+			["digest", "autopilot", "--dry-run", "--json", "--max-verified", "1"],
+			{ from: "user" },
+		);
 
-    const json = out.mock.calls.map((c) => String(c[0])).join("");
-    expect(JSON.parse(json)).toMatchObject({
-      mode: "dry-run",
-      counts: { applied: 0 },
-      queues: { verified: { inspected: 1 } },
-    });
-  });
+		const json = out.mock.calls.map((c) => String(c[0])).join("");
+		expect(JSON.parse(json)).toMatchObject({
+			mode: "dry-run",
+			counts: { applied: 0 },
+			queues: { verified: { inspected: 1 } },
+		});
+	});
 
-  it("rejects conflicting dry-run/apply CLI flags and apply without state DB", async () => {
-    const dir = newDir();
-    const cfg = configFor(join(dir, "facts.db"));
-    const program = new Command("hybrid-mem");
-    program.exitOverride();
-    registerManageDigest(program as never, { cfg, factsDb: factsDb() } as ManageBindings);
+	it("rejects conflicting dry-run/apply CLI flags and apply without state DB", async () => {
+		const dir = newDir();
+		const cfg = configFor(join(dir, "facts.db"));
+		const program = new Command("hybrid-mem");
+		program.exitOverride();
+		registerManageDigest(
+			program as never,
+			{ cfg, factsDb: factsDb() } as ManageBindings,
+		);
 
-    await expect(
-      program.parseAsync(["digest", "autopilot", "--dry-run", "--apply", "--state-db", join(dir, "state.db")], {
-        from: "user",
-      }),
-    ).rejects.toThrow("--dry-run and --apply are mutually exclusive");
-    await expect(program.parseAsync(["digest", "autopilot", "--apply"], { from: "user" })).rejects.toThrow(
-      "--apply requires --state-db",
-    );
-  });
+		await expect(
+			program.parseAsync(
+				[
+					"digest",
+					"autopilot",
+					"--dry-run",
+					"--apply",
+					"--state-db",
+					join(dir, "state.db"),
+				],
+				{
+					from: "user",
+				},
+			),
+		).rejects.toThrow("--dry-run and --apply are mutually exclusive");
+		await expect(
+			program.parseAsync(["digest", "autopilot", "--apply"], { from: "user" }),
+		).rejects.toThrow("--apply requires --state-db");
+	});
 
-  it("uses canonical redacted JSON for stable structured output", async () => {
-    const dir = newDir();
-    const cfg = configFor(join(dir, "facts.db"));
-    const result = await runPendingDigestAutopilot({
-      cfg,
-      factsDb: factsDb(),
-      runId: "run-json-redaction",
-      adapters: {
-        tools: {
-          queue: "tools",
-          listPending: () => [
-            {
-              queue: "tools",
-              id: "secret-tool",
-              inputHash: computePendingInputHash({ id: "secret-tool" }),
-              policyVersion: PENDING_DIGEST_AUTOPILOT_POLICY_VERSION,
-              capabilityClasses: ["read-only"],
-              payload: { title: "token: sk-test_secret_value_123456789" },
-            },
-          ],
-          decide: decideReadOnlyItem,
-        },
-      },
-    });
+	it("uses canonical redacted JSON for stable structured output", async () => {
+		const dir = newDir();
+		const cfg = configFor(join(dir, "facts.db"));
+		const result = await runPendingDigestAutopilot({
+			cfg,
+			factsDb: factsDb(),
+			runId: "run-json-redaction",
+			adapters: {
+				tools: {
+					queue: "tools",
+					listPending: () => [
+						{
+							queue: "tools",
+							id: "secret-tool",
+							inputHash: computePendingInputHash({ id: "secret-tool" }),
+							policyVersion: PENDING_DIGEST_AUTOPILOT_POLICY_VERSION,
+							capabilityClasses: ["read-only"],
+							payload: { title: "token: sk-test_secret_value_123456789" },
+						},
+					],
+					decide: decideReadOnlyItem,
+				},
+			},
+		});
 
-    const json = stablePendingDigestAutopilotJson(result);
-    expect(json).toContain("[REDACTED]");
-    expect(json).not.toContain("sk-test_secret_value_123456789");
-    expect(Object.keys(JSON.parse(json))).toEqual([
-      "applyBehavior",
-      "counts",
-      "digestContext",
-      "foundationSummary",
-      "humanSummary",
-      "max",
-      "mode",
-      "policies",
-      "policyVersion",
-      "queues",
-      "runId",
-      "schemaVersion",
-    ]);
-  });
+		const json = stablePendingDigestAutopilotJson(result);
+		expect(json).toContain("[REDACTED]");
+		expect(json).not.toContain("sk-test_secret_value_123456789");
+		expect(Object.keys(JSON.parse(json))).toEqual([
+			"applyBehavior",
+			"counts",
+			"digestContext",
+			"foundationSummary",
+			"humanSummary",
+			"max",
+			"mode",
+			"policies",
+			"policyVersion",
+			"queues",
+			"runId",
+			"schemaVersion",
+		]);
+	});
 
-  it("uses the #1334 harness input hash contract for parent fixture decisions", () => {
-    const payload = { source: "fixture", title: "Stable item" };
-    const item = {
-      queue: "tools" as const,
-      id: "tool-1",
-      inputHash: computePendingInputHash({
-        queue: "tools",
-        id: "tool-1",
-        payload,
-        policyVersion: PENDING_DIGEST_AUTOPILOT_POLICY_VERSION,
-      }),
-      policyVersion: PENDING_DIGEST_AUTOPILOT_POLICY_VERSION,
-      capabilityClasses: ["read-only" as const],
-      payload,
-    };
-    const decision = decideReadOnlyItem(item, {
-      runId: "run",
-      mode: "dry-run",
-      policy: "classify",
-      policyVersion: PENDING_DIGEST_AUTOPILOT_POLICY_VERSION,
-      inputHash: item.inputHash,
-      actor: { type: "test", id: "unit" },
-    });
-    expect(decision).toMatchObject({
-      inputHash: item.inputHash,
-      policyVersion: PENDING_DIGEST_AUTOPILOT_POLICY_VERSION,
-    });
-  });
+	it("uses the #1334 harness input hash contract for parent fixture decisions", () => {
+		const payload = { source: "fixture", title: "Stable item" };
+		const item = {
+			queue: "tools" as const,
+			id: "tool-1",
+			inputHash: computePendingInputHash({
+				queue: "tools",
+				id: "tool-1",
+				payload,
+				policyVersion: PENDING_DIGEST_AUTOPILOT_POLICY_VERSION,
+			}),
+			policyVersion: PENDING_DIGEST_AUTOPILOT_POLICY_VERSION,
+			capabilityClasses: ["read-only" as const],
+			payload,
+		};
+		const decision = decideReadOnlyItem(item, {
+			runId: "run",
+			mode: "dry-run",
+			policy: "classify",
+			policyVersion: PENDING_DIGEST_AUTOPILOT_POLICY_VERSION,
+			inputHash: item.inputHash,
+			actor: { type: "test", id: "unit" },
+		});
+		expect(decision).toMatchObject({
+			inputHash: item.inputHash,
+			policyVersion: PENDING_DIGEST_AUTOPILOT_POLICY_VERSION,
+		});
+	});
 });

--- a/extensions/memory-hybrid/tests/pending-digest-autopilot.test.ts
+++ b/extensions/memory-hybrid/tests/pending-digest-autopilot.test.ts
@@ -1,0 +1,329 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { Command } from "commander";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { CrystallizationStore } from "../backends/crystallization-store.js";
+import type { ProcedureTriageReport } from "../backends/facts-db/procedures.js";
+import { ProposalsDB } from "../backends/proposals-db.js";
+import { ToolProposalStore } from "../backends/tool-proposal-store.js";
+import type { ManageBindings } from "../cli/commands/manage/bindings.js";
+import { registerManageDigest } from "../cli/commands/manage/register-digest.js";
+import { type HybridMemoryConfig, hybridConfigSchema } from "../config.js";
+import {
+  PendingAutopilotStore,
+  type PendingItem,
+  computePendingInputHash,
+} from "../services/pending-autopilot/index.js";
+import {
+  PENDING_DIGEST_AUTOPILOT_POLICY_VERSION,
+  type PendingDigestFactsDb,
+  createDefaultPendingDigestAdapters,
+  decideReadOnlyItem,
+  runPendingDigestAutopilot,
+} from "../services/pending-digest-autopilot.js";
+import { pendingStorePaths } from "../services/pending-review-digest.js";
+import { expectStandaloneAndParentDecisionsEquivalent } from "./helpers/pending-autopilot-equivalence.js";
+
+const dirs: string[] = [];
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  while (dirs.length > 0) {
+    const dir = dirs.pop();
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function newDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "pending-digest-autopilot-"));
+  dirs.push(dir);
+  return dir;
+}
+
+function configFor(sqlitePath: string): HybridMemoryConfig {
+  return hybridConfigSchema.parse({
+    embedding: { apiKey: "sk-test-embed-key-that-is-long-enough", model: "text-embedding-3-small" },
+    sqlitePath,
+    lanceDbPath: join(dirname(sqlitePath), "lancedb"),
+    credentials: { enabled: false },
+    wal: { enabled: false },
+    personaProposals: { enabled: true },
+    verification: { enabled: false },
+    provenance: { enabled: false },
+    nightlyCycle: { enabled: false },
+  });
+}
+
+function factsDb(): PendingDigestFactsDb {
+  return {
+    proceduresCount: () => 2,
+    proceduresValidatedCount: () => 2,
+    proceduresPromotedCount: () => 0,
+    countVerifiedFacts: () => 2,
+    proceduresValidatedSince: () => 1,
+    triageProcedures: ({ limit = 10_000 } = {}): ProcedureTriageReport => ({
+      rows: [
+        {
+          id: "proc-1",
+          title: "Review repeatable procedure",
+          validatedAt: 1,
+          promotionBlockReason: "awaiting_approval" as const,
+          lastRecall: 1,
+          successCount: 5,
+          confidence: 0.9,
+          skillPath: null,
+        },
+        {
+          id: "proc-2",
+          title: "Missing recipe anchor",
+          validatedAt: 1,
+          promotionBlockReason: "missing_anchor" as const,
+          lastRecall: 1,
+          successCount: 3,
+          confidence: 0.6,
+          skillPath: null,
+        },
+      ].slice(0, limit),
+      summary: {
+        total: 2,
+        byReason: { awaiting_approval: 1, missing_anchor: 1, unknown: 0, duplicate_skill: 0, low_recall: 0 },
+        topReason: "awaiting_approval",
+      },
+    }),
+  };
+}
+
+function seedQueues(cfg: HybridMemoryConfig): void {
+  const paths = pendingStorePaths(cfg.sqlitePath);
+  const persona = new ProposalsDB(paths.proposals);
+  const tools = new ToolProposalStore(paths.toolProposals);
+  const crystal = new CrystallizationStore(paths.crystallization);
+  persona.create({
+    targetFile: "SOUL.md",
+    title: "Change identity guidance",
+    observation: "Sensitive persona change.",
+    suggestedChange: "Rewrite identity.",
+    confidence: 0.91,
+    evidenceSessions: ["session-a"],
+  });
+  tools.create({
+    name: "safe_reporter",
+    description: "Draft read-only reports",
+    parameters: "{}",
+    rationale: "Useful reporting helper",
+    sourcePatterns: "[]",
+    implementationHint: "No external writes",
+  });
+  crystal.create({
+    patternId: "pattern-1",
+    skillName: "review-backlog",
+    skillContent: "# Skill",
+    patternSnapshot: "{}",
+  });
+  persona.close();
+  tools.close();
+  crystal.close();
+}
+
+describe("pending digest autopilot parent (#1326)", () => {
+  it("defaults to dry-run, inspects live pending queues, emits stable structured JSON, and writes no durable state", async () => {
+    const dir = newDir();
+    const cfg = configFor(join(dir, "facts.db"));
+    seedQueues(cfg);
+    const stateDb = join(dir, "autopilot.db");
+
+    const result = await runPendingDigestAutopilot({
+      cfg,
+      factsDb: factsDb(),
+      stateDbPath: stateDb,
+      runId: "run-dry",
+      now: new Date("2026-05-12T00:00:00.000Z"),
+    });
+
+    expect(result.mode).toBe("dry-run");
+    expect(result.applyBehavior).toBe("non-mutating-dry-run");
+    expect(result.digestContext).toMatchObject({
+      persona: 1,
+      procedures: 2,
+      tools: 1,
+      crystallization: 1,
+      verified: 2,
+    });
+    expect(result.counts.inspected).toBe(7);
+    expect(result.queues.persona.decisions[0]).toMatchObject({
+      action: "deferred-for-human",
+      reasonCode: "human-review-required",
+    });
+    expect(result.queues.tools.decisions[0]).toMatchObject({ action: "classified", reasonCode: "dry-run" });
+    expect(JSON.parse(JSON.stringify(result))).toMatchObject({
+      schemaVersion: 1,
+      runId: "run-dry",
+      policies: { persona: "cautious", procedures: "auto-safe", verified: "classify", tools: "classify" },
+      counts: { inspected: 7, applied: 0 },
+    });
+
+    const store = new PendingAutopilotStore(stateDb);
+    expect(store.tableCounts()).toEqual({
+      pending_autopilot_runs: 0,
+      pending_autopilot_decisions: 0,
+      pending_autopilot_cursors: 0,
+      pending_autopilot_locks: 0,
+    });
+    store.close();
+  });
+
+  it("apply mode records only foundation decisions and remains idempotent without queue mutations", async () => {
+    const dir = newDir();
+    const cfg = configFor(join(dir, "facts.db"));
+    seedQueues(cfg);
+    const stateDb = join(dir, "autopilot.db");
+
+    const first = await runPendingDigestAutopilot({
+      cfg,
+      factsDb: factsDb(),
+      stateDbPath: stateDb,
+      mode: "apply",
+      runId: "run-apply-1",
+    });
+    const second = await runPendingDigestAutopilot({
+      cfg,
+      factsDb: factsDb(),
+      stateDbPath: stateDb,
+      mode: "apply",
+      runId: "run-apply-2",
+    });
+
+    expect(first.applyBehavior).toBe("record-decisions-only");
+    expect(second.counts).toEqual(first.counts);
+    const paths = pendingStorePaths(cfg.sqlitePath);
+    const persona = new ProposalsDB(paths.proposals);
+    expect(persona.list({ status: "pending" })).toHaveLength(1);
+    persona.close();
+    const store = new PendingAutopilotStore(stateDb);
+    expect(store.listDecisions()).toHaveLength(7);
+    expect(store.tableCounts().pending_autopilot_runs).toBe(2);
+    expect(store.tableCounts().pending_autopilot_locks).toBe(0);
+    store.close();
+  });
+
+  it("supports disabled per-queue policies with stable skipped reason codes and max batch sizes", async () => {
+    const dir = newDir();
+    const cfg = configFor(join(dir, "facts.db"));
+    seedQueues(cfg);
+    const result = await runPendingDigestAutopilot({
+      cfg,
+      factsDb: factsDb(),
+      runId: "run-disabled",
+      policies: { tools: "disabled", crystallization: "report-only" },
+      max: { procedures: 1, verified: 1 },
+    });
+
+    expect(result.queues.tools).toMatchObject({ skipped: true, skipReason: "queue-disabled-by-policy", inspected: 0 });
+    expect(result.queues.tools.decisions[0]).toMatchObject({
+      action: "skipped-by-policy",
+      reasonCode: "policy-denied",
+    });
+    expect(result.queues.procedures.inspected).toBe(1);
+    expect(result.queues.verified.inspected).toBe(1);
+    expect(result.queues.crystallization.decisions[0]).toMatchObject({
+      action: "reported",
+      reasonCode: "policy-denied",
+    });
+  });
+
+  it("captures adapter/list failures as visible failed-validation decisions", async () => {
+    const dir = newDir();
+    const cfg = configFor(join(dir, "facts.db"));
+    const result = await runPendingDigestAutopilot({
+      cfg,
+      factsDb: factsDb(),
+      runId: "run-failure",
+      adapters: {
+        tools: {
+          queue: "tools",
+          listPending: () => {
+            throw new Error("backend down");
+          },
+          decide: decideReadOnlyItem,
+        },
+      },
+    });
+
+    expect(result.queues.tools).toMatchObject({ skipped: true, skipReason: "inventory-failed" });
+    expect(result.queues.tools.decisions[0]).toMatchObject({
+      action: "failed-validation",
+      reasonCode: "schema-validation-failed",
+      humanReviewRequired: true,
+    });
+    expect(result.humanSummary).toContain("failed validation 1");
+  });
+
+  it("parent route delegates to the same adapter decision path as standalone child route", async () => {
+    const dir = newDir();
+    const cfg = configFor(join(dir, "facts.db"));
+    seedQueues(cfg);
+    const adapters = createDefaultPendingDigestAdapters({ cfg, factsDb: factsDb() });
+    const listed = (await adapters.persona.listPending(null)) as PendingItem[];
+    const fixture = listed[0];
+
+    await expectStandaloneAndParentDecisionsEquivalent({
+      standalone: adapters.persona.decide,
+      parent: async (item, context) => {
+        const parentListed = (await adapters.persona.listPending(null)) as PendingItem[];
+        const matched = parentListed.find((candidate) => candidate.id === item.id);
+        if (!matched) throw new Error("fixture missing from parent inventory");
+        return adapters.persona.decide(matched, context);
+      },
+      fixtures: [{ item: fixture, policy: "default", policyVersion: PENDING_DIGEST_AUTOPILOT_POLICY_VERSION }],
+    });
+  });
+
+  it("registers digest autopilot CLI and emits JSON helpfully", async () => {
+    const dir = newDir();
+    const cfg = configFor(join(dir, "facts.db"));
+    seedQueues(cfg);
+    const program = new Command("hybrid-mem");
+    program.exitOverride();
+    registerManageDigest(program as never, { cfg, factsDb: factsDb() } as ManageBindings);
+    const out = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+    await program.parseAsync(["digest", "autopilot", "--dry-run", "--json", "--max-verified", "1"], { from: "user" });
+
+    const json = out.mock.calls.map((c) => String(c[0])).join("");
+    expect(JSON.parse(json)).toMatchObject({
+      mode: "dry-run",
+      counts: { applied: 0 },
+      queues: { verified: { inspected: 1 } },
+    });
+  });
+
+  it("uses the #1334 harness input hash contract for parent fixture decisions", () => {
+    const payload = { source: "fixture", title: "Stable item" };
+    const item = {
+      queue: "tools" as const,
+      id: "tool-1",
+      inputHash: computePendingInputHash({
+        queue: "tools",
+        id: "tool-1",
+        payload,
+        policyVersion: PENDING_DIGEST_AUTOPILOT_POLICY_VERSION,
+      }),
+      policyVersion: PENDING_DIGEST_AUTOPILOT_POLICY_VERSION,
+      capabilityClasses: ["read-only" as const],
+      payload,
+    };
+    const decision = decideReadOnlyItem(item, {
+      runId: "run",
+      mode: "dry-run",
+      policy: "classify",
+      policyVersion: PENDING_DIGEST_AUTOPILOT_POLICY_VERSION,
+      inputHash: item.inputHash,
+      actor: { type: "test", id: "unit" },
+    });
+    expect(decision).toMatchObject({
+      inputHash: item.inputHash,
+      policyVersion: PENDING_DIGEST_AUTOPILOT_POLICY_VERSION,
+    });
+  });
+});

--- a/extensions/memory-hybrid/tests/pending-digest-autopilot.test.ts
+++ b/extensions/memory-hybrid/tests/pending-digest-autopilot.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { Command } from "commander";
@@ -21,6 +21,7 @@ import {
   createDefaultPendingDigestAdapters,
   decideReadOnlyItem,
   runPendingDigestAutopilot,
+  stablePendingDigestAutopilotJson,
 } from "../services/pending-digest-autopilot.js";
 import { pendingStorePaths } from "../services/pending-review-digest.js";
 import { expectStandaloneAndParentDecisionsEquivalent } from "./helpers/pending-autopilot-equivalence.js";
@@ -127,7 +128,7 @@ function seedQueues(cfg: HybridMemoryConfig): void {
 }
 
 describe("pending digest autopilot parent (#1326)", () => {
-  it("defaults to dry-run, inspects live pending queues, emits stable structured JSON, and writes no durable state", async () => {
+  it("defaults to dry-run, inspects live pending queues, emits stable structured JSON, and does not open durable state", async () => {
     const dir = newDir();
     const cfg = configFor(join(dir, "facts.db"));
     seedQueues(cfg);
@@ -163,14 +164,7 @@ describe("pending digest autopilot parent (#1326)", () => {
       counts: { inspected: 7, applied: 0 },
     });
 
-    const store = new PendingAutopilotStore(stateDb);
-    expect(store.tableCounts()).toEqual({
-      pending_autopilot_runs: 0,
-      pending_autopilot_decisions: 0,
-      pending_autopilot_cursors: 0,
-      pending_autopilot_locks: 0,
-    });
-    store.close();
+    expect(existsSync(stateDb)).toBe(false);
   });
 
   it("apply mode records only foundation decisions and remains idempotent without queue mutations", async () => {
@@ -195,6 +189,7 @@ describe("pending digest autopilot parent (#1326)", () => {
     });
 
     expect(first.applyBehavior).toBe("record-decisions-only");
+    expect(first.queues.tools.decisions[0]).toMatchObject({ action: "classified", humanReviewRequired: false });
     expect(second.counts).toEqual(first.counts);
     const paths = pendingStorePaths(cfg.sqlitePath);
     const persona = new ProposalsDB(paths.proposals);
@@ -230,6 +225,21 @@ describe("pending digest autopilot parent (#1326)", () => {
       action: "reported",
       reasonCode: "policy-denied",
     });
+  });
+
+  it("requires a state DB before apply mode can record parent decisions", async () => {
+    const dir = newDir();
+    const cfg = configFor(join(dir, "facts.db"));
+    seedQueues(cfg);
+
+    await expect(
+      runPendingDigestAutopilot({
+        cfg,
+        factsDb: factsDb(),
+        mode: "apply",
+        runId: "run-apply-no-state",
+      }),
+    ).rejects.toThrow("--apply requires --state-db");
   });
 
   it("captures adapter/list failures as visible failed-validation decisions", async () => {
@@ -279,6 +289,26 @@ describe("pending digest autopilot parent (#1326)", () => {
     });
   });
 
+  it("propagates default inventory store failures as inventory-failed decisions", async () => {
+    const dir = newDir();
+    const cfg = configFor(join(dir, "facts.db"));
+    vi.spyOn(ProposalsDB.prototype, "list").mockImplementation(() => {
+      throw new Error("persona sqlite read failed");
+    });
+
+    const result = await runPendingDigestAutopilot({
+      cfg,
+      factsDb: factsDb(),
+      runId: "run-default-store-failure",
+    });
+
+    expect(result.queues.persona).toMatchObject({ skipped: true, skipReason: "inventory-failed" });
+    expect(result.queues.persona.decisions[0]).toMatchObject({
+      action: "failed-validation",
+      summary: { body: "persona sqlite read failed" },
+    });
+  });
+
   it("registers digest autopilot CLI and emits JSON helpfully", async () => {
     const dir = newDir();
     const cfg = configFor(join(dir, "facts.db"));
@@ -296,6 +326,67 @@ describe("pending digest autopilot parent (#1326)", () => {
       counts: { applied: 0 },
       queues: { verified: { inspected: 1 } },
     });
+  });
+
+  it("rejects conflicting dry-run/apply CLI flags and apply without state DB", async () => {
+    const dir = newDir();
+    const cfg = configFor(join(dir, "facts.db"));
+    const program = new Command("hybrid-mem");
+    program.exitOverride();
+    registerManageDigest(program as never, { cfg, factsDb: factsDb() } as ManageBindings);
+
+    await expect(
+      program.parseAsync(["digest", "autopilot", "--dry-run", "--apply", "--state-db", join(dir, "state.db")], {
+        from: "user",
+      }),
+    ).rejects.toThrow("--dry-run and --apply are mutually exclusive");
+    await expect(program.parseAsync(["digest", "autopilot", "--apply"], { from: "user" })).rejects.toThrow(
+      "--apply requires --state-db",
+    );
+  });
+
+  it("uses canonical redacted JSON for stable structured output", async () => {
+    const dir = newDir();
+    const cfg = configFor(join(dir, "facts.db"));
+    const result = await runPendingDigestAutopilot({
+      cfg,
+      factsDb: factsDb(),
+      runId: "run-json-redaction",
+      adapters: {
+        tools: {
+          queue: "tools",
+          listPending: () => [
+            {
+              queue: "tools",
+              id: "secret-tool",
+              inputHash: computePendingInputHash({ id: "secret-tool" }),
+              policyVersion: PENDING_DIGEST_AUTOPILOT_POLICY_VERSION,
+              capabilityClasses: ["read-only"],
+              payload: { title: "token: sk-test_secret_value_123456789" },
+            },
+          ],
+          decide: decideReadOnlyItem,
+        },
+      },
+    });
+
+    const json = stablePendingDigestAutopilotJson(result);
+    expect(json).toContain("[REDACTED]");
+    expect(json).not.toContain("sk-test_secret_value_123456789");
+    expect(Object.keys(JSON.parse(json))).toEqual([
+      "applyBehavior",
+      "counts",
+      "digestContext",
+      "foundationSummary",
+      "humanSummary",
+      "max",
+      "mode",
+      "policies",
+      "policyVersion",
+      "queues",
+      "runId",
+      "schemaVersion",
+    ]);
   });
 
   it("uses the #1334 harness input hash contract for parent fixture decisions", () => {

--- a/extensions/memory-hybrid/tests/pending-digest-autopilot.test.ts
+++ b/extensions/memory-hybrid/tests/pending-digest-autopilot.test.ts
@@ -11,17 +11,17 @@ import type { ManageBindings } from "../cli/commands/manage/bindings.js";
 import { registerManageDigest } from "../cli/commands/manage/register-digest.js";
 import { type HybridMemoryConfig, hybridConfigSchema } from "../config.js";
 import {
-	PendingAutopilotStore,
-	type PendingItem,
-	computePendingInputHash,
+  PendingAutopilotStore,
+  type PendingItem,
+  computePendingInputHash,
 } from "../services/pending-autopilot/index.js";
 import {
-	PENDING_DIGEST_AUTOPILOT_POLICY_VERSION,
-	type PendingDigestFactsDb,
-	createDefaultPendingDigestAdapters,
-	decideReadOnlyItem,
-	runPendingDigestAutopilot,
-	stablePendingDigestAutopilotJson,
+  PENDING_DIGEST_AUTOPILOT_POLICY_VERSION,
+  type PendingDigestFactsDb,
+  createDefaultPendingDigestAdapters,
+  decideReadOnlyItem,
+  runPendingDigestAutopilot,
+  stablePendingDigestAutopilotJson,
 } from "../services/pending-digest-autopilot.js";
 import { pendingStorePaths } from "../services/pending-review-digest.js";
 import { expectStandaloneAndParentDecisionsEquivalent } from "./helpers/pending-autopilot-equivalence.js";
@@ -29,458 +29,433 @@ import { expectStandaloneAndParentDecisionsEquivalent } from "./helpers/pending-
 const dirs: string[] = [];
 
 afterEach(() => {
-	vi.restoreAllMocks();
-	while (dirs.length > 0) {
-		const dir = dirs.pop();
-		if (dir) rmSync(dir, { recursive: true, force: true });
-	}
+  vi.restoreAllMocks();
+  while (dirs.length > 0) {
+    const dir = dirs.pop();
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  }
 });
 
 function newDir(): string {
-	const dir = mkdtempSync(join(tmpdir(), "pending-digest-autopilot-"));
-	dirs.push(dir);
-	return dir;
+  const dir = mkdtempSync(join(tmpdir(), "pending-digest-autopilot-"));
+  dirs.push(dir);
+  return dir;
 }
 
 function configFor(sqlitePath: string): HybridMemoryConfig {
-	return hybridConfigSchema.parse({
-		embedding: {
-			apiKey: "sk-test-embed-key-that-is-long-enough",
-			model: "text-embedding-3-small",
-		},
-		sqlitePath,
-		lanceDbPath: join(dirname(sqlitePath), "lancedb"),
-		credentials: { enabled: false },
-		wal: { enabled: false },
-		personaProposals: { enabled: true },
-		verification: { enabled: false },
-		provenance: { enabled: false },
-		nightlyCycle: { enabled: false },
-	});
+  return hybridConfigSchema.parse({
+    embedding: {
+      apiKey: "sk-test-embed-key-that-is-long-enough",
+      model: "text-embedding-3-small",
+    },
+    sqlitePath,
+    lanceDbPath: join(dirname(sqlitePath), "lancedb"),
+    credentials: { enabled: false },
+    wal: { enabled: false },
+    personaProposals: { enabled: true },
+    verification: { enabled: false },
+    provenance: { enabled: false },
+    nightlyCycle: { enabled: false },
+  });
 }
 
 function factsDb(): PendingDigestFactsDb {
-	return {
-		proceduresCount: () => 2,
-		proceduresValidatedCount: () => 2,
-		proceduresPromotedCount: () => 0,
-		countVerifiedFacts: () => 2,
-		proceduresValidatedSince: () => 1,
-		triageProcedures: ({ limit = 10_000 } = {}): ProcedureTriageReport => ({
-			rows: [
-				{
-					id: "proc-1",
-					title: "Review repeatable procedure",
-					validatedAt: 1,
-					promotionBlockReason: "awaiting_approval" as const,
-					lastRecall: 1,
-					successCount: 5,
-					confidence: 0.9,
-					skillPath: null,
-				},
-				{
-					id: "proc-2",
-					title: "Missing recipe anchor",
-					validatedAt: 1,
-					promotionBlockReason: "missing_anchor" as const,
-					lastRecall: 1,
-					successCount: 3,
-					confidence: 0.6,
-					skillPath: null,
-				},
-			].slice(0, limit),
-			summary: {
-				total: 2,
-				byReason: {
-					awaiting_approval: 1,
-					missing_anchor: 1,
-					unknown: 0,
-					duplicate_skill: 0,
-					low_recall: 0,
-				},
-				topReason: "awaiting_approval",
-			},
-		}),
-	};
+  return {
+    proceduresCount: () => 2,
+    proceduresValidatedCount: () => 2,
+    proceduresPromotedCount: () => 0,
+    countVerifiedFacts: () => 2,
+    proceduresValidatedSince: () => 1,
+    triageProcedures: ({ limit = 10_000 } = {}): ProcedureTriageReport => ({
+      rows: [
+        {
+          id: "proc-1",
+          title: "Review repeatable procedure",
+          validatedAt: 1,
+          promotionBlockReason: "awaiting_approval" as const,
+          lastRecall: 1,
+          successCount: 5,
+          confidence: 0.9,
+          skillPath: null,
+        },
+        {
+          id: "proc-2",
+          title: "Missing recipe anchor",
+          validatedAt: 1,
+          promotionBlockReason: "missing_anchor" as const,
+          lastRecall: 1,
+          successCount: 3,
+          confidence: 0.6,
+          skillPath: null,
+        },
+      ].slice(0, limit),
+      summary: {
+        total: 2,
+        byReason: {
+          awaiting_approval: 1,
+          missing_anchor: 1,
+          unknown: 0,
+          duplicate_skill: 0,
+          low_recall: 0,
+        },
+        topReason: "awaiting_approval",
+      },
+    }),
+  };
 }
 
 function seedQueues(cfg: HybridMemoryConfig): void {
-	const paths = pendingStorePaths(cfg.sqlitePath);
-	const persona = new ProposalsDB(paths.proposals);
-	const tools = new ToolProposalStore(paths.toolProposals);
-	const crystal = new CrystallizationStore(paths.crystallization);
-	persona.create({
-		targetFile: "SOUL.md",
-		title: "Change identity guidance",
-		observation: "Sensitive persona change.",
-		suggestedChange: "Rewrite identity.",
-		confidence: 0.91,
-		evidenceSessions: ["session-a"],
-	});
-	tools.create({
-		name: "safe_reporter",
-		description: "Draft read-only reports",
-		parameters: "{}",
-		rationale: "Useful reporting helper",
-		sourcePatterns: "[]",
-		implementationHint: "No external writes",
-	});
-	crystal.create({
-		patternId: "pattern-1",
-		skillName: "review-backlog",
-		skillContent: "# Skill",
-		patternSnapshot: "{}",
-	});
-	persona.close();
-	tools.close();
-	crystal.close();
+  const paths = pendingStorePaths(cfg.sqlitePath);
+  const persona = new ProposalsDB(paths.proposals);
+  const tools = new ToolProposalStore(paths.toolProposals);
+  const crystal = new CrystallizationStore(paths.crystallization);
+  persona.create({
+    targetFile: "SOUL.md",
+    title: "Change identity guidance",
+    observation: "Sensitive persona change.",
+    suggestedChange: "Rewrite identity.",
+    confidence: 0.91,
+    evidenceSessions: ["session-a"],
+  });
+  tools.create({
+    name: "safe_reporter",
+    description: "Draft read-only reports",
+    parameters: "{}",
+    rationale: "Useful reporting helper",
+    sourcePatterns: "[]",
+    implementationHint: "No external writes",
+  });
+  crystal.create({
+    patternId: "pattern-1",
+    skillName: "review-backlog",
+    skillContent: "# Skill",
+    patternSnapshot: "{}",
+  });
+  persona.close();
+  tools.close();
+  crystal.close();
 }
 
 describe("pending digest autopilot parent (#1326)", () => {
-	it("defaults to dry-run, inspects live pending queues, emits stable structured JSON, and does not open durable state", async () => {
-		const dir = newDir();
-		const cfg = configFor(join(dir, "facts.db"));
-		seedQueues(cfg);
-		const stateDb = join(dir, "autopilot.db");
+  it("defaults to dry-run, inspects live pending queues, emits stable structured JSON, and does not open durable state", async () => {
+    const dir = newDir();
+    const cfg = configFor(join(dir, "facts.db"));
+    seedQueues(cfg);
+    const stateDb = join(dir, "autopilot.db");
 
-		const result = await runPendingDigestAutopilot({
-			cfg,
-			factsDb: factsDb(),
-			stateDbPath: stateDb,
-			runId: "run-dry",
-			now: new Date("2026-05-12T00:00:00.000Z"),
-		});
+    const result = await runPendingDigestAutopilot({
+      cfg,
+      factsDb: factsDb(),
+      stateDbPath: stateDb,
+      runId: "run-dry",
+      now: new Date("2026-05-12T00:00:00.000Z"),
+    });
 
-		expect(result.mode).toBe("dry-run");
-		expect(result.applyBehavior).toBe("non-mutating-dry-run");
-		expect(result.digestContext).toMatchObject({
-			persona: 1,
-			procedures: 2,
-			tools: 1,
-			crystallization: 1,
-			verified: 2,
-		});
-		expect(result.counts.inspected).toBe(7);
-		expect(result.queues.persona.decisions[0]).toMatchObject({
-			action: "deferred-for-human",
-			reasonCode: "human-review-required",
-		});
-		expect(result.queues.tools.decisions[0]).toMatchObject({
-			action: "classified",
-			reasonCode: "dry-run",
-		});
-		expect(JSON.parse(JSON.stringify(result))).toMatchObject({
-			schemaVersion: 1,
-			runId: "run-dry",
-			policies: {
-				persona: "cautious",
-				procedures: "auto-safe",
-				verified: "classify",
-				tools: "classify",
-			},
-			counts: { inspected: 7, applied: 0 },
-		});
+    expect(result.mode).toBe("dry-run");
+    expect(result.applyBehavior).toBe("non-mutating-dry-run");
+    expect(result.digestContext).toMatchObject({
+      persona: 1,
+      procedures: 2,
+      tools: 1,
+      crystallization: 1,
+      verified: 2,
+    });
+    expect(result.counts.inspected).toBe(7);
+    expect(result.queues.persona.decisions[0]).toMatchObject({
+      action: "deferred-for-human",
+      reasonCode: "human-review-required",
+    });
+    expect(result.queues.tools.decisions[0]).toMatchObject({
+      action: "classified",
+      reasonCode: "dry-run",
+    });
+    expect(JSON.parse(JSON.stringify(result))).toMatchObject({
+      schemaVersion: 1,
+      runId: "run-dry",
+      policies: {
+        persona: "cautious",
+        procedures: "auto-safe",
+        verified: "classify",
+        tools: "classify",
+      },
+      counts: { inspected: 7, applied: 0 },
+    });
 
-		expect(existsSync(stateDb)).toBe(false);
-	});
+    expect(existsSync(stateDb)).toBe(false);
+  });
 
-	it("apply mode records only foundation decisions and remains idempotent without queue mutations", async () => {
-		const dir = newDir();
-		const cfg = configFor(join(dir, "facts.db"));
-		seedQueues(cfg);
-		const stateDb = join(dir, "autopilot.db");
+  it("apply mode records only foundation decisions and remains idempotent without queue mutations", async () => {
+    const dir = newDir();
+    const cfg = configFor(join(dir, "facts.db"));
+    seedQueues(cfg);
+    const stateDb = join(dir, "autopilot.db");
 
-		const first = await runPendingDigestAutopilot({
-			cfg,
-			factsDb: factsDb(),
-			stateDbPath: stateDb,
-			mode: "apply",
-			runId: "run-apply-1",
-		});
-		const second = await runPendingDigestAutopilot({
-			cfg,
-			factsDb: factsDb(),
-			stateDbPath: stateDb,
-			mode: "apply",
-			runId: "run-apply-2",
-		});
+    const first = await runPendingDigestAutopilot({
+      cfg,
+      factsDb: factsDb(),
+      stateDbPath: stateDb,
+      mode: "apply",
+      runId: "run-apply-1",
+    });
+    const second = await runPendingDigestAutopilot({
+      cfg,
+      factsDb: factsDb(),
+      stateDbPath: stateDb,
+      mode: "apply",
+      runId: "run-apply-2",
+    });
 
-		expect(first.applyBehavior).toBe("record-decisions-only");
-		expect(first.queues.tools.decisions[0]).toMatchObject({
-			action: "classified",
-			humanReviewRequired: false,
-			reasonCode: "read-only",
-			capabilityClass: "read-only",
-		});
-		expect(second.counts).toEqual(first.counts);
-		const paths = pendingStorePaths(cfg.sqlitePath);
-		const persona = new ProposalsDB(paths.proposals);
-		expect(persona.list({ status: "pending" })).toHaveLength(1);
-		persona.close();
-		const store = new PendingAutopilotStore(stateDb);
-		expect(store.listDecisions()).toHaveLength(7);
-		expect(store.tableCounts().pending_autopilot_runs).toBe(2);
-		expect(store.tableCounts().pending_autopilot_locks).toBe(0);
-		store.close();
-	});
+    expect(first.applyBehavior).toBe("record-decisions-only");
+    expect(first.queues.tools.decisions[0]).toMatchObject({
+      action: "classified",
+      humanReviewRequired: false,
+      reasonCode: "policy-threshold-not-met",
+      capabilityClass: "read-only",
+    });
+    expect(second.counts).toEqual(first.counts);
+    const paths = pendingStorePaths(cfg.sqlitePath);
+    const persona = new ProposalsDB(paths.proposals);
+    expect(persona.list({ status: "pending" })).toHaveLength(1);
+    persona.close();
+    const store = new PendingAutopilotStore(stateDb);
+    expect(store.listDecisions()).toHaveLength(7);
+    expect(store.tableCounts().pending_autopilot_runs).toBe(2);
+    expect(store.tableCounts().pending_autopilot_locks).toBe(0);
+    store.close();
+  });
 
-	it("supports disabled per-queue policies with stable skipped reason codes and max batch sizes", async () => {
-		const dir = newDir();
-		const cfg = configFor(join(dir, "facts.db"));
-		seedQueues(cfg);
-		const result = await runPendingDigestAutopilot({
-			cfg,
-			factsDb: factsDb(),
-			runId: "run-disabled",
-			policies: { tools: "disabled", crystallization: "report-only" },
-			max: { procedures: 1, verified: 1 },
-		});
+  it("supports disabled per-queue policies with stable skipped reason codes and max batch sizes", async () => {
+    const dir = newDir();
+    const cfg = configFor(join(dir, "facts.db"));
+    seedQueues(cfg);
+    const result = await runPendingDigestAutopilot({
+      cfg,
+      factsDb: factsDb(),
+      runId: "run-disabled",
+      policies: { tools: "disabled", crystallization: "report-only" },
+      max: { procedures: 1, verified: 1 },
+    });
 
-		expect(result.queues.tools).toMatchObject({
-			skipped: true,
-			skipReason: "queue-disabled-by-policy",
-			inspected: 0,
-		});
-		expect(result.queues.tools.decisions[0]).toMatchObject({
-			action: "skipped-by-policy",
-			reasonCode: "policy-denied",
-		});
-		expect(result.queues.procedures.inspected).toBe(1);
-		expect(result.queues.verified.inspected).toBe(1);
-		expect(result.queues.crystallization.decisions[0]).toMatchObject({
-			action: "reported",
-			reasonCode: "policy-denied",
-		});
-	});
+    expect(result.queues.tools).toMatchObject({
+      skipped: true,
+      skipReason: "queue-disabled-by-policy",
+      inspected: 0,
+    });
+    expect(result.queues.tools.decisions[0]).toMatchObject({
+      action: "skipped-by-policy",
+      reasonCode: "policy-denied",
+    });
+    expect(result.queues.procedures.inspected).toBe(1);
+    expect(result.queues.verified.inspected).toBe(1);
+    expect(result.queues.crystallization.decisions[0]).toMatchObject({
+      action: "reported",
+      reasonCode: "policy-denied",
+    });
+  });
 
-	it("requires a state DB before apply mode can record parent decisions", async () => {
-		const dir = newDir();
-		const cfg = configFor(join(dir, "facts.db"));
-		seedQueues(cfg);
+  it("requires a state DB before apply mode can record parent decisions", async () => {
+    const dir = newDir();
+    const cfg = configFor(join(dir, "facts.db"));
+    seedQueues(cfg);
 
-		await expect(
-			runPendingDigestAutopilot({
-				cfg,
-				factsDb: factsDb(),
-				mode: "apply",
-				runId: "run-apply-no-state",
-			}),
-		).rejects.toThrow("--apply requires --state-db");
-	});
+    await expect(
+      runPendingDigestAutopilot({
+        cfg,
+        factsDb: factsDb(),
+        mode: "apply",
+        runId: "run-apply-no-state",
+      }),
+    ).rejects.toThrow("--apply requires --state-db");
+  });
 
-	it("captures adapter/list failures as visible failed-validation decisions", async () => {
-		const dir = newDir();
-		const cfg = configFor(join(dir, "facts.db"));
-		const result = await runPendingDigestAutopilot({
-			cfg,
-			factsDb: factsDb(),
-			runId: "run-failure",
-			adapters: {
-				tools: {
-					queue: "tools",
-					listPending: () => {
-						throw new Error("backend down");
-					},
-					decide: decideReadOnlyItem,
-				},
-			},
-		});
+  it("captures adapter/list failures as visible failed-validation decisions", async () => {
+    const dir = newDir();
+    const cfg = configFor(join(dir, "facts.db"));
+    const result = await runPendingDigestAutopilot({
+      cfg,
+      factsDb: factsDb(),
+      runId: "run-failure",
+      adapters: {
+        tools: {
+          queue: "tools",
+          listPending: () => {
+            throw new Error("backend down");
+          },
+          decide: decideReadOnlyItem,
+        },
+      },
+    });
 
-		expect(result.queues.tools).toMatchObject({
-			skipped: true,
-			skipReason: "inventory-failed",
-		});
-		expect(result.queues.tools.decisions[0]).toMatchObject({
-			action: "failed-validation",
-			reasonCode: "schema-validation-failed",
-			humanReviewRequired: true,
-		});
-		expect(result.humanSummary).toContain("failed validation 1");
-	});
+    expect(result.queues.tools).toMatchObject({
+      skipped: true,
+      skipReason: "inventory-failed",
+    });
+    expect(result.queues.tools.decisions[0]).toMatchObject({
+      action: "failed-validation",
+      reasonCode: "schema-validation-failed",
+      humanReviewRequired: true,
+    });
+    expect(result.humanSummary).toContain("failed validation 1");
+  });
 
-	it("parent route delegates to the same adapter decision path as standalone child route", async () => {
-		const dir = newDir();
-		const cfg = configFor(join(dir, "facts.db"));
-		seedQueues(cfg);
-		const adapters = createDefaultPendingDigestAdapters({
-			cfg,
-			factsDb: factsDb(),
-		});
-		const listed = (await adapters.persona.listPending(null)) as PendingItem[];
-		const fixture = listed[0];
+  it("parent route delegates to the same adapter decision path as standalone child route", async () => {
+    const dir = newDir();
+    const cfg = configFor(join(dir, "facts.db"));
+    seedQueues(cfg);
+    const adapters = createDefaultPendingDigestAdapters({
+      cfg,
+      factsDb: factsDb(),
+    });
+    const listed = (await adapters.persona.listPending(null)) as PendingItem[];
+    const fixture = listed[0];
 
-		await expectStandaloneAndParentDecisionsEquivalent({
-			standalone: adapters.persona.decide,
-			parent: async (item, context) => {
-				const parentListed = (await adapters.persona.listPending(
-					null,
-				)) as PendingItem[];
-				const matched = parentListed.find(
-					(candidate) => candidate.id === item.id,
-				);
-				if (!matched) throw new Error("fixture missing from parent inventory");
-				return adapters.persona.decide(matched, context);
-			},
-			fixtures: [
-				{
-					item: fixture,
-					policy: "default",
-					policyVersion: PENDING_DIGEST_AUTOPILOT_POLICY_VERSION,
-				},
-			],
-		});
-	});
+    await expectStandaloneAndParentDecisionsEquivalent({
+      standalone: adapters.persona.decide,
+      parent: async (item, context) => {
+        const parentListed = (await adapters.persona.listPending(null)) as PendingItem[];
+        const matched = parentListed.find((candidate) => candidate.id === item.id);
+        if (!matched) throw new Error("fixture missing from parent inventory");
+        return adapters.persona.decide(matched, context);
+      },
+      fixtures: [
+        {
+          item: fixture,
+          policy: "default",
+          policyVersion: PENDING_DIGEST_AUTOPILOT_POLICY_VERSION,
+        },
+      ],
+    });
+  });
 
-	it("propagates default inventory store failures as inventory-failed decisions", async () => {
-		const dir = newDir();
-		const cfg = configFor(join(dir, "facts.db"));
-		vi.spyOn(ProposalsDB.prototype, "list").mockImplementation(() => {
-			throw new Error("persona sqlite read failed");
-		});
+  it("propagates default inventory store failures as inventory-failed decisions", async () => {
+    const dir = newDir();
+    const cfg = configFor(join(dir, "facts.db"));
+    vi.spyOn(ProposalsDB.prototype, "list").mockImplementation(() => {
+      throw new Error("persona sqlite read failed");
+    });
 
-		const result = await runPendingDigestAutopilot({
-			cfg,
-			factsDb: factsDb(),
-			runId: "run-default-store-failure",
-		});
+    const result = await runPendingDigestAutopilot({
+      cfg,
+      factsDb: factsDb(),
+      runId: "run-default-store-failure",
+    });
 
-		expect(result.queues.persona).toMatchObject({
-			skipped: true,
-			skipReason: "inventory-failed",
-		});
-		expect(result.queues.persona.decisions[0]).toMatchObject({
-			action: "failed-validation",
-			summary: { body: "persona sqlite read failed" },
-		});
-	});
+    expect(result.queues.persona).toMatchObject({
+      skipped: true,
+      skipReason: "inventory-failed",
+    });
+    expect(result.queues.persona.decisions[0]).toMatchObject({
+      action: "failed-validation",
+      summary: { body: "persona sqlite read failed" },
+    });
+  });
 
-	it("registers digest autopilot CLI and emits JSON helpfully", async () => {
-		const dir = newDir();
-		const cfg = configFor(join(dir, "facts.db"));
-		seedQueues(cfg);
-		const program = new Command("hybrid-mem");
-		program.exitOverride();
-		registerManageDigest(
-			program as never,
-			{ cfg, factsDb: factsDb() } as ManageBindings,
-		);
-		const out = vi
-			.spyOn(process.stdout, "write")
-			.mockImplementation(() => true);
+  it("registers digest autopilot CLI and emits JSON helpfully", async () => {
+    const dir = newDir();
+    const cfg = configFor(join(dir, "facts.db"));
+    seedQueues(cfg);
+    const program = new Command("hybrid-mem");
+    program.exitOverride();
+    registerManageDigest(program as never, { cfg, factsDb: factsDb() } as ManageBindings);
+    const out = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
 
-		await program.parseAsync(
-			["digest", "autopilot", "--dry-run", "--json", "--max-verified", "1"],
-			{ from: "user" },
-		);
+    await program.parseAsync(["digest", "autopilot", "--dry-run", "--json", "--max-verified", "1"], { from: "user" });
 
-		const json = out.mock.calls.map((c) => String(c[0])).join("");
-		expect(JSON.parse(json)).toMatchObject({
-			mode: "dry-run",
-			counts: { applied: 0 },
-			queues: { verified: { inspected: 1 } },
-		});
-	});
+    const json = out.mock.calls.map((c) => String(c[0])).join("");
+    expect(JSON.parse(json)).toMatchObject({
+      mode: "dry-run",
+      counts: { applied: 0 },
+      queues: { verified: { inspected: 1 } },
+    });
+  });
 
-	it("rejects conflicting dry-run/apply CLI flags and apply without state DB", async () => {
-		const dir = newDir();
-		const cfg = configFor(join(dir, "facts.db"));
-		const program = new Command("hybrid-mem");
-		program.exitOverride();
-		registerManageDigest(
-			program as never,
-			{ cfg, factsDb: factsDb() } as ManageBindings,
-		);
+  it("rejects conflicting dry-run/apply CLI flags and apply without state DB", async () => {
+    const dir = newDir();
+    const cfg = configFor(join(dir, "facts.db"));
+    const program = new Command("hybrid-mem");
+    program.exitOverride();
+    registerManageDigest(program as never, { cfg, factsDb: factsDb() } as ManageBindings);
 
-		await expect(
-			program.parseAsync(
-				[
-					"digest",
-					"autopilot",
-					"--dry-run",
-					"--apply",
-					"--state-db",
-					join(dir, "state.db"),
-				],
-				{
-					from: "user",
-				},
-			),
-		).rejects.toThrow("--dry-run and --apply are mutually exclusive");
-		await expect(
-			program.parseAsync(["digest", "autopilot", "--apply"], { from: "user" }),
-		).rejects.toThrow("--apply requires --state-db");
-	});
+    await expect(
+      program.parseAsync(["digest", "autopilot", "--dry-run", "--apply", "--state-db", join(dir, "state.db")], {
+        from: "user",
+      }),
+    ).rejects.toThrow("--dry-run and --apply are mutually exclusive");
+    await expect(program.parseAsync(["digest", "autopilot", "--apply"], { from: "user" })).rejects.toThrow(
+      "--apply requires --state-db",
+    );
+  });
 
-	it("uses canonical redacted JSON for stable structured output", async () => {
-		const dir = newDir();
-		const cfg = configFor(join(dir, "facts.db"));
-		const result = await runPendingDigestAutopilot({
-			cfg,
-			factsDb: factsDb(),
-			runId: "run-json-redaction",
-			adapters: {
-				tools: {
-					queue: "tools",
-					listPending: () => [
-						{
-							queue: "tools",
-							id: "secret-tool",
-							inputHash: computePendingInputHash({ id: "secret-tool" }),
-							policyVersion: PENDING_DIGEST_AUTOPILOT_POLICY_VERSION,
-							capabilityClasses: ["read-only"],
-							payload: { title: "token: sk-test_secret_value_123456789" },
-						},
-					],
-					decide: decideReadOnlyItem,
-				},
-			},
-		});
+  it("uses canonical redacted JSON for stable structured output", async () => {
+    const dir = newDir();
+    const cfg = configFor(join(dir, "facts.db"));
+    const result = await runPendingDigestAutopilot({
+      cfg,
+      factsDb: factsDb(),
+      runId: "run-json-redaction",
+      adapters: {
+        tools: {
+          queue: "tools",
+          listPending: () => [
+            {
+              queue: "tools",
+              id: "secret-tool",
+              inputHash: computePendingInputHash({ id: "secret-tool" }),
+              policyVersion: PENDING_DIGEST_AUTOPILOT_POLICY_VERSION,
+              capabilityClasses: ["read-only"],
+              payload: { title: "token: sk-test_secret_value_123456789" },
+            },
+          ],
+          decide: decideReadOnlyItem,
+        },
+      },
+    });
 
-		const json = stablePendingDigestAutopilotJson(result);
-		expect(json).toContain("[REDACTED]");
-		expect(json).not.toContain("sk-test_secret_value_123456789");
-		expect(Object.keys(JSON.parse(json))).toEqual([
-			"applyBehavior",
-			"counts",
-			"digestContext",
-			"foundationSummary",
-			"humanSummary",
-			"max",
-			"mode",
-			"policies",
-			"policyVersion",
-			"queues",
-			"runId",
-			"schemaVersion",
-		]);
-	});
+    const json = stablePendingDigestAutopilotJson(result);
+    expect(json).toContain("[REDACTED]");
+    expect(json).not.toContain("sk-test_secret_value_123456789");
+    expect(Object.keys(JSON.parse(json))).toEqual([
+      "applyBehavior",
+      "counts",
+      "digestContext",
+      "foundationSummary",
+      "humanSummary",
+      "max",
+      "mode",
+      "policies",
+      "policyVersion",
+      "queues",
+      "runId",
+      "schemaVersion",
+    ]);
+  });
 
-	it("uses the #1334 harness input hash contract for parent fixture decisions", () => {
-		const payload = { source: "fixture", title: "Stable item" };
-		const item = {
-			queue: "tools" as const,
-			id: "tool-1",
-			inputHash: computePendingInputHash({
-				queue: "tools",
-				id: "tool-1",
-				payload,
-				policyVersion: PENDING_DIGEST_AUTOPILOT_POLICY_VERSION,
-			}),
-			policyVersion: PENDING_DIGEST_AUTOPILOT_POLICY_VERSION,
-			capabilityClasses: ["read-only" as const],
-			payload,
-		};
-		const decision = decideReadOnlyItem(item, {
-			runId: "run",
-			mode: "dry-run",
-			policy: "classify",
-			policyVersion: PENDING_DIGEST_AUTOPILOT_POLICY_VERSION,
-			inputHash: item.inputHash,
-			actor: { type: "test", id: "unit" },
-		});
-		expect(decision).toMatchObject({
-			inputHash: item.inputHash,
-			policyVersion: PENDING_DIGEST_AUTOPILOT_POLICY_VERSION,
-		});
-	});
+  it("uses the #1334 harness input hash contract for parent fixture decisions", () => {
+    const payload = { source: "fixture", title: "Stable item" };
+    const item = {
+      queue: "tools" as const,
+      id: "tool-1",
+      inputHash: computePendingInputHash({
+        queue: "tools",
+        id: "tool-1",
+        payload,
+        policyVersion: PENDING_DIGEST_AUTOPILOT_POLICY_VERSION,
+      }),
+      policyVersion: PENDING_DIGEST_AUTOPILOT_POLICY_VERSION,
+      capabilityClasses: ["read-only" as const],
+      payload,
+    };
+    const decision = decideReadOnlyItem(item, {
+      runId: "run",
+      mode: "dry-run",
+      policy: "classify",
+      policyVersion: PENDING_DIGEST_AUTOPILOT_POLICY_VERSION,
+      inputHash: item.inputHash,
+      actor: { type: "test", id: "unit" },
+    });
+    expect(decision).toMatchObject({
+      inputHash: item.inputHash,
+      policyVersion: PENDING_DIGEST_AUTOPILOT_POLICY_VERSION,
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #1326.

Adds the Phase 1 parent `digest autopilot` skeleton on top of the merged #1334 pending-autopilot foundation:

- registers `openclaw hybrid-mem digest autopilot`
- defaults to read-only/non-mutating `--dry-run`
- supports `--apply`, per-queue policies, per-queue maxes, and `--json`
- builds live queue inventory from the same stores used by `digest pending`
- delegates decisions through shared `PendingQueueAdapter` adapters/stubs
- uses #1334 decision/action/reason/capability/input-hash/policy-version contracts
- limits Phase 1 apply to durable foundation decision records only; no queue mutations
- keeps tool/crystallization as read-only classify adapters
- documents the parent command and child-adapter boundaries

## Safety / boundaries

- No persona/procedure/verified child policy is duplicated here.
- Parent apply is intentionally explicit and limited: `record-decisions-only` via #1334 state when `--state-db` is supplied.
- Dry-run writes no pending-autopilot state.
- Verified queue remains a placeholder/count-based inventory until #1329 defines the exact review queue source.
- Cron/HM_EXIT wrapper remains for #1330; this PR does not add cron scheduling or notification behavior.

## #1326 checklist

- [x] Parent command/service: `digest autopilot`
- [x] Uses #1334 foundation contracts/state/summary/redaction/decision model
- [x] Default read-only dry-run/non-mutating mode
- [x] Live inventory using pending-review-digest sources/stores
- [x] Queue decisions delegated to adapter-style modules via `PendingQueueAdapter`
- [x] No deep child policies for #1327/#1328/#1329
- [x] Tool/crystallization lightweight read-only classify adapters
- [x] Stable structured JSON plus concise human summary
- [x] Durable decisions only in apply mode through #1334 store; dry-run does not mutate durable state
- [x] Flags: `--dry-run`, `--apply`, per-queue policies, per-queue maxes, `--json`
- [x] Parent/child equivalence test using #1334 harness
- [x] Tests for dry-run non-mutation, stable JSON shape, disabled/skipped reasons, live inventory, idempotency, failure handling, and no queue mutation in apply
- [x] Documentation/help updated with #1334 dependency and child-adapter boundaries

## Tests

- `./node_modules/.bin/vitest run tests/pending-digest-autopilot.test.ts tests/pending-autopilot-foundation.test.ts tests/pending-review-digest.test.ts` — 3 files / 21 tests passed
- `./node_modules/.bin/biome lint services/pending-digest-autopilot.ts cli/commands/manage/register-digest.ts tests/pending-digest-autopilot.test.ts services/pending-autopilot/README.md --max-diagnostics=none` — passed
- `./node_modules/.bin/tsc --noEmit` — failed on pre-existing/unrelated GraphQL server dependency/type errors (`graphql-yoga` missing + `routes/graphql-server.ts` payload typing); no new pending-autopilot errors after fixes

## Notes

Dependency installation in this fresh `/tmp` checkout hit `ENOSPC`, so verification used the existing installed dependency tree symlinked only during test execution and removed before commit. Worktree contains no `node_modules`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new `digest autopilot` orchestration path that can write to a durable SQLite state DB in `--apply` mode; while queue stores remain non-mutated, new decision recording/cursor logic could affect operational workflows and needs careful review.
> 
> **Overview**
> Adds a new Phase 1 `openclaw hybrid-mem digest autopilot` **parent orchestration** command that inventories the same pending queues as `digest pending`, delegates read-only decisions through `PendingQueueAdapter`s, and emits either a concise human summary or stable redacted JSON.
> 
> Implements `services/pending-digest-autopilot.ts` to normalize per-queue policies/max batch sizes, handle disabled/missing adapters and inventory failures, and optionally persist run/decision records to the #1334 `PendingAutopilotStore` **only in `--apply` mode** (explicitly *record-decisions-only*, no queue mutations).
> 
> Updates #1334 foundation docs to describe the new parent command and boundaries, and adds comprehensive tests covering dry-run non-persistence, apply idempotent decision recording, per-queue policy/max behavior, failure capture, CLI flag validation, and stable redaction/JSON shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45612e5b601bb31fa704e8654071b33cbcca0cf7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->