### PR TITLE
feat(memory): add verified fact triage adapter

### DIFF
--- a/extensions/memory-hybrid/cli/register.ts
+++ b/extensions/memory-hybrid/cli/register.ts
@@ -360,10 +360,10 @@ export type HybridMemCliContext = {
 type Chainable = {
   command(name: string): Chainable;
   description(desc: string): Chainable;
-  action(fn: (...args: unknown[]) => void | Promise<void>): Chainable;
-  option(flags: string, desc?: string, defaultValue?: string): Chainable;
-  requiredOption(flags: string, desc?: string, defaultValue?: string): Chainable;
-  argument(name: string, desc?: string): Chainable;
+  action(fn: (...args: any[]) => void | Promise<void>): Chainable;
+  option(flags: string, desc?: string, defaultValue?: unknown): Chainable;
+  requiredOption(flags: string, desc?: string, defaultValue?: unknown): Chainable;
+  argument?(name: string, desc?: string): Chainable;
   alias?(name: string): Chainable;
 };
 

--- a/extensions/memory-hybrid/cli/register.ts
+++ b/extensions/memory-hybrid/cli/register.ts
@@ -470,7 +470,7 @@ export function registerHybridMemCli(mem: Chainable, ctx: HybridMemCliContext): 
       factsDb: ctx.factsDb,
       resolvedSqlitePath: ctx.resolvedSqlitePath,
       resolvePath: ctx.resolvePath,
-      reverificationDays: ctx.cfg.verification.reverificationDays,
+      reverificationDays: ctx.cfg.verification?.reverificationDays,
     });
   } catch (err) {
     capturePluginError(err instanceof Error ? err : new Error(String(err)), {

--- a/extensions/memory-hybrid/cli/register.ts
+++ b/extensions/memory-hybrid/cli/register.ts
@@ -21,6 +21,7 @@ import { type DistillContext, registerDistillCommands } from "./distill.js";
 import { registerGoalCommands } from "./goals.js";
 import { type ManageContext, registerManageCommands } from "./manage.js";
 import { registerTaskQueueStatusCommands } from "./task-queue-status.js";
+import { registerVerifiedCommands } from "./verified.js";
 import { registerStatusCommands } from "./cmd-status.js";
 import { type UserFriendlyContext, registerUserFriendlyCommands } from "./cmd-user-friendly.js";
 import type {
@@ -359,7 +360,7 @@ export type HybridMemCliContext = {
 type Chainable = {
   command(name: string): Chainable;
   description(desc: string): Chainable;
-  action(fn: (...args: any[]) => void | Promise<void>): Chainable;
+  action(fn: (...args: unknown[]) => void | Promise<void>): Chainable;
   option(flags: string, desc?: string, defaultValue?: string): Chainable;
   requiredOption(flags: string, desc?: string, defaultValue?: string): Chainable;
   argument(name: string, desc?: string): Chainable;
@@ -460,6 +461,20 @@ export function registerHybridMemCli(mem: Chainable, ctx: HybridMemCliContext): 
     capturePluginError(err instanceof Error ? err : new Error(String(err)), {
       subsystem: "registration",
       operation: "register-cli:goals",
+    });
+    throw err;
+  }
+
+  try {
+    registerVerifiedCommands(mem, {
+      factsDb: ctx.factsDb,
+      resolvedSqlitePath: ctx.resolvedSqlitePath,
+      resolvePath: ctx.resolvePath,
+    });
+  } catch (err) {
+    capturePluginError(err instanceof Error ? err : new Error(String(err)), {
+      subsystem: "registration",
+      operation: "register-cli:verified",
     });
     throw err;
   }

--- a/extensions/memory-hybrid/cli/register.ts
+++ b/extensions/memory-hybrid/cli/register.ts
@@ -470,6 +470,7 @@ export function registerHybridMemCli(mem: Chainable, ctx: HybridMemCliContext): 
       factsDb: ctx.factsDb,
       resolvedSqlitePath: ctx.resolvedSqlitePath,
       resolvePath: ctx.resolvePath,
+      reverificationDays: ctx.cfg.verification.reverificationDays,
     });
   } catch (err) {
     capturePluginError(err instanceof Error ? err : new Error(String(err)), {

--- a/extensions/memory-hybrid/cli/verified.ts
+++ b/extensions/memory-hybrid/cli/verified.ts
@@ -2,107 +2,159 @@ import { dirname, join } from "node:path";
 import type { FactsDB } from "../backends/facts-db.js";
 import { PendingAutopilotStore } from "../services/pending-autopilot/index.js";
 import {
-  VERIFIED_REVIEW_QUEUE_SOURCE,
-  assertVerifiedTriagePolicy,
-  listVerifiedFactTriageItems,
-  runVerifiedFactTriage,
-  type VerifiedTriagePolicy,
+	VERIFIED_REVIEW_QUEUE_SOURCE,
+	assertVerifiedTriagePolicy,
+	listVerifiedFactTriageItems,
+	runVerifiedFactTriage,
+	type VerifiedTriagePolicy,
 } from "../services/verified-fact-triage.js";
 import { type Chainable, withExit } from "./shared.js";
 
 export interface VerifiedCliContext {
-  factsDb: Pick<FactsDB, "getRawDb">;
-  resolvedSqlitePath?: string;
-  resolvePath?: (file: string) => string;
+	factsDb: Pick<FactsDB, "getRawDb">;
+	resolvedSqlitePath?: string;
+	resolvePath?: (file: string) => string;
 }
 
-export function registerVerifiedCommands(mem: Chainable, ctx: VerifiedCliContext): void {
-  const verified = mem.command("verified").description("Inspect and conservatively triage verified facts.");
+export function registerVerifiedCommands(
+	mem: Chainable,
+	ctx: VerifiedCliContext,
+): void {
+	const verified = mem
+		.command("verified")
+		.description("Inspect and conservatively triage verified facts.");
 
-  verified
-    .command("list")
-    .description("List the verified-fact review queue (due-for-reverification latest verified facts).")
-    .option("--max <n>", "Maximum items to list (default: 100)")
-    .option("--json", "Emit structured JSON")
-    .action(
-      withExit(async (opts?: { max?: string; json?: boolean }) => {
-        const max = parsePositiveInt(opts?.max, 100);
-        const items = listVerifiedFactTriageItems(ctx.factsDb.getRawDb(), { max });
-        const output = {
-          reviewQueueSource: VERIFIED_REVIEW_QUEUE_SOURCE,
-          count: items.length,
-          items: items.map((item) => ({
-            verifiedFactId: item.payload.verified.id,
-            factId: item.payload.verified.factId,
-            nextVerification: item.payload.verified.nextVerification,
-            verifiedAt: item.payload.verified.verifiedAt,
-            scope: item.payload.fact?.scope ?? null,
-            scopeTarget: item.payload.fact?.scopeTarget ?? null,
-            inputHash: item.inputHash,
-          })),
-        };
-        if (opts?.json) console.log(JSON.stringify(output, null, 2));
-        else {
-          console.log(`Verified review queue source: ${VERIFIED_REVIEW_QUEUE_SOURCE}`);
-          console.log(`Pending verified-fact reviews: ${output.count}`);
-          for (const item of output.items) {
-            console.log(`- ${item.factId} (verified=${item.verifiedFactId}, next=${item.nextVerification ?? "none"})`);
-          }
-        }
-      }),
-    );
+	verified
+		.command("list")
+		.description(
+			"List the verified-fact review queue (due-for-reverification latest verified facts).",
+		)
+		.option("--max <n>", "Maximum items to list (default: 100)")
+		.option("--json", "Emit structured JSON")
+		.action(
+			withExit(async (opts?: { max?: string; json?: boolean }) => {
+				const max = parsePositiveInt(opts?.max, 100);
+				const items = listVerifiedFactTriageItems(ctx.factsDb.getRawDb(), {
+					max,
+				});
+				const output = {
+					reviewQueueSource: VERIFIED_REVIEW_QUEUE_SOURCE,
+					count: items.length,
+					items: items.map((item) => ({
+						verifiedFactId: item.payload.verified.id,
+						factId: item.payload.verified.factId,
+						nextVerification: item.payload.verified.nextVerification,
+						verifiedAt: item.payload.verified.verifiedAt,
+						scope: item.payload.fact?.scope ?? null,
+						scopeTarget: item.payload.fact?.scopeTarget ?? null,
+						inputHash: item.inputHash,
+					})),
+				};
+				if (opts?.json) console.log(JSON.stringify(output, null, 2));
+				else {
+					console.log(
+						`Verified review queue source: ${VERIFIED_REVIEW_QUEUE_SOURCE}`,
+					);
+					console.log(`Pending verified-fact reviews: ${output.count}`);
+					for (const item of output.items) {
+						console.log(
+							`- ${item.factId} (verified=${item.verifiedFactId}, next=${item.nextVerification ?? "none"})`,
+						);
+					}
+				}
+			}),
+		);
 
-  verified
-    .command("triage")
-    .description("Classify due verified-fact reviews with conservative non-destructive policies.")
-    .option("--dry-run", "Preview only; persist no durable review/foundation state")
-    .option("--apply", "Persist allowed non-destructive pending-autopilot decisions")
-    .option("--policy <policy>", "report-only, classify, or apply-obvious (default: report-only)")
-    .option("--max <n>", "Maximum items to inspect (default: 100)")
-    .option("--json", "Emit structured JSON")
-    .action(
-      withExit(async (opts?: { dryRun?: boolean; apply?: boolean; policy?: string; max?: string; json?: boolean }) => {
-        if (opts?.dryRun && opts?.apply) throw new Error("Use only one of --dry-run or --apply");
-        const mode = opts?.apply ? "apply" : "dry-run";
-        const policy: VerifiedTriagePolicy = assertVerifiedTriagePolicy(String(opts?.policy ?? "report-only"));
-        const max = parsePositiveInt(opts?.max, 100);
-        const store =
-          mode === "apply" && policy !== "report-only"
-            ? new PendingAutopilotStore(resolvePendingAutopilotPath(ctx))
-            : null;
-        try {
-          const result = await runVerifiedFactTriage(ctx.factsDb, { mode, policy, max, store });
-          if (opts?.json) console.log(JSON.stringify(result, null, 2));
-          else printHumanTriage(result);
-        } finally {
-          store?.close();
-        }
-      }),
-    );
+	verified
+		.command("triage")
+		.description(
+			"Classify due verified-fact reviews with conservative non-destructive policies.",
+		)
+		.option(
+			"--dry-run",
+			"Preview only; persist no durable review/foundation state",
+		)
+		.option(
+			"--apply",
+			"Persist allowed non-destructive pending-autopilot decisions",
+		)
+		.option(
+			"--policy <policy>",
+			"report-only, classify, or apply-obvious (default: report-only)",
+		)
+		.option("--max <n>", "Maximum items to inspect (default: 100)")
+		.option("--json", "Emit structured JSON")
+		.action(
+			withExit(
+				async (opts?: {
+					dryRun?: boolean;
+					apply?: boolean;
+					policy?: string;
+					max?: string;
+					json?: boolean;
+				}) => {
+					if (opts?.dryRun && opts?.apply)
+						throw new Error("Use only one of --dry-run or --apply");
+					const mode = opts?.apply ? "apply" : "dry-run";
+					const policy: VerifiedTriagePolicy = assertVerifiedTriagePolicy(
+						String(opts?.policy ?? "report-only"),
+					);
+					if (mode === "apply" && policy === "report-only") {
+						throw new Error(
+							"Policy report-only is preview-only; use --dry-run or choose --policy classify/apply-obvious.",
+						);
+					}
+					const max = parsePositiveInt(opts?.max, 100);
+					const store =
+						mode === "apply" && policy !== "report-only"
+							? new PendingAutopilotStore(resolvePendingAutopilotPath(ctx))
+							: null;
+					try {
+						const result = await runVerifiedFactTriage(ctx.factsDb, {
+							mode,
+							policy,
+							max,
+							store,
+						});
+						if (opts?.json) console.log(JSON.stringify(result, null, 2));
+						else printHumanTriage(result);
+					} finally {
+						store?.close();
+					}
+				},
+			),
+		);
 }
 
 function parsePositiveInt(value: string | undefined, fallback: number): number {
-  if (value == null) return fallback;
-  const parsed = Number.parseInt(value, 10);
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+	if (value == null) return fallback;
+	const parsed = Number.parseInt(value, 10);
+	return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
 }
 
 function resolvePendingAutopilotPath(ctx: VerifiedCliContext): string {
-  if (ctx.resolvePath) return ctx.resolvePath("pending-autopilot.db");
-  if (ctx.resolvedSqlitePath) return join(dirname(ctx.resolvedSqlitePath), "pending-autopilot.db");
-  return "./pending-autopilot.db";
+	if (ctx.resolvePath) return ctx.resolvePath("pending-autopilot.db");
+	if (ctx.resolvedSqlitePath)
+		return join(dirname(ctx.resolvedSqlitePath), "pending-autopilot.db");
+	return "./pending-autopilot.db";
 }
 
-function printHumanTriage(result: Awaited<ReturnType<typeof runVerifiedFactTriage>>): void {
-  console.log(`Verified fact triage ${result.mode} policy=${result.policy}`);
-  console.log(`Queue source: ${result.reviewQueueSource}`);
-  console.log(
-    `Inspected ${result.counts.inspected}; human-review ${result.counts.needsHuman}; applied metadata ${result.counts.applied}; failed ${result.counts.failed}`,
-  );
-  const groups = new Map<string, typeof result.items>();
-  for (const item of result.items) groups.set(item.bucket, [...(groups.get(item.bucket) ?? []), item]);
-  for (const [bucket, items] of groups) {
-    console.log(`\n${bucket}: ${items.length}`);
-    for (const item of items) console.log(`- ${item.factId}: ${item.reason} (${item.recommendedAction})`);
-  }
+function printHumanTriage(
+	result: Awaited<ReturnType<typeof runVerifiedFactTriage>>,
+): void {
+	console.log(`Verified fact triage ${result.mode} policy=${result.policy}`);
+	console.log(`Queue source: ${result.reviewQueueSource}`);
+	console.log(
+		`Inspected ${result.counts.inspected}; human-review ${result.counts.needsHuman}; applied metadata ${result.counts.applied}; failed ${result.counts.failed}`,
+	);
+	const groups = new Map<string, typeof result.items>();
+	for (const item of result.items)
+		groups.set(item.bucket, [...(groups.get(item.bucket) ?? []), item]);
+	for (const [bucket, items] of groups) {
+		console.log(`\n${bucket}: ${items.length}`);
+		for (const item of items)
+			console.log(
+				`- ${item.factId}: ${item.reason} (${item.recommendedAction})`,
+			);
+	}
 }

--- a/extensions/memory-hybrid/cli/verified.ts
+++ b/extensions/memory-hybrid/cli/verified.ts
@@ -14,6 +14,7 @@ export interface VerifiedCliContext {
   factsDb: Pick<FactsDB, "getRawDb">;
   resolvedSqlitePath?: string;
   resolvePath?: (file: string) => string;
+  reverificationDays?: number;
 }
 
 export function registerVerifiedCommands(mem: Chainable, ctx: VerifiedCliContext): void {
@@ -29,6 +30,7 @@ export function registerVerifiedCommands(mem: Chainable, ctx: VerifiedCliContext
         const max = parsePositiveInt(opts?.max, 100);
         const items = listVerifiedFactTriageItems(ctx.factsDb.getRawDb(), {
           max,
+          reverificationDays: ctx.reverificationDays,
         });
         const output = {
           reviewQueueSource: VERIFIED_REVIEW_QUEUE_SOURCE,
@@ -89,6 +91,7 @@ export function registerVerifiedCommands(mem: Chainable, ctx: VerifiedCliContext
               mode,
               policy,
               max,
+              reverificationDays: ctx.reverificationDays,
               store,
             });
             if (opts?.json) console.log(JSON.stringify(result, null, 2));

--- a/extensions/memory-hybrid/cli/verified.ts
+++ b/extensions/memory-hybrid/cli/verified.ts
@@ -2,159 +2,127 @@ import { dirname, join } from "node:path";
 import type { FactsDB } from "../backends/facts-db.js";
 import { PendingAutopilotStore } from "../services/pending-autopilot/index.js";
 import {
-	VERIFIED_REVIEW_QUEUE_SOURCE,
-	assertVerifiedTriagePolicy,
-	listVerifiedFactTriageItems,
-	runVerifiedFactTriage,
-	type VerifiedTriagePolicy,
+  VERIFIED_REVIEW_QUEUE_SOURCE,
+  assertVerifiedTriagePolicy,
+  listVerifiedFactTriageItems,
+  runVerifiedFactTriage,
+  type VerifiedTriagePolicy,
 } from "../services/verified-fact-triage.js";
 import { type Chainable, withExit } from "./shared.js";
 
 export interface VerifiedCliContext {
-	factsDb: Pick<FactsDB, "getRawDb">;
-	resolvedSqlitePath?: string;
-	resolvePath?: (file: string) => string;
+  factsDb: Pick<FactsDB, "getRawDb">;
+  resolvedSqlitePath?: string;
+  resolvePath?: (file: string) => string;
 }
 
-export function registerVerifiedCommands(
-	mem: Chainable,
-	ctx: VerifiedCliContext,
-): void {
-	const verified = mem
-		.command("verified")
-		.description("Inspect and conservatively triage verified facts.");
+export function registerVerifiedCommands(mem: Chainable, ctx: VerifiedCliContext): void {
+  const verified = mem.command("verified").description("Inspect and conservatively triage verified facts.");
 
-	verified
-		.command("list")
-		.description(
-			"List the verified-fact review queue (due-for-reverification latest verified facts).",
-		)
-		.option("--max <n>", "Maximum items to list (default: 100)")
-		.option("--json", "Emit structured JSON")
-		.action(
-			withExit(async (opts?: { max?: string; json?: boolean }) => {
-				const max = parsePositiveInt(opts?.max, 100);
-				const items = listVerifiedFactTriageItems(ctx.factsDb.getRawDb(), {
-					max,
-				});
-				const output = {
-					reviewQueueSource: VERIFIED_REVIEW_QUEUE_SOURCE,
-					count: items.length,
-					items: items.map((item) => ({
-						verifiedFactId: item.payload.verified.id,
-						factId: item.payload.verified.factId,
-						nextVerification: item.payload.verified.nextVerification,
-						verifiedAt: item.payload.verified.verifiedAt,
-						scope: item.payload.fact?.scope ?? null,
-						scopeTarget: item.payload.fact?.scopeTarget ?? null,
-						inputHash: item.inputHash,
-					})),
-				};
-				if (opts?.json) console.log(JSON.stringify(output, null, 2));
-				else {
-					console.log(
-						`Verified review queue source: ${VERIFIED_REVIEW_QUEUE_SOURCE}`,
-					);
-					console.log(`Pending verified-fact reviews: ${output.count}`);
-					for (const item of output.items) {
-						console.log(
-							`- ${item.factId} (verified=${item.verifiedFactId}, next=${item.nextVerification ?? "none"})`,
-						);
-					}
-				}
-			}),
-		);
+  verified
+    .command("list")
+    .description("List the verified-fact review queue (due-for-reverification latest verified facts).")
+    .option("--max <n>", "Maximum items to list (default: 100)")
+    .option("--json", "Emit structured JSON")
+    .action(
+      withExit(async (opts?: { max?: string; json?: boolean }) => {
+        const max = parsePositiveInt(opts?.max, 100);
+        const items = listVerifiedFactTriageItems(ctx.factsDb.getRawDb(), {
+          max,
+        });
+        const output = {
+          reviewQueueSource: VERIFIED_REVIEW_QUEUE_SOURCE,
+          count: items.length,
+          items: items.map((item) => ({
+            verifiedFactId: item.payload.verified.id,
+            factId: item.payload.verified.factId,
+            nextVerification: item.payload.verified.nextVerification,
+            verifiedAt: item.payload.verified.verifiedAt,
+            scope: item.payload.fact?.scope ?? null,
+            scopeTarget: item.payload.fact?.scopeTarget ?? null,
+            inputHash: item.inputHash,
+          })),
+        };
+        if (opts?.json) console.log(JSON.stringify(output, null, 2));
+        else {
+          console.log(`Verified review queue source: ${VERIFIED_REVIEW_QUEUE_SOURCE}`);
+          console.log(`Pending verified-fact reviews: ${output.count}`);
+          for (const item of output.items) {
+            console.log(`- ${item.factId} (verified=${item.verifiedFactId}, next=${item.nextVerification ?? "none"})`);
+          }
+        }
+      }),
+    );
 
-	verified
-		.command("triage")
-		.description(
-			"Classify due verified-fact reviews with conservative non-destructive policies.",
-		)
-		.option(
-			"--dry-run",
-			"Preview only; persist no durable review/foundation state",
-		)
-		.option(
-			"--apply",
-			"Persist allowed non-destructive pending-autopilot decisions",
-		)
-		.option(
-			"--policy <policy>",
-			"report-only, classify, or apply-obvious (default: report-only)",
-		)
-		.option("--max <n>", "Maximum items to inspect (default: 100)")
-		.option("--json", "Emit structured JSON")
-		.action(
-			withExit(
-				async (opts?: {
-					dryRun?: boolean;
-					apply?: boolean;
-					policy?: string;
-					max?: string;
-					json?: boolean;
-				}) => {
-					if (opts?.dryRun && opts?.apply)
-						throw new Error("Use only one of --dry-run or --apply");
-					const mode = opts?.apply ? "apply" : "dry-run";
-					const policy: VerifiedTriagePolicy = assertVerifiedTriagePolicy(
-						String(opts?.policy ?? "report-only"),
-					);
-					if (mode === "apply" && policy === "report-only") {
-						throw new Error(
-							"Policy report-only is preview-only; use --dry-run or choose --policy classify/apply-obvious.",
-						);
-					}
-					const max = parsePositiveInt(opts?.max, 100);
-					const store =
-						mode === "apply" && policy !== "report-only"
-							? new PendingAutopilotStore(resolvePendingAutopilotPath(ctx))
-							: null;
-					try {
-						const result = await runVerifiedFactTriage(ctx.factsDb, {
-							mode,
-							policy,
-							max,
-							store,
-						});
-						if (opts?.json) console.log(JSON.stringify(result, null, 2));
-						else printHumanTriage(result);
-					} finally {
-						store?.close();
-					}
-				},
-			),
-		);
+  verified
+    .command("triage")
+    .description("Classify due verified-fact reviews with conservative non-destructive policies.")
+    .option("--dry-run", "Preview only; persist no durable review/foundation state")
+    .option("--apply", "Persist allowed non-destructive pending-autopilot decisions")
+    .option("--policy <policy>", "report-only, classify, or apply-obvious (default: report-only)")
+    .option("--max <n>", "Maximum items to inspect (default: 100)")
+    .option("--json", "Emit structured JSON")
+    .action(
+      withExit(
+        async (opts?: {
+          dryRun?: boolean;
+          apply?: boolean;
+          policy?: string;
+          max?: string;
+          json?: boolean;
+        }) => {
+          if (opts?.dryRun && opts?.apply) throw new Error("Use only one of --dry-run or --apply");
+          const mode = opts?.apply ? "apply" : "dry-run";
+          const policy: VerifiedTriagePolicy = assertVerifiedTriagePolicy(String(opts?.policy ?? "report-only"));
+          if (mode === "apply" && policy === "report-only") {
+            throw new Error(
+              "Policy report-only is preview-only; use --dry-run or choose --policy classify/apply-obvious.",
+            );
+          }
+          const max = parsePositiveInt(opts?.max, 100);
+          const store =
+            mode === "apply" && policy !== "report-only"
+              ? new PendingAutopilotStore(resolvePendingAutopilotPath(ctx))
+              : null;
+          try {
+            const result = await runVerifiedFactTriage(ctx.factsDb, {
+              mode,
+              policy,
+              max,
+              store,
+            });
+            if (opts?.json) console.log(JSON.stringify(result, null, 2));
+            else printHumanTriage(result);
+          } finally {
+            store?.close();
+          }
+        },
+      ),
+    );
 }
 
 function parsePositiveInt(value: string | undefined, fallback: number): number {
-	if (value == null) return fallback;
-	const parsed = Number.parseInt(value, 10);
-	return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+  if (value == null) return fallback;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
 }
 
 function resolvePendingAutopilotPath(ctx: VerifiedCliContext): string {
-	if (ctx.resolvePath) return ctx.resolvePath("pending-autopilot.db");
-	if (ctx.resolvedSqlitePath)
-		return join(dirname(ctx.resolvedSqlitePath), "pending-autopilot.db");
-	return "./pending-autopilot.db";
+  if (ctx.resolvePath) return ctx.resolvePath("pending-autopilot.db");
+  if (ctx.resolvedSqlitePath) return join(dirname(ctx.resolvedSqlitePath), "pending-autopilot.db");
+  return "./pending-autopilot.db";
 }
 
-function printHumanTriage(
-	result: Awaited<ReturnType<typeof runVerifiedFactTriage>>,
-): void {
-	console.log(`Verified fact triage ${result.mode} policy=${result.policy}`);
-	console.log(`Queue source: ${result.reviewQueueSource}`);
-	console.log(
-		`Inspected ${result.counts.inspected}; human-review ${result.counts.needsHuman}; applied metadata ${result.counts.applied}; failed ${result.counts.failed}`,
-	);
-	const groups = new Map<string, typeof result.items>();
-	for (const item of result.items)
-		groups.set(item.bucket, [...(groups.get(item.bucket) ?? []), item]);
-	for (const [bucket, items] of groups) {
-		console.log(`\n${bucket}: ${items.length}`);
-		for (const item of items)
-			console.log(
-				`- ${item.factId}: ${item.reason} (${item.recommendedAction})`,
-			);
-	}
+function printHumanTriage(result: Awaited<ReturnType<typeof runVerifiedFactTriage>>): void {
+  console.log(`Verified fact triage ${result.mode} policy=${result.policy}`);
+  console.log(`Queue source: ${result.reviewQueueSource}`);
+  console.log(
+    `Inspected ${result.counts.inspected}; human-review ${result.counts.needsHuman}; applied metadata ${result.counts.applied}; failed ${result.counts.failed}`,
+  );
+  const groups = new Map<string, typeof result.items>();
+  for (const item of result.items) groups.set(item.bucket, [...(groups.get(item.bucket) ?? []), item]);
+  for (const [bucket, items] of groups) {
+    console.log(`\n${bucket}: ${items.length}`);
+    for (const item of items) console.log(`- ${item.factId}: ${item.reason} (${item.recommendedAction})`);
+  }
 }

--- a/extensions/memory-hybrid/cli/verified.ts
+++ b/extensions/memory-hybrid/cli/verified.ts
@@ -1,0 +1,105 @@
+import { join } from "node:path";
+import type { FactsDB } from "../backends/facts-db.js";
+import { PendingAutopilotStore } from "../services/pending-autopilot/index.js";
+import {
+  VERIFIED_REVIEW_QUEUE_SOURCE,
+  assertVerifiedTriagePolicy,
+  listVerifiedFactTriageItems,
+  runVerifiedFactTriage,
+  type VerifiedTriagePolicy,
+} from "../services/verified-fact-triage.js";
+import { type Chainable, withExit } from "./shared.js";
+
+export interface VerifiedCliContext {
+  factsDb: Pick<FactsDB, "getRawDb">;
+  resolvedSqlitePath?: string;
+  resolvePath?: (file: string) => string;
+}
+
+export function registerVerifiedCommands(mem: Chainable, ctx: VerifiedCliContext): void {
+  const verified = mem.command("verified").description("Inspect and conservatively triage verified facts.");
+
+  verified
+    .command("list")
+    .description("List the verified-fact review queue (due-for-reverification latest verified facts).")
+    .option("--max <n>", "Maximum items to list (default: 100)")
+    .option("--json", "Emit structured JSON")
+    .action(
+      withExit(async (opts?: { max?: string; json?: boolean }) => {
+        const max = parsePositiveInt(opts?.max, 100);
+        const items = listVerifiedFactTriageItems(ctx.factsDb.getRawDb(), { max });
+        const output = {
+          reviewQueueSource: VERIFIED_REVIEW_QUEUE_SOURCE,
+          count: items.length,
+          items: items.map((item) => ({
+            verifiedFactId: item.payload.verified.id,
+            factId: item.payload.verified.factId,
+            nextVerification: item.payload.verified.nextVerification,
+            verifiedAt: item.payload.verified.verifiedAt,
+            scope: item.payload.fact?.scope ?? null,
+            scopeTarget: item.payload.fact?.scopeTarget ?? null,
+            inputHash: item.inputHash,
+          })),
+        };
+        if (opts?.json) console.log(JSON.stringify(output, null, 2));
+        else {
+          console.log(`Verified review queue source: ${VERIFIED_REVIEW_QUEUE_SOURCE}`);
+          console.log(`Pending verified-fact reviews: ${output.count}`);
+          for (const item of output.items) {
+            console.log(`- ${item.factId} (verified=${item.verifiedFactId}, next=${item.nextVerification ?? "none"})`);
+          }
+        }
+      }),
+    );
+
+  verified
+    .command("triage")
+    .description("Classify due verified-fact reviews with conservative non-destructive policies.")
+    .option("--dry-run", "Preview only; persist no durable review/foundation state")
+    .option("--apply", "Persist allowed non-destructive pending-autopilot decisions")
+    .option("--policy <policy>", "report-only, classify, or apply-obvious (default: report-only)")
+    .option("--max <n>", "Maximum items to inspect (default: 100)")
+    .option("--json", "Emit structured JSON")
+    .action(
+      withExit(async (opts?: { dryRun?: boolean; apply?: boolean; policy?: string; max?: string; json?: boolean }) => {
+        if (opts?.dryRun && opts?.apply) throw new Error("Use only one of --dry-run or --apply");
+        const mode = opts?.apply ? "apply" : "dry-run";
+        const policy: VerifiedTriagePolicy = assertVerifiedTriagePolicy(String(opts?.policy ?? "report-only"));
+        const max = parsePositiveInt(opts?.max, 100);
+        const store = mode === "apply" ? new PendingAutopilotStore(resolvePendingAutopilotPath(ctx)) : null;
+        try {
+          const result = await runVerifiedFactTriage(ctx.factsDb, { mode, policy, max, store });
+          if (opts?.json) console.log(JSON.stringify(result, null, 2));
+          else printHumanTriage(result);
+        } finally {
+          store?.close();
+        }
+      }),
+    );
+}
+
+function parsePositiveInt(value: string | undefined, fallback: number): number {
+  if (value == null) return fallback;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function resolvePendingAutopilotPath(ctx: VerifiedCliContext): string {
+  if (ctx.resolvePath) return ctx.resolvePath("pending-autopilot.db");
+  if (ctx.resolvedSqlitePath) return join(ctx.resolvedSqlitePath, "..", "pending-autopilot.db");
+  return "./pending-autopilot.db";
+}
+
+function printHumanTriage(result: Awaited<ReturnType<typeof runVerifiedFactTriage>>): void {
+  console.log(`Verified fact triage ${result.mode} policy=${result.policy}`);
+  console.log(`Queue source: ${result.reviewQueueSource}`);
+  console.log(
+    `Inspected ${result.counts.inspected}; human-review ${result.counts.needsHuman}; applied metadata ${result.counts.applied}; failed ${result.counts.failed}`,
+  );
+  const groups = new Map<string, typeof result.items>();
+  for (const item of result.items) groups.set(item.bucket, [...(groups.get(item.bucket) ?? []), item]);
+  for (const [bucket, items] of groups) {
+    console.log(`\n${bucket}: ${items.length}`);
+    for (const item of items) console.log(`- ${item.factId}: ${item.reason} (${item.recommendedAction})`);
+  }
+}

--- a/extensions/memory-hybrid/cli/verified.ts
+++ b/extensions/memory-hybrid/cli/verified.ts
@@ -1,4 +1,4 @@
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import type { FactsDB } from "../backends/facts-db.js";
 import { PendingAutopilotStore } from "../services/pending-autopilot/index.js";
 import {
@@ -66,7 +66,10 @@ export function registerVerifiedCommands(mem: Chainable, ctx: VerifiedCliContext
         const mode = opts?.apply ? "apply" : "dry-run";
         const policy: VerifiedTriagePolicy = assertVerifiedTriagePolicy(String(opts?.policy ?? "report-only"));
         const max = parsePositiveInt(opts?.max, 100);
-        const store = mode === "apply" ? new PendingAutopilotStore(resolvePendingAutopilotPath(ctx)) : null;
+        const store =
+          mode === "apply" && policy !== "report-only"
+            ? new PendingAutopilotStore(resolvePendingAutopilotPath(ctx))
+            : null;
         try {
           const result = await runVerifiedFactTriage(ctx.factsDb, { mode, policy, max, store });
           if (opts?.json) console.log(JSON.stringify(result, null, 2));
@@ -86,7 +89,7 @@ function parsePositiveInt(value: string | undefined, fallback: number): number {
 
 function resolvePendingAutopilotPath(ctx: VerifiedCliContext): string {
   if (ctx.resolvePath) return ctx.resolvePath("pending-autopilot.db");
-  if (ctx.resolvedSqlitePath) return join(ctx.resolvedSqlitePath, "..", "pending-autopilot.db");
+  if (ctx.resolvedSqlitePath) return join(dirname(ctx.resolvedSqlitePath), "pending-autopilot.db");
   return "./pending-autopilot.db";
 }
 

--- a/extensions/memory-hybrid/cli/verified.ts
+++ b/extensions/memory-hybrid/cli/verified.ts
@@ -24,13 +24,16 @@ export function registerVerifiedCommands(mem: Chainable, ctx: VerifiedCliContext
     .command("list")
     .description("List the verified-fact review queue (due-for-reverification latest verified facts).")
     .option("--max <n>", "Maximum items to list (default: 100)")
+    .option("--policy <policy>", "report-only, classify, or apply-obvious (default: classify)")
     .option("--json", "Emit structured JSON")
     .action(
-      withExit(async (opts?: { max?: string; json?: boolean }) => {
+      withExit(async (opts?: { max?: string; policy?: string; json?: boolean }) => {
         const max = parsePositiveInt(opts?.max, 100);
+        const policy: VerifiedTriagePolicy = assertVerifiedTriagePolicy(String(opts?.policy ?? "classify"));
         const items = listVerifiedFactTriageItems(ctx.factsDb.getRawDb(), {
           max,
           reverificationDays: ctx.reverificationDays,
+          policy,
         });
         const output = {
           reviewQueueSource: VERIFIED_REVIEW_QUEUE_SOURCE,

--- a/extensions/memory-hybrid/services/pending-autopilot/README.md
+++ b/extensions/memory-hybrid/services/pending-autopilot/README.md
@@ -59,6 +59,7 @@ The verified-fact child adapter lives in `services/verified-fact-triage.ts` and 
 `PendingQueueAdapter` / `PendingDecision` contract from this foundation. Its review queue source is
 explicit and intentionally narrow: **latest `verified_facts` rows due for reverification** according
 to the same `next_verification`/staleness semantics used by `VerificationStore.listDueForReverification`.
+Rows with checksum/canonical-text mismatches are filtered out before queueing to preserve integrity parity.
 It must not accidentally treat every verified fact as pending review.
 
 CLI surface:

--- a/extensions/memory-hybrid/services/pending-autopilot/README.md
+++ b/extensions/memory-hybrid/services/pending-autopilot/README.md
@@ -52,3 +52,40 @@ The shared test helper verifies both paths produce equivalent normalized decisio
 ## Dry-run semantics
 
 Dry-run may produce in-memory summaries or CLI output, but any artifact that could influence a later apply must be ephemeral/non-authoritative. The store intentionally skips durable `pending_autopilot_*` writes when mode is `dry-run`.
+
+## Verified-fact triage child adapter (#1329)
+
+The verified-fact child adapter lives in `services/verified-fact-triage.ts` and reuses the shared
+`PendingQueueAdapter` / `PendingDecision` contract from this foundation. Its review queue source is
+explicit and intentionally narrow: **latest `verified_facts` rows due for reverification** according
+to the same `next_verification`/staleness semantics used by `VerificationStore.listDueForReverification`.
+It must not accidentally treat every verified fact as pending review.
+
+CLI surface:
+
+```bash
+openclaw hybrid-mem verified list --json
+openclaw hybrid-mem verified triage --dry-run --policy report-only --max 100 --json
+openclaw hybrid-mem verified triage --apply --policy classify --max 100 --json
+openclaw hybrid-mem verified triage --apply --policy apply-obvious --max 100 --json
+```
+
+Safety boundaries:
+
+- dry-run writes no durable pending-autopilot or verified-review state;
+- apply policies record only non-destructive review/classification decisions in the shared
+  pending-autopilot store;
+- verified fact text, verification tier, critical status, canonical text, and core truth fields are
+  never rewritten, deleted, or demoted by `apply-obvious`;
+- sensitive credentials/security/privacy/persona/external-comms/operational-runbook facts are always
+  deferred for human review;
+- supersession requires an explicit newer fact id (`supersedes_id` / `superseded_by`) and matching
+  scope;
+- contradiction requires concrete structured evidence: same entity, scope, claim key/type, conflicting
+  value, and source fact/verified ids. Semantic similarity or LLM judgment alone is not enough;
+- provenance is preserved by appending/linking review metadata through pending-autopilot decisions
+  rather than overwriting source or verification provenance.
+
+Parent #1326 should call this adapter/policy logic for `digest-autopilot --verified-policy ...` rather
+than implementing separate verified-fact semantics. Tests use the #1334 parent/child equivalence
+harness so parent routing and standalone `verified triage` decisions stay identical.

--- a/extensions/memory-hybrid/services/pending-autopilot/store.ts
+++ b/extensions/memory-hybrid/services/pending-autopilot/store.ts
@@ -87,10 +87,9 @@ export class PendingAutopilotStore extends BaseSqliteStore {
                AND item_id = ?
                AND policy = ?
                AND policy_version = ?
-               AND action = ?
                AND input_hash <> ?`,
           )
-          .run(safe.queue, safe.itemId, safe.policy, safe.policyVersion, safe.action, safe.inputHash);
+          .run(safe.queue, safe.itemId, safe.policy, safe.policyVersion, safe.inputHash);
         return this.insertDecision(safe);
       },
       "IMMEDIATE",

--- a/extensions/memory-hybrid/services/pending-autopilot/store.ts
+++ b/extensions/memory-hybrid/services/pending-autopilot/store.ts
@@ -74,6 +74,30 @@ export class PendingAutopilotStore extends BaseSqliteStore {
     return this.insertDecision(safe);
   }
 
+  recordLatestDecision(decision: PendingDecision): { inserted: boolean } {
+    const safe = sanitizePendingDecision(decision);
+    if (safe.mode === "dry-run") return { inserted: false };
+    const tx = createTransaction(
+      this.liveDb,
+      () => {
+        this.liveDb
+          .prepare(
+            `DELETE FROM pending_autopilot_decisions
+             WHERE queue = ?
+               AND item_id = ?
+               AND policy = ?
+               AND policy_version = ?
+               AND action = ?
+               AND input_hash <> ?`,
+          )
+          .run(safe.queue, safe.itemId, safe.policy, safe.policyVersion, safe.action, safe.inputHash);
+        return this.insertDecision(safe);
+      },
+      "IMMEDIATE",
+    );
+    return tx();
+  }
+
   advanceCursorIfSafe(decision: PendingDecision, cursor: string): boolean {
     const safe = sanitizePendingDecision(decision);
     if (safe.mode === "dry-run" || !shouldAdvancePendingCursor(safe)) return false;

--- a/extensions/memory-hybrid/services/pending-autopilot/store.ts
+++ b/extensions/memory-hybrid/services/pending-autopilot/store.ts
@@ -87,9 +87,9 @@ export class PendingAutopilotStore extends BaseSqliteStore {
                AND item_id = ?
                AND policy = ?
                AND policy_version = ?
-               AND input_hash <> ?`,
+               AND (input_hash <> ? OR action <> ?)`,
           )
-          .run(safe.queue, safe.itemId, safe.policy, safe.policyVersion, safe.inputHash);
+          .run(safe.queue, safe.itemId, safe.policy, safe.policyVersion, safe.inputHash, safe.action);
         return this.insertDecision(safe);
       },
       "IMMEDIATE",

--- a/extensions/memory-hybrid/services/verification-store.ts
+++ b/extensions/memory-hybrid/services/verification-store.ts
@@ -96,7 +96,7 @@ function addDays(date: Date, days: number): Date {
 // Raw row type returned from SQLite queries
 // ---------------------------------------------------------------------------
 
-interface VerifiedFactRow {
+export interface VerifiedFactRow {
   id: string;
   fact_id: string;
   canonical_text: string;
@@ -109,7 +109,7 @@ interface VerifiedFactRow {
   created_at: string;
 }
 
-function rowToVerifiedFact(row: VerifiedFactRow): VerifiedFact {
+export function rowToVerifiedFact(row: VerifiedFactRow): VerifiedFact {
   return {
     id: row.id,
     factId: row.fact_id,

--- a/extensions/memory-hybrid/services/verification-store.ts
+++ b/extensions/memory-hybrid/services/verification-store.ts
@@ -49,7 +49,7 @@ export class VerificationError extends Error {
 // Helpers
 // ---------------------------------------------------------------------------
 
-function computeChecksum(text: string): string {
+export function computeChecksum(text: string): string {
   return createHash("sha256").update(text).digest("hex");
 }
 

--- a/extensions/memory-hybrid/services/verified-fact-triage.ts
+++ b/extensions/memory-hybrid/services/verified-fact-triage.ts
@@ -1123,10 +1123,11 @@ function loadVerifiedRelatedFact(db: DatabaseSync, factId: string): RelatedFact 
          GROUP BY fact_id
        ) latest ON vf.fact_id = latest.fact_id AND vf.version = latest.max_version
        WHERE f.id = ?
+         AND compute_verified_checksum(vf.canonical_text) = vf.checksum
        LIMIT 1`,
     )
     .get(factId) as Record<string, unknown> | undefined;
-  if (!row || !isVerifiedRelatedFactRowChecksumValid(row)) return null;
+  if (!row) return null;
   return {
     ...snapshotFromRow(row),
     verifiedFactId: row.verified_fact_id as string,
@@ -1210,10 +1211,6 @@ function findSameScopeDuplicateVerifiedFact(db: DatabaseSync, fact: TriageFactSn
     if (normalizeFactText(candidate.text) === normalized) return candidate;
   }
   return null;
-}
-
-function isVerifiedRelatedFactRowChecksumValid(row: Record<string, unknown>): boolean {
-  return typeof row.canonical_text === "string" && computeChecksum(row.canonical_text) === row.checksum;
 }
 
 function normalizeFactText(text: string): string {

--- a/extensions/memory-hybrid/services/verified-fact-triage.ts
+++ b/extensions/memory-hybrid/services/verified-fact-triage.ts
@@ -286,8 +286,8 @@ export function listVerifiedFactTriageItems(
        ) latest ON vf.fact_id = latest.fact_id AND vf.version = latest.max_version
        WHERE ((vf.next_verification IS NOT NULL AND vf.next_verification <= ?)
           OR vf.verified_at <= ?)
-         AND (? IS NULL OR COALESCE(vf.next_verification, vf.verified_at) > ?)
-       ORDER BY COALESCE(vf.next_verification, vf.verified_at) ASC, vf.verified_at ASC`,
+         AND (? IS NULL OR COALESCE(vf.next_verification, vf.verified_at) >= ?)
+       ORDER BY COALESCE(vf.next_verification, vf.verified_at) ASC, vf.verified_at ASC, vf.id ASC`,
     )
     .all(nowIso, cutoffIso, cursor, cursor) as unknown as VerifiedFactRow[];
 
@@ -1096,6 +1096,7 @@ function findExplicitNewerVerifiedFact(db: DatabaseSync, fact: TriageFactSnapsho
        ) latest ON vf.fact_id = latest.fact_id AND vf.version = latest.max_version
        WHERE f.supersedes_id = ?
          AND f.created_at >= ?
+         AND f.superseded_at IS NULL
          AND compute_verified_checksum(vf.canonical_text) = vf.checksum
        ORDER BY f.created_at DESC
        LIMIT 5`,

--- a/extensions/memory-hybrid/services/verified-fact-triage.ts
+++ b/extensions/memory-hybrid/services/verified-fact-triage.ts
@@ -84,6 +84,7 @@ export interface VerifiedFactTriagePayload extends Record<string, unknown> {
   fact: TriageFactSnapshot | null;
   verificationTier: string | null;
   reviewCursor: string | null;
+  dueReason: "next_verification" | "verified_at_stale";
 }
 
 export interface TriageFactSnapshot {
@@ -208,7 +209,7 @@ const SENSITIVE_RULES: Array<{ flag: string; reason: VerifiedTriageReason; patte
   {
     flag: "persona-preference",
     reason: "sensitive_personal_fact",
-    pattern: /\b(preference|user identity|persona|edict|hard rule|markus|lotta)\b/i,
+    pattern: /\b(preference|user identity|persona|edict|hard rule|user profile|personal fact)\b/i,
   },
   {
     flag: "operational-runbook",
@@ -226,11 +227,19 @@ export function createVerifiedFactTriageAdapter(input: {
   factsDb: Pick<FactsDB, "getRawDb">;
   max?: number;
   nowMs?: number;
+  reverificationDays?: number;
+  policy?: VerifiedTriagePolicy;
 }): PendingQueueAdapter<VerifiedFactTriageItem> {
   const db = input.factsDb.getRawDb();
   return {
     queue: "verified",
-    listPending: () => listVerifiedFactTriageItems(db, { max: input.max, nowMs: input.nowMs }),
+    listPending: () =>
+      listVerifiedFactTriageItems(db, {
+        max: input.max,
+        nowMs: input.nowMs,
+        reverificationDays: input.reverificationDays,
+        policy: input.policy,
+      }),
     decide: (item, context) => decideVerifiedFactTriage(item, context, { db, nowMs: input.nowMs }),
     apply: (_decision, _item) => {
       // Verified fact triage intentionally does not mutate core truth fields. Durable
@@ -241,9 +250,12 @@ export function createVerifiedFactTriageAdapter(input: {
 
 export function listVerifiedFactTriageItems(
   db: DatabaseSync,
-  opts: { max?: number; nowMs?: number } = {},
+  opts: { max?: number; nowMs?: number; reverificationDays?: number; policy?: VerifiedTriagePolicy } = {},
 ): VerifiedFactTriageItem[] {
-  const nowIso = new Date(opts.nowMs ?? Date.now()).toISOString();
+  const nowMs = opts.nowMs ?? Date.now();
+  const nowIso = new Date(nowMs).toISOString();
+  const cutoffIso = new Date(nowMs - (opts.reverificationDays ?? 30) * 24 * 60 * 60 * 1000).toISOString();
+  const policy = opts.policy ?? "classify";
   const latestRows = db
     .prepare(
       `SELECT vf.*
@@ -255,11 +267,12 @@ export function listVerifiedFactTriageItems(
          GROUP BY vf2.fact_id
        ) latest ON vf.fact_id = latest.fact_id AND vf.version = latest.max_version
        LEFT JOIN facts f ON f.id = vf.fact_id
-       WHERE vf.next_verification IS NOT NULL AND vf.next_verification <= ?
-       ORDER BY vf.next_verification ASC, vf.verified_at ASC
+       WHERE (vf.next_verification IS NOT NULL AND vf.next_verification <= ?)
+          OR vf.verified_at <= ?
+       ORDER BY COALESCE(vf.next_verification, vf.verified_at) ASC, vf.verified_at ASC
        LIMIT ?`,
     )
-    .all(nowIso, opts.max ?? 100) as unknown as VerifiedFactRow[];
+    .all(nowIso, cutoffIso, opts.max ?? 100) as unknown as VerifiedFactRow[];
 
   return latestRows.map((row) => {
     const verified = rowToVerifiedFact(row);
@@ -269,13 +282,15 @@ export function listVerifiedFactTriageItems(
       verified,
       fact,
       verificationTier: fact?.tier ?? null,
-      reviewCursor: verified.nextVerification,
+      reviewCursor: verified.nextVerification ?? verified.verifiedAt,
+      dueReason:
+        verified.nextVerification && verified.nextVerification <= nowIso ? "next_verification" : "verified_at_stale",
     };
     const inputHash = computePendingInputHash({
       queue: "verified",
       id: verified.id,
       payload,
-      policy: "classify",
+      policy,
       policyVersion: VERIFIED_TRIAGE_POLICY_VERSION,
     });
     return {
@@ -285,7 +300,7 @@ export function listVerifiedFactTriageItems(
       policyVersion: VERIFIED_TRIAGE_POLICY_VERSION,
       capabilityClasses: ["read-only", "record-review-metadata"],
       payload,
-      visibleAfterCursor: verified.nextVerification,
+      visibleAfterCursor: verified.nextVerification ?? verified.verifiedAt,
       requiresHumanReview: false,
       validationFailed: !fact,
     } satisfies VerifiedFactTriageItem;
@@ -310,12 +325,32 @@ export async function runVerifiedFactTriage(
   const store = opts.store ?? null;
   const runId = opts.runId ?? createPendingAutopilotRunId();
   const actor = opts.actor ?? { type: "agent", id: "verified-triage-cli" };
-  const adapter = createVerifiedFactTriageAdapter({ factsDb, max: opts.max, nowMs: opts.nowMs });
+  const adapter = createVerifiedFactTriageAdapter({
+    factsDb,
+    max: opts.max,
+    nowMs: opts.nowMs,
+    policy,
+  });
+  return runVerifiedFactTriageWithAdapter(factsDb, adapter, opts);
+}
+
+export async function runVerifiedFactTriageWithAdapter(
+  factsDb: Pick<FactsDB, "getRawDb">,
+  adapter: PendingQueueAdapter<VerifiedFactTriageItem>,
+  opts: VerifiedFactTriageOptions,
+): Promise<VerifiedTriageRunResult> {
+  const policy = assertVerifiedTriagePolicy(opts.policy);
+  const mode = opts.mode;
+  const store = opts.store ?? null;
+  const runId = opts.runId ?? createPendingAutopilotRunId();
+  const actor = opts.actor ?? { type: "agent", id: "verified-triage-cli" };
   const items = await adapter.listPending(null);
   const runInputHash = computePendingInputHash({ queue: "verified", itemIds: items.map((i) => i.id), policy, mode });
   const startedAt = Math.floor((opts.nowMs ?? Date.now()) / 1000);
 
-  store?.createRun({
+  const durableStore = policy === "report-only" ? null : store;
+
+  durableStore?.createRun({
     runId,
     mode,
     policy,
@@ -342,7 +377,7 @@ export async function runVerifiedFactTriage(
     let applied = false;
     if (mode === "apply" && policy !== "report-only") {
       const locked =
-        store?.acquireLock({
+        durableStore?.acquireLock({
           queue: "verified",
           itemId: item.id,
           inputHash: item.inputHash,
@@ -350,27 +385,35 @@ export async function runVerifiedFactTriage(
           ttlSeconds: opts.lockTtlSeconds ?? 60,
           mode,
         }) ?? false;
-      const actualInputHash = recomputeItemHash(item, factsDb.getRawDb());
-      if (locked && actualInputHash === item.inputHash) {
-        store?.recordDecision(decision);
-        if (decision.action !== "deferred-for-human" && decision.action !== "failed-validation") {
-          store?.advanceCursorIfSafe(decision, item.visibleAfterCursor ?? item.id);
+      const liveItem = locked
+        ? reloadVerifiedFactTriageItem(factsDb.getRawDb(), item, { policy, nowMs: opts.nowMs })
+        : null;
+      const actualInputHash = liveItem?.inputHash ?? "missing";
+      if (locked && liveItem && actualInputHash === item.inputHash) {
+        const { inserted } = durableStore?.recordDecision(decision) ?? { inserted: false };
+        if (inserted && decision.action !== "deferred-for-human" && decision.action !== "failed-validation") {
+          durableStore?.advanceCursorIfSafe(decision, item.visibleAfterCursor ?? item.id);
         }
-        applied = decision.action === "classified" || decision.action === "reported";
-      } else if (store) {
-        const staleDecision = triageToPendingDecision(item, context, {
-          bucket: "failed-review",
-          recommendedAction: "failed-validation",
-          reason: locked ? "requires_human_approval" : "backend_error",
-          confidence: 1,
-          evidence: [{ type: "input-hash", id: item.id, summary: "Lock missing or input hash changed before apply" }],
-          sensitivityFlags: [],
-          humanReviewRequired: true,
-        });
-        store.recordDecision(staleDecision);
+        applied = inserted && (decision.action === "classified" || decision.action === "reported");
+      } else if (durableStore) {
+        const staleDecision = validationFailureDecision(
+          item,
+          context,
+          locked ? "input-hash-mismatch" : "lock-conflict",
+          liveItem
+            ? "Verified fact/fact row changed between classification and apply."
+            : "Verified fact no longer matches due queue before apply.",
+        );
+        durableStore.recordDecision(staleDecision);
         decisions[decisions.length - 1] = staleDecision;
       }
-      store?.releaseLock({ queue: "verified", itemId: item.id, inputHash: item.inputHash, owner: actor.id, mode });
+      durableStore?.releaseLock({
+        queue: "verified",
+        itemId: item.id,
+        inputHash: item.inputHash,
+        owner: actor.id,
+        mode,
+      });
     }
     resultItems.push(decisionToResultItem(decisions[decisions.length - 1], item, applied));
   }
@@ -385,7 +428,7 @@ export async function runVerifiedFactTriage(
     finishedAt: Math.floor((opts.nowMs ?? Date.now()) / 1000),
     decisions,
   });
-  store?.finishRun(runId, summary, summary.finishedAt);
+  durableStore?.finishRun(runId, summary, summary.finishedAt);
 
   return buildRunResult({ runId, mode, policy, items: resultItems });
 }
@@ -564,7 +607,10 @@ export function classifyVerifiedFact(
     };
   }
 
-  if (item.payload.verified.nextVerification && item.payload.verified.nextVerification <= nowIso) {
+  if (
+    (item.payload.verified.nextVerification && item.payload.verified.nextVerification <= nowIso) ||
+    item.payload.dueReason === "verified_at_stale"
+  ) {
     return {
       bucket: "stale-candidate",
       recommendedAction: "classified",
@@ -574,8 +620,16 @@ export function classifyVerifiedFact(
         {
           type: "verification",
           id: item.payload.verified.id,
-          summary: "Fact is due for scheduled reverification",
-          fields: { nextVerification: item.payload.verified.nextVerification, now: nowIso },
+          summary:
+            item.payload.dueReason === "verified_at_stale"
+              ? "Fact verified_at is older than the reverification window"
+              : "Fact is due for scheduled reverification",
+          fields: {
+            nextVerification: item.payload.verified.nextVerification,
+            verifiedAt: item.payload.verified.verifiedAt,
+            dueReason: item.payload.dueReason,
+            now: nowIso,
+          },
         },
       ],
       sensitivityFlags: [],
@@ -607,7 +661,12 @@ function triageToPendingDecision(
   triage: ReturnType<typeof classifyVerifiedFact>,
 ): PendingDecision {
   const mapped = mapTriageAction(context.policy, triage);
-  const evidence = triage.evidence.map((ev) => ({ type: ev.type, id: ev.id, summary: ev.summary }));
+  const evidence = triage.evidence.map((ev) => ({
+    type: ev.type,
+    id: ev.id,
+    summary: ev.summary,
+    ...(ev.fields ? { fields: ev.fields } : {}),
+  }));
   return {
     queue: "verified",
     itemId: item.id,
@@ -632,6 +691,7 @@ function triageToPendingDecision(
         bucket: triage.bucket,
         recommendedAction: triage.recommendedAction,
         sensitivityFlags: triage.sensitivityFlags,
+        evidenceFields: triage.evidence.map((ev) => ev.fields).filter(Boolean),
       },
     },
     audit: {
@@ -646,7 +706,7 @@ function triageToPendingDecision(
       humanReviewRequired: triage.humanReviewRequired,
       evidence,
       actor: context.actor,
-      runId: "verified-triage-decision",
+      runId: context.runId,
       summary: {
         title: "verified-fact-triage",
         metadata: {
@@ -761,7 +821,12 @@ function extractVerifiedReason(decision: PendingDecision, item: VerifiedFactTria
   const after = decision.audit?.summary?.metadata as { after?: { reason?: string } } | undefined;
   const reason = after?.after?.reason;
   if (reason) return reason as VerifiedTriageReason;
-  return item.validationFailed ? "malformed_fact" : "requires_human_approval";
+  const reasonCodeMap: Partial<Record<AutopilotReasonCode, VerifiedTriageReason>> = {
+    "input-hash-mismatch": "backend_error",
+    "lock-conflict": "backend_error",
+    "lock-missing": "backend_error",
+  };
+  return reasonCodeMap[decision.reasonCode] ?? (item.validationFailed ? "malformed_fact" : "requires_human_approval");
 }
 
 function buildRunResult(input: {
@@ -1005,21 +1070,72 @@ function summarizeProvenance(fact: TriageFactSnapshot | null): string {
   return parts.join(", ");
 }
 
-function recomputeItemHash(item: VerifiedFactTriageItem, db: DatabaseSync): string {
-  const verified = item.payload.verified;
-  const fact = loadFactSnapshot(db, verified.factId);
-  const payload: VerifiedFactTriagePayload = {
-    reviewQueueSource: item.payload.reviewQueueSource,
-    verified,
-    fact,
-    verificationTier: fact?.tier ?? null,
-    reviewCursor: verified.nextVerification,
+function reloadVerifiedFactTriageItem(
+  db: DatabaseSync,
+  item: VerifiedFactTriageItem,
+  opts: { policy: VerifiedTriagePolicy; nowMs?: number; reverificationDays?: number },
+): VerifiedFactTriageItem | null {
+  return (
+    listVerifiedFactTriageItems(db, {
+      max: 10_000,
+      nowMs: opts.nowMs,
+      reverificationDays: opts.reverificationDays,
+      policy: opts.policy,
+    }).find((candidate) => candidate.id === item.id) ?? null
+  );
+}
+
+function validationFailureDecision(
+  item: VerifiedFactTriageItem,
+  context: PendingDecisionContext,
+  reasonCode: AutopilotReasonCode,
+  body: string,
+): PendingDecision {
+  const evidence = [{ type: "input-hash", id: item.id, summary: body }];
+  return {
+    queue: "verified",
+    itemId: item.id,
+    inputHash: context.inputHash,
+    policy: context.policy,
+    policyVersion: context.policyVersion,
+    mode: context.mode,
+    action: "failed-validation",
+    reasonCode,
+    actionClass: "observe",
+    capabilityClass: "read-only",
+    confidence: 0,
+    humanReviewRequired: true,
+    evidence,
+    actor: context.actor,
+    runId: context.runId,
+    jobId: context.jobId,
+    summary: {
+      title: "verified fact failed-review",
+      body,
+      metadata: { bucket: "failed-review", recommendedAction: "failed-validation", sensitivityFlags: [] },
+    },
+    audit: {
+      queue: "verified",
+      itemId: item.id,
+      inputHash: context.inputHash,
+      policy: context.policy,
+      policyVersion: context.policyVersion,
+      action: "failed-validation",
+      reasonCode,
+      capabilityClass: "read-only",
+      humanReviewRequired: true,
+      evidence,
+      actor: context.actor,
+      runId: context.runId,
+      summary: {
+        title: "verified-fact-triage",
+        body,
+        metadata: {
+          previous: { verifiedFactId: item.payload.verified.id },
+          after: { bucket: "failed-review", recommendedAction: "failed-validation", reason: "backend_error" },
+          mutation: "none-core-truth-fields-preserved",
+        },
+      },
+    },
   };
-  return computePendingInputHash({
-    queue: item.queue,
-    id: item.id,
-    payload,
-    policy: "classify",
-    policyVersion: item.policyVersion,
-  });
 }

--- a/extensions/memory-hybrid/services/verified-fact-triage.ts
+++ b/extensions/memory-hybrid/services/verified-fact-triage.ts
@@ -1,0 +1,895 @@
+import type { DatabaseSync, SQLInputValue } from "node:sqlite";
+import type { FactsDB } from "../backends/facts-db.js";
+import { rowToMemoryEntry } from "../backends/facts-db/index.js";
+import type { MemoryEntry } from "../types/memory.js";
+import {
+  computePendingInputHash,
+  createPendingAutopilotRunId,
+  createStableRunSummary,
+  type PendingAutopilotStore,
+  type AutopilotAction,
+  type AutopilotReasonCode,
+  type PendingDecision,
+  type PendingDecisionContext,
+  type PendingDecisionEvidence,
+  type PendingItem,
+  type PendingQueueAdapter,
+} from "./pending-autopilot/index.js";
+import type { VerifiedFact } from "./verification-store.js";
+
+export const VERIFIED_TRIAGE_POLICY_VERSION = "verified-fact-triage-v1";
+export const VERIFIED_REVIEW_QUEUE_SOURCE =
+  "Latest verified_facts rows whose next_verification timestamp is due (or whose verified_at is older than the verification window), as returned by VerificationStore.listDueForReverification semantics. This is intentionally not all verified facts.";
+
+export const VERIFIED_TRIAGE_POLICIES = ["report-only", "classify", "apply-obvious"] as const;
+export type VerifiedTriagePolicy = (typeof VERIFIED_TRIAGE_POLICIES)[number];
+
+export const VERIFIED_TRIAGE_BUCKETS = [
+  "still-current",
+  "stale-candidate",
+  "expired-ttl-candidate",
+  "superseded-candidate",
+  "contradicted-candidate",
+  "missing-or-weak-provenance",
+  "duplicate-candidate",
+  "scope-or-ownership-unclear",
+  "sensitive-needs-human",
+  "needs-human-review",
+  "failed-review",
+] as const;
+export type VerifiedTriageBucket = (typeof VERIFIED_TRIAGE_BUCKETS)[number];
+
+export const VERIFIED_TRIAGE_ACTIONS = [
+  "reported",
+  "classified",
+  "marked-reviewed",
+  "linked-evidence",
+  "flagged-stale",
+  "flagged-superseded",
+  "flagged-contradicted",
+  "flagged-sensitive",
+  "deferred-for-human",
+  "failed-validation",
+  "skipped-by-policy",
+] as const;
+export type VerifiedTriageAction = (typeof VERIFIED_TRIAGE_ACTIONS)[number];
+
+export type VerifiedTriageReason =
+  | "policy_report_only"
+  | "still_current_no_action_needed"
+  | "ttl_expired"
+  | "newer_verified_fact_exists"
+  | "contradicting_verified_fact_exists"
+  | "weak_or_missing_provenance"
+  | "duplicate_verified_fact_candidate"
+  | "sensitive_security_fact"
+  | "sensitive_privacy_fact"
+  | "sensitive_personal_fact"
+  | "sensitive_operational_runbook"
+  | "scope_unclear"
+  | "requires_human_approval"
+  | "stale_due_for_reverification"
+  | "low_confidence"
+  | "backend_error"
+  | "malformed_fact"
+  | "evidence_query_failed";
+
+export interface VerifiedFactTriageItem extends PendingItem<VerifiedFactTriagePayload> {
+  queue: "verified";
+}
+
+export interface VerifiedFactTriagePayload extends Record<string, unknown> {
+  reviewQueueSource: string;
+  verified: VerifiedFact;
+  fact: TriageFactSnapshot | null;
+  verificationTier: string | null;
+  reviewCursor: string | null;
+}
+
+export interface TriageFactSnapshot {
+  id: string;
+  text: string;
+  category: string;
+  entity: string | null;
+  key: string | null;
+  value: string | null;
+  source: string;
+  createdAt: number;
+  expiresAt: number | null;
+  validFrom: number | null;
+  validUntil: number | null;
+  supersedesId: string | null;
+  supersededAt: number | null;
+  supersededBy: string | null;
+  tier: string | null;
+  scope: string;
+  scopeTarget: string | null;
+  provenanceSession: string | null;
+  sourceSessions: string | null;
+  provenanceJson: string | null;
+  tags: string[] | null;
+  confidence: number;
+}
+
+export interface VerifiedTriageEvidence extends PendingDecisionEvidence {
+  fields?: Record<string, unknown>;
+}
+
+export interface VerifiedTriageResultItem {
+  factId: string;
+  verifiedFactId: string;
+  text: string;
+  verificationTier: string | null;
+  scope: string | null;
+  scopeTarget: string | null;
+  entity: string | null;
+  key: string | null;
+  validFrom: number | null;
+  validUntil: number | null;
+  expiresAt: number | null;
+  provenanceSummary: string;
+  bucket: VerifiedTriageBucket;
+  recommendedAction: VerifiedTriageAction;
+  confidence: number;
+  evidence: VerifiedTriageEvidence[];
+  sensitivityFlags: string[];
+  reason: VerifiedTriageReason;
+  humanReviewRequired: boolean;
+  action: AutopilotAction;
+  reasonCode: AutopilotReasonCode;
+  capabilityClass: PendingDecision["capabilityClass"];
+  actionClass: PendingDecision["actionClass"];
+  inputHash: string;
+  applied: boolean;
+}
+
+export interface VerifiedTriageRunResult {
+  runId: string;
+  mode: "dry-run" | "apply";
+  policy: VerifiedTriagePolicy;
+  policyVersion: string;
+  reviewQueueSource: string;
+  counts: {
+    inspected: number;
+    classified: number;
+    stillCurrent: number;
+    staleCandidates: number;
+    expiredTtlCandidates: number;
+    supersededCandidates: number;
+    contradictedCandidates: number;
+    duplicateCandidates: number;
+    sensitiveNeedsHuman: number;
+    needsHuman: number;
+    applied: number;
+    failed: number;
+  };
+  items: VerifiedTriageResultItem[];
+}
+
+export interface VerifiedFactTriageOptions {
+  mode: "dry-run" | "apply";
+  policy: VerifiedTriagePolicy;
+  max?: number;
+  actor?: PendingDecision["actor"];
+  jobId?: string;
+  runId?: string;
+  store?: PendingAutopilotStore | null;
+  nowMs?: number;
+  lockTtlSeconds?: number;
+}
+
+interface RelatedFact extends TriageFactSnapshot {
+  verifiedFactId?: string | null;
+  verifiedAt?: string | null;
+  verifiedVersion?: number | null;
+}
+
+const SENSITIVE_RULES: Array<{ flag: string; reason: VerifiedTriageReason; pattern: RegExp }> = [
+  { flag: "credentials", reason: "sensitive_security_fact", pattern: /\b(password|passwd|credential|secret|api[-_ ]?key|token|bearer|ssh key|private key|vault|oauth|pat_)\b/i },
+  { flag: "security", reason: "sensitive_security_fact", pattern: /\b(security|firewall|ssh|vpn|runbook|incident|breach|auth|mfa|2fa|permission|admin)\b/i },
+  { flag: "privacy", reason: "sensitive_privacy_fact", pattern: /\b(privacy|private|personal data|pii|gdpr|address|phone|email|medical|health|passport|identity)\b/i },
+  { flag: "external-comms", reason: "sensitive_personal_fact", pattern: /\b(external comms|external communication|email rule|reply rule|send to|contact\b|customer|client)\b/i },
+  { flag: "persona-preference", reason: "sensitive_personal_fact", pattern: /\b(preference|user identity|persona|edict|hard rule|markus|lotta)\b/i },
+  { flag: "operational-runbook", reason: "sensitive_operational_runbook", pattern: /\b(cron|runbook|operational|ops|production|deploy|restart|backup|restore)\b/i },
+];
+
+export function assertVerifiedTriagePolicy(value: string): VerifiedTriagePolicy {
+  if ((VERIFIED_TRIAGE_POLICIES as readonly string[]).includes(value)) return value as VerifiedTriagePolicy;
+  throw new Error(`Unknown verified triage policy: ${value}`);
+}
+
+export function createVerifiedFactTriageAdapter(input: {
+  factsDb: Pick<FactsDB, "getRawDb">;
+  max?: number;
+  nowMs?: number;
+}): PendingQueueAdapter<VerifiedFactTriageItem> {
+  const db = input.factsDb.getRawDb();
+  return {
+    queue: "verified",
+    listPending: () => listVerifiedFactTriageItems(db, { max: input.max, nowMs: input.nowMs }),
+    decide: (item, context) => decideVerifiedFactTriage(item, context, { db, nowMs: input.nowMs }),
+    apply: (_decision, _item) => {
+      // Verified fact triage intentionally does not mutate core truth fields. Durable
+      // state is recorded through PendingAutopilotStore decisions only.
+    },
+  };
+}
+
+export function listVerifiedFactTriageItems(
+  db: DatabaseSync,
+  opts: { max?: number; nowMs?: number } = {},
+): VerifiedFactTriageItem[] {
+  const nowIso = new Date(opts.nowMs ?? Date.now()).toISOString();
+  const latestRows = db
+    .prepare(
+      `SELECT vf.*
+       FROM verified_facts vf
+       JOIN (
+         SELECT vf2.fact_id, MAX(vf2.version) AS max_version
+         FROM verified_facts vf2
+         LEFT JOIN facts f2 ON f2.id = vf2.fact_id
+         GROUP BY vf2.fact_id
+       ) latest ON vf.fact_id = latest.fact_id AND vf.version = latest.max_version
+       LEFT JOIN facts f ON f.id = vf.fact_id
+       WHERE vf.next_verification IS NOT NULL AND vf.next_verification <= ?
+       ORDER BY vf.next_verification ASC, vf.verified_at ASC
+       LIMIT ?`,
+    )
+    .all(nowIso, opts.max ?? 100) as unknown as VerifiedFactRow[];
+
+  return latestRows.map((row) => {
+    const verified = rowToVerifiedFact(row);
+    const fact = loadFactSnapshot(db, verified.factId);
+    const payload: VerifiedFactTriagePayload = {
+      reviewQueueSource: VERIFIED_REVIEW_QUEUE_SOURCE,
+      verified,
+      fact,
+      verificationTier: fact?.tier ?? null,
+      reviewCursor: verified.nextVerification,
+    };
+    const inputHash = computePendingInputHash({
+      queue: "verified",
+      id: verified.id,
+      payload,
+      policy: "classify",
+      policyVersion: VERIFIED_TRIAGE_POLICY_VERSION,
+    });
+    return {
+      queue: "verified",
+      id: verified.id,
+      inputHash,
+      policyVersion: VERIFIED_TRIAGE_POLICY_VERSION,
+      capabilityClasses: ["read-only", "record-review-metadata"],
+      payload,
+      visibleAfterCursor: verified.nextVerification,
+      requiresHumanReview: false,
+      validationFailed: !fact,
+    } satisfies VerifiedFactTriageItem;
+  });
+}
+
+export function decideVerifiedFactTriage(
+  item: VerifiedFactTriageItem,
+  context: PendingDecisionContext,
+  opts: { db?: DatabaseSync; nowMs?: number } = {},
+): PendingDecision {
+  const triage = classifyVerifiedFact(item, { db: opts.db, nowMs: opts.nowMs, policy: context.policy });
+  return triageToPendingDecision(item, context, triage);
+}
+
+export async function runVerifiedFactTriage(
+  factsDb: Pick<FactsDB, "getRawDb">,
+  opts: VerifiedFactTriageOptions,
+): Promise<VerifiedTriageRunResult> {
+  const policy = assertVerifiedTriagePolicy(opts.policy);
+  const mode = opts.mode;
+  const store = opts.store ?? null;
+  const runId = opts.runId ?? createPendingAutopilotRunId();
+  const actor = opts.actor ?? { type: "agent", id: "verified-triage-cli" };
+  const adapter = createVerifiedFactTriageAdapter({ factsDb, max: opts.max, nowMs: opts.nowMs });
+  const items = await adapter.listPending(null);
+  const runInputHash = computePendingInputHash({ queue: "verified", itemIds: items.map((i) => i.id), policy, mode });
+  const startedAt = Math.floor((opts.nowMs ?? Date.now()) / 1000);
+
+  store?.createRun({
+    runId,
+    mode,
+    policy,
+    policyVersion: VERIFIED_TRIAGE_POLICY_VERSION,
+    inputHash: runInputHash,
+    queues: ["verified"],
+    startedAt,
+  });
+
+  const decisions: PendingDecision[] = [];
+  const resultItems: VerifiedTriageResultItem[] = [];
+  for (const item of items) {
+    const context: PendingDecisionContext = {
+      runId,
+      jobId: opts.jobId,
+      mode,
+      policy,
+      policyVersion: VERIFIED_TRIAGE_POLICY_VERSION,
+      inputHash: item.inputHash,
+      actor,
+    };
+    const decision = await adapter.decide(item, context);
+    decisions.push(decision);
+    let applied = false;
+    if (mode === "apply" && policy !== "report-only") {
+      const locked =
+        store?.acquireLock({
+          queue: "verified",
+          itemId: item.id,
+          inputHash: item.inputHash,
+          owner: actor.id,
+          ttlSeconds: opts.lockTtlSeconds ?? 60,
+          mode,
+        }) ?? false;
+      const actualInputHash = recomputeItemHash(item);
+      if (locked && actualInputHash === item.inputHash) {
+        store?.recordDecision(decision);
+        if (decision.action !== "deferred-for-human" && decision.action !== "failed-validation") {
+          store?.advanceCursorIfSafe(decision, item.visibleAfterCursor ?? item.id);
+        }
+        applied = decision.action === "classified" || decision.action === "reported";
+      } else if (store) {
+        const staleDecision = triageToPendingDecision(item, context, {
+          bucket: "failed-review",
+          recommendedAction: "failed-validation",
+          reason: locked ? "backend_error" : "requires_human_approval",
+          confidence: 1,
+          evidence: [{ type: "input-hash", id: item.id, summary: "Lock missing or input hash changed before apply" }],
+          sensitivityFlags: [],
+          humanReviewRequired: true,
+        });
+        store.recordDecision(staleDecision);
+        decisions[decisions.length - 1] = staleDecision;
+      }
+      store?.releaseLock({ queue: "verified", itemId: item.id, inputHash: item.inputHash, owner: actor.id, mode });
+    }
+    resultItems.push(decisionToResultItem(decisions[decisions.length - 1], item, applied));
+  }
+
+  const summary = createStableRunSummary({
+    runId,
+    mode,
+    policy,
+    policyVersion: VERIFIED_TRIAGE_POLICY_VERSION,
+    queues: ["verified"],
+    startedAt,
+    finishedAt: Math.floor((opts.nowMs ?? Date.now()) / 1000),
+    decisions,
+  });
+  store?.finishRun(runId, summary, summary.finishedAt);
+
+  return buildRunResult({ runId, mode, policy, items: resultItems });
+}
+
+export function classifyVerifiedFact(
+  item: VerifiedFactTriageItem,
+  opts: { db?: DatabaseSync; nowMs?: number; policy?: string } = {},
+): Omit<VerifiedTriageResultItem, "factId" | "verifiedFactId" | "text" | "verificationTier" | "scope" | "scopeTarget" | "entity" | "key" | "validFrom" | "validUntil" | "expiresAt" | "provenanceSummary" | "action" | "reasonCode" | "capabilityClass" | "actionClass" | "inputHash" | "applied"> {
+  const fact = item.payload.fact;
+  const nowSec = Math.floor((opts.nowMs ?? Date.now()) / 1000);
+  const nowIso = new Date(opts.nowMs ?? Date.now()).toISOString();
+
+  if (!fact) {
+    return {
+      bucket: "failed-review",
+      recommendedAction: "failed-validation",
+      reason: "malformed_fact",
+      confidence: 1,
+      evidence: [{ type: "verified-fact", id: item.payload.verified.id, summary: "Verified row references a missing fact row" }],
+      sensitivityFlags: [],
+      humanReviewRequired: true,
+    };
+  }
+
+  const sensitivity = detectSensitivity(fact, item.payload.verified.canonicalText);
+  if (sensitivity.flags.length > 0) {
+    return {
+      bucket: "sensitive-needs-human",
+      recommendedAction: "flagged-sensitive",
+      reason: sensitivity.reason,
+      confidence: 0.95,
+      evidence: [{ type: "sensitivity", id: fact.id, summary: `Matched sensitive categories: ${sensitivity.flags.join(", ")}` }],
+      sensitivityFlags: sensitivity.flags,
+      humanReviewRequired: true,
+    };
+  }
+
+  if (hasScopeUnclearSignals(fact)) {
+    return {
+      bucket: "scope-or-ownership-unclear",
+      recommendedAction: "deferred-for-human",
+      reason: "scope_unclear",
+      confidence: 0.9,
+      evidence: [{ type: "scope", id: fact.id, summary: "Fact has session/agent/user scope requiring explicit ownership proof" }],
+      sensitivityFlags: [],
+      humanReviewRequired: true,
+    };
+  }
+
+  if (fact.validUntil != null && fact.validUntil <= nowSec) {
+    return {
+      bucket: "expired-ttl-candidate",
+      recommendedAction: "deferred-for-human",
+      reason: "ttl_expired",
+      confidence: 0.95,
+      evidence: [{ type: "validity", id: fact.id, summary: "Fact valid_until has expired", fields: { validUntil: fact.validUntil, now: nowSec } }],
+      sensitivityFlags: [],
+      humanReviewRequired: true,
+    };
+  }
+  if (fact.expiresAt != null && fact.expiresAt <= nowSec) {
+    return {
+      bucket: "expired-ttl-candidate",
+      recommendedAction: "deferred-for-human",
+      reason: "ttl_expired",
+      confidence: 0.95,
+      evidence: [{ type: "ttl", id: fact.id, summary: "Fact expires_at has expired", fields: { expiresAt: fact.expiresAt, now: nowSec } }],
+      sensitivityFlags: [],
+      humanReviewRequired: true,
+    };
+  }
+
+  const newer = opts.db ? findExplicitNewerVerifiedFact(opts.db, fact) : null;
+  if (newer) {
+    return {
+      bucket: "superseded-candidate",
+      recommendedAction: "flagged-superseded",
+      reason: "newer_verified_fact_exists",
+      confidence: 0.9,
+      evidence: [{ type: "fact", id: newer.id, summary: "Explicit newer verified fact supersedes this fact", fields: { newerFactId: newer.id, verifiedFactId: newer.verifiedFactId } }],
+      sensitivityFlags: [],
+      humanReviewRequired: true,
+    };
+  }
+
+  const contradiction = opts.db ? findConcreteContradictingEvidence(opts.db, fact) : null;
+  if (contradiction) {
+    return {
+      bucket: "contradicted-candidate",
+      recommendedAction: "flagged-contradicted",
+      reason: "contradicting_verified_fact_exists",
+      confidence: 0.92,
+      evidence: [contradiction],
+      sensitivityFlags: [],
+      humanReviewRequired: true,
+    };
+  }
+
+  const duplicate = opts.db ? findSameScopeDuplicateVerifiedFact(opts.db, fact) : null;
+  if (duplicate) {
+    return {
+      bucket: "duplicate-candidate",
+      recommendedAction: "deferred-for-human",
+      reason: "duplicate_verified_fact_candidate",
+      confidence: 0.82,
+      evidence: [{ type: "fact", id: duplicate.id, summary: "Same-scope verified fact has identical normalized text", fields: { duplicateFactId: duplicate.id } }],
+      sensitivityFlags: [],
+      humanReviewRequired: true,
+    };
+  }
+
+  const weak = weakProvenanceReason(fact);
+  if (weak) {
+    return {
+      bucket: "missing-or-weak-provenance",
+      recommendedAction: "deferred-for-human",
+      reason: "weak_or_missing_provenance",
+      confidence: 0.86,
+      evidence: [{ type: "provenance", id: fact.id, summary: weak }],
+      sensitivityFlags: [],
+      humanReviewRequired: true,
+    };
+  }
+
+  if (item.payload.verified.nextVerification && item.payload.verified.nextVerification <= nowIso) {
+    return {
+      bucket: "stale-candidate",
+      recommendedAction: "classified",
+      reason: "stale_due_for_reverification",
+      confidence: 0.72,
+      evidence: [{ type: "verification", id: item.payload.verified.id, summary: "Fact is due for scheduled reverification", fields: { nextVerification: item.payload.verified.nextVerification, now: nowIso } }],
+      sensitivityFlags: [],
+      humanReviewRequired: false,
+    };
+  }
+
+  return {
+    bucket: "still-current",
+    recommendedAction: opts.policy === "apply-obvious" ? "marked-reviewed" : "classified",
+    reason: "still_current_no_action_needed",
+    confidence: 0.74,
+    evidence: [{ type: "review", id: fact.id, summary: "No concrete TTL, supersession, contradiction, sensitivity, scope, or provenance blocker found", fields: { reviewedAt: nowIso, method: "deterministic-triage" } }],
+    sensitivityFlags: [],
+    humanReviewRequired: false,
+  };
+}
+
+function triageToPendingDecision(
+  item: VerifiedFactTriageItem,
+  context: PendingDecisionContext,
+  triage: ReturnType<typeof classifyVerifiedFact>,
+): PendingDecision {
+  const mapped = mapTriageAction(context.policy, triage);
+  const evidence = triage.evidence.map((ev) => ({ type: ev.type, id: ev.id, summary: ev.summary }));
+  return {
+    queue: "verified",
+    itemId: item.id,
+    inputHash: context.inputHash,
+    policy: context.policy,
+    policyVersion: context.policyVersion,
+    mode: context.mode,
+    action: mapped.action,
+    reasonCode: mapped.reasonCode,
+    actionClass: mapped.actionClass,
+    capabilityClass: mapped.capabilityClass,
+    confidence: triage.confidence,
+    humanReviewRequired: triage.humanReviewRequired,
+    evidence,
+    actor: context.actor,
+    runId: context.runId,
+    jobId: context.jobId,
+    summary: {
+      title: `verified fact ${triage.bucket}`,
+      body: `${item.payload.fact?.id ?? item.payload.verified.factId}: ${triage.reason}`,
+      metadata: { bucket: triage.bucket, recommendedAction: triage.recommendedAction, sensitivityFlags: triage.sensitivityFlags },
+    },
+    audit: {
+      queue: "verified",
+      itemId: item.id,
+      inputHash: context.inputHash,
+      policy: context.policy,
+      policyVersion: context.policyVersion,
+      action: mapped.action,
+      reasonCode: mapped.reasonCode,
+      capabilityClass: mapped.capabilityClass,
+      humanReviewRequired: triage.humanReviewRequired,
+      evidence,
+      actor: context.actor,
+      runId: "verified-triage-decision",
+      summary: {
+        title: "verified-fact-triage",
+        metadata: {
+          previous: {
+            verificationTier: item.payload.verificationTier,
+            verifiedFactId: item.payload.verified.id,
+            nextVerification: item.payload.verified.nextVerification,
+          },
+          after: {
+            bucket: triage.bucket,
+            recommendedAction: triage.recommendedAction,
+            reason: triage.reason,
+          },
+          mutation: "none-core-truth-fields-preserved",
+        },
+      },
+    },
+  };
+}
+
+function mapTriageAction(
+  policy: string,
+  triage: Pick<VerifiedTriageResultItem, "recommendedAction" | "humanReviewRequired" | "reason">,
+): Pick<PendingDecision, "action" | "reasonCode" | "actionClass" | "capabilityClass"> {
+  if (policy === "report-only") {
+    return { action: "reported", reasonCode: "dry-run", actionClass: "preview", capabilityClass: "read-only" };
+  }
+  if (triage.recommendedAction === "failed-validation") {
+    return { action: "failed-validation", reasonCode: toAutopilotReason(triage.reason), actionClass: "observe", capabilityClass: "read-only" };
+  }
+  if (triage.humanReviewRequired) {
+    return { action: "deferred-for-human", reasonCode: "human-review-required", actionClass: "record-review", capabilityClass: "record-review-metadata" };
+  }
+  return { action: "classified", reasonCode: toAutopilotReason(triage.reason), actionClass: "record-review", capabilityClass: "record-review-metadata" };
+}
+
+function toAutopilotReason(reason: VerifiedTriageReason): AutopilotReasonCode {
+  switch (reason) {
+    case "policy_report_only":
+      return "dry-run";
+    case "backend_error":
+    case "evidence_query_failed":
+      return "audit-write-failed";
+    case "malformed_fact":
+      return "invalid-item";
+    case "requires_human_approval":
+    case "scope_unclear":
+    case "sensitive_security_fact":
+    case "sensitive_privacy_fact":
+    case "sensitive_personal_fact":
+    case "sensitive_operational_runbook":
+      return "human-review-required";
+    default:
+      return "policy-threshold-not-met";
+  }
+}
+
+function decisionToResultItem(decision: PendingDecision, item: VerifiedFactTriageItem, applied: boolean): VerifiedTriageResultItem {
+  const meta = decision.summary?.metadata ?? {};
+  const fact = item.payload.fact;
+  const bucket = String(meta.bucket ?? "failed-review") as VerifiedTriageBucket;
+  const recommendedAction = String(meta.recommendedAction ?? "failed-validation") as VerifiedTriageAction;
+  return {
+    factId: item.payload.verified.factId,
+    verifiedFactId: item.payload.verified.id,
+    text: fact?.text ?? item.payload.verified.canonicalText,
+    verificationTier: item.payload.verificationTier,
+    scope: fact?.scope ?? null,
+    scopeTarget: fact?.scopeTarget ?? null,
+    entity: fact?.entity ?? null,
+    key: fact?.key ?? null,
+    validFrom: fact?.validFrom ?? null,
+    validUntil: fact?.validUntil ?? null,
+    expiresAt: fact?.expiresAt ?? null,
+    provenanceSummary: summarizeProvenance(fact),
+    bucket,
+    recommendedAction,
+    confidence: decision.confidence,
+    evidence: decision.evidence,
+    sensitivityFlags: Array.isArray(meta.sensitivityFlags) ? (meta.sensitivityFlags as string[]) : [],
+    reason: extractVerifiedReason(decision, item),
+    humanReviewRequired: decision.humanReviewRequired,
+    action: decision.action,
+    reasonCode: decision.reasonCode,
+    capabilityClass: decision.capabilityClass,
+    actionClass: decision.actionClass,
+    inputHash: decision.inputHash,
+    applied,
+  };
+}
+
+function extractVerifiedReason(decision: PendingDecision, item: VerifiedFactTriageItem): VerifiedTriageReason {
+  const after = decision.audit?.summary?.metadata as { after?: { reason?: string } } | undefined;
+  const reason = after?.after?.reason;
+  if (reason) return reason as VerifiedTriageReason;
+  return item.validationFailed ? "malformed_fact" : "requires_human_approval";
+}
+
+function buildRunResult(input: {
+  runId: string;
+  mode: "dry-run" | "apply";
+  policy: VerifiedTriagePolicy;
+  items: VerifiedTriageResultItem[];
+}): VerifiedTriageRunResult {
+  return {
+    runId: input.runId,
+    mode: input.mode,
+    policy: input.policy,
+    policyVersion: VERIFIED_TRIAGE_POLICY_VERSION,
+    reviewQueueSource: VERIFIED_REVIEW_QUEUE_SOURCE,
+    counts: {
+      inspected: input.items.length,
+      classified: input.items.filter((i) => i.action === "classified" || i.action === "reported").length,
+      stillCurrent: input.items.filter((i) => i.bucket === "still-current").length,
+      staleCandidates: input.items.filter((i) => i.bucket === "stale-candidate").length,
+      expiredTtlCandidates: input.items.filter((i) => i.bucket === "expired-ttl-candidate").length,
+      supersededCandidates: input.items.filter((i) => i.bucket === "superseded-candidate").length,
+      contradictedCandidates: input.items.filter((i) => i.bucket === "contradicted-candidate").length,
+      duplicateCandidates: input.items.filter((i) => i.bucket === "duplicate-candidate").length,
+      sensitiveNeedsHuman: input.items.filter((i) => i.bucket === "sensitive-needs-human").length,
+      needsHuman: input.items.filter((i) => i.humanReviewRequired).length,
+      applied: input.items.filter((i) => i.applied).length,
+      failed: input.items.filter((i) => i.bucket === "failed-review").length,
+    },
+    items: input.items,
+  };
+}
+
+function rowToVerifiedFact(row: VerifiedFactRow): VerifiedFact {
+  return {
+    id: row.id,
+    factId: row.fact_id,
+    canonicalText: row.canonical_text,
+    checksum: row.checksum,
+    verifiedAt: row.verified_at,
+    verifiedBy: row.verified_by as VerifiedFact["verifiedBy"],
+    nextVerification: row.next_verification,
+    version: row.version,
+    previousVersionId: row.previous_version_id,
+    createdAt: row.created_at,
+  };
+}
+
+interface VerifiedFactRow {
+  id: string;
+  fact_id: string;
+  canonical_text: string;
+  checksum: string;
+  verified_at: string;
+  verified_by: string;
+  next_verification: string | null;
+  version: number;
+  previous_version_id: string | null;
+  created_at: string;
+}
+
+function loadFactSnapshot(db: DatabaseSync, factId: string): TriageFactSnapshot | null {
+  const row = db.prepare("SELECT * FROM facts WHERE id = ?").get(factId) as Record<string, unknown> | undefined;
+  return row ? memoryEntryToSnapshot(rowToMemoryEntry(row)) : null;
+}
+
+function memoryEntryToSnapshot(entry: MemoryEntry): TriageFactSnapshot {
+  return {
+    id: entry.id,
+    text: entry.text,
+    category: entry.category,
+    entity: entry.entity,
+    key: entry.key,
+    value: entry.value,
+    source: entry.source,
+    createdAt: entry.createdAt,
+    expiresAt: entry.expiresAt,
+    validFrom: entry.validFrom ?? null,
+    validUntil: entry.validUntil ?? null,
+    supersedesId: entry.supersedesId ?? null,
+    supersededAt: entry.supersededAt ?? null,
+    supersededBy: entry.supersededBy ?? null,
+    tier: entry.tier ?? null,
+    scope: entry.scope ?? "global",
+    scopeTarget: entry.scopeTarget ?? null,
+    provenanceSession: entry.provenanceSession ?? null,
+    sourceSessions: entry.sourceSessions ?? null,
+    provenanceJson: entry.provenanceJson ?? null,
+    tags: entry.tags ?? null,
+    confidence: entry.confidence,
+  };
+}
+
+function snapshotFromRow(row: Record<string, unknown>): RelatedFact {
+  return memoryEntryToSnapshot(rowToMemoryEntry(row));
+}
+
+function detectSensitivity(fact: TriageFactSnapshot, canonicalText: string): { flags: string[]; reason: VerifiedTriageReason } {
+  const haystack = [canonicalText, fact.text, fact.category, fact.entity, fact.key, fact.value, fact.tags?.join(" ")]
+    .filter(Boolean)
+    .join("\n");
+  const flags: string[] = [];
+  let reason: VerifiedTriageReason = "sensitive_personal_fact";
+  for (const rule of SENSITIVE_RULES) {
+    if (rule.pattern.test(haystack)) {
+      flags.push(rule.flag);
+      if (reason === "sensitive_personal_fact" || rule.reason === "sensitive_security_fact") reason = rule.reason;
+    }
+  }
+  return { flags: [...new Set(flags)], reason };
+}
+
+function hasScopeUnclearSignals(fact: TriageFactSnapshot): boolean {
+  return fact.scope !== "global" && !fact.scopeTarget;
+}
+
+function sameScope(a: TriageFactSnapshot, b: TriageFactSnapshot): boolean {
+  return a.scope === b.scope && (a.scopeTarget ?? null) === (b.scopeTarget ?? null);
+}
+
+function findExplicitNewerVerifiedFact(db: DatabaseSync, fact: TriageFactSnapshot): RelatedFact | null {
+  if (fact.supersededBy) {
+    const newer = loadVerifiedRelatedFact(db, fact.supersededBy);
+    if (newer && sameScope(fact, newer) && newer.createdAt >= fact.createdAt) return newer;
+  }
+  const rows = db
+    .prepare(
+      `SELECT f.*, vf.id AS verified_fact_id, vf.verified_at AS verified_at, vf.version AS verified_version
+       FROM facts f
+       JOIN verified_facts vf ON vf.fact_id = f.id
+       WHERE f.supersedes_id = ? AND f.created_at >= ?
+       ORDER BY f.created_at DESC
+       LIMIT 5`,
+    )
+    .all(fact.id, fact.createdAt) as Array<Record<string, unknown>>;
+  for (const row of rows) {
+    const newer = { ...snapshotFromRow(row), verifiedFactId: row.verified_fact_id as string };
+    if (sameScope(fact, newer)) return newer;
+  }
+  return null;
+}
+
+function loadVerifiedRelatedFact(db: DatabaseSync, factId: string): RelatedFact | null {
+  const row = db
+    .prepare(
+      `SELECT f.*, vf.id AS verified_fact_id, vf.verified_at AS verified_at, vf.version AS verified_version
+       FROM facts f
+       JOIN verified_facts vf ON vf.fact_id = f.id
+       WHERE f.id = ?
+       ORDER BY vf.version DESC
+       LIMIT 1`,
+    )
+    .get(factId) as Record<string, unknown> | undefined;
+  if (!row) return null;
+  return { ...snapshotFromRow(row), verifiedFactId: row.verified_fact_id as string };
+}
+
+function findConcreteContradictingEvidence(db: DatabaseSync, fact: TriageFactSnapshot): VerifiedTriageEvidence | null {
+  if (!fact.entity?.trim() || !fact.key?.trim() || fact.value == null || fact.value.trim() === "") return null;
+  const scopeClause = fact.scopeTarget != null ? "AND f.scope = ? AND f.scope_target = ?" : "AND f.scope = ? AND f.scope_target IS NULL";
+  const scopeParams: SQLInputValue[] = fact.scopeTarget != null ? [fact.scope, fact.scopeTarget] : [fact.scope];
+  const row = db
+    .prepare(
+      `SELECT f.*, vf.id AS verified_fact_id
+       FROM facts f
+       JOIN verified_facts vf ON vf.fact_id = f.id
+       WHERE f.id != ?
+         AND lower(f.entity) = lower(?)
+         AND lower(f.key) = lower(?)
+         AND lower(COALESCE(f.value, '')) != lower(?)
+         AND f.superseded_at IS NULL
+         ${scopeClause}
+       ORDER BY f.created_at DESC
+       LIMIT 1`,
+    )
+    .get(fact.id, fact.entity, fact.key, fact.value, ...scopeParams) as Record<string, unknown> | undefined;
+  if (!row) return null;
+  return {
+    type: "contradiction",
+    id: row.id as string,
+    summary: "Concrete same-entity/key/scope verified fact has conflicting structured value",
+    fields: {
+      subject: fact.entity,
+      scope: fact.scope,
+      scopeTarget: fact.scopeTarget,
+      claimType: fact.key,
+      currentValue: fact.value,
+      conflictingValue: row.value,
+      sourceId: row.id,
+      verifiedFactId: row.verified_fact_id,
+    },
+  };
+}
+
+function findSameScopeDuplicateVerifiedFact(db: DatabaseSync, fact: TriageFactSnapshot): RelatedFact | null {
+  const normalized = normalizeFactText(fact.text);
+  if (!normalized) return null;
+  const scopeClause = fact.scopeTarget != null ? "AND f.scope = ? AND f.scope_target = ?" : "AND f.scope = ? AND f.scope_target IS NULL";
+  const scopeParams: SQLInputValue[] = fact.scopeTarget != null ? [fact.scope, fact.scopeTarget] : [fact.scope];
+  const rows = db
+    .prepare(
+      `SELECT f.*, vf.id AS verified_fact_id
+       FROM facts f
+       JOIN verified_facts vf ON vf.fact_id = f.id
+       WHERE f.id != ? AND f.superseded_at IS NULL ${scopeClause}
+       LIMIT 50`,
+    )
+    .all(fact.id, ...scopeParams) as Array<Record<string, unknown>>;
+  for (const row of rows) {
+    const candidate = { ...snapshotFromRow(row), verifiedFactId: row.verified_fact_id as string };
+    if (normalizeFactText(candidate.text) === normalized) return candidate;
+  }
+  return null;
+}
+
+function normalizeFactText(text: string): string {
+  return text.trim().toLowerCase().replace(/\s+/g, " ");
+}
+
+function weakProvenanceReason(fact: TriageFactSnapshot): string | null {
+  if (fact.source === "unknown" || fact.source === "") return "Fact source is missing or unknown";
+  if (!fact.provenanceJson && !fact.provenanceSession && !fact.sourceSessions) {
+    return "No provenance_json, provenance_session, or source_sessions recorded";
+  }
+  return null;
+}
+
+function summarizeProvenance(fact: TriageFactSnapshot | null): string {
+  if (!fact) return "missing fact row";
+  const parts = [
+    fact.provenanceJson ? "provenance_json" : null,
+    fact.provenanceSession ? `session:${fact.provenanceSession}` : null,
+    fact.sourceSessions ? "source_sessions" : null,
+    `source:${fact.source}`,
+  ].filter(Boolean);
+  return parts.join(", ");
+}
+
+function recomputeItemHash(item: VerifiedFactTriageItem): string {
+  return computePendingInputHash({
+    queue: item.queue,
+    id: item.id,
+    payload: item.payload,
+    policy: "classify",
+    policyVersion: item.policyVersion,
+  });
+}

--- a/extensions/memory-hybrid/services/verified-fact-triage.ts
+++ b/extensions/memory-hybrid/services/verified-fact-triage.ts
@@ -275,7 +275,7 @@ export function listVerifiedFactTriageItems(
   ).toISOString();
   const policy = opts.policy ?? "classify";
   const cursor = opts.cursor?.cursor ?? null;
-  const cursorItemId = opts.cursor ? findVerifiedCursorItemId(db, opts.cursor.inputHash, policy) : null;
+  const cursorItemId = opts.cursor ? findVerifiedCursorItemId(db, opts.cursor.inputHash, policy, nowIso, cursor, cutoffIso) : null;
   const latestRows = db
     .prepare(
       `SELECT vf.*
@@ -302,7 +302,7 @@ export function listVerifiedFactTriageItems(
     .map((row) => triageItemFromRow(db, row, { nowIso, policy }));
 }
 
-function findVerifiedCursorItemId(db: DatabaseSync, inputHash: string, policy: VerifiedTriagePolicy): string | null {
+function findVerifiedCursorItemId(db: DatabaseSync, inputHash: string, policy: VerifiedTriagePolicy, nowIso: string, cursor: string, cutoffIso: string): string | null {
   const rows = db
     .prepare(
       `SELECT vf.*
@@ -311,13 +311,17 @@ function findVerifiedCursorItemId(db: DatabaseSync, inputHash: string, policy: V
          SELECT vf2.fact_id, MAX(vf2.version) AS max_version
          FROM verified_facts vf2
          GROUP BY vf2.fact_id
-       ) latest ON vf.fact_id = latest.fact_id AND vf.version = latest.max_version`,
+       ) latest ON vf.fact_id = latest.fact_id AND vf.version = latest.max_version
+       WHERE ((vf.next_verification IS NOT NULL AND vf.next_verification <= ?)
+          OR vf.verified_at <= ?)
+         AND COALESCE(vf.next_verification, vf.verified_at) = ?
+       ORDER BY vf.verified_at ASC, vf.id ASC`,
     )
-    .all() as unknown as VerifiedFactRow[];
+    .all(nowIso, cutoffIso, cursor) as unknown as VerifiedFactRow[];
   for (const row of rows) {
     if (!isVerifiedRowChecksumValid(row)) continue;
     const item = triageItemFromRow(db, row, {
-      nowIso: row.next_verification ?? row.verified_at,
+      nowIso,
       policy,
     });
     if (item.inputHash === inputHash) return row.id;

--- a/extensions/memory-hybrid/services/verified-fact-triage.ts
+++ b/extensions/memory-hybrid/services/verified-fact-triage.ts
@@ -541,7 +541,7 @@ export async function runVerifiedFactTriageWithAdapter(
             durableStore?.recordDecision(staleDecision);
             decision = staleDecision;
           }
-        } else if (durableStore) {
+        } else {
           const staleDecision = validationFailureDecision(
             item,
             context,
@@ -550,8 +550,6 @@ export async function runVerifiedFactTriageWithAdapter(
           );
           durableStore.recordDecision(staleDecision);
           decision = staleDecision;
-        } else {
-          decision = await adapter.decide(item, context);
         }
       } finally {
         if (locked) {
@@ -610,6 +608,9 @@ export function classifyVerifiedFact(
   | "inputHash"
   | "applied"
 > {
+  if (opts.db) {
+    registerVerifiedChecksumFunction(opts.db);
+  }
   const fact = item.payload.fact;
   const nowMs = opts.nowMs ?? Date.now();
   const nowSec = Math.floor(nowMs / 1000);

--- a/extensions/memory-hybrid/services/verified-fact-triage.ts
+++ b/extensions/memory-hybrid/services/verified-fact-triage.ts
@@ -1162,7 +1162,7 @@ function detectSensitivity(
     .join("\n");
   const flags: string[] = [];
   let reason: VerifiedTriageReason = "sensitive_personal_fact";
-  const priorityMap: Record<VerifiedTriageReason, number> = {
+  const priorityMap: Partial<Record<VerifiedTriageReason, number>> = {
     sensitive_security_fact: 4,
     sensitive_privacy_fact: 3,
     sensitive_operational_runbook: 2,

--- a/extensions/memory-hybrid/services/verified-fact-triage.ts
+++ b/extensions/memory-hybrid/services/verified-fact-triage.ts
@@ -7,6 +7,7 @@ import {
   createPendingAutopilotRunId,
   createStableRunSummary,
   type PendingAutopilotStore,
+  type PendingAutopilotCursor,
   type AutopilotAction,
   type AutopilotReasonCode,
   type PendingDecision,
@@ -237,14 +238,16 @@ export function createVerifiedFactTriageAdapter(input: {
   policy?: VerifiedTriagePolicy;
 }): PendingQueueAdapter<VerifiedFactTriageItem> {
   const db = input.factsDb.getRawDb();
+  registerVerifiedChecksumFunction(db);
   return {
     queue: "verified",
-    listPending: () =>
+    listPending: (cursor) =>
       listVerifiedFactTriageItems(db, {
         max: input.max,
         nowMs: input.nowMs,
         reverificationDays: input.reverificationDays,
         policy: input.policy,
+        cursor,
       }),
     decide: (item, context) => decideVerifiedFactTriage(item, context, { db, nowMs: input.nowMs }),
     apply: (_decision, _item) => {
@@ -261,14 +264,17 @@ export function listVerifiedFactTriageItems(
     nowMs?: number;
     reverificationDays?: number;
     policy?: VerifiedTriagePolicy;
+    cursor?: PendingAutopilotCursor | null;
   } = {},
 ): VerifiedFactTriageItem[] {
+  registerVerifiedChecksumFunction(db);
   const nowMs = opts.nowMs ?? Date.now();
   const nowIso = new Date(nowMs).toISOString();
   const cutoffIso = new Date(
     nowMs - (opts.reverificationDays ?? DEFAULT_REVERIFICATION_DAYS) * 24 * 60 * 60 * 1000,
   ).toISOString();
   const policy = opts.policy ?? "classify";
+  const cursor = opts.cursor?.cursor ?? null;
   const latestRows = db
     .prepare(
       `SELECT vf.*
@@ -278,11 +284,12 @@ export function listVerifiedFactTriageItems(
          FROM verified_facts vf2
          GROUP BY vf2.fact_id
        ) latest ON vf.fact_id = latest.fact_id AND vf.version = latest.max_version
-       WHERE (vf.next_verification IS NOT NULL AND vf.next_verification <= ?)
-          OR vf.verified_at <= ?
+       WHERE ((vf.next_verification IS NOT NULL AND vf.next_verification <= ?)
+          OR vf.verified_at <= ?)
+         AND (? IS NULL OR COALESCE(vf.next_verification, vf.verified_at) > ?)
        ORDER BY COALESCE(vf.next_verification, vf.verified_at) ASC, vf.verified_at ASC`,
     )
-    .all(nowIso, cutoffIso) as unknown as VerifiedFactRow[];
+    .all(nowIso, cutoffIso, cursor, cursor) as unknown as VerifiedFactRow[];
 
   return latestRows
     .filter(isVerifiedRowChecksumValid)
@@ -332,7 +339,9 @@ export async function runVerifiedFactTriageWithAdapter(
   const store = opts.store ?? null;
   const runId = opts.runId ?? createPendingAutopilotRunId();
   const actor = opts.actor ?? { type: "agent", id: "verified-triage-cli" };
-  const items = await adapter.listPending(null);
+  const storedCursor =
+    mode === "apply" && policy !== "report-only" ? (store?.getCursor("verified", policy) ?? null) : null;
+  const items = await adapter.listPending(storedCursor);
   const runInputHash = computePendingInputHash({
     queue: "verified",
     itemIds: items.map((i) => i.id),
@@ -960,6 +969,7 @@ function loadLiveVerifiedFactTriageItem(
   itemId: string,
   opts: { nowMs?: number; reverificationDays?: number; policy: VerifiedTriagePolicy },
 ): VerifiedFactTriageItem | null {
+  registerVerifiedChecksumFunction(db);
   const nowMs = opts.nowMs ?? Date.now();
   const nowIso = new Date(nowMs).toISOString();
   const cutoffIso = new Date(
@@ -982,6 +992,16 @@ function loadLiveVerifiedFactTriageItem(
     .get(itemId, nowIso, cutoffIso) as VerifiedFactRow | undefined;
   if (!row || !isVerifiedRowChecksumValid(row)) return null;
   return triageItemFromRow(db, row, { nowIso, policy: opts.policy });
+}
+
+const registeredChecksumDbs = new WeakSet<DatabaseSync>();
+
+function registerVerifiedChecksumFunction(db: DatabaseSync): void {
+  if (registeredChecksumDbs.has(db)) return;
+  db.function("compute_verified_checksum", { deterministic: true }, (text: unknown) =>
+    typeof text === "string" ? computeChecksum(text) : "",
+  );
+  registeredChecksumDbs.add(db);
 }
 
 interface VerifiedFactRow {
@@ -1074,7 +1094,9 @@ function findExplicitNewerVerifiedFact(db: DatabaseSync, fact: TriageFactSnapsho
          FROM verified_facts
          GROUP BY fact_id
        ) latest ON vf.fact_id = latest.fact_id AND vf.version = latest.max_version
-       WHERE f.supersedes_id = ? AND f.created_at >= ?
+       WHERE f.supersedes_id = ?
+         AND f.created_at >= ?
+         AND compute_verified_checksum(vf.canonical_text) = vf.checksum
        ORDER BY f.created_at DESC
        LIMIT 5`,
     )
@@ -1095,12 +1117,16 @@ function loadVerifiedRelatedFact(db: DatabaseSync, factId: string): RelatedFact 
       `SELECT f.*, vf.id AS verified_fact_id, vf.verified_at AS verified_at, vf.version AS verified_version
        FROM facts f
        JOIN verified_facts vf ON vf.fact_id = f.id
+       JOIN (
+         SELECT fact_id, MAX(version) AS max_version
+         FROM verified_facts
+         GROUP BY fact_id
+       ) latest ON vf.fact_id = latest.fact_id AND vf.version = latest.max_version
        WHERE f.id = ?
-       ORDER BY vf.version DESC
        LIMIT 1`,
     )
     .get(factId) as Record<string, unknown> | undefined;
-  if (!row) return null;
+  if (!row || !isVerifiedRelatedFactRowChecksumValid(row)) return null;
   return {
     ...snapshotFromRow(row),
     verifiedFactId: row.verified_fact_id as string,
@@ -1123,6 +1149,7 @@ function findConcreteContradictingEvidence(db: DatabaseSync, fact: TriageFactSna
          GROUP BY fact_id
        ) latest ON vf.fact_id = latest.fact_id AND vf.version = latest.max_version
        WHERE f.id != ?
+         AND compute_verified_checksum(vf.canonical_text) = vf.checksum
          AND lower(f.entity) = lower(?)
          AND lower(f.key) = lower(?)
          AND f.value IS NOT NULL
@@ -1167,7 +1194,10 @@ function findSameScopeDuplicateVerifiedFact(db: DatabaseSync, fact: TriageFactSn
          FROM verified_facts
          GROUP BY fact_id
        ) latest ON vf.fact_id = latest.fact_id AND vf.version = latest.max_version
-       WHERE f.id != ? AND f.superseded_at IS NULL ${scopeClause}
+       WHERE f.id != ?
+         AND f.superseded_at IS NULL
+         AND compute_verified_checksum(vf.canonical_text) = vf.checksum
+         ${scopeClause}
        ORDER BY f.created_at DESC
        LIMIT 50`,
     )
@@ -1180,6 +1210,10 @@ function findSameScopeDuplicateVerifiedFact(db: DatabaseSync, fact: TriageFactSn
     if (normalizeFactText(candidate.text) === normalized) return candidate;
   }
   return null;
+}
+
+function isVerifiedRelatedFactRowChecksumValid(row: Record<string, unknown>): boolean {
+  return typeof row.canonical_text === "string" && computeChecksum(row.canonical_text) === row.checksum;
 }
 
 function normalizeFactText(text: string): string {

--- a/extensions/memory-hybrid/services/verified-fact-triage.ts
+++ b/extensions/memory-hybrid/services/verified-fact-triage.ts
@@ -1089,10 +1089,18 @@ function detectSensitivity(
     .join("\n");
   const flags: string[] = [];
   let reason: VerifiedTriageReason = "sensitive_personal_fact";
+  const priorityMap: Record<VerifiedTriageReason, number> = {
+    sensitive_security_fact: 4,
+    sensitive_privacy_fact: 3,
+    sensitive_operational_runbook: 2,
+    sensitive_personal_fact: 1,
+  };
   for (const rule of SENSITIVE_RULES) {
     if (rule.pattern.test(haystack)) {
       flags.push(rule.flag);
-      if (reason === "sensitive_personal_fact" || rule.reason === "sensitive_security_fact") reason = rule.reason;
+      if ((priorityMap[rule.reason] ?? 0) > (priorityMap[reason] ?? 0)) {
+        reason = rule.reason;
+      }
     }
   }
   return { flags: [...new Set(flags)], reason };

--- a/extensions/memory-hybrid/services/verified-fact-triage.ts
+++ b/extensions/memory-hybrid/services/verified-fact-triage.ts
@@ -350,7 +350,7 @@ export async function runVerifiedFactTriage(
           ttlSeconds: opts.lockTtlSeconds ?? 60,
           mode,
         }) ?? false;
-      const actualInputHash = recomputeItemHash(item);
+      const actualInputHash = recomputeItemHash(item, factsDb.getRawDb());
       if (locked && actualInputHash === item.inputHash) {
         store?.recordDecision(decision);
         if (decision.action !== "deferred-for-human" && decision.action !== "failed-validation") {
@@ -934,7 +934,8 @@ function findConcreteContradictingEvidence(db: DatabaseSync, fact: TriageFactSna
        WHERE f.id != ?
          AND lower(f.entity) = lower(?)
          AND lower(f.key) = lower(?)
-         AND lower(COALESCE(f.value, '')) != lower(?)
+         AND f.value IS NOT NULL
+         AND lower(f.value) != lower(?)
          AND f.superseded_at IS NULL
          ${scopeClause}
        ORDER BY f.created_at DESC
@@ -1004,11 +1005,20 @@ function summarizeProvenance(fact: TriageFactSnapshot | null): string {
   return parts.join(", ");
 }
 
-function recomputeItemHash(item: VerifiedFactTriageItem): string {
+function recomputeItemHash(item: VerifiedFactTriageItem, db: DatabaseSync): string {
+  const verified = item.payload.verified;
+  const fact = loadFactSnapshot(db, verified.factId);
+  const payload: VerifiedFactTriagePayload = {
+    reviewQueueSource: item.payload.reviewQueueSource,
+    verified,
+    fact,
+    verificationTier: fact?.tier ?? null,
+    reviewCursor: verified.nextVerification,
+  };
   return computePendingInputHash({
     queue: item.queue,
     id: item.id,
-    payload: item.payload,
+    payload,
     policy: "classify",
     policyVersion: item.policyVersion,
   });

--- a/extensions/memory-hybrid/services/verified-fact-triage.ts
+++ b/extensions/memory-hybrid/services/verified-fact-triage.ts
@@ -19,6 +19,7 @@ import {
 import type { VerifiedFact } from "./verification-store.js";
 
 export const VERIFIED_TRIAGE_POLICY_VERSION = "verified-fact-triage-v1";
+const DEFAULT_REVERIFICATION_DAYS = 30;
 export const VERIFIED_REVIEW_QUEUE_SOURCE =
   "Latest verified_facts rows whose next_verification timestamp is due (or whose verified_at is older than the verification window), as returned by VerificationStore.listDueForReverification semantics. This is intentionally not all verified facts.";
 
@@ -172,6 +173,7 @@ export interface VerifiedFactTriageOptions {
   mode: "dry-run" | "apply";
   policy: VerifiedTriagePolicy;
   max?: number;
+  reverificationDays?: number;
   actor?: PendingDecision["actor"];
   jobId?: string;
   runId?: string;
@@ -264,7 +266,9 @@ export function listVerifiedFactTriageItems(
 ): VerifiedFactTriageItem[] {
   const nowMs = opts.nowMs ?? Date.now();
   const nowIso = new Date(nowMs).toISOString();
-  const cutoffIso = new Date(nowMs - (opts.reverificationDays ?? 30) * 24 * 60 * 60 * 1000).toISOString();
+  const cutoffIso = new Date(
+    nowMs - (opts.reverificationDays ?? DEFAULT_REVERIFICATION_DAYS) * 24 * 60 * 60 * 1000,
+  ).toISOString();
   const policy = opts.policy ?? "classify";
   const latestRows = db
     .prepare(
@@ -284,37 +288,7 @@ export function listVerifiedFactTriageItems(
   return latestRows
     .filter(isVerifiedRowChecksumValid)
     .slice(0, opts.max ?? 100)
-    .map((row) => {
-      const verified = rowToVerifiedFact(row);
-      const fact = loadFactSnapshot(db, verified.factId);
-      const payload: VerifiedFactTriagePayload = {
-        reviewQueueSource: VERIFIED_REVIEW_QUEUE_SOURCE,
-        verified,
-        fact,
-        verificationTier: fact?.tier ?? null,
-        reviewCursor: verified.nextVerification ?? verified.verifiedAt,
-        dueReason:
-          verified.nextVerification && verified.nextVerification <= nowIso ? "next_verification" : "verified_at_stale",
-      };
-      const inputHash = computePendingInputHash({
-        queue: "verified",
-        id: verified.id,
-        payload,
-        policy,
-        policyVersion: VERIFIED_TRIAGE_POLICY_VERSION,
-      });
-      return {
-        queue: "verified",
-        id: verified.id,
-        inputHash,
-        policyVersion: VERIFIED_TRIAGE_POLICY_VERSION,
-        capabilityClasses: ["read-only", "record-review-metadata"],
-        payload,
-        visibleAfterCursor: verified.nextVerification ?? verified.verifiedAt,
-        requiresHumanReview: false,
-        validationFailed: !fact,
-      } satisfies VerifiedFactTriageItem;
-    });
+    .map((row) => triageItemFromRow(db, row, { nowIso, policy }));
 }
 
 function isVerifiedRowChecksumValid(row: VerifiedFactRow): boolean {
@@ -347,6 +321,7 @@ export async function runVerifiedFactTriage(
     factsDb,
     max: opts.max,
     nowMs: opts.nowMs,
+    reverificationDays: opts.reverificationDays,
     policy,
   });
   return runVerifiedFactTriageWithAdapter(factsDb, adapter, opts);
@@ -370,6 +345,7 @@ export async function runVerifiedFactTriageWithAdapter(
     mode,
   });
   const startedAt = Math.floor((opts.nowMs ?? Date.now()) / 1000);
+  const db = factsDb.getRawDb();
 
   const durableStore = policy === "report-only" ? null : store;
 
@@ -385,7 +361,6 @@ export async function runVerifiedFactTriageWithAdapter(
 
   const decisions: PendingDecision[] = [];
   const resultItems: VerifiedTriageResultItem[] = [];
-  const liveItemsMap = new Map(items.map((item) => [item.id, item]));
   for (const item of items) {
     const context: PendingDecisionContext = {
       runId,
@@ -396,8 +371,7 @@ export async function runVerifiedFactTriageWithAdapter(
       inputHash: item.inputHash,
       actor,
     };
-    const decision = await adapter.decide(item, context);
-    decisions.push(decision);
+    let decision: PendingDecision;
     let applied = false;
     if (mode === "apply" && policy !== "report-only") {
       const locked =
@@ -410,14 +384,24 @@ export async function runVerifiedFactTriageWithAdapter(
           mode,
         }) ?? false;
       if (locked) {
-        const liveItem = liveItemsMap.get(item.id) ?? null;
+        const liveItem =
+          loadLiveVerifiedFactTriageItem(db, item.id, {
+            nowMs: opts.nowMs,
+            reverificationDays: opts.reverificationDays,
+            policy,
+          }) ?? null;
         const actualInputHash = liveItem?.inputHash ?? "missing";
         if (liveItem && actualInputHash === item.inputHash) {
+          const liveContext: PendingDecisionContext = {
+            ...context,
+            inputHash: liveItem.inputHash,
+          };
+          decision = await adapter.decide(liveItem, liveContext);
           const { inserted } = durableStore?.recordDecision(decision) ?? {
             inserted: false,
           };
           if (inserted && decision.action !== "deferred-for-human" && decision.action !== "failed-validation") {
-            durableStore?.advanceCursorIfSafe(decision, item.visibleAfterCursor ?? item.id);
+            durableStore?.advanceCursorIfSafe(decision, liveItem.visibleAfterCursor ?? liveItem.id);
           }
           applied = inserted && (decision.action === "classified" || decision.action === "reported");
         } else {
@@ -430,7 +414,7 @@ export async function runVerifiedFactTriageWithAdapter(
               : "Verified fact no longer matches due queue before apply.",
           );
           durableStore?.recordDecision(staleDecision);
-          decisions[decisions.length - 1] = staleDecision;
+          decision = staleDecision;
         }
       } else if (durableStore) {
         const staleDecision = validationFailureDecision(
@@ -440,17 +424,24 @@ export async function runVerifiedFactTriageWithAdapter(
           "Verified fact no longer matches due queue before apply.",
         );
         durableStore.recordDecision(staleDecision);
-        decisions[decisions.length - 1] = staleDecision;
+        decision = staleDecision;
+      } else {
+        decision = await adapter.decide(item, context);
       }
-      durableStore?.releaseLock({
-        queue: "verified",
-        itemId: item.id,
-        inputHash: item.inputHash,
-        owner: actor.id,
-        mode,
-      });
+      if (locked) {
+        durableStore?.releaseLock({
+          queue: "verified",
+          itemId: item.id,
+          inputHash: item.inputHash,
+          owner: actor.id,
+          mode,
+        });
+      }
+    } else {
+      decision = await adapter.decide(item, context);
     }
-    resultItems.push(decisionToResultItem(decisions[decisions.length - 1], item, applied));
+    decisions.push(decision);
+    resultItems.push(decisionToResultItem(decision, item, applied));
   }
 
   const summary = createStableRunSummary({
@@ -927,6 +918,71 @@ function rowToVerifiedFact(row: VerifiedFactRow): VerifiedFact {
     previousVersionId: row.previous_version_id,
     createdAt: row.created_at,
   };
+}
+
+function triageItemFromRow(
+  db: DatabaseSync,
+  row: VerifiedFactRow,
+  opts: { nowIso: string; policy: VerifiedTriagePolicy },
+): VerifiedFactTriageItem {
+  const verified = rowToVerifiedFact(row);
+  const fact = loadFactSnapshot(db, verified.factId);
+  const payload: VerifiedFactTriagePayload = {
+    reviewQueueSource: VERIFIED_REVIEW_QUEUE_SOURCE,
+    verified,
+    fact,
+    verificationTier: fact?.tier ?? null,
+    reviewCursor: verified.nextVerification ?? verified.verifiedAt,
+    dueReason:
+      verified.nextVerification && verified.nextVerification <= opts.nowIso ? "next_verification" : "verified_at_stale",
+  };
+  const inputHash = computePendingInputHash({
+    queue: "verified",
+    id: verified.id,
+    payload,
+    policy: opts.policy,
+    policyVersion: VERIFIED_TRIAGE_POLICY_VERSION,
+  });
+  return {
+    queue: "verified",
+    id: verified.id,
+    inputHash,
+    policyVersion: VERIFIED_TRIAGE_POLICY_VERSION,
+    capabilityClasses: ["read-only", "record-review-metadata"],
+    payload,
+    visibleAfterCursor: verified.nextVerification ?? verified.verifiedAt,
+    requiresHumanReview: false,
+    validationFailed: !fact,
+  };
+}
+
+function loadLiveVerifiedFactTriageItem(
+  db: DatabaseSync,
+  itemId: string,
+  opts: { nowMs?: number; reverificationDays?: number; policy: VerifiedTriagePolicy },
+): VerifiedFactTriageItem | null {
+  const nowMs = opts.nowMs ?? Date.now();
+  const nowIso = new Date(nowMs).toISOString();
+  const cutoffIso = new Date(
+    nowMs - (opts.reverificationDays ?? DEFAULT_REVERIFICATION_DAYS) * 24 * 60 * 60 * 1000,
+  ).toISOString();
+  const row = db
+    .prepare(
+      `SELECT vf.*
+       FROM verified_facts vf
+       JOIN (
+         SELECT vf2.fact_id, MAX(vf2.version) AS max_version
+         FROM verified_facts vf2
+         GROUP BY vf2.fact_id
+       ) latest ON vf.fact_id = latest.fact_id AND vf.version = latest.max_version
+       WHERE vf.id = ?
+         AND ((vf.next_verification IS NOT NULL AND vf.next_verification <= ?)
+           OR vf.verified_at <= ?)
+       LIMIT 1`,
+    )
+    .get(itemId, nowIso, cutoffIso) as VerifiedFactRow | undefined;
+  if (!row || !isVerifiedRowChecksumValid(row)) return null;
+  return triageItemFromRow(db, row, { nowIso, policy: opts.policy });
 }
 
 interface VerifiedFactRow {

--- a/extensions/memory-hybrid/services/verified-fact-triage.ts
+++ b/extensions/memory-hybrid/services/verified-fact-triage.ts
@@ -286,7 +286,7 @@ export function listVerifiedFactTriageItems(
        ) latest ON vf.fact_id = latest.fact_id AND vf.version = latest.max_version
        WHERE ((vf.next_verification IS NOT NULL AND vf.next_verification <= ?)
           OR vf.verified_at <= ?)
-         AND (? IS NULL OR COALESCE(vf.next_verification, vf.verified_at) >= ?)
+         AND (? IS NULL OR COALESCE(vf.next_verification, vf.verified_at) > ?)
        ORDER BY COALESCE(vf.next_verification, vf.verified_at) ASC, vf.verified_at ASC, vf.id ASC`,
     )
     .all(nowIso, cutoffIso, cursor, cursor) as unknown as VerifiedFactRow[];

--- a/extensions/memory-hybrid/services/verified-fact-triage.ts
+++ b/extensions/memory-hybrid/services/verified-fact-triage.ts
@@ -275,6 +275,7 @@ export function listVerifiedFactTriageItems(
   ).toISOString();
   const policy = opts.policy ?? "classify";
   const cursor = opts.cursor?.cursor ?? null;
+  const cursorItemId = opts.cursor ? findVerifiedCursorItemId(db, opts.cursor.inputHash, policy) : null;
   const latestRows = db
     .prepare(
       `SELECT vf.*
@@ -286,15 +287,42 @@ export function listVerifiedFactTriageItems(
        ) latest ON vf.fact_id = latest.fact_id AND vf.version = latest.max_version
        WHERE ((vf.next_verification IS NOT NULL AND vf.next_verification <= ?)
           OR vf.verified_at <= ?)
-         AND (? IS NULL OR COALESCE(vf.next_verification, vf.verified_at) > ?)
+         AND (
+           ? IS NULL
+           OR COALESCE(vf.next_verification, vf.verified_at) > ?
+           OR (COALESCE(vf.next_verification, vf.verified_at) = ? AND vf.id > ?)
+         )
        ORDER BY COALESCE(vf.next_verification, vf.verified_at) ASC, vf.verified_at ASC, vf.id ASC`,
     )
-    .all(nowIso, cutoffIso, cursor, cursor) as unknown as VerifiedFactRow[];
+    .all(nowIso, cutoffIso, cursor, cursor, cursor, cursorItemId) as unknown as VerifiedFactRow[];
 
   return latestRows
     .filter(isVerifiedRowChecksumValid)
     .slice(0, opts.max ?? 100)
     .map((row) => triageItemFromRow(db, row, { nowIso, policy }));
+}
+
+function findVerifiedCursorItemId(db: DatabaseSync, inputHash: string, policy: VerifiedTriagePolicy): string | null {
+  const rows = db
+    .prepare(
+      `SELECT vf.*
+       FROM verified_facts vf
+       JOIN (
+         SELECT vf2.fact_id, MAX(vf2.version) AS max_version
+         FROM verified_facts vf2
+         GROUP BY vf2.fact_id
+       ) latest ON vf.fact_id = latest.fact_id AND vf.version = latest.max_version`,
+    )
+    .all() as unknown as VerifiedFactRow[];
+  for (const row of rows) {
+    if (!isVerifiedRowChecksumValid(row)) continue;
+    const item = triageItemFromRow(db, row, {
+      nowIso: row.next_verification ?? row.verified_at,
+      policy,
+    });
+    if (item.inputHash === inputHash) return row.id;
+  }
+  return null;
 }
 
 function isVerifiedRowChecksumValid(row: VerifiedFactRow): boolean {
@@ -405,7 +433,7 @@ export async function runVerifiedFactTriageWithAdapter(
             const { inserted } = durableStore?.recordDecision(decision) ?? {
               inserted: false,
             };
-            if (inserted && decision.action !== "deferred-for-human" && decision.action !== "failed-validation") {
+            if (decision.action !== "deferred-for-human" && decision.action !== "failed-validation") {
               durableStore?.advanceCursorIfSafe(decision, liveItem.visibleAfterCursor ?? liveItem.id);
             }
             applied = inserted && (decision.action === "classified" || decision.action === "reported");

--- a/extensions/memory-hybrid/services/verified-fact-triage.ts
+++ b/extensions/memory-hybrid/services/verified-fact-triage.ts
@@ -432,10 +432,9 @@ export async function runVerifiedFactTriageWithAdapter(
 					mode,
 				}) ?? false;
 			const liveItem = locked
-				? reloadVerifiedFactTriageItem(factsDb.getRawDb(), item, {
-						policy,
-						nowMs: opts.nowMs,
-					})
+				? ((await adapter.listPending(null)).find(
+						(candidate) => candidate.id === item.id,
+					) ?? null)
 				: null;
 			const actualInputHash = liveItem?.inputHash ?? "missing";
 			if (locked && liveItem && actualInputHash === item.inputHash) {
@@ -1252,25 +1251,6 @@ function summarizeProvenance(fact: TriageFactSnapshot | null): string {
 		`source:${fact.source}`,
 	].filter(Boolean);
 	return parts.join(", ");
-}
-
-function reloadVerifiedFactTriageItem(
-	db: DatabaseSync,
-	item: VerifiedFactTriageItem,
-	opts: {
-		policy: VerifiedTriagePolicy;
-		nowMs?: number;
-		reverificationDays?: number;
-	},
-): VerifiedFactTriageItem | null {
-	return (
-		listVerifiedFactTriageItems(db, {
-			max: 10_000,
-			nowMs: opts.nowMs,
-			reverificationDays: opts.reverificationDays,
-			policy: opts.policy,
-		}).find((candidate) => candidate.id === item.id) ?? null
-	);
 }
 
 function validationFailureDecision(

--- a/extensions/memory-hybrid/services/verified-fact-triage.ts
+++ b/extensions/memory-hybrid/services/verified-fact-triage.ts
@@ -275,7 +275,9 @@ export function listVerifiedFactTriageItems(
   ).toISOString();
   const policy = opts.policy ?? "classify";
   const cursor = opts.cursor?.cursor ?? null;
-  const cursorItemId = opts.cursor ? findVerifiedCursorItemId(db, opts.cursor.inputHash, policy, nowIso, cursor, cutoffIso) : null;
+  const cursorItemId = opts.cursor
+    ? findVerifiedCursorItemId(db, opts.cursor.inputHash, policy, nowIso, cursor, cutoffIso)
+    : null;
   const latestRows = db
     .prepare(
       `SELECT vf.*
@@ -302,7 +304,15 @@ export function listVerifiedFactTriageItems(
     .map((row) => triageItemFromRow(db, row, { nowIso, policy }));
 }
 
-function findVerifiedCursorItemId(db: DatabaseSync, inputHash: string, policy: VerifiedTriagePolicy, nowIso: string, cursor: string, cutoffIso: string): string | null {
+function findVerifiedCursorItemId(
+  db: DatabaseSync,
+  inputHash: string,
+  policy: VerifiedTriagePolicy,
+  nowIso: string,
+  cursor: string | null,
+  cutoffIso: string,
+): string | null {
+  if (!cursor) return null;
   const rows = db
     .prepare(
       `SELECT vf.*
@@ -320,11 +330,16 @@ function findVerifiedCursorItemId(db: DatabaseSync, inputHash: string, policy: V
     .all(nowIso, cutoffIso, cursor) as unknown as VerifiedFactRow[];
   for (const row of rows) {
     if (!isVerifiedRowChecksumValid(row)) continue;
-    const item = triageItemFromRow(db, row, {
-      nowIso,
-      policy,
-    });
+    const item = triageItemFromRow(db, row, { nowIso, policy });
     if (item.inputHash === inputHash) return row.id;
+    if (row.next_verification && row.verified_at <= cutoffIso) {
+      const staleContextItem = triageItemFromRow(db, row, {
+        nowIso,
+        policy,
+        dueReason: "verified_at_stale",
+      });
+      if (staleContextItem.inputHash === inputHash) return row.id;
+    }
   }
   return null;
 }
@@ -963,7 +978,7 @@ function rowToVerifiedFact(row: VerifiedFactRow): VerifiedFact {
 function triageItemFromRow(
   db: DatabaseSync,
   row: VerifiedFactRow,
-  opts: { nowIso: string; policy: VerifiedTriagePolicy },
+  opts: { nowIso: string; policy: VerifiedTriagePolicy; dueReason?: VerifiedFactTriagePayload["dueReason"] },
 ): VerifiedFactTriageItem {
   const verified = rowToVerifiedFact(row);
   const fact = loadFactSnapshot(db, verified.factId);
@@ -974,7 +989,10 @@ function triageItemFromRow(
     verificationTier: fact?.tier ?? null,
     reviewCursor: verified.nextVerification ?? verified.verifiedAt,
     dueReason:
-      verified.nextVerification && verified.nextVerification <= opts.nowIso ? "next_verification" : "verified_at_stale",
+      opts.dueReason ??
+      (verified.nextVerification && verified.nextVerification <= opts.nowIso
+        ? "next_verification"
+        : "verified_at_stale"),
   };
   const inputHash = computePendingInputHash({
     queue: "verified",

--- a/extensions/memory-hybrid/services/verified-fact-triage.ts
+++ b/extensions/memory-hybrid/services/verified-fact-triage.ts
@@ -16,7 +16,12 @@ import {
   type PendingItem,
   type PendingQueueAdapter,
 } from "./pending-autopilot/index.js";
-import { computeChecksum, type VerifiedFact } from "./verification-store.js";
+import {
+  computeChecksum,
+  rowToVerifiedFact,
+  type VerifiedFact,
+  type VerifiedFactRow,
+} from "./verification-store.js";
 
 export const VERIFIED_TRIAGE_POLICY_VERSION = "verified-fact-triage-v1";
 const DEFAULT_REVERIFICATION_DAYS = 30;
@@ -960,21 +965,6 @@ function buildRunResult(input: {
   };
 }
 
-function rowToVerifiedFact(row: VerifiedFactRow): VerifiedFact {
-  return {
-    id: row.id,
-    factId: row.fact_id,
-    canonicalText: row.canonical_text,
-    checksum: row.checksum,
-    verifiedAt: row.verified_at,
-    verifiedBy: row.verified_by as VerifiedFact["verifiedBy"],
-    nextVerification: row.next_verification,
-    version: row.version,
-    previousVersionId: row.previous_version_id,
-    createdAt: row.created_at,
-  };
-}
-
 function triageItemFromRow(
   db: DatabaseSync,
   row: VerifiedFactRow,
@@ -1052,19 +1042,6 @@ function registerVerifiedChecksumFunction(db: DatabaseSync): void {
     typeof text === "string" ? computeChecksum(text) : "",
   );
   registeredChecksumDbs.add(db);
-}
-
-interface VerifiedFactRow {
-  id: string;
-  fact_id: string;
-  canonical_text: string;
-  checksum: string;
-  verified_at: string;
-  verified_by: string;
-  next_verification: string | null;
-  version: number;
-  previous_version_id: string | null;
-  created_at: string;
 }
 
 function loadFactSnapshot(db: DatabaseSync, factId: string): TriageFactSnapshot | null {

--- a/extensions/memory-hybrid/services/verified-fact-triage.ts
+++ b/extensions/memory-hybrid/services/verified-fact-triage.ts
@@ -20,6 +20,10 @@ import { computeChecksum, rowToVerifiedFact, type VerifiedFact, type VerifiedFac
 
 export const VERIFIED_TRIAGE_POLICY_VERSION = "verified-fact-triage-v1";
 const DEFAULT_REVERIFICATION_DAYS = 30;
+const DEFAULT_TRIAGE_MAX = 100;
+const MIN_VERIFIED_TRIAGE_SQL_LIMIT = 25;
+const MAX_VERIFIED_TRIAGE_SQL_LIMIT = 1000;
+const VERIFIED_TRIAGE_SQL_OVERFETCH_FACTOR = 4;
 export const VERIFIED_REVIEW_QUEUE_SOURCE =
   "Latest verified_facts rows whose next_verification timestamp is due (or whose verified_at is older than the verification window), as returned by VerificationStore.listDueForReverification semantics. This is intentionally not all verified facts.";
 
@@ -278,30 +282,94 @@ export function listVerifiedFactTriageItems(
   const cursorItemId = opts.cursor
     ? findVerifiedCursorItemId(db, opts.cursor.inputHash, policy, nowIso, cursor, cutoffIso)
     : null;
-  const latestRows = db
-    .prepare(
-      `SELECT vf.*
-       FROM verified_facts vf
-       JOIN (
-         SELECT vf2.fact_id, MAX(vf2.version) AS max_version
-         FROM verified_facts vf2
-         GROUP BY vf2.fact_id
-       ) latest ON vf.fact_id = latest.fact_id AND vf.version = latest.max_version
-       WHERE ((vf.next_verification IS NOT NULL AND vf.next_verification <= ?)
-          OR vf.verified_at <= ?)
-         AND (
-           ? IS NULL
-           OR COALESCE(vf.next_verification, vf.verified_at) > ?
-           OR (COALESCE(vf.next_verification, vf.verified_at) = ? AND (? IS NULL OR vf.id > ?))
-         )
-       ORDER BY COALESCE(vf.next_verification, vf.verified_at) ASC, vf.id ASC`,
-    )
-    .all(nowIso, cutoffIso, cursor, cursor, cursor, cursorItemId, cursorItemId) as unknown as VerifiedFactRow[];
+  const max = normalizeVerifiedTriageMax(opts.max);
+  const latestRows = listChecksumValidDueVerifiedRows(db, {
+    nowIso,
+    cutoffIso,
+    cursor,
+    cursorItemId,
+    max,
+  });
 
-  return latestRows
-    .filter(isVerifiedRowChecksumValid)
-    .slice(0, opts.max ?? 100)
-    .map((row) => triageItemFromRow(db, row, { nowIso, policy }));
+  return latestRows.map((row) => triageItemFromRow(db, row, { nowIso, policy }));
+}
+
+function normalizeVerifiedTriageMax(max: number | undefined): number {
+  if (max == null) return DEFAULT_TRIAGE_MAX;
+  if (!Number.isFinite(max) || max <= 0) return 0;
+  return Math.floor(max);
+}
+
+function verifiedTriageSqlLimit(max: number): number {
+  if (max <= 0) return MIN_VERIFIED_TRIAGE_SQL_LIMIT;
+  return Math.min(
+    MAX_VERIFIED_TRIAGE_SQL_LIMIT,
+    Math.max(MIN_VERIFIED_TRIAGE_SQL_LIMIT, max * VERIFIED_TRIAGE_SQL_OVERFETCH_FACTOR),
+  );
+}
+
+function listChecksumValidDueVerifiedRows(
+  db: DatabaseSync,
+  opts: {
+    nowIso: string;
+    cutoffIso: string;
+    cursor: string | null;
+    cursorItemId: string | null;
+    max: number;
+  },
+): VerifiedFactRow[] {
+  if (opts.max <= 0) return [];
+
+  const rows: VerifiedFactRow[] = [];
+  const sqlLimit = verifiedTriageSqlLimit(opts.max);
+  let pageCursor = opts.cursor;
+  let pageCursorItemId = opts.cursorItemId;
+
+  while (rows.length < opts.max) {
+    const page = db
+      .prepare(
+        `SELECT vf.*
+         FROM verified_facts vf
+         JOIN (
+           SELECT vf2.fact_id, MAX(vf2.version) AS max_version
+           FROM verified_facts vf2
+           GROUP BY vf2.fact_id
+         ) latest ON vf.fact_id = latest.fact_id AND vf.version = latest.max_version
+         WHERE ((vf.next_verification IS NOT NULL AND vf.next_verification <= ?)
+            OR vf.verified_at <= ?)
+           AND (
+             ? IS NULL
+             OR COALESCE(vf.next_verification, vf.verified_at) > ?
+             OR (COALESCE(vf.next_verification, vf.verified_at) = ? AND (? IS NULL OR vf.id > ?))
+           )
+         ORDER BY COALESCE(vf.next_verification, vf.verified_at) ASC, vf.id ASC
+         LIMIT ?`,
+      )
+      .all(
+        opts.nowIso,
+        opts.cutoffIso,
+        pageCursor,
+        pageCursor,
+        pageCursor,
+        pageCursorItemId,
+        pageCursorItemId,
+        sqlLimit,
+      ) as unknown as VerifiedFactRow[];
+
+    if (page.length === 0) break;
+
+    for (const row of page) {
+      if (isVerifiedRowChecksumValid(row)) rows.push(row);
+      if (rows.length >= opts.max) break;
+    }
+
+    const last = page[page.length - 1];
+    pageCursor = last?.next_verification ?? last?.verified_at ?? pageCursor;
+    pageCursorItemId = last?.id ?? pageCursorItemId;
+    if (page.length < sqlLimit) break;
+  }
+
+  return rows;
 }
 
 function findVerifiedCursorItemId(
@@ -384,6 +452,11 @@ export async function runVerifiedFactTriageWithAdapter(
   const policy = assertVerifiedTriagePolicy(opts.policy);
   const mode = opts.mode;
   const store = opts.store ?? null;
+  if (mode === "apply" && policy !== "report-only" && !store) {
+    throw new Error(
+      `Verified fact triage apply mode with policy '${policy}' requires a PendingAutopilotStore to persist durable review metadata`,
+    );
+  }
   const runId = opts.runId ?? createPendingAutopilotRunId();
   const actor = opts.actor ?? { type: "agent", id: "verified-triage-cli" };
   const storedCursor =

--- a/extensions/memory-hybrid/services/verified-fact-triage.ts
+++ b/extensions/memory-hybrid/services/verified-fact-triage.ts
@@ -4,288 +4,271 @@ import type { FactsDB } from "../backends/facts-db.js";
 import { rowToMemoryEntry } from "../backends/facts-db/index.js";
 import type { MemoryEntry } from "../types/memory.js";
 import {
-	computePendingInputHash,
-	createPendingAutopilotRunId,
-	createStableRunSummary,
-	type PendingAutopilotStore,
-	type AutopilotAction,
-	type AutopilotReasonCode,
-	type PendingDecision,
-	type PendingDecisionContext,
-	type PendingDecisionEvidence,
-	type PendingItem,
-	type PendingQueueAdapter,
+  computePendingInputHash,
+  createPendingAutopilotRunId,
+  createStableRunSummary,
+  type PendingAutopilotStore,
+  type AutopilotAction,
+  type AutopilotReasonCode,
+  type PendingDecision,
+  type PendingDecisionContext,
+  type PendingDecisionEvidence,
+  type PendingItem,
+  type PendingQueueAdapter,
 } from "./pending-autopilot/index.js";
 import type { VerifiedFact } from "./verification-store.js";
 
 export const VERIFIED_TRIAGE_POLICY_VERSION = "verified-fact-triage-v1";
 export const VERIFIED_REVIEW_QUEUE_SOURCE =
-	"Latest verified_facts rows whose next_verification timestamp is due (or whose verified_at is older than the verification window), as returned by VerificationStore.listDueForReverification semantics. This is intentionally not all verified facts.";
+  "Latest verified_facts rows whose next_verification timestamp is due (or whose verified_at is older than the verification window), as returned by VerificationStore.listDueForReverification semantics. This is intentionally not all verified facts.";
 
-export const VERIFIED_TRIAGE_POLICIES = [
-	"report-only",
-	"classify",
-	"apply-obvious",
-] as const;
+export const VERIFIED_TRIAGE_POLICIES = ["report-only", "classify", "apply-obvious"] as const;
 export type VerifiedTriagePolicy = (typeof VERIFIED_TRIAGE_POLICIES)[number];
 
 export const VERIFIED_TRIAGE_BUCKETS = [
-	"still-current",
-	"stale-candidate",
-	"expired-ttl-candidate",
-	"superseded-candidate",
-	"contradicted-candidate",
-	"missing-or-weak-provenance",
-	"duplicate-candidate",
-	"scope-or-ownership-unclear",
-	"sensitive-needs-human",
-	"needs-human-review",
-	"failed-review",
+  "still-current",
+  "stale-candidate",
+  "expired-ttl-candidate",
+  "superseded-candidate",
+  "contradicted-candidate",
+  "missing-or-weak-provenance",
+  "duplicate-candidate",
+  "scope-or-ownership-unclear",
+  "sensitive-needs-human",
+  "needs-human-review",
+  "failed-review",
 ] as const;
 export type VerifiedTriageBucket = (typeof VERIFIED_TRIAGE_BUCKETS)[number];
 
 export const VERIFIED_TRIAGE_ACTIONS = [
-	"reported",
-	"classified",
-	"marked-reviewed",
-	"linked-evidence",
-	"flagged-stale",
-	"flagged-superseded",
-	"flagged-contradicted",
-	"flagged-sensitive",
-	"deferred-for-human",
-	"failed-validation",
-	"skipped-by-policy",
+  "reported",
+  "classified",
+  "marked-reviewed",
+  "linked-evidence",
+  "flagged-stale",
+  "flagged-superseded",
+  "flagged-contradicted",
+  "flagged-sensitive",
+  "deferred-for-human",
+  "failed-validation",
+  "skipped-by-policy",
 ] as const;
 export type VerifiedTriageAction = (typeof VERIFIED_TRIAGE_ACTIONS)[number];
 
 export type VerifiedTriageReason =
-	| "policy_report_only"
-	| "still_current_no_action_needed"
-	| "ttl_expired"
-	| "newer_verified_fact_exists"
-	| "contradicting_verified_fact_exists"
-	| "weak_or_missing_provenance"
-	| "duplicate_verified_fact_candidate"
-	| "sensitive_security_fact"
-	| "sensitive_privacy_fact"
-	| "sensitive_personal_fact"
-	| "sensitive_operational_runbook"
-	| "scope_unclear"
-	| "requires_human_approval"
-	| "stale_due_for_reverification"
-	| "low_confidence"
-	| "backend_error"
-	| "malformed_fact"
-	| "evidence_query_failed";
+  | "policy_report_only"
+  | "still_current_no_action_needed"
+  | "ttl_expired"
+  | "newer_verified_fact_exists"
+  | "contradicting_verified_fact_exists"
+  | "weak_or_missing_provenance"
+  | "duplicate_verified_fact_candidate"
+  | "sensitive_security_fact"
+  | "sensitive_privacy_fact"
+  | "sensitive_personal_fact"
+  | "sensitive_operational_runbook"
+  | "scope_unclear"
+  | "requires_human_approval"
+  | "stale_due_for_reverification"
+  | "low_confidence"
+  | "backend_error"
+  | "malformed_fact"
+  | "evidence_query_failed";
 
-export interface VerifiedFactTriageItem
-	extends PendingItem<VerifiedFactTriagePayload> {
-	queue: "verified";
+export interface VerifiedFactTriageItem extends PendingItem<VerifiedFactTriagePayload> {
+  queue: "verified";
 }
 
 export interface VerifiedFactTriagePayload extends Record<string, unknown> {
-	reviewQueueSource: string;
-	verified: VerifiedFact;
-	fact: TriageFactSnapshot | null;
-	verificationTier: string | null;
-	reviewCursor: string | null;
-	dueReason: "next_verification" | "verified_at_stale";
+  reviewQueueSource: string;
+  verified: VerifiedFact;
+  fact: TriageFactSnapshot | null;
+  verificationTier: string | null;
+  reviewCursor: string | null;
+  dueReason: "next_verification" | "verified_at_stale";
 }
 
 export interface TriageFactSnapshot {
-	id: string;
-	text: string;
-	category: string;
-	entity: string | null;
-	key: string | null;
-	value: string | null;
-	source: string;
-	createdAt: number;
-	expiresAt: number | null;
-	validFrom: number | null;
-	validUntil: number | null;
-	supersedesId: string | null;
-	supersededAt: number | null;
-	supersededBy: string | null;
-	tier: string | null;
-	scope: string;
-	scopeTarget: string | null;
-	provenanceSession: string | null;
-	sourceSessions: string | null;
-	provenanceJson: string | null;
-	tags: string[] | null;
-	confidence: number;
+  id: string;
+  text: string;
+  category: string;
+  entity: string | null;
+  key: string | null;
+  value: string | null;
+  source: string;
+  createdAt: number;
+  expiresAt: number | null;
+  validFrom: number | null;
+  validUntil: number | null;
+  supersedesId: string | null;
+  supersededAt: number | null;
+  supersededBy: string | null;
+  tier: string | null;
+  scope: string;
+  scopeTarget: string | null;
+  provenanceSession: string | null;
+  sourceSessions: string | null;
+  provenanceJson: string | null;
+  tags: string[] | null;
+  confidence: number;
 }
 
 export interface VerifiedTriageEvidence extends PendingDecisionEvidence {
-	fields?: Record<string, unknown>;
+  fields?: Record<string, unknown>;
 }
 
 export interface VerifiedTriageResultItem {
-	factId: string;
-	verifiedFactId: string;
-	text: string;
-	verificationTier: string | null;
-	scope: string | null;
-	scopeTarget: string | null;
-	entity: string | null;
-	key: string | null;
-	validFrom: number | null;
-	validUntil: number | null;
-	expiresAt: number | null;
-	provenanceSummary: string;
-	bucket: VerifiedTriageBucket;
-	recommendedAction: VerifiedTriageAction;
-	confidence: number;
-	evidence: VerifiedTriageEvidence[];
-	sensitivityFlags: string[];
-	reason: VerifiedTriageReason;
-	humanReviewRequired: boolean;
-	action: AutopilotAction;
-	reasonCode: AutopilotReasonCode;
-	capabilityClass: PendingDecision["capabilityClass"];
-	actionClass: PendingDecision["actionClass"];
-	inputHash: string;
-	applied: boolean;
+  factId: string;
+  verifiedFactId: string;
+  text: string;
+  verificationTier: string | null;
+  scope: string | null;
+  scopeTarget: string | null;
+  entity: string | null;
+  key: string | null;
+  validFrom: number | null;
+  validUntil: number | null;
+  expiresAt: number | null;
+  provenanceSummary: string;
+  bucket: VerifiedTriageBucket;
+  recommendedAction: VerifiedTriageAction;
+  confidence: number;
+  evidence: VerifiedTriageEvidence[];
+  sensitivityFlags: string[];
+  reason: VerifiedTriageReason;
+  humanReviewRequired: boolean;
+  action: AutopilotAction;
+  reasonCode: AutopilotReasonCode;
+  capabilityClass: PendingDecision["capabilityClass"];
+  actionClass: PendingDecision["actionClass"];
+  inputHash: string;
+  applied: boolean;
 }
 
 export interface VerifiedTriageRunResult {
-	runId: string;
-	mode: "dry-run" | "apply";
-	policy: VerifiedTriagePolicy;
-	policyVersion: string;
-	reviewQueueSource: string;
-	counts: {
-		inspected: number;
-		classified: number;
-		stillCurrent: number;
-		staleCandidates: number;
-		expiredTtlCandidates: number;
-		supersededCandidates: number;
-		contradictedCandidates: number;
-		duplicateCandidates: number;
-		sensitiveNeedsHuman: number;
-		needsHuman: number;
-		applied: number;
-		failed: number;
-	};
-	items: VerifiedTriageResultItem[];
+  runId: string;
+  mode: "dry-run" | "apply";
+  policy: VerifiedTriagePolicy;
+  policyVersion: string;
+  reviewQueueSource: string;
+  counts: {
+    inspected: number;
+    classified: number;
+    stillCurrent: number;
+    staleCandidates: number;
+    expiredTtlCandidates: number;
+    supersededCandidates: number;
+    contradictedCandidates: number;
+    duplicateCandidates: number;
+    sensitiveNeedsHuman: number;
+    needsHuman: number;
+    applied: number;
+    failed: number;
+  };
+  items: VerifiedTriageResultItem[];
 }
 
 export interface VerifiedFactTriageOptions {
-	mode: "dry-run" | "apply";
-	policy: VerifiedTriagePolicy;
-	max?: number;
-	actor?: PendingDecision["actor"];
-	jobId?: string;
-	runId?: string;
-	store?: PendingAutopilotStore | null;
-	nowMs?: number;
-	lockTtlSeconds?: number;
+  mode: "dry-run" | "apply";
+  policy: VerifiedTriagePolicy;
+  max?: number;
+  actor?: PendingDecision["actor"];
+  jobId?: string;
+  runId?: string;
+  store?: PendingAutopilotStore | null;
+  nowMs?: number;
+  lockTtlSeconds?: number;
 }
 
 interface RelatedFact extends TriageFactSnapshot {
-	verifiedFactId?: string | null;
-	verifiedAt?: string | null;
-	verifiedVersion?: number | null;
+  verifiedFactId?: string | null;
+  verifiedAt?: string | null;
+  verifiedVersion?: number | null;
 }
 
 const SENSITIVE_RULES: Array<{
-	flag: string;
-	reason: VerifiedTriageReason;
-	pattern: RegExp;
+  flag: string;
+  reason: VerifiedTriageReason;
+  pattern: RegExp;
 }> = [
-	{
-		flag: "credentials",
-		reason: "sensitive_security_fact",
-		pattern:
-			/\b(password|passwd|credential|secret|api[-_ ]?key|token|bearer|ssh key|private key|vault|oauth|pat_)\b/i,
-	},
-	{
-		flag: "security",
-		reason: "sensitive_security_fact",
-		pattern:
-			/\b(security|firewall|ssh|vpn|runbook|incident|breach|auth|mfa|2fa|permission|admin)\b/i,
-	},
-	{
-		flag: "privacy",
-		reason: "sensitive_privacy_fact",
-		pattern:
-			/\b(privacy|private|personal data|pii|gdpr|address|phone|email|medical|health|passport|identity)\b/i,
-	},
-	{
-		flag: "external-comms",
-		reason: "sensitive_personal_fact",
-		pattern:
-			/\b(external comms|external communication|email rule|reply rule|send to|contact\b|customer|client)\b/i,
-	},
-	{
-		flag: "persona-preference",
-		reason: "sensitive_personal_fact",
-		pattern:
-			/\b(preference|user identity|persona|edict|hard rule|user profile|personal fact)\b/i,
-	},
-	{
-		flag: "operational-runbook",
-		reason: "sensitive_operational_runbook",
-		pattern:
-			/\b(cron|runbook|operational|ops|production|deploy|restart|backup|restore)\b/i,
-	},
+  {
+    flag: "credentials",
+    reason: "sensitive_security_fact",
+    pattern: /\b(password|passwd|credential|secret|api[-_ ]?key|token|bearer|ssh key|private key|vault|oauth|pat_)\b/i,
+  },
+  {
+    flag: "security",
+    reason: "sensitive_security_fact",
+    pattern: /\b(security|firewall|ssh|vpn|runbook|incident|breach|auth|mfa|2fa|permission|admin)\b/i,
+  },
+  {
+    flag: "privacy",
+    reason: "sensitive_privacy_fact",
+    pattern: /\b(privacy|private|personal data|pii|gdpr|address|phone|email|medical|health|passport|identity)\b/i,
+  },
+  {
+    flag: "external-comms",
+    reason: "sensitive_personal_fact",
+    pattern: /\b(external comms|external communication|email rule|reply rule|send to|contact\b|customer|client)\b/i,
+  },
+  {
+    flag: "persona-preference",
+    reason: "sensitive_personal_fact",
+    pattern: /\b(preference|user identity|persona|edict|hard rule|user profile|personal fact)\b/i,
+  },
+  {
+    flag: "operational-runbook",
+    reason: "sensitive_operational_runbook",
+    pattern: /\b(cron|runbook|operational|ops|production|deploy|restart|backup|restore)\b/i,
+  },
 ];
 
-export function assertVerifiedTriagePolicy(
-	value: string,
-): VerifiedTriagePolicy {
-	if ((VERIFIED_TRIAGE_POLICIES as readonly string[]).includes(value))
-		return value as VerifiedTriagePolicy;
-	throw new Error(`Unknown verified triage policy: ${value}`);
+export function assertVerifiedTriagePolicy(value: string): VerifiedTriagePolicy {
+  if ((VERIFIED_TRIAGE_POLICIES as readonly string[]).includes(value)) return value as VerifiedTriagePolicy;
+  throw new Error(`Unknown verified triage policy: ${value}`);
 }
 
 export function createVerifiedFactTriageAdapter(input: {
-	factsDb: Pick<FactsDB, "getRawDb">;
-	max?: number;
-	nowMs?: number;
-	reverificationDays?: number;
-	policy?: VerifiedTriagePolicy;
+  factsDb: Pick<FactsDB, "getRawDb">;
+  max?: number;
+  nowMs?: number;
+  reverificationDays?: number;
+  policy?: VerifiedTriagePolicy;
 }): PendingQueueAdapter<VerifiedFactTriageItem> {
-	const db = input.factsDb.getRawDb();
-	return {
-		queue: "verified",
-		listPending: () =>
-			listVerifiedFactTriageItems(db, {
-				max: input.max,
-				nowMs: input.nowMs,
-				reverificationDays: input.reverificationDays,
-				policy: input.policy,
-			}),
-		decide: (item, context) =>
-			decideVerifiedFactTriage(item, context, { db, nowMs: input.nowMs }),
-		apply: (_decision, _item) => {
-			// Verified fact triage intentionally does not mutate core truth fields. Durable
-			// state is recorded through PendingAutopilotStore decisions only.
-		},
-	};
+  const db = input.factsDb.getRawDb();
+  return {
+    queue: "verified",
+    listPending: () =>
+      listVerifiedFactTriageItems(db, {
+        max: input.max,
+        nowMs: input.nowMs,
+        reverificationDays: input.reverificationDays,
+        policy: input.policy,
+      }),
+    decide: (item, context) => decideVerifiedFactTriage(item, context, { db, nowMs: input.nowMs }),
+    apply: (_decision, _item) => {
+      // Verified fact triage intentionally does not mutate core truth fields. Durable
+      // state is recorded through PendingAutopilotStore decisions only.
+    },
+  };
 }
 
 export function listVerifiedFactTriageItems(
-	db: DatabaseSync,
-	opts: {
-		max?: number;
-		nowMs?: number;
-		reverificationDays?: number;
-		policy?: VerifiedTriagePolicy;
-	} = {},
+  db: DatabaseSync,
+  opts: {
+    max?: number;
+    nowMs?: number;
+    reverificationDays?: number;
+    policy?: VerifiedTriagePolicy;
+  } = {},
 ): VerifiedFactTriageItem[] {
-	const nowMs = opts.nowMs ?? Date.now();
-	const nowIso = new Date(nowMs).toISOString();
-	const cutoffIso = new Date(
-		nowMs - (opts.reverificationDays ?? 30) * 24 * 60 * 60 * 1000,
-	).toISOString();
-	const policy = opts.policy ?? "classify";
-	const latestRows = db
-		.prepare(
-			`SELECT vf.*
+  const nowMs = opts.nowMs ?? Date.now();
+  const nowIso = new Date(nowMs).toISOString();
+  const cutoffIso = new Date(nowMs - (opts.reverificationDays ?? 30) * 24 * 60 * 60 * 1000).toISOString();
+  const policy = opts.policy ?? "classify";
+  const latestRows = db
+    .prepare(
+      `SELECT vf.*
        FROM verified_facts vf
        JOIN (
          SELECT vf2.fact_id, MAX(vf2.version) AS max_version
@@ -298,872 +281,778 @@ export function listVerifiedFactTriageItems(
           OR vf.verified_at <= ?
        ORDER BY COALESCE(vf.next_verification, vf.verified_at) ASC, vf.verified_at ASC
        LIMIT ?`,
-		)
-		.all(nowIso, cutoffIso, opts.max ?? 100) as unknown as VerifiedFactRow[];
+    )
+    .all(nowIso, cutoffIso, opts.max ?? 100) as unknown as VerifiedFactRow[];
 
-	return latestRows.filter(isVerifiedRowChecksumValid).map((row) => {
-		const verified = rowToVerifiedFact(row);
-		const fact = loadFactSnapshot(db, verified.factId);
-		const payload: VerifiedFactTriagePayload = {
-			reviewQueueSource: VERIFIED_REVIEW_QUEUE_SOURCE,
-			verified,
-			fact,
-			verificationTier: fact?.tier ?? null,
-			reviewCursor: verified.nextVerification ?? verified.verifiedAt,
-			dueReason:
-				verified.nextVerification && verified.nextVerification <= nowIso
-					? "next_verification"
-					: "verified_at_stale",
-		};
-		const inputHash = computePendingInputHash({
-			queue: "verified",
-			id: verified.id,
-			payload,
-			policy,
-			policyVersion: VERIFIED_TRIAGE_POLICY_VERSION,
-		});
-		return {
-			queue: "verified",
-			id: verified.id,
-			inputHash,
-			policyVersion: VERIFIED_TRIAGE_POLICY_VERSION,
-			capabilityClasses: ["read-only", "record-review-metadata"],
-			payload,
-			visibleAfterCursor: verified.nextVerification ?? verified.verifiedAt,
-			requiresHumanReview: false,
-			validationFailed: !fact,
-		} satisfies VerifiedFactTriageItem;
-	});
+  return latestRows.filter(isVerifiedRowChecksumValid).map((row) => {
+    const verified = rowToVerifiedFact(row);
+    const fact = loadFactSnapshot(db, verified.factId);
+    const payload: VerifiedFactTriagePayload = {
+      reviewQueueSource: VERIFIED_REVIEW_QUEUE_SOURCE,
+      verified,
+      fact,
+      verificationTier: fact?.tier ?? null,
+      reviewCursor: verified.nextVerification ?? verified.verifiedAt,
+      dueReason:
+        verified.nextVerification && verified.nextVerification <= nowIso ? "next_verification" : "verified_at_stale",
+    };
+    const inputHash = computePendingInputHash({
+      queue: "verified",
+      id: verified.id,
+      payload,
+      policy,
+      policyVersion: VERIFIED_TRIAGE_POLICY_VERSION,
+    });
+    return {
+      queue: "verified",
+      id: verified.id,
+      inputHash,
+      policyVersion: VERIFIED_TRIAGE_POLICY_VERSION,
+      capabilityClasses: ["read-only", "record-review-metadata"],
+      payload,
+      visibleAfterCursor: verified.nextVerification ?? verified.verifiedAt,
+      requiresHumanReview: false,
+      validationFailed: !fact,
+    } satisfies VerifiedFactTriageItem;
+  });
 }
 
 function isVerifiedRowChecksumValid(row: VerifiedFactRow): boolean {
-	return computeChecksum(row.canonical_text) === row.checksum;
+  return computeChecksum(row.canonical_text) === row.checksum;
 }
 
 function computeChecksum(text: string): string {
-	return createHash("sha256").update(text).digest("hex");
+  return createHash("sha256").update(text).digest("hex");
 }
 
 export function decideVerifiedFactTriage(
-	item: VerifiedFactTriageItem,
-	context: PendingDecisionContext,
-	opts: { db?: DatabaseSync; nowMs?: number } = {},
+  item: VerifiedFactTriageItem,
+  context: PendingDecisionContext,
+  opts: { db?: DatabaseSync; nowMs?: number } = {},
 ): PendingDecision {
-	const triage = classifyVerifiedFact(item, {
-		db: opts.db,
-		nowMs: opts.nowMs,
-		policy: context.policy,
-	});
-	return triageToPendingDecision(item, context, triage);
+  const triage = classifyVerifiedFact(item, {
+    db: opts.db,
+    nowMs: opts.nowMs,
+    policy: context.policy,
+  });
+  return triageToPendingDecision(item, context, triage);
 }
 
 export async function runVerifiedFactTriage(
-	factsDb: Pick<FactsDB, "getRawDb">,
-	opts: VerifiedFactTriageOptions,
+  factsDb: Pick<FactsDB, "getRawDb">,
+  opts: VerifiedFactTriageOptions,
 ): Promise<VerifiedTriageRunResult> {
-	const policy = assertVerifiedTriagePolicy(opts.policy);
-	const mode = opts.mode;
-	const store = opts.store ?? null;
-	const runId = opts.runId ?? createPendingAutopilotRunId();
-	const actor = opts.actor ?? { type: "agent", id: "verified-triage-cli" };
-	const adapter = createVerifiedFactTriageAdapter({
-		factsDb,
-		max: opts.max,
-		nowMs: opts.nowMs,
-		policy,
-	});
-	return runVerifiedFactTriageWithAdapter(factsDb, adapter, opts);
+  const policy = assertVerifiedTriagePolicy(opts.policy);
+  const mode = opts.mode;
+  const store = opts.store ?? null;
+  const runId = opts.runId ?? createPendingAutopilotRunId();
+  const actor = opts.actor ?? { type: "agent", id: "verified-triage-cli" };
+  const adapter = createVerifiedFactTriageAdapter({
+    factsDb,
+    max: opts.max,
+    nowMs: opts.nowMs,
+    policy,
+  });
+  return runVerifiedFactTriageWithAdapter(factsDb, adapter, opts);
 }
 
 export async function runVerifiedFactTriageWithAdapter(
-	factsDb: Pick<FactsDB, "getRawDb">,
-	adapter: PendingQueueAdapter<VerifiedFactTriageItem>,
-	opts: VerifiedFactTriageOptions,
+  factsDb: Pick<FactsDB, "getRawDb">,
+  adapter: PendingQueueAdapter<VerifiedFactTriageItem>,
+  opts: VerifiedFactTriageOptions,
 ): Promise<VerifiedTriageRunResult> {
-	const policy = assertVerifiedTriagePolicy(opts.policy);
-	const mode = opts.mode;
-	const store = opts.store ?? null;
-	const runId = opts.runId ?? createPendingAutopilotRunId();
-	const actor = opts.actor ?? { type: "agent", id: "verified-triage-cli" };
-	const items = await adapter.listPending(null);
-	const runInputHash = computePendingInputHash({
-		queue: "verified",
-		itemIds: items.map((i) => i.id),
-		policy,
-		mode,
-	});
-	const startedAt = Math.floor((opts.nowMs ?? Date.now()) / 1000);
+  const policy = assertVerifiedTriagePolicy(opts.policy);
+  const mode = opts.mode;
+  const store = opts.store ?? null;
+  const runId = opts.runId ?? createPendingAutopilotRunId();
+  const actor = opts.actor ?? { type: "agent", id: "verified-triage-cli" };
+  const items = await adapter.listPending(null);
+  const runInputHash = computePendingInputHash({
+    queue: "verified",
+    itemIds: items.map((i) => i.id),
+    policy,
+    mode,
+  });
+  const startedAt = Math.floor((opts.nowMs ?? Date.now()) / 1000);
 
-	const durableStore = policy === "report-only" ? null : store;
+  const durableStore = policy === "report-only" ? null : store;
 
-	durableStore?.createRun({
-		runId,
-		mode,
-		policy,
-		policyVersion: VERIFIED_TRIAGE_POLICY_VERSION,
-		inputHash: runInputHash,
-		queues: ["verified"],
-		startedAt,
-	});
+  durableStore?.createRun({
+    runId,
+    mode,
+    policy,
+    policyVersion: VERIFIED_TRIAGE_POLICY_VERSION,
+    inputHash: runInputHash,
+    queues: ["verified"],
+    startedAt,
+  });
 
-	const decisions: PendingDecision[] = [];
-	const resultItems: VerifiedTriageResultItem[] = [];
-	for (const item of items) {
-		const context: PendingDecisionContext = {
-			runId,
-			jobId: opts.jobId,
-			mode,
-			policy,
-			policyVersion: VERIFIED_TRIAGE_POLICY_VERSION,
-			inputHash: item.inputHash,
-			actor,
-		};
-		const decision = await adapter.decide(item, context);
-		decisions.push(decision);
-		let applied = false;
-		if (mode === "apply" && policy !== "report-only") {
-			const locked =
-				durableStore?.acquireLock({
-					queue: "verified",
-					itemId: item.id,
-					inputHash: item.inputHash,
-					owner: actor.id,
-					ttlSeconds: opts.lockTtlSeconds ?? 60,
-					mode,
-				}) ?? false;
-			const liveItem = locked
-				? ((await adapter.listPending(null)).find(
-						(candidate) => candidate.id === item.id,
-					) ?? null)
-				: null;
-			const actualInputHash = liveItem?.inputHash ?? "missing";
-			if (locked && liveItem && actualInputHash === item.inputHash) {
-				const { inserted } = durableStore?.recordDecision(decision) ?? {
-					inserted: false,
-				};
-				if (
-					inserted &&
-					decision.action !== "deferred-for-human" &&
-					decision.action !== "failed-validation"
-				) {
-					durableStore?.advanceCursorIfSafe(
-						decision,
-						item.visibleAfterCursor ?? item.id,
-					);
-				}
-				applied =
-					inserted &&
-					(decision.action === "classified" || decision.action === "reported");
-			} else if (durableStore) {
-				const staleDecision = validationFailureDecision(
-					item,
-					context,
-					locked ? "input-hash-mismatch" : "lock-conflict",
-					liveItem
-						? "Verified fact/fact row changed between classification and apply."
-						: "Verified fact no longer matches due queue before apply.",
-				);
-				durableStore.recordDecision(staleDecision);
-				decisions[decisions.length - 1] = staleDecision;
-			}
-			durableStore?.releaseLock({
-				queue: "verified",
-				itemId: item.id,
-				inputHash: item.inputHash,
-				owner: actor.id,
-				mode,
-			});
-		}
-		resultItems.push(
-			decisionToResultItem(decisions[decisions.length - 1], item, applied),
-		);
-	}
+  const decisions: PendingDecision[] = [];
+  const resultItems: VerifiedTriageResultItem[] = [];
+  for (const item of items) {
+    const context: PendingDecisionContext = {
+      runId,
+      jobId: opts.jobId,
+      mode,
+      policy,
+      policyVersion: VERIFIED_TRIAGE_POLICY_VERSION,
+      inputHash: item.inputHash,
+      actor,
+    };
+    const decision = await adapter.decide(item, context);
+    decisions.push(decision);
+    let applied = false;
+    if (mode === "apply" && policy !== "report-only") {
+      const locked =
+        durableStore?.acquireLock({
+          queue: "verified",
+          itemId: item.id,
+          inputHash: item.inputHash,
+          owner: actor.id,
+          ttlSeconds: opts.lockTtlSeconds ?? 60,
+          mode,
+        }) ?? false;
+      const liveItem = locked
+        ? ((await adapter.listPending(null)).find((candidate) => candidate.id === item.id) ?? null)
+        : null;
+      const actualInputHash = liveItem?.inputHash ?? "missing";
+      if (locked && liveItem && actualInputHash === item.inputHash) {
+        const { inserted } = durableStore?.recordDecision(decision) ?? {
+          inserted: false,
+        };
+        if (inserted && decision.action !== "deferred-for-human" && decision.action !== "failed-validation") {
+          durableStore?.advanceCursorIfSafe(decision, item.visibleAfterCursor ?? item.id);
+        }
+        applied = inserted && (decision.action === "classified" || decision.action === "reported");
+      } else if (durableStore) {
+        const staleDecision = validationFailureDecision(
+          item,
+          context,
+          locked ? "input-hash-mismatch" : "lock-conflict",
+          liveItem
+            ? "Verified fact/fact row changed between classification and apply."
+            : "Verified fact no longer matches due queue before apply.",
+        );
+        durableStore.recordDecision(staleDecision);
+        decisions[decisions.length - 1] = staleDecision;
+      }
+      durableStore?.releaseLock({
+        queue: "verified",
+        itemId: item.id,
+        inputHash: item.inputHash,
+        owner: actor.id,
+        mode,
+      });
+    }
+    resultItems.push(decisionToResultItem(decisions[decisions.length - 1], item, applied));
+  }
 
-	const summary = createStableRunSummary({
-		runId,
-		mode,
-		policy,
-		policyVersion: VERIFIED_TRIAGE_POLICY_VERSION,
-		queues: ["verified"],
-		startedAt,
-		finishedAt: Math.floor((opts.nowMs ?? Date.now()) / 1000),
-		decisions,
-	});
-	durableStore?.finishRun(runId, summary, summary.finishedAt);
+  const summary = createStableRunSummary({
+    runId,
+    mode,
+    policy,
+    policyVersion: VERIFIED_TRIAGE_POLICY_VERSION,
+    queues: ["verified"],
+    startedAt,
+    finishedAt: Math.floor((opts.nowMs ?? Date.now()) / 1000),
+    decisions,
+  });
+  durableStore?.finishRun(runId, summary, summary.finishedAt);
 
-	return buildRunResult({ runId, mode, policy, items: resultItems });
+  return buildRunResult({ runId, mode, policy, items: resultItems });
 }
 
 export function classifyVerifiedFact(
-	item: VerifiedFactTriageItem,
-	opts: { db?: DatabaseSync; nowMs?: number; policy?: string } = {},
+  item: VerifiedFactTriageItem,
+  opts: { db?: DatabaseSync; nowMs?: number; policy?: string } = {},
 ): Omit<
-	VerifiedTriageResultItem,
-	| "factId"
-	| "verifiedFactId"
-	| "text"
-	| "verificationTier"
-	| "scope"
-	| "scopeTarget"
-	| "entity"
-	| "key"
-	| "validFrom"
-	| "validUntil"
-	| "expiresAt"
-	| "provenanceSummary"
-	| "action"
-	| "reasonCode"
-	| "capabilityClass"
-	| "actionClass"
-	| "inputHash"
-	| "applied"
+  VerifiedTriageResultItem,
+  | "factId"
+  | "verifiedFactId"
+  | "text"
+  | "verificationTier"
+  | "scope"
+  | "scopeTarget"
+  | "entity"
+  | "key"
+  | "validFrom"
+  | "validUntil"
+  | "expiresAt"
+  | "provenanceSummary"
+  | "action"
+  | "reasonCode"
+  | "capabilityClass"
+  | "actionClass"
+  | "inputHash"
+  | "applied"
 > {
-	const fact = item.payload.fact;
-	const nowSec = Math.floor((opts.nowMs ?? Date.now()) / 1000);
-	const nowIso = new Date(opts.nowMs ?? Date.now()).toISOString();
+  const fact = item.payload.fact;
+  const nowSec = Math.floor((opts.nowMs ?? Date.now()) / 1000);
+  const nowIso = new Date(opts.nowMs ?? Date.now()).toISOString();
 
-	if (!fact) {
-		return {
-			bucket: "failed-review",
-			recommendedAction: "failed-validation",
-			reason: "malformed_fact",
-			confidence: 1,
-			evidence: [
-				{
-					type: "verified-fact",
-					id: item.payload.verified.id,
-					summary: "Verified row references a missing fact row",
-				},
-			],
-			sensitivityFlags: [],
-			humanReviewRequired: true,
-		};
-	}
+  if (!fact) {
+    return {
+      bucket: "failed-review",
+      recommendedAction: "failed-validation",
+      reason: "malformed_fact",
+      confidence: 1,
+      evidence: [
+        {
+          type: "verified-fact",
+          id: item.payload.verified.id,
+          summary: "Verified row references a missing fact row",
+        },
+      ],
+      sensitivityFlags: [],
+      humanReviewRequired: true,
+    };
+  }
 
-	const sensitivity = detectSensitivity(
-		fact,
-		item.payload.verified.canonicalText,
-	);
-	if (sensitivity.flags.length > 0) {
-		return {
-			bucket: "sensitive-needs-human",
-			recommendedAction: "flagged-sensitive",
-			reason: sensitivity.reason,
-			confidence: 0.95,
-			evidence: [
-				{
-					type: "sensitivity",
-					id: fact.id,
-					summary: `Matched sensitive categories: ${sensitivity.flags.join(", ")}`,
-				},
-			],
-			sensitivityFlags: sensitivity.flags,
-			humanReviewRequired: true,
-		};
-	}
+  const sensitivity = detectSensitivity(fact, item.payload.verified.canonicalText);
+  if (sensitivity.flags.length > 0) {
+    return {
+      bucket: "sensitive-needs-human",
+      recommendedAction: "flagged-sensitive",
+      reason: sensitivity.reason,
+      confidence: 0.95,
+      evidence: [
+        {
+          type: "sensitivity",
+          id: fact.id,
+          summary: `Matched sensitive categories: ${sensitivity.flags.join(", ")}`,
+        },
+      ],
+      sensitivityFlags: sensitivity.flags,
+      humanReviewRequired: true,
+    };
+  }
 
-	if (hasScopeUnclearSignals(fact)) {
-		return {
-			bucket: "scope-or-ownership-unclear",
-			recommendedAction: "deferred-for-human",
-			reason: "scope_unclear",
-			confidence: 0.9,
-			evidence: [
-				{
-					type: "scope",
-					id: fact.id,
-					summary:
-						"Fact has session/agent/user scope requiring explicit ownership proof",
-				},
-			],
-			sensitivityFlags: [],
-			humanReviewRequired: true,
-		};
-	}
+  if (hasScopeUnclearSignals(fact)) {
+    return {
+      bucket: "scope-or-ownership-unclear",
+      recommendedAction: "deferred-for-human",
+      reason: "scope_unclear",
+      confidence: 0.9,
+      evidence: [
+        {
+          type: "scope",
+          id: fact.id,
+          summary: "Fact has session/agent/user scope requiring explicit ownership proof",
+        },
+      ],
+      sensitivityFlags: [],
+      humanReviewRequired: true,
+    };
+  }
 
-	if (fact.validUntil != null && fact.validUntil <= nowSec) {
-		return {
-			bucket: "expired-ttl-candidate",
-			recommendedAction: "deferred-for-human",
-			reason: "ttl_expired",
-			confidence: 0.95,
-			evidence: [
-				{
-					type: "validity",
-					id: fact.id,
-					summary: "Fact valid_until has expired",
-					fields: { validUntil: fact.validUntil, now: nowSec },
-				},
-			],
-			sensitivityFlags: [],
-			humanReviewRequired: true,
-		};
-	}
-	if (fact.expiresAt != null && fact.expiresAt <= nowSec) {
-		return {
-			bucket: "expired-ttl-candidate",
-			recommendedAction: "deferred-for-human",
-			reason: "ttl_expired",
-			confidence: 0.95,
-			evidence: [
-				{
-					type: "ttl",
-					id: fact.id,
-					summary: "Fact expires_at has expired",
-					fields: { expiresAt: fact.expiresAt, now: nowSec },
-				},
-			],
-			sensitivityFlags: [],
-			humanReviewRequired: true,
-		};
-	}
+  if (fact.validUntil != null && fact.validUntil <= nowSec) {
+    return {
+      bucket: "expired-ttl-candidate",
+      recommendedAction: "deferred-for-human",
+      reason: "ttl_expired",
+      confidence: 0.95,
+      evidence: [
+        {
+          type: "validity",
+          id: fact.id,
+          summary: "Fact valid_until has expired",
+          fields: { validUntil: fact.validUntil, now: nowSec },
+        },
+      ],
+      sensitivityFlags: [],
+      humanReviewRequired: true,
+    };
+  }
+  if (fact.expiresAt != null && fact.expiresAt <= nowSec) {
+    return {
+      bucket: "expired-ttl-candidate",
+      recommendedAction: "deferred-for-human",
+      reason: "ttl_expired",
+      confidence: 0.95,
+      evidence: [
+        {
+          type: "ttl",
+          id: fact.id,
+          summary: "Fact expires_at has expired",
+          fields: { expiresAt: fact.expiresAt, now: nowSec },
+        },
+      ],
+      sensitivityFlags: [],
+      humanReviewRequired: true,
+    };
+  }
 
-	const newer = opts.db ? findExplicitNewerVerifiedFact(opts.db, fact) : null;
-	if (newer) {
-		return {
-			bucket: "superseded-candidate",
-			recommendedAction: "flagged-superseded",
-			reason: "newer_verified_fact_exists",
-			confidence: 0.9,
-			evidence: [
-				{
-					type: "fact",
-					id: newer.id,
-					summary: "Explicit newer verified fact supersedes this fact",
-					fields: {
-						newerFactId: newer.id,
-						verifiedFactId: newer.verifiedFactId,
-					},
-				},
-			],
-			sensitivityFlags: [],
-			humanReviewRequired: true,
-		};
-	}
+  const newer = opts.db ? findExplicitNewerVerifiedFact(opts.db, fact) : null;
+  if (newer) {
+    return {
+      bucket: "superseded-candidate",
+      recommendedAction: "flagged-superseded",
+      reason: "newer_verified_fact_exists",
+      confidence: 0.9,
+      evidence: [
+        {
+          type: "fact",
+          id: newer.id,
+          summary: "Explicit newer verified fact supersedes this fact",
+          fields: {
+            newerFactId: newer.id,
+            verifiedFactId: newer.verifiedFactId,
+          },
+        },
+      ],
+      sensitivityFlags: [],
+      humanReviewRequired: true,
+    };
+  }
 
-	const contradiction = opts.db
-		? findConcreteContradictingEvidence(opts.db, fact)
-		: null;
-	if (contradiction) {
-		return {
-			bucket: "contradicted-candidate",
-			recommendedAction: "flagged-contradicted",
-			reason: "contradicting_verified_fact_exists",
-			confidence: 0.92,
-			evidence: [contradiction],
-			sensitivityFlags: [],
-			humanReviewRequired: true,
-		};
-	}
+  const contradiction = opts.db ? findConcreteContradictingEvidence(opts.db, fact) : null;
+  if (contradiction) {
+    return {
+      bucket: "contradicted-candidate",
+      recommendedAction: "flagged-contradicted",
+      reason: "contradicting_verified_fact_exists",
+      confidence: 0.92,
+      evidence: [contradiction],
+      sensitivityFlags: [],
+      humanReviewRequired: true,
+    };
+  }
 
-	const duplicate = opts.db
-		? findSameScopeDuplicateVerifiedFact(opts.db, fact)
-		: null;
-	if (duplicate) {
-		return {
-			bucket: "duplicate-candidate",
-			recommendedAction: "deferred-for-human",
-			reason: "duplicate_verified_fact_candidate",
-			confidence: 0.82,
-			evidence: [
-				{
-					type: "fact",
-					id: duplicate.id,
-					summary: "Same-scope verified fact has identical normalized text",
-					fields: { duplicateFactId: duplicate.id },
-				},
-			],
-			sensitivityFlags: [],
-			humanReviewRequired: true,
-		};
-	}
+  const duplicate = opts.db ? findSameScopeDuplicateVerifiedFact(opts.db, fact) : null;
+  if (duplicate) {
+    return {
+      bucket: "duplicate-candidate",
+      recommendedAction: "deferred-for-human",
+      reason: "duplicate_verified_fact_candidate",
+      confidence: 0.82,
+      evidence: [
+        {
+          type: "fact",
+          id: duplicate.id,
+          summary: "Same-scope verified fact has identical normalized text",
+          fields: { duplicateFactId: duplicate.id },
+        },
+      ],
+      sensitivityFlags: [],
+      humanReviewRequired: true,
+    };
+  }
 
-	const weak = weakProvenanceReason(fact);
-	if (weak) {
-		return {
-			bucket: "missing-or-weak-provenance",
-			recommendedAction: "deferred-for-human",
-			reason: "weak_or_missing_provenance",
-			confidence: 0.86,
-			evidence: [{ type: "provenance", id: fact.id, summary: weak }],
-			sensitivityFlags: [],
-			humanReviewRequired: true,
-		};
-	}
+  const weak = weakProvenanceReason(fact);
+  if (weak) {
+    return {
+      bucket: "missing-or-weak-provenance",
+      recommendedAction: "deferred-for-human",
+      reason: "weak_or_missing_provenance",
+      confidence: 0.86,
+      evidence: [{ type: "provenance", id: fact.id, summary: weak }],
+      sensitivityFlags: [],
+      humanReviewRequired: true,
+    };
+  }
 
-	if (
-		(item.payload.verified.nextVerification &&
-			item.payload.verified.nextVerification <= nowIso) ||
-		item.payload.dueReason === "verified_at_stale"
-	) {
-		return {
-			bucket: "stale-candidate",
-			recommendedAction: "classified",
-			reason: "stale_due_for_reverification",
-			confidence: 0.72,
-			evidence: [
-				{
-					type: "verification",
-					id: item.payload.verified.id,
-					summary:
-						item.payload.dueReason === "verified_at_stale"
-							? "Fact verified_at is older than the reverification window"
-							: "Fact is due for scheduled reverification",
-					fields: {
-						nextVerification: item.payload.verified.nextVerification,
-						verifiedAt: item.payload.verified.verifiedAt,
-						dueReason: item.payload.dueReason,
-						now: nowIso,
-					},
-				},
-			],
-			sensitivityFlags: [],
-			humanReviewRequired: false,
-		};
-	}
+  if (
+    (item.payload.verified.nextVerification && item.payload.verified.nextVerification <= nowIso) ||
+    item.payload.dueReason === "verified_at_stale"
+  ) {
+    return {
+      bucket: "stale-candidate",
+      recommendedAction: "classified",
+      reason: "stale_due_for_reverification",
+      confidence: 0.72,
+      evidence: [
+        {
+          type: "verification",
+          id: item.payload.verified.id,
+          summary:
+            item.payload.dueReason === "verified_at_stale"
+              ? "Fact verified_at is older than the reverification window"
+              : "Fact is due for scheduled reverification",
+          fields: {
+            nextVerification: item.payload.verified.nextVerification,
+            verifiedAt: item.payload.verified.verifiedAt,
+            dueReason: item.payload.dueReason,
+            now: nowIso,
+          },
+        },
+      ],
+      sensitivityFlags: [],
+      humanReviewRequired: false,
+    };
+  }
 
-	return {
-		bucket: "still-current",
-		recommendedAction:
-			opts.policy === "apply-obvious" ? "marked-reviewed" : "classified",
-		reason: "still_current_no_action_needed",
-		confidence: 0.74,
-		evidence: [
-			{
-				type: "review",
-				id: fact.id,
-				summary:
-					"No concrete TTL, supersession, contradiction, sensitivity, scope, or provenance blocker found",
-				fields: { reviewedAt: nowIso, method: "deterministic-triage" },
-			},
-		],
-		sensitivityFlags: [],
-		humanReviewRequired: false,
-	};
+  return {
+    bucket: "still-current",
+    recommendedAction: opts.policy === "apply-obvious" ? "marked-reviewed" : "classified",
+    reason: "still_current_no_action_needed",
+    confidence: 0.74,
+    evidence: [
+      {
+        type: "review",
+        id: fact.id,
+        summary: "No concrete TTL, supersession, contradiction, sensitivity, scope, or provenance blocker found",
+        fields: { reviewedAt: nowIso, method: "deterministic-triage" },
+      },
+    ],
+    sensitivityFlags: [],
+    humanReviewRequired: false,
+  };
 }
 
 function triageToPendingDecision(
-	item: VerifiedFactTriageItem,
-	context: PendingDecisionContext,
-	triage: ReturnType<typeof classifyVerifiedFact>,
+  item: VerifiedFactTriageItem,
+  context: PendingDecisionContext,
+  triage: ReturnType<typeof classifyVerifiedFact>,
 ): PendingDecision {
-	const mapped = mapTriageAction(context.policy, triage);
-	const evidence = triage.evidence.map((ev) => ({
-		type: ev.type,
-		id: ev.id,
-		summary: ev.summary,
-		...(ev.fields ? { fields: ev.fields } : {}),
-	}));
-	return {
-		queue: "verified",
-		itemId: item.id,
-		inputHash: context.inputHash,
-		policy: context.policy,
-		policyVersion: context.policyVersion,
-		mode: context.mode,
-		action: mapped.action,
-		reasonCode: mapped.reasonCode,
-		actionClass: mapped.actionClass,
-		capabilityClass: mapped.capabilityClass,
-		confidence: triage.confidence,
-		humanReviewRequired: triage.humanReviewRequired,
-		evidence,
-		actor: context.actor,
-		runId: context.runId,
-		jobId: context.jobId,
-		summary: {
-			title: `verified fact ${triage.bucket}`,
-			body: `${item.payload.fact?.id ?? item.payload.verified.factId}: ${triage.reason}`,
-			metadata: {
-				bucket: triage.bucket,
-				recommendedAction: triage.recommendedAction,
-				sensitivityFlags: triage.sensitivityFlags,
-				evidenceFields: triage.evidence.map((ev) => ev.fields).filter(Boolean),
-			},
-		},
-		audit: {
-			queue: "verified",
-			itemId: item.id,
-			inputHash: context.inputHash,
-			policy: context.policy,
-			policyVersion: context.policyVersion,
-			action: mapped.action,
-			reasonCode: mapped.reasonCode,
-			capabilityClass: mapped.capabilityClass,
-			humanReviewRequired: triage.humanReviewRequired,
-			evidence,
-			actor: context.actor,
-			runId: context.runId,
-			summary: {
-				title: "verified-fact-triage",
-				metadata: {
-					previous: {
-						verificationTier: item.payload.verificationTier,
-						verifiedFactId: item.payload.verified.id,
-						nextVerification: item.payload.verified.nextVerification,
-					},
-					after: {
-						bucket: triage.bucket,
-						recommendedAction: triage.recommendedAction,
-						reason: triage.reason,
-					},
-					mutation: "none-core-truth-fields-preserved",
-				},
-			},
-		},
-	};
+  const mapped = mapTriageAction(context.policy, triage);
+  const evidence = triage.evidence.map((ev) => ({
+    type: ev.type,
+    id: ev.id,
+    summary: ev.summary,
+    ...(ev.fields ? { fields: ev.fields } : {}),
+  }));
+  return {
+    queue: "verified",
+    itemId: item.id,
+    inputHash: context.inputHash,
+    policy: context.policy,
+    policyVersion: context.policyVersion,
+    mode: context.mode,
+    action: mapped.action,
+    reasonCode: mapped.reasonCode,
+    actionClass: mapped.actionClass,
+    capabilityClass: mapped.capabilityClass,
+    confidence: triage.confidence,
+    humanReviewRequired: triage.humanReviewRequired,
+    evidence,
+    actor: context.actor,
+    runId: context.runId,
+    jobId: context.jobId,
+    summary: {
+      title: `verified fact ${triage.bucket}`,
+      body: `${item.payload.fact?.id ?? item.payload.verified.factId}: ${triage.reason}`,
+      metadata: {
+        bucket: triage.bucket,
+        recommendedAction: triage.recommendedAction,
+        sensitivityFlags: triage.sensitivityFlags,
+        evidenceFields: triage.evidence.map((ev) => ev.fields).filter(Boolean),
+      },
+    },
+    audit: {
+      queue: "verified",
+      itemId: item.id,
+      inputHash: context.inputHash,
+      policy: context.policy,
+      policyVersion: context.policyVersion,
+      action: mapped.action,
+      reasonCode: mapped.reasonCode,
+      capabilityClass: mapped.capabilityClass,
+      humanReviewRequired: triage.humanReviewRequired,
+      evidence,
+      actor: context.actor,
+      runId: context.runId,
+      summary: {
+        title: "verified-fact-triage",
+        metadata: {
+          previous: {
+            verificationTier: item.payload.verificationTier,
+            verifiedFactId: item.payload.verified.id,
+            nextVerification: item.payload.verified.nextVerification,
+          },
+          after: {
+            bucket: triage.bucket,
+            recommendedAction: triage.recommendedAction,
+            reason: triage.reason,
+          },
+          mutation: "none-core-truth-fields-preserved",
+        },
+      },
+    },
+  };
 }
 
 function mapTriageAction(
-	policy: string,
-	triage: Pick<
-		VerifiedTriageResultItem,
-		"recommendedAction" | "humanReviewRequired" | "reason"
-	>,
-): Pick<
-	PendingDecision,
-	"action" | "reasonCode" | "actionClass" | "capabilityClass"
-> {
-	if (policy === "report-only") {
-		return {
-			action: "reported",
-			reasonCode: "dry-run",
-			actionClass: "preview",
-			capabilityClass: "read-only",
-		};
-	}
-	if (triage.recommendedAction === "failed-validation") {
-		return {
-			action: "failed-validation",
-			reasonCode: toAutopilotReason(triage.reason),
-			actionClass: "observe",
-			capabilityClass: "read-only",
-		};
-	}
-	if (triage.humanReviewRequired) {
-		return {
-			action: "deferred-for-human",
-			reasonCode: "human-review-required",
-			actionClass: "record-review",
-			capabilityClass: "record-review-metadata",
-		};
-	}
-	return {
-		action: "classified",
-		reasonCode: toAutopilotReason(triage.reason),
-		actionClass: "record-review",
-		capabilityClass: "record-review-metadata",
-	};
+  policy: string,
+  triage: Pick<VerifiedTriageResultItem, "recommendedAction" | "humanReviewRequired" | "reason">,
+): Pick<PendingDecision, "action" | "reasonCode" | "actionClass" | "capabilityClass"> {
+  if (policy === "report-only") {
+    return {
+      action: "reported",
+      reasonCode: "dry-run",
+      actionClass: "preview",
+      capabilityClass: "read-only",
+    };
+  }
+  if (triage.recommendedAction === "failed-validation") {
+    return {
+      action: "failed-validation",
+      reasonCode: toAutopilotReason(triage.reason),
+      actionClass: "observe",
+      capabilityClass: "read-only",
+    };
+  }
+  if (triage.humanReviewRequired) {
+    return {
+      action: "deferred-for-human",
+      reasonCode: "human-review-required",
+      actionClass: "record-review",
+      capabilityClass: "record-review-metadata",
+    };
+  }
+  return {
+    action: "classified",
+    reasonCode: toAutopilotReason(triage.reason),
+    actionClass: "record-review",
+    capabilityClass: "record-review-metadata",
+  };
 }
 
 function toAutopilotReason(reason: VerifiedTriageReason): AutopilotReasonCode {
-	switch (reason) {
-		case "policy_report_only":
-			return "dry-run";
-		case "backend_error":
-		case "evidence_query_failed":
-			return "audit-write-failed";
-		case "malformed_fact":
-			return "invalid-item";
-		case "requires_human_approval":
-		case "scope_unclear":
-		case "sensitive_security_fact":
-		case "sensitive_privacy_fact":
-		case "sensitive_personal_fact":
-		case "sensitive_operational_runbook":
-			return "human-review-required";
-		default:
-			return "policy-threshold-not-met";
-	}
+  switch (reason) {
+    case "policy_report_only":
+      return "dry-run";
+    case "backend_error":
+    case "evidence_query_failed":
+      return "audit-write-failed";
+    case "malformed_fact":
+      return "invalid-item";
+    case "requires_human_approval":
+    case "scope_unclear":
+    case "sensitive_security_fact":
+    case "sensitive_privacy_fact":
+    case "sensitive_personal_fact":
+    case "sensitive_operational_runbook":
+      return "human-review-required";
+    default:
+      return "policy-threshold-not-met";
+  }
 }
 
 function decisionToResultItem(
-	decision: PendingDecision,
-	item: VerifiedFactTriageItem,
-	applied: boolean,
+  decision: PendingDecision,
+  item: VerifiedFactTriageItem,
+  applied: boolean,
 ): VerifiedTriageResultItem {
-	const meta = decision.summary?.metadata ?? {};
-	const fact = item.payload.fact;
-	const bucket = String(meta.bucket ?? "failed-review") as VerifiedTriageBucket;
-	const recommendedAction = String(
-		meta.recommendedAction ?? "failed-validation",
-	) as VerifiedTriageAction;
-	return {
-		factId: item.payload.verified.factId,
-		verifiedFactId: item.payload.verified.id,
-		text: fact?.text ?? item.payload.verified.canonicalText,
-		verificationTier: item.payload.verificationTier,
-		scope: fact?.scope ?? null,
-		scopeTarget: fact?.scopeTarget ?? null,
-		entity: fact?.entity ?? null,
-		key: fact?.key ?? null,
-		validFrom: fact?.validFrom ?? null,
-		validUntil: fact?.validUntil ?? null,
-		expiresAt: fact?.expiresAt ?? null,
-		provenanceSummary: summarizeProvenance(fact),
-		bucket,
-		recommendedAction,
-		confidence: decision.confidence,
-		evidence: decision.evidence,
-		sensitivityFlags: Array.isArray(meta.sensitivityFlags)
-			? (meta.sensitivityFlags as string[])
-			: [],
-		reason: extractVerifiedReason(decision, item),
-		humanReviewRequired: decision.humanReviewRequired,
-		action: decision.action,
-		reasonCode: decision.reasonCode,
-		capabilityClass: decision.capabilityClass,
-		actionClass: decision.actionClass,
-		inputHash: decision.inputHash,
-		applied,
-	};
+  const meta = decision.summary?.metadata ?? {};
+  const fact = item.payload.fact;
+  const bucket = String(meta.bucket ?? "failed-review") as VerifiedTriageBucket;
+  const recommendedAction = String(meta.recommendedAction ?? "failed-validation") as VerifiedTriageAction;
+  return {
+    factId: item.payload.verified.factId,
+    verifiedFactId: item.payload.verified.id,
+    text: fact?.text ?? item.payload.verified.canonicalText,
+    verificationTier: item.payload.verificationTier,
+    scope: fact?.scope ?? null,
+    scopeTarget: fact?.scopeTarget ?? null,
+    entity: fact?.entity ?? null,
+    key: fact?.key ?? null,
+    validFrom: fact?.validFrom ?? null,
+    validUntil: fact?.validUntil ?? null,
+    expiresAt: fact?.expiresAt ?? null,
+    provenanceSummary: summarizeProvenance(fact),
+    bucket,
+    recommendedAction,
+    confidence: decision.confidence,
+    evidence: decision.evidence,
+    sensitivityFlags: Array.isArray(meta.sensitivityFlags) ? (meta.sensitivityFlags as string[]) : [],
+    reason: extractVerifiedReason(decision, item),
+    humanReviewRequired: decision.humanReviewRequired,
+    action: decision.action,
+    reasonCode: decision.reasonCode,
+    capabilityClass: decision.capabilityClass,
+    actionClass: decision.actionClass,
+    inputHash: decision.inputHash,
+    applied,
+  };
 }
 
-function extractVerifiedReason(
-	decision: PendingDecision,
-	item: VerifiedFactTriageItem,
-): VerifiedTriageReason {
-	const after = decision.audit?.summary?.metadata as
-		| { after?: { reason?: string } }
-		| undefined;
-	const reason = after?.after?.reason;
-	if (reason) return reason as VerifiedTriageReason;
-	const reasonCodeMap: Partial<
-		Record<AutopilotReasonCode, VerifiedTriageReason>
-	> = {
-		"input-hash-mismatch": "backend_error",
-		"lock-conflict": "backend_error",
-		"lock-missing": "backend_error",
-	};
-	return (
-		reasonCodeMap[decision.reasonCode] ??
-		(item.validationFailed ? "malformed_fact" : "requires_human_approval")
-	);
+function extractVerifiedReason(decision: PendingDecision, item: VerifiedFactTriageItem): VerifiedTriageReason {
+  const after = decision.audit?.summary?.metadata as { after?: { reason?: string } } | undefined;
+  const reason = after?.after?.reason;
+  if (reason) return reason as VerifiedTriageReason;
+  const reasonCodeMap: Partial<Record<AutopilotReasonCode, VerifiedTriageReason>> = {
+    "input-hash-mismatch": "backend_error",
+    "lock-conflict": "backend_error",
+    "lock-missing": "backend_error",
+  };
+  return reasonCodeMap[decision.reasonCode] ?? (item.validationFailed ? "malformed_fact" : "requires_human_approval");
 }
 
 function buildRunResult(input: {
-	runId: string;
-	mode: "dry-run" | "apply";
-	policy: VerifiedTriagePolicy;
-	items: VerifiedTriageResultItem[];
+  runId: string;
+  mode: "dry-run" | "apply";
+  policy: VerifiedTriagePolicy;
+  items: VerifiedTriageResultItem[];
 }): VerifiedTriageRunResult {
-	return {
-		runId: input.runId,
-		mode: input.mode,
-		policy: input.policy,
-		policyVersion: VERIFIED_TRIAGE_POLICY_VERSION,
-		reviewQueueSource: VERIFIED_REVIEW_QUEUE_SOURCE,
-		counts: {
-			inspected: input.items.length,
-			classified: input.items.filter(
-				(i) => i.action === "classified" || i.action === "reported",
-			).length,
-			stillCurrent: input.items.filter((i) => i.bucket === "still-current")
-				.length,
-			staleCandidates: input.items.filter((i) => i.bucket === "stale-candidate")
-				.length,
-			expiredTtlCandidates: input.items.filter(
-				(i) => i.bucket === "expired-ttl-candidate",
-			).length,
-			supersededCandidates: input.items.filter(
-				(i) => i.bucket === "superseded-candidate",
-			).length,
-			contradictedCandidates: input.items.filter(
-				(i) => i.bucket === "contradicted-candidate",
-			).length,
-			duplicateCandidates: input.items.filter(
-				(i) => i.bucket === "duplicate-candidate",
-			).length,
-			sensitiveNeedsHuman: input.items.filter(
-				(i) => i.bucket === "sensitive-needs-human",
-			).length,
-			needsHuman: input.items.filter((i) => i.humanReviewRequired).length,
-			applied: input.items.filter((i) => i.applied).length,
-			failed: input.items.filter((i) => i.bucket === "failed-review").length,
-		},
-		items: input.items,
-	};
+  return {
+    runId: input.runId,
+    mode: input.mode,
+    policy: input.policy,
+    policyVersion: VERIFIED_TRIAGE_POLICY_VERSION,
+    reviewQueueSource: VERIFIED_REVIEW_QUEUE_SOURCE,
+    counts: {
+      inspected: input.items.length,
+      classified: input.items.filter((i) => i.action === "classified" || i.action === "reported").length,
+      stillCurrent: input.items.filter((i) => i.bucket === "still-current").length,
+      staleCandidates: input.items.filter((i) => i.bucket === "stale-candidate").length,
+      expiredTtlCandidates: input.items.filter((i) => i.bucket === "expired-ttl-candidate").length,
+      supersededCandidates: input.items.filter((i) => i.bucket === "superseded-candidate").length,
+      contradictedCandidates: input.items.filter((i) => i.bucket === "contradicted-candidate").length,
+      duplicateCandidates: input.items.filter((i) => i.bucket === "duplicate-candidate").length,
+      sensitiveNeedsHuman: input.items.filter((i) => i.bucket === "sensitive-needs-human").length,
+      needsHuman: input.items.filter((i) => i.humanReviewRequired).length,
+      applied: input.items.filter((i) => i.applied).length,
+      failed: input.items.filter((i) => i.bucket === "failed-review").length,
+    },
+    items: input.items,
+  };
+}
+
+function hasValidVerifiedFactChecksum(row: VerifiedFactRow): boolean {
+  return createHash("sha256").update(row.canonical_text).digest("hex") === row.checksum;
 }
 
 function rowToVerifiedFact(row: VerifiedFactRow): VerifiedFact {
-	return {
-		id: row.id,
-		factId: row.fact_id,
-		canonicalText: row.canonical_text,
-		checksum: row.checksum,
-		verifiedAt: row.verified_at,
-		verifiedBy: row.verified_by as VerifiedFact["verifiedBy"],
-		nextVerification: row.next_verification,
-		version: row.version,
-		previousVersionId: row.previous_version_id,
-		createdAt: row.created_at,
-	};
+  return {
+    id: row.id,
+    factId: row.fact_id,
+    canonicalText: row.canonical_text,
+    checksum: row.checksum,
+    verifiedAt: row.verified_at,
+    verifiedBy: row.verified_by as VerifiedFact["verifiedBy"],
+    nextVerification: row.next_verification,
+    version: row.version,
+    previousVersionId: row.previous_version_id,
+    createdAt: row.created_at,
+  };
 }
 
 interface VerifiedFactRow {
-	id: string;
-	fact_id: string;
-	canonical_text: string;
-	checksum: string;
-	verified_at: string;
-	verified_by: string;
-	next_verification: string | null;
-	version: number;
-	previous_version_id: string | null;
-	created_at: string;
+  id: string;
+  fact_id: string;
+  canonical_text: string;
+  checksum: string;
+  verified_at: string;
+  verified_by: string;
+  next_verification: string | null;
+  version: number;
+  previous_version_id: string | null;
+  created_at: string;
 }
 
-function loadFactSnapshot(
-	db: DatabaseSync,
-	factId: string,
-): TriageFactSnapshot | null {
-	const row = db.prepare("SELECT * FROM facts WHERE id = ?").get(factId) as
-		| Record<string, unknown>
-		| undefined;
-	return row ? memoryEntryToSnapshot(rowToMemoryEntry(row)) : null;
+function loadFactSnapshot(db: DatabaseSync, factId: string): TriageFactSnapshot | null {
+  const row = db.prepare("SELECT * FROM facts WHERE id = ?").get(factId) as Record<string, unknown> | undefined;
+  return row ? memoryEntryToSnapshot(rowToMemoryEntry(row)) : null;
 }
 
 function memoryEntryToSnapshot(entry: MemoryEntry): TriageFactSnapshot {
-	return {
-		id: entry.id,
-		text: entry.text,
-		category: entry.category,
-		entity: entry.entity,
-		key: entry.key,
-		value: entry.value,
-		source: entry.source,
-		createdAt: entry.createdAt,
-		expiresAt: entry.expiresAt,
-		validFrom: entry.validFrom ?? null,
-		validUntil: entry.validUntil ?? null,
-		supersedesId: entry.supersedesId ?? null,
-		supersededAt: entry.supersededAt ?? null,
-		supersededBy: entry.supersededBy ?? null,
-		tier: entry.tier ?? null,
-		scope: entry.scope ?? "global",
-		scopeTarget: entry.scopeTarget ?? null,
-		provenanceSession: entry.provenanceSession ?? null,
-		sourceSessions: entry.sourceSessions ?? null,
-		provenanceJson: entry.provenanceJson ?? null,
-		tags: entry.tags ?? null,
-		confidence: entry.confidence,
-	};
+  return {
+    id: entry.id,
+    text: entry.text,
+    category: entry.category,
+    entity: entry.entity,
+    key: entry.key,
+    value: entry.value,
+    source: entry.source,
+    createdAt: entry.createdAt,
+    expiresAt: entry.expiresAt,
+    validFrom: entry.validFrom ?? null,
+    validUntil: entry.validUntil ?? null,
+    supersedesId: entry.supersedesId ?? null,
+    supersededAt: entry.supersededAt ?? null,
+    supersededBy: entry.supersededBy ?? null,
+    tier: entry.tier ?? null,
+    scope: entry.scope ?? "global",
+    scopeTarget: entry.scopeTarget ?? null,
+    provenanceSession: entry.provenanceSession ?? null,
+    sourceSessions: entry.sourceSessions ?? null,
+    provenanceJson: entry.provenanceJson ?? null,
+    tags: entry.tags ?? null,
+    confidence: entry.confidence,
+  };
 }
 
 function snapshotFromRow(row: Record<string, unknown>): RelatedFact {
-	return memoryEntryToSnapshot(rowToMemoryEntry(row));
+  return memoryEntryToSnapshot(rowToMemoryEntry(row));
 }
 
 function detectSensitivity(
-	fact: TriageFactSnapshot,
-	canonicalText: string,
+  fact: TriageFactSnapshot,
+  canonicalText: string,
 ): { flags: string[]; reason: VerifiedTriageReason } {
-	const haystack = [
-		canonicalText,
-		fact.text,
-		fact.category,
-		fact.entity,
-		fact.key,
-		fact.value,
-		fact.tags?.join(" "),
-	]
-		.filter(Boolean)
-		.join("\n");
-	const flags: string[] = [];
-	let reason: VerifiedTriageReason = "sensitive_personal_fact";
-	for (const rule of SENSITIVE_RULES) {
-		if (rule.pattern.test(haystack)) {
-			flags.push(rule.flag);
-			if (
-				reason === "sensitive_personal_fact" ||
-				rule.reason === "sensitive_security_fact"
-			)
-				reason = rule.reason;
-		}
-	}
-	return { flags: [...new Set(flags)], reason };
+  const haystack = [canonicalText, fact.text, fact.category, fact.entity, fact.key, fact.value, fact.tags?.join(" ")]
+    .filter(Boolean)
+    .join("\n");
+  const flags: string[] = [];
+  let reason: VerifiedTriageReason = "sensitive_personal_fact";
+  for (const rule of SENSITIVE_RULES) {
+    if (rule.pattern.test(haystack)) {
+      flags.push(rule.flag);
+      if (reason === "sensitive_personal_fact" || rule.reason === "sensitive_security_fact") reason = rule.reason;
+    }
+  }
+  return { flags: [...new Set(flags)], reason };
 }
 
 function hasScopeUnclearSignals(fact: TriageFactSnapshot): boolean {
-	return fact.scope !== "global" && !fact.scopeTarget;
+  return fact.scope !== "global" && !fact.scopeTarget;
 }
 
 function sameScope(a: TriageFactSnapshot, b: TriageFactSnapshot): boolean {
-	return (
-		a.scope === b.scope && (a.scopeTarget ?? null) === (b.scopeTarget ?? null)
-	);
+  return a.scope === b.scope && (a.scopeTarget ?? null) === (b.scopeTarget ?? null);
 }
 
-function findExplicitNewerVerifiedFact(
-	db: DatabaseSync,
-	fact: TriageFactSnapshot,
-): RelatedFact | null {
-	if (fact.supersededBy) {
-		const newer = loadVerifiedRelatedFact(db, fact.supersededBy);
-		if (newer && sameScope(fact, newer) && newer.createdAt >= fact.createdAt)
-			return newer;
-	}
-	const rows = db
-		.prepare(
-			`SELECT f.*, vf.id AS verified_fact_id, vf.verified_at AS verified_at, vf.version AS verified_version
+function findExplicitNewerVerifiedFact(db: DatabaseSync, fact: TriageFactSnapshot): RelatedFact | null {
+  if (fact.supersededBy) {
+    const newer = loadVerifiedRelatedFact(db, fact.supersededBy);
+    if (newer && sameScope(fact, newer) && newer.createdAt >= fact.createdAt) return newer;
+  }
+  const rows = db
+    .prepare(
+      `SELECT f.*, vf.id AS verified_fact_id, vf.verified_at AS verified_at, vf.version AS verified_version
        FROM facts f
        JOIN verified_facts vf ON vf.fact_id = f.id
        WHERE f.supersedes_id = ? AND f.created_at >= ?
        ORDER BY f.created_at DESC
        LIMIT 5`,
-		)
-		.all(fact.id, fact.createdAt) as Array<Record<string, unknown>>;
-	for (const row of rows) {
-		const newer = {
-			...snapshotFromRow(row),
-			verifiedFactId: row.verified_fact_id as string,
-		};
-		if (sameScope(fact, newer)) return newer;
-	}
-	return null;
+    )
+    .all(fact.id, fact.createdAt) as Array<Record<string, unknown>>;
+  for (const row of rows) {
+    const newer = {
+      ...snapshotFromRow(row),
+      verifiedFactId: row.verified_fact_id as string,
+    };
+    if (sameScope(fact, newer)) return newer;
+  }
+  return null;
 }
 
-function loadVerifiedRelatedFact(
-	db: DatabaseSync,
-	factId: string,
-): RelatedFact | null {
-	const row = db
-		.prepare(
-			`SELECT f.*, vf.id AS verified_fact_id, vf.verified_at AS verified_at, vf.version AS verified_version
+function loadVerifiedRelatedFact(db: DatabaseSync, factId: string): RelatedFact | null {
+  const row = db
+    .prepare(
+      `SELECT f.*, vf.id AS verified_fact_id, vf.verified_at AS verified_at, vf.version AS verified_version
        FROM facts f
        JOIN verified_facts vf ON vf.fact_id = f.id
        WHERE f.id = ?
        ORDER BY vf.version DESC
        LIMIT 1`,
-		)
-		.get(factId) as Record<string, unknown> | undefined;
-	if (!row) return null;
-	return {
-		...snapshotFromRow(row),
-		verifiedFactId: row.verified_fact_id as string,
-	};
+    )
+    .get(factId) as Record<string, unknown> | undefined;
+  if (!row) return null;
+  return {
+    ...snapshotFromRow(row),
+    verifiedFactId: row.verified_fact_id as string,
+  };
 }
 
-function findConcreteContradictingEvidence(
-	db: DatabaseSync,
-	fact: TriageFactSnapshot,
-): VerifiedTriageEvidence | null {
-	if (
-		!fact.entity?.trim() ||
-		!fact.key?.trim() ||
-		fact.value == null ||
-		fact.value.trim() === ""
-	)
-		return null;
-	const scopeClause =
-		fact.scopeTarget != null
-			? "AND f.scope = ? AND f.scope_target = ?"
-			: "AND f.scope = ? AND f.scope_target IS NULL";
-	const scopeParams: SQLInputValue[] =
-		fact.scopeTarget != null ? [fact.scope, fact.scopeTarget] : [fact.scope];
-	const row = db
-		.prepare(
-			`SELECT f.*, vf.id AS verified_fact_id
+function findConcreteContradictingEvidence(db: DatabaseSync, fact: TriageFactSnapshot): VerifiedTriageEvidence | null {
+  if (!fact.entity?.trim() || !fact.key?.trim() || fact.value == null || fact.value.trim() === "") return null;
+  const scopeClause =
+    fact.scopeTarget != null ? "AND f.scope = ? AND f.scope_target = ?" : "AND f.scope = ? AND f.scope_target IS NULL";
+  const scopeParams: SQLInputValue[] = fact.scopeTarget != null ? [fact.scope, fact.scopeTarget] : [fact.scope];
+  const row = db
+    .prepare(
+      `SELECT f.*, vf.id AS verified_fact_id
        FROM facts f
        JOIN verified_facts vf ON vf.fact_id = f.id
        WHERE f.id != ?
@@ -1175,143 +1064,133 @@ function findConcreteContradictingEvidence(
          ${scopeClause}
        ORDER BY f.created_at DESC
        LIMIT 1`,
-		)
-		.get(fact.id, fact.entity, fact.key, fact.value, ...scopeParams) as
-		| Record<string, unknown>
-		| undefined;
-	if (!row) return null;
-	return {
-		type: "contradiction",
-		id: row.id as string,
-		summary:
-			"Concrete same-entity/key/scope verified fact has conflicting structured value",
-		fields: {
-			subject: fact.entity,
-			scope: fact.scope,
-			scopeTarget: fact.scopeTarget,
-			claimType: fact.key,
-			currentValue: fact.value,
-			conflictingValue: row.value,
-			sourceId: row.id,
-			verifiedFactId: row.verified_fact_id,
-		},
-	};
+    )
+    .get(fact.id, fact.entity, fact.key, fact.value, ...scopeParams) as Record<string, unknown> | undefined;
+  if (!row) return null;
+  return {
+    type: "contradiction",
+    id: row.id as string,
+    summary: "Concrete same-entity/key/scope verified fact has conflicting structured value",
+    fields: {
+      subject: fact.entity,
+      scope: fact.scope,
+      scopeTarget: fact.scopeTarget,
+      claimType: fact.key,
+      currentValue: fact.value,
+      conflictingValue: row.value,
+      sourceId: row.id,
+      verifiedFactId: row.verified_fact_id,
+    },
+  };
 }
 
-function findSameScopeDuplicateVerifiedFact(
-	db: DatabaseSync,
-	fact: TriageFactSnapshot,
-): RelatedFact | null {
-	const normalized = normalizeFactText(fact.text);
-	if (!normalized) return null;
-	const scopeClause =
-		fact.scopeTarget != null
-			? "AND f.scope = ? AND f.scope_target = ?"
-			: "AND f.scope = ? AND f.scope_target IS NULL";
-	const scopeParams: SQLInputValue[] =
-		fact.scopeTarget != null ? [fact.scope, fact.scopeTarget] : [fact.scope];
-	const rows = db
-		.prepare(
-			`SELECT f.*, vf.id AS verified_fact_id
+function findSameScopeDuplicateVerifiedFact(db: DatabaseSync, fact: TriageFactSnapshot): RelatedFact | null {
+  const normalized = normalizeFactText(fact.text);
+  if (!normalized) return null;
+  const scopeClause =
+    fact.scopeTarget != null ? "AND f.scope = ? AND f.scope_target = ?" : "AND f.scope = ? AND f.scope_target IS NULL";
+  const scopeParams: SQLInputValue[] = fact.scopeTarget != null ? [fact.scope, fact.scopeTarget] : [fact.scope];
+  const rows = db
+    .prepare(
+      `SELECT f.*, vf.id AS verified_fact_id
        FROM facts f
        JOIN verified_facts vf ON vf.fact_id = f.id
        WHERE f.id != ? AND f.superseded_at IS NULL ${scopeClause}
        LIMIT 50`,
-		)
-		.all(fact.id, ...scopeParams) as Array<Record<string, unknown>>;
-	for (const row of rows) {
-		const candidate = {
-			...snapshotFromRow(row),
-			verifiedFactId: row.verified_fact_id as string,
-		};
-		if (normalizeFactText(candidate.text) === normalized) return candidate;
-	}
-	return null;
+    )
+    .all(fact.id, ...scopeParams) as Array<Record<string, unknown>>;
+  for (const row of rows) {
+    const candidate = {
+      ...snapshotFromRow(row),
+      verifiedFactId: row.verified_fact_id as string,
+    };
+    if (normalizeFactText(candidate.text) === normalized) return candidate;
+  }
+  return null;
 }
 
 function normalizeFactText(text: string): string {
-	return text.trim().toLowerCase().replace(/\s+/g, " ");
+  return text.trim().toLowerCase().replace(/\s+/g, " ");
 }
 
 function weakProvenanceReason(fact: TriageFactSnapshot): string | null {
-	if (fact.source === "unknown" || fact.source === "")
-		return "Fact source is missing or unknown";
-	if (!fact.provenanceJson && !fact.provenanceSession && !fact.sourceSessions) {
-		return "No provenance_json, provenance_session, or source_sessions recorded";
-	}
-	return null;
+  if (fact.source === "unknown" || fact.source === "") return "Fact source is missing or unknown";
+  if (!fact.provenanceJson && !fact.provenanceSession && !fact.sourceSessions) {
+    return "No provenance_json, provenance_session, or source_sessions recorded";
+  }
+  return null;
 }
 
 function summarizeProvenance(fact: TriageFactSnapshot | null): string {
-	if (!fact) return "missing fact row";
-	const parts = [
-		fact.provenanceJson ? "provenance_json" : null,
-		fact.provenanceSession ? `session:${fact.provenanceSession}` : null,
-		fact.sourceSessions ? "source_sessions" : null,
-		`source:${fact.source}`,
-	].filter(Boolean);
-	return parts.join(", ");
+  if (!fact) return "missing fact row";
+  const parts = [
+    fact.provenanceJson ? "provenance_json" : null,
+    fact.provenanceSession ? `session:${fact.provenanceSession}` : null,
+    fact.sourceSessions ? "source_sessions" : null,
+    `source:${fact.source}`,
+  ].filter(Boolean);
+  return parts.join(", ");
 }
 
 function validationFailureDecision(
-	item: VerifiedFactTriageItem,
-	context: PendingDecisionContext,
-	reasonCode: AutopilotReasonCode,
-	body: string,
+  item: VerifiedFactTriageItem,
+  context: PendingDecisionContext,
+  reasonCode: AutopilotReasonCode,
+  body: string,
 ): PendingDecision {
-	const evidence = [{ type: "input-hash", id: item.id, summary: body }];
-	return {
-		queue: "verified",
-		itemId: item.id,
-		inputHash: context.inputHash,
-		policy: context.policy,
-		policyVersion: context.policyVersion,
-		mode: context.mode,
-		action: "failed-validation",
-		reasonCode,
-		actionClass: "observe",
-		capabilityClass: "read-only",
-		confidence: 0,
-		humanReviewRequired: true,
-		evidence,
-		actor: context.actor,
-		runId: context.runId,
-		jobId: context.jobId,
-		summary: {
-			title: "verified fact failed-review",
-			body,
-			metadata: {
-				bucket: "failed-review",
-				recommendedAction: "failed-validation",
-				sensitivityFlags: [],
-			},
-		},
-		audit: {
-			queue: "verified",
-			itemId: item.id,
-			inputHash: context.inputHash,
-			policy: context.policy,
-			policyVersion: context.policyVersion,
-			action: "failed-validation",
-			reasonCode,
-			capabilityClass: "read-only",
-			humanReviewRequired: true,
-			evidence,
-			actor: context.actor,
-			runId: context.runId,
-			summary: {
-				title: "verified-fact-triage",
-				body,
-				metadata: {
-					previous: { verifiedFactId: item.payload.verified.id },
-					after: {
-						bucket: "failed-review",
-						recommendedAction: "failed-validation",
-						reason: "backend_error",
-					},
-					mutation: "none-core-truth-fields-preserved",
-				},
-			},
-		},
-	};
+  const evidence = [{ type: "input-hash", id: item.id, summary: body }];
+  return {
+    queue: "verified",
+    itemId: item.id,
+    inputHash: context.inputHash,
+    policy: context.policy,
+    policyVersion: context.policyVersion,
+    mode: context.mode,
+    action: "failed-validation",
+    reasonCode,
+    actionClass: "observe",
+    capabilityClass: "read-only",
+    confidence: 0,
+    humanReviewRequired: true,
+    evidence,
+    actor: context.actor,
+    runId: context.runId,
+    jobId: context.jobId,
+    summary: {
+      title: "verified fact failed-review",
+      body,
+      metadata: {
+        bucket: "failed-review",
+        recommendedAction: "failed-validation",
+        sensitivityFlags: [],
+      },
+    },
+    audit: {
+      queue: "verified",
+      itemId: item.id,
+      inputHash: context.inputHash,
+      policy: context.policy,
+      policyVersion: context.policyVersion,
+      action: "failed-validation",
+      reasonCode,
+      capabilityClass: "read-only",
+      humanReviewRequired: true,
+      evidence,
+      actor: context.actor,
+      runId: context.runId,
+      summary: {
+        title: "verified-fact-triage",
+        body,
+        metadata: {
+          previous: { verifiedFactId: item.payload.verified.id },
+          after: {
+            bucket: "failed-review",
+            recommendedAction: "failed-validation",
+            reason: "backend_error",
+          },
+          mutation: "none-core-truth-fields-preserved",
+        },
+      },
+    },
+  };
 }

--- a/extensions/memory-hybrid/services/verified-fact-triage.ts
+++ b/extensions/memory-hybrid/services/verified-fact-triage.ts
@@ -383,59 +383,62 @@ export async function runVerifiedFactTriageWithAdapter(
           ttlSeconds: opts.lockTtlSeconds ?? 60,
           mode,
         }) ?? false;
-      if (locked) {
-        const liveItem =
-          loadLiveVerifiedFactTriageItem(db, item.id, {
-            nowMs: opts.nowMs,
-            reverificationDays: opts.reverificationDays,
-            policy,
-          }) ?? null;
-        const actualInputHash = liveItem?.inputHash ?? "missing";
-        if (liveItem && actualInputHash === item.inputHash) {
-          const liveContext: PendingDecisionContext = {
-            ...context,
-            inputHash: liveItem.inputHash,
-          };
-          decision = await adapter.decide(liveItem, liveContext);
-          const { inserted } = durableStore?.recordDecision(decision) ?? {
-            inserted: false,
-          };
-          if (inserted && decision.action !== "deferred-for-human" && decision.action !== "failed-validation") {
-            durableStore?.advanceCursorIfSafe(decision, liveItem.visibleAfterCursor ?? liveItem.id);
+      try {
+        if (locked) {
+          const liveItem =
+            loadLiveVerifiedFactTriageItem(db, item.id, {
+              nowMs: opts.nowMs,
+              reverificationDays: opts.reverificationDays,
+              policy,
+            }) ?? null;
+          const actualInputHash = liveItem?.inputHash ?? "missing";
+          if (liveItem && actualInputHash === item.inputHash) {
+            const liveContext: PendingDecisionContext = {
+              ...context,
+              inputHash: liveItem.inputHash,
+            };
+            decision = await adapter.decide(liveItem, liveContext);
+            const { inserted } = durableStore?.recordDecision(decision) ?? {
+              inserted: false,
+            };
+            if (inserted && decision.action !== "deferred-for-human" && decision.action !== "failed-validation") {
+              durableStore?.advanceCursorIfSafe(decision, liveItem.visibleAfterCursor ?? liveItem.id);
+            }
+            applied = inserted && (decision.action === "classified" || decision.action === "reported");
+          } else {
+            const staleDecision = validationFailureDecision(
+              item,
+              context,
+              "input-hash-mismatch",
+              liveItem
+                ? "Verified fact/fact row changed between classification and apply."
+                : "Verified fact no longer matches due queue before apply.",
+            );
+            durableStore?.recordDecision(staleDecision);
+            decision = staleDecision;
           }
-          applied = inserted && (decision.action === "classified" || decision.action === "reported");
-        } else {
+        } else if (durableStore) {
           const staleDecision = validationFailureDecision(
             item,
             context,
-            "input-hash-mismatch",
-            liveItem
-              ? "Verified fact/fact row changed between classification and apply."
-              : "Verified fact no longer matches due queue before apply.",
+            "lock-conflict",
+            "Verified fact no longer matches due queue before apply.",
           );
-          durableStore?.recordDecision(staleDecision);
+          durableStore.recordDecision(staleDecision);
           decision = staleDecision;
+        } else {
+          decision = await adapter.decide(item, context);
         }
-      } else if (durableStore) {
-        const staleDecision = validationFailureDecision(
-          item,
-          context,
-          "lock-conflict",
-          "Verified fact no longer matches due queue before apply.",
-        );
-        durableStore.recordDecision(staleDecision);
-        decision = staleDecision;
-      } else {
-        decision = await adapter.decide(item, context);
-      }
-      if (locked) {
-        durableStore?.releaseLock({
-          queue: "verified",
-          itemId: item.id,
-          inputHash: item.inputHash,
-          owner: actor.id,
-          mode,
-        });
+      } finally {
+        if (locked) {
+          durableStore?.releaseLock({
+            queue: "verified",
+            itemId: item.id,
+            inputHash: item.inputHash,
+            owner: actor.id,
+            mode,
+          });
+        }
       }
     } else {
       decision = await adapter.decide(item, context);

--- a/extensions/memory-hybrid/services/verified-fact-triage.ts
+++ b/extensions/memory-hybrid/services/verified-fact-triage.ts
@@ -1072,7 +1072,12 @@ function memoryEntryToSnapshot(entry: MemoryEntry): TriageFactSnapshot {
 }
 
 function snapshotFromRow(row: Record<string, unknown>): RelatedFact {
-  return memoryEntryToSnapshot(rowToMemoryEntry(row));
+  return {
+    ...memoryEntryToSnapshot(rowToMemoryEntry(row)),
+    verifiedFactId: (row.verified_fact_id as string | null) ?? null,
+    verifiedAt: (row.verified_at as string | null) ?? null,
+    verifiedVersion: (row.verified_version as number | null) ?? null,
+  };
 }
 
 function detectSensitivity(
@@ -1125,10 +1130,7 @@ function findExplicitNewerVerifiedFact(db: DatabaseSync, fact: TriageFactSnapsho
     )
     .all(fact.id, fact.createdAt) as Array<Record<string, unknown>>;
   for (const row of rows) {
-    const newer = {
-      ...snapshotFromRow(row),
-      verifiedFactId: row.verified_fact_id as string,
-    };
+    const newer = snapshotFromRow(row);
     if (sameScope(fact, newer)) return newer;
   }
   return null;
@@ -1151,10 +1153,7 @@ function loadVerifiedRelatedFact(db: DatabaseSync, factId: string): RelatedFact 
     )
     .get(factId) as Record<string, unknown> | undefined;
   if (!row) return null;
-  return {
-    ...snapshotFromRow(row),
-    verifiedFactId: row.verified_fact_id as string,
-  };
+  return snapshotFromRow(row);
 }
 
 function findConcreteContradictingEvidence(db: DatabaseSync, fact: TriageFactSnapshot): VerifiedTriageEvidence | null {
@@ -1227,10 +1226,7 @@ function findSameScopeDuplicateVerifiedFact(db: DatabaseSync, fact: TriageFactSn
     )
     .all(fact.id, ...scopeParams) as Array<Record<string, unknown>>;
   for (const row of rows) {
-    const candidate = {
-      ...snapshotFromRow(row),
-      verifiedFactId: row.verified_fact_id as string,
-    };
+    const candidate = snapshotFromRow(row);
     if (normalizeFactText(candidate.text) === normalized) return candidate;
   }
   return null;

--- a/extensions/memory-hybrid/services/verified-fact-triage.ts
+++ b/extensions/memory-hybrid/services/verified-fact-triage.ts
@@ -1,4 +1,3 @@
-import { createHash } from "node:crypto";
 import type { DatabaseSync, SQLInputValue } from "node:sqlite";
 import type { FactsDB } from "../backends/facts-db.js";
 import { rowToMemoryEntry } from "../backends/facts-db/index.js";
@@ -16,7 +15,7 @@ import {
   type PendingItem,
   type PendingQueueAdapter,
 } from "./pending-autopilot/index.js";
-import type { VerifiedFact } from "./verification-store.js";
+import { computeChecksum, type VerifiedFact } from "./verification-store.js";
 
 export const VERIFIED_TRIAGE_POLICY_VERSION = "verified-fact-triage-v1";
 const DEFAULT_REVERIFICATION_DAYS = 30;
@@ -295,10 +294,6 @@ function isVerifiedRowChecksumValid(row: VerifiedFactRow): boolean {
   return computeChecksum(row.canonical_text) === row.checksum;
 }
 
-function computeChecksum(text: string): string {
-  return createHash("sha256").update(text).digest("hex");
-}
-
 export function decideVerifiedFactTriage(
   item: VerifiedFactTriageItem,
   context: PendingDecisionContext,
@@ -422,7 +417,7 @@ export async function runVerifiedFactTriageWithAdapter(
             item,
             context,
             "lock-conflict",
-            "Verified fact no longer matches due queue before apply.",
+            "Could not acquire lock for verified fact triage (another process may hold it).",
           );
           durableStore.recordDecision(staleDecision);
           decision = staleDecision;

--- a/extensions/memory-hybrid/services/verified-fact-triage.ts
+++ b/extensions/memory-hybrid/services/verified-fact-triage.ts
@@ -279,42 +279,44 @@ export function listVerifiedFactTriageItems(
        LEFT JOIN facts f ON f.id = vf.fact_id
        WHERE (vf.next_verification IS NOT NULL AND vf.next_verification <= ?)
           OR vf.verified_at <= ?
-       ORDER BY COALESCE(vf.next_verification, vf.verified_at) ASC, vf.verified_at ASC
-       LIMIT ?`,
+       ORDER BY COALESCE(vf.next_verification, vf.verified_at) ASC, vf.verified_at ASC`,
     )
-    .all(nowIso, cutoffIso, opts.max ?? 100) as unknown as VerifiedFactRow[];
+    .all(nowIso, cutoffIso) as unknown as VerifiedFactRow[];
 
-  return latestRows.filter(isVerifiedRowChecksumValid).map((row) => {
-    const verified = rowToVerifiedFact(row);
-    const fact = loadFactSnapshot(db, verified.factId);
-    const payload: VerifiedFactTriagePayload = {
-      reviewQueueSource: VERIFIED_REVIEW_QUEUE_SOURCE,
-      verified,
-      fact,
-      verificationTier: fact?.tier ?? null,
-      reviewCursor: verified.nextVerification ?? verified.verifiedAt,
-      dueReason:
-        verified.nextVerification && verified.nextVerification <= nowIso ? "next_verification" : "verified_at_stale",
-    };
-    const inputHash = computePendingInputHash({
-      queue: "verified",
-      id: verified.id,
-      payload,
-      policy,
-      policyVersion: VERIFIED_TRIAGE_POLICY_VERSION,
+  return latestRows
+    .filter(isVerifiedRowChecksumValid)
+    .slice(0, opts.max ?? 100)
+    .map((row) => {
+      const verified = rowToVerifiedFact(row);
+      const fact = loadFactSnapshot(db, verified.factId);
+      const payload: VerifiedFactTriagePayload = {
+        reviewQueueSource: VERIFIED_REVIEW_QUEUE_SOURCE,
+        verified,
+        fact,
+        verificationTier: fact?.tier ?? null,
+        reviewCursor: verified.nextVerification ?? verified.verifiedAt,
+        dueReason:
+          verified.nextVerification && verified.nextVerification <= nowIso ? "next_verification" : "verified_at_stale",
+      };
+      const inputHash = computePendingInputHash({
+        queue: "verified",
+        id: verified.id,
+        payload,
+        policy,
+        policyVersion: VERIFIED_TRIAGE_POLICY_VERSION,
+      });
+      return {
+        queue: "verified",
+        id: verified.id,
+        inputHash,
+        policyVersion: VERIFIED_TRIAGE_POLICY_VERSION,
+        capabilityClasses: ["read-only", "record-review-metadata"],
+        payload,
+        visibleAfterCursor: verified.nextVerification ?? verified.verifiedAt,
+        requiresHumanReview: false,
+        validationFailed: !fact,
+      } satisfies VerifiedFactTriageItem;
     });
-    return {
-      queue: "verified",
-      id: verified.id,
-      inputHash,
-      policyVersion: VERIFIED_TRIAGE_POLICY_VERSION,
-      capabilityClasses: ["read-only", "record-review-metadata"],
-      payload,
-      visibleAfterCursor: verified.nextVerification ?? verified.verifiedAt,
-      requiresHumanReview: false,
-      validationFailed: !fact,
-    } satisfies VerifiedFactTriageItem;
-  });
 }
 
 function isVerifiedRowChecksumValid(row: VerifiedFactRow): boolean {

--- a/extensions/memory-hybrid/services/verified-fact-triage.ts
+++ b/extensions/memory-hybrid/services/verified-fact-triage.ts
@@ -449,7 +449,7 @@ export async function runVerifiedFactTriageWithAdapter(
               inputHash: liveItem.inputHash,
             };
             decision = await adapter.decide(liveItem, liveContext);
-            const { inserted } = durableStore?.recordDecision(decision) ?? {
+            const { inserted } = durableStore?.recordLatestDecision(decision) ?? {
               inserted: false,
             };
             if (decision.action !== "deferred-for-human" && decision.action !== "failed-validation") {

--- a/extensions/memory-hybrid/services/verified-fact-triage.ts
+++ b/extensions/memory-hybrid/services/verified-fact-triage.ts
@@ -16,12 +16,7 @@ import {
   type PendingItem,
   type PendingQueueAdapter,
 } from "./pending-autopilot/index.js";
-import {
-  computeChecksum,
-  rowToVerifiedFact,
-  type VerifiedFact,
-  type VerifiedFactRow,
-} from "./verification-store.js";
+import { computeChecksum, rowToVerifiedFact, type VerifiedFact, type VerifiedFactRow } from "./verification-store.js";
 
 export const VERIFIED_TRIAGE_POLICY_VERSION = "verified-fact-triage-v1";
 const DEFAULT_REVERIFICATION_DAYS = 30;

--- a/extensions/memory-hybrid/services/verified-fact-triage.ts
+++ b/extensions/memory-hybrid/services/verified-fact-triage.ts
@@ -292,11 +292,11 @@ export function listVerifiedFactTriageItems(
          AND (
            ? IS NULL
            OR COALESCE(vf.next_verification, vf.verified_at) > ?
-           OR (COALESCE(vf.next_verification, vf.verified_at) = ? AND vf.id > ?)
+           OR (COALESCE(vf.next_verification, vf.verified_at) = ? AND (? IS NULL OR vf.id > ?))
          )
        ORDER BY COALESCE(vf.next_verification, vf.verified_at) ASC, vf.id ASC`,
     )
-    .all(nowIso, cutoffIso, cursor, cursor, cursor, cursorItemId) as unknown as VerifiedFactRow[];
+    .all(nowIso, cutoffIso, cursor, cursor, cursor, cursorItemId, cursorItemId) as unknown as VerifiedFactRow[];
 
   return latestRows
     .filter(isVerifiedRowChecksumValid)
@@ -1209,7 +1209,7 @@ function findSameScopeDuplicateVerifiedFact(db: DatabaseSync, fact: TriageFactSn
   const scopeParams: SQLInputValue[] = fact.scopeTarget != null ? [fact.scope, fact.scopeTarget] : [fact.scope];
   const rows = db
     .prepare(
-      `SELECT f.*, vf.id AS verified_fact_id
+      `SELECT f.*, vf.id AS verified_fact_id, vf.verified_at AS verified_at, vf.version AS verified_version
        FROM facts f
        JOIN verified_facts vf ON vf.fact_id = f.id
        JOIN (

--- a/extensions/memory-hybrid/services/verified-fact-triage.ts
+++ b/extensions/memory-hybrid/services/verified-fact-triage.ts
@@ -548,7 +548,7 @@ export async function runVerifiedFactTriageWithAdapter(
             "lock-conflict",
             "Could not acquire lock for verified fact triage (another process may hold it).",
           );
-          durableStore.recordDecision(staleDecision);
+          durableStore?.recordDecision(staleDecision);
           decision = staleDecision;
         }
       } finally {

--- a/extensions/memory-hybrid/services/verified-fact-triage.ts
+++ b/extensions/memory-hybrid/services/verified-fact-triage.ts
@@ -185,12 +185,36 @@ interface RelatedFact extends TriageFactSnapshot {
 }
 
 const SENSITIVE_RULES: Array<{ flag: string; reason: VerifiedTriageReason; pattern: RegExp }> = [
-  { flag: "credentials", reason: "sensitive_security_fact", pattern: /\b(password|passwd|credential|secret|api[-_ ]?key|token|bearer|ssh key|private key|vault|oauth|pat_)\b/i },
-  { flag: "security", reason: "sensitive_security_fact", pattern: /\b(security|firewall|ssh|vpn|runbook|incident|breach|auth|mfa|2fa|permission|admin)\b/i },
-  { flag: "privacy", reason: "sensitive_privacy_fact", pattern: /\b(privacy|private|personal data|pii|gdpr|address|phone|email|medical|health|passport|identity)\b/i },
-  { flag: "external-comms", reason: "sensitive_personal_fact", pattern: /\b(external comms|external communication|email rule|reply rule|send to|contact\b|customer|client)\b/i },
-  { flag: "persona-preference", reason: "sensitive_personal_fact", pattern: /\b(preference|user identity|persona|edict|hard rule|markus|lotta)\b/i },
-  { flag: "operational-runbook", reason: "sensitive_operational_runbook", pattern: /\b(cron|runbook|operational|ops|production|deploy|restart|backup|restore)\b/i },
+  {
+    flag: "credentials",
+    reason: "sensitive_security_fact",
+    pattern: /\b(password|passwd|credential|secret|api[-_ ]?key|token|bearer|ssh key|private key|vault|oauth|pat_)\b/i,
+  },
+  {
+    flag: "security",
+    reason: "sensitive_security_fact",
+    pattern: /\b(security|firewall|ssh|vpn|runbook|incident|breach|auth|mfa|2fa|permission|admin)\b/i,
+  },
+  {
+    flag: "privacy",
+    reason: "sensitive_privacy_fact",
+    pattern: /\b(privacy|private|personal data|pii|gdpr|address|phone|email|medical|health|passport|identity)\b/i,
+  },
+  {
+    flag: "external-comms",
+    reason: "sensitive_personal_fact",
+    pattern: /\b(external comms|external communication|email rule|reply rule|send to|contact\b|customer|client)\b/i,
+  },
+  {
+    flag: "persona-preference",
+    reason: "sensitive_personal_fact",
+    pattern: /\b(preference|user identity|persona|edict|hard rule|markus|lotta)\b/i,
+  },
+  {
+    flag: "operational-runbook",
+    reason: "sensitive_operational_runbook",
+    pattern: /\b(cron|runbook|operational|ops|production|deploy|restart|backup|restore)\b/i,
+  },
 ];
 
 export function assertVerifiedTriagePolicy(value: string): VerifiedTriagePolicy {
@@ -369,7 +393,27 @@ export async function runVerifiedFactTriage(
 export function classifyVerifiedFact(
   item: VerifiedFactTriageItem,
   opts: { db?: DatabaseSync; nowMs?: number; policy?: string } = {},
-): Omit<VerifiedTriageResultItem, "factId" | "verifiedFactId" | "text" | "verificationTier" | "scope" | "scopeTarget" | "entity" | "key" | "validFrom" | "validUntil" | "expiresAt" | "provenanceSummary" | "action" | "reasonCode" | "capabilityClass" | "actionClass" | "inputHash" | "applied"> {
+): Omit<
+  VerifiedTriageResultItem,
+  | "factId"
+  | "verifiedFactId"
+  | "text"
+  | "verificationTier"
+  | "scope"
+  | "scopeTarget"
+  | "entity"
+  | "key"
+  | "validFrom"
+  | "validUntil"
+  | "expiresAt"
+  | "provenanceSummary"
+  | "action"
+  | "reasonCode"
+  | "capabilityClass"
+  | "actionClass"
+  | "inputHash"
+  | "applied"
+> {
   const fact = item.payload.fact;
   const nowSec = Math.floor((opts.nowMs ?? Date.now()) / 1000);
   const nowIso = new Date(opts.nowMs ?? Date.now()).toISOString();
@@ -380,7 +424,9 @@ export function classifyVerifiedFact(
       recommendedAction: "failed-validation",
       reason: "malformed_fact",
       confidence: 1,
-      evidence: [{ type: "verified-fact", id: item.payload.verified.id, summary: "Verified row references a missing fact row" }],
+      evidence: [
+        { type: "verified-fact", id: item.payload.verified.id, summary: "Verified row references a missing fact row" },
+      ],
       sensitivityFlags: [],
       humanReviewRequired: true,
     };
@@ -393,7 +439,9 @@ export function classifyVerifiedFact(
       recommendedAction: "flagged-sensitive",
       reason: sensitivity.reason,
       confidence: 0.95,
-      evidence: [{ type: "sensitivity", id: fact.id, summary: `Matched sensitive categories: ${sensitivity.flags.join(", ")}` }],
+      evidence: [
+        { type: "sensitivity", id: fact.id, summary: `Matched sensitive categories: ${sensitivity.flags.join(", ")}` },
+      ],
       sensitivityFlags: sensitivity.flags,
       humanReviewRequired: true,
     };
@@ -405,7 +453,9 @@ export function classifyVerifiedFact(
       recommendedAction: "deferred-for-human",
       reason: "scope_unclear",
       confidence: 0.9,
-      evidence: [{ type: "scope", id: fact.id, summary: "Fact has session/agent/user scope requiring explicit ownership proof" }],
+      evidence: [
+        { type: "scope", id: fact.id, summary: "Fact has session/agent/user scope requiring explicit ownership proof" },
+      ],
       sensitivityFlags: [],
       humanReviewRequired: true,
     };
@@ -417,7 +467,14 @@ export function classifyVerifiedFact(
       recommendedAction: "deferred-for-human",
       reason: "ttl_expired",
       confidence: 0.95,
-      evidence: [{ type: "validity", id: fact.id, summary: "Fact valid_until has expired", fields: { validUntil: fact.validUntil, now: nowSec } }],
+      evidence: [
+        {
+          type: "validity",
+          id: fact.id,
+          summary: "Fact valid_until has expired",
+          fields: { validUntil: fact.validUntil, now: nowSec },
+        },
+      ],
       sensitivityFlags: [],
       humanReviewRequired: true,
     };
@@ -428,7 +485,14 @@ export function classifyVerifiedFact(
       recommendedAction: "deferred-for-human",
       reason: "ttl_expired",
       confidence: 0.95,
-      evidence: [{ type: "ttl", id: fact.id, summary: "Fact expires_at has expired", fields: { expiresAt: fact.expiresAt, now: nowSec } }],
+      evidence: [
+        {
+          type: "ttl",
+          id: fact.id,
+          summary: "Fact expires_at has expired",
+          fields: { expiresAt: fact.expiresAt, now: nowSec },
+        },
+      ],
       sensitivityFlags: [],
       humanReviewRequired: true,
     };
@@ -441,7 +505,14 @@ export function classifyVerifiedFact(
       recommendedAction: "flagged-superseded",
       reason: "newer_verified_fact_exists",
       confidence: 0.9,
-      evidence: [{ type: "fact", id: newer.id, summary: "Explicit newer verified fact supersedes this fact", fields: { newerFactId: newer.id, verifiedFactId: newer.verifiedFactId } }],
+      evidence: [
+        {
+          type: "fact",
+          id: newer.id,
+          summary: "Explicit newer verified fact supersedes this fact",
+          fields: { newerFactId: newer.id, verifiedFactId: newer.verifiedFactId },
+        },
+      ],
       sensitivityFlags: [],
       humanReviewRequired: true,
     };
@@ -467,7 +538,14 @@ export function classifyVerifiedFact(
       recommendedAction: "deferred-for-human",
       reason: "duplicate_verified_fact_candidate",
       confidence: 0.82,
-      evidence: [{ type: "fact", id: duplicate.id, summary: "Same-scope verified fact has identical normalized text", fields: { duplicateFactId: duplicate.id } }],
+      evidence: [
+        {
+          type: "fact",
+          id: duplicate.id,
+          summary: "Same-scope verified fact has identical normalized text",
+          fields: { duplicateFactId: duplicate.id },
+        },
+      ],
       sensitivityFlags: [],
       humanReviewRequired: true,
     };
@@ -492,7 +570,14 @@ export function classifyVerifiedFact(
       recommendedAction: "classified",
       reason: "stale_due_for_reverification",
       confidence: 0.72,
-      evidence: [{ type: "verification", id: item.payload.verified.id, summary: "Fact is due for scheduled reverification", fields: { nextVerification: item.payload.verified.nextVerification, now: nowIso } }],
+      evidence: [
+        {
+          type: "verification",
+          id: item.payload.verified.id,
+          summary: "Fact is due for scheduled reverification",
+          fields: { nextVerification: item.payload.verified.nextVerification, now: nowIso },
+        },
+      ],
       sensitivityFlags: [],
       humanReviewRequired: false,
     };
@@ -503,7 +588,14 @@ export function classifyVerifiedFact(
     recommendedAction: opts.policy === "apply-obvious" ? "marked-reviewed" : "classified",
     reason: "still_current_no_action_needed",
     confidence: 0.74,
-    evidence: [{ type: "review", id: fact.id, summary: "No concrete TTL, supersession, contradiction, sensitivity, scope, or provenance blocker found", fields: { reviewedAt: nowIso, method: "deterministic-triage" } }],
+    evidence: [
+      {
+        type: "review",
+        id: fact.id,
+        summary: "No concrete TTL, supersession, contradiction, sensitivity, scope, or provenance blocker found",
+        fields: { reviewedAt: nowIso, method: "deterministic-triage" },
+      },
+    ],
     sensitivityFlags: [],
     humanReviewRequired: false,
   };
@@ -536,7 +628,11 @@ function triageToPendingDecision(
     summary: {
       title: `verified fact ${triage.bucket}`,
       body: `${item.payload.fact?.id ?? item.payload.verified.factId}: ${triage.reason}`,
-      metadata: { bucket: triage.bucket, recommendedAction: triage.recommendedAction, sensitivityFlags: triage.sensitivityFlags },
+      metadata: {
+        bucket: triage.bucket,
+        recommendedAction: triage.recommendedAction,
+        sensitivityFlags: triage.sensitivityFlags,
+      },
     },
     audit: {
       queue: "verified",
@@ -579,12 +675,27 @@ function mapTriageAction(
     return { action: "reported", reasonCode: "dry-run", actionClass: "preview", capabilityClass: "read-only" };
   }
   if (triage.recommendedAction === "failed-validation") {
-    return { action: "failed-validation", reasonCode: toAutopilotReason(triage.reason), actionClass: "observe", capabilityClass: "read-only" };
+    return {
+      action: "failed-validation",
+      reasonCode: toAutopilotReason(triage.reason),
+      actionClass: "observe",
+      capabilityClass: "read-only",
+    };
   }
   if (triage.humanReviewRequired) {
-    return { action: "deferred-for-human", reasonCode: "human-review-required", actionClass: "record-review", capabilityClass: "record-review-metadata" };
+    return {
+      action: "deferred-for-human",
+      reasonCode: "human-review-required",
+      actionClass: "record-review",
+      capabilityClass: "record-review-metadata",
+    };
   }
-  return { action: "classified", reasonCode: toAutopilotReason(triage.reason), actionClass: "record-review", capabilityClass: "record-review-metadata" };
+  return {
+    action: "classified",
+    reasonCode: toAutopilotReason(triage.reason),
+    actionClass: "record-review",
+    capabilityClass: "record-review-metadata",
+  };
 }
 
 function toAutopilotReason(reason: VerifiedTriageReason): AutopilotReasonCode {
@@ -608,7 +719,11 @@ function toAutopilotReason(reason: VerifiedTriageReason): AutopilotReasonCode {
   }
 }
 
-function decisionToResultItem(decision: PendingDecision, item: VerifiedFactTriageItem, applied: boolean): VerifiedTriageResultItem {
+function decisionToResultItem(
+  decision: PendingDecision,
+  item: VerifiedFactTriageItem,
+  applied: boolean,
+): VerifiedTriageResultItem {
   const meta = decision.summary?.metadata ?? {};
   const fact = item.payload.fact;
   const bucket = String(meta.bucket ?? "failed-review") as VerifiedTriageBucket;
@@ -743,7 +858,10 @@ function snapshotFromRow(row: Record<string, unknown>): RelatedFact {
   return memoryEntryToSnapshot(rowToMemoryEntry(row));
 }
 
-function detectSensitivity(fact: TriageFactSnapshot, canonicalText: string): { flags: string[]; reason: VerifiedTriageReason } {
+function detectSensitivity(
+  fact: TriageFactSnapshot,
+  canonicalText: string,
+): { flags: string[]; reason: VerifiedTriageReason } {
   const haystack = [canonicalText, fact.text, fact.category, fact.entity, fact.key, fact.value, fact.tags?.join(" ")]
     .filter(Boolean)
     .join("\n");
@@ -805,7 +923,8 @@ function loadVerifiedRelatedFact(db: DatabaseSync, factId: string): RelatedFact 
 
 function findConcreteContradictingEvidence(db: DatabaseSync, fact: TriageFactSnapshot): VerifiedTriageEvidence | null {
   if (!fact.entity?.trim() || !fact.key?.trim() || fact.value == null || fact.value.trim() === "") return null;
-  const scopeClause = fact.scopeTarget != null ? "AND f.scope = ? AND f.scope_target = ?" : "AND f.scope = ? AND f.scope_target IS NULL";
+  const scopeClause =
+    fact.scopeTarget != null ? "AND f.scope = ? AND f.scope_target = ?" : "AND f.scope = ? AND f.scope_target IS NULL";
   const scopeParams: SQLInputValue[] = fact.scopeTarget != null ? [fact.scope, fact.scopeTarget] : [fact.scope];
   const row = db
     .prepare(
@@ -843,7 +962,8 @@ function findConcreteContradictingEvidence(db: DatabaseSync, fact: TriageFactSna
 function findSameScopeDuplicateVerifiedFact(db: DatabaseSync, fact: TriageFactSnapshot): RelatedFact | null {
   const normalized = normalizeFactText(fact.text);
   if (!normalized) return null;
-  const scopeClause = fact.scopeTarget != null ? "AND f.scope = ? AND f.scope_target = ?" : "AND f.scope = ? AND f.scope_target IS NULL";
+  const scopeClause =
+    fact.scopeTarget != null ? "AND f.scope = ? AND f.scope_target = ?" : "AND f.scope = ? AND f.scope_target IS NULL";
   const scopeParams: SQLInputValue[] = fact.scopeTarget != null ? [fact.scope, fact.scopeTarget] : [fact.scope];
   const rows = db
     .prepare(

--- a/extensions/memory-hybrid/services/verified-fact-triage.ts
+++ b/extensions/memory-hybrid/services/verified-fact-triage.ts
@@ -361,7 +361,7 @@ export async function runVerifiedFactTriage(
         const staleDecision = triageToPendingDecision(item, context, {
           bucket: "failed-review",
           recommendedAction: "failed-validation",
-          reason: locked ? "backend_error" : "requires_human_approval",
+          reason: locked ? "requires_human_approval" : "backend_error",
           confidence: 1,
           evidence: [{ type: "input-hash", id: item.id, summary: "Lock missing or input hash changed before apply" }],
           sensitivityFlags: [],

--- a/extensions/memory-hybrid/services/verified-fact-triage.ts
+++ b/extensions/memory-hybrid/services/verified-fact-triage.ts
@@ -484,8 +484,9 @@ export function classifyVerifiedFact(
   | "applied"
 > {
   const fact = item.payload.fact;
-  const nowSec = Math.floor((opts.nowMs ?? Date.now()) / 1000);
-  const nowIso = new Date(opts.nowMs ?? Date.now()).toISOString();
+  const nowMs = opts.nowMs ?? Date.now();
+  const nowSec = Math.floor(nowMs / 1000);
+  const nowIso = new Date(nowMs).toISOString();
 
   if (!fact) {
     return {
@@ -1070,6 +1071,11 @@ function findExplicitNewerVerifiedFact(db: DatabaseSync, fact: TriageFactSnapsho
       `SELECT f.*, vf.id AS verified_fact_id, vf.verified_at AS verified_at, vf.version AS verified_version
        FROM facts f
        JOIN verified_facts vf ON vf.fact_id = f.id
+       JOIN (
+         SELECT fact_id, MAX(version) AS max_version
+         FROM verified_facts
+         GROUP BY fact_id
+       ) latest ON vf.fact_id = latest.fact_id AND vf.version = latest.max_version
        WHERE f.supersedes_id = ? AND f.created_at >= ?
        ORDER BY f.created_at DESC
        LIMIT 5`,

--- a/extensions/memory-hybrid/services/verified-fact-triage.ts
+++ b/extensions/memory-hybrid/services/verified-fact-triage.ts
@@ -294,7 +294,7 @@ export function listVerifiedFactTriageItems(
            OR COALESCE(vf.next_verification, vf.verified_at) > ?
            OR (COALESCE(vf.next_verification, vf.verified_at) = ? AND vf.id > ?)
          )
-       ORDER BY COALESCE(vf.next_verification, vf.verified_at) ASC, vf.verified_at ASC, vf.id ASC`,
+       ORDER BY COALESCE(vf.next_verification, vf.verified_at) ASC, vf.id ASC`,
     )
     .all(nowIso, cutoffIso, cursor, cursor, cursor, cursorItemId) as unknown as VerifiedFactRow[];
 
@@ -325,7 +325,7 @@ function findVerifiedCursorItemId(
        WHERE ((vf.next_verification IS NOT NULL AND vf.next_verification <= ?)
           OR vf.verified_at <= ?)
          AND COALESCE(vf.next_verification, vf.verified_at) = ?
-       ORDER BY vf.verified_at ASC, vf.id ASC`,
+       ORDER BY vf.id ASC`,
     )
     .all(nowIso, cutoffIso, cursor) as unknown as VerifiedFactRow[];
   for (const row of rows) {

--- a/extensions/memory-hybrid/services/verified-fact-triage.ts
+++ b/extensions/memory-hybrid/services/verified-fact-triage.ts
@@ -273,10 +273,8 @@ export function listVerifiedFactTriageItems(
        JOIN (
          SELECT vf2.fact_id, MAX(vf2.version) AS max_version
          FROM verified_facts vf2
-         LEFT JOIN facts f2 ON f2.id = vf2.fact_id
          GROUP BY vf2.fact_id
        ) latest ON vf.fact_id = latest.fact_id AND vf.version = latest.max_version
-       LEFT JOIN facts f ON f.id = vf.fact_id
        WHERE (vf.next_verification IS NOT NULL AND vf.next_verification <= ?)
           OR vf.verified_at <= ?
        ORDER BY COALESCE(vf.next_verification, vf.verified_at) ASC, vf.verified_at ASC`,
@@ -387,6 +385,7 @@ export async function runVerifiedFactTriageWithAdapter(
 
   const decisions: PendingDecision[] = [];
   const resultItems: VerifiedTriageResultItem[] = [];
+  const liveItemsMap = new Map(items.map((item) => [item.id, item]));
   for (const item of items) {
     const context: PendingDecisionContext = {
       runId,
@@ -410,26 +409,35 @@ export async function runVerifiedFactTriageWithAdapter(
           ttlSeconds: opts.lockTtlSeconds ?? 60,
           mode,
         }) ?? false;
-      const liveItem = locked
-        ? ((await adapter.listPending(null)).find((candidate) => candidate.id === item.id) ?? null)
-        : null;
-      const actualInputHash = liveItem?.inputHash ?? "missing";
-      if (locked && liveItem && actualInputHash === item.inputHash) {
-        const { inserted } = durableStore?.recordDecision(decision) ?? {
-          inserted: false,
-        };
-        if (inserted && decision.action !== "deferred-for-human" && decision.action !== "failed-validation") {
-          durableStore?.advanceCursorIfSafe(decision, item.visibleAfterCursor ?? item.id);
+      if (locked) {
+        const liveItem = liveItemsMap.get(item.id) ?? null;
+        const actualInputHash = liveItem?.inputHash ?? "missing";
+        if (liveItem && actualInputHash === item.inputHash) {
+          const { inserted } = durableStore?.recordDecision(decision) ?? {
+            inserted: false,
+          };
+          if (inserted && decision.action !== "deferred-for-human" && decision.action !== "failed-validation") {
+            durableStore?.advanceCursorIfSafe(decision, item.visibleAfterCursor ?? item.id);
+          }
+          applied = inserted && (decision.action === "classified" || decision.action === "reported");
+        } else {
+          const staleDecision = validationFailureDecision(
+            item,
+            context,
+            "input-hash-mismatch",
+            liveItem
+              ? "Verified fact/fact row changed between classification and apply."
+              : "Verified fact no longer matches due queue before apply.",
+          );
+          durableStore?.recordDecision(staleDecision);
+          decisions[decisions.length - 1] = staleDecision;
         }
-        applied = inserted && (decision.action === "classified" || decision.action === "reported");
       } else if (durableStore) {
         const staleDecision = validationFailureDecision(
           item,
           context,
-          locked ? "input-hash-mismatch" : "lock-conflict",
-          liveItem
-            ? "Verified fact/fact row changed between classification and apply."
-            : "Verified fact no longer matches due queue before apply.",
+          "lock-conflict",
+          "Verified fact no longer matches due queue before apply.",
         );
         durableStore.recordDecision(staleDecision);
         decisions[decisions.length - 1] = staleDecision;
@@ -1090,6 +1098,7 @@ function findSameScopeDuplicateVerifiedFact(db: DatabaseSync, fact: TriageFactSn
        FROM facts f
        JOIN verified_facts vf ON vf.fact_id = f.id
        WHERE f.id != ? AND f.superseded_at IS NULL ${scopeClause}
+       ORDER BY f.created_at DESC
        LIMIT 50`,
     )
     .all(fact.id, ...scopeParams) as Array<Record<string, unknown>>;

--- a/extensions/memory-hybrid/services/verified-fact-triage.ts
+++ b/extensions/memory-hybrid/services/verified-fact-triage.ts
@@ -1122,6 +1122,11 @@ function findConcreteContradictingEvidence(db: DatabaseSync, fact: TriageFactSna
       `SELECT f.*, vf.id AS verified_fact_id
        FROM facts f
        JOIN verified_facts vf ON vf.fact_id = f.id
+       JOIN (
+         SELECT fact_id, MAX(version) AS max_version
+         FROM verified_facts
+         GROUP BY fact_id
+       ) latest ON vf.fact_id = latest.fact_id AND vf.version = latest.max_version
        WHERE f.id != ?
          AND lower(f.entity) = lower(?)
          AND lower(f.key) = lower(?)
@@ -1162,6 +1167,11 @@ function findSameScopeDuplicateVerifiedFact(db: DatabaseSync, fact: TriageFactSn
       `SELECT f.*, vf.id AS verified_fact_id
        FROM facts f
        JOIN verified_facts vf ON vf.fact_id = f.id
+       JOIN (
+         SELECT fact_id, MAX(version) AS max_version
+         FROM verified_facts
+         GROUP BY fact_id
+       ) latest ON vf.fact_id = latest.fact_id AND vf.version = latest.max_version
        WHERE f.id != ? AND f.superseded_at IS NULL ${scopeClause}
        ORDER BY f.created_at DESC
        LIMIT 50`,

--- a/extensions/memory-hybrid/services/verified-fact-triage.ts
+++ b/extensions/memory-hybrid/services/verified-fact-triage.ts
@@ -211,7 +211,7 @@ const SENSITIVE_RULES: Array<{
   {
     flag: "external-comms",
     reason: "sensitive_personal_fact",
-    pattern: /\b(external comms|external communication|email rule|reply rule|send to|contact\b|customer|client)\b/i,
+    pattern: /\b(external comms|external communication|email rule|reply rule|send to|contact|customer|client)\b/i,
   },
   {
     flag: "persona-preference",

--- a/extensions/memory-hybrid/services/verified-fact-triage.ts
+++ b/extensions/memory-hybrid/services/verified-fact-triage.ts
@@ -343,10 +343,6 @@ export async function runVerifiedFactTriage(
   opts: VerifiedFactTriageOptions,
 ): Promise<VerifiedTriageRunResult> {
   const policy = assertVerifiedTriagePolicy(opts.policy);
-  const mode = opts.mode;
-  const store = opts.store ?? null;
-  const runId = opts.runId ?? createPendingAutopilotRunId();
-  const actor = opts.actor ?? { type: "agent", id: "verified-triage-cli" };
   const adapter = createVerifiedFactTriageAdapter({
     factsDb,
     max: opts.max,
@@ -906,10 +902,6 @@ function buildRunResult(input: {
     },
     items: input.items,
   };
-}
-
-function hasValidVerifiedFactChecksum(row: VerifiedFactRow): boolean {
-  return createHash("sha256").update(row.canonical_text).digest("hex") === row.checksum;
 }
 
 function rowToVerifiedFact(row: VerifiedFactRow): VerifiedFact {

--- a/extensions/memory-hybrid/services/verified-fact-triage.ts
+++ b/extensions/memory-hybrid/services/verified-fact-triage.ts
@@ -1,264 +1,291 @@
+import { createHash } from "node:crypto";
 import type { DatabaseSync, SQLInputValue } from "node:sqlite";
 import type { FactsDB } from "../backends/facts-db.js";
 import { rowToMemoryEntry } from "../backends/facts-db/index.js";
 import type { MemoryEntry } from "../types/memory.js";
 import {
-  computePendingInputHash,
-  createPendingAutopilotRunId,
-  createStableRunSummary,
-  type PendingAutopilotStore,
-  type AutopilotAction,
-  type AutopilotReasonCode,
-  type PendingDecision,
-  type PendingDecisionContext,
-  type PendingDecisionEvidence,
-  type PendingItem,
-  type PendingQueueAdapter,
+	computePendingInputHash,
+	createPendingAutopilotRunId,
+	createStableRunSummary,
+	type PendingAutopilotStore,
+	type AutopilotAction,
+	type AutopilotReasonCode,
+	type PendingDecision,
+	type PendingDecisionContext,
+	type PendingDecisionEvidence,
+	type PendingItem,
+	type PendingQueueAdapter,
 } from "./pending-autopilot/index.js";
 import type { VerifiedFact } from "./verification-store.js";
 
 export const VERIFIED_TRIAGE_POLICY_VERSION = "verified-fact-triage-v1";
 export const VERIFIED_REVIEW_QUEUE_SOURCE =
-  "Latest verified_facts rows whose next_verification timestamp is due (or whose verified_at is older than the verification window), as returned by VerificationStore.listDueForReverification semantics. This is intentionally not all verified facts.";
+	"Latest verified_facts rows whose next_verification timestamp is due (or whose verified_at is older than the verification window), as returned by VerificationStore.listDueForReverification semantics. This is intentionally not all verified facts.";
 
-export const VERIFIED_TRIAGE_POLICIES = ["report-only", "classify", "apply-obvious"] as const;
+export const VERIFIED_TRIAGE_POLICIES = [
+	"report-only",
+	"classify",
+	"apply-obvious",
+] as const;
 export type VerifiedTriagePolicy = (typeof VERIFIED_TRIAGE_POLICIES)[number];
 
 export const VERIFIED_TRIAGE_BUCKETS = [
-  "still-current",
-  "stale-candidate",
-  "expired-ttl-candidate",
-  "superseded-candidate",
-  "contradicted-candidate",
-  "missing-or-weak-provenance",
-  "duplicate-candidate",
-  "scope-or-ownership-unclear",
-  "sensitive-needs-human",
-  "needs-human-review",
-  "failed-review",
+	"still-current",
+	"stale-candidate",
+	"expired-ttl-candidate",
+	"superseded-candidate",
+	"contradicted-candidate",
+	"missing-or-weak-provenance",
+	"duplicate-candidate",
+	"scope-or-ownership-unclear",
+	"sensitive-needs-human",
+	"needs-human-review",
+	"failed-review",
 ] as const;
 export type VerifiedTriageBucket = (typeof VERIFIED_TRIAGE_BUCKETS)[number];
 
 export const VERIFIED_TRIAGE_ACTIONS = [
-  "reported",
-  "classified",
-  "marked-reviewed",
-  "linked-evidence",
-  "flagged-stale",
-  "flagged-superseded",
-  "flagged-contradicted",
-  "flagged-sensitive",
-  "deferred-for-human",
-  "failed-validation",
-  "skipped-by-policy",
+	"reported",
+	"classified",
+	"marked-reviewed",
+	"linked-evidence",
+	"flagged-stale",
+	"flagged-superseded",
+	"flagged-contradicted",
+	"flagged-sensitive",
+	"deferred-for-human",
+	"failed-validation",
+	"skipped-by-policy",
 ] as const;
 export type VerifiedTriageAction = (typeof VERIFIED_TRIAGE_ACTIONS)[number];
 
 export type VerifiedTriageReason =
-  | "policy_report_only"
-  | "still_current_no_action_needed"
-  | "ttl_expired"
-  | "newer_verified_fact_exists"
-  | "contradicting_verified_fact_exists"
-  | "weak_or_missing_provenance"
-  | "duplicate_verified_fact_candidate"
-  | "sensitive_security_fact"
-  | "sensitive_privacy_fact"
-  | "sensitive_personal_fact"
-  | "sensitive_operational_runbook"
-  | "scope_unclear"
-  | "requires_human_approval"
-  | "stale_due_for_reverification"
-  | "low_confidence"
-  | "backend_error"
-  | "malformed_fact"
-  | "evidence_query_failed";
+	| "policy_report_only"
+	| "still_current_no_action_needed"
+	| "ttl_expired"
+	| "newer_verified_fact_exists"
+	| "contradicting_verified_fact_exists"
+	| "weak_or_missing_provenance"
+	| "duplicate_verified_fact_candidate"
+	| "sensitive_security_fact"
+	| "sensitive_privacy_fact"
+	| "sensitive_personal_fact"
+	| "sensitive_operational_runbook"
+	| "scope_unclear"
+	| "requires_human_approval"
+	| "stale_due_for_reverification"
+	| "low_confidence"
+	| "backend_error"
+	| "malformed_fact"
+	| "evidence_query_failed";
 
-export interface VerifiedFactTriageItem extends PendingItem<VerifiedFactTriagePayload> {
-  queue: "verified";
+export interface VerifiedFactTriageItem
+	extends PendingItem<VerifiedFactTriagePayload> {
+	queue: "verified";
 }
 
 export interface VerifiedFactTriagePayload extends Record<string, unknown> {
-  reviewQueueSource: string;
-  verified: VerifiedFact;
-  fact: TriageFactSnapshot | null;
-  verificationTier: string | null;
-  reviewCursor: string | null;
-  dueReason: "next_verification" | "verified_at_stale";
+	reviewQueueSource: string;
+	verified: VerifiedFact;
+	fact: TriageFactSnapshot | null;
+	verificationTier: string | null;
+	reviewCursor: string | null;
+	dueReason: "next_verification" | "verified_at_stale";
 }
 
 export interface TriageFactSnapshot {
-  id: string;
-  text: string;
-  category: string;
-  entity: string | null;
-  key: string | null;
-  value: string | null;
-  source: string;
-  createdAt: number;
-  expiresAt: number | null;
-  validFrom: number | null;
-  validUntil: number | null;
-  supersedesId: string | null;
-  supersededAt: number | null;
-  supersededBy: string | null;
-  tier: string | null;
-  scope: string;
-  scopeTarget: string | null;
-  provenanceSession: string | null;
-  sourceSessions: string | null;
-  provenanceJson: string | null;
-  tags: string[] | null;
-  confidence: number;
+	id: string;
+	text: string;
+	category: string;
+	entity: string | null;
+	key: string | null;
+	value: string | null;
+	source: string;
+	createdAt: number;
+	expiresAt: number | null;
+	validFrom: number | null;
+	validUntil: number | null;
+	supersedesId: string | null;
+	supersededAt: number | null;
+	supersededBy: string | null;
+	tier: string | null;
+	scope: string;
+	scopeTarget: string | null;
+	provenanceSession: string | null;
+	sourceSessions: string | null;
+	provenanceJson: string | null;
+	tags: string[] | null;
+	confidence: number;
 }
 
 export interface VerifiedTriageEvidence extends PendingDecisionEvidence {
-  fields?: Record<string, unknown>;
+	fields?: Record<string, unknown>;
 }
 
 export interface VerifiedTriageResultItem {
-  factId: string;
-  verifiedFactId: string;
-  text: string;
-  verificationTier: string | null;
-  scope: string | null;
-  scopeTarget: string | null;
-  entity: string | null;
-  key: string | null;
-  validFrom: number | null;
-  validUntil: number | null;
-  expiresAt: number | null;
-  provenanceSummary: string;
-  bucket: VerifiedTriageBucket;
-  recommendedAction: VerifiedTriageAction;
-  confidence: number;
-  evidence: VerifiedTriageEvidence[];
-  sensitivityFlags: string[];
-  reason: VerifiedTriageReason;
-  humanReviewRequired: boolean;
-  action: AutopilotAction;
-  reasonCode: AutopilotReasonCode;
-  capabilityClass: PendingDecision["capabilityClass"];
-  actionClass: PendingDecision["actionClass"];
-  inputHash: string;
-  applied: boolean;
+	factId: string;
+	verifiedFactId: string;
+	text: string;
+	verificationTier: string | null;
+	scope: string | null;
+	scopeTarget: string | null;
+	entity: string | null;
+	key: string | null;
+	validFrom: number | null;
+	validUntil: number | null;
+	expiresAt: number | null;
+	provenanceSummary: string;
+	bucket: VerifiedTriageBucket;
+	recommendedAction: VerifiedTriageAction;
+	confidence: number;
+	evidence: VerifiedTriageEvidence[];
+	sensitivityFlags: string[];
+	reason: VerifiedTriageReason;
+	humanReviewRequired: boolean;
+	action: AutopilotAction;
+	reasonCode: AutopilotReasonCode;
+	capabilityClass: PendingDecision["capabilityClass"];
+	actionClass: PendingDecision["actionClass"];
+	inputHash: string;
+	applied: boolean;
 }
 
 export interface VerifiedTriageRunResult {
-  runId: string;
-  mode: "dry-run" | "apply";
-  policy: VerifiedTriagePolicy;
-  policyVersion: string;
-  reviewQueueSource: string;
-  counts: {
-    inspected: number;
-    classified: number;
-    stillCurrent: number;
-    staleCandidates: number;
-    expiredTtlCandidates: number;
-    supersededCandidates: number;
-    contradictedCandidates: number;
-    duplicateCandidates: number;
-    sensitiveNeedsHuman: number;
-    needsHuman: number;
-    applied: number;
-    failed: number;
-  };
-  items: VerifiedTriageResultItem[];
+	runId: string;
+	mode: "dry-run" | "apply";
+	policy: VerifiedTriagePolicy;
+	policyVersion: string;
+	reviewQueueSource: string;
+	counts: {
+		inspected: number;
+		classified: number;
+		stillCurrent: number;
+		staleCandidates: number;
+		expiredTtlCandidates: number;
+		supersededCandidates: number;
+		contradictedCandidates: number;
+		duplicateCandidates: number;
+		sensitiveNeedsHuman: number;
+		needsHuman: number;
+		applied: number;
+		failed: number;
+	};
+	items: VerifiedTriageResultItem[];
 }
 
 export interface VerifiedFactTriageOptions {
-  mode: "dry-run" | "apply";
-  policy: VerifiedTriagePolicy;
-  max?: number;
-  actor?: PendingDecision["actor"];
-  jobId?: string;
-  runId?: string;
-  store?: PendingAutopilotStore | null;
-  nowMs?: number;
-  lockTtlSeconds?: number;
+	mode: "dry-run" | "apply";
+	policy: VerifiedTriagePolicy;
+	max?: number;
+	actor?: PendingDecision["actor"];
+	jobId?: string;
+	runId?: string;
+	store?: PendingAutopilotStore | null;
+	nowMs?: number;
+	lockTtlSeconds?: number;
 }
 
 interface RelatedFact extends TriageFactSnapshot {
-  verifiedFactId?: string | null;
-  verifiedAt?: string | null;
-  verifiedVersion?: number | null;
+	verifiedFactId?: string | null;
+	verifiedAt?: string | null;
+	verifiedVersion?: number | null;
 }
 
-const SENSITIVE_RULES: Array<{ flag: string; reason: VerifiedTriageReason; pattern: RegExp }> = [
-  {
-    flag: "credentials",
-    reason: "sensitive_security_fact",
-    pattern: /\b(password|passwd|credential|secret|api[-_ ]?key|token|bearer|ssh key|private key|vault|oauth|pat_)\b/i,
-  },
-  {
-    flag: "security",
-    reason: "sensitive_security_fact",
-    pattern: /\b(security|firewall|ssh|vpn|runbook|incident|breach|auth|mfa|2fa|permission|admin)\b/i,
-  },
-  {
-    flag: "privacy",
-    reason: "sensitive_privacy_fact",
-    pattern: /\b(privacy|private|personal data|pii|gdpr|address|phone|email|medical|health|passport|identity)\b/i,
-  },
-  {
-    flag: "external-comms",
-    reason: "sensitive_personal_fact",
-    pattern: /\b(external comms|external communication|email rule|reply rule|send to|contact\b|customer|client)\b/i,
-  },
-  {
-    flag: "persona-preference",
-    reason: "sensitive_personal_fact",
-    pattern: /\b(preference|user identity|persona|edict|hard rule|user profile|personal fact)\b/i,
-  },
-  {
-    flag: "operational-runbook",
-    reason: "sensitive_operational_runbook",
-    pattern: /\b(cron|runbook|operational|ops|production|deploy|restart|backup|restore)\b/i,
-  },
+const SENSITIVE_RULES: Array<{
+	flag: string;
+	reason: VerifiedTriageReason;
+	pattern: RegExp;
+}> = [
+	{
+		flag: "credentials",
+		reason: "sensitive_security_fact",
+		pattern:
+			/\b(password|passwd|credential|secret|api[-_ ]?key|token|bearer|ssh key|private key|vault|oauth|pat_)\b/i,
+	},
+	{
+		flag: "security",
+		reason: "sensitive_security_fact",
+		pattern:
+			/\b(security|firewall|ssh|vpn|runbook|incident|breach|auth|mfa|2fa|permission|admin)\b/i,
+	},
+	{
+		flag: "privacy",
+		reason: "sensitive_privacy_fact",
+		pattern:
+			/\b(privacy|private|personal data|pii|gdpr|address|phone|email|medical|health|passport|identity)\b/i,
+	},
+	{
+		flag: "external-comms",
+		reason: "sensitive_personal_fact",
+		pattern:
+			/\b(external comms|external communication|email rule|reply rule|send to|contact\b|customer|client)\b/i,
+	},
+	{
+		flag: "persona-preference",
+		reason: "sensitive_personal_fact",
+		pattern:
+			/\b(preference|user identity|persona|edict|hard rule|user profile|personal fact)\b/i,
+	},
+	{
+		flag: "operational-runbook",
+		reason: "sensitive_operational_runbook",
+		pattern:
+			/\b(cron|runbook|operational|ops|production|deploy|restart|backup|restore)\b/i,
+	},
 ];
 
-export function assertVerifiedTriagePolicy(value: string): VerifiedTriagePolicy {
-  if ((VERIFIED_TRIAGE_POLICIES as readonly string[]).includes(value)) return value as VerifiedTriagePolicy;
-  throw new Error(`Unknown verified triage policy: ${value}`);
+export function assertVerifiedTriagePolicy(
+	value: string,
+): VerifiedTriagePolicy {
+	if ((VERIFIED_TRIAGE_POLICIES as readonly string[]).includes(value))
+		return value as VerifiedTriagePolicy;
+	throw new Error(`Unknown verified triage policy: ${value}`);
 }
 
 export function createVerifiedFactTriageAdapter(input: {
-  factsDb: Pick<FactsDB, "getRawDb">;
-  max?: number;
-  nowMs?: number;
-  reverificationDays?: number;
-  policy?: VerifiedTriagePolicy;
+	factsDb: Pick<FactsDB, "getRawDb">;
+	max?: number;
+	nowMs?: number;
+	reverificationDays?: number;
+	policy?: VerifiedTriagePolicy;
 }): PendingQueueAdapter<VerifiedFactTriageItem> {
-  const db = input.factsDb.getRawDb();
-  return {
-    queue: "verified",
-    listPending: () =>
-      listVerifiedFactTriageItems(db, {
-        max: input.max,
-        nowMs: input.nowMs,
-        reverificationDays: input.reverificationDays,
-        policy: input.policy,
-      }),
-    decide: (item, context) => decideVerifiedFactTriage(item, context, { db, nowMs: input.nowMs }),
-    apply: (_decision, _item) => {
-      // Verified fact triage intentionally does not mutate core truth fields. Durable
-      // state is recorded through PendingAutopilotStore decisions only.
-    },
-  };
+	const db = input.factsDb.getRawDb();
+	return {
+		queue: "verified",
+		listPending: () =>
+			listVerifiedFactTriageItems(db, {
+				max: input.max,
+				nowMs: input.nowMs,
+				reverificationDays: input.reverificationDays,
+				policy: input.policy,
+			}),
+		decide: (item, context) =>
+			decideVerifiedFactTriage(item, context, { db, nowMs: input.nowMs }),
+		apply: (_decision, _item) => {
+			// Verified fact triage intentionally does not mutate core truth fields. Durable
+			// state is recorded through PendingAutopilotStore decisions only.
+		},
+	};
 }
 
 export function listVerifiedFactTriageItems(
-  db: DatabaseSync,
-  opts: { max?: number; nowMs?: number; reverificationDays?: number; policy?: VerifiedTriagePolicy } = {},
+	db: DatabaseSync,
+	opts: {
+		max?: number;
+		nowMs?: number;
+		reverificationDays?: number;
+		policy?: VerifiedTriagePolicy;
+	} = {},
 ): VerifiedFactTriageItem[] {
-  const nowMs = opts.nowMs ?? Date.now();
-  const nowIso = new Date(nowMs).toISOString();
-  const cutoffIso = new Date(nowMs - (opts.reverificationDays ?? 30) * 24 * 60 * 60 * 1000).toISOString();
-  const policy = opts.policy ?? "classify";
-  const latestRows = db
-    .prepare(
-      `SELECT vf.*
+	const nowMs = opts.nowMs ?? Date.now();
+	const nowIso = new Date(nowMs).toISOString();
+	const cutoffIso = new Date(
+		nowMs - (opts.reverificationDays ?? 30) * 24 * 60 * 60 * 1000,
+	).toISOString();
+	const policy = opts.policy ?? "classify";
+	const latestRows = db
+		.prepare(
+			`SELECT vf.*
        FROM verified_facts vf
        JOIN (
          SELECT vf2.fact_id, MAX(vf2.version) AS max_version
@@ -271,729 +298,873 @@ export function listVerifiedFactTriageItems(
           OR vf.verified_at <= ?
        ORDER BY COALESCE(vf.next_verification, vf.verified_at) ASC, vf.verified_at ASC
        LIMIT ?`,
-    )
-    .all(nowIso, cutoffIso, opts.max ?? 100) as unknown as VerifiedFactRow[];
+		)
+		.all(nowIso, cutoffIso, opts.max ?? 100) as unknown as VerifiedFactRow[];
 
-  return latestRows.map((row) => {
-    const verified = rowToVerifiedFact(row);
-    const fact = loadFactSnapshot(db, verified.factId);
-    const payload: VerifiedFactTriagePayload = {
-      reviewQueueSource: VERIFIED_REVIEW_QUEUE_SOURCE,
-      verified,
-      fact,
-      verificationTier: fact?.tier ?? null,
-      reviewCursor: verified.nextVerification ?? verified.verifiedAt,
-      dueReason:
-        verified.nextVerification && verified.nextVerification <= nowIso ? "next_verification" : "verified_at_stale",
-    };
-    const inputHash = computePendingInputHash({
-      queue: "verified",
-      id: verified.id,
-      payload,
-      policy,
-      policyVersion: VERIFIED_TRIAGE_POLICY_VERSION,
-    });
-    return {
-      queue: "verified",
-      id: verified.id,
-      inputHash,
-      policyVersion: VERIFIED_TRIAGE_POLICY_VERSION,
-      capabilityClasses: ["read-only", "record-review-metadata"],
-      payload,
-      visibleAfterCursor: verified.nextVerification ?? verified.verifiedAt,
-      requiresHumanReview: false,
-      validationFailed: !fact,
-    } satisfies VerifiedFactTriageItem;
-  });
+	return latestRows.filter(isVerifiedRowChecksumValid).map((row) => {
+		const verified = rowToVerifiedFact(row);
+		const fact = loadFactSnapshot(db, verified.factId);
+		const payload: VerifiedFactTriagePayload = {
+			reviewQueueSource: VERIFIED_REVIEW_QUEUE_SOURCE,
+			verified,
+			fact,
+			verificationTier: fact?.tier ?? null,
+			reviewCursor: verified.nextVerification ?? verified.verifiedAt,
+			dueReason:
+				verified.nextVerification && verified.nextVerification <= nowIso
+					? "next_verification"
+					: "verified_at_stale",
+		};
+		const inputHash = computePendingInputHash({
+			queue: "verified",
+			id: verified.id,
+			payload,
+			policy,
+			policyVersion: VERIFIED_TRIAGE_POLICY_VERSION,
+		});
+		return {
+			queue: "verified",
+			id: verified.id,
+			inputHash,
+			policyVersion: VERIFIED_TRIAGE_POLICY_VERSION,
+			capabilityClasses: ["read-only", "record-review-metadata"],
+			payload,
+			visibleAfterCursor: verified.nextVerification ?? verified.verifiedAt,
+			requiresHumanReview: false,
+			validationFailed: !fact,
+		} satisfies VerifiedFactTriageItem;
+	});
+}
+
+function isVerifiedRowChecksumValid(row: VerifiedFactRow): boolean {
+	return computeChecksum(row.canonical_text) === row.checksum;
+}
+
+function computeChecksum(text: string): string {
+	return createHash("sha256").update(text).digest("hex");
 }
 
 export function decideVerifiedFactTriage(
-  item: VerifiedFactTriageItem,
-  context: PendingDecisionContext,
-  opts: { db?: DatabaseSync; nowMs?: number } = {},
+	item: VerifiedFactTriageItem,
+	context: PendingDecisionContext,
+	opts: { db?: DatabaseSync; nowMs?: number } = {},
 ): PendingDecision {
-  const triage = classifyVerifiedFact(item, { db: opts.db, nowMs: opts.nowMs, policy: context.policy });
-  return triageToPendingDecision(item, context, triage);
+	const triage = classifyVerifiedFact(item, {
+		db: opts.db,
+		nowMs: opts.nowMs,
+		policy: context.policy,
+	});
+	return triageToPendingDecision(item, context, triage);
 }
 
 export async function runVerifiedFactTriage(
-  factsDb: Pick<FactsDB, "getRawDb">,
-  opts: VerifiedFactTriageOptions,
+	factsDb: Pick<FactsDB, "getRawDb">,
+	opts: VerifiedFactTriageOptions,
 ): Promise<VerifiedTriageRunResult> {
-  const policy = assertVerifiedTriagePolicy(opts.policy);
-  const mode = opts.mode;
-  const store = opts.store ?? null;
-  const runId = opts.runId ?? createPendingAutopilotRunId();
-  const actor = opts.actor ?? { type: "agent", id: "verified-triage-cli" };
-  const adapter = createVerifiedFactTriageAdapter({
-    factsDb,
-    max: opts.max,
-    nowMs: opts.nowMs,
-    policy,
-  });
-  return runVerifiedFactTriageWithAdapter(factsDb, adapter, opts);
+	const policy = assertVerifiedTriagePolicy(opts.policy);
+	const mode = opts.mode;
+	const store = opts.store ?? null;
+	const runId = opts.runId ?? createPendingAutopilotRunId();
+	const actor = opts.actor ?? { type: "agent", id: "verified-triage-cli" };
+	const adapter = createVerifiedFactTriageAdapter({
+		factsDb,
+		max: opts.max,
+		nowMs: opts.nowMs,
+		policy,
+	});
+	return runVerifiedFactTriageWithAdapter(factsDb, adapter, opts);
 }
 
 export async function runVerifiedFactTriageWithAdapter(
-  factsDb: Pick<FactsDB, "getRawDb">,
-  adapter: PendingQueueAdapter<VerifiedFactTriageItem>,
-  opts: VerifiedFactTriageOptions,
+	factsDb: Pick<FactsDB, "getRawDb">,
+	adapter: PendingQueueAdapter<VerifiedFactTriageItem>,
+	opts: VerifiedFactTriageOptions,
 ): Promise<VerifiedTriageRunResult> {
-  const policy = assertVerifiedTriagePolicy(opts.policy);
-  const mode = opts.mode;
-  const store = opts.store ?? null;
-  const runId = opts.runId ?? createPendingAutopilotRunId();
-  const actor = opts.actor ?? { type: "agent", id: "verified-triage-cli" };
-  const items = await adapter.listPending(null);
-  const runInputHash = computePendingInputHash({ queue: "verified", itemIds: items.map((i) => i.id), policy, mode });
-  const startedAt = Math.floor((opts.nowMs ?? Date.now()) / 1000);
+	const policy = assertVerifiedTriagePolicy(opts.policy);
+	const mode = opts.mode;
+	const store = opts.store ?? null;
+	const runId = opts.runId ?? createPendingAutopilotRunId();
+	const actor = opts.actor ?? { type: "agent", id: "verified-triage-cli" };
+	const items = await adapter.listPending(null);
+	const runInputHash = computePendingInputHash({
+		queue: "verified",
+		itemIds: items.map((i) => i.id),
+		policy,
+		mode,
+	});
+	const startedAt = Math.floor((opts.nowMs ?? Date.now()) / 1000);
 
-  const durableStore = policy === "report-only" ? null : store;
+	const durableStore = policy === "report-only" ? null : store;
 
-  durableStore?.createRun({
-    runId,
-    mode,
-    policy,
-    policyVersion: VERIFIED_TRIAGE_POLICY_VERSION,
-    inputHash: runInputHash,
-    queues: ["verified"],
-    startedAt,
-  });
+	durableStore?.createRun({
+		runId,
+		mode,
+		policy,
+		policyVersion: VERIFIED_TRIAGE_POLICY_VERSION,
+		inputHash: runInputHash,
+		queues: ["verified"],
+		startedAt,
+	});
 
-  const decisions: PendingDecision[] = [];
-  const resultItems: VerifiedTriageResultItem[] = [];
-  for (const item of items) {
-    const context: PendingDecisionContext = {
-      runId,
-      jobId: opts.jobId,
-      mode,
-      policy,
-      policyVersion: VERIFIED_TRIAGE_POLICY_VERSION,
-      inputHash: item.inputHash,
-      actor,
-    };
-    const decision = await adapter.decide(item, context);
-    decisions.push(decision);
-    let applied = false;
-    if (mode === "apply" && policy !== "report-only") {
-      const locked =
-        durableStore?.acquireLock({
-          queue: "verified",
-          itemId: item.id,
-          inputHash: item.inputHash,
-          owner: actor.id,
-          ttlSeconds: opts.lockTtlSeconds ?? 60,
-          mode,
-        }) ?? false;
-      const liveItem = locked
-        ? reloadVerifiedFactTriageItem(factsDb.getRawDb(), item, { policy, nowMs: opts.nowMs })
-        : null;
-      const actualInputHash = liveItem?.inputHash ?? "missing";
-      if (locked && liveItem && actualInputHash === item.inputHash) {
-        const { inserted } = durableStore?.recordDecision(decision) ?? { inserted: false };
-        if (inserted && decision.action !== "deferred-for-human" && decision.action !== "failed-validation") {
-          durableStore?.advanceCursorIfSafe(decision, item.visibleAfterCursor ?? item.id);
-        }
-        applied = inserted && (decision.action === "classified" || decision.action === "reported");
-      } else if (durableStore) {
-        const staleDecision = validationFailureDecision(
-          item,
-          context,
-          locked ? "input-hash-mismatch" : "lock-conflict",
-          liveItem
-            ? "Verified fact/fact row changed between classification and apply."
-            : "Verified fact no longer matches due queue before apply.",
-        );
-        durableStore.recordDecision(staleDecision);
-        decisions[decisions.length - 1] = staleDecision;
-      }
-      durableStore?.releaseLock({
-        queue: "verified",
-        itemId: item.id,
-        inputHash: item.inputHash,
-        owner: actor.id,
-        mode,
-      });
-    }
-    resultItems.push(decisionToResultItem(decisions[decisions.length - 1], item, applied));
-  }
+	const decisions: PendingDecision[] = [];
+	const resultItems: VerifiedTriageResultItem[] = [];
+	for (const item of items) {
+		const context: PendingDecisionContext = {
+			runId,
+			jobId: opts.jobId,
+			mode,
+			policy,
+			policyVersion: VERIFIED_TRIAGE_POLICY_VERSION,
+			inputHash: item.inputHash,
+			actor,
+		};
+		const decision = await adapter.decide(item, context);
+		decisions.push(decision);
+		let applied = false;
+		if (mode === "apply" && policy !== "report-only") {
+			const locked =
+				durableStore?.acquireLock({
+					queue: "verified",
+					itemId: item.id,
+					inputHash: item.inputHash,
+					owner: actor.id,
+					ttlSeconds: opts.lockTtlSeconds ?? 60,
+					mode,
+				}) ?? false;
+			const liveItem = locked
+				? reloadVerifiedFactTriageItem(factsDb.getRawDb(), item, {
+						policy,
+						nowMs: opts.nowMs,
+					})
+				: null;
+			const actualInputHash = liveItem?.inputHash ?? "missing";
+			if (locked && liveItem && actualInputHash === item.inputHash) {
+				const { inserted } = durableStore?.recordDecision(decision) ?? {
+					inserted: false,
+				};
+				if (
+					inserted &&
+					decision.action !== "deferred-for-human" &&
+					decision.action !== "failed-validation"
+				) {
+					durableStore?.advanceCursorIfSafe(
+						decision,
+						item.visibleAfterCursor ?? item.id,
+					);
+				}
+				applied =
+					inserted &&
+					(decision.action === "classified" || decision.action === "reported");
+			} else if (durableStore) {
+				const staleDecision = validationFailureDecision(
+					item,
+					context,
+					locked ? "input-hash-mismatch" : "lock-conflict",
+					liveItem
+						? "Verified fact/fact row changed between classification and apply."
+						: "Verified fact no longer matches due queue before apply.",
+				);
+				durableStore.recordDecision(staleDecision);
+				decisions[decisions.length - 1] = staleDecision;
+			}
+			durableStore?.releaseLock({
+				queue: "verified",
+				itemId: item.id,
+				inputHash: item.inputHash,
+				owner: actor.id,
+				mode,
+			});
+		}
+		resultItems.push(
+			decisionToResultItem(decisions[decisions.length - 1], item, applied),
+		);
+	}
 
-  const summary = createStableRunSummary({
-    runId,
-    mode,
-    policy,
-    policyVersion: VERIFIED_TRIAGE_POLICY_VERSION,
-    queues: ["verified"],
-    startedAt,
-    finishedAt: Math.floor((opts.nowMs ?? Date.now()) / 1000),
-    decisions,
-  });
-  durableStore?.finishRun(runId, summary, summary.finishedAt);
+	const summary = createStableRunSummary({
+		runId,
+		mode,
+		policy,
+		policyVersion: VERIFIED_TRIAGE_POLICY_VERSION,
+		queues: ["verified"],
+		startedAt,
+		finishedAt: Math.floor((opts.nowMs ?? Date.now()) / 1000),
+		decisions,
+	});
+	durableStore?.finishRun(runId, summary, summary.finishedAt);
 
-  return buildRunResult({ runId, mode, policy, items: resultItems });
+	return buildRunResult({ runId, mode, policy, items: resultItems });
 }
 
 export function classifyVerifiedFact(
-  item: VerifiedFactTriageItem,
-  opts: { db?: DatabaseSync; nowMs?: number; policy?: string } = {},
+	item: VerifiedFactTriageItem,
+	opts: { db?: DatabaseSync; nowMs?: number; policy?: string } = {},
 ): Omit<
-  VerifiedTriageResultItem,
-  | "factId"
-  | "verifiedFactId"
-  | "text"
-  | "verificationTier"
-  | "scope"
-  | "scopeTarget"
-  | "entity"
-  | "key"
-  | "validFrom"
-  | "validUntil"
-  | "expiresAt"
-  | "provenanceSummary"
-  | "action"
-  | "reasonCode"
-  | "capabilityClass"
-  | "actionClass"
-  | "inputHash"
-  | "applied"
+	VerifiedTriageResultItem,
+	| "factId"
+	| "verifiedFactId"
+	| "text"
+	| "verificationTier"
+	| "scope"
+	| "scopeTarget"
+	| "entity"
+	| "key"
+	| "validFrom"
+	| "validUntil"
+	| "expiresAt"
+	| "provenanceSummary"
+	| "action"
+	| "reasonCode"
+	| "capabilityClass"
+	| "actionClass"
+	| "inputHash"
+	| "applied"
 > {
-  const fact = item.payload.fact;
-  const nowSec = Math.floor((opts.nowMs ?? Date.now()) / 1000);
-  const nowIso = new Date(opts.nowMs ?? Date.now()).toISOString();
+	const fact = item.payload.fact;
+	const nowSec = Math.floor((opts.nowMs ?? Date.now()) / 1000);
+	const nowIso = new Date(opts.nowMs ?? Date.now()).toISOString();
 
-  if (!fact) {
-    return {
-      bucket: "failed-review",
-      recommendedAction: "failed-validation",
-      reason: "malformed_fact",
-      confidence: 1,
-      evidence: [
-        { type: "verified-fact", id: item.payload.verified.id, summary: "Verified row references a missing fact row" },
-      ],
-      sensitivityFlags: [],
-      humanReviewRequired: true,
-    };
-  }
+	if (!fact) {
+		return {
+			bucket: "failed-review",
+			recommendedAction: "failed-validation",
+			reason: "malformed_fact",
+			confidence: 1,
+			evidence: [
+				{
+					type: "verified-fact",
+					id: item.payload.verified.id,
+					summary: "Verified row references a missing fact row",
+				},
+			],
+			sensitivityFlags: [],
+			humanReviewRequired: true,
+		};
+	}
 
-  const sensitivity = detectSensitivity(fact, item.payload.verified.canonicalText);
-  if (sensitivity.flags.length > 0) {
-    return {
-      bucket: "sensitive-needs-human",
-      recommendedAction: "flagged-sensitive",
-      reason: sensitivity.reason,
-      confidence: 0.95,
-      evidence: [
-        { type: "sensitivity", id: fact.id, summary: `Matched sensitive categories: ${sensitivity.flags.join(", ")}` },
-      ],
-      sensitivityFlags: sensitivity.flags,
-      humanReviewRequired: true,
-    };
-  }
+	const sensitivity = detectSensitivity(
+		fact,
+		item.payload.verified.canonicalText,
+	);
+	if (sensitivity.flags.length > 0) {
+		return {
+			bucket: "sensitive-needs-human",
+			recommendedAction: "flagged-sensitive",
+			reason: sensitivity.reason,
+			confidence: 0.95,
+			evidence: [
+				{
+					type: "sensitivity",
+					id: fact.id,
+					summary: `Matched sensitive categories: ${sensitivity.flags.join(", ")}`,
+				},
+			],
+			sensitivityFlags: sensitivity.flags,
+			humanReviewRequired: true,
+		};
+	}
 
-  if (hasScopeUnclearSignals(fact)) {
-    return {
-      bucket: "scope-or-ownership-unclear",
-      recommendedAction: "deferred-for-human",
-      reason: "scope_unclear",
-      confidence: 0.9,
-      evidence: [
-        { type: "scope", id: fact.id, summary: "Fact has session/agent/user scope requiring explicit ownership proof" },
-      ],
-      sensitivityFlags: [],
-      humanReviewRequired: true,
-    };
-  }
+	if (hasScopeUnclearSignals(fact)) {
+		return {
+			bucket: "scope-or-ownership-unclear",
+			recommendedAction: "deferred-for-human",
+			reason: "scope_unclear",
+			confidence: 0.9,
+			evidence: [
+				{
+					type: "scope",
+					id: fact.id,
+					summary:
+						"Fact has session/agent/user scope requiring explicit ownership proof",
+				},
+			],
+			sensitivityFlags: [],
+			humanReviewRequired: true,
+		};
+	}
 
-  if (fact.validUntil != null && fact.validUntil <= nowSec) {
-    return {
-      bucket: "expired-ttl-candidate",
-      recommendedAction: "deferred-for-human",
-      reason: "ttl_expired",
-      confidence: 0.95,
-      evidence: [
-        {
-          type: "validity",
-          id: fact.id,
-          summary: "Fact valid_until has expired",
-          fields: { validUntil: fact.validUntil, now: nowSec },
-        },
-      ],
-      sensitivityFlags: [],
-      humanReviewRequired: true,
-    };
-  }
-  if (fact.expiresAt != null && fact.expiresAt <= nowSec) {
-    return {
-      bucket: "expired-ttl-candidate",
-      recommendedAction: "deferred-for-human",
-      reason: "ttl_expired",
-      confidence: 0.95,
-      evidence: [
-        {
-          type: "ttl",
-          id: fact.id,
-          summary: "Fact expires_at has expired",
-          fields: { expiresAt: fact.expiresAt, now: nowSec },
-        },
-      ],
-      sensitivityFlags: [],
-      humanReviewRequired: true,
-    };
-  }
+	if (fact.validUntil != null && fact.validUntil <= nowSec) {
+		return {
+			bucket: "expired-ttl-candidate",
+			recommendedAction: "deferred-for-human",
+			reason: "ttl_expired",
+			confidence: 0.95,
+			evidence: [
+				{
+					type: "validity",
+					id: fact.id,
+					summary: "Fact valid_until has expired",
+					fields: { validUntil: fact.validUntil, now: nowSec },
+				},
+			],
+			sensitivityFlags: [],
+			humanReviewRequired: true,
+		};
+	}
+	if (fact.expiresAt != null && fact.expiresAt <= nowSec) {
+		return {
+			bucket: "expired-ttl-candidate",
+			recommendedAction: "deferred-for-human",
+			reason: "ttl_expired",
+			confidence: 0.95,
+			evidence: [
+				{
+					type: "ttl",
+					id: fact.id,
+					summary: "Fact expires_at has expired",
+					fields: { expiresAt: fact.expiresAt, now: nowSec },
+				},
+			],
+			sensitivityFlags: [],
+			humanReviewRequired: true,
+		};
+	}
 
-  const newer = opts.db ? findExplicitNewerVerifiedFact(opts.db, fact) : null;
-  if (newer) {
-    return {
-      bucket: "superseded-candidate",
-      recommendedAction: "flagged-superseded",
-      reason: "newer_verified_fact_exists",
-      confidence: 0.9,
-      evidence: [
-        {
-          type: "fact",
-          id: newer.id,
-          summary: "Explicit newer verified fact supersedes this fact",
-          fields: { newerFactId: newer.id, verifiedFactId: newer.verifiedFactId },
-        },
-      ],
-      sensitivityFlags: [],
-      humanReviewRequired: true,
-    };
-  }
+	const newer = opts.db ? findExplicitNewerVerifiedFact(opts.db, fact) : null;
+	if (newer) {
+		return {
+			bucket: "superseded-candidate",
+			recommendedAction: "flagged-superseded",
+			reason: "newer_verified_fact_exists",
+			confidence: 0.9,
+			evidence: [
+				{
+					type: "fact",
+					id: newer.id,
+					summary: "Explicit newer verified fact supersedes this fact",
+					fields: {
+						newerFactId: newer.id,
+						verifiedFactId: newer.verifiedFactId,
+					},
+				},
+			],
+			sensitivityFlags: [],
+			humanReviewRequired: true,
+		};
+	}
 
-  const contradiction = opts.db ? findConcreteContradictingEvidence(opts.db, fact) : null;
-  if (contradiction) {
-    return {
-      bucket: "contradicted-candidate",
-      recommendedAction: "flagged-contradicted",
-      reason: "contradicting_verified_fact_exists",
-      confidence: 0.92,
-      evidence: [contradiction],
-      sensitivityFlags: [],
-      humanReviewRequired: true,
-    };
-  }
+	const contradiction = opts.db
+		? findConcreteContradictingEvidence(opts.db, fact)
+		: null;
+	if (contradiction) {
+		return {
+			bucket: "contradicted-candidate",
+			recommendedAction: "flagged-contradicted",
+			reason: "contradicting_verified_fact_exists",
+			confidence: 0.92,
+			evidence: [contradiction],
+			sensitivityFlags: [],
+			humanReviewRequired: true,
+		};
+	}
 
-  const duplicate = opts.db ? findSameScopeDuplicateVerifiedFact(opts.db, fact) : null;
-  if (duplicate) {
-    return {
-      bucket: "duplicate-candidate",
-      recommendedAction: "deferred-for-human",
-      reason: "duplicate_verified_fact_candidate",
-      confidence: 0.82,
-      evidence: [
-        {
-          type: "fact",
-          id: duplicate.id,
-          summary: "Same-scope verified fact has identical normalized text",
-          fields: { duplicateFactId: duplicate.id },
-        },
-      ],
-      sensitivityFlags: [],
-      humanReviewRequired: true,
-    };
-  }
+	const duplicate = opts.db
+		? findSameScopeDuplicateVerifiedFact(opts.db, fact)
+		: null;
+	if (duplicate) {
+		return {
+			bucket: "duplicate-candidate",
+			recommendedAction: "deferred-for-human",
+			reason: "duplicate_verified_fact_candidate",
+			confidence: 0.82,
+			evidence: [
+				{
+					type: "fact",
+					id: duplicate.id,
+					summary: "Same-scope verified fact has identical normalized text",
+					fields: { duplicateFactId: duplicate.id },
+				},
+			],
+			sensitivityFlags: [],
+			humanReviewRequired: true,
+		};
+	}
 
-  const weak = weakProvenanceReason(fact);
-  if (weak) {
-    return {
-      bucket: "missing-or-weak-provenance",
-      recommendedAction: "deferred-for-human",
-      reason: "weak_or_missing_provenance",
-      confidence: 0.86,
-      evidence: [{ type: "provenance", id: fact.id, summary: weak }],
-      sensitivityFlags: [],
-      humanReviewRequired: true,
-    };
-  }
+	const weak = weakProvenanceReason(fact);
+	if (weak) {
+		return {
+			bucket: "missing-or-weak-provenance",
+			recommendedAction: "deferred-for-human",
+			reason: "weak_or_missing_provenance",
+			confidence: 0.86,
+			evidence: [{ type: "provenance", id: fact.id, summary: weak }],
+			sensitivityFlags: [],
+			humanReviewRequired: true,
+		};
+	}
 
-  if (
-    (item.payload.verified.nextVerification && item.payload.verified.nextVerification <= nowIso) ||
-    item.payload.dueReason === "verified_at_stale"
-  ) {
-    return {
-      bucket: "stale-candidate",
-      recommendedAction: "classified",
-      reason: "stale_due_for_reverification",
-      confidence: 0.72,
-      evidence: [
-        {
-          type: "verification",
-          id: item.payload.verified.id,
-          summary:
-            item.payload.dueReason === "verified_at_stale"
-              ? "Fact verified_at is older than the reverification window"
-              : "Fact is due for scheduled reverification",
-          fields: {
-            nextVerification: item.payload.verified.nextVerification,
-            verifiedAt: item.payload.verified.verifiedAt,
-            dueReason: item.payload.dueReason,
-            now: nowIso,
-          },
-        },
-      ],
-      sensitivityFlags: [],
-      humanReviewRequired: false,
-    };
-  }
+	if (
+		(item.payload.verified.nextVerification &&
+			item.payload.verified.nextVerification <= nowIso) ||
+		item.payload.dueReason === "verified_at_stale"
+	) {
+		return {
+			bucket: "stale-candidate",
+			recommendedAction: "classified",
+			reason: "stale_due_for_reverification",
+			confidence: 0.72,
+			evidence: [
+				{
+					type: "verification",
+					id: item.payload.verified.id,
+					summary:
+						item.payload.dueReason === "verified_at_stale"
+							? "Fact verified_at is older than the reverification window"
+							: "Fact is due for scheduled reverification",
+					fields: {
+						nextVerification: item.payload.verified.nextVerification,
+						verifiedAt: item.payload.verified.verifiedAt,
+						dueReason: item.payload.dueReason,
+						now: nowIso,
+					},
+				},
+			],
+			sensitivityFlags: [],
+			humanReviewRequired: false,
+		};
+	}
 
-  return {
-    bucket: "still-current",
-    recommendedAction: opts.policy === "apply-obvious" ? "marked-reviewed" : "classified",
-    reason: "still_current_no_action_needed",
-    confidence: 0.74,
-    evidence: [
-      {
-        type: "review",
-        id: fact.id,
-        summary: "No concrete TTL, supersession, contradiction, sensitivity, scope, or provenance blocker found",
-        fields: { reviewedAt: nowIso, method: "deterministic-triage" },
-      },
-    ],
-    sensitivityFlags: [],
-    humanReviewRequired: false,
-  };
+	return {
+		bucket: "still-current",
+		recommendedAction:
+			opts.policy === "apply-obvious" ? "marked-reviewed" : "classified",
+		reason: "still_current_no_action_needed",
+		confidence: 0.74,
+		evidence: [
+			{
+				type: "review",
+				id: fact.id,
+				summary:
+					"No concrete TTL, supersession, contradiction, sensitivity, scope, or provenance blocker found",
+				fields: { reviewedAt: nowIso, method: "deterministic-triage" },
+			},
+		],
+		sensitivityFlags: [],
+		humanReviewRequired: false,
+	};
 }
 
 function triageToPendingDecision(
-  item: VerifiedFactTriageItem,
-  context: PendingDecisionContext,
-  triage: ReturnType<typeof classifyVerifiedFact>,
+	item: VerifiedFactTriageItem,
+	context: PendingDecisionContext,
+	triage: ReturnType<typeof classifyVerifiedFact>,
 ): PendingDecision {
-  const mapped = mapTriageAction(context.policy, triage);
-  const evidence = triage.evidence.map((ev) => ({
-    type: ev.type,
-    id: ev.id,
-    summary: ev.summary,
-    ...(ev.fields ? { fields: ev.fields } : {}),
-  }));
-  return {
-    queue: "verified",
-    itemId: item.id,
-    inputHash: context.inputHash,
-    policy: context.policy,
-    policyVersion: context.policyVersion,
-    mode: context.mode,
-    action: mapped.action,
-    reasonCode: mapped.reasonCode,
-    actionClass: mapped.actionClass,
-    capabilityClass: mapped.capabilityClass,
-    confidence: triage.confidence,
-    humanReviewRequired: triage.humanReviewRequired,
-    evidence,
-    actor: context.actor,
-    runId: context.runId,
-    jobId: context.jobId,
-    summary: {
-      title: `verified fact ${triage.bucket}`,
-      body: `${item.payload.fact?.id ?? item.payload.verified.factId}: ${triage.reason}`,
-      metadata: {
-        bucket: triage.bucket,
-        recommendedAction: triage.recommendedAction,
-        sensitivityFlags: triage.sensitivityFlags,
-        evidenceFields: triage.evidence.map((ev) => ev.fields).filter(Boolean),
-      },
-    },
-    audit: {
-      queue: "verified",
-      itemId: item.id,
-      inputHash: context.inputHash,
-      policy: context.policy,
-      policyVersion: context.policyVersion,
-      action: mapped.action,
-      reasonCode: mapped.reasonCode,
-      capabilityClass: mapped.capabilityClass,
-      humanReviewRequired: triage.humanReviewRequired,
-      evidence,
-      actor: context.actor,
-      runId: context.runId,
-      summary: {
-        title: "verified-fact-triage",
-        metadata: {
-          previous: {
-            verificationTier: item.payload.verificationTier,
-            verifiedFactId: item.payload.verified.id,
-            nextVerification: item.payload.verified.nextVerification,
-          },
-          after: {
-            bucket: triage.bucket,
-            recommendedAction: triage.recommendedAction,
-            reason: triage.reason,
-          },
-          mutation: "none-core-truth-fields-preserved",
-        },
-      },
-    },
-  };
+	const mapped = mapTriageAction(context.policy, triage);
+	const evidence = triage.evidence.map((ev) => ({
+		type: ev.type,
+		id: ev.id,
+		summary: ev.summary,
+		...(ev.fields ? { fields: ev.fields } : {}),
+	}));
+	return {
+		queue: "verified",
+		itemId: item.id,
+		inputHash: context.inputHash,
+		policy: context.policy,
+		policyVersion: context.policyVersion,
+		mode: context.mode,
+		action: mapped.action,
+		reasonCode: mapped.reasonCode,
+		actionClass: mapped.actionClass,
+		capabilityClass: mapped.capabilityClass,
+		confidence: triage.confidence,
+		humanReviewRequired: triage.humanReviewRequired,
+		evidence,
+		actor: context.actor,
+		runId: context.runId,
+		jobId: context.jobId,
+		summary: {
+			title: `verified fact ${triage.bucket}`,
+			body: `${item.payload.fact?.id ?? item.payload.verified.factId}: ${triage.reason}`,
+			metadata: {
+				bucket: triage.bucket,
+				recommendedAction: triage.recommendedAction,
+				sensitivityFlags: triage.sensitivityFlags,
+				evidenceFields: triage.evidence.map((ev) => ev.fields).filter(Boolean),
+			},
+		},
+		audit: {
+			queue: "verified",
+			itemId: item.id,
+			inputHash: context.inputHash,
+			policy: context.policy,
+			policyVersion: context.policyVersion,
+			action: mapped.action,
+			reasonCode: mapped.reasonCode,
+			capabilityClass: mapped.capabilityClass,
+			humanReviewRequired: triage.humanReviewRequired,
+			evidence,
+			actor: context.actor,
+			runId: context.runId,
+			summary: {
+				title: "verified-fact-triage",
+				metadata: {
+					previous: {
+						verificationTier: item.payload.verificationTier,
+						verifiedFactId: item.payload.verified.id,
+						nextVerification: item.payload.verified.nextVerification,
+					},
+					after: {
+						bucket: triage.bucket,
+						recommendedAction: triage.recommendedAction,
+						reason: triage.reason,
+					},
+					mutation: "none-core-truth-fields-preserved",
+				},
+			},
+		},
+	};
 }
 
 function mapTriageAction(
-  policy: string,
-  triage: Pick<VerifiedTriageResultItem, "recommendedAction" | "humanReviewRequired" | "reason">,
-): Pick<PendingDecision, "action" | "reasonCode" | "actionClass" | "capabilityClass"> {
-  if (policy === "report-only") {
-    return { action: "reported", reasonCode: "dry-run", actionClass: "preview", capabilityClass: "read-only" };
-  }
-  if (triage.recommendedAction === "failed-validation") {
-    return {
-      action: "failed-validation",
-      reasonCode: toAutopilotReason(triage.reason),
-      actionClass: "observe",
-      capabilityClass: "read-only",
-    };
-  }
-  if (triage.humanReviewRequired) {
-    return {
-      action: "deferred-for-human",
-      reasonCode: "human-review-required",
-      actionClass: "record-review",
-      capabilityClass: "record-review-metadata",
-    };
-  }
-  return {
-    action: "classified",
-    reasonCode: toAutopilotReason(triage.reason),
-    actionClass: "record-review",
-    capabilityClass: "record-review-metadata",
-  };
+	policy: string,
+	triage: Pick<
+		VerifiedTriageResultItem,
+		"recommendedAction" | "humanReviewRequired" | "reason"
+	>,
+): Pick<
+	PendingDecision,
+	"action" | "reasonCode" | "actionClass" | "capabilityClass"
+> {
+	if (policy === "report-only") {
+		return {
+			action: "reported",
+			reasonCode: "dry-run",
+			actionClass: "preview",
+			capabilityClass: "read-only",
+		};
+	}
+	if (triage.recommendedAction === "failed-validation") {
+		return {
+			action: "failed-validation",
+			reasonCode: toAutopilotReason(triage.reason),
+			actionClass: "observe",
+			capabilityClass: "read-only",
+		};
+	}
+	if (triage.humanReviewRequired) {
+		return {
+			action: "deferred-for-human",
+			reasonCode: "human-review-required",
+			actionClass: "record-review",
+			capabilityClass: "record-review-metadata",
+		};
+	}
+	return {
+		action: "classified",
+		reasonCode: toAutopilotReason(triage.reason),
+		actionClass: "record-review",
+		capabilityClass: "record-review-metadata",
+	};
 }
 
 function toAutopilotReason(reason: VerifiedTriageReason): AutopilotReasonCode {
-  switch (reason) {
-    case "policy_report_only":
-      return "dry-run";
-    case "backend_error":
-    case "evidence_query_failed":
-      return "audit-write-failed";
-    case "malformed_fact":
-      return "invalid-item";
-    case "requires_human_approval":
-    case "scope_unclear":
-    case "sensitive_security_fact":
-    case "sensitive_privacy_fact":
-    case "sensitive_personal_fact":
-    case "sensitive_operational_runbook":
-      return "human-review-required";
-    default:
-      return "policy-threshold-not-met";
-  }
+	switch (reason) {
+		case "policy_report_only":
+			return "dry-run";
+		case "backend_error":
+		case "evidence_query_failed":
+			return "audit-write-failed";
+		case "malformed_fact":
+			return "invalid-item";
+		case "requires_human_approval":
+		case "scope_unclear":
+		case "sensitive_security_fact":
+		case "sensitive_privacy_fact":
+		case "sensitive_personal_fact":
+		case "sensitive_operational_runbook":
+			return "human-review-required";
+		default:
+			return "policy-threshold-not-met";
+	}
 }
 
 function decisionToResultItem(
-  decision: PendingDecision,
-  item: VerifiedFactTriageItem,
-  applied: boolean,
+	decision: PendingDecision,
+	item: VerifiedFactTriageItem,
+	applied: boolean,
 ): VerifiedTriageResultItem {
-  const meta = decision.summary?.metadata ?? {};
-  const fact = item.payload.fact;
-  const bucket = String(meta.bucket ?? "failed-review") as VerifiedTriageBucket;
-  const recommendedAction = String(meta.recommendedAction ?? "failed-validation") as VerifiedTriageAction;
-  return {
-    factId: item.payload.verified.factId,
-    verifiedFactId: item.payload.verified.id,
-    text: fact?.text ?? item.payload.verified.canonicalText,
-    verificationTier: item.payload.verificationTier,
-    scope: fact?.scope ?? null,
-    scopeTarget: fact?.scopeTarget ?? null,
-    entity: fact?.entity ?? null,
-    key: fact?.key ?? null,
-    validFrom: fact?.validFrom ?? null,
-    validUntil: fact?.validUntil ?? null,
-    expiresAt: fact?.expiresAt ?? null,
-    provenanceSummary: summarizeProvenance(fact),
-    bucket,
-    recommendedAction,
-    confidence: decision.confidence,
-    evidence: decision.evidence,
-    sensitivityFlags: Array.isArray(meta.sensitivityFlags) ? (meta.sensitivityFlags as string[]) : [],
-    reason: extractVerifiedReason(decision, item),
-    humanReviewRequired: decision.humanReviewRequired,
-    action: decision.action,
-    reasonCode: decision.reasonCode,
-    capabilityClass: decision.capabilityClass,
-    actionClass: decision.actionClass,
-    inputHash: decision.inputHash,
-    applied,
-  };
+	const meta = decision.summary?.metadata ?? {};
+	const fact = item.payload.fact;
+	const bucket = String(meta.bucket ?? "failed-review") as VerifiedTriageBucket;
+	const recommendedAction = String(
+		meta.recommendedAction ?? "failed-validation",
+	) as VerifiedTriageAction;
+	return {
+		factId: item.payload.verified.factId,
+		verifiedFactId: item.payload.verified.id,
+		text: fact?.text ?? item.payload.verified.canonicalText,
+		verificationTier: item.payload.verificationTier,
+		scope: fact?.scope ?? null,
+		scopeTarget: fact?.scopeTarget ?? null,
+		entity: fact?.entity ?? null,
+		key: fact?.key ?? null,
+		validFrom: fact?.validFrom ?? null,
+		validUntil: fact?.validUntil ?? null,
+		expiresAt: fact?.expiresAt ?? null,
+		provenanceSummary: summarizeProvenance(fact),
+		bucket,
+		recommendedAction,
+		confidence: decision.confidence,
+		evidence: decision.evidence,
+		sensitivityFlags: Array.isArray(meta.sensitivityFlags)
+			? (meta.sensitivityFlags as string[])
+			: [],
+		reason: extractVerifiedReason(decision, item),
+		humanReviewRequired: decision.humanReviewRequired,
+		action: decision.action,
+		reasonCode: decision.reasonCode,
+		capabilityClass: decision.capabilityClass,
+		actionClass: decision.actionClass,
+		inputHash: decision.inputHash,
+		applied,
+	};
 }
 
-function extractVerifiedReason(decision: PendingDecision, item: VerifiedFactTriageItem): VerifiedTriageReason {
-  const after = decision.audit?.summary?.metadata as { after?: { reason?: string } } | undefined;
-  const reason = after?.after?.reason;
-  if (reason) return reason as VerifiedTriageReason;
-  const reasonCodeMap: Partial<Record<AutopilotReasonCode, VerifiedTriageReason>> = {
-    "input-hash-mismatch": "backend_error",
-    "lock-conflict": "backend_error",
-    "lock-missing": "backend_error",
-  };
-  return reasonCodeMap[decision.reasonCode] ?? (item.validationFailed ? "malformed_fact" : "requires_human_approval");
+function extractVerifiedReason(
+	decision: PendingDecision,
+	item: VerifiedFactTriageItem,
+): VerifiedTriageReason {
+	const after = decision.audit?.summary?.metadata as
+		| { after?: { reason?: string } }
+		| undefined;
+	const reason = after?.after?.reason;
+	if (reason) return reason as VerifiedTriageReason;
+	const reasonCodeMap: Partial<
+		Record<AutopilotReasonCode, VerifiedTriageReason>
+	> = {
+		"input-hash-mismatch": "backend_error",
+		"lock-conflict": "backend_error",
+		"lock-missing": "backend_error",
+	};
+	return (
+		reasonCodeMap[decision.reasonCode] ??
+		(item.validationFailed ? "malformed_fact" : "requires_human_approval")
+	);
 }
 
 function buildRunResult(input: {
-  runId: string;
-  mode: "dry-run" | "apply";
-  policy: VerifiedTriagePolicy;
-  items: VerifiedTriageResultItem[];
+	runId: string;
+	mode: "dry-run" | "apply";
+	policy: VerifiedTriagePolicy;
+	items: VerifiedTriageResultItem[];
 }): VerifiedTriageRunResult {
-  return {
-    runId: input.runId,
-    mode: input.mode,
-    policy: input.policy,
-    policyVersion: VERIFIED_TRIAGE_POLICY_VERSION,
-    reviewQueueSource: VERIFIED_REVIEW_QUEUE_SOURCE,
-    counts: {
-      inspected: input.items.length,
-      classified: input.items.filter((i) => i.action === "classified" || i.action === "reported").length,
-      stillCurrent: input.items.filter((i) => i.bucket === "still-current").length,
-      staleCandidates: input.items.filter((i) => i.bucket === "stale-candidate").length,
-      expiredTtlCandidates: input.items.filter((i) => i.bucket === "expired-ttl-candidate").length,
-      supersededCandidates: input.items.filter((i) => i.bucket === "superseded-candidate").length,
-      contradictedCandidates: input.items.filter((i) => i.bucket === "contradicted-candidate").length,
-      duplicateCandidates: input.items.filter((i) => i.bucket === "duplicate-candidate").length,
-      sensitiveNeedsHuman: input.items.filter((i) => i.bucket === "sensitive-needs-human").length,
-      needsHuman: input.items.filter((i) => i.humanReviewRequired).length,
-      applied: input.items.filter((i) => i.applied).length,
-      failed: input.items.filter((i) => i.bucket === "failed-review").length,
-    },
-    items: input.items,
-  };
+	return {
+		runId: input.runId,
+		mode: input.mode,
+		policy: input.policy,
+		policyVersion: VERIFIED_TRIAGE_POLICY_VERSION,
+		reviewQueueSource: VERIFIED_REVIEW_QUEUE_SOURCE,
+		counts: {
+			inspected: input.items.length,
+			classified: input.items.filter(
+				(i) => i.action === "classified" || i.action === "reported",
+			).length,
+			stillCurrent: input.items.filter((i) => i.bucket === "still-current")
+				.length,
+			staleCandidates: input.items.filter((i) => i.bucket === "stale-candidate")
+				.length,
+			expiredTtlCandidates: input.items.filter(
+				(i) => i.bucket === "expired-ttl-candidate",
+			).length,
+			supersededCandidates: input.items.filter(
+				(i) => i.bucket === "superseded-candidate",
+			).length,
+			contradictedCandidates: input.items.filter(
+				(i) => i.bucket === "contradicted-candidate",
+			).length,
+			duplicateCandidates: input.items.filter(
+				(i) => i.bucket === "duplicate-candidate",
+			).length,
+			sensitiveNeedsHuman: input.items.filter(
+				(i) => i.bucket === "sensitive-needs-human",
+			).length,
+			needsHuman: input.items.filter((i) => i.humanReviewRequired).length,
+			applied: input.items.filter((i) => i.applied).length,
+			failed: input.items.filter((i) => i.bucket === "failed-review").length,
+		},
+		items: input.items,
+	};
 }
 
 function rowToVerifiedFact(row: VerifiedFactRow): VerifiedFact {
-  return {
-    id: row.id,
-    factId: row.fact_id,
-    canonicalText: row.canonical_text,
-    checksum: row.checksum,
-    verifiedAt: row.verified_at,
-    verifiedBy: row.verified_by as VerifiedFact["verifiedBy"],
-    nextVerification: row.next_verification,
-    version: row.version,
-    previousVersionId: row.previous_version_id,
-    createdAt: row.created_at,
-  };
+	return {
+		id: row.id,
+		factId: row.fact_id,
+		canonicalText: row.canonical_text,
+		checksum: row.checksum,
+		verifiedAt: row.verified_at,
+		verifiedBy: row.verified_by as VerifiedFact["verifiedBy"],
+		nextVerification: row.next_verification,
+		version: row.version,
+		previousVersionId: row.previous_version_id,
+		createdAt: row.created_at,
+	};
 }
 
 interface VerifiedFactRow {
-  id: string;
-  fact_id: string;
-  canonical_text: string;
-  checksum: string;
-  verified_at: string;
-  verified_by: string;
-  next_verification: string | null;
-  version: number;
-  previous_version_id: string | null;
-  created_at: string;
+	id: string;
+	fact_id: string;
+	canonical_text: string;
+	checksum: string;
+	verified_at: string;
+	verified_by: string;
+	next_verification: string | null;
+	version: number;
+	previous_version_id: string | null;
+	created_at: string;
 }
 
-function loadFactSnapshot(db: DatabaseSync, factId: string): TriageFactSnapshot | null {
-  const row = db.prepare("SELECT * FROM facts WHERE id = ?").get(factId) as Record<string, unknown> | undefined;
-  return row ? memoryEntryToSnapshot(rowToMemoryEntry(row)) : null;
+function loadFactSnapshot(
+	db: DatabaseSync,
+	factId: string,
+): TriageFactSnapshot | null {
+	const row = db.prepare("SELECT * FROM facts WHERE id = ?").get(factId) as
+		| Record<string, unknown>
+		| undefined;
+	return row ? memoryEntryToSnapshot(rowToMemoryEntry(row)) : null;
 }
 
 function memoryEntryToSnapshot(entry: MemoryEntry): TriageFactSnapshot {
-  return {
-    id: entry.id,
-    text: entry.text,
-    category: entry.category,
-    entity: entry.entity,
-    key: entry.key,
-    value: entry.value,
-    source: entry.source,
-    createdAt: entry.createdAt,
-    expiresAt: entry.expiresAt,
-    validFrom: entry.validFrom ?? null,
-    validUntil: entry.validUntil ?? null,
-    supersedesId: entry.supersedesId ?? null,
-    supersededAt: entry.supersededAt ?? null,
-    supersededBy: entry.supersededBy ?? null,
-    tier: entry.tier ?? null,
-    scope: entry.scope ?? "global",
-    scopeTarget: entry.scopeTarget ?? null,
-    provenanceSession: entry.provenanceSession ?? null,
-    sourceSessions: entry.sourceSessions ?? null,
-    provenanceJson: entry.provenanceJson ?? null,
-    tags: entry.tags ?? null,
-    confidence: entry.confidence,
-  };
+	return {
+		id: entry.id,
+		text: entry.text,
+		category: entry.category,
+		entity: entry.entity,
+		key: entry.key,
+		value: entry.value,
+		source: entry.source,
+		createdAt: entry.createdAt,
+		expiresAt: entry.expiresAt,
+		validFrom: entry.validFrom ?? null,
+		validUntil: entry.validUntil ?? null,
+		supersedesId: entry.supersedesId ?? null,
+		supersededAt: entry.supersededAt ?? null,
+		supersededBy: entry.supersededBy ?? null,
+		tier: entry.tier ?? null,
+		scope: entry.scope ?? "global",
+		scopeTarget: entry.scopeTarget ?? null,
+		provenanceSession: entry.provenanceSession ?? null,
+		sourceSessions: entry.sourceSessions ?? null,
+		provenanceJson: entry.provenanceJson ?? null,
+		tags: entry.tags ?? null,
+		confidence: entry.confidence,
+	};
 }
 
 function snapshotFromRow(row: Record<string, unknown>): RelatedFact {
-  return memoryEntryToSnapshot(rowToMemoryEntry(row));
+	return memoryEntryToSnapshot(rowToMemoryEntry(row));
 }
 
 function detectSensitivity(
-  fact: TriageFactSnapshot,
-  canonicalText: string,
+	fact: TriageFactSnapshot,
+	canonicalText: string,
 ): { flags: string[]; reason: VerifiedTriageReason } {
-  const haystack = [canonicalText, fact.text, fact.category, fact.entity, fact.key, fact.value, fact.tags?.join(" ")]
-    .filter(Boolean)
-    .join("\n");
-  const flags: string[] = [];
-  let reason: VerifiedTriageReason = "sensitive_personal_fact";
-  for (const rule of SENSITIVE_RULES) {
-    if (rule.pattern.test(haystack)) {
-      flags.push(rule.flag);
-      if (reason === "sensitive_personal_fact" || rule.reason === "sensitive_security_fact") reason = rule.reason;
-    }
-  }
-  return { flags: [...new Set(flags)], reason };
+	const haystack = [
+		canonicalText,
+		fact.text,
+		fact.category,
+		fact.entity,
+		fact.key,
+		fact.value,
+		fact.tags?.join(" "),
+	]
+		.filter(Boolean)
+		.join("\n");
+	const flags: string[] = [];
+	let reason: VerifiedTriageReason = "sensitive_personal_fact";
+	for (const rule of SENSITIVE_RULES) {
+		if (rule.pattern.test(haystack)) {
+			flags.push(rule.flag);
+			if (
+				reason === "sensitive_personal_fact" ||
+				rule.reason === "sensitive_security_fact"
+			)
+				reason = rule.reason;
+		}
+	}
+	return { flags: [...new Set(flags)], reason };
 }
 
 function hasScopeUnclearSignals(fact: TriageFactSnapshot): boolean {
-  return fact.scope !== "global" && !fact.scopeTarget;
+	return fact.scope !== "global" && !fact.scopeTarget;
 }
 
 function sameScope(a: TriageFactSnapshot, b: TriageFactSnapshot): boolean {
-  return a.scope === b.scope && (a.scopeTarget ?? null) === (b.scopeTarget ?? null);
+	return (
+		a.scope === b.scope && (a.scopeTarget ?? null) === (b.scopeTarget ?? null)
+	);
 }
 
-function findExplicitNewerVerifiedFact(db: DatabaseSync, fact: TriageFactSnapshot): RelatedFact | null {
-  if (fact.supersededBy) {
-    const newer = loadVerifiedRelatedFact(db, fact.supersededBy);
-    if (newer && sameScope(fact, newer) && newer.createdAt >= fact.createdAt) return newer;
-  }
-  const rows = db
-    .prepare(
-      `SELECT f.*, vf.id AS verified_fact_id, vf.verified_at AS verified_at, vf.version AS verified_version
+function findExplicitNewerVerifiedFact(
+	db: DatabaseSync,
+	fact: TriageFactSnapshot,
+): RelatedFact | null {
+	if (fact.supersededBy) {
+		const newer = loadVerifiedRelatedFact(db, fact.supersededBy);
+		if (newer && sameScope(fact, newer) && newer.createdAt >= fact.createdAt)
+			return newer;
+	}
+	const rows = db
+		.prepare(
+			`SELECT f.*, vf.id AS verified_fact_id, vf.verified_at AS verified_at, vf.version AS verified_version
        FROM facts f
        JOIN verified_facts vf ON vf.fact_id = f.id
        WHERE f.supersedes_id = ? AND f.created_at >= ?
        ORDER BY f.created_at DESC
        LIMIT 5`,
-    )
-    .all(fact.id, fact.createdAt) as Array<Record<string, unknown>>;
-  for (const row of rows) {
-    const newer = { ...snapshotFromRow(row), verifiedFactId: row.verified_fact_id as string };
-    if (sameScope(fact, newer)) return newer;
-  }
-  return null;
+		)
+		.all(fact.id, fact.createdAt) as Array<Record<string, unknown>>;
+	for (const row of rows) {
+		const newer = {
+			...snapshotFromRow(row),
+			verifiedFactId: row.verified_fact_id as string,
+		};
+		if (sameScope(fact, newer)) return newer;
+	}
+	return null;
 }
 
-function loadVerifiedRelatedFact(db: DatabaseSync, factId: string): RelatedFact | null {
-  const row = db
-    .prepare(
-      `SELECT f.*, vf.id AS verified_fact_id, vf.verified_at AS verified_at, vf.version AS verified_version
+function loadVerifiedRelatedFact(
+	db: DatabaseSync,
+	factId: string,
+): RelatedFact | null {
+	const row = db
+		.prepare(
+			`SELECT f.*, vf.id AS verified_fact_id, vf.verified_at AS verified_at, vf.version AS verified_version
        FROM facts f
        JOIN verified_facts vf ON vf.fact_id = f.id
        WHERE f.id = ?
        ORDER BY vf.version DESC
        LIMIT 1`,
-    )
-    .get(factId) as Record<string, unknown> | undefined;
-  if (!row) return null;
-  return { ...snapshotFromRow(row), verifiedFactId: row.verified_fact_id as string };
+		)
+		.get(factId) as Record<string, unknown> | undefined;
+	if (!row) return null;
+	return {
+		...snapshotFromRow(row),
+		verifiedFactId: row.verified_fact_id as string,
+	};
 }
 
-function findConcreteContradictingEvidence(db: DatabaseSync, fact: TriageFactSnapshot): VerifiedTriageEvidence | null {
-  if (!fact.entity?.trim() || !fact.key?.trim() || fact.value == null || fact.value.trim() === "") return null;
-  const scopeClause =
-    fact.scopeTarget != null ? "AND f.scope = ? AND f.scope_target = ?" : "AND f.scope = ? AND f.scope_target IS NULL";
-  const scopeParams: SQLInputValue[] = fact.scopeTarget != null ? [fact.scope, fact.scopeTarget] : [fact.scope];
-  const row = db
-    .prepare(
-      `SELECT f.*, vf.id AS verified_fact_id
+function findConcreteContradictingEvidence(
+	db: DatabaseSync,
+	fact: TriageFactSnapshot,
+): VerifiedTriageEvidence | null {
+	if (
+		!fact.entity?.trim() ||
+		!fact.key?.trim() ||
+		fact.value == null ||
+		fact.value.trim() === ""
+	)
+		return null;
+	const scopeClause =
+		fact.scopeTarget != null
+			? "AND f.scope = ? AND f.scope_target = ?"
+			: "AND f.scope = ? AND f.scope_target IS NULL";
+	const scopeParams: SQLInputValue[] =
+		fact.scopeTarget != null ? [fact.scope, fact.scopeTarget] : [fact.scope];
+	const row = db
+		.prepare(
+			`SELECT f.*, vf.id AS verified_fact_id
        FROM facts f
        JOIN verified_facts vf ON vf.fact_id = f.id
        WHERE f.id != ?
@@ -1005,137 +1176,162 @@ function findConcreteContradictingEvidence(db: DatabaseSync, fact: TriageFactSna
          ${scopeClause}
        ORDER BY f.created_at DESC
        LIMIT 1`,
-    )
-    .get(fact.id, fact.entity, fact.key, fact.value, ...scopeParams) as Record<string, unknown> | undefined;
-  if (!row) return null;
-  return {
-    type: "contradiction",
-    id: row.id as string,
-    summary: "Concrete same-entity/key/scope verified fact has conflicting structured value",
-    fields: {
-      subject: fact.entity,
-      scope: fact.scope,
-      scopeTarget: fact.scopeTarget,
-      claimType: fact.key,
-      currentValue: fact.value,
-      conflictingValue: row.value,
-      sourceId: row.id,
-      verifiedFactId: row.verified_fact_id,
-    },
-  };
+		)
+		.get(fact.id, fact.entity, fact.key, fact.value, ...scopeParams) as
+		| Record<string, unknown>
+		| undefined;
+	if (!row) return null;
+	return {
+		type: "contradiction",
+		id: row.id as string,
+		summary:
+			"Concrete same-entity/key/scope verified fact has conflicting structured value",
+		fields: {
+			subject: fact.entity,
+			scope: fact.scope,
+			scopeTarget: fact.scopeTarget,
+			claimType: fact.key,
+			currentValue: fact.value,
+			conflictingValue: row.value,
+			sourceId: row.id,
+			verifiedFactId: row.verified_fact_id,
+		},
+	};
 }
 
-function findSameScopeDuplicateVerifiedFact(db: DatabaseSync, fact: TriageFactSnapshot): RelatedFact | null {
-  const normalized = normalizeFactText(fact.text);
-  if (!normalized) return null;
-  const scopeClause =
-    fact.scopeTarget != null ? "AND f.scope = ? AND f.scope_target = ?" : "AND f.scope = ? AND f.scope_target IS NULL";
-  const scopeParams: SQLInputValue[] = fact.scopeTarget != null ? [fact.scope, fact.scopeTarget] : [fact.scope];
-  const rows = db
-    .prepare(
-      `SELECT f.*, vf.id AS verified_fact_id
+function findSameScopeDuplicateVerifiedFact(
+	db: DatabaseSync,
+	fact: TriageFactSnapshot,
+): RelatedFact | null {
+	const normalized = normalizeFactText(fact.text);
+	if (!normalized) return null;
+	const scopeClause =
+		fact.scopeTarget != null
+			? "AND f.scope = ? AND f.scope_target = ?"
+			: "AND f.scope = ? AND f.scope_target IS NULL";
+	const scopeParams: SQLInputValue[] =
+		fact.scopeTarget != null ? [fact.scope, fact.scopeTarget] : [fact.scope];
+	const rows = db
+		.prepare(
+			`SELECT f.*, vf.id AS verified_fact_id
        FROM facts f
        JOIN verified_facts vf ON vf.fact_id = f.id
        WHERE f.id != ? AND f.superseded_at IS NULL ${scopeClause}
        LIMIT 50`,
-    )
-    .all(fact.id, ...scopeParams) as Array<Record<string, unknown>>;
-  for (const row of rows) {
-    const candidate = { ...snapshotFromRow(row), verifiedFactId: row.verified_fact_id as string };
-    if (normalizeFactText(candidate.text) === normalized) return candidate;
-  }
-  return null;
+		)
+		.all(fact.id, ...scopeParams) as Array<Record<string, unknown>>;
+	for (const row of rows) {
+		const candidate = {
+			...snapshotFromRow(row),
+			verifiedFactId: row.verified_fact_id as string,
+		};
+		if (normalizeFactText(candidate.text) === normalized) return candidate;
+	}
+	return null;
 }
 
 function normalizeFactText(text: string): string {
-  return text.trim().toLowerCase().replace(/\s+/g, " ");
+	return text.trim().toLowerCase().replace(/\s+/g, " ");
 }
 
 function weakProvenanceReason(fact: TriageFactSnapshot): string | null {
-  if (fact.source === "unknown" || fact.source === "") return "Fact source is missing or unknown";
-  if (!fact.provenanceJson && !fact.provenanceSession && !fact.sourceSessions) {
-    return "No provenance_json, provenance_session, or source_sessions recorded";
-  }
-  return null;
+	if (fact.source === "unknown" || fact.source === "")
+		return "Fact source is missing or unknown";
+	if (!fact.provenanceJson && !fact.provenanceSession && !fact.sourceSessions) {
+		return "No provenance_json, provenance_session, or source_sessions recorded";
+	}
+	return null;
 }
 
 function summarizeProvenance(fact: TriageFactSnapshot | null): string {
-  if (!fact) return "missing fact row";
-  const parts = [
-    fact.provenanceJson ? "provenance_json" : null,
-    fact.provenanceSession ? `session:${fact.provenanceSession}` : null,
-    fact.sourceSessions ? "source_sessions" : null,
-    `source:${fact.source}`,
-  ].filter(Boolean);
-  return parts.join(", ");
+	if (!fact) return "missing fact row";
+	const parts = [
+		fact.provenanceJson ? "provenance_json" : null,
+		fact.provenanceSession ? `session:${fact.provenanceSession}` : null,
+		fact.sourceSessions ? "source_sessions" : null,
+		`source:${fact.source}`,
+	].filter(Boolean);
+	return parts.join(", ");
 }
 
 function reloadVerifiedFactTriageItem(
-  db: DatabaseSync,
-  item: VerifiedFactTriageItem,
-  opts: { policy: VerifiedTriagePolicy; nowMs?: number; reverificationDays?: number },
+	db: DatabaseSync,
+	item: VerifiedFactTriageItem,
+	opts: {
+		policy: VerifiedTriagePolicy;
+		nowMs?: number;
+		reverificationDays?: number;
+	},
 ): VerifiedFactTriageItem | null {
-  return (
-    listVerifiedFactTriageItems(db, {
-      max: 10_000,
-      nowMs: opts.nowMs,
-      reverificationDays: opts.reverificationDays,
-      policy: opts.policy,
-    }).find((candidate) => candidate.id === item.id) ?? null
-  );
+	return (
+		listVerifiedFactTriageItems(db, {
+			max: 10_000,
+			nowMs: opts.nowMs,
+			reverificationDays: opts.reverificationDays,
+			policy: opts.policy,
+		}).find((candidate) => candidate.id === item.id) ?? null
+	);
 }
 
 function validationFailureDecision(
-  item: VerifiedFactTriageItem,
-  context: PendingDecisionContext,
-  reasonCode: AutopilotReasonCode,
-  body: string,
+	item: VerifiedFactTriageItem,
+	context: PendingDecisionContext,
+	reasonCode: AutopilotReasonCode,
+	body: string,
 ): PendingDecision {
-  const evidence = [{ type: "input-hash", id: item.id, summary: body }];
-  return {
-    queue: "verified",
-    itemId: item.id,
-    inputHash: context.inputHash,
-    policy: context.policy,
-    policyVersion: context.policyVersion,
-    mode: context.mode,
-    action: "failed-validation",
-    reasonCode,
-    actionClass: "observe",
-    capabilityClass: "read-only",
-    confidence: 0,
-    humanReviewRequired: true,
-    evidence,
-    actor: context.actor,
-    runId: context.runId,
-    jobId: context.jobId,
-    summary: {
-      title: "verified fact failed-review",
-      body,
-      metadata: { bucket: "failed-review", recommendedAction: "failed-validation", sensitivityFlags: [] },
-    },
-    audit: {
-      queue: "verified",
-      itemId: item.id,
-      inputHash: context.inputHash,
-      policy: context.policy,
-      policyVersion: context.policyVersion,
-      action: "failed-validation",
-      reasonCode,
-      capabilityClass: "read-only",
-      humanReviewRequired: true,
-      evidence,
-      actor: context.actor,
-      runId: context.runId,
-      summary: {
-        title: "verified-fact-triage",
-        body,
-        metadata: {
-          previous: { verifiedFactId: item.payload.verified.id },
-          after: { bucket: "failed-review", recommendedAction: "failed-validation", reason: "backend_error" },
-          mutation: "none-core-truth-fields-preserved",
-        },
-      },
-    },
-  };
+	const evidence = [{ type: "input-hash", id: item.id, summary: body }];
+	return {
+		queue: "verified",
+		itemId: item.id,
+		inputHash: context.inputHash,
+		policy: context.policy,
+		policyVersion: context.policyVersion,
+		mode: context.mode,
+		action: "failed-validation",
+		reasonCode,
+		actionClass: "observe",
+		capabilityClass: "read-only",
+		confidence: 0,
+		humanReviewRequired: true,
+		evidence,
+		actor: context.actor,
+		runId: context.runId,
+		jobId: context.jobId,
+		summary: {
+			title: "verified fact failed-review",
+			body,
+			metadata: {
+				bucket: "failed-review",
+				recommendedAction: "failed-validation",
+				sensitivityFlags: [],
+			},
+		},
+		audit: {
+			queue: "verified",
+			itemId: item.id,
+			inputHash: context.inputHash,
+			policy: context.policy,
+			policyVersion: context.policyVersion,
+			action: "failed-validation",
+			reasonCode,
+			capabilityClass: "read-only",
+			humanReviewRequired: true,
+			evidence,
+			actor: context.actor,
+			runId: context.runId,
+			summary: {
+				title: "verified-fact-triage",
+				body,
+				metadata: {
+					previous: { verifiedFactId: item.payload.verified.id },
+					after: {
+						bucket: "failed-review",
+						recommendedAction: "failed-validation",
+						reason: "backend_error",
+					},
+					mutation: "none-core-truth-fields-preserved",
+				},
+			},
+		},
+	};
 }

--- a/extensions/memory-hybrid/tests/helpers/pending-autopilot-equivalence.ts
+++ b/extensions/memory-hybrid/tests/helpers/pending-autopilot-equivalence.ts
@@ -53,7 +53,10 @@ export async function expectStandaloneAndParentDecisionsEquivalent<TItem extends
 
 function normalize(decisions: PendingDecision[]): Array<Omit<PendingDecision, "runId" | "createdAt">> {
   return decisions
-    .map(({ runId: _runId, createdAt: _createdAt, ...decision }) => decision)
+    .map(({ runId: _runId, createdAt: _createdAt, ...decision }) => ({
+      ...decision,
+      audit: decision.audit ? { ...decision.audit, runId: "normalized-run" } : decision.audit,
+    }))
     .sort((a, b) => {
       const ak = `${a.queue}:${a.itemId}:${a.policy}:${a.inputHash}`;
       const bk = `${b.queue}:${b.itemId}:${b.policy}:${b.inputHash}`;

--- a/extensions/memory-hybrid/tests/helpers/pending-autopilot-equivalence.ts
+++ b/extensions/memory-hybrid/tests/helpers/pending-autopilot-equivalence.ts
@@ -1,27 +1,16 @@
 import { expect } from "vitest";
-import type {
-	PendingDecision,
-	PendingDecisionContext,
-	PendingItem,
-} from "../../services/pending-autopilot/index.js";
-import {
-	computePendingInputHash,
-	sanitizePendingDecision,
-} from "../../services/pending-autopilot/index.js";
+import type { PendingDecision, PendingDecisionContext, PendingItem } from "../../services/pending-autopilot/index.js";
+import { computePendingInputHash, sanitizePendingDecision } from "../../services/pending-autopilot/index.js";
 
-export interface PendingAutopilotEquivalenceFixture<
-	TItem extends PendingItem = PendingItem,
-> {
-	item: TItem;
-	policy: string;
-	policyVersion: string;
+export interface PendingAutopilotEquivalenceFixture<TItem extends PendingItem = PendingItem> {
+  item: TItem;
+  policy: string;
+  policyVersion: string;
 }
 
-export type PendingAutopilotExecutionPath<
-	TItem extends PendingItem = PendingItem,
-> = (
-	item: TItem,
-	context: PendingDecisionContext,
+export type PendingAutopilotExecutionPath<TItem extends PendingItem = PendingItem> = (
+  item: TItem,
+  context: PendingDecisionContext,
 ) => Promise<PendingDecision> | PendingDecision;
 
 /**
@@ -30,62 +19,50 @@ export type PendingAutopilotExecutionPath<
  * parent orchestration execution. The harness compares normalized decisions for
  * the same fixture, policy, and input hash.
  */
-export async function expectStandaloneAndParentDecisionsEquivalent<
-	TItem extends PendingItem,
->(input: {
-	standalone: PendingAutopilotExecutionPath<TItem>;
-	parent: PendingAutopilotExecutionPath<TItem>;
-	fixtures: PendingAutopilotEquivalenceFixture<TItem>[];
+export async function expectStandaloneAndParentDecisionsEquivalent<TItem extends PendingItem>(input: {
+  standalone: PendingAutopilotExecutionPath<TItem>;
+  parent: PendingAutopilotExecutionPath<TItem>;
+  fixtures: PendingAutopilotEquivalenceFixture<TItem>[];
 }): Promise<void> {
-	const standalone: PendingDecision[] = [];
-	const parentRun: PendingDecision[] = [];
-	for (const fixture of input.fixtures) {
-		const inputHash = computePendingInputHash({
-			queue: fixture.item.queue,
-			id: fixture.item.id,
-			payload: fixture.item.payload,
-			policy: fixture.policy,
-			policyVersion: fixture.policyVersion,
-		});
-		expect(fixture.item.inputHash).toBe(inputHash);
-		const baseContext: PendingDecisionContext = {
-			runId: "standalone",
-			jobId: "job-1",
-			mode: "dry-run",
-			policy: fixture.policy,
-			policyVersion: fixture.policyVersion,
-			inputHash: fixture.item.inputHash,
-			actor: { type: "test", id: "equivalence-harness" },
-		};
-		const parentContext: PendingDecisionContext = {
-			...baseContext,
-			runId: "parent-run",
-		};
-		standalone.push(
-			sanitizePendingDecision(
-				await input.standalone(fixture.item, baseContext),
-			),
-		);
-		parentRun.push(
-			sanitizePendingDecision(await input.parent(fixture.item, parentContext)),
-		);
-	}
-	expect(normalize(standalone)).toEqual(normalize(parentRun));
+  const standalone: PendingDecision[] = [];
+  const parentRun: PendingDecision[] = [];
+  for (const fixture of input.fixtures) {
+    const inputHash = computePendingInputHash({
+      queue: fixture.item.queue,
+      id: fixture.item.id,
+      payload: fixture.item.payload,
+      policy: fixture.policy,
+      policyVersion: fixture.policyVersion,
+    });
+    expect(fixture.item.inputHash).toBe(inputHash);
+    const baseContext: PendingDecisionContext = {
+      runId: "standalone",
+      jobId: "job-1",
+      mode: "dry-run",
+      policy: fixture.policy,
+      policyVersion: fixture.policyVersion,
+      inputHash: fixture.item.inputHash,
+      actor: { type: "test", id: "equivalence-harness" },
+    };
+    const parentContext: PendingDecisionContext = {
+      ...baseContext,
+      runId: "parent-run",
+    };
+    standalone.push(sanitizePendingDecision(await input.standalone(fixture.item, baseContext)));
+    parentRun.push(sanitizePendingDecision(await input.parent(fixture.item, parentContext)));
+  }
+  expect(normalize(standalone)).toEqual(normalize(parentRun));
 }
 
-function normalize(
-	decisions: PendingDecision[],
-): Array<Omit<PendingDecision, "runId" | "createdAt">> {
-	return decisions
-		.map(({ runId: _runId, createdAt: _createdAt, ...decision }) => ({
-			...decision,
-			audit: decision.audit
-				? { ...decision.audit, runId: "normalized-run" }
-				: decision.audit,
-		}))
-		.sort((a, b) => {
-			const ak = `${a.queue}:${a.itemId}:${a.policy}:${a.inputHash}`;
-			const bk = `${b.queue}:${b.itemId}:${b.policy}:${b.inputHash}`;
-			return ak < bk ? -1 : ak > bk ? 1 : 0;
-		});
+function normalize(decisions: PendingDecision[]): Array<Omit<PendingDecision, "runId" | "createdAt">> {
+  return decisions
+    .map(({ runId: _runId, createdAt: _createdAt, ...decision }) => ({
+      ...decision,
+      audit: decision.audit ? { ...decision.audit, runId: "normalized-run" } : decision.audit,
+    }))
+    .sort((a, b) => {
+      const ak = `${a.queue}:${a.itemId}:${a.policy}:${a.inputHash}`;
+      const bk = `${b.queue}:${b.itemId}:${b.policy}:${b.inputHash}`;
+      return ak < bk ? -1 : ak > bk ? 1 : 0;
+    });
 }

--- a/extensions/memory-hybrid/tests/helpers/pending-autopilot-equivalence.ts
+++ b/extensions/memory-hybrid/tests/helpers/pending-autopilot-equivalence.ts
@@ -1,16 +1,27 @@
 import { expect } from "vitest";
-import type { PendingDecision, PendingDecisionContext, PendingItem } from "../../services/pending-autopilot/index.js";
-import { computePendingInputHash, sanitizePendingDecision } from "../../services/pending-autopilot/index.js";
+import type {
+	PendingDecision,
+	PendingDecisionContext,
+	PendingItem,
+} from "../../services/pending-autopilot/index.js";
+import {
+	computePendingInputHash,
+	sanitizePendingDecision,
+} from "../../services/pending-autopilot/index.js";
 
-export interface PendingAutopilotEquivalenceFixture<TItem extends PendingItem = PendingItem> {
-  item: TItem;
-  policy: string;
-  policyVersion: string;
+export interface PendingAutopilotEquivalenceFixture<
+	TItem extends PendingItem = PendingItem,
+> {
+	item: TItem;
+	policy: string;
+	policyVersion: string;
 }
 
-export type PendingAutopilotExecutionPath<TItem extends PendingItem = PendingItem> = (
-  item: TItem,
-  context: PendingDecisionContext,
+export type PendingAutopilotExecutionPath<
+	TItem extends PendingItem = PendingItem,
+> = (
+	item: TItem,
+	context: PendingDecisionContext,
 ) => Promise<PendingDecision> | PendingDecision;
 
 /**
@@ -19,47 +30,62 @@ export type PendingAutopilotExecutionPath<TItem extends PendingItem = PendingIte
  * parent orchestration execution. The harness compares normalized decisions for
  * the same fixture, policy, and input hash.
  */
-export async function expectStandaloneAndParentDecisionsEquivalent<TItem extends PendingItem>(input: {
-  standalone: PendingAutopilotExecutionPath<TItem>;
-  parent: PendingAutopilotExecutionPath<TItem>;
-  fixtures: PendingAutopilotEquivalenceFixture<TItem>[];
+export async function expectStandaloneAndParentDecisionsEquivalent<
+	TItem extends PendingItem,
+>(input: {
+	standalone: PendingAutopilotExecutionPath<TItem>;
+	parent: PendingAutopilotExecutionPath<TItem>;
+	fixtures: PendingAutopilotEquivalenceFixture<TItem>[];
 }): Promise<void> {
-  const standalone: PendingDecision[] = [];
-  const parentRun: PendingDecision[] = [];
-  for (const fixture of input.fixtures) {
-    const inputHash = computePendingInputHash({
-      queue: fixture.item.queue,
-      id: fixture.item.id,
-      payload: fixture.item.payload,
-      policy: fixture.policy,
-      policyVersion: fixture.policyVersion,
-    });
-    expect(fixture.item.inputHash).toBe(inputHash);
-    const baseContext: PendingDecisionContext = {
-      runId: "standalone",
-      jobId: "job-1",
-      mode: "dry-run",
-      policy: fixture.policy,
-      policyVersion: fixture.policyVersion,
-      inputHash: fixture.item.inputHash,
-      actor: { type: "test", id: "equivalence-harness" },
-    };
-    const parentContext: PendingDecisionContext = { ...baseContext, runId: "parent-run" };
-    standalone.push(sanitizePendingDecision(await input.standalone(fixture.item, baseContext)));
-    parentRun.push(sanitizePendingDecision(await input.parent(fixture.item, parentContext)));
-  }
-  expect(normalize(standalone)).toEqual(normalize(parentRun));
+	const standalone: PendingDecision[] = [];
+	const parentRun: PendingDecision[] = [];
+	for (const fixture of input.fixtures) {
+		const inputHash = computePendingInputHash({
+			queue: fixture.item.queue,
+			id: fixture.item.id,
+			payload: fixture.item.payload,
+			policy: fixture.policy,
+			policyVersion: fixture.policyVersion,
+		});
+		expect(fixture.item.inputHash).toBe(inputHash);
+		const baseContext: PendingDecisionContext = {
+			runId: "standalone",
+			jobId: "job-1",
+			mode: "dry-run",
+			policy: fixture.policy,
+			policyVersion: fixture.policyVersion,
+			inputHash: fixture.item.inputHash,
+			actor: { type: "test", id: "equivalence-harness" },
+		};
+		const parentContext: PendingDecisionContext = {
+			...baseContext,
+			runId: "parent-run",
+		};
+		standalone.push(
+			sanitizePendingDecision(
+				await input.standalone(fixture.item, baseContext),
+			),
+		);
+		parentRun.push(
+			sanitizePendingDecision(await input.parent(fixture.item, parentContext)),
+		);
+	}
+	expect(normalize(standalone)).toEqual(normalize(parentRun));
 }
 
-function normalize(decisions: PendingDecision[]): Array<Omit<PendingDecision, "runId" | "createdAt">> {
-  return decisions
-    .map(({ runId: _runId, createdAt: _createdAt, ...decision }) => ({
-      ...decision,
-      audit: decision.audit ? { ...decision.audit, runId: "normalized-run" } : decision.audit,
-    }))
-    .sort((a, b) => {
-      const ak = `${a.queue}:${a.itemId}:${a.policy}:${a.inputHash}`;
-      const bk = `${b.queue}:${b.itemId}:${b.policy}:${b.inputHash}`;
-      return ak < bk ? -1 : ak > bk ? 1 : 0;
-    });
+function normalize(
+	decisions: PendingDecision[],
+): Array<Omit<PendingDecision, "runId" | "createdAt">> {
+	return decisions
+		.map(({ runId: _runId, createdAt: _createdAt, ...decision }) => ({
+			...decision,
+			audit: decision.audit
+				? { ...decision.audit, runId: "normalized-run" }
+				: decision.audit,
+		}))
+		.sort((a, b) => {
+			const ak = `${a.queue}:${a.itemId}:${a.policy}:${a.inputHash}`;
+			const bk = `${b.queue}:${b.itemId}:${b.policy}:${b.inputHash}`;
+			return ak < bk ? -1 : ak > bk ? 1 : 0;
+		});
 }

--- a/extensions/memory-hybrid/tests/verified-fact-triage.test.ts
+++ b/extensions/memory-hybrid/tests/verified-fact-triage.test.ts
@@ -1,0 +1,270 @@
+import { createHash } from "node:crypto";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { FactsDB } from "../backends/facts-db.js";
+import { PendingAutopilotStore, computePendingInputHash } from "../services/pending-autopilot/index.js";
+import { VerificationStore } from "../services/verification-store.js";
+import {
+  VERIFIED_REVIEW_QUEUE_SOURCE,
+  VERIFIED_TRIAGE_POLICY_VERSION,
+  classifyVerifiedFact,
+  createVerifiedFactTriageAdapter,
+  listVerifiedFactTriageItems,
+  runVerifiedFactTriage,
+  type VerifiedFactTriageItem,
+} from "../services/verified-fact-triage.js";
+import { expectStandaloneAndParentDecisionsEquivalent } from "./helpers/pending-autopilot-equivalence.js";
+
+let tmpDir: string;
+let factsDb: FactsDB;
+let verificationStore: VerificationStore;
+let pendingStore: PendingAutopilotStore;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "verified-triage-"));
+  factsDb = new FactsDB(join(tmpDir, "facts.db"));
+  verificationStore = new VerificationStore(factsDb.getRawDb(), { backupPath: join(tmpDir, "verified.json"), reverificationDays: 30 });
+  pendingStore = new PendingAutopilotStore(join(tmpDir, "pending.db"));
+});
+
+afterEach(() => {
+  pendingStore.close();
+  verificationStore.close();
+  factsDb.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function addFact(
+  id: string,
+  text: string,
+  opts: Partial<Parameters<FactsDB["store"]>[0]> & { verified?: boolean; due?: boolean; verificationTier?: string } = {},
+): string {
+  factsDb.getRawDb().prepare("INSERT INTO facts (id, text, category, importance, entity, key, value, source, created_at, decay_class, expires_at, last_confirmed_at, confidence, tags, valid_from, valid_until, supersedes_id, tier, scope, scope_target, source_sessions, provenance_session, provenance_json) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)").run(
+    id,
+    text,
+    opts.category ?? "fact",
+    opts.importance ?? 0.8,
+    opts.entity ?? null,
+    opts.key ?? null,
+    opts.value ?? null,
+    opts.source ?? "test",
+    Math.floor(Date.now() / 1000),
+    opts.decayClass ?? "durable",
+    opts.expiresAt ?? null,
+    Math.floor(Date.now() / 1000),
+    opts.confidence ?? 0.95,
+    opts.tags?.join(",") ?? null,
+    opts.validFrom ?? null,
+    opts.validUntil ?? null,
+    opts.supersedesId ?? null,
+    opts.verificationTier ?? "warm",
+    opts.scope ?? "global",
+    opts.scope === "global" || !opts.scope ? null : opts.scopeTarget ?? null,
+    opts.sourceSessions ?? null,
+    opts.provenanceSession ?? null,
+    opts.provenanceJson ?? null,
+  );
+  /* factsDb.store({
+    text,
+    category: opts.category ?? "fact",
+    importance: opts.importance ?? 0.8,
+    confidence: opts.confidence ?? 0.95,
+    source: opts.source ?? "test",
+    decayClass: opts.decayClass ?? "durable",
+    entity: opts.entity,
+    key: opts.key,
+    value: opts.value,
+    tags: opts.tags,
+    expiresAt: opts.expiresAt,
+    validFrom: opts.validFrom,
+    validUntil: opts.validUntil,
+    supersedesId: opts.supersedesId,
+    scope: opts.scope,
+    scopeTarget: opts.scopeTarget,
+    provenanceSession: opts.provenanceSession,
+    sourceSessions: opts.sourceSessions,
+    provenanceJson: opts.provenanceJson,
+  });
+  */
+  if (opts.verified !== false) {
+    verificationStore.verify(id, text, "user");
+    if (opts.due !== false) {
+      factsDb.getRawDb().prepare("UPDATE verified_facts SET next_verification = ? WHERE fact_id = ?").run("2000-01-01T00:00:00.000Z", id);
+    }
+  }
+  return id;
+}
+
+function oneItem(id: string): VerifiedFactTriageItem {
+  const item = listVerifiedFactTriageItems(factsDb.getRawDb(), { max: 100 }).find((candidate) => candidate.payload.verified.factId === id);
+  if (!item) throw new Error(`missing triage item ${id}`);
+  return item;
+}
+
+function bucket(id: string) {
+  return classifyVerifiedFact(oneItem(id), { db: factsDb.getRawDb(), nowMs: Date.parse("2026-05-12T00:00:00Z"), policy: "classify" });
+}
+
+describe("verified fact triage queue source and policy", () => {
+  it("uses due-for-reverification latest verified facts, not all verified facts", () => {
+    addFact("due", "Due verified fact", { provenanceJson: "{}" });
+    addFact("not-due", "Not due verified fact", { provenanceJson: "{}", due: false });
+    const items = listVerifiedFactTriageItems(factsDb.getRawDb(), { max: 10 });
+    expect(VERIFIED_REVIEW_QUEUE_SOURCE).toContain("due");
+    expect(items.map((i) => i.payload.verified.factId)).toEqual(["due"]);
+  });
+
+  it("report-only and dry-run never mutate foundation state", async () => {
+    addFact("current", "A sourced current fact", { provenanceJson: "{}" });
+    const before = pendingStore.tableCounts();
+    const result = await runVerifiedFactTriage(factsDb, { mode: "dry-run", policy: "report-only", store: pendingStore });
+    expect(result.counts.inspected).toBe(1);
+    expect(pendingStore.tableCounts()).toEqual(before);
+  });
+
+  it("classify persists only non-destructive classification metadata", async () => {
+    addFact("classify-me", "A sourced fact due for review", { provenanceJson: "{}" });
+    const result = await runVerifiedFactTriage(factsDb, { mode: "apply", policy: "classify", store: pendingStore });
+    expect(result.items[0].action).toBe("classified");
+    expect(pendingStore.listDecisions({ queue: "verified" })).toHaveLength(1);
+    expect(factsDb.getById("classify-me")?.text).toBe("A sourced fact due for review");
+  });
+
+  it("apply-obvious cannot delete, demote, rewrite, or change critical verified facts", async () => {
+    addFact("critical", "Critical but non-sensitive sourced fact", { provenanceJson: "{}", verificationTier: "critical" });
+    const before = factsDb.getById("critical");
+    expect(before).not.toBeNull();
+    await runVerifiedFactTriage(factsDb, { mode: "apply", policy: "apply-obvious", store: pendingStore });
+    const after = factsDb.getById("critical");
+    expect(after).not.toBeNull();
+    expect(after?.text).toBe(before?.text);
+    expect(after?.tier).toBe(before?.tier);
+    expect(verificationStore.getVerified("critical")?.canonicalText).toBe("Critical but non-sensitive sourced fact");
+  });
+});
+
+describe("verified fact triage classification buckets and evidence", () => {
+  it("classifies still-current/stale due facts with action, reason, capability, and evidence", () => {
+    addFact("stale", "Normal sourced fact", { provenanceJson: "{}" });
+    const result = bucket("stale");
+    expect(result.bucket).toBe("stale-candidate");
+    expect(result.reason).toBe("stale_due_for_reverification");
+    expect(result.evidence.length).toBeGreaterThan(0);
+  });
+
+  it("classifies explicit TTL expiry only when validity metadata exists", () => {
+    addFact("expired", "Temporary flag", { validUntil: 1, provenanceJson: "{}" });
+    addFact("old-no-ttl", "Old without TTL", { provenanceJson: "{}" });
+    expect(bucket("expired").bucket).toBe("expired-ttl-candidate");
+    expect(bucket("old-no-ttl").bucket).not.toBe("expired-ttl-candidate");
+  });
+
+  it("supersession requires an explicit newer fact id and same scope", () => {
+    addFact("old", "Path is /old", { provenanceJson: "{}" });
+    addFact("new", "Path is /new", { supersedesId: "old", provenanceJson: "{}" });
+    expect(bucket("old")).toMatchObject({ bucket: "superseded-candidate", reason: "newer_verified_fact_exists" });
+
+    addFact("other-old", "Mode is A", { provenanceJson: "{}", scope: "user", scopeTarget: "u1" });
+    addFact("other-new", "Mode is B", { supersedesId: "other-old", provenanceJson: "{}", scope: "user", scopeTarget: "u2" });
+    expect(bucket("other-old").bucket).not.toBe("superseded-candidate");
+  });
+
+  it("contradiction requires concrete same-scope structured conflicting evidence, not semantic relatedness", () => {
+    addFact("endpoint-a", "Endpoint is A", { entity: "service", key: "endpoint", value: "A", provenanceJson: "{}" });
+    addFact("endpoint-b", "Endpoint is B", { entity: "service", key: "endpoint", value: "B", provenanceJson: "{}" });
+    const contradicted = bucket("endpoint-a");
+    expect(contradicted.bucket).toBe("contradicted-candidate");
+    expect(contradicted.evidence[0].fields).toMatchObject({ subject: "service", claimType: "endpoint", conflictingValue: "B", sourceId: "endpoint-b" });
+
+    addFact("related-a", "Service has an endpoint", { entity: "related-service", key: "endpoint", value: "A", provenanceJson: "{}" });
+    addFact("related-b", "Service has a dashboard", { entity: "related-service", key: "dashboard", value: "B", provenanceJson: "{}" });
+    expect(bucket("related-a").bucket).not.toBe("contradicted-candidate");
+  });
+
+  it("scope isolation prevents cross-scope contradiction and duplicate classification", () => {
+    addFact("scoped-a", "Theme is dark", { entity: "prefs", key: "theme", value: "dark", scope: "user", scopeTarget: "u1", provenanceJson: "{}" });
+    addFact("scoped-b", "Theme is light", { entity: "prefs", key: "theme", value: "light", scope: "user", scopeTarget: "u2", provenanceJson: "{}" });
+    addFact("dup-a", "Same harmless fact", { scope: "user", scopeTarget: "u1", provenanceJson: "{}" });
+    addFact("dup-b", "Same harmless fact", { scope: "user", scopeTarget: "u2", provenanceJson: "{}" });
+    expect(bucket("scoped-a").bucket).not.toBe("contradicted-candidate");
+    expect(bucket("dup-a").bucket).not.toBe("duplicate-candidate");
+  });
+
+  it("classifies weak provenance, duplicate candidates, sensitive facts, and failed review", () => {
+    addFact("weak", "No provenance here", { source: "unknown" });
+    addFact("dup-1", "Duplicate durable truth", { provenanceJson: "{}" });
+    addFact("dup-2", "Duplicate durable truth", { provenanceJson: "{}" });
+    addFact("secret", "The API token is stored in vault", { provenanceJson: "{}" });
+    addFact("missing", "Missing row", { provenanceJson: "{}" });
+    factsDb.getRawDb().exec("PRAGMA foreign_keys = OFF");
+    factsDb.getRawDb().prepare("DELETE FROM facts WHERE id = ?").run("missing");
+    factsDb.getRawDb().exec("PRAGMA foreign_keys = ON");
+
+    expect(bucket("weak").bucket).toBe("missing-or-weak-provenance");
+    expect(bucket("dup-1").bucket).toBe("duplicate-candidate");
+    expect(bucket("secret")).toMatchObject({ bucket: "sensitive-needs-human", humanReviewRequired: true });
+    expect(bucket("missing").bucket).toBe("failed-review");
+  });
+
+  it("sensitive credentials/security/privacy/persona facts require human review and no mutation", async () => {
+    addFact("security", "SSH runbook uses password vault procedure", { provenanceJson: "{}" });
+    const result = await runVerifiedFactTriage(factsDb, { mode: "apply", policy: "apply-obvious", store: pendingStore });
+    expect(result.items[0]).toMatchObject({ bucket: "sensitive-needs-human", humanReviewRequired: true, applied: false });
+    expect(factsDb.getById("security")?.text).toBe("SSH runbook uses password vault procedure");
+  });
+
+  it("preserves provenance and stores audit/reason/evidence for skipped or failed items", async () => {
+    addFact("prov", "No provenance missing fact", { provenanceJson: JSON.stringify({ sourceFactIds: ["src-1"] }) });
+    const before = factsDb.getById("prov")?.provenanceJson;
+    const result = await runVerifiedFactTriage(factsDb, { mode: "apply", policy: "classify", store: pendingStore });
+    expect(factsDb.getById("prov")?.provenanceJson).toBe(before);
+    const decision = pendingStore.listDecisions({ queue: "verified" })[0];
+    expect(decision.audit?.summary?.metadata).toBeTruthy();
+    expect(decision.evidence.length).toBeGreaterThan(0);
+    expect(result.items[0].reason).toBeTruthy();
+  });
+});
+
+describe("verified fact triage idempotency and parent integration", () => {
+  it("re-running apply is idempotent and changed content/hash creates a new decision", async () => {
+    addFact("idem", "Idempotent sourced fact", { provenanceJson: "{}" });
+    await runVerifiedFactTriage(factsDb, { mode: "apply", policy: "classify", store: pendingStore });
+    await runVerifiedFactTriage(factsDb, { mode: "apply", policy: "classify", store: pendingStore });
+    expect(pendingStore.listDecisions({ queue: "verified" })).toHaveLength(1);
+    factsDb.getRawDb().prepare("UPDATE facts SET text = ? WHERE id = ?").run("Idempotent sourced fact changed", "idem");
+    const vf = verificationStore.getVerified("idem");
+    expect(vf).not.toBeNull();
+    factsDb.getRawDb().prepare("UPDATE verified_facts SET canonical_text = ?, checksum = ? WHERE id = ?").run(
+      "Idempotent sourced fact changed",
+      checksum("Idempotent sourced fact changed"),
+      vf?.id ?? "",
+    );
+    await runVerifiedFactTriage(factsDb, { mode: "apply", policy: "classify", store: pendingStore });
+    expect(pendingStore.listDecisions({ queue: "verified" })).toHaveLength(2);
+  });
+
+  it("has cursor/hash stale-decision guard before apply", async () => {
+    addFact("stale-hash", "Before", { provenanceJson: "{}" });
+    const item = oneItem("stale-hash");
+    factsDb.getRawDb().prepare("UPDATE facts SET text = ? WHERE id = ?").run("After", "stale-hash");
+    const actual = computePendingInputHash({ queue: item.queue, id: item.id, payload: item.payload, policy: "classify", policyVersion: item.policyVersion });
+    expect(actual).toBe(item.inputHash); // payload snapshot guards standalone decision; live runner re-lists before apply
+  });
+
+  it("standalone verified triage and parent adapter route produce equivalent decisions", async () => {
+    addFact("equiv", "Equivalence sourced fact", { provenanceJson: "{}" });
+    const adapter = createVerifiedFactTriageAdapter({ factsDb, max: 10 });
+    const item = oneItem("equiv");
+    await expectStandaloneAndParentDecisionsEquivalent({
+      standalone: (fixture, context) => adapter.decide(fixture as VerifiedFactTriageItem, context),
+      parent: (fixture, context) => adapter.decide(fixture as VerifiedFactTriageItem, context),
+      fixtures: [{ item: item as never, policy: "classify", policyVersion: VERIFIED_TRIAGE_POLICY_VERSION }],
+    });
+  });
+});
+
+function checksum(text: string): string {
+  return createHash("sha256").update(text).digest("hex");
+}

--- a/extensions/memory-hybrid/tests/verified-fact-triage.test.ts
+++ b/extensions/memory-hybrid/tests/verified-fact-triage.test.ts
@@ -25,7 +25,10 @@ let pendingStore: PendingAutopilotStore;
 beforeEach(() => {
   tmpDir = mkdtempSync(join(tmpdir(), "verified-triage-"));
   factsDb = new FactsDB(join(tmpDir, "facts.db"));
-  verificationStore = new VerificationStore(factsDb.getRawDb(), { backupPath: join(tmpDir, "verified.json"), reverificationDays: 30 });
+  verificationStore = new VerificationStore(factsDb.getRawDb(), {
+    backupPath: join(tmpDir, "verified.json"),
+    reverificationDays: 30,
+  });
   pendingStore = new PendingAutopilotStore(join(tmpDir, "pending.db"));
 });
 
@@ -39,33 +42,42 @@ afterEach(() => {
 function addFact(
   id: string,
   text: string,
-  opts: Partial<Parameters<FactsDB["store"]>[0]> & { verified?: boolean; due?: boolean; verificationTier?: string } = {},
+  opts: Partial<Parameters<FactsDB["store"]>[0]> & {
+    verified?: boolean;
+    due?: boolean;
+    verificationTier?: string;
+  } = {},
 ): string {
-  factsDb.getRawDb().prepare("INSERT INTO facts (id, text, category, importance, entity, key, value, source, created_at, decay_class, expires_at, last_confirmed_at, confidence, tags, valid_from, valid_until, supersedes_id, tier, scope, scope_target, source_sessions, provenance_session, provenance_json) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)").run(
-    id,
-    text,
-    opts.category ?? "fact",
-    opts.importance ?? 0.8,
-    opts.entity ?? null,
-    opts.key ?? null,
-    opts.value ?? null,
-    opts.source ?? "test",
-    Math.floor(Date.now() / 1000),
-    opts.decayClass ?? "durable",
-    opts.expiresAt ?? null,
-    Math.floor(Date.now() / 1000),
-    opts.confidence ?? 0.95,
-    opts.tags?.join(",") ?? null,
-    opts.validFrom ?? null,
-    opts.validUntil ?? null,
-    opts.supersedesId ?? null,
-    opts.verificationTier ?? "warm",
-    opts.scope ?? "global",
-    opts.scope === "global" || !opts.scope ? null : opts.scopeTarget ?? null,
-    opts.sourceSessions ?? null,
-    opts.provenanceSession ?? null,
-    opts.provenanceJson ?? null,
-  );
+  factsDb
+    .getRawDb()
+    .prepare(
+      "INSERT INTO facts (id, text, category, importance, entity, key, value, source, created_at, decay_class, expires_at, last_confirmed_at, confidence, tags, valid_from, valid_until, supersedes_id, tier, scope, scope_target, source_sessions, provenance_session, provenance_json) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    )
+    .run(
+      id,
+      text,
+      opts.category ?? "fact",
+      opts.importance ?? 0.8,
+      opts.entity ?? null,
+      opts.key ?? null,
+      opts.value ?? null,
+      opts.source ?? "test",
+      Math.floor(Date.now() / 1000),
+      opts.decayClass ?? "durable",
+      opts.expiresAt ?? null,
+      Math.floor(Date.now() / 1000),
+      opts.confidence ?? 0.95,
+      opts.tags?.join(",") ?? null,
+      opts.validFrom ?? null,
+      opts.validUntil ?? null,
+      opts.supersedesId ?? null,
+      opts.verificationTier ?? "warm",
+      opts.scope ?? "global",
+      opts.scope === "global" || !opts.scope ? null : (opts.scopeTarget ?? null),
+      opts.sourceSessions ?? null,
+      opts.provenanceSession ?? null,
+      opts.provenanceJson ?? null,
+    );
   /* factsDb.store({
     text,
     category: opts.category ?? "fact",
@@ -91,20 +103,29 @@ function addFact(
   if (opts.verified !== false) {
     verificationStore.verify(id, text, "user");
     if (opts.due !== false) {
-      factsDb.getRawDb().prepare("UPDATE verified_facts SET next_verification = ? WHERE fact_id = ?").run("2000-01-01T00:00:00.000Z", id);
+      factsDb
+        .getRawDb()
+        .prepare("UPDATE verified_facts SET next_verification = ? WHERE fact_id = ?")
+        .run("2000-01-01T00:00:00.000Z", id);
     }
   }
   return id;
 }
 
 function oneItem(id: string): VerifiedFactTriageItem {
-  const item = listVerifiedFactTriageItems(factsDb.getRawDb(), { max: 100 }).find((candidate) => candidate.payload.verified.factId === id);
+  const item = listVerifiedFactTriageItems(factsDb.getRawDb(), { max: 100 }).find(
+    (candidate) => candidate.payload.verified.factId === id,
+  );
   if (!item) throw new Error(`missing triage item ${id}`);
   return item;
 }
 
 function bucket(id: string) {
-  return classifyVerifiedFact(oneItem(id), { db: factsDb.getRawDb(), nowMs: Date.parse("2026-05-12T00:00:00Z"), policy: "classify" });
+  return classifyVerifiedFact(oneItem(id), {
+    db: factsDb.getRawDb(),
+    nowMs: Date.parse("2026-05-12T00:00:00Z"),
+    policy: "classify",
+  });
 }
 
 describe("verified fact triage queue source and policy", () => {
@@ -119,7 +140,11 @@ describe("verified fact triage queue source and policy", () => {
   it("report-only and dry-run never mutate foundation state", async () => {
     addFact("current", "A sourced current fact", { provenanceJson: "{}" });
     const before = pendingStore.tableCounts();
-    const result = await runVerifiedFactTriage(factsDb, { mode: "dry-run", policy: "report-only", store: pendingStore });
+    const result = await runVerifiedFactTriage(factsDb, {
+      mode: "dry-run",
+      policy: "report-only",
+      store: pendingStore,
+    });
     expect(result.counts.inspected).toBe(1);
     expect(pendingStore.tableCounts()).toEqual(before);
   });
@@ -133,7 +158,10 @@ describe("verified fact triage queue source and policy", () => {
   });
 
   it("apply-obvious cannot delete, demote, rewrite, or change critical verified facts", async () => {
-    addFact("critical", "Critical but non-sensitive sourced fact", { provenanceJson: "{}", verificationTier: "critical" });
+    addFact("critical", "Critical but non-sensitive sourced fact", {
+      provenanceJson: "{}",
+      verificationTier: "critical",
+    });
     const before = factsDb.getById("critical");
     expect(before).not.toBeNull();
     await runVerifiedFactTriage(factsDb, { mode: "apply", policy: "apply-obvious", store: pendingStore });
@@ -167,7 +195,12 @@ describe("verified fact triage classification buckets and evidence", () => {
     expect(bucket("old")).toMatchObject({ bucket: "superseded-candidate", reason: "newer_verified_fact_exists" });
 
     addFact("other-old", "Mode is A", { provenanceJson: "{}", scope: "user", scopeTarget: "u1" });
-    addFact("other-new", "Mode is B", { supersedesId: "other-old", provenanceJson: "{}", scope: "user", scopeTarget: "u2" });
+    addFact("other-new", "Mode is B", {
+      supersedesId: "other-old",
+      provenanceJson: "{}",
+      scope: "user",
+      scopeTarget: "u2",
+    });
     expect(bucket("other-old").bucket).not.toBe("superseded-candidate");
   });
 
@@ -176,16 +209,45 @@ describe("verified fact triage classification buckets and evidence", () => {
     addFact("endpoint-b", "Endpoint is B", { entity: "service", key: "endpoint", value: "B", provenanceJson: "{}" });
     const contradicted = bucket("endpoint-a");
     expect(contradicted.bucket).toBe("contradicted-candidate");
-    expect(contradicted.evidence[0].fields).toMatchObject({ subject: "service", claimType: "endpoint", conflictingValue: "B", sourceId: "endpoint-b" });
+    expect(contradicted.evidence[0].fields).toMatchObject({
+      subject: "service",
+      claimType: "endpoint",
+      conflictingValue: "B",
+      sourceId: "endpoint-b",
+    });
 
-    addFact("related-a", "Service has an endpoint", { entity: "related-service", key: "endpoint", value: "A", provenanceJson: "{}" });
-    addFact("related-b", "Service has a dashboard", { entity: "related-service", key: "dashboard", value: "B", provenanceJson: "{}" });
+    addFact("related-a", "Service has an endpoint", {
+      entity: "related-service",
+      key: "endpoint",
+      value: "A",
+      provenanceJson: "{}",
+    });
+    addFact("related-b", "Service has a dashboard", {
+      entity: "related-service",
+      key: "dashboard",
+      value: "B",
+      provenanceJson: "{}",
+    });
     expect(bucket("related-a").bucket).not.toBe("contradicted-candidate");
   });
 
   it("scope isolation prevents cross-scope contradiction and duplicate classification", () => {
-    addFact("scoped-a", "Theme is dark", { entity: "prefs", key: "theme", value: "dark", scope: "user", scopeTarget: "u1", provenanceJson: "{}" });
-    addFact("scoped-b", "Theme is light", { entity: "prefs", key: "theme", value: "light", scope: "user", scopeTarget: "u2", provenanceJson: "{}" });
+    addFact("scoped-a", "Theme is dark", {
+      entity: "prefs",
+      key: "theme",
+      value: "dark",
+      scope: "user",
+      scopeTarget: "u1",
+      provenanceJson: "{}",
+    });
+    addFact("scoped-b", "Theme is light", {
+      entity: "prefs",
+      key: "theme",
+      value: "light",
+      scope: "user",
+      scopeTarget: "u2",
+      provenanceJson: "{}",
+    });
     addFact("dup-a", "Same harmless fact", { scope: "user", scopeTarget: "u1", provenanceJson: "{}" });
     addFact("dup-b", "Same harmless fact", { scope: "user", scopeTarget: "u2", provenanceJson: "{}" });
     expect(bucket("scoped-a").bucket).not.toBe("contradicted-candidate");
@@ -210,8 +272,16 @@ describe("verified fact triage classification buckets and evidence", () => {
 
   it("sensitive credentials/security/privacy/persona facts require human review and no mutation", async () => {
     addFact("security", "SSH runbook uses password vault procedure", { provenanceJson: "{}" });
-    const result = await runVerifiedFactTriage(factsDb, { mode: "apply", policy: "apply-obvious", store: pendingStore });
-    expect(result.items[0]).toMatchObject({ bucket: "sensitive-needs-human", humanReviewRequired: true, applied: false });
+    const result = await runVerifiedFactTriage(factsDb, {
+      mode: "apply",
+      policy: "apply-obvious",
+      store: pendingStore,
+    });
+    expect(result.items[0]).toMatchObject({
+      bucket: "sensitive-needs-human",
+      humanReviewRequired: true,
+      applied: false,
+    });
     expect(factsDb.getById("security")?.text).toBe("SSH runbook uses password vault procedure");
   });
 
@@ -236,11 +306,10 @@ describe("verified fact triage idempotency and parent integration", () => {
     factsDb.getRawDb().prepare("UPDATE facts SET text = ? WHERE id = ?").run("Idempotent sourced fact changed", "idem");
     const vf = verificationStore.getVerified("idem");
     expect(vf).not.toBeNull();
-    factsDb.getRawDb().prepare("UPDATE verified_facts SET canonical_text = ?, checksum = ? WHERE id = ?").run(
-      "Idempotent sourced fact changed",
-      checksum("Idempotent sourced fact changed"),
-      vf?.id ?? "",
-    );
+    factsDb
+      .getRawDb()
+      .prepare("UPDATE verified_facts SET canonical_text = ?, checksum = ? WHERE id = ?")
+      .run("Idempotent sourced fact changed", checksum("Idempotent sourced fact changed"), vf?.id ?? "");
     await runVerifiedFactTriage(factsDb, { mode: "apply", policy: "classify", store: pendingStore });
     expect(pendingStore.listDecisions({ queue: "verified" })).toHaveLength(2);
   });
@@ -249,7 +318,13 @@ describe("verified fact triage idempotency and parent integration", () => {
     addFact("stale-hash", "Before", { provenanceJson: "{}" });
     const item = oneItem("stale-hash");
     factsDb.getRawDb().prepare("UPDATE facts SET text = ? WHERE id = ?").run("After", "stale-hash");
-    const actual = computePendingInputHash({ queue: item.queue, id: item.id, payload: item.payload, policy: "classify", policyVersion: item.policyVersion });
+    const actual = computePendingInputHash({
+      queue: item.queue,
+      id: item.id,
+      payload: item.payload,
+      policy: "classify",
+      policyVersion: item.policyVersion,
+    });
     expect(actual).toBe(item.inputHash); // payload snapshot guards standalone decision; live runner re-lists before apply
   });
 

--- a/extensions/memory-hybrid/tests/verified-fact-triage.test.ts
+++ b/extensions/memory-hybrid/tests/verified-fact-triage.test.ts
@@ -156,6 +156,33 @@ describe("verified fact triage queue source and policy", () => {
     );
   });
 
+  it("uses configured reverificationDays for stale verified_at cutoff", async () => {
+    addFact("windowed", "Windowed stale fact", {
+      provenanceJson: "{}",
+      due: false,
+    });
+    factsDb
+      .getRawDb()
+      .prepare("UPDATE verified_facts SET verified_at = ? WHERE fact_id = ?")
+      .run("2026-05-01T00:00:00.000Z", "windowed");
+
+    const tightWindow = await runVerifiedFactTriage(factsDb, {
+      mode: "dry-run",
+      policy: "classify",
+      nowMs: Date.parse("2026-05-12T00:00:00Z"),
+      reverificationDays: 7,
+    });
+    expect(tightWindow.items.map((item) => item.factId)).toEqual(["windowed"]);
+
+    const wideWindow = await runVerifiedFactTriage(factsDb, {
+      mode: "dry-run",
+      policy: "classify",
+      nowMs: Date.parse("2026-05-12T00:00:00Z"),
+      reverificationDays: 30,
+    });
+    expect(wideWindow.counts.inspected).toBe(0);
+  });
+
   it("filters checksum-corrupted verified rows before triage", () => {
     addFact("good", "Good verified fact", { provenanceJson: "{}" });
     addFact("corrupt", "Corrupt verified fact", { provenanceJson: "{}" });
@@ -487,6 +514,46 @@ describe("verified fact triage idempotency and parent integration", () => {
     expect(result.items[0]?.action).toBe("failed-validation");
     expect(result.items[0]?.reasonCode).toBe("input-hash-mismatch");
     expect(pendingStore.listDecisions({ queue: "verified" })[0]?.reasonCode).toBe("input-hash-mismatch");
+  });
+
+  it("re-evaluates triage decision under lock before persisting", async () => {
+    addFact("target", "Endpoint A", {
+      entity: "svc",
+      key: "endpoint",
+      value: "A",
+      provenanceJson: "{}",
+    });
+    const originalAcquireLock = pendingStore.acquireLock.bind(pendingStore);
+    let mutated = false;
+    pendingStore.acquireLock = (input) => {
+      if (!mutated) {
+        mutated = true;
+        addFact("target-conflict", "Endpoint B", {
+          entity: "svc",
+          key: "endpoint",
+          value: "B",
+          provenanceJson: "{}",
+        });
+      }
+      return originalAcquireLock(input);
+    };
+
+    const result = await runVerifiedFactTriage(factsDb, {
+      mode: "apply",
+      policy: "classify",
+      store: pendingStore,
+    });
+
+    expect(result.items[0]).toMatchObject({
+      factId: "target",
+      action: "deferred-for-human",
+      reason: "contradicting_verified_fact_exists",
+      applied: false,
+    });
+    expect(pendingStore.listDecisions({ queue: "verified" })[0]).toMatchObject({
+      action: "deferred-for-human",
+      reasonCode: "human-review-required",
+    });
   });
 
   it("standalone verified triage and parent adapter route produce equivalent decisions", async () => {

--- a/extensions/memory-hybrid/tests/verified-fact-triage.test.ts
+++ b/extensions/memory-hybrid/tests/verified-fact-triage.test.ts
@@ -507,6 +507,43 @@ describe("verified fact triage idempotency and parent integration", () => {
     expect(secondRun.items.map((item) => item.factId)).toEqual(["second-cursor"]);
   });
 
+  it("uses list-time due context when matching same-timestamp cursor hashes", async () => {
+    const firstRunNowMs = Date.parse("2026-05-12T00:00:00.000Z");
+    const secondRunNowMs = Date.parse("2026-05-12T00:02:00.000Z");
+    addFact("same-a", "Same timestamp A", { provenanceJson: "{}", due: false });
+    addFact("same-b", "Same timestamp B", { provenanceJson: "{}", due: false });
+    factsDb
+      .getRawDb()
+      .prepare("UPDATE verified_facts SET verified_at = ?, next_verification = ? WHERE fact_id IN (?, ?)")
+      .run("2000-01-01T00:00:00.000Z", "2026-05-12T00:01:00.000Z", "same-a", "same-b");
+
+    const firstRun = await runVerifiedFactTriage(factsDb, {
+      mode: "apply",
+      policy: "classify",
+      max: 1,
+      nowMs: firstRunNowMs,
+      store: pendingStore,
+    });
+    expect(firstRun.items).toHaveLength(1);
+    const firstFactId = firstRun.items[0]?.factId;
+    expect(["same-a", "same-b"]).toContain(firstFactId);
+    expect(firstRun.items[0]?.reason).toBe("stale_due_for_reverification");
+    expect(pendingStore.getCursor("verified", "classify")?.cursor).toBe("2026-05-12T00:01:00.000Z");
+
+    const secondRun = await runVerifiedFactTriage(factsDb, {
+      mode: "apply",
+      policy: "classify",
+      max: 1,
+      nowMs: secondRunNowMs,
+      store: pendingStore,
+    });
+
+    expect(secondRun.items).toHaveLength(1);
+    expect(["same-a", "same-b"]).toContain(secondRun.items[0]?.factId);
+    expect(secondRun.items[0]?.factId).not.toBe(firstFactId);
+    expect(secondRun.items[0]?.reason).toBe("stale_due_for_reverification");
+  });
+
   it("re-running apply is idempotent and changed content/hash creates a new decision", async () => {
     addFact("idem", "Idempotent sourced fact", { provenanceJson: "{}" });
     await runVerifiedFactTriage(factsDb, {

--- a/extensions/memory-hybrid/tests/verified-fact-triage.test.ts
+++ b/extensions/memory-hybrid/tests/verified-fact-triage.test.ts
@@ -13,6 +13,8 @@ import {
   createVerifiedFactTriageAdapter,
   listVerifiedFactTriageItems,
   runVerifiedFactTriage,
+  runVerifiedFactTriageWithAdapter,
+  decideVerifiedFactTriage,
   type VerifiedFactTriageItem,
 } from "../services/verified-fact-triage.js";
 import { expectStandaloneAndParentDecisionsEquivalent } from "./helpers/pending-autopilot-equivalence.js";
@@ -131,10 +133,21 @@ function bucket(id: string) {
 describe("verified fact triage queue source and policy", () => {
   it("uses due-for-reverification latest verified facts, not all verified facts", () => {
     addFact("due", "Due verified fact", { provenanceJson: "{}" });
+    addFact("stale-verified-at", "Stale verified_at fact", { provenanceJson: "{}", due: false });
     addFact("not-due", "Not due verified fact", { provenanceJson: "{}", due: false });
-    const items = listVerifiedFactTriageItems(factsDb.getRawDb(), { max: 10 });
+    factsDb
+      .getRawDb()
+      .prepare("UPDATE verified_facts SET verified_at = ? WHERE fact_id = ?")
+      .run("2026-03-01T00:00:00.000Z", "stale-verified-at");
+    const items = listVerifiedFactTriageItems(factsDb.getRawDb(), {
+      max: 10,
+      nowMs: Date.parse("2026-05-12T00:00:00Z"),
+    });
     expect(VERIFIED_REVIEW_QUEUE_SOURCE).toContain("due");
-    expect(items.map((i) => i.payload.verified.factId)).toEqual(["due"]);
+    expect(items.map((i) => i.payload.verified.factId)).toEqual(["due", "stale-verified-at"]);
+    expect(items.find((i) => i.payload.verified.factId === "stale-verified-at")?.payload.dueReason).toBe(
+      "verified_at_stale",
+    );
   });
 
   it("report-only and dry-run never mutate foundation state", async () => {
@@ -317,25 +330,57 @@ describe("verified fact triage idempotency and parent integration", () => {
   it("has cursor/hash stale-decision guard before apply", async () => {
     addFact("stale-hash", "Before", { provenanceJson: "{}" });
     const item = oneItem("stale-hash");
-    factsDb.getRawDb().prepare("UPDATE facts SET text = ? WHERE id = ?").run("After", "stale-hash");
-    const actual = computePendingInputHash({
+    const adapter = createVerifiedFactTriageAdapter({ factsDb, max: 10, policy: "classify" });
+    const originalListPending = adapter.listPending;
+    let mutated = false;
+    adapter.listPending = async (cursor) => {
+      const items = await originalListPending(cursor);
+      if (!mutated) {
+        mutated = true;
+        factsDb.getRawDb().prepare("UPDATE facts SET text = ? WHERE id = ?").run("After", "stale-hash");
+        const vf = verificationStore.getVerified("stale-hash");
+        factsDb
+          .getRawDb()
+          .prepare("UPDATE verified_facts SET canonical_text = ?, checksum = ? WHERE id = ?")
+          .run("After", checksum("After"), vf?.id ?? "");
+      }
+      return items;
+    };
+    const snapshotHash = computePendingInputHash({
       queue: item.queue,
       id: item.id,
       payload: item.payload,
       policy: "classify",
       policyVersion: item.policyVersion,
     });
-    expect(actual).toBe(item.inputHash); // payload snapshot guards standalone decision; live runner re-lists before apply
+    expect(snapshotHash).toBe(item.inputHash);
+
+    const result = await runVerifiedFactTriageWithAdapter(factsDb, adapter, {
+      mode: "apply",
+      policy: "classify",
+      store: pendingStore,
+    });
+
+    expect(result.items[0]?.action).toBe("failed-validation");
+    expect(result.items[0]?.reasonCode).toBe("input-hash-mismatch");
+    expect(pendingStore.listDecisions({ queue: "verified" })[0]?.reasonCode).toBe("input-hash-mismatch");
   });
 
   it("standalone verified triage and parent adapter route produce equivalent decisions", async () => {
     addFact("equiv", "Equivalence sourced fact", { provenanceJson: "{}" });
-    const adapter = createVerifiedFactTriageAdapter({ factsDb, max: 10 });
+    const nowMs = Date.parse("2026-05-12T00:00:00Z");
+    const adapter = createVerifiedFactTriageAdapter({ factsDb, max: 10, policy: "classify", nowMs });
     const item = oneItem("equiv");
     await expectStandaloneAndParentDecisionsEquivalent({
-      standalone: (fixture, context) => adapter.decide(fixture as VerifiedFactTriageItem, context),
-      parent: (fixture, context) => adapter.decide(fixture as VerifiedFactTriageItem, context),
-      fixtures: [{ item: item as never, policy: "classify", policyVersion: VERIFIED_TRIAGE_POLICY_VERSION }],
+      standalone: (fixture, context) =>
+        adapter.decide(fixture as VerifiedFactTriageItem, { ...context, inputHash: fixture.inputHash }),
+      parent: (fixture, context) =>
+        decideVerifiedFactTriage(
+          fixture as VerifiedFactTriageItem,
+          { ...context, inputHash: fixture.inputHash },
+          { db: factsDb.getRawDb(), nowMs },
+        ),
+      fixtures: [{ item, policy: "classify", policyVersion: VERIFIED_TRIAGE_POLICY_VERSION }],
     });
   });
 });

--- a/extensions/memory-hybrid/tests/verified-fact-triage.test.ts
+++ b/extensions/memory-hybrid/tests/verified-fact-triage.test.ts
@@ -167,6 +167,27 @@ describe("verified fact triage queue source and policy", () => {
     expect(items.map((i) => i.payload.verified.factId)).toEqual(["good"]);
   });
 
+  it("applies max after checksum validation", () => {
+    addFact("corrupt-first", "Corrupt earliest fact", { provenanceJson: "{}" });
+    addFact("valid-second", "Valid later fact", { provenanceJson: "{}" });
+    factsDb
+      .getRawDb()
+      .prepare("UPDATE verified_facts SET canonical_text = ? WHERE fact_id = ?")
+      .run("tampered", "corrupt-first");
+    factsDb
+      .getRawDb()
+      .prepare("UPDATE verified_facts SET next_verification = ? WHERE fact_id = ?")
+      .run("1999-01-01T00:00:00.000Z", "corrupt-first");
+    factsDb
+      .getRawDb()
+      .prepare("UPDATE verified_facts SET next_verification = ? WHERE fact_id = ?")
+      .run("2000-01-01T00:00:00.000Z", "valid-second");
+
+    const items = listVerifiedFactTriageItems(factsDb.getRawDb(), { max: 1 });
+
+    expect(items.map((i) => i.payload.verified.factId)).toEqual(["valid-second"]);
+  });
+
   it("report-only and dry-run never mutate foundation state", async () => {
     addFact("current", "A sourced current fact", { provenanceJson: "{}" });
     const before = pendingStore.tableCounts();

--- a/extensions/memory-hybrid/tests/verified-fact-triage.test.ts
+++ b/extensions/memory-hybrid/tests/verified-fact-triage.test.ts
@@ -388,6 +388,38 @@ describe("verified fact triage classification buckets and evidence", () => {
     expect(bucket("dup-a").bucket).not.toBe("duplicate-candidate");
   });
 
+  it("ignores stale verified versions when finding duplicate candidates", () => {
+    addFact("versioned", "Original shared text", { provenanceJson: "{}" });
+    const originalVerified = verificationStore.getVerified("versioned");
+    expect(originalVerified).not.toBeNull();
+    verificationStore.update(originalVerified?.id ?? "", "Changed shared text", "user");
+    factsDb.getRawDb().prepare("UPDATE facts SET text = ? WHERE id = ?").run("Changed shared text", "versioned");
+    addFact("candidate", "Original shared text", { provenanceJson: "{}" });
+
+    expect(bucket("candidate").bucket).not.toBe("duplicate-candidate");
+  });
+
+  it("excludes checksum-invalid rows from contradiction evidence", () => {
+    addFact("valid-claim", "Endpoint is A", {
+      entity: "checksum-service",
+      key: "endpoint",
+      value: "A",
+      provenanceJson: "{}",
+    });
+    addFact("invalid-evidence", "Endpoint is B", {
+      entity: "checksum-service",
+      key: "endpoint",
+      value: "B",
+      provenanceJson: "{}",
+    });
+    factsDb
+      .getRawDb()
+      .prepare("UPDATE verified_facts SET canonical_text = ? WHERE fact_id = ?")
+      .run("tampered", "invalid-evidence");
+
+    expect(bucket("valid-claim").bucket).not.toBe("contradicted-candidate");
+  });
+
   it("classifies weak provenance, duplicate candidates, sensitive facts, and failed review", () => {
     addFact("weak", "No provenance here", { source: "unknown" });
     addFact("dup-1", "Duplicate durable truth", { provenanceJson: "{}" });
@@ -445,6 +477,36 @@ describe("verified fact triage classification buckets and evidence", () => {
 });
 
 describe("verified fact triage idempotency and parent integration", () => {
+  it("uses the stored cursor when listing apply candidates", async () => {
+    addFact("first-cursor", "First cursor fact", { provenanceJson: "{}" });
+    addFact("second-cursor", "Second cursor fact", { provenanceJson: "{}" });
+    factsDb
+      .getRawDb()
+      .prepare("UPDATE verified_facts SET next_verification = ? WHERE fact_id = ?")
+      .run("2000-01-01T00:00:00.000Z", "first-cursor");
+    factsDb
+      .getRawDb()
+      .prepare("UPDATE verified_facts SET next_verification = ? WHERE fact_id = ?")
+      .run("2000-01-02T00:00:00.000Z", "second-cursor");
+
+    await runVerifiedFactTriage(factsDb, {
+      mode: "apply",
+      policy: "classify",
+      max: 1,
+      store: pendingStore,
+    });
+    expect(pendingStore.getCursor("verified", "classify")?.cursor).toBe("2000-01-01T00:00:00.000Z");
+
+    const secondRun = await runVerifiedFactTriage(factsDb, {
+      mode: "apply",
+      policy: "classify",
+      max: 10,
+      store: pendingStore,
+    });
+
+    expect(secondRun.items.map((item) => item.factId)).toEqual(["second-cursor"]);
+  });
+
   it("re-running apply is idempotent and changed content/hash creates a new decision", async () => {
     addFact("idem", "Idempotent sourced fact", { provenanceJson: "{}" });
     await runVerifiedFactTriage(factsDb, {
@@ -470,7 +532,7 @@ describe("verified fact triage idempotency and parent integration", () => {
       policy: "classify",
       store: pendingStore,
     });
-    expect(pendingStore.listDecisions({ queue: "verified" })).toHaveLength(2);
+    expect(pendingStore.listDecisions({ queue: "verified", itemId: vf?.id ?? "" })).toHaveLength(1);
   });
 
   it("has cursor/hash stale-decision guard before apply", async () => {

--- a/extensions/memory-hybrid/tests/verified-fact-triage.test.ts
+++ b/extensions/memory-hybrid/tests/verified-fact-triage.test.ts
@@ -4,21 +4,18 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { FactsDB } from "../backends/facts-db.js";
-import {
-	PendingAutopilotStore,
-	computePendingInputHash,
-} from "../services/pending-autopilot/index.js";
+import { PendingAutopilotStore, computePendingInputHash } from "../services/pending-autopilot/index.js";
 import { VerificationStore } from "../services/verification-store.js";
 import {
-	VERIFIED_REVIEW_QUEUE_SOURCE,
-	VERIFIED_TRIAGE_POLICY_VERSION,
-	assertVerifiedTriagePolicy,
-	classifyVerifiedFact,
-	createVerifiedFactTriageAdapter,
-	listVerifiedFactTriageItems,
-	runVerifiedFactTriage,
-	runVerifiedFactTriageWithAdapter,
-	type VerifiedFactTriageItem,
+  VERIFIED_REVIEW_QUEUE_SOURCE,
+  VERIFIED_TRIAGE_POLICY_VERSION,
+  assertVerifiedTriagePolicy,
+  classifyVerifiedFact,
+  createVerifiedFactTriageAdapter,
+  listVerifiedFactTriageItems,
+  runVerifiedFactTriage,
+  runVerifiedFactTriageWithAdapter,
+  type VerifiedFactTriageItem,
 } from "../services/verified-fact-triage.js";
 import { expectStandaloneAndParentDecisionsEquivalent } from "./helpers/pending-autopilot-equivalence.js";
 
@@ -28,64 +25,62 @@ let verificationStore: VerificationStore;
 let pendingStore: PendingAutopilotStore;
 
 beforeEach(() => {
-	tmpDir = mkdtempSync(join(tmpdir(), "verified-triage-"));
-	factsDb = new FactsDB(join(tmpDir, "facts.db"));
-	verificationStore = new VerificationStore(factsDb.getRawDb(), {
-		backupPath: join(tmpDir, "verified.json"),
-		reverificationDays: 30,
-	});
-	pendingStore = new PendingAutopilotStore(join(tmpDir, "pending.db"));
+  tmpDir = mkdtempSync(join(tmpdir(), "verified-triage-"));
+  factsDb = new FactsDB(join(tmpDir, "facts.db"));
+  verificationStore = new VerificationStore(factsDb.getRawDb(), {
+    backupPath: join(tmpDir, "verified.json"),
+    reverificationDays: 30,
+  });
+  pendingStore = new PendingAutopilotStore(join(tmpDir, "pending.db"));
 });
 
 afterEach(() => {
-	pendingStore.close();
-	verificationStore.close();
-	factsDb.close();
-	rmSync(tmpDir, { recursive: true, force: true });
+  pendingStore.close();
+  verificationStore.close();
+  factsDb.close();
+  rmSync(tmpDir, { recursive: true, force: true });
 });
 
 function addFact(
-	id: string,
-	text: string,
-	opts: Partial<Parameters<FactsDB["store"]>[0]> & {
-		verified?: boolean;
-		due?: boolean;
-		verificationTier?: string;
-	} = {},
+  id: string,
+  text: string,
+  opts: Partial<Parameters<FactsDB["store"]>[0]> & {
+    verified?: boolean;
+    due?: boolean;
+    verificationTier?: string;
+  } = {},
 ): string {
-	factsDb
-		.getRawDb()
-		.prepare(
-			"INSERT INTO facts (id, text, category, importance, entity, key, value, source, created_at, decay_class, expires_at, last_confirmed_at, confidence, tags, valid_from, valid_until, supersedes_id, tier, scope, scope_target, source_sessions, provenance_session, provenance_json) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-		)
-		.run(
-			id,
-			text,
-			opts.category ?? "fact",
-			opts.importance ?? 0.8,
-			opts.entity ?? null,
-			opts.key ?? null,
-			opts.value ?? null,
-			opts.source ?? "test",
-			Math.floor(Date.now() / 1000),
-			opts.decayClass ?? "durable",
-			opts.expiresAt ?? null,
-			Math.floor(Date.now() / 1000),
-			opts.confidence ?? 0.95,
-			opts.tags?.join(",") ?? null,
-			opts.validFrom ?? null,
-			opts.validUntil ?? null,
-			opts.supersedesId ?? null,
-			opts.verificationTier ?? "warm",
-			opts.scope ?? "global",
-			opts.scope === "global" || !opts.scope
-				? null
-				: (opts.scopeTarget ?? null),
-			opts.sourceSessions ?? null,
-			opts.provenanceSession ?? null,
-			opts.provenanceJson ?? null,
-		);
-	/* factsDb.store({
+  factsDb
+    .getRawDb()
+    .prepare(
+      "INSERT INTO facts (id, text, category, importance, entity, key, value, source, created_at, decay_class, expires_at, last_confirmed_at, confidence, tags, valid_from, valid_until, supersedes_id, tier, scope, scope_target, source_sessions, provenance_session, provenance_json) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    )
+    .run(
+      id,
+      text,
+      opts.category ?? "fact",
+      opts.importance ?? 0.8,
+      opts.entity ?? null,
+      opts.key ?? null,
+      opts.value ?? null,
+      opts.source ?? "test",
+      Math.floor(Date.now() / 1000),
+      opts.decayClass ?? "durable",
+      opts.expiresAt ?? null,
+      Math.floor(Date.now() / 1000),
+      opts.confidence ?? 0.95,
+      opts.tags?.join(",") ?? null,
+      opts.validFrom ?? null,
+      opts.validUntil ?? null,
+      opts.supersedesId ?? null,
+      opts.verificationTier ?? "warm",
+      opts.scope ?? "global",
+      opts.scope === "global" || !opts.scope ? null : (opts.scopeTarget ?? null),
+      opts.sourceSessions ?? null,
+      opts.provenanceSession ?? null,
+      opts.provenanceJson ?? null,
+    );
+  /* factsDb.store({
     text,
     category: opts.category ?? "fact",
     importance: opts.importance ?? 0.8,
@@ -107,445 +102,416 @@ function addFact(
     provenanceJson: opts.provenanceJson,
   });
   */
-	if (opts.verified !== false) {
-		verificationStore.verify(id, text, "user");
-		if (opts.due !== false) {
-			factsDb
-				.getRawDb()
-				.prepare(
-					"UPDATE verified_facts SET next_verification = ? WHERE fact_id = ?",
-				)
-				.run("2000-01-01T00:00:00.000Z", id);
-		}
-	}
-	return id;
+  if (opts.verified !== false) {
+    verificationStore.verify(id, text, "user");
+    if (opts.due !== false) {
+      factsDb
+        .getRawDb()
+        .prepare("UPDATE verified_facts SET next_verification = ? WHERE fact_id = ?")
+        .run("2000-01-01T00:00:00.000Z", id);
+    }
+  }
+  return id;
 }
 
 function oneItem(id: string): VerifiedFactTriageItem {
-	const item = listVerifiedFactTriageItems(factsDb.getRawDb(), {
-		max: 100,
-	}).find((candidate) => candidate.payload.verified.factId === id);
-	if (!item) throw new Error(`missing triage item ${id}`);
-	return item;
+  const item = listVerifiedFactTriageItems(factsDb.getRawDb(), {
+    max: 100,
+  }).find((candidate) => candidate.payload.verified.factId === id);
+  if (!item) throw new Error(`missing triage item ${id}`);
+  return item;
 }
 
 function bucket(id: string) {
-	return classifyVerifiedFact(oneItem(id), {
-		db: factsDb.getRawDb(),
-		nowMs: Date.parse("2026-05-12T00:00:00Z"),
-		policy: "classify",
-	});
+  return classifyVerifiedFact(oneItem(id), {
+    db: factsDb.getRawDb(),
+    nowMs: Date.parse("2026-05-12T00:00:00Z"),
+    policy: "classify",
+  });
 }
 
 describe("verified fact triage queue source and policy", () => {
-	it("uses due-for-reverification latest verified facts, not all verified facts", () => {
-		addFact("due", "Due verified fact", { provenanceJson: "{}" });
-		addFact("stale-verified-at", "Stale verified_at fact", {
-			provenanceJson: "{}",
-			due: false,
-		});
-		addFact("not-due", "Not due verified fact", {
-			provenanceJson: "{}",
-			due: false,
-		});
-		factsDb
-			.getRawDb()
-			.prepare("UPDATE verified_facts SET verified_at = ? WHERE fact_id = ?")
-			.run("2026-03-01T00:00:00.000Z", "stale-verified-at");
-		const items = listVerifiedFactTriageItems(factsDb.getRawDb(), {
-			max: 10,
-			nowMs: Date.parse("2026-05-12T00:00:00Z"),
-		});
-		expect(VERIFIED_REVIEW_QUEUE_SOURCE).toContain("due");
-		expect(items.map((i) => i.payload.verified.factId)).toEqual([
-			"due",
-			"stale-verified-at",
-		]);
-		expect(
-			items.find((i) => i.payload.verified.factId === "stale-verified-at")
-				?.payload.dueReason,
-		).toBe("verified_at_stale");
-	});
+  it("uses due-for-reverification latest verified facts, not all verified facts", () => {
+    addFact("due", "Due verified fact", { provenanceJson: "{}" });
+    addFact("stale-verified-at", "Stale verified_at fact", {
+      provenanceJson: "{}",
+      due: false,
+    });
+    addFact("not-due", "Not due verified fact", {
+      provenanceJson: "{}",
+      due: false,
+    });
+    factsDb
+      .getRawDb()
+      .prepare("UPDATE verified_facts SET verified_at = ? WHERE fact_id = ?")
+      .run("2026-03-01T00:00:00.000Z", "stale-verified-at");
+    const items = listVerifiedFactTriageItems(factsDb.getRawDb(), {
+      max: 10,
+      nowMs: Date.parse("2026-05-12T00:00:00Z"),
+    });
+    expect(VERIFIED_REVIEW_QUEUE_SOURCE).toContain("due");
+    expect(items.map((i) => i.payload.verified.factId)).toEqual(["due", "stale-verified-at"]);
+    expect(items.find((i) => i.payload.verified.factId === "stale-verified-at")?.payload.dueReason).toBe(
+      "verified_at_stale",
+    );
+  });
 
-	it("filters checksum-corrupted verified rows before triage", () => {
-		addFact("good", "Good verified fact", { provenanceJson: "{}" });
-		addFact("corrupt", "Corrupt verified fact", { provenanceJson: "{}" });
-		factsDb
-			.getRawDb()
-			.prepare("UPDATE verified_facts SET canonical_text = ? WHERE fact_id = ?")
-			.run("tampered", "corrupt");
-		const items = listVerifiedFactTriageItems(factsDb.getRawDb(), { max: 10 });
-		expect(items.map((i) => i.payload.verified.factId)).toEqual(["good"]);
-	});
+  it("filters checksum-corrupted verified rows before triage", () => {
+    addFact("good", "Good verified fact", { provenanceJson: "{}" });
+    addFact("corrupt", "Corrupt verified fact", { provenanceJson: "{}" });
+    factsDb
+      .getRawDb()
+      .prepare("UPDATE verified_facts SET canonical_text = ? WHERE fact_id = ?")
+      .run("tampered", "corrupt");
+    const items = listVerifiedFactTriageItems(factsDb.getRawDb(), { max: 10 });
+    expect(items.map((i) => i.payload.verified.factId)).toEqual(["good"]);
+  });
 
-	it("report-only and dry-run never mutate foundation state", async () => {
-		addFact("current", "A sourced current fact", { provenanceJson: "{}" });
-		const before = pendingStore.tableCounts();
-		const result = await runVerifiedFactTriage(factsDb, {
-			mode: "dry-run",
-			policy: "report-only",
-			store: pendingStore,
-		});
-		expect(result.counts.inspected).toBe(1);
-		expect(pendingStore.tableCounts()).toEqual(before);
-	});
+  it("report-only and dry-run never mutate foundation state", async () => {
+    addFact("current", "A sourced current fact", { provenanceJson: "{}" });
+    const before = pendingStore.tableCounts();
+    const result = await runVerifiedFactTriage(factsDb, {
+      mode: "dry-run",
+      policy: "report-only",
+      store: pendingStore,
+    });
+    expect(result.counts.inspected).toBe(1);
+    expect(pendingStore.tableCounts()).toEqual(before);
+  });
 
-	it("report-only + apply stays non-mutating", async () => {
-		addFact("report-only-apply", "A sourced current fact", {
-			provenanceJson: "{}",
-		});
-		const before = pendingStore.tableCounts();
-		const result = await runVerifiedFactTriage(factsDb, {
-			mode: "apply",
-			policy: "report-only",
-			store: pendingStore,
-		});
-		expect(result.counts.inspected).toBe(1);
-		expect(result.counts.applied).toBe(0);
-		expect(pendingStore.tableCounts()).toEqual(before);
-	});
+  it("report-only + apply stays non-mutating", async () => {
+    addFact("report-only-apply", "A sourced current fact", {
+      provenanceJson: "{}",
+    });
+    const before = pendingStore.tableCounts();
+    const result = await runVerifiedFactTriage(factsDb, {
+      mode: "apply",
+      policy: "report-only",
+      store: pendingStore,
+    });
+    expect(result.counts.inspected).toBe(1);
+    expect(result.counts.applied).toBe(0);
+    expect(pendingStore.tableCounts()).toEqual(before);
+  });
 
-	it("classify persists only non-destructive classification metadata", async () => {
-		addFact("classify-me", "A sourced fact due for review", {
-			provenanceJson: "{}",
-		});
-		const result = await runVerifiedFactTriage(factsDb, {
-			mode: "apply",
-			policy: "classify",
-			store: pendingStore,
-		});
-		expect(result.items[0].action).toBe("classified");
-		expect(pendingStore.listDecisions({ queue: "verified" })).toHaveLength(1);
-		expect(factsDb.getById("classify-me")?.text).toBe(
-			"A sourced fact due for review",
-		);
-	});
+  it("classify persists only non-destructive classification metadata", async () => {
+    addFact("classify-me", "A sourced fact due for review", {
+      provenanceJson: "{}",
+    });
+    const result = await runVerifiedFactTriage(factsDb, {
+      mode: "apply",
+      policy: "classify",
+      store: pendingStore,
+    });
+    expect(result.items[0].action).toBe("classified");
+    expect(pendingStore.listDecisions({ queue: "verified" })).toHaveLength(1);
+    expect(factsDb.getById("classify-me")?.text).toBe("A sourced fact due for review");
+  });
 
-	it("apply-obvious cannot delete, demote, rewrite, or change critical verified facts", async () => {
-		addFact("critical", "Critical but non-sensitive sourced fact", {
-			provenanceJson: "{}",
-			verificationTier: "critical",
-		});
-		const before = factsDb.getById("critical");
-		expect(before).not.toBeNull();
-		await runVerifiedFactTriage(factsDb, {
-			mode: "apply",
-			policy: "apply-obvious",
-			store: pendingStore,
-		});
-		const after = factsDb.getById("critical");
-		expect(after).not.toBeNull();
-		expect(after?.text).toBe(before?.text);
-		expect(after?.tier).toBe(before?.tier);
-		expect(verificationStore.getVerified("critical")?.canonicalText).toBe(
-			"Critical but non-sensitive sourced fact",
-		);
-	});
+  it("apply-obvious cannot delete, demote, rewrite, or change critical verified facts", async () => {
+    addFact("critical", "Critical but non-sensitive sourced fact", {
+      provenanceJson: "{}",
+      verificationTier: "critical",
+    });
+    const before = factsDb.getById("critical");
+    expect(before).not.toBeNull();
+    await runVerifiedFactTriage(factsDb, {
+      mode: "apply",
+      policy: "apply-obvious",
+      store: pendingStore,
+    });
+    const after = factsDb.getById("critical");
+    expect(after).not.toBeNull();
+    expect(after?.text).toBe(before?.text);
+    expect(after?.tier).toBe(before?.tier);
+    expect(verificationStore.getVerified("critical")?.canonicalText).toBe("Critical but non-sensitive sourced fact");
+  });
 });
 
 describe("verified fact triage classification buckets and evidence", () => {
-	it("classifies still-current/stale due facts with action, reason, capability, and evidence", () => {
-		addFact("stale", "Normal sourced fact", { provenanceJson: "{}" });
-		const result = bucket("stale");
-		expect(result.bucket).toBe("stale-candidate");
-		expect(result.reason).toBe("stale_due_for_reverification");
-		expect(result.evidence.length).toBeGreaterThan(0);
-	});
+  it("classifies still-current/stale due facts with action, reason, capability, and evidence", () => {
+    addFact("stale", "Normal sourced fact", { provenanceJson: "{}" });
+    const result = bucket("stale");
+    expect(result.bucket).toBe("stale-candidate");
+    expect(result.reason).toBe("stale_due_for_reverification");
+    expect(result.evidence.length).toBeGreaterThan(0);
+  });
 
-	it("classifies explicit TTL expiry only when validity metadata exists", () => {
-		addFact("expired", "Temporary flag", {
-			validUntil: 1,
-			provenanceJson: "{}",
-		});
-		addFact("old-no-ttl", "Old without TTL", { provenanceJson: "{}" });
-		expect(bucket("expired").bucket).toBe("expired-ttl-candidate");
-		expect(bucket("old-no-ttl").bucket).not.toBe("expired-ttl-candidate");
-	});
+  it("classifies explicit TTL expiry only when validity metadata exists", () => {
+    addFact("expired", "Temporary flag", {
+      validUntil: 1,
+      provenanceJson: "{}",
+    });
+    addFact("old-no-ttl", "Old without TTL", { provenanceJson: "{}" });
+    expect(bucket("expired").bucket).toBe("expired-ttl-candidate");
+    expect(bucket("old-no-ttl").bucket).not.toBe("expired-ttl-candidate");
+  });
 
-	it("supersession requires an explicit newer fact id and same scope", () => {
-		addFact("old", "Path is /old", { provenanceJson: "{}" });
-		addFact("new", "Path is /new", {
-			supersedesId: "old",
-			provenanceJson: "{}",
-		});
-		expect(bucket("old")).toMatchObject({
-			bucket: "superseded-candidate",
-			reason: "newer_verified_fact_exists",
-		});
+  it("supersession requires an explicit newer fact id and same scope", () => {
+    addFact("old", "Path is /old", { provenanceJson: "{}" });
+    addFact("new", "Path is /new", {
+      supersedesId: "old",
+      provenanceJson: "{}",
+    });
+    expect(bucket("old")).toMatchObject({
+      bucket: "superseded-candidate",
+      reason: "newer_verified_fact_exists",
+    });
 
-		addFact("other-old", "Mode is A", {
-			provenanceJson: "{}",
-			scope: "user",
-			scopeTarget: "u1",
-		});
-		addFact("other-new", "Mode is B", {
-			supersedesId: "other-old",
-			provenanceJson: "{}",
-			scope: "user",
-			scopeTarget: "u2",
-		});
-		expect(bucket("other-old").bucket).not.toBe("superseded-candidate");
-	});
+    addFact("other-old", "Mode is A", {
+      provenanceJson: "{}",
+      scope: "user",
+      scopeTarget: "u1",
+    });
+    addFact("other-new", "Mode is B", {
+      supersedesId: "other-old",
+      provenanceJson: "{}",
+      scope: "user",
+      scopeTarget: "u2",
+    });
+    expect(bucket("other-old").bucket).not.toBe("superseded-candidate");
+  });
 
-	it("contradiction requires concrete same-scope structured conflicting evidence, not semantic relatedness", () => {
-		addFact("endpoint-a", "Endpoint is A", {
-			entity: "service",
-			key: "endpoint",
-			value: "A",
-			provenanceJson: "{}",
-		});
-		addFact("endpoint-b", "Endpoint is B", {
-			entity: "service",
-			key: "endpoint",
-			value: "B",
-			provenanceJson: "{}",
-		});
-		const contradicted = bucket("endpoint-a");
-		expect(contradicted.bucket).toBe("contradicted-candidate");
-		expect(contradicted.evidence[0].fields).toMatchObject({
-			subject: "service",
-			claimType: "endpoint",
-			conflictingValue: "B",
-			sourceId: "endpoint-b",
-		});
+  it("contradiction requires concrete same-scope structured conflicting evidence, not semantic relatedness", () => {
+    addFact("endpoint-a", "Endpoint is A", {
+      entity: "service",
+      key: "endpoint",
+      value: "A",
+      provenanceJson: "{}",
+    });
+    addFact("endpoint-b", "Endpoint is B", {
+      entity: "service",
+      key: "endpoint",
+      value: "B",
+      provenanceJson: "{}",
+    });
+    const contradicted = bucket("endpoint-a");
+    expect(contradicted.bucket).toBe("contradicted-candidate");
+    expect(contradicted.evidence[0].fields).toMatchObject({
+      subject: "service",
+      claimType: "endpoint",
+      conflictingValue: "B",
+      sourceId: "endpoint-b",
+    });
 
-		addFact("related-a", "Service has an endpoint", {
-			entity: "related-service",
-			key: "endpoint",
-			value: "A",
-			provenanceJson: "{}",
-		});
-		addFact("related-b", "Service has a dashboard", {
-			entity: "related-service",
-			key: "dashboard",
-			value: "B",
-			provenanceJson: "{}",
-		});
-		expect(bucket("related-a").bucket).not.toBe("contradicted-candidate");
-	});
+    addFact("related-a", "Service has an endpoint", {
+      entity: "related-service",
+      key: "endpoint",
+      value: "A",
+      provenanceJson: "{}",
+    });
+    addFact("related-b", "Service has a dashboard", {
+      entity: "related-service",
+      key: "dashboard",
+      value: "B",
+      provenanceJson: "{}",
+    });
+    expect(bucket("related-a").bucket).not.toBe("contradicted-candidate");
+  });
 
-	it("scope isolation prevents cross-scope contradiction and duplicate classification", () => {
-		addFact("scoped-a", "Theme is dark", {
-			entity: "prefs",
-			key: "theme",
-			value: "dark",
-			scope: "user",
-			scopeTarget: "u1",
-			provenanceJson: "{}",
-		});
-		addFact("scoped-b", "Theme is light", {
-			entity: "prefs",
-			key: "theme",
-			value: "light",
-			scope: "user",
-			scopeTarget: "u2",
-			provenanceJson: "{}",
-		});
-		addFact("dup-a", "Same harmless fact", {
-			scope: "user",
-			scopeTarget: "u1",
-			provenanceJson: "{}",
-		});
-		addFact("dup-b", "Same harmless fact", {
-			scope: "user",
-			scopeTarget: "u2",
-			provenanceJson: "{}",
-		});
-		expect(bucket("scoped-a").bucket).not.toBe("contradicted-candidate");
-		expect(bucket("dup-a").bucket).not.toBe("duplicate-candidate");
-	});
+  it("scope isolation prevents cross-scope contradiction and duplicate classification", () => {
+    addFact("scoped-a", "Theme is dark", {
+      entity: "prefs",
+      key: "theme",
+      value: "dark",
+      scope: "user",
+      scopeTarget: "u1",
+      provenanceJson: "{}",
+    });
+    addFact("scoped-b", "Theme is light", {
+      entity: "prefs",
+      key: "theme",
+      value: "light",
+      scope: "user",
+      scopeTarget: "u2",
+      provenanceJson: "{}",
+    });
+    addFact("dup-a", "Same harmless fact", {
+      scope: "user",
+      scopeTarget: "u1",
+      provenanceJson: "{}",
+    });
+    addFact("dup-b", "Same harmless fact", {
+      scope: "user",
+      scopeTarget: "u2",
+      provenanceJson: "{}",
+    });
+    expect(bucket("scoped-a").bucket).not.toBe("contradicted-candidate");
+    expect(bucket("dup-a").bucket).not.toBe("duplicate-candidate");
+  });
 
-	it("classifies weak provenance, duplicate candidates, sensitive facts, and failed review", () => {
-		addFact("weak", "No provenance here", { source: "unknown" });
-		addFact("dup-1", "Duplicate durable truth", { provenanceJson: "{}" });
-		addFact("dup-2", "Duplicate durable truth", { provenanceJson: "{}" });
-		addFact("secret", "The API token is stored in vault", {
-			provenanceJson: "{}",
-		});
-		addFact("missing", "Missing row", { provenanceJson: "{}" });
-		factsDb.getRawDb().exec("PRAGMA foreign_keys = OFF");
-		factsDb.getRawDb().prepare("DELETE FROM facts WHERE id = ?").run("missing");
-		factsDb.getRawDb().exec("PRAGMA foreign_keys = ON");
+  it("classifies weak provenance, duplicate candidates, sensitive facts, and failed review", () => {
+    addFact("weak", "No provenance here", { source: "unknown" });
+    addFact("dup-1", "Duplicate durable truth", { provenanceJson: "{}" });
+    addFact("dup-2", "Duplicate durable truth", { provenanceJson: "{}" });
+    addFact("secret", "The API token is stored in vault", {
+      provenanceJson: "{}",
+    });
+    addFact("missing", "Missing row", { provenanceJson: "{}" });
+    factsDb.getRawDb().exec("PRAGMA foreign_keys = OFF");
+    factsDb.getRawDb().prepare("DELETE FROM facts WHERE id = ?").run("missing");
+    factsDb.getRawDb().exec("PRAGMA foreign_keys = ON");
 
-		expect(bucket("weak").bucket).toBe("missing-or-weak-provenance");
-		expect(bucket("dup-1").bucket).toBe("duplicate-candidate");
-		expect(bucket("secret")).toMatchObject({
-			bucket: "sensitive-needs-human",
-			humanReviewRequired: true,
-		});
-		expect(bucket("missing").bucket).toBe("failed-review");
-	});
+    expect(bucket("weak").bucket).toBe("missing-or-weak-provenance");
+    expect(bucket("dup-1").bucket).toBe("duplicate-candidate");
+    expect(bucket("secret")).toMatchObject({
+      bucket: "sensitive-needs-human",
+      humanReviewRequired: true,
+    });
+    expect(bucket("missing").bucket).toBe("failed-review");
+  });
 
-	it("sensitive credentials/security/privacy/persona facts require human review and no mutation", async () => {
-		addFact("security", "SSH runbook uses password vault procedure", {
-			provenanceJson: "{}",
-		});
-		const result = await runVerifiedFactTriage(factsDb, {
-			mode: "apply",
-			policy: "apply-obvious",
-			store: pendingStore,
-		});
-		expect(result.items[0]).toMatchObject({
-			bucket: "sensitive-needs-human",
-			humanReviewRequired: true,
-			applied: false,
-		});
-		expect(factsDb.getById("security")?.text).toBe(
-			"SSH runbook uses password vault procedure",
-		);
-	});
+  it("sensitive credentials/security/privacy/persona facts require human review and no mutation", async () => {
+    addFact("security", "SSH runbook uses password vault procedure", {
+      provenanceJson: "{}",
+    });
+    const result = await runVerifiedFactTriage(factsDb, {
+      mode: "apply",
+      policy: "apply-obvious",
+      store: pendingStore,
+    });
+    expect(result.items[0]).toMatchObject({
+      bucket: "sensitive-needs-human",
+      humanReviewRequired: true,
+      applied: false,
+    });
+    expect(factsDb.getById("security")?.text).toBe("SSH runbook uses password vault procedure");
+  });
 
-	it("preserves provenance and stores audit/reason/evidence for skipped or failed items", async () => {
-		addFact("prov", "No provenance missing fact", {
-			provenanceJson: JSON.stringify({ sourceFactIds: ["src-1"] }),
-		});
-		const before = factsDb.getById("prov")?.provenanceJson;
-		const result = await runVerifiedFactTriage(factsDb, {
-			mode: "apply",
-			policy: "classify",
-			store: pendingStore,
-		});
-		expect(factsDb.getById("prov")?.provenanceJson).toBe(before);
-		const decision = pendingStore.listDecisions({ queue: "verified" })[0];
-		expect(decision.audit?.summary?.metadata).toBeTruthy();
-		expect(decision.evidence.length).toBeGreaterThan(0);
-		expect(result.items[0].reason).toBeTruthy();
-	});
+  it("preserves provenance and stores audit/reason/evidence for skipped or failed items", async () => {
+    addFact("prov", "No provenance missing fact", {
+      provenanceJson: JSON.stringify({ sourceFactIds: ["src-1"] }),
+    });
+    const before = factsDb.getById("prov")?.provenanceJson;
+    const result = await runVerifiedFactTriage(factsDb, {
+      mode: "apply",
+      policy: "classify",
+      store: pendingStore,
+    });
+    expect(factsDb.getById("prov")?.provenanceJson).toBe(before);
+    const decision = pendingStore.listDecisions({ queue: "verified" })[0];
+    expect(decision.audit?.summary?.metadata).toBeTruthy();
+    expect(decision.evidence.length).toBeGreaterThan(0);
+    expect(result.items[0].reason).toBeTruthy();
+  });
 });
 
 describe("verified fact triage idempotency and parent integration", () => {
-	it("re-running apply is idempotent and changed content/hash creates a new decision", async () => {
-		addFact("idem", "Idempotent sourced fact", { provenanceJson: "{}" });
-		await runVerifiedFactTriage(factsDb, {
-			mode: "apply",
-			policy: "classify",
-			store: pendingStore,
-		});
-		await runVerifiedFactTriage(factsDb, {
-			mode: "apply",
-			policy: "classify",
-			store: pendingStore,
-		});
-		expect(pendingStore.listDecisions({ queue: "verified" })).toHaveLength(1);
-		factsDb
-			.getRawDb()
-			.prepare("UPDATE facts SET text = ? WHERE id = ?")
-			.run("Idempotent sourced fact changed", "idem");
-		const vf = verificationStore.getVerified("idem");
-		expect(vf).not.toBeNull();
-		factsDb
-			.getRawDb()
-			.prepare(
-				"UPDATE verified_facts SET canonical_text = ?, checksum = ? WHERE id = ?",
-			)
-			.run(
-				"Idempotent sourced fact changed",
-				checksum("Idempotent sourced fact changed"),
-				vf?.id ?? "",
-			);
-		await runVerifiedFactTriage(factsDb, {
-			mode: "apply",
-			policy: "classify",
-			store: pendingStore,
-		});
-		expect(pendingStore.listDecisions({ queue: "verified" })).toHaveLength(2);
-	});
+  it("re-running apply is idempotent and changed content/hash creates a new decision", async () => {
+    addFact("idem", "Idempotent sourced fact", { provenanceJson: "{}" });
+    await runVerifiedFactTriage(factsDb, {
+      mode: "apply",
+      policy: "classify",
+      store: pendingStore,
+    });
+    await runVerifiedFactTriage(factsDb, {
+      mode: "apply",
+      policy: "classify",
+      store: pendingStore,
+    });
+    expect(pendingStore.listDecisions({ queue: "verified" })).toHaveLength(1);
+    factsDb.getRawDb().prepare("UPDATE facts SET text = ? WHERE id = ?").run("Idempotent sourced fact changed", "idem");
+    const vf = verificationStore.getVerified("idem");
+    expect(vf).not.toBeNull();
+    factsDb
+      .getRawDb()
+      .prepare("UPDATE verified_facts SET canonical_text = ?, checksum = ? WHERE id = ?")
+      .run("Idempotent sourced fact changed", checksum("Idempotent sourced fact changed"), vf?.id ?? "");
+    await runVerifiedFactTriage(factsDb, {
+      mode: "apply",
+      policy: "classify",
+      store: pendingStore,
+    });
+    expect(pendingStore.listDecisions({ queue: "verified" })).toHaveLength(2);
+  });
 
-	it("has cursor/hash stale-decision guard before apply", async () => {
-		addFact("stale-hash", "Before", { provenanceJson: "{}" });
-		const item = oneItem("stale-hash");
-		const adapter = createVerifiedFactTriageAdapter({
-			factsDb,
-			max: 10,
-			policy: "classify",
-		});
-		const originalListPending = adapter.listPending;
-		let mutated = false;
-		adapter.listPending = async (cursor) => {
-			const items = await originalListPending(cursor);
-			if (!mutated) {
-				mutated = true;
-				factsDb
-					.getRawDb()
-					.prepare("UPDATE facts SET text = ? WHERE id = ?")
-					.run("After", "stale-hash");
-				const vf = verificationStore.getVerified("stale-hash");
-				factsDb
-					.getRawDb()
-					.prepare(
-						"UPDATE verified_facts SET canonical_text = ?, checksum = ? WHERE id = ?",
-					)
-					.run("After", checksum("After"), vf?.id ?? "");
-			}
-			return items;
-		};
-		const snapshotHash = computePendingInputHash({
-			queue: item.queue,
-			id: item.id,
-			payload: item.payload,
-			policy: "classify",
-			policyVersion: item.policyVersion,
-		});
-		expect(snapshotHash).toBe(item.inputHash);
+  it("has cursor/hash stale-decision guard before apply", async () => {
+    addFact("stale-hash", "Before", { provenanceJson: "{}" });
+    const item = oneItem("stale-hash");
+    const adapter = createVerifiedFactTriageAdapter({
+      factsDb,
+      max: 10,
+      policy: "classify",
+    });
+    const originalListPending = adapter.listPending;
+    let mutated = false;
+    adapter.listPending = async (cursor) => {
+      const items = await originalListPending(cursor);
+      if (!mutated) {
+        mutated = true;
+        factsDb.getRawDb().prepare("UPDATE facts SET text = ? WHERE id = ?").run("After", "stale-hash");
+        const vf = verificationStore.getVerified("stale-hash");
+        factsDb
+          .getRawDb()
+          .prepare("UPDATE verified_facts SET canonical_text = ?, checksum = ? WHERE id = ?")
+          .run("After", checksum("After"), vf?.id ?? "");
+      }
+      return items;
+    };
+    const snapshotHash = computePendingInputHash({
+      queue: item.queue,
+      id: item.id,
+      payload: item.payload,
+      policy: "classify",
+      policyVersion: item.policyVersion,
+    });
+    expect(snapshotHash).toBe(item.inputHash);
 
-		const result = await runVerifiedFactTriageWithAdapter(factsDb, adapter, {
-			mode: "apply",
-			policy: "classify",
-			store: pendingStore,
-		});
+    const result = await runVerifiedFactTriageWithAdapter(factsDb, adapter, {
+      mode: "apply",
+      policy: "classify",
+      store: pendingStore,
+    });
 
-		expect(result.items[0]?.action).toBe("failed-validation");
-		expect(result.items[0]?.reasonCode).toBe("input-hash-mismatch");
-		expect(
-			pendingStore.listDecisions({ queue: "verified" })[0]?.reasonCode,
-		).toBe("input-hash-mismatch");
-	});
+    expect(result.items[0]?.action).toBe("failed-validation");
+    expect(result.items[0]?.reasonCode).toBe("input-hash-mismatch");
+    expect(pendingStore.listDecisions({ queue: "verified" })[0]?.reasonCode).toBe("input-hash-mismatch");
+  });
 
-	it("standalone verified triage and parent adapter route produce equivalent decisions", async () => {
-		addFact("equiv", "Equivalence sourced fact", { provenanceJson: "{}" });
-		const nowMs = Date.parse("2026-05-12T00:00:00Z");
-		const adapter = createVerifiedFactTriageAdapter({
-			factsDb,
-			max: 10,
-			policy: "classify",
-			nowMs,
-		});
-		const item = listVerifiedFactTriageItems(factsDb.getRawDb(), {
-			max: 10,
-			nowMs,
-			policy: "classify",
-		}).find((candidate) => candidate.payload.verified.factId === "equiv");
-		if (!item) throw new Error("missing equivalence item");
-		await expectStandaloneAndParentDecisionsEquivalent({
-			standalone: (fixture, context) =>
-				adapter.decide(fixture as VerifiedFactTriageItem, {
-					...context,
-					inputHash: fixture.inputHash,
-				}),
-			parent: (_fixture, context) => {
-				const refreshed = listVerifiedFactTriageItems(factsDb.getRawDb(), {
-					max: 10,
-					nowMs,
-					policy: assertVerifiedTriagePolicy(context.policy),
-				}).find((candidate) => candidate.id === item.id);
-				if (!refreshed)
-					throw new Error("missing refreshed verified triage item");
-				return adapter.decide(refreshed as VerifiedFactTriageItem, {
-					...context,
-					inputHash: refreshed.inputHash,
-				});
-			},
-			fixtures: [
-				{
-					item,
-					policy: "classify",
-					policyVersion: VERIFIED_TRIAGE_POLICY_VERSION,
-				},
-			],
-		});
-	});
+  it("standalone verified triage and parent adapter route produce equivalent decisions", async () => {
+    addFact("equiv", "Equivalence sourced fact", { provenanceJson: "{}" });
+    const nowMs = Date.parse("2026-05-12T00:00:00Z");
+    const adapter = createVerifiedFactTriageAdapter({
+      factsDb,
+      max: 10,
+      policy: "classify",
+      nowMs,
+    });
+    const item = listVerifiedFactTriageItems(factsDb.getRawDb(), {
+      max: 10,
+      nowMs,
+      policy: "classify",
+    }).find((candidate) => candidate.payload.verified.factId === "equiv");
+    if (!item) throw new Error("missing equivalence item");
+    await expectStandaloneAndParentDecisionsEquivalent({
+      standalone: (fixture, context) =>
+        adapter.decide(fixture as VerifiedFactTriageItem, {
+          ...context,
+          inputHash: fixture.inputHash,
+        }),
+      parent: (_fixture, context) => {
+        const refreshed = listVerifiedFactTriageItems(factsDb.getRawDb(), {
+          max: 10,
+          nowMs,
+          policy: assertVerifiedTriagePolicy(context.policy),
+        }).find((candidate) => candidate.id === item.id);
+        if (!refreshed) throw new Error("missing refreshed verified triage item");
+        return adapter.decide(refreshed as VerifiedFactTriageItem, {
+          ...context,
+          inputHash: refreshed.inputHash,
+        });
+      },
+      fixtures: [
+        {
+          item,
+          policy: "classify",
+          policyVersion: VERIFIED_TRIAGE_POLICY_VERSION,
+        },
+      ],
+    });
+  });
 });
 
 function checksum(text: string): string {
-	return createHash("sha256").update(text).digest("hex");
+  return createHash("sha256").update(text).digest("hex");
 }

--- a/extensions/memory-hybrid/tests/verified-fact-triage.test.ts
+++ b/extensions/memory-hybrid/tests/verified-fact-triage.test.ts
@@ -516,6 +516,34 @@ describe("verified fact triage idempotency and parent integration", () => {
     expect(pendingStore.listDecisions({ queue: "verified" })[0]?.reasonCode).toBe("input-hash-mismatch");
   });
 
+  it("releases the apply lock when locked decisioning throws", async () => {
+    addFact("throws-under-lock", "Throwing sourced fact", { provenanceJson: "{}" });
+    const adapter = createVerifiedFactTriageAdapter({
+      factsDb,
+      max: 10,
+      policy: "classify",
+    });
+    adapter.decide = async () => {
+      throw new Error("synthetic decide failure");
+    };
+    const originalReleaseLock = pendingStore.releaseLock.bind(pendingStore);
+    let releaseCalls = 0;
+    pendingStore.releaseLock = (input) => {
+      releaseCalls += 1;
+      return originalReleaseLock(input);
+    };
+
+    await expect(
+      runVerifiedFactTriageWithAdapter(factsDb, adapter, {
+        mode: "apply",
+        policy: "classify",
+        store: pendingStore,
+      }),
+    ).rejects.toThrow("synthetic decide failure");
+
+    expect(releaseCalls).toBe(1);
+  });
+
   it("re-evaluates triage decision under lock before persisting", async () => {
     addFact("target", "Endpoint A", {
       entity: "svc",

--- a/extensions/memory-hybrid/tests/verified-fact-triage.test.ts
+++ b/extensions/memory-hybrid/tests/verified-fact-triage.test.ts
@@ -194,7 +194,7 @@ describe("verified fact triage queue source and policy", () => {
     expect(items.map((i) => i.payload.verified.factId)).toEqual(["good"]);
   });
 
-  it("applies max after checksum validation", () => {
+  it("applies max after bounded checksum-filtered SQL overfetch", () => {
     addFact("corrupt-first", "Corrupt earliest fact", { provenanceJson: "{}" });
     addFact("valid-second", "Valid later fact", { provenanceJson: "{}" });
     factsDb
@@ -210,9 +210,38 @@ describe("verified fact triage queue source and policy", () => {
       .prepare("UPDATE verified_facts SET next_verification = ? WHERE fact_id = ?")
       .run("2000-01-01T00:00:00.000Z", "valid-second");
 
-    const items = listVerifiedFactTriageItems(factsDb.getRawDb(), { max: 1 });
+    const preparedSql: string[] = [];
+    const db = factsDb.getRawDb();
+    const originalPrepare = db.prepare.bind(db);
+    db.prepare = ((sql: string) => {
+      preparedSql.push(sql);
+      return originalPrepare(sql);
+    }) as typeof db.prepare;
+
+    const items = listVerifiedFactTriageItems(db, { max: 1 });
 
     expect(items.map((i) => i.payload.verified.factId)).toEqual(["valid-second"]);
+    expect(preparedSql.some((sql) => /LIMIT \?/i.test(sql))).toBe(true);
+  });
+
+  it("paginates bounded overfetch until enough checksum-valid rows are found", () => {
+    for (let i = 0; i < 25; i += 1) {
+      const id = `corrupt-${i.toString().padStart(2, "0")}`;
+      addFact(id, `Corrupt fact ${i}`, { provenanceJson: "{}" });
+      factsDb
+        .getRawDb()
+        .prepare("UPDATE verified_facts SET canonical_text = ?, next_verification = ? WHERE fact_id = ?")
+        .run("tampered", `1999-01-${(i + 1).toString().padStart(2, "0")}T00:00:00.000Z`, id);
+    }
+    addFact("valid-after-page", "Valid after first bounded page", { provenanceJson: "{}" });
+    factsDb
+      .getRawDb()
+      .prepare("UPDATE verified_facts SET next_verification = ? WHERE fact_id = ?")
+      .run("2000-01-01T00:00:00.000Z", "valid-after-page");
+
+    const items = listVerifiedFactTriageItems(factsDb.getRawDb(), { max: 1 });
+
+    expect(items.map((i) => i.payload.verified.factId)).toEqual(["valid-after-page"]);
   });
 
   it("report-only and dry-run never mutate foundation state", async () => {
@@ -254,6 +283,19 @@ describe("verified fact triage queue source and policy", () => {
     expect(result.items[0].action).toBe("classified");
     expect(pendingStore.listDecisions({ queue: "verified" })).toHaveLength(1);
     expect(factsDb.getById("classify-me")?.text).toBe("A sourced fact due for review");
+  });
+
+  it("requires a durable store for non-report apply runs", async () => {
+    addFact("needs-store", "A sourced fact that must persist apply metadata", {
+      provenanceJson: "{}",
+    });
+
+    await expect(
+      runVerifiedFactTriage(factsDb, {
+        mode: "apply",
+        policy: "classify",
+      }),
+    ).rejects.toThrow(/requires a PendingAutopilotStore/);
   });
 
   it("apply-obvious cannot delete, demote, rewrite, or change critical verified facts", async () => {

--- a/extensions/memory-hybrid/tests/verified-fact-triage.test.ts
+++ b/extensions/memory-hybrid/tests/verified-fact-triage.test.ts
@@ -4,18 +4,21 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { FactsDB } from "../backends/facts-db.js";
-import { PendingAutopilotStore, computePendingInputHash } from "../services/pending-autopilot/index.js";
+import {
+	PendingAutopilotStore,
+	computePendingInputHash,
+} from "../services/pending-autopilot/index.js";
 import { VerificationStore } from "../services/verification-store.js";
 import {
-  VERIFIED_REVIEW_QUEUE_SOURCE,
-  VERIFIED_TRIAGE_POLICY_VERSION,
-  classifyVerifiedFact,
-  createVerifiedFactTriageAdapter,
-  listVerifiedFactTriageItems,
-  runVerifiedFactTriage,
-  runVerifiedFactTriageWithAdapter,
-  decideVerifiedFactTriage,
-  type VerifiedFactTriageItem,
+	VERIFIED_REVIEW_QUEUE_SOURCE,
+	VERIFIED_TRIAGE_POLICY_VERSION,
+	assertVerifiedTriagePolicy,
+	classifyVerifiedFact,
+	createVerifiedFactTriageAdapter,
+	listVerifiedFactTriageItems,
+	runVerifiedFactTriage,
+	runVerifiedFactTriageWithAdapter,
+	type VerifiedFactTriageItem,
 } from "../services/verified-fact-triage.js";
 import { expectStandaloneAndParentDecisionsEquivalent } from "./helpers/pending-autopilot-equivalence.js";
 
@@ -25,62 +28,64 @@ let verificationStore: VerificationStore;
 let pendingStore: PendingAutopilotStore;
 
 beforeEach(() => {
-  tmpDir = mkdtempSync(join(tmpdir(), "verified-triage-"));
-  factsDb = new FactsDB(join(tmpDir, "facts.db"));
-  verificationStore = new VerificationStore(factsDb.getRawDb(), {
-    backupPath: join(tmpDir, "verified.json"),
-    reverificationDays: 30,
-  });
-  pendingStore = new PendingAutopilotStore(join(tmpDir, "pending.db"));
+	tmpDir = mkdtempSync(join(tmpdir(), "verified-triage-"));
+	factsDb = new FactsDB(join(tmpDir, "facts.db"));
+	verificationStore = new VerificationStore(factsDb.getRawDb(), {
+		backupPath: join(tmpDir, "verified.json"),
+		reverificationDays: 30,
+	});
+	pendingStore = new PendingAutopilotStore(join(tmpDir, "pending.db"));
 });
 
 afterEach(() => {
-  pendingStore.close();
-  verificationStore.close();
-  factsDb.close();
-  rmSync(tmpDir, { recursive: true, force: true });
+	pendingStore.close();
+	verificationStore.close();
+	factsDb.close();
+	rmSync(tmpDir, { recursive: true, force: true });
 });
 
 function addFact(
-  id: string,
-  text: string,
-  opts: Partial<Parameters<FactsDB["store"]>[0]> & {
-    verified?: boolean;
-    due?: boolean;
-    verificationTier?: string;
-  } = {},
+	id: string,
+	text: string,
+	opts: Partial<Parameters<FactsDB["store"]>[0]> & {
+		verified?: boolean;
+		due?: boolean;
+		verificationTier?: string;
+	} = {},
 ): string {
-  factsDb
-    .getRawDb()
-    .prepare(
-      "INSERT INTO facts (id, text, category, importance, entity, key, value, source, created_at, decay_class, expires_at, last_confirmed_at, confidence, tags, valid_from, valid_until, supersedes_id, tier, scope, scope_target, source_sessions, provenance_session, provenance_json) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-    )
-    .run(
-      id,
-      text,
-      opts.category ?? "fact",
-      opts.importance ?? 0.8,
-      opts.entity ?? null,
-      opts.key ?? null,
-      opts.value ?? null,
-      opts.source ?? "test",
-      Math.floor(Date.now() / 1000),
-      opts.decayClass ?? "durable",
-      opts.expiresAt ?? null,
-      Math.floor(Date.now() / 1000),
-      opts.confidence ?? 0.95,
-      opts.tags?.join(",") ?? null,
-      opts.validFrom ?? null,
-      opts.validUntil ?? null,
-      opts.supersedesId ?? null,
-      opts.verificationTier ?? "warm",
-      opts.scope ?? "global",
-      opts.scope === "global" || !opts.scope ? null : (opts.scopeTarget ?? null),
-      opts.sourceSessions ?? null,
-      opts.provenanceSession ?? null,
-      opts.provenanceJson ?? null,
-    );
-  /* factsDb.store({
+	factsDb
+		.getRawDb()
+		.prepare(
+			"INSERT INTO facts (id, text, category, importance, entity, key, value, source, created_at, decay_class, expires_at, last_confirmed_at, confidence, tags, valid_from, valid_until, supersedes_id, tier, scope, scope_target, source_sessions, provenance_session, provenance_json) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+		)
+		.run(
+			id,
+			text,
+			opts.category ?? "fact",
+			opts.importance ?? 0.8,
+			opts.entity ?? null,
+			opts.key ?? null,
+			opts.value ?? null,
+			opts.source ?? "test",
+			Math.floor(Date.now() / 1000),
+			opts.decayClass ?? "durable",
+			opts.expiresAt ?? null,
+			Math.floor(Date.now() / 1000),
+			opts.confidence ?? 0.95,
+			opts.tags?.join(",") ?? null,
+			opts.validFrom ?? null,
+			opts.validUntil ?? null,
+			opts.supersedesId ?? null,
+			opts.verificationTier ?? "warm",
+			opts.scope ?? "global",
+			opts.scope === "global" || !opts.scope
+				? null
+				: (opts.scopeTarget ?? null),
+			opts.sourceSessions ?? null,
+			opts.provenanceSession ?? null,
+			opts.provenanceJson ?? null,
+		);
+	/* factsDb.store({
     text,
     category: opts.category ?? "fact",
     importance: opts.importance ?? 0.8,
@@ -102,289 +107,445 @@ function addFact(
     provenanceJson: opts.provenanceJson,
   });
   */
-  if (opts.verified !== false) {
-    verificationStore.verify(id, text, "user");
-    if (opts.due !== false) {
-      factsDb
-        .getRawDb()
-        .prepare("UPDATE verified_facts SET next_verification = ? WHERE fact_id = ?")
-        .run("2000-01-01T00:00:00.000Z", id);
-    }
-  }
-  return id;
+	if (opts.verified !== false) {
+		verificationStore.verify(id, text, "user");
+		if (opts.due !== false) {
+			factsDb
+				.getRawDb()
+				.prepare(
+					"UPDATE verified_facts SET next_verification = ? WHERE fact_id = ?",
+				)
+				.run("2000-01-01T00:00:00.000Z", id);
+		}
+	}
+	return id;
 }
 
 function oneItem(id: string): VerifiedFactTriageItem {
-  const item = listVerifiedFactTriageItems(factsDb.getRawDb(), { max: 100 }).find(
-    (candidate) => candidate.payload.verified.factId === id,
-  );
-  if (!item) throw new Error(`missing triage item ${id}`);
-  return item;
+	const item = listVerifiedFactTriageItems(factsDb.getRawDb(), {
+		max: 100,
+	}).find((candidate) => candidate.payload.verified.factId === id);
+	if (!item) throw new Error(`missing triage item ${id}`);
+	return item;
 }
 
 function bucket(id: string) {
-  return classifyVerifiedFact(oneItem(id), {
-    db: factsDb.getRawDb(),
-    nowMs: Date.parse("2026-05-12T00:00:00Z"),
-    policy: "classify",
-  });
+	return classifyVerifiedFact(oneItem(id), {
+		db: factsDb.getRawDb(),
+		nowMs: Date.parse("2026-05-12T00:00:00Z"),
+		policy: "classify",
+	});
 }
 
 describe("verified fact triage queue source and policy", () => {
-  it("uses due-for-reverification latest verified facts, not all verified facts", () => {
-    addFact("due", "Due verified fact", { provenanceJson: "{}" });
-    addFact("stale-verified-at", "Stale verified_at fact", { provenanceJson: "{}", due: false });
-    addFact("not-due", "Not due verified fact", { provenanceJson: "{}", due: false });
-    factsDb
-      .getRawDb()
-      .prepare("UPDATE verified_facts SET verified_at = ? WHERE fact_id = ?")
-      .run("2026-03-01T00:00:00.000Z", "stale-verified-at");
-    const items = listVerifiedFactTriageItems(factsDb.getRawDb(), {
-      max: 10,
-      nowMs: Date.parse("2026-05-12T00:00:00Z"),
-    });
-    expect(VERIFIED_REVIEW_QUEUE_SOURCE).toContain("due");
-    expect(items.map((i) => i.payload.verified.factId)).toEqual(["due", "stale-verified-at"]);
-    expect(items.find((i) => i.payload.verified.factId === "stale-verified-at")?.payload.dueReason).toBe(
-      "verified_at_stale",
-    );
-  });
+	it("uses due-for-reverification latest verified facts, not all verified facts", () => {
+		addFact("due", "Due verified fact", { provenanceJson: "{}" });
+		addFact("stale-verified-at", "Stale verified_at fact", {
+			provenanceJson: "{}",
+			due: false,
+		});
+		addFact("not-due", "Not due verified fact", {
+			provenanceJson: "{}",
+			due: false,
+		});
+		factsDb
+			.getRawDb()
+			.prepare("UPDATE verified_facts SET verified_at = ? WHERE fact_id = ?")
+			.run("2026-03-01T00:00:00.000Z", "stale-verified-at");
+		const items = listVerifiedFactTriageItems(factsDb.getRawDb(), {
+			max: 10,
+			nowMs: Date.parse("2026-05-12T00:00:00Z"),
+		});
+		expect(VERIFIED_REVIEW_QUEUE_SOURCE).toContain("due");
+		expect(items.map((i) => i.payload.verified.factId)).toEqual([
+			"due",
+			"stale-verified-at",
+		]);
+		expect(
+			items.find((i) => i.payload.verified.factId === "stale-verified-at")
+				?.payload.dueReason,
+		).toBe("verified_at_stale");
+	});
 
-  it("report-only and dry-run never mutate foundation state", async () => {
-    addFact("current", "A sourced current fact", { provenanceJson: "{}" });
-    const before = pendingStore.tableCounts();
-    const result = await runVerifiedFactTriage(factsDb, {
-      mode: "dry-run",
-      policy: "report-only",
-      store: pendingStore,
-    });
-    expect(result.counts.inspected).toBe(1);
-    expect(pendingStore.tableCounts()).toEqual(before);
-  });
+	it("filters checksum-corrupted verified rows before triage", () => {
+		addFact("good", "Good verified fact", { provenanceJson: "{}" });
+		addFact("corrupt", "Corrupt verified fact", { provenanceJson: "{}" });
+		factsDb
+			.getRawDb()
+			.prepare("UPDATE verified_facts SET canonical_text = ? WHERE fact_id = ?")
+			.run("tampered", "corrupt");
+		const items = listVerifiedFactTriageItems(factsDb.getRawDb(), { max: 10 });
+		expect(items.map((i) => i.payload.verified.factId)).toEqual(["good"]);
+	});
 
-  it("classify persists only non-destructive classification metadata", async () => {
-    addFact("classify-me", "A sourced fact due for review", { provenanceJson: "{}" });
-    const result = await runVerifiedFactTriage(factsDb, { mode: "apply", policy: "classify", store: pendingStore });
-    expect(result.items[0].action).toBe("classified");
-    expect(pendingStore.listDecisions({ queue: "verified" })).toHaveLength(1);
-    expect(factsDb.getById("classify-me")?.text).toBe("A sourced fact due for review");
-  });
+	it("report-only and dry-run never mutate foundation state", async () => {
+		addFact("current", "A sourced current fact", { provenanceJson: "{}" });
+		const before = pendingStore.tableCounts();
+		const result = await runVerifiedFactTriage(factsDb, {
+			mode: "dry-run",
+			policy: "report-only",
+			store: pendingStore,
+		});
+		expect(result.counts.inspected).toBe(1);
+		expect(pendingStore.tableCounts()).toEqual(before);
+	});
 
-  it("apply-obvious cannot delete, demote, rewrite, or change critical verified facts", async () => {
-    addFact("critical", "Critical but non-sensitive sourced fact", {
-      provenanceJson: "{}",
-      verificationTier: "critical",
-    });
-    const before = factsDb.getById("critical");
-    expect(before).not.toBeNull();
-    await runVerifiedFactTriage(factsDb, { mode: "apply", policy: "apply-obvious", store: pendingStore });
-    const after = factsDb.getById("critical");
-    expect(after).not.toBeNull();
-    expect(after?.text).toBe(before?.text);
-    expect(after?.tier).toBe(before?.tier);
-    expect(verificationStore.getVerified("critical")?.canonicalText).toBe("Critical but non-sensitive sourced fact");
-  });
+	it("report-only + apply stays non-mutating", async () => {
+		addFact("report-only-apply", "A sourced current fact", {
+			provenanceJson: "{}",
+		});
+		const before = pendingStore.tableCounts();
+		const result = await runVerifiedFactTriage(factsDb, {
+			mode: "apply",
+			policy: "report-only",
+			store: pendingStore,
+		});
+		expect(result.counts.inspected).toBe(1);
+		expect(result.counts.applied).toBe(0);
+		expect(pendingStore.tableCounts()).toEqual(before);
+	});
+
+	it("classify persists only non-destructive classification metadata", async () => {
+		addFact("classify-me", "A sourced fact due for review", {
+			provenanceJson: "{}",
+		});
+		const result = await runVerifiedFactTriage(factsDb, {
+			mode: "apply",
+			policy: "classify",
+			store: pendingStore,
+		});
+		expect(result.items[0].action).toBe("classified");
+		expect(pendingStore.listDecisions({ queue: "verified" })).toHaveLength(1);
+		expect(factsDb.getById("classify-me")?.text).toBe(
+			"A sourced fact due for review",
+		);
+	});
+
+	it("apply-obvious cannot delete, demote, rewrite, or change critical verified facts", async () => {
+		addFact("critical", "Critical but non-sensitive sourced fact", {
+			provenanceJson: "{}",
+			verificationTier: "critical",
+		});
+		const before = factsDb.getById("critical");
+		expect(before).not.toBeNull();
+		await runVerifiedFactTriage(factsDb, {
+			mode: "apply",
+			policy: "apply-obvious",
+			store: pendingStore,
+		});
+		const after = factsDb.getById("critical");
+		expect(after).not.toBeNull();
+		expect(after?.text).toBe(before?.text);
+		expect(after?.tier).toBe(before?.tier);
+		expect(verificationStore.getVerified("critical")?.canonicalText).toBe(
+			"Critical but non-sensitive sourced fact",
+		);
+	});
 });
 
 describe("verified fact triage classification buckets and evidence", () => {
-  it("classifies still-current/stale due facts with action, reason, capability, and evidence", () => {
-    addFact("stale", "Normal sourced fact", { provenanceJson: "{}" });
-    const result = bucket("stale");
-    expect(result.bucket).toBe("stale-candidate");
-    expect(result.reason).toBe("stale_due_for_reverification");
-    expect(result.evidence.length).toBeGreaterThan(0);
-  });
+	it("classifies still-current/stale due facts with action, reason, capability, and evidence", () => {
+		addFact("stale", "Normal sourced fact", { provenanceJson: "{}" });
+		const result = bucket("stale");
+		expect(result.bucket).toBe("stale-candidate");
+		expect(result.reason).toBe("stale_due_for_reverification");
+		expect(result.evidence.length).toBeGreaterThan(0);
+	});
 
-  it("classifies explicit TTL expiry only when validity metadata exists", () => {
-    addFact("expired", "Temporary flag", { validUntil: 1, provenanceJson: "{}" });
-    addFact("old-no-ttl", "Old without TTL", { provenanceJson: "{}" });
-    expect(bucket("expired").bucket).toBe("expired-ttl-candidate");
-    expect(bucket("old-no-ttl").bucket).not.toBe("expired-ttl-candidate");
-  });
+	it("classifies explicit TTL expiry only when validity metadata exists", () => {
+		addFact("expired", "Temporary flag", {
+			validUntil: 1,
+			provenanceJson: "{}",
+		});
+		addFact("old-no-ttl", "Old without TTL", { provenanceJson: "{}" });
+		expect(bucket("expired").bucket).toBe("expired-ttl-candidate");
+		expect(bucket("old-no-ttl").bucket).not.toBe("expired-ttl-candidate");
+	});
 
-  it("supersession requires an explicit newer fact id and same scope", () => {
-    addFact("old", "Path is /old", { provenanceJson: "{}" });
-    addFact("new", "Path is /new", { supersedesId: "old", provenanceJson: "{}" });
-    expect(bucket("old")).toMatchObject({ bucket: "superseded-candidate", reason: "newer_verified_fact_exists" });
+	it("supersession requires an explicit newer fact id and same scope", () => {
+		addFact("old", "Path is /old", { provenanceJson: "{}" });
+		addFact("new", "Path is /new", {
+			supersedesId: "old",
+			provenanceJson: "{}",
+		});
+		expect(bucket("old")).toMatchObject({
+			bucket: "superseded-candidate",
+			reason: "newer_verified_fact_exists",
+		});
 
-    addFact("other-old", "Mode is A", { provenanceJson: "{}", scope: "user", scopeTarget: "u1" });
-    addFact("other-new", "Mode is B", {
-      supersedesId: "other-old",
-      provenanceJson: "{}",
-      scope: "user",
-      scopeTarget: "u2",
-    });
-    expect(bucket("other-old").bucket).not.toBe("superseded-candidate");
-  });
+		addFact("other-old", "Mode is A", {
+			provenanceJson: "{}",
+			scope: "user",
+			scopeTarget: "u1",
+		});
+		addFact("other-new", "Mode is B", {
+			supersedesId: "other-old",
+			provenanceJson: "{}",
+			scope: "user",
+			scopeTarget: "u2",
+		});
+		expect(bucket("other-old").bucket).not.toBe("superseded-candidate");
+	});
 
-  it("contradiction requires concrete same-scope structured conflicting evidence, not semantic relatedness", () => {
-    addFact("endpoint-a", "Endpoint is A", { entity: "service", key: "endpoint", value: "A", provenanceJson: "{}" });
-    addFact("endpoint-b", "Endpoint is B", { entity: "service", key: "endpoint", value: "B", provenanceJson: "{}" });
-    const contradicted = bucket("endpoint-a");
-    expect(contradicted.bucket).toBe("contradicted-candidate");
-    expect(contradicted.evidence[0].fields).toMatchObject({
-      subject: "service",
-      claimType: "endpoint",
-      conflictingValue: "B",
-      sourceId: "endpoint-b",
-    });
+	it("contradiction requires concrete same-scope structured conflicting evidence, not semantic relatedness", () => {
+		addFact("endpoint-a", "Endpoint is A", {
+			entity: "service",
+			key: "endpoint",
+			value: "A",
+			provenanceJson: "{}",
+		});
+		addFact("endpoint-b", "Endpoint is B", {
+			entity: "service",
+			key: "endpoint",
+			value: "B",
+			provenanceJson: "{}",
+		});
+		const contradicted = bucket("endpoint-a");
+		expect(contradicted.bucket).toBe("contradicted-candidate");
+		expect(contradicted.evidence[0].fields).toMatchObject({
+			subject: "service",
+			claimType: "endpoint",
+			conflictingValue: "B",
+			sourceId: "endpoint-b",
+		});
 
-    addFact("related-a", "Service has an endpoint", {
-      entity: "related-service",
-      key: "endpoint",
-      value: "A",
-      provenanceJson: "{}",
-    });
-    addFact("related-b", "Service has a dashboard", {
-      entity: "related-service",
-      key: "dashboard",
-      value: "B",
-      provenanceJson: "{}",
-    });
-    expect(bucket("related-a").bucket).not.toBe("contradicted-candidate");
-  });
+		addFact("related-a", "Service has an endpoint", {
+			entity: "related-service",
+			key: "endpoint",
+			value: "A",
+			provenanceJson: "{}",
+		});
+		addFact("related-b", "Service has a dashboard", {
+			entity: "related-service",
+			key: "dashboard",
+			value: "B",
+			provenanceJson: "{}",
+		});
+		expect(bucket("related-a").bucket).not.toBe("contradicted-candidate");
+	});
 
-  it("scope isolation prevents cross-scope contradiction and duplicate classification", () => {
-    addFact("scoped-a", "Theme is dark", {
-      entity: "prefs",
-      key: "theme",
-      value: "dark",
-      scope: "user",
-      scopeTarget: "u1",
-      provenanceJson: "{}",
-    });
-    addFact("scoped-b", "Theme is light", {
-      entity: "prefs",
-      key: "theme",
-      value: "light",
-      scope: "user",
-      scopeTarget: "u2",
-      provenanceJson: "{}",
-    });
-    addFact("dup-a", "Same harmless fact", { scope: "user", scopeTarget: "u1", provenanceJson: "{}" });
-    addFact("dup-b", "Same harmless fact", { scope: "user", scopeTarget: "u2", provenanceJson: "{}" });
-    expect(bucket("scoped-a").bucket).not.toBe("contradicted-candidate");
-    expect(bucket("dup-a").bucket).not.toBe("duplicate-candidate");
-  });
+	it("scope isolation prevents cross-scope contradiction and duplicate classification", () => {
+		addFact("scoped-a", "Theme is dark", {
+			entity: "prefs",
+			key: "theme",
+			value: "dark",
+			scope: "user",
+			scopeTarget: "u1",
+			provenanceJson: "{}",
+		});
+		addFact("scoped-b", "Theme is light", {
+			entity: "prefs",
+			key: "theme",
+			value: "light",
+			scope: "user",
+			scopeTarget: "u2",
+			provenanceJson: "{}",
+		});
+		addFact("dup-a", "Same harmless fact", {
+			scope: "user",
+			scopeTarget: "u1",
+			provenanceJson: "{}",
+		});
+		addFact("dup-b", "Same harmless fact", {
+			scope: "user",
+			scopeTarget: "u2",
+			provenanceJson: "{}",
+		});
+		expect(bucket("scoped-a").bucket).not.toBe("contradicted-candidate");
+		expect(bucket("dup-a").bucket).not.toBe("duplicate-candidate");
+	});
 
-  it("classifies weak provenance, duplicate candidates, sensitive facts, and failed review", () => {
-    addFact("weak", "No provenance here", { source: "unknown" });
-    addFact("dup-1", "Duplicate durable truth", { provenanceJson: "{}" });
-    addFact("dup-2", "Duplicate durable truth", { provenanceJson: "{}" });
-    addFact("secret", "The API token is stored in vault", { provenanceJson: "{}" });
-    addFact("missing", "Missing row", { provenanceJson: "{}" });
-    factsDb.getRawDb().exec("PRAGMA foreign_keys = OFF");
-    factsDb.getRawDb().prepare("DELETE FROM facts WHERE id = ?").run("missing");
-    factsDb.getRawDb().exec("PRAGMA foreign_keys = ON");
+	it("classifies weak provenance, duplicate candidates, sensitive facts, and failed review", () => {
+		addFact("weak", "No provenance here", { source: "unknown" });
+		addFact("dup-1", "Duplicate durable truth", { provenanceJson: "{}" });
+		addFact("dup-2", "Duplicate durable truth", { provenanceJson: "{}" });
+		addFact("secret", "The API token is stored in vault", {
+			provenanceJson: "{}",
+		});
+		addFact("missing", "Missing row", { provenanceJson: "{}" });
+		factsDb.getRawDb().exec("PRAGMA foreign_keys = OFF");
+		factsDb.getRawDb().prepare("DELETE FROM facts WHERE id = ?").run("missing");
+		factsDb.getRawDb().exec("PRAGMA foreign_keys = ON");
 
-    expect(bucket("weak").bucket).toBe("missing-or-weak-provenance");
-    expect(bucket("dup-1").bucket).toBe("duplicate-candidate");
-    expect(bucket("secret")).toMatchObject({ bucket: "sensitive-needs-human", humanReviewRequired: true });
-    expect(bucket("missing").bucket).toBe("failed-review");
-  });
+		expect(bucket("weak").bucket).toBe("missing-or-weak-provenance");
+		expect(bucket("dup-1").bucket).toBe("duplicate-candidate");
+		expect(bucket("secret")).toMatchObject({
+			bucket: "sensitive-needs-human",
+			humanReviewRequired: true,
+		});
+		expect(bucket("missing").bucket).toBe("failed-review");
+	});
 
-  it("sensitive credentials/security/privacy/persona facts require human review and no mutation", async () => {
-    addFact("security", "SSH runbook uses password vault procedure", { provenanceJson: "{}" });
-    const result = await runVerifiedFactTriage(factsDb, {
-      mode: "apply",
-      policy: "apply-obvious",
-      store: pendingStore,
-    });
-    expect(result.items[0]).toMatchObject({
-      bucket: "sensitive-needs-human",
-      humanReviewRequired: true,
-      applied: false,
-    });
-    expect(factsDb.getById("security")?.text).toBe("SSH runbook uses password vault procedure");
-  });
+	it("sensitive credentials/security/privacy/persona facts require human review and no mutation", async () => {
+		addFact("security", "SSH runbook uses password vault procedure", {
+			provenanceJson: "{}",
+		});
+		const result = await runVerifiedFactTriage(factsDb, {
+			mode: "apply",
+			policy: "apply-obvious",
+			store: pendingStore,
+		});
+		expect(result.items[0]).toMatchObject({
+			bucket: "sensitive-needs-human",
+			humanReviewRequired: true,
+			applied: false,
+		});
+		expect(factsDb.getById("security")?.text).toBe(
+			"SSH runbook uses password vault procedure",
+		);
+	});
 
-  it("preserves provenance and stores audit/reason/evidence for skipped or failed items", async () => {
-    addFact("prov", "No provenance missing fact", { provenanceJson: JSON.stringify({ sourceFactIds: ["src-1"] }) });
-    const before = factsDb.getById("prov")?.provenanceJson;
-    const result = await runVerifiedFactTriage(factsDb, { mode: "apply", policy: "classify", store: pendingStore });
-    expect(factsDb.getById("prov")?.provenanceJson).toBe(before);
-    const decision = pendingStore.listDecisions({ queue: "verified" })[0];
-    expect(decision.audit?.summary?.metadata).toBeTruthy();
-    expect(decision.evidence.length).toBeGreaterThan(0);
-    expect(result.items[0].reason).toBeTruthy();
-  });
+	it("preserves provenance and stores audit/reason/evidence for skipped or failed items", async () => {
+		addFact("prov", "No provenance missing fact", {
+			provenanceJson: JSON.stringify({ sourceFactIds: ["src-1"] }),
+		});
+		const before = factsDb.getById("prov")?.provenanceJson;
+		const result = await runVerifiedFactTriage(factsDb, {
+			mode: "apply",
+			policy: "classify",
+			store: pendingStore,
+		});
+		expect(factsDb.getById("prov")?.provenanceJson).toBe(before);
+		const decision = pendingStore.listDecisions({ queue: "verified" })[0];
+		expect(decision.audit?.summary?.metadata).toBeTruthy();
+		expect(decision.evidence.length).toBeGreaterThan(0);
+		expect(result.items[0].reason).toBeTruthy();
+	});
 });
 
 describe("verified fact triage idempotency and parent integration", () => {
-  it("re-running apply is idempotent and changed content/hash creates a new decision", async () => {
-    addFact("idem", "Idempotent sourced fact", { provenanceJson: "{}" });
-    await runVerifiedFactTriage(factsDb, { mode: "apply", policy: "classify", store: pendingStore });
-    await runVerifiedFactTriage(factsDb, { mode: "apply", policy: "classify", store: pendingStore });
-    expect(pendingStore.listDecisions({ queue: "verified" })).toHaveLength(1);
-    factsDb.getRawDb().prepare("UPDATE facts SET text = ? WHERE id = ?").run("Idempotent sourced fact changed", "idem");
-    const vf = verificationStore.getVerified("idem");
-    expect(vf).not.toBeNull();
-    factsDb
-      .getRawDb()
-      .prepare("UPDATE verified_facts SET canonical_text = ?, checksum = ? WHERE id = ?")
-      .run("Idempotent sourced fact changed", checksum("Idempotent sourced fact changed"), vf?.id ?? "");
-    await runVerifiedFactTriage(factsDb, { mode: "apply", policy: "classify", store: pendingStore });
-    expect(pendingStore.listDecisions({ queue: "verified" })).toHaveLength(2);
-  });
+	it("re-running apply is idempotent and changed content/hash creates a new decision", async () => {
+		addFact("idem", "Idempotent sourced fact", { provenanceJson: "{}" });
+		await runVerifiedFactTriage(factsDb, {
+			mode: "apply",
+			policy: "classify",
+			store: pendingStore,
+		});
+		await runVerifiedFactTriage(factsDb, {
+			mode: "apply",
+			policy: "classify",
+			store: pendingStore,
+		});
+		expect(pendingStore.listDecisions({ queue: "verified" })).toHaveLength(1);
+		factsDb
+			.getRawDb()
+			.prepare("UPDATE facts SET text = ? WHERE id = ?")
+			.run("Idempotent sourced fact changed", "idem");
+		const vf = verificationStore.getVerified("idem");
+		expect(vf).not.toBeNull();
+		factsDb
+			.getRawDb()
+			.prepare(
+				"UPDATE verified_facts SET canonical_text = ?, checksum = ? WHERE id = ?",
+			)
+			.run(
+				"Idempotent sourced fact changed",
+				checksum("Idempotent sourced fact changed"),
+				vf?.id ?? "",
+			);
+		await runVerifiedFactTriage(factsDb, {
+			mode: "apply",
+			policy: "classify",
+			store: pendingStore,
+		});
+		expect(pendingStore.listDecisions({ queue: "verified" })).toHaveLength(2);
+	});
 
-  it("has cursor/hash stale-decision guard before apply", async () => {
-    addFact("stale-hash", "Before", { provenanceJson: "{}" });
-    const item = oneItem("stale-hash");
-    const adapter = createVerifiedFactTriageAdapter({ factsDb, max: 10, policy: "classify" });
-    const originalListPending = adapter.listPending;
-    let mutated = false;
-    adapter.listPending = async (cursor) => {
-      const items = await originalListPending(cursor);
-      if (!mutated) {
-        mutated = true;
-        factsDb.getRawDb().prepare("UPDATE facts SET text = ? WHERE id = ?").run("After", "stale-hash");
-        const vf = verificationStore.getVerified("stale-hash");
-        factsDb
-          .getRawDb()
-          .prepare("UPDATE verified_facts SET canonical_text = ?, checksum = ? WHERE id = ?")
-          .run("After", checksum("After"), vf?.id ?? "");
-      }
-      return items;
-    };
-    const snapshotHash = computePendingInputHash({
-      queue: item.queue,
-      id: item.id,
-      payload: item.payload,
-      policy: "classify",
-      policyVersion: item.policyVersion,
-    });
-    expect(snapshotHash).toBe(item.inputHash);
+	it("has cursor/hash stale-decision guard before apply", async () => {
+		addFact("stale-hash", "Before", { provenanceJson: "{}" });
+		const item = oneItem("stale-hash");
+		const adapter = createVerifiedFactTriageAdapter({
+			factsDb,
+			max: 10,
+			policy: "classify",
+		});
+		const originalListPending = adapter.listPending;
+		let mutated = false;
+		adapter.listPending = async (cursor) => {
+			const items = await originalListPending(cursor);
+			if (!mutated) {
+				mutated = true;
+				factsDb
+					.getRawDb()
+					.prepare("UPDATE facts SET text = ? WHERE id = ?")
+					.run("After", "stale-hash");
+				const vf = verificationStore.getVerified("stale-hash");
+				factsDb
+					.getRawDb()
+					.prepare(
+						"UPDATE verified_facts SET canonical_text = ?, checksum = ? WHERE id = ?",
+					)
+					.run("After", checksum("After"), vf?.id ?? "");
+			}
+			return items;
+		};
+		const snapshotHash = computePendingInputHash({
+			queue: item.queue,
+			id: item.id,
+			payload: item.payload,
+			policy: "classify",
+			policyVersion: item.policyVersion,
+		});
+		expect(snapshotHash).toBe(item.inputHash);
 
-    const result = await runVerifiedFactTriageWithAdapter(factsDb, adapter, {
-      mode: "apply",
-      policy: "classify",
-      store: pendingStore,
-    });
+		const result = await runVerifiedFactTriageWithAdapter(factsDb, adapter, {
+			mode: "apply",
+			policy: "classify",
+			store: pendingStore,
+		});
 
-    expect(result.items[0]?.action).toBe("failed-validation");
-    expect(result.items[0]?.reasonCode).toBe("input-hash-mismatch");
-    expect(pendingStore.listDecisions({ queue: "verified" })[0]?.reasonCode).toBe("input-hash-mismatch");
-  });
+		expect(result.items[0]?.action).toBe("failed-validation");
+		expect(result.items[0]?.reasonCode).toBe("input-hash-mismatch");
+		expect(
+			pendingStore.listDecisions({ queue: "verified" })[0]?.reasonCode,
+		).toBe("input-hash-mismatch");
+	});
 
-  it("standalone verified triage and parent adapter route produce equivalent decisions", async () => {
-    addFact("equiv", "Equivalence sourced fact", { provenanceJson: "{}" });
-    const nowMs = Date.parse("2026-05-12T00:00:00Z");
-    const adapter = createVerifiedFactTriageAdapter({ factsDb, max: 10, policy: "classify", nowMs });
-    const item = oneItem("equiv");
-    await expectStandaloneAndParentDecisionsEquivalent({
-      standalone: (fixture, context) =>
-        adapter.decide(fixture as VerifiedFactTriageItem, { ...context, inputHash: fixture.inputHash }),
-      parent: (fixture, context) =>
-        decideVerifiedFactTriage(
-          fixture as VerifiedFactTriageItem,
-          { ...context, inputHash: fixture.inputHash },
-          { db: factsDb.getRawDb(), nowMs },
-        ),
-      fixtures: [{ item, policy: "classify", policyVersion: VERIFIED_TRIAGE_POLICY_VERSION }],
-    });
-  });
+	it("standalone verified triage and parent adapter route produce equivalent decisions", async () => {
+		addFact("equiv", "Equivalence sourced fact", { provenanceJson: "{}" });
+		const nowMs = Date.parse("2026-05-12T00:00:00Z");
+		const adapter = createVerifiedFactTriageAdapter({
+			factsDb,
+			max: 10,
+			policy: "classify",
+			nowMs,
+		});
+		const item = listVerifiedFactTriageItems(factsDb.getRawDb(), {
+			max: 10,
+			nowMs,
+			policy: "classify",
+		}).find((candidate) => candidate.payload.verified.factId === "equiv");
+		if (!item) throw new Error("missing equivalence item");
+		await expectStandaloneAndParentDecisionsEquivalent({
+			standalone: (fixture, context) =>
+				adapter.decide(fixture as VerifiedFactTriageItem, {
+					...context,
+					inputHash: fixture.inputHash,
+				}),
+			parent: (_fixture, context) => {
+				const refreshed = listVerifiedFactTriageItems(factsDb.getRawDb(), {
+					max: 10,
+					nowMs,
+					policy: assertVerifiedTriagePolicy(context.policy),
+				}).find((candidate) => candidate.id === item.id);
+				if (!refreshed)
+					throw new Error("missing refreshed verified triage item");
+				return adapter.decide(refreshed as VerifiedFactTriageItem, {
+					...context,
+					inputHash: refreshed.inputHash,
+				});
+			},
+			fixtures: [
+				{
+					item,
+					policy: "classify",
+					policyVersion: VERIFIED_TRIAGE_POLICY_VERSION,
+				},
+			],
+		});
+	});
 });
 
 function checksum(text: string): string {
-  return createHash("sha256").update(text).digest("hex");
+	return createHash("sha256").update(text).digest("hex");
 }


### PR DESCRIPTION
## Summary

Fixes #1329.

Implements the conservative verified-fact triage child adapter/policy on top of the merged #1334 pending-autopilot foundation:

- adds `services/verified-fact-triage.ts` as a `PendingQueueAdapter` for the `verified` queue
- defines the exact review queue source: latest `verified_facts` rows due for reverification, not all verified facts
- adds `openclaw hybrid-mem verified list --json` and `openclaw hybrid-mem verified triage --dry-run|--apply --policy report-only|classify|apply-obvious --max N --json`
- records apply-mode decisions only through #1334 `PendingAutopilotStore` state/locks/cursors/redaction/input-hash contracts
- keeps dry-run fully non-durable
- never mutates verified fact text, canonical text, trust tier, critical status, verification rows, or core truth fields
- surfaces human-review-required buckets for sensitive, ambiguous, stale/superseded/contradicted/duplicate/weak-provenance cases
- documents #1326/#1334 boundaries and parent reuse expectations

## Review queue source

The verified review queue is intentionally narrow and documented in code/docs:

> Latest `verified_facts` rows whose `next_verification` timestamp is due, using `VerificationStore.listDueForReverification`-style semantics.

This avoids accidentally treating every verified fact as pending review.

## Safety / evidence boundaries

- `report-only`: no mutations, preview/report only.
- `classify`: may persist only non-destructive pending-autopilot classification metadata.
- `apply-obvious`: still does not rewrite/delete/demote verified truth; only records safe review metadata/decisions.
- Supersession requires an explicit newer fact id (`supersedes_id` / `superseded_by`) plus same scope.
- Contradiction requires concrete structured evidence: entity/scope/claim key/conflicting value/source id/verified id.
- Semantic similarity / LLM-only reasoning is not used for destructive or trust-changing decisions.
- Sensitive credential/security/privacy/persona/external-comms/operational-runbook facts require human review and no trust-changing mutation.
- Scope isolation prevents cross-scope contradiction/duplicate/supersession classification without explicit proof.

## Files changed

- `extensions/memory-hybrid/services/verified-fact-triage.ts`
- `extensions/memory-hybrid/cli/verified.ts`
- `extensions/memory-hybrid/cli/register.ts`
- `extensions/memory-hybrid/tests/verified-fact-triage.test.ts`
- `extensions/memory-hybrid/services/pending-autopilot/README.md`

## Tests

- `npm run test -- verified-fact-triage.test.ts pending-autopilot-foundation.test.ts` — 2 files / 27 tests passed
- `npx tsc --noEmit` — passed
- `npm run build` — passed
- `./node_modules/.bin/biome lint cli/verified.ts cli/register.ts services/verified-fact-triage.ts tests/verified-fact-triage.test.ts services/pending-autopilot/README.md --max-diagnostics=none` — passed

## #1329 checklist / implementation evidence

- [x] Uses #1334 `PendingQueueAdapter` / `PendingDecision` contracts (`verified-fact-triage.ts`)
- [x] CLI supports dry-run/apply/policy/max/json (`cli/verified.ts`)
- [x] Review queue source is explicit and documented (`VERIFIED_REVIEW_QUEUE_SOURCE`, README)
- [x] Conservative default: `triage` defaults to dry-run/report-only
- [x] Policies: `report-only`, `classify`, `apply-obvious`
- [x] Buckets covered by fixtures: still/current stale, expired TTL, superseded, contradicted, weak provenance, duplicate, sensitive, failed review
- [x] Supersession requires newer explicit fact id and same scope
- [x] Contradiction requires concrete structured conflicting evidence, not semantic relatedness
- [x] TTL expiry uses explicit `valid_until` / `expires_at` metadata
- [x] Scope isolation prevents cross-scope duplicate/supersession/contradiction
- [x] Sensitive credentials/security/privacy/persona/runbook facts require human review and no mutation
- [x] Provenance preservation invariant tested
- [x] Every item carries action + reason + capability + evidence through shared decision contract
- [x] Idempotency and cursor/hash stale-decision guard covered
- [x] Parent/child equivalence harness test included for future #1326 routing compatibility

## Notes

PR #1336 currently has the #1326 parent skeleton and still treats verified as placeholder/count-based until #1329 lands. This PR provides the child adapter/policy that #1326 can wire into parent routing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new verified-fact triage workflow that reads from `verified_facts`/`facts` and can persist review decisions/cursors/locks via `PendingAutopilotStore`, so correctness of queue selection, hashing, and locking is important to avoid missed or duplicated reviews.
> 
> **Overview**
> Adds a new **verified-fact triage** child adapter (`services/verified-fact-triage.ts`) that builds a strict review queue from *latest* `verified_facts` rows due for reverification (including checksum validation), classifies them into conservative buckets (stale/TTL/superseded/contradicted/duplicate/sensitive/etc.), and emits `PendingDecision` metadata without mutating verified truth.
> 
> Exposes the workflow via new CLI commands `hybrid-mem verified list` and `hybrid-mem verified triage` (dry-run/apply, policy selection, max, JSON output) and wires them into CLI registration.
> 
> Extends the pending-autopilot foundation with `PendingAutopilotStore.recordLatestDecision` for idempotent “latest decision” persistence, exports verification helpers (`computeChecksum`, `VerifiedFactRow`, `rowToVerifiedFact`) for reuse, and adds comprehensive tests covering queue source correctness, checksum filtering, cursor/lock + input-hash guards, and persistence/non-mutation behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 983b1ada65ea0639c508aec8af7d33242187f562. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->