### PR TITLE
fix(skill-validator): complete #1348 fence and Examples gate feedback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Dependencies
 node_modules/
+.pnpm-store/
 
 # Test coverage (Vitest, etc.)
 coverage/

--- a/extensions/memory-hybrid/services/skill-validator.ts
+++ b/extensions/memory-hybrid/services/skill-validator.ts
@@ -297,11 +297,14 @@ export class SkillValidator {
       const trimmed = line.trim();
 
       // Track fenced blocks; closing delimiter must match opener (``` vs ~~~) and length (CommonMark).
-      const fenceMatch = trimmed.match(/^(`{3,}|~{3,})(\w*)/);
-      if (fenceMatch) {
-        const marker = fenceMatch[1];
+      // Closing lines must be fence + optional whitespace only — not ```json mid-block, etc.
+      const fenceStart = trimmed.match(/^(`{3,}|~{3,})/);
+      if (fenceStart) {
+        const marker = fenceStart[1];
         const ch = marker[0] as "`" | "~";
         const len = marker.length;
+        const afterMarker = trimmed.slice(marker.length);
+        const isCloseLine = /^\s*$/.test(afterMarker);
         if (!inCodeBlock) {
           inCodeBlock = true;
           fenceChar = ch;
@@ -316,7 +319,7 @@ export class SkillValidator {
           }
           continue;
         }
-        if (fenceChar === ch && len >= fenceOpenLen) {
+        if (isCloseLine && fenceChar === ch && len >= fenceOpenLen) {
           if (currentFenceLines > MAX_FENCED_BLOCK_LINES) {
             violations.push(
               `Line ${currentFenceStartLine}: [codeblock-size] Fenced code/log block has ${currentFenceLines} lines (max ${MAX_FENCED_BLOCK_LINES}). Summarize instead.`,
@@ -410,18 +413,20 @@ function parseH2Headings(lines: string[]): Array<{ raw: string; normalized: stri
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i] ?? "";
     const trimmed = line.trim();
-    const fenceMatch = trimmed.match(/^(`{3,}|~{3,})/);
-    if (fenceMatch) {
-      const marker = fenceMatch[1];
+    const fenceStart = trimmed.match(/^(`{3,}|~{3,})/);
+    if (fenceStart) {
+      const marker = fenceStart[1];
       const ch = marker[0] as "`" | "~";
       const len = marker.length;
+      const afterMarker = trimmed.slice(marker.length);
+      const isCloseLine = /^\s*$/.test(afterMarker);
       if (!inFence) {
         inFence = true;
         fenceChar = ch;
         fenceOpenLen = len;
         continue;
       }
-      if (fenceChar === ch && len >= fenceOpenLen) {
+      if (isCloseLine && fenceChar === ch && len >= fenceOpenLen) {
         inFence = false;
         fenceChar = null;
         fenceOpenLen = 0;
@@ -464,7 +469,7 @@ function containsConcreteExample(examplesBody: string): boolean {
     .filter(Boolean);
   // Accept any bullet/numbered item that isn't an obvious placeholder.
   return lines.some((l) => {
-    if (!/^[-*]|\d+\./.test(l)) return false;
+    if (!/^(?:[-*+]|\d+\.)\s+\S/.test(l)) return false;
     if (/\b(?:tbd|todo|placeholder|example here|fill in)\b/i.test(l)) return false;
     return l.length >= 18;
   });

--- a/extensions/memory-hybrid/tests/crystallization.test.ts
+++ b/extensions/memory-hybrid/tests/crystallization.test.ts
@@ -770,9 +770,9 @@ ${extra.extraBody ?? ""}`;
   it("does not treat ```-prefixed lines inside a fence as closing unless the line is a real closing fence", () => {
     const content = compactValidSkill({
       workflow: [
-        "Example (mid-block line that starts with backticks but is not a closing delimiter):",
+        "Example (mid-block line starts with a fence run but is not a CommonMark closer):",
         "```bash",
-        "echo '``` not a fence'",
+        "```json this line is still inside the bash fence (info string after opening run)",
         "curl https://evil.example",
         "```",
       ].join("\n"),

--- a/extensions/memory-hybrid/tests/crystallization.test.ts
+++ b/extensions/memory-hybrid/tests/crystallization.test.ts
@@ -767,6 +767,31 @@ ${extra.extraBody ?? ""}`;
     expect(result.violations.some((v: string) => v.includes("eval") || v.includes("curl"))).toBe(true);
   });
 
+  it("does not treat ```-prefixed lines inside a fence as closing unless the line is a real closing fence", () => {
+    const content = compactValidSkill({
+      workflow: [
+        "Example (mid-block line that starts with backticks but is not a closing delimiter):",
+        "```bash",
+        "echo '``` not a fence'",
+        "curl https://evil.example",
+        "```",
+      ].join("\n"),
+    });
+    const result = validator.validate(content);
+    expect(result.valid).toBe(false);
+    expect(result.violations.some((v: string) => v.includes("curl"))).toBe(true);
+  });
+
+  it("rejects Examples sections that only contain prose with embedded version tokens (no list examples)", () => {
+    const content = compactValidSkill().replace(
+      /## Examples\n[\s\S]*?(?=## Related tools\/skills|## Provenance)/,
+      "## Examples\nThis skill targets OpenAPI v2.0 and gRPC v1.54 behavior only.\n\n",
+    );
+    const result = validator.validate(content);
+    expect(result.valid).toBe(false);
+    expect(result.violations.some((v: string) => v.includes("Examples section must"))).toBe(true);
+  });
+
   it("denies rm -rf absolute path", () => {
     const content = compactValidSkill({
       workflow: ["Example command:", "```bash", "rm -rf /home/user", "```"].join("\n"),


### PR DESCRIPTION
## Summary

Follow-up to merged [#1348](https://github.com/markus-lassfolk/openclaw-hybrid-memory/pull/1348) / [#1342](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/1342): Codex review called out two gaps that were still present on `main` after the merge.

### Changes

1. **Fence handling (`skill-validator.ts`)**  
   Only treat a line as closing a fenced block when the opening delimiter character matches, the closing run length is sufficient, **and** the line is a well-formed CommonMark closer (fence run plus optional whitespace only). This prevents lines like `` ```json`` inside a backtick block from ending the fence early and bypassing `codeBlockOnly` rules or heading detection.

2. **Examples quality gate**  
   Replace the regex that anchored only the bullet branch with an anchored pattern for bullets (`-`, `*`, `+`) and numbered lists, so prose such as `v2.0` / `v1.54` cannot masquerade as a concrete example.

### Tests

- Mid-fence line starting with backticks that is **not** a real closer still leaves `curl` inside the block and is denied.
- **Examples** section with only version-like prose (no list items) is rejected.

## Test plan

- [ ] `npx vitest run extensions/memory-hybrid/tests/crystallization.test.ts -t SkillValidator` (or full hybrid test job in CI)

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core `SkillValidator` parsing heuristics for fenced blocks and Examples detection, which could newly reject or (if buggy) miss content in generated `SKILL.md` files. Covered by added regression tests, but the logic affects security-related validation paths.
> 
> **Overview**
> Prevents fenced code blocks from being considered closed unless the line is a *true* CommonMark closer (fence run plus optional whitespace only), so mid-block lines like ```json no longer prematurely end a block and bypass code-block-only deny rules or `##` heading detection.
> 
> Tightens the Examples quality gate by requiring actual bullet/numbered list items (`-`/`*`/`+` or `1.`) with content, avoiding false positives from prose containing tokens like `v2.0`. Adds tests covering both bypass scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4dbe9742df6dc788d1c802a2c5271edd2d8966ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->