### PR TITLE
fix: canonical outputDir path equivalence in skill path validation

### DIFF
--- a/extensions/memory-hybrid/services/crystallization-proposer.ts
+++ b/extensions/memory-hybrid/services/crystallization-proposer.ts
@@ -11,7 +11,7 @@ import { getEnv } from "../utils/env-manager.js";
 
 import { mkdirSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { dirname } from "node:path";
+import { dirname, resolve } from "node:path";
 import type { CrystallizationStore } from "../backends/crystallization-store.js";
 import type { WorkflowPattern, WorkflowStore } from "../backends/workflow-store.js";
 import type { CrystallizationConfig } from "../config/types/features.js";
@@ -342,7 +342,7 @@ export class CrystallizationProposer {
 
   private computeOutputPath(skillName: string): string {
     const outputDir = this.cfg.outputDir.replace(/^~/, getEnv("HOME") || homedir());
-    return `${outputDir}/${skillName}/SKILL.md`;
+    return resolve(outputDir, skillName, "SKILL.md");
   }
 
   private applyOverridesToDraft(

--- a/extensions/memory-hybrid/services/generated-skill-validation.ts
+++ b/extensions/memory-hybrid/services/generated-skill-validation.ts
@@ -212,7 +212,7 @@ export class GeneratedSkillValidationService {
   ): SkillProposalValidationResult["staticValidation"] {
     const violations: string[] = [];
     const safeOutputPath = resolve(input.outputDir, input.skillName, "SKILL.md");
-    const proposedOutputPath = resolve(input.proposedOutputPath);
+    const proposedOutputPath = input.proposedOutputPath;
 
     if (input.skillContent.length > MAX_SKILL_CHARS) {
       violations.push(`Skill exceeds ${MAX_SKILL_CHARS} characters`);

--- a/extensions/memory-hybrid/services/generated-skill-validation.ts
+++ b/extensions/memory-hybrid/services/generated-skill-validation.ts
@@ -399,7 +399,8 @@ function isCanonicalSkillPath(outputDir: string, proposedOutputPath: string, ski
   const outputRoot = resolve(outputDir);
   const skillDir = resolve(outputRoot, skillName);
   const expected = resolve(skillDir, "SKILL.md");
-  if (proposedOutputPath !== expected || !isWithinDir(outputRoot, dirname(proposedOutputPath))) return false;
+  const resolvedProposed = resolve(proposedOutputPath);
+  if (resolvedProposed !== expected || !isWithinDir(outputRoot, dirname(resolvedProposed))) return false;
 
   return existingSkillPathIsSafe(outputRoot, skillDir, expected);
 }

--- a/extensions/memory-hybrid/services/skill-crystallizer.ts
+++ b/extensions/memory-hybrid/services/skill-crystallizer.ts
@@ -8,6 +8,7 @@ import { getEnv } from "../utils/env-manager.js";
  */
 
 import { homedir } from "node:os";
+import { resolve } from "node:path";
 import type { WorkflowPattern } from "../backends/workflow-store.js";
 import type { CrystallizationConfig } from "../config/types/features.js";
 import type { SkillProposalCard, SkillProposalRecommendedOutput } from "../backends/crystallization-store.js";
@@ -299,7 +300,7 @@ export class SkillCrystallizer {
 
     // Resolve output directory (expand ~ for home dir)
     const outputDir = this.cfg.outputDir.replace(/^~/, getEnv("HOME") || homedir());
-    const proposedOutputPath = `${outputDir}/${skillName}/SKILL.md`;
+    const proposedOutputPath = resolve(outputDir, skillName, "SKILL.md");
 
     // Generate shell script for exec-only sequences
     const hasScript = isExecOnlySequence(pattern.toolSequence);

--- a/extensions/memory-hybrid/tests/generated-skill-validation.test.ts
+++ b/extensions/memory-hybrid/tests/generated-skill-validation.test.ts
@@ -416,6 +416,113 @@ Bounded symlink validation workflow.
     expect(validation.staticValidation.violations.some((v) => v.includes("Unsafe proposed output path"))).toBe(true);
   });
 
+  // Regression tests for canonical outputDir path equivalence (Issue #1373)
+  const CANONICAL_SKILL_CONTENT = `---
+name: canonical-path-skill
+description: Use when the user asks to test canonical path equivalence.
+category: crystallized-workflow
+provenance: test-suite
+---
+
+# Canonical Path Skill
+
+## Trigger
+Use this skill for canonical path equivalence testing.
+
+## Scope
+Bounded canonical path workflow.
+
+## When not to use
+- Do not use for unrelated tasks.
+
+## Workflow
+1. Resolve output path canonically.
+2. Compare resolved forms for equivalence.
+
+## Verification
+- Confirm output paths stay inside the skills directory.
+
+## Anti-patterns / Known Failures
+- Do not compare raw path strings without resolving first.
+
+## Examples
+- Validate canonical path equivalence for generated skills.
+
+## Provenance
+- Source pattern ID: \`pattern-canonical\``;
+
+  it("accepts outputDir with a trailing slash (canonical path equivalence)", () => {
+    tmpDir = mkdtempSync(join(tmpdir(), "generated-skill-trailing-slash-"));
+    const service = new GeneratedSkillValidationService();
+    const canonicalOutputDir = join(tmpDir, "skills");
+    // Trailing slash form — must be accepted as equivalent
+    const outputDirWithSlash = canonicalOutputDir + "/";
+    const validation = service.validate({
+      outputDir: outputDirWithSlash,
+      proposedOutputPath: join(canonicalOutputDir, "canonical-path-skill", "SKILL.md"),
+      skillName: "canonical-path-skill",
+      skillContent: CANONICAL_SKILL_CONTENT,
+    });
+    expect(
+      validation.staticValidation.violations.filter((v) => v.includes("Unsafe proposed output path")),
+      "Trailing-slash outputDir should not trigger path safety rejection",
+    ).toHaveLength(0);
+  });
+
+  it("accepts outputDir prefixed with ./ (canonical path equivalence)", () => {
+    tmpDir = mkdtempSync(join(tmpdir(), "generated-skill-dot-slash-"));
+    const service = new GeneratedSkillValidationService();
+    const canonicalOutputDir = join(tmpDir, "skills");
+    // Insert a "./" segment in the middle: /tmp/xxx/./skills — resolves to /tmp/xxx/skills
+    const outputDirDotSlash = `${tmpDir}/./skills`;
+    const validation = service.validate({
+      outputDir: outputDirDotSlash,
+      proposedOutputPath: join(canonicalOutputDir, "canonical-path-skill", "SKILL.md"),
+      skillName: "canonical-path-skill",
+      skillContent: CANONICAL_SKILL_CONTENT,
+    });
+    expect(
+      validation.staticValidation.violations.filter((v) => v.includes("Unsafe proposed output path")),
+      "./ prefixed outputDir should not trigger path safety rejection",
+    ).toHaveLength(0);
+  });
+
+  it("accepts outputDir with redundant separators (canonical path equivalence)", () => {
+    tmpDir = mkdtempSync(join(tmpdir(), "generated-skill-redundant-sep-"));
+    const service = new GeneratedSkillValidationService();
+    const canonicalOutputDir = join(tmpDir, "skills");
+    // Double-slash form — must be accepted as equivalent
+    const outputDirDoubleSlash = canonicalOutputDir.replace(/\/([^/]+)$/, "//$1");
+    const validation = service.validate({
+      outputDir: outputDirDoubleSlash,
+      proposedOutputPath: join(canonicalOutputDir, "canonical-path-skill", "SKILL.md"),
+      skillName: "canonical-path-skill",
+      skillContent: CANONICAL_SKILL_CONTENT,
+    });
+    expect(
+      validation.staticValidation.violations.filter((v) => v.includes("Unsafe proposed output path")),
+      "Redundant-separator outputDir should not trigger path safety rejection",
+    ).toHaveLength(0);
+  });
+
+  it("rejects proposedOutputPath that escapes the outputDir (canonical path equivalence)", () => {
+    tmpDir = mkdtempSync(join(tmpdir(), "generated-skill-escape-"));
+    const service = new GeneratedSkillValidationService();
+    const outputDir = join(tmpDir, "skills");
+    // Path traversal attempt: escapes the outputDir
+    const escapingPath = join(outputDir, "..", "evil-skill", "SKILL.md");
+    const validation = service.validate({
+      outputDir,
+      proposedOutputPath: escapingPath,
+      skillName: "evil-skill",
+      skillContent: CANONICAL_SKILL_CONTENT,
+    });
+    expect(
+      validation.staticValidation.violations.some((v) => v.includes("Unsafe proposed output path")),
+      "Path traversal escaping outputDir must be rejected",
+    ).toBe(true);
+  });
+
   it("requires explicit override for activation warnings during approval", () => {
     tmpDir = mkdtempSync(join(tmpdir(), "generated-skill-override-"));
     const validationService = new GeneratedSkillValidationService();

--- a/extensions/memory-hybrid/tests/generated-skill-validation.test.ts
+++ b/extensions/memory-hybrid/tests/generated-skill-validation.test.ts
@@ -1,6 +1,6 @@
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { basename, dirname, join, sep } from "node:path";
 import { Command } from "commander";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { CrystallizationStore } from "../backends/crystallization-store.js";
@@ -455,8 +455,8 @@ Bounded canonical path workflow.
     tmpDir = mkdtempSync(join(tmpdir(), "generated-skill-trailing-slash-"));
     const service = new GeneratedSkillValidationService();
     const canonicalOutputDir = join(tmpDir, "skills");
-    // Trailing slash form — must be accepted as equivalent
-    const outputDirWithSlash = canonicalOutputDir + "/";
+    // Trailing separator form — must be accepted as equivalent
+    const outputDirWithSlash = `${canonicalOutputDir}${sep}`;
     const validation = service.validate({
       outputDir: outputDirWithSlash,
       proposedOutputPath: join(canonicalOutputDir, "canonical-path-skill", "SKILL.md"),
@@ -473,8 +473,8 @@ Bounded canonical path workflow.
     tmpDir = mkdtempSync(join(tmpdir(), "generated-skill-dot-slash-"));
     const service = new GeneratedSkillValidationService();
     const canonicalOutputDir = join(tmpDir, "skills");
-    // Insert a "./" segment in the middle: /tmp/xxx/./skills — resolves to /tmp/xxx/skills
-    const outputDirDotSlash = `${tmpDir}/./skills`;
+    // Insert a "." segment in the middle: /tmp/xxx/./skills — resolves to /tmp/xxx/skills
+    const outputDirDotSlash = join(tmpDir, ".", "skills");
     const validation = service.validate({
       outputDir: outputDirDotSlash,
       proposedOutputPath: join(canonicalOutputDir, "canonical-path-skill", "SKILL.md"),
@@ -491,8 +491,8 @@ Bounded canonical path workflow.
     tmpDir = mkdtempSync(join(tmpdir(), "generated-skill-redundant-sep-"));
     const service = new GeneratedSkillValidationService();
     const canonicalOutputDir = join(tmpDir, "skills");
-    // Double-slash form — must be accepted as equivalent
-    const outputDirDoubleSlash = canonicalOutputDir.replace(/\/([^/]+)$/, "//$1");
+    // Redundant-separator form — must be accepted as equivalent
+    const outputDirDoubleSlash = `${dirname(canonicalOutputDir)}${sep}${sep}${basename(canonicalOutputDir)}`;
     const validation = service.validate({
       outputDir: outputDirDoubleSlash,
       proposedOutputPath: join(canonicalOutputDir, "canonical-path-skill", "SKILL.md"),
@@ -510,11 +510,11 @@ Bounded canonical path workflow.
     const service = new GeneratedSkillValidationService();
     const outputDir = join(tmpDir, "skills");
     // Path traversal attempt: escapes the outputDir
-    const escapingPath = join(outputDir, "..", "evil-skill", "SKILL.md");
+    const escapingPath = join(outputDir, "..", "canonical-path-skill", "SKILL.md");
     const validation = service.validate({
       outputDir,
       proposedOutputPath: escapingPath,
-      skillName: "evil-skill",
+      skillName: "canonical-path-skill",
       skillContent: CANONICAL_SKILL_CONTENT,
     });
     expect(

--- a/extensions/memory-hybrid/tests/generated-skill-validation.test.ts
+++ b/extensions/memory-hybrid/tests/generated-skill-validation.test.ts
@@ -474,7 +474,7 @@ Bounded canonical path workflow.
     const service = new GeneratedSkillValidationService();
     const canonicalOutputDir = join(tmpDir, "skills");
     // Insert a "." segment in the middle: /tmp/xxx/./skills — resolves to /tmp/xxx/skills
-    const outputDirDotSlash = join(tmpDir, ".", "skills");
+    const outputDirDotSlash = `${tmpDir}${sep}.${sep}skills`;
     const validation = service.validate({
       outputDir: outputDirDotSlash,
       proposedOutputPath: join(canonicalOutputDir, "canonical-path-skill", "SKILL.md"),

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,9 +13,6 @@
       "devDependencies": {
         "husky": "^9.0.0",
         "lint-staged": "^15.0.0"
-      },
-      "engines": {
-        "node": ">=22.16.0"
       }
     },
     "node_modules/@lancedb/lancedb": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,9 @@
       "devDependencies": {
         "husky": "^9.0.0",
         "lint-staged": "^15.0.0"
+      },
+      "engines": {
+        "node": ">=22.16.0"
       }
     },
     "node_modules/@lancedb/lancedb": {


### PR DESCRIPTION
`GeneratedSkillValidationService.validateStatic` rejected valid proposed paths whenever `cfg.outputDir` wasn't byte-identical to its `resolve()`d form — trailing slashes, `./` components, or redundant separators all caused false "Unsafe proposed output path" violations.

## Root causes

- **`isCanonicalSkillPath`** compared raw `proposedOutputPath` string against a `resolve()`d `expected`, so any normalisation noise in `outputDir` produced a mismatch.
- **`SkillCrystallizer.crystallize`** and **`CrystallizationProposer.computeOutputPath`** both built `proposedOutputPath` via template-string concatenation (`${outputDir}/${skillName}/SKILL.md`), not `path.resolve()`, so the path was never normalised before validation.

## Changes

- **`generated-skill-validation.ts`** — resolve `proposedOutputPath` before comparing; cache result to avoid double `resolve()` call:
  ```ts
  // before
  if (proposedOutputPath !== expected || !isWithinDir(outputRoot, dirname(proposedOutputPath)))

  // after
  const resolvedProposed = resolve(proposedOutputPath);
  if (resolvedProposed !== expected || !isWithinDir(outputRoot, dirname(resolvedProposed)))
  ```
- **`skill-crystallizer.ts`** — replace string concatenation with `resolve(outputDir, skillName, "SKILL.md")`.
- **`crystallization-proposer.ts`** — same fix in `computeOutputPath`.

## Tests

Four regression tests added to `generated-skill-validation.test.ts`:
- `outputDir` with trailing slash → passes
- `outputDir` containing a `./` segment (e.g. `/tmp/x/./skills`) → passes
- `outputDir` with redundant separators → passes
- `proposedOutputPath` that escapes `outputDir` via `..` → still rejected

> [!WARNING]
>
> <details>
> <summary>Firewall rules blocked me from connecting to one or more addresses (expand for details)</summary>
>
> #### I tried to connect to the following addresses, but was blocked by firewall rules:
>
> - `api.openai.com`
>   - Triggering command: `/opt/hostedtoolcache/node/24.14.1/x64/bin/node /opt/hostedtoolcache/node/24.14.1/x64/bin/node --experimental-import-meta-resolve --require /home/REDACTED/work/openclaw-hybrid-memory/openclaw-hybrid-memory/extensions/memory-hybrid/node_modules/vitest/suppress-warnings.cjs --conditions node --conditions development /home/REDACTED/work/openclaw-hybrid-memory/openclaw-hybrid-memory/extensions/memory-hybrid/node_modules/vitest/dist/workers/forks.js` (dns block)
> - `https://api.github.com/graphql`
>   - Triggering command: `/usr/bin/gh gh pr list --limit 10 --json number,title,state,url,createdAt ******&#34;; }; f` (http block)
>   - Triggering command: `/usr/bin/gh gh issue list --limit 10 --json number,title,state,url,createdAt github.com` (http block)
>   - Triggering command: `/usr/bin/gh gh issue list --limit 10 --json number,title,state,url,createdAt extensions/memory-hybrid/node_modules/node_modules/.bin/sh` (http block)
> - `my-glitchtip.example.com`
>   - Triggering command: `/opt/hostedtoolcache/node/24.14.1/x64/bin/node /opt/hostedtoolcache/node/24.14.1/x64/bin/node --experimental-import-meta-resolve --require /home/REDACTED/work/openclaw-hybrid-memory/openclaw-hybrid-memory/extensions/memory-hybrid/node_modules/vitest/suppress-warnings.cjs --conditions node --conditions development /home/REDACTED/work/openclaw-hybrid-memory/openclaw-hybrid-memory/extensions/memory-hybrid/node_modules/vitest/dist/workers/forks.js` (dns block)
>
> If you need me to access, download, or install something from one of these locations, you can either:
>
> - Configure [Actions setup steps](https://gh.io/copilot/actions-setup-steps) to set up my environment, which run before the firewall is enabled
> - Add the appropriate URLs or hosts to the custom allowlist in this repository's [Copilot coding agent settings](https://github.com/markus-lassfolk/openclaw-hybrid-memory/settings/copilot/coding_agent) (admins only)
>
> </details>

---

Reopened by Maeve as a human-owned branch/PR to avoid bot/app PR workflow and review limitations.

Supersedes: https://github.com/markus-lassfolk/openclaw-hybrid-memory/pull/1439
Closes #1426

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts filesystem path canonicalization in the skill crystallization/validation pipeline; mistakes here could either wrongly reject valid skills or weaken path-escape protections, though changes are narrowly scoped and covered by new regression tests.
> 
> **Overview**
> Fixes false "Unsafe proposed output path" rejections by **canonicalizing skill output paths** during crystallization and validation.
> 
> `SkillCrystallizer` and `CrystallizationProposer` now build `proposedOutputPath` via `path.resolve()` instead of string concatenation, and `GeneratedSkillValidationService` resolves `proposedOutputPath` before comparing against the expected `SKILL.md` location.
> 
> Adds regression tests to ensure `outputDir` normalization variants (trailing slash, `./`, redundant separators) are accepted while `..` traversal escapes are still rejected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 908710fbe696d9da6212222348bd6cbb926984bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->