### PR TITLE
fix: make procedure task similarity symmetric

### DIFF
--- a/extensions/memory-hybrid/services/procedure-extractor.ts
+++ b/extensions/memory-hybrid/services/procedure-extractor.ts
@@ -236,7 +236,7 @@ type ExtractProceduresOptions = {
 };
 
 /** Calculate word overlap ratio between two task patterns (0.0 to 1.0). */
-function taskSimilarity(pattern1: string, pattern2: string): number {
+export function taskSimilarity(pattern1: string, pattern2: string): number {
   const words1 = new Set(
     pattern1
       .toLowerCase()
@@ -251,8 +251,11 @@ function taskSimilarity(pattern1: string, pattern2: string): number {
   );
   if (words1.size === 0 || words2.size === 0) return 0;
   const intersection = new Set([...words1].filter((w) => words2.has(w)));
-  return intersection.size / Math.min(words1.size, words2.size);
+  const union = new Set([...words1, ...words2]);
+  return intersection.size / Math.max(1, union.size);
 }
+
+const PROCEDURE_MERGE_SIMILARITY_THRESHOLD = 0.35;
 
 /**
  * Read session JSONL files (from directory or explicit paths), parse tool sequences,
@@ -329,7 +332,7 @@ export async function extractProceduresFromSessions(
     }
 
     const existing = factsDb.findProcedureByTaskPattern(parsed.taskIntent, 1)[0];
-    if (existing && taskSimilarity(existing.taskPattern, parsed.taskIntent) >= 0.5) {
+    if (existing && taskSimilarity(existing.taskPattern, parsed.taskIntent) >= PROCEDURE_MERGE_SIMILARITY_THRESHOLD) {
       let recorded = false;
       if (parsed.success) {
         recorded = factsDb.recordProcedureSuccess(existing.id, recipeJson, sessionId);

--- a/extensions/memory-hybrid/tests/procedure-extractor.test.ts
+++ b/extensions/memory-hybrid/tests/procedure-extractor.test.ts
@@ -4,8 +4,8 @@ import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import type { FactsDB } from "../backends/facts-db.js";
 import {
-  extractProceduresFromSessions,
   type ParsedSession,
+  extractProceduresFromSessions,
   minimalRecipe,
   parseSessionJsonl,
   taskSimilarity,
@@ -209,7 +209,11 @@ describe("procedure-extractor", () => {
       } as unknown as FactsDB;
 
       try {
-        await extractProceduresFromSessions(factsDb, { filePaths: [join(dir, "session-1.jsonl")] }, { info: vi.fn(), warn: vi.fn() });
+        await extractProceduresFromSessions(
+          factsDb,
+          { filePaths: [join(dir, "session-1.jsonl")] },
+          { info: vi.fn(), warn: vi.fn() },
+        );
       } finally {
         rmSync(dir, { recursive: true, force: true });
       }
@@ -231,7 +235,11 @@ describe("procedure-extractor", () => {
       } as unknown as FactsDB;
 
       try {
-        await extractProceduresFromSessions(factsDb, { filePaths: [join(dir, "session-1.jsonl")] }, { info: vi.fn(), warn: vi.fn() });
+        await extractProceduresFromSessions(
+          factsDb,
+          { filePaths: [join(dir, "session-1.jsonl")] },
+          { info: vi.fn(), warn: vi.fn() },
+        );
       } finally {
         rmSync(dir, { recursive: true, force: true });
       }

--- a/extensions/memory-hybrid/tests/procedure-extractor.test.ts
+++ b/extensions/memory-hybrid/tests/procedure-extractor.test.ts
@@ -1,5 +1,15 @@
-import { describe, expect, it } from "vitest";
-import { type ParsedSession, minimalRecipe, parseSessionJsonl } from "../services/procedure-extractor.js";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import type { FactsDB } from "../backends/facts-db.js";
+import {
+  extractProceduresFromSessions,
+  type ParsedSession,
+  minimalRecipe,
+  parseSessionJsonl,
+  taskSimilarity,
+} from "../services/procedure-extractor.js";
 import type { ProcedureStep } from "../types/memory.js";
 
 describe("procedure-extractor", () => {
@@ -145,6 +155,89 @@ describe("procedure-extractor", () => {
       expect(out[0].tool).toBe("memory_recall");
       expect(out[0].args).toEqual({ query: "test", limit: 5 });
       expect(out[0].summary).toBe("recall");
+    });
+  });
+
+  describe("taskSimilarity", () => {
+    it("is symmetric", () => {
+      const a = "fix bug";
+      const b = "fix the failing ci bug that prevents deploys and update the release notes";
+      expect(taskSimilarity(a, b)).toBe(taskSimilarity(b, a));
+    });
+
+    it("does not treat a short task as identical to a long task that contains its words", () => {
+      const shortTask = "fix bug";
+      const longTask = "fix the failing ci bug that prevents deploys and update the release notes";
+      expect(taskSimilarity(shortTask, longTask)).toBeLessThan(0.35);
+    });
+  });
+
+  describe("extractProceduresFromSessions", () => {
+    function writeSession(taskIntent: string): string {
+      const dir = mkdtempSync(join(tmpdir(), "proc-extractor-"));
+      const filePath = join(dir, "session-1.jsonl");
+      const lines = [
+        JSON.stringify({
+          type: "message",
+          message: { role: "user", content: [{ type: "text", text: taskIntent }] },
+        }),
+        JSON.stringify({
+          type: "message",
+          message: {
+            role: "assistant",
+            content: [
+              { type: "tool_use", id: "t1", name: "web_fetch", input: { url: "https://example.com" } },
+              { type: "tool_use", id: "t2", name: "message", input: { text: "Done" } },
+            ],
+          },
+        }),
+      ];
+      writeFileSync(filePath, lines.join("\n"), "utf-8");
+      return dir;
+    }
+
+    it("does not merge unrelated long task into short-task procedure", async () => {
+      const dir = writeSession("fix the failing ci bug that prevents deploys and update the release notes");
+      const findProcedureByTaskPattern = vi.fn(() => [{ id: "p1", taskPattern: "fix bug" }]);
+      const recordProcedureSuccess = vi.fn(() => true);
+      const upsertProcedure = vi.fn();
+      const factsDb = {
+        findProcedureByTaskPattern,
+        recordProcedureSuccess,
+        recordProcedureFailure: vi.fn(() => true),
+        upsertProcedure,
+      } as unknown as FactsDB;
+
+      try {
+        await extractProceduresFromSessions(factsDb, { filePaths: [join(dir, "session-1.jsonl")] }, { info: vi.fn(), warn: vi.fn() });
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+
+      expect(recordProcedureSuccess).not.toHaveBeenCalled();
+      expect(upsertProcedure).toHaveBeenCalledTimes(1);
+    });
+
+    it("still merges true task matches", async () => {
+      const dir = writeSession("fix deployment pipeline bug in ci");
+      const findProcedureByTaskPattern = vi.fn(() => [{ id: "p1", taskPattern: "fix deployment pipeline bug" }]);
+      const recordProcedureSuccess = vi.fn(() => true);
+      const upsertProcedure = vi.fn();
+      const factsDb = {
+        findProcedureByTaskPattern,
+        recordProcedureSuccess,
+        recordProcedureFailure: vi.fn(() => true),
+        upsertProcedure,
+      } as unknown as FactsDB;
+
+      try {
+        await extractProceduresFromSessions(factsDb, { filePaths: [join(dir, "session-1.jsonl")] }, { info: vi.fn(), warn: vi.fn() });
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+
+      expect(recordProcedureSuccess).toHaveBeenCalledTimes(1);
+      expect(upsertProcedure).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
`taskSimilarity` was asymmetric (`intersection / min(size)`), causing short intents to match long, unrelated intents as perfect matches and incorrectly merge procedure evidence. This updates the similarity metric and merge threshold so only genuinely similar intents coalesce.

- **Similarity metric: replace asymmetric overlap with Jaccard**
  - Updated `taskSimilarity` in `procedure-extractor.ts` to compute:
    - `|A ∩ B| / |A ∪ B|`
  - Exported `taskSimilarity` for direct test coverage of metric behavior.

- **Merge policy: recalibrate threshold for new score distribution**
  - Replaced hardcoded merge threshold (`0.5`) with a constant set to `0.35` for Jaccard-based matching in `extractProceduresFromSessions`.

- **Tests: cover asymmetry regression and merge behavior**
  - Added/extended `procedure-extractor.test.ts` to assert:
    - symmetry (`sim(a,b) === sim(b,a)`)
    - short-vs-long intent no longer scores as near-identical
    - true semantic matches still merge into existing procedures

Example of the core metric change:

```ts
const intersection = new Set([...words1].filter((w) => words2.has(w)));
const union = new Set([...words1, ...words2]);
return intersection.size / Math.max(1, union.size);
```

> [!WARNING]
>
> <details>
> <summary>Firewall rules blocked me from connecting to one or more addresses (expand for details)</summary>
>
> #### I tried to connect to the following addresses, but was blocked by firewall rules:
>
> - `api.openai.com`
>   - Triggering command: `/opt/hostedtoolcache/node/24.14.1/x64/bin/node /opt/hostedtoolcache/node/24.14.1/x64/bin/node --experimental-import-meta-resolve --require /home/REDACTED/work/openclaw-hybrid-memory/openclaw-hybrid-memory/extensions/memory-hybrid/node_modules/vitest/suppress-warnings.cjs --conditions node --conditions development /home/REDACTED/work/openclaw-hybrid-memory/openclaw-hybrid-memory/extensions/memory-hybrid/node_modules/vitest/dist/workers/forks.js` (dns block)
>   - Triggering command: `/opt/hostedtoolcache/node/24.14.1/x64/bin/node /opt/hostedtoolcache/node/24.14.1/x64/bin/node --experimental-import-meta-resolve --require /home/REDACTED/work/openclaw-hybrid-memory/openclaw-hybrid-memory/extensions/memory-hybrid/node_modules/vitest/suppress-warnings.cjs --conditions node --conditions development /home/REDACTED/work/openclaw-hybrid-memory/openclaw-hybrid-memory/extensions/memory-hybrid/node_modules/vitest/dist/workers/forks.js js k/_temp/ghcca-nolist d-memory/opencla--limit ness^D^X ctor.test.ts js w-hybrid-memory/extensions/memory-hybrid/node_modules/.bin/gh get dules/vitest/supdiff dules/.bin/mkdir--no-index /opt/hostedtoolc--label` (dns block)
>   - Triggering command: `/opt/hostedtoolcache/node/24.14.1/x64/bin/node /opt/hostedtoolcache/node/24.14.1/x64/bin/node --experimental-import-meta-resolve --require /home/REDACTED/work/openclaw-hybrid-memory/openclaw-hybrid-memory/extensions/memory-hybrid/node_modules/vitest/suppress-warnings.cjs --conditions node --conditions development /home/REDACTED/work/openclaw-hybrid-memory/openclaw-hybrid-memory/extensions/memory-hybrid/node_modules/vitest/dist/workers/forks.js press-warnings.cissue tnet/tools/git true ness^D^X` (dns block)
> - `https://api.github.com/graphql`
>   - Triggering command: `/usr/bin/gh gh issue list --limit 10 --json number,title,state,url,createdAt ******&#34;; }; f` (http block)
>   - Triggering command: `/usr/bin/gh gh pr list --limit 10 --json number,title,state,url,createdAt` (http block)
>   - Triggering command: `/usr/bin/gh gh issue list --limit 10 --json number,title,state,url,createdAt extensions/memory-hybrid/node_modules/.bin/tsdown` (http block)
> - `my-glitchtip.example.com`
>   - Triggering command: `/opt/hostedtoolcache/node/24.14.1/x64/bin/node /opt/hostedtoolcache/node/24.14.1/x64/bin/node --experimental-import-meta-resolve --require /home/REDACTED/work/openclaw-hybrid-memory/openclaw-hybrid-memory/extensions/memory-hybrid/node_modules/vitest/suppress-warnings.cjs --conditions node --conditions development /home/REDACTED/work/openclaw-hybrid-memory/openclaw-hybrid-memory/extensions/memory-hybrid/node_modules/vitest/dist/workers/forks.js` (dns block)
>
> If you need me to access, download, or install something from one of these locations, you can either:
>
> - Configure [Actions setup steps](https://gh.io/copilot/actions-setup-steps) to set up my environment, which run before the firewall is enabled
> - Add the appropriate URLs or hosts to the custom allowlist in this repository's [Copilot coding agent settings](https://github.com/markus-lassfolk/openclaw-hybrid-memory/settings/copilot/coding_agent) (admins only)
>
> </details>

---

Reopened by Maeve as a human-owned branch/PR to avoid bot/app PR workflow and review limitations.

Supersedes: https://github.com/markus-lassfolk/openclaw-hybrid-memory/pull/1438
Closes #1425

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the similarity metric and merge threshold used to coalesce procedures, which can alter how new session evidence is attributed and may affect existing procedure quality until re-ingested.
> 
> **Overview**
> Updates `taskSimilarity` to use a symmetric Jaccard-style score (intersection/union) and exports it for testing, preventing short task intents from matching longer unrelated intents as perfect overlaps.
> 
> Replaces the hardcoded merge cutoff with `PROCEDURE_MERGE_SIMILARITY_THRESHOLD` (0.35) in `extractProceduresFromSessions`, and adds Vitest coverage to ensure unrelated long intents no longer merge while genuinely similar intents still do.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 766a432fb68e44bd5b5512ef431af58d7e8f61cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->