### PR TITLE
fix: skill safety validation — case-insensitive PEM, dotfile tilde paths, loopback IP exclusion, configurable email allow-list

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -707,7 +707,8 @@ Workflow crystallization analyses tool-sequence patterns and generates pending *
     "autoApprove": false,
     "outputDir": "~/.openclaw/workspace/skills/auto",
     "maxCrystallized": 50,
-    "pruneUnusedDays": 30
+    "pruneUnusedDays": 30,
+    "placeholderEmailDomains": ["example.com", "localhost", "test.com", "example.org"]
   }
 }
 ```
@@ -721,6 +722,7 @@ Workflow crystallization analyses tool-sequence patterns and generates pending *
 | `outputDir` | `~/.openclaw/workspace/skills/auto` | Directory for approved SKILL.md files |
 | `maxCrystallized` | `50` | Max number of crystallized skills to keep |
 | `pruneUnusedDays` | `30` | Prune proposals unused for this many days |
+| `placeholderEmailDomains` | `["example.com","localhost","test.com","example.org"]` | Email domains treated as safe placeholders during skill validation. Extend with your organisation's internal placeholder domains (e.g. `"company.test"`) so they are not flagged as real addresses. |
 
 **Agent tools:** `memory_crystallize`, `memory_crystallize_list`, `memory_crystallize_approve`, `memory_crystallize_reject`.
 

--- a/extensions/memory-hybrid/backends/facts-db/procedures.ts
+++ b/extensions/memory-hybrid/backends/facts-db/procedures.ts
@@ -956,7 +956,7 @@ export function getProceduresReadyForSkill(
 ): ProcedureEntry[] {
   const rows = db
     .prepare(
-      `SELECT * FROM procedures WHERE procedure_type = 'positive' AND success_count >= ? AND promoted_to_skill = 0 ORDER BY success_count DESC, last_validated DESC LIMIT ?`,
+      `SELECT * FROM procedures WHERE procedure_type = 'positive' AND success_count >= ? AND promoted_to_skill = 0 ORDER BY success_count DESC, last_validated DESC, created_at ASC, rowid ASC LIMIT ?`,
     )
     .all(validationThreshold, limit) as Array<Record<string, unknown>>;
   return rows.map((r) => procedureRowToEntry(db, r));

--- a/extensions/memory-hybrid/config/parsers/features.ts
+++ b/extensions/memory-hybrid/config/parsers/features.ts
@@ -539,7 +539,9 @@ export function parseCrystallizationConfig(cfg: Record<string, unknown>): Crysta
     placeholderEmailDomains: (() => {
       const raw_domains = raw?.placeholderEmailDomains;
       if (!Array.isArray(raw_domains)) return [...DEFAULT_PLACEHOLDER_EMAIL_DOMAINS];
-      const valid = raw_domains.filter((d): d is string => typeof d === "string" && d.trim().length > 0).map((d) => d.trim());
+      const valid = raw_domains
+        .filter((d): d is string => typeof d === "string" && d.trim().length > 0)
+        .map((d) => d.trim());
       return valid.length > 0 ? valid : [...DEFAULT_PLACEHOLDER_EMAIL_DOMAINS];
     })(),
   };

--- a/extensions/memory-hybrid/config/parsers/features.ts
+++ b/extensions/memory-hybrid/config/parsers/features.ts
@@ -1,4 +1,5 @@
 import { DEFAULT_GLITCHTIP_DSN } from "../../services/error-reporter.js";
+import { DEFAULT_PLACEHOLDER_EMAIL_DOMAINS } from "../../services/skill-validator.js";
 import { pluginLogger } from "../../utils/logger.js";
 import type { PersonaProposalsConfig } from "../types/agents.js";
 import { IDENTITY_FILE_TYPES, type IdentityFileType } from "../types/agents.js";
@@ -535,6 +536,12 @@ export function parseCrystallizationConfig(cfg: Record<string, unknown>): Crysta
       typeof raw?.maxCrystallized === "number" && raw.maxCrystallized > 0 ? Math.floor(raw.maxCrystallized) : 50,
     pruneUnusedDays:
       typeof raw?.pruneUnusedDays === "number" && raw.pruneUnusedDays >= 0 ? Math.floor(raw.pruneUnusedDays) : 30,
+    placeholderEmailDomains: (() => {
+      const raw_domains = raw?.placeholderEmailDomains;
+      if (!Array.isArray(raw_domains)) return [...DEFAULT_PLACEHOLDER_EMAIL_DOMAINS];
+      const valid = raw_domains.filter((d): d is string => typeof d === "string" && d.trim().length > 0).map((d) => d.trim());
+      return valid.length > 0 ? valid : [...DEFAULT_PLACEHOLDER_EMAIL_DOMAINS];
+    })(),
   };
 }
 

--- a/extensions/memory-hybrid/config/types/features.ts
+++ b/extensions/memory-hybrid/config/types/features.ts
@@ -197,6 +197,12 @@ export type CrystallizationConfig = {
   maxCrystallized: number;
   /** Prune unused auto-skills older than N days (default: 30; 0 = disabled). */
   pruneUnusedDays: number;
+  /**
+   * Email domains treated as safe placeholders during skill validation (Issue #1383).
+   * Extend this list with your organisation's internal placeholder domains so they are
+   * not flagged as real addresses. Default: ["example.com", "localhost", "test.com", "example.org"].
+   */
+  placeholderEmailDomains: string[];
 };
 
 /** Document ingestion via MarkItDown Python bridge (Issue #206). */

--- a/extensions/memory-hybrid/index.ts
+++ b/extensions/memory-hybrid/index.ts
@@ -302,7 +302,7 @@ import { GapDetector, computeGapId, deriveToolNameFromSequence } from "./service
 import { PatternDetector, computeEvidenceHash, computePatternId, scorePattern } from "./services/pattern-detector.js";
 import { ProvenanceService } from "./services/provenance.js";
 import { SkillCrystallizer, deriveSkillName, isExecOnlySequence } from "./services/skill-crystallizer.js";
-import { SkillValidator } from "./services/skill-validator.js";
+import { SkillValidator, buildNonPlaceholderEmailPattern } from "./services/skill-validator.js";
 import { ToolProposer } from "./services/tool-proposer.js";
 import { VerificationError, VerificationStore, shouldAutoVerify } from "./services/verification-store.js";
 import { WorkflowTracker } from "./services/workflow-tracker.js";
@@ -988,6 +988,7 @@ export const _testing = {
   PatternDetector,
   SkillCrystallizer,
   SkillValidator,
+  buildNonPlaceholderEmailPattern,
   CrystallizationProposer,
   computePatternId,
   computeEvidenceHash,

--- a/extensions/memory-hybrid/openclaw.plugin.json
+++ b/extensions/memory-hybrid/openclaw.plugin.json
@@ -588,6 +588,10 @@
       "label": "Crystallization (skill proposals)",
       "help": "Generate AgentSkill SKILL.md proposals from workflow patterns. Default: false."
     },
+    "crystallization.placeholderEmailDomains": {
+      "label": "Placeholder Email Domains",
+      "help": "Email domains treated as safe placeholders during skill validation. Extend with your organisation's internal placeholder domains (e.g. 'company.test') so they are not flagged as real addresses. Default: ['example.com', 'localhost', 'test.com', 'example.org']."
+    },
     "multiAgent.orchestratorId": {
       "label": "Orchestrator Agent ID",
       "placeholder": "main",
@@ -1827,6 +1831,12 @@
           },
           "pruneUnusedDays": {
             "type": "number"
+          },
+          "placeholderEmailDomains": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           }
         },
         "description": "Auto-generate SKILL.md from repeated patterns"

--- a/extensions/memory-hybrid/services/crystallization-proposer.ts
+++ b/extensions/memory-hybrid/services/crystallization-proposer.ts
@@ -23,6 +23,7 @@ import {
 } from "./generated-skill-validation.js";
 import { PatternDetector } from "./pattern-detector.js";
 import { SkillCrystallizer } from "./skill-crystallizer.js";
+import { buildNonPlaceholderEmailPattern } from "./skill-validator.js";
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -56,7 +57,11 @@ export class CrystallizationProposer {
   ) {
     this.detector = workflowStore ? new PatternDetector(workflowStore, crystallizationStore, cfg) : null;
     this.crystallizer = new SkillCrystallizer(cfg);
-    this.validator = new GeneratedSkillValidationService();
+    this.validator = new GeneratedSkillValidationService(
+      cfg.placeholderEmailDomains?.length
+        ? { emailPattern: buildNonPlaceholderEmailPattern(cfg.placeholderEmailDomains) }
+        : undefined,
+    );
   }
 
   // -------------------------------------------------------------------------

--- a/extensions/memory-hybrid/services/generated-skill-validation.ts
+++ b/extensions/memory-hybrid/services/generated-skill-validation.ts
@@ -14,7 +14,7 @@ import { tmpdir } from "node:os";
 import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 import type { WorkflowPattern } from "../backends/workflow-store.js";
 import { normalizeSkillName } from "./skill-crystallizer.js";
-import { NON_PLACEHOLDER_EMAIL_PATTERN, PEM_PRIVATE_KEY_PATTERN, SkillValidator, buildNonPlaceholderEmailPattern } from "./skill-validator.js";
+import { NON_PLACEHOLDER_EMAIL_PATTERN, PEM_PRIVATE_KEY_PATTERN, SkillValidator } from "./skill-validator.js";
 
 export type ValidationStageStatus = "passed" | "warn" | "failed";
 export type ProposalApprovalDecision = "allow" | "allow-with-override" | "deny";

--- a/extensions/memory-hybrid/services/generated-skill-validation.ts
+++ b/extensions/memory-hybrid/services/generated-skill-validation.ts
@@ -14,7 +14,12 @@ import { tmpdir } from "node:os";
 import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 import type { WorkflowPattern } from "../backends/workflow-store.js";
 import { normalizeSkillName } from "./skill-crystallizer.js";
-import { NON_PLACEHOLDER_EMAIL_PATTERN, PEM_PRIVATE_KEY_PATTERN, PRIVATE_IP_PATTERN, SkillValidator } from "./skill-validator.js";
+import {
+  NON_PLACEHOLDER_EMAIL_PATTERN,
+  PEM_PRIVATE_KEY_PATTERN,
+  PRIVATE_IP_PATTERN,
+  SkillValidator,
+} from "./skill-validator.js";
 
 export type ValidationStageStatus = "passed" | "warn" | "failed";
 export type ProposalApprovalDecision = "allow" | "allow-with-override" | "deny";

--- a/extensions/memory-hybrid/services/generated-skill-validation.ts
+++ b/extensions/memory-hybrid/services/generated-skill-validation.ts
@@ -161,7 +161,7 @@ function buildSecretOrPrivatePatterns(emailPattern: RegExp): RegExp[] {
     /gh[pousr]_[a-z0-9_]{20,}/i,
     PEM_PRIVATE_KEY_PATTERN,
     emailPattern,
-    /\b(?:10\.|172\.(?:1[6-9]|2\d|3[01])\.|192\.168\.)\d{1,3}\.\d{1,3}\b/,
+    /\b(?:10\.\d{1,3}\.|172\.(?:1[6-9]|2\d|3[01])\.|192\.168\.)\d{1,3}\.\d{1,3}\b/,
     /\/(?:Users|home)\/[^\s/]+/i,
   ];
 }

--- a/extensions/memory-hybrid/services/generated-skill-validation.ts
+++ b/extensions/memory-hybrid/services/generated-skill-validation.ts
@@ -14,7 +14,7 @@ import { tmpdir } from "node:os";
 import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 import type { WorkflowPattern } from "../backends/workflow-store.js";
 import { normalizeSkillName } from "./skill-crystallizer.js";
-import { NON_PLACEHOLDER_EMAIL_PATTERN, PEM_PRIVATE_KEY_PATTERN, SkillValidator } from "./skill-validator.js";
+import { NON_PLACEHOLDER_EMAIL_PATTERN, PEM_PRIVATE_KEY_PATTERN, PRIVATE_IP_PATTERN, SkillValidator } from "./skill-validator.js";
 
 export type ValidationStageStatus = "passed" | "warn" | "failed";
 export type ProposalApprovalDecision = "allow" | "allow-with-override" | "deny";
@@ -153,7 +153,7 @@ export function detailSkillProposalValidation(result?: SkillProposalValidationRe
  * Build the secret/private-data pattern list for GSV.
  * Accepts an email pattern so operators can supply a custom allow-list (Issue #1383).
  * PEM detector is case-insensitive and uses the shared constant (Issue #1382).
- * Loopback (127.x) is intentionally excluded from private-IP matching (Issue #1385).
+ * Private IP pattern uses the shared constant to prevent drift across validators.
  */
 function buildSecretOrPrivatePatterns(emailPattern: RegExp): RegExp[] {
   return [
@@ -161,7 +161,7 @@ function buildSecretOrPrivatePatterns(emailPattern: RegExp): RegExp[] {
     /gh[pousr]_[a-z0-9_]{20,}/i,
     PEM_PRIVATE_KEY_PATTERN,
     emailPattern,
-    /\b(?:10\.\d{1,3}\.|172\.(?:1[6-9]|2\d|3[01])\.|192\.168\.)\d{1,3}\.\d{1,3}\b/,
+    PRIVATE_IP_PATTERN,
     /\/(?:Users|home)\/[^\s/]+/i,
   ];
 }

--- a/extensions/memory-hybrid/services/generated-skill-validation.ts
+++ b/extensions/memory-hybrid/services/generated-skill-validation.ts
@@ -14,7 +14,7 @@ import { tmpdir } from "node:os";
 import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 import type { WorkflowPattern } from "../backends/workflow-store.js";
 import { normalizeSkillName } from "./skill-crystallizer.js";
-import { NON_PLACEHOLDER_EMAIL_PATTERN, SkillValidator } from "./skill-validator.js";
+import { NON_PLACEHOLDER_EMAIL_PATTERN, PEM_PRIVATE_KEY_PATTERN, SkillValidator, buildNonPlaceholderEmailPattern } from "./skill-validator.js";
 
 export type ValidationStageStatus = "passed" | "warn" | "failed";
 export type ProposalApprovalDecision = "allow" | "allow-with-override" | "deny";
@@ -80,14 +80,6 @@ const TRANSCRIPT_LINE_RE = /^(?:user|assistant|system|tool):/i;
 const TIMESTAMP_LINE_RE = /^\d{4}-\d{2}-\d{2}[t ](?:[0-9:.+\-]|z)+/i;
 const EXPLANATION_PATTERN = /\b(?:explain|describe|summarize|review)\b/;
 const NEGATION_PATTERN = /\b(?:without|do not|don't|avoid)\b/;
-const SECRET_OR_PRIVATE_PATTERNS = [
-  /sk-[a-z0-9]{20,}/i,
-  /gh[pousr]_[a-z0-9_]{20,}/i,
-  /-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----/,
-  NON_PLACEHOLDER_EMAIL_PATTERN,
-  /\b(?:10|127)\.\d{1,3}\.\d{1,3}\.\d{1,3}\b/,
-  /\/(?:Users|home)\/[^\s/]+/i,
-];
 const STOP_WORDS = new Set([
   "about",
   "after",
@@ -157,8 +149,36 @@ export function detailSkillProposalValidation(result?: SkillProposalValidationRe
   return `${summarizeSkillProposalValidation(result)}; violations: ${details.slice(0, 8).join("; ")}`;
 }
 
+/**
+ * Build the secret/private-data pattern list for GSV.
+ * Accepts an email pattern so operators can supply a custom allow-list (Issue #1383).
+ * PEM detector is case-insensitive and uses the shared constant (Issue #1382).
+ * Loopback (127.x) is intentionally excluded from private-IP matching (Issue #1385).
+ */
+function buildSecretOrPrivatePatterns(emailPattern: RegExp): RegExp[] {
+  return [
+    /sk-[a-z0-9]{20,}/i,
+    /gh[pousr]_[a-z0-9_]{20,}/i,
+    PEM_PRIVATE_KEY_PATTERN,
+    emailPattern,
+    /\b(?:10\.|172\.(?:1[6-9]|2\d|3[01])\.|192\.168\.)\d{1,3}\.\d{1,3}\b/,
+    /\/(?:Users|home)\/[^\s/]+/i,
+  ];
+}
+
 export class GeneratedSkillValidationService {
-  private readonly skillValidator = new SkillValidator();
+  private readonly skillValidator: SkillValidator;
+  private readonly secretOrPrivatePatterns: RegExp[];
+
+  /**
+   * @param options.emailPattern - custom non-placeholder email regex; defaults to
+   *   {@link NON_PLACEHOLDER_EMAIL_PATTERN}. Build with {@link buildNonPlaceholderEmailPattern}.
+   */
+  constructor(options?: { emailPattern?: RegExp }) {
+    const emailPattern = options?.emailPattern ?? NON_PLACEHOLDER_EMAIL_PATTERN;
+    this.skillValidator = new SkillValidator({ emailPattern });
+    this.secretOrPrivatePatterns = buildSecretOrPrivatePatterns(emailPattern);
+  }
 
   validate(
     input: ValidateGeneratedSkillInput,
@@ -250,7 +270,7 @@ export class GeneratedSkillValidationService {
     if (!isCanonicalSkillPath(input.outputDir, proposedOutputPath, input.skillName)) {
       violations.push(`Unsafe proposed output path: ${input.proposedOutputPath}`);
     }
-    for (const pattern of SECRET_OR_PRIVATE_PATTERNS) {
+    for (const pattern of this.secretOrPrivatePatterns) {
       if (pattern.test(input.skillContent)) {
         violations.push(`Secret/private-data pattern detected: ${pattern}`);
       }

--- a/extensions/memory-hybrid/services/procedure-promotion-policy.ts
+++ b/extensions/memory-hybrid/services/procedure-promotion-policy.ts
@@ -13,7 +13,7 @@ import {
   redactAutopilotText,
   redactAutopilotValue,
 } from "./pending-autopilot/index.js";
-import { SkillValidator } from "./skill-validator.js";
+import { NON_PLACEHOLDER_EMAIL_PATTERN, PEM_PRIVATE_KEY_PATTERN, SkillValidator } from "./skill-validator.js";
 
 export const PROCEDURE_PROMOTION_POLICY_VERSION = "procedure-promotion-policy-v1";
 
@@ -246,13 +246,15 @@ const CREDENTIAL_PATTERNS: RegExp[] = [
   /\b(?:password|passwd|pwd|secret|token|api[_-]?key|authorization|private[_-]?key)\s*[:=]\s*[^\s,;}{\[\]]+/i,
   /\b(?:sk|pk|rk|ghp|gho|github_pat|xox[baprs])[-_][A-Za-z0-9_-]{8,}\b/,
   /\bBearer\s+[A-Za-z0-9._~+/-]+=*/i,
-  /-----BEGIN [A-Z ]*PRIVATE KEY-----/,
+  PEM_PRIVATE_KEY_PATTERN,
 ];
 
 const PRIVATE_DATA_PATTERNS: RegExp[] = [
-  /\b(?:10\.|127\.|172\.(?:1[6-9]|2\d|3[01])\.|192\.168\.)\d{1,3}\.\d{1,3}\b/,
+  // Loopback (127.x) is intentionally excluded — it reveals nothing about the network topology
+  // and causes false positives on health-check examples (Issue #1385).
+  /\b(?:10\.|172\.(?:1[6-9]|2\d|3[01])\.|192\.168\.)\d{1,3}\.\d{1,3}\b/,
   /(?:^|[\s"'=:])(?:\/home\/[^\s"']+|\/Users\/[^\s"']+|~\/[^\s"']+)/,
-  /\b[A-Za-z0-9._%+-]+@(?!example\.com|localhost|test\.com|example\.org)[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/,
+  NON_PLACEHOLDER_EMAIL_PATTERN,
 ];
 
 export function parseProcedurePromotionPolicy(policy: string | undefined): ProcedurePromotionPolicy {

--- a/extensions/memory-hybrid/services/procedure-promotion-policy.ts
+++ b/extensions/memory-hybrid/services/procedure-promotion-policy.ts
@@ -13,7 +13,7 @@ import {
   redactAutopilotText,
   redactAutopilotValue,
 } from "./pending-autopilot/index.js";
-import { NON_PLACEHOLDER_EMAIL_PATTERN, PEM_PRIVATE_KEY_PATTERN, SkillValidator } from "./skill-validator.js";
+import { NON_PLACEHOLDER_EMAIL_PATTERN, PEM_PRIVATE_KEY_PATTERN, PRIVATE_IP_PATTERN, SkillValidator } from "./skill-validator.js";
 
 export const PROCEDURE_PROMOTION_POLICY_VERSION = "procedure-promotion-policy-v1";
 
@@ -250,9 +250,7 @@ const CREDENTIAL_PATTERNS: RegExp[] = [
 ];
 
 const PRIVATE_DATA_PATTERNS: RegExp[] = [
-  // Loopback (127.x) is intentionally excluded — it reveals nothing about the network topology
-  // and causes false positives on health-check examples (Issue #1385).
-  /\b(?:10\.\d{1,3}\.|172\.(?:1[6-9]|2\d|3[01])\.|192\.168\.)\d{1,3}\.\d{1,3}\b/,
+  PRIVATE_IP_PATTERN,
   /(?:^|[\s"'=:])(?:\/home\/[^\s"']+|\/Users\/[^\s"']+|~\/[^\s"']+)/,
   NON_PLACEHOLDER_EMAIL_PATTERN,
 ];

--- a/extensions/memory-hybrid/services/procedure-promotion-policy.ts
+++ b/extensions/memory-hybrid/services/procedure-promotion-policy.ts
@@ -13,7 +13,12 @@ import {
   redactAutopilotText,
   redactAutopilotValue,
 } from "./pending-autopilot/index.js";
-import { NON_PLACEHOLDER_EMAIL_PATTERN, PEM_PRIVATE_KEY_PATTERN, PRIVATE_IP_PATTERN, SkillValidator } from "./skill-validator.js";
+import {
+  NON_PLACEHOLDER_EMAIL_PATTERN,
+  PEM_PRIVATE_KEY_PATTERN,
+  PRIVATE_IP_PATTERN,
+  SkillValidator,
+} from "./skill-validator.js";
 
 export const PROCEDURE_PROMOTION_POLICY_VERSION = "procedure-promotion-policy-v1";
 

--- a/extensions/memory-hybrid/services/procedure-promotion-policy.ts
+++ b/extensions/memory-hybrid/services/procedure-promotion-policy.ts
@@ -252,7 +252,7 @@ const CREDENTIAL_PATTERNS: RegExp[] = [
 const PRIVATE_DATA_PATTERNS: RegExp[] = [
   // Loopback (127.x) is intentionally excluded — it reveals nothing about the network topology
   // and causes false positives on health-check examples (Issue #1385).
-  /\b(?:10\.|172\.(?:1[6-9]|2\d|3[01])\.|192\.168\.)\d{1,3}\.\d{1,3}\b/,
+  /\b(?:10\.\d{1,3}\.|172\.(?:1[6-9]|2\d|3[01])\.|192\.168\.)\d{1,3}\.\d{1,3}\b/,
   /(?:^|[\s"'=:])(?:\/home\/[^\s"']+|\/Users\/[^\s"']+|~\/[^\s"']+)/,
   NON_PLACEHOLDER_EMAIL_PATTERN,
 ];

--- a/extensions/memory-hybrid/services/skill-validator.ts
+++ b/extensions/memory-hybrid/services/skill-validator.ts
@@ -66,7 +66,7 @@ export function buildNonPlaceholderEmailPattern(allowList: string[]): RegExp {
     // No placeholder domains: flag all valid-looking email addresses.
     return /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/i;
   }
-  return new RegExp(`\\b[A-Za-z0-9._%+-]+@(?!(?:${escaped})\\b)[A-Za-z0-9.-]+\\.[A-Za-z]{2,}\\b`, "i");
+  return new RegExp(`\\b[A-Za-z0-9._%+-]+@(?!(?:${escaped})(?![A-Za-z0-9.-]))[A-Za-z0-9.-]+\\.[A-Za-z]{2,}\\b`, "i");
 }
 
 const SECRET_PATTERNS: Array<[name: string, pattern: RegExp, description: string]> = [
@@ -103,7 +103,7 @@ function buildPrivateContextPatterns(
       "private-ip",
       // Loopback (127.x) is intentionally excluded — it reveals nothing about the network
       // topology and causes noisy false positives on health-check examples (Issue #1385).
-      /\b(?:10\.|172\.(?:1[6-9]|2\d|3[01])\.|192\.168\.)\d{1,3}\.\d{1,3}\b/,
+      /\b(?:10\.\d{1,3}\.|172\.(?:1[6-9]|2\d|3[01])\.|192\.168\.)\d{1,3}\.\d{1,3}\b/,
       "Private IP / host inventory detected (replace with placeholders)",
     ],
     [
@@ -123,11 +123,7 @@ function buildPrivateContextPatterns(
       /(?:^|[\s"'=:])~\/[^\s"']+/,
       "Tilde home path detected (replace with placeholders; avoid personal paths in skills)",
     ],
-    [
-      "email-address",
-      emailPattern,
-      "Non-example email address detected (remove or replace with example.com)",
-    ],
+    ["email-address", emailPattern, "Non-example email address detected (remove or replace with example.com)"],
   ];
 }
 
@@ -235,9 +231,7 @@ export class SkillValidator {
    *   {@link NON_PLACEHOLDER_EMAIL_PATTERN}. Build with {@link buildNonPlaceholderEmailPattern}.
    */
   constructor(options?: { emailPattern?: RegExp }) {
-    this.privateContextPatterns = buildPrivateContextPatterns(
-      options?.emailPattern ?? NON_PLACEHOLDER_EMAIL_PATTERN,
-    );
+    this.privateContextPatterns = buildPrivateContextPatterns(options?.emailPattern ?? NON_PLACEHOLDER_EMAIL_PATTERN);
   }
 
   /**

--- a/extensions/memory-hybrid/services/skill-validator.ts
+++ b/extensions/memory-hybrid/services/skill-validator.ts
@@ -54,6 +54,7 @@ export const DEFAULT_PLACEHOLDER_EMAIL_DOMAINS = ["example.com", "localhost", "t
 /**
  * Build a regex that matches real-looking email addresses while excluding placeholder domains.
  * Domain entries are regex-escaped so arbitrary strings are safe to pass.
+ * If the allow-list is empty, returns a pattern that flags all valid-looking email addresses.
  * @param allowList - domains to treat as safe placeholders (default: {@link DEFAULT_PLACEHOLDER_EMAIL_DOMAINS})
  */
 export function buildNonPlaceholderEmailPattern(allowList: string[]): RegExp {
@@ -61,6 +62,10 @@ export function buildNonPlaceholderEmailPattern(allowList: string[]): RegExp {
     .filter((d) => d.length > 0)
     .map((d) => d.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
     .join("|");
+  if (escaped.length === 0) {
+    // No placeholder domains: flag all valid-looking email addresses.
+    return /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/;
+  }
   return new RegExp(`\\b[A-Za-z0-9._%+-]+@(?!${escaped})[A-Za-z0-9.-]+\\.[A-Za-z]{2,}\\b`);
 }
 

--- a/extensions/memory-hybrid/services/skill-validator.ts
+++ b/extensions/memory-hybrid/services/skill-validator.ts
@@ -39,8 +39,33 @@ interface DenyRule {
   description: string;
 }
 
+/**
+ * Case-insensitive PEM private-key block detector.
+ * Shared with generated-skill-validation.ts and procedure-promotion-policy.ts (Issue #1382).
+ * Character class includes digits and allows trailing words (e.g. "BLOCK" in PGP markers).
+ * Matches: -----BEGIN PRIVATE KEY-----, -----BEGIN RSA PRIVATE KEY-----,
+ *          -----BEGIN PGP PRIVATE KEY BLOCK-----, -----begin private key-----, etc.
+ */
+export const PEM_PRIVATE_KEY_PATTERN = /-----BEGIN [A-Za-z0-9 ]*PRIVATE KEY[A-Za-z0-9 ]*-----/i;
+
+/** Default placeholder email domains used by {@link buildNonPlaceholderEmailPattern}. */
+export const DEFAULT_PLACEHOLDER_EMAIL_DOMAINS = ["example.com", "localhost", "test.com", "example.org"];
+
+/**
+ * Build a regex that matches real-looking email addresses while excluding placeholder domains.
+ * Domain entries are regex-escaped so arbitrary strings are safe to pass.
+ * @param allowList - domains to treat as safe placeholders (default: {@link DEFAULT_PLACEHOLDER_EMAIL_DOMAINS})
+ */
+export function buildNonPlaceholderEmailPattern(allowList: string[]): RegExp {
+  const escaped = allowList
+    .filter((d) => d.length > 0)
+    .map((d) => d.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
+    .join("|");
+  return new RegExp(`\\b[A-Za-z0-9._%+-]+@(?!${escaped})[A-Za-z0-9.-]+\\.[A-Za-z]{2,}\\b`);
+}
+
 const SECRET_PATTERNS: Array<[name: string, pattern: RegExp, description: string]> = [
-  ["private-key-block", /-----BEGIN [A-Z ]*PRIVATE KEY-----/, "Private key block detected"],
+  ["private-key-block", PEM_PRIVATE_KEY_PATTERN, "Private key block detected"],
   [
     "bearer-token",
     /\bBearer\s+[A-Za-z0-9._~+/-]+=*/i,
@@ -59,36 +84,47 @@ const SECRET_PATTERNS: Array<[name: string, pattern: RegExp, description: string
 ];
 
 /** Real-looking emails only; allows example.com, localhost, test.com, example.org placeholders. */
-export const NON_PLACEHOLDER_EMAIL_PATTERN =
-  /\b[A-Za-z0-9._%+-]+@(?!example\.com|localhost|test\.com|example\.org)[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/;
+export const NON_PLACEHOLDER_EMAIL_PATTERN = buildNonPlaceholderEmailPattern(DEFAULT_PLACEHOLDER_EMAIL_DOMAINS);
 
-const PRIVATE_CONTEXT_PATTERNS: Array<[name: string, pattern: RegExp, description: string]> = [
-  [
-    "private-ip",
-    /\b(?:10\.|127\.|172\.(?:1[6-9]|2\d|3[01])\.|192\.168\.)\d{1,3}\.\d{1,3}\b/,
-    "Private IP / host inventory detected (replace with placeholders)",
-  ],
-  [
-    "home-path-linux",
-    /(?:^|[\s"'=:])\/home\/(?!user\/|runner\/|ubuntu\/)[^\s"'/:]+\/[^\s"']+/,
-    "User-specific /home/... path detected (replace with placeholders)",
-  ],
-  [
-    "home-path-macos",
-    /(?:^|[\s"'=:])\/Users\/(?!user\/|runner\/)[^\s"'/:]+\/[^\s"']+/,
-    "User-specific /Users/... path detected (replace with placeholders)",
-  ],
-  [
-    "tilde-home-path",
-    /(?:^|[\s"'=:])~\/(?!\.)[^\s"']+/,
-    "Tilde home path detected (replace with placeholders; avoid personal paths in skills)",
-  ],
-  [
-    "email-address",
-    NON_PLACEHOLDER_EMAIL_PATTERN,
-    "Non-example email address detected (remove or replace with example.com)",
-  ],
-];
+/**
+ * Build the private-context pattern list. Accepts an optional email pattern override so that
+ * operators can supply a custom placeholder-domain allow-list (Issue #1383).
+ */
+function buildPrivateContextPatterns(
+  emailPattern: RegExp,
+): Array<[name: string, pattern: RegExp, description: string]> {
+  return [
+    [
+      "private-ip",
+      // Loopback (127.x) is intentionally excluded — it reveals nothing about the network
+      // topology and causes noisy false positives on health-check examples (Issue #1385).
+      /\b(?:10\.|172\.(?:1[6-9]|2\d|3[01])\.|192\.168\.)\d{1,3}\.\d{1,3}\b/,
+      "Private IP / host inventory detected (replace with placeholders)",
+    ],
+    [
+      "home-path-linux",
+      /(?:^|[\s"'=:])\/home\/(?!user\/|runner\/|ubuntu\/)[^\s"'/:]+\/[^\s"']+/,
+      "User-specific /home/... path detected (replace with placeholders)",
+    ],
+    [
+      "home-path-macos",
+      /(?:^|[\s"'=:])\/Users\/(?!user\/|runner\/)[^\s"'/:]+\/[^\s"']+/,
+      "User-specific /Users/... path detected (replace with placeholders)",
+    ],
+    [
+      "tilde-home-path",
+      // Negative lookahead (?!\.) has been removed — dotfile paths (e.g. ~/.ssh, ~/.aws)
+      // are the most sensitive and must be flagged, not excluded (Issue #1384).
+      /(?:^|[\s"'=:])~\/[^\s"']+/,
+      "Tilde home path detected (replace with placeholders; avoid personal paths in skills)",
+    ],
+    [
+      "email-address",
+      emailPattern,
+      "Non-example email address detected (remove or replace with example.com)",
+    ],
+  ];
+}
 
 const DENY_RULES: DenyRule[] = [
   // Shell execution
@@ -187,6 +223,18 @@ const DENY_RULES: DenyRule[] = [
 // ---------------------------------------------------------------------------
 
 export class SkillValidator {
+  private readonly privateContextPatterns: Array<[name: string, pattern: RegExp, description: string]>;
+
+  /**
+   * @param options.emailPattern - custom non-placeholder email regex; defaults to
+   *   {@link NON_PLACEHOLDER_EMAIL_PATTERN}. Build with {@link buildNonPlaceholderEmailPattern}.
+   */
+  constructor(options?: { emailPattern?: RegExp }) {
+    this.privateContextPatterns = buildPrivateContextPatterns(
+      options?.emailPattern ?? NON_PLACEHOLDER_EMAIL_PATTERN,
+    );
+  }
+
   /**
    * Validate generated SKILL.md content for:
    * - security violations (deny rules inside code blocks)
@@ -211,7 +259,7 @@ export class SkillValidator {
     }
 
     // Reject private context that should not be embedded into reusable skills.
-    for (const [name, pattern, desc] of PRIVATE_CONTEXT_PATTERNS) {
+    for (const [name, pattern, desc] of this.privateContextPatterns) {
       if (pattern.test(skillContent)) {
         violations.push(`[${name}] ${desc}`);
       }

--- a/extensions/memory-hybrid/services/skill-validator.ts
+++ b/extensions/memory-hybrid/services/skill-validator.ts
@@ -108,11 +108,7 @@ function buildPrivateContextPatterns(
   emailPattern: RegExp,
 ): Array<[name: string, pattern: RegExp, description: string]> {
   return [
-    [
-      "private-ip",
-      PRIVATE_IP_PATTERN,
-      "Private IP / host inventory detected (replace with placeholders)",
-    ],
+    ["private-ip", PRIVATE_IP_PATTERN, "Private IP / host inventory detected (replace with placeholders)"],
     [
       "home-path-linux",
       /(?:^|[\s"'=:])\/home\/(?!user\/|runner\/|ubuntu\/)[^\s"'/:]+\/[^\s"']+/,

--- a/extensions/memory-hybrid/services/skill-validator.ts
+++ b/extensions/memory-hybrid/services/skill-validator.ts
@@ -48,6 +48,15 @@ interface DenyRule {
  */
 export const PEM_PRIVATE_KEY_PATTERN = /-----BEGIN [A-Za-z0-9 ]*PRIVATE KEY[A-Za-z0-9 ]*-----/i;
 
+/**
+ * Private IP address pattern (RFC 1918 ranges).
+ * Shared with generated-skill-validation.ts and procedure-promotion-policy.ts.
+ * Matches: 10.x.x.x, 172.16-31.x.x, 192.168.x.x (four-octet private IPs).
+ * Loopback (127.x) is intentionally excluded — it reveals nothing about network topology
+ * and causes noisy false positives on health-check examples (Issue #1385).
+ */
+export const PRIVATE_IP_PATTERN = /\b(?:10\.\d{1,3}\.|172\.(?:1[6-9]|2\d|3[01])\.|192\.168\.)\d{1,3}\.\d{1,3}\b/;
+
 /** Default placeholder email domains used by {@link buildNonPlaceholderEmailPattern}. */
 export const DEFAULT_PLACEHOLDER_EMAIL_DOMAINS = ["example.com", "localhost", "test.com", "example.org"];
 
@@ -101,9 +110,7 @@ function buildPrivateContextPatterns(
   return [
     [
       "private-ip",
-      // Loopback (127.x) is intentionally excluded — it reveals nothing about the network
-      // topology and causes noisy false positives on health-check examples (Issue #1385).
-      /\b(?:10\.\d{1,3}\.|172\.(?:1[6-9]|2\d|3[01])\.|192\.168\.)\d{1,3}\.\d{1,3}\b/,
+      PRIVATE_IP_PATTERN,
       "Private IP / host inventory detected (replace with placeholders)",
     ],
     [

--- a/extensions/memory-hybrid/services/skill-validator.ts
+++ b/extensions/memory-hybrid/services/skill-validator.ts
@@ -66,7 +66,7 @@ export function buildNonPlaceholderEmailPattern(allowList: string[]): RegExp {
     // No placeholder domains: flag all valid-looking email addresses.
     return /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/i;
   }
-  return new RegExp(`\\b[A-Za-z0-9._%+-]+@(?!${escaped}\\b)[A-Za-z0-9.-]+\\.[A-Za-z]{2,}\\b`, "i");
+  return new RegExp(`\\b[A-Za-z0-9._%+-]+@(?!(?:${escaped})\\b)[A-Za-z0-9.-]+\\.[A-Za-z]{2,}\\b`, "i");
 }
 
 const SECRET_PATTERNS: Array<[name: string, pattern: RegExp, description: string]> = [

--- a/extensions/memory-hybrid/services/skill-validator.ts
+++ b/extensions/memory-hybrid/services/skill-validator.ts
@@ -64,9 +64,9 @@ export function buildNonPlaceholderEmailPattern(allowList: string[]): RegExp {
     .join("|");
   if (escaped.length === 0) {
     // No placeholder domains: flag all valid-looking email addresses.
-    return /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/;
+    return /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/i;
   }
-  return new RegExp(`\\b[A-Za-z0-9._%+-]+@(?!${escaped})[A-Za-z0-9.-]+\\.[A-Za-z]{2,}\\b`);
+  return new RegExp(`\\b[A-Za-z0-9._%+-]+@(?!${escaped}\\b)[A-Za-z0-9.-]+\\.[A-Za-z]{2,}\\b`, "i");
 }
 
 const SECRET_PATTERNS: Array<[name: string, pattern: RegExp, description: string]> = [

--- a/extensions/memory-hybrid/tests/crystallization-proposer.test.ts
+++ b/extensions/memory-hybrid/tests/crystallization-proposer.test.ts
@@ -53,6 +53,7 @@ const BASE_CFG: CrystallizationConfig = {
   outputDir: "", // will be set in beforeEach
   maxCrystallized: 50,
   pruneUnusedDays: 30,
+  placeholderEmailDomains: ["example.com", "localhost", "test.com", "example.org"],
 };
 
 beforeEach(() => {

--- a/extensions/memory-hybrid/tests/crystallization.test.ts
+++ b/extensions/memory-hybrid/tests/crystallization.test.ts
@@ -1008,7 +1008,10 @@ ${extra.extraBody ?? ""}`;
   });
 
   it("does not flag custom domain when validator is configured with custom allow-list", () => {
-    const customValidator = new SkillValidator({ emailPattern: buildNonPlaceholderEmailPattern(["example.com", "localhost", "test.com", "example.org", "acme-internal.corp"]) });
+    const customEmailPattern = buildNonPlaceholderEmailPattern([
+      "example.com", "localhost", "test.com", "example.org", "acme-internal.corp",
+    ]);
+    const customValidator = new SkillValidator({ emailPattern: customEmailPattern });
     const content = compactValidSkill({
       extraBody: "\nContact: team@acme-internal.corp\n",
     });

--- a/extensions/memory-hybrid/tests/crystallization.test.ts
+++ b/extensions/memory-hybrid/tests/crystallization.test.ts
@@ -42,6 +42,7 @@ const DEFAULT_CRYSTALLIZATION_CFG = {
   outputDir: "",
   maxCrystallized: 50,
   pruneUnusedDays: 30,
+  placeholderEmailDomains: ["example.com", "localhost", "test.com", "example.org"],
 };
 
 function makeTmpOutputDir(): string {
@@ -1009,7 +1010,11 @@ ${extra.extraBody ?? ""}`;
 
   it("does not flag custom domain when validator is configured with custom allow-list", () => {
     const customEmailPattern = buildNonPlaceholderEmailPattern([
-      "example.com", "localhost", "test.com", "example.org", "acme-internal.corp",
+      "example.com",
+      "localhost",
+      "test.com",
+      "example.org",
+      "acme-internal.corp",
     ]);
     const customValidator = new SkillValidator({ emailPattern: customEmailPattern });
     const content = compactValidSkill({

--- a/extensions/memory-hybrid/tests/crystallization.test.ts
+++ b/extensions/memory-hybrid/tests/crystallization.test.ts
@@ -23,6 +23,7 @@ const {
   scorePattern,
   deriveSkillName,
   isExecOnlySequence,
+  buildNonPlaceholderEmailPattern,
 } = _testing as any;
 
 // ---------------------------------------------------------------------------
@@ -887,6 +888,132 @@ ${extra.extraBody ?? ""}`;
     expect(result.valid).toBe(false);
     expect(result.violations.some((v: string) => v.includes("private-ip"))).toBe(true);
   });
+
+  // -------------------------------------------------------------------------
+  // Issue #1382 — PEM private-key regex must be case-insensitive
+  // -------------------------------------------------------------------------
+
+  it("rejects all-lowercase PEM private-key marker", () => {
+    const content = compactValidSkill({
+      extraBody: "\n-----begin private key-----\nMIIEvgIBADANBg==\n-----end private key-----\n",
+    });
+    const result = validator.validate(content);
+    expect(result.valid).toBe(false);
+    expect(result.violations.some((v: string) => v.includes("private-key-block"))).toBe(true);
+  });
+
+  it("rejects mixed-case PEM private-key marker", () => {
+    const content = compactValidSkill({
+      extraBody: "\n-----BEGIN Rsa Private Key-----\nMIIEvgIBADANBg==\n-----END Rsa Private Key-----\n",
+    });
+    const result = validator.validate(content);
+    expect(result.valid).toBe(false);
+    expect(result.violations.some((v: string) => v.includes("private-key-block"))).toBe(true);
+  });
+
+  it("rejects PGP PRIVATE KEY BLOCK marker", () => {
+    const content = compactValidSkill({
+      extraBody: "\n-----BEGIN PGP PRIVATE KEY BLOCK-----\nlQIEBxyz\n-----END PGP PRIVATE KEY BLOCK-----\n",
+    });
+    const result = validator.validate(content);
+    expect(result.valid).toBe(false);
+    expect(result.violations.some((v: string) => v.includes("private-key-block"))).toBe(true);
+  });
+
+  // -------------------------------------------------------------------------
+  // Issue #1384 — tilde-home-path must also catch dotfile paths like ~/.ssh
+  // -------------------------------------------------------------------------
+
+  it("rejects ~/.ssh dotfile paths", () => {
+    const content = compactValidSkill({
+      extraBody: "\nKey location: ~/.ssh/id_rsa\n",
+    });
+    const result = validator.validate(content);
+    expect(result.valid).toBe(false);
+    expect(result.violations.some((v: string) => v.includes("tilde-home-path"))).toBe(true);
+  });
+
+  it("rejects ~/.aws dotfile paths", () => {
+    const content = compactValidSkill({
+      extraBody: "\nCredentials at ~/.aws/credentials\n",
+    });
+    const result = validator.validate(content);
+    expect(result.valid).toBe(false);
+    expect(result.violations.some((v: string) => v.includes("tilde-home-path"))).toBe(true);
+  });
+
+  it("rejects ~/.gnupg dotfile paths", () => {
+    const content = compactValidSkill({
+      extraBody: "\nKey ring: ~/.gnupg/secring.gpg\n",
+    });
+    const result = validator.validate(content);
+    expect(result.valid).toBe(false);
+    expect(result.violations.some((v: string) => v.includes("tilde-home-path"))).toBe(true);
+  });
+
+  it("still rejects non-dotfile tilde paths like ~/projects/foo", () => {
+    const content = compactValidSkill({
+      extraBody: "\nDocument: ~/projects/aws-creds.txt\n",
+    });
+    const result = validator.validate(content);
+    expect(result.valid).toBe(false);
+    expect(result.violations.some((v: string) => v.includes("tilde-home-path"))).toBe(true);
+  });
+
+  // -------------------------------------------------------------------------
+  // Issue #1385 — loopback (127.x) must NOT be flagged as private-ip
+  // -------------------------------------------------------------------------
+
+  it("does not flag loopback address 127.0.0.1 as private-ip", () => {
+    const content = compactValidSkill({
+      extraBody: "\nHealth-check URL: http://127.0.0.1:8080/health\n",
+    });
+    const result = validator.validate(content);
+    // Only check that private-ip violation is not present (other violations may exist)
+    expect(result.violations.some((v: string) => v.includes("private-ip"))).toBe(false);
+  });
+
+  it("still flags RFC1918 address 192.168.1.10 as private-ip", () => {
+    const content = compactValidSkill({
+      extraBody: "\nDatabase host: 192.168.1.10\n",
+    });
+    const result = validator.validate(content);
+    expect(result.violations.some((v: string) => v.includes("private-ip"))).toBe(true);
+  });
+
+  it("still flags RFC1918 address 10.0.0.1 as private-ip", () => {
+    const content = compactValidSkill({
+      extraBody: "\nInternal service: 10.0.0.1\n",
+    });
+    const result = validator.validate(content);
+    expect(result.violations.some((v: string) => v.includes("private-ip"))).toBe(true);
+  });
+
+  // -------------------------------------------------------------------------
+  // Issue #1383 — custom placeholder-email allow-list via constructor
+  // -------------------------------------------------------------------------
+
+  it("uses default allow-list when no emailPattern provided", () => {
+    const content = compactValidSkill({
+      extraBody: "\nContact: ops@example.com\n",
+    });
+    expect(validator.validate(content).violations.some((v: string) => v.includes("email-address"))).toBe(false);
+  });
+
+  it("flags real-looking email addresses with default allow-list", () => {
+    const content = compactValidSkill({
+      extraBody: "\nContact: admin@acme-internal.corp\n",
+    });
+    expect(validator.validate(content).violations.some((v: string) => v.includes("email-address"))).toBe(true);
+  });
+
+  it("does not flag custom domain when validator is configured with custom allow-list", () => {
+    const customValidator = new SkillValidator({ emailPattern: buildNonPlaceholderEmailPattern(["example.com", "localhost", "test.com", "example.org", "acme-internal.corp"]) });
+    const content = compactValidSkill({
+      extraBody: "\nContact: team@acme-internal.corp\n",
+    });
+    expect(customValidator.validate(content).violations.some((v: string) => v.includes("email-address"))).toBe(false);
+  });
 });
 
 // ============================================================================
@@ -1162,5 +1289,43 @@ describe("parseCrystallizationConfig", () => {
       crystallization: { minSuccessRate: 2.5 },
     });
     expect(cfg.crystallization.minSuccessRate).toBe(0.7); // falls back to default
+  });
+
+  // Issue #1383 — configurable placeholder email allow-list
+
+  it("parses custom placeholderEmailDomains from config", async () => {
+    const { hybridConfigSchema } = await import("../config.js");
+    const cfg = hybridConfigSchema.parse({
+      ...BASE_CFG,
+      crystallization: {
+        placeholderEmailDomains: ["example.com", "company.test"],
+      },
+    });
+    expect(cfg.crystallization.placeholderEmailDomains).toEqual(["example.com", "company.test"]);
+  });
+
+  it("defaults placeholderEmailDomains to standard four when omitted", async () => {
+    const { hybridConfigSchema } = await import("../config.js");
+    const cfg = hybridConfigSchema.parse({ ...BASE_CFG, mode: "minimal" });
+    expect(cfg.crystallization.placeholderEmailDomains).toEqual([
+      "example.com",
+      "localhost",
+      "test.com",
+      "example.org",
+    ]);
+  });
+
+  it("falls back to default placeholderEmailDomains when an empty array is provided", async () => {
+    const { hybridConfigSchema } = await import("../config.js");
+    const cfg = hybridConfigSchema.parse({
+      ...BASE_CFG,
+      crystallization: { placeholderEmailDomains: [] },
+    });
+    expect(cfg.crystallization.placeholderEmailDomains).toEqual([
+      "example.com",
+      "localhost",
+      "test.com",
+      "example.org",
+    ]);
   });
 });

--- a/extensions/memory-hybrid/tests/generated-skill-validation.test.ts
+++ b/extensions/memory-hybrid/tests/generated-skill-validation.test.ts
@@ -11,6 +11,7 @@ import type { CrystallizationConfig } from "../config/types/features.js";
 import { CrystallizationProposer } from "../services/crystallization-proposer.js";
 import { GeneratedSkillValidationService } from "../services/generated-skill-validation.js";
 import { SkillCrystallizer } from "../services/skill-crystallizer.js";
+import { buildNonPlaceholderEmailPattern } from "../services/skill-validator.js";
 
 const BASE_CFG: CrystallizationConfig = {
   enabled: true,
@@ -20,6 +21,7 @@ const BASE_CFG: CrystallizationConfig = {
   outputDir: "",
   maxCrystallized: 50,
   pruneUnusedDays: 30,
+  placeholderEmailDomains: ["example.com", "localhost", "test.com", "example.org"],
 };
 const MIN_CONCRETE_EXAMPLE_LENGTH_THRESHOLD_CHARS = 18;
 
@@ -803,3 +805,136 @@ Bounded metadata installation workflow.
     }
   });
 });
+
+// ============================================================================
+// Issue #1383 — custom placeholder-email allow-list
+// ============================================================================
+
+describe("GeneratedSkillValidationService — custom placeholderEmailDomains", () => {
+  let tmpDir: string;
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (tmpDir) {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("flags an internal-placeholder email address with the default allow-list", () => {
+    tmpDir = mkdtempSync(join(tmpdir(), "gsv-custom-email-default-"));
+    const service = new GeneratedSkillValidationService();
+    const skillContent = makeMinimalSkill(join(tmpDir, "skills"), "custom-domain-test", "team@company.internal");
+    const violations: string[] = [];
+    for (const pattern of [buildNonPlaceholderEmailPattern(["example.com", "localhost", "test.com", "example.org"])]) {
+      if (pattern.test(skillContent)) violations.push("email detected");
+    }
+    expect(violations.length).toBeGreaterThan(0);
+  });
+
+  it("does not flag custom placeholder domain when configured with extended allow-list", () => {
+    tmpDir = mkdtempSync(join(tmpdir(), "gsv-custom-email-extended-"));
+    const customEmailPattern = buildNonPlaceholderEmailPattern([
+      "example.com",
+      "localhost",
+      "test.com",
+      "example.org",
+      "company.internal",
+    ]);
+    const service = new GeneratedSkillValidationService({ emailPattern: customEmailPattern });
+    const cfg: CrystallizationConfig = {
+      ...BASE_CFG,
+      outputDir: join(tmpDir, "skills"),
+      placeholderEmailDomains: ["example.com", "localhost", "test.com", "example.org", "company.internal"],
+    };
+    const crystallizer = new SkillCrystallizer(cfg);
+    const pattern = {
+      toolSequence: ["read", "write"],
+      totalCount: 5,
+      successCount: 5,
+      failureCount: 0,
+      successRate: 1,
+      avgDurationMs: 400,
+      exampleGoals: ["Send the weekly summary to ops@company.internal after deploy"],
+    };
+    const result = crystallizer.crystallize({ patternId: "custom-domain-goal", evidenceHash: "ev-custom", pattern });
+    const validation = service.validate({
+      outputDir: cfg.outputDir,
+      proposedOutputPath: result.proposedOutputPath,
+      skillName: result.skillName,
+      skillContent: result.skillContent,
+      pattern,
+    });
+    const emailViolations = validation.staticValidation.violations.filter(
+      (v) => v.includes("email") || v.includes("company.internal"),
+    );
+    expect(emailViolations).toHaveLength(0);
+  });
+
+  it("parseCrystallizationConfig picks up custom placeholderEmailDomains", async () => {
+    const { hybridConfigSchema } = await import("../config.js");
+    const cfg = hybridConfigSchema.parse({
+      embedding: {
+        provider: "openai",
+        apiKey: "sk-test-key-12345678",
+        model: "text-embedding-3-small",
+      },
+      crystallization: {
+        placeholderEmailDomains: ["example.com", "company.internal"],
+      },
+    });
+    expect(cfg.crystallization.placeholderEmailDomains).toEqual(["example.com", "company.internal"]);
+  });
+
+  it("parseCrystallizationConfig defaults to standard domains when field is omitted", async () => {
+    const { hybridConfigSchema } = await import("../config.js");
+    const cfg = hybridConfigSchema.parse({
+      embedding: {
+        provider: "openai",
+        apiKey: "sk-test-key-12345678",
+        model: "text-embedding-3-small",
+      },
+      mode: "minimal",
+    });
+    expect(cfg.crystallization.placeholderEmailDomains).toEqual([
+      "example.com",
+      "localhost",
+      "test.com",
+      "example.org",
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeMinimalSkill(outputDir: string, skillName: string, emailInContent: string): string {
+  return `---
+name: ${skillName}
+description: Minimal skill for email pattern tests.
+category: test
+provenance: test-suite
+---
+
+# ${skillName}
+
+## Trigger
+- Use this skill for email-pattern validation tests.
+
+## Scope
+- Bounded to test fixtures.
+
+## When not to use
+- When no email validation is needed.
+
+## Workflow
+1. Contact: ${emailInContent}
+2. Verify output.
+
+## Examples
+- Good: "Test the email pattern validation."
+
+## Provenance
+- Generated for email-pattern tests.
+`;
+}

--- a/extensions/memory-hybrid/tests/generated-skill-validation.test.ts
+++ b/extensions/memory-hybrid/tests/generated-skill-validation.test.ts
@@ -822,13 +822,10 @@ describe("GeneratedSkillValidationService — custom placeholderEmailDomains", (
 
   it("flags an internal-placeholder email address with the default allow-list", () => {
     tmpDir = mkdtempSync(join(tmpdir(), "gsv-custom-email-default-"));
-    const service = new GeneratedSkillValidationService();
-    const skillContent = makeMinimalSkill(join(tmpDir, "skills"), "custom-domain-test", "team@company.internal");
-    const violations: string[] = [];
-    for (const pattern of [buildNonPlaceholderEmailPattern(["example.com", "localhost", "test.com", "example.org"])]) {
-      if (pattern.test(skillContent)) violations.push("email detected");
-    }
-    expect(violations.length).toBeGreaterThan(0);
+    const skillContent = makeMinimalSkill("custom-domain-test", "team@company.internal");
+    const defaultPattern = buildNonPlaceholderEmailPattern(["example.com", "localhost", "test.com", "example.org"]);
+    expect(defaultPattern.test(skillContent)).toBe(true);
+    expect(defaultPattern.test(makeMinimalSkill("custom-domain-test", "team@EXAMPLE.COM"))).toBe(false);
   });
 
   it("does not flag custom placeholder domain when configured with extended allow-list", () => {
@@ -908,7 +905,7 @@ describe("GeneratedSkillValidationService — custom placeholderEmailDomains", (
 // Helpers
 // ---------------------------------------------------------------------------
 
-function makeMinimalSkill(outputDir: string, skillName: string, emailInContent: string): string {
+function makeMinimalSkill(skillName: string, emailInContent: string): string {
   return `---
 name: ${skillName}
 description: Minimal skill for email pattern tests.

--- a/extensions/memory-hybrid/tests/procedure-promotion-policy.test.ts
+++ b/extensions/memory-hybrid/tests/procedure-promotion-policy.test.ts
@@ -995,4 +995,76 @@ Source procedure id: proc-weather
       parent: (_fixture, context) => adapter.decide(listed, context),
     });
   });
+
+  // -------------------------------------------------------------------------
+  // Issue #1385 — loopback (127.x) must NOT trigger private_data_risk
+  // -------------------------------------------------------------------------
+
+  it("does not flag loopback 127.0.0.1 as private_data_risk", () => {
+    const proc = addProcedure({
+      taskPattern: "Run health check on local development server",
+      recipeJson: JSON.stringify([
+        {
+          tool: "exec",
+          args: { command: "curl http://127.0.0.1:8080/health" },
+          summary: "Ping local dev server health endpoint",
+        },
+        {
+          tool: "exec",
+          args: { command: "npm test" },
+          summary: "Run test suite",
+        },
+        {
+          tool: "read",
+          args: { path: "test-report.json" },
+          summary: "Verify test output",
+        },
+      ]),
+      sourceSessionId: "loopback-a",
+    });
+    db.recordProcedureSuccess(proc.id, undefined, "loopback-b");
+    db.recordProcedureSuccess(proc.id, undefined, "loopback-c");
+
+    const evaluation = evaluateProcedureForPromotion(
+      createProcedurePromotionItem(proc, parseProcedurePromotionPolicy("auto-safe")),
+      parseProcedurePromotionPolicy("auto-safe"),
+      { skillsAutoPath: skillsDir, validationThreshold: 3 },
+    );
+
+    expect(evaluation.metadata.rejectionReasons).not.toContain("private_data_risk");
+  });
+
+  it("still flags RFC1918 address 192.168.x.x as private_data_risk", () => {
+    const proc = addProcedure({
+      taskPattern: "Connect to internal server for report",
+      recipeJson: JSON.stringify([
+        {
+          tool: "exec",
+          args: { command: "curl http://192.168.1.10/api/status" },
+          summary: "Query internal server",
+        },
+        {
+          tool: "exec",
+          args: { command: "npm test" },
+          summary: "Run test",
+        },
+        {
+          tool: "read",
+          args: { path: "report.json" },
+          summary: "Read report",
+        },
+      ]),
+      sourceSessionId: "rfc1918-a",
+    });
+    db.recordProcedureSuccess(proc.id, undefined, "rfc1918-b");
+    db.recordProcedureSuccess(proc.id, undefined, "rfc1918-c");
+
+    const evaluation = evaluateProcedureForPromotion(
+      createProcedurePromotionItem(proc, parseProcedurePromotionPolicy("auto-safe")),
+      parseProcedurePromotionPolicy("auto-safe"),
+      { skillsAutoPath: skillsDir, validationThreshold: 3 },
+    );
+
+    expect(evaluation.metadata.rejectionReasons).toContain("private_data_risk");
+  });
 });

--- a/extensions/memory-hybrid/tests/procedures-db.test.ts
+++ b/extensions/memory-hybrid/tests/procedures-db.test.ts
@@ -122,6 +122,25 @@ describe("FactsDB procedures table", () => {
     expect(ready.some((p) => p.id === high.id)).toBe(true);
   });
 
+  it("getProceduresReadyForSkill uses deterministic insertion order for equal validation scores", () => {
+    const first = db.upsertProcedure({
+      taskPattern: "First equal score",
+      recipeJson: "[]",
+      procedureType: "positive",
+      successCount: 3,
+      lastValidated: 123,
+    });
+    const second = db.upsertProcedure({
+      taskPattern: "Second equal score",
+      recipeJson: "[]",
+      procedureType: "positive",
+      successCount: 3,
+      lastValidated: 123,
+    });
+    const ready = db.getProceduresReadyForSkill(3, 2);
+    expect(ready.map((p) => p.id)).toEqual([first.id, second.id]);
+  });
+
   it("markProcedurePromoted sets promoted_to_skill and skill_path", () => {
     const created = db.upsertProcedure({
       taskPattern: "Promote me",


### PR DESCRIPTION
Four independent security validation gaps across `SkillValidator`, `GeneratedSkillValidationService`, and `ProcedurePromotionPolicy`. Each allowed content that should be caught to slip through, or flagged benign content that should be allowed.

## Changes

### #1382 — Case-insensitive PEM detection
`-----begin private key-----` and mixed-case variants bypassed both validators. Introduced a shared exported constant used by all three validators:
```ts
// skill-validator.ts (re-exported, used by all three)
export const PEM_PRIVATE_KEY_PATTERN = /-----BEGIN [A-Za-z0-9 ]*PRIVATE KEY[A-Za-z0-9 ]*-----/i;
```
The trailing `[A-Za-z0-9 ]*` also catches `-----BEGIN PGP PRIVATE KEY BLOCK-----`.

### #1384 — Tilde-path negative lookahead was inverted
`(?!\.)` was explicitly *excluding* `~/.ssh`, `~/.aws`, `~/.gnupg` — exactly the paths that matter most. Lookahead removed; all `~/…` paths are now flagged uniformly.

### #1385 — Loopback address removed from private-IP pattern
`127.x.x.x` was treated as a private-network indicator alongside RFC 1918 ranges. It reveals nothing about host topology and caused false positives on common dev examples (`curl http://127.0.0.1:8080/health`). `127\.` dropped from `PRIVATE_DATA_PATTERNS` and `PRIVATE_CONTEXT_PATTERNS` in all three service files; RFC 1918 ranges (`10.`, `172.16-31.`, `192.168.`) unchanged.

### #1383 — Configurable placeholder-email allow-list
Hard-coded four-domain whitelist prevented organisations with internal placeholder domains from passing validation. Replaced with:
```ts
export const DEFAULT_PLACEHOLDER_EMAIL_DOMAINS = ["example.com", "localhost", "test.com", "example.org"];
export function buildNonPlaceholderEmailPattern(allowList: string[]): RegExp { … }
```
- `SkillValidator` and `GeneratedSkillValidationService` accept `options.emailPattern` in their constructors.
- `CrystallizationConfig` gains `placeholderEmailDomains: string[]`; `CrystallizationProposer` builds and passes the configured pattern to both validators.
- Defaults are unchanged; empty array falls back to defaults at parse time.
- `docs/CONFIGURATION.md` updated with the new key and its semantics.

> [!WARNING]
>
> <details>
> <summary>Firewall rules blocked me from connecting to one or more addresses (expand for details)</summary>
>
> #### I tried to connect to the following addresses, but was blocked by firewall rules:
>
> - `api.openai.com`
>   - Triggering command: `/opt/hostedtoolcache/node/24.14.1/x64/bin/node /opt/hostedtoolcache/node/24.14.1/x64/bin/node --experimental-import-meta-resolve --require /home/REDACTED/work/openclaw-hybrid-memory/openclaw-hybrid-memory/extensions/memory-hybrid/node_modules/vitest/suppress-warnings.cjs --conditions node --conditions development /home/REDACTED/work/openclaw-hybrid-memory/openclaw-hybrid-memory/extensions/memory-hybrid/node_modules/vitest/dist/workers/forks.js` (dns block)
> - `https://api.github.com/graphql`
>   - Triggering command: `/usr/bin/gh gh issue list --limit 10 --json number,title,state,url,createdAt` (http block)
>   - Triggering command: `/usr/bin/gh gh pr list --limit 10 --json number,title,state,url,createdAt` (http block)
>   - Triggering command: `/usr/bin/gh gh issue list --limit 10 --json number,title,state,url,createdAt extensions/memory-hybrid/node_modules/.bin/node` (http block)
> - `my-glitchtip.example.com`
>   - Triggering command: `/opt/hostedtoolcache/node/24.14.1/x64/bin/node /opt/hostedtoolcache/node/24.14.1/x64/bin/node --experimental-import-meta-resolve --require /home/REDACTED/work/openclaw-hybrid-memory/openclaw-hybrid-memory/extensions/memory-hybrid/node_modules/vitest/suppress-warnings.cjs --conditions node --conditions development /home/REDACTED/work/openclaw-hybrid-memory/openclaw-hybrid-memory/extensions/memory-hybrid/node_modules/vitest/dist/workers/forks.js` (dns block)
>
> If you need me to access, download, or install something from one of these locations, you can either:
>
> - Configure [Actions setup steps](https://gh.io/copilot/actions-setup-steps) to set up my environment, which run before the firewall is enabled
> - Add the appropriate URLs or hosts to the custom allowlist in this repository's [Copilot coding agent settings](https://github.com/markus-lassfolk/openclaw-hybrid-memory/settings/copilot/coding_agent) (admins only)
>
> </details>

---

Reopened by Maeve as a human-owned branch/PR to avoid bot/app PR workflow and review limitations.

Supersedes: https://github.com/markus-lassfolk/openclaw-hybrid-memory/pull/1436
Closes #1423

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches security/PII validation logic used to gate generated skills and auto-promotion; incorrect regex/config handling could create false negatives (leaks) or new false positives that block valid skills. Changes are well-covered by new targeted tests but affect multiple validators and policy paths.
> 
> **Overview**
> Tightens safety validation for generated `SKILL.md` content across `SkillValidator`, `GeneratedSkillValidationService`, and procedure auto-promotion by **sharing and reusing common detectors** (case-insensitive PEM private key blocks, RFC1918 private IPs while *excluding* loopback `127.x`, and corrected `~/...` dotfile path detection).
> 
> Adds **configurable placeholder email allow-listing** for crystallization via new `crystallization.placeholderEmailDomains`, plumbs it into validators (via an overridable email regex), and documents/exposes the setting in config docs and `openclaw.plugin.json` schema/help.
> 
> Improves determinism in auto-skill promotion selection by making `getProceduresReadyForSkill` ordering stable for ties, with a new test asserting insertion-order behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2bd12277cf3a970bb22a272d4ee63719c7f9722. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->