### PR TITLE
feat: atomic SKILL.md and sidecar writes with completion marker

### DIFF
--- a/extensions/memory-hybrid/services/crystallization-proposer.ts
+++ b/extensions/memory-hybrid/services/crystallization-proposer.ts
@@ -10,8 +10,7 @@ import { getEnv } from "../utils/env-manager.js";
  */
 
 import { homedir } from "node:os";
-import { dirname } from "node:path";
-import { atomicWriteSkillDir } from "../utils/atomic-write.js";
+import { atomicWriteFile } from "../utils/atomic-write.js";
 import type { CrystallizationStore } from "../backends/crystallization-store.js";
 import type { WorkflowPattern, WorkflowStore } from "../backends/workflow-store.js";
 import type { CrystallizationConfig } from "../config/types/features.js";
@@ -437,7 +436,7 @@ ${proposal.skillContent}`;
   }
 
   private writeSkillToDisk(outputPath: string, skillContent: string): void {
-    atomicWriteSkillDir(dirname(outputPath), { "SKILL.md": skillContent });
+    atomicWriteFile(outputPath, skillContent);
   }
 }
 

--- a/extensions/memory-hybrid/services/crystallization-proposer.ts
+++ b/extensions/memory-hybrid/services/crystallization-proposer.ts
@@ -10,7 +10,8 @@ import { getEnv } from "../utils/env-manager.js";
  */
 
 import { homedir } from "node:os";
-import { atomicWriteFile } from "../utils/atomic-write.js";
+import { dirname } from "node:path";
+import { atomicWriteSkillDir } from "../utils/atomic-write.js";
 import type { CrystallizationStore } from "../backends/crystallization-store.js";
 import type { WorkflowPattern, WorkflowStore } from "../backends/workflow-store.js";
 import type { CrystallizationConfig } from "../config/types/features.js";
@@ -436,7 +437,7 @@ ${proposal.skillContent}`;
   }
 
   private writeSkillToDisk(outputPath: string, skillContent: string): void {
-    atomicWriteFile(outputPath, skillContent);
+    atomicWriteSkillDir(dirname(outputPath), { "SKILL.md": skillContent });
   }
 }
 

--- a/extensions/memory-hybrid/services/crystallization-proposer.ts
+++ b/extensions/memory-hybrid/services/crystallization-proposer.ts
@@ -9,9 +9,8 @@ import { getEnv } from "../utils/env-manager.js";
  * When autoApprove=true the proposer immediately writes the skill to disk.
  */
 
-import { mkdirSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { dirname } from "node:path";
+import { atomicWriteFile } from "../utils/atomic-write.js";
 import type { CrystallizationStore } from "../backends/crystallization-store.js";
 import type { WorkflowPattern, WorkflowStore } from "../backends/workflow-store.js";
 import type { CrystallizationConfig } from "../config/types/features.js";
@@ -437,8 +436,7 @@ ${proposal.skillContent}`;
   }
 
   private writeSkillToDisk(outputPath: string, skillContent: string): void {
-    mkdirSync(dirname(outputPath), { recursive: true });
-    writeFileSync(outputPath, skillContent, "utf-8");
+    atomicWriteFile(outputPath, skillContent);
   }
 }
 

--- a/extensions/memory-hybrid/services/generated-skill-validation.ts
+++ b/extensions/memory-hybrid/services/generated-skill-validation.ts
@@ -5,7 +5,6 @@ import {
   mkdirSync,
   mkdtempSync,
   readFileSync,
-  readdirSync,
   realpathSync,
   rmSync,
   writeFileSync,
@@ -13,6 +12,8 @@ import {
 import { tmpdir } from "node:os";
 import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 import type { WorkflowPattern } from "../backends/workflow-store.js";
+import { SKILL_COMPLETE_MARKER } from "../utils/atomic-write.js";
+import { discoverCompletedSkillDirs } from "../utils/skill-discovery.js";
 import { normalizeSkillName } from "./skill-crystallizer.js";
 import { NON_PLACEHOLDER_EMAIL_PATTERN, SkillValidator } from "./skill-validator.js";
 
@@ -289,6 +290,7 @@ export class GeneratedSkillValidationService {
       mkdirSync(skillDir, { recursive: true });
       const skillPath = join(skillDir, "SKILL.md");
       writeFileSync(skillPath, skillContent, "utf-8");
+      writeFileSync(join(skillDir, SKILL_COMPLETE_MARKER), new Date().toISOString(), "utf-8");
 
       const skillDirStat = lstatSync(skillDir);
       const skillPathStat = lstatSync(skillPath);
@@ -435,9 +437,8 @@ function isWithinDir(rootDir: string, candidatePath: string): boolean {
 
 function loadDrySkillEntries(skillsDir: string): Array<Record<string, string>> {
   const out: Array<Record<string, string>> = [];
-  for (const entry of readdirSync(skillsDir, { withFileTypes: true })) {
-    if (!entry.isDirectory()) continue;
-    const skillPath = join(skillsDir, entry.name, "SKILL.md");
+  for (const entry of discoverCompletedSkillDirs(skillsDir)) {
+    const skillPath = entry.skillPath;
     let skillContent = "";
     try {
       skillContent = readFileSync(skillPath, "utf-8");

--- a/extensions/memory-hybrid/services/procedure-promotion-policy.ts
+++ b/extensions/memory-hybrid/services/procedure-promotion-policy.ts
@@ -13,7 +13,7 @@ import {
   redactAutopilotText,
   redactAutopilotValue,
 } from "./pending-autopilot/index.js";
-import { SKILL_ATOMIC_TEMP_PREFIX } from "../utils/atomic-write.js";
+import { isAtomicSkillWriteScratchDir } from "../utils/skill-discovery.js";
 import { SkillValidator } from "./skill-validator.js";
 
 export const PROCEDURE_PROMOTION_POLICY_VERSION = "procedure-promotion-policy-v1";
@@ -1159,10 +1159,6 @@ function defer(reason: ProcedurePromotionReason, detail: string): ProcedurePromo
 
 function fail(reason: ProcedurePromotionReason, detail: string): ProcedurePromotionGateResult {
   return { reason, severity: "fail-validation", detail };
-}
-
-function isAtomicSkillWriteScratchDir(name: string): boolean {
-  return name.startsWith(SKILL_ATOMIC_TEMP_PREFIX) || /^.+\.tmp-\d+-[a-f0-9]+$/i.test(name) || /^\..+\.bak-/.test(name);
 }
 
 function safeReadDir(dir: string): string[] {

--- a/extensions/memory-hybrid/services/procedure-promotion-policy.ts
+++ b/extensions/memory-hybrid/services/procedure-promotion-policy.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 import type { ProcedureEntry } from "../types/memory.js";
+import { isSkillDirComplete } from "../utils/atomic-write.js";
 import { slugifyForSkill, titleCase } from "../utils/text.js";
 import {
   type AutopilotReasonCode,
@@ -1109,6 +1110,8 @@ function isDuplicateSkill(
     for (const entry of safeReadDir(dir)) {
       const skillPath = join(dir, entry, "SKILL.md");
       if (!existsSync(skillPath)) continue;
+      // Skip directories that are in-progress writes (no completion marker).
+      if (!isSkillDirComplete(join(dir, entry))) continue;
       if (entry === slug) return true;
       const content = safeReadFile(skillPath).toLowerCase();
       if (content.includes(`name: ${slug}`)) return true;

--- a/extensions/memory-hybrid/services/procedure-promotion-policy.ts
+++ b/extensions/memory-hybrid/services/procedure-promotion-policy.ts
@@ -13,6 +13,7 @@ import {
   redactAutopilotText,
   redactAutopilotValue,
 } from "./pending-autopilot/index.js";
+import { SKILL_ATOMIC_TEMP_PREFIX } from "../utils/atomic-write.js";
 import { SkillValidator } from "./skill-validator.js";
 
 export const PROCEDURE_PROMOTION_POLICY_VERSION = "procedure-promotion-policy-v1";
@@ -1107,6 +1108,7 @@ function isDuplicateSkill(
   for (const dir of dirs) {
     if (!existsSync(dir)) continue;
     for (const entry of safeReadDir(dir)) {
+      if (isAtomicSkillWriteScratchDir(entry)) continue;
       const skillPath = join(dir, entry, "SKILL.md");
       if (!existsSync(skillPath)) continue;
       // Legacy skill directories may not have the atomic completion marker. If
@@ -1157,6 +1159,10 @@ function defer(reason: ProcedurePromotionReason, detail: string): ProcedurePromo
 
 function fail(reason: ProcedurePromotionReason, detail: string): ProcedurePromotionGateResult {
   return { reason, severity: "fail-validation", detail };
+}
+
+function isAtomicSkillWriteScratchDir(name: string): boolean {
+  return name.startsWith(SKILL_ATOMIC_TEMP_PREFIX) || /^.+\.tmp-\d+-[a-f0-9]+$/i.test(name) || /^\..+\.bak-/.test(name);
 }
 
 function safeReadDir(dir: string): string[] {

--- a/extensions/memory-hybrid/services/procedure-promotion-policy.ts
+++ b/extensions/memory-hybrid/services/procedure-promotion-policy.ts
@@ -1,7 +1,6 @@
 import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 import type { ProcedureEntry } from "../types/memory.js";
-import { isSkillDirComplete } from "../utils/atomic-write.js";
 import { slugifyForSkill, titleCase } from "../utils/text.js";
 import {
   type AutopilotReasonCode,
@@ -1110,8 +1109,9 @@ function isDuplicateSkill(
     for (const entry of safeReadDir(dir)) {
       const skillPath = join(dir, entry, "SKILL.md");
       if (!existsSync(skillPath)) continue;
-      // Skip directories that are in-progress writes (no completion marker).
-      if (!isSkillDirComplete(join(dir, entry))) continue;
+      // Legacy skill directories may not have the atomic completion marker. If
+      // they contain SKILL.md, treat them as valid duplicates so marker rollout
+      // never overwrites or re-promotes existing skills.
       if (entry === slug) return true;
       const content = safeReadFile(skillPath).toLowerCase();
       if (content.includes(`name: ${slug}`)) return true;

--- a/extensions/memory-hybrid/services/procedure-promotion-policy.ts
+++ b/extensions/memory-hybrid/services/procedure-promotion-policy.ts
@@ -249,13 +249,13 @@ const CREDENTIAL_PATTERNS: RegExp[] = [
   /\b(?:password|passwd|pwd|secret|token|api[_-]?key|authorization|private[_-]?key)\s*[:=]\s*[^\s,;}{\[\]]+/i,
   /\b(?:sk|pk|rk|ghp|gho|github_pat|xox[baprs])[-_][A-Za-z0-9_-]{8,}\b/,
   /\bBearer\s+[A-Za-z0-9._~+/-]+=*/i,
-  /-----BEGIN [A-Z ]*PRIVATE KEY-----/,
+  /-----BEGIN [A-Za-z0-9 ]*PRIVATE KEY[A-Za-z0-9 ]*-----/i,
 ];
 
 const PRIVATE_DATA_PATTERNS: RegExp[] = [
-  /\b(?:10\.|127\.|172\.(?:1[6-9]|2\d|3[01])\.|192\.168\.)\d{1,3}\.\d{1,3}\b/,
+  /\b(?:10\.\d{1,3}\.|172\.(?:1[6-9]|2\d|3[01])\.|192\.168\.)\d{1,3}\.\d{1,3}\b/,
   /(?:^|[\s"'=:])(?:\/home\/[^\s"']+|\/Users\/[^\s"']+|~\/[^\s"']+)/,
-  /\b[A-Za-z0-9._%+-]+@(?!example\.com|localhost|test\.com|example\.org)[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/,
+  /\b[A-Za-z0-9._%+-]+@(?!(?:example\.com|localhost|test\.com|example\.org)(?![A-Za-z0-9.-]))[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/i,
 ];
 
 export function parseProcedurePromotionPolicy(policy: string | undefined): ProcedurePromotionPolicy {

--- a/extensions/memory-hybrid/services/procedure-skill-generator.ts
+++ b/extensions/memory-hybrid/services/procedure-skill-generator.ts
@@ -2,11 +2,12 @@
  * Procedural memory: generate verified draft SKILL.md + recipe.json from validated procedures.
  */
 
-import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import type { FactsDB } from "../backends/facts-db.js";
 import type { GenerateAutoSkillsResult } from "../cli/register.js";
 import type { MemoryEntry, MemoryScope, ProcedureEntry, ScopeFilter } from "../types/memory.js";
+import { atomicWriteSkillDir, isSkillDirComplete } from "../utils/atomic-write.js";
 import { resolveWorkspacePath } from "../utils/path.js";
 import { titleCase } from "../utils/text.js";
 import { capturePluginError } from "./error-reporter.js";
@@ -75,7 +76,13 @@ export type GenerateAutoSkillResult =
 function ensureUniqueSlug(basePath: string, slug: string, reservedSlugs?: ReadonlySet<string>): string {
   let candidate = slug;
   let n = 0;
-  while (existsSync(join(basePath, candidate)) || reservedSlugs?.has(candidate)) {
+  // A directory that exists but lacks the completion marker is an in-progress
+  // (or crashed) write — treat it as free so retries reuse the same slug and
+  // the atomic write can overwrite the incomplete directory.
+  while (
+    (existsSync(join(basePath, candidate)) && isSkillDirComplete(join(basePath, candidate))) ||
+    reservedSlugs?.has(candidate)
+  ) {
     n++;
     candidate = `${slug}-${n}`;
   }
@@ -488,12 +495,16 @@ function writeDraftSkill(
     proposalMetadataJson: string;
   },
 ): void {
-  mkdirSync(join(skillDir, "evals"), { recursive: true });
-  writeFileSync(join(skillDir, "SKILL.md"), draft.skillMd, "utf-8");
-  writeFileSync(join(skillDir, "recipe.json"), draft.recipeJson, "utf-8");
-  writeFileSync(join(skillDir, "verification.json"), draft.verificationJson, "utf-8");
-  writeFileSync(join(skillDir, "proposal-metadata.json"), draft.proposalMetadataJson, "utf-8");
-  writeFileSync(join(skillDir, "evals", "evals.json"), draft.evalsJson, "utf-8");
+  // Write all sidecar files atomically (temp dir → rename). SKILL.md is
+  // written last among content files so it is the final content write before
+  // the completion marker.
+  atomicWriteSkillDir(skillDir, {
+    "recipe.json": draft.recipeJson,
+    "verification.json": draft.verificationJson,
+    "proposal-metadata.json": draft.proposalMetadataJson,
+    "evals/evals.json": draft.evalsJson,
+    "SKILL.md": draft.skillMd,
+  });
 }
 
 function releaseInRunReservation(

--- a/extensions/memory-hybrid/services/procedure-skill-generator.ts
+++ b/extensions/memory-hybrid/services/procedure-skill-generator.ts
@@ -7,7 +7,7 @@ import { join } from "node:path";
 import type { FactsDB } from "../backends/facts-db.js";
 import type { GenerateAutoSkillsResult } from "../cli/register.js";
 import type { MemoryEntry, MemoryScope, ProcedureEntry, ScopeFilter } from "../types/memory.js";
-import { atomicWriteSkillDir } from "../utils/atomic-write.js";
+import { SKILL_COMPLETE_MARKER, atomicWriteSkillDir } from "../utils/atomic-write.js";
 import { resolveWorkspacePath } from "../utils/path.js";
 import { titleCase } from "../utils/text.js";
 import { capturePluginError } from "./error-reporter.js";
@@ -78,12 +78,16 @@ function ensureUniqueSlug(basePath: string, slug: string, reservedSlugs?: Readon
   let n = 0;
   // Legacy skill directories created before the atomic completion marker rollout
   // do not contain `.openclaw-skill-complete`. They are still occupied names and
-  // must not be overwritten. Only atomic temp/backup siblings are reusable.
-  while (reservedSlugs?.has(candidate) || existsSync(join(basePath, candidate))) {
+  // must not be overwritten. Only incomplete atomic drafts are reusable.
+  while (reservedSlugs?.has(candidate) || isOccupiedSkillDir(join(basePath, candidate))) {
     n++;
     candidate = `${slug}-${n}`;
   }
   return candidate;
+}
+
+function isOccupiedSkillDir(skillDir: string): boolean {
+  return existsSync(join(skillDir, SKILL_COMPLETE_MARKER)) || existsSync(join(skillDir, "SKILL.md"));
 }
 
 function rebaseDraftSlug(
@@ -492,6 +496,10 @@ function writeDraftSkill(
     proposalMetadataJson: string;
   },
 ): void {
+  if (existsSync(skillDir) && !isOccupiedSkillDir(skillDir)) {
+    rmSync(skillDir, { recursive: true, force: true });
+  }
+
   // Write all sidecar files atomically (temp dir → rename). SKILL.md is
   // written last among content files so it is the final content write before
   // the completion marker.

--- a/extensions/memory-hybrid/services/procedure-skill-generator.ts
+++ b/extensions/memory-hybrid/services/procedure-skill-generator.ts
@@ -79,10 +79,7 @@ function ensureUniqueSlug(basePath: string, slug: string, reservedSlugs?: Readon
   // A directory that exists but lacks the completion marker is an in-progress
   // (or crashed) write — treat it as free so retries reuse the same slug and
   // the atomic write can overwrite the incomplete directory.
-  while (
-    (existsSync(join(basePath, candidate)) && isSkillDirComplete(join(basePath, candidate))) ||
-    reservedSlugs?.has(candidate)
-  ) {
+  while (reservedSlugs?.has(candidate) || isSkillDirComplete(join(basePath, candidate))) {
     n++;
     candidate = `${slug}-${n}`;
   }

--- a/extensions/memory-hybrid/services/procedure-skill-generator.ts
+++ b/extensions/memory-hybrid/services/procedure-skill-generator.ts
@@ -7,7 +7,7 @@ import { join } from "node:path";
 import type { FactsDB } from "../backends/facts-db.js";
 import type { GenerateAutoSkillsResult } from "../cli/register.js";
 import type { MemoryEntry, MemoryScope, ProcedureEntry, ScopeFilter } from "../types/memory.js";
-import { atomicWriteSkillDir, isSkillDirComplete } from "../utils/atomic-write.js";
+import { atomicWriteSkillDir } from "../utils/atomic-write.js";
 import { resolveWorkspacePath } from "../utils/path.js";
 import { titleCase } from "../utils/text.js";
 import { capturePluginError } from "./error-reporter.js";
@@ -76,10 +76,10 @@ export type GenerateAutoSkillResult =
 function ensureUniqueSlug(basePath: string, slug: string, reservedSlugs?: ReadonlySet<string>): string {
   let candidate = slug;
   let n = 0;
-  // A directory that exists but lacks the completion marker is an in-progress
-  // (or crashed) write — treat it as free so retries reuse the same slug and
-  // the atomic write can overwrite the incomplete directory.
-  while (reservedSlugs?.has(candidate) || isSkillDirComplete(join(basePath, candidate))) {
+  // Legacy skill directories created before the atomic completion marker rollout
+  // do not contain `.openclaw-skill-complete`. They are still occupied names and
+  // must not be overwritten. Only atomic temp/backup siblings are reusable.
+  while (reservedSlugs?.has(candidate) || existsSync(join(basePath, candidate))) {
     n++;
     candidate = `${slug}-${n}`;
   }

--- a/extensions/memory-hybrid/services/procedure-skill-generator.ts
+++ b/extensions/memory-hybrid/services/procedure-skill-generator.ts
@@ -526,7 +526,6 @@ function releaseInRunReservation(
 
 function rollbackDraftSkill(skillDir: string): void {
   if (!existsSync(skillDir)) return;
-  if (isOccupiedSkillDir(skillDir)) return;
   try {
     rmSync(skillDir, { recursive: true, force: true });
   } catch (err) {

--- a/extensions/memory-hybrid/services/procedure-skill-generator.ts
+++ b/extensions/memory-hybrid/services/procedure-skill-generator.ts
@@ -526,6 +526,7 @@ function releaseInRunReservation(
 
 function rollbackDraftSkill(skillDir: string): void {
   if (!existsSync(skillDir)) return;
+  if (isOccupiedSkillDir(skillDir)) return;
   try {
     rmSync(skillDir, { recursive: true, force: true });
   } catch (err) {

--- a/extensions/memory-hybrid/services/procedure-skill-generator.ts
+++ b/extensions/memory-hybrid/services/procedure-skill-generator.ts
@@ -575,10 +575,6 @@ function writeDraftSkill(
     proposalMetadataJson: string;
   },
 ): void {
-  if (existsSync(skillDir) && !isOccupiedSkillDir(skillDir)) {
-    rmSync(skillDir, { recursive: true, force: true });
-  }
-
   // Write all sidecar files atomically (temp dir → rename). SKILL.md is
   // written last among content files so it is the final content write before
   // the completion marker.

--- a/extensions/memory-hybrid/tests/atomic-write.test.ts
+++ b/extensions/memory-hybrid/tests/atomic-write.test.ts
@@ -15,6 +15,7 @@ import {
   mkdtempSync,
   readFileSync,
   readdirSync,
+  renameSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
@@ -22,6 +23,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
+  SKILL_ATOMIC_TEMP_PREFIX,
   SKILL_COMPLETE_MARKER,
   atomicWriteFile,
   atomicWriteSkillDir,
@@ -186,32 +188,40 @@ describe("atomicWriteSkillDir", () => {
     expect(entries.every((e) => !e.includes(".tmp-"))).toBe(true);
   });
 
-  it("overwrites an existing incomplete (no-marker) directory", () => {
+  it("refuses to overwrite an existing incomplete (no-marker) directory with SKILL.md", () => {
     const skillDir = join(tmpDir, "my-skill");
-    // Simulate a partially-written dir from a previous crashed write.
+    // Simulate a legacy/partial final dir. Callers must explicitly decide if it
+    // is safe to clean it; atomicWriteSkillDir itself must never hide it.
     mkdirSync(skillDir, { recursive: true });
     writeFileSync(join(skillDir, "SKILL.md"), "# Incomplete\n", "utf-8");
-    // No marker → incomplete.
-    expect(existsSync(join(skillDir, SKILL_COMPLETE_MARKER))).toBe(false);
 
-    // Should succeed and replace with complete content.
+    expect(() => atomicWriteSkillDir(skillDir, DRAFT)).toThrow("Atomic skill directory target already exists");
+    expect(readFileSync(join(skillDir, "SKILL.md"), "utf-8")).toContain("# Incomplete");
+    expect(existsSync(join(skillDir, SKILL_COMPLETE_MARKER))).toBe(false);
+  });
+
+  it("refuses to replace a complete directory when called again with updated content", () => {
+    const skillDir = join(tmpDir, "my-skill");
     atomicWriteSkillDir(skillDir, DRAFT);
+
+    const updated = { ...DRAFT, "SKILL.md": "# Updated Skill\n" };
+    expect(() => atomicWriteSkillDir(skillDir, updated)).toThrow("Atomic skill directory target already exists");
 
     expect(readFileSync(join(skillDir, "SKILL.md"), "utf-8")).toContain("# My Skill");
     expect(existsSync(join(skillDir, SKILL_COMPLETE_MARKER))).toBe(true);
   });
 
-  it("replaces a complete directory when called again with updated content", () => {
+  it("does not hide an existing directory if promotion rename fails", () => {
     const skillDir = join(tmpDir, "my-skill");
-    // Write first complete version.
-    atomicWriteSkillDir(skillDir, DRAFT);
+    const tmpSkillDir = join(tmpDir, `${SKILL_ATOMIC_TEMP_PREFIX}manual`);
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(join(skillDir, "SKILL.md"), "# Existing\n", "utf-8");
+    mkdirSync(tmpSkillDir, { recursive: true });
 
-    // Overwrite with updated content.
-    const updated = { ...DRAFT, "SKILL.md": "# Updated Skill\n" };
-    atomicWriteSkillDir(skillDir, updated);
+    expect(() => renameSync(tmpSkillDir, skillDir)).toThrow();
 
-    expect(readFileSync(join(skillDir, "SKILL.md"), "utf-8")).toContain("# Updated Skill");
-    expect(existsSync(join(skillDir, SKILL_COMPLETE_MARKER))).toBe(true);
+    expect(readFileSync(join(skillDir, "SKILL.md"), "utf-8")).toContain("# Existing");
+    expect(existsSync(tmpSkillDir)).toBe(true);
   });
 });
 

--- a/extensions/memory-hybrid/tests/atomic-write.test.ts
+++ b/extensions/memory-hybrid/tests/atomic-write.test.ts
@@ -1,0 +1,248 @@
+/**
+ * Tests for utils/atomic-write.ts (Issue #1405).
+ *
+ * Covers:
+ *  - atomicWriteFile: correct write, atomicity on error, temp-file cleanup
+ *  - atomicWriteSkillDir: all files present, completion marker written,
+ *    subdirectory creation, temp-dir cleanup on error, overwrite of incomplete
+ *    existing dir
+ *  - isSkillDirComplete: true only when marker exists
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  SKILL_COMPLETE_MARKER,
+  atomicWriteFile,
+  atomicWriteSkillDir,
+  isSkillDirComplete,
+} from "../utils/atomic-write.js";
+
+// ---------------------------------------------------------------------------
+// Controlled failure injection via vi.mock
+// ---------------------------------------------------------------------------
+
+let simulateRenameFailure = false;
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return {
+    ...actual,
+    renameSync(...args: Parameters<typeof actual.renameSync>) {
+      if (simulateRenameFailure) {
+        throw new Error("simulated rename failure");
+      }
+      return actual.renameSync(...args);
+    },
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "atomic-write-test-"));
+  simulateRenameFailure = false;
+});
+
+afterEach(() => {
+  simulateRenameFailure = false;
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// SKILL_COMPLETE_MARKER
+// ---------------------------------------------------------------------------
+
+describe("SKILL_COMPLETE_MARKER", () => {
+  it("is the expected constant string", () => {
+    expect(SKILL_COMPLETE_MARKER).toBe(".openclaw-skill-complete");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// atomicWriteFile
+// ---------------------------------------------------------------------------
+
+describe("atomicWriteFile", () => {
+  it("writes file content correctly", () => {
+    const targetPath = join(tmpDir, "output.txt");
+    atomicWriteFile(targetPath, "hello world");
+    expect(readFileSync(targetPath, "utf-8")).toBe("hello world");
+  });
+
+  it("creates parent directories if they do not exist", () => {
+    const targetPath = join(tmpDir, "nested", "dir", "output.txt");
+    atomicWriteFile(targetPath, "content");
+    expect(readFileSync(targetPath, "utf-8")).toBe("content");
+  });
+
+  it("overwrites an existing file atomically", () => {
+    const targetPath = join(tmpDir, "output.txt");
+    writeFileSync(targetPath, "original", "utf-8");
+    atomicWriteFile(targetPath, "updated");
+    expect(readFileSync(targetPath, "utf-8")).toBe("updated");
+  });
+
+  it("leaves no temp file behind on success", () => {
+    const targetPath = join(tmpDir, "output.txt");
+    atomicWriteFile(targetPath, "content");
+    const files = readdirSync(tmpDir);
+    expect(files.every((f) => !f.includes(".tmp-"))).toBe(true);
+  });
+
+  it("removes temp file and re-throws on rename error", () => {
+    simulateRenameFailure = true;
+    const targetPath = join(tmpDir, "output.txt");
+    expect(() => atomicWriteFile(targetPath, "content")).toThrow("simulated rename failure");
+
+    // Target file must not exist (write was not committed).
+    expect(existsSync(targetPath)).toBe(false);
+    // No temp file should remain.
+    const files = readdirSync(tmpDir);
+    expect(files.every((f) => !f.includes(".tmp-"))).toBe(true);
+  });
+
+  it("preserves original file content when rename fails", () => {
+    const targetPath = join(tmpDir, "output.txt");
+    writeFileSync(targetPath, "original", "utf-8");
+
+    simulateRenameFailure = true;
+    expect(() => atomicWriteFile(targetPath, "new-content")).toThrow();
+
+    // Original content must be intact.
+    expect(readFileSync(targetPath, "utf-8")).toBe("original");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// atomicWriteSkillDir
+// ---------------------------------------------------------------------------
+
+describe("atomicWriteSkillDir", () => {
+  const DRAFT = {
+    "recipe.json": '{"steps":[]}',
+    "verification.json": '{"ok":true}',
+    "proposal-metadata.json": '{"meta":1}',
+    "evals/evals.json": '{"evals":[]}',
+    "SKILL.md": "# My Skill\n\nContent.",
+  };
+
+  it("writes all files to the skill directory", () => {
+    const skillDir = join(tmpDir, "my-skill");
+    atomicWriteSkillDir(skillDir, DRAFT);
+
+    expect(readFileSync(join(skillDir, "SKILL.md"), "utf-8")).toContain("# My Skill");
+    expect(readFileSync(join(skillDir, "recipe.json"), "utf-8")).toBe('{"steps":[]}');
+    expect(readFileSync(join(skillDir, "verification.json"), "utf-8")).toBe('{"ok":true}');
+    expect(readFileSync(join(skillDir, "proposal-metadata.json"), "utf-8")).toBe('{"meta":1}');
+    expect(readFileSync(join(skillDir, "evals", "evals.json"), "utf-8")).toBe('{"evals":[]}');
+  });
+
+  it("creates the skill directory and any needed subdirectories", () => {
+    const skillDir = join(tmpDir, "nested", "path", "my-skill");
+    atomicWriteSkillDir(skillDir, DRAFT);
+    expect(existsSync(skillDir)).toBe(true);
+  });
+
+  it("writes the completion marker as the last operation", () => {
+    const skillDir = join(tmpDir, "my-skill");
+    atomicWriteSkillDir(skillDir, DRAFT);
+    const markerPath = join(skillDir, SKILL_COMPLETE_MARKER);
+    expect(existsSync(markerPath)).toBe(true);
+    // Marker content is an ISO timestamp (truthy non-empty string).
+    expect(readFileSync(markerPath, "utf-8").length).toBeGreaterThan(0);
+  });
+
+  it("leaves no temp directory behind on success", () => {
+    const skillDir = join(tmpDir, "my-skill");
+    atomicWriteSkillDir(skillDir, DRAFT);
+    const entries = readdirSync(tmpDir);
+    expect(entries.every((e) => !e.includes(".tmp-"))).toBe(true);
+  });
+
+  it("cleans up temp dir and re-throws on rename error", () => {
+    simulateRenameFailure = true;
+    const skillDir = join(tmpDir, "my-skill");
+    expect(() => atomicWriteSkillDir(skillDir, DRAFT)).toThrow("simulated rename failure");
+
+    // Final skill dir must not exist — no partial state survived.
+    expect(existsSync(skillDir)).toBe(false);
+    // No temp dirs should remain.
+    const entries = readdirSync(tmpDir);
+    expect(entries.every((e) => !e.includes(".tmp-"))).toBe(true);
+  });
+
+  it("overwrites an existing incomplete (no-marker) directory", () => {
+    const skillDir = join(tmpDir, "my-skill");
+    // Simulate a partially-written dir from a previous crashed write.
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(join(skillDir, "SKILL.md"), "# Incomplete\n", "utf-8");
+    // No marker → incomplete.
+    expect(existsSync(join(skillDir, SKILL_COMPLETE_MARKER))).toBe(false);
+
+    // Should succeed and replace with complete content.
+    atomicWriteSkillDir(skillDir, DRAFT);
+
+    expect(readFileSync(join(skillDir, "SKILL.md"), "utf-8")).toContain("# My Skill");
+    expect(existsSync(join(skillDir, SKILL_COMPLETE_MARKER))).toBe(true);
+  });
+
+  it("replaces a complete directory when called again with updated content", () => {
+    const skillDir = join(tmpDir, "my-skill");
+    // Write first complete version.
+    atomicWriteSkillDir(skillDir, DRAFT);
+
+    // Overwrite with updated content.
+    const updated = { ...DRAFT, "SKILL.md": "# Updated Skill\n" };
+    atomicWriteSkillDir(skillDir, updated);
+
+    expect(readFileSync(join(skillDir, "SKILL.md"), "utf-8")).toContain("# Updated Skill");
+    expect(existsSync(join(skillDir, SKILL_COMPLETE_MARKER))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isSkillDirComplete
+// ---------------------------------------------------------------------------
+
+describe("isSkillDirComplete", () => {
+  it("returns false for a non-existent directory", () => {
+    expect(isSkillDirComplete(join(tmpDir, "does-not-exist"))).toBe(false);
+  });
+
+  it("returns false for a directory without the marker", () => {
+    const skillDir = join(tmpDir, "my-skill");
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(join(skillDir, "SKILL.md"), "# Skill\n", "utf-8");
+    expect(isSkillDirComplete(skillDir)).toBe(false);
+  });
+
+  it("returns true for a directory written by atomicWriteSkillDir", () => {
+    const skillDir = join(tmpDir, "my-skill");
+    atomicWriteSkillDir(skillDir, {
+      "SKILL.md": "# Skill\n",
+    });
+    expect(isSkillDirComplete(skillDir)).toBe(true);
+  });
+
+  it("returns true when the marker file is manually present", () => {
+    const skillDir = join(tmpDir, "my-skill");
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(join(skillDir, SKILL_COMPLETE_MARKER), "2024-01-01T00:00:00.000Z", "utf-8");
+    expect(isSkillDirComplete(skillDir)).toBe(true);
+  });
+});

--- a/extensions/memory-hybrid/tests/atomic-write.test.ts
+++ b/extensions/memory-hybrid/tests/atomic-write.test.ts
@@ -21,7 +21,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   SKILL_ATOMIC_TEMP_PREFIX,
   SKILL_COMPLETE_MARKER,
@@ -29,6 +29,7 @@ import {
   atomicWriteSkillDir,
   isSkillDirComplete,
 } from "../utils/atomic-write.js";
+import { discoverCompletedSkillDirs, isAtomicSkillWriteScratchDir } from "../utils/skill-discovery.js";
 
 // ---------------------------------------------------------------------------
 // Controlled failure injection via vi.mock
@@ -222,6 +223,41 @@ describe("atomicWriteSkillDir", () => {
 
     expect(readFileSync(join(skillDir, "SKILL.md"), "utf-8")).toContain("# Existing");
     expect(existsSync(tmpSkillDir)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// discoverCompletedSkillDirs
+// ---------------------------------------------------------------------------
+
+describe("discoverCompletedSkillDirs", () => {
+  it("discovers only completed skill directories", () => {
+    atomicWriteSkillDir(join(tmpDir, "complete-skill"), { "SKILL.md": "# Complete\n" });
+
+    const markerlessDir = join(tmpDir, "markerless-skill");
+    mkdirSync(markerlessDir, { recursive: true });
+    writeFileSync(join(markerlessDir, "SKILL.md"), "# In-progress\n", "utf-8");
+
+    const scratchDir = join(tmpDir, `${SKILL_ATOMIC_TEMP_PREFIX}1234-deadbeef`);
+    mkdirSync(scratchDir, { recursive: true });
+    writeFileSync(join(scratchDir, SKILL_COMPLETE_MARKER), "2024-01-01T00:00:00.000Z", "utf-8");
+    writeFileSync(join(scratchDir, "SKILL.md"), "# Scratch\n", "utf-8");
+
+    expect(discoverCompletedSkillDirs(tmpDir).map((entry) => entry.name)).toEqual(["complete-skill"]);
+  });
+
+  it("treats markerless directories with SKILL.md as in-progress loader candidates", () => {
+    const skillDir = join(tmpDir, "half-written-skill");
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(join(skillDir, "SKILL.md"), "# Half-written\n", "utf-8");
+
+    expect(discoverCompletedSkillDirs(tmpDir)).toEqual([]);
+  });
+
+  it("identifies atomic scratch directory names", () => {
+    expect(isAtomicSkillWriteScratchDir(`${SKILL_ATOMIC_TEMP_PREFIX}1234-deadbeef`)).toBe(true);
+    expect(isAtomicSkillWriteScratchDir("skill.tmp-1234-deadbeef")).toBe(true);
+    expect(isAtomicSkillWriteScratchDir("normal-skill")).toBe(false);
   });
 });
 

--- a/extensions/memory-hybrid/tests/atomic-write.test.ts
+++ b/extensions/memory-hybrid/tests/atomic-write.test.ts
@@ -256,8 +256,9 @@ describe("discoverCompletedSkillDirs", () => {
 
   it("identifies atomic scratch directory names", () => {
     expect(isAtomicSkillWriteScratchDir(`${SKILL_ATOMIC_TEMP_PREFIX}1234-deadbeef`)).toBe(true);
-    expect(isAtomicSkillWriteScratchDir("skill.tmp-1234-deadbeef")).toBe(true);
+    expect(isAtomicSkillWriteScratchDir(".some-skill.bak-1234")).toBe(true);
     expect(isAtomicSkillWriteScratchDir("normal-skill")).toBe(false);
+    expect(isAtomicSkillWriteScratchDir("skill.tmp-1234-deadbeef")).toBe(false);
   });
 });
 

--- a/extensions/memory-hybrid/tests/generated-skill-validation.test.ts
+++ b/extensions/memory-hybrid/tests/generated-skill-validation.test.ts
@@ -22,6 +22,7 @@ const BASE_CFG: CrystallizationConfig = {
   outputDir: "",
   maxCrystallized: 50,
   pruneUnusedDays: 30,
+  placeholderEmailDomains: ["example.com", "localhost", "test.com", "example.org"],
 };
 const MIN_CONCRETE_EXAMPLE_LENGTH_THRESHOLD_CHARS = 18;
 

--- a/extensions/memory-hybrid/tests/generated-skill-validation.test.ts
+++ b/extensions/memory-hybrid/tests/generated-skill-validation.test.ts
@@ -11,6 +11,8 @@ import type { CrystallizationConfig } from "../config/types/features.js";
 import { CrystallizationProposer } from "../services/crystallization-proposer.js";
 import { GeneratedSkillValidationService } from "../services/generated-skill-validation.js";
 import { SkillCrystallizer } from "../services/skill-crystallizer.js";
+import { SKILL_COMPLETE_MARKER } from "../utils/atomic-write.js";
+import { discoverCompletedSkillDirs } from "../utils/skill-discovery.js";
 
 const BASE_CFG: CrystallizationConfig = {
   enabled: true,
@@ -190,6 +192,55 @@ Bounded release-health review workflow.
     expect(validation.syntheticActivationEval.status).toBe("passed");
     expect(validation.approvalDecision).toBe("allow");
     expect(validation.syntheticActivationEval.score).toBeGreaterThanOrEqual(100 / 3);
+  });
+
+  it("dry-load discovery skips markerless skill directories as in-progress", () => {
+    tmpDir = mkdtempSync(join(tmpdir(), "generated-skill-markerless-dry-load-"));
+    const skillsDir = join(tmpDir, "skills");
+    const markerlessDir = join(skillsDir, "half-written-skill");
+    mkdirSync(markerlessDir, { recursive: true });
+    writeFileSync(
+      join(markerlessDir, "SKILL.md"),
+      `---
+name: half-written-skill
+description: This markerless skill must be treated as in-progress.
+---
+`,
+      "utf-8",
+    );
+
+    expect(discoverCompletedSkillDirs(skillsDir)).toEqual([]);
+  });
+
+  it("dry-load discovery includes only skills with the completion marker", () => {
+    tmpDir = mkdtempSync(join(tmpdir(), "generated-skill-complete-dry-load-"));
+    const skillsDir = join(tmpDir, "skills");
+    const completedDir = join(skillsDir, "complete-skill");
+    mkdirSync(completedDir, { recursive: true });
+    writeFileSync(
+      join(completedDir, "SKILL.md"),
+      `---
+name: complete-skill
+description: This skill has a completion marker.
+---
+`,
+      "utf-8",
+    );
+    writeFileSync(join(completedDir, SKILL_COMPLETE_MARKER), "2024-01-01T00:00:00.000Z", "utf-8");
+
+    const markerlessDir = join(skillsDir, "half-written-skill");
+    mkdirSync(markerlessDir, { recursive: true });
+    writeFileSync(
+      join(markerlessDir, "SKILL.md"),
+      `---
+name: half-written-skill
+description: This markerless skill must be treated as in-progress.
+---
+`,
+      "utf-8",
+    );
+
+    expect(discoverCompletedSkillDirs(skillsDir).map((entry) => entry.name)).toEqual(["complete-skill"]);
   });
 
   it("uses a deterministic fallback negative prompt when canned prompts overlap the skill surface", () => {
@@ -557,7 +608,8 @@ Bounded CLI release-health review workflow.
       const output = JSON.parse(String(logSpy.mock.calls[0]?.[0] ?? "{}")) as { ok?: boolean; outputPath?: string };
       expect(output.ok).toBe(true);
       expect(output.outputPath).toBeDefined();
-      expect(existsSync(output.outputPath!)).toBe(true);
+      if (!output.outputPath) return;
+      expect(existsSync(output.outputPath)).toBe(true);
     } finally {
       cStore.close();
     }

--- a/extensions/memory-hybrid/tests/procedure-promotion-policy.test.ts
+++ b/extensions/memory-hybrid/tests/procedure-promotion-policy.test.ts
@@ -335,6 +335,32 @@ Source procedure id: proc-weather
     expect(duplicateEval.metadata.rejectionReasons).toContain("duplicate_existing_skill");
   });
 
+  it("ignores leftover atomic temp directories when checking duplicates", () => {
+    const tempSkillDir = join(skillsDir, ".openclaw-skill-tmp-1234-deadbeef");
+    mkdirSync(tempSkillDir, { recursive: true });
+    writeFileSync(
+      join(tempSkillDir, "SKILL.md"),
+      `---
+name: validate-release-health-report-with-objective-checks
+description: Use when the user asks to validate release health report with objective checks.
+---
+`,
+      "utf-8",
+    );
+
+    const proc = addProcedure({ sourceSessionId: "temp-dir-overlap-a" });
+    db.recordProcedureSuccess(proc.id, undefined, "temp-dir-overlap-b");
+    db.recordProcedureSuccess(proc.id, undefined, "temp-dir-overlap-c");
+
+    const policy = parseProcedurePromotionPolicy("auto-safe");
+    const evaluation = evaluateProcedureForPromotion(createProcedurePromotionItem(proc, policy), policy, {
+      skillsAutoPath: skillsDir,
+      validationThreshold: 3,
+    });
+
+    expect(evaluation.metadata.rejectionReasons).not.toContain("duplicate_existing_skill");
+  });
+
   it("treats legacy skill directories without completion markers as duplicate skills", () => {
     const existingSkillDir = join(skillsDir, "collect-markerless-legacy-report");
     mkdirSync(existingSkillDir, { recursive: true });

--- a/extensions/memory-hybrid/tests/procedure-promotion-policy.test.ts
+++ b/extensions/memory-hybrid/tests/procedure-promotion-policy.test.ts
@@ -335,6 +335,45 @@ Source procedure id: proc-weather
     expect(duplicateEval.metadata.rejectionReasons).toContain("duplicate_existing_skill");
   });
 
+  it("treats legacy skill directories without completion markers as duplicate skills", () => {
+    const existingSkillDir = join(skillsDir, "collect-markerless-legacy-report");
+    mkdirSync(existingSkillDir, { recursive: true });
+    writeFileSync(
+      join(existingSkillDir, "SKILL.md"),
+      `---
+name: collect-markerless-legacy-report
+description: Use when collecting markerless legacy reports.
+---
+
+# Collect Markerless Legacy Report
+
+## Trigger
+Use for collecting markerless legacy reports.
+
+## Workflow
+1. Read status.json.
+2. Verify report output exists.
+`,
+      "utf-8",
+    );
+
+    const proc = addProcedure({
+      taskPattern: "Collect markerless legacy report",
+      sourceSessionId: "markerless-legacy-a",
+    });
+    db.recordProcedureSuccess(proc.id, undefined, "markerless-legacy-b");
+    db.recordProcedureSuccess(proc.id, undefined, "markerless-legacy-c");
+
+    const policy = parseProcedurePromotionPolicy("auto-safe");
+    const evaluation = evaluateProcedureForPromotion(createProcedurePromotionItem(proc, policy), policy, {
+      skillsAutoPath: skillsDir,
+      validationThreshold: 3,
+    });
+
+    expect(evaluation.metadata.rejectionReasons).toContain("duplicate_existing_skill");
+    expect(evaluation.metadata.duplicateHandling).toBe("merge");
+  });
+
   it("does not report generated skill paths for deferred procedures", () => {
     const proc = addProcedure({
       taskPattern: "Validate deferred low confidence report",

--- a/extensions/memory-hybrid/tests/procedure-promotion-policy.test.ts
+++ b/extensions/memory-hybrid/tests/procedure-promotion-policy.test.ts
@@ -13,6 +13,7 @@ import {
 } from "../services/procedure-promotion-policy.js";
 import { generateAutoSkills } from "../services/procedure-skill-generator.js";
 import type { ProcedureEntry } from "../types/memory.js";
+import { SKILL_COMPLETE_MARKER } from "../utils/atomic-write.js";
 import { expectStandaloneAndParentDecisionsEquivalent } from "./helpers/pending-autopilot-equivalence.js";
 
 let tmpDir: string;
@@ -271,6 +272,7 @@ describe("procedure promotion policy and adapter", () => {
   it("compares duplicate skills against task-specific sections instead of template boilerplate", () => {
     const existingSkillDir = join(skillsDir, "collect-weather-sensor-status");
     mkdirSync(existingSkillDir, { recursive: true });
+    writeFileSync(join(existingSkillDir, SKILL_COMPLETE_MARKER), new Date().toISOString(), "utf-8");
     writeFileSync(
       join(existingSkillDir, "SKILL.md"),
       `---

--- a/extensions/memory-hybrid/tests/procedure-skill-generator.test.ts
+++ b/extensions/memory-hybrid/tests/procedure-skill-generator.test.ts
@@ -1,9 +1,10 @@
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { FactsDB } from "../backends/facts-db.js";
 import { generateAutoSkillForProcedure, generateAutoSkills } from "../services/procedure-skill-generator.js";
+import { SKILL_COMPLETE_MARKER } from "../utils/atomic-write.js";
 
 let tmpDir: string;
 let db: FactsDB;
@@ -112,6 +113,7 @@ describe("generateAutoSkills", () => {
 
   it("keeps collision-adjusted draft metadata aligned with the output directory", () => {
     mkdirSync(join(skillsDir, "validate-colliding-release-report"), { recursive: true });
+    writeFileSync(join(skillsDir, "validate-colliding-release-report", SKILL_COMPLETE_MARKER), new Date().toISOString(), "utf-8");
     const proc = db.upsertProcedure({
       taskPattern: "Validate colliding release report",
       recipeJson: JSON.stringify([

--- a/extensions/memory-hybrid/tests/procedure-skill-generator.test.ts
+++ b/extensions/memory-hybrid/tests/procedure-skill-generator.test.ts
@@ -113,7 +113,11 @@ describe("generateAutoSkills", () => {
 
   it("keeps collision-adjusted draft metadata aligned with the output directory", () => {
     mkdirSync(join(skillsDir, "validate-colliding-release-report"), { recursive: true });
-    writeFileSync(join(skillsDir, "validate-colliding-release-report", SKILL_COMPLETE_MARKER), new Date().toISOString(), "utf-8");
+    writeFileSync(
+      join(skillsDir, "validate-colliding-release-report", SKILL_COMPLETE_MARKER),
+      new Date().toISOString(),
+      "utf-8",
+    );
     const proc = db.upsertProcedure({
       taskPattern: "Validate colliding release report",
       recipeJson: JSON.stringify([
@@ -152,6 +156,57 @@ describe("generateAutoSkills", () => {
       skill: "validate-colliding-release-report-1",
       generatedSkillPath: join(skillsDir, "validate-colliding-release-report-1"),
     });
+  });
+
+  it("preserves legacy skill directories that lack completion markers when resolving slug collisions", () => {
+    const legacyDir = join(skillsDir, "validate-markerless-legacy-report");
+    mkdirSync(legacyDir, { recursive: true });
+    writeFileSync(
+      join(legacyDir, "SKILL.md"),
+      `---
+name: unrelated-legacy-skill
+description: Existing legacy skill created before completion markers.
+---
+
+# Unrelated Legacy Skill
+
+## Workflow
+1. Keep this legacy skill untouched.
+`,
+      "utf-8",
+    );
+
+    const proc = db.upsertProcedure({
+      taskPattern: "Validate markerless legacy report",
+      recipeJson: JSON.stringify([
+        { tool: "read", args: { path: "status.json" }, summary: "Check status input" },
+        { tool: "exec", args: { command: "npm test" }, summary: "Run validation test" },
+        { tool: "read", args: { path: "report.json" }, summary: "Verify report output" },
+      ]),
+      procedureType: "positive",
+      successCount: 3,
+      confidence: 0.9,
+      sourceSessionId: "legacy-markerless-a1",
+    });
+    recordDistinctSuccesses(proc.id);
+
+    const result = generateAutoSkills(
+      db,
+      {
+        skillsAutoPath: skillsDir,
+        validationThreshold: 3,
+        skillTTLDays: 30,
+        apply: true,
+        policy: "auto-safe",
+        maxPerRun: 1,
+      },
+      { info: () => {}, warn: () => {} },
+    );
+
+    expect(result.generated).toBe(1);
+    expect(result.paths).toEqual([join(skillsDir, "validate-markerless-legacy-report-1", "SKILL.md")]);
+    expect(readFileSync(join(legacyDir, "SKILL.md"), "utf-8")).toContain("unrelated-legacy-skill");
+    expect(existsSync(join(skillsDir, "validate-markerless-legacy-report-1", "SKILL.md"))).toBe(true);
   });
 
   it("dry-run does not write files", () => {

--- a/extensions/memory-hybrid/utils/atomic-write.ts
+++ b/extensions/memory-hybrid/utils/atomic-write.ts
@@ -16,10 +16,13 @@
 
 import { existsSync, mkdirSync, renameSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
 import { randomBytes } from "node:crypto";
-import { basename, dirname, join } from "node:path";
+import { dirname, join } from "node:path";
 
 /** Marker file written as the last step inside an atomic skill directory. */
 export const SKILL_COMPLETE_MARKER = ".openclaw-skill-complete";
+
+/** Prefix used for hidden sibling directories that are still being written. */
+export const SKILL_ATOMIC_TEMP_PREFIX = ".openclaw-skill-tmp-";
 
 /**
  * Atomically write a single file.
@@ -51,15 +54,15 @@ export function atomicWriteFile(targetPath: string, content: string): void {
  * Atomically write a multi-file skill directory.
  *
  * All files in `files` (keyed by path relative to `skillDir`) are written
- * into a temporary sibling directory `${skillDir}.tmp-${pid}-${rand}`.  A
+ * into a temporary sibling directory `${SKILL_ATOMIC_TEMP_PREFIX}${pid}-${rand}`.  A
  * `.openclaw-skill-complete` marker is written as the very last file.  The
  * temp directory is then atomically renamed to `skillDir`.
  *
- * If `skillDir` already exists it is first moved to a backup directory so
- * that the rename always targets a free path.  On success the backup is
- * removed.  On failure the backup is restored (best-effort) and the temp
- * directory is cleaned up, so `skillDir` is never left in a
- * partially-written state.
+ * If `skillDir` already exists, this helper fails instead of moving the
+ * existing directory aside. That keeps replacement crash-atomic: a process
+ * crash can leave only a hidden temp sibling, never a missing final directory.
+ * Callers that intentionally want to replace an incomplete draft must remove
+ * that incomplete directory before calling this helper.
  *
  * Pass files in the order you want them written.  Convention: put `SKILL.md`
  * last so it is the final content file before the marker.
@@ -67,10 +70,13 @@ export function atomicWriteFile(targetPath: string, content: string): void {
 export function atomicWriteSkillDir(skillDir: string, files: Record<string, string>): void {
   const parent = dirname(skillDir);
   const rand = randomBytes(8).toString("hex");
-  const tmpDir = `${skillDir}.tmp-${process.pid}-${rand}`;
-  const backupDir = existsSync(skillDir) ? join(parent, `.${basename(skillDir)}.bak-${Date.now()}-${rand}`) : null;
+  const tmpDir = join(parent, `${SKILL_ATOMIC_TEMP_PREFIX}${process.pid}-${rand}`);
 
   try {
+    if (existsSync(skillDir)) {
+      throw new Error(`Atomic skill directory target already exists: ${skillDir}`);
+    }
+
     // Write every sidecar into the temp directory.
     for (const [relPath, content] of Object.entries(files)) {
       const fullPath = join(tmpDir, relPath);
@@ -81,36 +87,16 @@ export function atomicWriteSkillDir(skillDir: string, files: Record<string, stri
     // Stamp the completion marker as the final write inside the temp dir.
     writeFileSync(join(tmpDir, SKILL_COMPLETE_MARKER), new Date().toISOString(), "utf-8");
 
-    // Move existing skill dir out of the way so the rename targets a free path.
-    if (backupDir) renameSync(skillDir, backupDir);
-
-    // Atomic promotion: temp dir → final skill dir.
+    // Atomic promotion: temp dir → final skill dir. This succeeds only when
+    // skillDir does not exist, so crashes never hide an existing final dir.
     renameSync(tmpDir, skillDir);
   } catch (err) {
-    // Best-effort rollback: restore the backup if we moved it.
-    try {
-      if (backupDir && existsSync(backupDir) && !existsSync(skillDir)) {
-        renameSync(backupDir, skillDir);
-      }
-    } catch {
-      // ignore rollback errors; caller will see original error
-    }
-    // Clean up temp dir.
     try {
       if (existsSync(tmpDir)) rmSync(tmpDir, { recursive: true, force: true });
     } catch {
       // best-effort temp cleanup; swallow to surface original error
     }
     throw err;
-  }
-
-  // Clean up the backup on success.
-  if (backupDir) {
-    try {
-      rmSync(backupDir, { recursive: true, force: true });
-    } catch {
-      // Non-fatal: the skill is already committed to skillDir.
-    }
   }
 }
 

--- a/extensions/memory-hybrid/utils/atomic-write.ts
+++ b/extensions/memory-hybrid/utils/atomic-write.ts
@@ -104,11 +104,31 @@ export function atomicWriteSkillDir(skillDir: string, files: Record<string, stri
     // Atomic promotion: temp dir → final skill dir. On POSIX, renameSync
     // atomically replaces empty directories, preserving the allocation lock.
     // On Windows, renameSync fails if the target exists (even when empty), so
-    // we remove the empty reservation directory first.
+    // we move the reservation aside, rename the temp dir, then clean up. This
+    // maintains crash-safety: if we crash after moving the reservation but before
+    // rename completes, the reservation survives as a .bak directory.
+    let reservationBackup: string | null = null;
     if (process.platform === "win32" && existsSync(skillDir) && isEmptyDir(skillDir)) {
-      rmSync(skillDir, { recursive: true, force: true });
+      reservationBackup = `${skillDir}.bak-${process.pid}-${randomBytes(4).toString("hex")}`;
+      renameSync(skillDir, reservationBackup);
     }
-    renameSync(tmpDir, skillDir);
+    try {
+      renameSync(tmpDir, skillDir);
+      // Success: remove the reservation backup if we made one.
+      if (reservationBackup && existsSync(reservationBackup)) {
+        rmSync(reservationBackup, { recursive: true, force: true });
+      }
+    } catch (err) {
+      // Restore the reservation lock if rename failed.
+      if (reservationBackup && existsSync(reservationBackup)) {
+        try {
+          renameSync(reservationBackup, skillDir);
+        } catch {
+          // best-effort restoration
+        }
+      }
+      throw err;
+    }
   } catch (err) {
     try {
       if (existsSync(tmpDir)) rmSync(tmpDir, { recursive: true, force: true });

--- a/extensions/memory-hybrid/utils/atomic-write.ts
+++ b/extensions/memory-hybrid/utils/atomic-write.ts
@@ -16,7 +16,7 @@
 
 import { existsSync, mkdirSync, renameSync, rmSync, unlinkSync, writeFileSync, readdirSync } from "node:fs";
 import { randomBytes } from "node:crypto";
-import { dirname, join } from "node:path";
+import { basename, dirname, join } from "node:path";
 
 /** Marker file written as the last step inside an atomic skill directory. */
 export const SKILL_COMPLETE_MARKER = ".openclaw-skill-complete";
@@ -109,7 +109,7 @@ export function atomicWriteSkillDir(skillDir: string, files: Record<string, stri
     // rename completes, the reservation survives as a .bak directory.
     let reservationBackup: string | null = null;
     if (process.platform === "win32" && existsSync(skillDir) && isEmptyDir(skillDir)) {
-      reservationBackup = `${skillDir}.bak-${process.pid}-${randomBytes(4).toString("hex")}`;
+      reservationBackup = join(parent, `.${basename(skillDir)}.bak-${process.pid}-${randomBytes(4).toString("hex")}`);
       renameSync(skillDir, reservationBackup);
     }
     try {

--- a/extensions/memory-hybrid/utils/atomic-write.ts
+++ b/extensions/memory-hybrid/utils/atomic-write.ts
@@ -15,6 +15,7 @@
  */
 
 import { existsSync, mkdirSync, renameSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
+import { randomBytes } from "node:crypto";
 import { basename, dirname, join } from "node:path";
 
 /** Marker file written as the last step inside an atomic skill directory. */
@@ -29,7 +30,7 @@ export const SKILL_COMPLETE_MARKER = ".openclaw-skill-complete";
  */
 export function atomicWriteFile(targetPath: string, content: string): void {
   const dir = dirname(targetPath);
-  const rand = Math.random().toString(36).slice(2, 10);
+  const rand = randomBytes(8).toString("hex");
   const tmpPath = `${targetPath}.tmp-${process.pid}-${rand}`;
 
   mkdirSync(dir, { recursive: true });
@@ -65,7 +66,7 @@ export function atomicWriteFile(targetPath: string, content: string): void {
  */
 export function atomicWriteSkillDir(skillDir: string, files: Record<string, string>): void {
   const parent = dirname(skillDir);
-  const rand = Math.random().toString(36).slice(2, 10);
+  const rand = randomBytes(8).toString("hex");
   const tmpDir = `${skillDir}.tmp-${process.pid}-${rand}`;
   const backupDir = existsSync(skillDir) ? join(parent, `.${basename(skillDir)}.bak-${Date.now()}-${rand}`) : null;
 

--- a/extensions/memory-hybrid/utils/atomic-write.ts
+++ b/extensions/memory-hybrid/utils/atomic-write.ts
@@ -103,6 +103,11 @@ export function atomicWriteSkillDir(skillDir: string, files: Record<string, stri
 
     // Atomic promotion: temp dir → final skill dir. On POSIX, renameSync
     // atomically replaces empty directories, preserving the allocation lock.
+    // On Windows, renameSync fails if the target exists (even when empty), so
+    // we remove the empty reservation directory first.
+    if (process.platform === "win32" && existsSync(skillDir) && isEmptyDir(skillDir)) {
+      rmSync(skillDir, { recursive: true, force: true });
+    }
     renameSync(tmpDir, skillDir);
   } catch (err) {
     try {

--- a/extensions/memory-hybrid/utils/atomic-write.ts
+++ b/extensions/memory-hybrid/utils/atomic-write.ts
@@ -1,0 +1,122 @@
+/**
+ * Atomic file and skill-directory write helpers (Issue #1405).
+ *
+ * Partial skill directories created by a process crash between individual
+ * `writeFileSync` calls can be mistaken for valid installed skills.  These
+ * helpers prevent that by:
+ *
+ *  • `atomicWriteFile`    – write to a temp file then rename (one file).
+ *  • `atomicWriteSkillDir` – write all sidecar files into a temp directory,
+ *                            stamp `.openclaw-skill-complete`, then rename the
+ *                            temp directory to the final location (multi-file).
+ *  • `isSkillDirComplete` – returns true only when the marker is present.
+ *
+ * The marker name is exported so loaders can skip in-progress directories.
+ */
+
+import { existsSync, mkdirSync, renameSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
+import { basename, dirname, join } from "node:path";
+
+/** Marker file written as the last step inside an atomic skill directory. */
+export const SKILL_COMPLETE_MARKER = ".openclaw-skill-complete";
+
+/**
+ * Atomically write a single file.
+ *
+ * Writes content to `${targetPath}.tmp-${pid}-${rand}` then renames it to
+ * `targetPath`.  If any step fails the temp file is removed and the error is
+ * re-thrown, so `targetPath` is never left in a partially-written state.
+ */
+export function atomicWriteFile(targetPath: string, content: string): void {
+  const dir = dirname(targetPath);
+  const rand = Math.random().toString(36).slice(2, 10);
+  const tmpPath = `${targetPath}.tmp-${process.pid}-${rand}`;
+
+  mkdirSync(dir, { recursive: true });
+  try {
+    writeFileSync(tmpPath, content, "utf-8");
+    renameSync(tmpPath, targetPath);
+  } catch (err) {
+    try {
+      if (existsSync(tmpPath)) unlinkSync(tmpPath);
+    } catch {
+      // best-effort temp cleanup; swallow to surface original error
+    }
+    throw err;
+  }
+}
+
+/**
+ * Atomically write a multi-file skill directory.
+ *
+ * All files in `files` (keyed by path relative to `skillDir`) are written
+ * into a temporary sibling directory `${skillDir}.tmp-${pid}-${rand}`.  A
+ * `.openclaw-skill-complete` marker is written as the very last file.  The
+ * temp directory is then atomically renamed to `skillDir`.
+ *
+ * If `skillDir` already exists it is first moved to a backup directory so
+ * that the rename always targets a free path.  On success the backup is
+ * removed.  On failure the backup is restored (best-effort) and the temp
+ * directory is cleaned up, so `skillDir` is never left in a
+ * partially-written state.
+ *
+ * Pass files in the order you want them written.  Convention: put `SKILL.md`
+ * last so it is the final content file before the marker.
+ */
+export function atomicWriteSkillDir(skillDir: string, files: Record<string, string>): void {
+  const parent = dirname(skillDir);
+  const rand = Math.random().toString(36).slice(2, 10);
+  const tmpDir = `${skillDir}.tmp-${process.pid}-${rand}`;
+  const backupDir = existsSync(skillDir) ? join(parent, `.${basename(skillDir)}.bak-${Date.now()}-${rand}`) : null;
+
+  try {
+    // Write every sidecar into the temp directory.
+    for (const [relPath, content] of Object.entries(files)) {
+      const fullPath = join(tmpDir, relPath);
+      mkdirSync(dirname(fullPath), { recursive: true });
+      writeFileSync(fullPath, content, "utf-8");
+    }
+
+    // Stamp the completion marker as the final write inside the temp dir.
+    writeFileSync(join(tmpDir, SKILL_COMPLETE_MARKER), new Date().toISOString(), "utf-8");
+
+    // Move existing skill dir out of the way so the rename targets a free path.
+    if (backupDir) renameSync(skillDir, backupDir);
+
+    // Atomic promotion: temp dir → final skill dir.
+    renameSync(tmpDir, skillDir);
+  } catch (err) {
+    // Best-effort rollback: restore the backup if we moved it.
+    try {
+      if (backupDir && existsSync(backupDir) && !existsSync(skillDir)) {
+        renameSync(backupDir, skillDir);
+      }
+    } catch {
+      // ignore rollback errors; caller will see original error
+    }
+    // Clean up temp dir.
+    try {
+      if (existsSync(tmpDir)) rmSync(tmpDir, { recursive: true, force: true });
+    } catch {
+      // best-effort temp cleanup; swallow to surface original error
+    }
+    throw err;
+  }
+
+  // Clean up the backup on success.
+  if (backupDir) {
+    try {
+      rmSync(backupDir, { recursive: true, force: true });
+    } catch {
+      // Non-fatal: the skill is already committed to skillDir.
+    }
+  }
+}
+
+/**
+ * Returns `true` when `skillDir` contains the completion marker, indicating
+ * that the directory was written atomically and is not an in-progress write.
+ */
+export function isSkillDirComplete(skillDir: string): boolean {
+  return existsSync(join(skillDir, SKILL_COMPLETE_MARKER));
+}

--- a/extensions/memory-hybrid/utils/atomic-write.ts
+++ b/extensions/memory-hybrid/utils/atomic-write.ts
@@ -38,6 +38,35 @@ function isEmptyDir(dir: string): boolean {
 }
 
 /**
+ * Validates that a relative path is safe for use within a skill directory.
+ * Rejects paths that:
+ *  - contain null bytes
+ *  - are absolute (POSIX or Windows)
+ *  - attempt parent directory traversal (..)
+ *  - are empty
+ *  - collide with the completion marker name
+ *
+ * Throws an error if the path is unsafe.
+ */
+function assertSafeRelativeSkillPath(relPath: string): void {
+  if (relPath.includes("\0")) {
+    throw new Error(`Unsafe path: contains null byte: ${relPath}`);
+  }
+  if (relPath.startsWith("/") || /^[A-Za-z]:[\\/]/.test(relPath)) {
+    throw new Error(`Unsafe path: absolute path not allowed: ${relPath}`);
+  }
+  if (relPath.includes("..")) {
+    throw new Error(`Unsafe path: parent directory traversal not allowed: ${relPath}`);
+  }
+  if (relPath.trim().length === 0) {
+    throw new Error(`Unsafe path: empty path not allowed`);
+  }
+  if (relPath === SKILL_COMPLETE_MARKER || basename(relPath) === SKILL_COMPLETE_MARKER) {
+    throw new Error(`Unsafe path: collision with completion marker: ${relPath}`);
+  }
+}
+
+/**
  * Atomically write a single file.
  *
  * Writes content to `${targetPath}.tmp-${pid}-${rand}` then renames it to
@@ -93,6 +122,7 @@ export function atomicWriteSkillDir(skillDir: string, files: Record<string, stri
 
     // Write every sidecar into the temp directory.
     for (const [relPath, content] of Object.entries(files)) {
+      assertSafeRelativeSkillPath(relPath);
       const fullPath = join(tmpDir, relPath);
       mkdirSync(dirname(fullPath), { recursive: true });
       writeFileSync(fullPath, content, "utf-8");

--- a/extensions/memory-hybrid/utils/atomic-write.ts
+++ b/extensions/memory-hybrid/utils/atomic-write.ts
@@ -14,7 +14,7 @@
  * The marker name is exported so loaders can skip in-progress directories.
  */
 
-import { existsSync, mkdirSync, renameSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, renameSync, rmSync, unlinkSync, writeFileSync, readdirSync } from "node:fs";
 import { randomBytes } from "node:crypto";
 import { dirname, join } from "node:path";
 
@@ -23,6 +23,19 @@ export const SKILL_COMPLETE_MARKER = ".openclaw-skill-complete";
 
 /** Prefix used for hidden sibling directories that are still being written. */
 export const SKILL_ATOMIC_TEMP_PREFIX = ".openclaw-skill-tmp-";
+
+/**
+ * Returns `true` when `dir` exists and contains no entries (empty directory).
+ */
+function isEmptyDir(dir: string): boolean {
+  if (!existsSync(dir)) return false;
+  try {
+    const entries = readdirSync(dir);
+    return entries.length === 0;
+  } catch {
+    return false;
+  }
+}
 
 /**
  * Atomically write a single file.
@@ -58,11 +71,12 @@ export function atomicWriteFile(targetPath: string, content: string): void {
  * `.openclaw-skill-complete` marker is written as the very last file.  The
  * temp directory is then atomically renamed to `skillDir`.
  *
- * If `skillDir` already exists, this helper fails instead of moving the
- * existing directory aside. That keeps replacement crash-atomic: a process
- * crash can leave only a hidden temp sibling, never a missing final directory.
- * Callers that intentionally want to replace an incomplete draft must remove
- * that incomplete directory before calling this helper.
+ * If `skillDir` already exists and is non-empty, this helper fails instead of
+ * moving the existing directory aside. That keeps replacement crash-atomic: a
+ * process crash can leave only a hidden temp sibling, never a missing final
+ * directory. Empty directories (e.g. from `allocateDraftSkillDir` reservation
+ * locks) are allowed and will be atomically replaced by the rename, preserving
+ * the allocation lock throughout the write operation.
  *
  * Pass files in the order you want them written.  Convention: put `SKILL.md`
  * last so it is the final content file before the marker.
@@ -73,7 +87,7 @@ export function atomicWriteSkillDir(skillDir: string, files: Record<string, stri
   const tmpDir = join(parent, `${SKILL_ATOMIC_TEMP_PREFIX}${process.pid}-${rand}`);
 
   try {
-    if (existsSync(skillDir)) {
+    if (existsSync(skillDir) && !isEmptyDir(skillDir)) {
       throw new Error(`Atomic skill directory target already exists: ${skillDir}`);
     }
 
@@ -87,8 +101,8 @@ export function atomicWriteSkillDir(skillDir: string, files: Record<string, stri
     // Stamp the completion marker as the final write inside the temp dir.
     writeFileSync(join(tmpDir, SKILL_COMPLETE_MARKER), new Date().toISOString(), "utf-8");
 
-    // Atomic promotion: temp dir → final skill dir. This succeeds only when
-    // skillDir does not exist, so crashes never hide an existing final dir.
+    // Atomic promotion: temp dir → final skill dir. On POSIX, renameSync
+    // atomically replaces empty directories, preserving the allocation lock.
     renameSync(tmpDir, skillDir);
   } catch (err) {
     try {

--- a/extensions/memory-hybrid/utils/skill-discovery.ts
+++ b/extensions/memory-hybrid/utils/skill-discovery.ts
@@ -16,7 +16,7 @@ export interface DiscoveredSkillDir {
  * atomic skill writes. These are never valid loader candidates.
  */
 export function isAtomicSkillWriteScratchDir(name: string): boolean {
-  return name.startsWith(SKILL_ATOMIC_TEMP_PREFIX) || /^.+\.tmp-\d+-[a-f0-9]+$/i.test(name) || /^\..+\.bak-/.test(name);
+  return name.startsWith(SKILL_ATOMIC_TEMP_PREFIX) || /^\..+\.bak-/.test(name);
 }
 
 /**

--- a/extensions/memory-hybrid/utils/skill-discovery.ts
+++ b/extensions/memory-hybrid/utils/skill-discovery.ts
@@ -1,0 +1,59 @@
+import { existsSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { SKILL_ATOMIC_TEMP_PREFIX, isSkillDirComplete } from "./atomic-write.js";
+
+export interface DiscoveredSkillDir {
+  /** Directory name under the scanned skills root. */
+  name: string;
+  /** Absolute path to the completed skill directory. */
+  dirPath: string;
+  /** Absolute path to the directory's SKILL.md file. */
+  skillPath: string;
+}
+
+/**
+ * Returns true for hidden scratch directories left behind by interrupted
+ * atomic skill writes. These are never valid loader candidates.
+ */
+export function isAtomicSkillWriteScratchDir(name: string): boolean {
+  return name.startsWith(SKILL_ATOMIC_TEMP_PREFIX) || /^.+\.tmp-\d+-[a-f0-9]+$/i.test(name) || /^\..+\.bak-/.test(name);
+}
+
+/**
+ * Discover skill directories that are safe for loader-style consumption.
+ *
+ * Auto-generated skill directories must contain `.openclaw-skill-complete`;
+ * markerless directories are treated as in-progress writes and skipped even if
+ * they already contain `SKILL.md`. Legacy compatibility belongs in migration or
+ * duplicate-detection paths, not in active loader discovery.
+ */
+export function discoverCompletedSkillDirs(skillsDir: string): DiscoveredSkillDir[] {
+  const out: DiscoveredSkillDir[] = [];
+  if (!existsSync(skillsDir)) return out;
+
+  for (const entry of safeReadSkillDir(skillsDir)) {
+    if (isAtomicSkillWriteScratchDir(entry.name)) continue;
+    if (!entry.isDirectory) continue;
+
+    const dirPath = join(skillsDir, entry.name);
+    if (!isSkillDirComplete(dirPath)) continue;
+
+    const skillPath = join(dirPath, "SKILL.md");
+    if (!existsSync(skillPath)) continue;
+
+    out.push({ name: entry.name, dirPath, skillPath });
+  }
+
+  return out;
+}
+
+function safeReadSkillDir(dir: string): Array<{ name: string; isDirectory: boolean }> {
+  try {
+    return readdirSync(dir, { withFileTypes: true }).map((entry) => ({
+      name: entry.name,
+      isDirectory: entry.isDirectory(),
+    }));
+  } catch {
+    return [];
+  }
+}


### PR DESCRIPTION
Both skill-write pipelines used bare `writeFileSync` calls — a SIGTERM or crash between any two writes leaves a partial skill directory that the loader treats as valid. The DB lifecycle could also advance to `installed`/`promoted` before disk writes completed.

## New utility: `utils/atomic-write.ts`

- **`atomicWriteFile(targetPath, content)`** — writes to `.tmp-{pid}-{rand}` (using `crypto.randomBytes`), then `renameSync`. Temp file cleaned up on any failure.
- **`atomicWriteSkillDir(skillDir, files)`** — writes all sidecars into a temp sibling dir, stamps `.openclaw-skill-complete` as the final write, then `renameSync` to final location. An existing dir is moved to a hidden backup before rename; restored on failure, removed on success.
- **`isSkillDirComplete(skillDir)`** — returns `true` only when the marker is present.
- **`SKILL_COMPLETE_MARKER`** (`.openclaw-skill-complete`) — exported so loaders can skip in-progress directories.

## Pipeline changes

| Location | Before | After |
|---|---|---|
| `crystallization-proposer.ts` `writeSkillToDisk` | `mkdirSync` + `writeFileSync` | `atomicWriteFile` |
| `procedure-skill-generator.ts` `writeDraftSkill` | 5× sequential `writeFileSync` | `atomicWriteSkillDir` (all-or-nothing, SKILL.md last, marker final) |
| `procedure-skill-generator.ts` `ensureUniqueSlug` | `existsSync` blocks slug | `isSkillDirComplete` — incomplete dirs don't steal slugs, allowing clean retries |
| `procedure-promotion-policy.ts` `isDuplicateSkill` | matches any dir with SKILL.md | skips dirs without marker (in-progress writes are not valid skills) |

## Tests

`tests/atomic-write.test.ts` (18 tests) covers write correctness, temp cleanup on simulated rename failure, incomplete-dir overwrite, and marker semantics. Existing test fixtures that manually create skill directories updated to include the completion marker.

> [!WARNING]
>
> <details>
> <summary>Firewall rules blocked me from connecting to one or more addresses (expand for details)</summary>
>
> #### I tried to connect to the following addresses, but was blocked by firewall rules:
>
> - `api.openai.com`
>   - Triggering command: `/opt/hostedtoolcache/node/24.14.1/x64/bin/node /opt/hostedtoolcache/node/24.14.1/x64/bin/node --experimental-import-meta-resolve --require /home/REDACTED/work/openclaw-hybrid-memory/openclaw-hybrid-memory/extensions/memory-hybrid/node_modules/vitest/suppress-warnings.cjs --conditions node --conditions development /home/REDACTED/work/openclaw-hybrid-memory/openclaw-hybrid-memory/extensions/memory-hybrid/node_modules/vitest/dist/workers/forks.js` (dns block)
> - `https://api.github.com/graphql`
>   - Triggering command: `/usr/bin/gh gh issue list --limit 10 --json number,title,state,url,createdAt de/node/bin/git r` (http block)
>   - Triggering command: `/usr/bin/gh gh pr list --limit 10 --json number,title,state,url,createdAt de/node/bin/git` (http block)
>   - Triggering command: `/usr/bin/gh gh pr list --limit 10 --json number,title,state,url,createdAt k/_temp/ghcca-node/node/bin/git` (http block)
> - `my-glitchtip.example.com`
>   - Triggering command: `/opt/hostedtoolcache/node/24.14.1/x64/bin/node /opt/hostedtoolcache/node/24.14.1/x64/bin/node --experimental-import-meta-resolve --require /home/REDACTED/work/openclaw-hybrid-memory/openclaw-hybrid-memory/extensions/memory-hybrid/node_modules/vitest/suppress-warnings.cjs --conditions node --conditions development /home/REDACTED/work/openclaw-hybrid-memory/openclaw-hybrid-memory/extensions/memory-hybrid/node_modules/vitest/dist/workers/forks.js` (dns block)
>
> If you need me to access, download, or install something from one of these locations, you can either:
>
> - Configure [Actions setup steps](https://gh.io/copilot/actions-setup-steps) to set up my environment, which run before the firewall is enabled
> - Add the appropriate URLs or hosts to the custom allowlist in this repository's [Copilot coding agent settings](https://github.com/markus-lassfolk/openclaw-hybrid-memory/settings/copilot/coding_agent) (admins only)
>
> </details>

---

Reopened by Maeve as a human-owned branch/PR to avoid bot/app PR workflow and review limitations.

Supersedes: https://github.com/markus-lassfolk/openclaw-hybrid-memory/pull/1435
Closes #1419

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches skill generation, validation, and duplicate-detection paths; mistakes could cause skills to be skipped or draft writes to fail/rollback incorrectly, especially under concurrent runs and Windows rename semantics.
> 
> **Overview**
> Introduces a completion-marker-based workflow for skills so partially written skill directories are no longer treated as valid. `atomicWriteSkillDir` now writes into a hidden temp sibling directory (with a new `SKILL_ATOMIC_TEMP_PREFIX`) and promotes via rename, allowing replacement of *empty* reservation dirs while refusing to overwrite non-empty targets; Windows-specific rename handling preserves crash-safety.
> 
> Updates the pipelines to align with this model: generated-skill dry-load now writes the marker and discovers skills via new `discoverCompletedSkillDirs`, procedure skill generation adds an explicit directory reservation step (`allocateDraftSkillDir`) before atomically writing sidecars, and duplicate detection ignores atomic scratch/backup dirs while still treating legacy markerless `SKILL.md` directories as occupied/duplicate.
> 
> Adds `utils/skill-discovery.ts` plus expanded tests to cover completed-skill discovery, scratch-dir filtering, and updated atomic-write overwrite/rename-failure behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91875fe2afb985a5f2a1ad23c6d80b133c046dcc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->