### PR TITLE
fix: slug collision rebase, reservation, and H1 heading correctness

### DIFF
--- a/extensions/memory-hybrid/services/procedure-skill-generator.ts
+++ b/extensions/memory-hybrid/services/procedure-skill-generator.ts
@@ -121,10 +121,7 @@ function rebaseDraftSlug(
   // Match the H1 heading in either its title-cased form (e.g. "# My Skill") or
   // its raw slug form (e.g. "# my-skill") so that non-standard headings are also
   // rebased correctly after a slug collision.
-  const h1Pattern = new RegExp(
-    `^# (?:${escapeRegExp(titleCase(originalSlug))}|${escapeRegExp(originalSlug)})$`,
-    "m",
-  );
+  const h1Pattern = new RegExp(`^# (?:${escapeRegExp(titleCase(originalSlug))}|${escapeRegExp(originalSlug)})$`, "m");
   const skillMd = draft.skillMd
     .replace(new RegExp(`^name: ${escapeRegExp(originalSlug)}$`, "m"), `name: ${resolvedSlug}`)
     .replace(h1Pattern, `# ${titleCase(resolvedSlug)}`);

--- a/extensions/memory-hybrid/services/procedure-skill-generator.ts
+++ b/extensions/memory-hybrid/services/procedure-skill-generator.ts
@@ -149,19 +149,24 @@ function rebaseDraftSlug(
   const verification = JSON.parse(draft.verificationJson) as {
     skill?: unknown;
     generatedSkillPath?: unknown;
+    telemetryCommand?: unknown;
   };
   const originalSlug =
     typeof verification.skill === "string" && verification.skill.length > 0 ? verification.skill : resolvedSlug;
   verification.skill = resolvedSlug;
   verification.generatedSkillPath = generatedSkillPath;
+  verification.telemetryCommand = `openclaw hybrid-mem skills record ${resolvedSlug}`;
 
   // Match the H1 heading in either its title-cased form (e.g. "# My Skill") or
   // its raw slug form (e.g. "# my-skill") so that non-standard headings are also
   // rebased correctly after a slug collision.
   const h1Pattern = new RegExp(`^# (?:${escapeRegExp(titleCase(originalSlug))}|${escapeRegExp(originalSlug)})$`, "m");
+  const originalTelemetryCommand = `openclaw hybrid-mem skills record ${originalSlug}`;
+  const newTelemetryCommand = `openclaw hybrid-mem skills record ${resolvedSlug}`;
   const skillMd = draft.skillMd
     .replace(new RegExp(`^name: ${escapeRegExp(originalSlug)}$`, "m"), `name: ${resolvedSlug}`)
-    .replace(h1Pattern, `# ${titleCase(resolvedSlug)}`);
+    .replace(h1Pattern, `# ${titleCase(resolvedSlug)}`)
+    .replace(new RegExp(escapeRegExp(originalTelemetryCommand), "g"), newTelemetryCommand);
 
   return {
     ...draft,
@@ -296,6 +301,18 @@ export function generateAutoSkills(
     let allocated: AllocatedSkillDir | null = null;
     try {
       allocated = allocateDraftSkillDir(basePath, options.skillsAutoPath, item.payload.skillSlug);
+      // Update reservation tracking if allocation resolved to a different slug
+      if (allocated.slug !== resolvedSlug) {
+        reservedSlugs.delete(resolvedSlug);
+        reservedSlugs.add(allocated.slug);
+        const candidateIndex = inRunSkillCandidates.findIndex(
+          (c) => c.slug === resolvedSlug && c.taskPattern === proc.taskPattern,
+        );
+        if (candidateIndex >= 0) {
+          inRunSkillCandidates[candidateIndex] = { slug: allocated.slug, taskPattern: proc.taskPattern };
+        }
+        reservedCandidate.slug = allocated.slug;
+      }
       writeDraftSkill(allocated.skillDir, rebaseDraftSlug(evaluation.draft, allocated.slug, allocated.relativePath));
       // #1328: generated skills are draft/quarantine artifacts and are not enabled. The
       // existing promoted marker is used as a churn guard only after all auto-safe gates pass.

--- a/extensions/memory-hybrid/services/procedure-skill-generator.ts
+++ b/extensions/memory-hybrid/services/procedure-skill-generator.ts
@@ -82,6 +82,16 @@ function ensureUniqueSlug(basePath: string, slug: string, reservedSlugs?: Readon
   return candidate;
 }
 
+/**
+ * Rebase all slug-identity and path-identity fields in a generated draft after
+ * {@link ensureUniqueSlug} resolves a different slug than the base slug.
+ *
+ * **Invariant**: `recipeJson`, `evalsJson`, and `proposalMetadataJson` MUST NOT
+ * contain slug or path identity fields (`skill`, `generatedSkillPath`, etc.).
+ * If new fields with slug/path identity are ever added to those artifacts, they
+ * must also be rebased here. Regression tests in `procedure-skill-generator.test.ts`
+ * enforce this invariant.
+ */
 function rebaseDraftSlug(
   draft: {
     skillMd: string;
@@ -108,9 +118,16 @@ function rebaseDraftSlug(
   verification.skill = resolvedSlug;
   verification.generatedSkillPath = generatedSkillPath;
 
+  // Match the H1 heading in either its title-cased form (e.g. "# My Skill") or
+  // its raw slug form (e.g. "# my-skill") so that non-standard headings are also
+  // rebased correctly after a slug collision.
+  const h1Pattern = new RegExp(
+    `^# (?:${escapeRegExp(titleCase(originalSlug))}|${escapeRegExp(originalSlug)})$`,
+    "m",
+  );
   const skillMd = draft.skillMd
     .replace(new RegExp(`^name: ${escapeRegExp(originalSlug)}$`, "m"), `name: ${resolvedSlug}`)
-    .replace(new RegExp(`^# ${escapeRegExp(titleCase(originalSlug))}$`, "m"), `# ${titleCase(resolvedSlug)}`);
+    .replace(h1Pattern, `# ${titleCase(resolvedSlug)}`);
 
   return {
     ...draft,
@@ -184,7 +201,11 @@ export function generateAutoSkills(
       slug: resolvedSlug,
       taskPattern: proc.taskPattern,
     };
-    if (evaluation.eligible && evaluation.draft) {
+    // Only reserve the slug when a draft write will actually occur (or is simulated
+    // to occur under the same policy path as apply). Deferred-for-human procedures
+    // must NOT consume reservations: doing so causes later same-batch procedures to
+    // receive spurious -N suffixed slugs even though nothing was written.
+    if (evaluation.eligible && evaluation.draft && !evaluation.metadata.requiresHumanApproval) {
       reservedSlugs.add(resolvedSlug);
       inRunSkillCandidates.push(reservedCandidate);
     }

--- a/extensions/memory-hybrid/services/procedure-skill-generator.ts
+++ b/extensions/memory-hybrid/services/procedure-skill-generator.ts
@@ -82,15 +82,52 @@ function ensureUniqueSlug(basePath: string, slug: string, reservedSlugs?: Readon
   return candidate;
 }
 
+type AllocatedSkillDir = {
+  slug: string;
+  skillDir: string;
+  relativePath: string;
+};
+
+/**
+ * Atomically reserve a draft skill directory. `ensureUniqueSlug` is only a preview
+ * used for policy evaluation; this function is the write-time source of truth so
+ * concurrent generators cannot select and overwrite the same path.
+ */
+function allocateDraftSkillDir(basePath: string, skillsAutoPath: string, slug: string): AllocatedSkillDir {
+  mkdirSync(basePath, { recursive: true });
+  let n = 0;
+  while (true) {
+    const candidate = n === 0 ? slug : `${slug}-${n}`;
+    const skillDir = join(basePath, candidate);
+    try {
+      mkdirSync(skillDir, { recursive: false });
+      return {
+        slug: candidate,
+        skillDir,
+        relativePath: join(skillsAutoPath, candidate),
+      };
+    } catch (err) {
+      if (isPathExistsError(err)) {
+        n++;
+        continue;
+      }
+      throw err;
+    }
+  }
+}
+
+function isPathExistsError(err: unknown): boolean {
+  return typeof err === "object" && err !== null && "code" in err && (err as { code?: unknown }).code === "EEXIST";
+}
+
 /**
  * Rebase all slug-identity and path-identity fields in a generated draft after
  * {@link ensureUniqueSlug} resolves a different slug than the base slug.
  *
- * **Invariant**: `recipeJson`, `evalsJson`, and `proposalMetadataJson` MUST NOT
- * contain slug or path identity fields (`skill`, `generatedSkillPath`, etc.).
- * If new fields with slug/path identity are ever added to those artifacts, they
- * must also be rebased here. Regression tests in `procedure-skill-generator.test.ts`
- * enforce this invariant.
+ * **Invariant**: generated sidecars must not preserve pre-collision slug/path
+ * identity after rebasing. Regression tests scan the full serialized
+ * `recipeJson`, `evalsJson`, and `proposalMetadataJson` artifacts for stale
+ * identity strings and recursive identity keys.
  */
 function rebaseDraftSlug(
   draft: {
@@ -256,28 +293,30 @@ export function generateAutoSkills(
       continue;
     }
 
+    let allocated: AllocatedSkillDir | null = null;
     try {
-      const relativePath = join(options.skillsAutoPath, resolvedSlug);
-      writeDraftSkill(skillDir, rebaseDraftSlug(evaluation.draft, resolvedSlug, relativePath));
+      allocated = allocateDraftSkillDir(basePath, options.skillsAutoPath, item.payload.skillSlug);
+      writeDraftSkill(allocated.skillDir, rebaseDraftSlug(evaluation.draft, allocated.slug, allocated.relativePath));
       // #1328: generated skills are draft/quarantine artifacts and are not enabled. The
       // existing promoted marker is used as a churn guard only after all auto-safe gates pass.
-      factsDb.markProcedurePromoted(proc.id, relativePath);
+      factsDb.markProcedurePromoted(proc.id, allocated.relativePath);
+      const allocatedSkillPath = join(allocated.skillDir, "SKILL.md");
       decisions.push({
         procedureId: proc.id,
         action: decision.action,
         reasons: evaluation.metadata.rejectionReasons,
-        skillPath: evaluation.metadata.generatedSkillPath,
+        skillPath: allocated.relativePath,
         inputHash: item.inputHash,
         policyVersion: PROCEDURE_PROMOTION_POLICY_VERSION,
         runId: decision.runId,
         enabled: false,
         humanReviewRequired: decision.humanReviewRequired,
       });
-      paths.push(skillPath);
+      paths.push(allocatedSkillPath);
       drafted++;
-      logger.info(`procedure-skill-generator: drafted ${skillPath} (enabled=false)`);
+      logger.info(`procedure-skill-generator: drafted ${allocatedSkillPath} (enabled=false)`);
     } catch (err) {
-      rollbackDraftSkill(skillDir);
+      rollbackDraftSkill(allocated?.skillDir ?? skillDir);
       releaseInRunReservation(reservedSlugs, inRunSkillCandidates, reservedCandidate);
       capturePluginError(err instanceof Error ? err : new Error(String(err)), {
         subsystem: "procedure-skill-generator",
@@ -294,7 +333,9 @@ export function generateAutoSkills(
         enabled: false,
         humanReviewRequired: decision.humanReviewRequired,
       });
-      logger.warn(`procedure-skill-generator: write ${skillPath}: ${err}`);
+      logger.warn(
+        `procedure-skill-generator: write ${allocated ? join(allocated.skillDir, "SKILL.md") : skillPath}: ${err}`,
+      );
       failedValidation++;
       skipped++;
     }
@@ -396,11 +437,13 @@ export function generateAutoSkillForProcedure(
     };
   }
 
+  let allocated: AllocatedSkillDir | null = null;
   try {
-    writeDraftSkill(skillDir, rebaseDraftSlug(evaluation.draft, resolvedSlug, relativePath));
-    factsDb.markProcedurePromoted(proc.id, relativePath);
+    allocated = allocateDraftSkillDir(basePath, options.skillsAutoPath, item.payload.skillSlug);
+    writeDraftSkill(allocated.skillDir, rebaseDraftSlug(evaluation.draft, allocated.slug, allocated.relativePath));
+    factsDb.markProcedurePromoted(proc.id, allocated.relativePath);
   } catch (err) {
-    rollbackDraftSkill(skillDir);
+    rollbackDraftSkill(allocated?.skillDir ?? skillDir);
     capturePluginError(err instanceof Error ? err : new Error(String(err)), {
       subsystem: "procedure-skill-generator",
       operation: "promote-write-draft",
@@ -408,12 +451,13 @@ export function generateAutoSkillForProcedure(
     return { ok: false, reason: "write-failed", error: String(err) };
   }
 
-  logger.info(`procedure-skill-generator: drafted ${proc.id} → ${skillPath} (enabled=false)`);
+  const allocatedSkillPath = join(allocated.skillDir, "SKILL.md");
+  logger.info(`procedure-skill-generator: drafted ${proc.id} → ${allocatedSkillPath} (enabled=false)`);
   return {
     ok: true,
     alreadyPromoted: false,
-    skillPath,
-    relativePath,
+    skillPath: allocatedSkillPath,
+    relativePath: allocated.relativePath,
     dryRun: false,
     enabled: false,
   };
@@ -506,7 +550,7 @@ function writeDraftSkill(
     proposalMetadataJson: string;
   },
 ): void {
-  mkdirSync(join(skillDir, "evals"), { recursive: true });
+  mkdirSync(join(skillDir, "evals"), { recursive: false });
   writeFileSync(join(skillDir, "SKILL.md"), draft.skillMd, "utf-8");
   writeFileSync(join(skillDir, "recipe.json"), draft.recipeJson, "utf-8");
   writeFileSync(join(skillDir, "verification.json"), draft.verificationJson, "utf-8");

--- a/extensions/memory-hybrid/tests/procedure-skill-generator.test.ts
+++ b/extensions/memory-hybrid/tests/procedure-skill-generator.test.ts
@@ -1,6 +1,6 @@
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, relative } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { FactsDB } from "../backends/facts-db.js";
 import { generateAutoSkillForProcedure, generateAutoSkills } from "../services/procedure-skill-generator.js";
@@ -23,6 +23,32 @@ afterEach(() => {
 function recordDistinctSuccesses(procId: string): void {
   db.recordProcedureSuccess(procId, undefined, `${procId}-session-2`);
   db.recordProcedureSuccess(procId, undefined, `${procId}-session-3`);
+}
+
+function collectIdentityKeyFindings(value: unknown, path = "$", findings: string[] = []): string[] {
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => collectIdentityKeyFindings(item, `${path}[${index}]`, findings));
+    return findings;
+  }
+  if (!value || typeof value !== "object") return findings;
+  for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+    const childPath = `${path}.${key}`;
+    if (isSlugOrPathIdentityKey(key, childPath)) findings.push(childPath);
+    collectIdentityKeyFindings(child, childPath, findings);
+  }
+  return findings;
+}
+
+function isSlugOrPathIdentityKey(key: string, path: string): boolean {
+  if (key === "path" && /^\$\[\d+\]\.args\.path$/.test(path)) return false;
+  return /^(?:skill|skillSlug|generatedSkillPath|generatedPath|skillPath|path)$/i.test(key);
+}
+
+function expectSidecarHasNoStaleIdentity(sidecarPath: string, originalSlug: string, originalPath: string): void {
+  const serialized = readFileSync(sidecarPath, "utf-8");
+  expect(serialized, `${relative(tmpDir, sidecarPath)} must not preserve original slug`).not.toContain(originalSlug);
+  expect(serialized, `${relative(tmpDir, sidecarPath)} must not preserve original path`).not.toContain(originalPath);
+  expect(collectIdentityKeyFindings(JSON.parse(serialized))).toEqual([]);
 }
 
 describe("generateAutoSkills", () => {
@@ -151,32 +177,15 @@ describe("generateAutoSkills", () => {
       generatedSkillPath: join(skillsDir, "validate-colliding-release-report-1"),
     });
 
-    // Invariant: recipe.json, proposal-metadata.json, and evals/evals.json must NOT
-    // contain slug or path identity fields. If any future addition embeds a slug/path
-    // identity field in these artifacts, it must also be rebased in rebaseDraftSlug.
-    const recipe = JSON.parse(readFileSync(join(collidedDir, "recipe.json"), "utf-8")) as Array<
-      Record<string, unknown>
-    >;
-    expect(Array.isArray(recipe)).toBe(true);
-    // Verify each recipe step carries no slug/path identity keys
-    for (const step of recipe) {
-      expect(step).not.toHaveProperty("skill");
-      expect(step).not.toHaveProperty("generatedSkillPath");
+    const originalSlug = "validate-colliding-release-report";
+    const originalPath = join(skillsDir, originalSlug);
+    for (const sidecarPath of [
+      join(collidedDir, "recipe.json"),
+      join(collidedDir, "proposal-metadata.json"),
+      join(collidedDir, "evals", "evals.json"),
+    ]) {
+      expectSidecarHasNoStaleIdentity(sidecarPath, originalSlug, originalPath);
     }
-
-    const proposalMeta = JSON.parse(readFileSync(join(collidedDir, "proposal-metadata.json"), "utf-8")) as Record<
-      string,
-      unknown
-    >;
-    expect(proposalMeta).not.toHaveProperty("skill");
-    expect(proposalMeta).not.toHaveProperty("generatedSkillPath");
-
-    const evalsContent = JSON.parse(readFileSync(join(collidedDir, "evals", "evals.json"), "utf-8")) as Record<
-      string,
-      unknown
-    >;
-    expect(evalsContent).not.toHaveProperty("skill");
-    expect(evalsContent).not.toHaveProperty("generatedSkillPath");
   });
 
   it("dry-run does not write files", () => {
@@ -544,6 +553,56 @@ describe("generateAutoSkills", () => {
       enabled: false,
     });
     expect(existsSync(join(skillsDir, "validate-single-apply-report", "SKILL.md"))).toBe(true);
+  });
+
+  it("retries allocation when a competing writer claims the previewed slug", () => {
+    const proc = db.upsertProcedure({
+      taskPattern: "Validate raced draft allocation",
+      recipeJson: JSON.stringify([
+        { tool: "read", args: { path: "status.json" }, summary: "Check status" },
+        { tool: "exec", args: { command: "npm test" }, summary: "Run validation test" },
+        { tool: "read", args: { path: "report.json" }, summary: "Verify report output" },
+      ]),
+      procedureType: "positive",
+      successCount: 3,
+      confidence: 0.9,
+      sourceSessionId: "raced-draft-a1",
+    });
+    recordDistinctSuccesses(proc.id);
+
+    const originalGetProcedureVersions = db.getProcedureVersions.bind(db);
+    const versionSpy = vi.spyOn(db, "getProcedureVersions").mockImplementationOnce((procId: string) => {
+      // Simulate another generator creating the directory after this process has
+      // previewed the slug but before it attempts to reserve the write path.
+      mkdirSync(join(skillsDir, "validate-raced-draft-allocation"), { recursive: true });
+      return originalGetProcedureVersions(procId);
+    });
+
+    const result = generateAutoSkillForProcedure(
+      db,
+      {
+        skillsAutoPath: skillsDir,
+        validationThreshold: 3,
+        skillTTLDays: 30,
+        procedureId: proc.id,
+        apply: true,
+        policy: "auto-safe",
+      },
+      { info: () => {}, warn: () => {} },
+    );
+
+    versionSpy.mockRestore();
+
+    expect(result).toMatchObject({
+      ok: true,
+      relativePath: join(skillsDir, "validate-raced-draft-allocation-1"),
+      skillPath: join(skillsDir, "validate-raced-draft-allocation-1", "SKILL.md"),
+    });
+    expect(existsSync(join(skillsDir, "validate-raced-draft-allocation", "SKILL.md"))).toBe(false);
+    expect(existsSync(join(skillsDir, "validate-raced-draft-allocation-1", "SKILL.md"))).toBe(true);
+    expect(readFileSync(join(skillsDir, "validate-raced-draft-allocation-1", "verification.json"), "utf-8")).toContain(
+      '"skill": "validate-raced-draft-allocation-1"',
+    );
   });
 
   it("does not count deferred procedures as generated dry-run paths", () => {

--- a/extensions/memory-hybrid/tests/procedure-skill-generator.test.ts
+++ b/extensions/memory-hybrid/tests/procedure-skill-generator.test.ts
@@ -154,12 +154,13 @@ describe("generateAutoSkills", () => {
     // Invariant: recipe.json, proposal-metadata.json, and evals/evals.json must NOT
     // contain slug or path identity fields. If any future addition embeds a slug/path
     // identity field in these artifacts, it must also be rebased in rebaseDraftSlug.
-    const recipe = JSON.parse(readFileSync(join(collidedDir, "recipe.json"), "utf-8")) as unknown;
+    const recipe = JSON.parse(readFileSync(join(collidedDir, "recipe.json"), "utf-8")) as Array<Record<string, unknown>>;
     expect(Array.isArray(recipe)).toBe(true);
-    // Check for identity keys ("skill":, "generatedSkillPath":) not merely the substring
-    const recipeStr = JSON.stringify(recipe);
-    expect(recipeStr).not.toMatch(/"skill"\s*:/);
-    expect(recipeStr).not.toMatch(/"generatedSkillPath"\s*:/);
+    // Verify each recipe step carries no slug/path identity keys
+    for (const step of recipe) {
+      expect(step).not.toHaveProperty("skill");
+      expect(step).not.toHaveProperty("generatedSkillPath");
+    }
 
     const proposalMeta = JSON.parse(readFileSync(join(collidedDir, "proposal-metadata.json"), "utf-8")) as Record<string, unknown>;
     expect(proposalMeta).not.toHaveProperty("skill");

--- a/extensions/memory-hybrid/tests/procedure-skill-generator.test.ts
+++ b/extensions/memory-hybrid/tests/procedure-skill-generator.test.ts
@@ -156,15 +156,14 @@ describe("generateAutoSkills", () => {
     // identity field in these artifacts, it must also be rebased in rebaseDraftSlug.
     const recipe = JSON.parse(readFileSync(join(collidedDir, "recipe.json"), "utf-8")) as unknown;
     expect(Array.isArray(recipe)).toBe(true);
+    // Check for identity keys ("skill":, "generatedSkillPath":) not merely the substring
     const recipeStr = JSON.stringify(recipe);
-    expect(recipeStr).not.toContain('"skill"');
-    expect(recipeStr).not.toContain('"generatedSkillPath"');
+    expect(recipeStr).not.toMatch(/"skill"\s*:/);
+    expect(recipeStr).not.toMatch(/"generatedSkillPath"\s*:/);
 
     const proposalMeta = JSON.parse(readFileSync(join(collidedDir, "proposal-metadata.json"), "utf-8")) as Record<string, unknown>;
     expect(proposalMeta).not.toHaveProperty("skill");
     expect(proposalMeta).not.toHaveProperty("generatedSkillPath");
-    // Proposal metadata must not contain the pre-collision slug as a value
-    expect(JSON.stringify(proposalMeta)).not.toContain('"validate-colliding-release-report"');
 
     const evalsContent = JSON.parse(readFileSync(join(collidedDir, "evals", "evals.json"), "utf-8")) as Record<string, unknown>;
     expect(evalsContent).not.toHaveProperty("skill");

--- a/extensions/memory-hybrid/tests/procedure-skill-generator.test.ts
+++ b/extensions/memory-hybrid/tests/procedure-skill-generator.test.ts
@@ -154,7 +154,9 @@ describe("generateAutoSkills", () => {
     // Invariant: recipe.json, proposal-metadata.json, and evals/evals.json must NOT
     // contain slug or path identity fields. If any future addition embeds a slug/path
     // identity field in these artifacts, it must also be rebased in rebaseDraftSlug.
-    const recipe = JSON.parse(readFileSync(join(collidedDir, "recipe.json"), "utf-8")) as Array<Record<string, unknown>>;
+    const recipe = JSON.parse(readFileSync(join(collidedDir, "recipe.json"), "utf-8")) as Array<
+      Record<string, unknown>
+    >;
     expect(Array.isArray(recipe)).toBe(true);
     // Verify each recipe step carries no slug/path identity keys
     for (const step of recipe) {
@@ -162,11 +164,17 @@ describe("generateAutoSkills", () => {
       expect(step).not.toHaveProperty("generatedSkillPath");
     }
 
-    const proposalMeta = JSON.parse(readFileSync(join(collidedDir, "proposal-metadata.json"), "utf-8")) as Record<string, unknown>;
+    const proposalMeta = JSON.parse(readFileSync(join(collidedDir, "proposal-metadata.json"), "utf-8")) as Record<
+      string,
+      unknown
+    >;
     expect(proposalMeta).not.toHaveProperty("skill");
     expect(proposalMeta).not.toHaveProperty("generatedSkillPath");
 
-    const evalsContent = JSON.parse(readFileSync(join(collidedDir, "evals", "evals.json"), "utf-8")) as Record<string, unknown>;
+    const evalsContent = JSON.parse(readFileSync(join(collidedDir, "evals", "evals.json"), "utf-8")) as Record<
+      string,
+      unknown
+    >;
     expect(evalsContent).not.toHaveProperty("skill");
     expect(evalsContent).not.toHaveProperty("generatedSkillPath");
   });

--- a/extensions/memory-hybrid/tests/procedure-skill-generator.test.ts
+++ b/extensions/memory-hybrid/tests/procedure-skill-generator.test.ts
@@ -150,6 +150,25 @@ describe("generateAutoSkills", () => {
       skill: "validate-colliding-release-report-1",
       generatedSkillPath: join(skillsDir, "validate-colliding-release-report-1"),
     });
+
+    // Invariant: recipe.json, proposal-metadata.json, and evals/evals.json must NOT
+    // contain slug or path identity fields. If any future addition embeds a slug/path
+    // identity field in these artifacts, it must also be rebased in rebaseDraftSlug.
+    const recipe = JSON.parse(readFileSync(join(collidedDir, "recipe.json"), "utf-8")) as unknown;
+    expect(Array.isArray(recipe)).toBe(true);
+    const recipeStr = JSON.stringify(recipe);
+    expect(recipeStr).not.toContain('"skill"');
+    expect(recipeStr).not.toContain('"generatedSkillPath"');
+
+    const proposalMeta = JSON.parse(readFileSync(join(collidedDir, "proposal-metadata.json"), "utf-8")) as Record<string, unknown>;
+    expect(proposalMeta).not.toHaveProperty("skill");
+    expect(proposalMeta).not.toHaveProperty("generatedSkillPath");
+    // Proposal metadata must not contain the pre-collision slug as a value
+    expect(JSON.stringify(proposalMeta)).not.toContain('"validate-colliding-release-report"');
+
+    const evalsContent = JSON.parse(readFileSync(join(collidedDir, "evals", "evals.json"), "utf-8")) as Record<string, unknown>;
+    expect(evalsContent).not.toHaveProperty("skill");
+    expect(evalsContent).not.toHaveProperty("generatedSkillPath");
   });
 
   it("dry-run does not write files", () => {
@@ -385,6 +404,60 @@ describe("generateAutoSkills", () => {
       humanReviewRequired: true,
     });
     expect(existsSync(join(skillsDir, "validate-explicit-draft-policy-report", "SKILL.md"))).toBe(false);
+  });
+
+  it("draft-only batch: deferred procedures do not consume slug reservations for later entries", () => {
+    // Two procedures with identical task patterns → same base slug.
+    // Under draft-only policy both defer and neither should inflate the other's resolved slug.
+    const recipeJson = JSON.stringify([
+      { tool: "read", args: { path: "status.json" }, summary: "Check status" },
+      { tool: "exec", args: { command: "npm test" }, summary: "Run validation test" },
+      { tool: "read", args: { path: "report.json" }, summary: "Verify report output" },
+    ]);
+    const procA = db.upsertProcedure({
+      id: "deferred-slug-res-a",
+      taskPattern: "Validate deferred slug reservation",
+      recipeJson,
+      procedureType: "positive",
+      successCount: 3,
+      confidence: 0.9,
+      sourceSessionId: "deferred-slug-res-a1",
+    });
+    recordDistinctSuccesses(procA.id);
+    const procB = db.upsertProcedure({
+      id: "deferred-slug-res-b",
+      taskPattern: "Validate deferred slug reservation",
+      recipeJson,
+      procedureType: "positive",
+      successCount: 3,
+      confidence: 0.9,
+      sourceSessionId: "deferred-slug-res-b1",
+    });
+    recordDistinctSuccesses(procB.id);
+
+    const result = generateAutoSkills(
+      db,
+      {
+        skillsAutoPath: skillsDir,
+        validationThreshold: 3,
+        skillTTLDays: 30,
+        apply: true,
+        policy: "draft-only",
+        maxPerRun: 2,
+      },
+      { info: () => {}, warn: () => {} },
+    );
+
+    expect(result.summary).toMatchObject({ deferred: 2, drafted: 0 });
+    expect(result.generated).toBe(0);
+    // No skill file should be written for either procedure
+    expect(existsSync(join(skillsDir, "validate-deferred-slug-reservation", "SKILL.md"))).toBe(false);
+    expect(existsSync(join(skillsDir, "validate-deferred-slug-reservation-1", "SKILL.md"))).toBe(false);
+    // Neither decision should have a slug-inflated (-1 suffix) skillPath caused by
+    // the other deferred procedure spuriously reserving the base slug.
+    const deferredDecisions = (result.decisions ?? []).filter((d) => d.action === "deferred-for-human");
+    expect(deferredDecisions).toHaveLength(2);
+    expect(deferredDecisions.every((d) => !d.skillPath?.endsWith("-1"))).toBe(true);
   });
 
   it("single procedure dry-run under default draft-only policy requires human approval and writes nothing", () => {


### PR DESCRIPTION
Three related bugs in the procedural skill generator around slug collision resolution: incomplete metadata rebase after collision, spurious slug suffix inflation from deferred procedures consuming reservations, and a brittle H1 heading regex that silently no-ops on non-title-cased headings.

## `rebaseDraftSlug` — H1 heading regex (#1364)

Old regex only matched `# My Skill` (title-cased). If the heading was stored as `# my-skill`, the replace was a silent no-op:

```ts
// Before — only matches title-cased form
.replace(new RegExp(`^# ${escapeRegExp(titleCase(originalSlug))}$`, "m"), ...)

// After — matches both forms
const h1Pattern = new RegExp(
  `^# (?:${escapeRegExp(titleCase(originalSlug))}|${escapeRegExp(originalSlug)})$`,
  "m",
);
```

## `rebaseDraftSlug` — invariant documentation + regression tests (#1372)

`recipeJson`, `evalsJson`, and `proposalMetadataJson` currently carry no slug/path identity fields, so no rewrite is needed today. A JSDoc invariant comment documents this explicitly and regression tests now assert `recipe.json`, `proposal-metadata.json`, and `evals/evals.json` have no `skill` or `generatedSkillPath` keys — ensuring any future addition that embeds a slug identity field breaks the test rather than silently diverging from the written directory name.

## Slug reservation gated on actual write (#1356)

Under `draft-only` policy (or any policy where `requiresHumanApproval=true`), every procedure in a batch was being added to `reservedSlugs` and `inRunSkillCandidates` even though nothing would be written. The second procedure sharing a base slug would resolve to `my-skill-1` while the first was also merely deferred:

```ts
// Before — reserves even for deferred procedures
if (evaluation.eligible && evaluation.draft) {

// After — only reserves when a draft write will actually occur
if (evaluation.eligible && evaluation.draft && !evaluation.metadata.requiresHumanApproval) {
```

A new test covers the two-procedure draft-only batch: both entries must resolve to the base slug with no `-1` inflation and no files written.

> [!WARNING]
>
> <details>
> <summary>Firewall rules blocked me from connecting to one or more addresses (expand for details)</summary>
>
> #### I tried to connect to the following addresses, but was blocked by firewall rules:
>
> - `api.openai.com`
>   - Triggering command: `/opt/hostedtoolcache/node/24.14.1/x64/bin/node /opt/hostedtoolcache/node/24.14.1/x64/bin/node --experimental-import-meta-resolve --require /home/REDACTED/work/openclaw-hybrid-memory/openclaw-hybrid-memory/extensions/memory-hybrid/node_modules/vitest/suppress-warnings.cjs --conditions node --conditions development /home/REDACTED/work/openclaw-hybrid-memory/openclaw-hybrid-memory/extensions/memory-hybrid/node_modules/vitest/dist/workers/forks.js` (dns block)
> - `https://api.github.com/graphql`
>   - Triggering command: `/usr/bin/gh gh issue list --limit 10 --json number,title,state,url,createdAt cal/bin/git hub.com/.extrahebash` (http block)
>   - Triggering command: `/usr/bin/gh gh pr list --limit 10 --json number,title,state,url,createdAt w-hybrid-memory/extensions/node_modules/.bin/sh` (http block)
>   - Triggering command: `/usr/bin/gh gh pr list --limit 10 --json number,title,state,url,createdAt p/bin/git r` (http block)
> - `my-glitchtip.example.com`
>   - Triggering command: `/opt/hostedtoolcache/node/24.14.1/x64/bin/node /opt/hostedtoolcache/node/24.14.1/x64/bin/node --experimental-import-meta-resolve --require /home/REDACTED/work/openclaw-hybrid-memory/openclaw-hybrid-memory/extensions/memory-hybrid/node_modules/vitest/suppress-warnings.cjs --conditions node --conditions development /home/REDACTED/work/openclaw-hybrid-memory/openclaw-hybrid-memory/extensions/memory-hybrid/node_modules/vitest/dist/workers/forks.js` (dns block)
>
> If you need me to access, download, or install something from one of these locations, you can either:
>
> - Configure [Actions setup steps](https://gh.io/copilot/actions-setup-steps) to set up my environment, which run before the firewall is enabled
> - Add the appropriate URLs or hosts to the custom allowlist in this repository's [Copilot coding agent settings](https://github.com/markus-lassfolk/openclaw-hybrid-memory/settings/copilot/coding_agent) (admins only)
>
> </details>

---

Reopened by Maeve as a human-owned branch/PR to avoid bot/app PR workflow and review limitations.

Supersedes: https://github.com/markus-lassfolk/openclaw-hybrid-memory/pull/1433
Closes #1413

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes draft-skill path allocation and slug reservation behavior, which can affect where/when files are written and how procedures are marked promoted; main risk is unexpected slug/path outputs under concurrency or policy edge-cases.
> 
> **Overview**
> Fixes slug-collision handling in the procedure skill generator by **atomically allocating** a unique draft directory at write time (retrying on `EEXIST`) and updating reservation tracking/decision paths based on the actually-allocated slug.
> 
> Improves collision rebasing by updating `verification.json` telemetry, making the H1 rewrite match both title-cased and raw-slug headings, and tightening `writeDraftSkill` to fail if `evals/` already exists (avoiding silent overwrites).
> 
> Adjusts in-run slug reservations to only occur when a draft will actually be written (preventing deferred procedures from inflating `-N` suffixes), and adds tests covering stale identity leakage in sidecars, deferred reservation behavior, and raced allocation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40438bcc3b7a181972b8c216b37b97ee476943ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->