### PR TITLE
fix: handle HTML comment prefix in frontmatter parsing and legacy skill detection

### DIFF
--- a/extensions/memory-hybrid/services/crystallization-proposer.ts
+++ b/extensions/memory-hybrid/services/crystallization-proposer.ts
@@ -489,8 +489,14 @@ function parsePatternSnapshot(snapshot: string): WorkflowPattern | undefined {
 
 /** Queued proposals from older crystallizers start Markdown without YAML frontmatter. */
 function isLegacyMarkdownCrystallizationProposal(skillContent: string): boolean {
-  // Strip optional leading HTML comment (e.g., injected by injectInstallMetadata)
-  const body = skillContent.replace(/^\uFEFF?[\s\r\n]*<!--[\s\S]*?-->\s*/, "").replace(/^\uFEFF/, "");
+  // Strip optional leading HTML comment(s) (e.g., injected by injectInstallMetadata)
+  let body = skillContent.replace(/^\uFEFF/, "");
+  // Strip multiple leading HTML comments (consistent with parseFrontmatter in skill-validator.ts)
+  while (true) {
+    const stripped = body.replace(/^[\s\r\n]*<!--[\s\S]*?-->\s*/, "");
+    if (stripped === body) break;
+    body = stripped;
+  }
   const lines = body.split("\n");
   let i = 0;
   while (i < lines.length && lines[i]?.trim() === "") i++;

--- a/extensions/memory-hybrid/services/crystallization-proposer.ts
+++ b/extensions/memory-hybrid/services/crystallization-proposer.ts
@@ -489,18 +489,21 @@ function parsePatternSnapshot(snapshot: string): WorkflowPattern | undefined {
 
 /** Queued proposals from older crystallizers start Markdown without YAML frontmatter. */
 function isLegacyMarkdownCrystallizationProposal(skillContent: string): boolean {
-  // Strip optional leading HTML comment(s) (e.g., injected by injectInstallMetadata)
-  let body = skillContent.replace(/^\uFEFF/, "");
-  // Strip multiple leading HTML comments (consistent with parseFrontmatter in skill-validator.ts)
+  const body = stripLeadingHtmlComments(skillContent);
+  const lines = body.split("\n");
+  let i = 0;
+  while (i < lines.length && lines[i]?.trim() === "") i++;
+  return lines[i]?.trim() !== "---";
+}
+
+function stripLeadingHtmlComments(content: string): string {
+  let body = content.replace(/^\uFEFF/, "");
   while (true) {
     const stripped = body.replace(/^[\s\r\n]*<!--[\s\S]*?-->\s*/, "");
     if (stripped === body) break;
     body = stripped;
   }
-  const lines = body.split("\n");
-  let i = 0;
-  while (i < lines.length && lines[i]?.trim() === "") i++;
-  return lines[i]?.trim() !== "---";
+  return body;
 }
 
 function validationRejectionReason(

--- a/extensions/memory-hybrid/services/crystallization-proposer.ts
+++ b/extensions/memory-hybrid/services/crystallization-proposer.ts
@@ -15,6 +15,7 @@ import { dirname } from "node:path";
 import type { CrystallizationStore } from "../backends/crystallization-store.js";
 import type { WorkflowPattern, WorkflowStore } from "../backends/workflow-store.js";
 import type { CrystallizationConfig } from "../config/types/features.js";
+import { stripLeadingHtmlComments } from "../utils/text.js";
 import { capturePluginError } from "./error-reporter.js";
 import {
   GeneratedSkillValidationService,
@@ -494,16 +495,6 @@ function isLegacyMarkdownCrystallizationProposal(skillContent: string): boolean 
   let i = 0;
   while (i < lines.length && lines[i]?.trim() === "") i++;
   return lines[i]?.trim() !== "---";
-}
-
-function stripLeadingHtmlComments(content: string): string {
-  let body = content.replace(/^\uFEFF/, "");
-  while (true) {
-    const stripped = body.replace(/^[\s\r\n]*<!--[\s\S]*?-->\s*/, "");
-    if (stripped === body) break;
-    body = stripped;
-  }
-  return body;
 }
 
 function validationRejectionReason(

--- a/extensions/memory-hybrid/services/crystallization-proposer.ts
+++ b/extensions/memory-hybrid/services/crystallization-proposer.ts
@@ -490,7 +490,7 @@ function parsePatternSnapshot(snapshot: string): WorkflowPattern | undefined {
 /** Queued proposals from older crystallizers start Markdown without YAML frontmatter. */
 function isLegacyMarkdownCrystallizationProposal(skillContent: string): boolean {
   // Strip optional leading HTML comment (e.g., injected by injectInstallMetadata)
-  const body = skillContent.replace(/^<!--[\s\S]*?-->\s*\n*/, "");
+  const body = skillContent.replace(/^<!--[\s\S]*?-->\s*/, "");
   const lines = body.split("\n");
   let i = 0;
   while (i < lines.length && lines[i]?.trim() === "") i++;

--- a/extensions/memory-hybrid/services/crystallization-proposer.ts
+++ b/extensions/memory-hybrid/services/crystallization-proposer.ts
@@ -490,7 +490,7 @@ function parsePatternSnapshot(snapshot: string): WorkflowPattern | undefined {
 /** Queued proposals from older crystallizers start Markdown without YAML frontmatter. */
 function isLegacyMarkdownCrystallizationProposal(skillContent: string): boolean {
   // Strip optional leading HTML comment (e.g., injected by injectInstallMetadata)
-  const body = skillContent.replace(/^<!--[\s\S]*?-->\s*/, "");
+  const body = skillContent.replace(/^\uFEFF?[\s\r\n]*<!--[\s\S]*?-->\s*/, "").replace(/^\uFEFF/, "");
   const lines = body.split("\n");
   let i = 0;
   while (i < lines.length && lines[i]?.trim() === "") i++;

--- a/extensions/memory-hybrid/services/crystallization-proposer.ts
+++ b/extensions/memory-hybrid/services/crystallization-proposer.ts
@@ -489,7 +489,9 @@ function parsePatternSnapshot(snapshot: string): WorkflowPattern | undefined {
 
 /** Queued proposals from older crystallizers start Markdown without YAML frontmatter. */
 function isLegacyMarkdownCrystallizationProposal(skillContent: string): boolean {
-  const lines = skillContent.split("\n");
+  // Strip optional leading HTML comment (e.g., injected by injectInstallMetadata)
+  const body = skillContent.replace(/^<!--[\s\S]*?-->\s*\n*/, "");
+  const lines = body.split("\n");
   let i = 0;
   while (i < lines.length && lines[i]?.trim() === "") i++;
   return lines[i]?.trim() !== "---";

--- a/extensions/memory-hybrid/services/generated-skill-validation.ts
+++ b/extensions/memory-hybrid/services/generated-skill-validation.ts
@@ -122,7 +122,7 @@ const STOP_WORDS = new Set([
 
 export function parseSkillFrontmatter(skillContent: string): Record<string, string> {
   // Strip optional leading HTML comment (e.g., injected by injectInstallMetadata)
-  const body = skillContent.replace(/^<!--[\s\S]*?-->\s*\r?\n*/, "");
+  const body = skillContent.replace(/^<!--[\s\S]*?-->\s*/, "");
   const match = body.match(/^---\s*\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/);
   if (!match) return {};
   const frontmatter: Record<string, string> = {};

--- a/extensions/memory-hybrid/services/generated-skill-validation.ts
+++ b/extensions/memory-hybrid/services/generated-skill-validation.ts
@@ -121,7 +121,9 @@ const STOP_WORDS = new Set([
 ]);
 
 export function parseSkillFrontmatter(skillContent: string): Record<string, string> {
-  const match = skillContent.match(/^---\s*\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/);
+  // Strip optional leading HTML comment (e.g., injected by injectInstallMetadata)
+  const body = skillContent.replace(/^<!--[\s\S]*?-->\s*\r?\n*/, "");
+  const match = body.match(/^---\s*\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/);
   if (!match) return {};
   const frontmatter: Record<string, string> = {};
   for (const rawLine of match[1].split(/\r?\n/)) {

--- a/extensions/memory-hybrid/services/generated-skill-validation.ts
+++ b/extensions/memory-hybrid/services/generated-skill-validation.ts
@@ -122,15 +122,18 @@ const STOP_WORDS = new Set([
   "without",
 ]);
 
-export function parseSkillFrontmatter(skillContent: string): SkillFrontmatter {
-  // Strip optional leading HTML comment(s) (e.g., injected by injectInstallMetadata)
-  let body = skillContent.replace(/^\uFEFF/, "");
-  // Strip multiple leading HTML comments (consistent with parseFrontmatter in skill-validator.ts)
+function stripLeadingHtmlComments(content: string): string {
+  let body = content.replace(/^\uFEFF/, "");
   while (true) {
     const stripped = body.replace(/^[\s\r\n]*<!--[\s\S]*?-->\s*/, "");
     if (stripped === body) break;
     body = stripped;
   }
+  return body;
+}
+
+export function parseSkillFrontmatter(skillContent: string): SkillFrontmatter {
+  const body = stripLeadingHtmlComments(skillContent);
   const match = body.match(/^---\s*\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/);
   if (!match) return {};
   const frontmatter: SkillFrontmatter = {};

--- a/extensions/memory-hybrid/services/generated-skill-validation.ts
+++ b/extensions/memory-hybrid/services/generated-skill-validation.ts
@@ -13,6 +13,7 @@ import {
 import { tmpdir } from "node:os";
 import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 import type { WorkflowPattern } from "../backends/workflow-store.js";
+import { stripLeadingHtmlComments } from "../utils/text.js";
 import { normalizeSkillName } from "./skill-crystallizer.js";
 import { NON_PLACEHOLDER_EMAIL_PATTERN, SkillValidator } from "./skill-validator.js";
 
@@ -121,16 +122,6 @@ const STOP_WORDS = new Set([
   "workflow",
   "without",
 ]);
-
-function stripLeadingHtmlComments(content: string): string {
-  let body = content.replace(/^\uFEFF/, "");
-  while (true) {
-    const stripped = body.replace(/^[\s\r\n]*<!--[\s\S]*?-->\s*/, "");
-    if (stripped === body) break;
-    body = stripped;
-  }
-  return body;
-}
 
 export function parseSkillFrontmatter(skillContent: string): SkillFrontmatter {
   const body = stripLeadingHtmlComments(skillContent);

--- a/extensions/memory-hybrid/services/generated-skill-validation.ts
+++ b/extensions/memory-hybrid/services/generated-skill-validation.ts
@@ -25,6 +25,8 @@ export interface SyntheticActivationCases {
   edge: string;
 }
 
+export type SkillFrontmatter = Record<string, string | undefined>;
+
 export interface SkillProposalValidationResult {
   schemaVersion: 1;
   validatedAt: string;
@@ -33,7 +35,7 @@ export interface SkillProposalValidationResult {
   staticValidation: {
     status: ValidationStageStatus;
     violations: string[];
-    frontmatter: Record<string, string>;
+    frontmatter: SkillFrontmatter;
     safeOutputPath: string;
   };
   dryLoadValidation: {
@@ -120,12 +122,12 @@ const STOP_WORDS = new Set([
   "without",
 ]);
 
-export function parseSkillFrontmatter(skillContent: string): Record<string, string> {
+export function parseSkillFrontmatter(skillContent: string): SkillFrontmatter {
   // Strip optional leading HTML comment (e.g., injected by injectInstallMetadata)
-  const body = skillContent.replace(/^<!--[\s\S]*?-->\s*/, "");
+  const body = skillContent.replace(/^\uFEFF?[\s\r\n]*<!--[\s\S]*?-->\s*/, "").replace(/^\uFEFF/, "");
   const match = body.match(/^---\s*\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/);
   if (!match) return {};
-  const frontmatter: Record<string, string> = {};
+  const frontmatter: SkillFrontmatter = {};
   for (const rawLine of match[1].split(/\r?\n/)) {
     const line = rawLine.trim();
     if (line.length === 0 || line.startsWith("#")) continue;
@@ -209,7 +211,7 @@ export class GeneratedSkillValidationService {
 
   private validateStatic(
     input: ValidateGeneratedSkillInput,
-    frontmatter: Record<string, string>,
+    frontmatter: SkillFrontmatter,
     legacy: boolean,
   ): SkillProposalValidationResult["staticValidation"] {
     const violations: string[] = [];
@@ -275,7 +277,7 @@ export class GeneratedSkillValidationService {
 
   private validateDryLoad(
     skillContent: string,
-    frontmatter: Record<string, string>,
+    frontmatter: SkillFrontmatter,
     skillName: string,
   ): SkillProposalValidationResult["dryLoadValidation"] {
     const violations: string[] = [];
@@ -305,7 +307,9 @@ export class GeneratedSkillValidationService {
 
       const entries = loadDrySkillEntries(skillsDir);
       const entry = entries.find(
-        (candidate) => candidate.name === skillName || normalizeSkillName(candidate.name) === normalizedSkillName,
+        (candidate) =>
+          candidate.name === skillName ||
+          (candidate.name ? normalizeSkillName(candidate.name) === normalizedSkillName : false),
       );
       if (!entry) {
         violations.push("Dry-load discovery did not return the generated skill");
@@ -334,7 +338,7 @@ export class GeneratedSkillValidationService {
 
   private evaluateActivation(
     input: ValidateGeneratedSkillInput,
-    frontmatter: Record<string, string>,
+    frontmatter: SkillFrontmatter,
   ): SkillProposalValidationResult["syntheticActivationEval"] {
     const cases = buildSyntheticActivationCases(input, frontmatter);
     const triggerSection = extractSection(input.skillContent, "Trigger");
@@ -435,8 +439,8 @@ function isWithinDir(rootDir: string, candidatePath: string): boolean {
   return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
 }
 
-function loadDrySkillEntries(skillsDir: string): Array<Record<string, string>> {
-  const out: Array<Record<string, string>> = [];
+function loadDrySkillEntries(skillsDir: string): SkillFrontmatter[] {
+  const out: SkillFrontmatter[] = [];
   for (const entry of readdirSync(skillsDir, { withFileTypes: true })) {
     if (!entry.isDirectory()) continue;
     const skillPath = join(skillsDir, entry.name, "SKILL.md");
@@ -465,7 +469,7 @@ function extractSection(skillContent: string, heading: string): string {
 
 function buildSyntheticActivationCases(
   input: ValidateGeneratedSkillInput,
-  frontmatter: Record<string, string>,
+  frontmatter: SkillFrontmatter,
 ): SyntheticActivationCases {
   const positive =
     input.pattern?.exampleGoals

--- a/extensions/memory-hybrid/services/generated-skill-validation.ts
+++ b/extensions/memory-hybrid/services/generated-skill-validation.ts
@@ -123,8 +123,14 @@ const STOP_WORDS = new Set([
 ]);
 
 export function parseSkillFrontmatter(skillContent: string): SkillFrontmatter {
-  // Strip optional leading HTML comment (e.g., injected by injectInstallMetadata)
-  const body = skillContent.replace(/^\uFEFF?[\s\r\n]*<!--[\s\S]*?-->\s*/, "").replace(/^\uFEFF/, "");
+  // Strip optional leading HTML comment(s) (e.g., injected by injectInstallMetadata)
+  let body = skillContent.replace(/^\uFEFF/, "");
+  // Strip multiple leading HTML comments (consistent with parseFrontmatter in skill-validator.ts)
+  while (true) {
+    const stripped = body.replace(/^[\s\r\n]*<!--[\s\S]*?-->\s*/, "");
+    if (stripped === body) break;
+    body = stripped;
+  }
   const match = body.match(/^---\s*\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/);
   if (!match) return {};
   const frontmatter: SkillFrontmatter = {};

--- a/extensions/memory-hybrid/services/skill-validator.ts
+++ b/extensions/memory-hybrid/services/skill-validator.ts
@@ -499,10 +499,21 @@ function parseFrontmatter(lines: string[]): {
   while (i < lines.length && lines[i]?.trim() === "") i++;
   // Skip optional leading HTML comment block(s) (e.g., injected by injectInstallMetadata).
   while (i < lines.length && lines[i]?.trimStart().startsWith("<!--")) {
-    while (i < lines.length && !(lines[i] ?? "").includes("-->")) {
+    while (i < lines.length) {
+      const currentLine = lines[i] ?? "";
+      const closePos = currentLine.indexOf("-->");
+      if (closePos !== -1) {
+        // Check if there's non-whitespace content after -->
+        const afterClose = currentLine.slice(closePos + 3).trim();
+        if (afterClose.length > 0) {
+          // Content after -->, don't skip this line entirely
+          break;
+        }
+        i++; // skip the line with closing -->
+        break;
+      }
       i++;
     }
-    if (i < lines.length) i++; // skip the line containing the closing -->
     while (i < lines.length && lines[i]?.trim() === "") i++;
   }
   if (lines[i]?.trim() !== "---") return { present: false, keys, endLine: -1 };

--- a/extensions/memory-hybrid/services/skill-validator.ts
+++ b/extensions/memory-hybrid/services/skill-validator.ts
@@ -496,14 +496,16 @@ function parseFrontmatter(lines: string[]): {
   endLine: number;
 } {
   const keys = new Map<string, string>();
-  const body = stripLeadingHtmlComments(lines.join("\n"));
+  const originalContent = lines.join("\n");
+  const body = stripLeadingHtmlComments(originalContent);
   const bodyLines = body.split("\n");
+  const strippedLineCount = originalContent.split("\n").length - bodyLines.length;
   let i = 0;
   if (bodyLines[i]?.trim() !== "---") return { present: false, keys, endLine: -1 };
   i++;
   for (; i < bodyLines.length; i++) {
     const line = bodyLines[i] ?? "";
-    if (line.trim() === "---") return { present: true, keys, endLine: i + 1 };
+    if (line.trim() === "---") return { present: true, keys, endLine: i + 1 + strippedLineCount };
     const match = line.match(/^\s*([A-Za-z0-9_-]+)\s*:\s*(.*)\s*$/);
     if (!match) continue;
     const key = match[1].toLowerCase();

--- a/extensions/memory-hybrid/services/skill-validator.ts
+++ b/extensions/memory-hybrid/services/skill-validator.ts
@@ -497,6 +497,12 @@ function parseFrontmatter(lines: string[]): {
   // Only treat it as frontmatter when it starts the document (after optional leading blank lines).
   let i = 0;
   while (i < lines.length && lines[i]?.trim() === "") i++;
+  // Skip optional leading HTML comment block(s) (e.g., injected by injectInstallMetadata).
+  while (i < lines.length && lines[i]?.trimStart().startsWith("<!--")) {
+    while (i < lines.length && !(lines[i] ?? "").includes("-->")) i++;
+    i++; // skip the line containing the closing -->
+    while (i < lines.length && lines[i]?.trim() === "") i++;
+  }
   if (lines[i]?.trim() !== "---") return { present: false, keys, endLine: -1 };
   i++;
   for (; i < lines.length; i++) {

--- a/extensions/memory-hybrid/services/skill-validator.ts
+++ b/extensions/memory-hybrid/services/skill-validator.ts
@@ -506,7 +506,8 @@ function parseFrontmatter(lines: string[]): {
         // Check if there's non-whitespace content after -->
         const afterClose = currentLine.slice(closePos + 3).trim();
         if (afterClose.length > 0) {
-          // Content after -->, don't skip this line entirely
+          // Content after -->, we've consumed the comment portion; advance past this line
+          i++;
           break;
         }
         i++; // skip the line with closing -->

--- a/extensions/memory-hybrid/services/skill-validator.ts
+++ b/extensions/memory-hybrid/services/skill-validator.ts
@@ -11,6 +11,8 @@
  * false negatives (allowing dangerous content) are not.
  */
 
+import { stripLeadingHtmlComments } from "../utils/text.js";
+
 // ---------------------------------------------------------------------------
 // Public types
 // ---------------------------------------------------------------------------
@@ -494,33 +496,13 @@ function parseFrontmatter(lines: string[]): {
   endLine: number;
 } {
   const keys = new Map<string, string>();
-  // Only treat it as frontmatter when it starts the document (after optional leading blank lines).
+  const body = stripLeadingHtmlComments(lines.join("\n"));
+  const bodyLines = body.split("\n");
   let i = 0;
-  while (i < lines.length && lines[i]?.trim() === "") i++;
-  // Skip optional leading HTML comment block(s) (e.g., injected by injectInstallMetadata).
-  while (i < lines.length && lines[i]?.trimStart().startsWith("<!--")) {
-    while (i < lines.length) {
-      const currentLine = lines[i] ?? "";
-      const closePos = currentLine.indexOf("-->");
-      if (closePos !== -1) {
-        // Check if there's non-whitespace content after -->
-        const afterClose = currentLine.slice(closePos + 3).trim();
-        if (afterClose.length > 0) {
-          // Content after -->, we've consumed the comment portion; advance past this line
-          i++;
-          break;
-        }
-        i++; // skip the line with closing -->
-        break;
-      }
-      i++;
-    }
-    while (i < lines.length && lines[i]?.trim() === "") i++;
-  }
-  if (lines[i]?.trim() !== "---") return { present: false, keys, endLine: -1 };
+  if (bodyLines[i]?.trim() !== "---") return { present: false, keys, endLine: -1 };
   i++;
-  for (; i < lines.length; i++) {
-    const line = lines[i] ?? "";
+  for (; i < bodyLines.length; i++) {
+    const line = bodyLines[i] ?? "";
     if (line.trim() === "---") return { present: true, keys, endLine: i + 1 };
     const match = line.match(/^\s*([A-Za-z0-9_-]+)\s*:\s*(.*)\s*$/);
     if (!match) continue;

--- a/extensions/memory-hybrid/services/skill-validator.ts
+++ b/extensions/memory-hybrid/services/skill-validator.ts
@@ -499,7 +499,9 @@ function parseFrontmatter(lines: string[]): {
   while (i < lines.length && lines[i]?.trim() === "") i++;
   // Skip optional leading HTML comment block(s) (e.g., injected by injectInstallMetadata).
   while (i < lines.length && lines[i]?.trimStart().startsWith("<!--")) {
-    while (i < lines.length && !(lines[i] ?? "").includes("-->")) i++;
+    while (i < lines.length && !(lines[i] ?? "").includes("-->")) {
+      i++;
+    }
     i++; // skip the line containing the closing -->
     while (i < lines.length && lines[i]?.trim() === "") i++;
   }

--- a/extensions/memory-hybrid/services/skill-validator.ts
+++ b/extensions/memory-hybrid/services/skill-validator.ts
@@ -502,7 +502,7 @@ function parseFrontmatter(lines: string[]): {
     while (i < lines.length && !(lines[i] ?? "").includes("-->")) {
       i++;
     }
-    i++; // skip the line containing the closing -->
+    if (i < lines.length) i++; // skip the line containing the closing -->
     while (i < lines.length && lines[i]?.trim() === "") i++;
   }
   if (lines[i]?.trim() !== "---") return { present: false, keys, endLine: -1 };

--- a/extensions/memory-hybrid/tests/crystallization-proposer.test.ts
+++ b/extensions/memory-hybrid/tests/crystallization-proposer.test.ts
@@ -402,7 +402,7 @@ Bounded HTML prefix validation workflow.
     const proposer = new CrystallizationProposer(wfStore, cStore, cfg);
 
     const htmlComment = `<!-- openclaw:skill-proposal id=test-id pattern_id=html-prefix-pattern evidence_hash=ev-html output_path=${outputDir}/html-prefix-skill/SKILL.md -->`;
-    const contentWithHtmlPrefix = `${htmlComment}\n${FULL_SKILL_CONTENT}`;
+    const contentWithHtmlPrefix = `\uFEFF\n  \n${htmlComment}\n${FULL_SKILL_CONTENT}`;
 
     const proposal = cStore.create({
       patternId: "html-prefix-pattern",

--- a/extensions/memory-hybrid/tests/crystallization-proposer.test.ts
+++ b/extensions/memory-hybrid/tests/crystallization-proposer.test.ts
@@ -402,7 +402,7 @@ Bounded HTML prefix validation workflow.
     const proposer = new CrystallizationProposer(wfStore, cStore, cfg);
 
     const htmlComment = `<!-- openclaw:skill-proposal id=test-id pattern_id=html-prefix-pattern evidence_hash=ev-html output_path=${outputDir}/html-prefix-skill/SKILL.md -->`;
-    const contentWithHtmlPrefix = `\uFEFF\n  \n${htmlComment}\n${FULL_SKILL_CONTENT}`;
+    const contentWithHtmlPrefix = `\uFEFF\n\t\n${htmlComment}\n${FULL_SKILL_CONTENT}`;
 
     const proposal = cStore.create({
       patternId: "html-prefix-pattern",
@@ -414,10 +414,36 @@ Bounded HTML prefix validation workflow.
     });
 
     const result = proposer.approveProposal(proposal.id);
-    // After the fix, the skill is NOT treated as legacy, so full validation runs.
-    // A well-formed skill with all sections should approve (possibly with override for minor warnings).
-    expect(result.success === true || /override/i.test(result.message)).toBe(true);
-    // Verify the stored validation result is not the legacy bypass
+    expect(result.success).toBe(true);
+    expect(result.outputPath).toBeDefined();
+
+    // Verify the stored validation result is not the legacy bypass.
+    const stored = cStore.getById(proposal.id);
+    const activationNotes = stored?.validationResult?.syntheticActivationEval?.notes ?? [];
+    expect(activationNotes.every((n: string) => !n.includes("legacy crystallization"))).toBe(true);
+  });
+
+  it("does not treat skills with multiple leading HTML comments as legacy", () => {
+    const outputDir = join(tmpDir, "multi-html-prefix-skills");
+    const cfg: CrystallizationConfig = { ...BASE_CFG, outputDir, autoApprove: false };
+    const proposer = new CrystallizationProposer(wfStore, cStore, cfg);
+
+    const contentWithHtmlPrefix = `<!-- first metadata wrapper -->
+<!-- second metadata wrapper -->
+${FULL_SKILL_CONTENT}`;
+
+    const proposal = cStore.create({
+      patternId: "html-prefix-pattern",
+      evidenceHash: "ev-html-multiple",
+      skillName: "html-prefix-skill",
+      skillContent: contentWithHtmlPrefix,
+      patternSnapshot: "{}",
+      status: "validated",
+    });
+
+    const result = proposer.approveProposal(proposal.id, { overrideWarnings: true });
+    expect(result.success).toBe(true);
+
     const stored = cStore.getById(proposal.id);
     const activationNotes = stored?.validationResult?.syntheticActivationEval?.notes ?? [];
     expect(activationNotes.every((n: string) => !n.includes("legacy crystallization"))).toBe(true);

--- a/extensions/memory-hybrid/tests/crystallization-proposer.test.ts
+++ b/extensions/memory-hybrid/tests/crystallization-proposer.test.ts
@@ -355,3 +355,100 @@ describe("CrystallizationProposer.rejectProposal", () => {
     expect(result.message).toMatch(/not rejectable|not pending/i);
   });
 });
+
+// ---------------------------------------------------------------------------
+// isLegacyMarkdownCrystallizationProposal — HTML comment prefix (Issue #1362)
+// ---------------------------------------------------------------------------
+
+describe("CrystallizationProposer — legacy detection with HTML comment prefix", () => {
+  const FULL_SKILL_CONTENT = `---
+name: html-prefix-skill
+description: Use when the user asks to validate HTML-prefixed skills.
+category: crystallized-workflow
+provenance: test-suite
+---
+
+# Html-Prefix-Skill
+
+## Trigger
+Use this skill when the user asks to validate HTML-prefixed skills.
+
+## Scope
+Bounded HTML prefix validation workflow.
+
+## When not to use
+- Do not use for unrelated tasks.
+
+## Workflow
+1. Inspect the HTML comment prefix.
+2. Validate the YAML frontmatter.
+
+## Verification
+- Confirm frontmatter fields are correctly parsed.
+
+## Anti-patterns / Known Failures
+- Do not treat injected metadata comments as content.
+
+## Examples
+- Validate an HTML-prefixed crystallized skill for correct frontmatter parsing.
+
+## Provenance
+- Source pattern ID: \`html-prefix-pattern\`
+`;
+
+  it("does not treat an HTML-prefixed YAML-frontmatter skill as legacy (approves successfully)", () => {
+    const outputDir = join(tmpDir, "html-prefix-skills");
+    const cfg: CrystallizationConfig = { ...BASE_CFG, outputDir, autoApprove: false };
+    const proposer = new CrystallizationProposer(wfStore, cStore, cfg);
+
+    const htmlComment = `<!-- openclaw:skill-proposal id=test-id pattern_id=html-prefix-pattern evidence_hash=ev-html output_path=${outputDir}/html-prefix-skill/SKILL.md -->`;
+    const contentWithHtmlPrefix = `${htmlComment}\n${FULL_SKILL_CONTENT}`;
+
+    const proposal = cStore.create({
+      patternId: "html-prefix-pattern",
+      evidenceHash: "ev-html",
+      skillName: "html-prefix-skill",
+      skillContent: contentWithHtmlPrefix,
+      patternSnapshot: "{}",
+      status: "validated",
+    });
+
+    const result = proposer.approveProposal(proposal.id);
+    // After the fix, the skill is NOT treated as legacy, so full validation runs.
+    // A well-formed skill with all sections should approve (possibly with override for minor warnings).
+    expect(result.success === true || /override/i.test(result.message)).toBe(true);
+    // Verify the stored validation result is not the legacy bypass
+    const stored = cStore.getById(proposal.id);
+    const activationNotes = stored?.validationResult?.syntheticActivationEval?.notes ?? [];
+    expect(activationNotes.every((n: string) => !n.includes("legacy crystallization"))).toBe(true);
+  });
+
+  it("still treats a plain markdown skill without frontmatter as legacy", () => {
+    const outputDir = join(tmpDir, "legacy-markdown-skills");
+    const cfg: CrystallizationConfig = { ...BASE_CFG, outputDir, autoApprove: false };
+    const proposer = new CrystallizationProposer(wfStore, cStore, cfg);
+
+    const legacyContent = `# Legacy Crystallized Workflow
+
+> Auto-crystallized from workflow pattern on 2020-01-01.
+
+Bounded narrative body without YAML.
+`;
+
+    const proposal = cStore.create({
+      patternId: "legacy-pattern",
+      evidenceHash: "ev-legacy",
+      skillName: "legacy-skill",
+      skillContent: legacyContent,
+      patternSnapshot: "{}",
+      status: "validated",
+    });
+
+    const result = proposer.approveProposal(proposal.id);
+    // Legacy proposals without frontmatter are approved via the legacy bypass path.
+    expect(result.success).toBe(true);
+    const stored = cStore.getById(proposal.id);
+    const activationNotes = stored?.validationResult?.syntheticActivationEval?.notes ?? [];
+    expect(activationNotes.some((n: string) => n.includes("legacy crystallization"))).toBe(true);
+  });
+});

--- a/extensions/memory-hybrid/tests/generated-skill-validation.test.ts
+++ b/extensions/memory-hybrid/tests/generated-skill-validation.test.ts
@@ -834,6 +834,13 @@ provenance: test-suite
     expect(fm.description).toBe("Use when the user asks to test things.");
   });
 
+  it("parses frontmatter when BOM and whitespace precede an HTML comment", () => {
+    const content = `\uFEFF\n  \t\n<!-- openclaw:skill-proposal id=abc123 -->\n${FRONTMATTER_BODY}`;
+    const fm = parseSkillFrontmatter(content);
+    expect(fm.name).toBe("test-skill");
+    expect(fm.description).toBe("Use when the user asks to test things.");
+  });
+
   it("parses frontmatter when a multi-line HTML comment precedes ---", () => {
     const content = `<!-- openclaw:skill-proposal\n  id=abc123\n  pattern_id=p1\n-->\n${FRONTMATTER_BODY}`;
     const fm = parseSkillFrontmatter(content);

--- a/extensions/memory-hybrid/tests/generated-skill-validation.test.ts
+++ b/extensions/memory-hybrid/tests/generated-skill-validation.test.ts
@@ -9,7 +9,7 @@ import { WorkflowStore } from "../backends/workflow-store.js";
 import { registerSkillsCommands } from "../cli/skills.js";
 import type { CrystallizationConfig } from "../config/types/features.js";
 import { CrystallizationProposer } from "../services/crystallization-proposer.js";
-import { GeneratedSkillValidationService } from "../services/generated-skill-validation.js";
+import { GeneratedSkillValidationService, parseSkillFrontmatter } from "../services/generated-skill-validation.js";
 import { SkillCrystallizer } from "../services/skill-crystallizer.js";
 
 const BASE_CFG: CrystallizationConfig = {
@@ -801,5 +801,54 @@ Bounded metadata installation workflow.
       wfStore.close();
       cStore.close();
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseSkillFrontmatter — HTML comment prefix (Issue #1363)
+// ---------------------------------------------------------------------------
+
+describe("parseSkillFrontmatter — HTML comment prefix", () => {
+  const FRONTMATTER_BODY = `---
+name: test-skill
+description: Use when the user asks to test things.
+category: crystallized-workflow
+provenance: test-suite
+---
+
+# Test Skill
+`;
+
+  it("parses frontmatter from content that starts with --- (baseline)", () => {
+    const fm = parseSkillFrontmatter(FRONTMATTER_BODY);
+    expect(fm.name).toBe("test-skill");
+    expect(fm.description).toBe("Use when the user asks to test things.");
+    expect(fm.category).toBe("crystallized-workflow");
+    expect(fm.provenance).toBe("test-suite");
+  });
+
+  it("parses frontmatter when a single-line HTML comment precedes ---", () => {
+    const content = `<!-- openclaw:skill-proposal id=abc123 pattern_id=p1 evidence_hash=eh1 output_path=/skills/test-skill/SKILL.md -->\n${FRONTMATTER_BODY}`;
+    const fm = parseSkillFrontmatter(content);
+    expect(fm.name).toBe("test-skill");
+    expect(fm.description).toBe("Use when the user asks to test things.");
+  });
+
+  it("parses frontmatter when a multi-line HTML comment precedes ---", () => {
+    const content = `<!-- openclaw:skill-proposal\n  id=abc123\n  pattern_id=p1\n-->\n${FRONTMATTER_BODY}`;
+    const fm = parseSkillFrontmatter(content);
+    expect(fm.name).toBe("test-skill");
+    expect(fm.description).toBe("Use when the user asks to test things.");
+  });
+
+  it("returns empty object when content is only an HTML comment with no frontmatter", () => {
+    const content = "<!-- openclaw:skill-proposal id=abc123 -->\n# Plain Markdown\n\nNo frontmatter here.";
+    const fm = parseSkillFrontmatter(content);
+    expect(fm).toEqual({});
+  });
+
+  it("returns empty object for plain markdown with no frontmatter and no HTML comment", () => {
+    const fm = parseSkillFrontmatter("# Plain Markdown\n\nNo frontmatter here.");
+    expect(fm).toEqual({});
   });
 });

--- a/extensions/memory-hybrid/tests/generated-skill-validation.test.ts
+++ b/extensions/memory-hybrid/tests/generated-skill-validation.test.ts
@@ -848,6 +848,22 @@ provenance: test-suite
     expect(fm.description).toBe("Use when the user asks to test things.");
   });
 
+  it("parses frontmatter after multiple leading HTML comments", () => {
+    const content = `<!-- first metadata wrapper -->
+<!-- second metadata wrapper -->
+${FRONTMATTER_BODY}`;
+    const fm = parseSkillFrontmatter(content);
+    expect(fm.name).toBe("test-skill");
+    expect(fm.description).toBe("Use when the user asks to test things.");
+  });
+
+  it("parses frontmatter after an inline closing HTML comment marker", () => {
+    const content = `<!-- openclaw:skill-proposal id=abc123 --> ${FRONTMATTER_BODY}`;
+    const fm = parseSkillFrontmatter(content);
+    expect(fm.name).toBe("test-skill");
+    expect(fm.description).toBe("Use when the user asks to test things.");
+  });
+
   it("returns empty object when content is only an HTML comment with no frontmatter", () => {
     const content = "<!-- openclaw:skill-proposal id=abc123 -->\n# Plain Markdown\n\nNo frontmatter here.";
     const fm = parseSkillFrontmatter(content);

--- a/extensions/memory-hybrid/utils/text.ts
+++ b/extensions/memory-hybrid/utils/text.ts
@@ -158,15 +158,25 @@ export function titleCase(slug: string): string {
 }
 
 /**
- * Strip leading HTML comments and BOM from content (used by skill parsers).
- * Repeatedly removes HTML comments at the start of the string until none remain.
+ * Strip leading whitespace plus repeated HTML comment blocks from skill content.
+ *
+ * Skill installers can prepend metadata comments before YAML frontmatter. This
+ * helper keeps parser behavior consistent across generated-skill validation,
+ * legacy crystallization detection, and static skill validation. If a closing
+ * comment marker is followed by content on the same line (for example
+ * `<!-- meta --> ---`), scanning resumes at that content instead of discarding
+ * the whole line.
  */
 export function stripLeadingHtmlComments(content: string): string {
   let body = content.replace(/^\uFEFF/, "");
+
   while (true) {
-    const stripped = body.replace(/^[\s\r\n]*<!--[\s\S]*?-->\s*/, "");
-    if (stripped === body) break;
-    body = stripped;
+    const trimmed = body.replace(/^\s*/, "");
+    if (!trimmed.startsWith("<!--")) return trimmed;
+
+    const closeIndex = trimmed.indexOf("-->");
+    if (closeIndex === -1) return trimmed;
+
+    body = trimmed.slice(closeIndex + 3);
   }
-  return body;
 }

--- a/extensions/memory-hybrid/utils/text.ts
+++ b/extensions/memory-hybrid/utils/text.ts
@@ -156,3 +156,17 @@ export function titleCase(slug: string): string {
     .map((p) => (p ? p[0]?.toUpperCase() + p.slice(1) : p))
     .join(" ");
 }
+
+/**
+ * Strip leading HTML comments and BOM from content (used by skill parsers).
+ * Repeatedly removes HTML comments at the start of the string until none remain.
+ */
+export function stripLeadingHtmlComments(content: string): string {
+  let body = content.replace(/^\uFEFF/, "");
+  while (true) {
+    const stripped = body.replace(/^[\s\r\n]*<!--[\s\S]*?-->\s*/, "");
+    if (stripped === body) break;
+    body = stripped;
+  }
+  return body;
+}


### PR DESCRIPTION
Skills installed via `injectInstallMetadata` can have an HTML comment prepended before the `---` frontmatter block. Three parsing sites failed to account for this, causing parse failures and a validation bypass.

## Root causes

- **`parseSkillFrontmatter`** (`generated-skill-validation.ts`): regex anchored to `^` missed frontmatter when `<!-- openclaw:skill-proposal ... -->` appeared first → returned `{}` → `loadDrySkillEntries` threw "missing name or description frontmatter"
- **`isLegacyMarkdownCrystallizationProposal`** (`crystallization-proposer.ts`): skipped blank lines but not HTML comments → saw the comment as first non-empty line → returned `true` (legacy) for skills with valid YAML frontmatter → bypassed strict validation, dry-load, and activation eval
- **`parseFrontmatter`** (`skill-validator.ts`): same HTML-comment-blindness → emitted "Missing required YAML frontmatter" violation on otherwise valid skills

## Changes

- **`generated-skill-validation.ts`**: strip leading HTML comment before frontmatter regex
  ```ts
  const body = skillContent.replace(/^<!--[\s\S]*?-->\s*/, "");
  const match = body.match(/^---\s*\r?\n.../);
  ```
- **`crystallization-proposer.ts`**: strip leading HTML comment before legacy boundary check
  ```ts
  const body = skillContent.replace(/^<!--[\s\S]*?-->\s*/, "");
  const lines = body.split("\n");
  ```
- **`skill-validator.ts`**: skip leading HTML comment block(s) with an explicit while loop and bounds guard before the `---` check
- **Tests**: added `parseSkillFrontmatter — HTML comment prefix` (5 cases) and `CrystallizationProposer — legacy detection with HTML comment prefix` (2 cases) covering single-line, multi-line, and comment-only inputs

> [!WARNING]
>
> <details>
> <summary>Firewall rules blocked me from connecting to one or more addresses (expand for details)</summary>
>
> #### I tried to connect to the following addresses, but was blocked by firewall rules:
>
> - `api.openai.com`
>   - Triggering command: `/opt/hostedtoolcache/node/24.14.1/x64/bin/node /opt/hostedtoolcache/node/24.14.1/x64/bin/node --experimental-import-meta-resolve --require /home/REDACTED/work/openclaw-hybrid-memory/openclaw-hybrid-memory/extensions/memory-hybrid/node_modules/vitest/suppress-warnings.cjs --conditions node --conditions development /home/REDACTED/work/openclaw-hybrid-memory/openclaw-hybrid-memory/extensions/memory-hybrid/node_modules/vitest/dist/workers/forks.js` (dns block)
> - `https://api.github.com/graphql`
>   - Triggering command: `/usr/bin/gh gh pr list --limit 10 --json number,title,state,url,createdAt w-hybrid-memory/.git/copilot-hooks` (http block)
>   - Triggering command: `/usr/bin/gh gh issue list --limit 10 --json number,title,state,url,createdAt modules/@npmcli/run-script/lib/node-gyp-bin/sh` (http block)
>   - Triggering command: `/usr/bin/gh gh pr list --limit 10 --json number,title,state,url,createdAt tnet/tools/git` (http block)
> - `my-glitchtip.example.com`
>   - Triggering command: `/opt/hostedtoolcache/node/24.14.1/x64/bin/node /opt/hostedtoolcache/node/24.14.1/x64/bin/node --experimental-import-meta-resolve --require /home/REDACTED/work/openclaw-hybrid-memory/openclaw-hybrid-memory/extensions/memory-hybrid/node_modules/vitest/suppress-warnings.cjs --conditions node --conditions development /home/REDACTED/work/openclaw-hybrid-memory/openclaw-hybrid-memory/extensions/memory-hybrid/node_modules/vitest/dist/workers/forks.js` (dns block)
>
> If you need me to access, download, or install something from one of these locations, you can either:
>
> - Configure [Actions setup steps](https://gh.io/copilot/actions-setup-steps) to set up my environment, which run before the firewall is enabled
> - Add the appropriate URLs or hosts to the custom allowlist in this repository's [Copilot coding agent settings](https://github.com/markus-lassfolk/openclaw-hybrid-memory/settings/copilot/coding_agent) (admins only)
>
> </details>

---

Reopened by Maeve as a human-owned branch/PR to avoid bot/app PR workflow and review limitations.

Supersedes: https://github.com/markus-lassfolk/openclaw-hybrid-memory/pull/1432
Closes #1412

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches skill validation and approval/legacy-detection logic; while the change is small and well-tested, mistakes here could reintroduce validation bypasses or false rejections during skill installation.
> 
> **Overview**
> Fixes cases where installed/generated `SKILL.md` files start with injected `<!-- ... -->` metadata, which previously broke YAML frontmatter parsing and could incorrectly classify valid skills as *legacy* (skipping stricter validation).
> 
> Adds `stripLeadingHtmlComments()` and uses it across `parseSkillFrontmatter`, `SkillValidator` frontmatter detection, and `isLegacyMarkdownCrystallizationProposal`, plus updates dry-load discovery typing/guards and adds regression tests covering BOM/whitespace, single/multi comment blocks, and legacy markdown without frontmatter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 193baa90e9bb0e25dbed63bcab0fc8661c5ac6aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->