### PR TITLE
feat: procedure scoring and risk-aware thresholds (#1414)

### DIFF
--- a/docs/PROCEDURAL-MEMORY.md
+++ b/docs/PROCEDURAL-MEMORY.md
@@ -73,7 +73,17 @@ openclaw hybrid-mem skills demote moltbook-check --reason "over-triggering"
 ```
 
 Generated skills now start in the `experimental` lifecycle state. Each activation or near-miss can be recorded with `openclaw hybrid-mem skills record <skill-name> ...`, and a specific activation can later be marked as a false-positive with `openclaw hybrid-mem skills correct <activation-id> --reason "..."`
-Telemetry reports surface activations per week, near-misses, false-positive/false-negative signals, success/failure/partial rates, repeated corrections, and archive/revision candidates. The lifecycle policy auto-promotes experimental skills to `trusted` after repeated successful uses without correction, auto-demotes when false-positive rate crosses the threshold, and auto-archives never-used skills after the configured window.
+Telemetry reports surface activations per week, near-misses, false-positive/false-negative signals, success/failure/partial rates, repeated corrections, and archive/revision candidates. Each report row includes a heuristic **`riskLevel`** (`low` | `medium` | `high`) derived from the same classifier as procedure promotion (task pattern + `recipe_json`). The lifecycle policy auto-promotes experimental skills to `trusted` after repeated successful uses without correction, auto-demotes when false-positive rate crosses a **risk-adjusted** threshold (higher-risk skills demote sooner; low-risk skills use a slightly higher FP bar to reduce noisy demotions), and auto-archives never-used skills after the configured window.
+
+### Procedure candidate score, user signal, and risk (#1414)
+
+When ranking promotion candidates and populating `verification.json`:
+
+- **User signal** uses a **0 baseline** in raw space (no evidence is not treated as a positive prior). Manual workflow requests, rules/preferences (capped so repeated rules cannot dominate), user corrections, and failure episodes contribute with documented weights; the raw value is clamped to `[-1, 1]` and remapped to `[0, 1]` for the additive score term so “no signal” and “one manual + one correction” do not spuriously tie.
+- **Risk** is applied as a **multiplier** on the evidence base score (not a 5% additive nudge): high-risk ≈ **0.35×**, medium ≈ **0.65×**, low **1×**, so two procedures with the same evidence but different risk tiers order consistently.
+- **Promote gates** already require extra successes / distinct contexts / success-rate headroom for higher-risk procedures; **demote gates** now apply symmetric adjustments from the same `riskLevel` (stricter for high/medium, slightly looser FP bar for low).
+
+Implementation: `extensions/memory-hybrid/services/procedure-promotion-policy.ts` (scoring + `determineRiskLevel`), `extensions/memory-hybrid/backends/facts-db/generated-skills.ts` (telemetry rollup + `effectiveDemoteThresholdsForRisk`).
 
 ---
 

--- a/extensions/memory-hybrid/backends/facts-db/generated-skills.ts
+++ b/extensions/memory-hybrid/backends/facts-db/generated-skills.ts
@@ -819,7 +819,12 @@ export function refreshGeneratedSkillLifecycleState(
   policy: GeneratedSkillLifecyclePolicy,
   now: number,
   returnMetrics: true,
-): { proc: ProcedureEntry; metrics: GeneratedSkillTelemetryMetrics; flags: GeneratedSkillTelemetryFlags } | null;
+): {
+  proc: ProcedureEntry;
+  metrics: GeneratedSkillTelemetryMetrics;
+  flags: GeneratedSkillTelemetryFlags;
+  riskLevel: "low" | "medium" | "high";
+} | null;
 export function refreshGeneratedSkillLifecycleState(
   db: DatabaseSync,
   skillName: string,
@@ -828,18 +833,17 @@ export function refreshGeneratedSkillLifecycleState(
   returnMetrics = false,
 ):
   | ProcedureEntry
-  | { proc: ProcedureEntry; metrics: GeneratedSkillTelemetryMetrics; flags: GeneratedSkillTelemetryFlags }
+  | {
+      proc: ProcedureEntry;
+      metrics: GeneratedSkillTelemetryMetrics;
+      flags: GeneratedSkillTelemetryFlags;
+      riskLevel: "low" | "medium" | "high";
+    }
   | null {
   const proc = findGeneratedSkillProcedure(db, skillName);
   if (!proc?.skillPath) return null;
   const canonicalSkillName = basename(proc.skillPath);
-  const { metrics, flags, riskLevel } = summarizeSkillTelemetryFromRollups(
-    db,
-    proc,
-    canonicalSkillName,
-    policy,
-    now,
-  );
+  const { metrics, flags, riskLevel } = summarizeSkillTelemetryFromRollups(db, proc, canonicalSkillName, policy, now);
   const currentState = proc.skillState ?? "experimental";
   const transition = desiredLifecycleTransition(currentState, flags, metrics, policy, riskLevel);
   const updatedProc =
@@ -847,7 +851,7 @@ export function refreshGeneratedSkillLifecycleState(
       ? proc
       : (setGeneratedSkillLifecycleState(db, canonicalSkillName, transition.state, transition.reason, now) ?? proc);
   if (returnMetrics) {
-    return { proc: updatedProc, metrics, flags };
+    return { proc: updatedProc, metrics, flags, riskLevel };
   }
   return updatedProc;
 }
@@ -881,8 +885,7 @@ export function buildGeneratedSkillTelemetryReport(
           procFresh = proc;
           ({ metrics, flags, riskLevel } = summarizeSkillTelemetryFromRollups(db, proc, skillName, policy, now));
         } else {
-          ({ proc: procFresh, metrics, flags } = result);
-          ({ riskLevel } = summarizeSkillTelemetryFromRollups(db, procFresh, skillName, policy, now));
+          ({ proc: procFresh, metrics, flags, riskLevel } = result);
         }
       } else {
         procFresh = proc;

--- a/extensions/memory-hybrid/backends/facts-db/generated-skills.ts
+++ b/extensions/memory-hybrid/backends/facts-db/generated-skills.ts
@@ -1,6 +1,7 @@
 import { createHash, randomUUID } from "node:crypto";
 import { basename } from "node:path";
 import type { DatabaseSync } from "node:sqlite";
+import { determineRiskLevel } from "../../services/procedure-promotion-policy.js";
 import type {
   GeneratedSkillLifecycleState,
   GeneratedSkillTelemetryDecision,
@@ -79,6 +80,8 @@ export type GeneratedSkillTelemetryReportRow = {
   skillName: string;
   skillPath: string;
   skillVersion: number;
+  /** Heuristic tier from procedure task + recipe (same classifier as procedure promotion). */
+  riskLevel: "low" | "medium" | "high";
   state: GeneratedSkillLifecycleState;
   stateReason: string | null;
   generatedAt: number | null;
@@ -128,6 +131,31 @@ type GeneratedSkillTelemetryRow = {
   session_id: string | null;
   created_at: number;
 };
+
+function parseProcedureRecipeJson(recipeJson: string): unknown {
+  try {
+    return JSON.parse(recipeJson) as unknown;
+  } catch {
+    return { malformed: true, raw: recipeJson };
+  }
+}
+
+/**
+ * Demote thresholds mirror promotion risk bumps: higher-risk generated skills need **stricter** false-positive
+ * evidence to stay trusted (lower FP rate threshold, fewer minimum activations); low-risk skills use a slightly
+ * **higher** FP bar to avoid noisy demotions. Documented in docs/PROCEDURAL-MEMORY.md.
+ */
+export function effectiveDemoteThresholdsForRisk(
+  riskLevel: "low" | "medium" | "high",
+  policy: GeneratedSkillLifecyclePolicy,
+): { falsePositiveRate: number; minSamples: number } {
+  const fpAdjust = riskLevel === "high" ? -0.1 : riskLevel === "medium" ? -0.05 : 0.05;
+  const minSamplesAdjust = riskLevel === "high" ? -1 : 0;
+  return {
+    falsePositiveRate: Math.max(0.1, policy.demoteFalsePositiveRate + fpAdjust),
+    minSamples: Math.max(1, policy.demoteMinSamples + minSamplesAdjust),
+  };
+}
 
 function mapGeneratedSkillTelemetryRow(row: GeneratedSkillTelemetryRow): GeneratedSkillTelemetryEntry {
   return {
@@ -349,7 +377,11 @@ function summarizeSkillTelemetry(
   activations: GeneratedSkillTelemetryEntry[],
   policy: GeneratedSkillLifecyclePolicy,
   now: number,
-): { metrics: GeneratedSkillTelemetryMetrics; flags: GeneratedSkillTelemetryFlags } {
+): {
+  metrics: GeneratedSkillTelemetryMetrics;
+  flags: GeneratedSkillTelemetryFlags;
+  riskLevel: "low" | "medium" | "high";
+} {
   const weekAgo = now - 7 * 24 * 60 * 60;
   let activationCountPerWeek = 0;
   let activationCountTotal = 0;
@@ -401,6 +433,11 @@ function summarizeSkillTelemetry(
   const partialRate = knownOutcomeTotal > 0 ? partialCount / knownOutcomeTotal : null;
   const unknownRate = knownOutcomeTotal > 0 ? unknownCount / knownOutcomeTotal : null;
   const falsePositiveRate = activationCountTotal > 0 ? falsePositiveSignals / activationCountTotal : null;
+  const riskLevel = determineRiskLevel(proc, parseProcedureRecipeJson(proc.recipeJson));
+  const { falsePositiveRate: demoteFpRate, minSamples: demoteMinSamples } = effectiveDemoteThresholdsForRisk(
+    riskLevel,
+    policy,
+  );
   const generatedAt = proc.skillGeneratedAt ?? proc.promotedAt ?? proc.updatedAt ?? proc.createdAt ?? now;
   const archiveCandidate =
     activationCountTotal === 0 && generatedAt <= now - policy.archiveAfterUnusedDays * 24 * 60 * 60;
@@ -410,9 +447,7 @@ function summarizeSkillTelemetry(
     proc.skillState !== "trusted" &&
     successfulUsesWithoutCorrection >= policy.promoteAfterSuccessfulUses;
   const overTriggering =
-    activationCountTotal >= policy.demoteMinSamples &&
-    falsePositiveRate != null &&
-    falsePositiveRate >= policy.demoteFalsePositiveRate;
+    activationCountTotal >= demoteMinSamples && falsePositiveRate != null && falsePositiveRate >= demoteFpRate;
   const revisionCandidate = nearMissCount >= policy.revisionNearMissThreshold && skippedCount >= consideredCount;
 
   return {
@@ -446,6 +481,7 @@ function summarizeSkillTelemetry(
       neverUsed: activationCountTotal === 0,
       archiveCandidate,
     },
+    riskLevel,
   };
 }
 
@@ -454,6 +490,7 @@ function desiredLifecycleTransition(
   flags: GeneratedSkillTelemetryFlags,
   metrics: GeneratedSkillTelemetryMetrics,
   policy: GeneratedSkillLifecyclePolicy,
+  proc: ProcedureEntry,
 ): { state: GeneratedSkillLifecycleState; reason: string } | null {
   if (currentState !== "archived" && flags.archiveCandidate) {
     return {
@@ -462,9 +499,14 @@ function desiredLifecycleTransition(
     };
   }
   if (currentState !== "demoted" && flags.overTriggering) {
+    const riskLevel = determineRiskLevel(proc, parseProcedureRecipeJson(proc.recipeJson));
+    const { falsePositiveRate: demoteFpRate, minSamples: demoteMinSamples } = effectiveDemoteThresholdsForRisk(
+      riskLevel,
+      policy,
+    );
     return {
       state: "demoted",
-      reason: `auto-demoted after false-positive rate reached ${Math.round((metrics.falsePositiveRate ?? 0) * 100)}%`,
+      reason: `auto-demoted (${riskLevel} risk): FP rate ${Math.round((metrics.falsePositiveRate ?? 0) * 100)}% reached threshold ${Math.round(demoteFpRate * 100)}% over ${demoteMinSamples}+ activations`,
     };
   }
   if (currentState === "experimental" && flags.promotionCandidate) {
@@ -488,7 +530,7 @@ export function refreshGeneratedSkillLifecycleState(
   const activations = skillTelemetryEntries(db, canonicalSkillName);
   const { metrics, flags } = summarizeSkillTelemetry(proc, activations, policy, now);
   const currentState = proc.skillState ?? "experimental";
-  const transition = desiredLifecycleTransition(currentState, flags, metrics, policy);
+  const transition = desiredLifecycleTransition(currentState, flags, metrics, policy, proc);
   if (transition == null) return proc;
   return setGeneratedSkillLifecycleState(db, canonicalSkillName, transition.state, transition.reason, now);
 }
@@ -519,7 +561,7 @@ export function buildGeneratedSkillTelemetryReport(
     .map((proc) => {
       const skillName = basename(proc.skillPath ?? proc.taskPattern);
       const activations = skillTelemetryEntries(db, skillName);
-      const { metrics, flags } = summarizeSkillTelemetry(proc, activations, policy, now);
+      const { metrics, flags, riskLevel } = summarizeSkillTelemetry(proc, activations, policy, now);
       const recommendation = flags.archiveCandidate
         ? "archive"
         : flags.overTriggering
@@ -534,6 +576,7 @@ export function buildGeneratedSkillTelemetryReport(
         skillName,
         skillPath: proc.skillPath ?? skillName,
         skillVersion: proc.skillVersion ?? 1,
+        riskLevel,
         state: proc.skillState ?? "experimental",
         stateReason: proc.skillStateReason ?? null,
         generatedAt: proc.skillGeneratedAt ?? proc.promotedAt ?? null,

--- a/extensions/memory-hybrid/backends/facts-db/generated-skills.ts
+++ b/extensions/memory-hybrid/backends/facts-db/generated-skills.ts
@@ -1,7 +1,7 @@
 import { createHash, randomUUID } from "node:crypto";
 import { basename } from "node:path";
 import type { DatabaseSync } from "node:sqlite";
-import { determineRiskLevel } from "../../services/procedure-promotion-policy.js";
+import { determineRiskLevel, parseRecipeOrRaw } from "../../utils/procedure-risk.js";
 import type {
   GeneratedSkillLifecycleState,
   GeneratedSkillTelemetryDecision,
@@ -132,14 +132,6 @@ type GeneratedSkillTelemetryRow = {
   created_at: number;
 };
 
-function parseProcedureRecipeJson(recipeJson: string): unknown {
-  try {
-    return JSON.parse(recipeJson) as unknown;
-  } catch {
-    return { malformed: true, raw: recipeJson };
-  }
-}
-
 /**
  * Demote thresholds mirror promotion risk bumps: higher-risk generated skills need **stricter** false-positive
  * evidence to stay trusted (lower FP rate threshold, fewer minimum activations); low-risk skills use a slightly
@@ -152,7 +144,7 @@ export function effectiveDemoteThresholdsForRisk(
   const fpAdjust = riskLevel === "high" ? -0.1 : riskLevel === "medium" ? -0.05 : 0.05;
   const minSamplesAdjust = riskLevel === "high" ? -1 : 0;
   return {
-    falsePositiveRate: Math.max(0.1, policy.demoteFalsePositiveRate + fpAdjust),
+    falsePositiveRate: Math.min(1, Math.max(0.1, policy.demoteFalsePositiveRate + fpAdjust)),
     minSamples: Math.max(1, policy.demoteMinSamples + minSamplesAdjust),
   };
 }
@@ -433,7 +425,7 @@ function summarizeSkillTelemetry(
   const partialRate = knownOutcomeTotal > 0 ? partialCount / knownOutcomeTotal : null;
   const unknownRate = knownOutcomeTotal > 0 ? unknownCount / knownOutcomeTotal : null;
   const falsePositiveRate = activationCountTotal > 0 ? falsePositiveSignals / activationCountTotal : null;
-  const riskLevel = determineRiskLevel(proc, parseProcedureRecipeJson(proc.recipeJson));
+  const riskLevel = determineRiskLevel(proc, parseRecipeOrRaw(proc.recipeJson));
   const { falsePositiveRate: demoteFpRate, minSamples: demoteMinSamples } = effectiveDemoteThresholdsForRisk(
     riskLevel,
     policy,
@@ -499,7 +491,7 @@ function desiredLifecycleTransition(
     };
   }
   if (currentState !== "demoted" && flags.overTriggering) {
-    const riskLevel = determineRiskLevel(proc, parseProcedureRecipeJson(proc.recipeJson));
+    const riskLevel = determineRiskLevel(proc, parseRecipeOrRaw(proc.recipeJson));
     const { falsePositiveRate: demoteFpRate, minSamples: demoteMinSamples } = effectiveDemoteThresholdsForRisk(
       riskLevel,
       policy,

--- a/extensions/memory-hybrid/backends/facts-db/generated-skills.ts
+++ b/extensions/memory-hybrid/backends/facts-db/generated-skills.ts
@@ -482,7 +482,7 @@ function desiredLifecycleTransition(
   flags: GeneratedSkillTelemetryFlags,
   metrics: GeneratedSkillTelemetryMetrics,
   policy: GeneratedSkillLifecyclePolicy,
-  proc: ProcedureEntry,
+  riskLevel: "low" | "medium" | "high",
 ): { state: GeneratedSkillLifecycleState; reason: string } | null {
   if (currentState !== "archived" && flags.archiveCandidate) {
     return {
@@ -491,7 +491,6 @@ function desiredLifecycleTransition(
     };
   }
   if (currentState !== "demoted" && flags.overTriggering) {
-    const riskLevel = determineRiskLevel(proc, parseRecipeOrRaw(proc.recipeJson));
     const { falsePositiveRate: demoteFpRate, minSamples: demoteMinSamples } = effectiveDemoteThresholdsForRisk(
       riskLevel,
       policy,
@@ -520,9 +519,9 @@ export function refreshGeneratedSkillLifecycleState(
   if (!proc?.skillPath) return null;
   const canonicalSkillName = basename(proc.skillPath);
   const activations = skillTelemetryEntries(db, canonicalSkillName);
-  const { metrics, flags } = summarizeSkillTelemetry(proc, activations, policy, now);
+  const { metrics, flags, riskLevel } = summarizeSkillTelemetry(proc, activations, policy, now);
   const currentState = proc.skillState ?? "experimental";
-  const transition = desiredLifecycleTransition(currentState, flags, metrics, policy, proc);
+  const transition = desiredLifecycleTransition(currentState, flags, metrics, policy, riskLevel);
   if (transition == null) return proc;
   return setGeneratedSkillLifecycleState(db, canonicalSkillName, transition.state, transition.reason, now);
 }

--- a/extensions/memory-hybrid/services/procedure-promotion-policy.ts
+++ b/extensions/memory-hybrid/services/procedure-promotion-policy.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 import type { ProcedureEntry } from "../types/memory.js";
+import { determineRiskLevel, parseRecipeOrRaw } from "../utils/procedure-risk.js";
 import { slugifyForSkill, titleCase } from "../utils/text.js";
 import {
   type AutopilotReasonCode,
@@ -808,14 +809,6 @@ function shellQuote(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`;
 }
 
-function parseRecipeOrRaw(recipeJson: string): unknown {
-  try {
-    return JSON.parse(recipeJson);
-  } catch {
-    return { malformed: true, raw: recipeJson };
-  }
-}
-
 function countDistinctSourceSessions(raw: string | undefined): number {
   const tokens = parseSourceSessionTokenList(raw);
   if (tokens.length === 0) return 1;
@@ -955,27 +948,6 @@ function collectDistinctSessionIds(
       source.add(episode.sessionId.trim());
   }
   return [...source];
-}
-
-/**
- * Heuristic risk tier for procedure text + recipe (used for promotion gates, scoring, and lifecycle demotion).
- * Aligns with destructive / network / install patterns in `scanSafety` and promotion scoring.
- */
-export function determineRiskLevel(proc: ProcedureEntry, recipe: unknown): "low" | "medium" | "high" {
-  const combined = `${proc.taskPattern}\n${JSON.stringify(recipe)}`;
-  if (
-    /(?:\brm\s+-[rf]+\b|\bdd\s+if=|\bmkfs\b|\bshred\b|\bdrop\s+table\b|\btruncate\s+table\b)|(?:\bprivate[_-]?key\b|\b(?:token|password)\b)\s*[:=]/i.test(
-      combined,
-    )
-  )
-    return "high";
-  if (
-    /\b(systemctl|service)\s+(?:start|stop|restart|reload|enable|disable)\b|\b(npm|pnpm|yarn|pip|apt|brew|cargo)\s+(install|add|remove|uninstall|upgrade)\b|\bssh\b|\bscp\b|\brsync\b|\b(curl|wget)\b[^\n]*(?:-X\s*(?:POST|PUT|PATCH|DELETE)|--request\s*(?:POST|PUT|PATCH|DELETE))/i.test(
-      combined,
-    )
-  )
-    return "medium";
-  return "low";
 }
 
 /**

--- a/extensions/memory-hybrid/services/procedure-promotion-policy.ts
+++ b/extensions/memory-hybrid/services/procedure-promotion-policy.ts
@@ -15,7 +15,7 @@ import {
 } from "./pending-autopilot/index.js";
 import { SkillValidator } from "./skill-validator.js";
 
-export const PROCEDURE_PROMOTION_POLICY_VERSION = "procedure-promotion-policy-v1";
+export const PROCEDURE_PROMOTION_POLICY_VERSION = "procedure-promotion-policy-v2";
 
 export const PROCEDURE_PROMOTION_POLICIES = ["draft-only", "manual", "auto-safe"] as const;
 export type ProcedurePromotionPolicy = (typeof PROCEDURE_PROMOTION_POLICIES)[number];
@@ -906,13 +906,24 @@ function summarizeProcedureEvidence(
   const correctionCount = evidence?.userCorrections?.length ?? 0;
   const manualRequestCount = evidence?.manualWorkflowRequests?.length ?? 0;
   const rulesPreferenceCount = evidence?.rulesAndPreferences?.length ?? 0;
-  const userSignal = Math.max(
-    0,
+  /**
+   * User-signal score (documented in docs/PROCEDURAL-MEMORY.md):
+   * - Baseline **0** in raw space: absence of evidence is not treated as a positive prior.
+   * - Manual workflow requests **+0.28** each; corrections **−0.32** each (asymmetric so “one request + one correction”
+   *   nets slightly negative and never ties “no signal”, which stays at 0 raw).
+   * - Rules/preferences: **+0.1** per signal, **capped at 5** signals so repeated rules cannot dominate.
+   * - Failure episodes (user-signal slice): **−0.15** each (distinct from failureSeverity in the main score).
+   * Raw is clamped to **[-1, 1]**, then remapped to **[0, 1]** via `(raw + 1) / 2` for the additive candidate term.
+   */
+  const cappedRulesForSignal = Math.min(rulesPreferenceCount, 5);
+  const userSignalRaw = Math.max(
+    -1,
     Math.min(
       1,
-      0.5 + manualRequestCount * 0.15 + rulesPreferenceCount * 0.05 - correctionCount * 0.15 - failureEpisodes * 0.08,
+      manualRequestCount * 0.28 + cappedRulesForSignal * 0.1 - correctionCount * 0.32 - failureEpisodes * 0.15,
     ),
   );
+  const userSignal = (userSignalRaw + 1) / 2;
 
   const sourceSessionIds = collectDistinctSessionIds(item.procedure.sourceSessions, evidence);
   return {
@@ -946,7 +957,11 @@ function collectDistinctSessionIds(
   return [...source];
 }
 
-function determineRiskLevel(proc: ProcedureEntry, recipe: unknown): "low" | "medium" | "high" {
+/**
+ * Heuristic risk tier for procedure text + recipe (used for promotion gates, scoring, and lifecycle demotion).
+ * Aligns with destructive / network / install patterns in `scanSafety` and promotion scoring.
+ */
+export function determineRiskLevel(proc: ProcedureEntry, recipe: unknown): "low" | "medium" | "high" {
   const combined = `${proc.taskPattern}\n${JSON.stringify(recipe)}`;
   if (
     /(?:\brm\s+-[rf]+\b|\bdd\s+if=|\bmkfs\b|\bshred\b|\bdrop\s+table\b|\btruncate\s+table\b)|(?:\bprivate[_-]?key\b|\b(?:token|password)\b)\s*[:=]/i.test(
@@ -963,6 +978,11 @@ function determineRiskLevel(proc: ProcedureEntry, recipe: unknown): "low" | "med
   return "low";
 }
 
+/**
+ * Procedure candidate score: evidence terms form a **base** in [0, ~1]; **risk is a multiplier** on that base
+ * (high ≈ 0.35×, medium ≈ 0.65×, low 1×) so materially different risk at the same evidence changes ordering.
+ * Weights are documented in docs/PROCEDURAL-MEMORY.md.
+ */
 function scoreProcedureCandidate(input: {
   successCount: number;
   successRate: number;
@@ -978,18 +998,18 @@ function scoreProcedureCandidate(input: {
   const failureSeverity = Math.max(0, Math.min(1, input.failureSeverity));
   const userSignal = Math.max(0, Math.min(1, input.userSignal));
   const generality = Math.max(0, Math.min(1, input.generality));
-  const risk = input.riskLevel === "high" ? 0.35 : input.riskLevel === "medium" ? 0.65 : 1;
+  const riskMultiplier = input.riskLevel === "high" ? 0.35 : input.riskLevel === "medium" ? 0.65 : 1;
   const activationSpecificity = Math.max(0, Math.min(1, input.activationSpecificity));
   const duplicatePenalty = input.similarSkillExists ? 0.5 : 1;
-  const rawScore =
-    repeatCount * 0.2 +
-    successRate * 0.25 +
+  const baseScore =
+    repeatCount * 0.25 +
+    successRate * 0.3 +
     (1 - failureSeverity) * 0.2 +
     userSignal * 0.1 +
     generality * 0.1 +
-    risk * 0.05 +
-    activationSpecificity * 0.1;
-  const score = Number(Math.max(0, Math.min(1, rawScore * duplicatePenalty)).toFixed(3));
+    activationSpecificity * 0.05;
+  const rawScore = baseScore * riskMultiplier * duplicatePenalty;
+  const score = Number(Math.max(0, Math.min(1, rawScore)).toFixed(3));
   return {
     score,
     breakdown: {
@@ -998,7 +1018,7 @@ function scoreProcedureCandidate(input: {
       failureSeverity: Number(failureSeverity.toFixed(3)),
       userSignal: Number(userSignal.toFixed(3)),
       generality: Number(generality.toFixed(3)),
-      risk: Number(risk.toFixed(3)),
+      risk: Number(riskMultiplier.toFixed(3)),
       activationSpecificity: Number(activationSpecificity.toFixed(3)),
       duplicatePenalty: Number(duplicatePenalty.toFixed(3)),
     },

--- a/extensions/memory-hybrid/tests/generated-skill-telemetry.test.ts
+++ b/extensions/memory-hybrid/tests/generated-skill-telemetry.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { Command } from "commander";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { FactsDB } from "../backends/facts-db.js";
+import { effectiveDemoteThresholdsForRisk } from "../backends/facts-db/generated-skills.js";
 import { registerSkillsCommands } from "../cli/skills.js";
 
 let tmpDir: string;
@@ -119,6 +120,27 @@ describe("generated skill telemetry", () => {
     expect(report.rows[0]?.flags.overTriggering).toBe(true);
     expect(report.rows[0]?.recommendation).toBe("demote");
     expect(report.rows[0]?.riskLevel).toBe("low");
+  });
+
+  it("clamps risk-adjusted demote false-positive thresholds into the valid rate range", () => {
+    expect(
+      effectiveDemoteThresholdsForRisk("low", {
+        promoteAfterSuccessfulUses: 3,
+        demoteFalsePositiveRate: 0.98,
+        demoteMinSamples: 3,
+        archiveAfterUnusedDays: 30,
+        revisionNearMissThreshold: 3,
+      }).falsePositiveRate,
+    ).toBe(1);
+    expect(
+      effectiveDemoteThresholdsForRisk("high", {
+        promoteAfterSuccessfulUses: 3,
+        demoteFalsePositiveRate: 0.05,
+        demoteMinSamples: 3,
+        archiveAfterUnusedDays: 30,
+        revisionNearMissThreshold: 3,
+      }).falsePositiveRate,
+    ).toBe(0.1);
   });
 
   it("demotes high-risk generated skills earlier than low-risk under the same false-positive pressure", () => {

--- a/extensions/memory-hybrid/tests/generated-skill-telemetry.test.ts
+++ b/extensions/memory-hybrid/tests/generated-skill-telemetry.test.ts
@@ -74,6 +74,7 @@ describe("generated skill telemetry", () => {
     expect(report.rows[0]?.metrics.successRate).toBe(1);
     expect(report.rows[0]?.flags.promotionCandidate).toBe(false);
     expect(report.rows[0]?.recommendation).toBe("observe");
+    expect(report.rows[0]?.riskLevel).toBe("low");
     expect(report.rows[0]?.metrics.savedToolCalls).toBe(3);
     expect(report.rows[0]?.metrics.savedTimeMs).toBe(4000);
     expect(report.rows[0]?.metrics.lastUsedAt).not.toBeNull();
@@ -117,6 +118,67 @@ describe("generated skill telemetry", () => {
     expect(report.rows[0]?.metrics.repeatedCorrectionCount).toBe(2);
     expect(report.rows[0]?.flags.overTriggering).toBe(true);
     expect(report.rows[0]?.recommendation).toBe("demote");
+    expect(report.rows[0]?.riskLevel).toBe("low");
+  });
+
+  it("demotes high-risk generated skills earlier than low-risk under the same false-positive pressure", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-14T12:00:00Z"));
+    const safeRecipe = JSON.stringify([
+      { tool: "read", args: { path: "status.json" }, summary: "Read status" },
+      { tool: "exec", args: { command: "npm test" }, summary: "Run validation" },
+    ]);
+    const destructiveRecipe = JSON.stringify([
+      { tool: "exec", args: { command: "rm -rf /tmp/x" }, summary: "delete" },
+      { tool: "exec", args: { command: "echo verify" }, summary: "verify" },
+    ]);
+
+    const highProc = db.upsertProcedure({
+      taskPattern: "Validate high risk telemetry demote workflow",
+      recipeJson: destructiveRecipe,
+      procedureType: "positive",
+      successCount: 3,
+      confidence: 0.9,
+      sourceSessionId: "hr-1",
+    });
+    const highSkill = "high-risk-fp-test";
+    db.markProcedurePromoted(highProc.id, `skills/auto/${highSkill}`);
+
+    const lowProc = db.upsertProcedure({
+      taskPattern: "Validate low risk telemetry demote comparison workflow",
+      recipeJson: safeRecipe,
+      procedureType: "positive",
+      successCount: 3,
+      confidence: 0.9,
+      sourceSessionId: "lr-1",
+    });
+    const lowSkill = "low-risk-fp-test";
+    db.markProcedurePromoted(lowProc.id, `skills/auto/${lowSkill}`);
+
+    for (const skillName of [highSkill, lowSkill]) {
+      db.recordGeneratedSkillTelemetry({
+        skillName,
+        decision: "selected",
+        requestSummary: "first unrelated activation",
+        taskOutcome: "success",
+        userCorrection: true,
+      });
+      db.recordGeneratedSkillTelemetry({
+        skillName,
+        decision: "selected",
+        requestSummary: "second unrelated activation",
+        taskOutcome: "success",
+        causedRework: true,
+      });
+    }
+
+    const report = db.buildGeneratedSkillTelemetryReport();
+    const highRow = report.rows.find((r) => r.skillName === highSkill);
+    const lowRow = report.rows.find((r) => r.skillName === lowSkill);
+    expect(highRow?.riskLevel).toBe("high");
+    expect(lowRow?.riskLevel).toBe("low");
+    expect(db.getGeneratedSkillByName(highSkill)?.skillState).toBe("demoted");
+    expect(db.getGeneratedSkillByName(lowSkill)?.skillState).not.toBe("demoted");
   });
 
   it("archives generated skills that are never used after the configured period", () => {

--- a/extensions/memory-hybrid/tests/procedure-promotion-policy.test.ts
+++ b/extensions/memory-hybrid/tests/procedure-promotion-policy.test.ts
@@ -995,4 +995,192 @@ Source procedure id: proc-weather
       parent: (_fixture, context) => adapter.decide(listed, context),
     });
   });
+
+  describe("procedure scoring and risk-aware policy (#1414)", () => {
+    it("userSignal separates no user evidence from one manual request plus one correction", () => {
+      const proc = addProcedure({
+        sourceSessionId: "usig-a",
+        successCount: 6,
+        failureCount: 0,
+        confidence: 0.92,
+      });
+      db.recordProcedureSuccess(proc.id, undefined, "usig-b");
+      db.recordProcedureSuccess(proc.id, undefined, "usig-c");
+      const policy = parseProcedurePromotionPolicy("auto-safe");
+      const item = createProcedurePromotionItem(requireProcedure(proc.id), policy);
+      const baseOpts = {
+        skillsAutoPath: skillsDir,
+        validationThreshold: 3,
+        minDistinctContexts: 1,
+      };
+      const none = evaluateProcedureForPromotion(item, policy, { ...baseOpts, evidence: {} });
+      const mixed = evaluateProcedureForPromotion(item, policy, {
+        ...baseOpts,
+        evidence: {
+          manualWorkflowRequests: [{ id: "m1", sourceSession: "usig-a" }],
+          userCorrections: [{ id: "c1", sourceSession: "usig-a" }],
+        },
+      });
+      expect(none.metadata.candidateScoreBreakdown.userSignal).toBeGreaterThan(
+        mixed.metadata.candidateScoreBreakdown.userSignal,
+      );
+    });
+
+    it("userSignal is monotone: more manual requests increases score; more corrections decreases it", () => {
+      const proc = addProcedure({
+        taskPattern: "Validate monotone user signal scoring workflow",
+        sourceSessionId: "mono-a",
+        successCount: 6,
+        failureCount: 0,
+        confidence: 0.92,
+      });
+      db.recordProcedureSuccess(proc.id, undefined, "mono-b");
+      db.recordProcedureSuccess(proc.id, undefined, "mono-c");
+      const policy = parseProcedurePromotionPolicy("auto-safe");
+      const item = createProcedurePromotionItem(requireProcedure(proc.id), policy);
+      const baseOpts = {
+        skillsAutoPath: skillsDir,
+        validationThreshold: 3,
+        minDistinctContexts: 1,
+      };
+      const baseline = evaluateProcedureForPromotion(item, policy, { ...baseOpts, evidence: {} });
+      const oneManual = evaluateProcedureForPromotion(item, policy, {
+        ...baseOpts,
+        evidence: { manualWorkflowRequests: [{ id: "m1" }] },
+      });
+      const twoManual = evaluateProcedureForPromotion(item, policy, {
+        ...baseOpts,
+        evidence: { manualWorkflowRequests: [{ id: "m1" }, { id: "m2" }] },
+      });
+      expect(oneManual.metadata.candidateScoreBreakdown.userSignal).toBeGreaterThan(
+        baseline.metadata.candidateScoreBreakdown.userSignal,
+      );
+      expect(twoManual.metadata.candidateScoreBreakdown.userSignal).toBeGreaterThan(
+        oneManual.metadata.candidateScoreBreakdown.userSignal,
+      );
+
+      const oneCorrection = evaluateProcedureForPromotion(item, policy, {
+        ...baseOpts,
+        evidence: { userCorrections: [{ id: "c1" }] },
+      });
+      const twoCorrections = evaluateProcedureForPromotion(item, policy, {
+        ...baseOpts,
+        evidence: { userCorrections: [{ id: "c1" }, { id: "c2" }] },
+      });
+      expect(oneCorrection.metadata.candidateScoreBreakdown.userSignal).toBeLessThan(
+        baseline.metadata.candidateScoreBreakdown.userSignal,
+      );
+      expect(twoCorrections.metadata.candidateScoreBreakdown.userSignal).toBeLessThan(
+        oneCorrection.metadata.candidateScoreBreakdown.userSignal,
+      );
+    });
+
+    it("caps rules-and-preferences contribution so repeated rules do not dominate userSignal", () => {
+      const proc = addProcedure({
+        taskPattern: "Validate rules cap user signal scoring workflow",
+        sourceSessionId: "cap-a",
+        successCount: 6,
+        failureCount: 0,
+        confidence: 0.92,
+      });
+      db.recordProcedureSuccess(proc.id, undefined, "cap-b");
+      db.recordProcedureSuccess(proc.id, undefined, "cap-c");
+      const policy = parseProcedurePromotionPolicy("auto-safe");
+      const item = createProcedurePromotionItem(requireProcedure(proc.id), policy);
+      const baseOpts = {
+        skillsAutoPath: skillsDir,
+        validationThreshold: 3,
+        minDistinctContexts: 1,
+      };
+      const manyRules = Array.from({ length: 12 }, (_, i) => ({ id: `rule-${i}` }));
+      const fiveRules = manyRules.slice(0, 5);
+      const capped = evaluateProcedureForPromotion(item, policy, {
+        ...baseOpts,
+        evidence: { rulesAndPreferences: fiveRules },
+      });
+      const uncappedWouldDiffer = evaluateProcedureForPromotion(item, policy, {
+        ...baseOpts,
+        evidence: { rulesAndPreferences: manyRules },
+      });
+      expect(uncappedWouldDiffer.metadata.candidateScoreBreakdown.userSignal).toBe(
+        capped.metadata.candidateScoreBreakdown.userSignal,
+      );
+    });
+
+    it("ranks low-risk candidates above high-risk with otherwise similar promotion evidence", () => {
+      const lowProc = addProcedure({
+        taskPattern: "Validate low risk ranking workflow with objective checks",
+        recipeJson: goodRecipe(),
+        sourceSessionId: "rank-low-a",
+        successCount: 6,
+        failureCount: 0,
+        confidence: 0.92,
+      });
+      db.recordProcedureSuccess(lowProc.id, undefined, "rank-low-b");
+      db.recordProcedureSuccess(lowProc.id, undefined, "rank-low-c");
+
+      const highProc = addProcedure({
+        taskPattern: "Validate high risk ranking workflow with objective checks",
+        recipeJson: JSON.stringify([
+          {
+            tool: "exec",
+            args: { command: "rm -rf /tmp/x" },
+            summary: "delete temp",
+          },
+          {
+            tool: "exec",
+            args: { command: "npm test -- --runInBand" },
+            summary: "Run validation test command",
+          },
+          {
+            tool: "read",
+            args: { path: "report.json" },
+            summary: "Verify generated report exists",
+          },
+        ]),
+        sourceSessionId: "rank-high-a",
+        successCount: 6,
+        failureCount: 0,
+        confidence: 0.92,
+      });
+      db.recordProcedureSuccess(highProc.id, undefined, "rank-high-b");
+      db.recordProcedureSuccess(highProc.id, undefined, "rank-high-c");
+
+      const policy = parseProcedurePromotionPolicy("auto-safe");
+      const sharedEvidence = {
+        procedureVersions: [
+          {
+            id: "v1",
+            versionNumber: 1,
+            successCount: 6,
+            failureCount: 0,
+            avoidanceNotes: null,
+            createdAt: 1_700_000_001,
+          },
+        ],
+        episodes: [{ id: "e1", outcome: "success" as const, sessionId: "s-shared" }],
+      };
+      const baseOpts = {
+        skillsAutoPath: skillsDir,
+        validationThreshold: 3,
+        minDistinctContexts: 1,
+        evidence: sharedEvidence,
+      };
+
+      const lowEval = evaluateProcedureForPromotion(
+        createProcedurePromotionItem(requireProcedure(lowProc.id), policy),
+        policy,
+        baseOpts,
+      );
+      const highEval = evaluateProcedureForPromotion(
+        createProcedurePromotionItem(requireProcedure(highProc.id), policy),
+        policy,
+        baseOpts,
+      );
+
+      expect(lowEval.metadata.riskLevel).toBe("low");
+      expect(highEval.metadata.riskLevel).toBe("high");
+      expect(lowEval.metadata.candidateScore).toBeGreaterThan(highEval.metadata.candidateScore);
+    });
+  });
 });

--- a/extensions/memory-hybrid/tests/procedure-promotion-policy.test.ts
+++ b/extensions/memory-hybrid/tests/procedure-promotion-policy.test.ts
@@ -12,6 +12,7 @@ import {
   parseProcedurePromotionPolicy,
 } from "../services/procedure-promotion-policy.js";
 import { generateAutoSkills } from "../services/procedure-skill-generator.js";
+import { determineRiskLevel, parseRecipeOrRaw } from "../utils/procedure-risk.js";
 import type { ProcedureEntry } from "../types/memory.js";
 import { expectStandaloneAndParentDecisionsEquivalent } from "./helpers/pending-autopilot-equivalence.js";
 
@@ -1105,6 +1106,19 @@ Source procedure id: proc-weather
       expect(uncappedWouldDiffer.metadata.candidateScoreBreakdown.userSignal).toBe(
         capped.metadata.candidateScoreBreakdown.userSignal,
       );
+    });
+
+    it("classifies risk with the same command variants covered by safety scanning", () => {
+      const base = requireProcedure(addProcedure({ taskPattern: "Validate procedure risk classifier variants" }).id);
+      const mediumRecipes = [
+        JSON.stringify([{ tool: "exec", args: { command: "fetch https://api.example.com -X POST" } }]),
+        JSON.stringify([{ tool: "exec", args: { command: "pip3 install example-package" } }]),
+        JSON.stringify([{ tool: "exec", args: { command: "apt-get upgrade example-package" } }]),
+      ];
+
+      for (const recipeJson of mediumRecipes) {
+        expect(determineRiskLevel(base, parseRecipeOrRaw(recipeJson))).toBe("medium");
+      }
     });
 
     it("ranks low-risk candidates above high-risk with otherwise similar promotion evidence", () => {

--- a/extensions/memory-hybrid/utils/procedure-risk.ts
+++ b/extensions/memory-hybrid/utils/procedure-risk.ts
@@ -1,0 +1,25 @@
+import type { ProcedureEntry } from "../types/memory.js";
+
+export type ProcedureRiskLevel = "low" | "medium" | "high";
+
+const HIGH_RISK_PATTERN =
+  /(?:\brm\s+-[rf]+\b|\bdd\s+if=|\bmkfs\b|\bshred\b|\bdrop\s+table\b|\btruncate\s+table\b)|(?:\bprivate[_-]?key\b|\b(?:token|password)\b)\s*[:=]/i;
+
+const MEDIUM_RISK_PATTERN =
+  /\b(systemctl|service)\s+(?:start|stop|restart|reload|enable|disable)\b|\b(npm|pnpm|yarn|pip|pip3|apt|apt-get|brew|cargo|gem)\s+(install|add|remove|uninstall|upgrade)\b|\bssh\s+[^\n]+@|\bscp\s+|\brsync\s+[^\n]+:|\b(curl|wget|fetch)\b[^\n]*(?:-X\s*(?:POST|PUT|PATCH|DELETE)|--request\s*(?:POST|PUT|PATCH|DELETE))/i;
+
+export function parseRecipeOrRaw(recipeJson: string): unknown {
+  try {
+    return JSON.parse(recipeJson) as unknown;
+  } catch {
+    return { malformed: true, raw: recipeJson };
+  }
+}
+
+/** Heuristic risk tier for procedure text + recipe (used for promotion gates, scoring, and lifecycle demotion). */
+export function determineRiskLevel(proc: ProcedureEntry, recipe: unknown): ProcedureRiskLevel {
+  const combined = `${proc.taskPattern}\n${JSON.stringify(recipe)}`;
+  if (HIGH_RISK_PATTERN.test(combined)) return "high";
+  if (MEDIUM_RISK_PATTERN.test(combined)) return "medium";
+  return "low";
+}


### PR DESCRIPTION
Closes https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/1414

## Summary
Implements the merged epic from #1414 (supersedes #1396, #1395, #1394): coherent **userSignal** scoring, **risk as a multiplier** on procedure candidate scores, **risk-aware demotion** in generated-skill telemetry, and documentation.

## Changes
- **userSignal** (`summarizeProcedureEvidence`): zero baseline; manual/correction weights slightly asymmetric so one manual + one correction does not tie no-signal; rules/preferences capped at 5; raw in `[-1,1]` remapped to `[0,1]` for the additive term.
- **Candidate score** (`scoreProcedureCandidate`): base evidence sum × **risk multiplier** (high 0.35×, medium 0.65×, low 1×) × duplicate penalty; weights documented in code and `docs/PROCEDURAL-MEMORY.md`.
- **Policy version** bumped to `procedure-promotion-policy-v2` (scoring semantics changed).
- **Telemetry** (`generated-skills.ts`): `determineRiskLevel` on procedure row; `effectiveDemoteThresholdsForRisk` adjusts FP threshold (↑ for low-risk, ↓ for medium/high) and min samples (−1 for high); report rows include `riskLevel`; demotion reason mentions risk tier and effective thresholds.

## Tests
- Monotonicity, no-signal vs mixed signal, rules cap, low vs high risk candidate ordering.
- High-risk demotes after 2 FP activations where low-risk still requires default sample count.

Commits are authored as **Markus Lassfolk** (noreply GitHub email). CI: `npm test` in `extensions/memory-hybrid` expects Node ≥22.16 (`node:sqlite`).

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes procedure promotion scoring semantics and generated-skill lifecycle demotion thresholds, which can reorder promotion candidates and alter when skills are auto-demoted in production telemetry.
> 
> **Overview**
> Updates procedure promotion scoring to use a redefined **user signal** (zero-baseline, asymmetric weights, capped rules contribution) and applies **risk as a multiplier** on the evidence score; the policy version is bumped to `procedure-promotion-policy-v2` to reflect the new semantics.
> 
> Extends generated-skill telemetry to compute and surface `riskLevel` per skill, and makes auto-demotion thresholds **risk-adjusted** (high-risk demotes sooner; low-risk slightly later) with improved demotion reasons. Adds a shared `procedure-risk` utility plus targeted tests and documentation covering the new scoring, risk classifier, and demotion behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfd3880147a0bd70f6bfdbf7afbb18e3ae154319. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->