### PR TITLE
perf(memory-hybrid): workflow patterns telemetry and duplicate detection

### DIFF
--- a/extensions/memory-hybrid/backends/facts-db/generated-skills.ts
+++ b/extensions/memory-hybrid/backends/facts-db/generated-skills.ts
@@ -747,15 +747,38 @@ export function refreshGeneratedSkillLifecycleState(
   skillName: string,
   policy: GeneratedSkillLifecyclePolicy = DEFAULT_GENERATED_SKILL_LIFECYCLE_POLICY,
   now = Math.floor(Date.now() / 1000),
-): ProcedureEntry | null {
+): ProcedureEntry | null;
+export function refreshGeneratedSkillLifecycleState(
+  db: DatabaseSync,
+  skillName: string,
+  policy: GeneratedSkillLifecyclePolicy,
+  now: number,
+  returnMetrics: true,
+): { proc: ProcedureEntry; metrics: GeneratedSkillTelemetryMetrics; flags: GeneratedSkillTelemetryFlags } | null;
+export function refreshGeneratedSkillLifecycleState(
+  db: DatabaseSync,
+  skillName: string,
+  policy: GeneratedSkillLifecyclePolicy = DEFAULT_GENERATED_SKILL_LIFECYCLE_POLICY,
+  now = Math.floor(Date.now() / 1000),
+  returnMetrics = false,
+):
+  | ProcedureEntry
+  | { proc: ProcedureEntry; metrics: GeneratedSkillTelemetryMetrics; flags: GeneratedSkillTelemetryFlags }
+  | null {
   const proc = findGeneratedSkillProcedure(db, skillName);
   if (!proc?.skillPath) return null;
   const canonicalSkillName = basename(proc.skillPath);
   const { metrics, flags } = summarizeSkillTelemetryFromRollups(db, proc, canonicalSkillName, policy, now);
   const currentState = proc.skillState ?? "experimental";
   const transition = desiredLifecycleTransition(currentState, flags, metrics, policy);
-  if (transition == null) return proc;
-  return setGeneratedSkillLifecycleState(db, canonicalSkillName, transition.state, transition.reason, now);
+  const updatedProc =
+    transition == null
+      ? proc
+      : (setGeneratedSkillLifecycleState(db, canonicalSkillName, transition.state, transition.reason, now) ?? proc);
+  if (returnMetrics) {
+    return { proc: updatedProc, metrics, flags };
+  }
+  return updatedProc;
 }
 
 export function buildGeneratedSkillTelemetryReport(
@@ -777,10 +800,21 @@ export function buildGeneratedSkillTelemetryReport(
   const rows = procedures
     .map((proc) => {
       const skillName = basename(proc.skillPath ?? proc.taskPattern);
-      const procFresh = proc.skillPath
-        ? (refreshGeneratedSkillLifecycleState(db, skillName, policy, now) ?? proc)
-        : proc;
-      const { metrics, flags } = summarizeSkillTelemetryFromRollups(db, procFresh, skillName, policy, now);
+      let procFresh: ProcedureEntry;
+      let metrics: GeneratedSkillTelemetryMetrics;
+      let flags: GeneratedSkillTelemetryFlags;
+      if (proc.skillPath) {
+        const result = refreshGeneratedSkillLifecycleState(db, skillName, policy, now, true);
+        if (result == null) {
+          procFresh = proc;
+          ({ metrics, flags } = summarizeSkillTelemetryFromRollups(db, proc, skillName, policy, now));
+        } else {
+          ({ proc: procFresh, metrics, flags } = result);
+        }
+      } else {
+        procFresh = proc;
+        ({ metrics, flags } = summarizeSkillTelemetryFromRollups(db, proc, skillName, policy, now));
+      }
       const recommendation = flags.archiveCandidate
         ? "archive"
         : flags.overTriggering

--- a/extensions/memory-hybrid/backends/facts-db/generated-skills.ts
+++ b/extensions/memory-hybrid/backends/facts-db/generated-skills.ts
@@ -552,8 +552,10 @@ function summarizeSkillTelemetry(
   let savedTimeMs = 0;
 
   for (const activation of activations) {
-    savedToolCalls += activation.savedToolCalls ?? 0;
-    savedTimeMs += activation.savedTimeMs ?? 0;
+    const calls = activation.savedToolCalls ?? 0;
+    const timeMs = activation.savedTimeMs ?? 0;
+    savedToolCalls += calls > 0 ? calls : 0;
+    savedTimeMs += timeMs > 0 ? timeMs : 0;
     if (activation.decision === "selected") {
       activationCountTotal++;
       if (activation.createdAt >= weekAgo) activationCountPerWeek++;

--- a/extensions/memory-hybrid/backends/facts-db/generated-skills.ts
+++ b/extensions/memory-hybrid/backends/facts-db/generated-skills.ts
@@ -777,8 +777,9 @@ export function buildGeneratedSkillTelemetryReport(
   const rows = procedures
     .map((proc) => {
       const skillName = basename(proc.skillPath ?? proc.taskPattern);
-      if (proc.skillPath) refreshGeneratedSkillLifecycleState(db, skillName, policy, now);
-      const procFresh = findGeneratedSkillProcedure(db, skillName) ?? proc;
+      const procFresh = proc.skillPath
+        ? (refreshGeneratedSkillLifecycleState(db, skillName, policy, now) ?? proc)
+        : proc;
       const { metrics, flags } = summarizeSkillTelemetryFromRollups(db, procFresh, skillName, policy, now);
       const recommendation = flags.archiveCandidate
         ? "archive"

--- a/extensions/memory-hybrid/backends/facts-db/generated-skills.ts
+++ b/extensions/memory-hybrid/backends/facts-db/generated-skills.ts
@@ -745,8 +745,8 @@ function desiredLifecycleTransition(
 export function refreshGeneratedSkillLifecycleState(
   db: DatabaseSync,
   skillName: string,
-  policy: GeneratedSkillLifecyclePolicy = DEFAULT_GENERATED_SKILL_LIFECYCLE_POLICY,
-  now = Math.floor(Date.now() / 1000),
+  policy?: GeneratedSkillLifecyclePolicy,
+  now?: number,
 ): ProcedureEntry | null;
 export function refreshGeneratedSkillLifecycleState(
   db: DatabaseSync,

--- a/extensions/memory-hybrid/backends/facts-db/generated-skills.ts
+++ b/extensions/memory-hybrid/backends/facts-db/generated-skills.ts
@@ -322,13 +322,13 @@ function applyTelemetryRollupDelta(
   );
 }
 
-function countSelectedActivationsSince(db: DatabaseSync, skillName: string, sinceSec: number): number {
+function countSelectedActivationsSince(db: DatabaseSync, procedureId: string, sinceSec: number): number {
   const row = db
     .prepare(
       `SELECT COUNT(*) as c FROM generated_skill_telemetry
-        WHERE skill_name = ? AND decision = 'selected' AND created_at >= ?`,
+        WHERE procedure_id = ? AND decision = 'selected' AND created_at >= ?`,
     )
-    .get(skillName, sinceSec) as { c: number };
+    .get(procedureId, sinceSec) as { c: number };
   return row?.c ?? 0;
 }
 
@@ -644,7 +644,7 @@ function summarizeSkillTelemetryFromRollups(
     return summarizeSkillTelemetry(proc, skillTelemetryEntries(db, canonicalSkillName), policy, now);
   }
   const weekAgo = now - 7 * 24 * 60 * 60;
-  const activationCountPerWeek = countSelectedActivationsSince(db, canonicalSkillName, weekAgo);
+  const activationCountPerWeek = countSelectedActivationsSince(db, proc.id, weekAgo);
   const activationCountTotal = r.gst_sel_total;
   const nearMissCount = r.gst_near_miss_total;
   const falsePositiveSignals = r.gst_fp_signals_total;

--- a/extensions/memory-hybrid/backends/facts-db/generated-skills.ts
+++ b/extensions/memory-hybrid/backends/facts-db/generated-skills.ts
@@ -171,6 +171,167 @@ function requestHashFromInput(
   return createHash("sha256").update(normalizedSummary).digest("hex").slice(0, 16);
 }
 
+/** Per-procedure counters maintained incrementally on telemetry insert (#1415 / #1400). */
+type TelemetryRollupRow = {
+  gst_sel_total: number;
+  gst_near_miss_total: number;
+  gst_fp_signals_total: number;
+  gst_fn_signals_total: number;
+  gst_user_correction_total: number;
+  gst_outcome_success: number;
+  gst_outcome_failure: number;
+  gst_outcome_partial: number;
+  gst_outcome_unknown: number;
+  gst_success_clear_total: number;
+  gst_considered_total: number;
+  gst_skipped_total: number;
+  gst_saved_tool_calls_sum: number;
+  gst_saved_time_ms_sum: number;
+  gst_last_selected_at: number | null;
+};
+
+function readTelemetryRollup(db: DatabaseSync, procedureId: string): TelemetryRollupRow | null {
+  const row = db
+    .prepare(
+      `SELECT gst_sel_total, gst_near_miss_total, gst_fp_signals_total, gst_fn_signals_total,
+              gst_user_correction_total, gst_outcome_success, gst_outcome_failure, gst_outcome_partial,
+              gst_outcome_unknown, gst_success_clear_total, gst_considered_total, gst_skipped_total,
+              gst_saved_tool_calls_sum, gst_saved_time_ms_sum, gst_last_selected_at
+         FROM procedures WHERE id = ?`,
+    )
+    .get(procedureId) as Record<string, unknown> | undefined;
+  if (!row) return null;
+  return {
+    gst_sel_total: (row.gst_sel_total as number) ?? 0,
+    gst_near_miss_total: (row.gst_near_miss_total as number) ?? 0,
+    gst_fp_signals_total: (row.gst_fp_signals_total as number) ?? 0,
+    gst_fn_signals_total: (row.gst_fn_signals_total as number) ?? 0,
+    gst_user_correction_total: (row.gst_user_correction_total as number) ?? 0,
+    gst_outcome_success: (row.gst_outcome_success as number) ?? 0,
+    gst_outcome_failure: (row.gst_outcome_failure as number) ?? 0,
+    gst_outcome_partial: (row.gst_outcome_partial as number) ?? 0,
+    gst_outcome_unknown: (row.gst_outcome_unknown as number) ?? 0,
+    gst_success_clear_total: (row.gst_success_clear_total as number) ?? 0,
+    gst_considered_total: (row.gst_considered_total as number) ?? 0,
+    gst_skipped_total: (row.gst_skipped_total as number) ?? 0,
+    gst_saved_tool_calls_sum: (row.gst_saved_tool_calls_sum as number) ?? 0,
+    gst_saved_time_ms_sum: (row.gst_saved_time_ms_sum as number) ?? 0,
+    gst_last_selected_at: (row.gst_last_selected_at as number | null) ?? null,
+  };
+}
+
+/** Recompute rollup columns from `generated_skill_telemetry` (e.g. after correction edits). */
+export function rebuildGeneratedSkillTelemetryRollupsForProcedure(db: DatabaseSync, procedureId: string): void {
+  db.prepare(
+    `UPDATE procedures AS p
+       SET gst_sel_total = (SELECT COUNT(*) FROM generated_skill_telemetry t WHERE t.procedure_id = p.id AND t.decision = 'selected'),
+           gst_near_miss_total = (SELECT COUNT(*) FROM generated_skill_telemetry t WHERE t.procedure_id = p.id AND t.decision != 'selected'),
+           gst_fp_signals_total = (SELECT COUNT(*) FROM generated_skill_telemetry t WHERE t.procedure_id = p.id AND t.decision = 'selected' AND (t.user_correction = 1 OR t.caused_rework = 1)),
+           gst_fn_signals_total = (SELECT COUNT(*) FROM generated_skill_telemetry t WHERE t.procedure_id = p.id AND t.false_negative_signal = 1),
+           gst_user_correction_total = (SELECT COUNT(*) FROM generated_skill_telemetry t WHERE t.procedure_id = p.id AND t.user_correction = 1),
+           gst_outcome_success = (SELECT COUNT(*) FROM generated_skill_telemetry t WHERE t.procedure_id = p.id AND t.decision = 'selected' AND t.task_outcome = 'success'),
+           gst_outcome_failure = (SELECT COUNT(*) FROM generated_skill_telemetry t WHERE t.procedure_id = p.id AND t.decision = 'selected' AND t.task_outcome = 'failure'),
+           gst_outcome_partial = (SELECT COUNT(*) FROM generated_skill_telemetry t WHERE t.procedure_id = p.id AND t.decision = 'selected' AND t.task_outcome = 'partial'),
+           gst_outcome_unknown = (SELECT COUNT(*) FROM generated_skill_telemetry t WHERE t.procedure_id = p.id AND t.decision = 'selected' AND (t.task_outcome IS NULL OR t.task_outcome NOT IN ('success','failure','partial'))),
+           gst_success_clear_total = (SELECT COUNT(*) FROM generated_skill_telemetry t WHERE t.procedure_id = p.id AND t.decision = 'selected' AND t.task_outcome = 'success' AND t.user_correction = 0),
+           gst_considered_total = (SELECT COUNT(*) FROM generated_skill_telemetry t WHERE t.procedure_id = p.id AND t.decision = 'considered'),
+           gst_skipped_total = (SELECT COUNT(*) FROM generated_skill_telemetry t WHERE t.procedure_id = p.id AND t.decision = 'skipped'),
+           gst_saved_tool_calls_sum = (SELECT COALESCE(SUM(t.saved_tool_calls), 0) FROM generated_skill_telemetry t WHERE t.procedure_id = p.id),
+           gst_saved_time_ms_sum = (SELECT COALESCE(SUM(t.saved_time_ms), 0) FROM generated_skill_telemetry t WHERE t.procedure_id = p.id),
+           gst_last_selected_at = (SELECT MAX(t.created_at) FROM generated_skill_telemetry t WHERE t.procedure_id = p.id AND t.decision = 'selected')
+     WHERE p.id = ?`,
+  ).run(procedureId);
+}
+
+function applyTelemetryRollupDelta(
+  db: DatabaseSync,
+  procedureId: string,
+  input: GeneratedSkillTelemetryRecordInput,
+  savedCalls: number,
+  savedTimeMs: number,
+  nowSec: number,
+): void {
+  let dSel = 0;
+  let dNear = 0;
+  let dFp = 0;
+  let dFn = 0;
+  let dUserCorr = 0;
+  let dSucc = 0;
+  let dFail = 0;
+  let dPart = 0;
+  let dUnk = 0;
+  let dClear = 0;
+  let dConsidered = 0;
+  let dSkipped = 0;
+  if (input.decision === "selected") {
+    dSel = 1;
+    if (input.userCorrection === true || input.causedRework === true) dFp = 1;
+    const o = input.taskOutcome;
+    if (o === "success") {
+      dSucc = 1;
+      if (input.userCorrection !== true) dClear = 1;
+    } else if (o === "failure") dFail = 1;
+    else if (o === "partial") dPart = 1;
+    else dUnk = 1;
+  } else {
+    dNear = 1;
+    if (input.decision === "considered") dConsidered = 1;
+    if (input.decision === "skipped") dSkipped = 1;
+  }
+  if (input.falseNegativeSignal === true) dFn = 1;
+  if (input.userCorrection === true) dUserCorr = 1;
+  const sc = savedCalls > 0 ? savedCalls : 0;
+  const st = savedTimeMs > 0 ? savedTimeMs : 0;
+  const lastBump = input.decision === "selected" ? nowSec : 0;
+  db.prepare(
+    `UPDATE procedures SET
+       gst_sel_total = gst_sel_total + ?,
+       gst_near_miss_total = gst_near_miss_total + ?,
+       gst_fp_signals_total = gst_fp_signals_total + ?,
+       gst_fn_signals_total = gst_fn_signals_total + ?,
+       gst_user_correction_total = gst_user_correction_total + ?,
+       gst_outcome_success = gst_outcome_success + ?,
+       gst_outcome_failure = gst_outcome_failure + ?,
+       gst_outcome_partial = gst_outcome_partial + ?,
+       gst_outcome_unknown = gst_outcome_unknown + ?,
+       gst_success_clear_total = gst_success_clear_total + ?,
+       gst_considered_total = gst_considered_total + ?,
+       gst_skipped_total = gst_skipped_total + ?,
+       gst_saved_tool_calls_sum = gst_saved_tool_calls_sum + ?,
+       gst_saved_time_ms_sum = gst_saved_time_ms_sum + ?,
+       gst_last_selected_at = CASE WHEN ? > COALESCE(gst_last_selected_at, 0) THEN ? ELSE gst_last_selected_at END
+     WHERE id = ?`,
+  ).run(
+    dSel,
+    dNear,
+    dFp,
+    dFn,
+    dUserCorr,
+    dSucc,
+    dFail,
+    dPart,
+    dUnk,
+    dClear,
+    dConsidered,
+    dSkipped,
+    sc,
+    st,
+    lastBump,
+    lastBump,
+    procedureId,
+  );
+}
+
+function countSelectedActivationsSince(db: DatabaseSync, skillName: string, sinceSec: number): number {
+  const row = db
+    .prepare(
+      `SELECT COUNT(*) as c FROM generated_skill_telemetry
+        WHERE skill_name = ? AND decision = 'selected' AND created_at >= ?`,
+    )
+    .get(skillName, sinceSec) as { c: number };
+  return row?.c ?? 0;
+}
+
 function generatedSkillRows(db: DatabaseSync): Array<Record<string, unknown>> {
   return db
     .prepare(
@@ -280,6 +441,7 @@ export function recordGeneratedSkillTelemetry(
     input.sessionId ?? null,
     now,
   );
+  applyTelemetryRollupDelta(db, proc.id, input, input.savedToolCalls ?? 0, input.savedTimeMs ?? 0, now);
   refreshGeneratedSkillLifecycleState(db, proc.skillPath ? basename(proc.skillPath) : input.skillName, policy, now);
   return mapGeneratedSkillTelemetryRow(
     db.prepare("SELECT * FROM generated_skill_telemetry WHERE id = ?").get(id) as GeneratedSkillTelemetryRow,
@@ -302,6 +464,7 @@ export function markGeneratedSkillTelemetryFalsePositive(
             correction_reason = COALESCE(?, correction_reason)
       WHERE id = ?`,
   ).run(normalizeSummary(correctionReason), activationId);
+  rebuildGeneratedSkillTelemetryRollupsForProcedure(db, row.procedure_id);
   refreshGeneratedSkillLifecycleState(db, row.skill_name, policy);
   return mapGeneratedSkillTelemetryRow(
     db.prepare("SELECT * FROM generated_skill_telemetry WHERE id = ?").get(activationId) as GeneratedSkillTelemetryRow,
@@ -341,6 +504,26 @@ function skillTelemetryEntries(db: DatabaseSync, skillName: string): GeneratedSk
           ORDER BY created_at DESC`,
       )
       .all(skillName) as GeneratedSkillTelemetryRow[]
+  ).map(mapGeneratedSkillTelemetryRow);
+}
+
+function skillTelemetryRecentEntries(
+  db: DatabaseSync,
+  skillName: string,
+  limit: number,
+): GeneratedSkillTelemetryEntry[] {
+  return (
+    db
+      .prepare(
+        `SELECT id, procedure_id, skill_name, skill_version, request_hash, request_summary, decision, confidence,
+                reason, task_outcome, user_correction, correction_reason, false_negative_signal, caused_rework,
+                saved_tool_calls, saved_time_ms, scope, scope_target, agent_id, session_id, created_at
+           FROM generated_skill_telemetry
+          WHERE skill_name = ?
+          ORDER BY created_at DESC
+          LIMIT ?`,
+      )
+      .all(skillName, limit) as GeneratedSkillTelemetryRow[]
   ).map(mapGeneratedSkillTelemetryRow);
 }
 
@@ -449,6 +632,89 @@ function summarizeSkillTelemetry(
   };
 }
 
+function summarizeSkillTelemetryFromRollups(
+  db: DatabaseSync,
+  proc: ProcedureEntry,
+  canonicalSkillName: string,
+  policy: GeneratedSkillLifecyclePolicy,
+  now: number,
+): { metrics: GeneratedSkillTelemetryMetrics; flags: GeneratedSkillTelemetryFlags } {
+  const r = readTelemetryRollup(db, proc.id);
+  if (!r) {
+    return summarizeSkillTelemetry(proc, skillTelemetryEntries(db, canonicalSkillName), policy, now);
+  }
+  const weekAgo = now - 7 * 24 * 60 * 60;
+  const activationCountPerWeek = countSelectedActivationsSince(db, canonicalSkillName, weekAgo);
+  const activationCountTotal = r.gst_sel_total;
+  const nearMissCount = r.gst_near_miss_total;
+  const falsePositiveSignals = r.gst_fp_signals_total;
+  const falseNegativeSignals = r.gst_fn_signals_total;
+  const repeatedCorrectionCount = r.gst_user_correction_total;
+  const lastUsedAt = r.gst_last_selected_at;
+  const successCount = r.gst_outcome_success;
+  const failureCount = r.gst_outcome_failure;
+  const partialCount = r.gst_outcome_partial;
+  const unknownCount = r.gst_outcome_unknown;
+  const successfulUsesWithoutCorrection = r.gst_success_clear_total;
+  const consideredCount = r.gst_considered_total;
+  const skippedCount = r.gst_skipped_total;
+  const savedToolCalls = r.gst_saved_tool_calls_sum;
+  const savedTimeMs = r.gst_saved_time_ms_sum;
+
+  const knownOutcomeTotal = successCount + failureCount + partialCount + unknownCount;
+  const successRate = knownOutcomeTotal > 0 ? successCount / knownOutcomeTotal : null;
+  const failureRate = knownOutcomeTotal > 0 ? failureCount / knownOutcomeTotal : null;
+  const partialRate = knownOutcomeTotal > 0 ? partialCount / knownOutcomeTotal : null;
+  const unknownRate = knownOutcomeTotal > 0 ? unknownCount / knownOutcomeTotal : null;
+  const falsePositiveRate = activationCountTotal > 0 ? falsePositiveSignals / activationCountTotal : null;
+  const generatedAt = proc.skillGeneratedAt ?? proc.promotedAt ?? proc.updatedAt ?? proc.createdAt ?? now;
+  const archiveCandidate =
+    activationCountTotal === 0 && generatedAt <= now - policy.archiveAfterUnusedDays * 24 * 60 * 60;
+  const promotionCandidate =
+    proc.skillState !== "demoted" &&
+    proc.skillState !== "archived" &&
+    proc.skillState !== "trusted" &&
+    successfulUsesWithoutCorrection >= policy.promoteAfterSuccessfulUses;
+  const overTriggering =
+    activationCountTotal >= policy.demoteMinSamples &&
+    falsePositiveRate != null &&
+    falsePositiveRate >= policy.demoteFalsePositiveRate;
+  const revisionCandidate = nearMissCount >= policy.revisionNearMissThreshold && skippedCount >= consideredCount;
+
+  return {
+    metrics: {
+      activationCountPerWeek,
+      activationCountTotal,
+      nearMissCount,
+      falsePositiveSignals,
+      falseNegativeSignals,
+      repeatedCorrectionCount,
+      lastUsedAt,
+      successCount,
+      failureCount,
+      partialCount,
+      unknownCount,
+      successRate,
+      failureRate,
+      partialRate,
+      unknownRate,
+      successfulUsesWithoutCorrection,
+      consideredCount,
+      skippedCount,
+      savedToolCalls,
+      savedTimeMs,
+      falsePositiveRate,
+    },
+    flags: {
+      promotionCandidate,
+      overTriggering,
+      revisionCandidate,
+      neverUsed: activationCountTotal === 0,
+      archiveCandidate,
+    },
+  };
+}
+
 function desiredLifecycleTransition(
   currentState: GeneratedSkillLifecycleState,
   flags: GeneratedSkillTelemetryFlags,
@@ -485,8 +751,7 @@ export function refreshGeneratedSkillLifecycleState(
   const proc = findGeneratedSkillProcedure(db, skillName);
   if (!proc?.skillPath) return null;
   const canonicalSkillName = basename(proc.skillPath);
-  const activations = skillTelemetryEntries(db, canonicalSkillName);
-  const { metrics, flags } = summarizeSkillTelemetry(proc, activations, policy, now);
+  const { metrics, flags } = summarizeSkillTelemetryFromRollups(db, proc, canonicalSkillName, policy, now);
   const currentState = proc.skillState ?? "experimental";
   const transition = desiredLifecycleTransition(currentState, flags, metrics, policy);
   if (transition == null) return proc;
@@ -504,22 +769,17 @@ export function buildGeneratedSkillTelemetryReport(
 ): GeneratedSkillTelemetryReport {
   const policy = { ...DEFAULT_GENERATED_SKILL_LIFECYCLE_POLICY, ...(options?.policy ?? {}) };
   const now = options?.now ?? Math.floor(Date.now() / 1000);
+  const recentLimit = options?.recentActivationLimit ?? 10;
   const procedures = listGeneratedSkillProcedures(db).filter((proc) => {
     if (!options?.skillName) return true;
     return proc.skillPath != null && basename(proc.skillPath) === options.skillName;
   });
-  for (const proc of procedures) {
-    if (proc.skillPath) refreshGeneratedSkillLifecycleState(db, basename(proc.skillPath), policy, now);
-  }
-  const rows = listGeneratedSkillProcedures(db)
-    .filter((proc) => {
-      if (!options?.skillName) return true;
-      return proc.skillPath != null && basename(proc.skillPath) === options.skillName;
-    })
+  const rows = procedures
     .map((proc) => {
       const skillName = basename(proc.skillPath ?? proc.taskPattern);
-      const activations = skillTelemetryEntries(db, skillName);
-      const { metrics, flags } = summarizeSkillTelemetry(proc, activations, policy, now);
+      if (proc.skillPath) refreshGeneratedSkillLifecycleState(db, skillName, policy, now);
+      const procFresh = findGeneratedSkillProcedure(db, skillName) ?? proc;
+      const { metrics, flags } = summarizeSkillTelemetryFromRollups(db, procFresh, skillName, policy, now);
       const recommendation = flags.archiveCandidate
         ? "archive"
         : flags.overTriggering
@@ -530,17 +790,17 @@ export function buildGeneratedSkillTelemetryReport(
               ? "revise"
               : "observe";
       return {
-        procedureId: proc.id,
+        procedureId: procFresh.id,
         skillName,
-        skillPath: proc.skillPath ?? skillName,
-        skillVersion: proc.skillVersion ?? 1,
-        state: proc.skillState ?? "experimental",
-        stateReason: proc.skillStateReason ?? null,
-        generatedAt: proc.skillGeneratedAt ?? proc.promotedAt ?? null,
+        skillPath: procFresh.skillPath ?? skillName,
+        skillVersion: procFresh.skillVersion ?? 1,
+        state: procFresh.skillState ?? "experimental",
+        stateReason: procFresh.skillStateReason ?? null,
+        generatedAt: procFresh.skillGeneratedAt ?? procFresh.promotedAt ?? null,
         metrics,
         flags,
         recommendation,
-        recentActivations: activations.slice(0, options?.recentActivationLimit ?? 10),
+        recentActivations: skillTelemetryRecentEntries(db, skillName, recentLimit),
       } satisfies GeneratedSkillTelemetryReportRow;
     })
     .sort((a, b) => a.skillName.localeCompare(b.skillName));

--- a/extensions/memory-hybrid/backends/facts-db/generated-skills.ts
+++ b/extensions/memory-hybrid/backends/facts-db/generated-skills.ts
@@ -236,8 +236,8 @@ export function rebuildGeneratedSkillTelemetryRollupsForProcedure(db: DatabaseSy
            gst_success_clear_total = (SELECT COUNT(*) FROM generated_skill_telemetry t WHERE t.procedure_id = p.id AND t.decision = 'selected' AND t.task_outcome = 'success' AND t.user_correction = 0),
            gst_considered_total = (SELECT COUNT(*) FROM generated_skill_telemetry t WHERE t.procedure_id = p.id AND t.decision = 'considered'),
            gst_skipped_total = (SELECT COUNT(*) FROM generated_skill_telemetry t WHERE t.procedure_id = p.id AND t.decision = 'skipped'),
-           gst_saved_tool_calls_sum = (SELECT COALESCE(SUM(t.saved_tool_calls), 0) FROM generated_skill_telemetry t WHERE t.procedure_id = p.id),
-           gst_saved_time_ms_sum = (SELECT COALESCE(SUM(t.saved_time_ms), 0) FROM generated_skill_telemetry t WHERE t.procedure_id = p.id),
+           gst_saved_tool_calls_sum = (SELECT COALESCE(SUM(CASE WHEN t.saved_tool_calls > 0 THEN t.saved_tool_calls ELSE 0 END), 0) FROM generated_skill_telemetry t WHERE t.procedure_id = p.id),
+           gst_saved_time_ms_sum = (SELECT COALESCE(SUM(CASE WHEN t.saved_time_ms > 0 THEN t.saved_time_ms ELSE 0 END), 0) FROM generated_skill_telemetry t WHERE t.procedure_id = p.id),
            gst_last_selected_at = (SELECT MAX(t.created_at) FROM generated_skill_telemetry t WHERE t.procedure_id = p.id AND t.decision = 'selected')
      WHERE p.id = ?`,
   ).run(procedureId);

--- a/extensions/memory-hybrid/backends/facts-db/generated-skills.ts
+++ b/extensions/memory-hybrid/backends/facts-db/generated-skills.ts
@@ -527,6 +527,87 @@ function skillTelemetryRecentEntries(
   ).map(mapGeneratedSkillTelemetryRow);
 }
 
+type RawTelemetryCounts = {
+  activationCountPerWeek: number;
+  activationCountTotal: number;
+  nearMissCount: number;
+  falsePositiveSignals: number;
+  falseNegativeSignals: number;
+  repeatedCorrectionCount: number;
+  lastUsedAt: number | null;
+  successCount: number;
+  failureCount: number;
+  partialCount: number;
+  unknownCount: number;
+  successfulUsesWithoutCorrection: number;
+  consideredCount: number;
+  skippedCount: number;
+  savedToolCalls: number;
+  savedTimeMs: number;
+};
+
+function deriveMetricsAndFlags(
+  counts: RawTelemetryCounts,
+  proc: ProcedureEntry,
+  policy: GeneratedSkillLifecyclePolicy,
+  now: number,
+): { metrics: GeneratedSkillTelemetryMetrics; flags: GeneratedSkillTelemetryFlags } {
+  const knownOutcomeTotal = counts.successCount + counts.failureCount + counts.partialCount + counts.unknownCount;
+  const successRate = knownOutcomeTotal > 0 ? counts.successCount / knownOutcomeTotal : null;
+  const failureRate = knownOutcomeTotal > 0 ? counts.failureCount / knownOutcomeTotal : null;
+  const partialRate = knownOutcomeTotal > 0 ? counts.partialCount / knownOutcomeTotal : null;
+  const unknownRate = knownOutcomeTotal > 0 ? counts.unknownCount / knownOutcomeTotal : null;
+  const falsePositiveRate =
+    counts.activationCountTotal > 0 ? counts.falsePositiveSignals / counts.activationCountTotal : null;
+  const generatedAt = proc.skillGeneratedAt ?? proc.promotedAt ?? proc.updatedAt ?? proc.createdAt ?? now;
+  const archiveCandidate =
+    counts.activationCountTotal === 0 && generatedAt <= now - policy.archiveAfterUnusedDays * 24 * 60 * 60;
+  const promotionCandidate =
+    proc.skillState !== "demoted" &&
+    proc.skillState !== "archived" &&
+    proc.skillState !== "trusted" &&
+    counts.successfulUsesWithoutCorrection >= policy.promoteAfterSuccessfulUses;
+  const overTriggering =
+    counts.activationCountTotal >= policy.demoteMinSamples &&
+    falsePositiveRate != null &&
+    falsePositiveRate >= policy.demoteFalsePositiveRate;
+  const revisionCandidate =
+    counts.nearMissCount >= policy.revisionNearMissThreshold && counts.skippedCount >= counts.consideredCount;
+
+  return {
+    metrics: {
+      activationCountPerWeek: counts.activationCountPerWeek,
+      activationCountTotal: counts.activationCountTotal,
+      nearMissCount: counts.nearMissCount,
+      falsePositiveSignals: counts.falsePositiveSignals,
+      falseNegativeSignals: counts.falseNegativeSignals,
+      repeatedCorrectionCount: counts.repeatedCorrectionCount,
+      lastUsedAt: counts.lastUsedAt,
+      successCount: counts.successCount,
+      failureCount: counts.failureCount,
+      partialCount: counts.partialCount,
+      unknownCount: counts.unknownCount,
+      successRate,
+      failureRate,
+      partialRate,
+      unknownRate,
+      successfulUsesWithoutCorrection: counts.successfulUsesWithoutCorrection,
+      consideredCount: counts.consideredCount,
+      skippedCount: counts.skippedCount,
+      savedToolCalls: counts.savedToolCalls,
+      savedTimeMs: counts.savedTimeMs,
+      falsePositiveRate,
+    },
+    flags: {
+      promotionCandidate,
+      overTriggering,
+      revisionCandidate,
+      neverUsed: counts.activationCountTotal === 0,
+      archiveCandidate,
+    },
+  };
+}
+
 function summarizeSkillTelemetry(
   proc: ProcedureEntry,
   activations: GeneratedSkillTelemetryEntry[],
@@ -580,28 +661,8 @@ function summarizeSkillTelemetry(
     if (activation.userCorrection) repeatedCorrectionCount++;
   }
 
-  const knownOutcomeTotal = successCount + failureCount + partialCount + unknownCount;
-  const successRate = knownOutcomeTotal > 0 ? successCount / knownOutcomeTotal : null;
-  const failureRate = knownOutcomeTotal > 0 ? failureCount / knownOutcomeTotal : null;
-  const partialRate = knownOutcomeTotal > 0 ? partialCount / knownOutcomeTotal : null;
-  const unknownRate = knownOutcomeTotal > 0 ? unknownCount / knownOutcomeTotal : null;
-  const falsePositiveRate = activationCountTotal > 0 ? falsePositiveSignals / activationCountTotal : null;
-  const generatedAt = proc.skillGeneratedAt ?? proc.promotedAt ?? proc.updatedAt ?? proc.createdAt ?? now;
-  const archiveCandidate =
-    activationCountTotal === 0 && generatedAt <= now - policy.archiveAfterUnusedDays * 24 * 60 * 60;
-  const promotionCandidate =
-    proc.skillState !== "demoted" &&
-    proc.skillState !== "archived" &&
-    proc.skillState !== "trusted" &&
-    successfulUsesWithoutCorrection >= policy.promoteAfterSuccessfulUses;
-  const overTriggering =
-    activationCountTotal >= policy.demoteMinSamples &&
-    falsePositiveRate != null &&
-    falsePositiveRate >= policy.demoteFalsePositiveRate;
-  const revisionCandidate = nearMissCount >= policy.revisionNearMissThreshold && skippedCount >= consideredCount;
-
-  return {
-    metrics: {
+  return deriveMetricsAndFlags(
+    {
       activationCountPerWeek,
       activationCountTotal,
       nearMissCount,
@@ -613,25 +674,16 @@ function summarizeSkillTelemetry(
       failureCount,
       partialCount,
       unknownCount,
-      successRate,
-      failureRate,
-      partialRate,
-      unknownRate,
       successfulUsesWithoutCorrection,
       consideredCount,
       skippedCount,
       savedToolCalls,
       savedTimeMs,
-      falsePositiveRate,
     },
-    flags: {
-      promotionCandidate,
-      overTriggering,
-      revisionCandidate,
-      neverUsed: activationCountTotal === 0,
-      archiveCandidate,
-    },
-  };
+    proc,
+    policy,
+    now,
+  );
 }
 
 function summarizeSkillTelemetryFromRollups(
@@ -663,28 +715,8 @@ function summarizeSkillTelemetryFromRollups(
   const savedToolCalls = r.gst_saved_tool_calls_sum;
   const savedTimeMs = r.gst_saved_time_ms_sum;
 
-  const knownOutcomeTotal = successCount + failureCount + partialCount + unknownCount;
-  const successRate = knownOutcomeTotal > 0 ? successCount / knownOutcomeTotal : null;
-  const failureRate = knownOutcomeTotal > 0 ? failureCount / knownOutcomeTotal : null;
-  const partialRate = knownOutcomeTotal > 0 ? partialCount / knownOutcomeTotal : null;
-  const unknownRate = knownOutcomeTotal > 0 ? unknownCount / knownOutcomeTotal : null;
-  const falsePositiveRate = activationCountTotal > 0 ? falsePositiveSignals / activationCountTotal : null;
-  const generatedAt = proc.skillGeneratedAt ?? proc.promotedAt ?? proc.updatedAt ?? proc.createdAt ?? now;
-  const archiveCandidate =
-    activationCountTotal === 0 && generatedAt <= now - policy.archiveAfterUnusedDays * 24 * 60 * 60;
-  const promotionCandidate =
-    proc.skillState !== "demoted" &&
-    proc.skillState !== "archived" &&
-    proc.skillState !== "trusted" &&
-    successfulUsesWithoutCorrection >= policy.promoteAfterSuccessfulUses;
-  const overTriggering =
-    activationCountTotal >= policy.demoteMinSamples &&
-    falsePositiveRate != null &&
-    falsePositiveRate >= policy.demoteFalsePositiveRate;
-  const revisionCandidate = nearMissCount >= policy.revisionNearMissThreshold && skippedCount >= consideredCount;
-
-  return {
-    metrics: {
+  return deriveMetricsAndFlags(
+    {
       activationCountPerWeek,
       activationCountTotal,
       nearMissCount,
@@ -696,25 +728,16 @@ function summarizeSkillTelemetryFromRollups(
       failureCount,
       partialCount,
       unknownCount,
-      successRate,
-      failureRate,
-      partialRate,
-      unknownRate,
       successfulUsesWithoutCorrection,
       consideredCount,
       skippedCount,
       savedToolCalls,
       savedTimeMs,
-      falsePositiveRate,
     },
-    flags: {
-      promotionCandidate,
-      overTriggering,
-      revisionCandidate,
-      neverUsed: activationCountTotal === 0,
-      archiveCandidate,
-    },
-  };
+    proc,
+    policy,
+    now,
+  );
 }
 
 function desiredLifecycleTransition(

--- a/extensions/memory-hybrid/backends/migrations/facts-migrations.ts
+++ b/extensions/memory-hybrid/backends/migrations/facts-migrations.ts
@@ -435,12 +435,13 @@ function migrateGeneratedSkillTelemetryTable(db: DatabaseSync): void {
 /** O(1) telemetry rollups on procedures (#1415 / #1400). */
 function migrateGeneratedSkillTelemetryRollupColumns(db: DatabaseSync): void {
   const cols0 = db.prepare("PRAGMA table_info(procedures)").all() as Array<{ name: string }>;
-  const hadGst = new Set(cols0.map((c) => c.name)).has("gst_sel_total");
   const colNames = new Set(cols0.map((c) => c.name));
+  let addedRollupColumn = false;
   const add = (name: string, ddl: string) => {
     if (!colNames.has(name)) {
       db.exec(ddl);
       colNames.add(name);
+      addedRollupColumn = true;
     }
   };
   add("gst_sel_total", "ALTER TABLE procedures ADD COLUMN gst_sel_total INTEGER NOT NULL DEFAULT 0");
@@ -468,10 +469,10 @@ function migrateGeneratedSkillTelemetryRollupColumns(db: DatabaseSync): void {
   add("gst_saved_time_ms_sum", "ALTER TABLE procedures ADD COLUMN gst_saved_time_ms_sum INTEGER NOT NULL DEFAULT 0");
   add("gst_last_selected_at", "ALTER TABLE procedures ADD COLUMN gst_last_selected_at INTEGER");
 
-  // Idempotent backfill: run if columns were just added (!hadGst) OR if any procedure has
+  // Idempotent backfill: run if any rollup column was added OR if any procedure has
   // telemetry but zero rollups (indicating incomplete backfill from a previous crash).
   const needsBackfill =
-    !hadGst ||
+    addedRollupColumn ||
     (
       db
         .prepare(
@@ -498,8 +499,8 @@ function migrateGeneratedSkillTelemetryRollupColumns(db: DatabaseSync): void {
            gst_success_clear_total = (SELECT COUNT(*) FROM generated_skill_telemetry t WHERE t.procedure_id = p.id AND t.decision = 'selected' AND t.task_outcome = 'success' AND t.user_correction = 0),
            gst_considered_total = (SELECT COUNT(*) FROM generated_skill_telemetry t WHERE t.procedure_id = p.id AND t.decision = 'considered'),
            gst_skipped_total = (SELECT COUNT(*) FROM generated_skill_telemetry t WHERE t.procedure_id = p.id AND t.decision = 'skipped'),
-           gst_saved_tool_calls_sum = (SELECT COALESCE(SUM(t.saved_tool_calls), 0) FROM generated_skill_telemetry t WHERE t.procedure_id = p.id),
-           gst_saved_time_ms_sum = (SELECT COALESCE(SUM(t.saved_time_ms), 0) FROM generated_skill_telemetry t WHERE t.procedure_id = p.id),
+           gst_saved_tool_calls_sum = (SELECT COALESCE(SUM(CASE WHEN t.saved_tool_calls > 0 THEN t.saved_tool_calls ELSE 0 END), 0) FROM generated_skill_telemetry t WHERE t.procedure_id = p.id),
+           gst_saved_time_ms_sum = (SELECT COALESCE(SUM(CASE WHEN t.saved_time_ms > 0 THEN t.saved_time_ms ELSE 0 END), 0) FROM generated_skill_telemetry t WHERE t.procedure_id = p.id),
            gst_last_selected_at = (SELECT MAX(t.created_at) FROM generated_skill_telemetry t WHERE t.procedure_id = p.id AND t.decision = 'selected')
      WHERE EXISTS (SELECT 1 FROM generated_skill_telemetry t WHERE t.procedure_id = p.id)
   `);

--- a/extensions/memory-hybrid/backends/migrations/facts-migrations.ts
+++ b/extensions/memory-hybrid/backends/migrations/facts-migrations.ts
@@ -472,14 +472,15 @@ function migrateGeneratedSkillTelemetryRollupColumns(db: DatabaseSync): void {
   // telemetry but zero rollups (indicating incomplete backfill from a previous crash).
   const needsBackfill =
     !hadGst ||
-    (db
-      .prepare(
-        `SELECT COUNT(*) as c FROM procedures p
+    (
+      db
+        .prepare(
+          `SELECT COUNT(*) as c FROM procedures p
          WHERE EXISTS (SELECT 1 FROM generated_skill_telemetry t WHERE t.procedure_id = p.id)
            AND p.gst_sel_total = 0
            AND p.gst_near_miss_total = 0`,
-      )
-      .get() as { c: number }
+        )
+        .get() as { c: number }
     ).c > 0;
 
   if (needsBackfill) {

--- a/extensions/memory-hybrid/backends/migrations/facts-migrations.ts
+++ b/extensions/memory-hybrid/backends/migrations/facts-migrations.ts
@@ -427,6 +427,68 @@ function migrateGeneratedSkillTelemetryTable(db: DatabaseSync): void {
   db.exec(
     "CREATE INDEX IF NOT EXISTS idx_gst_decision_created_at ON generated_skill_telemetry(skill_name, decision, created_at DESC)",
   );
+  db.exec(
+    "CREATE INDEX IF NOT EXISTS idx_gst_skill_name_created_at ON generated_skill_telemetry(skill_name, created_at DESC)",
+  );
+}
+
+/** O(1) telemetry rollups on procedures (#1415 / #1400). */
+function migrateGeneratedSkillTelemetryRollupColumns(db: DatabaseSync): void {
+  const cols0 = db.prepare("PRAGMA table_info(procedures)").all() as Array<{ name: string }>;
+  const hadGst = new Set(cols0.map((c) => c.name)).has("gst_sel_total");
+  const colNames = new Set(cols0.map((c) => c.name));
+  const add = (name: string, ddl: string) => {
+    if (!colNames.has(name)) {
+      db.exec(ddl);
+      colNames.add(name);
+    }
+  };
+  add("gst_sel_total", "ALTER TABLE procedures ADD COLUMN gst_sel_total INTEGER NOT NULL DEFAULT 0");
+  add("gst_near_miss_total", "ALTER TABLE procedures ADD COLUMN gst_near_miss_total INTEGER NOT NULL DEFAULT 0");
+  add("gst_fp_signals_total", "ALTER TABLE procedures ADD COLUMN gst_fp_signals_total INTEGER NOT NULL DEFAULT 0");
+  add("gst_fn_signals_total", "ALTER TABLE procedures ADD COLUMN gst_fn_signals_total INTEGER NOT NULL DEFAULT 0");
+  add(
+    "gst_user_correction_total",
+    "ALTER TABLE procedures ADD COLUMN gst_user_correction_total INTEGER NOT NULL DEFAULT 0",
+  );
+  add("gst_outcome_success", "ALTER TABLE procedures ADD COLUMN gst_outcome_success INTEGER NOT NULL DEFAULT 0");
+  add("gst_outcome_failure", "ALTER TABLE procedures ADD COLUMN gst_outcome_failure INTEGER NOT NULL DEFAULT 0");
+  add("gst_outcome_partial", "ALTER TABLE procedures ADD COLUMN gst_outcome_partial INTEGER NOT NULL DEFAULT 0");
+  add("gst_outcome_unknown", "ALTER TABLE procedures ADD COLUMN gst_outcome_unknown INTEGER NOT NULL DEFAULT 0");
+  add(
+    "gst_success_clear_total",
+    "ALTER TABLE procedures ADD COLUMN gst_success_clear_total INTEGER NOT NULL DEFAULT 0",
+  );
+  add("gst_considered_total", "ALTER TABLE procedures ADD COLUMN gst_considered_total INTEGER NOT NULL DEFAULT 0");
+  add("gst_skipped_total", "ALTER TABLE procedures ADD COLUMN gst_skipped_total INTEGER NOT NULL DEFAULT 0");
+  add(
+    "gst_saved_tool_calls_sum",
+    "ALTER TABLE procedures ADD COLUMN gst_saved_tool_calls_sum INTEGER NOT NULL DEFAULT 0",
+  );
+  add("gst_saved_time_ms_sum", "ALTER TABLE procedures ADD COLUMN gst_saved_time_ms_sum INTEGER NOT NULL DEFAULT 0");
+  add("gst_last_selected_at", "ALTER TABLE procedures ADD COLUMN gst_last_selected_at INTEGER");
+
+  if (!hadGst) {
+    db.exec(`
+    UPDATE procedures AS p
+       SET gst_sel_total = (SELECT COUNT(*) FROM generated_skill_telemetry t WHERE t.procedure_id = p.id AND t.decision = 'selected'),
+           gst_near_miss_total = (SELECT COUNT(*) FROM generated_skill_telemetry t WHERE t.procedure_id = p.id AND t.decision != 'selected'),
+           gst_fp_signals_total = (SELECT COUNT(*) FROM generated_skill_telemetry t WHERE t.procedure_id = p.id AND t.decision = 'selected' AND (t.user_correction = 1 OR t.caused_rework = 1)),
+           gst_fn_signals_total = (SELECT COUNT(*) FROM generated_skill_telemetry t WHERE t.procedure_id = p.id AND t.false_negative_signal = 1),
+           gst_user_correction_total = (SELECT COUNT(*) FROM generated_skill_telemetry t WHERE t.procedure_id = p.id AND t.user_correction = 1),
+           gst_outcome_success = (SELECT COUNT(*) FROM generated_skill_telemetry t WHERE t.procedure_id = p.id AND t.decision = 'selected' AND t.task_outcome = 'success'),
+           gst_outcome_failure = (SELECT COUNT(*) FROM generated_skill_telemetry t WHERE t.procedure_id = p.id AND t.decision = 'selected' AND t.task_outcome = 'failure'),
+           gst_outcome_partial = (SELECT COUNT(*) FROM generated_skill_telemetry t WHERE t.procedure_id = p.id AND t.decision = 'selected' AND t.task_outcome = 'partial'),
+           gst_outcome_unknown = (SELECT COUNT(*) FROM generated_skill_telemetry t WHERE t.procedure_id = p.id AND t.decision = 'selected' AND (t.task_outcome IS NULL OR t.task_outcome = '' OR t.task_outcome NOT IN ('success','failure','partial'))),
+           gst_success_clear_total = (SELECT COUNT(*) FROM generated_skill_telemetry t WHERE t.procedure_id = p.id AND t.decision = 'selected' AND t.task_outcome = 'success' AND t.user_correction = 0),
+           gst_considered_total = (SELECT COUNT(*) FROM generated_skill_telemetry t WHERE t.procedure_id = p.id AND t.decision = 'considered'),
+           gst_skipped_total = (SELECT COUNT(*) FROM generated_skill_telemetry t WHERE t.procedure_id = p.id AND t.decision = 'skipped'),
+           gst_saved_tool_calls_sum = (SELECT COALESCE(SUM(t.saved_tool_calls), 0) FROM generated_skill_telemetry t WHERE t.procedure_id = p.id),
+           gst_saved_time_ms_sum = (SELECT COALESCE(SUM(t.saved_time_ms), 0) FROM generated_skill_telemetry t WHERE t.procedure_id = p.id),
+           gst_last_selected_at = (SELECT MAX(t.created_at) FROM generated_skill_telemetry t WHERE t.procedure_id = p.id AND t.decision = 'selected')
+     WHERE EXISTS (SELECT 1 FROM generated_skill_telemetry t WHERE t.procedure_id = p.id)
+  `);
+  }
 }
 
 /**
@@ -1241,6 +1303,7 @@ export function runFactsMigrations(db: DatabaseSync): void {
   migrateProcedureScopeColumns(db);
   migrateGeneratedSkillLifecycleColumns(db);
   migrateGeneratedSkillTelemetryTable(db);
+  migrateGeneratedSkillTelemetryRollupColumns(db);
 
   // FTS5 tags support (must run after migrateTagsColumn)
   migrateFtsTagsSupport(db);

--- a/extensions/memory-hybrid/backends/migrations/facts-migrations.ts
+++ b/extensions/memory-hybrid/backends/migrations/facts-migrations.ts
@@ -468,7 +468,21 @@ function migrateGeneratedSkillTelemetryRollupColumns(db: DatabaseSync): void {
   add("gst_saved_time_ms_sum", "ALTER TABLE procedures ADD COLUMN gst_saved_time_ms_sum INTEGER NOT NULL DEFAULT 0");
   add("gst_last_selected_at", "ALTER TABLE procedures ADD COLUMN gst_last_selected_at INTEGER");
 
-  if (!hadGst) {
+  // Idempotent backfill: run if columns were just added (!hadGst) OR if any procedure has
+  // telemetry but zero rollups (indicating incomplete backfill from a previous crash).
+  const needsBackfill =
+    !hadGst ||
+    (db
+      .prepare(
+        `SELECT COUNT(*) as c FROM procedures p
+         WHERE EXISTS (SELECT 1 FROM generated_skill_telemetry t WHERE t.procedure_id = p.id)
+           AND p.gst_sel_total = 0
+           AND p.gst_near_miss_total = 0`,
+      )
+      .get() as { c: number }
+    ).c > 0;
+
+  if (needsBackfill) {
     db.exec(`
     UPDATE procedures AS p
        SET gst_sel_total = (SELECT COUNT(*) FROM generated_skill_telemetry t WHERE t.procedure_id = p.id AND t.decision = 'selected'),

--- a/extensions/memory-hybrid/backends/workflow-store.ts
+++ b/extensions/memory-hybrid/backends/workflow-store.ts
@@ -173,6 +173,14 @@ export class WorkflowStore extends BaseSqliteStore {
     patterns: WorkflowPattern[];
   } | null = null;
 
+  private static clonePatterns(patterns: WorkflowPattern[]): WorkflowPattern[] {
+    return patterns.map((pattern) => ({
+      ...pattern,
+      toolSequence: [...pattern.toolSequence],
+      exampleGoals: [...pattern.exampleGoals],
+    }));
+  }
+
   /** Monotonic in-process revision for cheap memo validation without table scans. */
   private workflowPatternsRevision = 0;
 
@@ -390,7 +398,7 @@ export class WorkflowStore extends BaseSqliteStore {
         memo.minSuccessRate === minRate &&
         memo.resultLimit === resultLimit
       ) {
-        return memo.patterns;
+        return WorkflowStore.clonePatterns(memo.patterns);
       }
 
       const allRows = this.liveDb
@@ -471,9 +479,9 @@ export class WorkflowStore extends BaseSqliteStore {
         similarityThreshold: threshold,
         minSuccessRate: minRate,
         resultLimit,
-        patterns: out,
+        patterns: WorkflowStore.clonePatterns(out),
       };
-      return out;
+      return WorkflowStore.clonePatterns(out);
     });
   }
 

--- a/extensions/memory-hybrid/backends/workflow-store.ts
+++ b/extensions/memory-hybrid/backends/workflow-store.ts
@@ -160,6 +160,20 @@ export function hashToolSequence(toolSequence: string[]): string {
 // ---------------------------------------------------------------------------
 
 export class WorkflowStore extends BaseSqliteStore {
+  /**
+   * Memoized {@link WorkflowStore.getPatterns} result invalidated on `record` / `prune`.
+   * Keyed by table fingerprint + options (#1415 / #1399).
+   */
+  private workflowPatternsMemo: {
+    rowCount: number;
+    newestCreatedAt: string | null;
+    traceSampleLimit: number;
+    similarityThreshold: number;
+    minSuccessRate: number;
+    resultLimit: number;
+    patterns: WorkflowPattern[];
+  } | null = null;
+
   constructor(dbPath: string) {
     mkdirSync(dirname(dbPath), { recursive: true });
     const db = new DatabaseSync(dbPath);
@@ -226,6 +240,7 @@ export class WorkflowStore extends BaseSqliteStore {
           sessionId,
           now,
         );
+      this.workflowPatternsMemo = null;
     });
 
     // biome-ignore lint/style/noNonNullAssertion: Known to exist
@@ -352,14 +367,58 @@ export class WorkflowStore extends BaseSqliteStore {
   // getPatterns — group similar sequences and compute aggregate stats
   // -------------------------------------------------------------------------
 
-  getPatterns(options?: { minSuccessRate?: number; similarityThreshold?: number; limit?: number }): WorkflowPattern[] {
+  getPatterns(options?: {
+    minSuccessRate?: number;
+    similarityThreshold?: number;
+    limit?: number;
+    /** Cap rows scanned from `workflow_traces` (newest first). Default 2000. */
+    traceSampleLimit?: number;
+  }): WorkflowPattern[] {
     return this.runSqliteOp("getPatterns", () => {
       const threshold = options?.similarityThreshold ?? 0.8;
-      const allRows = this.liveDb
-        .prepare("SELECT goal, tool_sequence, outcome, duration_ms FROM workflow_traces ORDER BY created_at DESC")
-        .all() as { goal: string; tool_sequence: string; outcome: string; duration_ms: number }[];
+      const traceSampleLimit = options?.traceSampleLimit ?? 2000;
+      const minRate = options?.minSuccessRate ?? 0;
+      const resultLimit = options?.limit ?? 20;
+      const meta = this.liveDb.prepare("SELECT COUNT(*) as c, MAX(created_at) as m FROM workflow_traces").get() as {
+        c: number;
+        m: string | null;
+      };
+      const memo = this.workflowPatternsMemo;
+      if (
+        memo &&
+        memo.rowCount === meta.c &&
+        memo.newestCreatedAt === meta.m &&
+        memo.traceSampleLimit === traceSampleLimit &&
+        memo.similarityThreshold === threshold &&
+        memo.minSuccessRate === minRate &&
+        memo.resultLimit === resultLimit
+      ) {
+        return memo.patterns;
+      }
 
-      // Cluster by similarity
+      const allRows = this.liveDb
+        .prepare(
+          `SELECT goal, tool_sequence, outcome, duration_ms, args_hash
+             FROM workflow_traces
+            ORDER BY created_at DESC
+            LIMIT ?`,
+        )
+        .all(traceSampleLimit) as {
+        goal: string;
+        tool_sequence: string;
+        outcome: string;
+        duration_ms: number;
+        args_hash: string;
+      }[];
+
+      const byHash = new Map<string, typeof allRows>();
+      for (const row of allRows) {
+        const h = row.args_hash || "";
+        const bucket = byHash.get(h);
+        if (bucket) bucket.push(row);
+        else byHash.set(h, [row]);
+      }
+
       const clusters: {
         representative: string[];
         goals: string[];
@@ -367,32 +426,33 @@ export class WorkflowStore extends BaseSqliteStore {
         durations: number[];
       }[] = [];
 
-      for (const row of allRows) {
-        let seq: string[];
-        try {
-          seq = JSON.parse(row.tool_sequence) as string[];
-        } catch {
-          continue;
-        }
-
-        // Find an existing cluster this sequence belongs to
-        let found = false;
-        for (const cluster of clusters) {
-          if (sequenceSimilarity(seq, cluster.representative) >= threshold) {
-            cluster.goals.push(row.goal);
-            cluster.outcomes.push(row.outcome);
-            cluster.durations.push(row.duration_ms);
-            found = true;
-            break;
+      for (const group of byHash.values()) {
+        for (const row of group) {
+          let seq: string[];
+          try {
+            seq = JSON.parse(row.tool_sequence) as string[];
+          } catch {
+            continue;
           }
-        }
-        if (!found) {
-          clusters.push({
-            representative: seq,
-            goals: [row.goal],
-            outcomes: [row.outcome],
-            durations: [row.duration_ms],
-          });
+
+          let found = false;
+          for (const cluster of clusters) {
+            if (sequenceSimilarity(seq, cluster.representative) >= threshold) {
+              cluster.goals.push(row.goal);
+              cluster.outcomes.push(row.outcome);
+              cluster.durations.push(row.duration_ms);
+              found = true;
+              break;
+            }
+          }
+          if (!found) {
+            clusters.push({
+              representative: seq,
+              goals: [row.goal],
+              outcomes: [row.outcome],
+              durations: [row.duration_ms],
+            });
+          }
         }
       }
 
@@ -402,7 +462,6 @@ export class WorkflowStore extends BaseSqliteStore {
         const failureCount = c.outcomes.filter((o) => o === "failure").length;
         const successRate = totalCount > 0 ? successCount / totalCount : 0;
         const avgDurationMs = c.durations.length > 0 ? c.durations.reduce((a, b) => a + b, 0) / c.durations.length : 0;
-        // Deduplicate example goals
         const uniqueGoals = [...new Set(c.goals)].slice(0, 3);
 
         return {
@@ -416,15 +475,19 @@ export class WorkflowStore extends BaseSqliteStore {
         };
       });
 
-      // Filter by min success rate
-      const minRate = options?.minSuccessRate ?? 0;
       const filtered = patterns.filter((p) => p.successRate >= minRate);
-
-      // Sort by total count desc
       filtered.sort((a, b) => b.totalCount - a.totalCount);
-
-      const limit = options?.limit ?? 20;
-      return filtered.slice(0, limit);
+      const out = filtered.slice(0, resultLimit);
+      this.workflowPatternsMemo = {
+        rowCount: meta.c,
+        newestCreatedAt: meta.m,
+        traceSampleLimit,
+        similarityThreshold: threshold,
+        minSuccessRate: minRate,
+        resultLimit,
+        patterns: out,
+      };
+      return out;
     });
   }
 
@@ -436,6 +499,7 @@ export class WorkflowStore extends BaseSqliteStore {
     return this.runSqliteOp("prune", () => {
       const cutoff = new Date(Date.now() - olderThanDays * 24 * 60 * 60 * 1000).toISOString();
       const result = this.liveDb.prepare("DELETE FROM workflow_traces WHERE created_at < ?").run(cutoff);
+      this.workflowPatternsMemo = null;
       return Number(result.changes);
     });
   }

--- a/extensions/memory-hybrid/backends/workflow-store.ts
+++ b/extensions/memory-hybrid/backends/workflow-store.ts
@@ -162,17 +162,19 @@ export function hashToolSequence(toolSequence: string[]): string {
 export class WorkflowStore extends BaseSqliteStore {
   /**
    * Memoized {@link WorkflowStore.getPatterns} result invalidated on `record` / `prune`.
-   * Keyed by table fingerprint + options (#1415 / #1399).
+   * Keyed by an in-memory mutation counter + options (#1415 / #1399).
    */
   private workflowPatternsMemo: {
-    rowCount: number;
-    newestCreatedAt: string | null;
+    revision: number;
     traceSampleLimit: number;
     similarityThreshold: number;
     minSuccessRate: number;
     resultLimit: number;
     patterns: WorkflowPattern[];
   } | null = null;
+
+  /** Monotonic in-process revision for cheap memo validation without table scans. */
+  private workflowPatternsRevision = 0;
 
   constructor(dbPath: string) {
     mkdirSync(dirname(dbPath), { recursive: true });
@@ -240,7 +242,7 @@ export class WorkflowStore extends BaseSqliteStore {
           sessionId,
           now,
         );
-      this.workflowPatternsMemo = null;
+      this.invalidateWorkflowPatternsMemo();
     });
 
     // biome-ignore lint/style/noNonNullAssertion: Known to exist
@@ -379,15 +381,10 @@ export class WorkflowStore extends BaseSqliteStore {
       const traceSampleLimit = options?.traceSampleLimit ?? 2000;
       const minRate = options?.minSuccessRate ?? 0;
       const resultLimit = options?.limit ?? 20;
-      const meta = this.liveDb.prepare("SELECT COUNT(*) as c, MAX(created_at) as m FROM workflow_traces").get() as {
-        c: number;
-        m: string | null;
-      };
       const memo = this.workflowPatternsMemo;
       if (
         memo &&
-        memo.rowCount === meta.c &&
-        memo.newestCreatedAt === meta.m &&
+        memo.revision === this.workflowPatternsRevision &&
         memo.traceSampleLimit === traceSampleLimit &&
         memo.similarityThreshold === threshold &&
         memo.minSuccessRate === minRate &&
@@ -488,8 +485,7 @@ export class WorkflowStore extends BaseSqliteStore {
       filtered.sort((a, b) => b.totalCount - a.totalCount);
       const out = filtered.slice(0, resultLimit);
       this.workflowPatternsMemo = {
-        rowCount: meta.c,
-        newestCreatedAt: meta.m,
+        revision: this.workflowPatternsRevision,
         traceSampleLimit,
         similarityThreshold: threshold,
         minSuccessRate: minRate,
@@ -508,7 +504,7 @@ export class WorkflowStore extends BaseSqliteStore {
     return this.runSqliteOp("prune", () => {
       const cutoff = new Date(Date.now() - olderThanDays * 24 * 60 * 60 * 1000).toISOString();
       const result = this.liveDb.prepare("DELETE FROM workflow_traces WHERE created_at < ?").run(cutoff);
-      this.workflowPatternsMemo = null;
+      if (Number(result.changes) > 0) this.invalidateWorkflowPatternsMemo();
       return Number(result.changes);
     });
   }
@@ -527,6 +523,11 @@ export class WorkflowStore extends BaseSqliteStore {
   // -------------------------------------------------------------------------
   // Private helpers
   // -------------------------------------------------------------------------
+
+  private invalidateWorkflowPatternsMemo(): void {
+    this.workflowPatternsMemo = null;
+    this.workflowPatternsRevision++;
+  }
 
   private rowToTrace(row: Record<string, unknown>): WorkflowTrace {
     function parseJsonArray(value: unknown, fallback: string[]): string[] {

--- a/extensions/memory-hybrid/backends/workflow-store.ts
+++ b/extensions/memory-hybrid/backends/workflow-store.ts
@@ -419,7 +419,7 @@ export class WorkflowStore extends BaseSqliteStore {
         else byHash.set(h, [row]);
       }
 
-      const clusters: {
+      const allClusters: {
         representative: string[];
         goals: string[];
         outcomes: string[];
@@ -427,6 +427,13 @@ export class WorkflowStore extends BaseSqliteStore {
       }[] = [];
 
       for (const group of byHash.values()) {
+        const clusters: {
+          representative: string[];
+          goals: string[];
+          outcomes: string[];
+          durations: number[];
+        }[] = [];
+
         for (const row of group) {
           let seq: string[];
           try {
@@ -454,9 +461,11 @@ export class WorkflowStore extends BaseSqliteStore {
             });
           }
         }
+
+        allClusters.push(...clusters);
       }
 
-      const patterns: WorkflowPattern[] = clusters.map((c) => {
+      const patterns: WorkflowPattern[] = allClusters.map((c) => {
         const totalCount = c.outcomes.length;
         const successCount = c.outcomes.filter((o) => o === "success").length;
         const failureCount = c.outcomes.filter((o) => o === "failure").length;

--- a/extensions/memory-hybrid/backends/workflow-store.ts
+++ b/extensions/memory-hybrid/backends/workflow-store.ts
@@ -408,61 +408,42 @@ export class WorkflowStore extends BaseSqliteStore {
         args_hash: string;
       }[];
 
-      const byHash = new Map<string, typeof allRows>();
-      for (const row of allRows) {
-        const h = row.args_hash || "";
-        const bucket = byHash.get(h);
-        if (bucket) bucket.push(row);
-        else byHash.set(h, [row]);
-      }
-
-      const allClusters: {
+      const clusters: {
         representative: string[];
         goals: string[];
         outcomes: string[];
         durations: number[];
       }[] = [];
 
-      for (const group of byHash.values()) {
-        const clusters: {
-          representative: string[];
-          goals: string[];
-          outcomes: string[];
-          durations: number[];
-        }[] = [];
-
-        for (const row of group) {
-          let seq: string[];
-          try {
-            seq = JSON.parse(row.tool_sequence) as string[];
-          } catch {
-            continue;
-          }
-
-          let found = false;
-          for (const cluster of clusters) {
-            if (sequenceSimilarity(seq, cluster.representative) >= threshold) {
-              cluster.goals.push(row.goal);
-              cluster.outcomes.push(row.outcome);
-              cluster.durations.push(row.duration_ms);
-              found = true;
-              break;
-            }
-          }
-          if (!found) {
-            clusters.push({
-              representative: seq,
-              goals: [row.goal],
-              outcomes: [row.outcome],
-              durations: [row.duration_ms],
-            });
-          }
+      for (const row of allRows) {
+        let seq: string[];
+        try {
+          seq = JSON.parse(row.tool_sequence) as string[];
+        } catch {
+          continue;
         }
 
-        allClusters.push(...clusters);
+        let found = false;
+        for (const cluster of clusters) {
+          if (sequenceSimilarity(seq, cluster.representative) >= threshold) {
+            cluster.goals.push(row.goal);
+            cluster.outcomes.push(row.outcome);
+            cluster.durations.push(row.duration_ms);
+            found = true;
+            break;
+          }
+        }
+        if (!found) {
+          clusters.push({
+            representative: seq,
+            goals: [row.goal],
+            outcomes: [row.outcome],
+            durations: [row.duration_ms],
+          });
+        }
       }
 
-      const patterns: WorkflowPattern[] = allClusters.map((c) => {
+      const patterns: WorkflowPattern[] = clusters.map((c) => {
         const totalCount = c.outcomes.length;
         const successCount = c.outcomes.filter((o) => o === "success").length;
         const failureCount = c.outcomes.filter((o) => o === "failure").length;

--- a/extensions/memory-hybrid/backends/workflow-store.ts
+++ b/extensions/memory-hybrid/backends/workflow-store.ts
@@ -403,7 +403,7 @@ export class WorkflowStore extends BaseSqliteStore {
 
       const allRows = this.liveDb
         .prepare(
-          `SELECT goal, tool_sequence, outcome, duration_ms, args_hash
+          `SELECT goal, tool_sequence, outcome, duration_ms
              FROM workflow_traces
             ORDER BY created_at DESC
             LIMIT ?`,
@@ -413,7 +413,6 @@ export class WorkflowStore extends BaseSqliteStore {
         tool_sequence: string;
         outcome: string;
         duration_ms: number;
-        args_hash: string;
       }[];
 
       const clusters: {

--- a/extensions/memory-hybrid/cli/cmd-extract.ts
+++ b/extensions/memory-hybrid/cli/cmd-extract.ts
@@ -21,12 +21,13 @@ import {
   getLLMModelPreference,
   resolveReflectionModelAndFallbacks,
 } from "../config.js";
+import { chatCompleteWithAdaptiveMaintenanceRetry } from "../services/adaptive-maintenance-llm.js";
 import { VAULT_POINTER_PREFIX, isCredentialLike, tryParseCredentialForVault } from "../services/auto-capture.js";
 import { chatCompleteWithRetryDetailed, distillMaxOutputTokens } from "../services/chat.js";
-import { chatCompleteWithAdaptiveMaintenanceRetry } from "../services/adaptive-maintenance-llm.js";
-import { type MemoryClassification, classifyMemoryOperationsBatch } from "../services/classification.js";
 import { validateScopedClassificationTarget } from "../services/classification-scope.js";
+import { type MemoryClassification, classifyMemoryOperationsBatch } from "../services/classification.js";
 import { CostFeature } from "../services/cost-feature-labels.js";
+import { shouldReportVectorDedupeFallback } from "../services/dedupe-policy.js";
 import { type DirectiveExtractResult, runDirectiveExtract } from "../services/directive-extract.js";
 import { capturePluginError } from "../services/error-reporter.js";
 import { extractStructuredFields } from "../services/fact-extraction.js";
@@ -40,7 +41,7 @@ import { generateAutoSkills } from "../services/procedure-skill-generator.js";
 import { type ReinforcementExtractResult, runReinforcementExtract } from "../services/reinforcement-extract.js";
 import { preFilterSessions } from "../services/session-pre-filter.js";
 import { insertRulesUnderSection } from "../services/tools-md-section.js";
-import { shouldReportVectorDedupeFallback } from "../services/dedupe-policy.js";
+import { cleanupEvictedVector, deleteVectorForFactId } from "../services/vector-maintenance.js";
 import { findSimilarByEmbedding } from "../services/vector-search.js";
 import type { MemoryEntry } from "../types/memory.js";
 import { BATCH_STORE_IMPORTANCE, CLI_STORE_IMPORTANCE } from "../utils/constants.js";
@@ -54,7 +55,6 @@ import { inferTargetFile } from "./cmd-store.js";
 import type { HandlerContext } from "./handlers.js";
 import { capProposalConfidence } from "./proposals.js";
 import { acquireScanSlot, clearScanLock } from "./shared.js";
-import { cleanupEvictedVector, deleteVectorForFactId } from "../services/vector-maintenance.js";
 import type {
   ExtractDailyResult,
   ExtractDailySink,
@@ -214,6 +214,7 @@ export async function runGenerateAutoSkillsForCli(
     max?: number;
     policy?: string;
     json?: boolean;
+    bypassDuplicateSkillCache?: boolean;
   },
 ): Promise<GenerateAutoSkillsResult> {
   const { factsDb, cfg, logger } = ctx;
@@ -230,6 +231,7 @@ export async function runGenerateAutoSkillsForCli(
         apply: opts.apply,
         maxPerRun: opts.max,
         policy: opts.policy,
+        bypassDuplicateSkillCache: opts.bypassDuplicateSkillCache,
       },
       { info, warn },
     );

--- a/extensions/memory-hybrid/cli/distill.ts
+++ b/extensions/memory-hybrid/cli/distill.ts
@@ -36,6 +36,7 @@ export type DistillContext = {
     max?: number;
     policy?: string;
     json?: boolean;
+    bypassDuplicateSkillCache?: boolean;
   }) => Promise<GenerateAutoSkillsResult>;
   runDistill: (
     opts: {
@@ -291,6 +292,7 @@ export function registerDistillCommands(mem: Chainable, ctx: DistillContext): vo
       "Promotion policy: draft-only, manual, auto-safe (default: dry-run draft-only; non-dry-run/apply defaults to auto-safe for legacy maintenance callers)",
     )
     .option("--json", "Emit structured JSON summary")
+    .option("--bypass-skill-duplicate-cache", "Re-read every SKILL.md for duplicate detection (ignore mtime cache)")
     .option("-v, --verbose", "Log each decision and generated skill path")
     .action(
       withExit(
@@ -302,6 +304,7 @@ export function registerDistillCommands(mem: Chainable, ctx: DistillContext): vo
             max?: string;
             policy?: string;
             json?: boolean;
+            bypassSkillDuplicateCache?: boolean;
           },
           cmd?: CommanderOptsParent,
         ) => {
@@ -319,6 +322,7 @@ export function registerDistillCommands(mem: Chainable, ctx: DistillContext): vo
             policy: opts.policy,
             json: opts.json,
             verbose: !!opts.verbose || readHybridMemVerbose(cmd),
+            bypassDuplicateSkillCache: opts.bypassSkillDuplicateCache === true,
           });
           if (opts.json) {
             console.log(JSON.stringify(result, null, 2));

--- a/extensions/memory-hybrid/cli/register.ts
+++ b/extensions/memory-hybrid/cli/register.ts
@@ -4,8 +4,8 @@
  * Thin orchestrator that delegates to specialized command modules.
  */
 
-import type { FactsDB } from "../backends/facts-db.js";
 import type { CrystallizationStore } from "../backends/crystallization-store.js";
+import type { FactsDB } from "../backends/facts-db.js";
 import type { VectorDB } from "../backends/vector-db.js";
 import type { HybridMemoryConfig } from "../config.js";
 import type { EmbeddingProvider } from "../services/embeddings.js";
@@ -14,18 +14,17 @@ import { filterByScope, type mergeResults } from "../services/merge-results.js";
 import type { AliasDB } from "../services/retrieval-aliases.js";
 import type { SearchResult } from "../types/memory.js";
 import type { ScopeFilter } from "../types/memory.js";
-import { parseSourceDate } from "../utils/dates.js";
 import { PLUGIN_ID } from "../utils/constants.js";
+import { parseSourceDate } from "../utils/dates.js";
 import { type ActiveTaskContext, registerActiveTaskCommands } from "./active-tasks.js";
 import { registerBenchmarkCommands } from "./benchmark.js";
+import { registerStatusCommands } from "./cmd-status.js";
+import { type UserFriendlyContext, registerUserFriendlyCommands } from "./cmd-user-friendly.js";
 import { type DistillContext, registerDistillCommands } from "./distill.js";
 import { registerGoalCommands } from "./goals.js";
 import { type ManageContext, registerManageCommands } from "./manage.js";
 import { registerSkillsCommands } from "./skills.js";
 import { registerTaskQueueStatusCommands } from "./task-queue-status.js";
-import { registerVerifiedCommands } from "./verified.js";
-import { registerStatusCommands } from "./cmd-status.js";
-import { type UserFriendlyContext, registerUserFriendlyCommands } from "./cmd-user-friendly.js";
 import type {
   AnalyzeFeedbackPhrasesResult,
   BackfillCliResult,
@@ -54,6 +53,7 @@ import type {
   UpgradeCliResult,
   VerifyCliSink,
 } from "./types.js";
+import { registerVerifiedCommands } from "./verified.js";
 import { type VerifyContext, registerVerifyCommands } from "./verify.js";
 
 export type {
@@ -134,6 +134,7 @@ export type HybridMemCliContext = {
     max?: number;
     policy?: string;
     json?: boolean;
+    bypassDuplicateSkillCache?: boolean;
   }) => Promise<GenerateAutoSkillsResult>;
   runSkillsSuggest: (opts: {
     dryRun?: boolean;

--- a/extensions/memory-hybrid/services/pattern-detector.ts
+++ b/extensions/memory-hybrid/services/pattern-detector.ts
@@ -85,6 +85,7 @@ export class PatternDetector {
     try {
       patterns = this.workflowStore.getPatterns({
         minSuccessRate: this.cfg.minSuccessRate,
+        traceSampleLimit: 6000,
         // Fetch more than needed to allow filtering by usage count
         limit: 200,
       });

--- a/extensions/memory-hybrid/services/procedure-promotion-policy.ts
+++ b/extensions/memory-hybrid/services/procedure-promotion-policy.ts
@@ -1094,8 +1094,8 @@ function hasValidationCheck(recipe: unknown, _task: string): boolean {
 }
 const skillMdDuplicateDigestCache = new Map<string, { mtimeMs: number; lower: string }>();
 
-/** Clears the SKILL.md mtime cache used by duplicate-skill detection (tests / --no-skill-duplicate-cache). */
-export function clearProcedurePromotionDuplicateSkillCache(): void {
+/** Clears the SKILL.md mtime cache used by duplicate-skill detection (for future test use). */
+function clearProcedurePromotionDuplicateSkillCache(): void {
   skillMdDuplicateDigestCache.clear();
 }
 

--- a/extensions/memory-hybrid/services/procedure-promotion-policy.ts
+++ b/extensions/memory-hybrid/services/procedure-promotion-policy.ts
@@ -1094,8 +1094,8 @@ function hasValidationCheck(recipe: unknown, _task: string): boolean {
 }
 const skillMdDuplicateDigestCache = new Map<string, { mtimeMs: number; lower: string }>();
 
-/** Clears the SKILL.md mtime cache used by duplicate-skill detection (for future test use). */
-function clearProcedurePromotionDuplicateSkillCache(): void {
+/** Clears the SKILL.md mtime cache used by duplicate-skill detection (for tests and --bypass-skill-duplicate-cache). */
+export function clearProcedurePromotionDuplicateSkillCache(): void {
   skillMdDuplicateDigestCache.clear();
 }
 

--- a/extensions/memory-hybrid/services/procedure-promotion-policy.ts
+++ b/extensions/memory-hybrid/services/procedure-promotion-policy.ts
@@ -1092,7 +1092,41 @@ function hasValidationCheck(recipe: unknown, _task: string): boolean {
     return explicitValidationPattern.test(`${fields}\n${argFields}`);
   });
 }
-const skillMdDuplicateDigestCache = new Map<string, { mtimeMs: number; lower: string }>();
+
+/** Minimal LRU cache with max-size cap for skill MD digest cache. */
+class LRUCache<K, V> {
+  private readonly cache: Map<K, V>;
+  private readonly capacity: number;
+
+  constructor(capacity: number) {
+    this.cache = new Map();
+    this.capacity = Math.max(1, capacity);
+  }
+
+  get(key: K): V | undefined {
+    if (!this.cache.has(key)) return undefined;
+    const value = this.cache.get(key)!;
+    this.cache.delete(key);
+    this.cache.set(key, value);
+    return value;
+  }
+
+  set(key: K, value: V): void {
+    if (this.cache.has(key)) {
+      this.cache.delete(key);
+    } else if (this.cache.size >= this.capacity) {
+      const oldest = this.cache.keys().next().value as K;
+      this.cache.delete(oldest);
+    }
+    this.cache.set(key, value);
+  }
+
+  clear(): void {
+    this.cache.clear();
+  }
+}
+
+const skillMdDuplicateDigestCache = new LRUCache<string, { mtimeMs: number; lower: string }>(500);
 
 /** Clears the SKILL.md mtime cache used by duplicate-skill detection (for tests and --bypass-skill-duplicate-cache). */
 export function clearProcedurePromotionDuplicateSkillCache(): void {

--- a/extensions/memory-hybrid/services/procedure-promotion-policy.ts
+++ b/extensions/memory-hybrid/services/procedure-promotion-policy.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { join } from "node:path";
 import type { ProcedureEntry } from "../types/memory.js";
 import { slugifyForSkill, titleCase } from "../utils/text.js";
@@ -197,6 +197,8 @@ export interface ProcedurePromotionPolicyOptions {
   now?: number;
   resolvedSlug?: string;
   evidence?: ProcedurePromotionEvidence;
+  /** When true, re-read every SKILL.md from disk for duplicate detection (ignore mtime cache). */
+  bypassDuplicateSkillCache?: boolean;
 }
 
 const DEFAULT_MIN_DISTINCT_CONTEXTS = 2;
@@ -368,6 +370,7 @@ export function evaluateProcedureForPromotion(
     options.skillsAutoPath,
     options.existingSkillDirs,
     options.inRunSkillCandidates,
+    options.bypassDuplicateSkillCache === true,
   );
   if (similarSkillExists)
     gates.push(defer("duplicate_existing_skill", "existing or earlier same-run skill appears to cover this trigger"));
@@ -1089,12 +1092,39 @@ function hasValidationCheck(recipe: unknown, _task: string): boolean {
     return explicitValidationPattern.test(`${fields}\n${argFields}`);
   });
 }
+const skillMdDuplicateDigestCache = new Map<string, { mtimeMs: number; lower: string }>();
+
+/** Clears the SKILL.md mtime cache used by duplicate-skill detection (tests / --no-skill-duplicate-cache). */
+export function clearProcedurePromotionDuplicateSkillCache(): void {
+  skillMdDuplicateDigestCache.clear();
+}
+
+function readSkillMdLowerCached(skillPath: string, bypassCache: boolean): string | null {
+  if (bypassCache) {
+    const raw = safeReadFile(skillPath);
+    return raw ? raw.toLowerCase() : null;
+  }
+  try {
+    const mtimeMs = Math.trunc(statSync(skillPath).mtimeMs);
+    const hit = skillMdDuplicateDigestCache.get(skillPath);
+    if (hit && hit.mtimeMs === mtimeMs) return hit.lower;
+    const raw = safeReadFile(skillPath);
+    if (!raw) return null;
+    const lower = raw.toLowerCase();
+    skillMdDuplicateDigestCache.set(skillPath, { mtimeMs, lower });
+    return lower;
+  } catch {
+    return null;
+  }
+}
+
 function isDuplicateSkill(
   slug: string,
   task: string,
   skillsAutoPath: string,
   extraDirs: string[] = [],
   inRunCandidates: readonly ProcedurePromotionDuplicateCandidate[] = [],
+  bypassDiskCache = false,
 ): boolean {
   const dirs = [skillsAutoPath, ...extraDirs];
   const taskWords = significantWords(task);
@@ -1110,7 +1140,8 @@ function isDuplicateSkill(
       const skillPath = join(dir, entry, "SKILL.md");
       if (!existsSync(skillPath)) continue;
       if (entry === slug) return true;
-      const content = safeReadFile(skillPath).toLowerCase();
+      const content = readSkillMdLowerCached(skillPath, bypassDiskCache);
+      if (!content) continue;
       if (content.includes(`name: ${slug}`)) return true;
       const taskContent = extractTaskContentFromSkill(content);
       const contentWords = significantWords(taskContent);

--- a/extensions/memory-hybrid/services/procedure-skill-generator.ts
+++ b/extensions/memory-hybrid/services/procedure-skill-generator.ts
@@ -131,6 +131,8 @@ type GenerateAutoSkillsOptions = {
   dryRun?: boolean;
   apply?: boolean;
   policy?: string;
+  /** When true, duplicate-skill detection re-reads every SKILL.md (bypass mtime cache). */
+  bypassDuplicateSkillCache?: boolean;
 };
 
 /**
@@ -178,6 +180,7 @@ export function generateAutoSkills(
       resolvedSlug,
       inRunSkillCandidates,
       evidence,
+      bypassDuplicateSkillCache: options.bypassDuplicateSkillCache,
     });
     const decision = createProcedurePromotionDecision(item, context, evaluation);
     const reservedCandidate = {
@@ -346,6 +349,7 @@ export function generateAutoSkillForProcedure(
     validationThreshold: options.requireValidation === false ? 1 : options.validationThreshold,
     resolvedSlug,
     evidence,
+    bypassDuplicateSkillCache: options.bypassDuplicateSkillCache,
   });
   if (!evaluation.eligible || !evaluation.draft || evaluation.metadata.requiresHumanApproval) {
     const reasons =

--- a/extensions/memory-hybrid/tests/crystallization.test.ts
+++ b/extensions/memory-hybrid/tests/crystallization.test.ts
@@ -350,6 +350,25 @@ describe("scorePattern", () => {
   });
 });
 
+describe("WorkflowStore.getPatterns memo (#1415)", () => {
+  it("returns identical JSON for repeated calls until a new trace is recorded", () => {
+    for (let i = 0; i < 3; i++) {
+      wfStore.record({
+        goal: `stable-${i}`,
+        toolSequence: ["t1", "t2"],
+        outcome: "success",
+        argsHash: "memo-bucket",
+      });
+    }
+    const a = wfStore.getPatterns({ minSuccessRate: 0, limit: 10 });
+    const b = wfStore.getPatterns({ minSuccessRate: 0, limit: 10 });
+    expect(JSON.stringify(a)).toEqual(JSON.stringify(b));
+    wfStore.record({ goal: "bump", toolSequence: ["z"], outcome: "success" });
+    const c = wfStore.getPatterns({ minSuccessRate: 0, limit: 10 });
+    expect(c.length).toBeGreaterThan(0);
+  });
+});
+
 // ============================================================================
 // PatternDetector
 // ============================================================================

--- a/extensions/memory-hybrid/tests/generated-skill-telemetry.test.ts
+++ b/extensions/memory-hybrid/tests/generated-skill-telemetry.test.ts
@@ -59,6 +59,37 @@ describe("generated skill telemetry", () => {
     expect(m2).toEqual(m1);
   });
 
+  it("keeps positive-only saved rollups consistent after rebuild", () => {
+    const { id, skillName } = createGeneratedSkill();
+
+    db.recordGeneratedSkillTelemetry({
+      skillName,
+      decision: "selected",
+      requestSummary: "positive savings",
+      taskOutcome: "success",
+      savedToolCalls: 3,
+      savedTimeMs: 1000,
+    });
+    db.recordGeneratedSkillTelemetry({
+      skillName,
+      decision: "selected",
+      requestSummary: "negative savings ignored",
+      taskOutcome: "success",
+      savedToolCalls: -7,
+      savedTimeMs: -2000,
+    });
+
+    const before = db.buildGeneratedSkillTelemetryReport({ skillName }).rows[0]?.metrics;
+    rebuildGeneratedSkillTelemetryRollupsForProcedure(db.getRawDb(), id);
+    const after = db.buildGeneratedSkillTelemetryReport({ skillName }).rows[0]?.metrics;
+
+    expect(before?.savedToolCalls).toBe(3);
+    expect(before?.savedTimeMs).toBe(1000);
+    expect(after?.savedToolCalls).toBe(3);
+    expect(after?.savedTimeMs).toBe(1000);
+    expect(after).toEqual(before);
+  });
+
   it("promotes experimental skills after repeated successful activations without correction", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-05-14T12:00:00Z"));

--- a/extensions/memory-hybrid/tests/generated-skill-telemetry.test.ts
+++ b/extensions/memory-hybrid/tests/generated-skill-telemetry.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { Command } from "commander";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { FactsDB } from "../backends/facts-db.js";
+import { rebuildGeneratedSkillTelemetryRollupsForProcedure } from "../backends/facts-db/generated-skills.js";
 import { registerSkillsCommands } from "../cli/skills.js";
 
 let tmpDir: string;
@@ -39,6 +40,25 @@ function createGeneratedSkill(taskPattern = "Validate release health report"): {
 }
 
 describe("generated skill telemetry", () => {
+  it("rollup counters stay consistent with a full rebuild (#1415 / #1400)", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-14T12:00:00Z"));
+    const { id, skillName } = createGeneratedSkill();
+    for (let i = 0; i < 4; i++) {
+      db.recordGeneratedSkillTelemetry({
+        skillName,
+        decision: "selected",
+        requestSummary: `req-${i}`,
+        taskOutcome: "success",
+      });
+    }
+    const m1 = db.buildGeneratedSkillTelemetryReport({ skillName }).rows[0]?.metrics;
+    rebuildGeneratedSkillTelemetryRollupsForProcedure(db.getRawDb(), id);
+    const m2 = db.buildGeneratedSkillTelemetryReport({ skillName }).rows[0]?.metrics;
+    expect(m1?.activationCountTotal).toBe(4);
+    expect(m2).toEqual(m1);
+  });
+
   it("promotes experimental skills after repeated successful activations without correction", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-05-14T12:00:00Z"));

--- a/extensions/memory-hybrid/tests/workflow-store.test.ts
+++ b/extensions/memory-hybrid/tests/workflow-store.test.ts
@@ -357,6 +357,42 @@ describe("WorkflowStore.getPatterns", () => {
     expect(patterns.length).toBeGreaterThan(0);
     expect(ms).toBeLessThan(3000);
   });
+
+  it("clusters similar-but-not-identical sequences without custom argsHash (#1415 bugfix)", () => {
+    // This test verifies the fix for the bug where default argsHash bucketing
+    // prevented Levenshtein clustering of similar sequences
+
+    // Create a fresh store without beforeEach data
+    const freshDir = mkdtempSync(join(tmpdir(), "similarity-test-"));
+    const freshStore = new WorkflowStore(join(freshDir, "test.db"));
+
+    freshStore.record({
+      goal: "test workflow 1",
+      toolSequence: ["read_file", "edit_file", "run_tests"],
+      outcome: "success",
+    });
+    freshStore.record({
+      goal: "test workflow 2",
+      toolSequence: ["read_file", "write_file", "run_tests"],
+      outcome: "success",
+    });
+    freshStore.record({
+      goal: "test workflow 3",
+      toolSequence: ["read_file", "edit_file", "run_tests"],
+      outcome: "success",
+    });
+
+    // With similarity threshold 0.66, these should cluster into 1 pattern
+    // because they differ by only 1 element out of 3 (similarity ~0.667-1.0)
+    const patterns = freshStore.getPatterns({ similarityThreshold: 0.66, minSuccessRate: 0, limit: 10 });
+
+    // Should get 1 cluster containing all 3 sequences
+    expect(patterns.length).toBe(1);
+    expect(patterns[0].totalCount).toBe(3);
+
+    freshStore.close();
+    rmSync(freshDir, { recursive: true, force: true });
+  });
 });
 
 describe("WorkflowStore.prune", () => {

--- a/extensions/memory-hybrid/tests/workflow-store.test.ts
+++ b/extensions/memory-hybrid/tests/workflow-store.test.ts
@@ -333,6 +333,23 @@ describe("WorkflowStore.getPatterns", () => {
     expect(patterns.length).toBeLessThanOrEqual(1);
   });
 
+  it("returns defensive copies for memoized pattern arrays", () => {
+    const first = store.getPatterns();
+    expect(first.length).toBeGreaterThan(0);
+
+    first.length = 0;
+
+    const second = store.getPatterns();
+    expect(second.length).toBeGreaterThan(0);
+
+    second[0].toolSequence.push("mutated-tool");
+    second[0].exampleGoals.push("mutated-goal");
+
+    const third = store.getPatterns();
+    expect(third[0].toolSequence).not.toContain("mutated-tool");
+    expect(third[0].exampleGoals).not.toContain("mutated-goal");
+  });
+
   it("reopens and returns results when native DB handle was unexpectedly closed", () => {
     const db = (store as any).db as import("node:sqlite").DatabaseSync;
     db.close();

--- a/extensions/memory-hybrid/tests/workflow-store.test.ts
+++ b/extensions/memory-hybrid/tests/workflow-store.test.ts
@@ -341,6 +341,22 @@ describe("WorkflowStore.getPatterns", () => {
     const patterns = store.getPatterns();
     expect(Array.isArray(patterns)).toBe(true);
   });
+
+  it("getPatterns stays within a few seconds for hundreds of traces using sampling (#1415)", () => {
+    for (let i = 0; i < 400; i++) {
+      store.record({
+        goal: `goal-${i}`,
+        toolSequence: ["alpha", "beta"],
+        outcome: i % 6 === 0 ? "failure" : "success",
+        argsHash: "perf-bucket",
+      });
+    }
+    const t0 = performance.now();
+    const patterns = store.getPatterns({ minSuccessRate: 0, limit: 30, traceSampleLimit: 2000 });
+    const ms = performance.now() - t0;
+    expect(patterns.length).toBeGreaterThan(0);
+    expect(ms).toBeLessThan(3000);
+  });
 });
 
 describe("WorkflowStore.prune", () => {


### PR DESCRIPTION
Closes https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/1415

## #1399 WorkflowStore.getPatterns
- Bounded `SELECT` (default `traceSampleLimit: 2000`, overridable).
- Cluster Levenshtein **within** `args_hash` buckets to cut cross-comparisons.
- **Memoization** on table `(COUNT, MAX(created_at))` fingerprint + options; invalidated on `record()` / `prune()`.
- Pattern detector passes `traceSampleLimit: 6000` for headroom.

## #1400 Telemetry IO
- New `gst_*` rollup columns on `procedures` (migration + one-time backfill when columns first appear).
- `recordGeneratedSkillTelemetry`: **O(1)** delta `UPDATE` after insert; lifecycle refresh uses rollups + a single **COUNT** for last-7d activations (no full `SELECT *` scan).
- `buildGeneratedSkillTelemetryReport`: **single** `listGeneratedSkillProcedures`; recent rows use explicit column list + `LIMIT`.
- `rebuildGeneratedSkillTelemetryRollupsForProcedure` for correction paths (`markGeneratedSkillTelemetryFalsePositive`).

## #1401 isDuplicateSkill
- **mtime cache** per absolute `SKILL.md` path (re-read when mtime changes).
- `--bypass-skill-duplicate-cache` on `generate-auto-skills` → `bypassDuplicateSkillCache` on promotion options.
- `clearProcedurePromotionDuplicateSkillCache()` for tests.

## Tests
- Memo determinism; sampled `getPatterns` perf smoke; rollup vs rebuild parity.

Commit author: **Markus Lassfolk** (noreply GitHub email).

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches SQLite schema/migrations and changes how generated-skill telemetry metrics are computed (rollup deltas + backfills), which could skew lifecycle decisions/reports if counters drift. Also adds memoization/sampling to workflow pattern detection, which is performance-driven but could change which patterns surface under some option combinations.
> 
> **Overview**
> **Performance-focused updates to memory-hybrid telemetry and skill generation.** Generated-skill telemetry reporting/lifecycle refresh is reworked to use new per-`procedure` `gst_*` rollup columns that are incrementally updated on telemetry insert, with an idempotent migration/backfill and a rebuild helper used after correction edits; reports now fetch only a limited set of recent activation rows and ignore negative “savings” values.
> 
> **Workflow pattern detection is bounded and cached.** `WorkflowStore.getPatterns` now samples a limited number of newest traces, memoizes results (with defensive copies) and invalidates on `record`/`prune`; `PatternDetector` opts into a higher sample limit.
> 
> **Duplicate-skill detection is cached + controllable.** `SKILL.md` reads are cached by mtime via a small LRU, with a new `--bypass-skill-duplicate-cache` flag plumbed through the CLI and skill generator to force re-reads; tests added for rollup parity, memoization behavior, sampling performance, and clustering edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47551faf229829be3d62c131ac99aa6796aba6d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->