### PR TITLE
feat: false-positive vs user-correction telemetry (#1416)

### DIFF
--- a/extensions/memory-hybrid/backends/facts-db/generated-skills.ts
+++ b/extensions/memory-hybrid/backends/facts-db/generated-skills.ts
@@ -231,7 +231,7 @@ export function rebuildGeneratedSkillTelemetryRollupsForProcedure(db: DatabaseSy
            gst_outcome_success = (SELECT COUNT(*) FROM generated_skill_telemetry t WHERE t.procedure_id = p.id AND t.decision = 'selected' AND t.task_outcome = 'success'),
            gst_outcome_failure = (SELECT COUNT(*) FROM generated_skill_telemetry t WHERE t.procedure_id = p.id AND t.decision = 'selected' AND t.task_outcome = 'failure'),
            gst_outcome_partial = (SELECT COUNT(*) FROM generated_skill_telemetry t WHERE t.procedure_id = p.id AND t.decision = 'selected' AND t.task_outcome = 'partial'),
-           gst_outcome_unknown = (SELECT COUNT(*) FROM generated_skill_telemetry t WHERE t.procedure_id = p.id AND t.decision = 'selected' AND (t.task_outcome IS NULL OR t.task_outcome NOT IN ('success','failure','partial'))),
+           gst_outcome_unknown = (SELECT COUNT(*) FROM generated_skill_telemetry t WHERE t.procedure_id = p.id AND t.decision = 'selected' AND (t.task_outcome IS NULL OR t.task_outcome = '' OR t.task_outcome NOT IN ('success','failure','partial'))),
            gst_success_clear_total = (SELECT COUNT(*) FROM generated_skill_telemetry t WHERE t.procedure_id = p.id AND t.decision = 'selected' AND t.task_outcome = 'success' AND t.user_correction = 0),
            gst_considered_total = (SELECT COUNT(*) FROM generated_skill_telemetry t WHERE t.procedure_id = p.id AND t.decision = 'considered'),
            gst_skipped_total = (SELECT COUNT(*) FROM generated_skill_telemetry t WHERE t.procedure_id = p.id AND t.decision = 'skipped'),

--- a/extensions/memory-hybrid/backends/facts-db/generated-skills.ts
+++ b/extensions/memory-hybrid/backends/facts-db/generated-skills.ts
@@ -567,7 +567,7 @@ function summarizeSkillTelemetry(
     }
     if (activation.falseNegativeSignal) falseNegativeSignals++;
   }
-  const repeatedCorrectionCount = countRepeatedUserCorrectionBuckets(activations, now);
+  const repeatedCorrectionCount = countRepeatedUserCorrectionBuckets(evalActivations, now);
 
   const knownOutcomeTotal = successCount + failureCount + partialCount + unknownCount;
   const successRate = knownOutcomeTotal > 0 ? successCount / knownOutcomeTotal : null;

--- a/extensions/memory-hybrid/backends/facts-db/generated-skills.ts
+++ b/extensions/memory-hybrid/backends/facts-db/generated-skills.ts
@@ -727,6 +727,7 @@ function summarizeSkillTelemetryFromRollups(
   canonicalSkillName: string,
   policy: GeneratedSkillLifecyclePolicy,
   now: number,
+  computeRepeatedCorrections = false,
 ): { metrics: GeneratedSkillTelemetryMetrics; flags: GeneratedSkillTelemetryFlags } {
   const r = readTelemetryRollup(db, proc.id);
   if (!r) {
@@ -739,7 +740,9 @@ function summarizeSkillTelemetryFromRollups(
   const falsePositiveSignals = r.gst_fp_signals_total;
   const falseNegativeSignals = r.gst_fn_signals_total;
   const correctionCount = r.gst_user_correction_total;
-  const repeatedCorrectionCount = countRepeatedUserCorrectionBuckets(skillTelemetryEntries(db, canonicalSkillName), now);
+  const repeatedCorrectionCount = computeRepeatedCorrections
+    ? countRepeatedUserCorrectionBuckets(skillTelemetryEntries(db, canonicalSkillName), now)
+    : 0;
   const lastUsedAt = r.gst_last_selected_at;
   const successCount = r.gst_outcome_success;
   const failureCount = r.gst_outcome_failure;
@@ -830,7 +833,7 @@ export function refreshGeneratedSkillLifecycleState(
   const proc = findGeneratedSkillProcedure(db, skillName);
   if (!proc?.skillPath) return null;
   const canonicalSkillName = basename(proc.skillPath);
-  const { metrics, flags } = summarizeSkillTelemetryFromRollups(db, proc, canonicalSkillName, policy, now);
+  const { metrics, flags } = summarizeSkillTelemetryFromRollups(db, proc, canonicalSkillName, policy, now, returnMetrics);
   const currentState = proc.skillState ?? "experimental";
   const transition = desiredLifecycleTransition(currentState, flags, metrics, policy);
   const updatedProc =
@@ -869,13 +872,13 @@ export function buildGeneratedSkillTelemetryReport(
         const result = refreshGeneratedSkillLifecycleState(db, skillName, policy, now, true);
         if (result == null) {
           procFresh = proc;
-          ({ metrics, flags } = summarizeSkillTelemetryFromRollups(db, proc, skillName, policy, now));
+          ({ metrics, flags } = summarizeSkillTelemetryFromRollups(db, proc, skillName, policy, now, true));
         } else {
           ({ proc: procFresh, metrics, flags } = result);
         }
       } else {
         procFresh = proc;
-        ({ metrics, flags } = summarizeSkillTelemetryFromRollups(db, proc, skillName, policy, now));
+        ({ metrics, flags } = summarizeSkillTelemetryFromRollups(db, proc, skillName, policy, now, true));
       }
       const recommendation = flags.archiveCandidate
         ? "archive"

--- a/extensions/memory-hybrid/backends/facts-db/generated-skills.ts
+++ b/extensions/memory-hybrid/backends/facts-db/generated-skills.ts
@@ -239,7 +239,7 @@ export function rebuildGeneratedSkillTelemetryRollupsForProcedure(db: DatabaseSy
            gst_outcome_success = (SELECT COUNT(*) FROM generated_skill_telemetry t WHERE t.procedure_id = p.id AND t.decision = 'selected' AND t.task_outcome = 'success'),
            gst_outcome_failure = (SELECT COUNT(*) FROM generated_skill_telemetry t WHERE t.procedure_id = p.id AND t.decision = 'selected' AND t.task_outcome = 'failure'),
            gst_outcome_partial = (SELECT COUNT(*) FROM generated_skill_telemetry t WHERE t.procedure_id = p.id AND t.decision = 'selected' AND t.task_outcome = 'partial'),
-           gst_outcome_unknown = (SELECT COUNT(*) FROM generated_skill_telemetry t WHERE t.procedure_id = p.id AND t.decision = 'selected' AND (t.task_outcome IS NULL OR t.task_outcome NOT IN ('success','failure','partial'))),
+           gst_outcome_unknown = (SELECT COUNT(*) FROM generated_skill_telemetry t WHERE t.procedure_id = p.id AND t.decision = 'selected' AND (t.task_outcome IS NULL OR t.task_outcome = '' OR t.task_outcome NOT IN ('success','failure','partial'))),
            gst_success_clear_total = (SELECT COUNT(*) FROM generated_skill_telemetry t WHERE t.procedure_id = p.id AND t.decision = 'selected' AND t.task_outcome = 'success' AND t.user_correction = 0),
            gst_considered_total = (SELECT COUNT(*) FROM generated_skill_telemetry t WHERE t.procedure_id = p.id AND t.decision = 'considered'),
            gst_skipped_total = (SELECT COUNT(*) FROM generated_skill_telemetry t WHERE t.procedure_id = p.id AND t.decision = 'skipped'),

--- a/extensions/memory-hybrid/backends/facts-db/generated-skills.ts
+++ b/extensions/memory-hybrid/backends/facts-db/generated-skills.ts
@@ -48,6 +48,12 @@ export type GeneratedSkillTelemetryMetrics = {
   nearMissCount: number;
   falsePositiveSignals: number;
   falseNegativeSignals: number;
+  /** Activations with `user_correction` set (explicit user pushback). */
+  correctionCount: number;
+  /**
+   * Count of distinct `request_hash` values (non-null) in the last 30 days that have
+   * at least two user-correction activations for this skill.
+   */
   repeatedCorrectionCount: number;
   lastUsedAt: number | null;
   successCount: number;
@@ -63,6 +69,7 @@ export type GeneratedSkillTelemetryMetrics = {
   skippedCount: number;
   savedToolCalls: number;
   savedTimeMs: number;
+  /** `falsePositiveSignals / (activationCountTotal + nearMissCount)` when there is any exposure. */
   falsePositiveRate: number | null;
 };
 
@@ -230,6 +237,12 @@ export function recordGeneratedSkillTelemetry(
   input: GeneratedSkillTelemetryRecordInput,
   policy: GeneratedSkillLifecyclePolicy = DEFAULT_GENERATED_SKILL_LIFECYCLE_POLICY,
 ): GeneratedSkillTelemetryEntry {
+  if (input.userCorrection === true) {
+    const cr = normalizeSummary(input.correctionReason);
+    if (!cr) {
+      throw new Error("user correction telemetry requires a non-empty correctionReason");
+    }
+  }
   let proc = findGeneratedSkillProcedure(db, input.skillName);
   if (input.procedureId != null) {
     const row = db.prepare("SELECT * FROM procedures WHERE id = ? LIMIT 1").get(input.procedureId) as
@@ -344,6 +357,24 @@ function skillTelemetryEntries(db: DatabaseSync, skillName: string): GeneratedSk
   ).map(mapGeneratedSkillTelemetryRow);
 }
 
+const REPEATED_CORRECTION_WINDOW_SEC = 30 * 24 * 60 * 60;
+
+function countRepeatedUserCorrectionBuckets(activations: GeneratedSkillTelemetryEntry[], now: number): number {
+  const windowStart = now - REPEATED_CORRECTION_WINDOW_SEC;
+  const byHash = new Map<string, number>();
+  for (const a of activations) {
+    if (!a.userCorrection || a.createdAt < windowStart) continue;
+    const h = a.requestHash;
+    if (typeof h !== "string" || h.length === 0) continue;
+    byHash.set(h, (byHash.get(h) ?? 0) + 1);
+  }
+  let buckets = 0;
+  for (const c of byHash.values()) {
+    if (c >= 2) buckets++;
+  }
+  return buckets;
+}
+
 function summarizeSkillTelemetry(
   proc: ProcedureEntry,
   activations: GeneratedSkillTelemetryEntry[],
@@ -356,7 +387,7 @@ function summarizeSkillTelemetry(
   let nearMissCount = 0;
   let falsePositiveSignals = 0;
   let falseNegativeSignals = 0;
-  let repeatedCorrectionCount = 0;
+  let correctionCount = 0;
   let lastUsedAt: number | null = null;
   let successCount = 0;
   let failureCount = 0;
@@ -371,11 +402,12 @@ function summarizeSkillTelemetry(
   for (const activation of activations) {
     savedToolCalls += activation.savedToolCalls ?? 0;
     savedTimeMs += activation.savedTimeMs ?? 0;
+    if (activation.userCorrection || activation.causedRework) falsePositiveSignals++;
+    if (activation.userCorrection) correctionCount++;
     if (activation.decision === "selected") {
       activationCountTotal++;
       if (activation.createdAt >= weekAgo) activationCountPerWeek++;
       lastUsedAt = lastUsedAt == null ? activation.createdAt : Math.max(lastUsedAt, activation.createdAt);
-      if (activation.userCorrection || activation.causedRework) falsePositiveSignals++;
       if (activation.taskOutcome === "success") {
         successCount++;
         if (!activation.userCorrection) successfulUsesWithoutCorrection++;
@@ -392,7 +424,6 @@ function summarizeSkillTelemetry(
       if (activation.decision === "skipped") skippedCount++;
     }
     if (activation.falseNegativeSignal) falseNegativeSignals++;
-    if (activation.userCorrection) repeatedCorrectionCount++;
   }
 
   const knownOutcomeTotal = successCount + failureCount + partialCount + unknownCount;
@@ -400,7 +431,9 @@ function summarizeSkillTelemetry(
   const failureRate = knownOutcomeTotal > 0 ? failureCount / knownOutcomeTotal : null;
   const partialRate = knownOutcomeTotal > 0 ? partialCount / knownOutcomeTotal : null;
   const unknownRate = knownOutcomeTotal > 0 ? unknownCount / knownOutcomeTotal : null;
-  const falsePositiveRate = activationCountTotal > 0 ? falsePositiveSignals / activationCountTotal : null;
+  const exposureTotal = activationCountTotal + nearMissCount;
+  const falsePositiveRate = exposureTotal > 0 ? falsePositiveSignals / exposureTotal : null;
+  const repeatedCorrectionCount = countRepeatedUserCorrectionBuckets(activations, now);
   const generatedAt = proc.skillGeneratedAt ?? proc.promotedAt ?? proc.updatedAt ?? proc.createdAt ?? now;
   const archiveCandidate =
     activationCountTotal === 0 && generatedAt <= now - policy.archiveAfterUnusedDays * 24 * 60 * 60;
@@ -410,7 +443,7 @@ function summarizeSkillTelemetry(
     proc.skillState !== "trusted" &&
     successfulUsesWithoutCorrection >= policy.promoteAfterSuccessfulUses;
   const overTriggering =
-    activationCountTotal >= policy.demoteMinSamples &&
+    exposureTotal >= policy.demoteMinSamples &&
     falsePositiveRate != null &&
     falsePositiveRate >= policy.demoteFalsePositiveRate;
   const revisionCandidate = nearMissCount >= policy.revisionNearMissThreshold && skippedCount >= consideredCount;
@@ -422,6 +455,7 @@ function summarizeSkillTelemetry(
       nearMissCount,
       falsePositiveSignals,
       falseNegativeSignals,
+      correctionCount,
       repeatedCorrectionCount,
       lastUsedAt,
       successCount,

--- a/extensions/memory-hybrid/cli/skills.ts
+++ b/extensions/memory-hybrid/cli/skills.ts
@@ -6,9 +6,9 @@
  * - hybrid-mem skills telemetry | record | correct | demote (when FactsDB is available)
  */
 
-import type { FactsDB } from "../backends/facts-db.js";
 import type { CrystallizationStatus } from "../backends/crystallization-store.js";
 import type { CrystallizationStore } from "../backends/crystallization-store.js";
+import type { FactsDB } from "../backends/facts-db.js";
 import type { HybridMemoryConfig } from "../config.js";
 import { CrystallizationProposer } from "../services/crystallization-proposer.js";
 import { SkillValidator } from "../services/skill-validator.js";
@@ -236,7 +236,7 @@ function registerGeneratedSkillTelemetryCli(skills: ArgumentChainable, factsDb: 
             `- ${row.skillName} state=${row.state} activations/week=${row.metrics.activationCountPerWeek} near-miss=${row.metrics.nearMissCount} false+=${row.metrics.falsePositiveSignals} false-=${row.metrics.falseNegativeSignals} lastUsed=${row.metrics.lastUsedAt ? relativeTime(row.metrics.lastUsedAt * 1000) : "never"} recommendation=${row.recommendation}`,
           );
           console.log(
-            `  outcomes: success=${formatRate(row.metrics.successRate)} failure=${formatRate(row.metrics.failureRate)} partial=${formatRate(row.metrics.partialRate)} corrections=${row.metrics.repeatedCorrectionCount} generatedAt=${formatIso(row.generatedAt)}`,
+            `  outcomes: success=${formatRate(row.metrics.successRate)} failure=${formatRate(row.metrics.failureRate)} partial=${formatRate(row.metrics.partialRate)} userCorrections=${row.metrics.correctionCount} repeatedRequestCorrections=${row.metrics.repeatedCorrectionCount} generatedAt=${formatIso(row.generatedAt)}`,
           );
           if (row.stateReason) console.log(`  stateReason: ${row.stateReason}`);
           if (row.flags.overTriggering || row.flags.archiveCandidate || row.flags.revisionCandidate) {
@@ -266,9 +266,16 @@ function registerGeneratedSkillTelemetryCli(skills: ArgumentChainable, factsDb: 
     .option("--request-summary <summary>", "Redacted request summary")
     .option("--request-hash <hash>", "Optional request hash override")
     .option("--confidence <value>", "Selection confidence (0-1)")
-    .option("--reason <reason>", "Why the skill was selected or skipped")
+    .option(
+      "--reason <reason>",
+      "Why the skill was selected or skipped (or correction explanation when using --user-correction)",
+    )
     .option("--outcome <outcome>", "success, failure, partial, or unknown")
-    .option("--false-positive", "Mark this activation as immediately corrected/rejected")
+    .option(
+      "--false-positive",
+      "Operator false-positive signal (sets caused rework; does not record a user correction)",
+    )
+    .option("--user-correction", "Explicit user correction (requires non-empty --reason as correction explanation)")
     .option("--false-negative", "Mark this near-miss as a false-negative signal")
     .option("--caused-rework", "Mark this activation as having caused rework")
     .option("--saved-tool-calls <n>", "Estimate tool calls saved")
@@ -290,6 +297,7 @@ function registerGeneratedSkillTelemetryCli(skills: ArgumentChainable, factsDb: 
             reason?: string;
             outcome?: string;
             falsePositive?: boolean;
+            userCorrection?: boolean;
             falseNegative?: boolean;
             causedRework?: boolean;
             savedToolCalls?: string;
@@ -342,6 +350,17 @@ function registerGeneratedSkillTelemetryCli(skills: ArgumentChainable, factsDb: 
             process.exitCode = 1;
             return;
           }
+          const userCorrection = opts?.userCorrection === true;
+          const operatorFalsePositive = opts?.falsePositive === true;
+          if (userCorrection) {
+            const r = (opts?.reason ?? "").trim();
+            if (!r) {
+              console.error("error: --user-correction requires a non-empty --reason (correction explanation)");
+              process.exitCode = 1;
+              return;
+            }
+          }
+          const causedRework = opts?.causedRework === true || operatorFalsePositive;
           try {
             const activation = factsDb.recordGeneratedSkillTelemetry({
               skillName,
@@ -349,12 +368,12 @@ function registerGeneratedSkillTelemetryCli(skills: ArgumentChainable, factsDb: 
               requestSummary: opts?.requestSummary,
               requestHash: opts?.requestHash,
               confidence,
-              reason: opts?.reason,
+              reason: userCorrection ? undefined : opts?.reason,
               taskOutcome: outcome as "success" | "failure" | "partial" | "unknown" | undefined,
-              userCorrection: opts?.falsePositive,
-              correctionReason: opts?.falsePositive ? (opts.reason ?? "user rejected skill") : undefined,
+              userCorrection,
+              correctionReason: userCorrection ? opts?.reason?.trim() : undefined,
               falseNegativeSignal: opts?.falseNegative,
-              causedRework: opts?.causedRework,
+              causedRework,
               savedToolCalls,
               savedTimeMs,
               scope: opts?.scope as "global" | "user" | "agent" | "session" | undefined,

--- a/extensions/memory-hybrid/services/procedure-promotion-policy.ts
+++ b/extensions/memory-hybrid/services/procedure-promotion-policy.ts
@@ -14,7 +14,7 @@ import {
   redactAutopilotValue,
 } from "./pending-autopilot/index.js";
 import { isAtomicSkillWriteScratchDir } from "../utils/skill-discovery.js";
-import { SkillValidator } from "./skill-validator.js";
+import { PEM_PRIVATE_KEY_PATTERN, PRIVATE_IP_PATTERN, SkillValidator } from "./skill-validator.js";
 
 export const PROCEDURE_PROMOTION_POLICY_VERSION = "procedure-promotion-policy-v1";
 
@@ -249,11 +249,11 @@ const CREDENTIAL_PATTERNS: RegExp[] = [
   /\b(?:password|passwd|pwd|secret|token|api[_-]?key|authorization|private[_-]?key)\s*[:=]\s*[^\s,;}{\[\]]+/i,
   /\b(?:sk|pk|rk|ghp|gho|github_pat|xox[baprs])[-_][A-Za-z0-9_-]{8,}\b/,
   /\bBearer\s+[A-Za-z0-9._~+/-]+=*/i,
-  /-----BEGIN [A-Za-z0-9 ]*PRIVATE KEY[A-Za-z0-9 ]*-----/i,
+  PEM_PRIVATE_KEY_PATTERN,
 ];
 
 const PRIVATE_DATA_PATTERNS: RegExp[] = [
-  /\b(?:10\.\d{1,3}\.|172\.(?:1[6-9]|2\d|3[01])\.|192\.168\.)\d{1,3}\.\d{1,3}\b/,
+  PRIVATE_IP_PATTERN,
   /(?:^|[\s"'=:])(?:\/home\/[^\s"']+|\/Users\/[^\s"']+|~\/[^\s"']+)/,
   /\b[A-Za-z0-9._%+-]+@(?!(?:example\.com|localhost|test\.com|example\.org)(?![A-Za-z0-9.-]))[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/i,
 ];

--- a/extensions/memory-hybrid/tests/generated-skill-telemetry.test.ts
+++ b/extensions/memory-hybrid/tests/generated-skill-telemetry.test.ts
@@ -101,6 +101,7 @@ describe("generated skill telemetry", () => {
       requestSummary: "another unrelated request",
       taskOutcome: "failure",
       userCorrection: true,
+      correctionReason: "unrelated to task",
     });
     db.recordGeneratedSkillTelemetry({
       skillName,

--- a/extensions/memory-hybrid/tests/generated-skill-telemetry.test.ts
+++ b/extensions/memory-hybrid/tests/generated-skill-telemetry.test.ts
@@ -10,6 +10,7 @@ let tmpDir: string;
 let db: FactsDB;
 
 beforeEach(() => {
+  process.exitCode = undefined;
   tmpDir = mkdtempSync(join(tmpdir(), "generated-skill-telemetry-"));
   db = new FactsDB(join(tmpDir, "facts.db"));
 });
@@ -114,7 +115,8 @@ describe("generated skill telemetry", () => {
 
     expect(skill?.skillState).toBe("demoted");
     expect(report.rows[0]?.metrics.falsePositiveSignals).toBe(3);
-    expect(report.rows[0]?.metrics.repeatedCorrectionCount).toBe(2);
+    expect(report.rows[0]?.metrics.correctionCount).toBe(2);
+    expect(report.rows[0]?.metrics.repeatedCorrectionCount).toBe(0);
     expect(report.rows[0]?.flags.overTriggering).toBe(true);
     expect(report.rows[0]?.recommendation).toBe("demote");
   });
@@ -234,5 +236,100 @@ describe("generated skill telemetry", () => {
     };
     expect(demoted.skillState).toBe("demoted");
     expect(demoted.skillStateReason).toContain("over-triggering");
+  });
+
+  it("counts considered/skipped user corrections toward false-positive rate (#1416)", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-14T12:00:00Z"));
+    const { skillName } = createGeneratedSkill();
+    for (let i = 0; i < 3; i++) {
+      db.recordGeneratedSkillTelemetry({
+        skillName,
+        decision: "considered",
+        requestSummary: `near-miss-${i}`,
+        userCorrection: true,
+        correctionReason: "should not have been offered",
+      });
+    }
+    const report = db.buildGeneratedSkillTelemetryReport({ skillName });
+    expect(report.rows[0]?.metrics.activationCountTotal).toBe(0);
+    expect(report.rows[0]?.metrics.nearMissCount).toBe(3);
+    expect(report.rows[0]?.metrics.falsePositiveSignals).toBe(3);
+    expect(report.rows[0]?.metrics.correctionCount).toBe(3);
+    expect(report.rows[0]?.metrics.falsePositiveRate).toBe(1);
+    expect(report.rows[0]?.flags.overTriggering).toBe(true);
+  });
+
+  it("tracks repeated user corrections on the same request hash within 30 days (#1416)", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-14T12:00:00Z"));
+    const { skillName } = createGeneratedSkill();
+    const summary = "same request context for repeat";
+    db.recordGeneratedSkillTelemetry({
+      skillName,
+      decision: "selected",
+      requestSummary: summary,
+      taskOutcome: "success",
+      userCorrection: true,
+      correctionReason: "first",
+    });
+    db.recordGeneratedSkillTelemetry({
+      skillName,
+      decision: "selected",
+      requestSummary: summary,
+      taskOutcome: "failure",
+      userCorrection: true,
+      correctionReason: "second",
+    });
+    const report = db.buildGeneratedSkillTelemetryReport({ skillName });
+    expect(report.rows[0]?.metrics.correctionCount).toBe(2);
+    expect(report.rows[0]?.metrics.repeatedCorrectionCount).toBe(1);
+  });
+
+  it("CLI record rejects --user-correction without --reason (#1416)", async () => {
+    const { skillName } = createGeneratedSkill();
+    process.argv = ["node", "vitest", "hybrid-mem"];
+    const program = new Command("hybrid-mem");
+    program.exitOverride();
+    registerSkillsCommands(program, { factsDb: db, crystallizationStore: null, cfg: {} as never });
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await program.parseAsync(["skills", "record", skillName, "--decision", "selected", "--user-correction", "--json"], {
+      from: "user",
+    });
+    expect(process.exitCode).toBe(1);
+    expect(String(errSpy.mock.calls[0]?.[0] ?? "")).toMatch(/user-correction requires/i);
+  });
+
+  it("rejects telemetry record with user correction but no correctionReason", () => {
+    const { skillName } = createGeneratedSkill();
+    expect(() =>
+      db.recordGeneratedSkillTelemetry({
+        skillName,
+        decision: "selected",
+        requestSummary: "x",
+        userCorrection: true,
+      }),
+    ).toThrow(/correctionReason/i);
+  });
+
+  it("CLI record maps --false-positive to caused rework without user correction (#1416)", async () => {
+    const { skillName } = createGeneratedSkill();
+    process.argv = ["node", "vitest", "hybrid-mem"];
+    const program = new Command("hybrid-mem");
+    program.exitOverride();
+    registerSkillsCommands(program, { factsDb: db, crystallizationStore: null, cfg: {} as never });
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await program.parseAsync(
+      ["skills", "record", skillName, "--decision", "considered", "--false-positive", "--json"],
+      { from: "user" },
+    );
+    const payload = JSON.parse(String(logSpy.mock.calls[0]?.[0] ?? "{}")) as {
+      activation?: { userCorrection?: boolean; causedRework?: boolean; correctionReason?: string | null };
+    };
+    expect(payload.activation?.userCorrection).toBe(false);
+    expect(payload.activation?.causedRework).toBe(true);
+    expect(payload.activation?.correctionReason).toBeFalsy();
   });
 });

--- a/extensions/memory-hybrid/tests/generated-skill-validation.test.ts
+++ b/extensions/memory-hybrid/tests/generated-skill-validation.test.ts
@@ -716,8 +716,7 @@ Bounded CLI release-health review workflow.
       const output = JSON.parse(String(logSpy.mock.calls[0]?.[0] ?? "{}")) as { ok?: boolean; outputPath?: string };
       expect(output.ok).toBe(true);
       expect(output.outputPath).toBeDefined();
-      if (!output.outputPath) return;
-      expect(existsSync(output.outputPath)).toBe(true);
+      expect(existsSync(output.outputPath!)).toBe(true);
     } finally {
       cStore.close();
     }


### PR DESCRIPTION
Closes https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/1416

## CLI (`skills record`)
- `--false-positive`: operator signal only — sets **caused rework**, does **not** set `user_correction`, and does **not** invent a correction reason.
- `--user-correction`: sets **user correction**; requires a non-empty `--reason` used as `correctionReason`. Activation `reason` column is left unset in this path so it is not conflated with correction text.
- Help text distinguishes the two flags.

## DB / metrics (`generated-skills.ts`)
- `recordGeneratedSkillTelemetry` throws if `userCorrection` is true without a non-empty `correctionReason`.
- **correctionCount**: number of activations with `user_correction` (replaces the old misleading `repeatedCorrectionCount` meaning).
- **repeatedCorrectionCount**: distinct non-null `request_hash` values in the last **30 days** with ≥2 user-correction rows.
- **falsePositiveSignals**: increments for **any** decision when `user_correction` or `caused_rework`.
- **falsePositiveRate** / **overTriggering**: denominator is **selected + near-miss** exposure so corrections on `considered`/`skipped` affect demotion.

## Tests
- API rejection test; considered-only corrections and demotion; repeated-hash bucket; CLI validation and `--false-positive` JSON shape.

**Note:** CI should run tests on **Node ≥ 22.16** (`node:sqlite`). Local Node 20 cannot execute this suite.

Commit author: **Markus Lassfolk**.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes generated-skill telemetry semantics and demotion/over-triggering calculations, which can alter when skills get auto-demoted/flagged. Also tightens input validation for correction records and adjusts rollup backfills, so misclassification could affect stored metrics and CLI behavior.
> 
> **Overview**
> **Generated-skill telemetry now separates operator signals from explicit user pushback.** `skills record` adds `--user-correction` (requires non-empty `--reason` stored as `correctionReason`) and redefines `--false-positive` to *only* set `causedRework` without marking `user_correction`.
> 
> **Telemetry metrics and lifecycle evaluation were updated.** Rollups now count false-positive signals for any decision (`user_correction` or `caused_rework`), `falsePositiveRate`/`overTriggering` use an exposure denominator of `selected + near-miss`, and metrics add `correctionCount` plus a new `repeatedCorrectionCount` that buckets repeated corrections by `request_hash` within 30 days; recording `userCorrection` without `correctionReason` is rejected.
> 
> **Safety scanning refactor and tests.** Procedure promotion policy reuses shared `PEM_PRIVATE_KEY_PATTERN`/`PRIVATE_IP_PATTERN`, and the test suite is expanded to cover the new CLI validation, correction requirements, and the updated demotion/metrics behavior (including considered/skipped corrections and repeated-hash counting).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ffbf504a1a4f23ec9a592d57a40ee0e925a98a02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->