### PR TITLE
fix(crystallization): YAML multiline patch + H1 rename (closes #1427)

### DIFF
--- a/extensions/memory-hybrid/backends/crystallization-store.ts
+++ b/extensions/memory-hybrid/backends/crystallization-store.ts
@@ -31,6 +31,7 @@ export type CrystallizationStatus =
   | "validated"
   | "approved"
   | "installed"
+  | "quarantined"
   | "rejected"
   | "superseded";
 
@@ -426,6 +427,21 @@ export class CrystallizationStore extends BaseSqliteStore {
         )
         .run(reason ?? null, now, id);
 
+      if (result.changes === 0) return null;
+      return this.getByIdInternal(id);
+    });
+  }
+
+  quarantine(id: string, reason?: string): CrystallizationProposal | null {
+    return this.runWithDb("quarantine", () => {
+      const now = new Date().toISOString();
+      const result = this.liveDb
+        .prepare(
+          `UPDATE crystallization_proposals
+           SET status = 'quarantined', rejection_reason = ?, updated_at = ?
+           WHERE id = ? AND status = 'installed'`,
+        )
+        .run(reason ?? null, now, id);
       if (result.changes === 0) return null;
       return this.getByIdInternal(id);
     });

--- a/extensions/memory-hybrid/services/crystallization-proposer.ts
+++ b/extensions/memory-hybrid/services/crystallization-proposer.ts
@@ -33,23 +33,12 @@ function replaceFirstBodyH1AfterFrontmatter(skillContent: string, newTitle: stri
   const stripped = stripLeadingHtmlComments(skillContent);
   const head = skillContent.slice(0, skillContent.length - stripped.length);
   let body = stripped;
+  let prefix = head;
   const fmMatch = body.match(/^---\r?\n[\s\S]*?\r?\n---\r?\n?/);
   if (fmMatch) {
     const frontmatter = fmMatch[0];
+    prefix += frontmatter;
     body = body.slice(frontmatter.length);
-    const leadingNewlineMatch = body.match(/^\r?\n/);
-    const leadingNewline = leadingNewlineMatch ? leadingNewlineMatch[0] : "";
-    body = body.replace(/^\r?\n/, "");
-    const h1Line = /^(#[ \t]+(?!#)\S[^\r\n]*)(\r?)$/m;
-    if (!h1Line.test(body)) {
-      return skillContent;
-    }
-    return (
-      head +
-      frontmatter +
-      leadingNewline +
-      body.replace(h1Line, (_match, _oldLine: string, cr: string) => `# ${newTitle}${cr}`)
-    );
   }
   const leadingNewlineMatch = body.match(/^\r?\n/);
   const leadingNewline = leadingNewlineMatch ? leadingNewlineMatch[0] : "";
@@ -58,7 +47,7 @@ function replaceFirstBodyH1AfterFrontmatter(skillContent: string, newTitle: stri
   if (!h1Line.test(body)) {
     return skillContent;
   }
-  return head + leadingNewline + body.replace(h1Line, (_match, _oldLine: string, cr: string) => `# ${newTitle}${cr}`);
+  return prefix + leadingNewline + body.replace(h1Line, (_match, _oldLine: string, cr: string) => `# ${newTitle}${cr}`);
 }
 
 // ---------------------------------------------------------------------------

--- a/extensions/memory-hybrid/services/crystallization-proposer.ts
+++ b/extensions/memory-hybrid/services/crystallization-proposer.ts
@@ -577,6 +577,20 @@ export function patchOpeningYamlField(skillContent: string, key: string, value: 
 
 function formatYamlFrontmatterScalar(value: string): string {
   if (value === "") return '""';
+  
+  // YAML 1.1 reserved words that must be quoted to be treated as strings
+  const yamlReservedWords = new Set([
+    "true", "false", "True", "False", "TRUE", "FALSE",
+    "yes", "no", "Yes", "No", "YES", "NO",
+    "on", "off", "On", "Off", "ON", "OFF",
+    "null", "Null", "NULL", "~"
+  ]);
+  
+  // Check if value is a reserved word or looks like a number
+  if (yamlReservedWords.has(value) || /^[-+]?(\d+\.?\d*|\.\d+)([eE][-+]?\d+)?$/.test(value)) {
+    return JSON.stringify(value);
+  }
+  
   if (/^[\w.-]+$/.test(value)) return value;
   return JSON.stringify(value);
 }

--- a/extensions/memory-hybrid/services/crystallization-proposer.ts
+++ b/extensions/memory-hybrid/services/crystallization-proposer.ts
@@ -41,7 +41,7 @@ function replaceFirstBodyH1AfterFrontmatter(skillContent: string, newTitle: stri
   const leadingNewlineMatch = body.match(/^\r?\n/);
   const leadingNewline = leadingNewlineMatch ? leadingNewlineMatch[0] : "";
   body = body.replace(/^\r?\n/, "");
-  const h1Line = /^#\s+(?!#)\S.*$/m;
+  const h1Line = /^#[ \t]+(?!#)\S.*$/m;
   if (!h1Line.test(body)) {
     return skillContent;
   }
@@ -577,20 +577,38 @@ export function patchOpeningYamlField(skillContent: string, key: string, value: 
 
 function formatYamlFrontmatterScalar(value: string): string {
   if (value === "") return '""';
-  
+
   // YAML 1.1 reserved words that must be quoted to be treated as strings
   const yamlReservedWords = new Set([
-    "true", "false", "True", "False", "TRUE", "FALSE",
-    "yes", "no", "Yes", "No", "YES", "NO",
-    "on", "off", "On", "Off", "ON", "OFF",
-    "null", "Null", "NULL", "~"
+    "true",
+    "false",
+    "True",
+    "False",
+    "TRUE",
+    "FALSE",
+    "yes",
+    "no",
+    "Yes",
+    "No",
+    "YES",
+    "NO",
+    "on",
+    "off",
+    "On",
+    "Off",
+    "ON",
+    "OFF",
+    "null",
+    "Null",
+    "NULL",
+    "~",
   ]);
-  
+
   // Check if value is a reserved word or looks like a number
   if (yamlReservedWords.has(value) || /^[-+]?(\d+\.?\d*|\.\d+)([eE][-+]?\d+)?$/.test(value)) {
     return JSON.stringify(value);
   }
-  
+
   if (/^[\w.-]+$/.test(value)) return value;
   return JSON.stringify(value);
 }

--- a/extensions/memory-hybrid/services/crystallization-proposer.ts
+++ b/extensions/memory-hybrid/services/crystallization-proposer.ts
@@ -9,7 +9,7 @@ import { getEnv } from "../utils/env-manager.js";
  * When autoApprove=true the proposer immediately writes the skill to disk.
  */
 
-import { mkdirSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname } from "node:path";
 import type { CrystallizationStore } from "../backends/crystallization-store.js";
@@ -23,6 +23,28 @@ import {
 } from "./generated-skill-validation.js";
 import { PatternDetector } from "./pattern-detector.js";
 import { SkillCrystallizer } from "./skill-crystallizer.js";
+
+/** When renaming, replace the first Markdown ATX H1 in the body (after frontmatter), if any. */
+function replaceFirstBodyH1AfterFrontmatter(skillContent: string, newTitle: string): string {
+  let body = skillContent;
+  let head = "";
+  const commentMatch = body.match(/^<!--[\s\S]*?-->\s*\r?\n*/);
+  if (commentMatch) {
+    head += commentMatch[0];
+    body = body.slice(commentMatch[0].length);
+  }
+  const fmMatch = body.match(/^---\r?\n[\s\S]*?\r?\n---\r?\n?/);
+  if (fmMatch) {
+    head += fmMatch[0];
+    body = body.slice(fmMatch[0].length);
+  }
+  body = body.replace(/^\r?\n/, "");
+  const h1Line = /^#\s+(?!#)\S.*$/m;
+  if (!h1Line.test(body)) {
+    return skillContent;
+  }
+  return head + body.replace(h1Line, `# ${newTitle}`);
+}
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -38,6 +60,14 @@ interface ApproveResult {
   success: boolean;
   outputPath?: string;
   message: string;
+}
+
+export interface RescanInstalledSkillsResult {
+  scanned: number;
+  quarantined: number;
+  skipped: number;
+  errors: string[];
+  messages: string[];
 }
 
 // ---------------------------------------------------------------------------
@@ -336,6 +366,71 @@ export class CrystallizationProposer {
     return { success: true, message: `Proposal '${proposalId}' rejected` };
   }
 
+  /**
+   * Re-validate on-disk SKILL.md for every installed proposal (operator / cron hygiene).
+   * Persists validation via {@link CrystallizationStore.saveValidationResult}; on `deny`, sets status `quarantined`.
+   */
+  rescanInstalledSkills(): RescanInstalledSkillsResult {
+    const installed = this.crystallizationStore.list({ status: "installed", limit: 500 });
+    let scanned = 0;
+    let quarantined = 0;
+    let skipped = 0;
+    const errors: string[] = [];
+    const messages: string[] = [];
+    const outputDir = this.cfg.outputDir.replace(/^~/, getEnv("HOME") || homedir());
+
+    for (const proposal of installed) {
+      if (!proposal.outputPath?.trim()) {
+        skipped++;
+        messages.push(`Skipped ${proposal.id} (${proposal.skillName}): no outputPath`);
+        continue;
+      }
+      let skillContent: string;
+      try {
+        skillContent = readFileSync(proposal.outputPath, "utf-8");
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        errors.push(`${proposal.id}: read failed — ${msg}`);
+        continue;
+      }
+
+      scanned++;
+      try {
+        const pattern = parsePatternSnapshot(proposal.patternSnapshot);
+        const legacy = isLegacyMarkdownCrystallizationProposal(skillContent);
+        const validation = this.validator.validate(
+          {
+            outputDir,
+            proposedOutputPath: proposal.outputPath,
+            skillName: proposal.skillName,
+            skillContent,
+            pattern,
+          },
+          { legacyQueuedCrystallization: legacy },
+        );
+        this.crystallizationStore.saveValidationResult(proposal.id, validation);
+        if (validation.approvalDecision === "deny") {
+          const detail = detailSkillProposalValidation(validation);
+          const reason = `stale validation: ${detail}`;
+          const updated = this.crystallizationStore.quarantine(proposal.id, reason);
+          if (updated) {
+            quarantined++;
+            messages.push(`Quarantined ${proposal.skillName}: ${summarizeSkillProposalValidation(validation)}`);
+          } else {
+            errors.push(`${proposal.id}: quarantine update failed`);
+          }
+        } else {
+          messages.push(`OK ${proposal.skillName}: ${summarizeSkillProposalValidation(validation)}`);
+        }
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        errors.push(`${proposal.id}: validate failed — ${msg}`);
+      }
+    }
+
+    return { scanned, quarantined, skipped, errors, messages };
+  }
+
   // -------------------------------------------------------------------------
   // Private helpers
   // -------------------------------------------------------------------------
@@ -359,10 +454,7 @@ export class CrystallizationProposer {
   ): { skillContent: string; proposalCardJson?: string } {
     let skillContent = proposal.skillContent;
     if (overrides.skillName && overrides.skillName !== proposal.skillName) {
-      skillContent = skillContent.replace(
-        new RegExp(`^#\\s+${escapeRegExp(proposal.skillName)}\\s*$`, "m"),
-        `# ${overrides.skillName}`,
-      );
+      skillContent = replaceFirstBodyH1AfterFrontmatter(skillContent, overrides.skillName);
       skillContent = patchOpeningYamlField(skillContent, "name", overrides.skillName);
     }
     if (overrides.category) {
@@ -442,22 +534,113 @@ ${proposal.skillContent}`;
   }
 }
 
+/** Max lines scanned inside frontmatter when locating a multiline YAML value (bounded behavior). */
+const MAX_YAML_VALUE_SCAN_LINES = 512;
+
 /** Update a key in the opening YAML frontmatter block (after optional leading HTML comment). */
-function patchOpeningYamlField(skillContent: string, key: string, value: string): string {
+export function patchOpeningYamlField(skillContent: string, key: string, value: string): string {
   let body = skillContent;
   let prefix = "";
-  const commentMatch = body.match(/^<!--[\s\S]*?-->\s*\n*/);
+  const commentMatch = body.match(/^<!--[\s\S]*?-->\s*\r?\n*/);
   if (commentMatch) {
     prefix = commentMatch[0];
     body = body.slice(commentMatch[0].length);
   }
-  const m = body.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n/);
+  const m = body.match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/);
   if (!m) return skillContent;
-  const inner = m[1];
-  const re = new RegExp(`^${escapeRegExp(key)}:\\s*.*$`, "m");
-  const nextInner = re.test(inner) ? inner.replace(re, `${key}: ${value}`) : `${key}: ${value}\n${inner}`;
-  const newBlock = `---\n${nextInner}\n---\n`;
-  return prefix + body.replace(/^---\r?\n[\s\S]*?\r?\n---\r?\n/, newBlock);
+  const inner = m[1]!;
+  const innerLineBreak = inner.includes("\r\n") ? "\r\n" : "\n";
+  const lines = inner.split(/\r?\n/);
+  const keyLineRe = new RegExp(`^${escapeRegExp(key)}:\\s*(.*)$`);
+  let keyIdx = -1;
+  const scanCap = Math.min(lines.length, MAX_YAML_VALUE_SCAN_LINES);
+  for (let i = 0; i < scanCap; i++) {
+    if (keyLineRe.test(lines[i]!)) {
+      keyIdx = i;
+      break;
+    }
+  }
+  const yamlScalar = formatYamlFrontmatterScalar(value);
+  let nextLines: string[];
+  if (keyIdx < 0) {
+    nextLines = [`${key}: ${yamlScalar}`, ...lines];
+  } else {
+    const endExclusive = endIndexForYamlValueBlock(lines, keyIdx, keyLineRe);
+    nextLines = [...lines.slice(0, keyIdx), `${key}: ${yamlScalar}`, ...lines.slice(endExclusive)];
+  }
+  const nextInner = nextLines.join(innerLineBreak);
+  const newBlock = `---${innerLineBreak}${nextInner}${innerLineBreak}---${innerLineBreak}`;
+  return prefix + body.replace(/^---\r?\n[\s\S]*?\r?\n---(?:\r?\n|$)/, newBlock);
+}
+
+function formatYamlFrontmatterScalar(value: string): string {
+  if (value === "") return '""';
+  if (/^[\w.-]+$/.test(value)) return value;
+  return JSON.stringify(value);
+}
+
+function stripInlineYamlTrailingComment(fragment: string): string {
+  let inSingle = false;
+  let inDouble = false;
+  for (let i = 0; i < fragment.length; i++) {
+    const ch = fragment[i]!;
+    if (ch === "'" && !inDouble) inSingle = !inSingle;
+    else if (ch === '"' && !inSingle) inDouble = !inDouble;
+    else if (ch === "#" && !inSingle && !inDouble) return fragment.slice(0, i).trimEnd();
+  }
+  return fragment.trimEnd();
+}
+
+function isTopLevelYamlKeyLine(line: string): boolean {
+  return /^[A-Za-z_][A-Za-z0-9_-]*:\s/.test(line);
+}
+
+function leadingIndentLen(line: string): number {
+  const m = /^([ \t]*)/.exec(line);
+  return m ? m[1]!.length : 0;
+}
+
+function endIndexForYamlValueBlock(lines: string[], startIdx: number, keyLineRe: RegExp): number {
+  const line = lines[startIdx]!;
+  const km = keyLineRe.exec(line);
+  if (!km) return startIdx + 1;
+  const afterColon = km[1] ?? "";
+  const trimmed = stripInlineYamlTrailingComment(afterColon).trim();
+  const blockHdr = trimmed.match(/^([|>])(.*)$/);
+  if (blockHdr) {
+    const afterMarker = (blockHdr[2] ?? "").trim();
+    if (/^([-+]|[1-9][0-9]*)?$/.test(afterMarker)) {
+      let j = startIdx + 1;
+      while (j < lines.length && j - startIdx < MAX_YAML_VALUE_SCAN_LINES) {
+        if (isTopLevelYamlKeyLine(lines[j]!)) break;
+        j++;
+      }
+      return j;
+    }
+  }
+  const keyIndent = leadingIndentLen(line);
+  let j = startIdx + 1;
+  while (j < lines.length && j - startIdx < MAX_YAML_VALUE_SCAN_LINES) {
+    const L = lines[j]!;
+    if (isTopLevelYamlKeyLine(L)) break;
+    if (L.trim() === "") {
+      let k = j + 1;
+      while (k < lines.length && lines[k]!.trim() === "") k++;
+      if (k >= lines.length) return j;
+      if (isTopLevelYamlKeyLine(lines[k]!)) break;
+      if (leadingIndentLen(lines[k]!) > keyIndent) {
+        j++;
+        continue;
+      }
+      break;
+    }
+    if (leadingIndentLen(L) > keyIndent) {
+      j++;
+      continue;
+    }
+    break;
+  }
+  return j;
 }
 
 function escapeRegExp(value: string): string {

--- a/extensions/memory-hybrid/services/crystallization-proposer.ts
+++ b/extensions/memory-hybrid/services/crystallization-proposer.ts
@@ -551,7 +551,7 @@ export function patchOpeningYamlField(skillContent: string, key: string, value: 
   const m = body.match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/);
   if (!m) return skillContent;
   const inner = m[1]!;
-  const innerLineBreak = inner.includes("\r\n") ? "\r\n" : "\n";
+  const innerLineBreak = m[0].includes("\r\n") ? "\r\n" : "\n";
   const lines = inner.split(/\r?\n/);
   const keyLineRe = new RegExp(`^${escapeRegExp(key)}:\\s*(.*)$`);
   let keyIdx = -1;

--- a/extensions/memory-hybrid/services/crystallization-proposer.ts
+++ b/extensions/memory-hybrid/services/crystallization-proposer.ts
@@ -27,17 +27,26 @@ import { SkillCrystallizer } from "./skill-crystallizer.js";
 
 /** When renaming, replace the first Markdown ATX H1 in the body (after frontmatter), if any. */
 function replaceFirstBodyH1AfterFrontmatter(skillContent: string, newTitle: string): string {
-  let body = skillContent;
-  let head = "";
-  const commentMatch = body.match(/^<!--[\s\S]*?-->\s*\r?\n*/);
-  if (commentMatch) {
-    head += commentMatch[0];
-    body = body.slice(commentMatch[0].length);
-  }
+  const stripped = stripLeadingHtmlComments(skillContent);
+  const head = skillContent.slice(0, skillContent.length - stripped.length);
+  let body = stripped;
   const fmMatch = body.match(/^---\r?\n[\s\S]*?\r?\n---\r?\n?/);
   if (fmMatch) {
-    head += fmMatch[0];
-    body = body.slice(fmMatch[0].length);
+    const frontmatter = fmMatch[0];
+    body = body.slice(frontmatter.length);
+    const leadingNewlineMatch = body.match(/^\r?\n/);
+    const leadingNewline = leadingNewlineMatch ? leadingNewlineMatch[0] : "";
+    body = body.replace(/^\r?\n/, "");
+    const h1Line = /^(#[ \t]+(?!#)\S[^\r\n]*)(\r?)$/m;
+    if (!h1Line.test(body)) {
+      return skillContent;
+    }
+    return (
+      head +
+      frontmatter +
+      leadingNewline +
+      body.replace(h1Line, (_match, _oldLine: string, cr: string) => `# ${newTitle}${cr}`)
+    );
   }
   const leadingNewlineMatch = body.match(/^\r?\n/);
   const leadingNewline = leadingNewlineMatch ? leadingNewlineMatch[0] : "";

--- a/extensions/memory-hybrid/services/crystallization-proposer.ts
+++ b/extensions/memory-hybrid/services/crystallization-proposer.ts
@@ -38,12 +38,14 @@ function replaceFirstBodyH1AfterFrontmatter(skillContent: string, newTitle: stri
     head += fmMatch[0];
     body = body.slice(fmMatch[0].length);
   }
+  const leadingNewlineMatch = body.match(/^\r?\n/);
+  const leadingNewline = leadingNewlineMatch ? leadingNewlineMatch[0] : "";
   body = body.replace(/^\r?\n/, "");
   const h1Line = /^#\s+(?!#)\S.*$/m;
   if (!h1Line.test(body)) {
     return skillContent;
   }
-  return head + body.replace(h1Line, `# ${newTitle}`);
+  return head + leadingNewline + body.replace(h1Line, `# ${newTitle}`);
 }
 
 // ---------------------------------------------------------------------------
@@ -592,7 +594,7 @@ function stripInlineYamlTrailingComment(fragment: string): string {
 }
 
 function isTopLevelYamlKeyLine(line: string): boolean {
-  return /^[A-Za-z_][A-Za-z0-9_-]*:\s/.test(line);
+  return /^[A-Za-z_][A-Za-z0-9_-]*:(\s|$)/.test(line);
 }
 
 function leadingIndentLen(line: string): number {

--- a/extensions/memory-hybrid/services/crystallization-proposer.ts
+++ b/extensions/memory-hybrid/services/crystallization-proposer.ts
@@ -617,7 +617,7 @@ export function patchOpeningYamlField(skillContent: string, key: string, value: 
   const m = body.match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/);
   if (!m) return skillContent;
   const inner = m[1]!;
-  const innerLineBreak = inner.includes("\r\n") ? "\r\n" : "\n";
+  const innerLineBreak = m[0].includes("\r\n") ? "\r\n" : "\n";
   const lines = inner.split(/\r?\n/);
   const keyLineRe = new RegExp(`^${escapeRegExp(key)}:\\s*(.*)$`);
   let keyIdx = -1;

--- a/extensions/memory-hybrid/services/crystallization-proposer.ts
+++ b/extensions/memory-hybrid/services/crystallization-proposer.ts
@@ -41,11 +41,11 @@ function replaceFirstBodyH1AfterFrontmatter(skillContent: string, newTitle: stri
   const leadingNewlineMatch = body.match(/^\r?\n/);
   const leadingNewline = leadingNewlineMatch ? leadingNewlineMatch[0] : "";
   body = body.replace(/^\r?\n/, "");
-  const h1Line = /^#[ \t]+(?!#)\S.*$/m;
+  const h1Line = /^(#[ \t]+(?!#)\S[^\r\n]*)(\r?)$/m;
   if (!h1Line.test(body)) {
     return skillContent;
   }
-  return head + leadingNewline + body.replace(h1Line, `# ${newTitle}`);
+  return head + leadingNewline + body.replace(h1Line, (_match, _oldLine: string, cr: string) => `# ${newTitle}${cr}`);
 }
 
 // ---------------------------------------------------------------------------
@@ -626,7 +626,7 @@ function stripInlineYamlTrailingComment(fragment: string): string {
 }
 
 function isTopLevelYamlKeyLine(line: string): boolean {
-  return /^[A-Za-z_][A-Za-z0-9_-]*:(\s|$)/.test(line);
+  return /^[A-Za-z_][A-Za-z0-9_-]*:(?:\s|$)/.test(line);
 }
 
 function leadingIndentLen(line: string): number {
@@ -643,7 +643,7 @@ function endIndexForYamlValueBlock(lines: string[], startIdx: number, keyLineRe:
   const blockHdr = trimmed.match(/^([|>])(.*)$/);
   if (blockHdr) {
     const afterMarker = (blockHdr[2] ?? "").trim();
-    if (/^([-+]|[1-9][0-9]*)?$/.test(afterMarker)) {
+    if (/^(?:[-+]?([1-9][0-9]*)?|([1-9][0-9]*)?[-+]?)$/.test(afterMarker)) {
       let j = startIdx + 1;
       while (j < lines.length && j - startIdx < MAX_YAML_VALUE_SCAN_LINES) {
         if (isTopLevelYamlKeyLine(lines[j]!)) break;

--- a/extensions/memory-hybrid/tests/crystallization-proposer.test.ts
+++ b/extensions/memory-hybrid/tests/crystallization-proposer.test.ts
@@ -414,6 +414,17 @@ category: cat
     expect(out).toContain("category: z");
   });
 
+  it("preserves CRLF in single-key frontmatter", () => {
+    const src = "---\r\nname: foo\r\n---\r\n\r\n# x\r\n";
+    const out = patchOpeningYamlField(src, "name", "bar");
+    expect(out).toBe("---\r\nname: bar\r\n---\r\n\r\n# x\r\n");
+    // Verify all line endings are CRLF, not just LF
+    const linesWithCrlf = out.split("\r\n");
+    expect(linesWithCrlf).toHaveLength(6);
+    // Ensure no standalone LF (would indicate mixed line endings)
+    expect(out.replace(/\r\n/g, "X").includes("\n")).toBe(false);
+  });
+
   it("stops block scalar replacement at a top-level key with no inline value", () => {
     const src = `---
 description: |

--- a/extensions/memory-hybrid/tests/crystallization-proposer.test.ts
+++ b/extensions/memory-hybrid/tests/crystallization-proposer.test.ts
@@ -413,6 +413,40 @@ category: cat
     expect(out).not.toContain("  a");
     expect(out).toContain("category: z");
   });
+
+  it("stops block scalar replacement at a top-level key with no inline value", () => {
+    const src = `---
+description: |
+  line one
+  line two
+tags:
+  - keep-me
+category: keep-category
+---
+`;
+    const out = patchOpeningYamlField(src, "description", "short");
+    expect(out).toMatch(/description: short\r?\n/);
+    expect(out).not.toContain("line one");
+    expect(out).toContain("tags:");
+    expect(out).toContain("  - keep-me");
+    expect(out).toContain("category: keep-category");
+  });
+
+  it("recognizes combined YAML block scalar indicators", () => {
+    const src = `---
+description: |2-
+    indented line
+
+category: keep-category
+---
+`;
+    const out = patchOpeningYamlField(src, "description", "short");
+    expect(out).toBe(`---
+description: short
+category: keep-category
+---
+`);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -437,23 +471,31 @@ First gather context then apply changes safely.
 
 ## Examples
 
-Good: user requests a bounded automation sequence.
+- Good: user says, "Run the deployment checklist for this release and report the command output."
 
 ## Provenance
 
 Synthetic fixture for crystallization proposer tests.`;
 
-function skillFixture(skillName: string, h1Title: string): string {
+function skillFixture(skillName: string, h1Title: string, lineBreak = "\n"): string {
   return `---
 name: ${skillName}
 description: Short description for validation.
 category: testing
+source_pattern_id: p-h1
 ---
 
 # ${h1Title}
 
 ${MINIMAL_VALID_SKILL_SECTIONS}
-`;
+## Verification
+
+Run this workflow in a temporary workspace and confirm expected output.
+
+## Anti-patterns / Known Failures
+
+Do not run it for unrelated explain-only prompts.
+`.replace(/\n/g, lineBreak);
 }
 
 describe("CrystallizationProposer.approveProposal — custom H1 on rename", () => {
@@ -475,10 +517,35 @@ describe("CrystallizationProposer.approveProposal — custom H1 on rename", () =
     if (!result.success && /explicit override/i.test(result.message)) {
       result = proposer.approveProposal(proposal.id, { name: "renamed-h1-skill", overrideWarnings: true });
     }
-    expect(result.success).toBe(true);
+    expect(result.success, result.message).toBe(true);
     const written = readFileSync(result.outputPath!, "utf-8");
     expect(written).toMatch(/^#\s+renamed-h1-skill\s*$/m);
     expect(written).not.toContain("# Custom Human Title");
     expect(written).toMatch(/name:\s*renamed-h1-skill/);
+  });
+
+  it("preserves CRLF line endings when replacing the body H1", () => {
+    const outputDir = join(tmpDir, "skills-h1-crlf");
+    const cfg: CrystallizationConfig = { ...BASE_CFG, outputDir, maxCrystallized: 50 };
+    const proposer = new CrystallizationProposer(wfStore, cStore, cfg);
+
+    const proposal = cStore.create({
+      patternId: "p-h1-crlf",
+      evidenceHash: "ev-h1-crlf",
+      skillName: "orig-crlf-skill",
+      skillContent: skillFixture("orig-crlf-skill", "Custom Human Title", "\r\n"),
+      patternSnapshot: "{}",
+      status: "validated",
+    });
+
+    let result = proposer.approveProposal(proposal.id, { name: "renamed-crlf-skill" });
+    if (!result.success && /explicit override/i.test(result.message)) {
+      result = proposer.approveProposal(proposal.id, { name: "renamed-crlf-skill", overrideWarnings: true });
+    }
+    expect(result.success, result.message).toBe(true);
+    const written = readFileSync(result.outputPath!, "utf-8");
+    const h1Index = written.indexOf("# renamed-crlf-skill");
+    expect(h1Index).toBeGreaterThanOrEqual(0);
+    expect(written.slice(h1Index, h1Index + "# renamed-crlf-skill\r\n".length)).toBe("# renamed-crlf-skill\r\n");
   });
 });

--- a/extensions/memory-hybrid/tests/crystallization-proposer.test.ts
+++ b/extensions/memory-hybrid/tests/crystallization-proposer.test.ts
@@ -53,7 +53,6 @@ const BASE_CFG: CrystallizationConfig = {
   outputDir: "", // will be set in beforeEach
   maxCrystallized: 50,
   pruneUnusedDays: 30,
-  evidenceCountBucketSize: 5,
 };
 
 beforeEach(() => {

--- a/extensions/memory-hybrid/tests/crystallization-proposer.test.ts
+++ b/extensions/memory-hybrid/tests/crystallization-proposer.test.ts
@@ -35,7 +35,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { CrystallizationStore } from "../backends/crystallization-store.js";
 import { WorkflowStore } from "../backends/workflow-store.js";
 import type { CrystallizationConfig } from "../config/types/features.js";
-import { CrystallizationProposer } from "../services/crystallization-proposer.js";
+import { CrystallizationProposer, patchOpeningYamlField } from "../services/crystallization-proposer.js";
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -53,6 +53,7 @@ const BASE_CFG: CrystallizationConfig = {
   outputDir: "", // will be set in beforeEach
   maxCrystallized: 50,
   pruneUnusedDays: 30,
+  evidenceCountBucketSize: 5,
 };
 
 beforeEach(() => {
@@ -353,5 +354,131 @@ describe("CrystallizationProposer.rejectProposal", () => {
     const result = proposer.rejectProposal(proposal.id);
     expect(result.success).toBe(false);
     expect(result.message).toMatch(/not rejectable|not pending/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// patchOpeningYamlField — multiline YAML (Issue #1427)
+// ---------------------------------------------------------------------------
+
+describe("patchOpeningYamlField", () => {
+  it("replaces a literal block scalar (|) through the next top-level key", () => {
+    const src = `---
+description: |
+  line one
+  line two
+category: keep-me
+---
+
+# Title
+`;
+    const out = patchOpeningYamlField(src, "description", "short");
+    expect(out).toMatch(/description: short\r?\n/);
+    expect(out).not.toContain("line one");
+    expect(out).toContain("category: keep-me");
+  });
+
+  it("replaces a folded block scalar (>) through the next top-level key", () => {
+    const src = `---
+notes: >
+  folded a
+  folded b
+name: keep-name
+---
+`;
+    const out = patchOpeningYamlField(src, "notes", "x");
+    expect(out).toMatch(/notes: x\r?\n/);
+    expect(out).not.toContain("folded a");
+    expect(out).toContain("name: keep-name");
+  });
+
+  it("replaces plain multiline values with indented continuation lines", () => {
+    const src = `---
+title: first line
+  second line
+category: cat
+---
+`;
+    const out = patchOpeningYamlField(src, "title", "single");
+    expect(out).toMatch(/title: single\r?\n/);
+    expect(out).not.toContain("second line");
+    expect(out).toContain("category: cat");
+  });
+
+  it("preserves CRLF inside frontmatter when present", () => {
+    const src = "---\r\ndescription: |\r\n  a\r\n  b\r\ncategory: z\r\n---\r\n\r\n# x\r\n";
+    const out = patchOpeningYamlField(src, "description", "n");
+    expect(out).toContain("\r\n");
+    expect(out).toMatch(/description: n\r\n/);
+    expect(out).not.toContain("  a");
+    expect(out).toContain("category: z");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// approveProposal — H1 override when renaming (Issue #1427)
+// ---------------------------------------------------------------------------
+
+const MINIMAL_VALID_SKILL_SECTIONS = `## Trigger
+
+Positive: user asks to run a minimal workflow for deployment tasks without explain-only fluff.
+
+## Scope
+
+Covers only scripted steps described in workflow.
+
+## When not to use
+
+Avoid when credentials or secrets appear in goals.
+
+## Workflow
+
+First gather context then apply changes safely.
+
+## Examples
+
+Good: user requests a bounded automation sequence.
+
+## Provenance
+
+Synthetic fixture for crystallization proposer tests.`;
+
+function skillFixture(skillName: string, h1Title: string): string {
+  return `---
+name: ${skillName}
+description: Short description for validation.
+category: testing
+---
+
+# ${h1Title}
+
+${MINIMAL_VALID_SKILL_SECTIONS}
+`;
+}
+
+describe("CrystallizationProposer.approveProposal — custom H1 on rename", () => {
+  it("replaces the first body H1 when it differs from the proposal skill name", () => {
+    const outputDir = join(tmpDir, "skills-h1");
+    const cfg: CrystallizationConfig = { ...BASE_CFG, outputDir, maxCrystallized: 50 };
+    const proposer = new CrystallizationProposer(wfStore, cStore, cfg);
+
+    const proposal = cStore.create({
+      patternId: "p-h1",
+      evidenceHash: "ev-h1",
+      skillName: "orig-skill-name",
+      skillContent: skillFixture("orig-skill-name", "Custom Human Title"),
+      patternSnapshot: "{}",
+      status: "validated",
+    });
+
+    let result = proposer.approveProposal(proposal.id, { name: "renamed-h1-skill" });
+    if (!result.success && /explicit override/i.test(result.message)) {
+      result = proposer.approveProposal(proposal.id, { name: "renamed-h1-skill", overrideWarnings: true });
+    }
+    expect(result.success).toBe(true);
+    const written = readFileSync(result.outputPath!, "utf-8");
+    expect(written).toMatch(/^#\s+renamed-h1-skill\s*$/m);
+    expect(written).not.toContain("# Custom Human Title");
+    expect(written).toMatch(/name:\s*renamed-h1-skill/);
   });
 });


### PR DESCRIPTION
## Summary
- **`patchOpeningYamlField`**: Replaces the full YAML value for a key, including literal/folded block scalars (`|`, `>` and common chomping/indent indicators) up to the next top-level key, plus indented plain multiline continuations. Bounded scan (512 lines). Preserves CRLF inside frontmatter when present. Values with special characters use JSON-style quoting.
- **Rename / approve overrides**: Replaces the first Markdown ATX H1 in the body after frontmatter when present, instead of only rewriting a heading that exactly matched the old `proposal.skillName`.

## Tests
- Unit tests for `patchOpeningYamlField` (literal block, folded block, indented continuation, CRLF).
- Integration-style test for `approveProposal` with a custom H1 title and rename.

Closes #1427.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches crystallization install/validation flow and persistence by adding a new lifecycle state and rewriting frontmatter/H1 mutation logic, which could affect how skills are written and validated. Main risk is unexpected content rewriting or status transitions for installed skills during rescans.
> 
> **Overview**
> Improves `approveProposal` rename behavior by updating the *first* body H1 after frontmatter (CRLF-safe) and strengthening `patchOpeningYamlField` to correctly replace **multiline YAML values** (literal/folded block scalars and indented continuations) while preserving existing line endings.
> 
> Extends proposal lifecycle with a new `quarantined` status, adds `CrystallizationStore.quarantine()`, and introduces `CrystallizationProposer.rescanInstalledSkills()` to re-validate on-disk installed `SKILL.md` files, persist fresh validation results, and quarantine installs that now fail validation.
> 
> Adds comprehensive tests covering multiline YAML patching edge cases, rename/H1 rewriting, and legacy detection when skills are prefixed with HTML comments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8607cf675701d792060169fd11a283c583dbf77d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->