### PR TITLE
fix(forge): ignore external-coder request comments

### DIFF
--- a/.github/scripts/forge-feedback-loop.mjs
+++ b/.github/scripts/forge-feedback-loop.mjs
@@ -9,6 +9,8 @@ const BOT_LOGIN_RE = /\[bot\]$/i;
 const NON_BLOCKING_REVIEW_STATES = new Set(['APPROVED', 'DISMISSED']);
 const PASSING_CONCLUSIONS = new Set(['success', 'skipped', 'neutral']);
 const SELF_CHECK_NAMES = new Set(['Inspect PR blockers and dispatch Forge']);
+const EXTERNAL_CODER_REQUEST_MARKER_RE = /<!--\s*maeve-external-coder\b[\s\S]*?-->/i;
+const EXTERNAL_CODER_MENTION_RE = /(?:^|\n)\s*@(cursoragent|copilot)\b/i;
 
 function normalizeWhitespace(value) {
   return String(value ?? '')
@@ -23,6 +25,11 @@ function truncateText(value, maxChars = DEFAULT_MAX_BODY_CHARS) {
   if (!normalized) return '';
   if (normalized.length <= maxChars) return normalized;
   return `${normalized.slice(0, Math.max(0, maxChars - 1)).trimEnd()}…`;
+}
+
+function isExternalCoderRequestComment(body) {
+  const text = String(body ?? '');
+  return EXTERNAL_CODER_REQUEST_MARKER_RE.test(text) || EXTERNAL_CODER_MENTION_RE.test(text);
 }
 
 function isBotActor(actor) {
@@ -70,6 +77,7 @@ function summarizeIssueComments(issueComments, headCommittedAt) {
     .filter((comment) => {
       if (!comment || typeof comment !== 'object') return false;
       if (isBotActor(comment.user)) return false;
+      if (isExternalCoderRequestComment(comment.body)) return false;
       const body = truncateText(comment.body ?? '');
       if (!body) return false;
       if (cutoffMs == null) return true;

--- a/.github/workflows/forge-feedback-loop.yml
+++ b/.github/workflows/forge-feedback-loop.yml
@@ -58,6 +58,13 @@ jobs:
                 core.setOutput('skip_reason', 'Ignoring bot-authored issue comment event to avoid feedback loops.');
                 return;
               }
+              const commentBody = String(context.payload.comment?.body ?? '');
+              const isExternalCoderRequest = /<!--\s*maeve-external-coder\b[\s\S]*?-->/i.test(commentBody) || /(?:^|\n)\s*@(cursoragent|copilot)\b/i.test(commentBody);
+              if (isExternalCoderRequest) {
+                core.setOutput('should_skip', 'true');
+                core.setOutput('skip_reason', 'Ignoring external-coder request comment.');
+                return;
+              }
               if (!context.payload.issue?.pull_request) {
                 core.setOutput('should_skip', 'true');
                 core.setOutput('skip_reason', 'Issue comment is not attached to a pull request.');


### PR DESCRIPTION
## Summary
- Ignore Maeve external-coder request markers in Forge feedback classification
- Skip issue_comment workflow dispatches for @cursoragent/@copilot offload requests
- Preserve normal human PR comment dispatch behavior

## Verification
- Synthetic external-coder work item: newIssueComments=0, shouldDispatch=false
- Synthetic human feedback work item: newIssueComments=1, shouldDispatch=true
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts Forge feedback-loop filtering/dispatch conditions to ignore specific marker/mention comments, without touching repo write logic beyond skipping runs.
> 
> **Overview**
> Prevents Forge’s feedback loop from treating external-coder offload requests as human feedback.
> 
> The `forge-feedback-loop.mjs` work-item builder now filters out issue comments containing the `<!-- maeve-external-coder -->` marker or `@cursoragent/@copilot` mentions, and the `issue_comment` workflow trigger similarly short-circuits these comments to avoid dispatching Forge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9fdfbc8b95ca930ba45b3701539cc7dc97270f8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->