### PR TITLE
fix(retrieval): log breadcrumb failures without swallowing semantic embed (#1466)

### DIFF
--- a/extensions/memory-hybrid/services/retrieval-orchestrator.ts
+++ b/extensions/memory-hybrid/services/retrieval-orchestrator.ts
@@ -99,6 +99,25 @@ export async function buildExplicitSemanticQueryVector({
       .catch((error: unknown) => {
         logger.debug?.(`memory-hybrid: failed to record retrieval breadcrumb: ${String(error)}`);
       });
+    let textToEmbed = query;
+
+    if (policy.allowHyde && cfg.queryExpansion.enabled) {
+      textToEmbed = await expandQueryWithHyde({
+        query,
+        rawCfg: cfg as Parameters<typeof import("../config/index.js").getCronModelConfig>[0],
+        model: cfg.queryExpansion.model,
+        timeoutMs: cfg.queryExpansion.timeoutMs,
+        openai: openai as any,
+        label: "HyDE",
+        pendingWarnings: pendingLLMWarnings,
+        logger,
+        subsystem: "retrieval",
+        operation: "explicit-hyde-generation",
+      });
+    }
+
+    return { queryVector: await embeddings.embed(textToEmbed), warning: null };
+  } catch (err) {
     if (!shouldSuppressEmbeddingError(err)) {
       capturePluginError(err instanceof Error ? err : new Error(String(err)), {
         subsystem: "retrieval",

--- a/extensions/memory-hybrid/services/retrieval-orchestrator.ts
+++ b/extensions/memory-hybrid/services/retrieval-orchestrator.ts
@@ -96,26 +96,9 @@ export async function buildExplicitSemanticQueryVector({
   try {
     void import("./error-reporter.js")
       .then(({ addOperationBreadcrumb }) => addOperationBreadcrumb("retrieval", `${policy.mode}-vector-recall`))
-      .catch(() => undefined);
-    let textToEmbed = query;
-
-    if (policy.allowHyde && cfg.queryExpansion.enabled) {
-      textToEmbed = await expandQueryWithHyde({
-        query,
-        rawCfg: cfg as Parameters<typeof import("../config/index.js").getCronModelConfig>[0],
-        model: cfg.queryExpansion.model,
-        timeoutMs: cfg.queryExpansion.timeoutMs,
-        openai: openai as any,
-        label: "HyDE",
-        pendingWarnings: pendingLLMWarnings,
-        logger,
-        subsystem: "retrieval",
-        operation: "explicit-hyde-generation",
+      .catch((error: unknown) => {
+        logger.debug?.(`memory-hybrid: failed to record retrieval breadcrumb: ${String(error)}`);
       });
-    }
-
-    return { queryVector: await embeddings.embed(textToEmbed), warning: null };
-  } catch (err) {
     if (!shouldSuppressEmbeddingError(err)) {
       capturePluginError(err instanceof Error ? err : new Error(String(err)), {
         subsystem: "retrieval",

--- a/extensions/memory-hybrid/tests/retrieval-modes.test.ts
+++ b/extensions/memory-hybrid/tests/retrieval-modes.test.ts
@@ -229,6 +229,45 @@ describe("buildExplicitSemanticQueryVector", () => {
     expect(result.warning).toBeNull();
     expect(result.queryVector).toEqual([20]);
   });
+
+  it("does not emit unhandled rejections when breadcrumb recording fails", async () => {
+    const embeddings = { embed: vi.fn(async (text: string) => [text.length]) };
+    const logger = { warn: vi.fn(), debug: vi.fn() };
+    vi.spyOn(errorReporter, "addOperationBreadcrumb").mockImplementation(() => {
+      throw new Error("breadcrumb failed");
+    });
+    const unhandled: unknown[] = [];
+    const onUnhandled = (reason: unknown): void => {
+      unhandled.push(reason);
+    };
+    process.on("unhandledRejection", onUnhandled);
+
+    try {
+      const result = await buildExplicitSemanticQueryVector({
+        query: "find the backup host",
+        cfg: {
+          llm: undefined,
+          retrieval: DEFAULT_RETRIEVAL_CONFIG,
+          queryExpansion: { enabled: false, mode: "always", maxVariants: 4, cacheSize: 50, timeoutMs: 5000 },
+        },
+        embeddings,
+        openai: makeMockOpenAI("unused") as never,
+        pendingLLMWarnings: { add: vi.fn(), drain: vi.fn(() => []) },
+        logger,
+      });
+
+      await vi.dynamicImportSettled();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(result.warning).toBeNull();
+      expect(result.queryVector).toEqual([20]);
+      expect(unhandled).toHaveLength(0);
+      expect(logger.debug).toHaveBeenCalled();
+    } finally {
+      process.off("unhandledRejection", onUnhandled);
+    }
+  });
+
   it("suppresses expected all-provider embedding failures on the explicit/deep path", async () => {
     const embeddings = {
       embed: vi.fn(async () => {


### PR DESCRIPTION
<!-- issue-stewardship-pr issue:1466 -->
Fixes #1466

Issue: https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/1466

Status: draft implementation PR created by Issue Stewardship as Markus/current gh auth.
Protection: keep as draft and `stage/implementing` until Issue Stewardship dispatches/receives implementation and explicitly hands off to PR Stewardship.

Enrichment present on issue: 1
Priority inherited from issue: Medium (source labels: priority:medium)
Dependencies/blocked labels inherited from issue: none

Implementation PR created by Issue Stewardship. Detailed enrichment should be attached to the issue before Copilot implementation dispatch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: behavior change is limited to error handling/logging around optional breadcrumb recording and adds a regression test to prevent unhandled promise rejections.
> 
> **Overview**
> Prevents optional retrieval breadcrumb recording from causing silent/unhandled promise rejections by catching dynamic import failures and logging them via `logger.debug` in `buildExplicitSemanticQueryVector`.
> 
> Adds a Vitest regression test that forces `addOperationBreadcrumb` to throw and asserts no `unhandledRejection` events are emitted while semantic embedding still succeeds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc4eaee84693add90b70e242fb2f52f98aa74fd0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->