### PR TITLE
fix(procedures): guard unsafe JSON parse for avoidance_notes (#1470)

### DIFF
--- a/extensions/memory-hybrid/backends/facts-db/procedures.ts
+++ b/extensions/memory-hybrid/backends/facts-db/procedures.ts
@@ -89,6 +89,17 @@ function hasRecipeAnchor(recipeJson: string | null | undefined): boolean {
   }
 }
 
+function parseAvoidanceNotes(raw: string | null | undefined): string[] {
+  if (!raw || raw.trim() === "") return [];
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((note): note is string => typeof note === "string");
+  } catch {
+    return [];
+  }
+}
+
 function procedureBlockReason(
   row: ProcedureEntry,
   duplicateSlugs: Set<string>,
@@ -180,12 +191,8 @@ export function enrichProcedureWithFeedback(db: DatabaseSync, base: ProcedureEnt
     // Merge avoidance notes across all versions
     const allNotes = new Set<string>(base.avoidanceNotes ?? []);
     if (versionRow.avoidance_notes) {
-      try {
-        const notes = JSON.parse(versionRow.avoidance_notes) as string[];
-        notes.forEach((n) => allNotes.add(n));
-      } catch {
-        // ignore parse errors
-      }
+      const notes = parseAvoidanceNotes(versionRow.avoidance_notes);
+      notes.forEach((n) => allNotes.add(n));
     }
 
     return {
@@ -350,12 +357,8 @@ export function procedureFeedback(
       .all(input.procedureId) as Array<{ avoidance_notes: string | null }>;
     for (const row of prevNotes) {
       if (row.avoidance_notes) {
-        try {
-          const existing = JSON.parse(row.avoidance_notes) as string[];
-          avoidanceNotes.push(...existing);
-        } catch {
-          // ignore
-        }
+        const existing = parseAvoidanceNotes(row.avoidance_notes);
+        avoidanceNotes.push(...existing);
       }
     }
 

--- a/extensions/memory-hybrid/backends/facts-db/procedures/crud.ts
+++ b/extensions/memory-hybrid/backends/facts-db/procedures/crud.ts
@@ -360,23 +360,17 @@ export function getProcedureVersions(
     )
     .all(procedureId) as Array<Record<string, unknown>>;
 
-  return rows.map((r) => ({
-    id: r.id as string,
-    versionNumber: r.version_number as number,
-    successCount: r.success_count as number,
-    failureCount: r.failure_count as number,
-    avoidanceNotes: (() => {
-      const raw = r.avoidance_notes as string | null;
-      if (!raw) return null;
-      try {
-        const parsed = JSON.parse(raw);
-        return Array.isArray(parsed) ? parsed.filter((n: unknown) => typeof n === "string") : null;
-      } catch {
-        return null;
-      }
-    })(),
-    createdAt: r.created_at as number,
-  }));
+  return rows.map((r) => {
+    const notes = parseAvoidanceNotes(r.avoidance_notes as string | null);
+    return {
+      id: r.id as string,
+      versionNumber: r.version_number as number,
+      successCount: r.success_count as number,
+      failureCount: r.failure_count as number,
+      avoidanceNotes: notes.length > 0 ? notes : null,
+      createdAt: r.created_at as number,
+    };
+  });
 }
 
 /**

--- a/extensions/memory-hybrid/backends/facts-db/procedures/crud.ts
+++ b/extensions/memory-hybrid/backends/facts-db/procedures/crud.ts
@@ -11,6 +11,17 @@ import { sanitizeFts5QueryForFacts } from "../fts-text.js";
 
 // ---------- Procedural memory: procedures table CRUD ----------
 
+function parseAvoidanceNotes(raw: string | null | undefined): string[] {
+  if (!raw || raw.trim() === "") return [];
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((note): note is string => typeof note === "string");
+  } catch {
+    return [];
+  }
+}
+
 /**
  * Load version-level feedback data for a procedure and merge into ProcedureEntry.
  * Called after the base row is mapped so we keep procedureRowToEntry pure.
@@ -86,12 +97,8 @@ export function enrichProcedureWithFeedback(db: DatabaseSync, base: ProcedureEnt
     // Merge avoidance notes across all versions
     const allNotes = new Set<string>(base.avoidanceNotes ?? []);
     if (versionRow.avoidance_notes) {
-      try {
-        const notes = JSON.parse(versionRow.avoidance_notes) as string[];
-        for (const n of notes) allNotes.add(n);
-      } catch {
-        // ignore parse errors
-      }
+      const notes = parseAvoidanceNotes(versionRow.avoidance_notes);
+      for (const n of notes) allNotes.add(n);
     }
 
     return {
@@ -256,12 +263,8 @@ export function procedureFeedback(
       .all(input.procedureId) as Array<{ avoidance_notes: string | null }>;
     for (const row of prevNotes) {
       if (row.avoidance_notes) {
-        try {
-          const existing = JSON.parse(row.avoidance_notes) as string[];
-          avoidanceNotes.push(...existing);
-        } catch {
-          // ignore
-        }
+        const existing = parseAvoidanceNotes(row.avoidance_notes);
+        avoidanceNotes.push(...existing);
       }
     }
 

--- a/extensions/memory-hybrid/tests/procedures-db.test.ts
+++ b/extensions/memory-hybrid/tests/procedures-db.test.ts
@@ -7,7 +7,6 @@ import { FactsDB } from "../backends/facts-db.js";
 
 let tmpDir: string;
 let db: FactsDB;
-type FactsDbWithLiveDb = FactsDB & { liveDb: { prepare: (sql: string) => { run: (...args: unknown[]) => unknown } } };
 
 beforeEach(() => {
   tmpDir = mkdtempSync(join(tmpdir(), "procedures-db-test-"));
@@ -679,7 +678,11 @@ describe("FactsDB procedureFeedback", () => {
       context: "baseline note",
     });
 
-    (db as unknown as FactsDbWithLiveDb).liveDb
+    (
+      db as unknown as FactsDB & {
+        liveDb: { prepare: (sql: string) => { run: (...args: unknown[]) => unknown } };
+      }
+    ).liveDb
       .prepare("UPDATE procedure_versions SET avoidance_notes = ? WHERE procedure_id = ?")
       .run('{"unexpected":"object"}', proc.id);
 
@@ -701,7 +704,11 @@ describe("FactsDB procedureFeedback", () => {
       context: "first failure",
     });
 
-    (db as unknown as FactsDbWithLiveDb).liveDb
+    (
+      db as unknown as FactsDB & {
+        liveDb: { prepare: (sql: string) => { run: (...args: unknown[]) => unknown } };
+      }
+    ).liveDb
       .prepare("UPDATE procedure_versions SET avoidance_notes = ? WHERE procedure_id = ?")
       .run('["keep me",42,null,{"bad":true}]', proc.id);
 

--- a/extensions/memory-hybrid/tests/procedures-db.test.ts
+++ b/extensions/memory-hybrid/tests/procedures-db.test.ts
@@ -7,6 +7,7 @@ import { FactsDB } from "../backends/facts-db.js";
 
 let tmpDir: string;
 let db: FactsDB;
+type FactsDbWithLiveDb = FactsDB & { liveDb: { prepare: (sql: string) => { run: (...args: unknown[]) => unknown } } };
 
 beforeEach(() => {
   tmpDir = mkdtempSync(join(tmpdir(), "procedures-db-test-"));
@@ -663,6 +664,56 @@ describe("FactsDB procedureFeedback", () => {
     const result = db.getProcedureById(proc.id);
     expect(result?.avoidanceNotes).toBeDefined();
     expect(result?.avoidanceNotes?.some((n) => n.includes("SSH key may be dropped"))).toBe(true);
+  });
+
+  it("getProcedureById ignores malformed avoidance_notes JSON", () => {
+    const proc = db.upsertProcedure({
+      taskPattern: "Malformed avoidance notes",
+      recipeJson: "[]",
+      procedureType: "positive",
+    });
+
+    db.procedureFeedback({
+      procedureId: proc.id,
+      success: false,
+      context: "baseline note",
+    });
+
+    (db as unknown as FactsDbWithLiveDb).liveDb
+      .prepare("UPDATE procedure_versions SET avoidance_notes = ? WHERE procedure_id = ?")
+      .run('{"unexpected":"object"}', proc.id);
+
+    const result = db.getProcedureById(proc.id);
+    expect(result?.id).toBe(proc.id);
+    expect(result?.avoidanceNotes).toEqual([]);
+  });
+
+  it("procedureFeedback keeps only string avoidance notes from previous versions", () => {
+    const proc = db.upsertProcedure({
+      taskPattern: "Mixed avoidance notes",
+      recipeJson: "[]",
+      procedureType: "positive",
+    });
+
+    db.procedureFeedback({
+      procedureId: proc.id,
+      success: false,
+      context: "first failure",
+    });
+
+    (db as unknown as FactsDbWithLiveDb).liveDb
+      .prepare("UPDATE procedure_versions SET avoidance_notes = ? WHERE procedure_id = ?")
+      .run('["keep me",42,null,{"bad":true}]', proc.id);
+
+    const result = db.procedureFeedback({
+      procedureId: proc.id,
+      success: false,
+      context: "second failure",
+    });
+
+    expect(result?.avoidanceNotes).toContain("keep me");
+    expect(result?.avoidanceNotes?.some((note) => note.includes("second failure"))).toBe(true);
+    expect(result?.avoidanceNotes?.every((note) => typeof note === "string")).toBe(true);
   });
 
   it("procedureFeedback creates an episode record on failure", () => {

--- a/extensions/memory-hybrid/tests/procedures-db.test.ts
+++ b/extensions/memory-hybrid/tests/procedures-db.test.ts
@@ -672,7 +672,7 @@ describe("FactsDB procedureFeedback", () => {
 
     const result = db.getProcedureById(proc.id);
     expect(result?.id).toBe(proc.id);
-    expect(result?.avoidanceNotes).toEqual([]);
+    expect(result?.avoidanceNotes).toBeUndefined();
   });
 
   it("procedureFeedback keeps only string avoidance notes from previous versions", () => {

--- a/extensions/memory-hybrid/tests/procedures-db.test.ts
+++ b/extensions/memory-hybrid/tests/procedures-db.test.ts
@@ -7,6 +7,7 @@ import { FactsDB } from "../backends/facts-db.js";
 
 let tmpDir: string;
 let db: FactsDB;
+type FactsDbWithLiveDb = FactsDB & { liveDb: { prepare: (sql: string) => { run: (...args: unknown[]) => unknown } } };
 
 beforeEach(() => {
   tmpDir = mkdtempSync(join(tmpdir(), "procedures-db-test-"));
@@ -647,6 +648,56 @@ describe("FactsDB procedureFeedback", () => {
     const result = db.getProcedureById(proc.id);
     expect(result?.avoidanceNotes).toBeDefined();
     expect(result?.avoidanceNotes?.some((n) => n.includes("SSH key may be dropped"))).toBe(true);
+  });
+
+  it("getProcedureById ignores malformed avoidance_notes JSON", () => {
+    const proc = db.upsertProcedure({
+      taskPattern: "Malformed avoidance notes",
+      recipeJson: "[]",
+      procedureType: "positive",
+    });
+
+    db.procedureFeedback({
+      procedureId: proc.id,
+      success: false,
+      context: "baseline note",
+    });
+
+    (db as unknown as FactsDbWithLiveDb).liveDb
+      .prepare("UPDATE procedure_versions SET avoidance_notes = ? WHERE procedure_id = ?")
+      .run('{"unexpected":"object"}', proc.id);
+
+    const result = db.getProcedureById(proc.id);
+    expect(result?.id).toBe(proc.id);
+    expect(result?.avoidanceNotes).toEqual([]);
+  });
+
+  it("procedureFeedback keeps only string avoidance notes from previous versions", () => {
+    const proc = db.upsertProcedure({
+      taskPattern: "Mixed avoidance notes",
+      recipeJson: "[]",
+      procedureType: "positive",
+    });
+
+    db.procedureFeedback({
+      procedureId: proc.id,
+      success: false,
+      context: "first failure",
+    });
+
+    (db as unknown as FactsDbWithLiveDb).liveDb
+      .prepare("UPDATE procedure_versions SET avoidance_notes = ? WHERE procedure_id = ?")
+      .run('["keep me",42,null,{"bad":true}]', proc.id);
+
+    const result = db.procedureFeedback({
+      procedureId: proc.id,
+      success: false,
+      context: "second failure",
+    });
+
+    expect(result?.avoidanceNotes).toContain("keep me");
+    expect(result?.avoidanceNotes?.some((note) => note.includes("second failure"))).toBe(true);
+    expect(result?.avoidanceNotes?.every((note) => typeof note === "string")).toBe(true);
   });
 
   it("procedureFeedback creates an episode record on failure", () => {

--- a/extensions/memory-hybrid/tests/procedures-db.test.ts
+++ b/extensions/memory-hybrid/tests/procedures-db.test.ts
@@ -7,7 +7,6 @@ import { FactsDB } from "../backends/facts-db.js";
 
 let tmpDir: string;
 let db: FactsDB;
-type FactsDbWithLiveDb = FactsDB & { liveDb: { prepare: (sql: string) => { run: (...args: unknown[]) => unknown } } };
 
 beforeEach(() => {
   tmpDir = mkdtempSync(join(tmpdir(), "procedures-db-test-"));
@@ -663,7 +662,11 @@ describe("FactsDB procedureFeedback", () => {
       context: "baseline note",
     });
 
-    (db as unknown as FactsDbWithLiveDb).liveDb
+    (
+      db as unknown as FactsDB & {
+        liveDb: { prepare: (sql: string) => { run: (...args: unknown[]) => unknown } };
+      }
+    ).liveDb
       .prepare("UPDATE procedure_versions SET avoidance_notes = ? WHERE procedure_id = ?")
       .run('{"unexpected":"object"}', proc.id);
 
@@ -685,7 +688,11 @@ describe("FactsDB procedureFeedback", () => {
       context: "first failure",
     });
 
-    (db as unknown as FactsDbWithLiveDb).liveDb
+    (
+      db as unknown as FactsDB & {
+        liveDb: { prepare: (sql: string) => { run: (...args: unknown[]) => unknown } };
+      }
+    ).liveDb
       .prepare("UPDATE procedure_versions SET avoidance_notes = ? WHERE procedure_id = ?")
       .run('["keep me",42,null,{"bad":true}]', proc.id);
 

--- a/extensions/memory-hybrid/tests/procedures-db.test.ts
+++ b/extensions/memory-hybrid/tests/procedures-db.test.ts
@@ -688,7 +688,7 @@ describe("FactsDB procedureFeedback", () => {
 
     const result = db.getProcedureById(proc.id);
     expect(result?.id).toBe(proc.id);
-    expect(result?.avoidanceNotes).toEqual([]);
+    expect(result?.avoidanceNotes).toBeUndefined();
   });
 
   it("procedureFeedback keeps only string avoidance notes from previous versions", () => {


### PR DESCRIPTION
<!-- issue-stewardship-pr issue:1470 -->
Fixes #1470

Issue: https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/1470

Status: draft implementation PR created by Issue Stewardship as Markus/current gh auth.
Protection: keep as draft and `stage/implementing` until Issue Stewardship dispatches/receives implementation and explicitly hands off to PR Stewardship.

Enrichment present on issue: 1
Priority inherited from issue: Medium (source labels: priority:medium)
Dependencies/blocked labels inherited from issue: none

Implementation PR created by Issue Stewardship. Detailed enrichment should be attached to the issue before Copilot implementation dispatch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: behavior change is limited to defensive parsing/sanitization of `avoidance_notes` and adds tests to lock in handling of malformed data.
> 
> **Overview**
> **Hardens procedure feedback enrichment against malformed `avoidance_notes`.** Introduces a shared `parseAvoidanceNotes` helper and uses it when merging version notes in `enrichProcedureWithFeedback`, `procedureFeedback`, and `getProcedureVersions`, ensuring invalid JSON or non-array/non-string values are ignored rather than throwing.
> 
> Adds regression tests covering malformed JSON/object payloads and mixed-type arrays to verify `getProcedureById` stays stable and only string notes are retained.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a1e0a948285f3f85d15e4ac7d2d2e36eb6f0ef8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->