### PR TITLE
WIP: [Similar sweep] cmd-distill — broad-json-parse-no-guard in cmd-distill (#1471)

### DIFF
--- a/extensions/memory-hybrid/cli/cmd-distill.ts
+++ b/extensions/memory-hybrid/cli/cmd-distill.ts
@@ -47,6 +47,7 @@ import { loadPrompt } from "../utils/prompt-loader.js";
 import { extractTags } from "../utils/tags.js";
 import { chunkSessionText, estimateTokens } from "../utils/text.js";
 import { getMaxMtime } from "./cmd-extract.js";
+import { extractTextFromSessionJsonl } from "./distill-session-jsonl.js";
 import { buildPreFilterConfig, createProgressReporter } from "./cmd-install.js";
 import type { HandlerContext } from "./handlers.js";
 import { acquireScanSlot, clearScanLock } from "./shared.js";
@@ -94,39 +95,6 @@ export function gatherSessionFiles(opts: {
   }
   out.sort((a, b) => a.mtime - b.mtime);
   return out;
-}
-
-/**
- * Extract text content from session JSONL file
- */
-function extractTextFromSessionJsonl(filePath: string): string {
-  const lines = readFileSync(filePath, "utf-8").split("\n");
-  const parts: string[] = [];
-  for (const line of lines) {
-    const trimmed = line.trim();
-    if (!trimmed) continue;
-    try {
-      const obj = JSON.parse(trimmed) as {
-        type?: string;
-        message?: { role?: string; content?: Array<{ type?: string; text?: string }> };
-      };
-      if (obj.type !== "message" || !obj.message) continue;
-      const msg = obj.message;
-      if (msg.role !== "user" && msg.role !== "assistant") continue;
-      const content = msg.content;
-      if (!Array.isArray(content)) continue;
-      for (const block of content) {
-        if (block?.type === "text" && typeof block.text === "string" && block.text.trim().length > 0) {
-          parts.push(block.text.trim());
-        }
-      }
-    } catch {
-      // NOTE: Intentionally NOT using capturePluginError here to avoid flooding
-      // error logs with JSON parse errors from malformed session lines.
-      // This is a best-effort parser; we skip bad lines silently.
-    }
-  }
-  return parts.join("\n\n");
 }
 
 export function runDistillWindowForCli(ctx: HandlerContext, _opts: { json: boolean }): DistillWindowResult {

--- a/extensions/memory-hybrid/cli/distill-session-jsonl.ts
+++ b/extensions/memory-hybrid/cli/distill-session-jsonl.ts
@@ -14,7 +14,7 @@ export function extractTextFromSessionJsonl(filePath: string): string {
         type?: string;
         message?: { role?: string; content?: Array<{ type?: string; text?: string }> };
       };
-      if (!obj || typeof obj !== "object") continue;
+      if (!obj || typeof obj !== "object" || Array.isArray(obj)) continue;
       if (obj.type !== "message" || !obj.message) continue;
       const msg = obj.message;
       if (msg.role !== "user" && msg.role !== "assistant") continue;

--- a/extensions/memory-hybrid/cli/distill-session-jsonl.ts
+++ b/extensions/memory-hybrid/cli/distill-session-jsonl.ts
@@ -1,0 +1,35 @@
+import { readFileSync } from "node:fs";
+
+/**
+ * Extract text content from session JSONL file.
+ */
+export function extractTextFromSessionJsonl(filePath: string): string {
+  const lines = readFileSync(filePath, "utf-8").split("\n");
+  const parts: string[] = [];
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      const obj = JSON.parse(trimmed) as {
+        type?: string;
+        message?: { role?: string; content?: Array<{ type?: string; text?: string }> };
+      };
+      if (!obj || typeof obj !== "object") continue;
+      if (obj.type !== "message" || !obj.message) continue;
+      const msg = obj.message;
+      if (msg.role !== "user" && msg.role !== "assistant") continue;
+      const content = msg.content;
+      if (!Array.isArray(content)) continue;
+      for (const block of content) {
+        if (block?.type === "text" && typeof block.text === "string" && block.text.trim().length > 0) {
+          parts.push(block.text.trim());
+        }
+      }
+    } catch {
+      // NOTE: Intentionally NOT using capturePluginError here to avoid flooding
+      // error logs with JSON parse errors from malformed session lines.
+      // This is a best-effort parser; we skip bad lines silently.
+    }
+  }
+  return parts.join("\n\n");
+}

--- a/extensions/memory-hybrid/tests/cmd-distill.test.ts
+++ b/extensions/memory-hybrid/tests/cmd-distill.test.ts
@@ -1,0 +1,37 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { extractTextFromSessionJsonl } from "../cli/distill-session-jsonl.js";
+
+describe("extractTextFromSessionJsonl", () => {
+  const tmpDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of tmpDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("ignores non-object JSON lines and still extracts valid message text", () => {
+    const dir = mkdtempSync(join(tmpdir(), "hm-distill-jsonl-"));
+    tmpDirs.push(dir);
+    const filePath = join(dir, "session.jsonl");
+    writeFileSync(
+      filePath,
+      [
+        `{"type":"message","message":{"role":"user","content":[{"type":"text","text":"keep me"}]}}`,
+        "null",
+        '"string-value"',
+        "123",
+        "{ malformed json",
+      ].join("\n"),
+      "utf-8",
+    );
+
+    expect(() => extractTextFromSessionJsonl(filePath)).not.toThrow();
+    expect(extractTextFromSessionJsonl(filePath)).toBe("keep me");
+  });
+});


### PR DESCRIPTION
<!-- issue-stewardship-pr issue:1471 -->
Fixes #1471

Issue: https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/1471

Status: draft implementation PR created by Issue Stewardship as Markus/current gh auth.
Protection: keep as draft and `stage/implementing` until Issue Stewardship dispatches/receives implementation and explicitly hands off to PR Stewardship.

Enrichment present on issue: 1
Priority inherited from issue: Medium (source labels: priority:medium)
Dependencies/blocked labels inherited from issue: none

Implementation PR created by Issue Stewardship. Detailed enrichment should be attached to the issue before Copilot implementation dispatch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: refactors a helper into a dedicated module and adds a small defensive JSON type-guard plus unit coverage, affecting only session text extraction for `cmd-distill`.
> 
> **Overview**
> **Hardens `cmd-distill` session JSONL parsing** by extracting `extractTextFromSessionJsonl` into a new `distill-session-jsonl.ts` helper and adding a guard to skip non-object JSON values (e.g., `null`, primitives) without throwing.
> 
> Adds a Vitest regression test to ensure malformed/non-object lines are ignored while valid message text is still extracted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca85c303e0d27b3c1d3a644563bbc46959779816. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->