### PR TITLE
fix(cmd-backfill): guard session JSONL parse in analyze-feedback (#1472)

### DIFF
--- a/extensions/memory-hybrid/cli/cmd-backfill.ts
+++ b/extensions/memory-hybrid/cli/cmd-backfill.ts
@@ -366,7 +366,8 @@ export async function runAnalyzeFeedbackPhrasesForCli(
       scannedSessions++;
     } catch (err) {
       capturePluginError(err as Error, { subsystem: "cli", operation: "runAnalyzeFeedbackPhrasesForCli:read-session" });
-      if (!firstSessionParseError) firstSessionParseError = err instanceof Error ? err.message : String(err);
+      const message = err instanceof Error ? err.message : String(err);
+      if (!firstSessionParseError) firstSessionParseError = `Failed to parse session file ${fp}: ${message}`;
     }
   }
   if (firstSessionParseError) {
@@ -374,7 +375,7 @@ export async function runAnalyzeFeedbackPhrasesForCli(
       reinforcement: [],
       correction: [],
       sessionsScanned: scannedSessions,
-      error: firstSessionParseError,
+      error: `${firstSessionParseError}; discarded extracted messages from ${scannedSessions} successfully scanned session file(s).`,
     };
   }
   const unmatched = allTexts.filter((text) => {

--- a/extensions/memory-hybrid/cli/cmd-backfill.ts
+++ b/extensions/memory-hybrid/cli/cmd-backfill.ts
@@ -390,8 +390,7 @@ export async function runAnalyzeFeedbackPhrasesForCli(
     return {
       reinforcement: [],
       correction: [],
-      sessionsScanned:
-        successfullyScannedSessions > 0 ? successfullyScannedSessions : sessionFiles.length,
+      sessionsScanned: successfullyScannedSessions > 0 ? successfullyScannedSessions : sessionFiles.length,
       error: firstSessionParseError,
     };
   }

--- a/extensions/memory-hybrid/cli/cmd-backfill.ts
+++ b/extensions/memory-hybrid/cli/cmd-backfill.ts
@@ -360,9 +360,10 @@ export async function runAnalyzeFeedbackPhrasesForCli(
   let scannedSessions = 0;
   let firstSessionParseError: string | null = null;
   for (const { path: fp } of sessionFiles) {
-    scannedSessions++;
     try {
-      allTexts.push(...extractUserMessageTextsFromSessionJsonl(fp));
+      const texts = extractUserMessageTextsFromSessionJsonl(fp);
+      allTexts.push(...texts);
+      scannedSessions++;
     } catch (err) {
       capturePluginError(err as Error, { subsystem: "cli", operation: "runAnalyzeFeedbackPhrasesForCli:read-session" });
       if (!firstSessionParseError) firstSessionParseError = err instanceof Error ? err.message : String(err);

--- a/extensions/memory-hybrid/cli/cmd-backfill.ts
+++ b/extensions/memory-hybrid/cli/cmd-backfill.ts
@@ -187,7 +187,8 @@ function extractBackfillFact(line: string): {
 export function extractUserMessageTextsFromSessionJsonl(filePath: string): string[] {
   const lines = readFileSync(filePath, "utf-8").split("\n");
   const out: string[] = [];
-  for (const line of lines) {
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
     const trimmed = line.trim();
     if (!trimmed) continue;
     try {
@@ -204,8 +205,9 @@ export function extractUserMessageTextsFromSessionJsonl(filePath: string): strin
           out.push(block.text.trim());
         }
       }
-    } catch {
-      // skip malformed
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      throw new Error(`Malformed session JSONL at ${filePath}:${i + 1} (${message})`);
     }
   }
   return out;
@@ -360,6 +362,12 @@ export async function runAnalyzeFeedbackPhrasesForCli(
       allTexts.push(...extractUserMessageTextsFromSessionJsonl(fp));
     } catch (err) {
       capturePluginError(err as Error, { subsystem: "cli", operation: "runAnalyzeFeedbackPhrasesForCli:read-session" });
+      return {
+        reinforcement: [],
+        correction: [],
+        sessionsScanned: sessionFiles.length,
+        error: err instanceof Error ? err.message : String(err),
+      };
     }
   }
   const unmatched = allTexts.filter((text) => {

--- a/extensions/memory-hybrid/cli/cmd-backfill.ts
+++ b/extensions/memory-hybrid/cli/cmd-backfill.ts
@@ -205,9 +205,8 @@ export function extractUserMessageTextsFromSessionJsonl(filePath: string): strin
           out.push(block.text.trim());
         }
       }
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      throw new Error(`Malformed session JSONL at ${filePath}:${i + 1} (${message})`);
+    } catch {
+      continue;
     }
   }
   return out;

--- a/extensions/memory-hybrid/cli/cmd-backfill.ts
+++ b/extensions/memory-hybrid/cli/cmd-backfill.ts
@@ -357,18 +357,24 @@ export async function runAnalyzeFeedbackPhrasesForCli(
   const reinforcementRegex = getReinforcementSignalRegex();
   const correctionRegex = getCorrectionSignalRegex();
   const allTexts: string[] = [];
+  let scannedSessions = 0;
+  let firstSessionParseError: string | null = null;
   for (const { path: fp } of sessionFiles) {
+    scannedSessions++;
     try {
       allTexts.push(...extractUserMessageTextsFromSessionJsonl(fp));
     } catch (err) {
       capturePluginError(err as Error, { subsystem: "cli", operation: "runAnalyzeFeedbackPhrasesForCli:read-session" });
-      return {
-        reinforcement: [],
-        correction: [],
-        sessionsScanned: sessionFiles.length,
-        error: err instanceof Error ? err.message : String(err),
-      };
+      if (!firstSessionParseError) firstSessionParseError = err instanceof Error ? err.message : String(err);
     }
+  }
+  if (firstSessionParseError) {
+    return {
+      reinforcement: [],
+      correction: [],
+      sessionsScanned: scannedSessions,
+      error: firstSessionParseError,
+    };
   }
   const unmatched = allTexts.filter((text) => {
     return !reinforcementRegex.test(text) && !correctionRegex.test(text);

--- a/extensions/memory-hybrid/cli/cmd-backfill.ts
+++ b/extensions/memory-hybrid/cli/cmd-backfill.ts
@@ -15,7 +15,7 @@ import { getEnv } from "../utils/env-manager.js";
  *   - runIngestFilesForCli       — ingest workspace markdown files via LLM
  */
 
-import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { basename, dirname, join } from "node:path";
 
@@ -25,6 +25,7 @@ import { chatCompleteWithRetry, distillBatchTokenLimit, distillMaxOutputTokens }
 import { CostFeature } from "../services/cost-feature-labels.js";
 import { capturePluginError } from "../services/error-reporter.js";
 import { gatherIngestFiles } from "../services/ingest-utils.js";
+import { cleanupEvictedVector } from "../services/vector-maintenance.js";
 import { BATCH_STORE_IMPORTANCE, DISTILL_DEDUP_THRESHOLD } from "../utils/constants.js";
 import { tryExtractionFromTemplates } from "../utils/extraction-from-template.js";
 import {
@@ -36,12 +37,10 @@ import {
 } from "../utils/language-keywords.js";
 import { fillPrompt, loadPrompt } from "../utils/prompt-loader.js";
 import { chunkTextByChars, estimateTokens } from "../utils/text.js";
-
 import { gatherSessionFiles } from "./cmd-distill.js";
 import { createProgressReporter } from "./cmd-install.js";
 import type { HandlerContext } from "./handlers.js";
 import type { BackfillCliResult, BackfillCliSink, IngestFilesResult, IngestFilesSink } from "./types.js";
-import { cleanupEvictedVector } from "../services/vector-maintenance.js";
 
 // ---------------------------------------------------------------------------
 // Module-level constants
@@ -214,7 +213,6 @@ export function extractUserMessageTextsFromSessionJsonlWithMeta(filePath: string
       }
     } catch {
       if (firstMalformedLine === null) firstMalformedLine = i + 1;
-      continue;
     }
   }
   return { texts, firstMalformedLine };
@@ -389,8 +387,7 @@ export async function runAnalyzeFeedbackPhrasesForCli(
     }
   }
   if (firstSessionParseError) {
-    const sessionsScanned =
-      successfullyScannedSessions > 0 ? successfullyScannedSessions : sessionFiles.length;
+    const sessionsScanned = successfullyScannedSessions > 0 ? successfullyScannedSessions : sessionFiles.length;
     return {
       reinforcement: [],
       correction: [],

--- a/extensions/memory-hybrid/cli/cmd-backfill.ts
+++ b/extensions/memory-hybrid/cli/cmd-backfill.ts
@@ -183,10 +183,17 @@ function extractBackfillFact(line: string): {
   return { text: t, category, entity, key, value, source_date };
 }
 
-/** Extract raw user message texts from a session file (for regex/sentiment). */
-export function extractUserMessageTextsFromSessionJsonl(filePath: string): string[] {
+export type SessionJsonlUserMessageExtraction = {
+  texts: string[];
+  /** First 1-based line number that failed JSON.parse, if any. */
+  firstMalformedLine: number | null;
+};
+
+/** Extract user message texts and record the first malformed JSONL line (best-effort per line). */
+export function extractUserMessageTextsFromSessionJsonlWithMeta(filePath: string): SessionJsonlUserMessageExtraction {
   const lines = readFileSync(filePath, "utf-8").split("\n");
-  const out: string[] = [];
+  const texts: string[] = [];
+  let firstMalformedLine: number | null = null;
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
     const trimmed = line.trim();
@@ -202,14 +209,20 @@ export function extractUserMessageTextsFromSessionJsonl(filePath: string): strin
       if (!Array.isArray(content)) continue;
       for (const block of content) {
         if (block?.type === "text" && typeof block.text === "string" && block.text.trim().length > 0) {
-          out.push(block.text.trim());
+          texts.push(block.text.trim());
         }
       }
     } catch {
+      if (firstMalformedLine === null) firstMalformedLine = i + 1;
       continue;
     }
   }
-  return out;
+  return { texts, firstMalformedLine };
+}
+
+/** Extract raw user message texts from a session file (for regex/sentiment). */
+export function extractUserMessageTextsFromSessionJsonl(filePath: string): string[] {
+  return extractUserMessageTextsFromSessionJsonlWithMeta(filePath).texts;
 }
 
 // ---------------------------------------------------------------------------
@@ -356,13 +369,19 @@ export async function runAnalyzeFeedbackPhrasesForCli(
   const reinforcementRegex = getReinforcementSignalRegex();
   const correctionRegex = getCorrectionSignalRegex();
   const allTexts: string[] = [];
-  let scannedSessions = 0;
+  let successfullyScannedSessions = 0;
   let firstSessionParseError: string | null = null;
   for (const { path: fp } of sessionFiles) {
     try {
-      const texts = extractUserMessageTextsFromSessionJsonl(fp);
+      const { texts, firstMalformedLine } = extractUserMessageTextsFromSessionJsonlWithMeta(fp);
+      if (firstMalformedLine !== null) {
+        if (!firstSessionParseError) {
+          firstSessionParseError = `Malformed session JSONL at ${basename(fp)}:${firstMalformedLine}`;
+        }
+      } else {
+        successfullyScannedSessions++;
+      }
       allTexts.push(...texts);
-      scannedSessions++;
     } catch (err) {
       capturePluginError(err as Error, { subsystem: "cli", operation: "runAnalyzeFeedbackPhrasesForCli:read-session" });
       const message = err instanceof Error ? err.message : String(err);
@@ -370,11 +389,13 @@ export async function runAnalyzeFeedbackPhrasesForCli(
     }
   }
   if (firstSessionParseError) {
+    const sessionsScanned =
+      successfullyScannedSessions > 0 ? successfullyScannedSessions : sessionFiles.length;
     return {
       reinforcement: [],
       correction: [],
-      sessionsScanned: scannedSessions,
-      error: `${firstSessionParseError}; discarded extracted messages from ${scannedSessions} successfully scanned session file(s).`,
+      sessionsScanned,
+      error: firstSessionParseError,
     };
   }
   const unmatched = allTexts.filter((text) => {

--- a/extensions/memory-hybrid/cli/cmd-backfill.ts
+++ b/extensions/memory-hybrid/cli/cmd-backfill.ts
@@ -387,11 +387,10 @@ export async function runAnalyzeFeedbackPhrasesForCli(
     }
   }
   if (firstSessionParseError) {
-    const sessionsScanned = successfullyScannedSessions > 0 ? successfullyScannedSessions : sessionFiles.length;
     return {
       reinforcement: [],
       correction: [],
-      sessionsScanned,
+      sessionsScanned: sessionFiles.length,
       error: firstSessionParseError,
     };
   }

--- a/extensions/memory-hybrid/cli/cmd-backfill.ts
+++ b/extensions/memory-hybrid/cli/cmd-backfill.ts
@@ -390,7 +390,8 @@ export async function runAnalyzeFeedbackPhrasesForCli(
     return {
       reinforcement: [],
       correction: [],
-      sessionsScanned: sessionFiles.length,
+      sessionsScanned:
+        successfullyScannedSessions > 0 ? successfullyScannedSessions : sessionFiles.length,
       error: firstSessionParseError,
     };
   }

--- a/extensions/memory-hybrid/tests/cmd-backfill-analyze-feedback.test.ts
+++ b/extensions/memory-hybrid/tests/cmd-backfill-analyze-feedback.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { runAnalyzeFeedbackPhrasesForCli } from "../cli/cmd-backfill.js";
 import type { HandlerContext } from "../cli/handlers.js";
+import { getEnv, setEnv } from "../utils/env-manager.js";
 
 describe("runAnalyzeFeedbackPhrasesForCli session JSONL parsing", () => {
   let tempHome: string;
@@ -12,17 +13,15 @@ describe("runAnalyzeFeedbackPhrasesForCli session JSONL parsing", () => {
 
   beforeEach(() => {
     tempHome = mkdtempSync(join(tmpdir(), "hybrid-backfill-analyze-"));
-    previousHome = process.env.HOME;
-    previousUserProfile = process.env.USERPROFILE;
-    process.env.HOME = tempHome;
-    process.env.USERPROFILE = tempHome;
+    previousHome = getEnv("HOME");
+    previousUserProfile = getEnv("USERPROFILE");
+    setEnv("HOME", tempHome);
+    setEnv("USERPROFILE", tempHome);
   });
 
   afterEach(() => {
-    if (previousHome === undefined) process.env.HOME = undefined;
-    else process.env.HOME = previousHome;
-    if (previousUserProfile === undefined) process.env.USERPROFILE = undefined;
-    else process.env.USERPROFILE = previousUserProfile;
+    setEnv("HOME", previousHome);
+    setEnv("USERPROFILE", previousUserProfile);
     rmSync(tempHome, { recursive: true, force: true });
   });
 

--- a/extensions/memory-hybrid/tests/cmd-backfill-analyze-feedback.test.ts
+++ b/extensions/memory-hybrid/tests/cmd-backfill-analyze-feedback.test.ts
@@ -1,0 +1,65 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { runAnalyzeFeedbackPhrasesForCli } from "../cli/cmd-backfill.js";
+import type { HandlerContext } from "../cli/handlers.js";
+
+describe("runAnalyzeFeedbackPhrasesForCli session JSONL parsing", () => {
+  let tempHome: string;
+  let previousHome: string | undefined;
+
+  beforeEach(() => {
+    tempHome = mkdtempSync(join(tmpdir(), "hybrid-backfill-analyze-"));
+    previousHome = process.env.HOME;
+    process.env.HOME = tempHome;
+  });
+
+  afterEach(() => {
+    if (previousHome === undefined) process.env.HOME = undefined;
+    else process.env.HOME = previousHome;
+    rmSync(tempHome, { recursive: true, force: true });
+  });
+
+  function writeSessionFile(contents: string): void {
+    const sessionsDir = join(tempHome, ".openclaw", "agents", "agent-1", "sessions");
+    mkdirSync(sessionsDir, { recursive: true });
+    writeFileSync(join(sessionsDir, "session.jsonl"), contents, "utf-8");
+  }
+
+  function makeContext(): HandlerContext {
+    return {
+      cfg: {} as HandlerContext["cfg"],
+      logger: {},
+      openai: {} as HandlerContext["openai"],
+    } as HandlerContext;
+  }
+
+  it("returns a controlled error for malformed session JSONL", async () => {
+    writeSessionFile('{"type":"message"\n');
+
+    const result = await runAnalyzeFeedbackPhrasesForCli(makeContext(), { days: 30 });
+
+    expect(result.error).toContain("Malformed session JSONL at");
+    expect(result.error).toContain("session.jsonl:1");
+    expect(result.reinforcement).toEqual([]);
+    expect(result.correction).toEqual([]);
+    expect(result.sessionsScanned).toBe(1);
+  });
+
+  it("keeps valid JSONL behavior unchanged", async () => {
+    writeSessionFile(
+      `${JSON.stringify({
+        type: "message",
+        message: { role: "assistant", content: [{ type: "text", text: "all good" }] },
+      })}\n`,
+    );
+
+    const result = await runAnalyzeFeedbackPhrasesForCli(makeContext(), { days: 30 });
+
+    expect(result.error).toBeUndefined();
+    expect(result.reinforcement).toEqual([]);
+    expect(result.correction).toEqual([]);
+    expect(result.sessionsScanned).toBe(1);
+  });
+});

--- a/extensions/memory-hybrid/tests/cmd-backfill-analyze-feedback.test.ts
+++ b/extensions/memory-hybrid/tests/cmd-backfill-analyze-feedback.test.ts
@@ -70,7 +70,7 @@ describe("runAnalyzeFeedbackPhrasesForCli session JSONL parsing", () => {
     expect(result.sessionsScanned).toBe(1);
   });
 
-  it("continues scanning files after malformed JSONL and reports scanned count accurately", async () => {
+  it("continues scanning files after malformed JSONL and reports successfully scanned count", async () => {
     writeSessionFile('{"type":"message"\n', { agentId: "agent-1", fileName: "bad.jsonl" });
     writeSessionFile(
       `${JSON.stringify({
@@ -84,6 +84,6 @@ describe("runAnalyzeFeedbackPhrasesForCli session JSONL parsing", () => {
 
     expect(result.error).toContain("Malformed session JSONL at");
     expect(result.error).toContain("bad.jsonl:1");
-    expect(result.sessionsScanned).toBe(2);
+    expect(result.sessionsScanned).toBe(1);
   });
 });

--- a/extensions/memory-hybrid/tests/cmd-backfill-analyze-feedback.test.ts
+++ b/extensions/memory-hybrid/tests/cmd-backfill-analyze-feedback.test.ts
@@ -8,23 +8,30 @@ import type { HandlerContext } from "../cli/handlers.js";
 describe("runAnalyzeFeedbackPhrasesForCli session JSONL parsing", () => {
   let tempHome: string;
   let previousHome: string | undefined;
+  let previousUserProfile: string | undefined;
 
   beforeEach(() => {
     tempHome = mkdtempSync(join(tmpdir(), "hybrid-backfill-analyze-"));
     previousHome = process.env.HOME;
+    previousUserProfile = process.env.USERPROFILE;
     process.env.HOME = tempHome;
+    process.env.USERPROFILE = tempHome;
   });
 
   afterEach(() => {
     if (previousHome === undefined) process.env.HOME = undefined;
     else process.env.HOME = previousHome;
+    if (previousUserProfile === undefined) process.env.USERPROFILE = undefined;
+    else process.env.USERPROFILE = previousUserProfile;
     rmSync(tempHome, { recursive: true, force: true });
   });
 
-  function writeSessionFile(contents: string): void {
-    const sessionsDir = join(tempHome, ".openclaw", "agents", "agent-1", "sessions");
+  function writeSessionFile(contents: string, opts?: { agentId?: string; fileName?: string }): void {
+    const agentId = opts?.agentId ?? "agent-1";
+    const fileName = opts?.fileName ?? "session.jsonl";
+    const sessionsDir = join(tempHome, ".openclaw", "agents", agentId, "sessions");
     mkdirSync(sessionsDir, { recursive: true });
-    writeFileSync(join(sessionsDir, "session.jsonl"), contents, "utf-8");
+    writeFileSync(join(sessionsDir, fileName), contents, "utf-8");
   }
 
   function makeContext(): HandlerContext {
@@ -61,5 +68,22 @@ describe("runAnalyzeFeedbackPhrasesForCli session JSONL parsing", () => {
     expect(result.reinforcement).toEqual([]);
     expect(result.correction).toEqual([]);
     expect(result.sessionsScanned).toBe(1);
+  });
+
+  it("continues scanning files after malformed JSONL and reports scanned count accurately", async () => {
+    writeSessionFile('{"type":"message"\n', { agentId: "agent-1", fileName: "bad.jsonl" });
+    writeSessionFile(
+      `${JSON.stringify({
+        type: "message",
+        message: { role: "assistant", content: [{ type: "text", text: "all good" }] },
+      })}\n`,
+      { agentId: "agent-2", fileName: "good.jsonl" },
+    );
+
+    const result = await runAnalyzeFeedbackPhrasesForCli(makeContext(), { days: 30 });
+
+    expect(result.error).toContain("Malformed session JSONL at");
+    expect(result.error).toContain("bad.jsonl:1");
+    expect(result.sessionsScanned).toBe(2);
   });
 });

--- a/extensions/memory-hybrid/tests/cmd-backfill-jsonl.test.ts
+++ b/extensions/memory-hybrid/tests/cmd-backfill-jsonl.test.ts
@@ -5,7 +5,7 @@
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { extractUserMessageTextsFromSessionJsonl } from "../cli/cmd-backfill.js";
 
 describe("extractUserMessageTextsFromSessionJsonl", () => {


### PR DESCRIPTION
<!-- issue-stewardship-pr issue:1472 -->
Fixes #1472

Issue: https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/1472

Status: draft implementation PR created by Issue Stewardship as Markus/current gh auth.
Protection: keep as draft and `stage/implementing` until Issue Stewardship dispatches/receives implementation and explicitly hands off to PR Stewardship.

Enrichment present on issue: 1
Priority inherited from issue: Medium (source labels: priority:medium)
Dependencies/blocked labels inherited from issue: none

Implementation PR created by Issue Stewardship. Detailed enrichment should be attached to the issue before Copilot implementation dispatch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: scoped to CLI session-log parsing and error reporting, with tests covering malformed and valid JSONL paths.
> 
> **Overview**
> **Hardens** `analyze-feedback-phrases` against malformed session JSONL by adding `extractUserMessageTextsFromSessionJsonlWithMeta`, tracking the first bad line, and returning a controlled error instead of silently skipping parse failures.
> 
> Updates the scan loop to report a clearer error message and a *successfully scanned* session count, and adds/adjusts Vitest coverage for malformed, valid, and mixed session-file scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea4d82d575d607674b24ac00d254008a91dc4105. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->