### PR TITLE
WIP: [Similar sweep] cmd-extract — broad-missing-await-silent-failure in cmd-extract (#1493)

### DIFF
--- a/extensions/memory-hybrid/cli/cmd-extract.ts
+++ b/extensions/memory-hybrid/cli/cmd-extract.ts
@@ -92,6 +92,11 @@ export function getSessionFilePathsSince(sessionDir: string, days: number, since
       subsystem: "cli",
       operation: "getSessionFilePathsSince",
     });
+    console.warn(
+      "[memory-hybrid] getSessionFilePathsSince: could not list session directory",
+      sessionDir,
+      (err as Error)?.message ?? String(err),
+    );
     return [];
   }
 }

--- a/extensions/memory-hybrid/tests/cmd-extract-session-paths.test.ts
+++ b/extensions/memory-hybrid/tests/cmd-extract-session-paths.test.ts
@@ -73,19 +73,27 @@ describe("getSessionFilePathsSince", () => {
     expect(result).toEqual([]);
   });
 
-  it("returns only .jsonl files modified after the cutoff", () => {
-    const old = join(tmpDir, "old-session.jsonl");
-    const recent = join(tmpDir, "recent-session.jsonl");
+  it("returns .jsonl files and excludes non-jsonl files", () => {
+    const jsonlFile = join(tmpDir, "session.jsonl");
     const nonJsonl = join(tmpDir, "readme.txt");
 
-    writeFileSync(old, "{}");
+    writeFileSync(jsonlFile, "{}");
     writeFileSync(nonJsonl, "ignore me");
-    writeFileSync(recent, "{}");
 
-    // Use sinceTimestamp = 0 so all files pass the mtime check (both were just created)
+    // sinceTimestamp = 0 means cutoff is epoch start — all freshly created files pass
     const result = getSessionFilePathsSince(tmpDir, 0, 0);
-    expect(result).toContain(recent);
+    expect(result).toContain(jsonlFile);
     expect(result).not.toContain(nonJsonl);
+  });
+
+  it("excludes .jsonl files whose mtime is at or before the cutoff", () => {
+    const jsonlFile = join(tmpDir, "session.jsonl");
+    writeFileSync(jsonlFile, "{}");
+
+    // Use a future cutoff so the just-created file is considered too old
+    const futureCutoff = Date.now() + 60_000;
+    const result = getSessionFilePathsSince(tmpDir, 0, futureCutoff);
+    expect(result).not.toContain(jsonlFile);
   });
 
   it("excludes .deleted .jsonl files", () => {

--- a/extensions/memory-hybrid/tests/cmd-extract-session-paths.test.ts
+++ b/extensions/memory-hybrid/tests/cmd-extract-session-paths.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Regression tests for getSessionFilePathsSince (Issue #1493).
+ *
+ * Guards the outer-catch silent-failure path: when readdirSync throws,
+ * the function must return [] AND emit a console.warn so the failure is
+ * diagnosable even when telemetry/capturePluginError is a no-op.
+ */
+
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getSessionFilePathsSince } from "../cli/cmd-extract.js";
+
+// ---------------------------------------------------------------------------
+// Controlled readdirSync failure injection
+// ---------------------------------------------------------------------------
+
+let simulateReaddirFailure = false;
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return {
+    ...actual,
+    readdirSync(...args: Parameters<typeof actual.readdirSync>) {
+      if (simulateReaddirFailure) {
+        throw new Error("simulated readdirSync failure");
+      }
+      return actual.readdirSync(...args);
+    },
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+let tmpDir: string;
+
+beforeEach(() => {
+  simulateReaddirFailure = false;
+  tmpDir = mkdtempSync(join(tmpdir(), "cmd-extract-session-paths-test-"));
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("getSessionFilePathsSince", () => {
+  it("returns [] and emits console.warn when readdirSync throws (outer-catch silent-failure guard)", () => {
+    simulateReaddirFailure = true;
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const result = getSessionFilePathsSince(tmpDir, 7);
+
+    expect(result).toEqual([]);
+    expect(warnSpy).toHaveBeenCalledOnce();
+    const [msg, dir, errMsg] = warnSpy.mock.calls[0];
+    expect(msg).toContain("getSessionFilePathsSince");
+    expect(dir).toBe(tmpDir);
+    expect(typeof errMsg).toBe("string");
+    expect(errMsg).toContain("simulated readdirSync failure");
+
+    warnSpy.mockRestore();
+  });
+
+  it("returns [] for a non-existent session directory (existsSync guard)", () => {
+    const result = getSessionFilePathsSince("/nonexistent-session-dir-abc123", 7);
+    expect(result).toEqual([]);
+  });
+
+  it("returns only .jsonl files modified after the cutoff", () => {
+    const old = join(tmpDir, "old-session.jsonl");
+    const recent = join(tmpDir, "recent-session.jsonl");
+    const nonJsonl = join(tmpDir, "readme.txt");
+
+    writeFileSync(old, "{}");
+    writeFileSync(nonJsonl, "ignore me");
+    writeFileSync(recent, "{}");
+
+    // Use sinceTimestamp = 0 so all files pass the mtime check (both were just created)
+    const result = getSessionFilePathsSince(tmpDir, 0, 0);
+    expect(result).toContain(recent);
+    expect(result).not.toContain(nonJsonl);
+  });
+
+  it("excludes .deleted .jsonl files", () => {
+    const deleted = join(tmpDir, ".deleted-session.jsonl");
+    const normal = join(tmpDir, "normal-session.jsonl");
+
+    writeFileSync(deleted, "{}");
+    writeFileSync(normal, "{}");
+
+    const result = getSessionFilePathsSince(tmpDir, 0, 0);
+    expect(result).toContain(normal);
+    expect(result).not.toContain(deleted);
+  });
+});


### PR DESCRIPTION
<!-- issue-stewardship-pr issue:1493 -->
Fixes #1493

Issue: https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/1493

Status: draft implementation PR created by Issue Stewardship as Markus/current gh auth.
Protection: keep as draft and `stage/implementing` until Issue Stewardship dispatches/receives implementation and explicitly hands off to PR Stewardship.

Enrichment present on issue: 1
Priority inherited from issue: Medium (source labels: priority:medium)
Dependencies/blocked labels inherited from issue: none

<!-- issue-stewardship-enrichment issue:1493 version:1 -->

Problem summary:
- Similarity sweep found `broad-missing-await-silent-failure` in `/home/markus/repos/openclaw-hybrid-memory/extensions/memory-hybrid/cli/cmd-extract.ts` around line 86.
- The concrete risk is that the similarity sweep flagged `broad-missing-await-silent-failure` as a likely real robustness issue.
- Source similarity issue: #1249.

Desired outcome:
- the flagged code path is guarded or made explicit while preserving existing valid behavior.
- Existing valid/happy-path behavior remains unchanged.

Intent / product interpretation:
- Treat this as a focused robustness bug for the flagged call site, not a broad refactor.

Likely touched areas:
- `/home/markus/repos/openclaw-hybrid-memory/extensions/memory-hybrid/cli/cmd-extract.ts`
- Focused tests near the owning module/CLI/service if present.

Architecture considerations:
- Follow existing local error-handling/logging conventions.
- Keep the change scoped to the flagged file/line and immediately related tests.

Risks:
- over-broad refactor or behavior drift outside the flagged call site.

Mitigations:
- Preserve valid behavior and keep the implementation local.
- Add focused regression coverage where the repository already has a suitable harness.

Acceptance criteria:
- [ ] The flagged `broad-missing-await-silent-failure` path is handled explicitly.
- [ ] Valid existing behavior remains unchanged.
- [ ] Failure/edge behavior is controlled and diagnosable.
- [ ] Relevant lint/typecheck/tests pass.

Required tests:
- Add focused regression coverage if an existing harness exists; run lint/typecheck.

Docs to update:
- None expected unless the implementation changes user-visible CLI/API behavior.

Dependencies:
- Blocks: none known
- Blocked by: none known
- Related PRs/issues: #1249

Split recommendation:
- Keep as one focused issue because the finding maps to a single file/line area.

Priority recommendation:
- P2 because this is a plausible robustness bug from similarity sweep with local implementation scope.

Implementation plan:
1. Inspect the flagged code in `/home/markus/repos/openclaw-hybrid-memory/extensions/memory-hybrid/cli/cmd-extract.ts` near line 86.
2. Implement the smallest safe guard/cleanup/error-handling change.
3. Add focused regression coverage where practical.
4. Run lint/typecheck and relevant focused tests.

Copilot implementation brief:
- Scope: Fix `broad-missing-await-silent-failure` in `/home/markus/repos/openclaw-hybrid-memory/extensions/memory-hybrid/cli/cmd-extract.ts` near line 86.
- Branch/PR: Stewardship-created draft PR in Phase 3.
- Acceptance: controlled edge behavior, valid behavior preserved, tests green.
- Tests: Add focused regression coverage if an existing harness exists; run lint/typecheck.
- Do not: broaden into unrelated refactors or fix unrelated similarity findings.

PR Stewardship handoff hints:
- likely labels: bug, similarity:sweep, priority:medium
- review risks: over-broad refactor or behavior drift outside the flagged call site
- Council/deep needed: no unless implementation expands beyond the local issue.

Enrichment confidence:
- medium

Needs Markus before implementation:
- no

Issue body snippet:
```ts
capturePluginError(err as Error, { subsystem: "cli", operation: "getSessionFilePathsSince" });
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a `console.warn` on an existing error path and introduces isolated unit tests; no changes to normal extraction logic or data handling.
> 
> **Overview**
> Improves diagnosability of `cmd-extract` session scanning by logging a `console.warn` when `getSessionFilePathsSince` fails to `readdirSync` the session directory (while still returning an empty list).
> 
> Adds Vitest regression coverage for this failure path (Issue #1493) and for core filtering behavior: only `.jsonl` files are returned, `.deleted*` and non-`.jsonl` files are excluded, and mtime cutoffs are respected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb731a6caf1d6813005efcc5aae71b2dcce3f828. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->