### PR TITLE
fix(retrieval-aliases): guard AliasVectorIndex.ensureInitialized() against closed-state races (#1494)

### DIFF
--- a/extensions/memory-hybrid/services/retrieval-aliases.ts
+++ b/extensions/memory-hybrid/services/retrieval-aliases.ts
@@ -52,16 +52,38 @@ class AliasVectorIndex {
   ) {}
 
   private async ensureInitialized(): Promise<void> {
+    if (this.closed) {
+      throw new Error("AliasVectorIndex is closed");
+    }
     if (this.table) return;
     if (this.initPromise) return this.initPromise;
-    this.initPromise = this.doInitialize().catch((err) => {
-      capturePluginError(err as Error, {
-        operation: "alias-vector-db-init",
-        subsystem: "aliases",
+    this.initPromise = this.doInitialize()
+      .then(() => {
+        // close() may have been called while doInitialize() was in flight.
+        // Release the newly-opened connection so it does not leak.
+        if (this.closed) {
+          try {
+            this.db?.close();
+          } catch {
+            // ignore
+          }
+          this.db = null;
+          this.table = null;
+          throw new Error("AliasVectorIndex closed during initialization");
+        }
+      })
+      .catch((err) => {
+        this.initPromise = null;
+        // Suppress error reporting for expected closed-state errors; only report
+        // genuine initialization failures so they reach error tracking.
+        if (!this.closed) {
+          capturePluginError(err as Error, {
+            operation: "alias-vector-db-init",
+            subsystem: "aliases",
+          });
+        }
+        throw err;
       });
-      this.initPromise = null;
-      throw err;
-    });
     return this.initPromise;
   }
 
@@ -143,10 +165,12 @@ class AliasVectorIndex {
         },
       ]);
     } catch (err) {
-      capturePluginError(err as Error, {
-        operation: "alias-vector-store",
-        subsystem: "aliases",
-      });
+      if (!this.closed) {
+        capturePluginError(err as Error, {
+          operation: "alias-vector-store",
+          subsystem: "aliases",
+        });
+      }
       pluginLogger.warn(`memory-hybrid: alias LanceDB store failed (non-fatal): ${err}`);
     }
   }
@@ -178,7 +202,7 @@ class AliasVectorIndex {
     } catch (err) {
       if (err instanceof Error && err.message.includes(LANCE_NO_VECTOR_COL_MSG)) {
         this.schemaValid = false;
-      } else {
+      } else if (!this.closed) {
         capturePluginError(err as Error, {
           operation: "alias-vector-search",
           severity: "info",
@@ -199,10 +223,12 @@ class AliasVectorIndex {
       }
       await this.getTable().delete(`factId = '${factId.toLowerCase()}'`);
     } catch (err) {
-      capturePluginError(err as Error, {
-        operation: "alias-vector-delete",
-        subsystem: "aliases",
-      });
+      if (!this.closed) {
+        capturePluginError(err as Error, {
+          operation: "alias-vector-delete",
+          subsystem: "aliases",
+        });
+      }
       pluginLogger.warn(`memory-hybrid: alias LanceDB delete failed (non-fatal): ${err}`);
     }
   }

--- a/extensions/memory-hybrid/services/retrieval-aliases.ts
+++ b/extensions/memory-hybrid/services/retrieval-aliases.ts
@@ -71,6 +71,8 @@ class AliasVectorIndex {
           this.table = null;
           throw new Error("AliasVectorIndex closed during initialization");
         }
+        // Init complete; table is ready — drop the promise so close() and tests see a clean idle state.
+        this.initPromise = null;
       })
       .catch((err) => {
         this.initPromise = null;
@@ -170,8 +172,8 @@ class AliasVectorIndex {
           operation: "alias-vector-store",
           subsystem: "aliases",
         });
+        pluginLogger.warn(`memory-hybrid: alias LanceDB store failed (non-fatal): ${err}`);
       }
-      pluginLogger.warn(`memory-hybrid: alias LanceDB store failed (non-fatal): ${err}`);
     }
   }
 
@@ -208,8 +210,8 @@ class AliasVectorIndex {
           severity: "info",
           subsystem: "aliases",
         });
+        pluginLogger.warn(`memory-hybrid: alias LanceDB search failed (non-fatal): ${err}`);
       }
-      pluginLogger.warn(`memory-hybrid: alias LanceDB search failed (non-fatal): ${err}`);
       return [];
     }
   }
@@ -228,8 +230,8 @@ class AliasVectorIndex {
           operation: "alias-vector-delete",
           subsystem: "aliases",
         });
+        pluginLogger.warn(`memory-hybrid: alias LanceDB delete failed (non-fatal): ${err}`);
       }
-      pluginLogger.warn(`memory-hybrid: alias LanceDB delete failed (non-fatal): ${err}`);
     }
   }
 

--- a/extensions/memory-hybrid/services/retrieval-aliases.ts
+++ b/extensions/memory-hybrid/services/retrieval-aliases.ts
@@ -240,6 +240,7 @@ class AliasVectorIndex {
       this.table = null;
       this.db?.close();
       this.db = null;
+      this.initPromise = null;
     } catch {
       // Ignore close errors
     }

--- a/extensions/memory-hybrid/tests/retrieval-aliases-schema.test.ts
+++ b/extensions/memory-hybrid/tests/retrieval-aliases-schema.test.ts
@@ -69,3 +69,136 @@ describe("AliasDB LanceDB schema mismatch fallback", () => {
     expect(vi.mocked(errorReporter.capturePluginError)).not.toHaveBeenCalled();
   });
 });
+
+// ---------------------------------------------------------------------------
+// AliasVectorIndex closed-state safety (issue #1494)
+// ---------------------------------------------------------------------------
+
+describe("AliasVectorIndex closed-state safety (issue #1494)", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "alias-closed-test-"));
+    vi.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    // Allow pending LanceDB write transactions to flush before cleanup
+    await new Promise((r) => setTimeout(r, 250));
+    let retries = 5;
+    while (retries-- > 0) {
+      try {
+        rmSync(tmpDir, { recursive: true, force: true });
+        break;
+      } catch (err) {
+        if (retries === 0) throw err;
+        await new Promise((r) => setTimeout(r, 100));
+      }
+    }
+  });
+
+  it("store() on a closed AliasVectorIndex does not call capturePluginError", async () => {
+    const db = new AliasDB(join(tmpDir, "a.db"), join(tmpDir, "a.lance"), 4);
+    const aliasIndex = (db as any).aliasIndex;
+
+    // Close the vector index directly before any init has occurred
+    aliasIndex.close();
+
+    await aliasIndex.store({ id: randomUUID(), factId: randomUUID(), aliasText: "text", vector: unitVec() });
+
+    expect(vi.mocked(errorReporter.capturePluginError)).not.toHaveBeenCalled();
+    db.close();
+  });
+
+  it("search() on a closed AliasVectorIndex does not call capturePluginError", async () => {
+    const db = new AliasDB(join(tmpDir, "b.db"), join(tmpDir, "b.lance"), 4);
+    const aliasIndex = (db as any).aliasIndex;
+
+    aliasIndex.close();
+
+    const results = await aliasIndex.search(unitVec(), 5, 0.1);
+
+    expect(results).toEqual([]);
+    expect(vi.mocked(errorReporter.capturePluginError)).not.toHaveBeenCalled();
+    db.close();
+  });
+
+  it("deleteByFactId() on a closed AliasVectorIndex does not call capturePluginError", async () => {
+    const db = new AliasDB(join(tmpDir, "c.db"), join(tmpDir, "c.lance"), 4);
+    const aliasIndex = (db as any).aliasIndex;
+
+    aliasIndex.close();
+
+    await aliasIndex.deleteByFactId(randomUUID());
+
+    expect(vi.mocked(errorReporter.capturePluginError)).not.toHaveBeenCalled();
+    db.close();
+  });
+
+  it("ensureInitialized() does not restart initialization after close()", async () => {
+    const db = new AliasDB(join(tmpDir, "d.db"), join(tmpDir, "d.lance"), 4);
+    const aliasIndex = (db as any).aliasIndex;
+
+    // Trigger init to succeed (open the table properly)
+    await aliasIndex.store({ id: randomUUID(), factId: randomUUID(), aliasText: "seed", vector: unitVec() });
+
+    // Now close the index directly
+    aliasIndex.close();
+
+    vi.clearAllMocks();
+
+    // After close, a subsequent store() must not re-open the connection
+    await aliasIndex.store({ id: randomUUID(), factId: randomUUID(), aliasText: "post-close", vector: unitVec() });
+
+    // initPromise must remain null (closed guard fired; no new init was started)
+    expect(aliasIndex.initPromise).toBeNull();
+    // closed flag must still be true
+    expect(aliasIndex.closed).toBe(true);
+    expect(vi.mocked(errorReporter.capturePluginError)).not.toHaveBeenCalled();
+
+    db.close();
+  });
+
+  it("close() during in-flight doInitialize() leaves the index cleanly closed with no leaked resources", async () => {
+    const db = new AliasDB(join(tmpDir, "e.db"), join(tmpDir, "e.lance"), 4);
+    const aliasIndex = (db as any).aliasIndex;
+
+    // Intercept doInitialize to simulate a slow async init
+    let resolveInit!: () => void;
+    const initBarrier = new Promise<void>((res) => {
+      resolveInit = res;
+    });
+
+    const origDoInit = aliasIndex.doInitialize.bind(aliasIndex);
+    aliasIndex.doInitialize = async () => {
+      await initBarrier;
+      return origDoInit();
+    };
+
+    // Start store() — triggers ensureInitialized() → doInitialize() which blocks on initBarrier
+    const storePromise = aliasIndex.store({
+      id: randomUUID(),
+      factId: randomUUID(),
+      aliasText: "racing",
+      vector: unitVec(),
+    });
+
+    // Close while init is blocked
+    aliasIndex.close();
+
+    // Unblock the init — doInitialize() will complete, then the .then() guard cleans up
+    resolveInit();
+    await storePromise;
+
+    // After a close-during-init race, the index must be cleanly closed with no leaked resources
+    expect(aliasIndex.closed).toBe(true);
+    expect(aliasIndex.db).toBeNull();
+    expect(aliasIndex.table).toBeNull();
+    expect(aliasIndex.initPromise).toBeNull();
+
+    // No spurious error reports
+    expect(vi.mocked(errorReporter.capturePluginError)).not.toHaveBeenCalled();
+
+    db.close();
+  });
+});

--- a/extensions/memory-hybrid/tests/retrieval-aliases-schema.test.ts
+++ b/extensions/memory-hybrid/tests/retrieval-aliases-schema.test.ts
@@ -164,7 +164,7 @@ describe("AliasVectorIndex closed-state safety (issue #1494)", () => {
     const aliasIndex = (db as any).aliasIndex;
 
     // Intercept doInitialize to simulate a slow async init
-    let resolveInit!: () => void;
+    let resolveInit: () => void = () => {};
     const initBarrier = new Promise<void>((res) => {
       resolveInit = res;
     });


### PR DESCRIPTION
<!-- issue-stewardship-pr issue:1494 -->
Fixes #1494

Issue: https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/1494

Status: draft implementation PR created by Issue Stewardship as Markus/current gh auth.
Protection: keep as draft and `stage/implementing` until Issue Stewardship dispatches/receives implementation and explicitly hands off to PR Stewardship.

Enrichment present on issue: 1
Priority inherited from issue: Medium (source labels: priority:medium)
Dependencies/blocked labels inherited from issue: none

<!-- issue-stewardship-enrichment issue:1494 version:1 -->

Problem summary:
- Similarity sweep found `broad-init-promise-swallows-errors` in `/home/markus/repos/openclaw-hybrid-memory/extensions/memory-hybrid/services/retrieval-aliases.ts` around line 57.
- The concrete risk is that initialization/cache state can race or be observed inconsistently.
- Source similarity issue: #1255.

Desired outcome:
- the code handles concurrent/early access safely without changing the happy path.
- Existing valid/happy-path behavior remains unchanged.

Intent / product interpretation:
- Treat this as a focused robustness bug for the flagged call site, not a broad refactor.

Likely touched areas:
- `/home/markus/repos/openclaw-hybrid-memory/extensions/memory-hybrid/services/retrieval-aliases.ts`
- Focused tests near the owning module/CLI/service if present.

Architecture considerations:
- Follow existing local error-handling/logging conventions.
- Keep the change scoped to the flagged file/line and immediately related tests.

Risks:
- serializing hot paths unnecessarily or hiding initialization failures.

Mitigations:
- Preserve valid behavior and keep the implementation local.
- Add focused regression coverage where the repository already has a suitable harness.

Acceptance criteria:
- [ ] The flagged `broad-init-promise-swallows-errors` path is handled explicitly.
- [ ] Valid existing behavior remains unchanged.
- [ ] Failure/edge behavior is controlled and diagnosable.
- [ ] Relevant lint/typecheck/tests pass.

Required tests:
- Add or update focused race/init/cache coverage if harness exists; run lint/typecheck.

Docs to update:
- None expected unless the implementation changes user-visible CLI/API behavior.

Dependencies:
- Blocks: none known
- Blocked by: none known
- Related PRs/issues: #1255

Split recommendation:
- Keep as one focused issue because the finding maps to a single file/line area.

Priority recommendation:
- P2 because this is a plausible robustness bug from similarity sweep with local implementation scope.

Implementation plan:
1. Inspect the flagged code in `/home/markus/repos/openclaw-hybrid-memory/extensions/memory-hybrid/services/retrieval-aliases.ts` near line 57.
2. Implement the smallest safe guard/cleanup/error-handling change.
3. Add focused regression coverage where practical.
4. Run lint/typecheck and relevant focused tests.

Copilot implementation brief:
- Scope: Fix `broad-init-promise-swallows-errors` in `/home/markus/repos/openclaw-hybrid-memory/extensions/memory-hybrid/services/retrieval-aliases.ts` near line 57.
- Branch/PR: Stewardship-created draft PR in Phase 3.
- Acceptance: controlled edge behavior, valid behavior preserved, tests green.
- Tests: Add or update focused race/init/cache coverage if harness exists; run lint/typecheck.
- Do not: broaden into unrelated refactors or fix unrelated similarity findings.

PR Stewardship handoff hints:
- likely labels: bug, similarity:sweep, priority:medium
- review risks: serializing hot paths unnecessarily or hiding initialization failures
- Council/deep needed: no unless implementation expands beyond the local issue.

Enrichment confidence:
- medium

Needs Markus before implementation:
- no

Issue body snippet:
```ts
this.initPromise = this.doInitialize().catch((err) => {
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches LanceDB initialization and lifecycle handling; mistakes could cause leaked connections or suppressed real init errors, but changes are localized and covered by new race/closed-state tests.
> 
> **Overview**
> **Hardens `AliasVectorIndex` lifecycle handling** to avoid init/close races: `ensureInitialized()` now rejects work when closed, clears `initPromise` on completion/failure, and explicitly closes any newly-opened LanceDB connection if `close()` happened mid-initialization.
> 
> **Reduces noisy error reporting on shutdown paths** by suppressing `capturePluginError`/warn logs for expected failures after the index is closed (store/search/delete), while still reporting genuine initialization errors.
> 
> Adds focused Vitest coverage for closed-state behavior, including calling operations after `close()`, ensuring init doesn’t restart post-close, and a regression test for `close()` during an in-flight `doInitialize()` without leaking resources.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42f402d110447371e230036c1f2d8aa99629f360. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->