### PR TITLE
fix(wal): close file handles on append error (#1497)

### DIFF
--- a/extensions/memory-hybrid/tests/wal.test.ts
+++ b/extensions/memory-hybrid/tests/wal.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const fsyncError = vi.hoisted(() => ({ value: null as Error | null }));
 const failNextOpen = vi.hoisted(() => ({ value: null as Error | null }));
 const syncError = vi.hoisted(() => ({ value: null as Error | null }));
+// Tracks how many times fh.close() has been called via the intercepted open().
 const closedHandleCount = vi.hoisted(() => ({ value: 0 }));
 
 vi.mock("node:fs/promises", async (importOriginal) => {
@@ -664,17 +665,20 @@ describe("WriteAheadLog", () => {
     });
 
     it("closes file handle when both datasync and fsync fallback fail (EPERM cascade)", async () => {
+      // datasync() fails with EPERM, then sync() also fails — fh must still be closed.
       const epermError = Object.assign(new Error("operation not permitted"), { code: "EPERM" });
+      const syncFail = Object.assign(new Error("sync unsupported"), { code: "EPERM" });
       fsyncError.value = epermError;
-      syncError.value = Object.assign(new Error("operation not permitted on sync"), { code: "EPERM" });
+      syncError.value = syncFail;
       const before = closedHandleCount.value;
       const entry = {
         id: randomUUID(),
         timestamp: Date.now(),
         operation: "store" as const,
-        data: { text: "close-check cascade", category: "general", importance: 0.5, source: "test" },
+        data: { text: "close-check double-fail", category: "general", importance: 0.5, source: "test" },
       };
       await expect(wal.write(entry)).rejects.toThrow(/WAL write failed/);
+      // fh was opened (open() succeeded) so close() must have been called.
       expect(closedHandleCount.value).toBeGreaterThan(before);
     });
   });


### PR DESCRIPTION
<!-- issue-stewardship-pr issue:1497 -->
Fixes #1497

Issue: https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/1497

Status: draft implementation PR created by Issue Stewardship as Markus/current gh auth.
Protection: keep as draft and `stage/implementing` until Issue Stewardship dispatches/receives implementation and explicitly hands off to PR Stewardship.

Enrichment present on issue: 1
Priority inherited from issue: Medium (source labels: priority:medium)
Dependencies/blocked labels inherited from issue: none

<!-- issue-stewardship-enrichment issue:1497 version:1 -->

Problem summary:
- Similarity sweep found `broad-file-handle-leak-on-error` in `/home/markus/repos/openclaw-hybrid-memory/extensions/memory-hybrid/backends/wal.ts` around line 104.
- The concrete risk is that resource cleanup may be skipped on error paths.
- Source similarity issue: #1305.

Desired outcome:
- resources are released in success and failure paths.
- Existing valid/happy-path behavior remains unchanged.

Intent / product interpretation:
- Treat this as a focused robustness bug for the flagged call site, not a broad refactor.

Likely touched areas:
- `/home/markus/repos/openclaw-hybrid-memory/extensions/memory-hybrid/backends/wal.ts`
- Focused tests near the owning module/CLI/service if present.

Architecture considerations:
- Follow existing local error-handling/logging conventions.
- Keep the change scoped to the flagged file/line and immediately related tests.

Risks:
- double-close behavior or masking original errors.

Mitigations:
- Preserve valid behavior and keep the implementation local.
- Add focused regression coverage where the repository already has a suitable harness.

Acceptance criteria:
- [ ] The flagged `broad-file-handle-leak-on-error` path is handled explicitly.
- [ ] Valid existing behavior remains unchanged.
- [ ] Failure/edge behavior is controlled and diagnosable.
- [ ] Relevant lint/typecheck/tests pass.

Required tests:
- Add or update focused cleanup/error-path coverage; run lint/typecheck.

Docs to update:
- None expected unless the implementation changes user-visible CLI/API behavior.

Dependencies:
- Blocks: none known
- Blocked by: none known
- Related PRs/issues: #1305

Split recommendation:
- Keep as one focused issue because the finding maps to a single file/line area.

Priority recommendation:
- P2 because this is a plausible robustness bug from similarity sweep with local implementation scope.

Implementation plan:
1. Inspect the flagged code in `/home/markus/repos/openclaw-hybrid-memory/extensions/memory-hybrid/backends/wal.ts` near line 104.
2. Implement the smallest safe guard/cleanup/error-handling change.
3. Add focused regression coverage where practical.
4. Run lint/typecheck and relevant focused tests.

Copilot implementation brief:
- Scope: Fix `broad-file-handle-leak-on-error` in `/home/markus/repos/openclaw-hybrid-memory/extensions/memory-hybrid/backends/wal.ts` near line 104.
- Branch/PR: Stewardship-created draft PR in Phase 3.
- Acceptance: controlled edge behavior, valid behavior preserved, tests green.
- Tests: Add or update focused cleanup/error-path coverage; run lint/typecheck.
- Do not: broaden into unrelated refactors or fix unrelated similarity findings.

PR Stewardship handoff hints:
- likely labels: bug, similarity:sweep, priority:medium
- review risks: double-close behavior or masking original errors
- Council/deep needed: no unless implementation expands beyond the local issue.

Enrichment confidence:
- medium

Needs Markus before implementation:
- no

Issue body snippet:
```ts
`fh = await open(this.walPath, "a+")...} catch (err)...` missing `finally { await fh?.close(); }`
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that tighten coverage around WAL fsync error paths; low risk aside from potential CI flakiness due to fs mocking.
> 
> **Overview**
> Improves WAL robustness coverage by extending the `node:fs/promises` mock in `wal.test.ts` to count intercepted `fh.close()` calls.
> 
> Adds/clarifies assertions and comments around the EPERM “datasync then sync fallback” cascade so the tests explicitly verify the file handle is closed whenever `open()` succeeds, even when both sync strategies fail.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0caeeafbd6f9914a9196a3fe883e871def680677. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->