### PR TITLE
fix(memory-hybrid): PR #1506 dedupe SQLITE_BUSY retry and #1519 config --json CLI test

### DIFF
--- a/extensions/memory-hybrid/backends/facts-db/crud.ts
+++ b/extensions/memory-hybrid/backends/facts-db/crud.ts
@@ -15,6 +15,7 @@ import { normalizedHash, serializeTags } from "../../utils/tags.js";
 const SQLITE_BUSY_STORE_MAX_RETRIES = 3;
 const SQLITE_BUSY_STORE_BACKOFF_BASE_MS = 50;
 const SQLITE_BUSY_STORE_BACKOFF_MAX_MS = 500;
+const SQLITE_BUSY_STORE_SLEEP = new Int32Array(new SharedArrayBuffer(4));
 
 function isSqliteBusyError(err: unknown): boolean {
   const message = err instanceof Error ? err.message : String(err);
@@ -25,7 +26,7 @@ function isSqliteBusyError(err: unknown): boolean {
 
 function sleepSync(ms: number): void {
   if (ms <= 0) return;
-  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+  Atomics.wait(SQLITE_BUSY_STORE_SLEEP, 0, 0, ms);
 }
 
 function runWithSqliteBusyRetry(db: DatabaseSync, run: () => void): void {
@@ -170,11 +171,13 @@ export function storeFact(ctx: StoreFactContext, entry: StoreFactInput): StoreFa
     // of a near-duplicate, bump recall on the existing winner so the dedup acts as a
     // reinforcement signal instead of silently dropping the new evidence.
     if (dedupe.reason === "vector" || dedupe.reason === "lexical" || dedupe.reason === "hash") {
-      ctx.db
-        .prepare(
-          "UPDATE facts SET recall_count = recall_count + 1, access_count = access_count + 1, last_confirmed_at = ? WHERE id = ?",
-        )
-        .run(nowSec, dedupe.existingId);
+      runWithSqliteBusyRetry(ctx.db, () => {
+        ctx.db
+          .prepare(
+            "UPDATE facts SET recall_count = recall_count + 1, access_count = access_count + 1, last_confirmed_at = ? WHERE id = ?",
+          )
+          .run(nowSec, dedupe.existingId);
+      });
     }
     const existing = ctx.getById(dedupe.existingId);
     if (existing) return { entry: existing, evictedFactId: null };
@@ -184,11 +187,13 @@ export function storeFact(ctx: StoreFactContext, entry: StoreFactInput): StoreFa
   }
 
   if (dedupe.action === "boost") {
-    ctx.db
-      .prepare(
-        "UPDATE facts SET recall_count = recall_count + 1, access_count = access_count + 1, importance = min(1.0, importance + ?) WHERE id = ?",
-      )
-      .run(dedupe.boostBy, dedupe.existingId);
+    runWithSqliteBusyRetry(ctx.db, () => {
+      ctx.db
+        .prepare(
+          "UPDATE facts SET recall_count = recall_count + 1, access_count = access_count + 1, importance = min(1.0, importance + ?) WHERE id = ?",
+        )
+        .run(dedupe.boostBy, dedupe.existingId);
+    });
     const boosted = ctx.getById(dedupe.existingId);
     if (boosted) return { entry: boosted, evictedFactId: null };
     throw new Error(
@@ -222,7 +227,9 @@ export function storeFact(ctx: StoreFactContext, entry: StoreFactInput): StoreFa
           .prepare("UPDATE facts SET text = ?, normalized_hash = ? WHERE id = ?")
           .run(mergedText, mergedHash, existing.id);
       });
-      mergeTx();
+      runWithSqliteBusyRetry(ctx.db, () => {
+        mergeTx();
+      });
       // Signal callers to re-embed only when the persisted text changed. This handles edge
       // cases where append text is truncated and the final merged text remains unchanged.
       const embeddingStale = mergedText !== existing.text;

--- a/extensions/memory-hybrid/tests/register-corrections-config-cli.test.ts
+++ b/extensions/memory-hybrid/tests/register-corrections-config-cli.test.ts
@@ -57,15 +57,11 @@ function makeCtx(overrides?: Partial<HandlerContext["cfg"]>): HandlerContext {
 
   return {
     cfg,
-    dataDir: ".",
-    noEmoji: false,
     logger: {
       info: vi.fn(),
       warn: vi.fn(),
-      error: vi.fn(),
-      debug: vi.fn(),
-    } as unknown as HandlerContext["logger"],
-  };
+    },
+  } as unknown as HandlerContext;
 }
 
 /** Same wiring as registerManageCorrectionsAndPipeline `config` action. */

--- a/extensions/memory-hybrid/tests/register-corrections-config-cli.test.ts
+++ b/extensions/memory-hybrid/tests/register-corrections-config-cli.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Commander-level coverage for hybrid-mem `config --json` output routing (#1519).
+ * Mirrors the config action in register-corrections-and-pipeline.ts (createConfigOutputSink + runConfigView).
+ */
+import { Command } from "commander";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { runConfigViewForCli } from "../cli/cmd-config.js";
+import { createConfigOutputSink } from "../cli/config-output-sink.js";
+import type { HandlerContext } from "../cli/handlers.js";
+import { type Chainable, withExit } from "../cli/shared.js";
+
+function makeCtx(overrides?: Partial<HandlerContext["cfg"]>): HandlerContext {
+  const cfg = {
+    mode: "minimal",
+    verbosity: "normal",
+    autoCapture: true,
+    autoRecall: { enabled: true, entityLookup: { enabled: false }, retrievalDirectives: { enabled: false } },
+    credentials: { enabled: true },
+    procedures: { enabled: true },
+    memoryTiering: { enabled: true },
+    graph: { enabled: true },
+    autoClassify: { enabled: true },
+    nightlyCycle: { enabled: false },
+    passiveObserver: { enabled: false },
+    reflection: { enabled: true },
+    personaProposals: { enabled: false },
+    selfCorrection: { enabled: true },
+    selfExtension: { enabled: true },
+    crystallization: { enabled: true },
+    extraction: { extractionPasses: true },
+    goalStewardship: { enabled: false },
+    activeTask: { enabled: true, ledger: "markdown", filePath: "ACTIVE-TASKS.md" },
+    frustrationDetection: { enabled: false },
+    crossAgentLearning: { enabled: true },
+    toolEffectiveness: { enabled: true },
+    documents: { enabled: true },
+    provenance: { enabled: true },
+    workflowTracking: { enabled: false },
+    verification: { enabled: false },
+    aliases: { enabled: false },
+    reranking: { enabled: false },
+    contextualVariants: { enabled: false },
+    errorReporting: { enabled: false },
+    costTracking: { enabled: true },
+    queryExpansion: { enabled: true },
+    wal: { enabled: true },
+    ambient: {
+      enabled: true,
+      multiQuery: false,
+      topicShiftThreshold: 0.4,
+      maxQueriesPerTrigger: 4,
+      budgetTokens: 2000,
+    },
+    futureDateProtection: { enabled: true, maxFreezeDays: 365 },
+    ...overrides,
+  } as unknown as HandlerContext["cfg"];
+
+  return {
+    cfg,
+    dataDir: ".",
+    noEmoji: false,
+    logger: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    } as unknown as HandlerContext["logger"],
+  };
+}
+
+/** Same wiring as registerManageCorrectionsAndPipeline `config` action. */
+function registerConfigCommandLikeProduction(mem: Chainable, runConfigView: ManageBindingsRunConfigView): void {
+  const configCommand = mem.command("config").description("Show current configuration and feature toggles");
+  configCommand
+    .option("--json", "Output configuration as JSON")
+    .option("--format <format>", "Output format: text (default) or json")
+    .action(
+      withExit(async (opts?: { json?: boolean; format?: string }) => {
+        const fmtRaw = (opts?.format ?? "text").trim().toLowerCase();
+        if (opts?.json && opts.format && fmtRaw !== "json") {
+          console.error("Error: do not combine --json with --format text.");
+          process.exitCode = 1;
+          return;
+        }
+        if (!opts?.json && fmtRaw !== "text" && fmtRaw !== "json") {
+          console.error(`Error: invalid --format "${opts?.format ?? ""}". Use text or json.`);
+          process.exitCode = 1;
+          return;
+        }
+        const format = opts?.json ? "json" : fmtRaw === "json" ? "json" : "text";
+        runConfigView(createConfigOutputSink(format), { format });
+      }),
+    );
+}
+
+type ManageBindingsRunConfigView = (
+  sink: ReturnType<typeof createConfigOutputSink>,
+  opts?: { format?: "text" | "json"; featuresOnly?: boolean },
+) => void;
+
+describe("hybrid-mem config CLI wiring (#1519)", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("config --json writes parseable summary JSON to stdout via createConfigOutputSink", async () => {
+    const ctx = makeCtx();
+    const program = new Command("hybrid-mem");
+    program.exitOverride();
+    registerConfigCommandLikeProduction(program, (sink, opts) => runConfigViewForCli(ctx, sink, opts));
+
+    const stdoutChunks: string[] = [];
+    const stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation((chunk) => {
+      stdoutChunks.push(String(chunk));
+      return true;
+    });
+    const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {
+      throw new Error("process.exit called");
+    }) as never);
+
+    try {
+      await program.parseAsync(["config", "--json"], { from: "user" });
+      expect(exitSpy).not.toHaveBeenCalled();
+      expect(logSpy).not.toHaveBeenCalled();
+      expect(stdoutSpy).toHaveBeenCalled();
+      const parsed = JSON.parse(stdoutChunks.join("").trim()) as Record<string, unknown>;
+      expect(parsed.contract).toBe("openclaw.hybrid-mem.config-view.summary.v1");
+      expect(stderrSpy).not.toHaveBeenCalled();
+    } finally {
+      stdoutSpy.mockRestore();
+      stderrSpy.mockRestore();
+      logSpy.mockRestore();
+      exitSpy.mockRestore();
+    }
+  });
+
+  it("config --json routes non-JSON diagnostics from runConfigView to stderr", async () => {
+    const ctx = makeCtx();
+    const program = new Command("hybrid-mem");
+    program.exitOverride();
+    registerConfigCommandLikeProduction(program, (sink, opts) => {
+      runConfigViewForCli(ctx, sink, opts);
+      if (opts?.format === "json") {
+        sink.log("note: optional config diagnostic");
+      }
+    });
+
+    const stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      await program.parseAsync(["config", "--json"], { from: "user" });
+      expect(stdoutSpy).toHaveBeenCalled();
+      expect(stderrSpy).toHaveBeenCalledWith("note: optional config diagnostic");
+    } finally {
+      stdoutSpy.mockRestore();
+      stderrSpy.mockRestore();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- **#1506:** Wrap all `storeFact` dedupe write paths (skip recall bump, boost UPDATE, merge transaction) in `runWithSqliteBusyRetry`, matching the final INSERT path. Reuse a module-scoped `Int32Array` for backoff sleep instead of allocating a new `SharedArrayBuffer` per retry.
- **#1519:** Add Commander-level tests that mirror the `config --json` action wiring (`createConfigOutputSink` + `runConfigViewForCli`), asserting parseable JSON on stdout and diagnostics on stderr.

## Test plan

- [ ] CI green on this branch
- [x] `npx vitest run tests/register-corrections-config-cli.test.ts tests/register-corrections-config-output-sink.test.ts` (local)
- [ ] Resolve remaining review threads on #1506 / #1519 after merge


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches fact persistence/dedupe write paths by adding SQLITE_BUSY retry wrappers, which could affect write behavior under contention. Test-only additions for the `config --json` CLI reduce risk but don’t fully cover runtime DB concurrency scenarios.
> 
> **Overview**
> Hardens `storeFact` against SQLite lock contention by reusing a module-scoped sleep buffer and wrapping *all* dedupe-side writes (`skip` recall bump, `boost` update, and `merge` transaction) in `runWithSqliteBusyRetry`, aligning them with the existing retry behavior on the main insert path.
> 
> Adds Commander-level tests to ensure `hybrid-mem config --json` emits parseable summary JSON on stdout via `createConfigOutputSink`, while routing non-JSON diagnostics to stderr.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 505e7b19109da31874b607bf62f492ff08cabed8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->