### PR TITLE
fix: enforce generated skill byte limit

### DIFF
--- a/extensions/memory-hybrid/config/skill-size-limits.ts
+++ b/extensions/memory-hybrid/config/skill-size-limits.ts
@@ -1,0 +1,23 @@
+/**
+ * Generated skill size limits.
+ *
+ * OpenClaw's workspace skill loader skips SKILL.md files above 256 KB. Keep
+ * this hard cap aligned with that external loader contract and enforce it
+ * before generated procedure skills are written.
+ */
+
+/** OpenClaw loader hard cap for a single SKILL.md file. */
+export const MAX_SKILL_FILE_BYTES = 256_000;
+
+/** Safer generator target that leaves room for future loader metadata changes. */
+export const MAX_SKILL_FILE_BYTES_SAFE = 200_000;
+
+/** Initial cap for generated procedure recipe sidecars. */
+export const MAX_RECIPE_FILE_BYTES = 256_000;
+
+/** Initial cap for optional generated sidecars. */
+export const MAX_SKILL_SIDECAR_BYTES = 128_000;
+
+export function utf8ByteLength(value: string): number {
+  return Buffer.byteLength(value, "utf8");
+}

--- a/extensions/memory-hybrid/services/procedure-skill-generator.ts
+++ b/extensions/memory-hybrid/services/procedure-skill-generator.ts
@@ -6,6 +6,7 @@ import { existsSync, mkdirSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import type { FactsDB } from "../backends/facts-db.js";
 import type { GenerateAutoSkillsResult } from "../cli/register.js";
+import { MAX_SKILL_FILE_BYTES, utf8ByteLength } from "../config/skill-size-limits.js";
 import type { MemoryEntry, MemoryScope, ProcedureEntry, ScopeFilter } from "../types/memory.js";
 import { SKILL_COMPLETE_MARKER, atomicWriteSkillDir } from "../utils/atomic-write.js";
 import { resolveWorkspacePath, toWorkspaceRelativePath } from "../utils/path.js";
@@ -592,6 +593,13 @@ function writeDraftSkill(
     proposalMetadataJson: string;
   },
 ): void {
+  const skillBytes = utf8ByteLength(draft.skillMd);
+  if (skillBytes > MAX_SKILL_FILE_BYTES) {
+    throw new Error(
+      `Generated SKILL.md exceeds OpenClaw loader byte limit (${skillBytes} > ${MAX_SKILL_FILE_BYTES}); refusing to write oversized auto-skill`,
+    );
+  }
+
   // Write all sidecar files atomically (temp dir → rename). SKILL.md is
   // written last among content files so it is the final content write before
   // the completion marker.

--- a/extensions/memory-hybrid/services/skill-validator.ts
+++ b/extensions/memory-hybrid/services/skill-validator.ts
@@ -22,6 +22,7 @@ import {
   getSectionTaxonomy,
   type SectionTaxonomyOverrides,
 } from "../config/skill-sections.js";
+import { MAX_SKILL_FILE_BYTES, utf8ByteLength } from "../config/skill-size-limits.js";
 export {
   CATEGORY_FRONTMATTER_KEYS,
   DEFAULT_REQUIRED_SECTIONS,
@@ -29,6 +30,7 @@ export {
   getSectionTaxonomy,
   type SectionTaxonomyOverrides,
 } from "../config/skill-sections.js";
+export { MAX_SKILL_FILE_BYTES } from "../config/skill-size-limits.js";
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -268,6 +270,13 @@ export class SkillValidator {
     const violations: string[] = [];
     const normalizedSkillContent = stripLeadingHtmlComments(skillContent);
     const lines = normalizedSkillContent.split("\n");
+    const skillBytes = utf8ByteLength(normalizedSkillContent);
+
+    if (skillBytes > MAX_SKILL_FILE_BYTES) {
+      violations.push(
+        `Skill exceeds OpenClaw loader byte limit (${skillBytes} > ${MAX_SKILL_FILE_BYTES}). Shrink SKILL.md or move deterministic detail into bounded sidecars.`,
+      );
+    }
 
     if (lines.length > MAX_SKILL_LINES) {
       violations.push(

--- a/extensions/memory-hybrid/tests/crystallization.test.ts
+++ b/extensions/memory-hybrid/tests/crystallization.test.ts
@@ -11,6 +11,7 @@ import { DatabaseSync } from "node:sqlite";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { SkillProposalValidationResult } from "../services/generated-skill-validation.js";
+import { MAX_SKILL_FILE_BYTES } from "../config/skill-size-limits.js";
 import { _testing } from "../index.js";
 
 const {
@@ -964,6 +965,13 @@ ${extra.extraBody ?? ""}`;
   it("does not require related tools/skills section", () => {
     const result = validator.validate(compactValidSkill({ includeRelated: false }));
     expect(result.valid).toBe(true);
+  });
+
+  it("rejects SKILL.md content above the OpenClaw loader byte limit even when line count is low", () => {
+    const content = compactValidSkill({ extraBody: "\n" + "a".repeat(MAX_SKILL_FILE_BYTES + 1) });
+    const result = validator.validate(content);
+    expect(result.valid).toBe(false);
+    expect(result.violations.some((v: string) => v.includes("loader byte limit"))).toBe(true);
   });
 
   it("denies eval() in code block", () => {

--- a/extensions/memory-hybrid/tests/procedure-skill-generator.test.ts
+++ b/extensions/memory-hybrid/tests/procedure-skill-generator.test.ts
@@ -215,7 +215,9 @@ describe("generateAutoSkills", () => {
 
     expect(result.generated).toBe(0);
     expect(result.skipped).toBe(1);
-    expect(result.decisions?.[0]?.reasons.some((reason) => reason.includes("skill_static_validation_failed"))).toBe(true);
+    expect(result.decisions?.[0]?.reasons.some((reason) => reason.includes("skill_static_validation_failed"))).toBe(
+      true,
+    );
     expect(existsSync(join(skillsDir, "validate-huge-generated-skill-output"))).toBe(false);
     expect(db.getProcedureById(proc.id)?.promotedToSkill).toBe(0);
   });

--- a/extensions/memory-hybrid/tests/procedure-skill-generator.test.ts
+++ b/extensions/memory-hybrid/tests/procedure-skill-generator.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join, relative } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { FactsDB } from "../backends/facts-db.js";
+import { MAX_SKILL_FILE_BYTES } from "../config/skill-size-limits.js";
 import { generateAutoSkillForProcedure, generateAutoSkills } from "../services/procedure-skill-generator.js";
 import { getEnv, setEnv } from "../utils/env-manager.js";
 import { SKILL_COMPLETE_MARKER } from "../utils/atomic-write.js";
@@ -173,6 +174,50 @@ describe("generateAutoSkills", () => {
     expect(updated?.promotedToSkill).toBe(1);
     expect(updated?.skillPath).toContain("check-moltbook-notifications");
     expect(updated?.skillState).toBe("experimental");
+  });
+
+  it("does not write or mark promoted when generated SKILL.md would exceed the loader byte limit", () => {
+    const hugeSummary = "Verify bounded output " + "a".repeat(Math.ceil(MAX_SKILL_FILE_BYTES / 2));
+    const proc = db.upsertProcedure({
+      taskPattern: "Validate huge generated skill output",
+      recipeJson: JSON.stringify([
+        { tool: "read", args: { path: "status.json" }, summary: hugeSummary },
+        { tool: "exec", args: { command: "npm test" }, summary: hugeSummary },
+        { tool: "read", args: { path: "report.json" }, summary: hugeSummary },
+      ]),
+      procedureType: "positive",
+      successCount: 3,
+      confidence: 0.9,
+      sourceSessionId: "huge-s1",
+      ttlDays: 30,
+    });
+    recordDistinctSuccesses(proc.id);
+
+    const previousWorkspace = getEnv("OPENCLAW_WORKSPACE");
+    setEnv("OPENCLAW_WORKSPACE", tmpDir);
+    let result: ReturnType<typeof generateAutoSkills>;
+    try {
+      result = generateAutoSkills(
+        db,
+        {
+          skillsAutoPath: skillsDir,
+          validationThreshold: 3,
+          skillTTLDays: 30,
+          apply: true,
+          policy: "auto-safe",
+        },
+        { info: () => {}, warn: () => {} },
+      );
+    } finally {
+      if (previousWorkspace !== undefined) setEnv("OPENCLAW_WORKSPACE", previousWorkspace);
+      else setEnv("OPENCLAW_WORKSPACE", undefined);
+    }
+
+    expect(result.generated).toBe(0);
+    expect(result.skipped).toBe(1);
+    expect(result.decisions[0]?.reasons.some((reason) => reason.includes("skill_static_validation_failed"))).toBe(true);
+    expect(existsSync(join(skillsDir, "validate-huge-generated-skill-output"))).toBe(false);
+    expect(db.getProcedureById(proc.id)?.promotedToSkill).toBe(0);
   });
 
   it("keeps collision-adjusted draft metadata aligned with the output directory", () => {

--- a/extensions/memory-hybrid/tests/procedure-skill-generator.test.ts
+++ b/extensions/memory-hybrid/tests/procedure-skill-generator.test.ts
@@ -215,7 +215,7 @@ describe("generateAutoSkills", () => {
 
     expect(result.generated).toBe(0);
     expect(result.skipped).toBe(1);
-    expect(result.decisions[0]?.reasons.some((reason) => reason.includes("skill_static_validation_failed"))).toBe(true);
+    expect(result.decisions?.[0]?.reasons.some((reason) => reason.includes("skill_static_validation_failed"))).toBe(true);
     expect(existsSync(join(skillsDir, "validate-huge-generated-skill-output"))).toBe(false);
     expect(db.getProcedureById(proc.id)?.promotedToSkill).toBe(0);
   });


### PR DESCRIPTION
## Summary

- Add shared generated-skill byte limit constants aligned with OpenClaw's 256 KB loader cap.
- Make SkillValidator reject low-line-count but oversized SKILL.md content by UTF-8 byte length.
- Add a write-time fail-closed guard so generated procedure skills above the loader cap are not written or marked promoted.
- Add regression coverage for validator and generator behavior on oversized generated skill output.

Fixes #1537.
Related follow-ups: #1538, #1539, #1540, #1541, #1542.

## Verification

- npm test -- --run tests/crystallization.test.ts tests/procedure-skill-generator.test.ts
- npm run format:check -- config/skill-size-limits.ts services/skill-validator.ts services/procedure-skill-generator.ts tests/crystallization.test.ts tests/procedure-skill-generator.test.ts
- npm run build

## Notes

npm run lint -- ... is currently not path-scoped because the package script always passes . to Biome; it reports the repository's existing lint-warning backlog. No new lint-specific issue was identified in the edited files during format/build/test verification.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new byte-size validation and a hard write-time guard that can cause previously-generated auto-skills to be skipped/failed if they exceed the loader cap, affecting promotion outcomes. Risk is limited to the memory-hybrid skill generation/validation path and is covered by new regression tests.
> 
> **Overview**
> Introduces shared size-limit constants in `config/skill-size-limits.ts` (including the 256KB OpenClaw `SKILL.md` cap) plus a UTF-8 byte counter.
> 
> Updates `SkillValidator` to fail static validation when `SKILL.md` exceeds the byte limit (even if line counts are low), and exports `MAX_SKILL_FILE_BYTES` for downstream checks.
> 
> Adds a fail-closed check in `procedure-skill-generator` to refuse writing oversized generated `SKILL.md` files (preventing on-disk draft creation and `promotedToSkill` marking), with new tests covering both validator and generator behavior for oversized content.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2a50a24e5d73f546033acbc808f9824f445f2cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->