### PR TITLE
fix: active-task facts ledger must not inject arbitrary project entities as in-progress tasks (#1556)

### DIFF
--- a/extensions/memory-hybrid/cli/active-tasks.ts
+++ b/extensions/memory-hybrid/cli/active-tasks.ts
@@ -189,7 +189,10 @@ export async function runActiveTaskComplete(ctx: ActiveTaskContext, label: strin
   if (ctx.ledger === "facts") {
     const { factsDb, vectorDb, embeddings } = requireFacts(ctx);
     const { active } = loadTaskLedgerFromFacts(factsDb);
-    const { completed } = completeTask(active, label);
+    const normalizedLabel = label.trim().toLowerCase();
+    const matchedTask = active.find((t) => t.label.toLowerCase() === normalizedLabel);
+    const labelToUse = matchedTask?.label ?? label;
+    const { completed } = completeTask(active, labelToUse);
     if (!completed) {
       return { ok: false, error: `No active task found with label "${label}"` };
     }
@@ -249,8 +252,13 @@ export async function runActiveTaskAdd(
   if (ctx.ledger === "facts") {
     const { factsDb, vectorDb, embeddings } = requireFacts(ctx);
     const { active, completed } = loadTaskLedgerFromFacts(factsDb);
-    const wasExisting = active.some((t) => t.label === opts.label) || completed.some((t) => t.label === opts.label);
-    const existing = active.find((t) => t.label === opts.label) ?? completed.find((t) => t.label === opts.label);
+    const normalizedLabel = opts.label.trim().toLowerCase();
+    const wasExisting =
+      active.some((t) => t.label.toLowerCase() === normalizedLabel) ||
+      completed.some((t) => t.label.toLowerCase() === normalizedLabel);
+    const existing =
+      active.find((t) => t.label.toLowerCase() === normalizedLabel) ??
+      completed.find((t) => t.label.toLowerCase() === normalizedLabel);
     const status: ActiveTaskStatus = (() => {
       if (opts.status && ACTIVE_TASK_STATUSES.includes(opts.status as ActiveTaskStatus)) {
         return opts.status as ActiveTaskStatus;
@@ -258,7 +266,7 @@ export async function runActiveTaskAdd(
       return existing?.status ?? "In progress";
     })();
     const entry: ActiveTaskEntry = {
-      label: opts.label,
+      label: opts.label.trim().toLowerCase(),
       description: opts.description,
       status,
       branch: opts.branch ?? existing?.branch,

--- a/extensions/memory-hybrid/lifecycle/stage-active-task.ts
+++ b/extensions/memory-hybrid/lifecycle/stage-active-task.ts
@@ -55,7 +55,9 @@ export function registerActiveTaskInjection(
       let longRunningBlock = "";
       if (proposal) {
         const draft = buildLongRunningTaskDraft(proposal);
-        const alreadyActive = activeForInjection.some((t) => t.label === draft.label);
+        const alreadyActive = activeForInjection.some(
+          (t) => t.label.toLowerCase() === draft.label.toLowerCase(),
+        );
         let autoCreated = false;
 
         if (!alreadyActive && shouldAutoRegisterLongRunningTask(longRunningMode, sessionKey)) {

--- a/extensions/memory-hybrid/lifecycle/stage-active-task.ts
+++ b/extensions/memory-hybrid/lifecycle/stage-active-task.ts
@@ -55,9 +55,7 @@ export function registerActiveTaskInjection(
       let longRunningBlock = "";
       if (proposal) {
         const draft = buildLongRunningTaskDraft(proposal);
-        const alreadyActive = activeForInjection.some(
-          (t) => t.label.toLowerCase() === draft.label.toLowerCase(),
-        );
+        const alreadyActive = activeForInjection.some((t) => t.label.toLowerCase() === draft.label.toLowerCase());
         let autoCreated = false;
 
         if (!alreadyActive && shouldAutoRegisterLongRunningTask(longRunningMode, sessionKey)) {

--- a/extensions/memory-hybrid/services/active-task-checkpoint.ts
+++ b/extensions/memory-hybrid/services/active-task-checkpoint.ts
@@ -294,10 +294,11 @@ function primeLatestProjectFactCacheForEntityKeys(
   entity: string,
   keys: readonly string[],
 ): void {
+  const normalizedEntity = entity.trim().toLowerCase();
   for (const key of keys) {
     const normalizedKey = key.trim();
     if (!normalizedKey) continue;
-    const cacheKey = taskEntityKey(entity, normalizedKey);
+    const cacheKey = taskEntityKey(normalizedEntity, normalizedKey);
     if (cache.has(cacheKey)) continue;
     const hit = factsDb.lookup(entity, normalizedKey, undefined, { includeSuperseded: false, limit: 1 })[0]?.entry;
     if (!hit) continue;
@@ -307,7 +308,8 @@ function primeLatestProjectFactCacheForEntityKeys(
 }
 
 function getLatestProjectValue(cache: Map<string, MemoryEntry>, entity: string, key: string): string | undefined {
-  const row = cache.get(taskEntityKey(entity, key));
+  const normalizedEntity = entity.trim().toLowerCase();
+  const row = cache.get(taskEntityKey(normalizedEntity, key));
   if (!row) return undefined;
   if (typeof row.value === "string") return row.value.trim();
   if (typeof row.text === "string") {

--- a/extensions/memory-hybrid/services/task-ledger-facts.ts
+++ b/extensions/memory-hybrid/services/task-ledger-facts.ts
@@ -53,12 +53,14 @@ export type ActiveTaskProjectionStatus = {
   marker: ActiveTaskProjectionStaleMarker | null;
 };
 
-/** Latest value per entity+key from non-superseded project facts */
+/** Latest value per entity+key from non-superseded project facts.
+ *  Entity labels are normalised to lowercase (trim + toLowerCase) so that
+ *  case-variant entries (e.g. "Humanizer" / "humanizer") are merged into one group. */
 export function groupProjectFactsByEntity(facts: MemoryEntry[]): Map<string, Map<string, MemoryEntry>> {
   const byEntity = new Map<string, Map<string, MemoryEntry>>();
   for (const f of facts) {
     if (!f.entity?.trim()) continue;
-    const ent = f.entity.trim();
+    const ent = f.entity.trim().toLowerCase();
     const k = (f.key ?? "").trim() || "_body";
     let km = byEntity.get(ent);
     if (!km) {
@@ -174,7 +176,9 @@ export function buildTaskEntriesFromGroupedFacts(byEntity: Map<string, Map<strin
   for (const [entity, keyMap] of sorted) {
     const f = rowToRecord(keyMap);
     const bounds = createdBoundsFromKeyMap(keyMap);
-    const statusRaw = (f.status ?? "open").trim();
+    // Entities with no explicit `status` key must not default to in-progress.
+    const statusRaw = f.status?.trim();
+    if (!statusRaw) continue;
     const disp = factStatusToDisplay(statusRaw);
     const started = resolveTaskStarted(f, bounds);
     const updated = resolveTaskUpdated(f, bounds);
@@ -219,7 +223,7 @@ export function loadTaskLedgerFromFacts(
 } {
   const facts = factsDb
     .getAll({ scopeFilter })
-    .filter((fact) => fact.category === TASK_LEDGER_CATEGORY)
+    .filter((fact) => fact.category === TASK_LEDGER_CATEGORY && fact.source === "active-task")
     .slice(0, factLimit);
   const grouped = groupProjectFactsByEntity(facts);
   return buildTaskEntriesFromGroupedFacts(grouped);
@@ -788,22 +792,26 @@ export async function upsertProjectTaskKey(
   log?: { warn?: (m: string) => void },
   opts?: { latestByEntityKey?: Map<string, MemoryEntry> },
 ): Promise<void> {
-  const cacheKey = taskEntityKey(entity, key);
+  // Normalise entity labels on write (trim + lowercase) to prevent case-variant
+  // collisions (e.g. "Humanizer" and "humanizer" stored as separate entities).
+  const normalizedEntity = entity.trim().toLowerCase();
+  const cacheKey = taskEntityKey(normalizedEntity, key);
   let previous: MemoryEntry | undefined;
   if (opts?.latestByEntityKey) {
     previous = opts.latestByEntityKey.get(cacheKey);
   } else {
     const facts = factsDb.listFactsByCategory(TASK_LEDGER_CATEGORY, 8000);
-    const same = facts.filter((f) => f.entity === entity && (f.key ?? "") === key);
+    // Case-insensitive lookup so mixed-case legacy facts are also superseded.
+    const same = facts.filter((f) => f.entity?.toLowerCase() === normalizedEntity && (f.key ?? "") === key);
     same.sort((a, b) => b.createdAt - a.createdAt);
     previous = same[0];
   }
-  const text = `Task [${entity}] ${key}: ${value}`;
+  const text = `Task [${normalizedEntity}] ${key}: ${value}`;
   const entry = factsDb.store({
     text,
     category: TASK_LEDGER_CATEGORY,
     importance: CLI_STORE_IMPORTANCE,
-    entity,
+    entity: normalizedEntity,
     key,
     value,
     source: "active-task",
@@ -917,7 +925,7 @@ export async function applyActiveTaskHygieneFacts(
   const byLabel = new Map(active.map((task) => [task.label, task] as const));
   const latestByEntityKey = new Map<string, MemoryEntry>();
   for (const fact of factsDb.listFactsByCategory(TASK_LEDGER_CATEGORY, 8000)) {
-    const entity = fact.entity?.trim();
+    const entity = fact.entity?.trim().toLowerCase();
     if (!entity) continue;
     const key = (fact.key ?? "").trim();
     const cacheKey = taskEntityKey(entity, key);

--- a/extensions/memory-hybrid/services/task-ledger-facts.ts
+++ b/extensions/memory-hybrid/services/task-ledger-facts.ts
@@ -802,7 +802,10 @@ export async function upsertProjectTaskKey(
   } else {
     const facts = factsDb.listFactsByCategory(TASK_LEDGER_CATEGORY, 8000);
     // Case-insensitive lookup so mixed-case legacy facts are also superseded.
-    const same = facts.filter((f) => f.entity?.toLowerCase() === normalizedEntity && (f.key ?? "") === key);
+    // Only supersede facts from the active-task ledger (source:"active-task"), not memory_store.
+    const same = facts.filter(
+      (f) => f.source === "active-task" && f.entity?.toLowerCase() === normalizedEntity && (f.key ?? "") === key,
+    );
     same.sort((a, b) => b.createdAt - a.createdAt);
     previous = same[0];
   }
@@ -924,7 +927,9 @@ export async function applyActiveTaskHygieneFacts(
   const { active } = loadTaskLedgerFromFacts(factsDb);
   const byLabel = new Map(active.map((task) => [task.label, task] as const));
   const latestByEntityKey = new Map<string, MemoryEntry>();
+  // Only index active-task ledger facts, not memory_store project facts.
   for (const fact of factsDb.listFactsByCategory(TASK_LEDGER_CATEGORY, 8000)) {
+    if (fact.source !== "active-task") continue;
     const entity = fact.entity?.trim().toLowerCase();
     if (!entity) continue;
     const key = (fact.key ?? "").trim();

--- a/extensions/memory-hybrid/services/task-ledger-facts.ts
+++ b/extensions/memory-hybrid/services/task-ledger-facts.ts
@@ -797,14 +797,14 @@ export async function upsertProjectTaskKey(
   const normalizedEntity = entity.trim().toLowerCase();
   const cacheKey = taskEntityKey(normalizedEntity, key);
   let previous: MemoryEntry | undefined;
-  if (opts?.latestByEntityKey) {
-    const cached = opts.latestByEntityKey.get(cacheKey);
-    // Keep supersession scoped to active-task ledger rows only; cached
-    // memory_store rows must never be retired by active-task checkpoints.
-    if (cached?.source === "active-task") {
-      previous = cached;
-    }
-  } else {
+  const cached = opts?.latestByEntityKey?.get(cacheKey);
+  // Keep supersession scoped to active-task ledger rows only; cached
+  // memory_store rows must never be retired by active-task checkpoints.
+  if (cached?.source === "active-task") {
+    previous = cached;
+  } else if (!opts?.latestByEntityKey || cached) {
+    // Query database if: (a) no cache was provided, or (b) cache had a non-active-task
+    // entry (which we must not supersede, but an active-task row may still exist).
     const facts = factsDb.listFactsByCategory(TASK_LEDGER_CATEGORY, 8000);
     // Case-insensitive lookup so mixed-case legacy facts are also superseded.
     // Only supersede facts from the active-task ledger (source:"active-task"), not memory_store.

--- a/extensions/memory-hybrid/services/task-ledger-facts.ts
+++ b/extensions/memory-hybrid/services/task-ledger-facts.ts
@@ -798,7 +798,12 @@ export async function upsertProjectTaskKey(
   const cacheKey = taskEntityKey(normalizedEntity, key);
   let previous: MemoryEntry | undefined;
   if (opts?.latestByEntityKey) {
-    previous = opts.latestByEntityKey.get(cacheKey);
+    const cached = opts.latestByEntityKey.get(cacheKey);
+    // Keep supersession scoped to active-task ledger rows only; cached
+    // memory_store rows must never be retired by active-task checkpoints.
+    if (cached?.source === "active-task") {
+      previous = cached;
+    }
   } else {
     const facts = factsDb.listFactsByCategory(TASK_LEDGER_CATEGORY, 8000);
     // Case-insensitive lookup so mixed-case legacy facts are also superseded.

--- a/extensions/memory-hybrid/services/task-ledger-facts.ts
+++ b/extensions/memory-hybrid/services/task-ledger-facts.ts
@@ -1097,7 +1097,8 @@ export async function consumePendingTaskSignalsFacts(
   const active = detectStaleTasks(rawActive, staleMinutes);
 
   const findMatchingTask = (activeEntries: ActiveTaskEntry[], signal: PendingTaskSignal): ActiveTaskEntry | null => {
-    const byLabel = activeEntries.filter((t) => t.label === signal.taskRef);
+    const normalizedTaskRef = signal.taskRef.trim().toLowerCase();
+    const byLabel = activeEntries.filter((t) => t.label.toLowerCase() === normalizedTaskRef);
     if (byLabel.length === 1) return byLabel[0];
     if (byLabel.length > 1) {
       logger?.warn?.(`memory-hybrid: multiple active tasks share label ${signal.taskRef}; leaving signal pending`);

--- a/extensions/memory-hybrid/tests/context-audit.test.ts
+++ b/extensions/memory-hybrid/tests/context-audit.test.ts
@@ -45,7 +45,8 @@ describe("runContextAudit", () => {
         key: "status",
         value: "in_progress",
         text: "context audit alias status in progress",
-        source: "test",
+        // Must use source:"active-task" so loadTaskLedgerFromFacts picks it up (fix #1556).
+        source: "active-task",
         importance: 0.5,
         decayClass: "permanent",
       },

--- a/extensions/memory-hybrid/tests/memory-tools-embedding-registry.test.ts
+++ b/extensions/memory-hybrid/tests/memory-tools-embedding-registry.test.ts
@@ -631,8 +631,33 @@ describe("memory tools embedding registry wiring", () => {
       findSimilarByEmbedding as never,
     );
 
+    // Pre-load a real active-task-marked task so it appears in the projection.
+    // (memory_store uses source:"memory_store"; only source:"active-task" facts
+    // appear in the active-task ledger — fix #1556.)
+    factsDb.store({
+      text: "Task [task-1272] status: in_progress",
+      category: "project",
+      entity: "task-1272",
+      key: "status",
+      value: "in_progress",
+      source: "active-task",
+      importance: 0.9,
+      decayClass: "permanent",
+    });
+    factsDb.store({
+      text: "Task [task-1272] title: Ship lightweight active-task snapshot",
+      category: "project",
+      entity: "task-1272",
+      key: "title",
+      value: "Ship lightweight active-task snapshot",
+      source: "active-task",
+      importance: 0.9,
+      decayClass: "permanent",
+    });
+
     const tool = api.getTool("memory_store");
     expect(tool).toBeTruthy();
+    // This memory_store write triggers the projection refresh.
     await tool?.execute("tool-call", {
       text: "Task title: ship lightweight active-task snapshot",
       category: "project",

--- a/extensions/memory-hybrid/tests/plugin-e2e.test.ts
+++ b/extensions/memory-hybrid/tests/plugin-e2e.test.ts
@@ -13,10 +13,10 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { IssueStore } from "../backends/issue-store.js";
-import { type ActiveTaskProjectionConfig, hybridConfigSchema } from "../config.js";
+import { hybridConfigSchema } from "../config.js";
 import memoryHybridPlugin from "../index.js";
 import { _testing } from "../index.js";
-import { applyActiveTaskProjectionFilters, loadTaskLedgerFromFacts } from "../services/task-ledger-facts.js";
+import { groupProjectFactsByEntity } from "../services/task-ledger-facts.js";
 import { closeOldDatabases, initializeDatabases } from "../setup/init-databases.js";
 import { registerTools } from "../setup/register-tools.js";
 
@@ -609,13 +609,6 @@ describe("Core and common flows e2e", () => {
     const storeTool = api.getTool("memory_store");
     const entity = "stewardship-reliability-reset";
     const title = "Stewardship reliability reset and hardening";
-    const projection: ActiveTaskProjectionConfig = {
-      mode: "readable",
-      excludeGenericTitle: true,
-      titleMinChars: 0,
-      dedupeBy: "none",
-      sectioned: true,
-    };
 
     await storeTool?.execute("call-1", {
       text: "Task status in progress",
@@ -650,9 +643,6 @@ describe("Core and common flows e2e", () => {
       importance: 0.8,
     });
 
-    const beforeTitle = applyActiveTaskProjectionFilters(loadTaskLedgerFromFacts(factsDb).active, projection);
-    expect(beforeTitle).toHaveLength(0);
-
     const titleResult = (await storeTool?.execute("call-5", {
       text: title,
       category: "project",
@@ -664,13 +654,17 @@ describe("Core and common flows e2e", () => {
       details?: { action?: string; id?: string };
     };
 
+    // Key-awareness: the title key write must not be mistaken for a duplicate.
     expect(titleResult.details?.action).not.toBe("duplicate");
     expect(titleResult.details?.id).toBeDefined();
 
-    const afterTitle = applyActiveTaskProjectionFilters(loadTaskLedgerFromFacts(factsDb).active, projection);
-    expect(afterTitle).toHaveLength(1);
-    expect(afterTitle[0].label).toBe(entity);
-    expect(afterTitle[0].description).toBe(title);
+    // memory_store writes use source:"memory_store", not source:"active-task",
+    // so they must NOT appear in the active-task projection (fix #1556).
+    // Verify the raw key-aware DB state instead.
+    const projectRows = groupProjectFactsByEntity(factsDb.listFactsByCategory("project", 100));
+    const row = projectRows.get(entity);
+    expect(row?.get("title")?.value).toBe(title);
+    expect(row?.get("status")?.value).toBe("in_progress");
   });
 });
 

--- a/extensions/memory-hybrid/tests/public-api-routes.test.ts
+++ b/extensions/memory-hybrid/tests/public-api-routes.test.ts
@@ -307,7 +307,7 @@ describe("registerPublicApiRoutes", () => {
       entity: "task-1272",
       key: "title",
       value: "Ship active-task endpoint",
-      source: "conversation",
+      source: "active-task",
     });
     factsDb.store({
       text: "Task status: in progress",
@@ -316,7 +316,7 @@ describe("registerPublicApiRoutes", () => {
       entity: "task-1272",
       key: "status",
       value: "in_progress",
-      source: "conversation",
+      source: "active-task",
     });
 
     const { api, routes } = makeApi();
@@ -363,7 +363,7 @@ describe("registerPublicApiRoutes", () => {
       entity: "task-1272",
       key: "next",
       value: "Wire tests",
-      source: "conversation",
+      source: "active-task",
     });
 
     const staleAgainRes = await invokeNodeHttpRoute(
@@ -384,7 +384,7 @@ describe("registerPublicApiRoutes", () => {
       entity: "task-global",
       key: "title",
       value: "Global task",
-      source: "conversation",
+      source: "active-task",
       scope: "global",
       scopeTarget: null,
     });
@@ -395,7 +395,7 @@ describe("registerPublicApiRoutes", () => {
       entity: "task-global",
       key: "status",
       value: "in_progress",
-      source: "conversation",
+      source: "active-task",
       scope: "global",
       scopeTarget: null,
     });
@@ -406,7 +406,7 @@ describe("registerPublicApiRoutes", () => {
       entity: "task-agent-a",
       key: "title",
       value: "Agent A task",
-      source: "conversation",
+      source: "active-task",
       scope: "agent",
       scopeTarget: "agent-a",
     });
@@ -417,7 +417,7 @@ describe("registerPublicApiRoutes", () => {
       entity: "task-agent-a",
       key: "status",
       value: "in_progress",
-      source: "conversation",
+      source: "active-task",
       scope: "agent",
       scopeTarget: "agent-a",
     });

--- a/extensions/memory-hybrid/tests/task-ledger-facts.test.ts
+++ b/extensions/memory-hybrid/tests/task-ledger-facts.test.ts
@@ -17,6 +17,8 @@ import {
   groupProjectFactsByEntity,
   loadTaskLedgerFromFacts,
   planActiveTaskHygiene,
+  taskEntityKey,
+  upsertProjectTaskKey,
 } from "../services/task-ledger-facts.js";
 import type { MemoryEntry } from "../types/memory.js";
 
@@ -407,6 +409,55 @@ describe("task-ledger-facts", () => {
       // incomplete-task has no status key — must be excluded, not defaulted to in-progress.
       expect(allLabels).not.toContain("incomplete-task");
       expect(allLabels).toContain("proper-task");
+    } finally {
+      db.close();
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("upsertProjectTaskKey does not supersede cached memory_store rows", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "task-ledger-upsert-source-filter-"));
+    const db = new FactsDB(join(dir, "facts.db"));
+    const vectorDb = {
+      hasDuplicate: async () => true,
+      store: async () => {},
+    } as unknown as VectorDB;
+    const embeddings = {
+      modelName: "test-model",
+      embed: async () => new Float32Array([0.1, 0.2, 0.3]),
+    } as unknown as EmbeddingProvider;
+    try {
+      const memoryStoreFact = db.store({
+        category: "project",
+        importance: 0.7,
+        source: "memory_store",
+        decayClass: "permanent",
+        entity: "proj-1273",
+        key: "status",
+        value: "legacy-note",
+        text: "Task [proj-1273] status: legacy-note",
+      });
+      const latestByEntityKey = new Map<string, MemoryEntry>();
+      latestByEntityKey.set(taskEntityKey("proj-1273", "status"), memoryStoreFact);
+
+      await upsertProjectTaskKey(
+        db,
+        vectorDb,
+        embeddings,
+        "PROJ-1273",
+        "status",
+        "in_progress",
+        undefined,
+        { latestByEntityKey },
+      );
+
+      const untouched = db.getById(memoryStoreFact.id);
+      expect(untouched?.supersededBy).toBeNull();
+
+      const activeRows = db
+        .listFactsByCategory("project", 100)
+        .filter((row) => row.entity === "proj-1273" && row.key === "status" && row.source === "active-task");
+      expect(activeRows.length).toBeGreaterThanOrEqual(1);
     } finally {
       db.close();
       await rm(dir, { recursive: true, force: true });

--- a/extensions/memory-hybrid/tests/task-ledger-facts.test.ts
+++ b/extensions/memory-hybrid/tests/task-ledger-facts.test.ts
@@ -416,7 +416,14 @@ describe("task-ledger-facts", () => {
   it("groupProjectFactsByEntity merges case-variant entities under a normalised lowercase key", () => {
     const rows: MemoryEntry[] = [
       fact({ id: "h1", entity: "Humanizer", key: "status", value: "in_progress", createdAt: 1, source: "active-task" }),
-      fact({ id: "h2", entity: "humanizer", key: "title", value: "Humanizer task", createdAt: 2, source: "active-task" }),
+      fact({
+        id: "h2",
+        entity: "humanizer",
+        key: "title",
+        value: "Humanizer task",
+        createdAt: 2,
+        source: "active-task",
+      }),
       fact({ id: "h3", entity: "HUMANIZER", key: "next", value: "do stuff", createdAt: 3, source: "active-task" }),
     ];
     const g = groupProjectFactsByEntity(rows);

--- a/extensions/memory-hybrid/tests/task-ledger-facts.test.ts
+++ b/extensions/memory-hybrid/tests/task-ledger-facts.test.ts
@@ -440,16 +440,9 @@ describe("task-ledger-facts", () => {
       const latestByEntityKey = new Map<string, MemoryEntry>();
       latestByEntityKey.set(taskEntityKey("proj-1273", "status"), memoryStoreFact);
 
-      await upsertProjectTaskKey(
-        db,
-        vectorDb,
-        embeddings,
-        "PROJ-1273",
-        "status",
-        "in_progress",
-        undefined,
-        { latestByEntityKey },
-      );
+      await upsertProjectTaskKey(db, vectorDb, embeddings, "PROJ-1273", "status", "in_progress", undefined, {
+        latestByEntityKey,
+      });
 
       const untouched = db.getById(memoryStoreFact.id);
       expect(untouched?.supersededBy).toBeNull();

--- a/extensions/memory-hybrid/tests/task-ledger-facts.test.ts
+++ b/extensions/memory-hybrid/tests/task-ledger-facts.test.ts
@@ -268,7 +268,8 @@ describe("task-ledger-facts", () => {
       const base = {
         category: "project",
         importance: 0.7,
-        source: "test",
+        // Use "active-task" source so loadTaskLedgerFromFacts picks these up.
+        source: "active-task",
         decayClass: "permanent" as const,
         entity,
       };
@@ -323,5 +324,107 @@ describe("task-ledger-facts", () => {
       db.close();
       await rm(dir, { recursive: true, force: true });
     }
+  });
+
+  it("loadTaskLedgerFromFacts ignores category:project facts without source='active-task'", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "task-ledger-source-filter-"));
+    const db = new FactsDB(join(dir, "facts.db"));
+    try {
+      // Arbitrary project entity stored without the active-task marker.
+      db.store({
+        category: "project",
+        importance: 0.7,
+        source: "memory_store",
+        decayClass: "permanent",
+        entity: "some-random-note",
+        key: "pr_1338_plan",
+        value: "some plan text",
+        text: "Task [some-random-note] pr_1338_plan: some plan text",
+      });
+      // Another arbitrary entity — no status key at all.
+      db.store({
+        category: "project",
+        importance: 0.7,
+        source: "memory_store",
+        decayClass: "permanent",
+        entity: "release-history",
+        key: "v1.0",
+        value: "initial release",
+        text: "Task [release-history] v1.0: initial release",
+      });
+      // A real active task — has the marker.
+      db.store({
+        category: "project",
+        importance: 0.7,
+        source: "active-task",
+        decayClass: "permanent",
+        entity: "real-active-task",
+        key: "status",
+        value: "in_progress",
+        text: "Task [real-active-task] status: in_progress",
+      });
+
+      const { active, completed } = loadTaskLedgerFromFacts(db);
+      const allLabels = [...active, ...completed].map((t) => t.label);
+      expect(allLabels).not.toContain("some-random-note");
+      expect(allLabels).not.toContain("release-history");
+      expect(allLabels).toContain("real-active-task");
+    } finally {
+      db.close();
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("loadTaskLedgerFromFacts excludes active-task entities that have no status key", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "task-ledger-no-status-"));
+    const db = new FactsDB(join(dir, "facts.db"));
+    try {
+      // Active-task marker present but no status key written yet.
+      db.store({
+        category: "project",
+        importance: 0.7,
+        source: "active-task",
+        decayClass: "permanent",
+        entity: "incomplete-task",
+        key: "title",
+        value: "Not yet started",
+        text: "Task [incomplete-task] title: Not yet started",
+      });
+      // Properly formed active task.
+      db.store({
+        category: "project",
+        importance: 0.7,
+        source: "active-task",
+        decayClass: "permanent",
+        entity: "proper-task",
+        key: "status",
+        value: "in_progress",
+        text: "Task [proper-task] status: in_progress",
+      });
+
+      const { active, completed } = loadTaskLedgerFromFacts(db);
+      const allLabels = [...active, ...completed].map((t) => t.label);
+      // incomplete-task has no status key — must be excluded, not defaulted to in-progress.
+      expect(allLabels).not.toContain("incomplete-task");
+      expect(allLabels).toContain("proper-task");
+    } finally {
+      db.close();
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("groupProjectFactsByEntity merges case-variant entities under a normalised lowercase key", () => {
+    const rows: MemoryEntry[] = [
+      fact({ id: "h1", entity: "Humanizer", key: "status", value: "in_progress", createdAt: 1, source: "active-task" }),
+      fact({ id: "h2", entity: "humanizer", key: "title", value: "Humanizer task", createdAt: 2, source: "active-task" }),
+      fact({ id: "h3", entity: "HUMANIZER", key: "next", value: "do stuff", createdAt: 3, source: "active-task" }),
+    ];
+    const g = groupProjectFactsByEntity(rows);
+    // All three variants should collapse into one group keyed by the lowercase label.
+    expect(g.size).toBe(1);
+    expect(g.has("humanizer")).toBe(true);
+    expect(g.get("humanizer")?.get("status")?.value).toBe("in_progress");
+    expect(g.get("humanizer")?.get("title")?.value).toBe("Humanizer task");
+    expect(g.get("humanizer")?.get("next")?.value).toBe("do stuff");
   });
 });


### PR DESCRIPTION
<!-- issue-stewardship-pr issue:1556 -->
Fixes #1556

Issue: https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/1556

Status: draft implementation PR created by Issue Stewardship as Markus/current gh auth.
Protection: keep as draft and `stage/implementing` until Issue Stewardship dispatches/receives implementation and explicitly hands off to PR Stewardship.

Enrichment present on issue: 1
Priority inherited from issue: Critical (source labels: priority:critical)
Dependencies/blocked labels inherited from issue: none

Implementation PR created by Issue Stewardship. Detailed enrichment should be attached to the issue before Copilot implementation dispatch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how facts-backed active tasks are identified and grouped (source filtering + case-insensitive normalization), which can affect what gets injected/rendered and what gets superseded in the facts DB. Risk is moderate because it alters task ledger data selection and write/supersession behavior, but is limited to the active-task subsystem.
> 
> **Overview**
> Prevents arbitrary `category:project` facts from being treated as active tasks by **requiring `source:"active-task"`** when loading/rendering the facts-backed task ledger, and by **skipping entities that lack an explicit `status` key**.
> 
> Normalizes task identity to be **case-insensitive/lowercased** across grouping, matching, and writes (CLI add/complete, long-running auto-registration checks, pending signal matching, checkpoint cache keys), and updates `upsertProjectTaskKey` so it **only supersedes prior `active-task` facts** (never `memory_store`) while still handling legacy mixed-case rows.
> 
> Tests are updated/expanded to reflect the new source filter and normalization, including coverage for statusless exclusion, non-`active-task` project facts being ignored, and ensuring `memory_store` writes don’t appear in the active-task projection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40871f822207fa5404e855b228f090ffa273d589. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->