### PR TITLE
fix: auto-capture stores chain-of-thought and prompt artifacts as memory facts

### DIFF
--- a/docs/1560.md
+++ b/docs/1560.md
@@ -10,8 +10,6 @@ Status: WIP scaffold PR only — implementation pending.
 - Priority label: priority:critical
 - Labels: bug, priority:critical, issue/stage/enriching
 
-## Acceptance Criteria / Issue Body
-
 ## Summary
 
 The `agent_end` auto-capture path extracts raw text from every user and assistant message and stores it as a memory fact if it passes `shouldCapture()`. That function has no guard against chain-of-thought artifacts (`think`, `<think>`, `model think`, `Thinking Process`) or classifier prompt/output text. The result is hundreds of current facts that are raw LLM reasoning traces, classifier outputs, and capability hint blocks — exactly the garbage that pollutes hot memories and progressive recall.

--- a/docs/1560.md
+++ b/docs/1560.md
@@ -1,0 +1,58 @@
+# Issue #1560: fix: auto-capture stores chain-of-thought and prompt artifacts as memory facts
+
+Status: WIP scaffold PR only — implementation pending.
+
+## Source Issue
+
+- Issue: #1560
+- URL: https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/1560
+- State: OPEN
+- Priority label: priority:critical
+- Labels: bug, priority:critical, issue/stage/enriching
+
+## Acceptance Criteria / Issue Body
+
+## Summary
+
+The `agent_end` auto-capture path extracts raw text from every user and assistant message and stores it as a memory fact if it passes `shouldCapture()`. That function has no guard against chain-of-thought artifacts (`think`, `<think>`, `model think`, `Thinking Process`) or classifier prompt/output text. The result is hundreds of current facts that are raw LLM reasoning traces, classifier outputs, and capability hint blocks — exactly the garbage that pollutes hot memories and progressive recall.
+
+## Evidence
+
+**Code:**
+- `lifecycle/stage-capture.ts:236-267`: extracts raw text from every user/assistant message on `agent_end`
+- `lifecycle/stage-capture.ts:268`: stores candidate if `ctx.shouldCapture(candidate.text)`
+- `services/capture-utils.ts:8-18`: `shouldCapture()` checks length, relevant-memory wrappers, XML blocks, markdown bullets, emoji, sensitive patterns, and `memoryTriggers`; it has no `<think>`/`think` guard
+- `lifecycle/stage-capture.ts:281-486`: stores raw/truncated text as the memory fact; classification only runs when similar facts exist and does not reject reasoning artifacts
+
+**DB evidence (Maeve live facts.db):**
+- 562 current `category=fact` facts where trimmed text starts with `think`
+- 1,080 current facts matching `think`/`<think>`/`model think` patterns across categories
+- Many have recall_count in the thousands (e.g. 4133), making them dominate HOT retrieval
+
+**Root cause:** `shouldCapture()` is designed to filter out short phrases, bullets, and sensitive content — but it was never designed to filter reasoning traces or classifier outputs. Those pass all current filters.
+
+## Impact
+
+- Hot memories contain raw `think` artifacts on every prompt.
+- Self-reinforcing loop: artifacts get high recall counts → pinned in full → even higher counts.
+- Noise in context budget; relevant memories crowded out.
+- Degrades the entire recall quality system.
+
+## Acceptance criteria
+
+- Add a hard `isPromptArtifactOrReasoningTrace(text)` guard used by auto-capture, passive observer, CLI ingest, and `memory_store` classification paths.
+- Reject text beginning with `<think>`, `<thinking>`, `think\n`, `think Thinking Process`, `Thinking Process:`, `The user is asking me to classify/extract`, `NOOP |`, `ADD |`, `UPDATE |`, classifier JSON, or capability-hint markers.
+- Strip or demote existing reasoning-trace facts: add a migration to supersede or mark cold all current facts matching these patterns.
+- Regression test: send an assistant message containing `think ` and `<think>`; neither should become a stored memory fact.
+
+## Fix direction
+
+- Add `isPromptArtifactOrReasoningTrace()` to `services/capture-utils.ts` and use it in all capture paths.
+- Update `shouldCapture()` to call this guard first.
+- Add a `memory-hybrid capture-cleanup` maintenance command that supersedes existing reasoning-trace facts and removes their LanceDB vectors.
+- Consider switching from raw-message capture to the structured extraction prompt used by passive observer.
+
+
+## Stewardship Notes
+
+This placeholder document exists to create a draft PR branch for Issue Stewardship tracking. The implementation work remains pending and should replace or extend this scaffold with the actual fix and verification evidence.


### PR DESCRIPTION
Refs #1560

Status: WIP scaffold PR only. Implementation is pending.

This draft PR was created by Issue Stewardship so the critical/high issue has a tracked branch and PR for follow-up work.

Initial contents:
- Adds docs/1560.md with the source issue body / acceptance criteria copied from GitHub.

Next required work:
- Implement the actual fix.
- Add or update tests.
- Provide verification evidence before moving beyond review stage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because this PR only adds documentation; it does not change runtime capture, storage, or classification behavior.
> 
> **Overview**
> Adds a new WIP scaffold document `docs/1560.md` capturing Issue #1560’s problem statement, evidence, acceptance criteria, and proposed fix direction for preventing auto-capture from storing chain-of-thought/prompt artifacts as memory facts. No implementation changes are included in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2dd15e04bf304af88111215538ff6b2067bc2007. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->