### PR TITLE
perf: avoid loading all facts for active-task projection/injection

### DIFF
--- a/docs/1553.md
+++ b/docs/1553.md
@@ -1,0 +1,69 @@
+# Issue #1553: perf: avoid loading all facts for active-task projection/injection
+
+Status: WIP scaffold PR only — implementation pending.
+
+## Source Issue
+
+- Issue: #1553
+- URL: https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/1553
+- State: OPEN (snapshot: 2026-05-21)
+- Priority label: priority:high
+- Labels: enhancement, priority:high, issue/stage/enriching
+
+## Acceptance Criteria / Issue Body
+
+### Summary
+
+Active-task projection/injection appears to load all active facts and then filter to project/task facts in memory. With a large facts database, this causes unnecessary SQLite work, JS allocation churn, and memory pressure during every prompt build.
+
+### Evidence / suspected code path
+
+The active-task path appears to do a broad fetch before filtering:
+
+```ts
+const facts = factsDb
+  .getAll({ scopeFilter })
+  .filter((fact) => fact.category === TASK_LEDGER_CATEGORY)
+  .slice(0, factLimit);
+```
+
+On Maeve, the gateway logs reported:
+
+```text
+memory-hybrid: injecting 100 active task(s) from category:project facts (87 stale)
+```
+
+The `facts.db` file is ~421 MB and active fact volume is high. Reading all facts on prompt build is therefore expensive even if only a small subset is needed.
+
+### Impact
+
+- Prompt build performs unnecessary DB reads and allocations.
+- Stale/duplicate active-task rows amplify the cost.
+- In high-concurrency periods, this can add memory churn and latency.
+- It likely interacts badly with the separate duplicate SQLite-handle/native-RSS issue.
+
+### Acceptance criteria
+
+- Active-task selection should query only `category='project'` / task-ledger rows at the SQL level.
+- Query should select only relevant columns/keys for task reconstruction.
+- Query should apply candidate limits and terminal-status/staleness filters as early as possible.
+- Prompt injection should not require hydrating the entire facts table.
+- Add timing/row-count logs around active-task selection:
+  - SQL rows scanned/fetched
+  - active candidates
+  - stale skipped
+  - duplicates collapsed
+  - injected count
+  - elapsed ms
+
+### Suggested fix direction
+
+- Add `FactsDB.getProjectFacts()` or `getFactsByCategory(category, options)` with indexes.
+- Ensure category/key/entity indexes exist and are used.
+- Build active-task rows from latest facts per entity/key rather than all fact history.
+- Consider a materialized active-task table/view updated by `active_task_checkpoint`.
+
+
+## Stewardship Notes
+
+This placeholder document exists to create a draft PR branch for Issue Stewardship tracking. The implementation work remains pending and should replace or extend this scaffold with the actual fix and verification evidence.


### PR DESCRIPTION
Refs #1553

Status: WIP scaffold PR only. Implementation is pending.

This draft PR was created by Issue Stewardship so the critical/high issue has a tracked branch and PR for follow-up work.

Initial contents:
- Adds docs/1553.md with the source issue body / acceptance criteria copied from GitHub.

Next required work:
- Implement the actual fix.
- Add or update tests.
- Provide verification evidence before moving beyond review stage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change adding a WIP issue scaffold; no runtime or data-path behavior is modified, so risk is low.
> 
> **Overview**
> Adds a new placeholder document `docs/1553.md` capturing Issue #1553 context, suspected performance bottleneck, and acceptance criteria for avoiding full facts-table loads during active-task projection/injection. No implementation changes are included in this PR (scaffold/WIP only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3db67f8a3a52451080350a173e4961a5f282fb9f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->