### PR TITLE
fix: PR hygiene must verify live review threads before marking waiting

### DIFF
--- a/docs/1555.md
+++ b/docs/1555.md
@@ -1,0 +1,60 @@
+# Issue #1555: fix: PR hygiene must verify live review threads before marking waiting
+
+Status: WIP scaffold PR only — implementation pending.
+
+## Source Issue
+
+- Issue: #1555
+- URL: https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/1555
+- State: OPEN
+- Priority label: priority:high
+- Labels: bug, priority:high, issue/stage/enriching
+
+## Acceptance Criteria / Issue Body
+
+## Summary
+
+Active-task hygiene classified PR #1549 as waiting/blocked for many hours while it still had actionable unresolved review feedback. Hygiene/PR stewardship must treat active-task state as an index, not truth, and verify live PR state before reporting or deciding no action is needed.
+
+## Incident
+
+For ~10-12 hours, hygiene runs repeated bookkeeping such as duplicate task closures and waiting states, but PR #1549 still had unresolved review feedback that had not been implemented/pushed.
+
+Live GitHub verification later found unresolved non-outdated review threads on PR #1549. The worker had looked at shallow PR signals like `mergeStateStatus`, `reviewDecision`, and checks, and concluded it was waiting for approval rather than Stage 4 feedback work.
+
+## Required behavior
+
+For any active task referencing a GitHub PR, the worker must inspect live PR state before classifying as waiting:
+
+- PR state
+- headRefName/headRefOid
+- draft/mergeability/mergeStateStatus
+- substantive checks
+- unresolved non-outdated review threads
+- labels/stage
+- manual blocker comments where applicable
+
+It must not infer `waiting for approval` from `mergeStateStatus=BLOCKED` or empty `reviewDecision` alone.
+
+## Acceptance criteria
+
+- Shared PR task validation helper returns one of:
+  - `unresolved_review_threads`
+  - `red_ci`
+  - `pending_ci`
+  - `merge_conflict`
+  - `human_approval`
+  - `no_live_blocker`
+- Hygiene uses this helper before updating project task state for PR-backed tasks.
+- If unresolved review threads exist, state becomes Stage 4 feedback work and Forge is dispatched/steered.
+- If live state hash is unchanged, hygiene replies `NO_REPLY` and does not repeat bookkeeping.
+- Regression test using a PR fixture where checks are green/mergeStateStatus blocked but unresolved threads exist.
+
+## Notes
+
+Maeve has already adjusted local cron prompts to require this, but this should be encoded in repo logic/tests rather than prompt-only policy.
+
+
+## Stewardship Notes
+
+This placeholder document exists to create a draft PR branch for Issue Stewardship tracking. The implementation work remains pending and should replace or extend this scaffold with the actual fix and verification evidence.


### PR DESCRIPTION
Refs #1555

Status: WIP scaffold PR only. Implementation is pending.

This draft PR was created by Issue Stewardship so the critical/high issue has a tracked branch and PR for follow-up work.

Initial contents:
- Adds docs/1555.md with the source issue body / acceptance criteria copied from GitHub.

Next required work:
- Implement the actual fix.
- Add or update tests.
- Provide verification evidence before moving beyond review stage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because this PR only adds a documentation scaffold and does not change any runtime code, logic, or tests.
> 
> **Overview**
> Adds `docs/1555.md`, a *WIP scaffold* capturing Issue #1555’s incident description and acceptance criteria for improving PR hygiene to verify live unresolved review threads (and other live PR signals) before marking PR-backed tasks as waiting/blocked.
> 
> No implementation or tests are included yet; this PR is documentation-only to track the forthcoming fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73c06708572e9c5083af8a4735561f242c04b47e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->