### PR TITLE
fix(memory): add universal classification artifact pre-store guard

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -15,6 +15,7 @@ permissions:
   contents: read
   pull-requests: write
   issues: write
+  statuses: write
 
 jobs:
   size-label:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -114,6 +114,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
+          wip: true
           types: |
             feat
             fix

--- a/docs/1561.md
+++ b/docs/1561.md
@@ -1,0 +1,54 @@
+# Issue #1561: fix: add universal NOOP/classification-output pre-store guard to prevent artifact storage
+
+Status: WIP scaffold PR only — implementation pending.
+
+## Source Issue
+
+- Issue: #1561
+- URL: https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/1561
+- State: OPEN
+- Priority label: priority:high
+- Labels: bug, priority:high
+
+## Acceptance Criteria / Issue Body
+
+## Summary
+
+NOOP/classification decision facts are stored in the database because the same raw text that triggers `shouldCapture()` also triggers the store path — and the NOOP skip only applies inside classification flows, not as a universal pre-store quality rule. Additionally, classifier prompt text and output text are captured and stored as memory facts.
+
+## Evidence
+
+**Code:**
+- Classification paths correctly skip NOOP: `lifecycle/stage-capture.ts:360`, `cli/cmd-store.ts:159`, `cli/cmd-extract.ts:926`, `tools/memory-tools.ts:1583` all return/continue on `classification.action === "NOOP"`.
+- But: when classification is not triggered (e.g., no similar facts found, or the candidate bypasses the classification gate), raw capture stores the text directly via `factsDb.store()`.
+- `shouldCapture()` has no `NOOP |` / classifier output guard, so these artifacts pass through.
+- `services/classification.ts:373-376`: batch parser returns `NOOP` as valid action — protects only the candidate being classified, not previous classifier output.
+
+**DB evidence (Maeve live facts.db):**
+- 121 current facts whose text starts with or contains NOOP/classification decision artifacts:
+  - 102 `fact`, 18 `preference`, 1 `decision`
+  - Example: `NOOP | The new fact is an artifact of the AI's internal reasoning process...`
+  - Example: `NOOP | this is a recursive meta-prompt artifact...`
+
+## Impact
+
+- NOOP artifacts pollute hot memories and recall context.
+- Classifier prompts/outputs stored as facts are low-value, high-noise.
+- They enter the self-reinforcing recall loop just like `think` artifacts.
+
+## Acceptance criteria
+
+- Add a pre-store quality guard that rejects `NOOP |`, classifier JSON, classifier prompt text, and `classify a new memory fact` patterns before any store path (auto-capture, CLI, direct store tool).
+- Add a maintenance migration to supersede existing NOOP/classification-artifact facts and remove their LanceDB vectors.
+- Regression test: store a fact with text `NOOP | some classification decision text`; it must not appear in recall or HOT.
+
+## Fix direction
+
+- Add the guard to `services/capture-utils.ts` alongside the `isPromptArtifactOrReasoningTrace()` guard from issue #11.
+- Make it a universal pre-store filter used by all store paths.
+- Add `memory-hybrid cleanup classification-artifacts` maintenance command.
+
+
+## Stewardship Notes
+
+This placeholder document exists to create a draft PR branch for Issue Stewardship tracking. The implementation work remains pending and should replace or extend this scaffold with the actual fix and verification evidence.

--- a/docs/1561.md
+++ b/docs/1561.md
@@ -1,3 +1,10 @@
+---
+layout: default
+title: "Issue #1561 – NOOP/classification pre-store guard (WIP)"
+nav_exclude: true
+search_exclude: true
+---
+
 # Issue #1561: fix: add universal NOOP/classification-output pre-store guard to prevent artifact storage
 
 Status: WIP scaffold PR only — implementation pending.

--- a/extensions/memory-hybrid/backends/facts-db/facts-db-layer1.ts
+++ b/extensions/memory-hybrid/backends/facts-db/facts-db-layer1.ts
@@ -7,6 +7,7 @@ import { dirname } from "node:path";
 import { DatabaseSync } from "node:sqlite";
 
 import type { StoreConfig } from "../../config.js";
+import { assertNotClassificationArtifactForStorage } from "../../services/capture-utils.js";
 import type { MemoryEntry, MemoryScope, MemoryTier, ScopeFilter, SearchResult } from "../../types/memory.js";
 import { tryRestrictSqliteDbFileMode } from "../../utils/sqlite-file-perms.js";
 import { BaseSqliteStore } from "../base-sqlite-store.js";
@@ -251,6 +252,7 @@ export class FactsDBLayer1 extends BaseSqliteStore {
       suppressVectorFallbackWarning?: boolean;
     },
   ): StoreFactResult {
+    assertNotClassificationArtifactForStorage(entry.text);
     const warnOnce = (key: string, message: string): void => {
       if (this.storeDedupeWarnedKeys.has(key)) return;
       this.storeDedupeWarnedKeys.add(key);

--- a/extensions/memory-hybrid/cli/cmd-store.ts
+++ b/extensions/memory-hybrid/cli/cmd-store.ts
@@ -9,6 +9,7 @@ import type { MemoryCategory } from "../config.js";
 import { getCronModelConfig, getDefaultCronModel } from "../config.js";
 import { VAULT_POINTER_PREFIX, isCredentialLike, tryParseCredentialForVault } from "../services/auto-capture.js";
 import { classifyMemoryOperation } from "../services/classification.js";
+import { isClassificationArtifactForStorage } from "../services/capture-utils.js";
 import { validateScopedClassificationTarget } from "../services/classification-scope.js";
 import { capturePluginError } from "../services/error-reporter.js";
 import { extractStructuredFields } from "../services/fact-extraction.js";
@@ -41,6 +42,7 @@ export async function runStoreForCli(
 ): Promise<StoreCliResult> {
   const { factsDb, vectorDb, embeddings, openai, cfg, credentialsDb, aliasDb } = ctx;
   const text = opts.text;
+  if (isClassificationArtifactForStorage(text)) return { outcome: "noop", reason: "classification artifact rejected" };
   if (factsDb.hasDuplicate(text, "cli")) return { outcome: "duplicate" };
   const sourceDate = opts.sourceDate ? parseSourceDate(opts.sourceDate) : null;
   const extracted = extractStructuredFields(text, (opts.category ?? "other") as MemoryCategory);

--- a/extensions/memory-hybrid/cli/register.ts
+++ b/extensions/memory-hybrid/cli/register.ts
@@ -522,6 +522,9 @@ export function registerHybridMemCli(mem: Chainable, ctx: HybridMemCliContext): 
           console.log(
             `Classification-artifacts cleanup ${res.dryRun ? "dry-run" : "applied"}: scanned ${res.scanned}, matched ${res.matched}, superseded ${res.superseded}, vectors ${res.vectorDeleted}/${res.vectorAttempted} deleted${res.vectorFailed > 0 ? ` (${res.vectorFailed} failed)` : ""}.`,
           );
+          if (!res.dryRun && (res.superseded < res.matched || res.vectorFailed > 0)) {
+            process.exitCode = 2;
+          }
         }),
       );
 

--- a/extensions/memory-hybrid/cli/register.ts
+++ b/extensions/memory-hybrid/cli/register.ts
@@ -21,6 +21,7 @@ import { type DistillContext, registerDistillCommands } from "./distill.js";
 import { registerGoalCommands } from "./goals.js";
 import { type ManageContext, registerManageCommands } from "./manage.js";
 import { registerSkillsCommands } from "./skills.js";
+import { withExit } from "./shared.js";
 import { registerTaskQueueStatusCommands } from "./task-queue-status.js";
 import type {
   AnalyzeFeedbackPhrasesResult,
@@ -217,6 +218,9 @@ export type HybridMemCliContext = {
   runContinuousVerification: (opts?: {
     verbose?: boolean;
   }) => Promise<import("../services/continuous-verifier.js").VerificationCycleResult>;
+  runCleanupClassificationArtifacts: (opts?: {
+    dryRun?: boolean;
+  }) => Promise<import("../services/classification-artifact-cleanup.js").ClassificationArtifactCleanupResult>;
   runResolveContradictions: () => Promise<{
     autoResolved: Array<{
       contradictionId: string;
@@ -506,6 +510,21 @@ export function registerHybridMemCli(mem: Chainable, ctx: HybridMemCliContext): 
   }
 
   try {
+    mem
+      .command("cleanup")
+      .description("Cleanup stored memory artifacts")
+      .command("classification-artifacts")
+      .description("Supersede stored NOOP/classification artifacts and remove their vectors")
+      .option("--dry-run", "Report matching facts without changing storage")
+      .action(
+        withExit(async (opts?: { dryRun?: boolean }) => {
+          const res = await ctx.runCleanupClassificationArtifacts({ dryRun: opts?.dryRun === true });
+          console.log(
+            `Classification-artifacts cleanup ${res.dryRun ? "dry-run" : "applied"}: scanned ${res.scanned}, matched ${res.matched}, superseded ${res.superseded}, vectors ${res.vectorDeleted}/${res.vectorAttempted} deleted${res.vectorFailed > 0 ? ` (${res.vectorFailed} failed)` : ""}.`,
+          );
+        }),
+      );
+
     registerStatusCommands(mem, {
       factsDb: ctx.factsDb,
       vectorDb: ctx.vectorDb,

--- a/extensions/memory-hybrid/services/capture-utils.ts
+++ b/extensions/memory-hybrid/services/capture-utils.ts
@@ -5,9 +5,73 @@
 import type { MemoryCategory } from "../types/memory.js";
 import { CAPTURE_FILTER_PATTERNS } from "./auto-capture.js";
 
+const CLASSIFICATION_ARTIFACT_PHRASES = [
+  "classify a new memory fact",
+  "you are a memory classifier",
+  "a new fact is being stored",
+  "compare it against existing facts and decide what to do",
+  "respond with exactly one line in this format: action [id] | reason",
+  "respond with only a json array",
+] as const;
+
+const ONE_LINE_CLASSIFICATION_RE = /^(ADD|NOOP|UPDATE|DELETE)(?:\s+[^|\n]+)?\s*\|\s*\S+/i;
+
+function looksLikeClassifierJsonArtifact(value: unknown): boolean {
+  if (!value || typeof value !== "object") return false;
+  if (Array.isArray(value)) {
+    return value.length > 0 && value.every((item) => looksLikeClassifierJsonArtifact(item));
+  }
+
+  const obj = value as Record<string, unknown>;
+  if (Array.isArray(obj.classifications)) return looksLikeClassifierJsonArtifact(obj.classifications);
+
+  const action = typeof obj.action === "string" ? obj.action.trim().toUpperCase() : "";
+  if (!["ADD", "UPDATE", "DELETE", "NOOP"].includes(action)) return false;
+
+  const hasClassifierShape =
+    "reason" in obj || "targetId" in obj || "target_id" in obj || "classification" in obj || "existingFactId" in obj;
+  return hasClassifierShape;
+}
+
+/**
+ * Reject internal classifier prompts/results before they can become durable memory facts.
+ *
+ * This intentionally covers both one-line classification responses (for example
+ * `NOOP | ...`) and batch JSON classifier structures. These artifacts describe the
+ * storage decision, not user knowledge, so they must never enter SQLite or LanceDB.
+ */
+export function isClassificationArtifactForStorage(input: unknown): boolean {
+  if (typeof input !== "string") return looksLikeClassifierJsonArtifact(input);
+
+  const text = input.trim();
+  if (!text) return false;
+  const lower = text.toLowerCase();
+
+  if (text.startsWith("NOOP |")) return true;
+  if (ONE_LINE_CLASSIFICATION_RE.test(text)) return true;
+  if (CLASSIFICATION_ARTIFACT_PHRASES.some((phrase) => lower.includes(phrase))) return true;
+
+  if ((text.startsWith("{") && text.endsWith("}")) || (text.startsWith("[") && text.endsWith("]"))) {
+    try {
+      return looksLikeClassifierJsonArtifact(JSON.parse(text));
+    } catch {
+      return false;
+    }
+  }
+
+  return false;
+}
+
+export function assertNotClassificationArtifactForStorage(input: unknown): void {
+  if (isClassificationArtifactForStorage(input)) {
+    throw new Error("memory-hybrid: refusing to store classification artifact");
+  }
+}
+
 export function shouldCapture(text: string, captureMaxChars: number, memoryTriggers: RegExp[]): boolean {
   if (text.length < 10 || text.length > captureMaxChars) return false;
   if (text.includes("<relevant-memories>")) return false;
+  if (isClassificationArtifactForStorage(text)) return false;
   if (text.startsWith("<") && text.includes("</")) return false;
   if (text.includes("**") && text.includes("\n-")) return false;
   const emojiCount = (text.match(/[\u{1F300}-\u{1F9FF}]/gu) || []).length;

--- a/extensions/memory-hybrid/services/classification-artifact-cleanup.ts
+++ b/extensions/memory-hybrid/services/classification-artifact-cleanup.ts
@@ -31,10 +31,14 @@ export async function cleanupClassificationArtifacts(
   let vectorFailed = 0;
 
   if (!dryRun && matchedIds.length > 0) {
+    const supersededIds: string[] = [];
     for (const id of matchedIds) {
-      if (factsDb.supersede(id, null)) superseded += 1;
+      if (factsDb.supersede(id, null)) {
+        superseded += 1;
+        supersededIds.push(id);
+      }
     }
-    const vectorCleanup = await deleteVectorsForFactIds(vectorDb, matchedIds, {
+    const vectorCleanup = await deleteVectorsForFactIds(vectorDb, supersededIds, {
       operation: "classification-artifacts-cleanup",
       logger: opts.logger,
     });

--- a/extensions/memory-hybrid/services/classification-artifact-cleanup.ts
+++ b/extensions/memory-hybrid/services/classification-artifact-cleanup.ts
@@ -1,0 +1,56 @@
+import type { FactsDB } from "../backends/facts-db.js";
+import type { VectorDB } from "../backends/vector-db.js";
+import type { MemoryEntry } from "../types/memory.js";
+import { isClassificationArtifactForStorage } from "./capture-utils.js";
+import { deleteVectorsForFactIds } from "./vector-maintenance.js";
+
+export interface ClassificationArtifactCleanupResult {
+  scanned: number;
+  matched: number;
+  superseded: number;
+  vectorAttempted: number;
+  vectorDeleted: number;
+  vectorFailed: number;
+  dryRun: boolean;
+  matchedIds: string[];
+}
+
+export async function cleanupClassificationArtifacts(
+  factsDb: Pick<FactsDB, "getAll" | "supersede">,
+  vectorDb: Pick<VectorDB, "delete"> & Partial<Pick<VectorDB, "deleteMany" | "isLanceDbAvailable">>,
+  opts: { dryRun?: boolean; logger?: { warn?: (message: string) => void; info?: (message: string) => void } } = {},
+): Promise<ClassificationArtifactCleanupResult> {
+  const dryRun = opts.dryRun === true;
+  const facts = factsDb.getAll({ includeSuperseded: true }) as MemoryEntry[];
+  const matches = facts.filter((fact) => fact.supersededAt == null && isClassificationArtifactForStorage(fact.text));
+  const matchedIds = matches.map((fact) => fact.id);
+
+  let superseded = 0;
+  let vectorAttempted = 0;
+  let vectorDeleted = 0;
+  let vectorFailed = 0;
+
+  if (!dryRun && matchedIds.length > 0) {
+    for (const id of matchedIds) {
+      if (factsDb.supersede(id, null)) superseded += 1;
+    }
+    const vectorCleanup = await deleteVectorsForFactIds(vectorDb, matchedIds, {
+      operation: "classification-artifacts-cleanup",
+      logger: opts.logger,
+    });
+    vectorAttempted = vectorCleanup.attempted;
+    vectorDeleted = vectorCleanup.deleted;
+    vectorFailed = vectorCleanup.failed;
+  }
+
+  return {
+    scanned: facts.length,
+    matched: matches.length,
+    superseded,
+    vectorAttempted,
+    vectorDeleted,
+    vectorFailed,
+    dryRun,
+    matchedIds,
+  };
+}

--- a/extensions/memory-hybrid/setup/cli-context/cli-services.ts
+++ b/extensions/memory-hybrid/setup/cli-context/cli-services.ts
@@ -88,7 +88,9 @@ interface CliContextServices {
   }) => Promise<{ factsExported: number; proceduresExported: number; filesWritten: number; outputPath: string }>;
   runDreamCycle: (opts?: { verbose?: boolean }) => Promise<DreamCycleResult>;
   runContinuousVerification: (opts?: { verbose?: boolean }) => Promise<VerificationCycleResult>;
-  runCleanupClassificationArtifacts: (opts?: { dryRun?: boolean }) => Promise<import("../../services/classification-artifact-cleanup.js").ClassificationArtifactCleanupResult>;
+  runCleanupClassificationArtifacts: (opts?: {
+    dryRun?: boolean;
+  }) => Promise<import("../../services/classification-artifact-cleanup.js").ClassificationArtifactCleanupResult>;
   runResolveContradictions: () => Promise<{
     autoResolved: Array<{ contradictionId: string; factIdNew: string; factIdOld: string }>;
     ambiguous: Array<{ contradictionId: string; factIdNew: string; factIdOld: string }>;

--- a/extensions/memory-hybrid/setup/cli-context/cli-services.ts
+++ b/extensions/memory-hybrid/setup/cli-context/cli-services.ts
@@ -11,6 +11,7 @@ import { type DreamCycleResult, runDreamCycle } from "../../services/dream-cycle
 import { runEntityEnrichmentForCli } from "../../services/entity-enrichment-cli.js";
 import { runExport } from "../../services/export-memory.js";
 import { runFindDuplicates } from "../../services/find-duplicates.js";
+import { cleanupClassificationArtifacts } from "../../services/classification-artifact-cleanup.js";
 import { runBuildLanguageKeywords } from "../../services/language-keywords-build.js";
 import { mergeResults } from "../../services/merge-results.js";
 import { runPreConsolidationFlush } from "../../services/pre-consolidation-flush.js";
@@ -87,6 +88,7 @@ interface CliContextServices {
   }) => Promise<{ factsExported: number; proceduresExported: number; filesWritten: number; outputPath: string }>;
   runDreamCycle: (opts?: { verbose?: boolean }) => Promise<DreamCycleResult>;
   runContinuousVerification: (opts?: { verbose?: boolean }) => Promise<VerificationCycleResult>;
+  runCleanupClassificationArtifacts: (opts?: { dryRun?: boolean }) => Promise<import("../../services/classification-artifact-cleanup.js").ClassificationArtifactCleanupResult>;
   runResolveContradictions: () => Promise<{
     autoResolved: Array<{ contradictionId: string; factIdNew: string; factIdOld: string }>;
     ambiguous: Array<{ contradictionId: string; factIdNew: string; factIdOld: string }>;
@@ -388,6 +390,8 @@ export function buildCliContextServices(
           : {}),
       });
     },
+    runCleanupClassificationArtifacts: (opts?: { dryRun?: boolean }) =>
+      cleanupClassificationArtifacts(factsDb, vectorDb, { dryRun: opts?.dryRun === true, logger: api.logger }),
     runResolveContradictions: () => Promise.resolve(factsDb.resolveContradictions()),
     getMemoryCategories: () => [...getMemoryCategories()],
     mergeResults,

--- a/extensions/memory-hybrid/setup/cli-context/register-help.ts
+++ b/extensions/memory-hybrid/setup/cli-context/register-help.ts
@@ -98,7 +98,19 @@ export function registerHybridMemCliHelpOnlyWithApi(api: ClawdbotPluginApi): voi
     api,
   };
 
-  const services = buildCliContextServices(cliRegistrationCtx, api);
+  const services = {
+    ...buildCliContextServices(cliRegistrationCtx, api),
+    runCleanupClassificationArtifacts: async () => ({
+      scanned: 0,
+      matched: 0,
+      superseded: 0,
+      vectorAttempted: 0,
+      vectorDeleted: 0,
+      vectorFailed: 0,
+      dryRun: true,
+      matchedIds: [],
+    }),
+  };
   api.registerCli(
     ({ program }: { program: Command }) => {
       const cliCtx = createHybridMemCliContext(handlerCtx, api, services);

--- a/extensions/memory-hybrid/tests/capture-utils.test.ts
+++ b/extensions/memory-hybrid/tests/capture-utils.test.ts
@@ -110,8 +110,6 @@ describe("shouldCapture", () => {
   });
 });
 
-
-
 describe("classification artifact pre-store guard", () => {
   const MAX_CHARS = 500;
   const TRIGGERS = getMemoryTriggers();
@@ -125,7 +123,9 @@ describe("classification artifact pre-store guard", () => {
   it("detects classifier JSON output", () => {
     expect(isClassificationArtifactForStorage('{"action":"NOOP","targetId":null,"reason":"duplicate"}')).toBe(true);
     expect(isClassificationArtifactForStorage('[{"action":"ADD","targetId":null,"reason":"new"}]')).toBe(true);
-    expect(isClassificationArtifactForStorage({ classifications: [{ action: "NOOP", targetId: null, reason: "dup" }] })).toBe(true);
+    expect(
+      isClassificationArtifactForStorage({ classifications: [{ action: "NOOP", targetId: null, reason: "dup" }] }),
+    ).toBe(true);
   });
 
   it("detects classifier prompt text", () => {

--- a/extensions/memory-hybrid/tests/capture-utils.test.ts
+++ b/extensions/memory-hybrid/tests/capture-utils.test.ts
@@ -5,7 +5,7 @@
 
 import { describe, expect, it } from "vitest";
 import { getMemoryTriggers } from "../services/auto-capture.js";
-import { detectCategory, shouldCapture } from "../services/capture-utils.js";
+import { detectCategory, isClassificationArtifactForStorage, shouldCapture } from "../services/capture-utils.js";
 import {
   getCategoryDecisionRegex,
   getCategoryEntityRegex,
@@ -107,6 +107,30 @@ describe("shouldCapture", () => {
 
   it("is case-insensitive for trigger match", () => {
     expect(shouldCapture("I PREFER uppercase sometimes", MAX_CHARS, TRIGGERS)).toBe(true);
+  });
+});
+
+
+
+describe("classification artifact pre-store guard", () => {
+  const MAX_CHARS = 500;
+  const TRIGGERS = getMemoryTriggers();
+
+  it("detects and rejects NOOP classification decisions", () => {
+    const text = "NOOP | some classification decision text";
+    expect(isClassificationArtifactForStorage(text)).toBe(true);
+    expect(shouldCapture(text, MAX_CHARS, TRIGGERS)).toBe(false);
+  });
+
+  it("detects classifier JSON output", () => {
+    expect(isClassificationArtifactForStorage('{"action":"NOOP","targetId":null,"reason":"duplicate"}')).toBe(true);
+    expect(isClassificationArtifactForStorage('[{"action":"ADD","targetId":null,"reason":"new"}]')).toBe(true);
+    expect(isClassificationArtifactForStorage({ classifications: [{ action: "NOOP", targetId: null, reason: "dup" }] })).toBe(true);
+  });
+
+  it("detects classifier prompt text", () => {
+    expect(isClassificationArtifactForStorage("You are a memory classifier. A new fact is being stored.")).toBe(true);
+    expect(isClassificationArtifactForStorage("Please classify a new memory fact before storage")).toBe(true);
   });
 });
 

--- a/extensions/memory-hybrid/tests/classification-artifact-cleanup.test.ts
+++ b/extensions/memory-hybrid/tests/classification-artifact-cleanup.test.ts
@@ -23,13 +23,29 @@ describe("cleanupClassificationArtifacts", () => {
   });
 
   it("supersedes matching facts and deletes their vectors", async () => {
-    const artifact = factsDb.store({ text: "legacy artifact placeholder", category: "fact", source: "test" });
+    const artifact = factsDb.store({
+      text: "legacy artifact placeholder",
+      category: "fact",
+      source: "test",
+      entity: null,
+      key: null,
+      value: null,
+      importance: 0.5,
+    });
     factsDb
       .getRawDb()
       .prepare("UPDATE facts SET text = ? WHERE id = ?")
       .run("NOOP | some classification decision text", artifact.id);
     artifact.text = "NOOP | some classification decision text";
-    const normal = factsDb.store({ text: "Markus prefers practical answers", category: "preference", source: "test" });
+    const normal = factsDb.store({
+      text: "Markus prefers practical answers",
+      category: "preference",
+      source: "test",
+      entity: null,
+      key: null,
+      value: null,
+      importance: 0.5,
+    });
     const vectorDb = { deleteMany: vi.fn(async () => 1), delete: vi.fn(async () => true) };
 
     const result = await cleanupClassificationArtifacts(factsDb, vectorDb as never);
@@ -42,7 +58,15 @@ describe("cleanupClassificationArtifacts", () => {
   });
 
   it("supports dry-run without superseding or deleting vectors", async () => {
-    const artifact = factsDb.store({ text: "legacy json placeholder", category: "fact", source: "test" });
+    const artifact = factsDb.store({
+      text: "legacy json placeholder",
+      category: "fact",
+      source: "test",
+      entity: null,
+      key: null,
+      value: null,
+      importance: 0.5,
+    });
     const artifactText = '{"action":"NOOP","targetId":null,"reason":"duplicate"}';
     factsDb.getRawDb().prepare("UPDATE facts SET text = ? WHERE id = ?").run(artifactText, artifact.id);
     artifact.text = artifactText;

--- a/extensions/memory-hybrid/tests/classification-artifact-cleanup.test.ts
+++ b/extensions/memory-hybrid/tests/classification-artifact-cleanup.test.ts
@@ -1,0 +1,149 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Command } from "commander";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { FactsDB } from "../backends/facts-db.js";
+import { hybridConfigSchema } from "../config.js";
+import { registerHybridMemCli } from "../cli/register.js";
+import { cleanupClassificationArtifacts } from "../services/classification-artifact-cleanup.js";
+
+describe("cleanupClassificationArtifacts", () => {
+  let tmpDir: string;
+  let factsDb: FactsDB;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "classification-artifact-cleanup-"));
+    factsDb = new FactsDB(join(tmpDir, "facts.db"));
+  });
+
+  afterEach(() => {
+    factsDb.close();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("supersedes matching facts and deletes their vectors", async () => {
+    const artifact = factsDb.store({ text: "legacy artifact placeholder", category: "fact", source: "test" });
+    factsDb
+      .getRawDb()
+      .prepare("UPDATE facts SET text = ? WHERE id = ?")
+      .run("NOOP | some classification decision text", artifact.id);
+    artifact.text = "NOOP | some classification decision text";
+    const normal = factsDb.store({ text: "Markus prefers practical answers", category: "preference", source: "test" });
+    const vectorDb = { deleteMany: vi.fn(async () => 1), delete: vi.fn(async () => true) };
+
+    const result = await cleanupClassificationArtifacts(factsDb, vectorDb as never);
+
+    expect(result).toMatchObject({ scanned: 2, matched: 1, superseded: 1, vectorAttempted: 1, vectorDeleted: 1 });
+    expect(result.matchedIds).toEqual([artifact.id]);
+    expect(factsDb.getById(artifact.id)?.supersededAt).toBeTruthy();
+    expect(factsDb.getById(normal.id)?.text).toBe(normal.text);
+    expect(vectorDb.deleteMany).toHaveBeenCalledWith([artifact.id]);
+  });
+
+  it("supports dry-run without superseding or deleting vectors", async () => {
+    const artifact = factsDb.store({ text: "legacy json placeholder", category: "fact", source: "test" });
+    const artifactText = '{"action":"NOOP","targetId":null,"reason":"duplicate"}';
+    factsDb.getRawDb().prepare("UPDATE facts SET text = ? WHERE id = ?").run(artifactText, artifact.id);
+    artifact.text = artifactText;
+    const vectorDb = { deleteMany: vi.fn(async () => 1), delete: vi.fn(async () => true) };
+
+    const result = await cleanupClassificationArtifacts(factsDb, vectorDb as never, { dryRun: true });
+
+    expect(result).toMatchObject({
+      scanned: 1,
+      matched: 1,
+      superseded: 0,
+      vectorAttempted: 0,
+      vectorDeleted: 0,
+      dryRun: true,
+    });
+    expect(factsDb.getById(artifact.id)?.text).toBe(artifact.text);
+    expect(vectorDb.deleteMany).not.toHaveBeenCalled();
+  });
+});
+
+describe("cleanup classification-artifacts CLI", () => {
+  it("wires the cleanup command and reports counts", async () => {
+    const runCleanupClassificationArtifacts = vi.fn(async () => ({
+      scanned: 3,
+      matched: 1,
+      superseded: 1,
+      vectorAttempted: 1,
+      vectorDeleted: 1,
+      vectorFailed: 0,
+      dryRun: true,
+      matchedIds: ["fact-id"],
+    }));
+    const program = new Command("hybrid-mem");
+    program.exitOverride();
+    registerHybridMemCli(
+      program as never,
+      {
+        cfg: hybridConfigSchema.parse({ embedding: { provider: "ollama", model: "nomic-embed-text" } }),
+        factsDb: {},
+        vectorDb: {},
+        embeddings: {},
+        versionInfo: { pluginVersion: "test", memoryManagerVersion: "test", schemaVersion: 1 },
+        mergeResults: () => [],
+        parseSourceDate: () => null,
+        getMemoryCategories: () => ["fact", "other"],
+        runStore: async () => ({ outcome: "duplicate" }),
+        runInstall: async () => ({ ok: true }),
+        runVerify: async () => {},
+        runDistillWindow: async () => ({ windowStart: 0, windowEnd: 0, sessions: [] }),
+        runRecordDistill: async () => ({ recorded: 0 }),
+        runExtractDaily: async () => ({ sessionsScanned: 0, factsExtracted: 0, stored: 0, skipped: 0 }),
+        runExtractProcedures: async () => ({ sessionsScanned: 0, proceduresExtracted: 0, stored: 0 }),
+        runGenerateAutoSkills: async () => ({ generated: 0, written: 0, skipped: 0 }),
+        runSkillsSuggest: async () => ({ proposed: 0, skipped: 0, reasons: [] }),
+        runBackfill: async () => ({ scanned: 0, stored: 0, skipped: 0 }),
+        runIngestFiles: async () => ({ filesScanned: 0, filesIngested: 0, factsStored: 0 }),
+        runDistill: async () => ({ sessionsScanned: 0, narrativesStored: 0 }),
+        runMigrateToVault: async () => null,
+        runCredentialsList: () => [],
+        runCredentialsGet: () => null,
+        runCredentialsAudit: () => ({ total: 0, flagged: 0, items: [] }),
+        runCredentialsPrune: () => ({ scanned: 0, pruned: 0, dryRun: true, items: [] }),
+        runUninstall: async () => ({ removed: [] }),
+        runUpgrade: async () => ({ ok: true }),
+        runConfigMode: () => ({ ok: true }),
+        runConfigSet: () => ({ ok: true }),
+        runConfigSetHelp: () => ({ ok: true }),
+        runFindDuplicates: async () => ({ clusters: [], scanned: 0 }),
+        runConsolidate: async () => ({ clustersFound: 0, merged: 0, deleted: 0 }),
+        runReflection: async () => ({ factsAnalyzed: 0, patternsExtracted: 0, patternsStored: 0, window: 0 }),
+        runReflectionRules: async () => ({ rulesExtracted: 0, rulesStored: 0 }),
+        runReflectionMeta: async () => ({ metaExtracted: 0, metaStored: 0 }),
+        reflectionConfig: { enabled: false, defaultWindow: 7, minObservations: 2, model: "test" },
+        runDreamCycle: async () => ({ ok: true }),
+        runContinuousVerification: async () => ({ checked: 0, confirmed: 0, stale: 0, uncertain: 0, errors: 0 }),
+        runCleanupClassificationArtifacts,
+        runResolveContradictions: async () => ({ autoResolved: [], ambiguous: [] }),
+        runClassify: async () => ({ reclassified: 0, total: 0 }),
+        autoClassifyConfig: { model: "test", batchSize: 10 },
+        runCompaction: async () => ({ hot: 0, warm: 0, cold: 0, structural: 0 }),
+        runBuildLanguageKeywords: async () => ({ ok: true, path: "", topLanguages: [], languagesAdded: 0 }),
+        runEntityEnrichment: async () => ({ pending: 0, processed: 0, factsEnriched: 0 }),
+        runSelfCorrectionExtract: async () => ({ incidents: [], sessionsScanned: 0 }),
+        runSelfCorrectionRun: async () => ({ applied: 0, skipped: 0 }),
+        runAnalyzeFeedbackPhrases: async () => ({ phrases: [], sessionsScanned: 0 }),
+        runExtractDirectives: async () => ({ incidents: [], sessionsScanned: 0 }),
+        runExtractReinforcement: async () => ({ incidents: [], sessionsScanned: 0 }),
+        runExport: async () => ({ factsExported: 0, proceduresExported: 0, filesWritten: 0, outputPath: "" }),
+        tieringEnabled: false,
+      } as never,
+    );
+
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    try {
+      await program.parseAsync(["cleanup", "classification-artifacts", "--dry-run"], { from: "user" });
+    } finally {
+      // restored after assertions below
+    }
+
+    expect(runCleanupClassificationArtifacts).toHaveBeenCalledWith({ dryRun: true });
+    expect(log).toHaveBeenCalledWith(expect.stringContaining("Classification-artifacts cleanup dry-run"));
+    log.mockRestore();
+  });
+});

--- a/extensions/memory-hybrid/tests/plugin-e2e.test.ts
+++ b/extensions/memory-hybrid/tests/plugin-e2e.test.ts
@@ -272,6 +272,28 @@ describe("Store and recall e2e (real FactsDB + VectorDB, mock embeddings)", () =
     expect(recallByIdResult.content?.[0]?.text).toContain(text);
   });
 
+  it("memory_store rejects NOOP classification artifacts before recall", async () => {
+    registerTools(buildE2EContext({ tmpDir, factsDb, vectorDb, cfg, api }) as never, api as never);
+    const storeTool = api.getTool("memory_store");
+    const recallTool = api.getTool("memory_recall");
+    expect(storeTool).toBeDefined();
+    expect(recallTool).toBeDefined();
+
+    const text = "NOOP | some classification decision text";
+    const storeResult = (await storeTool?.execute("call-noop-store", { text, category: "fact" })) as {
+      details?: { action?: string };
+    };
+    expect(storeResult.details?.action).toBe("noop");
+
+    const recallResult = (await recallTool?.execute("call-noop-recall", { query: "classification decision text" })) as {
+      details?: { memories?: Array<{ text: string }> };
+      content?: Array<{ text?: string }>;
+    };
+    const recalledTexts = (recallResult.details?.memories ?? []).map((m) => m.text);
+    expect(recalledTexts.some((t) => t.includes(text))).toBe(false);
+    expect(recallResult.content?.[0]?.text ?? "").not.toContain(text);
+  });
+
   it("memory_store accepts why and memory_recall returns lineage context", async () => {
     registerTools(buildE2EContext({ tmpDir, factsDb, vectorDb, cfg, api }) as never, api as never);
 

--- a/extensions/memory-hybrid/tools/memory/register-store-tools.ts
+++ b/extensions/memory-hybrid/tools/memory/register-store-tools.ts
@@ -20,6 +20,7 @@ import {
 } from "../../config.js";
 import { VAULT_POINTER_PREFIX, isCredentialLike, tryParseCredentialForVault } from "../../services/auto-capture.js";
 import { classifyMemoryOperation } from "../../services/classification.js";
+import { isClassificationArtifactForStorage } from "../../services/capture-utils.js";
 import { AllEmbeddingProvidersFailed, shouldSuppressEmbeddingError } from "../../services/embeddings.js";
 import { extractEntityMentionsWithLlm } from "../../services/entity-enrichment.js";
 import { addOperationBreadcrumb, capturePluginError } from "../../services/error-reporter.js";
@@ -176,6 +177,13 @@ export function registerStoreTools(runtime: MemoryToolRuntime): void {
             verification_tier?: string;
             decayFreezeUntil?: number;
           };
+
+          if (isClassificationArtifactForStorage(text)) {
+            return {
+              content: [{ type: "text", text: "Skipped: classification artifact rejected." }],
+              details: { action: "noop", reason: "classification artifact rejected" },
+            };
+          }
 
           let textToStore = text;
           textToStore = truncateForStorage(textToStore, cfg.captureMaxChars);

--- a/extensions/memory-hybrid/utils/wal-replay.ts
+++ b/extensions/memory-hybrid/utils/wal-replay.ts
@@ -146,7 +146,16 @@ export async function replayWalEntries(
 
   for (const entry of walEntries) {
     try {
-      if (entry.operation === "store" && isSafeWalText(entry.data?.text)) {
+      if (
+        (entry.operation === "store" || entry.operation === "update") &&
+        isClassificationArtifactForStorage(entry.data?.text)
+      ) {
+        // Classification artifacts (NOOP/ADD/UPDATE/DELETE lines, JSON classifiers) cannot
+        // ever be stored into FactsDB due to assertNotClassificationArtifactForStorage guard.
+        // Skip and remove to prevent infinite retry loops.
+        skipped++;
+        await wal.remove(entry.id);
+      } else if (entry.operation === "store" && isSafeWalText(entry.data?.text)) {
         const text = safeString(entry.data.text);
         if (!text) continue;
         const source = safeString(entry.data.source) ?? "conversation";
@@ -342,15 +351,6 @@ export async function replayWalEntries(
         await wal.remove(entry.id);
       } else if ((entry.operation === "store" || entry.operation === "update") && !isSafeWalText(entry.data?.text)) {
         // Empty or whitespace-only text cannot ever be replayed into FactsDB.
-        skipped++;
-        await wal.remove(entry.id);
-      } else if (
-        (entry.operation === "store" || entry.operation === "update") &&
-        isClassificationArtifactForStorage(entry.data?.text)
-      ) {
-        // Classification artifacts (NOOP/ADD/UPDATE/DELETE lines, JSON classifiers) cannot
-        // ever be stored into FactsDB due to assertNotClassificationArtifactForStorage guard.
-        // Skip and remove to prevent infinite retry loops.
         skipped++;
         await wal.remove(entry.id);
       } else if (entry.operation === "update") {

--- a/extensions/memory-hybrid/utils/wal-replay.ts
+++ b/extensions/memory-hybrid/utils/wal-replay.ts
@@ -9,6 +9,7 @@ import type { FactsDB } from "../backends/facts-db.js";
 import type { VectorDB } from "../backends/vector-db.js";
 import type { WriteAheadLog } from "../backends/wal.js";
 import type { EmbeddingProvider } from "../services/embeddings.js";
+import { isClassificationArtifactForStorage } from "../services/capture-utils.js";
 import { capturePluginError } from "../services/error-reporter.js";
 
 export interface WalReplayResult {
@@ -341,6 +342,15 @@ export async function replayWalEntries(
         await wal.remove(entry.id);
       } else if ((entry.operation === "store" || entry.operation === "update") && !isSafeWalText(entry.data?.text)) {
         // Empty or whitespace-only text cannot ever be replayed into FactsDB.
+        skipped++;
+        await wal.remove(entry.id);
+      } else if (
+        (entry.operation === "store" || entry.operation === "update") &&
+        isClassificationArtifactForStorage(entry.data?.text)
+      ) {
+        // Classification artifacts (NOOP/ADD/UPDATE/DELETE lines, JSON classifiers) cannot
+        // ever be stored into FactsDB due to assertNotClassificationArtifactForStorage guard.
+        // Skip and remove to prevent infinite retry loops.
         skipped++;
         await wal.remove(entry.id);
       } else if (entry.operation === "update") {


### PR DESCRIPTION
Refs #1561

Status: WIP scaffold PR only. Implementation is pending.

This draft PR was created by Issue Stewardship so the critical/high issue has a tracked branch and PR for follow-up work.

Initial contents:
- Adds docs/1561.md with the source issue body / acceptance criteria copied from GitHub.

Next required work:
- Implement the actual fix.
- Add or update tests.
- Provide verification evidence before moving beyond review stage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches data-cleanup logic that supersedes facts and deletes vectors; mistakes could lead to unintended vector deletions or incomplete cleanup. Changes are small and add safer behavior plus clearer failure signaling, reducing overall risk.
> 
> **Overview**
> Improves the `cleanup classification-artifacts` workflow to be safer and more automation-friendly.
> 
> Vector deletion is now scoped to only those fact IDs that were actually superseded (instead of all matched IDs), and the CLI command sets `process.exitCode = 2` when an applied run is only partially successful (not all matches superseded or some vector deletions failed).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc4c79117cd91eb7651428f04e77720eac9db197. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->