### PR TITLE
fix: add early input validation to memory_store before WAL/embedding/DB writes

### DIFF
--- a/extensions/memory-hybrid/tests/memory-store-early-validation.test.ts
+++ b/extensions/memory-hybrid/tests/memory-store-early-validation.test.ts
@@ -225,7 +225,7 @@ describe("memory_store early validation — invalid importance", () => {
     const storeTool = api.getTool("memory_store");
     const result = (await storeTool?.execute("call-imp-nan", {
       text: "Valid text",
-      importance: Number.NaN,
+      importance: NaN,
     })) as { details: { error: string } };
 
     expect(result.details.error).toBe("invalid_importance");
@@ -241,7 +241,7 @@ describe("memory_store early validation — invalid importance", () => {
     const storeTool = api.getTool("memory_store");
     const result = (await storeTool?.execute("call-imp-inf", {
       text: "Valid text",
-      importance: Number.POSITIVE_INFINITY,
+      importance: Infinity,
     })) as { details: { error: string } };
 
     expect(result.details.error).toBe("invalid_importance");
@@ -312,7 +312,7 @@ describe("memory_store early validation — invalid decayFreezeUntil", () => {
     const result = (await storeTool?.execute("call-dfu-nan", {
       text: "Valid text",
       importance: 0.5,
-      decayFreezeUntil: Number.NaN,
+      decayFreezeUntil: NaN,
     })) as { details: { error: string } };
 
     expect(result.details.error).toBe("invalid_decay_freeze_until");

--- a/extensions/memory-hybrid/tests/memory-store-early-validation.test.ts
+++ b/extensions/memory-hybrid/tests/memory-store-early-validation.test.ts
@@ -178,6 +178,23 @@ describe("memory_store early validation — invalid text", () => {
     const all = factsDb.getAll();
     expect(all).toHaveLength(0);
   });
+
+  it("returns invalid_text error for whitespace-only string exceeding captureMaxChars", async () => {
+    const walWrite = vi.fn().mockResolvedValue("wal-id");
+    const embeddings = makeMockEmbeddings();
+    const { api } = setupTool(walWrite, embeddings);
+
+    const storeTool = api.getTool("memory_store");
+    // Create a whitespace-only string longer than captureMaxChars (2000)
+    const longWhitespace = " ".repeat(2001);
+    const result = (await storeTool?.execute("call-ws-long", { text: longWhitespace, importance: 0.5 })) as {
+      details: { error: string };
+    };
+
+    expect(result.details.error).toBe("invalid_text");
+    expect(walWrite).not.toHaveBeenCalled();
+    expect(embeddings.embed).not.toHaveBeenCalled();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/extensions/memory-hybrid/tests/memory-store-early-validation.test.ts
+++ b/extensions/memory-hybrid/tests/memory-store-early-validation.test.ts
@@ -1,0 +1,353 @@
+// @ts-nocheck
+/**
+ * Tests that memory_store performs early input validation (Issue #1575).
+ *
+ * Validates that empty/whitespace text and out-of-range importance values
+ * return structured errors BEFORE any side effects (WAL write, embedding
+ * generation, or FactsDB insert).
+ */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { _testing } from "../index.js";
+import { registerMemoryTools } from "../tools/memory-tools.js";
+
+const { FactsDB } = _testing;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeMockApi() {
+  const tools = new Map<string, { execute: (...args: unknown[]) => unknown }>();
+  return {
+    registerTool(opts: Record<string, unknown>, _options?: unknown) {
+      tools.set(opts.name as string, { execute: opts.execute as (...args: unknown[]) => unknown });
+    },
+    getTool(name: string) {
+      return tools.get(name);
+    },
+    logger: { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() },
+    context: { sessionId: "test-session-early-val", agentId: "test-agent" },
+  };
+}
+
+function makeMockVectorDb() {
+  return {
+    hasDuplicate: vi.fn().mockResolvedValue(false),
+    store: vi.fn().mockResolvedValue(undefined),
+    search: vi.fn().mockResolvedValue([]),
+    close: vi.fn(),
+  };
+}
+
+function makeMockEmbeddings() {
+  return {
+    embed: vi.fn().mockResolvedValue(new Array(384).fill(0.1)),
+    embedBatch: vi.fn().mockResolvedValue([]),
+    dimensions: 384,
+    modelName: "mock-model",
+  };
+}
+
+function makeCfg() {
+  return {
+    captureMaxChars: 2000,
+    categories: ["fact", "preference", "decision"],
+    store: { classifyBeforeWrite: false },
+    multiAgent: {
+      orchestratorId: "main",
+      defaultStoreScope: "global",
+      strictAgentScoping: false,
+    },
+    graph: {
+      enabled: false,
+      autoLink: false,
+      autoLinkLimit: 5,
+      autoLinkMinScore: 0.5,
+      useInRecall: false,
+      maxTraversalDepth: 2,
+      coOccurrenceWeight: 0.5,
+      autoSupersede: false,
+    },
+    graphRetrieval: { enabled: false, defaultExpand: false, maxExpandDepth: 3, maxExpandedResults: 20 },
+    credentials: { enabled: false },
+    autoRecall: { scopeFilter: null, summaryThreshold: 0, summaryMaxChars: 500 },
+    distill: { reinforcementBoost: 0.1 },
+    retrieval: { strategies: [], explicitBudgetTokens: 2000 },
+    aliases: { enabled: false },
+    procedures: { enabled: false },
+    clusters: null,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Test setup
+// ---------------------------------------------------------------------------
+
+let tmpDir: string;
+let factsDb: InstanceType<typeof FactsDB>;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "memory-store-early-val-test-"));
+  factsDb = new FactsDB(join(tmpDir, "facts.db"));
+});
+
+afterEach(() => {
+  factsDb.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function setupTool(walWriteMock: ReturnType<typeof vi.fn>, embeddings: ReturnType<typeof makeMockEmbeddings>) {
+  const api = makeMockApi();
+  const vectorDb = makeMockVectorDb();
+  const cfg = makeCfg();
+
+  registerMemoryTools(
+    {
+      factsDb: factsDb as never,
+      edictStore: null as any,
+      vectorDb: vectorDb as never,
+      cfg: cfg as never,
+      embeddings: embeddings as never,
+      openai: {} as never,
+      wal: null,
+      credentialsDb: null,
+      eventLog: null,
+      lastProgressiveIndexIds: [],
+      currentAgentIdRef: { value: "test-agent" },
+      pendingLLMWarnings: { drain: vi.fn().mockReturnValue([]) } as never,
+      aliasDb: null,
+    },
+    api as never,
+    (_params, _currentAgent, _cfg) => undefined,
+    walWriteMock,
+    (_id, _logger) => undefined,
+    async (_vdb, _fdb, _vec, _limit) => [],
+  );
+
+  return { api, vectorDb };
+}
+
+// ---------------------------------------------------------------------------
+// Tests: invalid text
+// ---------------------------------------------------------------------------
+
+describe("memory_store early validation — invalid text", () => {
+  it("returns invalid_text error for empty string without writing WAL", async () => {
+    const walWrite = vi.fn().mockResolvedValue("wal-id");
+    const embeddings = makeMockEmbeddings();
+    const { api } = setupTool(walWrite, embeddings);
+
+    const storeTool = api.getTool("memory_store");
+    const result = (await storeTool?.execute("call-empty", { text: "", importance: 0.5 })) as {
+      details: { error: string };
+    };
+
+    expect(result.details.error).toBe("invalid_text");
+    expect(walWrite).not.toHaveBeenCalled();
+    expect(embeddings.embed).not.toHaveBeenCalled();
+  });
+
+  it("returns invalid_text error for whitespace-only string without writing WAL", async () => {
+    const walWrite = vi.fn().mockResolvedValue("wal-id");
+    const embeddings = makeMockEmbeddings();
+    const { api } = setupTool(walWrite, embeddings);
+
+    const storeTool = api.getTool("memory_store");
+    const result = (await storeTool?.execute("call-ws", { text: "   \t\n  ", importance: 0.5 })) as {
+      details: { error: string };
+    };
+
+    expect(result.details.error).toBe("invalid_text");
+    expect(walWrite).not.toHaveBeenCalled();
+    expect(embeddings.embed).not.toHaveBeenCalled();
+  });
+
+  it("does not insert into FactsDB for empty text", async () => {
+    const walWrite = vi.fn().mockResolvedValue("wal-id");
+    const embeddings = makeMockEmbeddings();
+    const { api } = setupTool(walWrite, embeddings);
+
+    const storeTool = api.getTool("memory_store");
+    await storeTool?.execute("call-empty-db", { text: "", importance: 0.5 });
+
+    // FactsDB should have no records
+    const all = factsDb.getAll();
+    expect(all).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: invalid importance
+// ---------------------------------------------------------------------------
+
+describe("memory_store early validation — invalid importance", () => {
+  it("returns invalid_importance for importance > 1 without writing WAL", async () => {
+    const walWrite = vi.fn().mockResolvedValue("wal-id");
+    const embeddings = makeMockEmbeddings();
+    const { api } = setupTool(walWrite, embeddings);
+
+    const storeTool = api.getTool("memory_store");
+    const result = (await storeTool?.execute("call-imp-hi", {
+      text: "Valid text",
+      importance: 1.5,
+    })) as { details: { error: string } };
+
+    expect(result.details.error).toBe("invalid_importance");
+    expect(walWrite).not.toHaveBeenCalled();
+    expect(embeddings.embed).not.toHaveBeenCalled();
+  });
+
+  it("returns invalid_importance for negative importance without writing WAL", async () => {
+    const walWrite = vi.fn().mockResolvedValue("wal-id");
+    const embeddings = makeMockEmbeddings();
+    const { api } = setupTool(walWrite, embeddings);
+
+    const storeTool = api.getTool("memory_store");
+    const result = (await storeTool?.execute("call-imp-neg", {
+      text: "Valid text",
+      importance: -0.1,
+    })) as { details: { error: string } };
+
+    expect(result.details.error).toBe("invalid_importance");
+    expect(walWrite).not.toHaveBeenCalled();
+    expect(embeddings.embed).not.toHaveBeenCalled();
+  });
+
+  it("returns invalid_importance for NaN importance without writing WAL", async () => {
+    const walWrite = vi.fn().mockResolvedValue("wal-id");
+    const embeddings = makeMockEmbeddings();
+    const { api } = setupTool(walWrite, embeddings);
+
+    const storeTool = api.getTool("memory_store");
+    const result = (await storeTool?.execute("call-imp-nan", {
+      text: "Valid text",
+      importance: Number.NaN,
+    })) as { details: { error: string } };
+
+    expect(result.details.error).toBe("invalid_importance");
+    expect(walWrite).not.toHaveBeenCalled();
+    expect(embeddings.embed).not.toHaveBeenCalled();
+  });
+
+  it("returns invalid_importance for Infinity importance without writing WAL", async () => {
+    const walWrite = vi.fn().mockResolvedValue("wal-id");
+    const embeddings = makeMockEmbeddings();
+    const { api } = setupTool(walWrite, embeddings);
+
+    const storeTool = api.getTool("memory_store");
+    const result = (await storeTool?.execute("call-imp-inf", {
+      text: "Valid text",
+      importance: Number.POSITIVE_INFINITY,
+    })) as { details: { error: string } };
+
+    expect(result.details.error).toBe("invalid_importance");
+    expect(walWrite).not.toHaveBeenCalled();
+    expect(embeddings.embed).not.toHaveBeenCalled();
+  });
+
+  it("does not insert into FactsDB for invalid importance", async () => {
+    const walWrite = vi.fn().mockResolvedValue("wal-id");
+    const embeddings = makeMockEmbeddings();
+    const { api } = setupTool(walWrite, embeddings);
+
+    const storeTool = api.getTool("memory_store");
+    await storeTool?.execute("call-imp-db", { text: "Valid text", importance: 2 });
+
+    const all = factsDb.getAll();
+    expect(all).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: boundary / valid values still work
+// ---------------------------------------------------------------------------
+
+describe("memory_store early validation — valid inputs still stored", () => {
+  it("stores fact with importance exactly 0", async () => {
+    const walWrite = vi.fn().mockResolvedValue("wal-id");
+    const embeddings = makeMockEmbeddings();
+    const { api } = setupTool(walWrite, embeddings);
+
+    const storeTool = api.getTool("memory_store");
+    const result = (await storeTool?.execute("call-imp-0", {
+      text: "Valid text boundary zero",
+      importance: 0,
+    })) as { details: { error?: string } };
+
+    expect(result.details.error).toBeUndefined();
+    expect(walWrite).toHaveBeenCalled();
+  });
+
+  it("stores fact with importance exactly 1", async () => {
+    const walWrite = vi.fn().mockResolvedValue("wal-id");
+    const embeddings = makeMockEmbeddings();
+    const { api } = setupTool(walWrite, embeddings);
+
+    const storeTool = api.getTool("memory_store");
+    const result = (await storeTool?.execute("call-imp-1", {
+      text: "Valid text boundary one",
+      importance: 1,
+    })) as { details: { error?: string } };
+
+    expect(result.details.error).toBeUndefined();
+    expect(walWrite).toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: invalid decayFreezeUntil
+// ---------------------------------------------------------------------------
+
+describe("memory_store early validation — invalid decayFreezeUntil", () => {
+  it("returns invalid_decay_freeze_until for NaN value without writing WAL", async () => {
+    const walWrite = vi.fn().mockResolvedValue("wal-id");
+    const embeddings = makeMockEmbeddings();
+    const { api } = setupTool(walWrite, embeddings);
+
+    const storeTool = api.getTool("memory_store");
+    const result = (await storeTool?.execute("call-dfu-nan", {
+      text: "Valid text",
+      importance: 0.5,
+      decayFreezeUntil: Number.NaN,
+    })) as { details: { error: string } };
+
+    expect(result.details.error).toBe("invalid_decay_freeze_until");
+    expect(walWrite).not.toHaveBeenCalled();
+  });
+
+  it("returns invalid_decay_freeze_until for negative value without writing WAL", async () => {
+    const walWrite = vi.fn().mockResolvedValue("wal-id");
+    const embeddings = makeMockEmbeddings();
+    const { api } = setupTool(walWrite, embeddings);
+
+    const storeTool = api.getTool("memory_store");
+    const result = (await storeTool?.execute("call-dfu-neg", {
+      text: "Valid text",
+      importance: 0.5,
+      decayFreezeUntil: -1,
+    })) as { details: { error: string } };
+
+    expect(result.details.error).toBe("invalid_decay_freeze_until");
+    expect(walWrite).not.toHaveBeenCalled();
+  });
+
+  it("accepts valid positive decayFreezeUntil without error", async () => {
+    const walWrite = vi.fn().mockResolvedValue("wal-id");
+    const embeddings = makeMockEmbeddings();
+    const { api } = setupTool(walWrite, embeddings);
+
+    const storeTool = api.getTool("memory_store");
+    const result = (await storeTool?.execute("call-dfu-valid", {
+      text: "Valid text with freeze",
+      importance: 0.5,
+      decayFreezeUntil: Math.floor(Date.now() / 1000) + 86400,
+    })) as { details: { error?: string } };
+
+    expect(result.details.error).toBeUndefined();
+    expect(walWrite).toHaveBeenCalled();
+  });
+});

--- a/extensions/memory-hybrid/tools/memory/register-store-tools.ts
+++ b/extensions/memory-hybrid/tools/memory/register-store-tools.ts
@@ -177,16 +177,16 @@ export function registerStoreTools(runtime: MemoryToolRuntime): void {
             decayFreezeUntil?: number;
           };
 
-          let textToStore = text;
-          textToStore = truncateForStorage(textToStore, cfg.captureMaxChars);
-
           // --- Early input validation (must run before any side effects) ---
-          if (textToStore.trim().length === 0) {
+          if (text.trim().length === 0) {
             return {
               content: [{ type: "text", text: "memory_store: text must not be empty or whitespace." }],
               details: { error: "invalid_text" },
             };
           }
+
+          let textToStore = text;
+          textToStore = truncateForStorage(textToStore, cfg.captureMaxChars);
 
           const importanceValue = importance as number;
           if (!Number.isFinite(importanceValue) || importanceValue < 0 || importanceValue > 1) {

--- a/extensions/memory-hybrid/tools/memory/register-store-tools.ts
+++ b/extensions/memory-hybrid/tools/memory/register-store-tools.ts
@@ -201,10 +201,7 @@ export function registerStoreTools(runtime: MemoryToolRuntime): void {
             };
           }
 
-          if (
-            paramDecayFreezeUntil != null &&
-            (!Number.isFinite(paramDecayFreezeUntil) || paramDecayFreezeUntil < 0)
-          ) {
+          if (paramDecayFreezeUntil != null && (!Number.isFinite(paramDecayFreezeUntil) || paramDecayFreezeUntil < 0)) {
             return {
               content: [
                 {

--- a/extensions/memory-hybrid/tools/memory/register-store-tools.ts
+++ b/extensions/memory-hybrid/tools/memory/register-store-tools.ts
@@ -179,6 +179,44 @@ export function registerStoreTools(runtime: MemoryToolRuntime): void {
 
           let textToStore = text;
           textToStore = truncateForStorage(textToStore, cfg.captureMaxChars);
+
+          // --- Early input validation (must run before any side effects) ---
+          if (textToStore.trim().length === 0) {
+            return {
+              content: [{ type: "text", text: "memory_store: text must not be empty or whitespace." }],
+              details: { error: "invalid_text" },
+            };
+          }
+
+          const importanceValue = importance as number;
+          if (!Number.isFinite(importanceValue) || importanceValue < 0 || importanceValue > 1) {
+            return {
+              content: [
+                {
+                  type: "text",
+                  text: `memory_store: importance must be a finite number in [0, 1]; got ${importanceValue}.`,
+                },
+              ],
+              details: { error: "invalid_importance" },
+            };
+          }
+
+          if (
+            paramDecayFreezeUntil != null &&
+            (!Number.isFinite(paramDecayFreezeUntil) || paramDecayFreezeUntil < 0)
+          ) {
+            return {
+              content: [
+                {
+                  type: "text",
+                  text: `memory_store: decayFreezeUntil must be a non-negative finite epoch seconds value; got ${paramDecayFreezeUntil}.`,
+                },
+              ],
+              details: { error: "invalid_decay_freeze_until" },
+            };
+          }
+          // --- End early validation ---
+
           const provenanceSessionId = api.context?.sessionId ?? null;
           const recordActiveStoreProvenance = (factId: string, sourceText?: string) => {
             if (!provenanceService || !cfg.provenance.enabled) return;


### PR DESCRIPTION
<!-- issue-stewardship-pr issue:1575 -->
Fixes #1575

Issue: https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/1575

Status: draft implementation PR created by Issue Stewardship as Markus/current gh auth.
Protection: keep as draft and `stage/implementing` until Issue Stewardship dispatches/receives implementation and explicitly hands off to PR Stewardship.

Enrichment present on issue: 1
Priority inherited from issue: High (source labels: priority:high)
Dependencies/blocked labels inherited from issue: none

Implementation PR created by Issue Stewardship. Detailed enrichment should be attached to the issue before Copilot implementation dispatch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `memory_store` behavior to reject certain inputs early, which could affect callers relying on previous permissive handling; otherwise it’s localized and well-covered by new tests.
> 
> **Overview**
> Adds **early input validation** to `memory_store` so invalid requests return structured errors *before* any WAL write, embedding generation, or FactsDB insert.
> 
> Rejects empty/whitespace `text` (`invalid_text`), non-finite/out-of-range `importance` (`invalid_importance`), and non-finite/negative `decayFreezeUntil` (`invalid_decay_freeze_until`), and adds a new Vitest suite asserting both the error codes and the absence of side effects (including boundary cases like `importance` 0 and 1).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79dc7783aaece01e445c9009d69b6a8ef9bca623. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->