### PR TITLE
fix: auto-capture stores chain-of-thought and prompt artifacts as memory facts (#1560)

### DIFF
--- a/extensions/memory-hybrid/cli/cmd-capture-cleanup.ts
+++ b/extensions/memory-hybrid/cli/cmd-capture-cleanup.ts
@@ -14,7 +14,8 @@
 
 import { isPromptArtifactOrReasoningTrace } from "../services/capture-utils.js";
 import { deleteVectorForFactId } from "../services/vector-maintenance.js";
-import type { FactsDB, VectorDB } from "../types/memory.js";
+import type { FactsDB } from "../backends/facts-db.js";
+import type { VectorDB } from "../backends/vector-db.js";
 
 export interface CaptureCleanupResult {
   scanned: number;
@@ -89,7 +90,7 @@ export async function runCaptureCleanupForCli(options: {
             if (vectorDb) {
               try {
                 const deleted = await deleteVectorForFactId({
-                  vectorDb: vectorDb as VectorDB,
+                  vectorDb,
                   factId: row.id,
                   logger,
                   context: "capture-cleanup",

--- a/extensions/memory-hybrid/cli/cmd-capture-cleanup.ts
+++ b/extensions/memory-hybrid/cli/cmd-capture-cleanup.ts
@@ -12,20 +12,9 @@
  * Dry-run mode reports what would be cleaned without making changes.
  */
 
+import { isPromptArtifactOrReasoningTrace } from "../services/capture-utils.js";
 import { deleteVectorForFactId } from "../services/vector-maintenance.js";
 import type { FactsDB, VectorDB } from "../types/memory.js";
-
-/** Patterns matched by isPromptArtifactOrReasoningTrace — must stay in sync. */
-const REASONING_PATTERNS: Array<{ label: string; regex: RegExp }> = [
-  { label: "think-prefix", regex: /^think\s/i },
-  { label: "Thinking Process", regex: /^Thinking Process[;:]/i },
-  { label: "The user is asking me to classify/extract", regex: /^The user is asking me to (classify|extract)/i },
-  { label: "NOOP |", regex: /^NOOP \|/i },
-  { label: "ADD |", regex: /^ADD \|/i },
-  { label: "UPDATE |", regex: /^UPDATE \|/i },
-  { label: 'classifier JSON {"action"', regex: /^\{"action"\s*:/i },
-  { label: "capability-hints marker", regex: /^<!--\s*memory-hybrid\s*:\s*capability\s*hints/i },
-];
 
 export interface CaptureCleanupResult {
   scanned: number;
@@ -56,29 +45,27 @@ export async function runCaptureCleanupForCli(options: {
   };
 
   // Scan all active facts (source not explicitly excluded; reasoning traces come from auto-capture)
-  let pageOffset = 0;
   const PAGE_SIZE = 500;
 
   while (true) {
+    // Always query at offset 0: superseded facts drop out of the result set in non-dry-run mode
     const rows = factsDb.allRaw(
       `SELECT id, text, source, category, importance FROM facts
        WHERE superseded_at IS NULL
          AND (expires_at IS NULL OR expires_at > ?)
-       LIMIT ? OFFSET ?`,
-      [Math.floor(Date.now() / 1000), PAGE_SIZE, pageOffset],
+       LIMIT ?`,
+      [Math.floor(Date.now() / 1000), PAGE_SIZE],
     ) as Array<{ id: string; text: string; source: string; category: string; importance: number }>;
 
     if (rows.length === 0) break;
     result.scanned += rows.length;
 
     for (const row of rows) {
-      const matches = REASONING_PATTERNS.filter((p) => p.regex.test(row.text.trim()));
-      if (matches.length === 0) continue;
+      if (!isPromptArtifactOrReasoningTrace(row.text)) continue;
 
       result.matched++;
-      const matchLabels = matches.map((m) => m.label).join(", ");
       if (verbose || result.samples.length < 5) {
-        result.samples.push(`[${matchLabels}] ${row.text.slice(0, 80)}`);
+        result.samples.push(row.text.slice(0, 80));
       }
 
       if (!dryRun) {
@@ -105,14 +92,13 @@ export async function runCaptureCleanupForCli(options: {
           }
 
           result.superseded++;
-          logger?.info?.(`cleaned [${matchLabels}] fact ${row.id} (src=${row.source})`);
+          logger?.info?.(`cleaned fact ${row.id} (src=${row.source})`);
         } catch (err) {
           result.errors.push(`failed to supersede ${row.id}: ${err}`);
         }
       }
     }
 
-    pageOffset += PAGE_SIZE;
     if (rows.length < PAGE_SIZE) break;
   }
 

--- a/extensions/memory-hybrid/cli/cmd-capture-cleanup.ts
+++ b/extensions/memory-hybrid/cli/cmd-capture-cleanup.ts
@@ -46,19 +46,29 @@ export async function runCaptureCleanupForCli(options: {
 
   // Scan all active facts (source not explicitly excluded; reasoning traces come from auto-capture)
   const PAGE_SIZE = 500;
+  let offset = 0;
 
   while (true) {
-    // Always query at offset 0: superseded facts drop out of the result set in non-dry-run mode
-    const rows = factsDb.allRaw(
-      `SELECT id, text, source, category, importance FROM facts
-       WHERE superseded_at IS NULL
-         AND (expires_at IS NULL OR expires_at > ?)
-       LIMIT ?`,
-      [Math.floor(Date.now() / 1000), PAGE_SIZE],
-    ) as Array<{ id: string; text: string; source: string; category: string; importance: number }>;
+    const db = factsDb.getRawDb();
+    const rows = db
+      .prepare(
+        `SELECT id, text, source, category, importance FROM facts
+         WHERE superseded_at IS NULL
+           AND (expires_at IS NULL OR expires_at > ?)
+         LIMIT ? OFFSET ?`,
+      )
+      .all(Math.floor(Date.now() / 1000), PAGE_SIZE, offset) as Array<{
+      id: string;
+      text: string;
+      source: string;
+      category: string;
+      importance: number;
+    }>;
 
     if (rows.length === 0) break;
     result.scanned += rows.length;
+
+    let supersededInBatch = 0;
 
     for (const row of rows) {
       if (!isPromptArtifactOrReasoningTrace(row.text)) continue;
@@ -70,29 +80,29 @@ export async function runCaptureCleanupForCli(options: {
 
       if (!dryRun) {
         try {
-          // Demote: set superseded_at and lower importance
-          factsDb.allRaw(
-            `UPDATE facts SET superseded_at = ?, importance = ? WHERE id = ? AND superseded_at IS NULL`,
-            [Math.floor(Date.now() / 1000), Math.min(row.importance, 0.1), row.id],
-          );
+          const superseded = factsDb.supersede(row.id, null);
 
-          // Remove LanceDB vector
-          if (vectorDb) {
-            try {
-              const deleted = await deleteVectorForFactId({
-                vectorDb: vectorDb as VectorDB,
-                factId: row.id,
-                logger,
-                context: "capture-cleanup",
-              });
-              if (deleted) result.vectorDeleted++;
-            } catch (vecErr) {
-              result.errors.push(`vector delete failed for ${row.id}: ${vecErr}`);
+          if (superseded) {
+            db.prepare(`UPDATE facts SET importance = ? WHERE id = ?`).run(Math.min(row.importance, 0.1), row.id);
+
+            if (vectorDb) {
+              try {
+                const deleted = await deleteVectorForFactId({
+                  vectorDb: vectorDb as VectorDB,
+                  factId: row.id,
+                  logger,
+                  context: "capture-cleanup",
+                });
+                if (deleted) result.vectorDeleted++;
+              } catch (vecErr) {
+                result.errors.push(`vector delete failed for ${row.id}: ${vecErr}`);
+              }
             }
-          }
 
-          result.superseded++;
-          logger?.info?.(`cleaned fact ${row.id} (src=${row.source})`);
+            result.superseded++;
+            supersededInBatch++;
+            logger?.info?.(`cleaned fact ${row.id} (src=${row.source})`);
+          }
         } catch (err) {
           result.errors.push(`failed to supersede ${row.id}: ${err}`);
         }
@@ -100,6 +110,10 @@ export async function runCaptureCleanupForCli(options: {
     }
 
     if (rows.length < PAGE_SIZE) break;
+
+    if (dryRun || supersededInBatch === 0) {
+      offset += PAGE_SIZE;
+    }
   }
 
   return result;

--- a/extensions/memory-hybrid/cli/cmd-capture-cleanup.ts
+++ b/extensions/memory-hybrid/cli/cmd-capture-cleanup.ts
@@ -82,24 +82,24 @@ export async function runCaptureCleanupForCli(options: {
 
       if (!dryRun) {
         try {
+          if (vectorDb) {
+            try {
+              const deleted = await deleteVectorForFactId({
+                vectorDb,
+                factId: row.id,
+                logger,
+                context: "capture-cleanup",
+              });
+              if (deleted) result.vectorDeleted++;
+            } catch (vecErr) {
+              result.errors.push(`vector delete failed for ${row.id}: ${vecErr}`);
+            }
+          }
+
           const superseded = factsDb.supersede(row.id, null);
 
           if (superseded) {
             db.prepare(`UPDATE facts SET importance = ? WHERE id = ?`).run(Math.min(row.importance, 0.1), row.id);
-
-            if (vectorDb) {
-              try {
-                const deleted = await deleteVectorForFactId({
-                  vectorDb,
-                  factId: row.id,
-                  logger,
-                  context: "capture-cleanup",
-                });
-                if (deleted) result.vectorDeleted++;
-              } catch (vecErr) {
-                result.errors.push(`vector delete failed for ${row.id}: ${vecErr}`);
-              }
-            }
 
             result.superseded++;
             supersededInBatch++;

--- a/extensions/memory-hybrid/cli/cmd-capture-cleanup.ts
+++ b/extensions/memory-hybrid/cli/cmd-capture-cleanup.ts
@@ -1,0 +1,120 @@
+/**
+ * Capture Cleanup Maintenance Command (`memory-hybrid capture-cleanup`)
+ *
+ * Scans all active (non-superseded, non-expired) facts for text that matches
+ * chain-of-thought / reasoning-trace / classifier-prompt patterns that should NOT
+ * have been stored as memory facts (#1560).
+ *
+ * For each matching fact:
+ *   1. Marks it superseded in SQLite (sets superseded_at, decrements importance)
+ *   2. Removes its LanceDB vector to free space and stop semantic retrieval noise
+ *
+ * Dry-run mode reports what would be cleaned without making changes.
+ */
+
+import { deleteVectorForFactId } from "../services/vector-maintenance.js";
+import type { FactsDB, VectorDB } from "../types/memory.js";
+
+/** Patterns matched by isPromptArtifactOrReasoningTrace — must stay in sync. */
+const REASONING_PATTERNS: Array<{ label: string; regex: RegExp }> = [
+  { label: "think-prefix", regex: /^think\s/i },
+  { label: "Thinking Process", regex: /^Thinking Process[;:]/i },
+  { label: "The user is asking me to classify/extract", regex: /^The user is asking me to (classify|extract)/i },
+  { label: "NOOP |", regex: /^NOOP \|/i },
+  { label: "ADD |", regex: /^ADD \|/i },
+  { label: "UPDATE |", regex: /^UPDATE \|/i },
+  { label: 'classifier JSON {"action"', regex: /^\{"action"\s*:/i },
+  { label: "capability-hints marker", regex: /^<!--\s*memory-hybrid\s*:\s*capability\s*hints/i },
+];
+
+export interface CaptureCleanupResult {
+  scanned: number;
+  matched: number;
+  superseded: number;
+  vectorDeleted: number;
+  errors: string[];
+  dryRun: boolean;
+  samples: string[];
+}
+
+export async function runCaptureCleanupForCli(options: {
+  factsDb: FactsDB;
+  vectorDb: VectorDB | null;
+  logger?: { info?: (m: string) => void; warn?: (m: string) => void };
+  dryRun?: boolean;
+  verbose?: boolean;
+}): Promise<CaptureCleanupResult> {
+  const { factsDb, vectorDb, logger, dryRun = false, verbose = false } = options;
+  const result: CaptureCleanupResult = {
+    scanned: 0,
+    matched: 0,
+    superseded: 0,
+    vectorDeleted: 0,
+    errors: [],
+    dryRun,
+    samples: [],
+  };
+
+  // Scan all active facts (source not explicitly excluded; reasoning traces come from auto-capture)
+  let pageOffset = 0;
+  const PAGE_SIZE = 500;
+
+  while (true) {
+    const rows = factsDb.allRaw(
+      `SELECT id, text, source, category, importance FROM facts
+       WHERE superseded_at IS NULL
+         AND (expires_at IS NULL OR expires_at > ?)
+       LIMIT ? OFFSET ?`,
+      [Math.floor(Date.now() / 1000), PAGE_SIZE, pageOffset],
+    ) as Array<{ id: string; text: string; source: string; category: string; importance: number }>;
+
+    if (rows.length === 0) break;
+    result.scanned += rows.length;
+
+    for (const row of rows) {
+      const matches = REASONING_PATTERNS.filter((p) => p.regex.test(row.text.trim()));
+      if (matches.length === 0) continue;
+
+      result.matched++;
+      const matchLabels = matches.map((m) => m.label).join(", ");
+      if (verbose || result.samples.length < 5) {
+        result.samples.push(`[${matchLabels}] ${row.text.slice(0, 80)}`);
+      }
+
+      if (!dryRun) {
+        try {
+          // Demote: set superseded_at and lower importance
+          factsDb.allRaw(
+            `UPDATE facts SET superseded_at = ?, importance = ? WHERE id = ? AND superseded_at IS NULL`,
+            [Math.floor(Date.now() / 1000), Math.min(row.importance, 0.1), row.id],
+          );
+
+          // Remove LanceDB vector
+          if (vectorDb) {
+            try {
+              const deleted = await deleteVectorForFactId({
+                vectorDb: vectorDb as VectorDB,
+                factId: row.id,
+                logger,
+                context: "capture-cleanup",
+              });
+              if (deleted) result.vectorDeleted++;
+            } catch (vecErr) {
+              result.errors.push(`vector delete failed for ${row.id}: ${vecErr}`);
+            }
+          }
+
+          result.superseded++;
+          logger?.info?.(`cleaned [${matchLabels}] fact ${row.id} (src=${row.source})`);
+        } catch (err) {
+          result.errors.push(`failed to supersede ${row.id}: ${err}`);
+        }
+      }
+    }
+
+    pageOffset += PAGE_SIZE;
+    if (rows.length < PAGE_SIZE) break;
+  }
+
+  return result;
+}

--- a/extensions/memory-hybrid/cli/cmd-capture-cleanup.ts
+++ b/extensions/memory-hybrid/cli/cmd-capture-cleanup.ts
@@ -113,8 +113,10 @@ export async function runCaptureCleanupForCli(options: {
 
     if (rows.length < PAGE_SIZE) break;
 
-    if (dryRun || supersededInBatch === 0) {
+    if (dryRun) {
       offset += PAGE_SIZE;
+    } else {
+      offset += PAGE_SIZE - supersededInBatch;
     }
   }
 

--- a/extensions/memory-hybrid/cli/cmd-capture-cleanup.ts
+++ b/extensions/memory-hybrid/cli/cmd-capture-cleanup.ts
@@ -55,6 +55,7 @@ export async function runCaptureCleanupForCli(options: {
         `SELECT id, text, source, category, importance FROM facts
          WHERE superseded_at IS NULL
            AND (expires_at IS NULL OR expires_at > ?)
+         ORDER BY created_at DESC
          LIMIT ? OFFSET ?`,
       )
       .all(Math.floor(Date.now() / 1000), PAGE_SIZE, offset) as Array<{

--- a/extensions/memory-hybrid/cli/cmd-store.ts
+++ b/extensions/memory-hybrid/cli/cmd-store.ts
@@ -5,6 +5,7 @@
  * CLI implementation extracted from handlers.ts.
  */
 
+import { isPromptArtifactOrReasoningTrace } from "../services/capture-utils.js";
 import type { MemoryCategory } from "../config.js";
 import { getCronModelConfig, getDefaultCronModel } from "../config.js";
 import { VAULT_POINTER_PREFIX, isCredentialLike, tryParseCredentialForVault } from "../services/auto-capture.js";
@@ -41,6 +42,7 @@ export async function runStoreForCli(
 ): Promise<StoreCliResult> {
   const { factsDb, vectorDb, embeddings, openai, cfg, credentialsDb, aliasDb } = ctx;
   const text = opts.text;
+  if (isPromptArtifactOrReasoningTrace(text)) return { outcome: "noop", reason: "prompt artifact or reasoning trace" };
   if (factsDb.hasDuplicate(text, "cli")) return { outcome: "duplicate" };
   const sourceDate = opts.sourceDate ? parseSourceDate(opts.sourceDate) : null;
   const extracted = extractStructuredFields(text, (opts.category ?? "other") as MemoryCategory);

--- a/extensions/memory-hybrid/cli/handlers.ts
+++ b/extensions/memory-hybrid/cli/handlers.ts
@@ -70,4 +70,5 @@ export * from "./cmd-credentials.js";
 export * from "./cmd-selfcorrection.js";
 export * from "./cmd-feedback.js";
 export * from "./cmd-config.js";
+export * from "./cmd-capture-cleanup.js";
 export * from "./shared.js";

--- a/extensions/memory-hybrid/services/capture-utils.ts
+++ b/extensions/memory-hybrid/services/capture-utils.ts
@@ -5,8 +5,37 @@
 import type { MemoryCategory } from "../types/memory.js";
 import { CAPTURE_FILTER_PATTERNS } from "./auto-capture.js";
 
+/**
+ * Returns true if `text` matches patterns that indicate it is a chain-of-thought,
+ * reasoning-trace, or classifier prompt/output artifact rather than genuine user content.
+ * Used by auto-capture, CLI store, and memory_store classification paths to reject
+ * the garbage facts that pollute hot memories and progressive recall (#1560).
+ */
+export function isPromptArtifactOrReasoningTrace(text: string): boolean {
+  const trimmed = text.trim();
+  if (!trimmed) return false;
+
+  // Reject text beginning with think/think markers (with optional leading whitespace)
+  if (/^think\s/i.test(trimmed)) return true;
+  // Reject "Thinking Process" headers emitted by some models
+  if (/^Thinking Process[;:]/i.test(trimmed)) return true;
+  // Reject classifier/system prompt fragments
+  if (/^The user is asking me to (classify|extract)/i.test(trimmed)) return true;
+  // Reject structured operation markers from memory classification
+  if (/^NOOP \|/i.test(trimmed)) return true;
+  if (/^ADD \|/i.test(trimmed)) return true;
+  if (/^UPDATE \|/i.test(trimmed)) return true;
+  // Reject classifier JSON output
+  if (/^\{"action"\s*:/i.test(trimmed)) return true;
+  // Reject capability-hint markers injected into system context
+  if (/^<!--\s*memory-hybrid\s*:\s*capability\s*hints/i.test(trimmed)) return true;
+
+  return false;
+}
+
 export function shouldCapture(text: string, captureMaxChars: number, memoryTriggers: RegExp[]): boolean {
   if (text.length < 10 || text.length > captureMaxChars) return false;
+  if (isPromptArtifactOrReasoningTrace(text)) return false;
   if (text.includes("<relevant-memories>")) return false;
   if (text.startsWith("<") && text.includes("</")) return false;
   if (text.includes("**") && text.includes("\n-")) return false;

--- a/extensions/memory-hybrid/services/capture-utils.ts
+++ b/extensions/memory-hybrid/services/capture-utils.ts
@@ -17,6 +17,8 @@ export function isPromptArtifactOrReasoningTrace(text: string): boolean {
 
   // Reject text beginning with think/think markers (with optional leading whitespace)
   if (/^think\s/i.test(trimmed)) return true;
+  // Reject XML-like think wrappers from some model traces
+  if (/^<think(?:ing)?>/i.test(trimmed)) return true;
   // Reject "Thinking Process" headers emitted by some models
   if (/^Thinking Process[;:]/i.test(trimmed)) return true;
   // Reject classifier/system prompt fragments
@@ -26,7 +28,7 @@ export function isPromptArtifactOrReasoningTrace(text: string): boolean {
   if (/^ADD \|/i.test(trimmed)) return true;
   if (/^UPDATE \|/i.test(trimmed)) return true;
   // Reject classifier JSON output
-  if (/^\{"action"\s*:/i.test(trimmed)) return true;
+  if (/^\{\s*"action"\s*:/i.test(trimmed)) return true;
   // Reject capability-hint markers injected into system context
   if (/^<!--\s*memory-hybrid\s*:\s*capability\s*hints/i.test(trimmed)) return true;
 

--- a/extensions/memory-hybrid/services/capture-utils.ts
+++ b/extensions/memory-hybrid/services/capture-utils.ts
@@ -27,6 +27,7 @@ export function isPromptArtifactOrReasoningTrace(text: string): boolean {
   if (/^NOOP \|/i.test(trimmed)) return true;
   if (/^ADD \|/i.test(trimmed)) return true;
   if (/^UPDATE \|/i.test(trimmed)) return true;
+  if (/^DELETE \|/i.test(trimmed)) return true;
   // Reject classifier JSON output
   if (/^\{\s*"action"\s*:/i.test(trimmed)) return true;
   // Reject capability-hint markers injected into system context

--- a/extensions/memory-hybrid/tests/capture-utils.test.ts
+++ b/extensions/memory-hybrid/tests/capture-utils.test.ts
@@ -1,14 +1,23 @@
-// @ts-nocheck
-import { describe, expect, it } from "vitest";
+/**
+ * Unit tests for services/capture-utils.ts (Issue #559, #1560).
+ * Covers all short-circuit paths in shouldCapture and all category branches in detectCategory.
+ */
+
+import { describe, it, expect } from "vitest";
+import { shouldCapture, detectCategory, isPromptArtifactOrReasoningTrace } from "../services/capture-utils.js";
 import {
-  detectCategory,
-  isPromptArtifactOrReasoningTrace,
-  shouldCapture,
-} from "../services/capture-utils.js";
+  getCategoryDecisionRegex,
+  getCategoryPreferenceRegex,
+  getCategoryEntityRegex,
+  getCategoryFactRegex,
+} from "../utils/language-keywords.js";
+import { getMemoryTriggers } from "../services/auto-capture.js";
+
+// ---------------------------------------------------------------------------
+// isPromptArtifactOrReasoningTrace (Issue #1560)
+// ---------------------------------------------------------------------------
 
 describe("isPromptArtifactOrReasoningTrace", () => {
-  const True = () => true;
-
   describe("rejects think/think markers", () => {
     it("rejects text beginning with 'think '", () => {
       expect(isPromptArtifactOrReasoningTrace("think I should check the config first")).toBe(true);
@@ -98,19 +107,225 @@ describe("isPromptArtifactOrReasoningTrace", () => {
   });
 });
 
-describe("shouldCapture with reasoning trace guard", () => {
-  const alwaysTrigger = [/./];
+// ---------------------------------------------------------------------------
+// shouldCapture (Issue #559)
+// ---------------------------------------------------------------------------
+
+describe("shouldCapture", () => {
+  const MAX_CHARS = 500;
+  const TRIGGERS = getMemoryTriggers();
+
+  it("rejects text below minimum length (< 10 chars)", () => {
+    expect(shouldCapture("short", MAX_CHARS, TRIGGERS)).toBe(false);
+  });
+
+  it("rejects empty string", () => {
+    expect(shouldCapture("", MAX_CHARS, TRIGGERS)).toBe(false);
+  });
+
+  it("rejects text above captureMaxChars", () => {
+    const long = "remember ".repeat(100); // well over 500 chars, contains trigger
+    expect(shouldCapture(long, MAX_CHARS, TRIGGERS)).toBe(false);
+  });
+
+  it("rejects text containing <relevant-memories>", () => {
+    const text = "please remember this <relevant-memories>something</relevant-memories>";
+    expect(shouldCapture(text, MAX_CHARS, TRIGGERS)).toBe(false);
+  });
+
+  it("rejects XML-like text (starts with < and contains </)", () => {
+    expect(shouldCapture("<tool_result>I prefer dark mode</tool_result>", MAX_CHARS, TRIGGERS)).toBe(false);
+  });
+
+  it("rejects markdown-formatted text (contains ** and newline-dash)", () => {
+    const text = "**remember this**\n- bullet one\n- bullet two";
+    expect(shouldCapture(text, MAX_CHARS, TRIGGERS)).toBe(false);
+  });
+
+  it("rejects emoji-heavy text (more than 3 emojis)", () => {
+    const text = "I remember 🎉 you prefer 🚀 the dark 🌙 side 🦄";
+    expect(shouldCapture(text, MAX_CHARS, TRIGGERS)).toBe(false);
+  });
+
+  it("accepts text with exactly 3 emojis and a trigger", () => {
+    const text = "I prefer 🎉 dark 🚀 mode 🌙 always";
+    expect(shouldCapture(text, MAX_CHARS, TRIGGERS)).toBe(true);
+  });
+
+  it("rejects text matching a sensitive pattern (password)", () => {
+    const text = "remember that the password is hunter2";
+    expect(shouldCapture(text, MAX_CHARS, TRIGGERS)).toBe(false);
+  });
+
+  it("rejects text matching a sensitive pattern (api key)", () => {
+    const text = "remember the api_key for this service";
+    expect(shouldCapture(text, MAX_CHARS, TRIGGERS)).toBe(false);
+  });
+
+  it("rejects text matching a sensitive pattern (secret)", () => {
+    const text = "remember the client secret value for this application";
+    expect(shouldCapture(text, MAX_CHARS, TRIGGERS)).toBe(false);
+  });
+
+  it("rejects text matching a sensitive pattern (bearer keyword)", () => {
+    const text = "remember the bearer token for the API access here";
+    expect(shouldCapture(text, MAX_CHARS, TRIGGERS)).toBe(false);
+  });
+
+  it("rejects text matching a sensitive pattern (authorization header)", () => {
+    const text = "remember the authorization header value for the gateway";
+    expect(shouldCapture(text, MAX_CHARS, TRIGGERS)).toBe(false);
+  });
+
+  it("rejects text matching a sensitive pattern (credentials keyword)", () => {
+    const text = "remember the credentials for the home assistant system";
+    expect(shouldCapture(text, MAX_CHARS, TRIGGERS)).toBe(false);
+  });
+
+  it("rejects text with no trigger match", () => {
+    const text = "this text has no memory trigger at all in it here";
+    expect(shouldCapture(text, MAX_CHARS, TRIGGERS)).toBe(false);
+  });
+
+  it("accepts text that matches a trigger and passes all filters", () => {
+    expect(shouldCapture("I prefer dark mode when coding", MAX_CHARS, TRIGGERS)).toBe(true);
+  });
+
+  it("accepts text matching a second trigger", () => {
+    expect(shouldCapture("please remember to use tabs not spaces", MAX_CHARS, TRIGGERS)).toBe(true);
+  });
+
+  it("accepts text matching 'my name is' trigger", () => {
+    expect(shouldCapture("my name is Claude and I like TypeScript", MAX_CHARS, TRIGGERS)).toBe(true);
+  });
+
+  it("is case-insensitive for trigger match", () => {
+    expect(shouldCapture("I PREFER uppercase sometimes", MAX_CHARS, TRIGGERS)).toBe(true);
+  });
 
   it("rejects think-prefixed text via isPromptArtifactOrReasoningTrace guard", () => {
-    expect(shouldCapture("think I should fix this", 5000, alwaysTrigger)).toBe(false);
+    expect(shouldCapture("think I should fix this", MAX_CHARS, [/./])).toBe(false);
   });
+
   it("rejects Thinking Process text", () => {
-    expect(shouldCapture("Thinking Process: analyzing the request", 5000, alwaysTrigger)).toBe(false);
+    expect(shouldCapture("Thinking Process: analyzing the request", MAX_CHARS, [/./])).toBe(false);
   });
+
   it("rejects classifier JSON", () => {
-    expect(shouldCapture('{"action": "NOOP"}', 5000, alwaysTrigger)).toBe(false);
+    expect(shouldCapture('{"action": "NOOP"}', MAX_CHARS, [/./])).toBe(false);
   });
-  it("accepts genuine content that matches memory triggers", () => {
-    expect(shouldCapture("I prefer to use the config file", 5000, [/prefer/])).toBe(true);
+});
+
+// ---------------------------------------------------------------------------
+// detectCategory (Issue #559)
+// ---------------------------------------------------------------------------
+
+describe("detectCategory", () => {
+  const decisionRegex = getCategoryDecisionRegex();
+  const preferenceRegex = getCategoryPreferenceRegex();
+  const entityRegex = getCategoryEntityRegex();
+  const factRegex = getCategoryFactRegex();
+
+  it("returns 'decision' for text matching decision keywords", () => {
+    expect(
+      detectCategory(
+        "I decided to use TypeScript for this project",
+        decisionRegex,
+        preferenceRegex,
+        entityRegex,
+        factRegex,
+      ),
+    ).toBe("decision");
+  });
+
+  it("returns 'decision' for 'went with' keyword", () => {
+    expect(
+      detectCategory("we went with Postgres for the database", decisionRegex, preferenceRegex, entityRegex, factRegex),
+    ).toBe("decision");
+  });
+
+  it("returns 'preference' for text matching preference keywords", () => {
+    expect(
+      detectCategory(
+        "I prefer dark mode when working at night",
+        decisionRegex,
+        preferenceRegex,
+        entityRegex,
+        factRegex,
+      ),
+    ).toBe("preference");
+  });
+
+  it("returns 'decision' for 'always use' keyword", () => {
+    expect(
+      detectCategory("I always use two spaces for indentation", decisionRegex, preferenceRegex, entityRegex, factRegex),
+    ).toBe("decision");
+  });
+
+  it("returns 'entity' for text containing a phone-like pattern", () => {
+    // +10 digits triggers the phone regex in detectCategory
+    expect(
+      detectCategory("call me at +12025551234 anytime", decisionRegex, preferenceRegex, entityRegex, factRegex),
+    ).toBe("entity");
+  });
+
+  it("returns 'entity' for text with email-like pattern", () => {
+    expect(
+      detectCategory(
+        "reach me at user@example.com for details",
+        decisionRegex,
+        preferenceRegex,
+        entityRegex,
+        factRegex,
+      ),
+    ).toBe("entity");
+  });
+
+  it("returns 'entity' for text matching entity regex", () => {
+    expect(
+      detectCategory("the project is called Acme Corp", decisionRegex, preferenceRegex, entityRegex, factRegex),
+    ).toBe("entity");
+  });
+
+  it("returns 'fact' for text matching fact keywords", () => {
+    expect(
+      detectCategory("the capital of France is Paris", decisionRegex, preferenceRegex, entityRegex, factRegex),
+    ).toBe("fact");
+  });
+
+  it("returns 'fact' for 'has' pattern", () => {
+    expect(
+      detectCategory(
+        "the framework has many features and capabilities",
+        decisionRegex,
+        preferenceRegex,
+        entityRegex,
+        factRegex,
+      ),
+    ).toBe("fact");
+  });
+
+  it("returns 'other' when no category pattern matches", () => {
+    expect(
+      detectCategory(
+        "something entirely generic without keywords",
+        decisionRegex,
+        preferenceRegex,
+        entityRegex,
+        factRegex,
+      ),
+    ).toBe("other");
+  });
+
+  it("decision takes priority over preference when both match", () => {
+    expect(
+      detectCategory("I decided I prefer tabs over spaces", decisionRegex, preferenceRegex, entityRegex, factRegex),
+    ).toBe("decision");
+  });
+
+  it("is case-insensitive (uses lowercased text internally)", () => {
+    expect(
+      detectCategory("We DECIDED to deploy on Friday", decisionRegex, preferenceRegex, entityRegex, factRegex),
+    ).toBe("decision");
   });
 });

--- a/extensions/memory-hybrid/tests/capture-utils.test.ts
+++ b/extensions/memory-hybrid/tests/capture-utils.test.ts
@@ -1,225 +1,116 @@
-/**
- * Unit tests for services/capture-utils.ts (Issue #559).
- * Covers all short-circuit paths in shouldCapture and all category branches in detectCategory.
- */
-
+// @ts-nocheck
 import { describe, expect, it } from "vitest";
-import { getMemoryTriggers } from "../services/auto-capture.js";
-import { detectCategory, shouldCapture } from "../services/capture-utils.js";
 import {
-  getCategoryDecisionRegex,
-  getCategoryEntityRegex,
-  getCategoryFactRegex,
-  getCategoryPreferenceRegex,
-} from "../utils/language-keywords.js";
+  detectCategory,
+  isPromptArtifactOrReasoningTrace,
+  shouldCapture,
+} from "../services/capture-utils.js";
 
-// ---------------------------------------------------------------------------
-// shouldCapture
-// ---------------------------------------------------------------------------
+describe("isPromptArtifactOrReasoningTrace", () => {
+  const True = () => true;
 
-describe("shouldCapture", () => {
-  const MAX_CHARS = 500;
-  const TRIGGERS = getMemoryTriggers();
-
-  it("rejects text below minimum length (< 10 chars)", () => {
-    expect(shouldCapture("short", MAX_CHARS, TRIGGERS)).toBe(false);
+  describe("rejects think/think markers", () => {
+    it("rejects text beginning with 'think '", () => {
+      expect(isPromptArtifactOrReasoningTrace("think I should check the config first")).toBe(true);
+    });
+    it("rejects text beginning with 'think\n'", () => {
+      expect(isPromptArtifactOrReasoningTrace("think\nI should check the config first")).toBe(true);
+    });
+    it("rejects 'think' with leading whitespace", () => {
+      expect(isPromptArtifactOrReasoningTrace("  think I should check the config first")).toBe(true);
+    });
+    it("rejects 'Think I am a helpful assistant' (capitalized think)", () => {
+      expect(isPromptArtifactOrReasoningTrace("Think I am a helpful assistant")).toBe(true);
+    });
   });
 
-  it("rejects empty string", () => {
-    expect(shouldCapture("", MAX_CHARS, TRIGGERS)).toBe(false);
+  describe("rejects Thinking Process headers", () => {
+    it('rejects "Thinking Process:"', () => {
+      expect(isPromptArtifactOrReasoningTrace("Thinking Process: analyzing the request")).toBe(true);
+    });
+    it('rejects "Thinking Process;"', () => {
+      expect(isPromptArtifactOrReasoningTrace("Thinking Process; analyzing the request")).toBe(true);
+    });
+    it('rejects "thinking process" case-insensitively', () => {
+      expect(isPromptArtifactOrReasoningTrace("THINKING PROCESS: analyzing the request")).toBe(true);
+    });
   });
 
-  it("rejects text above captureMaxChars", () => {
-    const long = "remember ".repeat(100); // well over 500 chars, contains trigger
-    expect(shouldCapture(long, MAX_CHARS, TRIGGERS)).toBe(false);
+  describe("rejects classifier prompt fragments", () => {
+    it('rejects "The user is asking me to classify..."', () => {
+      expect(
+        isPromptArtifactOrReasoningTrace("The user is asking me to classify this message as a preference"),
+      ).toBe(true);
+    });
+    it('rejects "The user is asking me to extract..."', () => {
+      expect(
+        isPromptArtifactOrReasoningTrace("The user is asking me to extract entities from this message"),
+      ).toBe(true);
+    });
   });
 
-  it("rejects text containing <relevant-memories>", () => {
-    const text = "please remember this <relevant-memories>something</relevant-memories>";
-    expect(shouldCapture(text, MAX_CHARS, TRIGGERS)).toBe(false);
+  describe("rejects structured operation markers", () => {
+    it('rejects "NOOP |"', () => {
+      expect(isPromptArtifactOrReasoningTrace("NOOP | this classification decision is already captured")).toBe(true);
+    });
+    it('rejects "ADD |"', () => {
+      expect(isPromptArtifactOrReasoningTrace("ADD | new preference fact")).toBe(true);
+    });
+    it('rejects "UPDATE |"', () => {
+      expect(isPromptArtifactOrReasoningTrace("UPDATE | existing preference fact")).toBe(true);
+    });
   });
 
-  it("rejects XML-like text (starts with < and contains </)", () => {
-    expect(shouldCapture("<tool_result>I prefer dark mode</tool_result>", MAX_CHARS, TRIGGERS)).toBe(false);
+  describe("rejects classifier JSON output", () => {
+    it('rejects JSON starting with {"action"', () => {
+      expect(isPromptArtifactOrReasoningTrace('{"action": "NOOP", "reason": "..."}')).toBe(true);
+    });
+    it("rejects compact classifier JSON", () => {
+      expect(isPromptArtifactOrReasoningTrace('{"action":"UPDATE","targetId":"abc123"}')).toBe(true);
+    });
   });
 
-  it("rejects markdown-formatted text (contains ** and newline-dash)", () => {
-    const text = "**remember this**\n- bullet one\n- bullet two";
-    expect(shouldCapture(text, MAX_CHARS, TRIGGERS)).toBe(false);
+  describe("rejects capability-hint markers", () => {
+    it("rejects <!-- memory-hybrid: capability hints", () => {
+      expect(isPromptArtifactOrReasoningTrace("<!-- memory-hybrid: capability hints -->")).toBe(true);
+    });
+    it("rejects with leading whitespace", () => {
+      expect(isPromptArtifactOrReasoningTrace("  <!-- memory-hybrid: capability hints -->")).toBe(true);
+    });
   });
 
-  it("rejects emoji-heavy text (more than 3 emojis)", () => {
-    const text = "I remember 🎉 you prefer 🚀 the dark 🌙 side 🦄";
-    expect(shouldCapture(text, MAX_CHARS, TRIGGERS)).toBe(false);
-  });
-
-  it("accepts text with exactly 3 emojis and a trigger", () => {
-    const text = "I prefer 🎉 dark 🚀 mode 🌙 always";
-    expect(shouldCapture(text, MAX_CHARS, TRIGGERS)).toBe(true);
-  });
-
-  it("rejects text matching a sensitive pattern (password)", () => {
-    const text = "remember that the password is hunter2";
-    expect(shouldCapture(text, MAX_CHARS, TRIGGERS)).toBe(false);
-  });
-
-  it("rejects text matching a sensitive pattern (api key)", () => {
-    const text = "remember the api_key for this service";
-    expect(shouldCapture(text, MAX_CHARS, TRIGGERS)).toBe(false);
-  });
-
-  it("rejects text matching a sensitive pattern (secret)", () => {
-    const text = "remember the client secret value for this application";
-    expect(shouldCapture(text, MAX_CHARS, TRIGGERS)).toBe(false);
-  });
-
-  it("rejects text matching a sensitive pattern (bearer keyword)", () => {
-    const text = "remember the bearer token for the API access here";
-    expect(shouldCapture(text, MAX_CHARS, TRIGGERS)).toBe(false);
-  });
-
-  it("rejects text matching a sensitive pattern (authorization header)", () => {
-    const text = "remember the authorization header value for the gateway";
-    expect(shouldCapture(text, MAX_CHARS, TRIGGERS)).toBe(false);
-  });
-
-  it("rejects text matching a sensitive pattern (credentials keyword)", () => {
-    const text = "remember the credentials for the home assistant system";
-    expect(shouldCapture(text, MAX_CHARS, TRIGGERS)).toBe(false);
-  });
-
-  it("rejects text with no trigger match", () => {
-    const text = "this text has no memory trigger at all in it here";
-    expect(shouldCapture(text, MAX_CHARS, TRIGGERS)).toBe(false);
-  });
-
-  it("accepts text that matches a trigger and passes all filters", () => {
-    expect(shouldCapture("I prefer dark mode when coding", MAX_CHARS, TRIGGERS)).toBe(true);
-  });
-
-  it("accepts text matching a second trigger", () => {
-    expect(shouldCapture("please remember to use tabs not spaces", MAX_CHARS, TRIGGERS)).toBe(true);
-  });
-
-  it("accepts text matching 'my name is' trigger", () => {
-    expect(shouldCapture("my name is Claude and I like TypeScript", MAX_CHARS, TRIGGERS)).toBe(true);
-  });
-
-  it("is case-insensitive for trigger match", () => {
-    expect(shouldCapture("I PREFER uppercase sometimes", MAX_CHARS, TRIGGERS)).toBe(true);
+  describe("accepts genuine content", () => {
+    it("accepts plain user text", () => {
+      expect(isPromptArtifactOrReasoningTrace("I need to update the config file")).toBe(false);
+    });
+    it("accepts plain assistant text", () => {
+      expect(isPromptArtifactOrReasoningTrace("Sure, I can help you with that.")).toBe(false);
+    });
+    it("accepts text with think in the middle", () => {
+      expect(isPromptArtifactOrReasoningTrace("The user thinks it might be broken")).toBe(false);
+    });
+    it("accepts empty string", () => {
+      expect(isPromptArtifactOrReasoningTrace("")).toBe(false);
+    });
+    it("accepts whitespace-only string", () => {
+      expect(isPromptArtifactOrReasoningTrace("   \n\t  ")).toBe(false);
+    });
   });
 });
 
-// ---------------------------------------------------------------------------
-// detectCategory
-// ---------------------------------------------------------------------------
+describe("shouldCapture with reasoning trace guard", () => {
+  const alwaysTrigger = [/./];
 
-describe("detectCategory", () => {
-  const decisionRegex = getCategoryDecisionRegex();
-  const preferenceRegex = getCategoryPreferenceRegex();
-  const entityRegex = getCategoryEntityRegex();
-  const factRegex = getCategoryFactRegex();
-
-  it("returns 'decision' for text matching decision keywords", () => {
-    expect(
-      detectCategory(
-        "I decided to use TypeScript for this project",
-        decisionRegex,
-        preferenceRegex,
-        entityRegex,
-        factRegex,
-      ),
-    ).toBe("decision");
+  it("rejects think-prefixed text via isPromptArtifactOrReasoningTrace guard", () => {
+    expect(shouldCapture("think I should fix this", 5000, alwaysTrigger)).toBe(false);
   });
-
-  it("returns 'decision' for 'went with' keyword", () => {
-    expect(
-      detectCategory("we went with Postgres for the database", decisionRegex, preferenceRegex, entityRegex, factRegex),
-    ).toBe("decision");
+  it("rejects Thinking Process text", () => {
+    expect(shouldCapture("Thinking Process: analyzing the request", 5000, alwaysTrigger)).toBe(false);
   });
-
-  it("returns 'preference' for text matching preference keywords", () => {
-    expect(
-      detectCategory(
-        "I prefer dark mode when working at night",
-        decisionRegex,
-        preferenceRegex,
-        entityRegex,
-        factRegex,
-      ),
-    ).toBe("preference");
+  it("rejects classifier JSON", () => {
+    expect(shouldCapture('{"action": "NOOP"}', 5000, alwaysTrigger)).toBe(false);
   });
-
-  it("returns 'decision' for 'always use' keyword", () => {
-    expect(
-      detectCategory("I always use two spaces for indentation", decisionRegex, preferenceRegex, entityRegex, factRegex),
-    ).toBe("decision");
-  });
-
-  it("returns 'entity' for text containing a phone-like pattern", () => {
-    // +10 digits triggers the phone regex in detectCategory
-    expect(
-      detectCategory("call me at +12025551234 anytime", decisionRegex, preferenceRegex, entityRegex, factRegex),
-    ).toBe("entity");
-  });
-
-  it("returns 'entity' for text with email-like pattern", () => {
-    expect(
-      detectCategory(
-        "reach me at user@example.com for details",
-        decisionRegex,
-        preferenceRegex,
-        entityRegex,
-        factRegex,
-      ),
-    ).toBe("entity");
-  });
-
-  it("returns 'entity' for text matching entity regex", () => {
-    expect(
-      detectCategory("the project is called Acme Corp", decisionRegex, preferenceRegex, entityRegex, factRegex),
-    ).toBe("entity");
-  });
-
-  it("returns 'fact' for text matching fact keywords", () => {
-    expect(
-      detectCategory("the capital of France is Paris", decisionRegex, preferenceRegex, entityRegex, factRegex),
-    ).toBe("fact");
-  });
-
-  it("returns 'fact' for 'has' pattern", () => {
-    expect(
-      detectCategory(
-        "the framework has many features and capabilities",
-        decisionRegex,
-        preferenceRegex,
-        entityRegex,
-        factRegex,
-      ),
-    ).toBe("fact");
-  });
-
-  it("returns 'other' when no category pattern matches", () => {
-    expect(
-      detectCategory(
-        "something entirely generic without keywords",
-        decisionRegex,
-        preferenceRegex,
-        entityRegex,
-        factRegex,
-      ),
-    ).toBe("other");
-  });
-
-  it("decision takes priority over preference when both match", () => {
-    expect(
-      detectCategory("I decided I prefer tabs over spaces", decisionRegex, preferenceRegex, entityRegex, factRegex),
-    ).toBe("decision");
-  });
-
-  it("is case-insensitive (uses lowercased text internally)", () => {
-    expect(
-      detectCategory("We DECIDED to deploy on Friday", decisionRegex, preferenceRegex, entityRegex, factRegex),
-    ).toBe("decision");
+  it("accepts genuine content that matches memory triggers", () => {
+    expect(shouldCapture("I prefer to use the config file", 5000, [/prefer/])).toBe(true);
   });
 });

--- a/extensions/memory-hybrid/tests/capture-utils.test.ts
+++ b/extensions/memory-hybrid/tests/capture-utils.test.ts
@@ -31,6 +31,12 @@ describe("isPromptArtifactOrReasoningTrace", () => {
     it("rejects 'Think I am a helpful assistant' (capitalized think)", () => {
       expect(isPromptArtifactOrReasoningTrace("Think I am a helpful assistant")).toBe(true);
     });
+    it("rejects '<think>' wrapper prefix", () => {
+      expect(isPromptArtifactOrReasoningTrace("<think>I should check the config first")).toBe(true);
+    });
+    it("rejects '<thinking>' wrapper prefix", () => {
+      expect(isPromptArtifactOrReasoningTrace("<thinking>I should check the config first")).toBe(true);
+    });
   });
 
   describe("rejects Thinking Process headers", () => {
@@ -47,14 +53,14 @@ describe("isPromptArtifactOrReasoningTrace", () => {
 
   describe("rejects classifier prompt fragments", () => {
     it('rejects "The user is asking me to classify..."', () => {
-      expect(
-        isPromptArtifactOrReasoningTrace("The user is asking me to classify this message as a preference"),
-      ).toBe(true);
+      expect(isPromptArtifactOrReasoningTrace("The user is asking me to classify this message as a preference")).toBe(
+        true,
+      );
     });
     it('rejects "The user is asking me to extract..."', () => {
-      expect(
-        isPromptArtifactOrReasoningTrace("The user is asking me to extract entities from this message"),
-      ).toBe(true);
+      expect(isPromptArtifactOrReasoningTrace("The user is asking me to extract entities from this message")).toBe(
+        true,
+      );
     });
   });
 
@@ -76,6 +82,9 @@ describe("isPromptArtifactOrReasoningTrace", () => {
     });
     it("rejects compact classifier JSON", () => {
       expect(isPromptArtifactOrReasoningTrace('{"action":"UPDATE","targetId":"abc123"}')).toBe(true);
+    });
+    it('rejects JSON with whitespace after "{" before "action"', () => {
+      expect(isPromptArtifactOrReasoningTrace('{ "action": "NOOP", "reason": "..." }')).toBe(true);
     });
   });
 
@@ -213,6 +222,14 @@ describe("shouldCapture", () => {
 
   it("rejects classifier JSON", () => {
     expect(shouldCapture('{"action": "NOOP"}', MAX_CHARS, [/./])).toBe(false);
+  });
+
+  it("rejects classifier JSON with whitespace after opening brace", () => {
+    expect(shouldCapture('{ "action": "NOOP" }', MAX_CHARS, [/./])).toBe(false);
+  });
+
+  it("rejects <think>-prefixed text via isPromptArtifactOrReasoningTrace guard", () => {
+    expect(shouldCapture("<think>I should fix this</think>", MAX_CHARS, [/./])).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Fix #1560 — Reject chain-of-thought and classifier artifacts in auto-capture

### Problem
The agent_end auto-capture path extracts raw text from every user and assistant message and stores it as a memory fact if it passes shouldCapture(). That function had no guard against chain-of-thought artifacts (think, think, Thinking Process, Thinking Process:, classifier prompt fragments, etc.). The result is hundreds of garbage facts that pollute hot memories and progressive recall.

Evidence: DB has 562 facts where trimmed text starts with think, 1080 facts matching think/think/model think patterns.

### Changes

**services/capture-utils.ts**
- Add  — hard reject guard used by all capture paths
- Rejects text beginning with:
  -  (with optional leading whitespace)
  -  or 
  - 
  - , , 
  -  (classifier JSON)
  - 
-  now calls  first

**cli/cmd-store.ts**
- CLI  path also rejects prompt artifacts before storing

**cli/cmd-capture-cleanup.ts** (new)
-  maintenance command
- Scans all active (non-superseded, non-expired) facts
- For each fact matching reasoning-trace patterns: supersedes it in SQLite and removes its LanceDB vector
- Supports  to report without making changes
- Used to clean up the 562+ existing garbage facts

**tests/capture-utils.test.ts** (new)
- Regression tests:  and  assistant messages are NOT stored as memory facts
- Verifies all artifact patterns are rejected
- Verifies genuine content is still accepted

### Acceptance criteria
- [x]  and  in assistant messages do NOT become stored memory facts
- [x] Existing DB facts matching think patterns can be cleaned up via 
- [x] All 4 capture paths (auto-capture, CLI store, CLI ingest, memory_store classification) are protected

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes capture/store filtering logic (could block legitimate memories) and introduces a maintenance command that mutates persisted facts and deletes vectors.
> 
> **Overview**
> Prevents chain-of-thought, classifier prompt/output fragments, and other prompt artifacts from being stored as memory facts by adding `isPromptArtifactOrReasoningTrace()` and wiring it into `shouldCapture()` and the CLI `runStoreForCli()` path.
> 
> Adds a new `memory-hybrid capture-cleanup` maintenance command to scan existing active facts, supersede any matching artifacts (lowering importance), and optionally delete their vectors, with `dryRun`/`verbose` reporting.
> 
> Expands `capture-utils` unit tests to cover the new artifact-detection patterns and ensure `shouldCapture()` rejects them while still accepting normal content.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3be98bd5878e684dfd779b59f9076656ea2ecf4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->