### PR TITLE
fix: make capability hints injection session-only by default

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -118,6 +118,7 @@ Set **`interactiveEnrichment`** to **`fast`** for stable, cost-effective default
 {
   "autoRecall": {
     "enabled": true,
+    "capabilityHints": "session",
     "interactiveEnrichment": "fast",
     "maxTokens": 800,
     "maxPerMemoryChars": 0,
@@ -151,6 +152,7 @@ Set **`interactiveEnrichment`** to **`fast`** for stable, cost-effective default
 | `maxTokens` | `800` | Total tokens injected per turn |
 | `maxPerMemoryChars` | `0` | Truncate each memory to N chars (0 = no truncation) |
 | `injectionFormat` | `"full"` | `full` = `[backend/category] text`, `short` = `category: text`, `minimal` = text only, `progressive` = memory index (agent fetches via `memory_recall`), `progressive_hybrid` = pinned in full + rest as index |
+| `capabilityHints` | `"session"` | Capability-hints cadence: `session` = inject once per session (default), `always` = every prompt, `off` = disable static capability-hints block |
 | `limit` | `10` | Max memories considered for injection |
 | `minScore` | `0.3` | Minimum vector search score (0–1) |
 | `preferLongTerm` | `false` | Boost permanent (×1.2) and stable (×1.1) facts |

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -118,7 +118,7 @@ Set **`interactiveEnrichment`** to **`fast`** for stable, cost-effective default
 {
   "autoRecall": {
     "enabled": true,
-    "capabilityHints": "session",
+    "capabilityHints": "off",
     "interactiveEnrichment": "fast",
     "maxTokens": 800,
     "maxPerMemoryChars": 0,
@@ -152,7 +152,7 @@ Set **`interactiveEnrichment`** to **`fast`** for stable, cost-effective default
 | `maxTokens` | `800` | Total tokens injected per turn |
 | `maxPerMemoryChars` | `0` | Truncate each memory to N chars (0 = no truncation) |
 | `injectionFormat` | `"full"` | `full` = `[backend/category] text`, `short` = `category: text`, `minimal` = text only, `progressive` = memory index (agent fetches via `memory_recall`), `progressive_hybrid` = pinned in full + rest as index |
-| `capabilityHints` | `"session"` | Capability-hints cadence: `session` = inject once per session (default), `always` = every prompt, `off` = disable static capability-hints block |
+| `capabilityHints` | `"off"` | Capability-hints cadence: `off` = disable static capability-hints block (default), `session` = inject once per session, `always` = every prompt |
 | `limit` | `10` | Max memories considered for injection |
 | `minScore` | `0.3` | Minimum vector search score (0–1) |
 | `preferLongTerm` | `false` | Boost permanent (×1.2) and stable (×1.1) facts |

--- a/extensions/memory-hybrid/backends/vector-db/vector-db-class.ts
+++ b/extensions/memory-hybrid/backends/vector-db/vector-db-class.ts
@@ -2232,7 +2232,13 @@ export class VectorDB {
 
   /** Returns true if the VectorDB table and semantic query cache table are initialized and ready. */
   isInitialized(): boolean {
-    return this.table !== null && this.semanticQueryCacheTable !== null;
+    return (
+      !this.closed &&
+      this.db !== null &&
+      this.table !== null &&
+      this.semanticQueryCacheTable !== null &&
+      !this.lanceInitFailed
+    );
   }
 
   /** Returns true if an optimize operation is currently in progress. */

--- a/extensions/memory-hybrid/backends/vector-db/vector-db-class.ts
+++ b/extensions/memory-hybrid/backends/vector-db/vector-db-class.ts
@@ -2130,8 +2130,6 @@ export class VectorDB {
     return this.closeGeneration;
   }
 
-  /** LanceDB root path for this backend instance. */
-
   /** Lightweight search telemetry for diagnostics/health surfaces. */
   getSearchTelemetry(): {
     active: number;
@@ -2225,5 +2223,25 @@ export class VectorDB {
   /** Number of store() calls since the last auto-optimize reset (rough proxy for write pressure). */
   getStoreCount(): number {
     return this.storeCount;
+  }
+
+  /** LanceDB root path for this backend instance. */
+  getPath(): string {
+    return this.dbPath;
+  }
+
+  /** Returns true if the VectorDB table and semantic query cache table are initialized and ready. */
+  isInitialized(): boolean {
+    return this.table !== null && this.semanticQueryCacheTable !== null;
+  }
+
+  /** Returns true if an optimize operation is currently in progress. */
+  isOptimizing(): boolean {
+    return this.optimizePromise !== null;
+  }
+
+  /** Returns the current number of active readers (for exclusive lock coordination with optimize). */
+  getOpenReaderCount(): number {
+    return VectorDB._activeReadersByPath.get(this.dbPath) ?? 0;
   }
 }

--- a/extensions/memory-hybrid/backends/vector-db/vector-db-class.ts
+++ b/extensions/memory-hybrid/backends/vector-db/vector-db-class.ts
@@ -2131,24 +2131,6 @@ export class VectorDB {
   }
 
   /** LanceDB root path for this backend instance. */
-  getPath(): string {
-    return this.dbPath;
-  }
-
-  /** Reader slots currently held for this Lance path (search/count/getVectors, etc.). */
-  getOpenReaderCount(): number {
-    return VectorDB._activeReadersByPath.get(this.dbPath) ?? 0;
-  }
-
-  /** True while optimize() holds/awaits the exclusive maintenance lock for this path. */
-  isOptimizing(): boolean {
-    return optimizingByPath.get(this.dbPath) === true;
-  }
-
-  /** True when a live db/table handle exists and the instance is not closed/degraded-init-failed. */
-  isInitialized(): boolean {
-    return !this.closed && this.db != null && this.table != null && !this.lanceInitFailed;
-  }
 
   /** Lightweight search telemetry for diagnostics/health surfaces. */
   getSearchTelemetry(): {

--- a/extensions/memory-hybrid/config/parsers/retrieval.ts
+++ b/extensions/memory-hybrid/config/parsers/retrieval.ts
@@ -146,7 +146,7 @@ export function parseAutoRecallConfig(cfg: Record<string, unknown>): AutoRecallC
       typeof capabilityHintsRaw === "string" &&
       (VALID_CAPABILITY_HINTS as readonly string[]).includes(capabilityHintsRaw)
         ? (capabilityHintsRaw as CapabilityHintsMode)
-        : "session";
+        : "off";
     const scopeFilterRaw = ar.scopeFilter as Record<string, unknown> | undefined;
     const scopeFilter =
       scopeFilterRaw && typeof scopeFilterRaw === "object" && !Array.isArray(scopeFilterRaw)
@@ -216,7 +216,7 @@ export function parseAutoRecallConfig(cfg: Record<string, unknown>): AutoRecallC
   }
   return {
     enabled: arRaw !== false,
-    capabilityHints: "session",
+    capabilityHints: "off",
     recallTiming: "off",
     maxTokens: 800,
     maxPerMemoryChars: 0,

--- a/extensions/memory-hybrid/config/parsers/retrieval.ts
+++ b/extensions/memory-hybrid/config/parsers/retrieval.ts
@@ -4,6 +4,7 @@ import type {
   AutoClassifyConfig,
   AutoRecallConfig,
   AutoRecallInjectionFormat,
+  CapabilityHintsMode,
   ContextualVariantsConfig,
   DocumentGradingConfig,
   EntityLookupConfig,
@@ -139,6 +140,13 @@ export function parseAutoRecallConfig(cfg: Record<string, unknown>): AutoRecallC
           : typeof recallTimingRaw === "string" && (VALID_RECALL_TIMING as readonly string[]).includes(recallTimingRaw)
             ? (recallTimingRaw as (typeof VALID_RECALL_TIMING)[number])
             : "off";
+    const VALID_CAPABILITY_HINTS = ["session", "always", "off"] as const;
+    const capabilityHintsRaw = ar.capabilityHints;
+    const capabilityHints =
+      typeof capabilityHintsRaw === "string" &&
+      (VALID_CAPABILITY_HINTS as readonly string[]).includes(capabilityHintsRaw)
+        ? (capabilityHintsRaw as CapabilityHintsMode)
+        : "session";
     const scopeFilterRaw = ar.scopeFilter as Record<string, unknown> | undefined;
     const scopeFilter =
       scopeFilterRaw && typeof scopeFilterRaw === "object" && !Array.isArray(scopeFilterRaw)
@@ -172,6 +180,7 @@ export function parseAutoRecallConfig(cfg: Record<string, unknown>): AutoRecallC
     };
     return {
       enabled: ar.enabled !== false,
+      capabilityHints,
       recallTiming,
       maxTokens: typeof ar.maxTokens === "number" && ar.maxTokens > 0 ? ar.maxTokens : 800,
       maxPerMemoryChars:
@@ -207,6 +216,7 @@ export function parseAutoRecallConfig(cfg: Record<string, unknown>): AutoRecallC
   }
   return {
     enabled: arRaw !== false,
+    capabilityHints: "session",
     recallTiming: "off",
     maxTokens: 800,
     maxPerMemoryChars: 0,

--- a/extensions/memory-hybrid/config/types/retrieval.ts
+++ b/extensions/memory-hybrid/config/types/retrieval.ts
@@ -1,6 +1,6 @@
 /** Auto-recall injection line format: full = [backend/category] text, short = category: text, minimal = text only, progressive = memory index (agent fetches on demand), progressive_hybrid = pinned in full + rest as index */
 export type AutoRecallInjectionFormat = "full" | "short" | "minimal" | "progressive" | "progressive_hybrid";
-/** Capability hints injection cadence: session = once per session (default), always = every prompt, off = disable hints injection. */
+/** Capability hints injection cadence: session = once per session, always = every prompt, off = disable hints injection (default). */
 export type CapabilityHintsMode = "session" | "always" | "off";
 
 export type AutoClassifyConfig = {
@@ -60,7 +60,7 @@ export type RetrievalDirectivesConfig = {
 /** Auto-recall: enable/disable plus token cap, format, limit, minScore, preferLongTerm, importance/recency, entity lookup, summary, progressive options */
 export type AutoRecallConfig = {
   enabled: boolean;
-  /** Capability hints injection cadence for static memory tools guidance (default: "session"). */
+  /** Capability hints injection cadence for static memory tools guidance (default: "off"). */
   capabilityHints?: CapabilityHintsMode;
   /** Recall timing logs: off = disabled, basic = completed events only, verbose = started+completed with timestamps. */
   recallTiming?: "off" | "basic" | "verbose";

--- a/extensions/memory-hybrid/config/types/retrieval.ts
+++ b/extensions/memory-hybrid/config/types/retrieval.ts
@@ -1,5 +1,7 @@
 /** Auto-recall injection line format: full = [backend/category] text, short = category: text, minimal = text only, progressive = memory index (agent fetches on demand), progressive_hybrid = pinned in full + rest as index */
 export type AutoRecallInjectionFormat = "full" | "short" | "minimal" | "progressive" | "progressive_hybrid";
+/** Capability hints injection cadence: session = once per session (default), always = every prompt, off = disable hints injection. */
+export type CapabilityHintsMode = "session" | "always" | "off";
 
 export type AutoClassifyConfig = {
   enabled: boolean;
@@ -58,6 +60,8 @@ export type RetrievalDirectivesConfig = {
 /** Auto-recall: enable/disable plus token cap, format, limit, minScore, preferLongTerm, importance/recency, entity lookup, summary, progressive options */
 export type AutoRecallConfig = {
   enabled: boolean;
+  /** Capability hints injection cadence for static memory tools guidance (default: "session"). */
+  capabilityHints?: CapabilityHintsMode;
   /** Recall timing logs: off = disabled, basic = completed events only, verbose = started+completed with timestamps. */
   recallTiming?: "off" | "basic" | "verbose";
   maxTokens: number;

--- a/extensions/memory-hybrid/lifecycle/hooks.ts
+++ b/extensions/memory-hybrid/lifecycle/hooks.ts
@@ -268,5 +268,5 @@ export function createLifecycleHooks(ctx: LifecycleContext) {
 
   const dispose = getDispose(staleSweepTimer, sessionState);
 
-  return { onAgentStart, onAgentEnd, onFrustrationDetect, dispose };
+  return { onAgentStart, onAgentEnd, onFrustrationDetect, dispose, sessionState };
 }

--- a/extensions/memory-hybrid/lifecycle/session-state.ts
+++ b/extensions/memory-hybrid/lifecycle/session-state.ts
@@ -104,11 +104,22 @@ export function createSessionState(): SessionState {
       }
     }
     if (capabilityHintsSessionsSeen.size > MAX_TRACKED_SESSIONS) {
-      const excess = capabilityHintsSessionsSeen.size - MAX_TRACKED_SESSIONS;
-      const keys = capabilityHintsSessionsSeen.keys();
-      for (let i = 0; i < excess; i++) {
-        const { value } = keys.next();
-        if (value) capabilityHintsSessionsSeen.delete(value);
+      const keysToRemove: string[] = [];
+      for (const key of capabilityHintsSessionsSeen) {
+        if (!sessionLastActivity.has(key)) {
+          keysToRemove.push(key);
+        }
+      }
+      for (const key of keysToRemove) {
+        capabilityHintsSessionsSeen.delete(key);
+      }
+      if (capabilityHintsSessionsSeen.size > MAX_TRACKED_SESSIONS) {
+        const excess = capabilityHintsSessionsSeen.size - MAX_TRACKED_SESSIONS;
+        const keys = capabilityHintsSessionsSeen.keys();
+        for (let i = 0; i < excess; i++) {
+          const { value } = keys.next();
+          if (value) capabilityHintsSessionsSeen.delete(value);
+        }
       }
     }
     if (authFailureRecallsThisSession.size > MAX_TRACKED_SESSIONS * 3) {

--- a/extensions/memory-hybrid/lifecycle/session-state.ts
+++ b/extensions/memory-hybrid/lifecycle/session-state.ts
@@ -55,6 +55,7 @@ export function createSessionState(): SessionState {
   const ambientSeenFactsMap = new Map<string, SessionSeenFacts>();
   const ambientLastEmbeddingMap = new Map<string, number[] | null>();
   const sessionLastActivity = new Map<string, number>();
+  const capabilityHintsSessionsSeen = new Set<string>();
 
   function touchSession(sessionKey: string): void {
     sessionLastActivity.set(sessionKey, Date.now());
@@ -66,6 +67,7 @@ export function createSessionState(): SessionState {
     ambientLastEmbeddingMap.delete(sessionKey);
     frustrationStateMap.delete(sessionKey);
     sessionLastActivity.delete(sessionKey);
+    capabilityHintsSessionsSeen.delete(sessionKey);
     const prefix = `${sessionKey}:`;
     for (const key of authFailureRecallsThisSession.keys()) {
       if (key.startsWith(prefix)) authFailureRecallsThisSession.delete(key);
@@ -100,6 +102,14 @@ export function createSessionState(): SessionState {
         if (value) sessionStartSeen.delete(value);
       }
     }
+    if (capabilityHintsSessionsSeen.size > MAX_TRACKED_SESSIONS) {
+      const excess = capabilityHintsSessionsSeen.size - MAX_TRACKED_SESSIONS;
+      const keys = capabilityHintsSessionsSeen.keys();
+      for (let i = 0; i < excess; i++) {
+        const { value } = keys.next();
+        if (value) capabilityHintsSessionsSeen.delete(value);
+      }
+    }
     if (authFailureRecallsThisSession.size > MAX_TRACKED_SESSIONS * 3) {
       const excess = authFailureRecallsThisSession.size - MAX_TRACKED_SESSIONS * 3;
       const keys = authFailureRecallsThisSession.keys();
@@ -129,6 +139,7 @@ export function createSessionState(): SessionState {
     frustrationStateMap.clear();
     authFailureRecallsThisSession.clear();
     sessionLastActivity.clear();
+    capabilityHintsSessionsSeen.clear();
   };
 
   return {
@@ -138,6 +149,7 @@ export function createSessionState(): SessionState {
     frustrationStateMap,
     authFailureRecallsThisSession,
     sessionLastActivity,
+    capabilityHintsSessionsSeen,
     touchSession,
     clearSessionState,
     pruneSessionMaps,

--- a/extensions/memory-hybrid/lifecycle/session-state.ts
+++ b/extensions/memory-hybrid/lifecycle/session-state.ts
@@ -104,22 +104,11 @@ export function createSessionState(): SessionState {
       }
     }
     if (capabilityHintsSessionsSeen.size > MAX_TRACKED_SESSIONS) {
-      const keysToRemove: string[] = [];
-      for (const key of capabilityHintsSessionsSeen) {
-        if (!sessionLastActivity.has(key)) {
-          keysToRemove.push(key);
-        }
-      }
-      for (const key of keysToRemove) {
-        capabilityHintsSessionsSeen.delete(key);
-      }
-      if (capabilityHintsSessionsSeen.size > MAX_TRACKED_SESSIONS) {
-        const excess = capabilityHintsSessionsSeen.size - MAX_TRACKED_SESSIONS;
-        const keys = capabilityHintsSessionsSeen.keys();
-        for (let i = 0; i < excess; i++) {
-          const { value } = keys.next();
-          if (value) capabilityHintsSessionsSeen.delete(value);
-        }
+      const excess = capabilityHintsSessionsSeen.size - MAX_TRACKED_SESSIONS;
+      const keys = capabilityHintsSessionsSeen.keys();
+      for (let i = 0; i < excess; i++) {
+        const { value } = keys.next();
+        if (value) capabilityHintsSessionsSeen.delete(value);
       }
     }
     if (authFailureRecallsThisSession.size > MAX_TRACKED_SESSIONS * 3) {

--- a/extensions/memory-hybrid/lifecycle/session-state.ts
+++ b/extensions/memory-hybrid/lifecycle/session-state.ts
@@ -67,7 +67,8 @@ export function createSessionState(): SessionState {
     ambientLastEmbeddingMap.delete(sessionKey);
     frustrationStateMap.delete(sessionKey);
     sessionLastActivity.delete(sessionKey);
-    capabilityHintsSessionsSeen.delete(sessionKey);
+    // Do NOT clear capabilityHintsSessionsSeen here — that set persists across agent turns
+    // within the same chat session so "session" mode injects once per chat, not once per turn.
     const prefix = `${sessionKey}:`;
     for (const key of authFailureRecallsThisSession.keys()) {
       if (key.startsWith(prefix)) authFailureRecallsThisSession.delete(key);

--- a/extensions/memory-hybrid/lifecycle/stage-cleanup.ts
+++ b/extensions/memory-hybrid/lifecycle/stage-cleanup.ts
@@ -292,6 +292,7 @@ function sweepStaleSessions(sessionState: SessionState): number {
   for (const [sessionKey, lastActive] of sessionState.sessionLastActivity) {
     if (lastActive < cutoff) {
       sessionState.clearSessionState(sessionKey);
+      sessionState.capabilityHintsSessionsSeen.delete(sessionKey);
       swept++;
     }
   }

--- a/extensions/memory-hybrid/lifecycle/types.ts
+++ b/extensions/memory-hybrid/lifecycle/types.ts
@@ -87,6 +87,7 @@ export interface SessionState {
   frustrationStateMap: Map<string, { level: number; turns: FrustrationConversationTurn[] }>;
   authFailureRecallsThisSession: Map<string, number>;
   sessionLastActivity: Map<string, number>;
+  capabilityHintsSessionsSeen: Set<string>;
   touchSession: (sessionKey: string) => void;
   clearSessionState: (sessionKey: string) => void;
   pruneSessionMaps: () => void;

--- a/extensions/memory-hybrid/openclaw.plugin.json
+++ b/extensions/memory-hybrid/openclaw.plugin.json
@@ -777,6 +777,11 @@
                 ],
                 "description": "Structured recall timing logs: false/off=disabled, true/basic=completed events only, verbose=started+completed with timestamps."
               },
+              "capabilityHints": {
+                "type": "string",
+                "enum": ["session", "always", "off"],
+                "description": "Capability hints injection cadence for static memory tools guidance: session = inject once per session start, always = inject on every turn, off = disabled (default: off)."
+              },
               "progressiveMaxCandidates": {
                 "type": "number"
               },

--- a/extensions/memory-hybrid/services/task-ledger-facts.ts
+++ b/extensions/memory-hybrid/services/task-ledger-facts.ts
@@ -1099,7 +1099,8 @@ export function backfillActiveTaskCanonicalLabels(
       if (!opts.dryRun) factsDb.supersede(oldId, newId);
     };
     if (terminalStatus) {
-      for (const row of rows) {
+      const statusRows = byKey.get("status") ?? [];
+      for (const row of statusRows) {
         if (row.id !== terminalStatus!.id && !row.supersededAt) supersede(row.id, terminalStatus!.id);
       }
     } else {

--- a/extensions/memory-hybrid/services/task-ledger-facts.ts
+++ b/extensions/memory-hybrid/services/task-ledger-facts.ts
@@ -1034,6 +1034,105 @@ export async function syncActiveTaskEntryToFacts(
   );
 }
 
+export interface ActiveTaskCanonicalBackfillResult {
+  scannedFacts: number;
+  canonicalLabelsUpdated: number;
+  supersededFacts: number;
+  duplicateGroups: Array<{ canonicalLabel: string; facts: number; activeBefore: number; superseded: number }>;
+}
+
+export function backfillActiveTaskCanonicalLabels(
+  factsDb: FactsDB,
+  opts: { dryRun?: boolean; limit?: number } = {},
+): ActiveTaskCanonicalBackfillResult {
+  const facts = factsDb.listFactsByCategory(TASK_LEDGER_CATEGORY, opts.limit ?? 50_000);
+  const groups = new Map<string, MemoryEntry[]>();
+  let canonicalLabelsUpdated = 0;
+
+  for (const fact of facts) {
+    if (!fact.entity?.trim()) continue;
+    const canonical = canonicalLabel(fact.entity);
+    const existing = readCanonicalLabelFromFact(fact);
+    if (existing !== canonical) {
+      canonicalLabelsUpdated++;
+      if (!opts.dryRun) {
+        const rawDb = (
+          factsDb as unknown as {
+            getRawDb?: () => { prepare: (sql: string) => { run: (...args: unknown[]) => unknown } };
+          }
+        ).getRawDb?.();
+        rawDb
+          ?.prepare("UPDATE facts SET provenance_json = ? WHERE id = ?")
+          .run(activeTaskProvenance(canonical), fact.id);
+      }
+    }
+    const arr = groups.get(canonical) ?? [];
+    arr.push(fact);
+    groups.set(canonical, arr);
+  }
+
+  const duplicateGroups: ActiveTaskCanonicalBackfillResult["duplicateGroups"] = [];
+  let supersededFacts = 0;
+  for (const [canonical, rows] of groups) {
+    const activeBefore = rows.filter((f) => !f.supersededAt).length;
+    let groupSuperseded = 0;
+    const byKey = new Map<string, MemoryEntry[]>();
+    for (const row of rows) {
+      const key = (row.key ?? "").trim() || "_body";
+      const arr = byKey.get(key) ?? [];
+      arr.push(row);
+      byKey.set(key, arr);
+    }
+    let terminalStatus: MemoryEntry | undefined;
+    const statusRows = byKey.get("status") ?? [];
+    for (const row of statusRows) {
+      if (
+        isTerminalFactStatus(row.value ?? row.text ?? "") &&
+        (!terminalStatus || row.createdAt > terminalStatus.createdAt)
+      ) {
+        terminalStatus = row;
+      }
+    }
+    const supersede = (oldId: string, newId: string | null): void => {
+      supersededFacts++;
+      groupSuperseded++;
+      if (!opts.dryRun) factsDb.supersede(oldId, newId);
+    };
+    if (terminalStatus) {
+      for (const row of rows) {
+        if (row.id !== terminalStatus!.id && !row.supersededAt) supersede(row.id, terminalStatus!.id);
+      }
+    } else {
+      for (const sameKey of byKey.values()) {
+        const ranked = [...sameKey].sort((a, b) => b.createdAt - a.createdAt);
+        const keeper = ranked[0];
+        for (const row of ranked.slice(1)) {
+          if (!row.supersededAt) supersede(row.id, keeper.id);
+        }
+      }
+    }
+    if (activeBefore > 1 || groupSuperseded > 0) {
+      duplicateGroups.push({
+        canonicalLabel: canonical,
+        facts: rows.length,
+        activeBefore,
+        superseded: groupSuperseded,
+      });
+    }
+  }
+
+  if (!opts.dryRun) {
+    (factsDb as unknown as { invalidateSupersededTextsCache?: () => void }).invalidateSupersededTextsCache?.();
+  }
+
+  return {
+    scannedFacts: facts.length,
+    canonicalLabelsUpdated,
+    supersededFacts,
+    duplicateGroups: duplicateGroups.sort((a, b) => a.canonicalLabel.localeCompare(b.canonicalLabel)),
+  };
+}
+
 export interface ActiveTaskHygieneApplyResult {
   appliedCount: number;
   auditFactId?: string;

--- a/extensions/memory-hybrid/services/task-ledger-facts.ts
+++ b/extensions/memory-hybrid/services/task-ledger-facts.ts
@@ -1073,6 +1073,7 @@ export function backfillActiveTaskCanonicalLabels(
 
   const duplicateGroups: ActiveTaskCanonicalBackfillResult["duplicateGroups"] = [];
   let supersededFacts = 0;
+  const nowSec = Math.floor(Date.now() / 1000);
   for (const [canonical, rows] of groups) {
     const activeBefore = rows.filter((f) => !f.supersededAt).length;
     let groupSuperseded = 0;
@@ -1086,7 +1087,9 @@ export function backfillActiveTaskCanonicalLabels(
     let terminalStatus: MemoryEntry | undefined;
     const statusRows = byKey.get("status") ?? [];
     for (const row of statusRows) {
+      const isExpired = row.expiresAt !== null && row.expiresAt <= nowSec;
       if (
+        !isExpired &&
         isTerminalFactStatus(row.value ?? row.text ?? "") &&
         (!terminalStatus || row.createdAt > terminalStatus.createdAt)
       ) {

--- a/extensions/memory-hybrid/services/task-ledger-facts.ts
+++ b/extensions/memory-hybrid/services/task-ledger-facts.ts
@@ -1034,124 +1034,6 @@ export async function syncActiveTaskEntryToFacts(
   );
 }
 
-export interface ActiveTaskCanonicalBackfillResult {
-  scannedFacts: number;
-  canonicalLabelsUpdated: number;
-  supersededFacts: number;
-  duplicateGroups: Array<{ canonicalLabel: string; facts: number; activeBefore: number; superseded: number }>;
-}
-
-export function backfillActiveTaskCanonicalLabels(
-  factsDb: FactsDB,
-  opts: { dryRun?: boolean; limit?: number } = {},
-): ActiveTaskCanonicalBackfillResult {
-  const facts = factsDb.listFactsByCategory(TASK_LEDGER_CATEGORY, opts.limit ?? 50_000);
-  const groups = new Map<string, MemoryEntry[]>();
-  let canonicalLabelsUpdated = 0;
-
-  for (const fact of facts) {
-    if (!fact.entity?.trim()) continue;
-    const canonical = canonicalLabel(fact.entity);
-    const existing = readCanonicalLabelFromFact(fact);
-    if (existing !== canonical) {
-      canonicalLabelsUpdated++;
-      if (!opts.dryRun) {
-        const rawDb = (
-          factsDb as unknown as {
-            getRawDb?: () => { prepare: (sql: string) => { run: (...args: unknown[]) => unknown } };
-          }
-        ).getRawDb?.();
-        // Merge canonical label fields into existing provenance to preserve other
-        // fields (e.g. sourceEventIds, method) instead of replacing them entirely.
-        const existingProvenance = (() => {
-          if (!fact.provenanceJson) return {};
-          try {
-            return JSON.parse(fact.provenanceJson) as Record<string, unknown>;
-          } catch {
-            return {};
-          }
-        })();
-        const mergedProvenance = {
-          ...existingProvenance,
-          activeTask: { canonicalLabel: canonical },
-          canonical_label: canonical,
-        };
-        rawDb
-          ?.prepare("UPDATE facts SET provenance_json = ? WHERE id = ?")
-          .run(JSON.stringify(mergedProvenance), fact.id);
-      }
-    }
-    const arr = groups.get(canonical) ?? [];
-    arr.push(fact);
-    groups.set(canonical, arr);
-  }
-
-  const duplicateGroups: ActiveTaskCanonicalBackfillResult["duplicateGroups"] = [];
-  let supersededFacts = 0;
-  const nowSec = Math.floor(Date.now() / 1000);
-  for (const [canonical, rows] of groups) {
-    const activeBefore = rows.filter((f) => !f.supersededAt).length;
-    let groupSuperseded = 0;
-    const byKey = new Map<string, MemoryEntry[]>();
-    for (const row of rows) {
-      const key = (row.key ?? "").trim() || "_body";
-      const arr = byKey.get(key) ?? [];
-      arr.push(row);
-      byKey.set(key, arr);
-    }
-    let terminalStatus: MemoryEntry | undefined;
-    const statusRows = byKey.get("status") ?? [];
-    for (const row of statusRows) {
-      const isExpired = row.expiresAt !== null && row.expiresAt <= nowSec;
-      if (
-        !isExpired &&
-        isTerminalFactStatus(row.value ?? row.text ?? "") &&
-        (!terminalStatus || row.createdAt > terminalStatus.createdAt)
-      ) {
-        terminalStatus = row;
-      }
-    }
-    const supersede = (oldId: string, newId: string | null): void => {
-      supersededFacts++;
-      groupSuperseded++;
-      if (!opts.dryRun) factsDb.supersede(oldId, newId);
-    };
-    if (terminalStatus) {
-      const statusRows = byKey.get("status") ?? [];
-      for (const row of statusRows) {
-        if (row.id !== terminalStatus!.id && !row.supersededAt) supersede(row.id, terminalStatus!.id);
-      }
-    } else {
-      for (const sameKey of byKey.values()) {
-        const ranked = [...sameKey].sort((a, b) => b.createdAt - a.createdAt);
-        const keeper = ranked[0];
-        for (const row of ranked.slice(1)) {
-          if (!row.supersededAt) supersede(row.id, keeper.id);
-        }
-      }
-    }
-    if (activeBefore > 1 || groupSuperseded > 0) {
-      duplicateGroups.push({
-        canonicalLabel: canonical,
-        facts: rows.length,
-        activeBefore,
-        superseded: groupSuperseded,
-      });
-    }
-  }
-
-  if (!opts.dryRun) {
-    (factsDb as unknown as { invalidateSupersededTextsCache?: () => void }).invalidateSupersededTextsCache?.();
-  }
-
-  return {
-    scannedFacts: facts.length,
-    canonicalLabelsUpdated,
-    supersededFacts,
-    duplicateGroups: duplicateGroups.sort((a, b) => a.canonicalLabel.localeCompare(b.canonicalLabel)),
-  };
-}
-
 export interface ActiveTaskHygieneApplyResult {
   appliedCount: number;
   auditFactId?: string;
@@ -1222,6 +1104,7 @@ export function backfillActiveTaskCanonicalLabels(
       const isExpired = row.expiresAt !== null && row.expiresAt <= nowSec;
       if (
         !isExpired &&
+        !row.supersededAt &&
         isTerminalFactStatus(row.value ?? row.text ?? "") &&
         (!terminalStatus || row.createdAt > terminalStatus.createdAt)
       ) {

--- a/extensions/memory-hybrid/services/task-ledger-facts.ts
+++ b/extensions/memory-hybrid/services/task-ledger-facts.ts
@@ -1061,9 +1061,24 @@ export function backfillActiveTaskCanonicalLabels(
             getRawDb?: () => { prepare: (sql: string) => { run: (...args: unknown[]) => unknown } };
           }
         ).getRawDb?.();
+        // Merge canonical label fields into existing provenance to preserve other
+        // fields (e.g. sourceEventIds, method) instead of replacing them entirely.
+        const existingProvenance = (() => {
+          if (!fact.provenanceJson) return {};
+          try {
+            return JSON.parse(fact.provenanceJson) as Record<string, unknown>;
+          } catch {
+            return {};
+          }
+        })();
+        const mergedProvenance = {
+          ...existingProvenance,
+          activeTask: { canonicalLabel: canonical },
+          canonical_label: canonical,
+        };
         rawDb
           ?.prepare("UPDATE facts SET provenance_json = ? WHERE id = ?")
-          .run(activeTaskProvenance(canonical), fact.id);
+          .run(JSON.stringify(mergedProvenance), fact.id);
       }
     }
     const arr = groups.get(canonical) ?? [];

--- a/extensions/memory-hybrid/setup/register-hooks.ts
+++ b/extensions/memory-hybrid/setup/register-hooks.ts
@@ -249,6 +249,7 @@ export function registerLifecycleHooks(ctx: HooksContext, api: ClawdbotPluginApi
         if (!sessionKey) return;
         if (hooks.sessionState.capabilityHintsSessionsSeen.has(sessionKey)) return;
         hooks.sessionState.capabilityHintsSessionsSeen.add(sessionKey);
+        hooks.sessionState.touchSession(sessionKey);
         hooks.sessionState.pruneSessionMaps();
       }
       return { prependContext: staticMemoryInstructions };

--- a/extensions/memory-hybrid/setup/register-hooks.ts
+++ b/extensions/memory-hybrid/setup/register-hooks.ts
@@ -217,8 +217,6 @@ export function registerLifecycleHooks(ctx: HooksContext, api: ClawdbotPluginApi
   const capabilityHintsMode = ctx.cfg.autoRecall.capabilityHints ?? "off";
   if (ctx.cfg.autoRecall.enabled && ctx.cfg.verbosity !== "silent" && capabilityHintsMode !== "off") {
     let staticMemoryInstructions: string | null = null;
-    const capabilityHintsSessionsSeen = new Set<string>();
-    const MAX_CAPABILITY_HINT_SESSIONS = 200;
 
     // Build once and cache — these never change within a gateway session.
     const buildStaticInstructions = (): string => {
@@ -248,12 +246,9 @@ export function registerLifecycleHooks(ctx: HooksContext, api: ClawdbotPluginApi
       if (capabilityHintsMode === "session") {
         const rApi = withHookResolutionApi(api, hookCtx);
         const sessionKey = resolveSessionKeyFromHookEvent(event, rApi) ?? "default";
-        if (capabilityHintsSessionsSeen.has(sessionKey)) return;
-        capabilityHintsSessionsSeen.add(sessionKey);
-        if (capabilityHintsSessionsSeen.size > MAX_CAPABILITY_HINT_SESSIONS) {
-          const oldest = capabilityHintsSessionsSeen.values().next().value;
-          if (oldest) capabilityHintsSessionsSeen.delete(oldest);
-        }
+        if (hooks.sessionState.capabilityHintsSessionsSeen.has(sessionKey)) return;
+        hooks.sessionState.capabilityHintsSessionsSeen.add(sessionKey);
+        hooks.sessionState.pruneSessionMaps();
       }
       return { prependContext: staticMemoryInstructions };
     });

--- a/extensions/memory-hybrid/setup/register-hooks.ts
+++ b/extensions/memory-hybrid/setup/register-hooks.ts
@@ -213,8 +213,9 @@ export function registerLifecycleHooks(ctx: HooksContext, api: ClawdbotPluginApi
   //     it is supported by all OpenClaw versions and produces the correct runtime behaviour.
   //
   // We ONLY inject when autoRecall is enabled — if the user opted out they don't want hints.
+  // Silent mode suppresses capability hints (VerbosityLevel docs) regardless of explicit capabilityHints setting.
   const capabilityHintsMode = ctx.cfg.autoRecall.capabilityHints ?? "off";
-  if (ctx.cfg.autoRecall.enabled && capabilityHintsMode !== "off") {
+  if (ctx.cfg.autoRecall.enabled && capabilityHintsMode !== "off" && ctx.cfg.verbosity !== "silent") {
     let staticMemoryInstructions: string | null = null;
 
     // Build once and cache — these never change within a gateway session.
@@ -244,7 +245,7 @@ export function registerLifecycleHooks(ctx: HooksContext, api: ClawdbotPluginApi
       }
       if (capabilityHintsMode === "session") {
         const rApi = withHookResolutionApi(api, hookCtx);
-        const sessionKey = resolveSessionKeyFromHookEvent(event, rApi) ?? "default";
+        const sessionKey = resolveSessionKeyFromHookEvent(event, rApi) ?? ctx.currentAgentIdRef.value ?? "default";
         if (hooks.sessionState.capabilityHintsSessionsSeen.has(sessionKey)) return;
         hooks.sessionState.capabilityHintsSessionsSeen.add(sessionKey);
         hooks.sessionState.pruneSessionMaps();

--- a/extensions/memory-hybrid/setup/register-hooks.ts
+++ b/extensions/memory-hybrid/setup/register-hooks.ts
@@ -10,7 +10,9 @@ import type { ClawdbotPluginApi } from "openclaw/plugin-sdk/core";
 import type { MemoryPluginAPI } from "../api/memory-plugin-api.js";
 import { resolveOpenclawJsonPathForWorkspace } from "../cli/cmd-install.js";
 import { getMemoryCategories } from "../config.js";
+import { withHookResolutionApi } from "../lifecycle/hook-resolution-api.js";
 import { type LifecycleContext, createLifecycleHooks } from "../lifecycle/hooks.js";
+import { resolveSessionKeyFromHookEvent } from "../lifecycle/session-state.js";
 import { capturePluginError } from "../services/error-reporter.js";
 import { buildPostCompactionRecallSnippet } from "../services/post-compaction-recall.js";
 import { runPreConsolidationFlush } from "../services/pre-consolidation-flush.js";
@@ -212,8 +214,11 @@ export function registerLifecycleHooks(ctx: HooksContext, api: ClawdbotPluginApi
   //
   // We ONLY inject when autoRecall is enabled — if the user opted out they don't want hints.
   // Silent mode suppresses all unsolicited output including capability hints (Issue #317).
-  if (ctx.cfg.autoRecall.enabled && ctx.cfg.verbosity !== "silent") {
+  const capabilityHintsMode = ctx.cfg.autoRecall.capabilityHints ?? "session";
+  if (ctx.cfg.autoRecall.enabled && ctx.cfg.verbosity !== "silent" && capabilityHintsMode !== "off") {
     let staticMemoryInstructions: string | null = null;
+    const capabilityHintsSessionsSeen = new Set<string>();
+    const MAX_CAPABILITY_HINT_SESSIONS = 200;
 
     // Build once and cache — these never change within a gateway session.
     const buildStaticInstructions = (): string => {
@@ -236,9 +241,19 @@ export function registerLifecycleHooks(ctx: HooksContext, api: ClawdbotPluginApi
     // the prompt build. When a reliable capability signal for `appendSystemContext`
     // becomes available in the plugin SDK, this hook can be extended to prefer that
     // field without risking duplicate instructions.
-    api.on("before_prompt_build", (): undefined | { prependContext: string } => {
+    api.on("before_prompt_build", (event: unknown, hookCtx: unknown): undefined | { prependContext: string } => {
       if (!staticMemoryInstructions) {
         staticMemoryInstructions = buildStaticInstructions();
+      }
+      if (capabilityHintsMode === "session") {
+        const rApi = withHookResolutionApi(api, hookCtx);
+        const sessionKey = resolveSessionKeyFromHookEvent(event, rApi) ?? "default";
+        if (capabilityHintsSessionsSeen.has(sessionKey)) return;
+        capabilityHintsSessionsSeen.add(sessionKey);
+        if (capabilityHintsSessionsSeen.size > MAX_CAPABILITY_HINT_SESSIONS) {
+          const oldest = capabilityHintsSessionsSeen.values().next().value;
+          if (oldest) capabilityHintsSessionsSeen.delete(oldest);
+        }
       }
       return { prependContext: staticMemoryInstructions };
     });

--- a/extensions/memory-hybrid/setup/register-hooks.ts
+++ b/extensions/memory-hybrid/setup/register-hooks.ts
@@ -245,7 +245,8 @@ export function registerLifecycleHooks(ctx: HooksContext, api: ClawdbotPluginApi
       }
       if (capabilityHintsMode === "session") {
         const rApi = withHookResolutionApi(api, hookCtx);
-        const sessionKey = resolveSessionKeyFromHookEvent(event, rApi) ?? ctx.currentAgentIdRef.value ?? "default";
+        const sessionKey = resolveSessionKeyFromHookEvent(event, rApi);
+        if (!sessionKey) return;
         if (hooks.sessionState.capabilityHintsSessionsSeen.has(sessionKey)) return;
         hooks.sessionState.capabilityHintsSessionsSeen.add(sessionKey);
         hooks.sessionState.pruneSessionMaps();

--- a/extensions/memory-hybrid/setup/register-hooks.ts
+++ b/extensions/memory-hybrid/setup/register-hooks.ts
@@ -245,8 +245,8 @@ export function registerLifecycleHooks(ctx: HooksContext, api: ClawdbotPluginApi
       }
       if (capabilityHintsMode === "session") {
         const rApi = withHookResolutionApi(api, hookCtx);
-        const sessionKey = resolveSessionKeyFromHookEvent(event, rApi);
-        if (!sessionKey) return;
+        const sessionKey =
+          resolveSessionKeyFromHookEvent(event, rApi) ?? lifecycleContext.currentAgentIdRef.value ?? "default";
         if (hooks.sessionState.capabilityHintsSessionsSeen.has(sessionKey)) return;
         hooks.sessionState.capabilityHintsSessionsSeen.add(sessionKey);
         hooks.sessionState.touchSession(sessionKey);

--- a/extensions/memory-hybrid/setup/register-hooks.ts
+++ b/extensions/memory-hybrid/setup/register-hooks.ts
@@ -213,9 +213,8 @@ export function registerLifecycleHooks(ctx: HooksContext, api: ClawdbotPluginApi
   //     it is supported by all OpenClaw versions and produces the correct runtime behaviour.
   //
   // We ONLY inject when autoRecall is enabled — if the user opted out they don't want hints.
-  // Silent mode suppresses all unsolicited output including capability hints (Issue #317).
   const capabilityHintsMode = ctx.cfg.autoRecall.capabilityHints ?? "off";
-  if (ctx.cfg.autoRecall.enabled && ctx.cfg.verbosity !== "silent" && capabilityHintsMode !== "off") {
+  if (ctx.cfg.autoRecall.enabled && capabilityHintsMode !== "off") {
     let staticMemoryInstructions: string | null = null;
 
     // Build once and cache — these never change within a gateway session.

--- a/extensions/memory-hybrid/setup/register-hooks.ts
+++ b/extensions/memory-hybrid/setup/register-hooks.ts
@@ -214,7 +214,7 @@ export function registerLifecycleHooks(ctx: HooksContext, api: ClawdbotPluginApi
   //
   // We ONLY inject when autoRecall is enabled — if the user opted out they don't want hints.
   // Silent mode suppresses all unsolicited output including capability hints (Issue #317).
-  const capabilityHintsMode = ctx.cfg.autoRecall.capabilityHints ?? "session";
+  const capabilityHintsMode = ctx.cfg.autoRecall.capabilityHints ?? "off";
   if (ctx.cfg.autoRecall.enabled && ctx.cfg.verbosity !== "silent" && capabilityHintsMode !== "off") {
     let staticMemoryInstructions: string | null = null;
     const capabilityHintsSessionsSeen = new Set<string>();

--- a/extensions/memory-hybrid/tests/config.test.ts
+++ b/extensions/memory-hybrid/tests/config.test.ts
@@ -566,14 +566,14 @@ describe("hybridConfigSchema.parse", () => {
     expect(result.autoRecall.interactiveEnrichment).toBe("fast");
   });
 
-  it("defaults autoRecall.capabilityHints to session", () => {
+  it("defaults autoRecall.capabilityHints to off", () => {
     const result = hybridConfigSchema.parse({
       ...validBase,
       autoRecall: {
         enabled: true,
       },
     });
-    expect(result.autoRecall.capabilityHints).toBe("session");
+    expect(result.autoRecall.capabilityHints).toBe("off");
   });
 
   it("parses autoRecall.capabilityHints override", () => {

--- a/extensions/memory-hybrid/tests/config.test.ts
+++ b/extensions/memory-hybrid/tests/config.test.ts
@@ -566,6 +566,36 @@ describe("hybridConfigSchema.parse", () => {
     expect(result.autoRecall.interactiveEnrichment).toBe("fast");
   });
 
+  it("defaults autoRecall.capabilityHints to session", () => {
+    const result = hybridConfigSchema.parse({
+      ...validBase,
+      autoRecall: {
+        enabled: true,
+      },
+    });
+    expect(result.autoRecall.capabilityHints).toBe("session");
+  });
+
+  it("parses autoRecall.capabilityHints override", () => {
+    const always = hybridConfigSchema.parse({
+      ...validBase,
+      autoRecall: {
+        enabled: true,
+        capabilityHints: "always",
+      },
+    });
+    expect(always.autoRecall.capabilityHints).toBe("always");
+
+    const off = hybridConfigSchema.parse({
+      ...validBase,
+      autoRecall: {
+        enabled: true,
+        capabilityHints: "off",
+      },
+    });
+    expect(off.autoRecall.capabilityHints).toBe("off");
+  });
+
   it("parses autoRecall.recallTiming", () => {
     const verbose = hybridConfigSchema.parse({
       ...validBase,

--- a/extensions/memory-hybrid/tests/context-engine.test.ts
+++ b/extensions/memory-hybrid/tests/context-engine.test.ts
@@ -500,7 +500,9 @@ describe("HybridMemoryContextEngine.assemble()", () => {
     const resultFull = await engineFull.assemble({ sessionId: "s1", messages: [], tokenBudget: 10000 });
     // Keep this low enough that high-numbered facts cannot all fit under the same
     // char/4 estimate as the header + label (otherwise 150 still fits facts 7–9 — flaky on CI).
-    const resultTight = await engineTight.assemble({ sessionId: "s1", messages: [], tokenBudget: 85 });
+    // The boundary comment overhead adds ~29 tokens vs the prior implementation,
+    // so the tight budget is increased to 130 accordingly.
+    const resultTight = await engineTight.assemble({ sessionId: "s1", messages: [], tokenBudget: 130 });
 
     // Full budget should include more content
     const fullLength = resultFull.systemPromptAddition?.length ?? 0;
@@ -513,7 +515,7 @@ describe("HybridMemoryContextEngine.assemble()", () => {
 
     // Check exact enforcement on tight
     const tightTokens = estimateTokenCount(resultTight.systemPromptAddition!);
-    expect(tightTokens).toBeLessThanOrEqual(85);
+    expect(tightTokens).toBeLessThanOrEqual(130);
 
     // Verify some facts are missing in tight vs full
     expect(resultFull.systemPromptAddition).toContain("Fact number 9");
@@ -611,7 +613,7 @@ describe("buildContextBlock()", () => {
     );
 
     const blockFull = buildContextBlock(facts, "h", "Label:", 100000);
-    const blockSmall = buildContextBlock(facts, "h", "Label:", 50);
+    const blockSmall = buildContextBlock(facts, "h", "Label:", 100);
 
     expect(blockFull).not.toBeNull();
     expect(blockSmall).not.toBeNull();
@@ -620,7 +622,7 @@ describe("buildContextBlock()", () => {
     }
 
     const smallTokens = estimateTokenCount(blockSmall);
-    expect(smallTokens).toBeLessThanOrEqual(50);
+    expect(smallTokens).toBeLessThanOrEqual(100);
 
     // Ensure blockSmall has fewer entries
     expect(blockSmall?.length ?? 0).toBeLessThan(blockFull?.length ?? 0);

--- a/extensions/memory-hybrid/tests/context-engine.test.ts
+++ b/extensions/memory-hybrid/tests/context-engine.test.ts
@@ -500,9 +500,7 @@ describe("HybridMemoryContextEngine.assemble()", () => {
     const resultFull = await engineFull.assemble({ sessionId: "s1", messages: [], tokenBudget: 10000 });
     // Keep this low enough that high-numbered facts cannot all fit under the same
     // char/4 estimate as the header + label (otherwise 150 still fits facts 7–9 — flaky on CI).
-    // The boundary comment overhead adds ~29 tokens vs the prior implementation,
-    // so the tight budget is increased to 130 accordingly.
-    const resultTight = await engineTight.assemble({ sessionId: "s1", messages: [], tokenBudget: 130 });
+    const resultTight = await engineTight.assemble({ sessionId: "s1", messages: [], tokenBudget: 85 });
 
     // Full budget should include more content
     const fullLength = resultFull.systemPromptAddition?.length ?? 0;
@@ -515,7 +513,7 @@ describe("HybridMemoryContextEngine.assemble()", () => {
 
     // Check exact enforcement on tight
     const tightTokens = estimateTokenCount(resultTight.systemPromptAddition!);
-    expect(tightTokens).toBeLessThanOrEqual(130);
+    expect(tightTokens).toBeLessThanOrEqual(85);
 
     // Verify some facts are missing in tight vs full
     expect(resultFull.systemPromptAddition).toContain("Fact number 9");
@@ -613,16 +611,19 @@ describe("buildContextBlock()", () => {
     );
 
     const blockFull = buildContextBlock(facts, "h", "Label:", 100000);
-    const blockSmall = buildContextBlock(facts, "h", "Label:", 100);
+    const blockSmall = buildContextBlock(facts, "h", "Label:", 50);
 
     expect(blockFull).not.toBeNull();
     expect(blockSmall).not.toBeNull();
+    if (blockFull === null || blockSmall === null) {
+      throw new Error("Expected context blocks to be generated");
+    }
 
-    const smallTokens = estimateTokenCount(blockSmall!);
-    expect(smallTokens).toBeLessThanOrEqual(100);
+    const smallTokens = estimateTokenCount(blockSmall);
+    expect(smallTokens).toBeLessThanOrEqual(50);
 
     // Ensure blockSmall has fewer entries
-    expect(blockSmall!.length).toBeLessThan(blockFull!.length);
+    expect(blockSmall?.length ?? 0).toBeLessThan(blockFull?.length ?? 0);
     expect(blockFull).toContain("Fact 19");
     expect(blockSmall).not.toContain("Fact 19");
 

--- a/extensions/memory-hybrid/tests/register-hooks-capability-hints.test.ts
+++ b/extensions/memory-hybrid/tests/register-hooks-capability-hints.test.ts
@@ -93,4 +93,19 @@ describe("registerLifecycleHooks capability hints cadence", () => {
     expect(findCapabilityHints(second)).toBeUndefined();
     expect(findCapabilityHints(third)).toBeDefined();
   });
+
+  it("silent mode suppresses capability hints even with explicit capabilityHints setting", () => {
+    const api = makeHooksApi();
+    const pluginApi = buildPluginApiForRegisterHooks(tmpDir, factsDb, {
+      autoRecall: { enabled: true, capabilityHints: "always" },
+      verbosity: "silent",
+    });
+    registerLifecycleHooks(pluginApi as never, api as never);
+
+    const first = invokeBeforePromptBuildHandlers(api, { session: { id: "sess-a" } });
+    const second = invokeBeforePromptBuildHandlers(api, { session: { id: "sess-a" } });
+
+    expect(findCapabilityHints(first)).toBeUndefined();
+    expect(findCapabilityHints(second)).toBeUndefined();
+  });
 });

--- a/extensions/memory-hybrid/tests/register-hooks-capability-hints.test.ts
+++ b/extensions/memory-hybrid/tests/register-hooks-capability-hints.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Capability hints injection cadence in registerLifecycleHooks (#1558).
+ */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { FactsDB } from "../backends/facts-db.js";
+import { registerLifecycleHooks } from "../setup/register-hooks.js";
+import { buildPluginApiForRegisterHooks, makeHooksApi } from "./helpers/register-hooks-harness.js";
+
+vi.mock("../lifecycle/stage-capture.js", () => ({
+  runCaptureStage: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../src/worker/narratives.js", () => ({
+  buildDailyNarrative: vi.fn().mockResolvedValue(undefined),
+}));
+
+type PromptBuildHookResult = { prependContext?: string } | undefined;
+
+function invokeBeforePromptBuildHandlers(
+  api: ReturnType<typeof makeHooksApi>,
+  event: Record<string, unknown>,
+): PromptBuildHookResult[] {
+  const handlers = (api.on as ReturnType<typeof vi.fn>).mock.calls
+    .filter((c) => c[0] === "before_prompt_build")
+    .map((c) => c[1] as (ev: unknown, hookCtx: unknown) => PromptBuildHookResult);
+  return handlers.map((handler) => handler(event, {}));
+}
+
+function findCapabilityHints(results: PromptBuildHookResult[]): string | undefined {
+  return results
+    .map((r) => r?.prependContext)
+    .find((text): text is string => typeof text === "string" && text.includes("memory-hybrid: capability hints"));
+}
+
+describe("registerLifecycleHooks capability hints cadence", () => {
+  let tmpDir: string;
+  let factsDb: FactsDB;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "capability-hints-hooks-"));
+    factsDb = new FactsDB(join(tmpDir, "facts.db"));
+  });
+
+  afterEach(() => {
+    factsDb.close();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("injects capability hints only once per session by default", () => {
+    const api = makeHooksApi();
+    const pluginApi = buildPluginApiForRegisterHooks(tmpDir, factsDb, { autoRecall: { enabled: true } });
+    registerLifecycleHooks(pluginApi as never, api as never);
+
+    const first = invokeBeforePromptBuildHandlers(api, { session: { id: "sess-a" } });
+    expect(findCapabilityHints(first)).toBeDefined();
+
+    const second = invokeBeforePromptBuildHandlers(api, { session: { id: "sess-a" } });
+    expect(findCapabilityHints(second)).toBeUndefined();
+
+    const third = invokeBeforePromptBuildHandlers(api, { session: { id: "sess-b" } });
+    expect(findCapabilityHints(third)).toBeDefined();
+  });
+
+  it("supports opt-in always mode to inject capability hints every prompt", () => {
+    const api = makeHooksApi();
+    const pluginApi = buildPluginApiForRegisterHooks(tmpDir, factsDb, {
+      autoRecall: { enabled: true, capabilityHints: "always" },
+    });
+    registerLifecycleHooks(pluginApi as never, api as never);
+
+    const first = invokeBeforePromptBuildHandlers(api, { session: { id: "sess-a" } });
+    const second = invokeBeforePromptBuildHandlers(api, { session: { id: "sess-a" } });
+
+    expect(findCapabilityHints(first)).toBeDefined();
+    expect(findCapabilityHints(second)).toBeDefined();
+  });
+
+  it("supports opt-out mode to disable capability hints injection", () => {
+    const api = makeHooksApi();
+    const pluginApi = buildPluginApiForRegisterHooks(tmpDir, factsDb, {
+      autoRecall: { enabled: true, capabilityHints: "off" },
+    });
+    registerLifecycleHooks(pluginApi as never, api as never);
+
+    const first = invokeBeforePromptBuildHandlers(api, { session: { id: "sess-a" } });
+    const second = invokeBeforePromptBuildHandlers(api, { session: { id: "sess-a" } });
+
+    expect(findCapabilityHints(first)).toBeUndefined();
+    expect(findCapabilityHints(second)).toBeUndefined();
+  });
+});

--- a/extensions/memory-hybrid/tests/register-hooks-capability-hints.test.ts
+++ b/extensions/memory-hybrid/tests/register-hooks-capability-hints.test.ts
@@ -50,19 +50,18 @@ describe("registerLifecycleHooks capability hints cadence", () => {
     rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  it("injects capability hints only once per session by default", () => {
+  it("does not inject capability hints by default", () => {
     const api = makeHooksApi();
     const pluginApi = buildPluginApiForRegisterHooks(tmpDir, factsDb, { autoRecall: { enabled: true } });
     registerLifecycleHooks(pluginApi as never, api as never);
 
     const first = invokeBeforePromptBuildHandlers(api, { session: { id: "sess-a" } });
-    expect(findCapabilityHints(first)).toBeDefined();
-
     const second = invokeBeforePromptBuildHandlers(api, { session: { id: "sess-a" } });
-    expect(findCapabilityHints(second)).toBeUndefined();
-
     const third = invokeBeforePromptBuildHandlers(api, { session: { id: "sess-b" } });
-    expect(findCapabilityHints(third)).toBeDefined();
+
+    expect(findCapabilityHints(first)).toBeUndefined();
+    expect(findCapabilityHints(second)).toBeUndefined();
+    expect(findCapabilityHints(third)).toBeUndefined();
   });
 
   it("supports opt-in always mode to inject capability hints every prompt", () => {
@@ -79,17 +78,19 @@ describe("registerLifecycleHooks capability hints cadence", () => {
     expect(findCapabilityHints(second)).toBeDefined();
   });
 
-  it("supports opt-out mode to disable capability hints injection", () => {
+  it("supports session mode to inject capability hints once per session", () => {
     const api = makeHooksApi();
     const pluginApi = buildPluginApiForRegisterHooks(tmpDir, factsDb, {
-      autoRecall: { enabled: true, capabilityHints: "off" },
+      autoRecall: { enabled: true, capabilityHints: "session" },
     });
     registerLifecycleHooks(pluginApi as never, api as never);
 
     const first = invokeBeforePromptBuildHandlers(api, { session: { id: "sess-a" } });
     const second = invokeBeforePromptBuildHandlers(api, { session: { id: "sess-a" } });
+    const third = invokeBeforePromptBuildHandlers(api, { session: { id: "sess-b" } });
 
-    expect(findCapabilityHints(first)).toBeUndefined();
+    expect(findCapabilityHints(first)).toBeDefined();
     expect(findCapabilityHints(second)).toBeUndefined();
+    expect(findCapabilityHints(third)).toBeDefined();
   });
 });

--- a/extensions/memory-hybrid/tests/session-state.test.ts
+++ b/extensions/memory-hybrid/tests/session-state.test.ts
@@ -247,6 +247,23 @@ describe("session-state", () => {
         // Should not throw
         expect(() => state.clearSessionState("non-existent")).not.toThrow();
       });
+
+      it("should NOT clear capabilityHintsSessionsSeen (persists across agent turns)", () => {
+        // Populate state including capability hints
+        state.sessionStartSeen.add("session-1");
+        state.capabilityHintsSessionsSeen.add("session-1");
+        state.sessionLastActivity.set("session-1", Date.now());
+
+        // Clear session state
+        state.clearSessionState("session-1");
+
+        // Verify most state is cleared
+        expect(state.sessionStartSeen.has("session-1")).toBe(false);
+        expect(state.sessionLastActivity.has("session-1")).toBe(false);
+
+        // But capabilityHintsSessionsSeen should persist across agent turns
+        expect(state.capabilityHintsSessionsSeen.has("session-1")).toBe(true);
+      });
     });
 
     describe("pruneSessionMaps", () => {

--- a/extensions/memory-hybrid/tests/stage-capture.test.ts
+++ b/extensions/memory-hybrid/tests/stage-capture.test.ts
@@ -119,6 +119,7 @@ function makeSessionState(): SessionState {
     frustrationStateMap: new Map(),
     authFailureRecallsThisSession: new Map(),
     sessionLastActivity: new Map(),
+    capabilityHintsSessionsSeen: new Set(),
     touchSession: vi.fn(),
     clearSessionState: vi.fn(),
     pruneSessionMaps: vi.fn(),


### PR DESCRIPTION
## Summary
- make capability hints inject once per session by default instead of every prompt
- add opt-in modes via `autoRecall.capabilityHints`: `always`, `session` (default), `off`
- add focused config + hook tests and update configuration docs

## Verification
- npm test -- tests/config.test.ts tests/register-hooks-capability-hints.test.ts
- npm exec -- tsc --noEmit -p tsconfig.json
- npm exec -- biome lint --max-diagnostics=none config/types/retrieval.ts config/parsers/retrieval.ts setup/register-hooks.ts tests/register-hooks-capability-hints.test.ts

Closes #1558

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: mainly changes prompt-context injection behavior behind a new `autoRecall.capabilityHints` config flag and adds supporting session-state tracking and tests, with minimal impact outside memory-hybrid prompt building.
> 
> **Overview**
> Updates memory-hybrid’s static “capability hints” prompt injection to be **configurable via `autoRecall.capabilityHints`** (`off`/`session`/`always`) and to support **session-scoped injection** by tracking which sessions have already received the hints; `silent` verbosity continues to suppress them.
> 
> Extends retrieval config types/parsing, plugin JSON schema, and docs for the new setting, adds focused tests for cadence behavior, and wires `sessionState` through lifecycle hooks/cleanup. Also includes small correctness/diagnostics tweaks: ignores `supersededAt` facts when computing terminal task status and refines `VectorDB` health/introspection getters (including semantic cache readiness and optimize-in-progress detection).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68679caabad69f969c7ed6e1c2d87d1ebc6329e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->