### PR TITLE
feat(diagnostics): capture native RSS / fd evidence on memory pressure (#1551)

### DIFF
--- a/extensions/memory-hybrid/services/memory-diagnostics.ts
+++ b/extensions/memory-hybrid/services/memory-diagnostics.ts
@@ -6,6 +6,41 @@ import type { EmbeddingProvider } from "./embeddings.js";
 import { capturePluginError } from "./error-reporter.js";
 import { filterByScope, mergeResults } from "./merge-results.js";
 
+/** Native process metrics captured as evidence of memory pressure (#1551). */
+export interface MemoryPressureEvidence {
+  rssBytes: number;
+  heapUsedBytes: number;
+  heapTotalBytes: number;
+  openFdCount: number | null;
+  timestamp: number;
+}
+
+/**
+ * Capture native RSS, heap, and file-descriptor metrics as structured evidence.
+ * File descriptors are only available on Linux via process.resources.openFd.
+ */
+export function captureMemoryPressureEvidence(): MemoryPressureEvidence {
+  const mem = process.memoryUsage();
+  let openFdCount: number | null = null;
+  try {
+    // Node.js 18+: process.resources available
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const res = (process as any).resources;
+    if (res && typeof res.openFd === "function") {
+      openFdCount = res.openFd();
+    }
+  } catch {
+    // Not available on all platforms / Node versions — degrade gracefully
+  }
+  return {
+    rssBytes: mem.rss,
+    heapUsedBytes: mem.heapUsed,
+    heapTotalBytes: mem.heapTotal,
+    openFdCount,
+    timestamp: Date.now(),
+  };
+}
+
 type MemoryDiagnosticsResult = {
   markerId: string;
   markerText: string;
@@ -13,6 +48,8 @@ type MemoryDiagnosticsResult = {
   semantic: { ok: boolean; count: number; failReason?: string };
   hybrid: { ok: boolean; count: number };
   autoRecall: { ok: boolean; count: number };
+  /** Native RSS / heap / FD evidence captured at diagnostic time (#1551). */
+  memoryPressure?: MemoryPressureEvidence;
 };
 
 export async function runMemoryDiagnostics(opts: {
@@ -101,6 +138,7 @@ export async function runMemoryDiagnostics(opts: {
       },
       hybrid: { ok: hybridResults.some((r) => r.entry.id === entry.id), count: hybridResults.length },
       autoRecall: { ok: autoRecallResults.some((r) => r.entry.id === entry.id), count: autoRecallResults.length },
+      memoryPressure: captureMemoryPressureEvidence(),
     };
   } finally {
     try {

--- a/extensions/memory-hybrid/services/memory-diagnostics.ts
+++ b/extensions/memory-hybrid/services/memory-diagnostics.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { readdirSync, readFileSync, readlinkSync } from "node:fs";
 import type { FactsDB } from "../backends/facts-db.js";
 import type { VectorDB } from "../backends/vector-db.js";
 import type { ScopeFilter, SearchResult } from "../types/memory.js";
@@ -7,11 +8,21 @@ import { capturePluginError } from "./error-reporter.js";
 import { filterByScope, mergeResults } from "./merge-results.js";
 
 /** Native process metrics captured as evidence of memory pressure (#1551). */
+interface LinuxProcMemoryPressureEvidence {
+  statusRssKb: number | null;
+  statusHwmKb: number | null;
+  fdCount: number | null;
+  fdTargetGroups: Record<string, number>;
+}
+
 export interface MemoryPressureEvidence {
   rssBytes: number;
   heapUsedBytes: number;
   heapTotalBytes: number;
+  externalBytes: number;
+  arrayBuffersBytes: number;
   openFdCount: number | null;
+  linuxProc: LinuxProcMemoryPressureEvidence | null;
   timestamp: number;
 }
 
@@ -22,23 +33,82 @@ export interface MemoryPressureEvidence {
 export function captureMemoryPressureEvidence(): MemoryPressureEvidence {
   const mem = process.memoryUsage();
   let openFdCount: number | null = null;
+  const resources = (process as unknown as { resources?: { openFd?: () => number } }).resources;
   try {
-    // Node.js 18+: process.resources available
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const res = (process as any).resources;
-    if (res && typeof res.openFd === "function") {
-      openFdCount = res.openFd();
+    if (typeof resources?.openFd === "function") {
+      openFdCount = resources.openFd();
     }
   } catch {
     // Not available on all platforms / Node versions — degrade gracefully
+  }
+  const linuxProc = captureLinuxProcMemoryPressureEvidence();
+  if (openFdCount === null && linuxProc?.fdCount !== null) {
+    openFdCount = linuxProc.fdCount;
   }
   return {
     rssBytes: mem.rss,
     heapUsedBytes: mem.heapUsed,
     heapTotalBytes: mem.heapTotal,
+    externalBytes: mem.external,
+    arrayBuffersBytes: mem.arrayBuffers,
     openFdCount,
+    linuxProc,
     timestamp: Date.now(),
   };
+}
+
+function captureLinuxProcMemoryPressureEvidence(): LinuxProcMemoryPressureEvidence | null {
+  if (process.platform !== "linux") {
+    return null;
+  }
+
+  let statusRssKb: number | null = null;
+  let statusHwmKb: number | null = null;
+  let fdCount: number | null = null;
+  const fdTargetGroups: Record<string, number> = {};
+
+  try {
+    const status = readFileSync("/proc/self/status", "utf8");
+    statusRssKb = parseProcStatusKb(status, "VmRSS");
+    statusHwmKb = parseProcStatusKb(status, "VmHWM");
+  } catch {
+    // Degrade gracefully if /proc is unavailable.
+  }
+
+  try {
+    const fds = readdirSync("/proc/self/fd");
+    fdCount = fds.length;
+    for (const fd of fds) {
+      try {
+        const target = readlinkSync(`/proc/self/fd/${fd}`);
+        const group = classifyFdTarget(target);
+        fdTargetGroups[group] = (fdTargetGroups[group] ?? 0) + 1;
+      } catch {
+        // Ignore transient FD races while sampling.
+      }
+    }
+  } catch {
+    // Degrade gracefully if /proc/self/fd cannot be read.
+  }
+
+  return { statusRssKb, statusHwmKb, fdCount, fdTargetGroups };
+}
+
+function parseProcStatusKb(status: string, field: "VmRSS" | "VmHWM"): number | null {
+  const match = status.match(new RegExp(`^${field}:\\s+(\\d+)\\s+kB$`, "m"));
+  if (!match) {
+    return null;
+  }
+  const parsed = Number.parseInt(match[1], 10);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function classifyFdTarget(target: string): string {
+  if (target.startsWith("socket:")) return "socket";
+  if (target.startsWith("pipe:")) return "pipe";
+  if (target.startsWith("anon_inode:")) return "anon_inode";
+  if (target.startsWith("/") || target.startsWith("./")) return "path";
+  return "other";
 }
 
 type MemoryDiagnosticsResult = {
@@ -49,7 +119,7 @@ type MemoryDiagnosticsResult = {
   hybrid: { ok: boolean; count: number };
   autoRecall: { ok: boolean; count: number };
   /** Native RSS / heap / FD evidence captured at diagnostic time (#1551). */
-  memoryPressure?: MemoryPressureEvidence;
+  memoryPressure: MemoryPressureEvidence;
 };
 
 export async function runMemoryDiagnostics(opts: {

--- a/extensions/memory-hybrid/services/memory-diagnostics.ts
+++ b/extensions/memory-hybrid/services/memory-diagnostics.ts
@@ -49,7 +49,7 @@ export function captureMemoryPressureEvidence(): MemoryPressureEvidence {
   }
   const linuxProc = captureLinuxProcMemoryPressureEvidence();
   if (openFdCount === null && linuxProc?.fdCount !== null) {
-    openFdCount = linuxProc.fdCount;
+    openFdCount = linuxProc!.fdCount;
   }
   return {
     rssBytes: mem.rss,

--- a/extensions/memory-hybrid/services/memory-diagnostics.ts
+++ b/extensions/memory-hybrid/services/memory-diagnostics.ts
@@ -48,7 +48,7 @@ export function captureMemoryPressureEvidence(): MemoryPressureEvidence {
     // Not available on all platforms / Node versions — degrade gracefully
   }
   const linuxProc = captureLinuxProcMemoryPressureEvidence();
-  if (openFdCount === null && linuxProc?.fdCount !== null) {
+  if (openFdCount === null && linuxProc?.fdCount != null) {
     openFdCount = linuxProc!.fdCount;
   }
   return {

--- a/extensions/memory-hybrid/services/memory-diagnostics.ts
+++ b/extensions/memory-hybrid/services/memory-diagnostics.ts
@@ -15,6 +15,12 @@ interface LinuxProcMemoryPressureEvidence {
   fdTargetGroups: Record<string, number>;
 }
 
+type ProcessWithResources = NodeJS.Process & { resources?: { openFd?: () => number } };
+const PROC_STATUS_KB_REGEX: Record<"VmRSS" | "VmHWM", RegExp> = {
+  VmRSS: /^VmRSS:\s+(\d+)\s+kB$/m,
+  VmHWM: /^VmHWM:\s+(\d+)\s+kB$/m,
+};
+
 export interface MemoryPressureEvidence {
   rssBytes: number;
   heapUsedBytes: number;
@@ -33,7 +39,7 @@ export interface MemoryPressureEvidence {
 export function captureMemoryPressureEvidence(): MemoryPressureEvidence {
   const mem = process.memoryUsage();
   let openFdCount: number | null = null;
-  const resources = (process as unknown as { resources?: { openFd?: () => number } }).resources;
+  const resources = (process as ProcessWithResources).resources;
   try {
     if (typeof resources?.openFd === "function") {
       openFdCount = resources.openFd();
@@ -95,7 +101,7 @@ function captureLinuxProcMemoryPressureEvidence(): LinuxProcMemoryPressureEviden
 }
 
 function parseProcStatusKb(status: string, field: "VmRSS" | "VmHWM"): number | null {
-  const match = status.match(new RegExp(`^${field}:\\s+(\\d+)\\s+kB$`, "m"));
+  const match = status.match(PROC_STATUS_KB_REGEX[field]);
   if (!match) {
     return null;
   }

--- a/extensions/memory-hybrid/tests/memory-diagnostics.test.ts
+++ b/extensions/memory-hybrid/tests/memory-diagnostics.test.ts
@@ -61,9 +61,17 @@ describe("runMemoryDiagnostics", () => {
     );
     expect(result.memoryPressure.timestamp).toBeTypeOf("number");
     if (result.memoryPressure.linuxProc) {
-      expect(result.memoryPressure.linuxProc.statusRssKb === null || typeof result.memoryPressure.linuxProc.statusRssKb === "number").toBe(true);
-      expect(result.memoryPressure.linuxProc.statusHwmKb === null || typeof result.memoryPressure.linuxProc.statusHwmKb === "number").toBe(true);
-      expect(result.memoryPressure.linuxProc.fdCount === null || typeof result.memoryPressure.linuxProc.fdCount === "number").toBe(true);
+      expect(
+        result.memoryPressure.linuxProc.statusRssKb === null ||
+          typeof result.memoryPressure.linuxProc.statusRssKb === "number",
+      ).toBe(true);
+      expect(
+        result.memoryPressure.linuxProc.statusHwmKb === null ||
+          typeof result.memoryPressure.linuxProc.statusHwmKb === "number",
+      ).toBe(true);
+      expect(
+        result.memoryPressure.linuxProc.fdCount === null || typeof result.memoryPressure.linuxProc.fdCount === "number",
+      ).toBe(true);
       expect(result.memoryPressure.linuxProc.fdTargetGroups).toBeTypeOf("object");
     } else {
       expect(process.platform).not.toBe("linux");

--- a/extensions/memory-hybrid/tests/memory-diagnostics.test.ts
+++ b/extensions/memory-hybrid/tests/memory-diagnostics.test.ts
@@ -51,6 +51,23 @@ describe("runMemoryDiagnostics", () => {
     expect(result.semantic.failReason).toBeUndefined();
     expect(result.hybrid.ok).toBe(true);
     expect(result.autoRecall.ok).toBe(true);
+    expect(result.memoryPressure.rssBytes).toBeTypeOf("number");
+    expect(result.memoryPressure.heapUsedBytes).toBeTypeOf("number");
+    expect(result.memoryPressure.heapTotalBytes).toBeTypeOf("number");
+    expect(result.memoryPressure.externalBytes).toBeTypeOf("number");
+    expect(result.memoryPressure.arrayBuffersBytes).toBeTypeOf("number");
+    expect(result.memoryPressure.openFdCount === null || typeof result.memoryPressure.openFdCount === "number").toBe(
+      true,
+    );
+    expect(result.memoryPressure.timestamp).toBeTypeOf("number");
+    if (result.memoryPressure.linuxProc) {
+      expect(result.memoryPressure.linuxProc.statusRssKb === null || typeof result.memoryPressure.linuxProc.statusRssKb === "number").toBe(true);
+      expect(result.memoryPressure.linuxProc.statusHwmKb === null || typeof result.memoryPressure.linuxProc.statusHwmKb === "number").toBe(true);
+      expect(result.memoryPressure.linuxProc.fdCount === null || typeof result.memoryPressure.linuxProc.fdCount === "number").toBe(true);
+      expect(result.memoryPressure.linuxProc.fdTargetGroups).toBeTypeOf("object");
+    } else {
+      expect(process.platform).not.toBe("linux");
+    }
   });
 
   it("reports vector_dim_mismatch when embedding dimensions != LanceDB dimensions (#939)", async () => {


### PR DESCRIPTION
Closes #1551

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only adds diagnostic telemetry (RSS/heap/FD sampling) and augments the diagnostics result shape, with best-effort Linux `/proc` reads and graceful fallback on unsupported platforms.
> 
> **Overview**
> `runMemoryDiagnostics` now returns additional **memory-pressure evidence** captured at diagnostic time, including RSS/heap usage, timestamp, and best-effort open file descriptor counts.
> 
> On Linux, it also samples `/proc/self/status` and `/proc/self/fd` to record `VmRSS`/`VmHWM` and FD target type breakdowns, and tests were updated to assert the new `memoryPressure` payload and platform-specific behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3ea093d2ace7f3b7e4ab139604883be7b55984b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->