### PR TITLE
fix: expose unresolved review threads in forge-feedback context for pr-lifecycle gate (#1555)

### DIFF
--- a/.github/workflows/forge-feedback-loop.yml
+++ b/.github/workflows/forge-feedback-loop.yml
@@ -167,7 +167,7 @@ jobs:
               cursor = threads.pageInfo.endCursor;
             }
 
-            const unresolvedReviewThreads = reviewThreads.filter((t) => !t.isResolved);
+            const unresolvedReviewThreads = reviewThreads.filter((t) => !t.isResolved && !t.isOutdated);
             const payload = {
               repo: { owner, repo, fullName: `${owner}/${repo}` },
               pullRequest: {

--- a/.github/workflows/forge-feedback-loop.yml
+++ b/.github/workflows/forge-feedback-loop.yml
@@ -167,6 +167,7 @@ jobs:
               cursor = threads.pageInfo.endCursor;
             }
 
+            const unresolvedReviewThreads = reviewThreads.filter((t) => !t.isResolved);
             const payload = {
               repo: { owner, repo, fullName: `${owner}/${repo}` },
               pullRequest: {
@@ -185,11 +186,16 @@ jobs:
               issueComments,
               reviews,
               reviewThreads,
+              // Expose unresolved thread count as explicit output for pr-lifecycle-cron.sh gate (#1555)
+              has_unresolved_threads: unresolvedReviewThreads.length > 0,
+              unresolved_thread_count: unresolvedReviewThreads.length,
             };
 
             mkdirSync('.github/.tmp', { recursive: true });
             writeFileSync(join('.github', '.tmp', 'forge-feedback-context.json'), JSON.stringify(payload, null, 2));
             core.setOutput('should_skip', 'false');
+            core.setOutput('has_unresolved_threads', String(payload.has_unresolved_threads));
+            core.setOutput('unresolved_thread_count', String(payload.unresolved_thread_count));
 
       - name: Stop when PR inspection is skipped
         if: steps.gather.outputs.should_skip == 'true'


### PR DESCRIPTION
Closes #1555

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes GitHub Actions workflow outputs and payload shape used to gate PR lifecycle automation; miscounts or output name mismatches could alter merge/dispatch behavior.
> 
> **Overview**
> The Forge Feedback Loop workflow now computes *unresolved, non-outdated* PR review threads and adds both a boolean (`has_unresolved_threads`) and count (`unresolved_thread_count`) to the generated `forge-feedback-context.json`.
> 
> It also exposes these values as explicit step outputs from `Gather PR context`, enabling downstream gating logic (referenced by `pr-lifecycle-cron.sh`) to make decisions based on unresolved review feedback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea4084485deed181b973357a121b84b6c4a1a81d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->