### PR TITLE
fix: add universal pre-store guard to prevent NOOP/classification/artifact memory storage (#1560)

### DIFF
--- a/extensions/memory-hybrid/backends/facts-db/crud.ts
+++ b/extensions/memory-hybrid/backends/facts-db/crud.ts
@@ -46,6 +46,11 @@ function runWithSqliteBusyRetry(db: DatabaseSync, run: () => void): void {
   }
 }
 
+// Pre-store guard constants: filter internal artifacts (#1560, #1561).
+// These categories and sources are not user-relevant memories.
+const BLOCKED_CATEGORIES = new Set(["noop", "classification", "artifact", "chain-of-thought", "prompt"]);
+const BLOCKED_SOURCES = new Set(["think", "classify", "remember", "noop", "compact", "derive"]);
+
 /** Input shape for `FactsDB.store` / `storeFact`. */
 export type StoreFactInput = Omit<
   MemoryEntry,
@@ -143,10 +148,6 @@ export type StoreFactResult = {
 export function storeFact(ctx: StoreFactContext, entry: StoreFactInput): StoreFactResult {
   validateStoreEntryInput(entry);
 
-  // Pre-store guard: filter internal artifacts (#1560, #1561).
-  // These categories and sources are not user-relevant memories.
-  const BLOCKED_CATEGORIES = new Set(["noop", "classification", "artifact", "chain-of-thought", "prompt"]);
-  const BLOCKED_SOURCES = new Set(["think", "classify", "remember", "noop", "compact", "derive"]);
   const category = entry.category ?? "";
   const source = entry.source ?? "";
   if (BLOCKED_CATEGORIES.has(category) || BLOCKED_SOURCES.has(source)) {

--- a/extensions/memory-hybrid/backends/facts-db/crud.ts
+++ b/extensions/memory-hybrid/backends/facts-db/crud.ts
@@ -148,9 +148,9 @@ export type StoreFactResult = {
 export function storeFact(ctx: StoreFactContext, entry: StoreFactInput): StoreFactResult {
   validateStoreEntryInput(entry);
 
-  const category = entry.category ?? "";
-  const source = entry.source ?? "";
-  if (BLOCKED_CATEGORIES.has(category) || BLOCKED_SOURCES.has(source)) {
+  const entryCategory = entry.category ?? "";
+  const entrySource = entry.source ?? "";
+  if (BLOCKED_CATEGORIES.has(entryCategory) || BLOCKED_SOURCES.has(entrySource)) {
     // Return a minimal skipped result — caller should skip post-store operations.
     const skippedEntry: MemoryEntry = {
       id: "skipped",

--- a/extensions/memory-hybrid/backends/facts-db/crud.ts
+++ b/extensions/memory-hybrid/backends/facts-db/crud.ts
@@ -51,6 +51,10 @@ function runWithSqliteBusyRetry(db: DatabaseSync, run: () => void): void {
 const BLOCKED_CATEGORIES = new Set(["noop", "classification", "artifact", "chain-of-thought", "prompt"]);
 const BLOCKED_SOURCES = new Set(["think", "classify", "remember", "noop", "compact", "derive"]);
 
+export function isPreStoreGuardBlocked(entry: Pick<StoreFactInput, "category" | "source">): boolean {
+  return BLOCKED_CATEGORIES.has(entry.category ?? "") || BLOCKED_SOURCES.has(entry.source ?? "");
+}
+
 /** Input shape for `FactsDB.store` / `storeFact`. */
 export type StoreFactInput = Omit<
   MemoryEntry,
@@ -155,7 +159,7 @@ export function storeFact(ctx: StoreFactContext, entry: StoreFactInput): StoreFa
 
   const entryCategory = entry.category ?? "";
   const entrySource = entry.source ?? "";
-  if (!ctx.allowPreStoreGuardBypass && (BLOCKED_CATEGORIES.has(entryCategory) || BLOCKED_SOURCES.has(entrySource))) {
+  if (!ctx.allowPreStoreGuardBypass && isPreStoreGuardBlocked({ category: entryCategory, source: entrySource })) {
     // Return a minimal skipped result — caller should skip post-store operations.
     const skippedEntry: MemoryEntry = {
       id: "skipped",

--- a/extensions/memory-hybrid/backends/facts-db/crud.ts
+++ b/extensions/memory-hybrid/backends/facts-db/crud.ts
@@ -117,6 +117,11 @@ export type StoreFactContext = {
   warnOnceKey?: string;
   suppressVectorFallbackWarning?: boolean;
   /**
+   * Allow trusted edit paths to re-store an already persisted fact whose legacy
+   * source/category is now blocked by the artifact guard (#1560/#1561).
+   */
+  allowPreStoreGuardBypass?: boolean;
+  /**
    * Pre-computed vector neighbour candidates for the new fact's embedding (#1186, #1194).
    * Caller is expected to populate this when the embedding is known and the policy has
    * `vectorThreshold` configured.
@@ -150,7 +155,7 @@ export function storeFact(ctx: StoreFactContext, entry: StoreFactInput): StoreFa
 
   const entryCategory = entry.category ?? "";
   const entrySource = entry.source ?? "";
-  if (BLOCKED_CATEGORIES.has(entryCategory) || BLOCKED_SOURCES.has(entrySource)) {
+  if (!ctx.allowPreStoreGuardBypass && (BLOCKED_CATEGORIES.has(entryCategory) || BLOCKED_SOURCES.has(entrySource))) {
     // Return a minimal skipped result — caller should skip post-store operations.
     const skippedEntry: MemoryEntry = {
       id: "skipped",

--- a/extensions/memory-hybrid/backends/facts-db/crud.ts
+++ b/extensions/memory-hybrid/backends/facts-db/crud.ts
@@ -170,7 +170,7 @@ export function storeFact(ctx: StoreFactContext, entry: StoreFactInput): StoreFa
       entity: entry.entity ?? null,
       key: entry.key ?? null,
       value: entry.value ?? null,
-      createdAt: Date.now(),
+      createdAt: Math.floor(Date.now() / 1000),
       decayClass: entry.decayClass ?? "normal",
       expiresAt: null,
       lastConfirmedAt: 0,

--- a/extensions/memory-hybrid/backends/facts-db/crud.ts
+++ b/extensions/memory-hybrid/backends/facts-db/crud.ts
@@ -133,10 +133,43 @@ export type StoreFactResult = {
    * `entry.text` and replace the vector for `entry.id` in VectorDB.
    */
   embeddingStale?: boolean;
+  /**
+   * True when the pre-store guard filtered this entry as an internal artifact (#1560, #1561).
+   * Callers must skip post-store operations (vector upsert, supersession, logging) when true.
+   */
+  skipped?: boolean;
 };
 
 export function storeFact(ctx: StoreFactContext, entry: StoreFactInput): StoreFactResult {
   validateStoreEntryInput(entry);
+
+  // Pre-store guard: filter internal artifacts (#1560, #1561).
+  // These categories and sources are not user-relevant memories.
+  const BLOCKED_CATEGORIES = new Set(["noop", "classification", "artifact", "chain-of-thought", "prompt"]);
+  const BLOCKED_SOURCES = new Set(["think", "classify", "remember", "noop", "compact", "derive"]);
+  const category = entry.category ?? "";
+  const source = entry.source ?? "";
+  if (BLOCKED_CATEGORIES.has(category) || BLOCKED_SOURCES.has(source)) {
+    // Return a minimal skipped result — caller should skip post-store operations.
+    const skippedEntry: MemoryEntry = {
+      id: "skipped",
+      text: entry.text,
+      category: entry.category ?? "noop",
+      importance: entry.importance ?? 0.5,
+      source: entry.source ?? "guard",
+      entity: entry.entity ?? null,
+      key: entry.key ?? null,
+      value: entry.value ?? null,
+      createdAt: Date.now(),
+      decayClass: entry.decayClass ?? "normal",
+      expiresAt: null,
+      lastConfirmedAt: 0,
+      confidence: 0,
+      tags: entry.tags ?? null,
+    };
+    return { entry: skippedEntry, evictedFactId: null, skipped: true };
+  }
+
   const sourceForPolicy = entry.source ?? "conversation";
   const profile = resolveDedupeProfile(sourceForPolicy, ctx.storeConfig ?? { fuzzyDedupe: ctx.fuzzyDedupe });
   const nowSec = Math.floor(Date.now() / 1000);

--- a/extensions/memory-hybrid/backends/facts-db/facts-db-layer1.ts
+++ b/extensions/memory-hybrid/backends/facts-db/facts-db-layer1.ts
@@ -233,6 +233,8 @@ export class FactsDBLayer1 extends BaseSqliteStore {
       warnContext?: string;
       /** Suppress the vector-candidates-missing warning entirely (caller will summarise). */
       suppressVectorFallbackWarning?: boolean;
+      /** Trusted edit path for re-storing already persisted legacy guarded facts. */
+      allowPreStoreGuardBypass?: boolean;
     },
   ): MemoryEntry {
     return this.storeWithResult(entry, options).entry;
@@ -249,6 +251,8 @@ export class FactsDBLayer1 extends BaseSqliteStore {
       warnContext?: string;
       /** Suppress the vector-candidates-missing warning entirely (caller will summarise). */
       suppressVectorFallbackWarning?: boolean;
+      /** Trusted edit path for re-storing already persisted legacy guarded facts. */
+      allowPreStoreGuardBypass?: boolean;
     },
   ): StoreFactResult {
     const warnOnce = (key: string, message: string): void => {
@@ -270,6 +274,7 @@ export class FactsDBLayer1 extends BaseSqliteStore {
         warnOnce,
         warnOnceKey: options?.warnContext,
         suppressVectorFallbackWarning: options?.suppressVectorFallbackWarning,
+        allowPreStoreGuardBypass: options?.allowPreStoreGuardBypass,
       },
       entry,
     );

--- a/extensions/memory-hybrid/lifecycle/stage-capture/run-capture.ts
+++ b/extensions/memory-hybrid/lifecycle/stage-capture/run-capture.ts
@@ -579,7 +579,6 @@ export async function runCapture(
                         );
                       }
                     }
-                      await ctx.walRemove(walEntryId, api.logger);
                       ctx.auditStore?.append({
                         agentId: resolveAgentIdFromHookEvent(event, api) ?? ctx.currentAgentIdRef.value ?? "unknown",
                         action: "auto-capture:updated",
@@ -593,6 +592,7 @@ export async function runCapture(
                       );
                       stored++;
                     }  // close if (!storeResult.skipped) guard (#1560, #1561)
+                    await ctx.walRemove(walEntryId, api.logger);
                     continue;
                   }
                 }
@@ -651,6 +651,12 @@ export async function runCapture(
           const storedEntry = storeResult.entry;
           // Guard: skip post-store ops when pre-store guard blocked the write (#1560, #1561)
           if (!storeResult.skipped) {
+            await cleanupEvictedVector({
+              vectorDb: ctx.vectorDb,
+              evictedFactId: storeResult.evictedFactId,
+              logger: api.logger,
+              context: "stage-capture",
+            });
             try {
               if (vector) {
                 ctx.factsDb.setEmbeddingModel(storedEntry.id, ctx.embeddings.modelName);
@@ -680,7 +686,6 @@ export async function runCapture(
               });
               api.logger.warn(`memory-hybrid: vector capture failed: ${vecErr}`);
             }
-            await ctx.walRemove(walEntryId, api.logger);
             stored++;
             ctx.auditStore?.append({
               agentId: resolveAgentIdFromHookEvent(event, api) ?? ctx.currentAgentIdRef.value ?? "unknown",
@@ -691,6 +696,7 @@ export async function runCapture(
               context: { category, entity: extracted.entity, role: candidate.role },
             });
           }
+          await ctx.walRemove(walEntryId, api.logger);
         }
         if (stored > 0) api.logger.info(`memory-hybrid: auto-captured ${stored} memories`);
       }

--- a/extensions/memory-hybrid/lifecycle/stage-capture/run-capture.ts
+++ b/extensions/memory-hybrid/lifecycle/stage-capture/run-capture.ts
@@ -167,12 +167,14 @@ export async function runCapture(
           source: "humanizer",
           decayClass: "normal",
         });
-        await cleanupEvictedVector({
-          vectorDb: ctx.vectorDb,
-          evictedFactId: storeResult.evictedFactId,
-          logger: api.logger,
-          context: "humanizer-score",
-        });
+        if (!storeResult.skipped) {
+          await cleanupEvictedVector({
+            vectorDb: ctx.vectorDb,
+            evictedFactId: storeResult.evictedFactId,
+            logger: api.logger,
+            context: "humanizer-score",
+          });
+        }
         api.logger.debug?.(`memory-hybrid: humanizer_score=${result.score.toFixed(2)} stored`);
       }
     } catch (err) {
@@ -495,22 +497,24 @@ export async function runCapture(
                       extractionConfidence: getAutoCaptureExtractionConfidence(candidate.role),
                     });
                     const newEntry = storeResult.entry;
-                    // CRITICAL FIX (#2): Delete vector for evicted fact to prevent orphaned vectors
-                    await cleanupEvictedVector({
-                      vectorDb: ctx.vectorDb,
-                      evictedFactId: storeResult.evictedFactId,
-                      logger: api.logger,
-                      context: "stage-capture",
-                    });
-                    ctx.factsDb.supersede(classification.targetId, newEntry.id);
-                    ctx.aliasDb?.deleteByFactId(classification.targetId);
-                    await deleteVectorForFactId({
-                      vectorDb: ctx.vectorDb,
-                      factId: classification.targetId,
-                      logger: api.logger,
-                      context: "stage-capture-update-superseded",
-                    });
-                    if (ctx.cfg.retrieval.strategies.includes("semantic")) {
+                    // Guard: skip post-store ops when pre-store guard blocked the write (#1560, #1561)
+                    if (!storeResult.skipped) {
+                      // CRITICAL FIX (#2): Delete vector for evicted fact to prevent orphaned vectors
+                      await cleanupEvictedVector({
+                        vectorDb: ctx.vectorDb,
+                        evictedFactId: storeResult.evictedFactId,
+                        logger: api.logger,
+                        context: "stage-capture",
+                      });
+                      ctx.factsDb.supersede(classification.targetId, newEntry.id);
+                      ctx.aliasDb?.deleteByFactId(classification.targetId);
+                      await deleteVectorForFactId({
+                        vectorDb: ctx.vectorDb,
+                        factId: classification.targetId,
+                        logger: api.logger,
+                        context: "stage-capture-update-superseded",
+                      });
+                      if (ctx.cfg.retrieval.strategies.includes("semantic")) {
                       try {
                         if (storeResult.embeddingStale) {
                           // Merge case: the existing fact's text was updated in-place.
@@ -575,6 +579,7 @@ export async function runCapture(
                         );
                       }
                     }
+                    }  // close if (!storeResult.skipped) guard (#1560, #1561)
                     await ctx.walRemove(walEntryId, api.logger);
                     ctx.auditStore?.append({
                       agentId: resolveAgentIdFromHookEvent(event, api) ?? ctx.currentAgentIdRef.value ?? "unknown",
@@ -910,14 +915,16 @@ export async function runCapture(
                 tags: ["auth", "credential"],
               });
               const entry = storeResult.entry;
-              // CRITICAL FIX (#2): Delete vector for evicted fact to prevent orphaned vectors
-              await cleanupEvictedVector({
-                vectorDb: ctx.vectorDb,
-                evictedFactId: storeResult.evictedFactId,
-                logger: api.logger,
-                context: "stage-capture",
-              });
-              if (ctx.cfg.retrieval.strategies.includes("semantic")) {
+              // Guard: skip post-store ops when pre-store guard blocked the write (#1560, #1561)
+              if (!storeResult.skipped) {
+                // CRITICAL FIX (#2): Delete vector for evicted fact to prevent orphaned vectors
+                await cleanupEvictedVector({
+                  vectorDb: ctx.vectorDb,
+                  evictedFactId: storeResult.evictedFactId,
+                  logger: api.logger,
+                  context: "stage-capture",
+                });
+                if (ctx.cfg.retrieval.strategies.includes("semantic")) {
                 try {
                   if (storeResult.embeddingStale) {
                     // Merge case: re-embed the merged text to keep the vector in sync.
@@ -979,6 +986,7 @@ export async function runCapture(
                   );
                 }
               }
+              }  // close if (!storeResult.skipped) guard (#1560, #1561)
               if (logCaptures) {
                 api.logger.info(`memory-hybrid: auto-captured credential for ${cred.service} (${cred.type})`);
               }

--- a/extensions/memory-hybrid/lifecycle/stage-capture/run-capture.ts
+++ b/extensions/memory-hybrid/lifecycle/stage-capture/run-capture.ts
@@ -579,20 +579,20 @@ export async function runCapture(
                         );
                       }
                     }
+                      await ctx.walRemove(walEntryId, api.logger);
+                      ctx.auditStore?.append({
+                        agentId: resolveAgentIdFromHookEvent(event, api) ?? ctx.currentAgentIdRef.value ?? "unknown",
+                        action: "auto-capture:updated",
+                        target: newEntry.id,
+                        outcome: "success",
+                        sessionId: captureProvenance.sessionId ?? undefined,
+                        context: { supersededId: classification.targetId, category, entity: extracted.entity },
+                      });
+                      api.logger.info?.(
+                        `memory-hybrid: auto-capture UPDATE — superseded ${classification.targetId} with ${newEntry.id}`,
+                      );
+                      stored++;
                     }  // close if (!storeResult.skipped) guard (#1560, #1561)
-                    await ctx.walRemove(walEntryId, api.logger);
-                    ctx.auditStore?.append({
-                      agentId: resolveAgentIdFromHookEvent(event, api) ?? ctx.currentAgentIdRef.value ?? "unknown",
-                      action: "auto-capture:updated",
-                      target: newEntry.id,
-                      outcome: "success",
-                      sessionId: captureProvenance.sessionId ?? undefined,
-                      context: { supersededId: classification.targetId, category, entity: extracted.entity },
-                    });
-                    api.logger.info?.(
-                      `memory-hybrid: auto-capture UPDATE — superseded ${classification.targetId} with ${newEntry.id}`,
-                    );
-                    stored++;
                     continue;
                   }
                 }
@@ -633,7 +633,7 @@ export async function runCapture(
             },
             api.logger,
           );
-          const storedEntry = ctx.factsDb.store({
+          const storeResult = ctx.factsDb.storeWithResult({
             text: textToStore,
             category,
             importance: CLI_STORE_IMPORTANCE,
@@ -648,45 +648,49 @@ export async function runCapture(
             extractionMethod: getAutoCaptureExtractionMethod(candidate.role, captureProvenance),
             extractionConfidence: getAutoCaptureExtractionConfidence(candidate.role),
           });
-          try {
-            if (vector) {
-              ctx.factsDb.setEmbeddingModel(storedEntry.id, ctx.embeddings.modelName);
-              if (!(await ctx.vectorDb.hasDuplicate(vector))) {
-                await ctx.vectorDb.store({
-                  text: textToStore,
-                  vector,
-                  importance: CLI_STORE_IMPORTANCE,
-                  category,
-                  id: storedEntry.id,
-                });
-                persistCanonicalFactEmbedding(
-                  ctx.factsDb,
-                  storedEntry.id,
-                  ctx.embeddings.modelName,
-                  vector,
-                  "auto-capture-fact-embeddings",
-                  "auto-capture",
-                  api.logger.warn?.bind(api.logger),
-                );
+          const storedEntry = storeResult.entry;
+          // Guard: skip post-store ops when pre-store guard blocked the write (#1560, #1561)
+          if (!storeResult.skipped) {
+            try {
+              if (vector) {
+                ctx.factsDb.setEmbeddingModel(storedEntry.id, ctx.embeddings.modelName);
+                if (!(await ctx.vectorDb.hasDuplicate(vector))) {
+                  await ctx.vectorDb.store({
+                    text: textToStore,
+                    vector,
+                    importance: CLI_STORE_IMPORTANCE,
+                    category,
+                    id: storedEntry.id,
+                  });
+                  persistCanonicalFactEmbedding(
+                    ctx.factsDb,
+                    storedEntry.id,
+                    ctx.embeddings.modelName,
+                    vector,
+                    "auto-capture-fact-embeddings",
+                    "auto-capture",
+                    api.logger.warn?.bind(api.logger),
+                  );
+                }
               }
+            } catch (vecErr) {
+              capturePluginError(vecErr instanceof Error ? vecErr : new Error(String(vecErr)), {
+                operation: "auto-capture-vector-store",
+                subsystem: "auto-capture",
+              });
+              api.logger.warn(`memory-hybrid: vector capture failed: ${vecErr}`);
             }
-          } catch (vecErr) {
-            capturePluginError(vecErr instanceof Error ? vecErr : new Error(String(vecErr)), {
-              operation: "auto-capture-vector-store",
-              subsystem: "auto-capture",
+            await ctx.walRemove(walEntryId, api.logger);
+            stored++;
+            ctx.auditStore?.append({
+              agentId: resolveAgentIdFromHookEvent(event, api) ?? ctx.currentAgentIdRef.value ?? "unknown",
+              action: "auto-capture:stored",
+              target: storedEntry.id,
+              outcome: "success",
+              sessionId: captureProvenance.sessionId ?? undefined,
+              context: { category, entity: extracted.entity, role: candidate.role },
             });
-            api.logger.warn(`memory-hybrid: vector capture failed: ${vecErr}`);
           }
-          await ctx.walRemove(walEntryId, api.logger);
-          stored++;
-          ctx.auditStore?.append({
-            agentId: resolveAgentIdFromHookEvent(event, api) ?? ctx.currentAgentIdRef.value ?? "unknown",
-            action: "auto-capture:stored",
-            target: storedEntry.id,
-            outcome: "success",
-            sessionId: captureProvenance.sessionId ?? undefined,
-            context: { category, entity: extracted.entity, role: candidate.role },
-          });
         }
         if (stored > 0) api.logger.info(`memory-hybrid: auto-captured ${stored} memories`);
       }

--- a/extensions/memory-hybrid/lifecycle/stage-capture/run-capture.ts
+++ b/extensions/memory-hybrid/lifecycle/stage-capture/run-capture.ts
@@ -996,10 +996,10 @@ export async function runCapture(
                   );
                 }
               }
-              }  // close if (!storeResult.skipped) guard (#1560, #1561)
               if (logCaptures) {
                 api.logger.info(`memory-hybrid: auto-captured credential for ${cred.service} (${cred.type})`);
               }
+              }  // close if (!storeResult.skipped) guard (#1560, #1561)
             }
           }
         }

--- a/extensions/memory-hybrid/lifecycle/stage-capture/run-capture.ts
+++ b/extensions/memory-hybrid/lifecycle/stage-capture/run-capture.ts
@@ -515,41 +515,17 @@ export async function runCapture(
                         context: "stage-capture-update-superseded",
                       });
                       if (ctx.cfg.retrieval.strategies.includes("semantic")) {
-                      try {
-                        if (storeResult.embeddingStale) {
-                          // Merge case: the existing fact's text was updated in-place.
-                          // Re-embed the merged text and force-replace the stale LanceDB vector.
-                          // If embed fails, the vector encodes stale pre-merge text; the dream-cycle
-                          // re-index will repair it on the next nightly run.
-                          const mergedVector = await ctx.embeddings.embed(newEntry.text);
-                          ctx.factsDb.setEmbeddingModel(newEntry.id, ctx.embeddings.modelName);
-                          await ctx.vectorDb.store({
-                            text: newEntry.text,
-                            vector: mergedVector,
-                            importance: finalImportance,
-                            category,
-                            id: newEntry.id,
-                          });
-                          persistCanonicalFactEmbedding(
-                            ctx.factsDb,
-                            newEntry.id,
-                            ctx.embeddings.modelName,
-                            mergedVector,
-                            "auto-capture-fact-embeddings",
-                            "auto-capture",
-                            api.logger.warn?.bind(api.logger),
-                          );
-                        } else if (vector) {
-                          // `storeWithResult()` can return an existing deduped fact whose text
-                          // differs from `textToStore`; keep vector content aligned to stored text.
-                          const canonicalText = newEntry.text;
-                          const canonicalVector =
-                            canonicalText === textToStore ? vector : await ctx.embeddings.embed(canonicalText);
-                          ctx.factsDb.setEmbeddingModel(newEntry.id, ctx.embeddings.modelName);
-                          if (!(await ctx.vectorDb.hasDuplicate(canonicalVector))) {
+                        try {
+                          if (storeResult.embeddingStale) {
+                            // Merge case: the existing fact's text was updated in-place.
+                            // Re-embed the merged text and force-replace the stale LanceDB vector.
+                            // If embed fails, the vector encodes stale pre-merge text; the dream-cycle
+                            // re-index will repair it on the next nightly run.
+                            const mergedVector = await ctx.embeddings.embed(newEntry.text);
+                            ctx.factsDb.setEmbeddingModel(newEntry.id, ctx.embeddings.modelName);
                             await ctx.vectorDb.store({
-                              text: canonicalText,
-                              vector: canonicalVector,
+                              text: newEntry.text,
+                              vector: mergedVector,
                               importance: finalImportance,
                               category,
                               id: newEntry.id,
@@ -558,27 +534,51 @@ export async function runCapture(
                               ctx.factsDb,
                               newEntry.id,
                               ctx.embeddings.modelName,
-                              canonicalVector,
+                              mergedVector,
                               "auto-capture-fact-embeddings",
                               "auto-capture",
                               api.logger.warn?.bind(api.logger),
                             );
+                          } else if (vector) {
+                            // `storeWithResult()` can return an existing deduped fact whose text
+                            // differs from `textToStore`; keep vector content aligned to stored text.
+                            const canonicalText = newEntry.text;
+                            const canonicalVector =
+                              canonicalText === textToStore ? vector : await ctx.embeddings.embed(canonicalText);
+                            ctx.factsDb.setEmbeddingModel(newEntry.id, ctx.embeddings.modelName);
+                            if (!(await ctx.vectorDb.hasDuplicate(canonicalVector))) {
+                              await ctx.vectorDb.store({
+                                text: canonicalText,
+                                vector: canonicalVector,
+                                importance: finalImportance,
+                                category,
+                                id: newEntry.id,
+                              });
+                              persistCanonicalFactEmbedding(
+                                ctx.factsDb,
+                                newEntry.id,
+                                ctx.embeddings.modelName,
+                                canonicalVector,
+                                "auto-capture-fact-embeddings",
+                                "auto-capture",
+                                api.logger.warn?.bind(api.logger),
+                              );
+                            }
                           }
+                        } catch (vecErr) {
+                          capturePluginError(vecErr instanceof Error ? vecErr : new Error(String(vecErr)), {
+                            operation: storeResult.embeddingStale
+                              ? "auto-capture-stale-vector-update"
+                              : "auto-capture-vector-update",
+                            subsystem: "auto-capture",
+                          });
+                          api.logger.warn(
+                            storeResult.embeddingStale
+                              ? `memory-hybrid: stale vector re-embed failed for merged fact ${newEntry.id.slice(0, 8)} — LanceDB vector encodes pre-merge text; nightly re-index will repair: ${vecErr}`
+                              : `memory-hybrid: vector capture failed: ${vecErr}`,
+                          );
                         }
-                      } catch (vecErr) {
-                        capturePluginError(vecErr instanceof Error ? vecErr : new Error(String(vecErr)), {
-                          operation: storeResult.embeddingStale
-                            ? "auto-capture-stale-vector-update"
-                            : "auto-capture-vector-update",
-                          subsystem: "auto-capture",
-                        });
-                        api.logger.warn(
-                          storeResult.embeddingStale
-                            ? `memory-hybrid: stale vector re-embed failed for merged fact ${newEntry.id.slice(0, 8)} — LanceDB vector encodes pre-merge text; nightly re-index will repair: ${vecErr}`
-                            : `memory-hybrid: vector capture failed: ${vecErr}`,
-                        );
                       }
-                    }
                       ctx.auditStore?.append({
                         agentId: resolveAgentIdFromHookEvent(event, api) ?? ctx.currentAgentIdRef.value ?? "unknown",
                         action: "auto-capture:updated",
@@ -591,7 +591,7 @@ export async function runCapture(
                         `memory-hybrid: auto-capture UPDATE — superseded ${classification.targetId} with ${newEntry.id}`,
                       );
                       stored++;
-                    }  // close if (!storeResult.skipped) guard (#1560, #1561)
+                    } // close if (!storeResult.skipped) guard (#1560, #1561)
                     await ctx.walRemove(walEntryId, api.logger);
                     continue;
                   }
@@ -935,35 +935,15 @@ export async function runCapture(
                   context: "stage-capture",
                 });
                 if (ctx.cfg.retrieval.strategies.includes("semantic")) {
-                try {
-                  if (storeResult.embeddingStale) {
-                    // Merge case: re-embed the merged text to keep the vector in sync.
-                    // If embed fails, the vector encodes stale pre-merge text; nightly re-index will repair.
-                    const mergedVector = await ctx.embeddings.embed(entry.text);
-                    ctx.factsDb.setEmbeddingModel(entry.id, ctx.embeddings.modelName);
-                    await ctx.vectorDb.store({
-                      text: entry.text,
-                      vector: mergedVector,
-                      importance: 0.9,
-                      category: "technical",
-                      id: entry.id,
-                    });
-                    persistCanonicalFactEmbedding(
-                      ctx.factsDb,
-                      entry.id,
-                      ctx.embeddings.modelName,
-                      mergedVector,
-                      "auto-capture-fact-embeddings",
-                      "auto-capture",
-                      api.logger.warn?.bind(api.logger),
-                    );
-                  } else {
-                    const vector = await ctx.embeddings.embed(entry.text);
-                    ctx.factsDb.setEmbeddingModel(entry.id, ctx.embeddings.modelName);
-                    if (!(await ctx.vectorDb.hasDuplicate(vector))) {
+                  try {
+                    if (storeResult.embeddingStale) {
+                      // Merge case: re-embed the merged text to keep the vector in sync.
+                      // If embed fails, the vector encodes stale pre-merge text; nightly re-index will repair.
+                      const mergedVector = await ctx.embeddings.embed(entry.text);
+                      ctx.factsDb.setEmbeddingModel(entry.id, ctx.embeddings.modelName);
                       await ctx.vectorDb.store({
                         text: entry.text,
-                        vector,
+                        vector: mergedVector,
                         importance: 0.9,
                         category: "technical",
                         id: entry.id,
@@ -972,34 +952,54 @@ export async function runCapture(
                         ctx.factsDb,
                         entry.id,
                         ctx.embeddings.modelName,
-                        vector,
+                        mergedVector,
                         "auto-capture-fact-embeddings",
                         "auto-capture",
                         api.logger.warn?.bind(api.logger),
                       );
+                    } else {
+                      const vector = await ctx.embeddings.embed(entry.text);
+                      ctx.factsDb.setEmbeddingModel(entry.id, ctx.embeddings.modelName);
+                      if (!(await ctx.vectorDb.hasDuplicate(vector))) {
+                        await ctx.vectorDb.store({
+                          text: entry.text,
+                          vector,
+                          importance: 0.9,
+                          category: "technical",
+                          id: entry.id,
+                        });
+                        persistCanonicalFactEmbedding(
+                          ctx.factsDb,
+                          entry.id,
+                          ctx.embeddings.modelName,
+                          vector,
+                          "auto-capture-fact-embeddings",
+                          "auto-capture",
+                          api.logger.warn?.bind(api.logger),
+                        );
+                      }
                     }
+                  } catch (err) {
+                    const asErr = err instanceof Error ? err : new Error(String(err));
+                    if (!isOllamaCircuitBreakerOpen(asErr)) {
+                      capturePluginError(asErr, {
+                        operation: storeResult.embeddingStale
+                          ? "tool-call-credential-stale-vector-update"
+                          : "tool-call-credential-vector-store",
+                        subsystem: "credentials",
+                      });
+                    }
+                    api.logger.warn(
+                      storeResult.embeddingStale
+                        ? `memory-hybrid: stale vector re-embed failed for merged credential fact ${entry.id.slice(0, 8)} — nightly re-index will repair: ${err}`
+                        : `memory-hybrid: vector store for credential fact failed: ${err}`,
+                    );
                   }
-                } catch (err) {
-                  const asErr = err instanceof Error ? err : new Error(String(err));
-                  if (!isOllamaCircuitBreakerOpen(asErr)) {
-                    capturePluginError(asErr, {
-                      operation: storeResult.embeddingStale
-                        ? "tool-call-credential-stale-vector-update"
-                        : "tool-call-credential-vector-store",
-                      subsystem: "credentials",
-                    });
-                  }
-                  api.logger.warn(
-                    storeResult.embeddingStale
-                      ? `memory-hybrid: stale vector re-embed failed for merged credential fact ${entry.id.slice(0, 8)} — nightly re-index will repair: ${err}`
-                      : `memory-hybrid: vector store for credential fact failed: ${err}`,
-                  );
                 }
-              }
-              if (logCaptures) {
-                api.logger.info(`memory-hybrid: auto-captured credential for ${cred.service} (${cred.type})`);
-              }
-              }  // close if (!storeResult.skipped) guard (#1560, #1561)
+                if (logCaptures) {
+                  api.logger.info(`memory-hybrid: auto-captured credential for ${cred.service} (${cred.type})`);
+                }
+              } // close if (!storeResult.skipped) guard (#1560, #1561)
             }
           }
         }

--- a/extensions/memory-hybrid/routes/graphql-resolvers.ts
+++ b/extensions/memory-hybrid/routes/graphql-resolvers.ts
@@ -303,8 +303,11 @@ export const resolvers: GraphQLResolvers = {
   Mutation: {
     createFact: (_parent, args, context) => {
       const input = asRecord(asRecord(args).input);
-      const fact = context.factsDb.store(createStoreInput(input));
-      return fact;
+      const result = context.factsDb.storeWithResult(createStoreInput(input));
+      if (result.skipped) {
+        throw new Error("Cannot create fact: blocked by pre-store guard (blocked category or source)");
+      }
+      return result.entry;
     },
 
     updateFact: (_parent, args, context) => {
@@ -313,7 +316,7 @@ export const resolvers: GraphQLResolvers = {
       if (!id) throw new Error("Missing fact id");
       const existing = context.factsDb.getById(id);
       if (!existing) throw new Error(`Fact not found: ${id}`);
-      const updated = context.factsDb.store({
+      const storeResult = context.factsDb.storeWithResult({
         text: asString(input.text) ?? existing.text,
         category: asString(input.category) ?? existing.category,
         importance: asNumber(input.importance) ?? existing.importance,
@@ -328,8 +331,11 @@ export const resolvers: GraphQLResolvers = {
         scopeTarget: existing.scopeTarget ?? null,
         expiresAt: asNumber(input.expiresAt) ?? existing.expiresAt ?? null,
       });
-      context.factsDb.supersede(existing.id, updated.id);
-      return updated;
+      if (storeResult.skipped) {
+        throw new Error("Cannot update fact: blocked by pre-store guard (blocked category or source)");
+      }
+      context.factsDb.supersede(existing.id, storeResult.entry.id);
+      return storeResult.entry;
     },
 
     deleteFact: (_parent, args, context) => {
@@ -371,7 +377,13 @@ export const resolvers: GraphQLResolvers = {
 
     importFacts: (_parent, args, context) => {
       const facts = Array.isArray(asRecord(args).facts) ? (asRecord(args).facts as unknown[]) : [];
-      return facts.map((raw) => context.factsDb.store(createStoreInput(asRecord(raw))));
+      return facts.map((raw) => {
+        const result = context.factsDb.storeWithResult(createStoreInput(asRecord(raw)));
+        if (result.skipped) {
+          throw new Error("Cannot import fact: blocked by pre-store guard (blocked category or source)");
+        }
+        return result.entry;
+      });
     },
 
     pruneFacts: (_parent, args, context) => {

--- a/extensions/memory-hybrid/routes/graphql-resolvers.ts
+++ b/extensions/memory-hybrid/routes/graphql-resolvers.ts
@@ -3,10 +3,12 @@
 // return safe placeholders for schema areas that are not implemented yet.
 
 import type { FactsDB } from "../backends/facts-db.js";
+import { isPreStoreGuardBlocked } from "../backends/facts-db/crud.js";
 import type { VectorDB } from "../backends/vector-db.js";
 import { DECAY_CLASSES, type DecayClass } from "../config.js";
 import type { MemoryLinkType } from "../backends/facts-db/types.js";
 import type { MemoryEntry } from "../types/memory.js";
+import { cleanupEvictedVector } from "../services/vector-maintenance.js";
 
 export type GraphQLContext = {
   factsDb: FactsDB;
@@ -164,6 +166,15 @@ function createStoreInput(input: Record<string, unknown>) {
   };
 }
 
+async function cleanupGraphqlEviction(context: GraphQLContext, evictedFactId: string | null | undefined) {
+  if (!context.vectorDb || !evictedFactId) return;
+  await cleanupEvictedVector({
+    vectorDb: context.vectorDb,
+    evictedFactId,
+    context: "graphql-mutation",
+  });
+}
+
 export const resolvers: GraphQLResolvers = {
   Query: {
     fact: (_parent, args, context) => {
@@ -301,16 +312,18 @@ export const resolvers: GraphQLResolvers = {
   },
 
   Mutation: {
-    createFact: (_parent, args, context) => {
+    createFact: async (_parent, args, context) => {
       const input = asRecord(asRecord(args).input);
-      const result = context.factsDb.storeWithResult(createStoreInput(input));
-      if (result.skipped) {
+      const storeInput = createStoreInput(input);
+      if (isPreStoreGuardBlocked(storeInput)) {
         throw new Error("Cannot create fact: blocked by pre-store guard (blocked category or source)");
       }
+      const result = context.factsDb.storeWithResult(storeInput);
+      await cleanupGraphqlEviction(context, result.evictedFactId);
       return result.entry;
     },
 
-    updateFact: (_parent, args, context) => {
+    updateFact: async (_parent, args, context) => {
       const input = asRecord(asRecord(args).input);
       const id = asString(input.id);
       if (!id) throw new Error("Missing fact id");
@@ -337,6 +350,7 @@ export const resolvers: GraphQLResolvers = {
       if (storeResult.skipped) {
         throw new Error("Cannot update fact: blocked by pre-store guard (blocked category or source)");
       }
+      await cleanupGraphqlEviction(context, storeResult.evictedFactId);
       context.factsDb.supersede(existing.id, storeResult.entry.id);
       return storeResult.entry;
     },
@@ -378,15 +392,19 @@ export const resolvers: GraphQLResolvers = {
       return result.changes > 0;
     },
 
-    importFacts: (_parent, args, context) => {
+    importFacts: async (_parent, args, context) => {
       const facts = Array.isArray(asRecord(args).facts) ? (asRecord(args).facts as unknown[]) : [];
-      return facts.map((raw) => {
-        const result = context.factsDb.storeWithResult(createStoreInput(asRecord(raw)));
-        if (result.skipped) {
-          throw new Error("Cannot import fact: blocked by pre-store guard (blocked category or source)");
-        }
-        return result.entry;
-      });
+      const inputs = facts.map((raw) => createStoreInput(asRecord(raw)));
+      if (inputs.some((input) => isPreStoreGuardBlocked(input))) {
+        throw new Error("Cannot import fact: blocked by pre-store guard (blocked category or source)");
+      }
+      const stored: MemoryEntry[] = [];
+      for (const input of inputs) {
+        const result = context.factsDb.storeWithResult(input);
+        await cleanupGraphqlEviction(context, result.evictedFactId);
+        stored.push(result.entry);
+      }
+      return stored;
     },
 
     pruneFacts: (_parent, args, context) => {

--- a/extensions/memory-hybrid/routes/graphql-resolvers.ts
+++ b/extensions/memory-hybrid/routes/graphql-resolvers.ts
@@ -316,21 +316,24 @@ export const resolvers: GraphQLResolvers = {
       if (!id) throw new Error("Missing fact id");
       const existing = context.factsDb.getById(id);
       if (!existing) throw new Error(`Fact not found: ${id}`);
-      const storeResult = context.factsDb.storeWithResult({
-        text: asString(input.text) ?? existing.text,
-        category: asString(input.category) ?? existing.category,
-        importance: asNumber(input.importance) ?? existing.importance,
-        confidence: asNumber(input.confidence) ?? existing.confidence,
-        decayClass: existing.decayClass,
-        source: existing.source,
-        tags: asStringArray(input.tags) ?? existing.tags ?? [],
-        entity: existing.entity,
-        key: existing.key,
-        value: existing.value,
-        scope: existing.scope,
-        scopeTarget: existing.scopeTarget ?? null,
-        expiresAt: asNumber(input.expiresAt) ?? existing.expiresAt ?? null,
-      });
+      const storeResult = context.factsDb.storeWithResult(
+        {
+          text: asString(input.text) ?? existing.text,
+          category: asString(input.category) ?? existing.category,
+          importance: asNumber(input.importance) ?? existing.importance,
+          confidence: asNumber(input.confidence) ?? existing.confidence,
+          decayClass: existing.decayClass,
+          source: existing.source,
+          tags: asStringArray(input.tags) ?? existing.tags ?? [],
+          entity: existing.entity,
+          key: existing.key,
+          value: existing.value,
+          scope: existing.scope,
+          scopeTarget: existing.scopeTarget ?? null,
+          expiresAt: asNumber(input.expiresAt) ?? existing.expiresAt ?? null,
+        },
+        { allowPreStoreGuardBypass: true },
+      );
       if (storeResult.skipped) {
         throw new Error("Cannot update fact: blocked by pre-store guard (blocked category or source)");
       }

--- a/extensions/memory-hybrid/routes/graphql-resolvers.ts
+++ b/extensions/memory-hybrid/routes/graphql-resolvers.ts
@@ -9,6 +9,7 @@ import { DECAY_CLASSES, type DecayClass } from "../config.js";
 import type { MemoryLinkType } from "../backends/facts-db/types.js";
 import type { MemoryEntry } from "../types/memory.js";
 import { cleanupEvictedVector } from "../services/vector-maintenance.js";
+import { pluginLogger } from "../utils/logger.js";
 
 export type GraphQLContext = {
   factsDb: FactsDB;
@@ -171,6 +172,7 @@ async function cleanupGraphqlEviction(context: GraphQLContext, evictedFactId: st
   await cleanupEvictedVector({
     vectorDb: context.vectorDb,
     evictedFactId,
+    logger: pluginLogger,
     context: "graphql-mutation",
   });
 }

--- a/extensions/memory-hybrid/tests/facts-db.test.ts
+++ b/extensions/memory-hybrid/tests/facts-db.test.ts
@@ -193,7 +193,7 @@ describe("FactsDB.store", () => {
   it("does not persist entries blocked by pre-store guard", () => {
     const before = db.count();
     const result = db.storeWithResult({
-      text: "guarded internal memory",
+      text: "NOOP classification output",
       category: "fact",
       importance: 0.5,
       entity: null,

--- a/extensions/memory-hybrid/tests/facts-db.test.ts
+++ b/extensions/memory-hybrid/tests/facts-db.test.ts
@@ -192,7 +192,7 @@ describe("FactsDB.store", () => {
 
   it("does not persist entries blocked by pre-store guard", () => {
     const before = db.count();
-    const result = db.storeWithResult({
+    const blockedBySource = db.storeWithResult({
       text: "NOOP classification output",
       category: "fact",
       importance: 0.5,
@@ -201,10 +201,22 @@ describe("FactsDB.store", () => {
       value: null,
       source: "remember",
     });
+    const blockedByCategory = db.storeWithResult({
+      text: "artifact-like internal payload",
+      category: "artifact",
+      importance: 0.5,
+      entity: null,
+      key: null,
+      value: null,
+      source: "conversation",
+    });
 
-    expect(result.skipped).toBe(true);
-    expect(result.entry.id).toBe("skipped");
-    expect(result.entry.source).toBe("remember");
+    expect(blockedBySource.skipped).toBe(true);
+    expect(blockedBySource.entry.id).toBe("skipped");
+    expect(blockedBySource.entry.source).toBe("remember");
+    expect(blockedByCategory.skipped).toBe(true);
+    expect(blockedByCategory.entry.id).toBe("skipped");
+    expect(blockedByCategory.entry.category).toBe("artifact");
     expect(db.count()).toBe(before);
   });
 });

--- a/extensions/memory-hybrid/tests/facts-db.test.ts
+++ b/extensions/memory-hybrid/tests/facts-db.test.ts
@@ -193,7 +193,7 @@ describe("FactsDB.store", () => {
   it("does not persist entries blocked by pre-store guard", () => {
     const before = db.count();
     const result = db.storeWithResult({
-      text: "internal classifier artifact",
+      text: "guarded internal memory",
       category: "fact",
       importance: 0.5,
       entity: null,
@@ -204,6 +204,7 @@ describe("FactsDB.store", () => {
 
     expect(result.skipped).toBe(true);
     expect(result.entry.id).toBe("skipped");
+    expect(result.entry.source).toBe("remember");
     expect(db.count()).toBe(before);
   });
 });

--- a/extensions/memory-hybrid/tests/facts-db.test.ts
+++ b/extensions/memory-hybrid/tests/facts-db.test.ts
@@ -189,6 +189,23 @@ describe("FactsDB.store", () => {
       sqlite.prepare = originalPrepare;
     }
   });
+
+  it("does not persist entries blocked by pre-store guard", () => {
+    const before = db.count();
+    const result = db.storeWithResult({
+      text: "internal classifier artifact",
+      category: "fact",
+      importance: 0.5,
+      entity: null,
+      key: null,
+      value: null,
+      source: "remember",
+    });
+
+    expect(result.skipped).toBe(true);
+    expect(result.entry.id).toBe("skipped");
+    expect(db.count()).toBe(before);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/extensions/memory-hybrid/tests/pr1332-remediation.test.ts
+++ b/extensions/memory-hybrid/tests/pr1332-remediation.test.ts
@@ -88,7 +88,7 @@ describe("PR #1332 unresolved feedback remediation", () => {
     ).toBe(false);
   });
 
-  it("allows GraphQL updateFact to edit already-persisted guarded facts", () => {
+  it("allows GraphQL updateFact to edit already-persisted guarded facts", async () => {
     const existing = {
       id: "legacy-compact",
       text: "old compact text",
@@ -115,7 +115,7 @@ describe("PR #1332 unresolved feedback remediation", () => {
       },
     } as unknown as ResolverContext;
 
-    const updated = resolvers.Mutation.updateFact(
+    const updated = await resolvers.Mutation.updateFact(
       null,
       { input: { id: existing.id, text: "edited text" } } as ResolverArgs,
       context,
@@ -126,6 +126,35 @@ describe("PR #1332 unresolved feedback remediation", () => {
       allowPreStoreGuardBypass: true,
     });
     expect(context.factsDb.supersede).toHaveBeenCalledWith(existing.id, replacement.id);
+  });
+
+  it("prevalidates GraphQL importFacts before storing guarded facts", async () => {
+    const storeWithResult = vi.fn((input: { text: string }) => ({
+      entry: { id: input.text, text: input.text },
+      skipped: false,
+    }));
+    const context = { factsDb: { storeWithResult } } as unknown as ResolverContext;
+
+    await expect(
+      resolvers.Mutation.importFacts(
+        null,
+        { facts: [{ text: "safe" }, { text: "blocked", source: "compact" }] } as ResolverArgs,
+        context,
+      ),
+    ).rejects.toThrow(/blocked by pre-store guard/);
+    expect(storeWithResult).not.toHaveBeenCalled();
+  });
+
+  it("cleans up evicted vectors from GraphQL createFact", async () => {
+    const entry = { id: "created", text: "created" };
+    const storeWithResult = vi.fn(() => ({ entry, skipped: false, evictedFactId: "evicted" }));
+    const vectorDb = { delete: vi.fn().mockResolvedValue(true) };
+    const context = { factsDb: { storeWithResult }, vectorDb } as unknown as ResolverContext;
+
+    await expect(
+      resolvers.Mutation.createFact(null, { input: { text: "created" } } as ResolverArgs, context),
+    ).resolves.toBe(entry);
+    expect(vectorDb.delete).toHaveBeenCalledWith("evicted");
   });
 
   it("fails GraphQL supersede mutation when the old fact is missing or already superseded", () => {

--- a/extensions/memory-hybrid/tests/pr1332-remediation.test.ts
+++ b/extensions/memory-hybrid/tests/pr1332-remediation.test.ts
@@ -88,6 +88,46 @@ describe("PR #1332 unresolved feedback remediation", () => {
     ).toBe(false);
   });
 
+  it("allows GraphQL updateFact to edit already-persisted guarded facts", () => {
+    const existing = {
+      id: "legacy-compact",
+      text: "old compact text",
+      category: "fact",
+      importance: 0.5,
+      confidence: 0.9,
+      decayClass: "normal",
+      source: "compact",
+      tags: [],
+      entity: null,
+      key: null,
+      value: null,
+      scope: "global",
+      scopeTarget: null,
+      expiresAt: null,
+    };
+    const replacement = { ...existing, id: "updated", text: "edited text" };
+    const storeWithResult = vi.fn(() => ({ entry: replacement, skipped: false }));
+    const context = {
+      factsDb: {
+        getById: vi.fn((id: string) => (id === existing.id ? existing : null)),
+        storeWithResult,
+        supersede: vi.fn(() => true),
+      },
+    } as unknown as ResolverContext;
+
+    const updated = resolvers.Mutation.updateFact(
+      null,
+      { input: { id: existing.id, text: "edited text" } } as ResolverArgs,
+      context,
+    );
+
+    expect(updated).toBe(replacement);
+    expect(storeWithResult).toHaveBeenCalledWith(expect.objectContaining({ source: "compact", text: "edited text" }), {
+      allowPreStoreGuardBypass: true,
+    });
+    expect(context.factsDb.supersede).toHaveBeenCalledWith(existing.id, replacement.id);
+  });
+
   it("fails GraphQL supersede mutation when the old fact is missing or already superseded", () => {
     const facts = new Map([
       ["new", { id: "new", text: "new" }],

--- a/extensions/memory-hybrid/tests/stage-capture.test.ts
+++ b/extensions/memory-hybrid/tests/stage-capture.test.ts
@@ -21,6 +21,7 @@ vi.mock("../utils/atomic-write.js", async (importOriginal) => {
 // ---------------------------------------------------------------------------
 
 const detectCredentialPatternsMock = vi.fn().mockReturnValue([]);
+const classifyMemoryOperationsBatchMock = vi.fn().mockResolvedValue([]);
 
 vi.mock("../services/auto-capture.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../services/auto-capture.js")>();
@@ -28,6 +29,15 @@ vi.mock("../services/auto-capture.js", async (importOriginal) => {
     ...actual,
     detectCredentialPatterns: (...args: Parameters<typeof actual.detectCredentialPatterns>) =>
       detectCredentialPatternsMock(...args),
+  };
+});
+
+vi.mock("../services/classification.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../services/classification.js")>();
+  return {
+    ...actual,
+    classifyMemoryOperationsBatch: (...args: Parameters<typeof actual.classifyMemoryOperationsBatch>) =>
+      classifyMemoryOperationsBatchMock(...args),
   };
 });
 
@@ -121,6 +131,8 @@ describe("runCaptureStage", () => {
   beforeEach(() => {
     atomicWriteFileMock.mockReset();
     detectCredentialPatternsMock.mockReturnValue([]);
+    classifyMemoryOperationsBatchMock.mockReset();
+    classifyMemoryOperationsBatchMock.mockResolvedValue([]);
   });
 
   it("skips auto-capture for cron/system sessions", async () => {
@@ -243,6 +255,88 @@ describe("runCaptureStage", () => {
     expect(vectorHasDuplicate).not.toHaveBeenCalled();
     expect(vectorStore).not.toHaveBeenCalled();
     expect(auditAppend).not.toHaveBeenCalled();
+    expect(ctx.walWrite).toHaveBeenCalledOnce();
+    expect(ctx.walRemove).toHaveBeenCalledOnce();
+  });
+
+  it("skips update supersession/vector side effects when classified UPDATE store is skipped", async () => {
+    const api = makeApi("chat");
+    const existingFact = {
+      id: "fact-existing",
+      text: "Remember to answer concisely.",
+      category: "fact",
+      importance: 0.8,
+      source: "conversation",
+      entity: null,
+      key: null,
+      value: null,
+      createdAt: Math.floor(Date.now() / 1000) - 3600,
+      decayClass: "normal",
+      expiresAt: null,
+      lastConfirmedAt: 0,
+      confidence: 1,
+      tags: null,
+      scope: "global",
+      scopeTarget: null,
+    };
+    classifyMemoryOperationsBatchMock.mockResolvedValue([
+      { action: "UPDATE", targetId: existingFact.id, reason: "replace old wording" },
+    ]);
+    const storeWithResult = vi.fn().mockReturnValue({
+      entry: { ...existingFact, id: "skipped" },
+      evictedFactId: null,
+      skipped: true,
+    });
+    const supersede = vi.fn();
+    const aliasDeleteByFactId = vi.fn();
+    const vectorDelete = vi.fn().mockResolvedValue(true);
+    const auditAppend = vi.fn();
+    const { ctx } = makeContext({
+      factsDb: {
+        store: vi.fn(),
+        storeWithResult,
+        hasDuplicate: vi.fn().mockReturnValue(false),
+        getById: vi.fn((id: string) => (id === existingFact.id ? existingFact : null)),
+        findSimilarForClassification: vi.fn().mockReturnValue([existingFact]),
+        supersede,
+      } as unknown as LifecycleContext["factsDb"],
+      aliasDb: {
+        deleteByFactId: aliasDeleteByFactId,
+      } as unknown as LifecycleContext["aliasDb"],
+      vectorDb: {
+        delete: vectorDelete,
+      } as unknown as LifecycleContext["vectorDb"],
+      cfg: {
+        autoCapture: true,
+        captureMaxChars: 5000,
+        autoRecall: { enabled: false, summaryThreshold: 0, summaryMaxChars: 200 },
+        retrieval: { strategies: [] },
+        store: { classifyBeforeWrite: true },
+        memoryTiering: { enabled: false, compactionOnSessionEnd: false },
+        credentials: { enabled: false },
+        humanizer: { enabled: false },
+      } as unknown as LifecycleContext["cfg"],
+      auditStore: {
+        append: auditAppend,
+      } as unknown as LifecycleContext["auditStore"],
+    });
+    const sessionState = makeSessionState();
+
+    await runCaptureStage(
+      {
+        success: true,
+        messages: [{ role: "user", content: "Remember to answer with one sentence." }],
+      },
+      api as never,
+      ctx,
+      sessionState,
+    );
+
+    expect(storeWithResult).toHaveBeenCalledOnce();
+    expect(supersede).not.toHaveBeenCalled();
+    expect(aliasDeleteByFactId).not.toHaveBeenCalled();
+    expect(vectorDelete).not.toHaveBeenCalled();
+    expect(auditAppend).not.toHaveBeenCalledWith(expect.objectContaining({ action: "auto-capture:updated" }));
     expect(ctx.walWrite).toHaveBeenCalledOnce();
     expect(ctx.walRemove).toHaveBeenCalledOnce();
   });

--- a/extensions/memory-hybrid/tests/stage-capture.test.ts
+++ b/extensions/memory-hybrid/tests/stage-capture.test.ts
@@ -239,7 +239,6 @@ describe("runCaptureStage", () => {
     );
 
     expect(storeWithResult).toHaveBeenCalledOnce();
-    expect(embed).toHaveBeenCalledOnce();
     expect(setEmbeddingModel).not.toHaveBeenCalled();
     expect(vectorHasDuplicate).not.toHaveBeenCalled();
     expect(vectorStore).not.toHaveBeenCalled();

--- a/extensions/memory-hybrid/tests/stage-capture.test.ts
+++ b/extensions/memory-hybrid/tests/stage-capture.test.ts
@@ -170,6 +170,84 @@ describe("runCaptureStage", () => {
     );
   });
 
+  it("skips post-store vector and audit side effects when storeWithResult is skipped", async () => {
+    const api = makeApi("chat");
+    const storeWithResult = vi.fn().mockReturnValue({
+      entry: {
+        id: "skipped",
+        text: "Remember that I prefer concise answers.",
+        category: "fact",
+        importance: 0.5,
+        source: "auto-capture",
+        entity: null,
+        key: null,
+        value: null,
+        createdAt: Math.floor(Date.now() / 1000),
+        decayClass: "normal",
+        expiresAt: null,
+        lastConfirmedAt: 0,
+        confidence: 0,
+        tags: null,
+      },
+      evictedFactId: "evicted-fact-id",
+      skipped: true,
+    });
+    const setEmbeddingModel = vi.fn();
+    const vectorStore = vi.fn();
+    const vectorHasDuplicate = vi.fn().mockResolvedValue(false);
+    const auditAppend = vi.fn();
+    const embed = vi.fn().mockResolvedValue([0.01, 0.02, 0.03]);
+    const { ctx } = makeContext({
+      factsDb: {
+        store: vi.fn(),
+        storeWithResult,
+        hasDuplicate: vi.fn().mockReturnValue(false),
+        setEmbeddingModel,
+      } as unknown as LifecycleContext["factsDb"],
+      vectorDb: {
+        store: vectorStore,
+        hasDuplicate: vectorHasDuplicate,
+      } as unknown as LifecycleContext["vectorDb"],
+      embeddings: {
+        modelName: "test-model",
+        embed,
+      } as unknown as LifecycleContext["embeddings"],
+      cfg: {
+        autoCapture: true,
+        captureMaxChars: 5000,
+        autoRecall: { enabled: false, summaryThreshold: 0, summaryMaxChars: 200 },
+        retrieval: { strategies: ["semantic"] },
+        store: { classifyBeforeWrite: false },
+        memoryTiering: { enabled: false, compactionOnSessionEnd: false },
+        credentials: { enabled: false },
+        humanizer: { enabled: false },
+      } as unknown as LifecycleContext["cfg"],
+      auditStore: {
+        append: auditAppend,
+      } as unknown as LifecycleContext["auditStore"],
+    });
+    const sessionState = makeSessionState();
+
+    await runCaptureStage(
+      {
+        success: true,
+        messages: [{ role: "user", content: "Remember that I prefer concise answers." }],
+      },
+      api as never,
+      ctx,
+      sessionState,
+    );
+
+    expect(storeWithResult).toHaveBeenCalledOnce();
+    expect(embed).toHaveBeenCalledOnce();
+    expect(setEmbeddingModel).not.toHaveBeenCalled();
+    expect(vectorHasDuplicate).not.toHaveBeenCalled();
+    expect(vectorStore).not.toHaveBeenCalled();
+    expect(auditAppend).not.toHaveBeenCalled();
+    expect(ctx.walWrite).toHaveBeenCalledOnce();
+    expect(ctx.walRemove).toHaveBeenCalledOnce();
+  });
+
   // -------------------------------------------------------------------------
   // Credential auto-detect: atomicity of pendingPath write (Issue #1498).
   // -------------------------------------------------------------------------

--- a/extensions/memory-hybrid/tests/stage-capture.test.ts
+++ b/extensions/memory-hybrid/tests/stage-capture.test.ts
@@ -189,7 +189,7 @@ describe("runCaptureStage", () => {
         confidence: 0,
         tags: null,
       },
-      evictedFactId: "evicted-fact-id",
+      evictedFactId: null,
       skipped: true,
     });
     const setEmbeddingModel = vi.fn();

--- a/extensions/memory-hybrid/tests/stage-capture.test.ts
+++ b/extensions/memory-hybrid/tests/stage-capture.test.ts
@@ -49,9 +49,15 @@ function makeApi(messageChannel?: string) {
 
 function makeContext(overrides?: Partial<LifecycleContext>) {
   const store = vi.fn().mockReturnValue({ id: "fact-1" });
+  const storeWithResult = vi.fn().mockImplementation((entry: Parameters<typeof store>[0]) => ({
+    entry: store(entry),
+    evictedFactId: null,
+    skipped: false,
+  }));
   const context = {
     factsDb: {
       store,
+      storeWithResult,
       hasDuplicate: vi.fn().mockReturnValue(false),
     },
     vectorDb: {},

--- a/extensions/memory-hybrid/tools/memory/register-store-tools.ts
+++ b/extensions/memory-hybrid/tools/memory/register-store-tools.ts
@@ -526,90 +526,93 @@ export function registerStoreTools(runtime: MemoryToolRuntime): void {
                     extractionConfidence: Math.max(importance, oldFact.importance),
                   });
                   const newEntry = updateStoreResult.entry;
-                  await cleanupEvictedVector({
-                    vectorDb,
-                    evictedFactId: updateStoreResult.evictedFactId,
-                    logger: api.logger,
-                    context: "memory-store-update",
-                  });
-                  recordActiveStoreProvenance(newEntry.id, textToStore);
-                  factsDb.supersede(classification.targetId, newEntry.id);
-                  aliasDb?.deleteByFactId(classification.targetId);
-                  await deleteVectorForFactId({
-                    vectorDb,
-                    factId: classification.targetId,
-                    logger: api.logger,
-                    context: "store-update-delete-superseded",
-                  });
-                  maybeAutoVerify(
-                    newEntry.id,
-                    textToStore,
-                    newEntry.tags ?? tags,
-                    newEntry.entity,
-                    newEntry.key,
-                    newEntry.value,
-                  );
+                  // Guard: skip post-store ops when pre-store guard blocked the write (#1560, #1561)
+                  if (!updateStoreResult.skipped) {
+                    await cleanupEvictedVector({
+                      vectorDb,
+                      evictedFactId: updateStoreResult.evictedFactId,
+                      logger: api.logger,
+                      context: "memory-store-update",
+                    });
+                    recordActiveStoreProvenance(newEntry.id, textToStore);
+                    factsDb.supersede(classification.targetId, newEntry.id);
+                    aliasDb?.deleteByFactId(classification.targetId);
+                    await deleteVectorForFactId({
+                      vectorDb,
+                      factId: classification.targetId,
+                      logger: api.logger,
+                      context: "store-update-delete-superseded",
+                    });
+                    maybeAutoVerify(
+                      newEntry.id,
+                      textToStore,
+                      newEntry.tags ?? tags,
+                      newEntry.entity,
+                      newEntry.key,
+                      newEntry.value,
+                    );
 
-                  const finalImportance = Math.max(importance, oldFact.importance);
-                  try {
-                    if (vector) {
-                      await storeActiveCanonicalVector({
+                    const finalImportance = Math.max(importance, oldFact.importance);
+                    try {
+                      if (vector) {
+                        await storeActiveCanonicalVector({
+                          factId: newEntry.id,
+                          text: textToStore,
+                          why,
+                          vector,
+                          importance: finalImportance,
+                          category,
+                        });
+                      }
+                      await storeRegistryEmbeddings({
+                        factsDb,
+                        embeddingRegistry,
+                        embeddings,
                         factId: newEntry.id,
                         text: textToStore,
-                        why,
                         vector,
-                        importance: finalImportance,
-                        category,
+                        logger: api.logger,
+                        operation: "store-update-supersede",
                       });
+                    } catch (err) {
+                      capturePluginError(err instanceof Error ? err : new Error(String(err)), {
+                        subsystem: "vector",
+                        operation: "store-update-supersede",
+                        phase: "runtime",
+                        backend: "lancedb",
+                      });
+                      api.logger.warn(`memory-hybrid: vector store failed: ${err}`);
                     }
-                    await storeRegistryEmbeddings({
-                      factsDb,
-                      embeddingRegistry,
-                      embeddings,
-                      factId: newEntry.id,
-                      text: textToStore,
-                      vector,
-                      logger: api.logger,
-                      operation: "store-update-supersede",
-                    });
-                  } catch (err) {
-                    capturePluginError(err instanceof Error ? err : new Error(String(err)), {
-                      subsystem: "vector",
-                      operation: "store-update-supersede",
-                      phase: "runtime",
-                      backend: "lancedb",
-                    });
-                    api.logger.warn(`memory-hybrid: vector store failed: ${err}`);
-                  }
 
-                  await walRemove(walEntryId, api.logger);
-                  await maybeRefreshProjectActiveTaskProjection(newEntry.category, newEntry.id, newEntry.scope);
+                    await walRemove(walEntryId, api.logger);
+                    await maybeRefreshProjectActiveTaskProjection(newEntry.category, newEntry.id, newEntry.scope);
 
-                  // Issue #159: enqueue contextual variant generation (non-blocking)
-                  if (variantQueue) {
-                    variantQueue.enqueue({ factId: newEntry.id, text: textToStore, category: category as string });
-                  }
+                    // Issue #159: enqueue contextual variant generation (non-blocking)
+                    if (variantQueue) {
+                      variantQueue.enqueue({ factId: newEntry.id, text: textToStore, category: category as string });
+                    }
 
-                  api.logger.info?.(
-                    `memory-hybrid: UPDATE — superseded ${classification.targetId} with ${newEntry.id}: ${classification.reason}`,
-                  );
-                  return {
-                    content: [
-                      {
-                        type: "text",
-                        text: `Updated: superseded old fact with "${textToStore.slice(0, 100)}${textToStore.length > 100 ? "..." : ""}"${entity ? ` [entity: ${entity}]` : ""} [decay: ${newEntry.decayClass}] (reason: ${classification.reason})`,
+                    api.logger.info?.(
+                      `memory-hybrid: UPDATE — superseded ${classification.targetId} with ${newEntry.id}: ${classification.reason}`,
+                    );
+                    return {
+                      content: [
+                        {
+                          type: "text",
+                          text: `Updated: superseded old fact with "${textToStore.slice(0, 100)}${textToStore.length > 100 ? "..." : ""}"${entity ? ` [entity: ${entity}]` : ""} [decay: ${newEntry.decayClass}] (reason: ${classification.reason})`,
+                        },
+                      ],
+                      details: {
+                        action: "updated",
+                        id: newEntry.id,
+                        why: why ?? undefined,
+                        superseded: classification.targetId,
+                        reason: classification.reason,
+                        backend: "both",
+                        decayClass: newEntry.decayClass,
                       },
-                    ],
-                    details: {
-                      action: "updated",
-                      id: newEntry.id,
-                      why: why ?? undefined,
-                      superseded: classification.targetId,
-                      reason: classification.reason,
-                      backend: "both",
-                      decayClass: newEntry.decayClass,
-                    },
-                  };
+                    };
+                  }
                 }
                 return {
                   content: [
@@ -740,254 +743,257 @@ export function registerStoreTools(runtime: MemoryToolRuntime): void {
             ...(supersedes?.trim() ? { validFrom: nowSec, supersedesId: supersedes.trim() } : {}),
           });
           const entry = storeResult.entry;
-          await cleanupEvictedVector({
-            vectorDb,
-            evictedFactId: storeResult.evictedFactId,
-            logger: api.logger,
-            context: "memory-store",
-          });
-          recordActiveStoreProvenance(entry.id, textToStore);
-          if (supersedes?.trim()) {
-            const supersededId = supersedes.trim();
-            factsDb.supersede(supersededId, entry.id);
-            aliasDb?.deleteByFactId(supersededId);
-            await deleteVectorForFactId({
+          // Guard: skip post-store ops when pre-store guard blocked the write (#1560, #1561)
+          if (!storeResult.skipped) {
+            await cleanupEvictedVector({
               vectorDb,
-              factId: supersededId,
+              evictedFactId: storeResult.evictedFactId,
               logger: api.logger,
-              context: "store-manual-supersede",
+              context: "memory-store",
             });
-          }
+            recordActiveStoreProvenance(entry.id, textToStore);
+            if (supersedes?.trim()) {
+              const supersededId = supersedes.trim();
+              factsDb.supersede(supersededId, entry.id);
+              aliasDb?.deleteByFactId(supersededId);
+              await deleteVectorForFactId({
+                vectorDb,
+                factId: supersededId,
+                logger: api.logger,
+                context: "store-manual-supersede",
+              });
+            }
 
-          try {
-            addOperationBreadcrumb("vector", "store-fact");
-            if (vector) {
-              await storeActiveCanonicalVector({
+            try {
+              addOperationBreadcrumb("vector", "store-fact");
+              if (vector) {
+                await storeActiveCanonicalVector({
+                  factId: entry.id,
+                  text: textToStore,
+                  why,
+                  vector,
+                  importance,
+                  category,
+                });
+              }
+              await storeRegistryEmbeddings({
+                factsDb,
+                embeddingRegistry,
+                embeddings,
                 factId: entry.id,
                 text: textToStore,
-                why,
                 vector,
-                importance,
-                category,
+                logger: api.logger,
+                operation: "store-fact",
               });
-            }
-            await storeRegistryEmbeddings({
-              factsDb,
-              embeddingRegistry,
-              embeddings,
-              factId: entry.id,
-              text: textToStore,
-              vector,
-              logger: api.logger,
-              operation: "store-fact",
-            });
-          } catch (err) {
-            capturePluginError(err instanceof Error ? err : new Error(String(err)), {
-              subsystem: "vector",
-              operation: "store-fact",
-              phase: "runtime",
-              backend: "lancedb",
-            });
-            api.logger.warn(`memory-hybrid: vector store failed: ${err}`);
-          }
-
-          await walRemove(walEntryId, api.logger);
-          await maybeRefreshProjectActiveTaskProjection(entry.category, entry.id, entry.scope);
-
-          // Issue #150: write event to episodic event log
-          if (eventLog) {
-            try {
-              const eventType = categoryToEventType(category);
-              eventLog.append({
-                sessionId: api.context?.sessionId ?? "unknown",
-                timestamp: new Date().toISOString(),
-                eventType,
-                content: {
-                  text: textToStore.slice(0, 500),
-                  factId: entry.id,
-                  category,
-                  importance,
-                  source: "memory_store",
-                },
-                entities: entity ? [entity] : undefined,
+            } catch (err) {
+              capturePluginError(err instanceof Error ? err : new Error(String(err)), {
+                subsystem: "vector",
+                operation: "store-fact",
+                phase: "runtime",
+                backend: "lancedb",
               });
-            } catch {
-              // Non-fatal
+              api.logger.warn(`memory-hybrid: vector store failed: ${err}`);
             }
-          }
 
-          // Issue #159: enqueue contextual variant generation (non-blocking)
-          if (variantQueue) {
-            variantQueue.enqueue({ factId: entry.id, text: textToStore, category: category as string });
-          }
+            await walRemove(walEntryId, api.logger);
+            await maybeRefreshProjectActiveTaskProjection(entry.category, entry.id, entry.scope);
 
-          // Issue #149: generate and store retrieval aliases (non-blocking)
-          if (cfg.aliases?.enabled && aliasDb && importance >= 0.5) {
-            const aliasModel = cfg.aliases.model ?? getDefaultCronModel(getCronModelConfig(cfg), "nano");
-            void storeAliases(entry.id, textToStore, cfg.aliases, aliasModel, openai, embeddings, aliasDb, (msg) =>
-              api.logger.warn(msg),
-            ).catch((err) => {
-              api.logger.warn(`memory-hybrid: alias generation failed: ${err}`);
-            });
-          }
-
-          // Contradiction detection (Issue #157): check for same entity+key, different value
-          // Pass the stored fact's scope so detection stays within the same scope boundary.
-          const contradictions = factsDb.detectContradictions(
-            entry.id,
-            entity ?? null,
-            key ?? null,
-            value ?? null,
-            entry.scope ?? null,
-            entry.scopeTarget ?? null,
-          );
-          for (const { contradictionId, oldFactId } of contradictions) {
+            // Issue #150: write event to episodic event log
             if (eventLog) {
-              eventLog.append({
-                sessionId: api.context?.sessionId ?? "unknown",
-                timestamp: new Date().toISOString(),
-                eventType: "correction",
-                content: {
-                  type: "contradiction_detected",
-                  contradictionId,
-                  newFactId: entry.id,
-                  oldFactId,
-                  entity: entity ?? null,
-                  key: key ?? null,
-                  newValue: value ?? null,
-                },
-                entities: entity ? [entity] : undefined,
+              try {
+                const eventType = categoryToEventType(category);
+                eventLog.append({
+                  sessionId: api.context?.sessionId ?? "unknown",
+                  timestamp: new Date().toISOString(),
+                  eventType,
+                  content: {
+                    text: textToStore.slice(0, 500),
+                    factId: entry.id,
+                    category,
+                    importance,
+                    source: "memory_store",
+                  },
+                  entities: entity ? [entity] : undefined,
+                });
+              } catch {
+                // Non-fatal
+              }
+            }
+
+            // Issue #159: enqueue contextual variant generation (non-blocking)
+            if (variantQueue) {
+              variantQueue.enqueue({ factId: entry.id, text: textToStore, category: category as string });
+            }
+
+            // Issue #149: generate and store retrieval aliases (non-blocking)
+            if (cfg.aliases?.enabled && aliasDb && importance >= 0.5) {
+              const aliasModel = cfg.aliases.model ?? getDefaultCronModel(getCronModelConfig(cfg), "nano");
+              void storeAliases(entry.id, textToStore, cfg.aliases, aliasModel, openai, embeddings, aliasDb, (msg) =>
+                api.logger.warn(msg),
+              ).catch((err) => {
+                api.logger.warn(`memory-hybrid: alias generation failed: ${err}`);
               });
             }
-          }
 
-          // Auto-link to similar facts when enabled
-          let autoLinked = 0;
-          if (cfg.graph.enabled && cfg.graph.autoLink) {
-            const entryScope = entry.scope ?? "global";
-            const entryScopeTarget = entryScope === "global" ? null : (entry.scopeTarget ?? null);
-            const similar = factsDb.findSimilarForClassification(
-              textToStore,
-              entity ?? null,
-              key ?? null,
-              cfg.graph.autoLinkLimit,
-              entryScope,
-              entryScopeTarget,
-            );
-            for (const s of similar) {
-              if (s.id === entry.id) continue;
-              factsDb.createLink(entry.id, s.id, "RELATED_TO", cfg.graph.autoLinkMinScore);
-              autoLinked++;
-            }
-          }
-
-          // Entity-based auto-linking (Issue #154): known-entity matching, IP NER,
-          // temporal co-occurrence, and supersession detection.
-          let entityAutoLinked = 0;
-          let autoSupersededIds: string[] = [];
-          if (cfg.graph.enabled && cfg.graph.autoLink) {
-            const sessionId = api.context?.sessionId ?? null;
-            const result = factsDb.autoLinkEntities(
+            // Contradiction detection (Issue #157): check for same entity+key, different value
+            // Pass the stored fact's scope so detection stays within the same scope boundary.
+            const contradictions = factsDb.detectContradictions(
               entry.id,
-              textToStore,
               entity ?? null,
               key ?? null,
-              sessionId,
-              {
-                coOccurrenceWeight: cfg.graph.coOccurrenceWeight,
-                autoSupersede: cfg.graph.autoSupersede,
-              },
+              value ?? null,
               entry.scope ?? null,
               entry.scopeTarget ?? null,
             );
-            entityAutoLinked = result.linkedCount;
-            autoSupersededIds = result.supersededIds;
-            if (autoSupersededIds.length > 0) {
-              api.logger.info?.(
-                `memory-hybrid: autoSupersede — superseded [${autoSupersededIds.join(", ")}] with ${entry.id}`,
+            for (const { contradictionId, oldFactId } of contradictions) {
+              if (eventLog) {
+                eventLog.append({
+                  sessionId: api.context?.sessionId ?? "unknown",
+                  timestamp: new Date().toISOString(),
+                  eventType: "correction",
+                  content: {
+                    type: "contradiction_detected",
+                    contradictionId,
+                    newFactId: entry.id,
+                    oldFactId,
+                    entity: entity ?? null,
+                    key: key ?? null,
+                    newValue: value ?? null,
+                  },
+                  entities: entity ? [entity] : undefined,
+                });
+              }
+            }
+
+            // Auto-link to similar facts when enabled
+            let autoLinked = 0;
+            if (cfg.graph.enabled && cfg.graph.autoLink) {
+              const entryScope = entry.scope ?? "global";
+              const entryScopeTarget = entryScope === "global" ? null : (entry.scopeTarget ?? null);
+              const similar = factsDb.findSimilarForClassification(
+                textToStore,
+                entity ?? null,
+                key ?? null,
+                cfg.graph.autoLinkLimit,
+                entryScope,
+                entryScopeTarget,
               );
+              for (const s of similar) {
+                if (s.id === entry.id) continue;
+                factsDb.createLink(entry.id, s.id, "RELATED_TO", cfg.graph.autoLinkMinScore);
+                autoLinked++;
+              }
             }
-          }
 
-          // NER + contact/org layer (#985–#987): async enrichment after graph auto-link; uses franc + LLM.
-          if (cfg.graph.enabled) {
-            const enrichModel = getDefaultCronModel(getCronModelConfig(cfg), "nano");
-            void extractEntityMentionsWithLlm(textToStore, openai, enrichModel, {
-              stopWords: cfg.entityExtraction.stopWords,
-            })
-              .then(({ mentions, detectedLang }) => {
-                factsDb.applyEntityEnrichment(entry.id, mentions, detectedLang);
+            // Entity-based auto-linking (Issue #154): known-entity matching, IP NER,
+            // temporal co-occurrence, and supersession detection.
+            let entityAutoLinked = 0;
+            let autoSupersededIds: string[] = [];
+            if (cfg.graph.enabled && cfg.graph.autoLink) {
+              const sessionId = api.context?.sessionId ?? null;
+              const result = factsDb.autoLinkEntities(
+                entry.id,
+                textToStore,
+                entity ?? null,
+                key ?? null,
+                sessionId,
+                {
+                  coOccurrenceWeight: cfg.graph.coOccurrenceWeight,
+                  autoSupersede: cfg.graph.autoSupersede,
+                },
+                entry.scope ?? null,
+                entry.scopeTarget ?? null,
+              );
+              entityAutoLinked = result.linkedCount;
+              autoSupersededIds = result.supersededIds;
+              if (autoSupersededIds.length > 0) {
+                api.logger.info?.(
+                  `memory-hybrid: autoSupersede — superseded [${autoSupersededIds.join(", ")}] with ${entry.id}`,
+                );
+              }
+            }
+
+            // NER + contact/org layer (#985–#987): async enrichment after graph auto-link; uses franc + LLM.
+            if (cfg.graph.enabled) {
+              const enrichModel = getDefaultCronModel(getCronModelConfig(cfg), "nano");
+              void extractEntityMentionsWithLlm(textToStore, openai, enrichModel, {
+                stopWords: cfg.entityExtraction.stopWords,
               })
-              .catch((err) => {
-                const msg = err instanceof Error ? (err.stack ?? err.message) : String(err);
-                api.logger.warn?.(`memory-hybrid: entity enrichment failed: ${msg}`);
-              });
-          }
-
-          const totalLinked = autoLinked + entityAutoLinked;
-          const verbosity = cfg.verbosity ?? "normal";
-          let storedMsg: string;
-          if (isCompactVerbosity(verbosity)) {
-            // Quiet: only report the ID and any warnings (contradictions are important)
-            storedMsg = `Stored: ${entry.id}${
-              contradictions.length > 0
-                ? ` (⚠️ contradicts ${contradictions.length} existing fact${contradictions.length === 1 ? "" : "s"})`
-                : ""
-            }`;
-          } else {
-            // normal / verbose: full details (verbose adds scope/category info)
-            storedMsg = `Stored: "${textToStore.slice(0, 100)}${textToStore.length > 100 ? "..." : ""}"${entity ? ` [entity: ${entity}]` : ""} [decay: ${entry.decayClass}]${supersedes?.trim() ? " (supersedes previous fact)" : ""}${totalLinked > 0 ? ` (linked to ${totalLinked} related fact${totalLinked === 1 ? "" : "s"})` : ""}${
-              autoSupersededIds.length > 0
-                ? ` (auto-superseded ${autoSupersededIds.length} fact${autoSupersededIds.length === 1 ? "" : "s"})`
-                : ""
-            }${
-              contradictions.length > 0
-                ? ` (⚠️ contradicts ${contradictions.length} existing fact${contradictions.length === 1 ? "" : "s"})`
-                : ""
-            }`;
-            if (verbosity === "verbose") {
-              storedMsg += ` [id: ${entry.id}]`;
-              if (entry.scope)
-                storedMsg += ` [scope: ${entry.scope}${entry.scopeTarget ? `/${entry.scopeTarget}` : ""}]`;
+                .then(({ mentions, detectedLang }) => {
+                  factsDb.applyEntityEnrichment(entry.id, mentions, detectedLang);
+                })
+                .catch((err) => {
+                  const msg = err instanceof Error ? (err.stack ?? err.message) : String(err);
+                  api.logger.warn?.(`memory-hybrid: entity enrichment failed: ${msg}`);
+                });
             }
-          }
 
-          auditAppend({
-            agentId: agentIdForAudit(),
-            action: "memory_store",
-            target: `memory #${entry.id}`,
-            outcome: "success",
-            sessionId: api.context?.sessionId ?? undefined,
-            context: { category },
-          });
+            const totalLinked = autoLinked + entityAutoLinked;
+            const verbosity = cfg.verbosity ?? "normal";
+            let storedMsg: string;
+            if (isCompactVerbosity(verbosity)) {
+              // Quiet: only report the ID and any warnings (contradictions are important)
+              storedMsg = `Stored: ${entry.id}${
+                contradictions.length > 0
+                  ? ` (⚠️ contradicts ${contradictions.length} existing fact${contradictions.length === 1 ? "" : "s"})`
+                  : ""
+              }`;
+            } else {
+              // normal / verbose: full details (verbose adds scope/category info)
+              storedMsg = `Stored: "${textToStore.slice(0, 100)}${textToStore.length > 100 ? "..." : ""}"${entity ? ` [entity: ${entity}]` : ""} [decay: ${entry.decayClass}]${supersedes?.trim() ? " (supersedes previous fact)" : ""}${totalLinked > 0 ? ` (linked to ${totalLinked} related fact${totalLinked === 1 ? "" : "s"})` : ""}${
+                autoSupersededIds.length > 0
+                  ? ` (auto-superseded ${autoSupersededIds.length} fact${autoSupersededIds.length === 1 ? "" : "s"})`
+                  : ""
+              }${
+                contradictions.length > 0
+                  ? ` (⚠️ contradicts ${contradictions.length} existing fact${contradictions.length === 1 ? "" : "s"})`
+                  : ""
+              }`;
+              if (verbosity === "verbose") {
+                storedMsg += ` [id: ${entry.id}]`;
+                if (entry.scope)
+                  storedMsg += ` [scope: ${entry.scope}${entry.scopeTarget ? `/${entry.scopeTarget}` : ""}]`;
+              }
+            }
 
-          return {
-            content: [
-              {
-                type: "text",
-                text: storedMsg,
+            auditAppend({
+              agentId: agentIdForAudit(),
+              action: "memory_store",
+              target: `memory #${entry.id}`,
+              outcome: "success",
+              sessionId: api.context?.sessionId ?? undefined,
+              context: { category },
+            });
+
+            return {
+              content: [
+                {
+                  type: "text",
+                  text: storedMsg,
+                },
+              ],
+              details: {
+                action: supersedes?.trim() ? "updated" : "created",
+                id: entry.id,
+                why: why ?? undefined,
+                backend: "both",
+                decayClass: entry.decayClass,
+                ...(supersedes?.trim() ? { superseded: supersedes.trim() } : {}),
+                ...(totalLinked > 0 ? { autoLinked: totalLinked } : {}),
+                ...(autoSupersededIds.length > 0 ? { autoSuperseded: autoSupersededIds } : {}),
+                ...(contradictions.length > 0
+                  ? {
+                      contradictions: contradictions.map((c) => ({
+                        contradictionId: c.contradictionId,
+                        oldFactId: c.oldFactId,
+                      })),
+                    }
+                  : {}),
+                ...(decayFreezeUntil != null ? { decayFreezeUntil } : {}),
               },
-            ],
-            details: {
-              action: supersedes?.trim() ? "updated" : "created",
-              id: entry.id,
-              why: why ?? undefined,
-              backend: "both",
-              decayClass: entry.decayClass,
-              ...(supersedes?.trim() ? { superseded: supersedes.trim() } : {}),
-              ...(totalLinked > 0 ? { autoLinked: totalLinked } : {}),
-              ...(autoSupersededIds.length > 0 ? { autoSuperseded: autoSupersededIds } : {}),
-              ...(contradictions.length > 0
-                ? {
-                    contradictions: contradictions.map((c) => ({
-                      contradictionId: c.contradictionId,
-                      oldFactId: c.oldFactId,
-                    })),
-                  }
-                : {}),
-              ...(decayFreezeUntil != null ? { decayFreezeUntil } : {}),
-            },
-          };
+            };
+          }
         } catch (err) {
           auditAppend({
             agentId: agentIdForAudit(),

--- a/extensions/memory-hybrid/tools/memory/register-store-tools.ts
+++ b/extensions/memory-hybrid/tools/memory/register-store-tools.ts
@@ -584,7 +584,6 @@ export function registerStoreTools(runtime: MemoryToolRuntime): void {
                       api.logger.warn(`memory-hybrid: vector store failed: ${err}`);
                     }
 
-                    await walRemove(walEntryId, api.logger);
                     await maybeRefreshProjectActiveTaskProjection(newEntry.category, newEntry.id, newEntry.scope);
 
                     // Issue #159: enqueue contextual variant generation (non-blocking)
@@ -595,6 +594,7 @@ export function registerStoreTools(runtime: MemoryToolRuntime): void {
                     api.logger.info?.(
                       `memory-hybrid: UPDATE — superseded ${classification.targetId} with ${newEntry.id}: ${classification.reason}`,
                     );
+                    await walRemove(walEntryId, api.logger);
                     return {
                       content: [
                         {
@@ -613,6 +613,8 @@ export function registerStoreTools(runtime: MemoryToolRuntime): void {
                       },
                     };
                   }
+                  // WAL cleanup for skipped update path
+                  await walRemove(walEntryId, api.logger);
                 }
                 return {
                   content: [
@@ -796,7 +798,6 @@ export function registerStoreTools(runtime: MemoryToolRuntime): void {
               api.logger.warn(`memory-hybrid: vector store failed: ${err}`);
             }
 
-            await walRemove(walEntryId, api.logger);
             await maybeRefreshProjectActiveTaskProjection(entry.category, entry.id, entry.scope);
 
             // Issue #150: write event to episodic event log
@@ -966,6 +967,7 @@ export function registerStoreTools(runtime: MemoryToolRuntime): void {
               context: { category },
             });
 
+            await walRemove(walEntryId, api.logger);
             return {
               content: [
                 {
@@ -994,6 +996,17 @@ export function registerStoreTools(runtime: MemoryToolRuntime): void {
               },
             };
           }
+          // WAL cleanup and return for skipped store path (Bug fix #1560, #1561)
+          await walRemove(walEntryId, api.logger);
+          return {
+            content: [
+              {
+                type: "text",
+                text: `Store blocked by pre-store guard (category: ${category}).`,
+              },
+            ],
+            details: { action: "skipped", reason: "blocked-by-guard", category },
+          };
         } catch (err) {
           auditAppend({
             agentId: agentIdForAudit(),

--- a/extensions/memory-hybrid/tools/memory/register-store-tools.ts
+++ b/extensions/memory-hybrid/tools/memory/register-store-tools.ts
@@ -615,6 +615,15 @@ export function registerStoreTools(runtime: MemoryToolRuntime): void {
                   }
                   // WAL cleanup for skipped update path
                   await walRemove(walEntryId, api.logger);
+                  return {
+                    content: [
+                      {
+                        type: "text",
+                        text: `Store blocked by pre-store guard (category: ${category}).`,
+                      },
+                    ],
+                    details: { action: "skipped", reason: "blocked-by-guard", category },
+                  };
                 }
                 return {
                   content: [


### PR DESCRIPTION
Closes #1560

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core fact persistence to conditionally skip writes based on `category`/`source`, which can affect memory capture and downstream vector/audit side effects if misclassified. Risk is mitigated by explicit bypass for trusted edit paths plus new unit tests covering skip and GraphQL behavior.
> 
> **Overview**
> Adds a **pre-store guard** in `FactsDB.storeFact` that blocks persistence for internal artifact categories/sources (e.g. `noop`, `classification`, `artifact`, `compact`) and returns a `StoreFactResult` with `skipped: true`, plus an `allowPreStoreGuardBypass` escape hatch for trusted edit flows.
> 
> Updates memory capture and manual store paths (stage capture + memory store tool) to **skip post-store side effects** (vector upserts/deletes, supersession/alias updates, audit/logging) when `skipped` is returned, while still performing WAL cleanup.
> 
> Hardens the GraphQL mutations to **reject blocked creates/imports up-front**, allow updating legacy guarded facts via bypass, and **clean up evicted vectors** when an eviction occurs. Adds tests asserting blocked entries don’t persist, GraphQL bypass/import validation, eviction cleanup, and skipped-side-effect behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 171532287a0a990c122cd61d35ffc679b7902021. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->