### PR TITLE
fix: add universal pre-store guard to prevent NOOP/classification/artifact memory storage (#1561)

### DIFF
--- a/.github/scripts/check-pr-file-overlap.mjs
+++ b/.github/scripts/check-pr-file-overlap.mjs
@@ -6,73 +6,88 @@
 import { execSync } from "node:child_process";
 
 function parseMaxOpenArg() {
-  const eq = process.argv.find((a) => a.startsWith("--max-open="));
-  if (eq) return eq.split("=")[1];
-  const idx = process.argv.indexOf("--max-open");
-  if (idx >= 0 && process.argv[idx + 1] && !process.argv[idx + 1].startsWith("-")) {
-    return process.argv[idx + 1];
-  }
-  return process.env.PR_OVERLAP_MAX ?? "2";
+	const eq = process.argv.find((a) => a.startsWith("--max-open="));
+	if (eq) return eq.split("=")[1];
+	const idx = process.argv.indexOf("--max-open");
+	if (
+		idx >= 0 &&
+		process.argv[idx + 1] &&
+		!process.argv[idx + 1].startsWith("-")
+	) {
+		return process.argv[idx + 1];
+	}
+	return process.env.PR_OVERLAP_MAX ?? "2";
 }
 
 const maxOpen = Number.parseInt(parseMaxOpenArg(), 10);
 
 const prefix = "extensions/memory-hybrid/";
 const currentPr = process.env.GITHUB_PR_NUMBER
-  ? Number.parseInt(process.env.GITHUB_PR_NUMBER, 10)
-  : null;
+	? Number.parseInt(process.env.GITHUB_PR_NUMBER, 10)
+	: null;
 
 function ghJson(args) {
-  return JSON.parse(execSync(`gh ${args.join(" ")}`, { encoding: "utf8" }));
+	return JSON.parse(execSync(`gh ${args.join(" ")}`, { encoding: "utf8" }));
 }
 
-const prs = ghJson(["pr", "list", "--state", "open", "--json", "number,files,title"]);
+const prs = ghJson([
+	"pr",
+	"list",
+	"--state",
+	"open",
+	"--json",
+	"number,files,title",
+]);
 const byFile = new Map();
 /** Paths touched by the PR under review (when GITHUB_PR_NUMBER is set). */
 const currentPrPaths = new Set();
 
 for (const pr of prs) {
-  for (const f of pr.files ?? []) {
-    if (!f.path.startsWith(prefix)) continue;
-    if (currentPr != null && pr.number === currentPr) {
-      currentPrPaths.add(f.path);
-      continue;
-    }
-    if (!byFile.has(f.path)) byFile.set(f.path, []);
-    byFile.get(f.path).push({ number: pr.number, title: pr.title });
-  }
+	for (const f of pr.files ?? []) {
+		if (!f.path.startsWith(prefix)) continue;
+		if (currentPr != null && pr.number === currentPr) {
+			currentPrPaths.add(f.path);
+			continue;
+		}
+		if (!byFile.has(f.path)) byFile.set(f.path, []);
+		byFile.get(f.path).push({ number: pr.number, title: pr.title });
+	}
 }
 
 const pathsToCheck =
-  currentPr != null && currentPrPaths.size > 0
-    ? [...currentPrPaths]
-    : [...byFile.keys()];
+	currentPr != null && currentPrPaths.size > 0
+		? [...currentPrPaths]
+		: [...byFile.keys()];
 
 // When the current PR is excluded from byFile, list.length counts only *other* PRs;
 // use >= so current + maxOpen others (maxOpen+1 total) still triggers a violation.
 const exceedsMaxOpen = ([, list]) =>
-  currentPr != null && currentPrPaths.size > 0 ? list.length >= maxOpen : list.length > maxOpen;
+	currentPr != null && currentPrPaths.size > 0
+		? list.length >= maxOpen
+		: list.length > maxOpen;
 
 const violations = pathsToCheck
-  .map((path) => [path, byFile.get(path) ?? []])
-  .filter(exceedsMaxOpen)
-  .sort((a, b) => b[1].length - a[1].length);
+	.map((path) => [path, byFile.get(path) ?? []])
+	.filter(exceedsMaxOpen)
+	.sort((a, b) => b[1].length - a[1].length);
 
 if (violations.length === 0) {
-  const limitDesc =
-    currentPr != null && currentPrPaths.size > 0
-      ? `${maxOpen} other open PR(s) plus this PR`
-      : `more than ${maxOpen} open PRs`;
-  console.log(`OK: no path has ${limitDesc} under ${prefix}`);
-  process.exit(0);
+	const limitDesc =
+		currentPr != null && currentPrPaths.size > 0
+			? `${maxOpen} other open PR(s) plus this PR`
+			: `more than ${maxOpen} open PRs`;
+	console.log(`OK: no path has ${limitDesc} under ${prefix}`);
+	process.exit(0);
 }
 
-console.error(`Found ${violations.length} path(s) with more than ${maxOpen} open PRs:\n`);
+console.error(
+	`Found ${violations.length} path(s) with more than ${maxOpen} open PRs:\n`,
+);
 for (const [path, list] of violations) {
-  console.error(`  ${path} (${list.length} PRs)`);
-  for (const { number, title } of list) {
-    console.error(`    #${number} ${title}`);
-  }
-  console.error("");
+	console.error(`  ${path} (${list.length} PRs)`);
+	for (const { number, title } of list) {
+		console.error(`    #${number} ${title}`);
+	}
+	console.error("");
 }
 process.exit(1);

--- a/.github/scripts/forge-feedback-loop.mjs
+++ b/.github/scripts/forge-feedback-loop.mjs
@@ -1,329 +1,409 @@
 #!/usr/bin/env node
-import { createHash } from 'node:crypto';
-import { mkdir, readFile, writeFile } from 'node:fs/promises';
-import { dirname, resolve } from 'node:path';
+import { createHash } from "node:crypto";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
 
 const DEFAULT_MAX_BODY_CHARS = 1200;
 const DEFAULT_MAX_ITEMS_PER_SECTION = 12;
 const BOT_LOGIN_RE = /\[bot\]$/i;
-const NON_BLOCKING_REVIEW_STATES = new Set(['APPROVED', 'DISMISSED']);
-const PASSING_CONCLUSIONS = new Set(['success', 'skipped', 'neutral']);
-const SELF_CHECK_NAMES = new Set(['Inspect PR blockers and dispatch Forge']);
+const NON_BLOCKING_REVIEW_STATES = new Set(["APPROVED", "DISMISSED"]);
+const PASSING_CONCLUSIONS = new Set(["success", "skipped", "neutral"]);
+const SELF_CHECK_NAMES = new Set(["Inspect PR blockers and dispatch Forge"]);
 
 function normalizeWhitespace(value) {
-  return String(value ?? '')
-    .replace(/\r\n/g, '\n')
-    .replace(/[\t ]+/g, ' ')
-    .replace(/\n{3,}/g, '\n\n')
-    .trim();
+	return String(value ?? "")
+		.replace(/\r\n/g, "\n")
+		.replace(/[\t ]+/g, " ")
+		.replace(/\n{3,}/g, "\n\n")
+		.trim();
 }
 
 function truncateText(value, maxChars = DEFAULT_MAX_BODY_CHARS) {
-  const normalized = normalizeWhitespace(value);
-  if (!normalized) return '';
-  if (normalized.length <= maxChars) return normalized;
-  return `${normalized.slice(0, Math.max(0, maxChars - 1)).trimEnd()}…`;
+	const normalized = normalizeWhitespace(value);
+	if (!normalized) return "";
+	if (normalized.length <= maxChars) return normalized;
+	return `${normalized.slice(0, Math.max(0, maxChars - 1)).trimEnd()}…`;
 }
 
 function isBotActor(actor) {
-  if (!actor || typeof actor !== 'object') return false;
-  if (actor.type === 'Bot') return true;
-  const login = String(actor.login ?? '').trim();
-  return BOT_LOGIN_RE.test(login);
+	if (!actor || typeof actor !== "object") return false;
+	if (actor.type === "Bot") return true;
+	const login = String(actor.login ?? "").trim();
+	return BOT_LOGIN_RE.test(login);
 }
 
 function toIsoDate(value) {
-  if (!value) return null;
-  const date = new Date(value);
-  return Number.isNaN(date.getTime()) ? null : date.toISOString();
+	if (!value) return null;
+	const date = new Date(value);
+	return Number.isNaN(date.getTime()) ? null : date.toISOString();
 }
 
 function sortNewestFirst(items, getDate) {
-  return [...items].sort((left, right) => {
-    const leftDate = new Date(getDate(left) ?? 0).getTime();
-    const rightDate = new Date(getDate(right) ?? 0).getTime();
-    return rightDate - leftDate;
-  });
+	return [...items].sort((left, right) => {
+		const leftDate = new Date(getDate(left) ?? 0).getTime();
+		const rightDate = new Date(getDate(right) ?? 0).getTime();
+		return rightDate - leftDate;
+	});
 }
 
 function summarizeFailedChecks(checkRuns) {
-  return sortNewestFirst(checkRuns ?? [], (run) => run.completed_at ?? run.started_at)
-    .filter((run) => {
-      if (!run || typeof run !== 'object') return false;
-      if (run.status !== 'completed') return false;
-      const conclusion = String(run.conclusion ?? '').toLowerCase();
-      if (SELF_CHECK_NAMES.has(String(run.name ?? '')) && conclusion === 'cancelled') return false;
-      return conclusion && !PASSING_CONCLUSIONS.has(conclusion);
-    })
-    .slice(0, DEFAULT_MAX_ITEMS_PER_SECTION)
-    .map((run) => ({
-      name: String(run.name ?? 'Unnamed check'),
-      conclusion: String(run.conclusion ?? 'failure'),
-      detailsUrl: run.details_url ?? run.html_url ?? null,
-      summary: truncateText(run.output?.summary ?? run.output?.text ?? run.output?.title ?? ''),
-    }));
+	return sortNewestFirst(
+		checkRuns ?? [],
+		(run) => run.completed_at ?? run.started_at,
+	)
+		.filter((run) => {
+			if (!run || typeof run !== "object") return false;
+			if (run.status !== "completed") return false;
+			const conclusion = String(run.conclusion ?? "").toLowerCase();
+			if (
+				SELF_CHECK_NAMES.has(String(run.name ?? "")) &&
+				conclusion === "cancelled"
+			)
+				return false;
+			return conclusion && !PASSING_CONCLUSIONS.has(conclusion);
+		})
+		.slice(0, DEFAULT_MAX_ITEMS_PER_SECTION)
+		.map((run) => ({
+			name: String(run.name ?? "Unnamed check"),
+			conclusion: String(run.conclusion ?? "failure"),
+			detailsUrl: run.details_url ?? run.html_url ?? null,
+			summary: truncateText(
+				run.output?.summary ?? run.output?.text ?? run.output?.title ?? "",
+			),
+		}));
 }
 
 function summarizeIssueComments(issueComments, headCommittedAt) {
-  const cutoffMs = headCommittedAt ? new Date(headCommittedAt).getTime() : null;
-  return sortNewestFirst(issueComments ?? [], (comment) => comment.updated_at ?? comment.created_at)
-    .filter((comment) => {
-      if (!comment || typeof comment !== 'object') return false;
-      if (isBotActor(comment.user)) return false;
-      const body = truncateText(comment.body ?? '');
-      if (!body) return false;
-      if (cutoffMs == null) return true;
-      const updatedAt = new Date(comment.updated_at ?? comment.created_at ?? 0).getTime();
-      return Number.isFinite(updatedAt) && updatedAt > cutoffMs;
-    })
-    .slice(0, DEFAULT_MAX_ITEMS_PER_SECTION)
-    .map((comment) => ({
-      id: comment.id ?? null,
-      author: String(comment.user?.login ?? 'unknown'),
-      createdAt: toIsoDate(comment.created_at),
-      updatedAt: toIsoDate(comment.updated_at ?? comment.created_at),
-      body: truncateText(comment.body ?? ''),
-      url: comment.html_url ?? null,
-    }));
+	const cutoffMs = headCommittedAt ? new Date(headCommittedAt).getTime() : null;
+	return sortNewestFirst(
+		issueComments ?? [],
+		(comment) => comment.updated_at ?? comment.created_at,
+	)
+		.filter((comment) => {
+			if (!comment || typeof comment !== "object") return false;
+			if (isBotActor(comment.user)) return false;
+			const body = truncateText(comment.body ?? "");
+			if (!body) return false;
+			if (cutoffMs == null) return true;
+			const updatedAt = new Date(
+				comment.updated_at ?? comment.created_at ?? 0,
+			).getTime();
+			return Number.isFinite(updatedAt) && updatedAt > cutoffMs;
+		})
+		.slice(0, DEFAULT_MAX_ITEMS_PER_SECTION)
+		.map((comment) => ({
+			id: comment.id ?? null,
+			author: String(comment.user?.login ?? "unknown"),
+			createdAt: toIsoDate(comment.created_at),
+			updatedAt: toIsoDate(comment.updated_at ?? comment.created_at),
+			body: truncateText(comment.body ?? ""),
+			url: comment.html_url ?? null,
+		}));
 }
 
 function summarizeReviews(reviews, headCommittedAt) {
-  const cutoffMs = headCommittedAt ? new Date(headCommittedAt).getTime() : null;
-  return sortNewestFirst(reviews ?? [], (review) => review.submitted_at ?? review.created_at)
-    .filter((review) => {
-      if (!review || typeof review !== 'object') return false;
-      if (isBotActor(review.user)) return false;
-      const state = String(review.state ?? '').toUpperCase();
-      if (!state || NON_BLOCKING_REVIEW_STATES.has(state)) return false;
-      const body = truncateText(review.body ?? '');
-      if (!body) return false;
-      if (cutoffMs == null) return true;
-      const submittedAt = new Date(review.submitted_at ?? review.created_at ?? 0).getTime();
-      return Number.isFinite(submittedAt) && submittedAt > cutoffMs;
-    })
-    .slice(0, DEFAULT_MAX_ITEMS_PER_SECTION)
-    .map((review) => ({
-      id: review.id ?? null,
-      author: String(review.user?.login ?? 'unknown'),
-      state: String(review.state ?? 'COMMENTED').toUpperCase(),
-      submittedAt: toIsoDate(review.submitted_at ?? review.created_at),
-      body: truncateText(review.body ?? ''),
-      url: review.html_url ?? null,
-    }));
+	const cutoffMs = headCommittedAt ? new Date(headCommittedAt).getTime() : null;
+	return sortNewestFirst(
+		reviews ?? [],
+		(review) => review.submitted_at ?? review.created_at,
+	)
+		.filter((review) => {
+			if (!review || typeof review !== "object") return false;
+			if (isBotActor(review.user)) return false;
+			const state = String(review.state ?? "").toUpperCase();
+			if (!state || NON_BLOCKING_REVIEW_STATES.has(state)) return false;
+			const body = truncateText(review.body ?? "");
+			if (!body) return false;
+			if (cutoffMs == null) return true;
+			const submittedAt = new Date(
+				review.submitted_at ?? review.created_at ?? 0,
+			).getTime();
+			return Number.isFinite(submittedAt) && submittedAt > cutoffMs;
+		})
+		.slice(0, DEFAULT_MAX_ITEMS_PER_SECTION)
+		.map((review) => ({
+			id: review.id ?? null,
+			author: String(review.user?.login ?? "unknown"),
+			state: String(review.state ?? "COMMENTED").toUpperCase(),
+			submittedAt: toIsoDate(review.submitted_at ?? review.created_at),
+			body: truncateText(review.body ?? ""),
+			url: review.html_url ?? null,
+		}));
 }
 
 function summarizeUnresolvedThreads(reviewThreads) {
-  // Thread-level createdAt/updatedAt are not available on PullRequestReviewThread in GitHub's API.
-  // Use the newest comment's date as a proxy for thread age.
-  const getThreadDate = (thread) => {
-    const firstComment = thread.comments?.nodes?.[0];
-    return firstComment?.updatedAt ?? firstComment?.createdAt ?? thread.updatedAt ?? thread.createdAt ?? null;
-  };
-  return sortNewestFirst(reviewThreads ?? [], getThreadDate)
-    .filter((thread) => thread && typeof thread === 'object' && thread.isResolved === false)
-    .slice(0, DEFAULT_MAX_ITEMS_PER_SECTION)
-    .map((thread) => {
-      const comments = sortNewestFirst(thread.comments?.nodes ?? [], (comment) => comment.updatedAt ?? comment.createdAt)
-        .filter((comment) => !isBotActor(comment.author) && truncateText(comment.body ?? ''))
-        .slice(0, 3)
-        .map((comment) => ({
-          author: String(comment.author?.login ?? 'unknown'),
-          createdAt: toIsoDate(comment.createdAt),
-          body: truncateText(comment.body ?? ''),
-          url: comment.url ?? null,
-        }));
-      return {
-        id: thread.id ?? null,
-        path: thread.path ?? null,
-        line: thread.line ?? null,
-        isOutdated: Boolean(thread.isOutdated),
-        url: thread.comments?.nodes?.[0]?.url ?? null,
-        comments,
-      };
-    })
-    .filter((thread) => thread.comments.length > 0);
+	// Thread-level createdAt/updatedAt are not available on PullRequestReviewThread in GitHub's API.
+	// Use the newest comment's date as a proxy for thread age.
+	const getThreadDate = (thread) => {
+		const firstComment = thread.comments?.nodes?.[0];
+		return (
+			firstComment?.updatedAt ??
+			firstComment?.createdAt ??
+			thread.updatedAt ??
+			thread.createdAt ??
+			null
+		);
+	};
+	return sortNewestFirst(reviewThreads ?? [], getThreadDate)
+		.filter(
+			(thread) =>
+				thread && typeof thread === "object" && thread.isResolved === false,
+		)
+		.slice(0, DEFAULT_MAX_ITEMS_PER_SECTION)
+		.map((thread) => {
+			const comments = sortNewestFirst(
+				thread.comments?.nodes ?? [],
+				(comment) => comment.updatedAt ?? comment.createdAt,
+			)
+				.filter(
+					(comment) =>
+						!isBotActor(comment.author) && truncateText(comment.body ?? ""),
+				)
+				.slice(0, 3)
+				.map((comment) => ({
+					author: String(comment.author?.login ?? "unknown"),
+					createdAt: toIsoDate(comment.createdAt),
+					body: truncateText(comment.body ?? ""),
+					url: comment.url ?? null,
+				}));
+			return {
+				id: thread.id ?? null,
+				path: thread.path ?? null,
+				line: thread.line ?? null,
+				isOutdated: Boolean(thread.isOutdated),
+				url: thread.comments?.nodes?.[0]?.url ?? null,
+				comments,
+			};
+		})
+		.filter((thread) => thread.comments.length > 0);
 }
 
 function formatChecksSection(failedChecks) {
-  if (failedChecks.length === 0) return 'None.';
-  return failedChecks
-    .map((check, index) => {
-      const summary = check.summary ? ` — ${check.summary}` : '';
-      const detailsUrl = check.detailsUrl ? ` (${check.detailsUrl})` : '';
-      return `${index + 1}. ${check.name} [${check.conclusion}]${detailsUrl}${summary}`;
-    })
-    .join('\n');
+	if (failedChecks.length === 0) return "None.";
+	return failedChecks
+		.map((check, index) => {
+			const summary = check.summary ? ` — ${check.summary}` : "";
+			const detailsUrl = check.detailsUrl ? ` (${check.detailsUrl})` : "";
+			return `${index + 1}. ${check.name} [${check.conclusion}]${detailsUrl}${summary}`;
+		})
+		.join("\n");
 }
 
 function formatTopLevelFeedbackSection(title, items, mapper) {
-  if (items.length === 0) return `${title}: None.`;
-  return [title + ':', ...items.map((item, index) => mapper(item, index))].join('\n');
+	if (items.length === 0) return `${title}: None.`;
+	return [title + ":", ...items.map((item, index) => mapper(item, index))].join(
+		"\n",
+	);
 }
 
-function buildPrompt({ repo, pullRequest, headCommit, failedChecks, issueComments, reviews, unresolvedThreads }) {
-  const header = [
-    `You are Forge, the autonomous PR remediation agent for ${repo.fullName}.`,
-    `Use Codex with model gpt-5.4-pro to resolve this pull request in-place.`,
-    `Work on PR #${pullRequest.number}: ${pullRequest.title}`,
-    `Base branch: ${pullRequest.baseRef}`,
-    `Head branch: ${pullRequest.headRef}`,
-    `Head SHA: ${pullRequest.headSha}`,
-    headCommit.committedAt ? `Latest pushed commit: ${headCommit.committedAt}` : null,
-  ].filter(Boolean).join('\n');
+function buildPrompt({
+	repo,
+	pullRequest,
+	headCommit,
+	failedChecks,
+	issueComments,
+	reviews,
+	unresolvedThreads,
+}) {
+	const header = [
+		`You are Forge, the autonomous PR remediation agent for ${repo.fullName}.`,
+		`Use Codex with model gpt-5.4-pro to resolve this pull request in-place.`,
+		`Work on PR #${pullRequest.number}: ${pullRequest.title}`,
+		`Base branch: ${pullRequest.baseRef}`,
+		`Head branch: ${pullRequest.headRef}`,
+		`Head SHA: ${pullRequest.headSha}`,
+		headCommit.committedAt
+			? `Latest pushed commit: ${headCommit.committedAt}`
+			: null,
+	]
+		.filter(Boolean)
+		.join("\n");
 
-  const instructions = [
-    'Goals:',
-    '1. Fix every failing CI check listed below.',
-    '2. Address every unresolved review thread and every human PR comment newer than the latest push.',
-    '3. Keep changes minimal and focused; do not introduce unrelated churn.',
-    '4. Run `npm test` and `npx tsc --noEmit` inside `extensions/memory-hybrid` before pushing.',
-    '5. Push fixes back to the same PR branch and resolve review threads when the feedback is satisfied.',
-    '6. Stop only when CI is green and there is no remaining open feedback in this payload.',
-  ].join('\n');
+	const instructions = [
+		"Goals:",
+		"1. Fix every failing CI check listed below.",
+		"2. Address every unresolved review thread and every human PR comment newer than the latest push.",
+		"3. Keep changes minimal and focused; do not introduce unrelated churn.",
+		"4. Run `npm test` and `npx tsc --noEmit` inside `extensions/memory-hybrid` before pushing.",
+		"5. Push fixes back to the same PR branch and resolve review threads when the feedback is satisfied.",
+		"6. Stop only when CI is green and there is no remaining open feedback in this payload.",
+	].join("\n");
 
-  const sections = [
-    'Failed CI checks:',
-    formatChecksSection(failedChecks),
-    '',
-    formatTopLevelFeedbackSection('Top-level PR comments newer than the latest push', issueComments, (comment, index) => (
-      `${index + 1}. @${comment.author} (${comment.updatedAt ?? comment.createdAt ?? 'unknown time'})${comment.url ? ` ${comment.url}` : ''}\n${comment.body}`
-    )),
-    '',
-    formatTopLevelFeedbackSection('Review summaries newer than the latest push', reviews, (review, index) => (
-      `${index + 1}. @${review.author} [${review.state}] (${review.submittedAt ?? 'unknown time'})${review.url ? ` ${review.url}` : ''}\n${review.body}`
-    )),
-    '',
-    unresolvedThreads.length === 0
-      ? 'Unresolved review threads: None.'
-      : ['Unresolved review threads:', ...unresolvedThreads.map((thread, index) => {
-          const location = thread.path ? `${thread.path}${thread.line ? `:${thread.line}` : ''}` : 'unknown location';
-          const details = thread.comments
-            .map((comment) => `- @${comment.author} (${comment.createdAt ?? 'unknown time'})${comment.url ? ` ${comment.url}` : ''}\n  ${comment.body}`)
-            .join('\n');
-          return `${index + 1}. ${location}${thread.isOutdated ? ' [outdated diff context]' : ''}\n${details}`;
-        })].join('\n'),
-  ];
+	const sections = [
+		"Failed CI checks:",
+		formatChecksSection(failedChecks),
+		"",
+		formatTopLevelFeedbackSection(
+			"Top-level PR comments newer than the latest push",
+			issueComments,
+			(comment, index) =>
+				`${index + 1}. @${comment.author} (${comment.updatedAt ?? comment.createdAt ?? "unknown time"})${comment.url ? ` ${comment.url}` : ""}\n${comment.body}`,
+		),
+		"",
+		formatTopLevelFeedbackSection(
+			"Review summaries newer than the latest push",
+			reviews,
+			(review, index) =>
+				`${index + 1}. @${review.author} [${review.state}] (${review.submittedAt ?? "unknown time"})${review.url ? ` ${review.url}` : ""}\n${review.body}`,
+		),
+		"",
+		unresolvedThreads.length === 0
+			? "Unresolved review threads: None."
+			: [
+					"Unresolved review threads:",
+					...unresolvedThreads.map((thread, index) => {
+						const location = thread.path
+							? `${thread.path}${thread.line ? `:${thread.line}` : ""}`
+							: "unknown location";
+						const details = thread.comments
+							.map(
+								(comment) =>
+									`- @${comment.author} (${comment.createdAt ?? "unknown time"})${comment.url ? ` ${comment.url}` : ""}\n  ${comment.body}`,
+							)
+							.join("\n");
+						return `${index + 1}. ${location}${thread.isOutdated ? " [outdated diff context]" : ""}\n${details}`;
+					}),
+				].join("\n"),
+	];
 
-  return [header, '', instructions, '', ...sections].join('\n');
+	return [header, "", instructions, "", ...sections].join("\n");
 }
 
 export function buildForgeRemediationRequest(input) {
-  const repo = {
-    owner: String(input?.repo?.owner ?? ''),
-    repo: String(input?.repo?.repo ?? ''),
-    fullName: String(input?.repo?.fullName ?? `${input?.repo?.owner ?? ''}/${input?.repo?.repo ?? ''}`),
-  };
-  const pullRequest = {
-    number: Number(input?.pullRequest?.number ?? 0),
-    title: String(input?.pullRequest?.title ?? ''),
-    url: input?.pullRequest?.url ?? null,
-    baseRef: String(input?.pullRequest?.baseRef ?? 'main'),
-    headRef: String(input?.pullRequest?.headRef ?? ''),
-    headSha: String(input?.pullRequest?.headSha ?? ''),
-    author: String(input?.pullRequest?.author ?? ''),
-  };
-  const headCommit = {
-    committedAt: toIsoDate(input?.headCommit?.committedAt),
-  };
+	const repo = {
+		owner: String(input?.repo?.owner ?? ""),
+		repo: String(input?.repo?.repo ?? ""),
+		fullName: String(
+			input?.repo?.fullName ??
+				`${input?.repo?.owner ?? ""}/${input?.repo?.repo ?? ""}`,
+		),
+	};
+	const pullRequest = {
+		number: Number(input?.pullRequest?.number ?? 0),
+		title: String(input?.pullRequest?.title ?? ""),
+		url: input?.pullRequest?.url ?? null,
+		baseRef: String(input?.pullRequest?.baseRef ?? "main"),
+		headRef: String(input?.pullRequest?.headRef ?? ""),
+		headSha: String(input?.pullRequest?.headSha ?? ""),
+		author: String(input?.pullRequest?.author ?? ""),
+	};
+	const headCommit = {
+		committedAt: toIsoDate(input?.headCommit?.committedAt),
+	};
 
-  const failedChecks = summarizeFailedChecks(input?.checkRuns);
-  const issueComments = summarizeIssueComments(input?.issueComments, headCommit.committedAt);
-  const reviews = summarizeReviews(input?.reviews, headCommit.committedAt);
-  const unresolvedThreads = summarizeUnresolvedThreads(input?.reviewThreads);
+	const failedChecks = summarizeFailedChecks(input?.checkRuns);
+	const issueComments = summarizeIssueComments(
+		input?.issueComments,
+		headCommit.committedAt,
+	);
+	const reviews = summarizeReviews(input?.reviews, headCommit.committedAt);
+	const unresolvedThreads = summarizeUnresolvedThreads(input?.reviewThreads);
 
-  const reasons = [];
-  if (failedChecks.length > 0) reasons.push('failed-ci');
-  if (issueComments.length > 0 || reviews.length > 0 || unresolvedThreads.length > 0) reasons.push('review-feedback');
+	const reasons = [];
+	if (failedChecks.length > 0) reasons.push("failed-ci");
+	if (
+		issueComments.length > 0 ||
+		reviews.length > 0 ||
+		unresolvedThreads.length > 0
+	)
+		reasons.push("review-feedback");
 
-  const prompt = buildPrompt({
-    repo,
-    pullRequest,
-    headCommit,
-    failedChecks,
-    issueComments,
-    reviews,
-    unresolvedThreads,
-  });
+	const prompt = buildPrompt({
+		repo,
+		pullRequest,
+		headCommit,
+		failedChecks,
+		issueComments,
+		reviews,
+		unresolvedThreads,
+	});
 
-  const fingerprintSource = JSON.stringify({
-    headSha: pullRequest.headSha,
-    failedChecks,
-    issueComments,
-    reviews,
-    unresolvedThreads,
-  });
-  const fingerprint = createHash('sha256').update(fingerprintSource).digest('hex').slice(0, 20);
+	const fingerprintSource = JSON.stringify({
+		headSha: pullRequest.headSha,
+		failedChecks,
+		issueComments,
+		reviews,
+		unresolvedThreads,
+	});
+	const fingerprint = createHash("sha256")
+		.update(fingerprintSource)
+		.digest("hex")
+		.slice(0, 20);
 
-  return {
-    schemaVersion: 1,
-    agent: 'forge',
-    provider: 'codex',
-    model: 'gpt-5.4-pro',
-    repo,
-    pullRequest,
-    headCommit,
-    summary: {
-      failedChecks: failedChecks.length,
-      newIssueComments: issueComments.length,
-      newReviewSummaries: reviews.length,
-      unresolvedThreads: unresolvedThreads.length,
-      completionReady: reasons.length === 0,
-      shouldDispatch: reasons.length > 0,
-      reasons,
-    },
-    failedChecks,
-    issueComments,
-    reviews,
-    unresolvedThreads,
-    fingerprint,
-    prompt,
-  };
+	return {
+		schemaVersion: 1,
+		agent: "forge",
+		provider: "codex",
+		model: "gpt-5.4-pro",
+		repo,
+		pullRequest,
+		headCommit,
+		summary: {
+			failedChecks: failedChecks.length,
+			newIssueComments: issueComments.length,
+			newReviewSummaries: reviews.length,
+			unresolvedThreads: unresolvedThreads.length,
+			completionReady: reasons.length === 0,
+			shouldDispatch: reasons.length > 0,
+			reasons,
+		},
+		failedChecks,
+		issueComments,
+		reviews,
+		unresolvedThreads,
+		fingerprint,
+		prompt,
+	};
 }
 
 async function readJson(path) {
-  const raw = await readFile(resolve(path), 'utf8');
-  return JSON.parse(raw);
+	const raw = await readFile(resolve(path), "utf8");
+	return JSON.parse(raw);
 }
 
 async function writeJson(path, value) {
-  const outputPath = resolve(path);
-  await mkdir(dirname(outputPath), { recursive: true });
-  await writeFile(outputPath, JSON.stringify(value, null, 2) + '\n', 'utf8');
+	const outputPath = resolve(path);
+	await mkdir(dirname(outputPath), { recursive: true });
+	await writeFile(outputPath, JSON.stringify(value, null, 2) + "\n", "utf8");
 }
 
 async function main(argv) {
-  const [command, ...rest] = argv;
-  if (!command || command === '--help' || command === '-h') {
-    process.stdout.write('Usage: forge-feedback-loop.mjs build --input <file> [--output <file>]\n');
-    return;
-  }
-  if (command !== 'build') {
-    throw new Error(`Unsupported command: ${command}`);
-  }
+	const [command, ...rest] = argv;
+	if (!command || command === "--help" || command === "-h") {
+		process.stdout.write(
+			"Usage: forge-feedback-loop.mjs build --input <file> [--output <file>]\n",
+		);
+		return;
+	}
+	if (command !== "build") {
+		throw new Error(`Unsupported command: ${command}`);
+	}
 
-  let inputPath = null;
-  let outputPath = null;
-  for (let index = 0; index < rest.length; index += 1) {
-    const token = rest[index];
-    if (token === '--input') inputPath = rest[index + 1];
-    if (token === '--output') outputPath = rest[index + 1];
-  }
-  if (!inputPath) {
-    throw new Error('Missing --input <file>');
-  }
+	let inputPath = null;
+	let outputPath = null;
+	for (let index = 0; index < rest.length; index += 1) {
+		const token = rest[index];
+		if (token === "--input") inputPath = rest[index + 1];
+		if (token === "--output") outputPath = rest[index + 1];
+	}
+	if (!inputPath) {
+		throw new Error("Missing --input <file>");
+	}
 
-  const input = await readJson(inputPath);
-  const result = buildForgeRemediationRequest(input);
-  if (outputPath) {
-    await writeJson(outputPath, result);
-  } else {
-    process.stdout.write(JSON.stringify(result, null, 2) + '\n');
-  }
+	const input = await readJson(inputPath);
+	const result = buildForgeRemediationRequest(input);
+	if (outputPath) {
+		await writeJson(outputPath, result);
+	} else {
+		process.stdout.write(JSON.stringify(result, null, 2) + "\n");
+	}
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {
-  main(process.argv.slice(2)).catch((error) => {
-    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
-    process.exitCode = 1;
-  });
+	main(process.argv.slice(2)).catch((error) => {
+		process.stderr.write(
+			`${error instanceof Error ? error.message : String(error)}\n`,
+		);
+		process.exitCode = 1;
+	});
 }

--- a/extensions/memory-hybrid/backends/facts-db/crud.ts
+++ b/extensions/memory-hybrid/backends/facts-db/crud.ts
@@ -147,27 +147,10 @@ export function storeFact(ctx: StoreFactContext, entry: StoreFactInput): StoreFa
   // These categories and sources are not user-relevant memories.
   const BLOCKED_CATEGORIES = new Set(["noop", "classification", "artifact", "chain-of-thought", "prompt"]);
   const BLOCKED_SOURCES = new Set(["think", "classify", "remember", "noop", "compact", "derive"]);
-  const category = entry.category ?? "";
-  const source = entry.source ?? "";
+  const category = (entry.category ?? "").toLowerCase().trim();
+  const source = (entry.source ?? "").toLowerCase().trim();
   if (BLOCKED_CATEGORIES.has(category) || BLOCKED_SOURCES.has(source)) {
-    // Return a minimal skipped result — caller should skip post-store operations.
-    const skippedEntry: MemoryEntry = {
-      id: "skipped",
-      text: entry.text,
-      category: entry.category ?? "noop",
-      importance: entry.importance ?? 0.5,
-      source: entry.source ?? "guard",
-      entity: entry.entity ?? null,
-      key: entry.key ?? null,
-      value: entry.value ?? null,
-      createdAt: Date.now(),
-      decayClass: entry.decayClass ?? "normal",
-      expiresAt: null,
-      lastConfirmedAt: 0,
-      confidence: 0,
-      tags: entry.tags ?? null,
-    };
-    return { entry: skippedEntry, evictedFactId: null, skipped: true };
+    throw new Error(`memory-hybrid: fact blocked by pre-store guard (category=${category}, source=${source})`);
   }
 
   const sourceForPolicy = entry.source ?? "conversation";

--- a/extensions/memory-hybrid/backends/facts-db/crud.ts
+++ b/extensions/memory-hybrid/backends/facts-db/crud.ts
@@ -46,6 +46,11 @@ function runWithSqliteBusyRetry(db: DatabaseSync, run: () => void): void {
   }
 }
 
+// Pre-store guard constants: filter internal artifacts (#1560, #1561).
+// These categories and sources are not user-relevant memories.
+const BLOCKED_CATEGORIES = new Set(["noop", "classification", "artifact", "chain-of-thought", "prompt"]);
+const BLOCKED_SOURCES = new Set(["think", "classify", "remember", "noop", "compact", "derive"]);
+
 /** Input shape for `FactsDB.store` / `storeFact`. */
 export type StoreFactInput = Omit<
   MemoryEntry,
@@ -143,31 +148,27 @@ export type StoreFactResult = {
 export function storeFact(ctx: StoreFactContext, entry: StoreFactInput): StoreFactResult {
   validateStoreEntryInput(entry);
 
-  // Pre-store guard: filter internal artifacts (#1560, #1561).
-  // These categories and sources are not user-relevant memories.
-  const BLOCKED_CATEGORIES = new Set(["noop", "classification", "artifact", "chain-of-thought", "prompt"]);
-  const BLOCKED_SOURCES = new Set(["think", "classify", "remember", "noop", "compact", "derive"]);
-  const category = (entry.category ?? "").toLowerCase().trim();
-  const source = (entry.source ?? "").toLowerCase().trim();
-  if (BLOCKED_CATEGORIES.has(category) || BLOCKED_SOURCES.has(source)) {
-    const nowSec = Math.floor(Date.now() / 1000);
-    const stubEntry: MemoryEntry = {
-      id: randomUUID(),
+  const entryCategory = entry.category ?? "";
+  const entrySource = entry.source ?? "";
+  if (BLOCKED_CATEGORIES.has(entryCategory) || BLOCKED_SOURCES.has(entrySource)) {
+    // Return a minimal skipped result — caller should skip post-store operations.
+    const skippedEntry: MemoryEntry = {
+      id: "skipped",
       text: entry.text,
-      why: entry.why ?? null,
-      category: (entry.category?.trim() || "other") as MemoryCategory,
+      category: entry.category ?? "noop",
       importance: entry.importance ?? 0.5,
-      entity: entry.entity?.trim() || null,
-      key: entry.key?.trim() || null,
+      source: entry.source ?? "guard",
+      entity: entry.entity ?? null,
+      key: entry.key ?? null,
       value: entry.value ?? null,
-      source: entry.source ?? "conversation",
-      createdAt: nowSec,
-      decayClass: entry.decayClass ?? "ephemeral",
+      createdAt: Date.now(),
+      decayClass: entry.decayClass ?? "normal",
       expiresAt: null,
-      lastConfirmedAt: nowSec,
-      confidence: entry.confidence ?? 1.0,
+      lastConfirmedAt: 0,
+      confidence: 0,
+      tags: entry.tags ?? null,
     };
-    return { entry: stubEntry, skipped: true, evictedFactId: null };
+    return { entry: skippedEntry, evictedFactId: null, skipped: true };
   }
 
   const sourceForPolicy = entry.source ?? "conversation";

--- a/extensions/memory-hybrid/backends/facts-db/crud.ts
+++ b/extensions/memory-hybrid/backends/facts-db/crud.ts
@@ -150,7 +150,24 @@ export function storeFact(ctx: StoreFactContext, entry: StoreFactInput): StoreFa
   const category = (entry.category ?? "").toLowerCase().trim();
   const source = (entry.source ?? "").toLowerCase().trim();
   if (BLOCKED_CATEGORIES.has(category) || BLOCKED_SOURCES.has(source)) {
-    throw new Error(`memory-hybrid: fact blocked by pre-store guard (category=${category}, source=${source})`);
+    const nowSec = Math.floor(Date.now() / 1000);
+    const stubEntry: MemoryEntry = {
+      id: randomUUID(),
+      text: entry.text,
+      why: entry.why ?? null,
+      category: (entry.category?.trim() || "other") as MemoryCategory,
+      importance: entry.importance ?? 0.5,
+      entity: entry.entity?.trim() || null,
+      key: entry.key?.trim() || null,
+      value: entry.value ?? null,
+      source: entry.source ?? "conversation",
+      createdAt: nowSec,
+      decayClass: entry.decayClass ?? "ephemeral",
+      expiresAt: null,
+      lastConfirmedAt: nowSec,
+      confidence: entry.confidence ?? 1.0,
+    };
+    return { entry: stubEntry, skipped: true, evictedFactId: null };
   }
 
   const sourceForPolicy = entry.source ?? "conversation";

--- a/extensions/memory-hybrid/backends/facts-db/crud.ts
+++ b/extensions/memory-hybrid/backends/facts-db/crud.ts
@@ -151,8 +151,6 @@ export type SkippedStoreFactResult = {
    * No fact was written, so callers must skip all post-store operations.
    */
   skipped: true;
-  evictedFactId?: null;
-  embeddingStale?: false;
 };
 
 export type StoreFactResult = StoredFactResult | SkippedStoreFactResult;
@@ -163,7 +161,7 @@ export function storeFact(ctx: StoreFactContext, entry: StoreFactInput): StoreFa
   const entryCategory = entry.category ?? "";
   const entrySource = entry.source ?? "";
   if (BLOCKED_CATEGORIES.has(entryCategory) || BLOCKED_SOURCES.has(entrySource)) {
-    return { skipped: true, evictedFactId: null, embeddingStale: false };
+    return { skipped: true };
   }
 
   const sourceForPolicy = entry.source ?? "conversation";

--- a/extensions/memory-hybrid/backends/facts-db/crud.ts
+++ b/extensions/memory-hybrid/backends/facts-db/crud.ts
@@ -133,10 +133,43 @@ export type StoreFactResult = {
    * `entry.text` and replace the vector for `entry.id` in VectorDB.
    */
   embeddingStale?: boolean;
+  /**
+   * True when the pre-store guard filtered this entry as an internal artifact (#1560, #1561).
+   * Callers must skip post-store operations (vector upsert, supersession, logging) when true.
+   */
+  skipped?: boolean;
 };
 
 export function storeFact(ctx: StoreFactContext, entry: StoreFactInput): StoreFactResult {
   validateStoreEntryInput(entry);
+
+  // Pre-store guard: filter internal artifacts (#1560, #1561).
+  // These categories and sources are not user-relevant memories.
+  const BLOCKED_CATEGORIES = new Set(["noop", "classification", "artifact", "chain-of-thought", "prompt"]);
+  const BLOCKED_SOURCES = new Set(["think", "classify", "remember", "noop", "compact", "derive"]);
+  const category = entry.category ?? "";
+  const source = entry.source ?? "";
+  if (BLOCKED_CATEGORIES.has(category) || BLOCKED_SOURCES.has(source)) {
+    // Return a minimal skipped result — caller should skip post-store operations.
+    const skippedEntry: MemoryEntry = {
+      id: "skipped",
+      text: entry.text,
+      category: entry.category ?? "noop",
+      importance: entry.importance ?? 0.5,
+      source: entry.source ?? "guard",
+      entity: entry.entity ?? null,
+      key: entry.key ?? null,
+      value: entry.value ?? null,
+      createdAt: Date.now(),
+      decayClass: entry.decayClass ?? "normal",
+      expiresAt: null,
+      lastConfirmedAt: 0,
+      confidence: 0,
+      tags: entry.tags ?? null,
+    };
+    return { entry: skippedEntry, evictedFactId: null, skipped: true };
+  }
+
   const sourceForPolicy = entry.source ?? "conversation";
   const profile = resolveDedupeProfile(sourceForPolicy, ctx.storeConfig ?? { fuzzyDedupe: ctx.fuzzyDedupe });
   const nowSec = Math.floor(Date.now() / 1000);

--- a/extensions/memory-hybrid/backends/facts-db/crud.ts
+++ b/extensions/memory-hybrid/backends/facts-db/crud.ts
@@ -124,7 +124,7 @@ export type StoreFactContext = {
   vectorCandidates?: ReadonlyArray<{ id: string; score: number }>;
 };
 
-export type StoreFactResult = {
+export type StoredFactResult = {
   /** The stored fact entry */
   entry: MemoryEntry;
   /**
@@ -142,8 +142,20 @@ export type StoreFactResult = {
    * True when the pre-store guard filtered this entry as an internal artifact (#1560, #1561).
    * Callers must skip post-store operations (vector upsert, supersession, logging) when true.
    */
-  skipped?: boolean;
+  skipped?: false;
 };
+
+export type SkippedStoreFactResult = {
+  /**
+   * True when the pre-store guard filtered this entry as an internal artifact (#1560, #1561).
+   * No fact was written, so callers must skip all post-store operations.
+   */
+  skipped: true;
+  evictedFactId?: null;
+  embeddingStale?: false;
+};
+
+export type StoreFactResult = StoredFactResult | SkippedStoreFactResult;
 
 export function storeFact(ctx: StoreFactContext, entry: StoreFactInput): StoreFactResult {
   validateStoreEntryInput(entry);
@@ -151,24 +163,7 @@ export function storeFact(ctx: StoreFactContext, entry: StoreFactInput): StoreFa
   const entryCategory = entry.category ?? "";
   const entrySource = entry.source ?? "";
   if (BLOCKED_CATEGORIES.has(entryCategory) || BLOCKED_SOURCES.has(entrySource)) {
-    // Return a minimal skipped result — caller should skip post-store operations.
-    const skippedEntry: MemoryEntry = {
-      id: "skipped",
-      text: entry.text,
-      category: entry.category ?? "noop",
-      importance: entry.importance ?? 0.5,
-      source: entry.source ?? "guard",
-      entity: entry.entity ?? null,
-      key: entry.key ?? null,
-      value: entry.value ?? null,
-      createdAt: Date.now(),
-      decayClass: entry.decayClass ?? "normal",
-      expiresAt: null,
-      lastConfirmedAt: 0,
-      confidence: 0,
-      tags: entry.tags ?? null,
-    };
-    return { entry: skippedEntry, evictedFactId: null, skipped: true };
+    return { skipped: true, evictedFactId: null, embeddingStale: false };
   }
 
   const sourceForPolicy = entry.source ?? "conversation";

--- a/extensions/memory-hybrid/backends/facts-db/facts-db-layer1.ts
+++ b/extensions/memory-hybrid/backends/facts-db/facts-db-layer1.ts
@@ -235,7 +235,11 @@ export class FactsDBLayer1 extends BaseSqliteStore {
       suppressVectorFallbackWarning?: boolean;
     },
   ): MemoryEntry {
-    return this.storeWithResult(entry, options).entry;
+    const result = this.storeWithResult(entry, options);
+    if (result.skipped) {
+      throw new Error("memory-hybrid: store() skipped internal artifact fact; use storeWithResult() to handle skipped writes");
+    }
+    return result.entry;
   }
 
   storeWithResult(

--- a/extensions/memory-hybrid/cli/cmd-backfill.ts
+++ b/extensions/memory-hybrid/cli/cmd-backfill.ts
@@ -301,6 +301,11 @@ export async function runBackfillForCli(
         source: `backfill:${fact.source}`,
         sourceDate: sourceDateSec(fact.source_date),
       });
+      if (storeResult.skipped) {
+        skipped++;
+        processed++;
+        continue;
+      }
       const entry = storeResult.entry;
       // CRITICAL FIX (#2): Delete vector for evicted fact to prevent orphaned vectors
       await cleanupEvictedVector({
@@ -730,6 +735,10 @@ export async function runIngestFilesForCli(
         decayClass: "stable",
         tags: fact.tags,
       });
+      if (storeResult.skipped) {
+        skipped++;
+        continue;
+      }
       const entry = storeResult.entry;
       // CRITICAL FIX (#2): Delete vector for evicted fact to prevent orphaned vectors
       await cleanupEvictedVector({

--- a/extensions/memory-hybrid/cli/cmd-distill.ts
+++ b/extensions/memory-hybrid/cli/cmd-distill.ts
@@ -655,6 +655,14 @@ export async function runDistillForCli(
                 source: "distillation",
                 sourceDate: sourceDateSec(fact.source_date),
               });
+              if (storeResult.skipped) {
+                if (storedInVault) {
+                  credentialsDb.delete(parsed.service, parsed.type as any);
+                  storedInVault = false;
+                }
+                skipped++;
+                continue;
+              }
               const entry = storeResult.entry;
               // CRITICAL FIX (#2): Delete vector for evicted fact to prevent orphaned vectors
               await cleanupEvictedVector({
@@ -724,6 +732,10 @@ export async function runDistillForCli(
           sourceDate: sourceDateSec(fact.source_date),
           tags: fact.tags?.length ? fact.tags : extractTags(fact.text, fact.entity ?? undefined),
         });
+        if (storeResult.skipped) {
+          skipped++;
+          continue;
+        }
         const entry = storeResult.entry;
         // CRITICAL FIX (#2): Delete vector for evicted fact to prevent orphaned vectors
         await cleanupEvictedVector({

--- a/extensions/memory-hybrid/cli/cmd-extract-daily.ts
+++ b/extensions/memory-hybrid/cli/cmd-extract-daily.ts
@@ -106,6 +106,9 @@ export async function runExtractDailyForCli(
               validFrom: sourceDateSec,
               supersedesId: classification.targetId,
             });
+            if (storeResult.skipped) {
+              continue;
+            }
             const newEntry = storeResult.entry;
             // CRITICAL FIX (#2): Delete vector for evicted fact to prevent orphaned vectors
             await cleanupEvictedVector({
@@ -145,6 +148,9 @@ export async function runExtractDailyForCli(
           }
         }
         const storeResult = factsDb.storeWithResult(storePayload);
+        if (storeResult.skipped) {
+          continue;
+        }
         const entry = storeResult.entry;
         // CRITICAL FIX (#2): Delete vector for evicted fact to prevent orphaned vectors
         await cleanupEvictedVector({
@@ -225,6 +231,11 @@ export async function runExtractDailyForCli(
                   sourceDate: sourceDateSec,
                   tags: ["auth", ...extractTags(pointerText, "Credentials")],
                 });
+                if (pointerStoreResult.skipped) {
+                  credentialsDb.delete(parsed.service, parsed.type as any);
+                  storedInVault = false;
+                  continue;
+                }
                 const pointerEntry = pointerStoreResult.entry;
                 await cleanupEvictedVector({
                   vectorDb,
@@ -345,6 +356,9 @@ export async function runExtractDailyForCli(
       }
       await flushPendingExtractClassify();
       const storeResult = factsDb.storeWithResult(storePayload);
+      if (storeResult.skipped) {
+        continue;
+      }
       const entry = storeResult.entry;
       await cleanupEvictedVector({
         vectorDb,

--- a/extensions/memory-hybrid/cli/cmd-extract-directives.ts
+++ b/extensions/memory-hybrid/cli/cmd-extract-directives.ts
@@ -123,6 +123,9 @@ export async function runExtractDirectivesForCli(
               suppressVectorFallbackWarning: true,
             },
           );
+          if (storeResult.skipped) {
+            continue;
+          }
           // CRITICAL FIX (#2): Delete vector for evicted fact to prevent orphaned vectors
           await cleanupEvictedVector({
             vectorDb,

--- a/extensions/memory-hybrid/cli/cmd-extract-reinforcement.ts
+++ b/extensions/memory-hybrid/cli/cmd-extract-reinforcement.ts
@@ -276,6 +276,9 @@ export async function runExtractReinforcementForCli(
               source: "reinforcement-analysis",
               tags,
             });
+            if (storeResult.skipped) {
+              continue;
+            }
             const entry = storeResult.entry;
             // CRITICAL FIX (#2): Delete vector for evicted fact to prevent orphaned vectors
             await cleanupEvictedVector({

--- a/extensions/memory-hybrid/cli/cmd-feedback.ts
+++ b/extensions/memory-hybrid/cli/cmd-feedback.ts
@@ -546,6 +546,9 @@ export async function runExtractImplicitFeedbackForCli(
             tags: ["implicit-feedback", "negative", sig.type],
             decayClass: "normal",
           });
+          if (storeResult.skipped) {
+            continue;
+          }
           // CRITICAL FIX (#2): Delete vector for evicted fact to prevent orphaned vectors
           await cleanupEvictedVector({
             vectorDb: vectorDb,
@@ -661,6 +664,9 @@ export async function runExtractImplicitFeedbackForCli(
                   tags: IMPLICIT_FEEDBACK_LESSON_TAGS,
                   decayClass: "normal",
                 });
+                if (storeResult.skipped) {
+                  continue;
+                }
                 // CRITICAL FIX (#2): Delete vector for evicted fact to prevent orphaned vectors
                 await cleanupEvictedVector({
                   vectorDb: vectorDb,

--- a/extensions/memory-hybrid/cli/cmd-selfcorrection.ts
+++ b/extensions/memory-hybrid/cli/cmd-selfcorrection.ts
@@ -353,6 +353,9 @@ export async function runSelfCorrectionRunForCli(
             source: "self-correction",
             tags: Array.isArray(obj.tags) ? obj.tags : [],
           });
+          if (storeResult.skipped) {
+            continue;
+          }
           const entry = storeResult.entry;
           // CRITICAL FIX (#2): Delete vector for evicted fact to prevent orphaned vectors
           await cleanupEvictedVector({

--- a/extensions/memory-hybrid/cli/cmd-store.ts
+++ b/extensions/memory-hybrid/cli/cmd-store.ts
@@ -86,6 +86,10 @@ export async function runStoreForCli(
           sourceDate,
           tags: ["auth", ...extractTags(pointerText, "Credentials")],
         });
+        if (storeResult.skipped) {
+          credentialsDb.delete(parsed.service, parsed.type as any);
+          return { outcome: "credential_db_error" };
+        }
         pointerEntry = storeResult.entry;
         // CRITICAL FIX (#2): Delete vector for evicted fact to prevent orphaned vectors
         await cleanupEvictedVector({
@@ -220,6 +224,12 @@ export async function runStoreForCli(
                 scope,
                 scopeTarget,
               });
+              if (storeResult.skipped) {
+                return {
+                  outcome: "noop",
+                  reason: "skipped internal artifact fact during classified update",
+                };
+              }
               const newEntry = storeResult.entry;
               // CRITICAL FIX (#2): Delete vector for evicted fact to prevent orphaned vectors
               await cleanupEvictedVector({
@@ -283,6 +293,9 @@ export async function runStoreForCli(
       scopeTarget,
       ...(supersedesId ? { validFrom: nowSec, supersedesId } : {}),
     });
+    if (storeResult.skipped) {
+      return { outcome: "noop", reason: "skipped internal artifact fact" };
+    }
     const entry = storeResult.entry;
     // CRITICAL FIX (#2): Delete vector for evicted fact to prevent orphaned vectors
     await cleanupEvictedVector({

--- a/extensions/memory-hybrid/lifecycle/stage-capture/run-capture.ts
+++ b/extensions/memory-hybrid/lifecycle/stage-capture/run-capture.ts
@@ -493,6 +493,10 @@ export async function runCapture(
                       extractionMethod: getAutoCaptureExtractionMethod(candidate.role, captureProvenance),
                       extractionConfidence: getAutoCaptureExtractionConfidence(candidate.role),
                     });
+                    if (storeResult.skipped) {
+                      await ctx.walRemove(walEntryId, api.logger);
+                      continue;
+                    }
                     const newEntry = storeResult.entry;
                     // CRITICAL FIX (#2): Delete vector for evicted fact to prevent orphaned vectors
                     await cleanupEvictedVector({
@@ -907,6 +911,9 @@ export async function runCapture(
                 decayClass: "permanent",
                 tags: ["auth", "credential"],
               });
+              if (storeResult.skipped) {
+                continue;
+              }
               const entry = storeResult.entry;
               // CRITICAL FIX (#2): Delete vector for evicted fact to prevent orphaned vectors
               await cleanupEvictedVector({

--- a/extensions/memory-hybrid/lifecycle/stage-capture/run-capture.ts
+++ b/extensions/memory-hybrid/lifecycle/stage-capture/run-capture.ts
@@ -167,6 +167,9 @@ export async function runCapture(
           source: "humanizer",
           decayClass: "normal",
         });
+        if (storeResult.skipped) {
+          return;
+        }
         await cleanupEvictedVector({
           vectorDb: ctx.vectorDb,
           evictedFactId: storeResult.evictedFactId,

--- a/extensions/memory-hybrid/services/dream-cycle.ts
+++ b/extensions/memory-hybrid/services/dream-cycle.ts
@@ -459,6 +459,9 @@ export async function runEpisodicConsolidation(
           sourceEvents,
         }),
       });
+      if (storeResult.skipped) {
+        continue;
+      }
       consolidatedFact = storeResult.entry;
       // CRITICAL FIX (#2): Delete vector for evicted fact to prevent orphaned vectors
       if (vectorDb) {

--- a/extensions/memory-hybrid/services/reflection.ts
+++ b/extensions/memory-hybrid/services/reflection.ts
@@ -655,6 +655,9 @@ export async function runReflection(
         suppressVectorFallbackWarning: true,
       },
     );
+    if (storeResult.skipped) {
+      continue;
+    }
     const entry = storeResult.entry;
     // CRITICAL FIX (#2): Delete vector for evicted fact to prevent orphaned vectors
     await cleanupEvictedVector({
@@ -932,6 +935,9 @@ export async function runReflectionRules(
         suppressVectorFallbackWarning: true,
       },
     );
+    if (storeResult.skipped) {
+      continue;
+    }
     const entry = storeResult.entry;
     // CRITICAL FIX (#2): Delete vector for evicted fact to prevent orphaned vectors
     await cleanupEvictedVector({
@@ -1189,6 +1195,9 @@ export async function runReflectionMeta(
         suppressVectorFallbackWarning: true,
       },
     );
+    if (storeResult.skipped) {
+      continue;
+    }
     const entry = storeResult.entry;
     // CRITICAL FIX (#2): Delete vector for evicted fact to prevent orphaned vectors
     await cleanupEvictedVector({

--- a/extensions/memory-hybrid/setup/plugin-service.ts
+++ b/extensions/memory-hybrid/setup/plugin-service.ts
@@ -373,6 +373,9 @@ export function createPluginService(ctx: PluginServiceContext) {
                     summary,
                     tags,
                   });
+                  if (storeResult.skipped) {
+                    continue;
+                  }
                   const stored = storeResult.entry;
                   await cleanupEvictedVector({
                     vectorDb,

--- a/extensions/memory-hybrid/tests/facts-db.test.ts
+++ b/extensions/memory-hybrid/tests/facts-db.test.ts
@@ -189,6 +189,37 @@ describe("FactsDB.store", () => {
       sqlite.prepare = originalPrepare;
     }
   });
+
+  it("returns skipped result without writing internal artifact facts", () => {
+    const result = db.storeWithResult({
+      text: "internal noop artifact",
+      category: "noop",
+      importance: 0.7,
+      entity: null,
+      key: null,
+      value: null,
+      source: "conversation",
+    });
+
+    expect(result.skipped).toBe(true);
+    expect("entry" in result).toBe(false);
+    expect(db.count()).toBe(0);
+  });
+
+  it("throws from store() when an internal artifact fact is filtered", () => {
+    expect(() =>
+      db.store({
+        text: "internal noop artifact",
+        category: "noop",
+        importance: 0.7,
+        entity: null,
+        key: null,
+        value: null,
+        source: "conversation",
+      }),
+    ).toThrow(/skipped internal artifact fact/i);
+    expect(db.count()).toBe(0);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/extensions/memory-hybrid/tools/document-tools.ts
+++ b/extensions/memory-hybrid/tools/document-tools.ts
@@ -584,6 +584,9 @@ export function registerDocumentTools(ctx: DocumentToolsContext, api: ClawdbotPl
           tags: chunkTags,
           decayClass: "stable",
         });
+        if (storeResult.skipped) {
+          continue;
+        }
         entry = storeResult.entry;
         await cleanupEvictedVector({
           vectorDb,

--- a/extensions/memory-hybrid/tools/memory/register-store-tools.ts
+++ b/extensions/memory-hybrid/tools/memory/register-store-tools.ts
@@ -296,6 +296,13 @@ export function registerStoreTools(runtime: MemoryToolRuntime): void {
                 extractionMethod: "active",
                 extractionConfidence: importance,
               });
+              if (pointerStoreResult.skipped) {
+                credentialsDb.delete(parsed.service, parsed.type as any);
+                return {
+                  content: [{ type: "text", text: "Credential pointer was filtered and was not stored." }],
+                  details: { action: "credential_skipped_internal_artifact" },
+                };
+              }
               const pointerEntry = pointerStoreResult.entry;
               await cleanupEvictedVector({
                 vectorDb,
@@ -522,6 +529,13 @@ export function registerStoreTools(runtime: MemoryToolRuntime): void {
                     extractionMethod: "active",
                     extractionConfidence: Math.max(importance, oldFact.importance),
                   });
+                  if (updateStoreResult.skipped) {
+                    await walRemove(walEntryId, api.logger);
+                    return {
+                      content: [{ type: "text", text: "Skipped storing internal artifact memory." }],
+                      details: { action: "memory_skipped_internal_artifact" },
+                    };
+                  }
                   const newEntry = updateStoreResult.entry;
                   await cleanupEvictedVector({
                     vectorDb,
@@ -731,6 +745,13 @@ export function registerStoreTools(runtime: MemoryToolRuntime): void {
             decayFreezeUntil: decayFreezeUntil ?? undefined,
             ...(supersedes?.trim() ? { validFrom: nowSec, supersedesId: supersedes.trim() } : {}),
           });
+          if (storeResult.skipped) {
+            await walRemove(walEntryId, api.logger);
+            return {
+              content: [{ type: "text", text: "Skipped storing internal artifact memory." }],
+              details: { action: "memory_skipped_internal_artifact" },
+            };
+          }
           const entry = storeResult.entry;
           await cleanupEvictedVector({
             vectorDb,


### PR DESCRIPTION
Closes #1561

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a pre-store filter that prevents certain categories/sources from being written to the facts DB, which can change what gets persisted and may affect downstream workflows that previously assumed every `storeWithResult()` produced an entry.
> 
> **Overview**
> Adds a universal **pre-store guard** in `facts-db` that filters out internal memory artifacts (e.g. `noop`/`classification`/`artifact` categories or `think`/`classify` sources) and returns a new `{ skipped: true }` result instead of writing to SQLite.
> 
> Updates the `FactsDBLayer1.store()` API to **throw** when a write is skipped (forcing callers to use `storeWithResult()`), and threads `skipped` handling through CLIs/services so they **bail out of follow-on work** (vector upserts, supersession, vault pointer handling, WAL cleanup) when no fact was stored. Adds test coverage for skipped writes.
> 
> Separately, reformats `.github/scripts/check-pr-file-overlap.mjs` and `forge-feedback-loop.mjs` (no functional behavior change).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a7d46a3e60d02ddc4bb202e5b4ad85b4b0ce348. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->