### PR TITLE
feat: strict duplicate/superseded closure guard proof model

### DIFF
--- a/extensions/memory-hybrid/services/duplicate-closure-guard.ts
+++ b/extensions/memory-hybrid/services/duplicate-closure-guard.ts
@@ -1,0 +1,75 @@
+export type ClosureDecision = "safe" | "needs-reconciliation";
+
+export type ImplementationClass = "implementation" | "docs" | "workflow" | "mixed" | "unknown";
+
+export interface ClosureCandidate {
+  candidateRef: string;
+  replacementRef?: string | null;
+  sameIssueScope: boolean;
+  replacementState: "open" | "merged" | "closed-unmerged" | "missing";
+  replacementBranchRecoverable: boolean;
+  hasScopeCoverageNote: boolean;
+  implementationClassCompatibility: boolean;
+  hasFileOverlap: boolean;
+  hasSemanticCoverageNote: boolean;
+  hasEvidenceCommentText: boolean;
+}
+
+export interface ClosureAssessment {
+  candidateRef: string;
+  replacementRef?: string | null;
+  decision: ClosureDecision;
+  reasons: string[];
+}
+
+export interface ClosureGuardResult {
+  decision: ClosureDecision;
+  assessments: ClosureAssessment[];
+}
+
+export function evaluateStrictDuplicateClosureGuard(candidates: ClosureCandidate[]): ClosureGuardResult {
+  const assessments = candidates.map((candidate) => {
+    const reasons: string[] = [];
+
+    if (!candidate.sameIssueScope) {
+      reasons.push("different_issue_scope");
+    }
+    if (!candidate.replacementRef) {
+      reasons.push("missing_explicit_replacement");
+    }
+    if (!(candidate.replacementState === "open" || candidate.replacementState === "merged")) {
+      reasons.push("replacement_not_open_or_merged");
+    }
+    if (!candidate.replacementBranchRecoverable) {
+      reasons.push("replacement_branch_not_recoverable");
+    }
+    if (!candidate.hasScopeCoverageNote) {
+      reasons.push("missing_scope_coverage_note");
+    }
+    if (!candidate.implementationClassCompatibility) {
+      reasons.push("implementation_class_incompatible");
+    }
+    if (!candidate.hasFileOverlap && !candidate.hasSemanticCoverageNote) {
+      reasons.push("no_overlap_without_semantic_coverage");
+    }
+    if (!candidate.hasEvidenceCommentText) {
+      reasons.push("missing_individual_evidence_comment");
+    }
+
+    return {
+      candidateRef: candidate.candidateRef,
+      replacementRef: candidate.replacementRef,
+      decision: reasons.length === 0 ? "safe" : "needs-reconciliation",
+      reasons,
+    } satisfies ClosureAssessment;
+  });
+
+  const decision: ClosureDecision = assessments.every((item) => item.decision === "safe")
+    ? "safe"
+    : "needs-reconciliation";
+
+  return {
+    decision,
+    assessments,
+  };
+}

--- a/extensions/memory-hybrid/tests/duplicate-closure-guard.test.ts
+++ b/extensions/memory-hybrid/tests/duplicate-closure-guard.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  type ClosureCandidate,
+  evaluateStrictDuplicateClosureGuard,
+} from "../services/duplicate-closure-guard.js";
+
+function baseCandidate(overrides: Partial<ClosureCandidate> = {}): ClosureCandidate {
+  return {
+    candidateRef: "#1593",
+    replacementRef: "#1600",
+    sameIssueScope: true,
+    replacementState: "merged",
+    replacementBranchRecoverable: true,
+    hasScopeCoverageNote: true,
+    implementationClassCompatibility: true,
+    hasFileOverlap: true,
+    hasSemanticCoverageNote: false,
+    hasEvidenceCommentText: true,
+    ...overrides,
+  };
+}
+
+describe("evaluateStrictDuplicateClosureGuard", () => {
+  it("marks same-title different issue scope unsafe (#1560 vs #1561 style)", () => {
+    const result = evaluateStrictDuplicateClosureGuard([
+      baseCandidate({
+        candidateRef: "#1561",
+        replacementRef: "#1560",
+        sameIssueScope: false,
+      }),
+    ]);
+
+    expect(result.decision).toBe("needs-reconciliation");
+    expect(result.assessments[0]?.reasons).toContain("different_issue_scope");
+  });
+
+  it("marks zero file overlap unsafe without semantic evidence", () => {
+    const result = evaluateStrictDuplicateClosureGuard([
+      baseCandidate({
+        hasFileOverlap: false,
+        hasSemanticCoverageNote: false,
+      }),
+    ]);
+
+    expect(result.decision).toBe("needs-reconciliation");
+    expect(result.assessments[0]?.reasons).toContain("no_overlap_without_semantic_coverage");
+  });
+
+  it("marks docs/workflow-only replacement unsafe for implementation candidate", () => {
+    const result = evaluateStrictDuplicateClosureGuard([
+      baseCandidate({
+        implementationClassCompatibility: false,
+      }),
+    ]);
+
+    expect(result.decision).toBe("needs-reconciliation");
+    expect(result.assessments[0]?.reasons).toContain("implementation_class_incompatible");
+  });
+
+  it("marks deleted/missing replacement branch unsafe", () => {
+    const result = evaluateStrictDuplicateClosureGuard([
+      baseCandidate({
+        replacementBranchRecoverable: false,
+      }),
+    ]);
+
+    expect(result.decision).toBe("needs-reconciliation");
+    expect(result.assessments[0]?.reasons).toContain("replacement_branch_not_recoverable");
+  });
+
+  it("marks missing evidence comment unsafe", () => {
+    const result = evaluateStrictDuplicateClosureGuard([
+      baseCandidate({
+        hasEvidenceCommentText: false,
+      }),
+    ]);
+
+    expect(result.decision).toBe("needs-reconciliation");
+    expect(result.assessments[0]?.reasons).toContain("missing_individual_evidence_comment");
+  });
+
+  it("marks valid same-issue same-files merged replacement with full proof as safe", () => {
+    const result = evaluateStrictDuplicateClosureGuard([
+      baseCandidate({
+        candidateRef: "#1609",
+        replacementRef: "#1610",
+        sameIssueScope: true,
+        replacementState: "merged",
+        replacementBranchRecoverable: true,
+        hasScopeCoverageNote: true,
+        implementationClassCompatibility: true,
+        hasFileOverlap: true,
+        hasSemanticCoverageNote: false,
+        hasEvidenceCommentText: true,
+      }),
+    ]);
+
+    expect(result.decision).toBe("safe");
+    expect(result.assessments[0]?.reasons).toHaveLength(0);
+  });
+});

--- a/extensions/memory-hybrid/types/issue-types.ts
+++ b/extensions/memory-hybrid/types/issue-types.ts
@@ -47,3 +47,17 @@ export const ISSUE_TRANSITIONS: Record<IssueStatus, IssueStatus[]> = {
   verified: [],
   "wont-fix": ["open"],
 };
+
+export type DuplicateClosureDecision = "safe" | "needs-reconciliation";
+
+export interface DuplicateClosureAssessment {
+  candidateRef: string;
+  replacementRef?: string;
+  decision: DuplicateClosureDecision;
+  reasons: string[];
+}
+
+export interface DuplicateClosureGuardProof {
+  decision: DuplicateClosureDecision;
+  assessments: DuplicateClosureAssessment[];
+}


### PR DESCRIPTION
## Summary\n- add strict duplicate/superseded closure guard module with default-deny  decision\n- require per-candidate proof fields (scope match, explicit replacement, replacement viability, overlap/semantic coverage, evidence comment)\n- add tests covering unsafe cases and valid safe case\n- export guard proof types so automation can consume structured decisions\n\n## Validation\n- 
[1m[46m RUN [49m[22m [36mv4.1.2 [39m[90m/tmp/oc-duplicate-guard-20260523/extensions/memory-hybrid[39m

 [32m✓[39m tests/duplicate-closure-guard.test.ts [2m([22m[2m6 tests[22m[2m)[22m[32m 5[2mms[22m[39m
 [32m✓[39m tests/find-duplicates.test.ts [2m([22m[2m8 tests[22m[2m)[22m[32m 10[2mms[22m[39m

[2m Test Files [22m [1m[32m2 passed[39m[22m[90m (2)[39m
[2m      Tests [22m [1m[32m14 passed[39m[22m[90m (14)[39m
[2m   Start at [22m 05:53:52
[2m   Duration [22m 570ms[2m (transform 409ms, setup 0ms, import 516ms, tests 15ms, environment 0ms)[22m\n- \n\n## Notes\n- Existing auto-close call paths were not found in targeted files; this PR introduces reusable guard + structured proof model for wiring into closure scripts/workflows.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new default-deny evaluation helper and associated exported types, but does not modify any existing closure behavior or production code paths. Risk is mainly around future integration relying on the strict criteria and reason codes.
> 
> **Overview**
> Adds `evaluateStrictDuplicateClosureGuard` (default-deny) to produce per-candidate assessments and a top-level `safe` vs `needs-reconciliation` decision based on explicit proof fields (scope match, replacement viability, overlap/semantic evidence, and evidence comment).
> 
> Exports a structured `DuplicateClosureGuardProof` type model in `issue-types.ts` and adds Vitest coverage for several unsafe scenarios plus a fully-proven safe case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23e3a38a4830a66c2e6a45d24a60cc76fb5f7b2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->