### PR TITLE
fix: add active-task selection instrumentation

### DIFF
--- a/docs/ACTIVE-TASKS-PROJECTION.md
+++ b/docs/ACTIVE-TASKS-PROJECTION.md
@@ -32,6 +32,8 @@ The projection must not invent “when work started” or “last touch” from 
 
 Per-turn `prependContext` uses the same **readable** projection filters (`excludeGenericTitle`, `titleMinChars`, `dedupeBy`) and optional row caps (`injectionMaxTasks` or `projection.maxRowsPerSection`). Tasks are sorted **non-stale first**, then by relevance to the user message / session, then by **Updated**. Stale rows are detailed in the stale-warning block, not the `<active-tasks>` summary. All blocks share `activeTask.injectionBudget` (default 500 tokens).
 
+When plugin debug logging is enabled, facts-ledger selection and projection emit bounded diagnostics with fetched row counts, grouped entities / duplicate collapse, stale handling, rendered or injected task counts, and elapsed milliseconds. The detailed metrics stay on `debug` to keep normal production logs low-noise.
+
 ## Sections and filters (`activeTask.projection`)
 
 | Key | Meaning |

--- a/extensions/memory-hybrid/lifecycle/stage-active-task.ts
+++ b/extensions/memory-hybrid/lifecycle/stage-active-task.ts
@@ -4,7 +4,7 @@
  */
 
 import type { ClawdbotPluginApi } from "openclaw/plugin-sdk/core";
-import { readActiveTaskFile, upsertTask, writeActiveTaskFileGuarded } from "../services/active-task.js";
+import { detectStaleTasks, readActiveTaskFile, upsertTask, writeActiveTaskFileGuarded } from "../services/active-task.js";
 import { buildActiveTaskContextBundle } from "../services/active-task-injection.js";
 import { capturePluginError } from "../services/error-reporter.js";
 import { listGoals, resolveGoalsDir } from "../services/goal-registry.js";
@@ -16,7 +16,7 @@ import {
   detectLongRunningWorkflowProposal,
   shouldAutoRegisterLongRunningTask,
 } from "../services/task-hygiene.js";
-import { readActiveTaskRowsFromFacts, syncActiveTaskEntryToFacts } from "../services/task-ledger-facts.js";
+import { loadTaskLedgerFromFactsWithMetrics, syncActiveTaskEntryToFacts } from "../services/task-ledger-facts.js";
 import { parseDuration } from "../utils/duration.js";
 import { extractLastUserMessageText } from "../utils/extract-last-user-message.js";
 import { withHookResolutionApi } from "./hook-resolution-api.js";
@@ -42,15 +42,28 @@ export function registerActiveTaskInjection(
         userText && longRunningMode !== "off" ? detectLongRunningWorkflowProposal(userText, workspaceRoot) : null;
       const resolvedApi = withHookResolutionApi(api, hookCtx);
       const sessionKey = resolveSessionKeyFromHookEvent(event, resolvedApi);
+      let factsSelectionMetrics: import("../services/task-ledger-facts.js").ActiveTaskLedgerSelectionMetrics | null = null;
+      let factsSelectionStartMs: number | null = null;
+      let staleSkippedFromFacts = 0;
 
       if (ctx.cfg.activeTask.ledger === "facts") {
-        const { active } = readActiveTaskRowsFromFacts(ctx.factsDb, staleMinutes);
-        activeForInjection = active;
+        factsSelectionStartMs = Date.now();
+        const { active, metrics } = loadTaskLedgerFromFactsWithMetrics(ctx.factsDb);
+        activeForInjection = detectStaleTasks(active, staleMinutes);
+        factsSelectionMetrics = metrics;
+        staleSkippedFromFacts = activeForInjection.filter((task) => task.stale).length;
       } else {
         const taskFile = await readActiveTaskFile(resolvedActiveTaskPath, staleMinutes);
         activeForInjection = taskFile?.active ?? [];
         completedForWrite = taskFile?.completed ?? [];
       }
+
+      const logFactsSelection = (injectedCount: number): void => {
+        if (!factsSelectionMetrics || factsSelectionStartMs === null) return;
+        api.logger?.debug?.(
+          `memory-hybrid: active-task selection rowsFetched=${factsSelectionMetrics.projectRowsFetched} groupedEntities=${factsSelectionMetrics.groupedEntityCount} duplicatesCollapsed=${factsSelectionMetrics.duplicateRowsCollapsed} activeCandidates=${factsSelectionMetrics.activeCandidates} staleSkipped=${staleSkippedFromFacts} injected=${injectedCount} elapsedMs=${Date.now() - factsSelectionStartMs}`,
+        );
+      };
 
       let longRunningBlock = "";
       if (proposal) {
@@ -88,7 +101,10 @@ export function registerActiveTaskInjection(
         });
       }
 
-      if (activeForInjection.length === 0 && !longRunningBlock) return undefined;
+      if (activeForInjection.length === 0 && !longRunningBlock) {
+        logFactsSelection(0);
+        return undefined;
+      }
 
       const th = ctx.cfg.activeTask.taskHygiene;
       const isHeartbeat =
@@ -132,6 +148,8 @@ export function registerActiveTaskInjection(
       if (isHeartbeat && bundle.parts.some((p) => p.includes("<task-hygiene>"))) {
         api.logger?.info?.("memory-hybrid: task hygiene block appended (heartbeat match)");
       }
+
+      logFactsSelection(bundle.injectedTaskCount);
 
       const parts = [...bundle.parts, longRunningBlock].filter(Boolean);
       if (parts.length === 0) return undefined;

--- a/extensions/memory-hybrid/lifecycle/stage-active-task.ts
+++ b/extensions/memory-hybrid/lifecycle/stage-active-task.ts
@@ -4,7 +4,12 @@
  */
 
 import type { ClawdbotPluginApi } from "openclaw/plugin-sdk/core";
-import { detectStaleTasks, readActiveTaskFile, upsertTask, writeActiveTaskFileGuarded } from "../services/active-task.js";
+import {
+  detectStaleTasks,
+  readActiveTaskFile,
+  upsertTask,
+  writeActiveTaskFileGuarded,
+} from "../services/active-task.js";
 import { buildActiveTaskContextBundle } from "../services/active-task-injection.js";
 import { capturePluginError } from "../services/error-reporter.js";
 import { listGoals, resolveGoalsDir } from "../services/goal-registry.js";
@@ -42,7 +47,8 @@ export function registerActiveTaskInjection(
         userText && longRunningMode !== "off" ? detectLongRunningWorkflowProposal(userText, workspaceRoot) : null;
       const resolvedApi = withHookResolutionApi(api, hookCtx);
       const sessionKey = resolveSessionKeyFromHookEvent(event, resolvedApi);
-      let factsSelectionMetrics: import("../services/task-ledger-facts.js").ActiveTaskLedgerSelectionMetrics | null = null;
+      let factsSelectionMetrics: import("../services/task-ledger-facts.js").ActiveTaskLedgerSelectionMetrics | null =
+        null;
       let factsSelectionStartMs: number | null = null;
       let staleSkippedFromFacts = 0;
 

--- a/extensions/memory-hybrid/services/task-ledger-facts.ts
+++ b/extensions/memory-hybrid/services/task-ledger-facts.ts
@@ -312,7 +312,7 @@ export function loadTaskLedgerFromFactsWithMetrics(
   // But keyMaps only count unique (entity,key) pairs — so true duplicates are also in groupedFactRows.
   // Instead: track rows fed to grouping = only rows with entity AND canonicalLabel.
   // Use canonicalLabel directly to determine eligibility.
-  const eligibleRows = facts.filter(f => f.entity?.trim() && canonicalLabel(f.entity.trim())).length;
+  const eligibleRows = facts.filter((f) => f.entity?.trim() && canonicalLabel(f.entity.trim())).length;
   const metrics: ActiveTaskLedgerSelectionMetrics = {
     projectRowsFetched: facts.length,
     rowsDroppedMissingEntityOrCanonical: facts.length - eligibleRows,
@@ -480,7 +480,7 @@ export async function refreshActiveTaskProjectionBestEffort(opts: {
   logger?: { warn?: (m: string) => void };
 }): Promise<{ rendered: boolean; staleMarked: boolean; error?: string }> {
   try {
-    await renderActiveTaskMarkdownFile(opts.factsDb, opts.staleMinutes, opts.filePath, opts.projection, opts.logger);
+    await renderActiveTaskMarkdownFile(opts.factsDb, opts.staleMinutes, opts.filePath, opts.projection);
     return { rendered: true, staleMarked: false };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
@@ -1348,11 +1348,11 @@ export async function renderActiveTaskMarkdownFile(
   logger?: { debug?: (message: string) => void },
 ): Promise<void> {
   const renderStartMs = Date.now();
-  let {
-    active,
-    completed,
-    metrics,
-  } = loadTaskLedgerFromFactsWithMetrics(factsDb, 8000, ACTIVE_TASK_PROJECTION_GLOBAL_SCOPE_FILTER);
+  let { active, completed, metrics } = loadTaskLedgerFromFactsWithMetrics(
+    factsDb,
+    8000,
+    ACTIVE_TASK_PROJECTION_GLOBAL_SCOPE_FILTER,
+  );
   active = applyActiveTaskProjectionFilters(active, projection);
   completed = applyActiveTaskProjectionFilters(completed, projection);
   active = detectStaleTasks(active, staleMinutes);

--- a/extensions/memory-hybrid/services/task-ledger-facts.ts
+++ b/extensions/memory-hybrid/services/task-ledger-facts.ts
@@ -100,6 +100,7 @@ export type ActiveTaskProjectionStatus = {
 
 export type ActiveTaskLedgerSelectionMetrics = {
   projectRowsFetched: number;
+  rowsDroppedMissingEntityOrCanonical: number;
   groupedEntityCount: number;
   duplicateRowsCollapsed: number;
   activeCandidates: number;
@@ -298,16 +299,25 @@ export function loadTaskLedgerFromFactsWithMetrics(
   const startedAtMs = Date.now();
   // Use targeted query instead of loading all facts then filtering by category (#1553)
   const facts = factsDb.getProjectFacts(factLimit, scopeFilter);
+  // groupProjectFactsByEntity silently drops rows with no entity or no canonical label;
+  // count those separately so duplicateRowsCollapsed only reflects true duplicates.
   const grouped = groupProjectFactsByEntity(facts);
   const { active, completed } = buildTaskEntriesFromGroupedFacts(grouped);
   let groupedFactRows = 0;
   for (const keyMap of grouped.values()) {
     groupedFactRows += keyMap.size;
   }
+  // The rows fed to groupProjectFactsByEntity = facts that passed entity/canonical guard.
+  // We infer dropped rows = facts.length - sum of sizes of all keyMaps.
+  // But keyMaps only count unique (entity,key) pairs — so true duplicates are also in groupedFactRows.
+  // Instead: track rows fed to grouping = only rows with entity AND canonicalLabel.
+  // Use canonicalLabel directly to determine eligibility.
+  const eligibleRows = facts.filter(f => f.entity?.trim() && canonicalLabel(f.entity.trim())).length;
   const metrics: ActiveTaskLedgerSelectionMetrics = {
     projectRowsFetched: facts.length,
+    rowsDroppedMissingEntityOrCanonical: facts.length - eligibleRows,
     groupedEntityCount: grouped.size,
-    duplicateRowsCollapsed: Math.max(0, facts.length - groupedFactRows),
+    duplicateRowsCollapsed: Math.max(0, eligibleRows - groupedFactRows),
     activeCandidates: active.length,
     completedCandidates: completed.length,
     entitiesSkippedWithoutStatus: Math.max(0, grouped.size - active.length - completed.length),

--- a/extensions/memory-hybrid/services/task-ledger-facts.ts
+++ b/extensions/memory-hybrid/services/task-ledger-facts.ts
@@ -98,6 +98,16 @@ export type ActiveTaskProjectionStatus = {
   marker: ActiveTaskProjectionStaleMarker | null;
 };
 
+export type ActiveTaskLedgerSelectionMetrics = {
+  projectRowsFetched: number;
+  groupedEntityCount: number;
+  duplicateRowsCollapsed: number;
+  activeCandidates: number;
+  completedCandidates: number;
+  entitiesSkippedWithoutStatus: number;
+  elapsedMs: number;
+};
+
 /** Latest value per entity+key from non-superseded project facts.
  *  Entity labels are normalised to lowercase (trim + toLowerCase) so that
  *  case-variant entries (e.g. "Humanizer" / "humanizer") are merged into one group. */
@@ -272,10 +282,38 @@ export function loadTaskLedgerFromFacts(
   active: ActiveTaskEntry[];
   completed: ActiveTaskEntry[];
 } {
+  const { active, completed } = loadTaskLedgerFromFactsWithMetrics(factsDb, factLimit, scopeFilter);
+  return { active, completed };
+}
+
+export function loadTaskLedgerFromFactsWithMetrics(
+  factsDb: FactsDB,
+  factLimit = 8000,
+  scopeFilter?: ScopeFilter | null,
+): {
+  active: ActiveTaskEntry[];
+  completed: ActiveTaskEntry[];
+  metrics: ActiveTaskLedgerSelectionMetrics;
+} {
+  const startedAtMs = Date.now();
   // Use targeted query instead of loading all facts then filtering by category (#1553)
   const facts = factsDb.getProjectFacts(factLimit, scopeFilter);
   const grouped = groupProjectFactsByEntity(facts);
-  return buildTaskEntriesFromGroupedFacts(grouped);
+  const { active, completed } = buildTaskEntriesFromGroupedFacts(grouped);
+  let groupedFactRows = 0;
+  for (const keyMap of grouped.values()) {
+    groupedFactRows += keyMap.size;
+  }
+  const metrics: ActiveTaskLedgerSelectionMetrics = {
+    projectRowsFetched: facts.length,
+    groupedEntityCount: grouped.size,
+    duplicateRowsCollapsed: Math.max(0, facts.length - groupedFactRows),
+    activeCandidates: active.length,
+    completedCandidates: completed.length,
+    entitiesSkippedWithoutStatus: Math.max(0, grouped.size - active.length - completed.length),
+    elapsedMs: Date.now() - startedAtMs,
+  };
+  return { active, completed, metrics };
 }
 
 export function readActiveTaskRowsFromFacts(
@@ -432,7 +470,7 @@ export async function refreshActiveTaskProjectionBestEffort(opts: {
   logger?: { warn?: (m: string) => void };
 }): Promise<{ rendered: boolean; staleMarked: boolean; error?: string }> {
   try {
-    await renderActiveTaskMarkdownFile(opts.factsDb, opts.staleMinutes, opts.filePath, opts.projection);
+    await renderActiveTaskMarkdownFile(opts.factsDb, opts.staleMinutes, opts.filePath, opts.projection, opts.logger);
     return { rendered: true, staleMarked: false };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
@@ -1297,8 +1335,14 @@ export async function renderActiveTaskMarkdownFile(
   staleMinutes: number,
   filePath: string,
   projection: ActiveTaskProjectionConfig,
+  logger?: { debug?: (message: string) => void },
 ): Promise<void> {
-  let { active, completed } = loadTaskLedgerFromFacts(factsDb, 8000, ACTIVE_TASK_PROJECTION_GLOBAL_SCOPE_FILTER);
+  const renderStartMs = Date.now();
+  let {
+    active,
+    completed,
+    metrics,
+  } = loadTaskLedgerFromFactsWithMetrics(factsDb, 8000, ACTIVE_TASK_PROJECTION_GLOBAL_SCOPE_FILTER);
   active = applyActiveTaskProjectionFilters(active, projection);
   completed = applyActiveTaskProjectionFilters(completed, projection);
   active = detectStaleTasks(active, staleMinutes);
@@ -1352,6 +1396,9 @@ export async function renderActiveTaskMarkdownFile(
   } catch {
     // Keep render success best-effort even when marker cleanup fails.
   }
+  logger?.debug?.(
+    `memory-hybrid: active-task projection rowsFetched=${metrics.projectRowsFetched} groupedEntities=${metrics.groupedEntityCount} duplicatesCollapsed=${metrics.duplicateRowsCollapsed} activeCandidates=${metrics.activeCandidates} staleBucketed=${staleRaw.length} renderedActive=${capAct.rows.length} renderedStale=${capStale.rows.length} renderedCompleted=${capDone.rows.length} elapsedMs=${Date.now() - renderStartMs}`,
+  );
 }
 
 /**

--- a/extensions/memory-hybrid/tests/stage-active-task.test.ts
+++ b/extensions/memory-hybrid/tests/stage-active-task.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { ClawdbotPluginApi } from "openclaw/plugin-sdk/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { FactsDB } from "../backends/facts-db.js";
 import { hybridConfigSchema } from "../config.js";
 import { registerActiveTaskInjection } from "../lifecycle/stage-active-task.js";
 import type { LifecycleContext } from "../lifecycle/types.js";
@@ -148,5 +149,94 @@ describe("stage-active-task long-running registration", () => {
     expect(prep).toContain("Auto-registration policy only applies to main/private sessions");
     expect(prep).not.toContain("<active-tasks>");
     await expect(access(activeTaskPath, fsConstants.F_OK)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("logs facts-ledger selection diagnostics for active-task injection", async () => {
+    const cfg = parseCfg({
+      activeTask: {
+        enabled: true,
+        ledger: "facts",
+        filePath: "ACTIVE-TASKS.md",
+        staleThreshold: "60m",
+        taskHygiene: {
+          longRunningRegistration: {
+            mode: "suggest",
+          },
+        },
+      },
+    });
+    const factsDb = new FactsDB(join(workspaceRoot, "facts.db"));
+    const ctx = { cfg, factsDb } as LifecycleContext;
+    const api = createMockPluginApi();
+    const logger = {
+      info: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+    };
+    const apiWithLogger = { ...api, logger, context: {} } as unknown as ClawdbotPluginApi;
+
+    try {
+      const freshUpdated = new Date().toISOString();
+      const staleUpdated = new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString();
+      for (const [entity, title, updated] of [
+        ["fresh-task", "Fresh task", freshUpdated],
+        ["stale-task", "Stale task", staleUpdated],
+      ] as const) {
+        factsDb.store({
+          category: "project",
+          importance: 0.7,
+          source: "active-task",
+          decayClass: "permanent",
+          entity,
+          key: "title",
+          value: title,
+          text: `Task [${entity}] title: ${title}`,
+        });
+        factsDb.store({
+          category: "project",
+          importance: 0.7,
+          source: "active-task",
+          decayClass: "permanent",
+          entity,
+          key: "status",
+          value: "in_progress",
+          text: `Task [${entity}] status: in_progress`,
+        });
+        factsDb.store({
+          category: "project",
+          importance: 0.7,
+          source: "active-task",
+          decayClass: "permanent",
+          entity,
+          key: "task_updated",
+          value: updated,
+          text: `Task [${entity}] task_updated: ${updated}`,
+        });
+      }
+
+      registerActiveTaskInjection(apiWithLogger, ctx, activeTaskPath, workspaceRoot);
+
+      const result = await api.emitFirstResult(
+        "before_agent_start",
+        {
+          messages: [{ role: "user", content: "Continue work on fresh-task." }],
+        },
+        { sessionKey: "agent:forge:main" },
+      );
+
+      const prep = (result as { prependContext?: string } | undefined)?.prependContext ?? "";
+      expect(prep).toContain("<active-tasks>");
+      expect(logger.debug).toHaveBeenCalledTimes(1);
+      expect(logger.debug).toHaveBeenCalledWith(
+        expect.stringContaining("memory-hybrid: active-task selection rowsFetched=6"),
+      );
+      expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining("groupedEntities=2"));
+      expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining("activeCandidates=2"));
+      expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining("staleSkipped=1"));
+      expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining("injected=1"));
+      expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining("elapsedMs="));
+    } finally {
+      factsDb.close();
+    }
   });
 });

--- a/extensions/memory-hybrid/tests/task-ledger-facts.test.ts
+++ b/extensions/memory-hybrid/tests/task-ledger-facts.test.ts
@@ -1,7 +1,7 @@
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { FactsDB } from "../backends/facts-db.js";
 import type { VectorDB } from "../backends/vector-db.js";
 import type { ActiveTaskProjectionConfig } from "../config.js";
@@ -18,7 +18,9 @@ import {
   factStatusToDisplay,
   groupProjectFactsByEntity,
   loadTaskLedgerFromFacts,
+  loadTaskLedgerFromFactsWithMetrics,
   planActiveTaskHygiene,
+  renderActiveTaskMarkdownFile,
   syncActiveTaskEntryToFacts,
   taskEntityKey,
   upsertProjectTaskKey,
@@ -412,6 +414,146 @@ describe("task-ledger-facts", () => {
       // incomplete-task has no status key — must be excluded, not defaulted to in-progress.
       expect(allLabels).not.toContain("incomplete-task");
       expect(allLabels).toContain("proper-task");
+    } finally {
+      db.close();
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("loadTaskLedgerFromFactsWithMetrics reports fetched rows and collapsed duplicates", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "task-ledger-metrics-"));
+    const db = new FactsDB(join(dir, "facts.db"));
+    try {
+      db.store({
+        category: "project",
+        importance: 0.7,
+        source: "active-task",
+        decayClass: "permanent",
+        entity: "ship-release",
+        key: "status",
+        value: "open",
+        text: "Task [ship-release] status: open",
+        sourceDate: 1,
+      });
+      db.store({
+        category: "project",
+        importance: 0.7,
+        source: "active-task",
+        decayClass: "permanent",
+        entity: "ship-release",
+        key: "status",
+        value: "in_progress",
+        text: "Task [ship-release] status: in_progress",
+        sourceDate: 2,
+      });
+      db.store({
+        category: "project",
+        importance: 0.7,
+        source: "active-task",
+        decayClass: "permanent",
+        entity: "ship-release",
+        key: "title",
+        value: "Ship the release",
+        text: "Task [ship-release] title: Ship the release",
+        sourceDate: 3,
+      });
+      db.store({
+        category: "project",
+        importance: 0.7,
+        source: "active-task",
+        decayClass: "permanent",
+        entity: "draft-docs",
+        key: "title",
+        value: "Draft docs",
+        text: "Task [draft-docs] title: Draft docs",
+        sourceDate: 4,
+      });
+
+      const result = loadTaskLedgerFromFactsWithMetrics(db);
+      expect(result.active).toHaveLength(1);
+      expect(result.completed).toHaveLength(0);
+      expect(result.metrics).toMatchObject({
+        projectRowsFetched: 4,
+        groupedEntityCount: 2,
+        duplicateRowsCollapsed: 1,
+        activeCandidates: 1,
+        completedCandidates: 0,
+        entitiesSkippedWithoutStatus: 1,
+      });
+      expect(result.metrics.elapsedMs).toBeGreaterThanOrEqual(0);
+    } finally {
+      db.close();
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("renderActiveTaskMarkdownFile emits projection diagnostics when a logger is provided", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "task-ledger-render-metrics-"));
+    const db = new FactsDB(join(dir, "facts.db"));
+    const logger = { debug: vi.fn() };
+    try {
+      const staleUpdated = new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString();
+      const freshUpdated = new Date().toISOString();
+      for (const [entity, title, updated] of [
+        ["fresh-task", "Fresh task", freshUpdated],
+        ["stale-task", "Stale task", staleUpdated],
+      ] as const) {
+        db.store({
+          category: "project",
+          importance: 0.7,
+          source: "active-task",
+          decayClass: "permanent",
+          entity,
+          key: "title",
+          value: title,
+          text: `Task [${entity}] title: ${title}`,
+        });
+        db.store({
+          category: "project",
+          importance: 0.7,
+          source: "active-task",
+          decayClass: "permanent",
+          entity,
+          key: "status",
+          value: "in_progress",
+          text: `Task [${entity}] status: in_progress`,
+        });
+        db.store({
+          category: "project",
+          importance: 0.7,
+          source: "active-task",
+          decayClass: "permanent",
+          entity,
+          key: "task_updated",
+          value: updated,
+          text: `Task [${entity}] task_updated: ${updated}`,
+        });
+      }
+
+      await renderActiveTaskMarkdownFile(
+        db,
+        60,
+        join(dir, "ACTIVE-TASKS.md"),
+        {
+          mode: "readable",
+          excludeGenericTitle: true,
+          titleMinChars: 0,
+          dedupeBy: "none",
+          sectioned: true,
+        },
+        logger,
+      );
+
+      expect(logger.debug).toHaveBeenCalledTimes(1);
+      expect(logger.debug).toHaveBeenCalledWith(
+        expect.stringContaining("memory-hybrid: active-task projection rowsFetched=6"),
+      );
+      expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining("groupedEntities=2"));
+      expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining("activeCandidates=2"));
+      expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining("staleBucketed=1"));
+      expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining("renderedActive=1"));
+      expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining("renderedStale=1"));
+      expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining("elapsedMs="));
     } finally {
       db.close();
       await rm(dir, { recursive: true, force: true });


### PR DESCRIPTION
<!-- issue-stewardship-pr issue:1616 -->
Fixes #1616

Issue: https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/1616

Status: draft implementation PR created by Issue Stewardship as Markus/current gh auth.
Protection: keep as draft and `stage/implementing` until Issue Stewardship dispatches/receives implementation and explicitly hands off to PR Stewardship.

Enrichment present on issue: 0
Priority inherited from issue: Medium (source labels: priority:medium)
Dependencies/blocked labels inherited from issue: none

Implementation PR created by Issue Stewardship. Detailed enrichment should be attached to the issue before Copilot implementation dispatch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: primarily adds bounded `debug` diagnostics and lightweight metrics plumbing around facts-ledger task selection/projection, with minimal impact on runtime behavior.
> 
> **Overview**
> Adds instrumentation for facts-backed active tasks so reviewers/operators can see *why* rows are (or aren’t) injected/rendered.
> 
> Active-task injection now uses `loadTaskLedgerFromFactsWithMetrics` and emits a single `debug` log with fetched row counts, grouping/duplicate-collapsing stats, stale skips, injected count, and elapsed time (including logging when nothing is injected). The facts markdown renderer (`renderActiveTaskMarkdownFile`) similarly accepts an optional logger and logs projection metrics (stale bucket sizes and rendered counts).
> 
> Documentation is updated to describe the new debug-level diagnostics, and new tests cover metrics calculation plus the emitted debug log lines for both injection and projection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca9907b9de330fb1530e0675f6d83d9c3a3432fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->