### PR TITLE
fix: tee stdout→stderr in --json mode (fixes #1618)

### DIFF
--- a/extensions/memory-hybrid/setup/register-plugin.ts
+++ b/extensions/memory-hybrid/setup/register-plugin.ts
@@ -65,7 +65,7 @@ const runtimeRef: { value: PluginRuntime | null } = { value: null };
 async function performHybridMemCliTeardown(): Promise<void> {
   // Restore stdout before checking runtime ref, so teardown without runtime still cleans up (issue #1618).
   restoreStdoutAfterJsonCli();
-  
+
   const r = runtimeRef.value;
   if (!r) return;
   // Stop long-lived service timers first so one-shot CLI commands can exit promptly.

--- a/extensions/memory-hybrid/setup/register-plugin.ts
+++ b/extensions/memory-hybrid/setup/register-plugin.ts
@@ -33,7 +33,7 @@ import { registerLifecycleHooks } from "./register-hooks.js";
 import { registerTools } from "./register-tools.js";
 import { PLUGIN_ID } from "../utils/constants.js";
 import { isHybridMemHelpInvocation } from "../index-help.js";
-import { wrapApiLoggerStderrForJsonCli } from "../utils/hybrid-mem-json-cli.js";
+import { wrapApiLoggerStderrForJsonCli, restoreStdoutAfterJsonCli } from "../utils/hybrid-mem-json-cli.js";
 import {
   getCategoryDecisionRegex,
   getCategoryEntityRegex,
@@ -120,6 +120,8 @@ async function performHybridMemCliTeardown(): Promise<void> {
       operation: "hybrid-mem-teardown:python-bridge",
     });
   }
+  // Restore stdout after JSON CLI tee (issue #1618)
+  restoreStdoutAfterJsonCli();
 }
 
 export function runMemoryHybridRegister(api: ClawdbotPluginApi): void {

--- a/extensions/memory-hybrid/setup/register-plugin.ts
+++ b/extensions/memory-hybrid/setup/register-plugin.ts
@@ -63,6 +63,9 @@ const runtimeRef: { value: PluginRuntime | null } = { value: null };
 
 /** Release DBs and timers after a `hybrid-mem` CLI command so the Node process can exit (Issue #1039). */
 async function performHybridMemCliTeardown(): Promise<void> {
+  // Restore stdout before checking runtime ref, so teardown without runtime still cleans up (issue #1618).
+  restoreStdoutAfterJsonCli();
+  
   const r = runtimeRef.value;
   if (!r) return;
   // Stop long-lived service timers first so one-shot CLI commands can exit promptly.
@@ -120,8 +123,6 @@ async function performHybridMemCliTeardown(): Promise<void> {
       operation: "hybrid-mem-teardown:python-bridge",
     });
   }
-  // Restore stdout after JSON CLI tee (issue #1618)
-  restoreStdoutAfterJsonCli();
 }
 
 export function runMemoryHybridRegister(api: ClawdbotPluginApi): void {

--- a/extensions/memory-hybrid/tests/json-cli-stdout-clean.test.ts
+++ b/extensions/memory-hybrid/tests/json-cli-stdout-clean.test.ts
@@ -5,7 +5,12 @@ import type { ClawdbotPluginApi } from "openclaw/plugin-sdk/core";
  * Plugin startup logs/warnings must go to stderr to avoid breaking cron harnesses and JSON parsers.
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { isHybridMemJsonInvocation, wrapApiLoggerStderrForJsonCli } from "../utils/hybrid-mem-json-cli.js";
+import {
+  isHybridMemJsonInvocation,
+  restoreStdoutAfterJsonCli,
+  withJsonCliStdoutMirrorSuppressed,
+  wrapApiLoggerStderrForJsonCli,
+} from "../utils/hybrid-mem-json-cli.js";
 
 describe("isHybridMemJsonInvocation", () => {
   it("detects --json flag", () => {
@@ -61,8 +66,13 @@ describe("isHybridMemJsonInvocation", () => {
 
 describe("wrapApiLoggerStderrForJsonCli", () => {
   const savedArgv = [...process.argv];
+  const savedStdoutWrite = process.stdout.write;
+  const savedStderrWrite = process.stderr.write;
 
   afterEach(() => {
+    restoreStdoutAfterJsonCli();
+    process.stdout.write = savedStdoutWrite;
+    process.stderr.write = savedStderrWrite;
     process.argv = [...savedArgv];
     vi.restoreAllMocks();
   });
@@ -93,5 +103,92 @@ describe("wrapApiLoggerStderrForJsonCli", () => {
     expect(errSpy).toHaveBeenCalledWith("warn");
     expect(origInfo).not.toHaveBeenCalled();
     expect(origWarn).not.toHaveBeenCalled();
+  });
+
+  it("mirrors non-JSON stdout writes to stderr while preserving the original stdout write result", () => {
+    process.argv = ["node", "openclaw", "hybrid-mem", "config", "--json"];
+    const stdoutWrite = vi.fn(() => false);
+    const stderrWrite = vi.fn(() => true);
+    process.stdout.write = stdoutWrite as unknown as typeof process.stdout.write;
+    process.stderr.write = stderrWrite as unknown as typeof process.stderr.write;
+
+    const api = { logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } } as unknown as ClawdbotPluginApi;
+    wrapApiLoggerStderrForJsonCli(api);
+
+    const result = process.stdout.write(Buffer.from("bootstrap log\n"));
+
+    expect(result).toBe(false);
+    expect(stdoutWrite).toHaveBeenCalledWith(Buffer.from("bootstrap log\n"));
+    expect(stderrWrite).toHaveBeenCalledWith(Buffer.from("bootstrap log\n"));
+    restoreStdoutAfterJsonCli();
+    expect(process.stdout.write).toBe(stdoutWrite);
+  });
+
+  it("does not mirror final JSON payload writes to stderr", () => {
+    process.argv = ["node", "openclaw", "hybrid-mem", "config", "--json"];
+    const stdoutWrite = vi.fn(() => true);
+    const stderrWrite = vi.fn(() => true);
+    process.stdout.write = stdoutWrite as unknown as typeof process.stdout.write;
+    process.stderr.write = stderrWrite as unknown as typeof process.stderr.write;
+
+    const api = { logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } } as unknown as ClawdbotPluginApi;
+    wrapApiLoggerStderrForJsonCli(api);
+
+    const payload = `${JSON.stringify({ ok: true })}\n`;
+    const result = process.stdout.write(payload);
+
+    expect(result).toBe(true);
+    expect(stdoutWrite).toHaveBeenCalledWith(payload);
+    expect(stderrWrite).not.toHaveBeenCalled();
+  });
+
+  it("allows explicit suppression for JSON payload writes", () => {
+    process.argv = ["node", "openclaw", "hybrid-mem", "config", "--json"];
+    const stdoutWrite = vi.fn(() => true);
+    const stderrWrite = vi.fn(() => true);
+    process.stdout.write = stdoutWrite as unknown as typeof process.stdout.write;
+    process.stderr.write = stderrWrite as unknown as typeof process.stderr.write;
+
+    const api = { logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } } as unknown as ClawdbotPluginApi;
+    wrapApiLoggerStderrForJsonCli(api);
+
+    withJsonCliStdoutMirrorSuppressed(() => {
+      process.stdout.write("{\"ok\":true}\n");
+    });
+
+    expect(stdoutWrite).toHaveBeenCalledWith("{\"ok\":true}\n");
+    expect(stderrWrite).not.toHaveBeenCalled();
+  });
+
+  it("restores the original stdout write even when teardown runs without a JSON argv", () => {
+    process.argv = ["node", "openclaw", "hybrid-mem", "config", "--json"];
+    const stdoutWrite = vi.fn(() => true);
+    process.stdout.write = stdoutWrite as unknown as typeof process.stdout.write;
+
+    const api = { logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } } as unknown as ClawdbotPluginApi;
+    wrapApiLoggerStderrForJsonCli(api);
+    expect(process.stdout.write).not.toBe(stdoutWrite);
+
+    process.argv = ["node", "openclaw", "hybrid-mem", "config"];
+    restoreStdoutAfterJsonCli();
+
+    expect(process.stdout.write).toBe(stdoutWrite);
+  });
+
+  it("treats stdout EPIPE as best-effort and still mirrors diagnostics to stderr", () => {
+    process.argv = ["node", "openclaw", "hybrid-mem", "config", "--json"];
+    const epipe = Object.assign(new Error("broken pipe"), { code: "EPIPE" });
+    const stdoutWrite = vi.fn(() => {
+      throw epipe;
+    });
+    const stderrWrite = vi.fn(() => true);
+    process.stdout.write = stdoutWrite as unknown as typeof process.stdout.write;
+    process.stderr.write = stderrWrite as unknown as typeof process.stderr.write;
+
+    const api = { logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } } as unknown as ClawdbotPluginApi;
+    wrapApiLoggerStderrForJsonCli(api);
+
+    expect(() => process.stdout.write("diagnostic\n")).not.toThrow();
+    expect(stderrWrite).toHaveBeenCalledWith("diagnostic\n");
   });
 });

--- a/extensions/memory-hybrid/tests/json-cli-stdout-clean.test.ts
+++ b/extensions/memory-hybrid/tests/json-cli-stdout-clean.test.ts
@@ -112,7 +112,9 @@ describe("wrapApiLoggerStderrForJsonCli", () => {
     process.stdout.write = stdoutWrite as unknown as typeof process.stdout.write;
     process.stderr.write = stderrWrite as unknown as typeof process.stderr.write;
 
-    const api = { logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } } as unknown as ClawdbotPluginApi;
+    const api = {
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    } as unknown as ClawdbotPluginApi;
     wrapApiLoggerStderrForJsonCli(api);
 
     const result = process.stdout.write(Buffer.from("bootstrap log\n"));
@@ -131,7 +133,9 @@ describe("wrapApiLoggerStderrForJsonCli", () => {
     process.stdout.write = stdoutWrite as unknown as typeof process.stdout.write;
     process.stderr.write = stderrWrite as unknown as typeof process.stderr.write;
 
-    const api = { logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } } as unknown as ClawdbotPluginApi;
+    const api = {
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    } as unknown as ClawdbotPluginApi;
     wrapApiLoggerStderrForJsonCli(api);
 
     const payload = `${JSON.stringify({ ok: true })}\n`;
@@ -149,14 +153,16 @@ describe("wrapApiLoggerStderrForJsonCli", () => {
     process.stdout.write = stdoutWrite as unknown as typeof process.stdout.write;
     process.stderr.write = stderrWrite as unknown as typeof process.stderr.write;
 
-    const api = { logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } } as unknown as ClawdbotPluginApi;
+    const api = {
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    } as unknown as ClawdbotPluginApi;
     wrapApiLoggerStderrForJsonCli(api);
 
     withJsonCliStdoutMirrorSuppressed(() => {
-      process.stdout.write("{\"ok\":true}\n");
+      process.stdout.write('{"ok":true}\n');
     });
 
-    expect(stdoutWrite).toHaveBeenCalledWith("{\"ok\":true}\n");
+    expect(stdoutWrite).toHaveBeenCalledWith('{"ok":true}\n');
     expect(stderrWrite).not.toHaveBeenCalled();
   });
 
@@ -165,7 +171,9 @@ describe("wrapApiLoggerStderrForJsonCli", () => {
     const stdoutWrite = vi.fn(() => true);
     process.stdout.write = stdoutWrite as unknown as typeof process.stdout.write;
 
-    const api = { logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } } as unknown as ClawdbotPluginApi;
+    const api = {
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    } as unknown as ClawdbotPluginApi;
     wrapApiLoggerStderrForJsonCli(api);
     expect(process.stdout.write).not.toBe(stdoutWrite);
 
@@ -185,7 +193,9 @@ describe("wrapApiLoggerStderrForJsonCli", () => {
     process.stdout.write = stdoutWrite as unknown as typeof process.stdout.write;
     process.stderr.write = stderrWrite as unknown as typeof process.stderr.write;
 
-    const api = { logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } } as unknown as ClawdbotPluginApi;
+    const api = {
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    } as unknown as ClawdbotPluginApi;
     wrapApiLoggerStderrForJsonCli(api);
 
     expect(() => process.stdout.write("diagnostic\n")).not.toThrow();

--- a/extensions/memory-hybrid/tests/json-cli-stdout-clean.test.ts
+++ b/extensions/memory-hybrid/tests/json-cli-stdout-clean.test.ts
@@ -159,10 +159,10 @@ describe("wrapApiLoggerStderrForJsonCli", () => {
     wrapApiLoggerStderrForJsonCli(api);
 
     withJsonCliStdoutMirrorSuppressed(() => {
-      process.stdout.write('{"ok":true}\n');
+      process.stdout.write("diagnostic log\n");
     });
 
-    expect(stdoutWrite).toHaveBeenCalledWith('{"ok":true}\n');
+    expect(stdoutWrite).toHaveBeenCalledWith("diagnostic log\n");
     expect(stderrWrite).not.toHaveBeenCalled();
   });
 

--- a/extensions/memory-hybrid/utils/hybrid-mem-json-cli.ts
+++ b/extensions/memory-hybrid/utils/hybrid-mem-json-cli.ts
@@ -54,15 +54,37 @@ function writeToStream(
   callback?: WriteCallback,
 ): boolean {
   if (encoding !== undefined && callback) {
-    return write.call(stream, chunk, encoding, callback);
+    return (
+      write as unknown as (
+        this: Pick<NodeJS.WriteStream, "write">,
+        chunk: WriteChunk,
+        encoding: BufferEncoding,
+        callback: WriteCallback,
+      ) => boolean
+    ).call(stream, chunk, encoding, callback);
   }
   if (encoding !== undefined) {
-    return write.call(stream, chunk, encoding);
+    return (
+      write as unknown as (
+        this: Pick<NodeJS.WriteStream, "write">,
+        chunk: WriteChunk,
+        encoding: BufferEncoding,
+      ) => boolean
+    ).call(stream, chunk, encoding);
   }
   if (callback) {
-    return write.call(stream, chunk, callback);
+    return (
+      write as unknown as (
+        this: Pick<NodeJS.WriteStream, "write">,
+        chunk: WriteChunk,
+        callback: WriteCallback,
+      ) => boolean
+    ).call(stream, chunk, callback);
   }
-  return write.call(stream, chunk);
+  return (write as unknown as (this: Pick<NodeJS.WriteStream, "write">, chunk: WriteChunk) => boolean).call(
+    stream,
+    chunk,
+  );
 }
 
 /**

--- a/extensions/memory-hybrid/utils/hybrid-mem-json-cli.ts
+++ b/extensions/memory-hybrid/utils/hybrid-mem-json-cli.ts
@@ -45,11 +45,7 @@ class TeeStderr {
    */
   tee(): void {
     const originalWrite = this.originalWrite;
-    process.stdout.write = (
-      chunk: unknown,
-      encoding?: BufferEncoding | (() => void),
-      cb?: () => void,
-    ): boolean => {
+    process.stdout.write = (chunk: unknown, encoding?: BufferEncoding | (() => void), cb?: () => void): boolean => {
       const str = typeof chunk === "string" ? chunk : String(chunk);
       originalWrite(str, encoding as BufferEncoding, cb);
       process.stderr.write(str);

--- a/extensions/memory-hybrid/utils/hybrid-mem-json-cli.ts
+++ b/extensions/memory-hybrid/utils/hybrid-mem-json-cli.ts
@@ -21,62 +21,43 @@ export function isHybridMemJsonInvocation(argv: string[]): boolean {
 }
 
 /**
- * Tee write stream that mirrors all writes to both stdout and stderr.
- * Used in JSON mode so diagnostics on stderr are visible AND the JSON
- * document on stdout remains clean for `jq` / cron consumers.
+ * Track whether stdout.write has been modified, for cleanup in teardown.
+ * Note: We no longer tee stdout to stderr (that would duplicate JSON payloads),
+ * but keep this structure for potential future use.
  */
-class TeeStderr {
-  private originalWrite: (chunk: unknown, encoding?: BufferEncoding | (() => void), cb?: () => void) => boolean;
-
-  constructor() {
-    // Capture the original stdout.write before we replace it
-    this.originalWrite = process.stdout.write.bind(process.stdout);
-  }
+class StdoutTracker {
+  private modified = false;
 
   /**
-   * Replace process.stdout.write to tee all output to stderr as well.
-   * This ensures JSON emitted via `console.log` ends up on BOTH stdout and stderr,
-   * so cron harnesses that capture stderr still see the JSON while human operators
-   * can see diagnostics on stderr.
-   *
-   * Issue: #1618 — `hybrid-mem --json` stdout is empty; all output including JSON
-   * goes to stderr. Using a tee so stdout always has the JSON payload even if a
-   * host/process setup redirects stdout away.
+   * Mark that stdout handling has been set up for JSON mode.
+   * Currently a no-op since we don't modify stdout.write anymore.
    */
   tee(): void {
-    const originalWrite = this.originalWrite;
-    process.stdout.write = (chunk: unknown, encoding?: BufferEncoding | (() => void), cb?: () => void): boolean => {
-      const str = typeof chunk === "string" ? chunk : String(chunk);
-      originalWrite(str, encoding as BufferEncoding, cb);
-      process.stderr.write(str);
-      return true;
-    };
+    this.modified = true;
   }
 
   /**
-   * Restore the original stdout.write.
+   * Restore/cleanup after JSON CLI mode.
    */
   restore(): void {
-    process.stdout.write = this.originalWrite;
+    this.modified = false;
   }
 }
 
-const teeStderr = new TeeStderr();
+const stdoutTracker = new StdoutTracker();
 
 /**
  * For hybrid-mem `--json` / `--format json` CLI runs, OpenClaw's default `api.logger` may write
  * telemetry to stdout (e.g. `[plugins] …`), which breaks `jq` and cron harnesses.
- * Also tee stdout→stderr so JSON payloads are visible on stderr as a fallback stream.
+ * Redirect plugin logger output to stderr to keep stdout clean for JSON.
  *
- * Issue: #1618 — the repro showed stdout=0 bytes, all output including JSON on stderr.
- * Teeing stdout→stderr means any JSON written to stdout is ALSO captured on stderr,
- * making the command work regardless of which stream the caller monitors.
+ * Issue: #1618 / JSON-CLI-OUTPUT.md — JSON must stay on stdout only, diagnostics on stderr only.
  */
 export function wrapApiLoggerStderrForJsonCli(api: ClawdbotPluginApi): ClawdbotPluginApi {
   if (!isHybridMemJsonInvocation(process.argv)) return api;
 
-  // Tee stdout→stderr so JSON appears on both streams.
-  teeStderr.tee();
+  // Mark that we're in JSON mode (no actual stdout modification needed).
+  stdoutTracker.tee();
 
   const log = (msg: string) => {
     console.error(msg);
@@ -100,6 +81,6 @@ export function wrapApiLoggerStderrForJsonCli(api: ClawdbotPluginApi): ClawdbotP
  */
 export function restoreStdoutAfterJsonCli(): void {
   if (isHybridMemJsonInvocation(process.argv)) {
-    teeStderr.restore();
+    stdoutTracker.restore();
   }
 }

--- a/extensions/memory-hybrid/utils/hybrid-mem-json-cli.ts
+++ b/extensions/memory-hybrid/utils/hybrid-mem-json-cli.ts
@@ -21,12 +21,66 @@ export function isHybridMemJsonInvocation(argv: string[]): boolean {
 }
 
 /**
+ * Tee write stream that mirrors all writes to both stdout and stderr.
+ * Used in JSON mode so diagnostics on stderr are visible AND the JSON
+ * document on stdout remains clean for `jq` / cron consumers.
+ */
+class TeeStderr {
+  private originalWrite: (chunk: unknown, encoding?: BufferEncoding | (() => void), cb?: () => void) => boolean;
+
+  constructor() {
+    // Capture the original stdout.write before we replace it
+    this.originalWrite = process.stdout.write.bind(process.stdout);
+  }
+
+  /**
+   * Replace process.stdout.write to tee all output to stderr as well.
+   * This ensures JSON emitted via `console.log` ends up on BOTH stdout and stderr,
+   * so cron harnesses that capture stderr still see the JSON while human operators
+   * can see diagnostics on stderr.
+   *
+   * Issue: #1618 — `hybrid-mem --json` stdout is empty; all output including JSON
+   * goes to stderr. Using a tee so stdout always has the JSON payload even if a
+   * host/process setup redirects stdout away.
+   */
+  tee(): void {
+    const originalWrite = this.originalWrite;
+    process.stdout.write = (
+      chunk: unknown,
+      encoding?: BufferEncoding | (() => void),
+      cb?: () => void,
+    ): boolean => {
+      const str = typeof chunk === "string" ? chunk : String(chunk);
+      originalWrite(str, encoding as BufferEncoding, cb);
+      process.stderr.write(str);
+      return true;
+    };
+  }
+
+  /**
+   * Restore the original stdout.write.
+   */
+  restore(): void {
+    process.stdout.write = this.originalWrite;
+  }
+}
+
+const teeStderr = new TeeStderr();
+
+/**
  * For hybrid-mem `--json` / `--format json` CLI runs, OpenClaw's default `api.logger` may write
  * telemetry to stdout (e.g. `[plugins] …`), which breaks `jq` and cron harnesses.
- * Return a shallow copy of `api` whose `logger` methods write only to stderr.
+ * Also tee stdout→stderr so JSON payloads are visible on stderr as a fallback stream.
+ *
+ * Issue: #1618 — the repro showed stdout=0 bytes, all output including JSON on stderr.
+ * Teeing stdout→stderr means any JSON written to stdout is ALSO captured on stderr,
+ * making the command work regardless of which stream the caller monitors.
  */
 export function wrapApiLoggerStderrForJsonCli(api: ClawdbotPluginApi): ClawdbotPluginApi {
   if (!isHybridMemJsonInvocation(process.argv)) return api;
+
+  // Tee stdout→stderr so JSON appears on both streams.
+  teeStderr.tee();
 
   const log = (msg: string) => {
     console.error(msg);
@@ -42,4 +96,14 @@ export function wrapApiLoggerStderrForJsonCli(api: ClawdbotPluginApi): ClawdbotP
       debug: log,
     },
   };
+}
+
+/**
+ * Restore stdout after JSON CLI mode.
+ * Called from performHybridMemCliTeardown.
+ */
+export function restoreStdoutAfterJsonCli(): void {
+  if (isHybridMemJsonInvocation(process.argv)) {
+    teeStderr.restore();
+  }
 }

--- a/extensions/memory-hybrid/utils/hybrid-mem-json-cli.ts
+++ b/extensions/memory-hybrid/utils/hybrid-mem-json-cli.ts
@@ -20,31 +20,147 @@ export function isHybridMemJsonInvocation(argv: string[]): boolean {
   return false;
 }
 
-/**
- * Track whether stdout.write has been modified, for cleanup in teardown.
- * Note: We no longer tee stdout to stderr (that would duplicate JSON payloads),
- * but keep this structure for potential future use.
- */
-class StdoutTracker {
-  private modified = false;
+type WriteChunk = Parameters<NodeJS.WriteStream["write"]>[0];
+type WriteCallback = (error?: Error | null) => void;
 
-  /**
-   * Mark that stdout handling has been set up for JSON mode.
-   * Currently a no-op since we don't modify stdout.write anymore.
-   */
-  tee(): void {
-    this.modified = true;
+const stdoutWriteState: {
+  originalWrite: NodeJS.WriteStream["write"] | null;
+  patched: boolean;
+  suppressMirrorDepth: number;
+  cleanupHooksInstalled: boolean;
+} = {
+  originalWrite: null,
+  patched: false,
+  suppressMirrorDepth: 0,
+  cleanupHooksInstalled: false,
+};
+
+/** Preserve callback semantics for stream.write in both callback and non-callback forms. */
+function resolveWriteArgs(
+  encodingOrCb?: BufferEncoding | WriteCallback,
+  cb?: WriteCallback,
+): { encoding?: BufferEncoding; callback?: WriteCallback } {
+  if (typeof encodingOrCb === "function") {
+    return { callback: encodingOrCb };
   }
+  return { encoding: encodingOrCb, callback: cb };
+}
 
-  /**
-   * Restore/cleanup after JSON CLI mode.
-   */
-  restore(): void {
-    this.modified = false;
+function writeToStream(
+  stream: Pick<NodeJS.WriteStream, "write">,
+  write: NodeJS.WriteStream["write"],
+  chunk: WriteChunk,
+  encoding?: BufferEncoding,
+  callback?: WriteCallback,
+): boolean {
+  if (encoding !== undefined && callback) {
+    return write.call(stream, chunk, encoding, callback);
+  }
+  if (encoding !== undefined) {
+    return write.call(stream, chunk, encoding);
+  }
+  if (callback) {
+    return write.call(stream, chunk, callback);
+  }
+  return write.call(stream, chunk);
+}
+
+/**
+ * Temporarily disable stderr mirroring for the current sync call stack.
+ * Used by JSON CLI output paths so payloads remain stdout-only.
+ */
+export function withJsonCliStdoutMirrorSuppressed<T>(fn: () => T): T {
+  if (!stdoutWriteState.patched) return fn();
+  stdoutWriteState.suppressMirrorDepth += 1;
+  try {
+    return fn();
+  } finally {
+    stdoutWriteState.suppressMirrorDepth = Math.max(0, stdoutWriteState.suppressMirrorDepth - 1);
   }
 }
 
-const stdoutTracker = new StdoutTracker();
+function chunkAsUtf8String(chunk: WriteChunk): string | null {
+  if (typeof chunk === "string") return chunk;
+  if (Buffer.isBuffer(chunk)) return chunk.toString("utf8");
+  if (chunk instanceof Uint8Array) return Buffer.from(chunk).toString("utf8");
+  return null;
+}
+
+function isJsonPayloadChunk(chunk: WriteChunk): boolean {
+  const text = chunkAsUtf8String(chunk)?.trim();
+  if (!text) return false;
+  // Final hybrid-mem JSON output is always an object/array. Do not classify arbitrary
+  // primitives as payloads; diagnostics such as "true" or "123" should still mirror.
+  if (!text.startsWith("{") && !text.startsWith("[")) return false;
+  try {
+    JSON.parse(text);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function shouldMirrorStdoutChunk(chunk: WriteChunk): boolean {
+  if (stdoutWriteState.suppressMirrorDepth > 0) return false;
+  return !isJsonPayloadChunk(chunk);
+}
+
+function mirrorToStderr(chunk: WriteChunk, encoding?: BufferEncoding): void {
+  const stderr = process.stderr;
+  if (!stderr || typeof stderr.write !== "function") return;
+  try {
+    if (encoding !== undefined) {
+      stderr.write(chunk, encoding);
+      return;
+    }
+    stderr.write(chunk);
+  } catch {
+    // Stderr mirroring is best-effort; diagnostics must not make JSON commands fail.
+  }
+}
+
+function installCleanupHooks(): void {
+  if (stdoutWriteState.cleanupHooksInstalled) return;
+  stdoutWriteState.cleanupHooksInstalled = true;
+  process.once("exit", () => {
+    restoreStdoutAfterJsonCli();
+  });
+}
+
+function installStdoutTeeForJsonCli(): void {
+  if (stdoutWriteState.patched) return;
+
+  const originalWrite = process.stdout.write;
+  stdoutWriteState.originalWrite = originalWrite;
+
+  const patchedWrite: NodeJS.WriteStream["write"] = function patched(
+    chunk: WriteChunk,
+    encodingOrCb?: BufferEncoding | WriteCallback,
+    cb?: WriteCallback,
+  ): boolean {
+    const { encoding, callback } = resolveWriteArgs(encodingOrCb, cb);
+
+    let stdoutOk = true;
+    try {
+      stdoutOk = writeToStream(process.stdout, originalWrite, chunk, encoding, callback);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException)?.code !== "EPIPE") {
+        throw err;
+      }
+      stdoutOk = false;
+    }
+
+    if (shouldMirrorStdoutChunk(chunk)) {
+      mirrorToStderr(chunk, encoding);
+    }
+
+    return stdoutOk;
+  };
+
+  process.stdout.write = patchedWrite;
+  stdoutWriteState.patched = true;
+  installCleanupHooks();
+}
 
 /**
  * For hybrid-mem `--json` / `--format json` CLI runs, OpenClaw's default `api.logger` may write
@@ -56,8 +172,10 @@ const stdoutTracker = new StdoutTracker();
 export function wrapApiLoggerStderrForJsonCli(api: ClawdbotPluginApi): ClawdbotPluginApi {
   if (!isHybridMemJsonInvocation(process.argv)) return api;
 
-  // Mark that we're in JSON mode (no actual stdout modification needed).
-  stdoutTracker.tee();
+  // Tee bootstrap/plugin stdout writes to stderr in JSON CLI mode. JSON payload chunks
+  // are detected/suppressed centrally so command implementations do not need bespoke
+  // output plumbing just to preserve the stdout JSON contract.
+  installStdoutTeeForJsonCli();
 
   const log = (msg: string) => {
     console.error(msg);
@@ -77,10 +195,13 @@ export function wrapApiLoggerStderrForJsonCli(api: ClawdbotPluginApi): ClawdbotP
 
 /**
  * Restore stdout after JSON CLI mode.
- * Called from performHybridMemCliTeardown.
+ * Called from performHybridMemCliTeardown and process exit cleanup.
  */
 export function restoreStdoutAfterJsonCli(): void {
-  if (isHybridMemJsonInvocation(process.argv)) {
-    stdoutTracker.restore();
-  }
+  if (!stdoutWriteState.patched || !stdoutWriteState.originalWrite) return;
+
+  process.stdout.write = stdoutWriteState.originalWrite;
+  stdoutWriteState.originalWrite = null;
+  stdoutWriteState.patched = false;
+  stdoutWriteState.suppressMirrorDepth = 0;
 }


### PR DESCRIPTION
## Summary

Fixes the `--json` stdout contamination bug reported in issue #1618.

When `openclaw hybrid-mem goals list --json` runs, all output (including the JSON payload) was found on stderr while stdout was empty. This breaks `jq` consumers that read stdout and cron harnesses that read stderr.

## Root cause

`wrapApiLoggerStderrForJsonCli` existed (#1230/#1234) to route plugin/api logger through stderr, but `console.log(JSON.stringify(...))` in CLI commands still wrote JSON directly to stdout. Depending on host/process setup, stdout could be redirected or closed, making the JSON only visible on stderr.

## Fix

1. **TeeStderr class** — replaces `process.stdout.write` to mirror all stdout output to stderr. JSON written via `console.log` appears on BOTH streams, so any consumer (stdout or stderr) can capture it.

2. **Tee activated in `wrapApiLoggerStderrForJsonCli`** — when `--json` is detected, `teeStderr.tee()` is called before any command runs.

3. **Restore on teardown** — `restoreStdoutAfterJsonCli()` called in `performHybridMemCliTeardown` to restore the original `stdout.write` after the command completes.

4. **Updated `hybrid-mem-json-cli.ts` docstring** — reflects that the tee is a fallback to ensure JSON is visible on stderr as a secondary stream.

## Testing

After this change:
```bash
# stdout will have JSON; stderr will have diagnostics + JSON mirror
timeout 30 openclaw hybrid-mem goals list --json >/tmp/out 2>/tmp/err
python3 -m json.tool </tmp/out  # should parse cleanly
# stderr will have bootstrap logs + JSON mirror
```

`--json` stdout contract is preserved (clean JSON on stdout); stderr contains diagnostics.

---

Fixes #1618

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Patches `process.stdout.write` during JSON CLI runs to mirror non-JSON output to stderr and to restore it on teardown; global stream monkey-patching can have edge-case interactions with other writers despite being gated to `hybrid-mem --json`.
> 
> **Overview**
> Ensures `hybrid-mem --json` keeps **pure JSON on stdout** while still surfacing bootstrap/diagnostic output on stderr by temporarily patching `process.stdout.write` to mirror *non-JSON* chunks to stderr and tolerating `EPIPE`.
> 
> Adds explicit lifecycle cleanup via `restoreStdoutAfterJsonCli()` (called on CLI teardown and process exit) plus an opt-out helper `withJsonCliStdoutMirrorSuppressed()` for code paths that must write stdout-only. Extends the JSON CLI regression tests to cover mirroring behavior, suppression, restoration, and `EPIPE` handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd4562963c25befdd565490ea9d97248d7d1ed82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->