### PR TITLE
fix: TypeError in updateGoalOnSubagentEnd crashes goal lifecycle hook

### DIFF
--- a/extensions/memory-hybrid/lifecycle/stage-goal-subagent.ts
+++ b/extensions/memory-hybrid/lifecycle/stage-goal-subagent.ts
@@ -13,6 +13,18 @@ import {
 import { type SubagentEndedEvent, subagentEndedIsSuccess } from "../utils/subagent-ended-utils.js";
 import type { LifecycleContext } from "./types.js";
 
+function getEventStringField(event: unknown, key: string): string | null {
+  if (!event || typeof event !== "object") return null;
+  const value = (event as Record<string, unknown>)[key];
+  return typeof value === "string" ? value : null;
+}
+
+function getEventBooleanField(event: unknown, key: string): boolean | null {
+  if (!event || typeof event !== "object") return null;
+  const value = (event as Record<string, unknown>)[key];
+  return typeof value === "boolean" ? value : null;
+}
+
 export function registerGoalSubagentHandlers(api: ClawdbotPluginApi, ctx: LifecycleContext, goalsDir: string): void {
   if (!ctx.cfg.goalStewardship.enabled) return;
 
@@ -75,23 +87,11 @@ export function registerGoalSubagentHandlers(api: ClawdbotPluginApi, ctx: Lifecy
       capturePluginError(err instanceof Error ? err : new Error(String(err)), {
         subsystem: "goal-subagent",
         operation: "subagent_ended",
-        eventLabel: typeof (event as { label?: unknown })?.label === "string" ? (event as { label: string }).label : null,
-        eventSessionKey:
-          typeof (event as { sessionKey?: unknown })?.sessionKey === "string"
-            ? (event as { sessionKey: string }).sessionKey
-            : null,
-        eventTargetSessionKey:
-          typeof (event as { targetSessionKey?: unknown })?.targetSessionKey === "string"
-            ? (event as { targetSessionKey: string }).targetSessionKey
-            : null,
-        eventSuccess:
-          typeof (event as { success?: unknown })?.success === "boolean"
-            ? (event as { success: boolean }).success
-            : null,
-        eventOutcome:
-          typeof (event as { outcome?: unknown })?.outcome === "string"
-            ? (event as { outcome: string }).outcome
-            : null,
+        eventLabel: getEventStringField(event, "label"),
+        eventSessionKey: getEventStringField(event, "sessionKey"),
+        eventTargetSessionKey: getEventStringField(event, "targetSessionKey"),
+        eventSuccess: getEventBooleanField(event, "success"),
+        eventOutcome: getEventStringField(event, "outcome"),
       });
     }
   });

--- a/extensions/memory-hybrid/lifecycle/stage-goal-subagent.ts
+++ b/extensions/memory-hybrid/lifecycle/stage-goal-subagent.ts
@@ -75,6 +75,23 @@ export function registerGoalSubagentHandlers(api: ClawdbotPluginApi, ctx: Lifecy
       capturePluginError(err instanceof Error ? err : new Error(String(err)), {
         subsystem: "goal-subagent",
         operation: "subagent_ended",
+        eventLabel: typeof (event as { label?: unknown })?.label === "string" ? (event as { label: string }).label : null,
+        eventSessionKey:
+          typeof (event as { sessionKey?: unknown })?.sessionKey === "string"
+            ? (event as { sessionKey: string }).sessionKey
+            : null,
+        eventTargetSessionKey:
+          typeof (event as { targetSessionKey?: unknown })?.targetSessionKey === "string"
+            ? (event as { targetSessionKey: string }).targetSessionKey
+            : null,
+        eventSuccess:
+          typeof (event as { success?: unknown })?.success === "boolean"
+            ? (event as { success: boolean }).success
+            : null,
+        eventOutcome:
+          typeof (event as { outcome?: unknown })?.outcome === "string"
+            ? (event as { outcome: string }).outcome
+            : null,
       });
     }
   });

--- a/extensions/memory-hybrid/services/goal-health.ts
+++ b/extensions/memory-hybrid/services/goal-health.ts
@@ -4,6 +4,7 @@
 
 import { execFile } from "node:child_process";
 import { existsSync } from "node:fs";
+import { readFile } from "node:fs/promises";
 import { lookup } from "node:dns/promises";
 import { isIP } from "node:net";
 import { isAbsolute, join } from "node:path";
@@ -95,6 +96,19 @@ function extractActionableNext(goal: Goal): string | null {
   if (!next) return null;
   if (/^(none|n\/a|n-a|unknown|tbd)$/i.test(next)) return null;
   return next;
+}
+
+async function findInvalidLinkedTasksReason(goalsDir: string, goalId: string): Promise<string | null> {
+  const path = join(goalsDir, `${goalId}.json`);
+  try {
+    const raw = await readFile(path, "utf-8");
+    const parsed = JSON.parse(raw) as { linkedTasks?: unknown };
+    if (!Object.hasOwn(parsed, "linkedTasks")) return null;
+    if (parsed.linkedTasks === undefined || Array.isArray(parsed.linkedTasks)) return null;
+    return 'Goal file has invalid "linkedTasks" field (expected array).';
+  } catch {
+    return null;
+  }
 }
 
 const SHELL_DENY_RE = /[;&|`$(){}!\n\\<>~#]/;
@@ -372,6 +386,38 @@ export async function runGoalHealthCheck(opts: GoalHealthCheckOptions): Promise<
       let g = await readGoal(goalsDir, goal.id);
       if (!g) {
         recordOutcome("blocked", "Goal state could not be loaded for stewardship processing.");
+        continue;
+      }
+
+      const invalidLinkedTasksReason = await findInvalidLinkedTasksReason(goalsDir, goal.id);
+      if (invalidLinkedTasksReason) {
+        const blockers = g.currentBlockers.includes(invalidLinkedTasksReason)
+          ? g.currentBlockers
+          : [...g.currentBlockers, invalidLinkedTasksReason];
+        await updateGoal(
+          goalsDir,
+          g.id,
+          {
+            status: "blocked",
+            currentBlockers: blockers,
+            lastOutcome: invalidLinkedTasksReason,
+            consecutiveFailures: g.consecutiveFailures + 1,
+          },
+          {
+            timestamp: nowIso(),
+            action: "goal-schema-invalid",
+            detail: invalidLinkedTasksReason,
+            actor: "watchdog",
+          },
+        );
+        result.goalsUpdated++;
+        result.actions.push({
+          goalId: g.id,
+          label: g.label,
+          action: "goal-schema-invalid",
+          reason: invalidLinkedTasksReason,
+        });
+        recordOutcome("blocked", invalidLinkedTasksReason);
         continue;
       }
 

--- a/extensions/memory-hybrid/services/goal-registry.ts
+++ b/extensions/memory-hybrid/services/goal-registry.ts
@@ -160,6 +160,7 @@ export async function rebuildGoalIndex(goalsDir: string): Promise<void> {
 function normalizeGoalJson(g: Goal): Goal {
   return {
     ...g,
+    linkedTasks: Array.isArray(g.linkedTasks) ? g.linkedTasks : [],
     lastBlockerFingerprint: g.lastBlockerFingerprint ?? null,
     sameBlockerStreak: g.sameBlockerStreak ?? 0,
     circuitBreakerLastProgressAssessmentCount: g.circuitBreakerLastProgressAssessmentCount ?? 0,

--- a/extensions/memory-hybrid/services/goal-subagent.ts
+++ b/extensions/memory-hybrid/services/goal-subagent.ts
@@ -184,24 +184,25 @@ export async function updateGoalOnSubagentEnd(
   },
 ): Promise<void> {
   const goals = await listActiveGoals(goalsDir);
-  const matches: Array<{ goal: Goal; taskLabel: string }> = [];
+  const matches: Array<{ goal: Goal; linkedTasks: Goal["linkedTasks"]; taskLabel: string }> = [];
   for (const g of goals) {
+    const linkedTasks = Array.isArray(g.linkedTasks) ? g.linkedTasks : [];
     if (info.sessionKey) {
-      const task = g.linkedTasks.find((t) => t.sessionKey && t.sessionKey === info.sessionKey);
-      if (task) matches.push({ goal: g, taskLabel: task.label });
+      const task = linkedTasks.find((t) => t.sessionKey && t.sessionKey === info.sessionKey);
+      if (task) matches.push({ goal: g, linkedTasks, taskLabel: task.label });
       continue;
     }
-    const task = g.linkedTasks.find((t) => t.label === info.label);
-    if (task) matches.push({ goal: g, taskLabel: task.label });
+    const task = linkedTasks.find((t) => t.label === info.label);
+    if (task) matches.push({ goal: g, linkedTasks, taskLabel: task.label });
   }
   if (matches.length !== 1) {
     return;
   }
-  const { goal: g, taskLabel: matchedTaskLabel } = matches[0];
+  const { goal: g, linkedTasks: existingLinkedTasks, taskLabel: matchedTaskLabel } = matches[0];
 
   const ts = nowIso();
   const newStatus = info.success ? "completed" : "failed";
-  const linkedTasks = g.linkedTasks.map((t) =>
+  const linkedTasks = existingLinkedTasks.map((t) =>
     t.label === matchedTaskLabel
       ? { ...t, status: newStatus, updatedAt: ts, sessionKey: info.sessionKey ?? t.sessionKey }
       : t,

--- a/extensions/memory-hybrid/services/goal-subagent.ts
+++ b/extensions/memory-hybrid/services/goal-subagent.ts
@@ -174,6 +174,10 @@ function allLinkedTasksTerminal(g: Goal): boolean {
   );
 }
 
+function normalizedLinkedTasks(g: Goal): Goal["linkedTasks"] {
+  return Array.isArray(g.linkedTasks) ? g.linkedTasks : [];
+}
+
 export async function updateGoalOnSubagentEnd(
   goalsDir: string,
   info: {
@@ -184,25 +188,25 @@ export async function updateGoalOnSubagentEnd(
   },
 ): Promise<void> {
   const goals = await listActiveGoals(goalsDir);
-  const matches: Array<{ goal: Goal; linkedTasks: Goal["linkedTasks"]; taskLabel: string }> = [];
+  const matches: Array<{ goal: Goal; taskLabel: string }> = [];
   for (const g of goals) {
-    const linkedTasks = Array.isArray(g.linkedTasks) ? g.linkedTasks : [];
+    const linkedTasks = normalizedLinkedTasks(g);
     if (info.sessionKey) {
       const task = linkedTasks.find((t) => t.sessionKey && t.sessionKey === info.sessionKey);
-      if (task) matches.push({ goal: g, linkedTasks, taskLabel: task.label });
+      if (task) matches.push({ goal: g, taskLabel: task.label });
       continue;
     }
     const task = linkedTasks.find((t) => t.label === info.label);
-    if (task) matches.push({ goal: g, linkedTasks, taskLabel: task.label });
+    if (task) matches.push({ goal: g, taskLabel: task.label });
   }
   if (matches.length !== 1) {
     return;
   }
-  const { goal: g, linkedTasks: existingLinkedTasks, taskLabel: matchedTaskLabel } = matches[0];
+  const { goal: g, taskLabel: matchedTaskLabel } = matches[0];
 
   const ts = nowIso();
   const newStatus = info.success ? "completed" : "failed";
-  const linkedTasks = existingLinkedTasks.map((t) =>
+  const linkedTasks = normalizedLinkedTasks(g).map((t) =>
     t.label === matchedTaskLabel
       ? { ...t, status: newStatus, updatedAt: ts, sessionKey: info.sessionKey ?? t.sessionKey }
       : t,

--- a/extensions/memory-hybrid/tests/goal-stewardship-integration.test.ts
+++ b/extensions/memory-hybrid/tests/goal-stewardship-integration.test.ts
@@ -3,7 +3,7 @@
  * No OpenClaw core required — exercises registerGoalStewardshipInjection + registerGoalSubagentHandlers.
  */
 
-import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { ClawdbotPluginApi } from "openclaw/plugin-sdk/core";
@@ -336,6 +336,36 @@ describe("goal stewardship integration (mock plugin API)", () => {
     const after2 = await readGoal(goalsDir, g2.id);
     expect(after1?.linkedTasks.find((t) => t.label === "shared-task")?.status).toBe("in_progress");
     expect(after2?.linkedTasks.find((t) => t.label === "shared-task")?.status).toBe("in_progress");
+  });
+
+  it("subagent_ended ignores goals with missing linkedTasks arrays", async () => {
+    const cfg = parseCfg();
+    const ctx = minimalLifecycleContext(cfg);
+    const api = createMockPluginApi();
+    registerGoalSubagentHandlers(api as unknown as ClawdbotPluginApi, ctx, goalsDir);
+
+    const g = await createGoal(
+      goalsDir,
+      { label: "missing-linked-tasks", description: "legacy goal shape", acceptanceCriteria: ["ok"] },
+      defaults,
+    );
+    const goalPath = join(goalsDir, `${g.id}.json`);
+    const rawGoal = JSON.parse(await readFile(goalPath, "utf-8")) as Record<string, unknown>;
+    delete rawGoal.linkedTasks;
+    await writeFile(goalPath, JSON.stringify(rawGoal, null, 2), "utf-8");
+
+    await expect(
+      api.emitAll("subagent_ended", {
+        label: "legacy-task",
+        targetSessionKey: "legacy-session",
+        success: true,
+        outcome: "success",
+      }),
+    ).resolves.toBeUndefined();
+
+    const afterEnd = await readGoal(goalsDir, g.id);
+    expect(afterEnd?.status).toBe("active");
+    expect(afterEnd?.linkedTasks).toEqual([]);
   });
 
   it("before_agent_start returns undefined when no active goals exist", async () => {


### PR DESCRIPTION
<!-- issue-stewardship-pr issue:1622 -->
Fixes #1622

Issue: https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/1622

Status: draft implementation PR created by Issue Stewardship as Markus/current gh auth.
Protection: keep as draft and `stage/implementing` until Issue Stewardship dispatches/receives implementation and explicitly hands off to PR Stewardship.

Enrichment present on issue: 1
Priority inherited from issue: High (source labels: priority:high)
Dependencies/blocked labels inherited from issue: none

Implementation PR created by Issue Stewardship. Detailed enrichment should be attached to the issue before Copilot implementation dispatch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: changes goal lifecycle/watchdog behavior around `linkedTasks` normalization and may newly block goals with malformed persisted state, which could affect active workflows if incorrect detection occurs.
> 
> **Overview**
> Prevents `subagent_ended` goal updates from crashing when a goal’s persisted `linkedTasks` field is missing or malformed by normalizing it to an empty array before matching/updating tasks.
> 
> Adds schema health handling: the watchdog now detects goal files with an invalid non-array `linkedTasks` field and marks the goal **blocked** with a `goal-schema-invalid` history/action, and error reporting on `subagent_ended` includes selected event fields for easier debugging.
> 
> Extends integration tests to cover legacy goals missing `linkedTasks` and ensure the lifecycle hook no-ops safely.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68a1eccb59002f84f26aa3ebc59e072018b51ea9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->