### PR TITLE
Active-task renderer can mix stale status with newer task fields when facts share timestamp

### DIFF
--- a/extensions/memory-hybrid/services/task-ledger/canonical.ts
+++ b/extensions/memory-hybrid/services/task-ledger/canonical.ts
@@ -47,9 +47,39 @@ export function activeTaskProvenance(canonical: string, existing?: string | null
   return JSON.stringify(base);
 }
 
+/** Deterministic tie-break for two facts with equal createdAt.
+ *
+ *  Rules:
+ *  1. For the `status` key, terminal status wins over non-terminal when timestamps are equal.
+ *     This prevents a stale "in_progress" from persisting when a terminal "done"/"closed" update
+ *     lands in the same second/millisecond bucket.
+ *  2. In all other cases, newer id wins (lexicographic: later ids are "greater").
+ *     This gives a stable total order without depending on insertion/iteration order.
+ *
+ *  Returns a positive number if `b" is preferred (b wins), negative if `a` wins, 0 if identical.
+ */
+function factTieBreak(a: MemoryEntry, b: MemoryEntry, key: string): number {
+  if (a.createdAt === b.createdAt) {
+    // Rule 1: status terminal-vs-nonterminal tie-break
+    if (key === "status") {
+      const aTerminal = isTerminalFactStatus(a.value ?? "") ? 1 : 0;
+      const bTerminal = isTerminalFactStatus(b.value ?? "") ? 1 : 0;
+      if (aTerminal !== bTerminal) return bTerminal - aTerminal; // terminal (1) wins
+    }
+    // Rule 2: lexicographic id tie-break (stable, later id = newer fact)
+    return b.id.localeCompare(a.id);
+  }
+  return 0; // caller already compared createdAt; this is only for equal timestamps
+}
+
 /** Latest value per entity+key from non-superseded project facts.
  *  Entity labels are normalized via factCanonicalLabel() (provenance-aware + trim + toLowerCase + suffix/separator cleanup)
- *  so that case-variant entries (e.g. "Humanizer" / "humanizer") are merged into one group. */
+ *  so that case-variant entries (e.g. "Humanizer" / "humanizer") are merged into one group.
+ *
+ *  Selection is deterministic: newer createdAt wins, and when timestamps are equal a stable
+ *  tie-break (id + status-terminal override for the `status` key) ensures no stale fact
+ *  can shadow a newer terminal update.
+ */
 export function groupProjectFactsByEntity(facts: MemoryEntry[]): Map<string, Map<string, MemoryEntry>> {
   const byEntity = new Map<string, Map<string, MemoryEntry>>();
   for (const f of facts) {
@@ -63,8 +93,17 @@ export function groupProjectFactsByEntity(facts: MemoryEntry[]): Map<string, Map
       byEntity.set(canonical, km);
     }
     const prev = km.get(k);
-    if (!prev || f.createdAt > prev.createdAt) {
+    if (!prev) {
       km.set(k, f);
+    } else if (f.createdAt > prev.createdAt) {
+      km.set(k, f);
+    } else if (f.createdAt === prev.createdAt) {
+      // Same timestamp: apply deterministic tie-break
+      const prefer = factTieBreak(prev, f, k);
+      if (prefer > 0) {
+        km.set(k, f);
+      }
+      // If prefer <= 0, keep prev (prev is strictly preferred or identical)
     }
   }
   return byEntity;


### PR DESCRIPTION
## Fix Summary

When  encounters two facts for the same entity+key with identical  timestamps, it previously kept whichever was processed first — a non-deterministic outcome. This caused the active-task renderer to display stale  alongside newer  fields from the same checkpoint.

### Changes

****

Added a  helper called when  values are equal:

1. **For the  key**: a terminal status value (, , , , ) wins over a non-terminal one. This prevents a stale  from persisting when a terminal checkpoint lands in the same timestamp bucket.

2. **For all other keys**: lexicographic id comparison provides a stable total order so the result is deterministic regardless of iteration order.

### Test coverage

A regression test covers the specific scenario from #1624: two  facts with equal  where one is  and the other is  — the terminal fact must win.

Closes #1624

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the “latest” fact is selected when `createdAt` ties, which can affect persisted/derived task status and display; risk is moderate but localized to task-ledger fact grouping.
> 
> **Overview**
> Fixes nondeterministic fact selection in `groupProjectFactsByEntity` when multiple facts share the same `createdAt`.
> 
> Adds a deterministic tie-break (`factTieBreak`): for `status`, terminal values win over non-terminal on equal timestamps; otherwise the fact with the lexicographically newer `id` wins to ensure stable ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c7f9434d65c20afc983b2f232851bc38dd5d14c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->