### PR TITLE
fix: guard stale hybrid-memory registrations

### DIFF
--- a/extensions/memory-hybrid/api/memory-plugin-api.ts
+++ b/extensions/memory-hybrid/api/memory-plugin-api.ts
@@ -111,6 +111,10 @@ export interface MemoryPluginAPI {
   recallInFlightRef: { value: number };
   /** Last prompt used for before_agent_start recall; used to re-match memories after compaction (#957). */
   lastAutoRecallPromptRef: { value: string | null };
+  /** Monotonic lifecycle registration generation for stale-hook guards. */
+  registrationGeneration?: number;
+  /** Global generation ref updated on each plugin re-registration. */
+  currentRegistrationGenerationRef?: { value: number };
 
   // --- WAL & search (raw; caller binds wal where needed) ---
   walWrite: WalWriteFn;

--- a/extensions/memory-hybrid/api/plugin-runtime.ts
+++ b/extensions/memory-hybrid/api/plugin-runtime.ts
@@ -43,6 +43,7 @@ import type { PythonBridge } from "../services/python-bridge.js";
 import type { AliasDB } from "../services/retrieval-aliases.js";
 import type { VerificationStore } from "../services/verification-store.js";
 import type { LifecycleHooksHandle } from "../setup/register-hooks.js";
+import type { ToolRegistrationHandle } from "../setup/register-tools.js";
 
 /** All mutable per-instance state for the memory-hybrid plugin. */
 export interface PluginRuntime {
@@ -88,6 +89,8 @@ export interface PluginRuntime {
   // --- Lifecycle state ---
   /** Handle returned by registerLifecycleHooks; set after hooks are registered, null until then. */
   lifecycleHooksHandle: LifecycleHooksHandle | null;
+  /** Handle returned by registerTools; set after tool registration, null until then. */
+  toolRegistrationHandle: ToolRegistrationHandle | null;
   /**
    * Resolves when async bootstrap work from `initializeDatabases` finishes (embedding/vault checks, etc.).
    * Used to sequence CLI teardown so we do not close DBs while init I/O is still running (Issue #1039).

--- a/extensions/memory-hybrid/setup/hybrid-memory-generation-state.ts
+++ b/extensions/memory-hybrid/setup/hybrid-memory-generation-state.ts
@@ -1,0 +1,57 @@
+type ToolExecutor = (...args: unknown[]) => unknown;
+
+interface ToolExecutorOwner {
+  generation: number;
+  execute: ToolExecutor;
+}
+
+export interface HybridMemoryRegistrationState {
+  registrationGenerationRef: { value: number };
+  toolExecutorsByName: Map<string, ToolExecutorOwner>;
+}
+
+declare global {
+  // eslint-disable-next-line no-var
+  var __openclawHybridMemoryRegistrationState: HybridMemoryRegistrationState | undefined;
+}
+
+function createHybridMemoryRegistrationState(): HybridMemoryRegistrationState {
+  return {
+    registrationGenerationRef: { value: 0 },
+    toolExecutorsByName: new Map<string, ToolExecutorOwner>(),
+  };
+}
+
+export function getHybridMemoryRegistrationState(): HybridMemoryRegistrationState {
+  globalThis.__openclawHybridMemoryRegistrationState ??= createHybridMemoryRegistrationState();
+  return globalThis.__openclawHybridMemoryRegistrationState;
+}
+
+export function setCurrentToolExecutor(toolName: string, generation: number, execute: ToolExecutor): void {
+  if (!toolName) return;
+  const state = getHybridMemoryRegistrationState();
+  state.toolExecutorsByName.set(toolName, { generation, execute });
+}
+
+export function resolveCurrentToolExecutor(toolName: string, currentGeneration: number): ToolExecutor | null {
+  const state = getHybridMemoryRegistrationState();
+  const owner = state.toolExecutorsByName.get(toolName);
+  if (!owner) return null;
+  if (owner.generation !== currentGeneration) return null;
+  return owner.execute;
+}
+
+export function clearToolExecutorsForGeneration(generation: number): void {
+  const state = getHybridMemoryRegistrationState();
+  for (const [toolName, owner] of state.toolExecutorsByName.entries()) {
+    if (owner.generation === generation) {
+      state.toolExecutorsByName.delete(toolName);
+    }
+  }
+}
+
+export function resetHybridMemoryRegistrationStateForTests(): void {
+  const state = getHybridMemoryRegistrationState();
+  state.registrationGenerationRef.value = 0;
+  state.toolExecutorsByName.clear();
+}

--- a/extensions/memory-hybrid/setup/register-hooks.ts
+++ b/extensions/memory-hybrid/setup/register-hooks.ts
@@ -96,25 +96,33 @@ function emitCompactionModelWatchdogAlert(
  * Returns a handle for cleanup (dispose).
  */
 export function registerLifecycleHooks(ctx: HooksContext, api: ClawdbotPluginApi): LifecycleHooksHandle {
-  const registrationGeneration = ctx.registrationGeneration ?? 0;
-  const currentRegistrationGenerationRef = ctx.currentRegistrationGenerationRef ?? { value: registrationGeneration };
+  const registrationGeneration = ctx.registrationGeneration ?? -1;
+  const currentRegistrationGenerationRef = ctx.currentRegistrationGenerationRef;
+  if (!currentRegistrationGenerationRef) {
+    api.logger.warn?.(
+      "memory-hybrid: lifecycle generation ref missing; stale hooks may not be blocked on re-registration",
+    );
+  }
+  const effectiveRegistrationGenerationRef = currentRegistrationGenerationRef ?? { value: registrationGeneration };
   const hookUnsubscribers: Array<() => void> = [];
-  const registerGuardedHook = (event: unknown, handler: unknown): void => {
-    if (typeof handler !== "function") {
-      (api.on as (eventName: unknown, callback: unknown) => unknown)(event, handler);
-      return;
-    }
-    const guardedHandler = (...args: unknown[]): unknown => {
-      if (currentRegistrationGenerationRef.value !== registrationGeneration) return undefined;
-      return (handler as (...inner: unknown[]) => unknown)(...args);
-    };
-    const unsubscribe = (api.on as (eventName: unknown, callback: unknown) => unknown)(event, guardedHandler);
+  const trackUnsubscribe = (unsubscribe: unknown): void => {
     if (typeof unsubscribe === "function") {
       hookUnsubscribers.push(unsubscribe as () => void);
     }
   };
+  const registerGuardedHook = (event: unknown, handler: unknown): void => {
+    if (typeof handler !== "function") return;
+    const guardedHandler = (...args: unknown[]): unknown => {
+      if (effectiveRegistrationGenerationRef.value !== registrationGeneration) return undefined;
+      return (handler as (...inner: unknown[]) => unknown)(...args);
+    };
+    const unsubscribe = (api.on as (eventName: unknown, callback: unknown) => unknown)(event, guardedHandler);
+    trackUnsubscribe(unsubscribe);
+  };
   const disposeRegisteredHooks = (): void => {
-    for (const unsubscribe of hookUnsubscribers.splice(0)) {
+    const pendingUnsubscribers = [...hookUnsubscribers];
+    hookUnsubscribers.length = 0;
+    for (const unsubscribe of pendingUnsubscribers) {
       try {
         unsubscribe();
       } catch (err) {

--- a/extensions/memory-hybrid/setup/register-hooks.ts
+++ b/extensions/memory-hybrid/setup/register-hooks.ts
@@ -96,6 +96,41 @@ function emitCompactionModelWatchdogAlert(
  * Returns a handle for cleanup (dispose).
  */
 export function registerLifecycleHooks(ctx: HooksContext, api: ClawdbotPluginApi): LifecycleHooksHandle {
+  const registrationGeneration = ctx.registrationGeneration ?? 0;
+  const currentRegistrationGenerationRef = ctx.currentRegistrationGenerationRef ?? { value: registrationGeneration };
+  const hookUnsubscribers: Array<() => void> = [];
+  const registerGuardedHook = (event: unknown, handler: unknown): void => {
+    if (typeof handler !== "function") {
+      (api.on as (eventName: unknown, callback: unknown) => unknown)(event, handler);
+      return;
+    }
+    const guardedHandler = (...args: unknown[]): unknown => {
+      if (currentRegistrationGenerationRef.value !== registrationGeneration) return undefined;
+      return (handler as (...inner: unknown[]) => unknown)(...args);
+    };
+    const unsubscribe = (api.on as (eventName: unknown, callback: unknown) => unknown)(event, guardedHandler);
+    if (typeof unsubscribe === "function") {
+      hookUnsubscribers.push(unsubscribe as () => void);
+    }
+  };
+  const disposeRegisteredHooks = (): void => {
+    for (const unsubscribe of hookUnsubscribers.splice(0)) {
+      try {
+        unsubscribe();
+      } catch (err) {
+        capturePluginError(err instanceof Error ? err : new Error(String(err)), {
+          subsystem: "registration",
+          operation: "register-hooks:unsubscribe",
+          severity: "warning",
+        });
+      }
+    }
+  };
+  const guardedApi = {
+    ...api,
+    on: ((event: unknown, handler: unknown) => registerGuardedHook(event, handler)) as ClawdbotPluginApi["on"],
+  } as ClawdbotPluginApi;
+
   let lifecycleContext: LifecycleContext;
   try {
     lifecycleContext = {
@@ -153,14 +188,15 @@ export function registerLifecycleHooks(ctx: HooksContext, api: ClawdbotPluginApi
     throw err;
   }
   try {
-    hooks.onAgentStart(api);
-    hooks.onAgentEnd(api);
-    hooks.onFrustrationDetect?.(api);
+    hooks.onAgentStart(guardedApi);
+    hooks.onAgentEnd(guardedApi);
+    hooks.onFrustrationDetect?.(guardedApi);
   } catch (err) {
     capturePluginError(err instanceof Error ? err : new Error(String(err)), {
       subsystem: "registration",
       operation: "register-hooks:attach",
     });
+    disposeRegisteredHooks();
     hooks.dispose();
     throw err;
   }
@@ -168,7 +204,7 @@ export function registerLifecycleHooks(ctx: HooksContext, api: ClawdbotPluginApi
   // Inject pending LLM config warnings into the agent's context once per occurrence.
   // Fires when all models in a tier fail due to missing provider API keys, so the AI
   // can relay the issue to the user in its response.
-  api.on("before_prompt_build", (): undefined | { prependContext: string } => {
+  guardedApi.on("before_prompt_build", (): undefined | { prependContext: string } => {
     if (!ctx.pendingLLMWarnings) return;
     const warnings = ctx.pendingLLMWarnings.drain();
     if (warnings.length === 0) return;
@@ -187,7 +223,7 @@ export function registerLifecycleHooks(ctx: HooksContext, api: ClawdbotPluginApi
   // Temporary fix: ensure every tool_use has a tool_result immediately after (Claude API requirement).
   // Strip OpenAI Responses `reasoning` blocks (rs_*) so replay does not 400 (openclaw-maeve#23).
   // Mutates event.historyMessages in place so OpenClaw core uses the sanitized array.
-  api.on("llm_input", (ev: unknown) => {
+  guardedApi.on("llm_input", (ev: unknown) => {
     const event = ev as { historyMessages?: unknown[] };
     if (!event?.historyMessages || !Array.isArray(event.historyMessages)) return;
     let sanitized = sanitizeMessagesForClaude(event.historyMessages as MessageLike[]);
@@ -239,7 +275,7 @@ export function registerLifecycleHooks(ctx: HooksContext, api: ClawdbotPluginApi
     // the prompt build. When a reliable capability signal for `appendSystemContext`
     // becomes available in the plugin SDK, this hook can be extended to prefer that
     // field without risking duplicate instructions.
-    api.on("before_prompt_build", (event: unknown, hookCtx: unknown): undefined | { prependContext: string } => {
+    guardedApi.on("before_prompt_build", (event: unknown, hookCtx: unknown): undefined | { prependContext: string } => {
       if (!staticMemoryInstructions) {
         staticMemoryInstructions = buildStaticInstructions();
       }
@@ -265,7 +301,7 @@ export function registerLifecycleHooks(ctx: HooksContext, api: ClawdbotPluginApi
   // Feature detection: if the hook name is not recognised by this OpenClaw version
   // the api.on() call will silently no-op (unknown hooks are ignored by the registry).
   try {
-    api.on("before_compaction", async (event: unknown, hookCtx: unknown) => {
+    guardedApi.on("before_compaction", async (event: unknown, hookCtx: unknown) => {
       const ev = event as {
         messageCount?: number;
         tokenCount?: number;
@@ -358,7 +394,7 @@ export function registerLifecycleHooks(ctx: HooksContext, api: ClawdbotPluginApi
   // WAL flush before compaction-style work is handled solely by `before_compaction` above (runPreConsolidationFlush).
 
   try {
-    api.on(
+    guardedApi.on(
       "after_compaction",
       async (event: unknown, hookCtx: unknown): Promise<undefined | { prependContext: string }> => {
         const ev = event as {
@@ -494,7 +530,13 @@ export function registerLifecycleHooks(ctx: HooksContext, api: ClawdbotPluginApi
   // The hooks update ctx.currentAgentId and ctx.lastProgressiveIndexIds internally.
 
   // Issue #463: Return handle for cleanup
+  let disposed = false;
   return {
-    dispose: hooks.dispose,
+    dispose: () => {
+      if (disposed) return;
+      disposed = true;
+      disposeRegisteredHooks();
+      hooks.dispose();
+    },
   };
 }

--- a/extensions/memory-hybrid/setup/register-plugin.ts
+++ b/extensions/memory-hybrid/setup/register-plugin.ts
@@ -28,6 +28,7 @@ import {
   applyGatewayEmbeddingInheritanceBeforeParse,
   shallowClonePluginConfigForGatewayMerge,
 } from "./provider-router.js";
+import { getHybridMemoryRegistrationState } from "./hybrid-memory-generation-state.js";
 import { registerContextEngineBestEffort } from "./register-context-engine.js";
 import { registerLifecycleHooks } from "./register-hooks.js";
 import { registerTools } from "./register-tools.js";
@@ -60,7 +61,7 @@ function detectCategory(text: string): MemoryCategory {
 }
 
 const runtimeRef: { value: PluginRuntime | null } = { value: null };
-const registrationGenerationRef: { value: number } = { value: 0 };
+const registrationGenerationRef = getHybridMemoryRegistrationState().registrationGenerationRef;
 
 /** Release DBs and timers after a `hybrid-mem` CLI command so the Node process can exit (Issue #1039). */
 async function performHybridMemCliTeardown(): Promise<void> {
@@ -84,6 +85,14 @@ async function performHybridMemCliTeardown(): Promise<void> {
     capturePluginError(err instanceof Error ? err : new Error(String(err)), {
       subsystem: "cli",
       operation: "hybrid-mem-teardown:dispose-hooks",
+    });
+  }
+  try {
+    r.toolRegistrationHandle?.dispose();
+  } catch (err) {
+    capturePluginError(err instanceof Error ? err : new Error(String(err)), {
+      subsystem: "cli",
+      operation: "hybrid-mem-teardown:dispose-tools",
     });
   }
   try {
@@ -185,6 +194,8 @@ export function runMemoryHybridRegister(api: ClawdbotPluginApi): void {
     clearRuntimeTimers(old.timers);
     // Issue #463: Dispose lifecycle hooks (stale session sweep timer, per-session state)
     old.lifecycleHooksHandle?.dispose();
+    // Dispose tool registrations when API exposes unregister/dispose handles.
+    old.toolRegistrationHandle?.dispose();
     // Close SQLite/Lance and related stores before opening new connections (issue #802 — same paths must not be double-opened).
     closeOldDatabases({
       factsDb: old.factsDb,
@@ -363,6 +374,7 @@ export function runMemoryHybridRegister(api: ClawdbotPluginApi): void {
     auditStore,
     agentHealthStore,
     lifecycleHooksHandle: null, // set after registerLifecycleHooks below
+    toolRegistrationHandle: null, // set after registerTools below
     bootstrapAsyncInit: dbContext.initialized,
     pendingLLMWarnings: createPendingLLMWarnings(),
     currentAgentIdRef: { value: null },
@@ -428,7 +440,7 @@ export function runMemoryHybridRegister(api: ClawdbotPluginApi): void {
   // Tools
 
   try {
-    registerTools(pluginContext, logApi);
+    runtime.toolRegistrationHandle = registerTools(pluginContext, logApi);
   } catch (err) {
     capturePluginError(err instanceof Error ? err : new Error(String(err)), {
       subsystem: "registration",

--- a/extensions/memory-hybrid/setup/register-plugin.ts
+++ b/extensions/memory-hybrid/setup/register-plugin.ts
@@ -60,6 +60,7 @@ function detectCategory(text: string): MemoryCategory {
 }
 
 const runtimeRef: { value: PluginRuntime | null } = { value: null };
+const registrationGenerationRef: { value: number } = { value: 0 };
 
 /** Release DBs and timers after a `hybrid-mem` CLI command so the Node process can exit (Issue #1039). */
 async function performHybridMemCliTeardown(): Promise<void> {
@@ -175,6 +176,9 @@ export function runMemoryHybridRegister(api: ClawdbotPluginApi): void {
     });
     throw err;
   }
+
+  const registrationGeneration = registrationGenerationRef.value + 1;
+  registrationGenerationRef.value = registrationGeneration;
 
   if (old) {
     // Clear old timer handles to prevent leaks.
@@ -400,6 +404,8 @@ export function runMemoryHybridRegister(api: ClawdbotPluginApi): void {
     restartPendingClearedRef: runtime.restartPendingClearedRef,
     recallInFlightRef: runtime.recallInFlightRef,
     lastAutoRecallPromptRef: runtime.lastAutoRecallPromptRef,
+    registrationGeneration,
+    currentRegistrationGenerationRef: registrationGenerationRef,
     pendingLLMWarnings: runtime.pendingLLMWarnings,
     resolvedSqlitePath: runtime.resolvedSqlitePath,
     timers: { proposalsPruneTimer: runtime.timers.proposalsPruneTimer },

--- a/extensions/memory-hybrid/setup/register-tools.ts
+++ b/extensions/memory-hybrid/setup/register-tools.ts
@@ -45,7 +45,11 @@ function collectUnregister(disposeCandidates: Array<() => void>, registrationRes
   }
 }
 
-function buildStaleToolSafeResult(toolName: string, ownerGeneration: number, currentGeneration: number): {
+function buildStaleToolSafeResult(
+  toolName: string,
+  ownerGeneration: number,
+  currentGeneration: number,
+): {
   content: Array<{ type: "text"; text: string }>;
   details: Record<string, unknown>;
 } {

--- a/extensions/memory-hybrid/setup/register-tools.ts
+++ b/extensions/memory-hybrid/setup/register-tools.ts
@@ -10,7 +10,142 @@
  */
 
 import type { ClawdbotPluginApi } from "openclaw/plugin-sdk/core";
+import { capturePluginError } from "../services/error-reporter.js";
+import {
+  clearToolExecutorsForGeneration,
+  resolveCurrentToolExecutor,
+  setCurrentToolExecutor,
+} from "./hybrid-memory-generation-state.js";
 import { type ToolsContext, toolInstallers } from "./tool-installers.js";
+
+export interface ToolRegistrationHandle {
+  dispose: () => void;
+}
+
+function normalizeToolName(definition: unknown): string | null {
+  if (!definition || typeof definition !== "object") return null;
+  const name = (definition as { name?: unknown }).name;
+  if (typeof name !== "string") return null;
+  const normalized = name.trim();
+  return normalized.length > 0 ? normalized : null;
+}
+
+function collectUnregister(disposeCandidates: Array<() => void>, registrationResult: unknown): void {
+  if (typeof registrationResult === "function") {
+    disposeCandidates.push(registrationResult as () => void);
+    return;
+  }
+  if (!registrationResult || typeof registrationResult !== "object") return;
+  if (typeof (registrationResult as { dispose?: unknown }).dispose === "function") {
+    disposeCandidates.push(() => (registrationResult as { dispose: () => void }).dispose());
+    return;
+  }
+  if (typeof (registrationResult as { unregister?: unknown }).unregister === "function") {
+    disposeCandidates.push(() => (registrationResult as { unregister: () => void }).unregister());
+  }
+}
+
+function buildStaleToolSafeResult(toolName: string, ownerGeneration: number, currentGeneration: number): {
+  content: Array<{ type: "text"; text: string }>;
+  details: Record<string, unknown>;
+} {
+  return {
+    content: [
+      {
+        type: "text",
+        text:
+          `memory-hybrid: skipped stale tool registration for "${toolName}" ` +
+          `(generation ${ownerGeneration}, current ${currentGeneration})`,
+      },
+    ],
+    details: {
+      ok: false,
+      staleRegistration: true,
+      delegated: false,
+      skipped: true,
+      tool: toolName,
+      registrationGeneration: ownerGeneration,
+      currentGeneration,
+    },
+  };
+}
+
+export function createGenerationGuardedToolsApi(
+  ctx: Pick<ToolsContext, "registrationGeneration" | "currentRegistrationGenerationRef">,
+  api: ClawdbotPluginApi,
+): { api: ClawdbotPluginApi; handle: ToolRegistrationHandle } {
+  const ownerGeneration = ctx.registrationGeneration ?? ctx.currentRegistrationGenerationRef?.value ?? -1;
+  const generationRef = ctx.currentRegistrationGenerationRef ?? { value: ownerGeneration };
+  const baseRegisterTool = api.registerTool.bind(api) as (...args: unknown[]) => unknown;
+  const disposeCandidates: Array<() => void> = [];
+  let disposed = false;
+
+  const guardedRegisterTool = (...args: unknown[]): unknown => {
+    const [definition, options] = args as [{ execute?: unknown } | undefined, unknown];
+    const toolName = normalizeToolName(definition);
+    if (!definition || typeof definition !== "object" || typeof definition.execute !== "function" || !toolName) {
+      const registrationResult = baseRegisterTool(...args);
+      collectUnregister(disposeCandidates, registrationResult);
+      return registrationResult;
+    }
+
+    const originalExecute = definition.execute as (...executeArgs: unknown[]) => unknown;
+    const guardedExecute = (...executeArgs: unknown[]): unknown => {
+      const currentGeneration = generationRef.value;
+      if (currentGeneration === ownerGeneration) {
+        return originalExecute(...executeArgs);
+      }
+
+      const delegatedExecute = resolveCurrentToolExecutor(toolName, currentGeneration);
+      if (delegatedExecute) {
+        api.logger.debug?.(
+          `memory-hybrid: stale tool "${toolName}" generation ${ownerGeneration} delegated to ${currentGeneration}`,
+        );
+        return delegatedExecute(...executeArgs);
+      }
+
+      api.logger.warn?.(
+        `memory-hybrid: stale tool "${toolName}" generation ${ownerGeneration} has no delegate for current generation ${currentGeneration}; skipping`,
+      );
+      return buildStaleToolSafeResult(toolName, ownerGeneration, currentGeneration);
+    };
+
+    const guardedDefinition = { ...definition, execute: guardedExecute };
+    const registrationResult = baseRegisterTool(guardedDefinition, options);
+    setCurrentToolExecutor(toolName, ownerGeneration, guardedExecute);
+    collectUnregister(disposeCandidates, registrationResult);
+    return registrationResult;
+  };
+
+  const guardedApi = {
+    ...api,
+    registerTool: guardedRegisterTool as ClawdbotPluginApi["registerTool"],
+  } as ClawdbotPluginApi;
+
+  return {
+    api: guardedApi,
+    handle: {
+      dispose: () => {
+        if (disposed) return;
+        disposed = true;
+        const pendingDisposers = [...disposeCandidates];
+        disposeCandidates.length = 0;
+        for (const dispose of pendingDisposers) {
+          try {
+            dispose();
+          } catch (err) {
+            capturePluginError(err instanceof Error ? err : new Error(String(err)), {
+              subsystem: "registration",
+              operation: "register-tools:dispose-tool",
+              severity: "warning",
+            });
+          }
+        }
+        clearToolExecutorsForGeneration(ownerGeneration);
+      },
+    },
+  };
+}
 
 /** Tool registration receives the stable plugin API (Phase 3). */
 /**
@@ -20,8 +155,10 @@ import { type ToolsContext, toolInstallers } from "./tool-installers.js";
  * Tool `name` strings must satisfy provider schemas (e.g. Anthropic:
  * `^[a-zA-Z0-9_-]{1,128}$` — letters, digits, underscore, hyphen only; no dots).
  */
-export function registerTools(ctx: ToolsContext, api: ClawdbotPluginApi): void {
+export function registerTools(ctx: ToolsContext, api: ClawdbotPluginApi): ToolRegistrationHandle {
+  const { api: guardedApi, handle } = createGenerationGuardedToolsApi(ctx, api);
   for (const installer of toolInstallers) {
-    installer.install(installer.selectContext(ctx, api), api);
+    installer.install(installer.selectContext(ctx, guardedApi), guardedApi);
   }
+  return handle;
 }

--- a/extensions/memory-hybrid/tests/plugin-lifecycle-registration.test.ts
+++ b/extensions/memory-hybrid/tests/plugin-lifecycle-registration.test.ts
@@ -7,6 +7,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { FactsDB } from "../backends/facts-db.js";
+import { runCaptureStage } from "../lifecycle/stage-capture.js";
 import { registerLifecycleHooks } from "../setup/register-hooks.js";
 import { buildGuardTestConfig, buildGuardTestLifecycleContext } from "./helpers/lifecycle-hook-harness.js";
 
@@ -68,6 +69,8 @@ describe("registerLifecycleHooks", () => {
       runReflection: vi.fn(),
       runReflectionRules: vi.fn(),
       runReflectionMeta: vi.fn(),
+      registrationGeneration: 1,
+      currentRegistrationGenerationRef: { value: 1 },
     };
 
     const handle = registerLifecycleHooks(pluginApi as never, api as never);
@@ -75,5 +78,79 @@ describe("registerLifecycleHooks", () => {
     const events = (api.on as ReturnType<typeof vi.fn>).mock.calls.map((c) => c[0]);
     expect(events).toContain("agent_end");
     expect(handle.dispose).toBeTypeOf("function");
+  });
+
+  it("stale generation hooks no-op and dispose unsubscribes all handlers", async () => {
+    const lifecycleCtx = buildGuardTestLifecycleContext(tmpDir, factsDb);
+    const cfg = buildGuardTestConfig(tmpDir);
+    const currentRegistrationGenerationRef = { value: 1 };
+    const unsubscribers: Array<ReturnType<typeof vi.fn>> = [];
+    const api = {
+      on: vi.fn((event: string, handler: unknown) => {
+        void event;
+        void handler;
+        const unsubscribe = vi.fn();
+        unsubscribers.push(unsubscribe);
+        return unsubscribe;
+      }),
+      logger: { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() },
+      context: { sessionId: "e2e-session", sessionKey: "e2e-session", agentId: "e2e-agent" },
+    };
+    const pluginApi = {
+      ...lifecycleCtx,
+      cfg,
+      embeddingRegistry: null,
+      credentialsDb: null,
+      aliasDb: null,
+      wal: null,
+      proposalsDb: null,
+      eventLog: null,
+      narrativesDb: null,
+      workflowStore: null,
+      issueStore: null,
+      crystallizationStore: null,
+      toolProposalStore: null,
+      verificationStore: null,
+      variantQueue: null,
+      pythonBridge: null,
+      apitapStore: null,
+      auditStore: null,
+      agentHealthStore: null,
+      provenanceService: null,
+      timers: { proposalsPruneTimer: { value: null } },
+      buildToolScopeFilter: () => undefined,
+      runReflection: vi.fn(),
+      runReflectionRules: vi.fn(),
+      runReflectionMeta: vi.fn(),
+      registrationGeneration: 1,
+      currentRegistrationGenerationRef,
+    };
+
+    const captureMock = vi.mocked(runCaptureStage);
+    captureMock.mockClear();
+    const handle = registerLifecycleHooks(pluginApi as never, api as never);
+    const agentEndCall = (api.on as ReturnType<typeof vi.fn>).mock.calls.find((c) => c[0] === "agent_end");
+    expect(agentEndCall?.[1]).toBeTypeOf("function");
+    const agentEndHandler = agentEndCall?.[1] as ((event: unknown, hookCtx: unknown) => Promise<unknown>) | undefined;
+    expect(agentEndHandler).toBeDefined();
+
+    await agentEndHandler?.(
+      { messages: [], success: true, sessionKey: "e2e-session", sessionId: "e2e-session" },
+      { sessionKey: "e2e-session", sessionId: "e2e-session", agentId: "e2e-agent" },
+    );
+    expect(captureMock).toHaveBeenCalledTimes(1);
+
+    currentRegistrationGenerationRef.value = 2;
+    await agentEndHandler?.(
+      { messages: [], success: true, sessionKey: "e2e-session", sessionId: "e2e-session" },
+      { sessionKey: "e2e-session", sessionId: "e2e-session", agentId: "e2e-agent" },
+    );
+    expect(captureMock).toHaveBeenCalledTimes(1);
+
+    handle.dispose();
+    expect(unsubscribers.length).toBeGreaterThan(0);
+    for (const unsubscribe of unsubscribers) {
+      expect(unsubscribe).toHaveBeenCalledTimes(1);
+    }
   });
 });

--- a/extensions/memory-hybrid/tests/plugin-lifecycle-registration.test.ts
+++ b/extensions/memory-hybrid/tests/plugin-lifecycle-registration.test.ts
@@ -84,11 +84,9 @@ describe("registerLifecycleHooks", () => {
     const lifecycleCtx = buildGuardTestLifecycleContext(tmpDir, factsDb);
     const cfg = buildGuardTestConfig(tmpDir);
     const currentRegistrationGenerationRef = { value: 1 };
-    const unsubscribers: Array<ReturnType<typeof vi.fn>> = [];
+    const unsubscribers: Array<() => void> = [];
     const api = {
-      on: vi.fn((event: string, handler: unknown) => {
-        void event;
-        void handler;
+      on: vi.fn((_event: string, _handler: unknown) => {
         const unsubscribe = vi.fn();
         unsubscribers.push(unsubscribe);
         return unsubscribe;

--- a/extensions/memory-hybrid/tests/tool-registration-generation-guard.test.ts
+++ b/extensions/memory-hybrid/tests/tool-registration-generation-guard.test.ts
@@ -158,10 +158,9 @@ describe("tool registration generation guard", () => {
       api as never,
     );
     registration.api.registerTool({ name: "memory_recall", execute: vi.fn() } as never, { name: "memory_recall" });
-    registration.api.registerTool(
-      { name: "active_task_checkpoint", execute: vi.fn() } as never,
-      { name: "active_task_checkpoint" },
-    );
+    registration.api.registerTool({ name: "active_task_checkpoint", execute: vi.fn() } as never, {
+      name: "active_task_checkpoint",
+    });
     registration.api.registerTool({ name: "memory_store", execute: vi.fn() } as never, { name: "memory_store" });
     expect(getHybridMemoryRegistrationState().toolExecutorsByName.size).toBeGreaterThan(0);
 

--- a/extensions/memory-hybrid/tests/tool-registration-generation-guard.test.ts
+++ b/extensions/memory-hybrid/tests/tool-registration-generation-guard.test.ts
@@ -1,0 +1,189 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getHybridMemoryRegistrationState,
+  resetHybridMemoryRegistrationStateForTests,
+} from "../setup/hybrid-memory-generation-state.js";
+import { createGenerationGuardedToolsApi } from "../setup/register-tools.js";
+
+type RegisteredTool = {
+  name: string;
+  execute: (...args: unknown[]) => unknown;
+};
+
+function makeRegisterToolApi(registerToolImpl?: (tool: RegisteredTool, options?: unknown) => unknown): {
+  api: {
+    registerTool: (tool: RegisteredTool, options?: unknown) => unknown;
+    logger: { debug: ReturnType<typeof vi.fn>; warn: ReturnType<typeof vi.fn> };
+  };
+  tools: RegisteredTool[];
+} {
+  const tools: RegisteredTool[] = [];
+  const registerTool = vi.fn((tool: RegisteredTool, options?: unknown) => {
+    tools.push(tool);
+    if (registerToolImpl) return registerToolImpl(tool, options);
+    return undefined;
+  });
+  return {
+    api: {
+      registerTool,
+      logger: { debug: vi.fn(), warn: vi.fn() },
+    },
+    tools,
+  };
+}
+
+describe("tool registration generation guard", () => {
+  beforeEach(() => {
+    resetHybridMemoryRegistrationStateForTests();
+  });
+
+  afterEach(() => {
+    resetHybridMemoryRegistrationStateForTests();
+  });
+
+  it("delegates stale memory_recall and active_task_checkpoint executors to current generation", async () => {
+    const state = getHybridMemoryRegistrationState();
+    const { api, tools } = makeRegisterToolApi();
+
+    state.registrationGenerationRef.value = 1;
+    const oldRecallExecute = vi.fn(async () => {
+      throw new Error("The database connection is not open");
+    });
+    const oldCheckpointExecute = vi.fn(async () => {
+      throw new Error("The database connection is not open");
+    });
+
+    const oldRegistration = createGenerationGuardedToolsApi(
+      {
+        registrationGeneration: 1,
+        currentRegistrationGenerationRef: state.registrationGenerationRef,
+      },
+      api as never,
+    );
+    oldRegistration.api.registerTool({ name: "memory_recall", execute: oldRecallExecute } as never, {
+      name: "memory_recall",
+    });
+    oldRegistration.api.registerTool({ name: "active_task_checkpoint", execute: oldCheckpointExecute } as never, {
+      name: "active_task_checkpoint",
+    });
+
+    const staleRecallExecute = tools.find((tool) => tool.name === "memory_recall")?.execute;
+    const staleCheckpointExecute = tools.find((tool) => tool.name === "active_task_checkpoint")?.execute;
+    expect(staleRecallExecute).toBeTypeOf("function");
+    expect(staleCheckpointExecute).toBeTypeOf("function");
+
+    state.registrationGenerationRef.value = 2;
+    const newRecallResult = { content: [{ type: "text", text: "new recall generation" }] };
+    const newCheckpointResult = { content: [{ type: "text", text: "new checkpoint generation" }] };
+    const newRecallExecute = vi.fn(async () => newRecallResult);
+    const newCheckpointExecute = vi.fn(async () => newCheckpointResult);
+
+    const newRegistration = createGenerationGuardedToolsApi(
+      {
+        registrationGeneration: 2,
+        currentRegistrationGenerationRef: state.registrationGenerationRef,
+      },
+      api as never,
+    );
+    newRegistration.api.registerTool({ name: "memory_recall", execute: newRecallExecute } as never, {
+      name: "memory_recall",
+    });
+    newRegistration.api.registerTool({ name: "active_task_checkpoint", execute: newCheckpointExecute } as never, {
+      name: "active_task_checkpoint",
+    });
+
+    await expect(staleRecallExecute?.("old-call", {})).resolves.toEqual(newRecallResult);
+    await expect(staleCheckpointExecute?.("old-call", {})).resolves.toEqual(newCheckpointResult);
+    expect(oldRecallExecute).not.toHaveBeenCalled();
+    expect(oldCheckpointExecute).not.toHaveBeenCalled();
+    expect(newRecallExecute).toHaveBeenCalledTimes(1);
+    expect(newCheckpointExecute).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns safe stale result when delegation target is unavailable", async () => {
+    const state = getHybridMemoryRegistrationState();
+    const { api, tools } = makeRegisterToolApi();
+
+    state.registrationGenerationRef.value = 1;
+    const oldExecute = vi.fn(async () => {
+      throw new Error("The database connection is not open");
+    });
+
+    const registration = createGenerationGuardedToolsApi(
+      {
+        registrationGeneration: 1,
+        currentRegistrationGenerationRef: state.registrationGenerationRef,
+      },
+      api as never,
+    );
+    registration.api.registerTool({ name: "memory_recall", execute: oldExecute } as never, { name: "memory_recall" });
+
+    const staleExecute = tools.find((tool) => tool.name === "memory_recall")?.execute;
+    expect(staleExecute).toBeTypeOf("function");
+
+    state.registrationGenerationRef.value = 2;
+    const result = await staleExecute?.("old-call", {});
+    expect(oldExecute).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      content: [{ type: "text" }],
+      details: {
+        staleRegistration: true,
+        delegated: false,
+        skipped: true,
+        tool: "memory_recall",
+        registrationGeneration: 1,
+        currentGeneration: 2,
+      },
+    });
+  });
+
+  it("disposes unregister handles returned by registerTool and clears generation executors", () => {
+    const state = getHybridMemoryRegistrationState();
+    const disposeFn = vi.fn();
+    const unregisterFn = vi.fn();
+    const { api } = makeRegisterToolApi((_tool, options) => {
+      const name = (options as { name?: string } | undefined)?.name;
+      if (name === "memory_recall") return disposeFn;
+      if (name === "active_task_checkpoint") return { dispose: disposeFn };
+      if (name === "memory_store") return { unregister: unregisterFn };
+      return undefined;
+    });
+
+    state.registrationGenerationRef.value = 3;
+    const registration = createGenerationGuardedToolsApi(
+      {
+        registrationGeneration: 3,
+        currentRegistrationGenerationRef: state.registrationGenerationRef,
+      },
+      api as never,
+    );
+    registration.api.registerTool({ name: "memory_recall", execute: vi.fn() } as never, { name: "memory_recall" });
+    registration.api.registerTool(
+      { name: "active_task_checkpoint", execute: vi.fn() } as never,
+      { name: "active_task_checkpoint" },
+    );
+    registration.api.registerTool({ name: "memory_store", execute: vi.fn() } as never, { name: "memory_store" });
+    expect(getHybridMemoryRegistrationState().toolExecutorsByName.size).toBeGreaterThan(0);
+
+    registration.handle.dispose();
+    expect(disposeFn).toHaveBeenCalledTimes(2);
+    expect(unregisterFn).toHaveBeenCalledTimes(1);
+    expect(getHybridMemoryRegistrationState().toolExecutorsByName.size).toBe(0);
+
+    registration.handle.dispose();
+    expect(disposeFn).toHaveBeenCalledTimes(2);
+    expect(unregisterFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps generation state on globalThis across module reload", async () => {
+    vi.resetModules();
+    const moduleA = await import("../setup/hybrid-memory-generation-state.js");
+    moduleA.resetHybridMemoryRegistrationStateForTests();
+    moduleA.getHybridMemoryRegistrationState().registrationGenerationRef.value = 41;
+
+    vi.resetModules();
+    const moduleB = await import("../setup/hybrid-memory-generation-state.js");
+    expect(moduleB.getHybridMemoryRegistrationState().registrationGenerationRef.value).toBe(41);
+    moduleB.resetHybridMemoryRegistrationStateForTests();
+  });
+});


### PR DESCRIPTION
<!-- issue-stewardship-pr issue:1629 -->
Fixes #1629

Issue: https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/1629

Status: draft implementation PR created by Issue Stewardship as Markus/current gh auth.
Protection: keep as draft and `stage/implementing` until Issue Stewardship dispatches/receives implementation and explicitly hands off to PR Stewardship.

Enrichment present on issue: 1
Priority inherited from issue: High (source labels: priority:high)
Dependencies/blocked labels inherited from issue: none

Implementation PR created by Issue Stewardship. Detailed enrichment should be attached to the issue before Copilot implementation dispatch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes plugin registration/lifecycle behavior (event hook wiring and tool execution delegation) and adds new global generation state that affects hot-reload and teardown paths.
> 
> **Overview**
> Prevents **stale `memory-hybrid` registrations** (e.g. after hot-reload/re-register) from continuing to run against closed DB handles by introducing a monotonic `registrationGeneration` and guarding both lifecycle hooks and tool executors.
> 
> Lifecycle hook registration now wraps `api.on` handlers so they no-op when their generation is stale, tracks unsubscribe functions for cleanup, and makes `dispose()` idempotent. Tool registration now returns a `ToolRegistrationHandle`, wraps `registerTool` to delegate stale tool `execute` calls to the current generation (or return a safe “stale registration” result), and cleans up stored executors on dispose; `register-plugin` and CLI teardown now dispose tool registrations on reload/exit. Includes new tests covering stale-hook no-op/unsubscribe behavior and tool delegation/disposal across generations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a847d5f954197fe00f372cd874a5b4236c5819d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->