### PR TITLE
feat: Safely auto-resolve stale project-state contradictions (#1636)

### DIFF
--- a/extensions/memory-hybrid/backends/facts-db/contradictions.ts
+++ b/extensions/memory-hybrid/backends/facts-db/contradictions.ts
@@ -344,8 +344,7 @@ export function resolveContradictionsAuto(
     const newIsFromUser = resolvedNew.source === "conversation" || resolvedNew.source === "cli";
 
     if (newIsNewer && newIsHigherConf && newIsFromUser) {
-      const superseded = supersede(c.factIdOld, c.factIdNew);
-      if (superseded) {
+      if (resolvedOld.supersededAt != null) {
         resolveContradiction(db, c.id, "superseded");
         autoResolved.push({
           contradictionId: c.id,
@@ -353,11 +352,21 @@ export function resolveContradictionsAuto(
           factIdOld: c.factIdOld,
         });
       } else {
-        ambiguous.push({
-          contradictionId: c.id,
-          factIdNew: c.factIdNew,
-          factIdOld: c.factIdOld,
-        });
+        const superseded = supersede(c.factIdOld, c.factIdNew);
+        if (superseded) {
+          resolveContradiction(db, c.id, "superseded");
+          autoResolved.push({
+            contradictionId: c.id,
+            factIdNew: c.factIdNew,
+            factIdOld: c.factIdOld,
+          });
+        } else {
+          ambiguous.push({
+            contradictionId: c.id,
+            factIdNew: c.factIdNew,
+            factIdOld: c.factIdOld,
+          });
+        }
       }
     } else {
       ambiguous.push({
@@ -582,10 +591,15 @@ export function resolveProjectStateLww(
     });
 
     if (!dryRun && action === "supersede") {
-      const superseded = supersede(c.factIdOld, c.factIdNew);
-      if (superseded) {
+      if (oldFact.supersededAt != null) {
         resolveContradiction(db, c.id, "superseded");
         applied++;
+      } else {
+        const superseded = supersede(c.factIdOld, c.factIdNew);
+        if (superseded) {
+          resolveContradiction(db, c.id, "superseded");
+          applied++;
+        }
       }
     }
   }

--- a/extensions/memory-hybrid/backends/facts-db/contradictions.ts
+++ b/extensions/memory-hybrid/backends/facts-db/contradictions.ts
@@ -199,6 +199,11 @@ export function getContradictedIds(db: DatabaseSync, factIds: string[]): Set<str
   return result;
 }
 
+function isFactVerified(db: DatabaseSync, factId: string): boolean {
+  const row = db.prepare("SELECT 1 FROM verified_facts WHERE fact_id = ? LIMIT 1").get(factId);
+  return row != null;
+}
+
 export function previewResolveContradictionsAuto(
   db: DatabaseSync,
   getById: (id: string) => MemoryEntry | null,
@@ -245,7 +250,7 @@ export function previewResolveContradictionsAuto(
     const newIsHigherConf = newConf > oldConf;
     const newIsFromUser = newFact.source === "conversation" || newFact.source === "cli";
 
-    if (newIsNewer && newIsHigherConf && newIsFromUser) {
+    if (newIsNewer && newIsHigherConf && newIsFromUser && !isFactVerified(db, c.factIdOld)) {
       autoResolvable.push({
         contradictionId: c.id,
         factIdNew: c.factIdNew,

--- a/extensions/memory-hybrid/backends/facts-db/contradictions.ts
+++ b/extensions/memory-hybrid/backends/facts-db/contradictions.ts
@@ -221,6 +221,40 @@ function isAutoResolvableContradiction(
   return !isFactVerified(db, contradiction.factIdOld);
 }
 
+type AutoResolutionDecision =
+  | { autoResolvable: false }
+  | {
+      autoResolvable: true;
+      resolution: "superseded" | "kept";
+      requiresSupersede: boolean;
+    };
+
+function getAutoResolutionDecision(
+  db: DatabaseSync,
+  contradiction: ContradictionRecord,
+  newFact: MemoryEntry | null,
+  oldFact: MemoryEntry | null,
+): AutoResolutionDecision {
+  if (!newFact && !oldFact) {
+    return { autoResolvable: true, resolution: "superseded", requiresSupersede: false };
+  }
+  if (!newFact && oldFact) {
+    return { autoResolvable: true, resolution: "kept", requiresSupersede: false };
+  }
+  if (newFact && !oldFact) {
+    return { autoResolvable: true, resolution: "superseded", requiresSupersede: false };
+  }
+  if (!newFact || !oldFact) return { autoResolvable: false };
+  if (!isAutoResolvableContradiction(db, contradiction, newFact, oldFact)) {
+    return { autoResolvable: false };
+  }
+  return {
+    autoResolvable: true,
+    resolution: "superseded",
+    requiresSupersede: oldFact.supersededAt == null,
+  };
+}
+
 export function previewResolveContradictionsAuto(
   db: DatabaseSync,
   getById: (id: string) => MemoryEntry | null,
@@ -251,17 +285,8 @@ export function previewResolveContradictionsAuto(
   for (const c of unresolved) {
     const newFact = getById(c.factIdNew);
     const oldFact = getById(c.factIdOld);
-
-    if (!newFact || !oldFact) {
-      autoResolvable.push({
-        contradictionId: c.id,
-        factIdNew: c.factIdNew,
-        factIdOld: c.factIdOld,
-      });
-      continue;
-    }
-
-    if (isAutoResolvableContradiction(db, c, newFact, oldFact)) {
+    const decision = getAutoResolutionDecision(db, c, newFact, oldFact);
+    if (decision.autoResolvable) {
       autoResolvable.push({
         contradictionId: c.id,
         factIdNew: c.factIdNew,
@@ -310,76 +335,37 @@ export function resolveContradictionsAuto(
   for (const c of unresolved) {
     const newFact = getById(c.factIdNew);
     const oldFact = getById(c.factIdOld);
-
-    if (!newFact && !oldFact) {
-      resolveContradiction(db, c.id, "superseded");
-      autoResolved.push({
-        contradictionId: c.id,
-        factIdNew: c.factIdNew,
-        factIdOld: c.factIdOld,
-      });
-      continue;
-    }
-
-    if (!newFact && oldFact) {
-      resolveContradiction(db, c.id, "kept");
-      if (c.oldFactOriginalConfidence != null) {
-        db.prepare("UPDATE facts SET confidence = ? WHERE id = ?").run(c.oldFactOriginalConfidence, c.factIdOld);
-      }
-      autoResolved.push({
-        contradictionId: c.id,
-        factIdNew: c.factIdNew,
-        factIdOld: c.factIdOld,
-      });
-      continue;
-    }
-
-    if (newFact && !oldFact) {
-      resolveContradiction(db, c.id, "superseded");
-      autoResolved.push({
-        contradictionId: c.id,
-        factIdNew: c.factIdNew,
-        factIdOld: c.factIdOld,
-      });
-      continue;
-    }
-
-    // Both facts exist at this point (previous conditions handle null cases)
-    if (!newFact || !oldFact) continue;
-    const resolvedNew = newFact;
-    const resolvedOld = oldFact;
-    if (isAutoResolvableContradiction(db, c, resolvedNew, resolvedOld)) {
-      if (resolvedOld.supersededAt != null) {
-        resolveContradiction(db, c.id, "superseded");
-        autoResolved.push({
-          contradictionId: c.id,
-          factIdNew: c.factIdNew,
-          factIdOld: c.factIdOld,
-        });
-      } else {
-        const superseded = supersede(c.factIdOld, c.factIdNew);
-        if (superseded) {
-          resolveContradiction(db, c.id, "superseded");
-          autoResolved.push({
-            contradictionId: c.id,
-            factIdNew: c.factIdNew,
-            factIdOld: c.factIdOld,
-          });
-        } else {
-          ambiguous.push({
-            contradictionId: c.id,
-            factIdNew: c.factIdNew,
-            factIdOld: c.factIdOld,
-          });
-        }
-      }
-    } else {
+    const decision = getAutoResolutionDecision(db, c, newFact, oldFact);
+    if (!decision.autoResolvable) {
       ambiguous.push({
         contradictionId: c.id,
         factIdNew: c.factIdNew,
         factIdOld: c.factIdOld,
       });
+      continue;
     }
+
+    if (decision.requiresSupersede) {
+      const superseded = supersede(c.factIdOld, c.factIdNew);
+      if (!superseded) {
+        ambiguous.push({
+          contradictionId: c.id,
+          factIdNew: c.factIdNew,
+          factIdOld: c.factIdOld,
+        });
+        continue;
+      }
+    }
+
+    resolveContradiction(db, c.id, decision.resolution);
+    if (decision.resolution === "kept" && c.oldFactOriginalConfidence != null) {
+      db.prepare("UPDATE facts SET confidence = ? WHERE id = ?").run(c.oldFactOriginalConfidence, c.factIdOld);
+    }
+    autoResolved.push({
+      contradictionId: c.id,
+      factIdNew: c.factIdNew,
+      factIdOld: c.factIdOld,
+    });
   }
 
   return { autoResolved, ambiguous };

--- a/extensions/memory-hybrid/backends/facts-db/contradictions.ts
+++ b/extensions/memory-hybrid/backends/facts-db/contradictions.ts
@@ -493,9 +493,11 @@ export function resolveProjectStateLww(
     });
 
     if (!dryRun && action === "supersede") {
-      resolveContradiction(db, c.id, "superseded");
-      supersede(c.factIdOld, c.factIdNew);
-      applied++;
+      const resolved = resolveContradiction(db, c.id, "superseded");
+      const superseded = supersede(c.factIdOld, c.factIdNew);
+      if (resolved && superseded) {
+        applied++;
+      }
     }
   }
 

--- a/extensions/memory-hybrid/backends/facts-db/contradictions.ts
+++ b/extensions/memory-hybrid/backends/facts-db/contradictions.ts
@@ -1,5 +1,6 @@
 /**
  * Contradiction detection and resolution (Issue #157) (Issue #954 split).
+ * Project-state latest-wins (LWW) policy added in Issue #1636.
  */
 import { randomUUID } from "node:crypto";
 import type { SQLInputValue } from "node:sqlite";
@@ -285,6 +286,232 @@ export function resolveContradictionsAuto(
   }
 
   return { autoResolved, ambiguous };
+}
+
+// ---------------------------------------------------------------------------
+// Project-state latest-wins (LWW) policy (Issue #1636)
+// ---------------------------------------------------------------------------
+
+/**
+ * Mutable project/task state keys eligible for the latest-wins policy.
+ *
+ * Each key represents a "current-state snapshot" — a single mutable fact whose
+ * value is completely replaced when new information arrives (e.g. `status` moves
+ * from `in_progress` to `done`; `next` is replaced with a new action item).
+ * These differ from append-style project facts (e.g. decisions, milestones) where
+ * both old and new values may independently hold — those must go through manual
+ * contradiction review instead.
+ */
+export const PROJECT_STATE_LWW_KEYS: ReadonlySet<string> = new Set([
+  "status",
+  "next",
+  "task_updated",
+  "related_session",
+  "coverage",
+  "last_live_verified_at",
+  "live_state_hash",
+  "last_actionable_blocker",
+  "owner",
+]);
+
+/**
+ * Sources trusted for project-state LWW resolution.
+ * `distillation` is excluded by default to keep automated distilled facts conservative.
+ */
+export const PROJECT_STATE_LWW_TRUSTED_SOURCES: ReadonlySet<string> = new Set([
+  "conversation",
+  "cli",
+  "active-task",
+]);
+
+/** A single candidate contradiction eligible for project-state LWW resolution. */
+export interface ProjectStateLwwCandidate {
+  contradictionId: string;
+  factIdNew: string;
+  factIdOld: string;
+  entity: string;
+  key: string;
+  scope: string | null;
+  scopeTarget: string | null;
+  /** epoch seconds */
+  newFactDate: number;
+  /** epoch seconds */
+  oldFactDate: number;
+  newSource: string;
+  oldSource: string;
+  newConf: number;
+  oldConf: number;
+  newValueExcerpt: string;
+  oldValueExcerpt: string;
+  /** `supersede`: LWW policy applies — newer trusted fact wins. `manual-review`: skipped by LWW. */
+  action: "supersede" | "manual-review";
+  /** True when the entity/key pair appears to have been reused for follow-up work. */
+  possibleOverloadedEntity: boolean;
+}
+
+/** Grouped result of a project-state LWW resolution pass. */
+export interface ProjectStateLwwResult {
+  groups: Array<{
+    entity: string;
+    key: string;
+    scope: string | null;
+    scopeTarget: string | null;
+    candidates: ProjectStateLwwCandidate[];
+  }>;
+  totalCandidates: number;
+  wouldSupersede: number;
+  wouldManualReview: number;
+  /** Number of contradictions actually resolved (0 in dry-run). */
+  applied: number;
+}
+
+/**
+ * Distinct PR/issue reference count threshold above which an entity is considered
+ * "possibly overloaded" (i.e. the same entity key was reused across follow-up work).
+ * Pairs above this threshold are still reported but flagged for human review.
+ */
+const MAX_EXPECTED_REFS_PER_ENTITY = 2;
+
+/** Extract distinct PR/issue ref numbers like `#1234` from text. */
+function extractRefNumbers(text: string): Set<string> {
+  const matches = text.match(/#\d+/g);
+  return new Set(matches ?? []);
+}
+
+/** Heuristic: flag if multiple distinct PR/issue numbers appear across the two facts. */
+function isPossiblyOverloadedEntity(newFact: MemoryEntry, oldFact: MemoryEntry): boolean {
+  const combined = `${newFact.value ?? ""} ${newFact.text ?? ""} ${oldFact.value ?? ""} ${oldFact.text ?? ""}`;
+  const refs = extractRefNumbers(combined);
+  return refs.size > MAX_EXPECTED_REFS_PER_ENTITY;
+}
+
+function truncateExcerpt(s: string, maxLen: number): string {
+  const t = s.replace(/\s+/g, " ").trim();
+  return t.length <= maxLen ? t : `${t.slice(0, maxLen - 1)}…`;
+}
+
+/**
+ * Resolve stale project-state contradictions using a latest-wins policy.
+ *
+ * Eligible pairs must satisfy all of:
+ * - Both facts are category `project`
+ * - The key (case-insensitive) is in {@link PROJECT_STATE_LWW_KEYS}
+ * - The newer fact's source is in {@link PROJECT_STATE_LWW_TRUSTED_SOURCES}
+ * - The newer fact is strictly newer (`createdAt >` older)
+ * - The newer fact's confidence ≥ the older fact's original confidence
+ *
+ * In dry-run mode no mutations are made; results describe what would happen.
+ * In apply mode, qualifying contradictions are resolved as `superseded` and
+ * the older fact is marked superseded with provenance preserved.
+ */
+
+export type LwwEligibilityResult =
+  | { eligible: false }
+  | { eligible: true; qualifies: boolean; newConf: number; oldConf: number };
+
+/**
+ * Evaluate whether a (newFact, oldFact) pair is eligible for project-state LWW
+ * and, if so, whether the newer fact qualifies to supersede the older.
+ *
+ * Shared between the write-time path in `FactsDB.detectContradictions` and the
+ * batch `resolveProjectStateLww` pass to keep eligibility logic in one place.
+ *
+ * @param oldFactOriginalConfidence The confidence captured at contradiction-detection
+ *   time (before the -0.2 penalty). Pass `undefined` to fall back to `oldFact.confidence`.
+ */
+export function evaluateLwwEligibility(
+  newFact: MemoryEntry,
+  oldFact: MemoryEntry,
+  oldFactOriginalConfidence?: number,
+): LwwEligibilityResult {
+  if (newFact.category !== "project" || oldFact.category !== "project") return { eligible: false };
+  const keyLower = (newFact.key ?? oldFact.key ?? "").toLowerCase();
+  if (!PROJECT_STATE_LWW_KEYS.has(keyLower)) return { eligible: false };
+  if (!PROJECT_STATE_LWW_TRUSTED_SOURCES.has(newFact.source ?? "")) return { eligible: false };
+  const newConf = newFact.confidence ?? 1.0;
+  const oldConf = oldFactOriginalConfidence ?? oldFact.confidence ?? 1.0;
+  const qualifies = newFact.createdAt > oldFact.createdAt && newConf >= oldConf;
+  return { eligible: true, qualifies, newConf, oldConf };
+}
+
+export function resolveProjectStateLww(
+  db: DatabaseSync,
+  getById: (id: string) => MemoryEntry | null,
+  supersede: (oldId: string, newId: string | null) => boolean,
+  options: { dryRun?: boolean } = {},
+): ProjectStateLwwResult {
+  const { dryRun = false } = options;
+  const unresolved = getContradictions(db);
+
+  const groupMap = new Map<
+    string,
+    { entity: string; key: string; scope: string | null; scopeTarget: string | null; candidates: ProjectStateLwwCandidate[] }
+  >();
+  let applied = 0;
+
+  for (const c of unresolved) {
+    const newFact = getById(c.factIdNew);
+    const oldFact = getById(c.factIdOld);
+    if (!newFact || !oldFact) continue;
+
+    const lww = evaluateLwwEligibility(newFact, oldFact, c.oldFactOriginalConfidence);
+    if (!lww.eligible) continue;
+
+    const { qualifies, newConf, oldConf } = lww;
+    const overloaded = isPossiblyOverloadedEntity(newFact, oldFact);
+    const action: "supersede" | "manual-review" = qualifies ? "supersede" : "manual-review";
+
+    const entity = newFact.entity ?? oldFact.entity ?? "?";
+    const key = newFact.key ?? oldFact.key ?? "?";
+    const scope = newFact.scope ?? null;
+    const scopeTarget = newFact.scopeTarget ?? null;
+
+    const groupKey = `${entity}\0${key}\0${scope ?? ""}\0${scopeTarget ?? ""}`;
+    let group = groupMap.get(groupKey);
+    if (!group) {
+      group = { entity, key, scope, scopeTarget, candidates: [] };
+      groupMap.set(groupKey, group);
+    }
+    group.candidates.push({
+      contradictionId: c.id,
+      factIdNew: c.factIdNew,
+      factIdOld: c.factIdOld,
+      entity,
+      key,
+      scope,
+      scopeTarget,
+      newFactDate: newFact.createdAt,
+      oldFactDate: oldFact.createdAt,
+      newSource: newFact.source ?? "unknown",
+      oldSource: oldFact.source ?? "unknown",
+      newConf,
+      oldConf,
+      newValueExcerpt: truncateExcerpt(newFact.value ?? newFact.text ?? "", 80),
+      oldValueExcerpt: truncateExcerpt(oldFact.value ?? oldFact.text ?? "", 80),
+      action,
+      possibleOverloadedEntity: overloaded,
+    });
+
+    if (!dryRun && action === "supersede") {
+      resolveContradiction(db, c.id, "superseded");
+      supersede(c.factIdOld, c.factIdNew);
+      applied++;
+    }
+  }
+
+  const groups = Array.from(groupMap.values());
+  let totalCandidates = 0;
+  let wouldSupersede = 0;
+  let wouldManualReview = 0;
+  for (const g of groups) {
+    for (const cand of g.candidates) {
+      totalCandidates++;
+      if (cand.action === "supersede") wouldSupersede++;
+      else wouldManualReview++;
+    }
+  }
+
+  return { groups, totalCandidates, wouldSupersede, wouldManualReview, applied };
 }
 
 export function contradictionsCount(db: DatabaseSync): number {

--- a/extensions/memory-hybrid/backends/facts-db/contradictions.ts
+++ b/extensions/memory-hybrid/backends/facts-db/contradictions.ts
@@ -496,9 +496,11 @@ export function resolveProjectStateLww(
 
     if (!dryRun && action === "supersede") {
       const resolved = resolveContradiction(db, c.id, "superseded");
-      const superseded = supersede(c.factIdOld, c.factIdNew);
-      if (resolved && superseded) {
-        applied++;
+      if (resolved) {
+        const superseded = supersede(c.factIdOld, c.factIdNew);
+        if (superseded) {
+          applied++;
+        }
       }
     }
   }

--- a/extensions/memory-hybrid/backends/facts-db/contradictions.ts
+++ b/extensions/memory-hybrid/backends/facts-db/contradictions.ts
@@ -199,7 +199,7 @@ export function getContradictedIds(db: DatabaseSync, factIds: string[]): Set<str
   return result;
 }
 
-function isFactVerified(db: DatabaseSync, factId: string): boolean {
+export function isFactVerified(db: DatabaseSync, factId: string): boolean {
   const row = db.prepare("SELECT 1 FROM verified_facts WHERE fact_id = ? LIMIT 1").get(factId);
   return row != null;
 }

--- a/extensions/memory-hybrid/backends/facts-db/contradictions.ts
+++ b/extensions/memory-hybrid/backends/facts-db/contradictions.ts
@@ -90,27 +90,28 @@ export function recordContradiction(
   factIdNew: string,
   factIdOld: string,
   createLink: (a: string, b: string, t: MemoryLinkType, s?: number) => string,
-): string {
+): { id: string; oldFactOriginalConfidence: number } {
   const id = randomUUID();
   const detectedAt = new Date().toISOString();
+  let oldFactOriginalConfidence = 1.0;
 
   const tx = createTransaction(db, () => {
     const oldFactRow = db.prepare("SELECT confidence FROM facts WHERE id = ?").get(factIdOld) as
       | { confidence: number }
       | undefined;
-    const originalConfidence = oldFactRow?.confidence ?? 1.0;
+    oldFactOriginalConfidence = oldFactRow?.confidence ?? 1.0;
 
     db.prepare(
       `INSERT INTO contradictions (id, fact_id_new, fact_id_old, detected_at, resolved, resolution, old_fact_original_confidence)
            VALUES (?, ?, ?, ?, 0, NULL, ?)`,
-    ).run(id, factIdNew, factIdOld, detectedAt, originalConfidence);
+    ).run(id, factIdNew, factIdOld, detectedAt, oldFactOriginalConfidence);
 
     createLink(factIdNew, factIdOld, "CONTRADICTS", 1.0);
 
     updateConfidence(db, factIdOld, -0.2);
   });
   tx();
-  return id;
+  return { id, oldFactOriginalConfidence };
 }
 
 export function detectContradictions(
@@ -122,16 +123,20 @@ export function detectContradictions(
   scope: string | null | undefined,
   scopeTarget: string | null | undefined,
   createLink: (a: string, b: string, t: MemoryLinkType, s?: number) => string,
-): Array<{ contradictionId: string; oldFactId: string }> {
+): Array<{ contradictionId: string; oldFactId: string; oldFactOriginalConfidence: number }> {
   if (!entity?.trim() || !key?.trim() || !value?.trim()) return [];
 
   const conflicting = findConflictingFacts(db, entity.trim(), key.trim(), value.trim(), newFactId, scope, scopeTarget);
-  const results: Array<{ contradictionId: string; oldFactId: string }> = [];
+  const results: Array<{ contradictionId: string; oldFactId: string; oldFactOriginalConfidence: number }> = [];
 
   for (const old of conflicting) {
     if (old.value?.toLowerCase() === value.trim().toLowerCase()) continue;
-    const contradictionId = recordContradiction(db, newFactId, old.id, createLink);
-    results.push({ contradictionId, oldFactId: old.id });
+    const contradiction = recordContradiction(db, newFactId, old.id, createLink);
+    results.push({
+      contradictionId: contradiction.id,
+      oldFactId: old.id,
+      oldFactOriginalConfidence: contradiction.oldFactOriginalConfidence,
+    });
   }
 
   return results;
@@ -192,6 +197,70 @@ export function getContradictedIds(db: DatabaseSync, factIds: string[]): Set<str
     for (const r of rows) result.add(r.id);
   }
   return result;
+}
+
+export function previewResolveContradictionsAuto(
+  db: DatabaseSync,
+  getById: (id: string) => MemoryEntry | null,
+): {
+  autoResolvable: Array<{
+    contradictionId: string;
+    factIdNew: string;
+    factIdOld: string;
+  }>;
+  ambiguous: Array<{
+    contradictionId: string;
+    factIdNew: string;
+    factIdOld: string;
+  }>;
+} {
+  const unresolved = getContradictions(db);
+  const autoResolvable: Array<{
+    contradictionId: string;
+    factIdNew: string;
+    factIdOld: string;
+  }> = [];
+  const ambiguous: Array<{
+    contradictionId: string;
+    factIdNew: string;
+    factIdOld: string;
+  }> = [];
+
+  for (const c of unresolved) {
+    const newFact = getById(c.factIdNew);
+    const oldFact = getById(c.factIdOld);
+
+    if (!newFact || !oldFact) {
+      autoResolvable.push({
+        contradictionId: c.id,
+        factIdNew: c.factIdNew,
+        factIdOld: c.factIdOld,
+      });
+      continue;
+    }
+
+    const newConf = newFact.confidence ?? 1.0;
+    const oldConf = c.oldFactOriginalConfidence ?? oldFact.confidence ?? 1.0;
+    const newIsNewer = newFact.createdAt >= oldFact.createdAt;
+    const newIsHigherConf = newConf > oldConf;
+    const newIsFromUser = newFact.source === "conversation" || newFact.source === "cli";
+
+    if (newIsNewer && newIsHigherConf && newIsFromUser) {
+      autoResolvable.push({
+        contradictionId: c.id,
+        factIdNew: c.factIdNew,
+        factIdOld: c.factIdOld,
+      });
+    } else {
+      ambiguous.push({
+        contradictionId: c.id,
+        factIdNew: c.factIdNew,
+        factIdOld: c.factIdOld,
+      });
+    }
+  }
+
+  return { autoResolvable, ambiguous };
 }
 
 export function resolveContradictionsAuto(

--- a/extensions/memory-hybrid/backends/facts-db/contradictions.ts
+++ b/extensions/memory-hybrid/backends/facts-db/contradictions.ts
@@ -557,7 +557,8 @@ export function resolveProjectStateLww(
 
     const { qualifies, newConf, oldConf } = lww;
     const overloaded = isPossiblyOverloadedEntity(newFact, oldFact);
-    const action: "supersede" | "manual-review" = qualifies && !isFactVerified(db, c.factIdOld) ? "supersede" : "manual-review";
+    const action: "supersede" | "manual-review" =
+      qualifies && !isFactVerified(db, c.factIdOld) ? "supersede" : "manual-review";
 
     const entity = newFact.entity ?? oldFact.entity ?? "?";
     const key = newFact.key ?? oldFact.key ?? "?";

--- a/extensions/memory-hybrid/backends/facts-db/contradictions.ts
+++ b/extensions/memory-hybrid/backends/facts-db/contradictions.ts
@@ -278,6 +278,12 @@ export function resolveContradictionsAuto(
           factIdNew: c.factIdNew,
           factIdOld: c.factIdOld,
         });
+      } else {
+        ambiguous.push({
+          contradictionId: c.id,
+          factIdNew: c.factIdNew,
+          factIdOld: c.factIdOld,
+        });
       }
     } else {
       ambiguous.push({

--- a/extensions/memory-hybrid/backends/facts-db/contradictions.ts
+++ b/extensions/memory-hybrid/backends/facts-db/contradictions.ts
@@ -548,7 +548,7 @@ export function resolveProjectStateLww(
 
     const { qualifies, newConf, oldConf } = lww;
     const overloaded = isPossiblyOverloadedEntity(newFact, oldFact);
-    const action: "supersede" | "manual-review" = qualifies ? "supersede" : "manual-review";
+    const action: "supersede" | "manual-review" = qualifies && !isFactVerified(db, c.factIdOld) ? "supersede" : "manual-review";
 
     const entity = newFact.entity ?? oldFact.entity ?? "?";
     const key = newFact.key ?? oldFact.key ?? "?";

--- a/extensions/memory-hybrid/backends/facts-db/contradictions.ts
+++ b/extensions/memory-hybrid/backends/facts-db/contradictions.ts
@@ -204,6 +204,23 @@ function isFactVerified(db: DatabaseSync, factId: string): boolean {
   return row != null;
 }
 
+function isAutoResolvableContradiction(
+  db: DatabaseSync,
+  contradiction: ContradictionRecord,
+  newFact: MemoryEntry,
+  oldFact: MemoryEntry,
+): boolean {
+  const newConf = newFact.confidence ?? 1.0;
+  const oldConf = contradiction.oldFactOriginalConfidence ?? oldFact.confidence ?? 1.0;
+  const newIsNewer = newFact.createdAt >= oldFact.createdAt;
+  const newIsHigherConf = newConf > oldConf;
+  const newIsFromUser = newFact.source === "conversation" || newFact.source === "cli";
+
+  if (!(newIsNewer && newIsHigherConf && newIsFromUser)) return false;
+  if (oldFact.supersededAt != null) return true;
+  return !isFactVerified(db, contradiction.factIdOld);
+}
+
 export function previewResolveContradictionsAuto(
   db: DatabaseSync,
   getById: (id: string) => MemoryEntry | null,
@@ -244,13 +261,7 @@ export function previewResolveContradictionsAuto(
       continue;
     }
 
-    const newConf = newFact.confidence ?? 1.0;
-    const oldConf = c.oldFactOriginalConfidence ?? oldFact.confidence ?? 1.0;
-    const newIsNewer = newFact.createdAt >= oldFact.createdAt;
-    const newIsHigherConf = newConf > oldConf;
-    const newIsFromUser = newFact.source === "conversation" || newFact.source === "cli";
-
-    if (newIsNewer && newIsHigherConf && newIsFromUser && !isFactVerified(db, c.factIdOld)) {
+    if (isAutoResolvableContradiction(db, c, newFact, oldFact)) {
       autoResolvable.push({
         contradictionId: c.id,
         factIdNew: c.factIdNew,
@@ -337,13 +348,7 @@ export function resolveContradictionsAuto(
     if (!newFact || !oldFact) continue;
     const resolvedNew = newFact;
     const resolvedOld = oldFact;
-    const newConf = resolvedNew.confidence ?? 1.0;
-    const oldConf = c.oldFactOriginalConfidence ?? resolvedOld.confidence ?? 1.0;
-    const newIsNewer = resolvedNew.createdAt >= resolvedOld.createdAt;
-    const newIsHigherConf = newConf > oldConf;
-    const newIsFromUser = resolvedNew.source === "conversation" || resolvedNew.source === "cli";
-
-    if (newIsNewer && newIsHigherConf && newIsFromUser) {
+    if (isAutoResolvableContradiction(db, c, resolvedNew, resolvedOld)) {
       if (resolvedOld.supersededAt != null) {
         resolveContradiction(db, c.id, "superseded");
         autoResolved.push({

--- a/extensions/memory-hybrid/backends/facts-db/contradictions.ts
+++ b/extensions/memory-hybrid/backends/facts-db/contradictions.ts
@@ -423,7 +423,7 @@ export function evaluateLwwEligibility(
   oldFactOriginalConfidence?: number,
 ): LwwEligibilityResult {
   if (newFact.category !== "project" || oldFact.category !== "project") return { eligible: false };
-  const keyLower = (newFact.key ?? oldFact.key ?? "").toLowerCase();
+  const keyLower = (newFact.key ?? oldFact.key ?? "").trim().toLowerCase();
   if (!PROJECT_STATE_LWW_KEYS.has(keyLower)) return { eligible: false };
   if (!PROJECT_STATE_LWW_TRUSTED_SOURCES.has(newFact.source ?? "")) return { eligible: false };
   const newConf = newFact.confidence ?? 1.0;

--- a/extensions/memory-hybrid/backends/facts-db/contradictions.ts
+++ b/extensions/memory-hybrid/backends/facts-db/contradictions.ts
@@ -318,11 +318,7 @@ export const PROJECT_STATE_LWW_KEYS: ReadonlySet<string> = new Set([
  * Sources trusted for project-state LWW resolution.
  * `distillation` is excluded by default to keep automated distilled facts conservative.
  */
-export const PROJECT_STATE_LWW_TRUSTED_SOURCES: ReadonlySet<string> = new Set([
-  "conversation",
-  "cli",
-  "active-task",
-]);
+export const PROJECT_STATE_LWW_TRUSTED_SOURCES: ReadonlySet<string> = new Set(["conversation", "cli", "active-task"]);
 
 /** A single candidate contradiction eligible for project-state LWW resolution. */
 export interface ProjectStateLwwCandidate {
@@ -445,7 +441,13 @@ export function resolveProjectStateLww(
 
   const groupMap = new Map<
     string,
-    { entity: string; key: string; scope: string | null; scopeTarget: string | null; candidates: ProjectStateLwwCandidate[] }
+    {
+      entity: string;
+      key: string;
+      scope: string | null;
+      scopeTarget: string | null;
+      candidates: ProjectStateLwwCandidate[];
+    }
   >();
   let applied = 0;
 

--- a/extensions/memory-hybrid/backends/facts-db/contradictions.ts
+++ b/extensions/memory-hybrid/backends/facts-db/contradictions.ts
@@ -152,7 +152,8 @@ export function getContradictions(db: DatabaseSync, factId?: string): Contradict
     detectedAt: r.detected_at as string,
     resolved: (r.resolved as number) === 1,
     resolution: (r.resolution as "superseded" | "kept" | "merged" | null) ?? null,
-    oldFactOriginalConfidence: r.old_fact_original_confidence as number | undefined,
+    oldFactOriginalConfidence:
+      r.old_fact_original_confidence == null ? undefined : (r.old_fact_original_confidence as number),
   }));
 }
 
@@ -413,7 +414,8 @@ export type LwwEligibilityResult =
  * batch `resolveProjectStateLww` pass to keep eligibility logic in one place.
  *
  * @param oldFactOriginalConfidence The confidence captured at contradiction-detection
- *   time (before the -0.2 penalty). Pass `undefined` to fall back to `oldFact.confidence`.
+ *   time (before the -0.2 penalty). Missing values are treated as non-qualifying:
+ *   LWW will require manual review instead of guessing from a possibly penalized score.
  */
 export function evaluateLwwEligibility(
   newFact: MemoryEntry,
@@ -426,6 +428,9 @@ export function evaluateLwwEligibility(
   if (!PROJECT_STATE_LWW_TRUSTED_SOURCES.has(newFact.source ?? "")) return { eligible: false };
   const newConf = newFact.confidence ?? 1.0;
   const oldConf = oldFactOriginalConfidence ?? oldFact.confidence ?? 1.0;
+  if (oldFactOriginalConfidence == null) {
+    return { eligible: true, qualifies: false, newConf, oldConf };
+  }
   const qualifies = newFact.createdAt > oldFact.createdAt && newConf >= oldConf;
   return { eligible: true, qualifies, newConf, oldConf };
 }

--- a/extensions/memory-hybrid/backends/facts-db/contradictions.ts
+++ b/extensions/memory-hybrid/backends/facts-db/contradictions.ts
@@ -270,13 +270,15 @@ export function resolveContradictionsAuto(
     const newIsFromUser = resolvedNew.source === "conversation" || resolvedNew.source === "cli";
 
     if (newIsNewer && newIsHigherConf && newIsFromUser) {
-      resolveContradiction(db, c.id, "superseded");
-      supersede(c.factIdOld, c.factIdNew);
-      autoResolved.push({
-        contradictionId: c.id,
-        factIdNew: c.factIdNew,
-        factIdOld: c.factIdOld,
-      });
+      const superseded = supersede(c.factIdOld, c.factIdNew);
+      if (superseded) {
+        resolveContradiction(db, c.id, "superseded");
+        autoResolved.push({
+          contradictionId: c.id,
+          factIdNew: c.factIdNew,
+          factIdOld: c.factIdOld,
+        });
+      }
     } else {
       ambiguous.push({
         contradictionId: c.id,
@@ -500,12 +502,10 @@ export function resolveProjectStateLww(
     });
 
     if (!dryRun && action === "supersede") {
-      const resolved = resolveContradiction(db, c.id, "superseded");
-      if (resolved) {
-        const superseded = supersede(c.factIdOld, c.factIdNew);
-        if (superseded) {
-          applied++;
-        }
+      const superseded = supersede(c.factIdOld, c.factIdNew);
+      if (superseded) {
+        resolveContradiction(db, c.id, "superseded");
+        applied++;
       }
     }
   }

--- a/extensions/memory-hybrid/backends/facts-db/facts-db-layer1.ts
+++ b/extensions/memory-hybrid/backends/facts-db/facts-db-layer1.ts
@@ -513,7 +513,7 @@ export class FactsDBLayer1 extends BaseSqliteStore {
     const nowSec = Math.floor(Date.now() / 1000);
     const result = this.liveDb
       .prepare(
-        "UPDATE facts SET superseded_at = ?, superseded_by = ?, valid_until = ? WHERE id = ? AND superseded_at IS NULL",
+        "UPDATE facts SET superseded_at = ?, superseded_by = ?, valid_until = ? WHERE id = ? AND superseded_at IS NULL AND id NOT IN (SELECT fact_id FROM verified_facts)",
       )
       .run(nowSec, newId, nowSec, oldId);
     if (result.changes > 0) {

--- a/extensions/memory-hybrid/backends/facts-db/facts-db-layer1.ts
+++ b/extensions/memory-hybrid/backends/facts-db/facts-db-layer1.ts
@@ -513,7 +513,7 @@ export class FactsDBLayer1 extends BaseSqliteStore {
     const nowSec = Math.floor(Date.now() / 1000);
     const result = this.liveDb
       .prepare(
-        "UPDATE facts SET superseded_at = ?, superseded_by = ?, valid_until = ? WHERE id = ? AND superseded_at IS NULL AND id NOT IN (SELECT fact_id FROM verified_facts)",
+        "UPDATE facts SET superseded_at = ?, superseded_by = ?, valid_until = ? WHERE id = ? AND superseded_at IS NULL",
       )
       .run(nowSec, newId, nowSec, oldId);
     if (result.changes > 0) {

--- a/extensions/memory-hybrid/backends/facts-db/facts-db-layer3.ts
+++ b/extensions/memory-hybrid/backends/facts-db/facts-db-layer3.ts
@@ -243,7 +243,7 @@ export class FactsDB extends FactsDBLayer2 {
     // Project-state LWW: immediately resolve contradictions for known mutable keys so
     // active-task/project writes do not leave avoidable unresolved contradictions (#1636).
     if (results.length > 0 && key != null) {
-      const keyLower = key.toLowerCase();
+      const keyLower = key.trim().toLowerCase();
       if (PROJECT_STATE_LWW_KEYS.has(keyLower)) {
         const newFact = this.getById(newFactId);
         if (newFact) {

--- a/extensions/memory-hybrid/backends/facts-db/facts-db-layer3.ts
+++ b/extensions/memory-hybrid/backends/facts-db/facts-db-layer3.ts
@@ -236,8 +236,15 @@ export class FactsDB extends FactsDBLayer2 {
     scope?: string | null,
     scopeTarget?: string | null,
   ): Array<{ contradictionId: string; oldFactId: string }> {
-    const results = detectContradictionsImpl(this.liveDb, newFactId, entity, key, value, scope, scopeTarget, (a, b, t, s) =>
-      this.createLink(a, b, t, s ?? 1.0),
+    const results = detectContradictionsImpl(
+      this.liveDb,
+      newFactId,
+      entity,
+      key,
+      value,
+      scope,
+      scopeTarget,
+      (a, b, t, s) => this.createLink(a, b, t, s ?? 1.0),
     );
 
     // Project-state LWW: immediately resolve contradictions for known mutable keys so

--- a/extensions/memory-hybrid/backends/facts-db/facts-db-layer3.ts
+++ b/extensions/memory-hybrid/backends/facts-db/facts-db-layer3.ts
@@ -25,6 +25,7 @@ import {
   PROJECT_STATE_LWW_KEYS,
   recordContradiction as recordContradictionImpl,
   resolveContradiction as resolveContradictionImpl,
+  previewResolveContradictionsAuto as previewResolveContradictionsAutoImpl,
   resolveContradictionsAuto as resolveContradictionsAutoImpl,
   resolveProjectStateLww as resolveProjectStateLwwImpl,
   setConfidenceTo as setConfidenceToImpl,
@@ -223,9 +224,12 @@ export class FactsDB extends FactsDBLayer2 {
   }
 
   recordContradiction(factIdNew: string, factIdOld: string): string {
-    return recordContradictionImpl(this.liveDb, factIdNew, factIdOld, (a, b, t, s) =>
-      this.createLink(a, b, t, s ?? 1.0),
-    );
+    return recordContradictionImpl(
+      this.liveDb,
+      factIdNew,
+      factIdOld,
+      (a, b, t, s) => this.createLink(a, b, t, s ?? 1.0),
+    ).id;
   }
 
   detectContradictions(
@@ -235,7 +239,7 @@ export class FactsDB extends FactsDBLayer2 {
     value: string | null | undefined,
     scope?: string | null,
     scopeTarget?: string | null,
-  ): Array<{ contradictionId: string; oldFactId: string }> {
+  ): Array<{ contradictionId: string; oldFactId: string; oldFactOriginalConfidence: number }> {
     const results = detectContradictionsImpl(
       this.liveDb,
       newFactId,
@@ -254,12 +258,10 @@ export class FactsDB extends FactsDBLayer2 {
       if (PROJECT_STATE_LWW_KEYS.has(keyLower)) {
         const newFact = this.getById(newFactId);
         if (newFact) {
-          for (const { contradictionId, oldFactId } of results) {
+          for (const { contradictionId, oldFactId, oldFactOriginalConfidence } of results) {
             const oldFact = this.getById(oldFactId);
             if (!oldFact) continue;
-            const rec = this.getContradictions(oldFactId).find((c) => c.id === contradictionId);
-            if (!rec) continue;
-            const lww = evaluateLwwEligibility(newFact, oldFact, rec.oldFactOriginalConfidence);
+            const lww = evaluateLwwEligibility(newFact, oldFact, oldFactOriginalConfidence);
             if (lww.eligible && lww.qualifies) {
               const superseded = this.supersede(oldFactId, newFactId);
               if (superseded) {
@@ -296,6 +298,10 @@ export class FactsDB extends FactsDBLayer2 {
       (id) => this.getById(id),
       (o, n) => this.supersede(o, n),
     );
+  }
+
+  previewResolveContradictions(): ReturnType<typeof previewResolveContradictionsAutoImpl> {
+    return previewResolveContradictionsAutoImpl(this.liveDb, (id) => this.getById(id));
   }
 
   /**

--- a/extensions/memory-hybrid/backends/facts-db/facts-db-layer3.ts
+++ b/extensions/memory-hybrid/backends/facts-db/facts-db-layer3.ts
@@ -261,9 +261,9 @@ export class FactsDB extends FactsDBLayer2 {
             if (!rec) continue;
             const lww = evaluateLwwEligibility(newFact, oldFact, rec.oldFactOriginalConfidence);
             if (lww.eligible && lww.qualifies) {
-              const resolved = this.resolveContradiction(contradictionId, "superseded");
-              if (resolved) {
-                this.supersede(oldFactId, newFactId);
+              const superseded = this.supersede(oldFactId, newFactId);
+              if (superseded) {
+                this.resolveContradiction(contradictionId, "superseded");
               }
             }
           }

--- a/extensions/memory-hybrid/backends/facts-db/facts-db-layer3.ts
+++ b/extensions/memory-hybrid/backends/facts-db/facts-db-layer3.ts
@@ -261,8 +261,10 @@ export class FactsDB extends FactsDBLayer2 {
             if (!rec) continue;
             const lww = evaluateLwwEligibility(newFact, oldFact, rec.oldFactOriginalConfidence);
             if (lww.eligible && lww.qualifies) {
-              this.resolveContradiction(contradictionId, "superseded");
-              this.supersede(oldFactId, newFactId);
+              const resolved = this.resolveContradiction(contradictionId, "superseded");
+              if (resolved) {
+                this.supersede(oldFactId, newFactId);
+              }
             }
           }
         }

--- a/extensions/memory-hybrid/backends/facts-db/facts-db-layer3.ts
+++ b/extensions/memory-hybrid/backends/facts-db/facts-db-layer3.ts
@@ -22,6 +22,7 @@ import {
   getContradictedIds as getContradictedIdsImpl,
   getContradictions as getContradictionsImpl,
   isContradicted as isContradictedImpl,
+  isFactVerified,
   PROJECT_STATE_LWW_KEYS,
   recordContradiction as recordContradictionImpl,
   resolveContradiction as resolveContradictionImpl,
@@ -259,7 +260,7 @@ export class FactsDB extends FactsDBLayer2 {
             const oldFact = this.getById(oldFactId);
             if (!oldFact) continue;
             const lww = evaluateLwwEligibility(newFact, oldFact, oldFactOriginalConfidence);
-            if (lww.eligible && lww.qualifies) {
+            if (lww.eligible && lww.qualifies && !isFactVerified(this.liveDb, oldFactId)) {
               const superseded = this.supersede(oldFactId, newFactId);
               if (superseded) {
                 this.resolveContradiction(contradictionId, "superseded");

--- a/extensions/memory-hybrid/backends/facts-db/facts-db-layer3.ts
+++ b/extensions/memory-hybrid/backends/facts-db/facts-db-layer3.ts
@@ -224,11 +224,8 @@ export class FactsDB extends FactsDBLayer2 {
   }
 
   recordContradiction(factIdNew: string, factIdOld: string): string {
-    return recordContradictionImpl(
-      this.liveDb,
-      factIdNew,
-      factIdOld,
-      (a, b, t, s) => this.createLink(a, b, t, s ?? 1.0),
+    return recordContradictionImpl(this.liveDb, factIdNew, factIdOld, (a, b, t, s) =>
+      this.createLink(a, b, t, s ?? 1.0),
     ).id;
   }
 

--- a/extensions/memory-hybrid/backends/facts-db/facts-db-layer3.ts
+++ b/extensions/memory-hybrid/backends/facts-db/facts-db-layer3.ts
@@ -17,17 +17,20 @@ import {
   addTag as addTagImpl,
   contradictionsCount as contradictionsCountImpl,
   detectContradictions as detectContradictionsImpl,
+  evaluateLwwEligibility,
   findConflictingFacts as findConflictingFactsImpl,
   getContradictedIds as getContradictedIdsImpl,
   getContradictions as getContradictionsImpl,
   isContradicted as isContradictedImpl,
+  PROJECT_STATE_LWW_KEYS,
   recordContradiction as recordContradictionImpl,
   resolveContradiction as resolveContradictionImpl,
   resolveContradictionsAuto as resolveContradictionsAutoImpl,
+  resolveProjectStateLww as resolveProjectStateLwwImpl,
   setConfidenceTo as setConfidenceToImpl,
   updateConfidence as updateConfidenceImpl,
 } from "./contradictions.js";
-import type { ContradictionRecord } from "./contradictions.js";
+import type { ContradictionRecord, ProjectStateLwwResult } from "./contradictions.js";
 import {
   autoDetectInstanceOf as autoDetectInstanceOfImpl,
   autoLinkEntities as autoLinkEntitiesImpl,
@@ -233,9 +236,33 @@ export class FactsDB extends FactsDBLayer2 {
     scope?: string | null,
     scopeTarget?: string | null,
   ): Array<{ contradictionId: string; oldFactId: string }> {
-    return detectContradictionsImpl(this.liveDb, newFactId, entity, key, value, scope, scopeTarget, (a, b, t, s) =>
+    const results = detectContradictionsImpl(this.liveDb, newFactId, entity, key, value, scope, scopeTarget, (a, b, t, s) =>
       this.createLink(a, b, t, s ?? 1.0),
     );
+
+    // Project-state LWW: immediately resolve contradictions for known mutable keys so
+    // active-task/project writes do not leave avoidable unresolved contradictions (#1636).
+    if (results.length > 0 && key != null) {
+      const keyLower = key.toLowerCase();
+      if (PROJECT_STATE_LWW_KEYS.has(keyLower)) {
+        const newFact = this.getById(newFactId);
+        if (newFact) {
+          for (const { contradictionId, oldFactId } of results) {
+            const oldFact = this.getById(oldFactId);
+            if (!oldFact) continue;
+            const rec = this.getContradictions(oldFactId).find((c) => c.id === contradictionId);
+            if (!rec) continue;
+            const lww = evaluateLwwEligibility(newFact, oldFact, rec.oldFactOriginalConfidence);
+            if (lww.eligible && lww.qualifies) {
+              this.resolveContradiction(contradictionId, "superseded");
+              this.supersede(oldFactId, newFactId);
+            }
+          }
+        }
+      }
+    }
+
+    return results;
   }
 
   getContradictions(factId?: string): ContradictionRecord[] {
@@ -259,6 +286,22 @@ export class FactsDB extends FactsDBLayer2 {
       this.liveDb,
       (id) => this.getById(id),
       (o, n) => this.supersede(o, n),
+    );
+  }
+
+  /**
+   * Project-state latest-wins resolution pass (Issue #1636).
+   * Safely resolves stale `project` contradictions for known mutable keys when the newer
+   * trusted fact is strictly newer and has equal or higher confidence.
+   *
+   * Pass `{ dryRun: true }` to inspect candidates without mutating any data.
+   */
+  resolveContradictionsProjectStateLww(opts: { dryRun?: boolean } = {}): ProjectStateLwwResult {
+    return resolveProjectStateLwwImpl(
+      this.liveDb,
+      (id) => this.getById(id),
+      (o, n) => this.supersede(o, n),
+      opts,
     );
   }
 

--- a/extensions/memory-hybrid/cli/cmd-selfcorrection.ts
+++ b/extensions/memory-hybrid/cli/cmd-selfcorrection.ts
@@ -32,7 +32,6 @@ import {
   stripMarkdownCodeFence,
 } from "../utils/llm-json-array.js";
 import { resolveTierPreferenceWithSources } from "../utils/llm-selection.js";
-import { tryParseFirstJsonArray } from "../utils/llm-json-array.js";
 import { fillPrompt, loadPrompt } from "../utils/prompt-loader.js";
 import { gatherSessionFiles } from "./cmd-distill.js";
 import { buildPreFilterConfig } from "./cmd-install.js";
@@ -137,7 +136,10 @@ function isSelfCorrectionRemediationItem(item: unknown): boolean {
 
   const remediationContent = candidate.remediationContent;
   if (
-    !(typeof remediationContent === "string" || (typeof remediationContent === "object" && remediationContent !== null))
+    !(
+      typeof remediationContent === "string" ||
+      (typeof remediationContent === "object" && remediationContent !== null)
+    )
   ) {
     return false;
   }
@@ -372,7 +374,7 @@ export async function runSelfCorrectionRunForCli(
               : undefined,
           enabled: adaptiveEnabled,
         });
-        const repaired = tryParseFirstJsonArray(detail.content);
+        const repaired = parseSelfCorrectionLLMResponse(detail.content);
         return repaired === null ? null : (repaired as typeof analysed);
       };
 

--- a/extensions/memory-hybrid/cli/cmd-selfcorrection.ts
+++ b/extensions/memory-hybrid/cli/cmd-selfcorrection.ts
@@ -134,13 +134,18 @@ function isSelfCorrectionRemediationItem(item: unknown): boolean {
   const remediationType = candidate.remediationType;
   if (typeof remediationType !== "string" || remediationType.trim().length === 0) return false;
 
-  const remediationContent = candidate.remediationContent;
-  if (
-    !(
-      typeof remediationContent === "string" ||
-      (typeof remediationContent === "object" && remediationContent !== null)
-    )
-  ) {
+  const isNoAction = remediationType.trim().toUpperCase() === "NO_ACTION";
+  if ("remediationContent" in candidate) {
+    const remediationContent = candidate.remediationContent;
+    if (
+      !(
+        typeof remediationContent === "string" ||
+        (typeof remediationContent === "object" && remediationContent !== null)
+      )
+    ) {
+      return false;
+    }
+  } else if (!isNoAction) {
     return false;
   }
 

--- a/extensions/memory-hybrid/cli/cmd-selfcorrection.ts
+++ b/extensions/memory-hybrid/cli/cmd-selfcorrection.ts
@@ -26,11 +26,7 @@ import { cleanupEvictedVector } from "../services/vector-maintenance.js";
 import { atomicWriteFile } from "../utils/atomic-write.js";
 import { CLI_STORE_IMPORTANCE } from "../utils/constants.js";
 import { getCorrectionSignalRegex } from "../utils/language-keywords.js";
-import {
-  extractBalancedArraySlice,
-  stripBracketContextPreamble,
-  stripMarkdownCodeFence,
-} from "../utils/llm-json-array.js";
+import { tryParseFirstJsonArray } from "../utils/llm-json-array.js";
 import { resolveTierPreferenceWithSources } from "../utils/llm-selection.js";
 import { fillPrompt, loadPrompt } from "../utils/prompt-loader.js";
 import { gatherSessionFiles } from "./cmd-distill.js";
@@ -94,34 +90,17 @@ function sanitizeLlmResponseExcerpt(content: string): string {
  *   - **invalid JSON**: `[not valid]` / truncated → null returned, caller handles error
  */
 export function parseSelfCorrectionLLMResponse(content: string): unknown[] | null {
-  const normalized = stripBracketContextPreamble(stripMarkdownCodeFence(content));
-  let searchFrom = 0;
   let emptyArrayCandidate: unknown[] | null = null;
 
-  while (searchFrom < normalized.length) {
-    const start = normalized.indexOf("[", searchFrom);
-    if (start === -1) break;
-    const slice = extractBalancedArraySlice(normalized, start);
-    if (!slice) {
-      searchFrom = start + 1;
-      continue;
+  const result = tryParseFirstJsonArray(content, (parsed) => {
+    if (parsed.length === 0) {
+      emptyArrayCandidate = parsed;
+      return null;
     }
-    try {
-      const parsed: unknown = JSON.parse(slice);
-      if (Array.isArray(parsed)) {
-        if (parsed.length === 0) {
-          emptyArrayCandidate = parsed;
-        } else if (isSelfCorrectionRemediationArray(parsed)) {
-          return parsed;
-        }
-      }
-    } catch {
-      /* try next balanced span */
-    }
-    searchFrom = start + slice.length;
-  }
+    return isSelfCorrectionRemediationArray(parsed) ? parsed : null;
+  });
 
-  return emptyArrayCandidate;
+  return result ?? emptyArrayCandidate;
 }
 
 function isSelfCorrectionRemediationArray(items: unknown[]): boolean {

--- a/extensions/memory-hybrid/cli/cmd-selfcorrection.ts
+++ b/extensions/memory-hybrid/cli/cmd-selfcorrection.ts
@@ -447,6 +447,8 @@ export async function runSelfCorrectionRunForCli(
           (parseError as any).isParseFailure = true;
           throw parseError;
         }
+      } else {
+        analysed = [];
       }
       if (opts.verbose && analysed.length > 0) {
         logger.info?.(

--- a/extensions/memory-hybrid/cli/commands/manage/register-reflection-pipeline.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/register-reflection-pipeline.ts
@@ -727,7 +727,7 @@ export function registerManageReflectionPipeline(mem: Chainable, b: ManageBindin
           //   resolve-contradictions --dry-run
           //   resolve-contradictions --apply
           // Legacy compatibility: --project-state-lww keeps working as explicit LWW mode.
-          const projectStateLwwContractMode = projectStateLww || apply;
+          const projectStateLwwContractMode = projectStateLww || apply || dryRun;
           if (projectStateLwwContractMode) {
             const lwwDryRun = dryRun;
             // Project-state LWW mode: grouped, human-readable output.

--- a/extensions/memory-hybrid/cli/commands/manage/register-reflection-pipeline.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/register-reflection-pipeline.ts
@@ -754,12 +754,14 @@ export function registerManageReflectionPipeline(mem: Chainable, b: ManageBindin
                 for (const cand of group.candidates) {
                   const overloadNote = cand.possibleOverloadedEntity ? " [!] possible-entity-reuse" : "";
                   const actionLabel = cand.action === "supersede" ? "auto-safe: project-state-lww" : "manual: non-qualifying";
+                  const keepLabel = cand.action === "supersede" ? "keep" : "newer";
+                  const supersedeLabel = cand.action === "supersede" ? "supersede" : "older";
                   console.log(`    [${actionLabel}]${overloadNote}`);
                   console.log(
-                    `      keep:      ${formatEpochTimestamp(cand.newFactDate)} src=${cand.newSource} conf=${cand.newConf.toFixed(2)} "${cand.newValueExcerpt}"`,
+                    `      ${keepLabel.padEnd(10)}: ${formatEpochTimestamp(cand.newFactDate)} src=${cand.newSource} conf=${cand.newConf.toFixed(2)} "${cand.newValueExcerpt}"`,
                   );
                   console.log(
-                    `      supersede: ${formatEpochTimestamp(cand.oldFactDate)} src=${cand.oldSource} conf=${cand.oldConf.toFixed(2)} "${cand.oldValueExcerpt}"`,
+                    `      ${supersedeLabel.padEnd(10)}: ${formatEpochTimestamp(cand.oldFactDate)} src=${cand.oldSource} conf=${cand.oldConf.toFixed(2)} "${cand.oldValueExcerpt}"`,
                   );
                   console.log(`      contradiction: ${cand.contradictionId}`);
                 }

--- a/extensions/memory-hybrid/cli/commands/manage/register-reflection-pipeline.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/register-reflection-pipeline.ts
@@ -700,81 +700,163 @@ export function registerManageReflectionPipeline(mem: Chainable, b: ManageBindin
       "--details",
       "For ambiguous pairs, print entity/key/value summaries (not only UUIDs); implies listing all ambiguous rows",
     )
+    .option(
+      "--project-state-lww",
+      "Apply project-state latest-wins (LWW) policy: safely resolve stale project/task contradictions for known mutable keys",
+    )
+    .option(
+      "--dry-run",
+      "With --project-state-lww: report candidates and grouped details without mutating any facts",
+    )
     .action(
-      withExit(async (opts?: { verbose?: boolean; details?: boolean }, cmd?: CommanderOptsParent) => {
-        const verbose = !!opts?.verbose || readHybridMemVerbose(cmd);
-        const details = !!opts?.details;
-        let res;
-        try {
-          res = await ctx.runResolveContradictions();
-        } catch (err) {
-          capturePluginError(err instanceof Error ? err : new Error(String(err)), {
-            subsystem: "cli",
-            operation: "resolve-contradictions",
-          });
-          throw err;
-        }
-        console.log(
-          `Contradictions resolved: ${res.autoResolved.length} auto-resolved, ${res.ambiguous.length} ambiguous.`,
-        );
-        if (verbose && res.autoResolved.length > 0) {
-          console.log("Auto-resolved (--verbose):");
-          for (const a of res.autoResolved) {
-            console.log(`  - ${a.factIdNew} ↔ ${a.factIdOld} (${a.contradictionId})`);
-          }
-        }
-        if (res.ambiguous.length > 0) {
-          const trunc = (s: string | null | undefined, n: number): string => {
-            if (s == null || s === "") return "(empty)";
-            const t = s.replace(/\s+/g, " ").trim();
-            return t.length <= n ? t : `${t.slice(0, n - 1)}…`;
-          };
-          const ambiguousList = verbose || details ? res.ambiguous : res.ambiguous.slice(0, 10);
-          if (details) {
-            console.log("Ambiguous pairs (same entity + key, different value — pick which fact stays current):");
-            for (const a of ambiguousList) {
-              const newF = factsDb.getById(a.factIdNew);
-              const oldF = factsDb.getById(a.factIdOld);
-              const entity = newF?.entity ?? oldF?.entity ?? "?";
-              const key = newF?.key ?? oldF?.key ?? "?";
-              const newBits = newF
-                ? `value=${trunc(newF.value, 48)} | text=${trunc(newF.text, 72)} | conf=${(newF.confidence ?? 0).toFixed(2)} | src=${newF.source}`
-                : "(newer fact row missing)";
-              const oldBits = oldF
-                ? `value=${trunc(oldF.value, 48)} | text=${trunc(oldF.text, 72)} | conf=${(oldF.confidence ?? 0).toFixed(2)} | src=${oldF.source}`
-                : "(older fact row missing)";
-              console.log(`  · [${entity}] ${key}`);
-              console.log(`      newer fact ${a.factIdNew}: ${newBits}`);
-              console.log(`      older fact ${a.factIdOld}: ${oldBits}`);
-              console.log(`      contradiction row ${a.contradictionId}`);
+      withExit(
+        async (
+          opts?: { verbose?: boolean; details?: boolean; projectStateLww?: boolean; dryRun?: boolean },
+          cmd?: CommanderOptsParent,
+        ) => {
+          const verbose = !!opts?.verbose || readHybridMemVerbose(cmd);
+          const details = !!opts?.details;
+          const projectStateLww = !!opts?.projectStateLww;
+          const dryRun = !!opts?.dryRun;
+
+          if (projectStateLww) {
+            // Project-state LWW mode: grouped, human-readable output.
+            let lwwRes;
+            try {
+              lwwRes = await ctx.runResolveContradictionsProjectStateLww({ dryRun });
+            } catch (err) {
+              capturePluginError(err instanceof Error ? err : new Error(String(err)), {
+                subsystem: "cli",
+                operation: "resolve-contradictions-project-state-lww",
+              });
+              throw err;
             }
-          } else {
-            console.log("Ambiguous pairs (manual review recommended):");
-            for (const a of ambiguousList) {
+
+            const modeLabel = dryRun ? "(dry-run)" : "(applied)";
+            if (dryRun) {
+              console.log(
+                `project-state-lww candidates ${modeLabel}: ${lwwRes.totalCandidates} total — would supersede: ${lwwRes.wouldSupersede}, manual review: ${lwwRes.wouldManualReview}`,
+              );
+            } else {
+              console.log(
+                `project-state-lww ${modeLabel}: ${lwwRes.applied} superseded, ${lwwRes.wouldManualReview} manual-review remaining.`,
+              );
+            }
+
+            if (lwwRes.groups.length > 0) {
+              const formatEpochTimestamp = (t: number) => new Date(t * 1000).toISOString().replace("T", " ").slice(0, 19);
+              for (const group of lwwRes.groups) {
+                const scopeLabel =
+                  group.scope && group.scope !== "global"
+                    ? ` [scope=${group.scope}${group.scopeTarget ? `/${group.scopeTarget}` : ""}]`
+                    : "";
+                console.log(`\n  ${group.entity} / ${group.key}${scopeLabel}`);
+                for (const cand of group.candidates) {
+                  const overloadNote = cand.possibleOverloadedEntity ? " [!] possible-entity-reuse" : "";
+                  const actionLabel = cand.action === "supersede" ? "auto-safe: project-state-lww" : "manual: non-qualifying";
+                  console.log(`    [${actionLabel}]${overloadNote}`);
+                  console.log(
+                    `      keep:      ${formatEpochTimestamp(cand.newFactDate)} src=${cand.newSource} conf=${cand.newConf.toFixed(2)} "${cand.newValueExcerpt}"`,
+                  );
+                  console.log(
+                    `      supersede: ${formatEpochTimestamp(cand.oldFactDate)} src=${cand.oldSource} conf=${cand.oldConf.toFixed(2)} "${cand.oldValueExcerpt}"`,
+                  );
+                  console.log(`      contradiction: ${cand.contradictionId}`);
+                }
+              }
+              console.log("");
+            }
+
+            if (dryRun && lwwRes.wouldSupersede > 0) {
+              console.log(`Run without --dry-run to apply ${lwwRes.wouldSupersede} project-state-lww resolutions.`);
+            }
+            if (lwwRes.wouldManualReview > 0) {
+              console.log(
+                `${lwwRes.wouldManualReview} project-state pair(s) require manual review (non-qualifying for LWW).`,
+              );
+              console.log("  Inspect with: openclaw hybrid-mem resolve-contradictions --details");
+            }
+            return;
+          }
+
+          // Default (conservative) mode: unchanged behavior.
+          let res;
+          try {
+            res = await ctx.runResolveContradictions();
+          } catch (err) {
+            capturePluginError(err instanceof Error ? err : new Error(String(err)), {
+              subsystem: "cli",
+              operation: "resolve-contradictions",
+            });
+            throw err;
+          }
+          console.log(
+            `Contradictions resolved: ${res.autoResolved.length} auto-resolved, ${res.ambiguous.length} ambiguous.`,
+          );
+          if (verbose && res.autoResolved.length > 0) {
+            console.log("Auto-resolved (--verbose):");
+            for (const a of res.autoResolved) {
               console.log(`  - ${a.factIdNew} ↔ ${a.factIdOld} (${a.contradictionId})`);
             }
           }
-          if (!verbose && !details && res.ambiguous.length > 10) {
-            console.log(`  ...and ${res.ambiguous.length - 10} more`);
+          if (res.ambiguous.length > 0) {
+            const trunc = (s: string | null | undefined, n: number): string => {
+              if (s == null || s === "") return "(empty)";
+              const t = s.replace(/\s+/g, " ").trim();
+              return t.length <= n ? t : `${t.slice(0, n - 1)}…`;
+            };
+            const ambiguousList = verbose || details ? res.ambiguous : res.ambiguous.slice(0, 10);
+            if (details) {
+              console.log("Ambiguous pairs (same entity + key, different value — pick which fact stays current):");
+              for (const a of ambiguousList) {
+                const newF = factsDb.getById(a.factIdNew);
+                const oldF = factsDb.getById(a.factIdOld);
+                const entity = newF?.entity ?? oldF?.entity ?? "?";
+                const key = newF?.key ?? oldF?.key ?? "?";
+                const newBits = newF
+                  ? `value=${trunc(newF.value, 48)} | text=${trunc(newF.text, 72)} | conf=${(newF.confidence ?? 0).toFixed(2)} | src=${newF.source}`
+                  : "(newer fact row missing)";
+                const oldBits = oldF
+                  ? `value=${trunc(oldF.value, 48)} | text=${trunc(oldF.text, 72)} | conf=${(oldF.confidence ?? 0).toFixed(2)} | src=${oldF.source}`
+                  : "(older fact row missing)";
+                console.log(`  · [${entity}] ${key}`);
+                console.log(`      newer fact ${a.factIdNew}: ${newBits}`);
+                console.log(`      older fact ${a.factIdOld}: ${oldBits}`);
+                console.log(`      contradiction row ${a.contradictionId}`);
+              }
+            } else {
+              console.log("Ambiguous pairs (manual review recommended):");
+              for (const a of ambiguousList) {
+                console.log(`  - ${a.factIdNew} ↔ ${a.factIdOld} (${a.contradictionId})`);
+              }
+            }
+            if (!verbose && !details && res.ambiguous.length > 10) {
+              console.log(`  ...and ${res.ambiguous.length - 10} more`);
+            }
+            console.log("");
+            console.log(
+              "What this means: each line is two stored facts with the same entity and key but different values. " +
+                "Auto-resolution only runs when the newer fact is clearly stronger (newer, higher confidence, and from conversation or CLI).",
+            );
+            console.log("What to do:");
+            console.log(
+              "  1. Inspect: openclaw hybrid-mem show <fact-id>   (left/newer id first, then older id in each pair)",
+            );
+            console.log(
+              "  2. Fix memory: if the newer statement is right, add or correct with store --supersedes <older-fact-id>; " +
+                "if the older one is right, supersede or remove the newer fact (e.g. prune), then re-run this command.",
+            );
+            if (!details) {
+              console.log("  3. Easier scan: openclaw hybrid-mem resolve-contradictions --details");
+            }
+            if (res.ambiguous.length > 0) {
+              console.log(
+                "  4. Auto-resolve project-state: openclaw hybrid-mem resolve-contradictions --project-state-lww --dry-run",
+              );
+            }
           }
-          console.log("");
-          console.log(
-            "What this means: each line is two stored facts with the same entity and key but different values. " +
-              "Auto-resolution only runs when the newer fact is clearly stronger (newer, higher confidence, and from conversation or CLI).",
-          );
-          console.log("What to do:");
-          console.log(
-            "  1. Inspect: openclaw hybrid-mem show <fact-id>   (left/newer id first, then older id in each pair)",
-          );
-          console.log(
-            "  2. Fix memory: if the newer statement is right, add or correct with store --supersedes <older-fact-id>; " +
-              "if the older one is right, supersede or remove the newer fact (e.g. prune), then re-run this command.",
-          );
-          if (!details) {
-            console.log("  3. Easier scan: openclaw hybrid-mem resolve-contradictions --details");
-          }
-        }
-      }),
+        },
+      ),
     );
 
   mem

--- a/extensions/memory-hybrid/cli/commands/manage/register-reflection-pipeline.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/register-reflection-pipeline.ts
@@ -727,7 +727,7 @@ export function registerManageReflectionPipeline(mem: Chainable, b: ManageBindin
           //   resolve-contradictions --dry-run
           //   resolve-contradictions --apply
           // Legacy compatibility: --project-state-lww keeps working as explicit LWW mode.
-          const projectStateLwwContractMode = projectStateLww || dryRun || apply;
+          const projectStateLwwContractMode = projectStateLww || apply;
           if (projectStateLwwContractMode) {
             const lwwDryRun = dryRun;
             // Project-state LWW mode: grouped, human-readable output.

--- a/extensions/memory-hybrid/cli/commands/manage/register-reflection-pipeline.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/register-reflection-pipeline.ts
@@ -704,10 +704,7 @@ export function registerManageReflectionPipeline(mem: Chainable, b: ManageBindin
       "--project-state-lww",
       "Apply project-state latest-wins (LWW) policy: safely resolve stale project/task contradictions for known mutable keys",
     )
-    .option(
-      "--dry-run",
-      "With --project-state-lww: report candidates and grouped details without mutating any facts",
-    )
+    .option("--dry-run", "With --project-state-lww: report candidates and grouped details without mutating any facts")
     .action(
       withExit(
         async (
@@ -744,7 +741,8 @@ export function registerManageReflectionPipeline(mem: Chainable, b: ManageBindin
             }
 
             if (lwwRes.groups.length > 0) {
-              const formatEpochTimestamp = (t: number) => new Date(t * 1000).toISOString().replace("T", " ").slice(0, 19);
+              const formatEpochTimestamp = (t: number) =>
+                new Date(t * 1000).toISOString().replace("T", " ").slice(0, 19);
               for (const group of lwwRes.groups) {
                 const scopeLabel =
                   group.scope && group.scope !== "global"
@@ -753,7 +751,8 @@ export function registerManageReflectionPipeline(mem: Chainable, b: ManageBindin
                 console.log(`\n  ${group.entity} / ${group.key}${scopeLabel}`);
                 for (const cand of group.candidates) {
                   const overloadNote = cand.possibleOverloadedEntity ? " [!] possible-entity-reuse" : "";
-                  const actionLabel = cand.action === "supersede" ? "auto-safe: project-state-lww" : "manual: non-qualifying";
+                  const actionLabel =
+                    cand.action === "supersede" ? "auto-safe: project-state-lww" : "manual: non-qualifying";
                   const keepLabel = cand.action === "supersede" ? "keep" : "newer";
                   const supersedeLabel = cand.action === "supersede" ? "supersede" : "older";
                   console.log(`    [${actionLabel}]${overloadNote}`);

--- a/extensions/memory-hybrid/cli/commands/manage/register-reflection-pipeline.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/register-reflection-pipeline.ts
@@ -705,23 +705,35 @@ export function registerManageReflectionPipeline(mem: Chainable, b: ManageBindin
       "--project-state-lww",
       "Apply project-state latest-wins (LWW) policy: safely resolve stale project/task contradictions for known mutable keys",
     )
-    .option("--dry-run", "Report contradiction-resolution candidates without mutating any facts")
+    .option("--dry-run", "Project-state LWW contract mode: preview contradiction-resolution candidates")
+    .option("--apply", "Project-state LWW contract mode: apply contradiction-resolution candidates")
     .action(
       withExit(
         async (
-          opts?: { verbose?: boolean; details?: boolean; projectStateLww?: boolean; dryRun?: boolean },
+          opts?: { verbose?: boolean; details?: boolean; projectStateLww?: boolean; dryRun?: boolean; apply?: boolean },
           cmd?: CommanderOptsParent,
         ) => {
           const verbose = !!opts?.verbose || readHybridMemVerbose(cmd);
           const details = !!opts?.details;
           const projectStateLww = !!opts?.projectStateLww;
           const dryRun = !!opts?.dryRun;
+          const apply = !!opts?.apply;
 
-          if (projectStateLww) {
+          if (dryRun && apply) {
+            throw new Error("--dry-run and --apply are mutually exclusive");
+          }
+
+          // Operator contract mode for Issue #1636:
+          //   resolve-contradictions --dry-run
+          //   resolve-contradictions --apply
+          // Legacy compatibility: --project-state-lww keeps working as explicit LWW mode.
+          const projectStateLwwContractMode = projectStateLww || dryRun || apply;
+          if (projectStateLwwContractMode) {
+            const lwwDryRun = dryRun;
             // Project-state LWW mode: grouped, human-readable output.
             let lwwRes;
             try {
-              lwwRes = await ctx.runResolveContradictionsProjectStateLww({ dryRun });
+              lwwRes = await ctx.runResolveContradictionsProjectStateLww({ dryRun: lwwDryRun });
             } catch (err) {
               capturePluginError(err instanceof Error ? err : new Error(String(err)), {
                 subsystem: "cli",
@@ -730,8 +742,8 @@ export function registerManageReflectionPipeline(mem: Chainable, b: ManageBindin
               throw err;
             }
 
-            const modeLabel = dryRun ? "(dry-run)" : "(applied)";
-            if (dryRun) {
+            const modeLabel = lwwDryRun ? "(dry-run)" : "(applied)";
+            if (lwwDryRun) {
               console.log(
                 `project-state-lww candidates ${modeLabel}: ${lwwRes.totalCandidates} total — would supersede: ${lwwRes.wouldSupersede}, manual review: ${lwwRes.wouldManualReview}`,
               );
@@ -740,6 +752,10 @@ export function registerManageReflectionPipeline(mem: Chainable, b: ManageBindin
                 `project-state-lww ${modeLabel}: ${lwwRes.applied} superseded, ${lwwRes.wouldManualReview} manual-review remaining.`,
               );
             }
+            const autoResolved = lwwDryRun ? lwwRes.wouldSupersede : lwwRes.applied;
+            console.log(
+              `project-state-lww summary auto-resolved=${autoResolved} dry-run=${lwwDryRun ? 1 : 0} remaining=${lwwRes.wouldManualReview} total-candidates=${lwwRes.totalCandidates}`,
+            );
 
             if (lwwRes.groups.length > 0) {
               const formatEpochTimestamp = (t: number) =>
@@ -769,8 +785,8 @@ export function registerManageReflectionPipeline(mem: Chainable, b: ManageBindin
               console.log("");
             }
 
-            if (dryRun && lwwRes.wouldSupersede > 0) {
-              console.log(`Run without --dry-run to apply ${lwwRes.wouldSupersede} project-state-lww resolutions.`);
+            if (lwwDryRun && lwwRes.wouldSupersede > 0) {
+              console.log(`Run with --apply to resolve ${lwwRes.wouldSupersede} project-state-lww contradiction(s).`);
             }
             if (lwwRes.wouldManualReview > 0) {
               console.log(

--- a/extensions/memory-hybrid/cli/commands/manage/register-reflection-pipeline.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/register-reflection-pipeline.ts
@@ -705,7 +705,7 @@ export function registerManageReflectionPipeline(mem: Chainable, b: ManageBindin
       "--project-state-lww",
       "Apply project-state latest-wins (LWW) policy: safely resolve stale project/task contradictions for known mutable keys",
     )
-    .option("--dry-run", "With --project-state-lww: report candidates and grouped details without mutating any facts")
+    .option("--dry-run", "Report contradiction-resolution candidates without mutating any facts")
     .action(
       withExit(
         async (
@@ -777,6 +777,35 @@ export function registerManageReflectionPipeline(mem: Chainable, b: ManageBindin
                 `${lwwRes.wouldManualReview} project-state pair(s) require manual review (non-qualifying for LWW).`,
               );
               console.log("  Inspect with: openclaw hybrid-mem resolve-contradictions --details");
+            }
+            return;
+          }
+
+          if (dryRun) {
+            let res;
+            try {
+              res = await ctx.runResolveContradictionsDryRun();
+            } catch (err) {
+              capturePluginError(err instanceof Error ? err : new Error(String(err)), {
+                subsystem: "cli",
+                operation: "resolve-contradictions-dry-run",
+              });
+              throw err;
+            }
+            console.log(
+              `Contradictions dry-run: would auto-resolve ${res.autoResolvable.length}, ${res.ambiguous.length} ambiguous.`,
+            );
+            if (res.autoResolvable.length > 0) {
+              console.log("Would auto-resolve:");
+              for (const a of res.autoResolvable) {
+                console.log(`  - ${a.factIdNew} ↔ ${a.factIdOld} (${a.contradictionId})`);
+              }
+              console.log("Run without --dry-run to apply these conservative auto-resolutions.");
+            }
+            if (res.ambiguous.length > 0) {
+              console.log(
+                "Ambiguous pairs require manual review. Re-run with --details for entity/key/value summaries, or use --project-state-lww --dry-run for project-state candidates.",
+              );
             }
             return;
           }

--- a/extensions/memory-hybrid/cli/commands/manage/register-reflection-pipeline.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/register-reflection-pipeline.ts
@@ -8,6 +8,7 @@ import { getEffectivenessReport, runClosedLoopAnalysis } from "../../../services
 import { type CommanderOptsParent, readHybridMemVerbose } from "../../global-verbose.js";
 import { type Chainable, withExit } from "../../shared.js";
 import type { ManageBindings } from "./bindings.js";
+import { PROJECT_STATE_LWW_KEYS } from "../../../backends/facts-db/contradictions.js";
 
 import {
   formatExtractImplicitFeedbackProgress,
@@ -850,7 +851,15 @@ export function registerManageReflectionPipeline(mem: Chainable, b: ManageBindin
             if (!details) {
               console.log("  3. Easier scan: openclaw hybrid-mem resolve-contradictions --details");
             }
-            if (res.ambiguous.length > 0) {
+            const hasProjectStatePairs = res.ambiguous.some((a) => {
+              const newF = factsDb.getById(a.factIdNew);
+              const oldF = factsDb.getById(a.factIdOld);
+              if (!newF || !oldF) return false;
+              if (newF.category !== "project" || oldF.category !== "project") return false;
+              const keyLower = (newF.key ?? oldF.key ?? "").toLowerCase();
+              return PROJECT_STATE_LWW_KEYS.has(keyLower);
+            });
+            if (hasProjectStatePairs) {
               console.log(
                 "  4. Auto-resolve project-state: openclaw hybrid-mem resolve-contradictions --project-state-lww --dry-run",
               );

--- a/extensions/memory-hybrid/cli/context.ts
+++ b/extensions/memory-hybrid/cli/context.ts
@@ -155,9 +155,9 @@ export type ManageContext = {
     autoResolved: Array<{ contradictionId: string; factIdNew: string; factIdOld: string }>;
     ambiguous: Array<{ contradictionId: string; factIdNew: string; factIdOld: string }>;
   }>;
-  runResolveContradictionsProjectStateLww: (opts: { dryRun?: boolean }) => Promise<
-    import("../backends/facts-db/contradictions.js").ProjectStateLwwResult
-  >;
+  runResolveContradictionsProjectStateLww: (opts: {
+    dryRun?: boolean;
+  }) => Promise<import("../backends/facts-db/contradictions.js").ProjectStateLwwResult>;
   runSelfCorrectionExtract: (opts: {
     days?: number;
     outputPath?: string;

--- a/extensions/memory-hybrid/cli/context.ts
+++ b/extensions/memory-hybrid/cli/context.ts
@@ -155,6 +155,10 @@ export type ManageContext = {
     autoResolved: Array<{ contradictionId: string; factIdNew: string; factIdOld: string }>;
     ambiguous: Array<{ contradictionId: string; factIdNew: string; factIdOld: string }>;
   }>;
+  runResolveContradictionsDryRun: () => Promise<{
+    autoResolvable: Array<{ contradictionId: string; factIdNew: string; factIdOld: string }>;
+    ambiguous: Array<{ contradictionId: string; factIdNew: string; factIdOld: string }>;
+  }>;
   runResolveContradictionsProjectStateLww: (opts: {
     dryRun?: boolean;
   }) => Promise<import("../backends/facts-db/contradictions.js").ProjectStateLwwResult>;

--- a/extensions/memory-hybrid/cli/context.ts
+++ b/extensions/memory-hybrid/cli/context.ts
@@ -155,6 +155,9 @@ export type ManageContext = {
     autoResolved: Array<{ contradictionId: string; factIdNew: string; factIdOld: string }>;
     ambiguous: Array<{ contradictionId: string; factIdNew: string; factIdOld: string }>;
   }>;
+  runResolveContradictionsProjectStateLww: (opts: { dryRun?: boolean }) => Promise<
+    import("../backends/facts-db/contradictions.js").ProjectStateLwwResult
+  >;
   runSelfCorrectionExtract: (opts: {
     days?: number;
     outputPath?: string;

--- a/extensions/memory-hybrid/cli/register.ts
+++ b/extensions/memory-hybrid/cli/register.ts
@@ -231,6 +231,18 @@ export type HybridMemCliContext = {
       factIdOld: string;
     }>;
   }>;
+  runResolveContradictionsDryRun: () => Promise<{
+    autoResolvable: Array<{
+      contradictionId: string;
+      factIdNew: string;
+      factIdOld: string;
+    }>;
+    ambiguous: Array<{
+      contradictionId: string;
+      factIdNew: string;
+      factIdOld: string;
+    }>;
+  }>;
   runResolveContradictionsProjectStateLww: (opts: {
     dryRun?: boolean;
   }) => Promise<import("../backends/facts-db/contradictions.js").ProjectStateLwwResult>;

--- a/extensions/memory-hybrid/cli/register.ts
+++ b/extensions/memory-hybrid/cli/register.ts
@@ -231,6 +231,9 @@ export type HybridMemCliContext = {
       factIdOld: string;
     }>;
   }>;
+  runResolveContradictionsProjectStateLww: (opts: { dryRun?: boolean }) => Promise<
+    import("../backends/facts-db/contradictions.js").ProjectStateLwwResult
+  >;
   runClassify: (opts: { dryRun: boolean; limit: number; model?: string }) => Promise<{
     reclassified: number;
     total: number;

--- a/extensions/memory-hybrid/cli/register.ts
+++ b/extensions/memory-hybrid/cli/register.ts
@@ -231,9 +231,9 @@ export type HybridMemCliContext = {
       factIdOld: string;
     }>;
   }>;
-  runResolveContradictionsProjectStateLww: (opts: { dryRun?: boolean }) => Promise<
-    import("../backends/facts-db/contradictions.js").ProjectStateLwwResult
-  >;
+  runResolveContradictionsProjectStateLww: (opts: {
+    dryRun?: boolean;
+  }) => Promise<import("../backends/facts-db/contradictions.js").ProjectStateLwwResult>;
   runClassify: (opts: { dryRun: boolean; limit: number; model?: string }) => Promise<{
     reclassified: number;
     total: number;

--- a/extensions/memory-hybrid/setup/cli-context/cli-services.ts
+++ b/extensions/memory-hybrid/setup/cli-context/cli-services.ts
@@ -97,6 +97,10 @@ interface CliContextServices {
     autoResolved: Array<{ contradictionId: string; factIdNew: string; factIdOld: string }>;
     ambiguous: Array<{ contradictionId: string; factIdNew: string; factIdOld: string }>;
   }>;
+  runResolveContradictionsDryRun: () => Promise<{
+    autoResolvable: Array<{ contradictionId: string; factIdNew: string; factIdOld: string }>;
+    ambiguous: Array<{ contradictionId: string; factIdNew: string; factIdOld: string }>;
+  }>;
   runResolveContradictionsProjectStateLww: (opts: {
     dryRun?: boolean;
   }) => Promise<import("../../backends/facts-db/contradictions.js").ProjectStateLwwResult>;
@@ -398,6 +402,7 @@ export function buildCliContextServices(
       });
     },
     runResolveContradictions: () => Promise.resolve(factsDb.resolveContradictions()),
+    runResolveContradictionsDryRun: () => Promise.resolve(factsDb.previewResolveContradictions()),
     runResolveContradictionsProjectStateLww: (opts: { dryRun?: boolean }) =>
       Promise.resolve(factsDb.resolveContradictionsProjectStateLww(opts)),
     getMemoryCategories: () => [...getMemoryCategories()],

--- a/extensions/memory-hybrid/setup/cli-context/cli-services.ts
+++ b/extensions/memory-hybrid/setup/cli-context/cli-services.ts
@@ -97,6 +97,9 @@ interface CliContextServices {
     autoResolved: Array<{ contradictionId: string; factIdNew: string; factIdOld: string }>;
     ambiguous: Array<{ contradictionId: string; factIdNew: string; factIdOld: string }>;
   }>;
+  runResolveContradictionsProjectStateLww: (opts: { dryRun?: boolean }) => Promise<
+    import("../../backends/facts-db/contradictions.js").ProjectStateLwwResult
+  >;
   getMemoryCategories: () => string[];
   mergeResults: HybridMemCliContext["mergeResults"];
   parseSourceDate: (v: string | number | null | undefined) => number | null;
@@ -395,6 +398,8 @@ export function buildCliContextServices(
       });
     },
     runResolveContradictions: () => Promise.resolve(factsDb.resolveContradictions()),
+    runResolveContradictionsProjectStateLww: (opts: { dryRun?: boolean }) =>
+      Promise.resolve(factsDb.resolveContradictionsProjectStateLww(opts)),
     getMemoryCategories: () => [...getMemoryCategories()],
     mergeResults,
     parseSourceDate,

--- a/extensions/memory-hybrid/setup/cli-context/cli-services.ts
+++ b/extensions/memory-hybrid/setup/cli-context/cli-services.ts
@@ -97,9 +97,9 @@ interface CliContextServices {
     autoResolved: Array<{ contradictionId: string; factIdNew: string; factIdOld: string }>;
     ambiguous: Array<{ contradictionId: string; factIdNew: string; factIdOld: string }>;
   }>;
-  runResolveContradictionsProjectStateLww: (opts: { dryRun?: boolean }) => Promise<
-    import("../../backends/facts-db/contradictions.js").ProjectStateLwwResult
-  >;
+  runResolveContradictionsProjectStateLww: (opts: {
+    dryRun?: boolean;
+  }) => Promise<import("../../backends/facts-db/contradictions.js").ProjectStateLwwResult>;
   getMemoryCategories: () => string[];
   mergeResults: HybridMemCliContext["mergeResults"];
   parseSourceDate: (v: string | number | null | undefined) => number | null;

--- a/extensions/memory-hybrid/setup/cli-context/register-help.ts
+++ b/extensions/memory-hybrid/setup/cli-context/register-help.ts
@@ -535,6 +535,7 @@ export function createHybridMemCliContext(
     runDreamCycle: services.runDreamCycle,
     runContinuousVerification: services.runContinuousVerification,
     runResolveContradictions: services.runResolveContradictions,
+    runResolveContradictionsDryRun: services.runResolveContradictionsDryRun,
     runResolveContradictionsProjectStateLww: services.runResolveContradictionsProjectStateLww,
     reflectionConfig: {
       ...handlerCtx.cfg.reflection,

--- a/extensions/memory-hybrid/setup/cli-context/register-help.ts
+++ b/extensions/memory-hybrid/setup/cli-context/register-help.ts
@@ -535,6 +535,7 @@ export function createHybridMemCliContext(
     runDreamCycle: services.runDreamCycle,
     runContinuousVerification: services.runContinuousVerification,
     runResolveContradictions: services.runResolveContradictions,
+    runResolveContradictionsProjectStateLww: services.runResolveContradictionsProjectStateLww,
     reflectionConfig: {
       ...handlerCtx.cfg.reflection,
       model: handlerCtx.cfg.reflection.model ?? getDefaultCronModel(getCronModelConfig(handlerCtx.cfg), "maintenance"),

--- a/extensions/memory-hybrid/tests/contradiction-detection.test.ts
+++ b/extensions/memory-hybrid/tests/contradiction-detection.test.ts
@@ -21,6 +21,7 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import type { DatabaseSync } from "node:sqlite";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { _testing } from "../index.js";
 
@@ -252,6 +253,38 @@ describe("resolveContradictions", () => {
     expect(result.autoResolved).toHaveLength(0);
     expect(result.ambiguous).toHaveLength(1);
     expect(result.ambiguous[0].factIdNew).toBe(newFact.id);
+  });
+
+  it("keeps preview/apply consistent when old fact is verified but already superseded", () => {
+    const old = storeFact("user", "theme", "dark", "User prefers dark mode", 0.5);
+    const newFact = storeFact("user", "theme", "light", "User switched to light mode", 1.0);
+
+    db.detectContradictions(newFact.id, "user", "theme", "light");
+
+    const liveDb = (db as unknown as { liveDb: DatabaseSync }).liveDb;
+    const nowSec = Math.floor(Date.now() / 1000);
+    liveDb
+      .prepare("UPDATE facts SET superseded_at = ?, superseded_by = ? WHERE id = ?")
+      .run(nowSec, newFact.id, old.id);
+
+    const nowIso = new Date().toISOString();
+    liveDb
+      .prepare(
+        `INSERT INTO verified_facts (
+           id, fact_id, canonical_text, checksum, verified_at, verified_by, next_verification, version, previous_version_id, created_at
+         ) VALUES (?, ?, ?, ?, ?, ?, NULL, 1, NULL, ?)`,
+      )
+      .run(`vf-${old.id}`, old.id, old.text, "test-checksum", nowIso, "agent", nowIso);
+
+    const preview = db.previewResolveContradictions();
+    expect(preview.autoResolvable).toHaveLength(1);
+    expect(preview.ambiguous).toHaveLength(0);
+
+    const apply = db.resolveContradictions();
+    expect(apply.autoResolved).toHaveLength(1);
+    expect(apply.ambiguous).toHaveLength(0);
+    expect(apply.autoResolved[0].factIdOld).toBe(old.id);
+    expect(apply.autoResolved[0].factIdNew).toBe(newFact.id);
   });
 
   it("does not re-process already-resolved contradictions", () => {

--- a/extensions/memory-hybrid/tests/project-state-lww.test.ts
+++ b/extensions/memory-hybrid/tests/project-state-lww.test.ts
@@ -64,9 +64,7 @@ function storeProjectFact(opts: StoreOpts) {
   if (opts.createdAtOffset != null && opts.createdAtOffset !== 0) {
     // Directly adjust created_at so we can test ordering without real sleep.
     // @ts-expect-error accessing internal liveDb for test setup only
-    db.liveDb
-      .prepare("UPDATE facts SET created_at = created_at + ? WHERE id = ?")
-      .run(opts.createdAtOffset, entry.id);
+    db.liveDb.prepare("UPDATE facts SET created_at = created_at + ? WHERE id = ?").run(opts.createdAtOffset, entry.id);
   }
   return db.getById(entry.id)!;
 }
@@ -405,9 +403,9 @@ describe("project-state-lww: write-time auto-supersede", () => {
     db.detectContradictions(newer.id, "proj-write-time", "status", "done");
 
     // After write-time auto-supersede, no unresolved contradiction should remain
-    const unresolved = db.getContradictions().filter(
-      (c) => (c.factIdNew === newer.id || c.factIdOld === older.id) && !c.resolved,
-    );
+    const unresolved = db
+      .getContradictions()
+      .filter((c) => (c.factIdNew === newer.id || c.factIdOld === older.id) && !c.resolved);
     expect(unresolved).toHaveLength(0);
 
     // Old fact should be marked superseded

--- a/extensions/memory-hybrid/tests/project-state-lww.test.ts
+++ b/extensions/memory-hybrid/tests/project-state-lww.test.ts
@@ -404,7 +404,9 @@ describe("project-state-lww: missing original confidence requires manual-review"
     // Simulate legacy/backfilled contradiction rows where original confidence is absent.
     // @ts-expect-error accessing internal liveDb for deterministic legacy-row setup
     db.liveDb
-      .prepare("UPDATE contradictions SET old_fact_original_confidence = NULL WHERE fact_id_new = ? AND fact_id_old = ?")
+      .prepare(
+        "UPDATE contradictions SET old_fact_original_confidence = NULL WHERE fact_id_new = ? AND fact_id_old = ?",
+      )
       .run(newer.id, older.id);
 
     const dryRun = db.resolveContradictionsProjectStateLww({ dryRun: true });

--- a/extensions/memory-hybrid/tests/project-state-lww.test.ts
+++ b/extensions/memory-hybrid/tests/project-state-lww.test.ts
@@ -11,6 +11,7 @@
  *   - Write-time auto-supersede: project-state store avoids leaving unresolved contradictions
  *   - Trusted-source guard: distillation source does not qualify for LWW
  *   - Older-wins case: newer fact older than old → manual-review
+ *   - Missing old_fact_original_confidence stays manual-review (no penalized fallback)
  */
 
 import { mkdtempSync, rmSync } from "node:fs";
@@ -378,7 +379,50 @@ describe("project-state-lww: older-wins prevents auto-supersede", () => {
 });
 
 // ---------------------------------------------------------------------------
-// 8. Write-time auto-supersede: storing a newer project-state fact avoids
+// 8. Missing original confidence should not auto-supersede
+// ---------------------------------------------------------------------------
+describe("project-state-lww: missing original confidence requires manual-review", () => {
+  it("does not supersede when old_fact_original_confidence is missing", () => {
+    const older = storeProjectFact({
+      entity: "proj-missing-original-confidence",
+      key: "status",
+      value: "in_progress",
+      text: "Project in progress",
+      confidence: 1.0,
+    });
+    const newer = storeProjectFact({
+      entity: "proj-missing-original-confidence",
+      key: "status",
+      value: "done",
+      text: "Project done with lower confidence than original",
+      confidence: 0.9,
+      createdAtOffset: 60,
+    });
+
+    // recordContradiction stores the pre-penalty confidence then penalizes old fact by -0.2.
+    db.recordContradiction(newer.id, older.id);
+    // Simulate legacy/backfilled contradiction rows where original confidence is absent.
+    // @ts-expect-error accessing internal liveDb for deterministic legacy-row setup
+    db.liveDb
+      .prepare("UPDATE contradictions SET old_fact_original_confidence = NULL WHERE fact_id_new = ? AND fact_id_old = ?")
+      .run(newer.id, older.id);
+
+    const dryRun = db.resolveContradictionsProjectStateLww({ dryRun: true });
+    const candidate = dryRun.groups
+      .flatMap((g) => g.candidates)
+      .find((c) => c.factIdNew === newer.id && c.factIdOld === older.id);
+    expect(candidate).toBeDefined();
+    expect(candidate?.action).toBe("manual-review");
+
+    const apply = db.resolveContradictionsProjectStateLww({ dryRun: false });
+    expect(apply.applied).toBe(0);
+    const oldAfter = db.getById(older.id);
+    expect(oldAfter?.supersededAt).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 9. Write-time auto-supersede: storing a newer project-state fact avoids
 //    leaving an unresolved contradiction
 // ---------------------------------------------------------------------------
 describe("project-state-lww: write-time auto-supersede", () => {

--- a/extensions/memory-hybrid/tests/project-state-lww.test.ts
+++ b/extensions/memory-hybrid/tests/project-state-lww.test.ts
@@ -351,15 +351,17 @@ describe("project-state-lww: older-wins prevents auto-supersede", () => {
       text: "Next step A",
       confidence: 1.0,
     });
-    // Same created_at as older (no offset) → not strictly newer
-    const newer = storeProjectFact({
+    // Force same created_at as older to avoid wall-clock timing flake.
+    const newerInitial = storeProjectFact({
       entity: "proj-b",
       key: "next",
       value: "step B",
       text: "Next step B",
       confidence: 1.0,
-      createdAtOffset: 0,
     });
+    // @ts-expect-error accessing internal liveDb for deterministic test setup only
+    db.liveDb.prepare("UPDATE facts SET created_at = ? WHERE id = ?").run(older.createdAt, newerInitial.id);
+    const newer = db.getById(newerInitial.id)!;
 
     // Manually record the contradiction since detectContradictions at write time may auto-resolve
     // strictly newer project facts; here they have the same timestamp so it won't auto-resolve.

--- a/extensions/memory-hybrid/tests/project-state-lww.test.ts
+++ b/extensions/memory-hybrid/tests/project-state-lww.test.ts
@@ -1,0 +1,415 @@
+/**
+ * Tests for project-state latest-wins (LWW) contradiction resolution (Issue #1636).
+ *
+ * Covers:
+ *   - Equal-confidence project `status` transition in_progress → done
+ *   - Project `next` update from active-task → conversation
+ *   - Non-project equal-confidence conflict remains ambiguous (unchanged behavior)
+ *   - Overloaded task entity is flagged in LWW report
+ *   - Dry-run does not mutate facts or contradictions
+ *   - Apply mode resolves contradictions and supersedes old facts
+ *   - Write-time auto-supersede: project-state store avoids leaving unresolved contradictions
+ *   - Trusted-source guard: distillation source does not qualify for LWW
+ *   - Older-wins case: newer fact older than old → manual-review
+ */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { _testing } from "../index.js";
+
+const { FactsDB } = _testing;
+
+let tmpDir: string;
+let db: InstanceType<typeof FactsDB>;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "lww-test-"));
+  db = new FactsDB(join(tmpDir, "facts.db"));
+});
+
+afterEach(() => {
+  db.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type StoreOpts = {
+  entity: string;
+  key: string;
+  value: string;
+  text: string;
+  category?: string;
+  source?: string;
+  confidence?: number;
+  createdAtOffset?: number;
+};
+
+/** Store a fact and return it. createdAtOffset shifts created_at by N seconds from its initial stored value. */
+function storeProjectFact(opts: StoreOpts) {
+  const entry = db.store({
+    text: opts.text,
+    category: (opts.category ?? "project") as import("../config.js").MemoryCategory,
+    importance: 0.8,
+    entity: opts.entity,
+    key: opts.key,
+    value: opts.value,
+    source: opts.source ?? "conversation",
+    confidence: opts.confidence ?? 1.0,
+  });
+  if (opts.createdAtOffset != null && opts.createdAtOffset !== 0) {
+    // Directly adjust created_at so we can test ordering without real sleep.
+    // @ts-expect-error accessing internal liveDb for test setup only
+    db.liveDb
+      .prepare("UPDATE facts SET created_at = created_at + ? WHERE id = ?")
+      .run(opts.createdAtOffset, entry.id);
+  }
+  return db.getById(entry.id)!;
+}
+
+// ---------------------------------------------------------------------------
+// 1. Equal-confidence project status transition: in_progress → done
+// ---------------------------------------------------------------------------
+describe("project-state-lww: equal-confidence status transition", () => {
+  it("dry-run reports the transition as supersede candidate", () => {
+    const older = storeProjectFact({
+      entity: "hybrid-memory-issue-1636-pr",
+      key: "status",
+      value: "in_progress",
+      text: "PR #1636 is in progress",
+      confidence: 1.0,
+    });
+    const newer = storeProjectFact({
+      entity: "hybrid-memory-issue-1636-pr",
+      key: "status",
+      value: "done",
+      text: "PR #1636 merged",
+      confidence: 1.0,
+      createdAtOffset: 60,
+    });
+
+    // Use recordContradiction directly so the contradiction stays unresolved for
+    // the batch pass to find (detectContradictions triggers write-time LWW which
+    // would immediately resolve the pair before the batch run).
+    db.recordContradiction(newer.id, older.id);
+
+    const result = db.resolveContradictionsProjectStateLww({ dryRun: true });
+    expect(result.totalCandidates).toBeGreaterThanOrEqual(1);
+    expect(result.wouldSupersede).toBeGreaterThanOrEqual(1);
+    expect(result.applied).toBe(0); // dry-run: no mutations
+    const candidate = result.groups
+      .flatMap((g) => g.candidates)
+      .find((c) => c.factIdNew === newer.id || c.factIdOld === older.id);
+    expect(candidate).toBeDefined();
+    expect(candidate?.action).toBe("supersede");
+  });
+
+  it("apply mode resolves the contradiction and marks old fact superseded", () => {
+    const older = storeProjectFact({
+      entity: "hybrid-memory-issue-1636-pr",
+      key: "status",
+      value: "in_progress",
+      text: "PR #1636 is in progress",
+      confidence: 1.0,
+    });
+    const newer = storeProjectFact({
+      entity: "hybrid-memory-issue-1636-pr",
+      key: "status",
+      value: "done",
+      text: "PR #1636 merged",
+      confidence: 1.0,
+      createdAtOffset: 60,
+    });
+
+    // Use recordContradiction directly so the contradiction stays unresolved for
+    // the batch pass (detectContradictions triggers write-time LWW which would
+    // resolve the pair before the batch run, making beforeApply empty).
+    db.recordContradiction(newer.id, older.id);
+
+    // Verify contradiction was recorded
+    const beforeApply = db.getContradictions();
+    expect(beforeApply.some((c) => c.factIdNew === newer.id && c.factIdOld === older.id)).toBe(true);
+
+    const result = db.resolveContradictionsProjectStateLww({ dryRun: false });
+    expect(result.applied).toBeGreaterThanOrEqual(1);
+
+    // Contradiction should now be resolved
+    const afterApply = db.getContradictions();
+    expect(afterApply.every((c) => c.resolved || c.factIdNew !== newer.id)).toBe(true);
+
+    // Old fact should be superseded
+    const oldFactAfter = db.getById(older.id);
+    expect(oldFactAfter?.supersededAt).not.toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Project `next` update from active-task → conversation
+// ---------------------------------------------------------------------------
+describe("project-state-lww: next key update across sources", () => {
+  it("conversation source supersedes active-task source for next key", () => {
+    const older = storeProjectFact({
+      entity: "hybrid-memory",
+      key: "next",
+      value: "fix CI",
+      text: "Next: fix CI — from active-task",
+      source: "active-task",
+      confidence: 1.0,
+    });
+    const newer = storeProjectFact({
+      entity: "hybrid-memory",
+      key: "next",
+      value: "merge PR #1636",
+      text: "Next: merge PR #1636 — conversation update",
+      source: "conversation",
+      confidence: 1.0,
+      createdAtOffset: 120,
+    });
+
+    // Use recordContradiction directly so the contradiction stays unresolved for
+    // the batch pass (detectContradictions triggers write-time LWW which would
+    // resolve the pair before the batch run).
+    db.recordContradiction(newer.id, older.id);
+
+    const result = db.resolveContradictionsProjectStateLww({ dryRun: false });
+    expect(result.applied).toBeGreaterThanOrEqual(1);
+
+    // Old active-task fact should be superseded
+    const oldAfter = db.getById(older.id);
+    expect(oldAfter?.supersededAt).not.toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Non-project equal-confidence conflict remains ambiguous
+// ---------------------------------------------------------------------------
+describe("project-state-lww: non-project facts are not touched", () => {
+  it("fact category equal-confidence contradiction stays ambiguous under LWW", () => {
+    const older = db.store({
+      text: "User prefers dark theme",
+      category: "fact",
+      importance: 0.7,
+      entity: "user",
+      key: "theme",
+      value: "dark",
+      source: "conversation",
+      confidence: 1.0,
+    });
+    const newer = db.store({
+      text: "User prefers light theme",
+      category: "fact",
+      importance: 0.7,
+      entity: "user",
+      key: "theme",
+      value: "light",
+      source: "conversation",
+      confidence: 1.0,
+    });
+
+    db.detectContradictions(newer.id, "user", "theme", "light");
+
+    const result = db.resolveContradictionsProjectStateLww({ dryRun: true });
+    // LWW should not pick up non-project facts
+    const touched = result.groups
+      .flatMap((g) => g.candidates)
+      .find((c) => c.factIdNew === newer.id || c.factIdOld === older.id);
+    expect(touched).toBeUndefined();
+
+    // The contradiction should still be unresolved
+    const unresolvedAfter = db.getContradictions();
+    expect(unresolvedAfter.some((c) => c.factIdNew === newer.id)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Overloaded task entity is flagged in the LWW report
+// ---------------------------------------------------------------------------
+describe("project-state-lww: overloaded entity detection", () => {
+  it("flags when entity/key values reference many distinct PR/issue numbers", () => {
+    const older = storeProjectFact({
+      entity: "hybrid-memory-issue-1272-pr",
+      key: "status",
+      value: "done — PR #1284 merged",
+      text: "PR #1284 for issue #1272 merged",
+      confidence: 1.0,
+    });
+    const newer = storeProjectFact({
+      entity: "hybrid-memory-issue-1272-pr",
+      key: "status",
+      value: "in_progress — PR #1288 open",
+      text: "Follow-up PR #1288 for issue #1272 in progress, related to issue #999",
+      confidence: 1.0,
+      createdAtOffset: 30,
+    });
+
+    // Use recordContradiction directly so the contradiction stays unresolved for
+    // the batch pass (detectContradictions triggers write-time LWW which would
+    // resolve the pair before the batch run, preventing overloaded-entity detection).
+    db.recordContradiction(newer.id, older.id);
+
+    const result = db.resolveContradictionsProjectStateLww({ dryRun: true });
+    const candidate = result.groups
+      .flatMap((g) => g.candidates)
+      .find((c) => c.factIdNew === newer.id || c.factIdOld === older.id);
+
+    // Candidate should be found and flagged as possibly overloaded
+    expect(candidate).toBeDefined();
+    expect(candidate?.possibleOverloadedEntity).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. Dry-run does not mutate facts or contradictions
+// ---------------------------------------------------------------------------
+describe("project-state-lww: dry-run immutability", () => {
+  it("does not modify any facts or contradiction records in dry-run mode", () => {
+    const older = storeProjectFact({
+      entity: "test-project",
+      key: "status",
+      value: "in_progress",
+      text: "Test project in progress",
+      confidence: 1.0,
+    });
+    const newer = storeProjectFact({
+      entity: "test-project",
+      key: "status",
+      value: "done",
+      text: "Test project done",
+      confidence: 1.0,
+      createdAtOffset: 60,
+    });
+
+    // Use recordContradiction directly so the contradiction is present and unresolved
+    // when we check immutability. detectContradictions triggers write-time LWW which
+    // would immediately resolve the pair, making the before/after checks vacuous.
+    db.recordContradiction(newer.id, older.id);
+
+    const contradictionsBefore = db.getContradictions();
+    const olderFactBefore = db.getById(older.id);
+
+    db.resolveContradictionsProjectStateLww({ dryRun: true });
+
+    const contradictionsAfter = db.getContradictions();
+    const olderFactAfter = db.getById(older.id);
+
+    // Contradiction records unchanged
+    expect(contradictionsAfter.length).toBe(contradictionsBefore.length);
+    expect(contradictionsAfter.every((c) => !c.resolved)).toBe(true);
+    // Old fact NOT superseded
+    expect(olderFactAfter?.supersededAt).toBe(olderFactBefore?.supersededAt);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. Trusted-source guard: distillation source does not qualify for LWW
+// ---------------------------------------------------------------------------
+describe("project-state-lww: source trust guard", () => {
+  it("does not supersede when newer fact source is distillation", () => {
+    const older = storeProjectFact({
+      entity: "proj-a",
+      key: "status",
+      value: "in_progress",
+      text: "Project A in progress",
+      source: "conversation",
+      confidence: 1.0,
+    });
+    const newer = storeProjectFact({
+      entity: "proj-a",
+      key: "status",
+      value: "done",
+      text: "Project A done (distilled)",
+      source: "distillation",
+      confidence: 1.0,
+      createdAtOffset: 60,
+    });
+
+    db.detectContradictions(newer.id, "proj-a", "status", "done");
+
+    const result = db.resolveContradictionsProjectStateLww({ dryRun: true });
+    const candidate = result.groups
+      .flatMap((g) => g.candidates)
+      .find((c) => c.factIdNew === newer.id || c.factIdOld === older.id);
+
+    // distillation source → not eligible for LWW
+    expect(candidate).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 7. Older-wins case: newer fact timestamp is not strictly newer → manual-review
+// ---------------------------------------------------------------------------
+describe("project-state-lww: older-wins prevents auto-supersede", () => {
+  it("keeps action as manual-review when new fact is not strictly newer", () => {
+    const older = storeProjectFact({
+      entity: "proj-b",
+      key: "next",
+      value: "step A",
+      text: "Next step A",
+      confidence: 1.0,
+    });
+    // Same created_at as older (no offset) → not strictly newer
+    const newer = storeProjectFact({
+      entity: "proj-b",
+      key: "next",
+      value: "step B",
+      text: "Next step B",
+      confidence: 1.0,
+      createdAtOffset: 0,
+    });
+
+    // Manually record the contradiction since detectContradictions at write time may auto-resolve
+    // strictly newer project facts; here they have the same timestamp so it won't auto-resolve.
+    db.recordContradiction(newer.id, older.id);
+
+    const result = db.resolveContradictionsProjectStateLww({ dryRun: true });
+    const candidate = result.groups
+      .flatMap((g) => g.candidates)
+      .find((c) => c.factIdNew === newer.id && c.factIdOld === older.id);
+
+    if (candidate) {
+      expect(candidate.action).toBe("manual-review");
+    }
+    // If not in result, it means it was filtered out entirely (also acceptable for non-qualifying)
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 8. Write-time auto-supersede: storing a newer project-state fact avoids
+//    leaving an unresolved contradiction
+// ---------------------------------------------------------------------------
+describe("project-state-lww: write-time auto-supersede", () => {
+  it("immediately resolves the contradiction when a newer trusted project-state fact is stored", () => {
+    const older = storeProjectFact({
+      entity: "proj-write-time",
+      key: "status",
+      value: "in_progress",
+      text: "Write-time test: in progress",
+      confidence: 1.0,
+    });
+    const newer = storeProjectFact({
+      entity: "proj-write-time",
+      key: "status",
+      value: "done",
+      text: "Write-time test: done",
+      confidence: 1.0,
+      createdAtOffset: 10,
+    });
+
+    // detectContradictions at write time should auto-supersede for project-state facts
+    db.detectContradictions(newer.id, "proj-write-time", "status", "done");
+
+    // After write-time auto-supersede, no unresolved contradiction should remain
+    const unresolved = db.getContradictions().filter(
+      (c) => (c.factIdNew === newer.id || c.factIdOld === older.id) && !c.resolved,
+    );
+    expect(unresolved).toHaveLength(0);
+
+    // Old fact should be marked superseded
+    const oldAfter = db.getById(older.id);
+    expect(oldAfter?.supersededAt).not.toBeNull();
+  });
+});

--- a/extensions/memory-hybrid/tests/reinforcement-analysis.test.ts
+++ b/extensions/memory-hybrid/tests/reinforcement-analysis.test.ts
@@ -542,6 +542,37 @@ describe("AGENTS_RULE from self-correction creates proposal in DB (#260)", () =>
   });
 });
 
+describe("Self-correction NO_ACTION handling", () => {
+  it("treats NO_ACTION without remediationContent as a valid no-op", async () => {
+    const llmResponse = JSON.stringify([
+      {
+        category: "NO_ISSUE",
+        severity: "LOW",
+        remediationType: "NO_ACTION",
+      },
+    ]);
+
+    const openai = makeOpenAIMock(llmResponse);
+    const ctx = makeCtx(openai);
+    const result = await runSelfCorrectionRunForCli(ctx, {
+      incidents: [
+        {
+          userMessage: "Looks good now, no further changes needed.",
+          agentMessage: "I applied the requested update.",
+          sessionFile: "2026-01-01-session.jsonl",
+          timestamp: "2026-01-01T00:00:00.000Z",
+        } as any,
+      ],
+      workspace: tmpDir,
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(result.analysed).toBe(1);
+    expect(result.autoFixed).toBe(0);
+    expect(result.proposals).toEqual([]);
+  });
+});
+
 // ---------------------------------------------------------------------------
 // Semantic dedup: skip duplicate PATTERN_FACT
 // ---------------------------------------------------------------------------

--- a/extensions/memory-hybrid/tests/resolve-contradictions-cli.test.ts
+++ b/extensions/memory-hybrid/tests/resolve-contradictions-cli.test.ts
@@ -1,0 +1,222 @@
+import { Command } from "commander";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ManageBindings } from "../cli/commands/manage/bindings.js";
+import { registerManageReflectionPipeline } from "../cli/commands/manage/register-reflection-pipeline.js";
+
+type LwwResult = Awaited<ReturnType<ManageBindings["runResolveContradictionsProjectStateLww"]>>;
+
+function makeBindings(overrides: Partial<ManageBindings> = {}): ManageBindings {
+  const base = {
+    factsDb: {
+      getById: vi.fn().mockReturnValue(null),
+    },
+    cfg: {},
+    runFindDuplicates: vi.fn().mockResolvedValue({ pairs: [], candidatesCount: 0, skippedStructured: 0 }),
+    runConsolidate: vi.fn().mockResolvedValue({ clustersFound: 0, merged: 0, deleted: 0 }),
+    runReflection: vi.fn().mockResolvedValue({ factsAnalyzed: 0, patternsExtracted: 0, patternsStored: 0, window: 7 }),
+    reflectionConfig: { enabled: true, defaultWindow: 7, minObservations: 1, model: "test-model" },
+    runReflectionRules: vi.fn().mockResolvedValue({ rulesExtracted: 0, rulesStored: 0 }),
+    runReflectionMeta: vi.fn().mockResolvedValue({ metaExtracted: 0, metaStored: 0 }),
+    runReflectIdentity: vi.fn().mockResolvedValue({ insightsExtracted: 0, insightsStored: 0, questionsAsked: 0 }),
+    runClassify: vi.fn().mockResolvedValue({ reclassified: 0, total: 0, breakdown: {} }),
+    runEntityEnrichment: vi.fn().mockResolvedValue({ pending: 0, processed: 0, factsEnriched: 0 }),
+    runDreamCycle: vi.fn().mockResolvedValue({ skipped: true }),
+    runContinuousVerification: vi.fn().mockResolvedValue({ skipped: true }),
+    runExtractImplicitFeedback: vi
+      .fn()
+      .mockResolvedValue({
+        signalsExtracted: 0,
+        positiveCount: 0,
+        negativeCount: 0,
+        trajectoriesBuilt: 0,
+        sessionsScanned: 0,
+      }),
+    runCrossAgentLearning: vi.fn().mockResolvedValue({ stored: 0 }),
+    runToolEffectiveness: vi.fn().mockResolvedValue("ok"),
+    pruneCostLog: vi.fn().mockReturnValue(0),
+    runBackfill: vi.fn().mockResolvedValue({ stored: 0, skipped: 0, candidates: 0, files: 0 }),
+    runIngestFiles: vi.fn().mockResolvedValue({ stored: 0, skipped: 0, extracted: 0, files: 0 }),
+    runExport: vi
+      .fn()
+      .mockResolvedValue({ factsExported: 0, proceduresExported: 0, filesWritten: 0, outputPath: "/tmp" }),
+    runBuildLanguageKeywords: vi
+      .fn()
+      .mockResolvedValue({ ok: true, path: "/tmp/languages.json", topLanguages: [], languagesAdded: 0 }),
+    runResolveContradictions: vi.fn().mockResolvedValue({ autoResolved: [], ambiguous: [] }),
+    runResolveContradictionsDryRun: vi.fn().mockResolvedValue({ autoResolvable: [], ambiguous: [] }),
+    runResolveContradictionsProjectStateLww: vi.fn().mockResolvedValue({
+      groups: [],
+      totalCandidates: 0,
+      wouldSupersede: 0,
+      wouldManualReview: 0,
+      applied: 0,
+    }),
+    vectorDb: {},
+    versionInfo: { pluginVersion: "test", memoryManagerVersion: "test", schemaVersion: 1 },
+    embeddings: {},
+    mergeResults: vi.fn(),
+    parseSourceDate: vi.fn().mockReturnValue(null),
+    getMemoryCategories: vi.fn().mockReturnValue(["fact", "project"]),
+    runStore: vi.fn(),
+    runMigrateToVault: vi.fn().mockResolvedValue(null),
+    runEncryptVault: vi.fn(),
+    runCredentialsList: vi.fn().mockReturnValue([]),
+    runCredentialsGet: vi.fn().mockReturnValue(null),
+    runCredentialsAudit: vi.fn(),
+    runCredentialsPrune: vi.fn(),
+    runUninstall: vi.fn(),
+    runUpgrade: vi.fn(),
+    runConfigView: vi.fn(),
+    runConfigMode: vi.fn(),
+    runConfigSet: vi.fn(),
+    runConfigSetHelp: vi.fn(),
+    autoClassifyConfig: { model: "test-model", batchSize: 8 },
+    runCompaction: vi.fn().mockResolvedValue({ hot: 0, warm: 0, cold: 0, structural: 0 }),
+    runSelfCorrectionExtract: vi.fn(),
+    runSelfCorrectionRun: vi.fn(),
+    tieringEnabled: false,
+    resolvedSqlitePath: null,
+    resolvedLancePath: null,
+    aliasDb: null,
+    auditStore: null,
+    agentHealthStore: null,
+    listCommands: () => [],
+    merge: vi.fn(),
+    BACKFILL_DECAY_MARKER: ".backfill-decay-done",
+    ctx: { cfg: {} },
+  };
+  const merged = { ...base, ...overrides } as Record<string, unknown>;
+  if (!("ctx" in overrides)) {
+    merged.ctx = {
+      cfg: merged.cfg,
+      runResolveContradictions: merged.runResolveContradictions,
+      runResolveContradictionsDryRun: merged.runResolveContradictionsDryRun,
+      runResolveContradictionsProjectStateLww: merged.runResolveContradictionsProjectStateLww,
+    };
+  }
+  return merged as ManageBindings;
+}
+
+function makeProgram(bindings: ManageBindings): Command {
+  const mem = new Command("hybrid-mem");
+  mem.exitOverride();
+  registerManageReflectionPipeline(mem, bindings);
+  return mem;
+}
+
+function sampleLwwResult(overrides: Partial<LwwResult> = {}): LwwResult {
+  return {
+    groups: [
+      {
+        entity: "hybrid-memory-issue-1636-pr",
+        key: "status",
+        scope: null,
+        scopeTarget: null,
+        candidates: [
+          {
+            contradictionId: "c-1",
+            factIdNew: "new-1",
+            factIdOld: "old-1",
+            entity: "hybrid-memory-issue-1636-pr",
+            key: "status",
+            scope: null,
+            scopeTarget: null,
+            newFactDate: 1_700_000_060,
+            oldFactDate: 1_700_000_000,
+            newSource: "conversation",
+            oldSource: "active-task",
+            newConf: 1,
+            oldConf: 1,
+            newValueExcerpt: "done",
+            oldValueExcerpt: "in_progress",
+            action: "supersede",
+            possibleOverloadedEntity: false,
+          },
+        ],
+      },
+    ],
+    totalCandidates: 1,
+    wouldSupersede: 1,
+    wouldManualReview: 0,
+    applied: 1,
+    ...overrides,
+  };
+}
+
+describe("resolve-contradictions CLI contract mode", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    process.exitCode = undefined;
+  });
+
+  it("supports --dry-run contract mode with grouped details and structured summary", async () => {
+    const runResolveContradictionsProjectStateLww = vi.fn().mockResolvedValue(sampleLwwResult({ applied: 0 }));
+    const runResolveContradictions = vi.fn().mockResolvedValue({ autoResolved: [], ambiguous: [] });
+    const mem = makeProgram(
+      makeBindings({
+        runResolveContradictionsProjectStateLww,
+        runResolveContradictions,
+      }),
+    );
+    const lines: string[] = [];
+    vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+      lines.push(args.map((a) => String(a)).join(" "));
+    });
+
+    await mem.parseAsync(["resolve-contradictions", "--dry-run"], { from: "user" });
+
+    expect(runResolveContradictionsProjectStateLww).toHaveBeenCalledWith({ dryRun: true });
+    expect(runResolveContradictions).not.toHaveBeenCalled();
+    expect(lines.some((l) => l.includes("hybrid-memory-issue-1636-pr / status"))).toBe(true);
+    expect(lines.some((l) => l.includes("project-state-lww summary auto-resolved=1 dry-run=1 remaining=0"))).toBe(true);
+  });
+
+  it("supports --apply contract mode with grouped details and structured summary", async () => {
+    const runResolveContradictionsProjectStateLww = vi.fn().mockResolvedValue(sampleLwwResult({ applied: 1 }));
+    const mem = makeProgram(
+      makeBindings({
+        runResolveContradictionsProjectStateLww,
+      }),
+    );
+    const lines: string[] = [];
+    vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+      lines.push(args.map((a) => String(a)).join(" "));
+    });
+
+    await mem.parseAsync(["resolve-contradictions", "--apply"], { from: "user" });
+
+    expect(runResolveContradictionsProjectStateLww).toHaveBeenCalledWith({ dryRun: false });
+    expect(lines.some((l) => l.includes("hybrid-memory-issue-1636-pr / status"))).toBe(true);
+    expect(lines.some((l) => l.includes("project-state-lww summary auto-resolved=1 dry-run=0 remaining=0"))).toBe(true);
+  });
+
+  it("prints structured summary in empty dry-run output", async () => {
+    const runResolveContradictionsProjectStateLww = vi
+      .fn()
+      .mockResolvedValue(
+        sampleLwwResult({ groups: [], totalCandidates: 0, wouldSupersede: 0, wouldManualReview: 0, applied: 0 }),
+      );
+    const mem = makeProgram(
+      makeBindings({
+        runResolveContradictionsProjectStateLww,
+      }),
+    );
+    const lines: string[] = [];
+    vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+      lines.push(args.map((a) => String(a)).join(" "));
+    });
+
+    await mem.parseAsync(["resolve-contradictions", "--dry-run"], { from: "user" });
+
+    expect(lines.some((l) => l.includes("project-state-lww summary auto-resolved=0 dry-run=1 remaining=0"))).toBe(true);
+  });
+
+  it("rejects ambiguous flag combinations", async () => {
+    const mem = makeProgram(makeBindings());
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    await expect(mem.parseAsync(["resolve-contradictions", "--dry-run", "--apply"], { from: "user" })).rejects.toThrow(
+      "--dry-run and --apply are mutually exclusive",
+    );
+  });
+});

--- a/extensions/memory-hybrid/tests/resolve-contradictions-cli.test.ts
+++ b/extensions/memory-hybrid/tests/resolve-contradictions-cli.test.ts
@@ -22,15 +22,13 @@ function makeBindings(overrides: Partial<ManageBindings> = {}): ManageBindings {
     runEntityEnrichment: vi.fn().mockResolvedValue({ pending: 0, processed: 0, factsEnriched: 0 }),
     runDreamCycle: vi.fn().mockResolvedValue({ skipped: true }),
     runContinuousVerification: vi.fn().mockResolvedValue({ skipped: true }),
-    runExtractImplicitFeedback: vi
-      .fn()
-      .mockResolvedValue({
-        signalsExtracted: 0,
-        positiveCount: 0,
-        negativeCount: 0,
-        trajectoriesBuilt: 0,
-        sessionsScanned: 0,
-      }),
+    runExtractImplicitFeedback: vi.fn().mockResolvedValue({
+      signalsExtracted: 0,
+      positiveCount: 0,
+      negativeCount: 0,
+      trajectoriesBuilt: 0,
+      sessionsScanned: 0,
+    }),
     runCrossAgentLearning: vi.fn().mockResolvedValue({ stored: 0 }),
     runToolEffectiveness: vi.fn().mockResolvedValue("ok"),
     pruneCostLog: vi.fn().mockReturnValue(0),

--- a/extensions/memory-hybrid/tests/self-correction-run-parser.test.ts
+++ b/extensions/memory-hybrid/tests/self-correction-run-parser.test.ts
@@ -156,6 +156,20 @@ describe("parseSelfCorrectionLLMResponse", () => {
     expect((result as (typeof sampleItem)[])[0].remediationType).toBe("MEMORY_STORE");
   });
 
+  it("accepts NO_ACTION items when remediationContent is omitted", () => {
+    const items = [{ remediationType: "NO_ACTION", category: "INFO", severity: "LOW" }];
+    const result = parseSelfCorrectionLLMResponse(JSON.stringify(items));
+    expect(result).not.toBeNull();
+    expect(result).toHaveLength(1);
+    expect((result as { remediationType: string }[])[0].remediationType).toBe("NO_ACTION");
+  });
+
+  it("rejects actionable remediation items when remediationContent is omitted", () => {
+    const items = [{ remediationType: "TOOLS_RULE", category: "WRONG_APPROACH", severity: "MEDIUM" }];
+    const result = parseSelfCorrectionLLMResponse(JSON.stringify(items));
+    expect(result).toBeNull();
+  });
+
   it("handles a fenced block with trailing text (combined)", () => {
     const array = JSON.stringify([sampleItem]);
     const input = `\`\`\`json\n${array}\n\`\`\`\n\nI have summarized 1 correction item above.`;

--- a/extensions/memory-hybrid/tests/self-correction-run-parser.test.ts
+++ b/extensions/memory-hybrid/tests/self-correction-run-parser.test.ts
@@ -147,6 +147,32 @@ describe("parseSelfCorrectionLLMResponse", () => {
     expect(result).toHaveLength(2);
   });
 
+  it("accepts NO_ACTION items without remediationContent", () => {
+    const input = JSON.stringify([
+      {
+        category: "NO_ISSUE",
+        severity: "LOW",
+        remediationType: "NO_ACTION",
+      },
+    ]);
+    const result = parseSelfCorrectionLLMResponse(input);
+    expect(result).not.toBeNull();
+    expect(result).toHaveLength(1);
+    expect((result as Array<{ remediationType: string }>)[0].remediationType).toBe("NO_ACTION");
+  });
+
+  it("returns null when only actionable items are missing remediationContent", () => {
+    const input = JSON.stringify([
+      {
+        category: "WRONG_APPROACH",
+        severity: "MEDIUM",
+        remediationType: "MEMORY_STORE",
+      },
+    ]);
+    const result = parseSelfCorrectionLLMResponse(input);
+    expect(result).toBeNull();
+  });
+
   it("skips remediationType-only object arrays and parses a later valid remediation array", () => {
     const malformed = [{ remediationType: "MEMORY_STORE" }];
     const input = `${JSON.stringify(malformed)}\n${JSON.stringify([sampleItem])}`;

--- a/extensions/memory-hybrid/utils/llm-json-array.ts
+++ b/extensions/memory-hybrid/utils/llm-json-array.ts
@@ -81,8 +81,16 @@ export function extractFirstJsonArraySubstring(text: string): string | null {
 /**
  * Find the first balanced `[...]` in the response that parses as a JSON array.
  * Skips prose like `[see below]` or `[batch]` that are not valid JSON arrays.
+ *
+ * @param raw - The raw string to parse
+ * @param filter - Optional filter callback to validate parsed arrays; receives the parsed array
+ *                 and should return the array to accept or null/undefined to continue searching.
+ *                 When provided, the function returns the first array accepted by the filter.
  */
-export function tryParseFirstJsonArray(raw: string): unknown[] | null {
+export function tryParseFirstJsonArray(
+  raw: string,
+  filter?: (parsed: unknown[]) => unknown[] | null | undefined,
+): unknown[] | null {
   const s = stripBracketContextPreamble(stripMarkdownCodeFence(raw));
   let searchFrom = 0;
   while (searchFrom < s.length) {
@@ -95,7 +103,14 @@ export function tryParseFirstJsonArray(raw: string): unknown[] | null {
     }
     try {
       const parsed: unknown = JSON.parse(slice);
-      if (Array.isArray(parsed)) return parsed;
+      if (Array.isArray(parsed)) {
+        if (filter) {
+          const result = filter(parsed);
+          if (result !== null && result !== undefined) return result;
+        } else {
+          return parsed;
+        }
+      }
     } catch {
       /* try next [ — skip this whole balanced span (avoids O(n) single-char steps on long junk) */
     }


### PR DESCRIPTION
Implements issue #1636: adds a targeted **project-state latest-wins (LWW)** policy that safely auto-resolves stale project/task-state contradictions for known mutable keys, while keeping all other contradiction handling conservative and unchanged.

## Overview

The existing `resolveContradictionsAuto` path left many ambiguous contradiction pairs unresolved because equal-confidence project-state facts (status, next, task_updated, etc.) didn't meet the strict "strictly higher confidence" requirement. This PR adds a separate, scoped LWW policy that handles those cases safely.

## Changes

### Core logic (`backends/facts-db/contradictions.ts`)
- **`PROJECT_STATE_LWW_KEYS`** — 9 mutable project/task state keys eligible for LWW (`status`, `next`, `task_updated`, `related_session`, `coverage`, `last_live_verified_at`, `live_state_hash`, `last_actionable_blocker`, `owner`). Documented to explain why these are "current-state snapshot" keys (as opposed to append-style facts like decisions or milestones)
- **`PROJECT_STATE_LWW_TRUSTED_SOURCES`** — `conversation`, `cli`, `active-task`; distillation is explicitly excluded to keep automated facts conservative
- **`evaluateLwwEligibility()`** — exported shared helper used by both the write-time path and the batch pass to keep eligibility logic in a single place
- **`MAX_EXPECTED_REFS_PER_ENTITY`** — named constant for the overloaded-entity heuristic threshold (replaces inline magic number)
- **`resolveProjectStateLww()`** — batch resolution pass that evaluates all unresolved contradictions and emits grouped `supersede`/`manual-review` candidates; dry-run safe

### Safety guards
Every pair must satisfy **all** of:
- Both facts have `category = "project"`
- Key (case-insensitive) is in `PROJECT_STATE_LWW_KEYS`
- Newer fact's source is in `PROJECT_STATE_LWW_TRUSTED_SOURCES`
- Newer fact is strictly newer (`createdAt >` older fact)
- Newer fact confidence ≥ older fact's original confidence (captured at detection time, before the −0.2 penalty)

Pairs with many distinct PR/issue refs across their values are flagged as `possibleOverloadedEntity` in the report without blocking resolution.

### FactsDB write-time path (`backends/facts-db/facts-db-layer3.ts`)
- `detectContradictions()` now immediately resolves qualifying project-state pairs at write time using `evaluateLwwEligibility`, so active-task/project writes no longer leave avoidable unresolved contradictions
- New `resolveContradictionsProjectStateLww({ dryRun? })` method for the batch/nightly pass

### CLI (`cli/commands/manage/register-reflection-pipeline.ts`)
- `--project-state-lww` flag on `resolve-contradictions` to run the LWW batch pass
- `--dry-run` flag (with `--project-state-lww`) to report candidates with grouped details without mutating any data

### Service wiring
New method plumbed through `cli-services.ts` → `register-help.ts` → `cli/context.ts` → `cli/register.ts`.

## Tests

New test file `tests/project-state-lww.test.ts` with 9 tests covering all acceptance criteria:
- Equal-confidence `status` transition (`in_progress` → `done`)
- `next` key update across sources (`active-task` → `conversation`)
- Non-project equal-confidence conflict stays ambiguous (unchanged behavior)
- Overloaded entity flagging
- Dry-run immutability (no mutations)
- Distillation source guard (not eligible for LWW)
- Older-wins case → `manual-review` action
- Write-time auto-supersede on `detectContradictions`

All 373 test files (6390 tests) pass.


Fixes #1636

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when facts are auto-superseded and how contradictions resolve at write time and via CLI; mistakes could drop or mis-rank project memory, though guards (trusted sources, verified facts, missing original confidence) limit blast radius.
> 
> **Overview**
> Adds a **project-state latest-wins (LWW)** path for contradiction handling so stale `project` facts on mutable keys (`status`, `next`, etc.) can be superseded when a newer trusted fact wins, without changing the conservative default for other categories.
> 
> **Facts / contradiction engine:** `recordContradiction` / `detectContradictions` now return **pre-penalty** `oldFactOriginalConfidence`. Conservative auto-resolve is refactored behind shared `getAutoResolutionDecision`, with a non-mutating **`previewResolveContradictionsAuto`**, stricter apply behavior (supersede failures stay ambiguous; verified facts block auto-supersede unless the old row is already superseded). New **`evaluateLwwEligibility`**, **`resolveProjectStateLww`**, and write-time LWW in **`FactsDB.detectContradictions`** for eligible keys/sources.
> 
> **CLI:** `resolve-contradictions` gains **`--dry-run` / `--apply`** (and **`--project-state-lww`**) for grouped LWW preview/apply output; default apply mode unchanged. Wiring adds `previewResolveContradictions` and `resolveContradictionsProjectStateLww` through CLI context.
> 
> **Self-correction (smaller):** LLM JSON parsing accepts **`NO_ACTION`** without `remediationContent`; repair pass uses the same parser; `tryParseFirstJsonArray` supports an optional filter callback.
> 
> **Tests:** New coverage for project-state LWW, CLI contract, verified+superseded preview/apply parity, and NO_ACTION parsing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 891d87e107b72fe5689226cf6db7ab037542b8f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->