### PR TITLE
fix: extract-reinforcement reports success after 32 incidents but 0 annotations and no fallback (#1639)

### DIFF
--- a/extensions/memory-hybrid/cli/cmd-extract-reinforcement.ts
+++ b/extensions/memory-hybrid/cli/cmd-extract-reinforcement.ts
@@ -4,7 +4,12 @@ import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import type { ReinforcementContext } from "../backends/facts-db.js";
-import { getCronModelConfig, getDefaultCronModel, getLLMModelPreference, resolveReflectionModelAndFallbacks } from "../config.js";
+import {
+  getCronModelConfig,
+  getDefaultCronModel,
+  getLLMModelPreference,
+  resolveReflectionModelAndFallbacks,
+} from "../config.js";
 import { chatCompleteWithAdaptiveMaintenanceRetry } from "../services/adaptive-maintenance-llm.js";
 import { distillMaxOutputTokens } from "../services/chat.js";
 import { CostFeature } from "../services/cost-feature-labels.js";

--- a/extensions/memory-hybrid/cli/cmd-extract-reinforcement.ts
+++ b/extensions/memory-hybrid/cli/cmd-extract-reinforcement.ts
@@ -132,17 +132,14 @@ export async function runExtractReinforcementForCli(
           incidents_json: JSON.stringify(result.incidents),
         });
         const extractionTier = cfg.distill?.extractionModelTier ?? "nano";
-        const tierPrefWithSources = resolveTierPreferenceWithSources(
-          cfg,
-          extractionTier as "nano" | "default" | "heavy",
-        );
+        const tierPrefWithSources = resolveTierPreferenceWithSources(cfg, extractionTier);
         const cronCfg = getCronModelConfig(cfg);
         const tierPref = getLLMModelPreference(cronCfg, extractionTier);
         const model = tierPref[0] ?? getDefaultCronModel(cronCfg, extractionTier);
         // Derive fallback chain from the full tier preference list; when only one model is
         // configured, fall through to resolveReflectionModelAndFallbacks which picks up
         // llm.fallbackModel and distill.fallbackModels (mirrors the distill/self-correction fix).
-        const tierResolved = resolveReflectionModelAndFallbacks(cfg, extractionTier as "nano" | "default" | "heavy");
+        const tierResolved = resolveReflectionModelAndFallbacks(cfg, extractionTier);
         const fallbackModels = tierResolved.fallbackModels ?? [];
         const modelSource =
           tierPrefWithSources.models[0] === model ? (tierPrefWithSources.sources[0] ?? "built-in") : "built-in";
@@ -353,7 +350,7 @@ export async function runExtractReinforcementForCli(
 
     // Annotate facts/procedures with reinforcement if not dry-run
     let annotated = 0;
-    const annotationReasons: AnnotationReasons = { noRecalledIds: 0, reinforced: 0, errors: 0 };
+    const annotationReasons: AnnotationReasons = { noRecalledIds: 0, reinforced: 0, recalledIdsNoMatch: 0, errors: 0 };
 
     if (!opts.dryRun) {
       const trackContext = cfg.reinforcement?.trackContext !== false;
@@ -410,6 +407,7 @@ export async function runExtractReinforcementForCli(
           }
           annotated += incidentAnnotated;
           if (incidentAnnotated > 0) annotationReasons.reinforced++;
+          else annotationReasons.recalledIdsNoMatch++;
 
           // Reinforce procedures based on tool call sequence
           if (incident.toolCallSequence.length >= 2) {

--- a/extensions/memory-hybrid/cli/cmd-extract-reinforcement.ts
+++ b/extensions/memory-hybrid/cli/cmd-extract-reinforcement.ts
@@ -403,13 +403,23 @@ export async function runExtractReinforcementForCli(
               maxEventsPerFact,
               boostAmount: effectiveBoost,
             });
-            if (reinforced) incidentAnnotated++;
+            if (reinforced) {
+              incidentAnnotated++;
+              annotated++;
+            }
           }
-          annotated += incidentAnnotated;
           if (incidentAnnotated > 0) annotationReasons.reinforced++;
           else annotationReasons.recalledIdsNoMatch++;
+        } catch (err) {
+          annotationReasons.errors++;
+          capturePluginError(err as Error, {
+            subsystem: "cli",
+            operation: "runExtractReinforcementForCli",
+          });
+        }
 
-          // Reinforce procedures based on tool call sequence
+        // Reinforce procedures based on tool call sequence (separate try-catch to avoid double-counting)
+        try {
           if (incident.toolCallSequence.length >= 2) {
             const taskPattern = incident.toolCallSequence.join(" -> ");
             const procedures = factsDb.searchProcedures(
@@ -426,7 +436,6 @@ export async function runExtractReinforcementForCli(
             }
           }
         } catch (err) {
-          annotationReasons.errors++;
           capturePluginError(err as Error, {
             subsystem: "cli",
             operation: "runExtractReinforcementForCli",

--- a/extensions/memory-hybrid/cli/cmd-extract-reinforcement.ts
+++ b/extensions/memory-hybrid/cli/cmd-extract-reinforcement.ts
@@ -4,12 +4,17 @@ import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import type { ReinforcementContext } from "../backends/facts-db.js";
-import { getCronModelConfig, getDefaultCronModel, getLLMModelPreference } from "../config.js";
+import { getCronModelConfig, getDefaultCronModel, getLLMModelPreference, resolveReflectionModelAndFallbacks } from "../config.js";
 import { chatCompleteWithAdaptiveMaintenanceRetry } from "../services/adaptive-maintenance-llm.js";
 import { distillMaxOutputTokens } from "../services/chat.js";
 import { CostFeature } from "../services/cost-feature-labels.js";
 import { capturePluginError } from "../services/error-reporter.js";
-import { type ReinforcementExtractResult, runReinforcementExtract } from "../services/reinforcement-extract.js";
+import {
+  type AnnotationReasons,
+  type ReinforcementAnnotationStatus,
+  type ReinforcementExtractResult,
+  runReinforcementExtract,
+} from "../services/reinforcement-extract.js";
 import { preFilterSessions } from "../services/session-pre-filter.js";
 import { insertRulesUnderSection } from "../services/tools-md-section.js";
 import { cleanupEvictedVector } from "../services/vector-maintenance.js";
@@ -93,6 +98,7 @@ export async function runExtractReinforcementForCli(
       }
     }
 
+    let llmAnalysisFailed = false;
     const scCfg = cfg.selfCorrection;
     const runLLMAnalysis = scCfg?.reinforcementLLMAnalysis !== false && result.incidents.length > 0 && !opts.dryRun;
     let analysisCategory: string | undefined;
@@ -128,7 +134,11 @@ export async function runExtractReinforcementForCli(
         const cronCfg = getCronModelConfig(cfg);
         const tierPref = getLLMModelPreference(cronCfg, extractionTier);
         const model = tierPref[0] ?? getDefaultCronModel(cronCfg, extractionTier);
-        const fallbackModels = tierPref.length > 1 ? tierPref.slice(1) : (cfg.distill?.fallbackModels ?? []);
+        // Derive fallback chain from the full tier preference list; when only one model is
+        // configured, fall through to resolveReflectionModelAndFallbacks which picks up
+        // llm.fallbackModel and distill.fallbackModels (mirrors the distill/self-correction fix).
+        const tierResolved = resolveReflectionModelAndFallbacks(cfg, extractionTier as "nano" | "default" | "heavy");
+        const fallbackModels = tierResolved.fallbackModels ?? [];
         const modelSource =
           tierPrefWithSources.models[0] === model ? (tierPrefWithSources.sources[0] ?? "built-in") : "built-in";
         logger.info?.(`memory-hybrid: extract-reinforcement analysis tier = ${extractionTier}`);
@@ -169,6 +179,7 @@ export async function runExtractReinforcementForCli(
           analysisCategory = analysed.find((a) => a.category && a.remediationType !== "NO_ACTION")?.category;
         }
       } catch (e) {
+        llmAnalysisFailed = true;
         capturePluginError(e as Error, {
           subsystem: "cli",
           operation: "runExtractReinforcementForCli:llm-analysis",
@@ -336,10 +347,40 @@ export async function runExtractReinforcementForCli(
     }
 
     // Annotate facts/procedures with reinforcement if not dry-run
+    let annotated = 0;
+    const annotationReasons: AnnotationReasons = { noRecalledIds: 0, reinforced: 0, errors: 0 };
+
     if (!opts.dryRun) {
       const trackContext = cfg.reinforcement?.trackContext !== false;
       const maxEventsPerFact = cfg.reinforcement?.maxEventsPerFact ?? 50;
       for (const incident of result.incidents) {
+        if (incident.recalledMemoryIds.length === 0) {
+          annotationReasons.noRecalledIds++;
+          // Still process procedure boosts even without recalled fact IDs
+          try {
+            if (incident.toolCallSequence.length >= 2) {
+              const taskPattern = incident.toolCallSequence.join(" -> ");
+              const procedures = factsDb.searchProcedures(
+                taskPattern,
+                3,
+                cfg.distill?.reinforcementProcedureBoost ?? 0.1,
+              );
+              for (const proc of procedures) {
+                factsDb.reinforceProcedure(
+                  proc.id,
+                  incident.userMessage,
+                  cfg.distill?.reinforcementPromotionThreshold ?? 2,
+                );
+              }
+            }
+          } catch (err) {
+            capturePluginError(err as Error, {
+              subsystem: "cli",
+              operation: "runExtractReinforcementForCli:procedure-boost",
+            });
+          }
+          continue;
+        }
         try {
           const context: ReinforcementContext = {
             querySnippet: incident.precedingUserMessage.slice(0, 200) || incident.userMessage.slice(0, 200),
@@ -351,15 +392,19 @@ export async function runExtractReinforcementForCli(
           // Reinforce recalled memories with rich context, boosted by diversity score (#259)
           const diversityWeight = cfg.reinforcement?.diversityWeight ?? 1.0;
           const baseBoost = cfg.reinforcement?.boostAmount ?? 1.0;
+          let incidentAnnotated = 0;
           for (const memId of incident.recalledMemoryIds) {
             const diversityScore = factsDb.calculateDiversityScore(memId);
             const effectiveBoost = baseBoost * (1 - diversityWeight + diversityWeight * diversityScore);
-            factsDb.reinforceFact(memId, incident.userMessage, context, {
+            const reinforced = factsDb.reinforceFact(memId, incident.userMessage, context, {
               trackContext,
               maxEventsPerFact,
               boostAmount: effectiveBoost,
             });
+            if (reinforced) incidentAnnotated++;
           }
+          annotated += incidentAnnotated;
+          if (incidentAnnotated > 0) annotationReasons.reinforced++;
 
           // Reinforce procedures based on tool call sequence
           if (incident.toolCallSequence.length >= 2) {
@@ -378,6 +423,7 @@ export async function runExtractReinforcementForCli(
             }
           }
         } catch (err) {
+          annotationReasons.errors++;
           capturePluginError(err as Error, {
             subsystem: "cli",
             operation: "runExtractReinforcementForCli",
@@ -385,6 +431,31 @@ export async function runExtractReinforcementForCli(
         }
       }
     }
+
+    // Derive annotation status for the incidentsFound > 0 && annotated == 0 case
+    let annotationStatus: ReinforcementAnnotationStatus | undefined;
+    if (!opts.dryRun && result.incidents.length > 0 && annotated === 0) {
+      if (llmAnalysisFailed && annotationReasons.noRecalledIds === result.incidents.length) {
+        annotationStatus = "degraded_model_or_parser";
+      } else if (annotationReasons.errors > 0) {
+        annotationStatus = "failed_annotation";
+      } else if (annotationReasons.noRecalledIds === result.incidents.length) {
+        // All incidents had no recalled memory IDs — agent did not call memory_recall in
+        // these sessions. This is expected when sessions don't involve explicit memory recall.
+        annotationStatus = "partial_no_matches";
+      } else {
+        // Some incidents had recalled IDs but none were reinforced (unexpected)
+        annotationStatus = "failed_annotation";
+      }
+    } else if (!opts.dryRun && llmAnalysisFailed && result.incidents.length > 0) {
+      // LLM analysis failed but some facts were still reinforced via recalled IDs
+      annotationStatus = "degraded_model_or_parser";
+    }
+
+    // Attach annotation results to the returned value
+    result.annotated = annotated;
+    result.annotationReasons = annotationReasons;
+    if (annotationStatus !== undefined) result.annotationStatus = annotationStatus;
 
     if (!opts.dryRun) {
       const lastSessionTs = getMaxMtime(filePaths);

--- a/extensions/memory-hybrid/cli/cmd-extract-reinforcement.ts
+++ b/extensions/memory-hybrid/cli/cmd-extract-reinforcement.ts
@@ -177,8 +177,17 @@ export async function runExtractReinforcementForCli(
         }
         const jsonMatch = detail.content.match(/\[[\s\S]*\]/);
         if (jsonMatch) {
-          analysed = JSON.parse(jsonMatch[0]) as ReinforcementRemediation[];
-          analysisCategory = analysed.find((a) => a.category && a.remediationType !== "NO_ACTION")?.category;
+          const parsed = JSON.parse(jsonMatch[0]);
+          if (Array.isArray(parsed)) {
+            analysed = parsed as ReinforcementRemediation[];
+            analysisCategory = analysed.find((a) => a.category && a.remediationType !== "NO_ACTION")?.category;
+          } else {
+            llmAnalysisFailed = true;
+            logger.warn?.("memory-hybrid: extract-reinforcement analysis produced non-array JSON");
+          }
+        } else {
+          llmAnalysisFailed = true;
+          logger.warn?.("memory-hybrid: extract-reinforcement analysis produced no parseable JSON array");
         }
       } catch (e) {
         llmAnalysisFailed = true;
@@ -376,6 +385,7 @@ export async function runExtractReinforcementForCli(
               }
             }
           } catch (err) {
+            annotationReasons.errors++;
             capturePluginError(err as Error, {
               subsystem: "cli",
               operation: "runExtractReinforcementForCli:procedure-boost",

--- a/extensions/memory-hybrid/cli/cmd-extract-reinforcement.ts
+++ b/extensions/memory-hybrid/cli/cmd-extract-reinforcement.ts
@@ -448,8 +448,8 @@ export async function runExtractReinforcementForCli(
         annotationStatus = "failed_annotation";
       }
     } else if (!opts.dryRun && llmAnalysisFailed && result.incidents.length > 0) {
-      // LLM analysis failed but some facts were still reinforced via recalled IDs
-      annotationStatus = "degraded_model_or_parser";
+      // LLM analysis failed but some facts were still reinforced via recalled IDs.
+      // Do not override a successful annotation with a failure status — leave undefined.
     }
 
     // Attach annotation results to the returned value

--- a/extensions/memory-hybrid/cli/cmd-extract-reinforcement.ts
+++ b/extensions/memory-hybrid/cli/cmd-extract-reinforcement.ts
@@ -393,6 +393,7 @@ export async function runExtractReinforcementForCli(
           }
           continue;
         }
+        let incidentAnnotated = 0;
         try {
           const context: ReinforcementContext = {
             querySnippet: incident.precedingUserMessage.slice(0, 200) || incident.userMessage.slice(0, 200),
@@ -404,7 +405,6 @@ export async function runExtractReinforcementForCli(
           // Reinforce recalled memories with rich context, boosted by diversity score (#259)
           const diversityWeight = cfg.reinforcement?.diversityWeight ?? 1.0;
           const baseBoost = cfg.reinforcement?.boostAmount ?? 1.0;
-          let incidentAnnotated = 0;
           for (const memId of incident.recalledMemoryIds) {
             const diversityScore = factsDb.calculateDiversityScore(memId);
             const effectiveBoost = baseBoost * (1 - diversityWeight + diversityWeight * diversityScore);
@@ -418,8 +418,6 @@ export async function runExtractReinforcementForCli(
               annotated++;
             }
           }
-          if (incidentAnnotated > 0) annotationReasons.reinforced++;
-          else annotationReasons.recalledIdsNoMatch++;
         } catch (err) {
           annotationReasons.errors++;
           capturePluginError(err as Error, {
@@ -427,6 +425,8 @@ export async function runExtractReinforcementForCli(
             operation: "runExtractReinforcementForCli",
           });
         }
+        if (incidentAnnotated > 0) annotationReasons.reinforced++;
+        else annotationReasons.recalledIdsNoMatch++;
 
         // Reinforce procedures based on tool call sequence (separate try-catch to avoid double-counting)
         try {

--- a/extensions/memory-hybrid/cli/distill.ts
+++ b/extensions/memory-hybrid/cli/distill.ts
@@ -422,7 +422,7 @@ export function registerDistillCommands(mem: Chainable, ctx: DistillContext): vo
               const reasons = result.annotationReasons;
               if (reasons) {
                 console.log(
-                  `Annotation reason breakdown: noRecalledIds=${reasons.noRecalledIds} reinforced=${reasons.reinforced} errors=${reasons.errors}`,
+                  `Annotation reason breakdown: noRecalledIds=${reasons.noRecalledIds} reinforced=${reasons.reinforced} recalledIdsNoMatch=${reasons.recalledIdsNoMatch} errors=${reasons.errors}`,
                 );
               }
               const status = result.annotationStatus;

--- a/extensions/memory-hybrid/cli/distill.ts
+++ b/extensions/memory-hybrid/cli/distill.ts
@@ -432,6 +432,8 @@ export function registerDistillCommands(mem: Chainable, ctx: DistillContext): vo
                   process.exitCode = 1;
                 }
               }
+            } else if (factsReinforced > 0 && result.annotationReasons?.errors && result.annotationReasons.errors > 0) {
+              process.exitCode = 2;
             }
           }
         },

--- a/extensions/memory-hybrid/cli/distill.ts
+++ b/extensions/memory-hybrid/cli/distill.ts
@@ -422,8 +422,23 @@ export function registerDistillCommands(mem: Chainable, ctx: DistillContext): vo
           if (opts.dryRun) {
             console.log("[dry-run] Would annotate facts/procedures with reinforcement data.");
           } else {
-            const factsReinforced = result.incidents.reduce((sum, i) => sum + i.recalledMemoryIds.length, 0);
+            const factsReinforced = result.annotated ?? result.incidents.reduce((sum, i) => sum + i.recalledMemoryIds.length, 0);
             console.log(`Annotated ${factsReinforced} facts with reinforcement data.`);
+            if (result.incidents.length > 0 && factsReinforced === 0) {
+              const reasons = result.annotationReasons;
+              if (reasons) {
+                console.log(
+                  `Annotation reason breakdown: noRecalledIds=${reasons.noRecalledIds} reinforced=${reasons.reinforced} errors=${reasons.errors}`,
+                );
+              }
+              const status = result.annotationStatus;
+              if (status) {
+                console.log(`Annotation status: ${status}`);
+                if (status === "failed_annotation" || status === "degraded_model_or_parser") {
+                  process.exitCode = 1;
+                }
+              }
+            }
           }
         },
       ),

--- a/extensions/memory-hybrid/cli/distill.ts
+++ b/extensions/memory-hybrid/cli/distill.ts
@@ -422,7 +422,7 @@ export function registerDistillCommands(mem: Chainable, ctx: DistillContext): vo
           if (opts.dryRun) {
             console.log("[dry-run] Would annotate facts/procedures with reinforcement data.");
           } else {
-            const factsReinforced = result.annotated ?? result.incidents.reduce((sum, i) => sum + i.recalledMemoryIds.length, 0);
+            const factsReinforced = result.annotated ?? 0;
             console.log(`Annotated ${factsReinforced} facts with reinforcement data.`);
             if (result.incidents.length > 0 && factsReinforced === 0) {
               const reasons = result.annotationReasons;

--- a/extensions/memory-hybrid/cli/distill.ts
+++ b/extensions/memory-hybrid/cli/distill.ts
@@ -67,7 +67,12 @@ export type DistillContext = {
     stored?: number;
     skipped?: boolean;
   }>;
-  runExtractReinforcement: (opts: { days?: number; verbose?: boolean; dryRun?: boolean; full?: boolean }) => Promise<ReinforcementExtractResult>;
+  runExtractReinforcement: (opts: {
+    days?: number;
+    verbose?: boolean;
+    dryRun?: boolean;
+    full?: boolean;
+  }) => Promise<ReinforcementExtractResult>;
   runGenerateProposals?: (opts: { dryRun: boolean; verbose?: boolean }) => Promise<{ created: number }>;
 };
 

--- a/extensions/memory-hybrid/cli/distill.ts
+++ b/extensions/memory-hybrid/cli/distill.ts
@@ -4,6 +4,7 @@
 
 import { type CommanderOptsParent, readHybridMemVerbose } from "./global-verbose.js";
 import { type Chainable, withExit } from "./shared.js";
+import type { ReinforcementExtractResult } from "../services/reinforcement-extract.js";
 import type {
   DistillCliResult,
   DistillCliSink,
@@ -66,19 +67,7 @@ export type DistillContext = {
     stored?: number;
     skipped?: boolean;
   }>;
-  runExtractReinforcement: (opts: { days?: number; verbose?: boolean; dryRun?: boolean; full?: boolean }) => Promise<{
-    incidents: Array<{
-      userMessage: string;
-      agentBehavior: string;
-      recalledMemoryIds: string[];
-      toolCallSequence: string[];
-      confidence: number;
-      timestamp?: string;
-      sessionFile: string;
-    }>;
-    sessionsScanned: number;
-    skipped?: boolean;
-  }>;
+  runExtractReinforcement: (opts: { days?: number; verbose?: boolean; dryRun?: boolean; full?: boolean }) => Promise<ReinforcementExtractResult>;
   runGenerateProposals?: (opts: { dryRun: boolean; verbose?: boolean }) => Promise<{ created: number }>;
 };
 

--- a/extensions/memory-hybrid/services/reinforcement-extract.ts
+++ b/extensions/memory-hybrid/services/reinforcement-extract.ts
@@ -27,9 +27,42 @@ export type ReinforcementIncident = {
   sessionFile: string;
 };
 
+export type AnnotationReasons = {
+  /** Incidents where the agent made no memory_recall calls (no IDs to reinforce) */
+  noRecalledIds: number;
+  /** Incidents where at least one fact was successfully reinforced */
+  reinforced: number;
+  /** Incidents where annotation threw an error */
+  errors: number;
+};
+
+/**
+ * Semantic status for the case where incidentsFound > 0 && annotated == 0.
+ * - `success_no_action_expected`: incidents found but all are benign no-ops (e.g. no recalled IDs,
+ *   LLM remediation loop ran and processed items despite no fact reinforcement).
+ * - `partial_no_matches`: all incidents had no recalled memory IDs — agent did not use
+ *   memory_recall in the praised sessions, so no facts could be linked.
+ * - `failed_annotation`: some incidents had recalled IDs but reinforceFact() calls all failed.
+ * - `degraded_model_or_parser`: LLM analysis failed or produced unparseable output.
+ */
+export type ReinforcementAnnotationStatus =
+  | "success_no_action_expected"
+  | "partial_no_matches"
+  | "failed_annotation"
+  | "degraded_model_or_parser";
+
 export type ReinforcementExtractResult = {
   incidents: ReinforcementIncident[];
   sessionsScanned: number;
+  /** Total number of facts annotated with reinforcement data (set after annotation pass) */
+  annotated?: number;
+  /** Reason breakdown per incident (set after annotation pass) */
+  annotationReasons?: AnnotationReasons;
+  /**
+   * Semantic status when incidentsFound > 0 && annotated == 0.
+   * Undefined when annotated > 0 or incidentsFound == 0.
+   */
+  annotationStatus?: ReinforcementAnnotationStatus;
 };
 
 /** Hard cap on bytes read per file per run to avoid unbounded JSONL reads (matches passive observer). */

--- a/extensions/memory-hybrid/services/reinforcement-extract.ts
+++ b/extensions/memory-hybrid/services/reinforcement-extract.ts
@@ -32,6 +32,8 @@ export type AnnotationReasons = {
   noRecalledIds: number;
   /** Incidents where at least one fact was successfully reinforced */
   reinforced: number;
+  /** Incidents had recalled IDs but none could be reinforced (e.g., stale/non-existent IDs) */
+  recalledIdsNoMatch: number;
   /** Incidents where annotation threw an error */
   errors: number;
 };

--- a/extensions/memory-hybrid/services/reinforcement-extract.ts
+++ b/extensions/memory-hybrid/services/reinforcement-extract.ts
@@ -38,15 +38,13 @@ export type AnnotationReasons = {
 
 /**
  * Semantic status for the case where incidentsFound > 0 && annotated == 0.
- * - `success_no_action_expected`: incidents found but all are benign no-ops (e.g. no recalled IDs,
- *   LLM remediation loop ran and processed items despite no fact reinforcement).
  * - `partial_no_matches`: all incidents had no recalled memory IDs — agent did not use
- *   memory_recall in the praised sessions, so no facts could be linked.
+ *   memory_recall in the praised sessions, so no facts could be linked. Benign.
  * - `failed_annotation`: some incidents had recalled IDs but reinforceFact() calls all failed.
- * - `degraded_model_or_parser`: LLM analysis failed or produced unparseable output.
+ * - `degraded_model_or_parser`: LLM analysis failed or produced unparseable output and
+ *   no facts were reinforced.
  */
 export type ReinforcementAnnotationStatus =
-  | "success_no_action_expected"
   | "partial_no_matches"
   | "failed_annotation"
   | "degraded_model_or_parser";

--- a/extensions/memory-hybrid/services/reinforcement-extract.ts
+++ b/extensions/memory-hybrid/services/reinforcement-extract.ts
@@ -44,10 +44,7 @@ export type AnnotationReasons = {
  * - `degraded_model_or_parser`: LLM analysis failed or produced unparseable output and
  *   no facts were reinforced.
  */
-export type ReinforcementAnnotationStatus =
-  | "partial_no_matches"
-  | "failed_annotation"
-  | "degraded_model_or_parser";
+export type ReinforcementAnnotationStatus = "partial_no_matches" | "failed_annotation" | "degraded_model_or_parser";
 
 export type ReinforcementExtractResult = {
   incidents: ReinforcementIncident[];

--- a/extensions/memory-hybrid/tests/reinforcement-zero-annotations.test.ts
+++ b/extensions/memory-hybrid/tests/reinforcement-zero-annotations.test.ts
@@ -218,6 +218,7 @@ describe("successful annotation (#1639)", () => {
     expect(result.annotationStatus).toBeUndefined();
     expect(result.annotationReasons?.reinforced).toBeGreaterThan(0);
     expect(result.annotationReasons?.noRecalledIds).toBe(0);
+    expect(result.annotationReasons?.recalledIdsNoMatch).toBe(0);
     expect(result.annotationReasons?.errors).toBe(0);
   });
 });
@@ -240,6 +241,7 @@ describe("no-match benign (partial_no_matches) (#1639)", () => {
     expect(result.annotationStatus).toBe("partial_no_matches");
     expect(result.annotationReasons?.noRecalledIds).toBe(result.incidents.length);
     expect(result.annotationReasons?.reinforced).toBe(0);
+    expect(result.annotationReasons?.recalledIdsNoMatch).toBe(0);
     expect(result.annotationReasons?.errors).toBe(0);
   });
 
@@ -398,9 +400,27 @@ describe("maintenance validation semantics (#1639)", () => {
     expect(result.annotated).toBeGreaterThan(0);
     expect(result.annotationReasons).toBeDefined();
     expect(result.annotationReasons?.reinforced).toBeGreaterThan(0);
+    expect(result.annotationReasons?.recalledIdsNoMatch).toBe(0);
   });
 
-  it("dry-run does not set annotated or annotationStatus", async () => {
+  it("sets failed_annotation and recalledIdsNoMatch when recalled IDs do not map to reinforceable facts", async () => {
+    const sessionFile = join(tmpDir, "2026-01-01-session.jsonl");
+    writeSessionWithMemoryRecall(sessionFile, "bbbbbbbb-0000-0000-0000-000000000002");
+
+    const openai = makeOpenAIMock("[]");
+    const ctx = makeCtx(openai);
+    const result = await runExtractReinforcementForCli(ctx, { workspace: tmpDir });
+
+    expect(result.incidents.length).toBeGreaterThan(0);
+    expect(result.annotated).toBe(0);
+    expect(result.annotationStatus).toBe("failed_annotation");
+    expect(result.annotationReasons?.noRecalledIds).toBe(0);
+    expect(result.annotationReasons?.reinforced).toBe(0);
+    expect(result.annotationReasons?.recalledIdsNoMatch).toBe(result.incidents.length);
+    expect(result.annotationReasons?.errors).toBe(0);
+  });
+
+  it("dry-run leaves annotated at 0 and annotationStatus unset", async () => {
     const sessionFile = join(tmpDir, "2026-01-01-session.jsonl");
     // Write a session with some non-existent ID (dry-run won't annotate regardless)
     writeSessionWithMemoryRecall(sessionFile, "bbbbbbbb-0000-0000-0000-000000000002");
@@ -415,6 +435,7 @@ describe("maintenance validation semantics (#1639)", () => {
     // annotationReasons should reflect the un-run annotation pass (all zeros)
     expect(result.annotationReasons?.noRecalledIds).toBe(0);
     expect(result.annotationReasons?.reinforced).toBe(0);
+    expect(result.annotationReasons?.recalledIdsNoMatch).toBe(0);
     expect(result.annotationReasons?.errors).toBe(0);
   });
 

--- a/extensions/memory-hybrid/tests/reinforcement-zero-annotations.test.ts
+++ b/extensions/memory-hybrid/tests/reinforcement-zero-annotations.test.ts
@@ -1,0 +1,451 @@
+/**
+ * Tests for issue #1639: extract-reinforcement reports success after 32 incidents but 0 annotations.
+ *
+ * Covers:
+ * - Successful annotation (incidents with recalledMemoryIds)
+ * - No-match benign: all incidents have no recalled memory IDs → annotationStatus = "partial_no_matches"
+ * - No-match unexpected: incidents had recalled IDs but annotation errored → "failed_annotation"
+ * - LLM timeout/failure → annotationStatus = "degraded_model_or_parser"
+ * - Fallback chain is derived from resolveReflectionModelAndFallbacks, not empty when configured
+ * - Maintenance validation semantics: annotated count and reason breakdown are reported
+ */
+
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { FactsDB } from "../backends/facts-db.js";
+import { ProposalsDB } from "../backends/proposals-db.js";
+import { runExtractReinforcementForCli } from "../cli/handlers.js";
+import type { HandlerContext } from "../cli/handlers.js";
+
+// ---------------------------------------------------------------------------
+// Shared setup
+// ---------------------------------------------------------------------------
+
+let tmpDir: string;
+let factsDb: FactsDB;
+let proposalsDb: ProposalsDB;
+
+function makeOpenAIMock(responseText: string) {
+  return {
+    chat: {
+      completions: {
+        create: vi.fn().mockResolvedValue({
+          choices: [{ message: { content: responseText } }],
+          usage: { prompt_tokens: 10, completion_tokens: 20, total_tokens: 30 },
+        }),
+      },
+    },
+  } as any;
+}
+
+function makeOpenAIErrorMock(error: Error) {
+  return {
+    chat: {
+      completions: {
+        create: vi.fn().mockRejectedValue(error),
+      },
+    },
+  } as any;
+}
+
+function makeCtx(openai: any, extra: Partial<HandlerContext> = {}): HandlerContext {
+  return {
+    factsDb,
+    vectorDb: {
+      hasDuplicate: vi.fn().mockResolvedValue(false),
+      store: vi.fn().mockResolvedValue(undefined),
+    } as any,
+    embeddings: {
+      embed: vi.fn().mockResolvedValue([0.1, 0.2, 0.3]),
+      embedBatch: vi.fn().mockResolvedValue([[0.1, 0.2, 0.3]]),
+      modelName: "test-model",
+    } as any,
+    openai,
+    proposalsDb,
+    cfg: {
+      procedures: { sessionsDir: tmpDir },
+      distill: {},
+      reinforcement: {
+        enabled: true,
+        passiveBoost: 0.1,
+        activeBoost: 0.05,
+        maxConfidence: 1.0,
+        similarityThreshold: 0.85,
+        trackContext: true,
+        maxEventsPerFact: 50,
+        diversityWeight: 1.0,
+        boostAmount: 1.0,
+      },
+      selfCorrection: {
+        semanticDedup: false,
+        semanticDedupThreshold: 0.92,
+        toolsSection: "Self-correction rules",
+        applyToolsByDefault: true,
+        autoRewriteTools: false,
+        analyzeViaSpawn: false,
+        spawnThreshold: 15,
+        spawnModel: "",
+        positiveRulesSection: "Positive Reinforcement Rules",
+        reinforcementLLMAnalysis: true,
+        reinforcementToProposals: true,
+        agentsRuleToProposals: true,
+      },
+      llm: { default: ["test-model"], heavy: ["test-model"], _source: undefined },
+      store: { classifyBeforeWrite: false },
+      autoRecall: { enabled: false },
+    } as any,
+    credentialsDb: null,
+    aliasDb: null,
+    wal: null,
+    identityReflectionStore: null,
+    personaStateStore: null,
+    resolvedSqlitePath: join(tmpDir, "facts.db"),
+    resolvedLancePath: join(tmpDir, "lance"),
+    pluginId: "test",
+    logger: { info: vi.fn(), warn: vi.fn() },
+    detectCategory: () => "technical",
+    ...extra,
+  };
+}
+
+/** Write a session JSONL where agent response contains a recalled memory ID tool result. */
+function writeSessionWithMemoryRecall(path: string, memoryId: string): void {
+  writeFileSync(
+    path,
+    [
+      JSON.stringify({
+        type: "message",
+        message: {
+          role: "assistant",
+          content: [
+            { type: "tool_use", name: "memory_recall", id: "tool1" },
+            { type: "tool_result", tool_use_id: "tool1", content: `Found memory: ${memoryId}` },
+            { type: "text", text: "Based on what I know: here is a detailed fix with 10 steps." },
+          ],
+        },
+      }),
+      JSON.stringify({
+        type: "message",
+        message: {
+          role: "user",
+          content: [{ type: "text", text: "Perfect! Exactly what I needed." }],
+        },
+      }),
+    ].join("\n"),
+    "utf-8",
+  );
+}
+
+/** Write a session JSONL where agent response does NOT contain any memory recall (no IDs). */
+function writeSessionWithoutMemoryRecall(path: string): void {
+  writeFileSync(
+    path,
+    [
+      JSON.stringify({
+        type: "message",
+        message: {
+          role: "assistant",
+          content: [
+            {
+              type: "text",
+              text: "I implemented the fix you requested. Here is the complete solution with all edge cases covered.",
+            },
+          ],
+        },
+      }),
+      JSON.stringify({
+        type: "message",
+        message: {
+          role: "user",
+          content: [{ type: "text", text: "Brilliant! Exactly how I wanted this done." }],
+        },
+      }),
+    ].join("\n"),
+    "utf-8",
+  );
+}
+
+/**
+ * Store a fact in factsDb and return the generated ID.
+ * FactsDB.store() omits `id` from StoreFactInput; IDs are always generated internally.
+ */
+function storeFactGetId(
+  db: FactsDB,
+  text: string,
+  extra?: { category?: string; importance?: number },
+): string {
+  const entry = db.store({
+    text,
+    category: extra?.category ?? "technical",
+    importance: extra?.importance ?? 0.7,
+    source: "test",
+    entity: null,
+    key: null,
+    value: null,
+    tags: [],
+  });
+  return entry.id;
+}
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "reinf-zero-ann-test-"));
+  factsDb = new FactsDB(join(tmpDir, "facts.db"));
+  proposalsDb = new ProposalsDB(join(tmpDir, "proposals.db"));
+});
+
+afterEach(() => {
+  factsDb.close();
+  proposalsDb.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// Successful annotation path
+// ---------------------------------------------------------------------------
+
+describe("successful annotation (#1639)", () => {
+  it("annotated count is > 0 and annotationStatus is undefined when facts are reinforced", async () => {
+    // Store the fact first to get the real generated ID, then write session with that ID
+    const realId = storeFactGetId(factsDb, "Use proactive CI checks before merging");
+
+    const sessionFile = join(tmpDir, "2026-01-01-session.jsonl");
+    writeSessionWithMemoryRecall(sessionFile, realId);
+
+    const openai = makeOpenAIMock("[]");
+    const ctx = makeCtx(openai);
+    const result = await runExtractReinforcementForCli(ctx, { workspace: tmpDir });
+
+    expect(result.incidents.length).toBeGreaterThan(0);
+    expect(result.annotated).toBeGreaterThan(0);
+    expect(result.annotationStatus).toBeUndefined();
+    expect(result.annotationReasons?.reinforced).toBeGreaterThan(0);
+    expect(result.annotationReasons?.noRecalledIds).toBe(0);
+    expect(result.annotationReasons?.errors).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// No-match benign: all incidents have no recalled IDs
+// ---------------------------------------------------------------------------
+
+describe("no-match benign (partial_no_matches) (#1639)", () => {
+  it("annotationStatus is partial_no_matches when all incidents have no recalled memory IDs", async () => {
+    const sessionFile = join(tmpDir, "2026-01-01-session.jsonl");
+    writeSessionWithoutMemoryRecall(sessionFile);
+
+    const openai = makeOpenAIMock("[]");
+    const ctx = makeCtx(openai);
+    const result = await runExtractReinforcementForCli(ctx, { workspace: tmpDir });
+
+    expect(result.incidents.length).toBeGreaterThan(0);
+    expect(result.annotated).toBe(0);
+    expect(result.annotationStatus).toBe("partial_no_matches");
+    expect(result.annotationReasons?.noRecalledIds).toBe(result.incidents.length);
+    expect(result.annotationReasons?.reinforced).toBe(0);
+    expect(result.annotationReasons?.errors).toBe(0);
+  });
+
+  it("annotationReasons counts are correct for multiple sessions without memory recall", async () => {
+    for (let i = 1; i <= 3; i++) {
+      writeSessionWithoutMemoryRecall(join(tmpDir, `2026-01-0${i}-session.jsonl`));
+    }
+
+    const openai = makeOpenAIMock("[]");
+    const ctx = makeCtx(openai);
+    const result = await runExtractReinforcementForCli(ctx, { workspace: tmpDir });
+
+    expect(result.incidents.length).toBeGreaterThan(0);
+    expect(result.annotated).toBe(0);
+    expect(result.annotationStatus).toBe("partial_no_matches");
+    // All incidents should be counted as noRecalledIds
+    expect(result.annotationReasons?.noRecalledIds).toBe(result.incidents.length);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// LLM analysis failed → degraded_model_or_parser
+// ---------------------------------------------------------------------------
+
+describe("LLM failure → degraded_model_or_parser (#1639)", () => {
+  it("annotationStatus is degraded_model_or_parser when LLM throws and all incidents have no recalled IDs", async () => {
+    const sessionFile = join(tmpDir, "2026-01-01-session.jsonl");
+    writeSessionWithoutMemoryRecall(sessionFile);
+
+    const openai = makeOpenAIErrorMock(new Error("Connection timeout"));
+    const ctx = makeCtx(openai);
+    const result = await runExtractReinforcementForCli(ctx, { workspace: tmpDir });
+
+    expect(result.incidents.length).toBeGreaterThan(0);
+    expect(result.annotated).toBe(0);
+    // LLM failure + no recalled IDs = degraded_model_or_parser
+    expect(result.annotationStatus).toBe("degraded_model_or_parser");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fallback chain is non-empty when configured
+// ---------------------------------------------------------------------------
+
+describe("fallback chain derived from configured llm tier (#1639)", () => {
+  it("fallback chain is non-empty when llm.nano has multiple models configured", async () => {
+    const sessionFile = join(tmpDir, "2026-01-01-session.jsonl");
+    writeSessionWithoutMemoryRecall(sessionFile);
+
+    const openai = makeOpenAIMock("[]");
+    // Use ctx with explicit llm.nano list containing primary + fallback
+    const ctx = makeCtx(openai, {
+      cfg: {
+        procedures: { sessionsDir: tmpDir },
+        distill: { extractionModelTier: "nano" },
+        reinforcement: {
+          enabled: true,
+          trackContext: true,
+          maxEventsPerFact: 50,
+          diversityWeight: 1.0,
+          boostAmount: 1.0,
+        },
+        selfCorrection: {
+          semanticDedup: false,
+          reinforcementLLMAnalysis: true,
+          reinforcementToProposals: false,
+        },
+        llm: {
+          nano: ["minimax/MiniMax-M2.7-highspeed", "google/gemini-2.0-flash"],
+          default: ["minimax/MiniMax-M2.7-highspeed"],
+          _source: undefined,
+        },
+        store: { classifyBeforeWrite: false },
+        autoRecall: { enabled: false },
+      } as any,
+    });
+
+    // Capture logger output to verify fallback chain log
+    const logMessages: string[] = [];
+    ctx.logger = { info: vi.fn((msg: string) => logMessages.push(msg)), warn: vi.fn() };
+
+    await runExtractReinforcementForCli(ctx, { workspace: tmpDir });
+
+    // Find the fallback chain log message
+    const fallbackLog = logMessages.find((m) => m.includes("fallback chain"));
+    expect(fallbackLog).toBeDefined();
+    // With two models in nano, fallback chain should contain the second model
+    expect(fallbackLog).toContain("google/gemini-2.0-flash");
+  });
+
+  it("fallback chain picks up llm.fallbackModel when llm.nano has only one entry", async () => {
+    const sessionFile = join(tmpDir, "2026-01-01-session.jsonl");
+    writeSessionWithoutMemoryRecall(sessionFile);
+
+    const openai = makeOpenAIMock("[]");
+    const ctx = makeCtx(openai, {
+      cfg: {
+        procedures: { sessionsDir: tmpDir },
+        distill: { extractionModelTier: "nano" },
+        reinforcement: {
+          enabled: true,
+          trackContext: true,
+          maxEventsPerFact: 50,
+          diversityWeight: 1.0,
+          boostAmount: 1.0,
+        },
+        selfCorrection: {
+          semanticDedup: false,
+          reinforcementLLMAnalysis: true,
+          reinforcementToProposals: false,
+        },
+        llm: {
+          nano: ["minimax/MiniMax-M2.7-highspeed"],
+          default: ["minimax/MiniMax-M2.7-highspeed"],
+          fallbackModel: "google/gemini-2.0-flash",
+          _source: undefined,
+        },
+        store: { classifyBeforeWrite: false },
+        autoRecall: { enabled: false },
+      } as any,
+    });
+
+    const logMessages: string[] = [];
+    ctx.logger = { info: vi.fn((msg: string) => logMessages.push(msg)), warn: vi.fn() };
+
+    await runExtractReinforcementForCli(ctx, { workspace: tmpDir });
+
+    const fallbackLog = logMessages.find((m) => m.includes("fallback chain"));
+    expect(fallbackLog).toBeDefined();
+    // llm.fallbackModel should appear in the chain even when nano only has one model
+    expect(fallbackLog).toContain("google/gemini-2.0-flash");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Maintenance validation semantics
+// ---------------------------------------------------------------------------
+
+describe("maintenance validation semantics (#1639)", () => {
+  it("annotated field reflects actual reinforced facts, not just recalledMemoryIds count", async () => {
+    // Store fact first, get real ID, then write session with that ID
+    const realId = storeFactGetId(factsDb, "Always break tasks into milestones", {
+      category: "behavioral",
+      importance: 0.8,
+    });
+
+    const sessionFile = join(tmpDir, "2026-01-01-session.jsonl");
+    writeSessionWithMemoryRecall(sessionFile, realId);
+
+    const openai = makeOpenAIMock("[]");
+    const ctx = makeCtx(openai);
+    const result = await runExtractReinforcementForCli(ctx, { workspace: tmpDir });
+
+    // annotated should match actual reinforced facts
+    expect(typeof result.annotated).toBe("number");
+    expect(result.annotated).toBeGreaterThan(0);
+    expect(result.annotationReasons).toBeDefined();
+    expect(result.annotationReasons?.reinforced).toBeGreaterThan(0);
+  });
+
+  it("dry-run does not set annotated or annotationStatus", async () => {
+    const sessionFile = join(tmpDir, "2026-01-01-session.jsonl");
+    // Write a session with some non-existent ID (dry-run won't annotate regardless)
+    writeSessionWithMemoryRecall(sessionFile, "bbbbbbbb-0000-0000-0000-000000000002");
+
+    const openai = makeOpenAIMock("[]");
+    const ctx = makeCtx(openai);
+    const result = await runExtractReinforcementForCli(ctx, { workspace: tmpDir, dryRun: true });
+
+    // Dry-run should not annotate
+    expect(result.annotated).toBe(0);
+    expect(result.annotationStatus).toBeUndefined();
+    // annotationReasons should reflect the un-run annotation pass (all zeros)
+    expect(result.annotationReasons?.noRecalledIds).toBe(0);
+    expect(result.annotationReasons?.reinforced).toBe(0);
+    expect(result.annotationReasons?.errors).toBe(0);
+  });
+
+  it("skipped result returns no annotation fields set meaningfully", async () => {
+    const sessionFile = join(tmpDir, "2026-01-01-session.jsonl");
+    writeSessionWithoutMemoryRecall(sessionFile);
+
+    const openai = makeOpenAIMock("[]");
+    const ctx = makeCtx(openai);
+
+    // First run sets the cursor watermark
+    await runExtractReinforcementForCli(ctx, { workspace: tmpDir });
+
+    // Second run within 23h should be skipped
+    const result2 = await runExtractReinforcementForCli(ctx, { workspace: tmpDir });
+    expect((result2 as any).skipped).toBe(true);
+  });
+
+  it("annotationStatus is undefined when no incidents found", async () => {
+    // Empty session — no reinforcement signals
+    writeFileSync(join(tmpDir, "2026-01-01-empty.jsonl"), "", "utf-8");
+
+    const openai = makeOpenAIMock("[]");
+    const ctx = makeCtx(openai);
+    const result = await runExtractReinforcementForCli(ctx, { workspace: tmpDir });
+
+    expect(result.incidents.length).toBe(0);
+    expect(result.annotationStatus).toBeUndefined();
+  });
+});

--- a/extensions/memory-hybrid/tests/reinforcement-zero-annotations.test.ts
+++ b/extensions/memory-hybrid/tests/reinforcement-zero-annotations.test.ts
@@ -168,6 +168,37 @@ function writeSessionWithoutMemoryRecall(path: string): void {
 }
 
 /**
+ * Write a session JSONL with no memory recall IDs, but with a tool call sequence
+ * so procedure reinforcement runs.
+ */
+function writeSessionWithoutMemoryRecallWithTools(path: string): void {
+  writeFileSync(
+    path,
+    [
+      JSON.stringify({
+        type: "message",
+        message: {
+          role: "assistant",
+          content: [
+            { type: "tool_use", name: "read_file", id: "tool1" },
+            { type: "tool_use", name: "edit_file", id: "tool2" },
+            { type: "text", text: "Applied the requested update and verified the behavior." },
+          ],
+        },
+      }),
+      JSON.stringify({
+        type: "message",
+        message: {
+          role: "user",
+          content: [{ type: "text", text: "Perfect! Exactly what I needed." }],
+        },
+      }),
+    ].join("\n"),
+    "utf-8",
+  );
+}
+
+/**
  * Store a fact in factsDb and return the generated ID.
  * FactsDB.store() omits `id` from StoreFactInput; IDs are always generated internally.
  */
@@ -279,6 +310,40 @@ describe("LLM failure → degraded_model_or_parser (#1639)", () => {
     expect(result.annotated).toBe(0);
     // LLM failure + no recalled IDs = degraded_model_or_parser
     expect(result.annotationStatus).toBe("degraded_model_or_parser");
+  });
+
+  it("annotationStatus is degraded_model_or_parser when LLM returns unparseable output", async () => {
+    const sessionFile = join(tmpDir, "2026-01-01-session.jsonl");
+    writeSessionWithoutMemoryRecall(sessionFile);
+
+    const openai = makeOpenAIMock("No JSON available.");
+    const ctx = makeCtx(openai);
+    const result = await runExtractReinforcementForCli(ctx, { workspace: tmpDir });
+
+    expect(result.incidents.length).toBeGreaterThan(0);
+    expect(result.annotated).toBe(0);
+    expect(result.annotationStatus).toBe("degraded_model_or_parser");
+    expect(result.annotationReasons?.noRecalledIds).toBe(result.incidents.length);
+  });
+});
+
+describe("procedure boost errors are surfaced (#1639)", () => {
+  it("counts no-recall procedure boost failures as annotation errors", async () => {
+    const sessionFile = join(tmpDir, "2026-01-01-session.jsonl");
+    writeSessionWithoutMemoryRecallWithTools(sessionFile);
+    vi.spyOn(factsDb, "searchProcedures").mockImplementation(() => {
+      throw new Error("procedure lookup failed");
+    });
+
+    const openai = makeOpenAIMock("[]");
+    const ctx = makeCtx(openai);
+    const result = await runExtractReinforcementForCli(ctx, { workspace: tmpDir });
+
+    expect(result.incidents.length).toBeGreaterThan(0);
+    expect(result.annotated).toBe(0);
+    expect(result.annotationStatus).toBe("failed_annotation");
+    expect(result.annotationReasons?.noRecalledIds).toBe(result.incidents.length);
+    expect(result.annotationReasons?.errors).toBe(result.incidents.length);
   });
 });
 

--- a/extensions/memory-hybrid/tests/reinforcement-zero-annotations.test.ts
+++ b/extensions/memory-hybrid/tests/reinforcement-zero-annotations.test.ts
@@ -171,11 +171,7 @@ function writeSessionWithoutMemoryRecall(path: string): void {
  * Store a fact in factsDb and return the generated ID.
  * FactsDB.store() omits `id` from StoreFactInput; IDs are always generated internally.
  */
-function storeFactGetId(
-  db: FactsDB,
-  text: string,
-  extra?: { category?: string; importance?: number },
-): string {
+function storeFactGetId(db: FactsDB, text: string, extra?: { category?: string; importance?: number }): string {
   const entry = db.store({
     text,
     category: extra?.category ?? "technical",


### PR DESCRIPTION
Fixes the issue where `extract-reinforcement` found reinforcement incidents but annotated 0 facts, reported `maintenanceStatus: "success"`, and had an empty fallback chain.

## Root Cause

- **Empty fallback chain**: The fallback model list was derived by slicing the tier's model array. When `llm.nano` had only one entry and `distill.fallbackModels` was unset, the chain was empty.
- **Silent zero annotations**: `annotated` was computed as the sum of `recalledMemoryIds.length` across all incidents — which counts IDs present in sessions, not whether `reinforceFact()` actually found and updated those facts. Incidents with no recalled IDs, or only stale/non-matching IDs, could therefore produce 0 real annotations without an accurate explanation.

## Changes

### `cli/cmd-extract-reinforcement.ts`
- Replaced manual tier-slice fallback logic with `resolveReflectionModelAndFallbacks()`, which correctly picks up `llm.fallbackModel` and `distill.fallbackModels` even when the tier has only one model.
- `reinforceFact()` return value is now checked — `annotated` counts actual successful reinforcements, not just attempts.
- Added `llmAnalysisFailed` flag to distinguish LLM timeout/parse failures from annotation failures.
- Each incident is now categorised into one of four reasons: `noRecalledIds`, `reinforced`, `recalledIdsNoMatch`, or `errors`.
- `annotationStatus` is derived from reasons and attached to the result: `partial_no_matches` (benign), `failed_annotation`, or `degraded_model_or_parser`.
- Preserves partial-success signaling by returning exit code `2` when some reinforcements succeed but other incidents still fail during annotation.

### `services/reinforcement-extract.ts`
- Added `AnnotationReasons` type tracking per-incident outcome counts.
- Added `ReinforcementAnnotationStatus` union type: `"partial_no_matches" | "failed_annotation" | "degraded_model_or_parser"`.
- Extended `ReinforcementExtractResult` with optional `annotated`, `annotationReasons`, and `annotationStatus` fields.

### `cli/distill.ts`
- Reports reason breakdown when incidents were found but nothing was annotated.
- Logs `annotationStatus` when set.
- Sets non-zero exit codes for non-benign outcomes, including partial-success-with-errors cases.

## Tests

Added `tests/reinforcement-zero-annotations.test.ts` covering:
- Successful annotation path (fact stored → real generated ID used in session JSONL → `reinforceFact()` returns `true`)
- Benign no-match: all incidents have no recalled IDs → `annotationStatus = "partial_no_matches"`
- Stale/non-matching recalled IDs → `annotationReasons.recalledIdsNoMatch` is tracked correctly
- LLM failure + no recalled IDs → `annotationStatus = "degraded_model_or_parser"`
- Fallback chain picks up second model from `llm.nano` array
- Fallback chain picks up `llm.fallbackModel` when `llm.nano` has only one entry
- `annotated` reflects actual `reinforceFact()` successes, not just ID counts
- Dry-run produces zero annotation fields
- Skipped result (within 23h cursor window)
- No incidents found → `annotationStatus` is undefined

> [!NOTE]
> **Low Risk**
> Changes are confined to reinforcement extraction CLI reporting, LLM fallback resolution, and tests; no auth or core runtime paths.
> 
> **Overview**
> Fixes **extract-reinforcement** falsely looking healthy when many incidents produced **zero fact annotations** and when the LLM **fallback chain was empty**.
> 
> **LLM routing:** Reinforcement analysis now uses `resolveReflectionModelAndFallbacks()` for fallbacks (including `llm.fallbackModel` / `distill.fallbackModels` when the tier has a single model), instead of only slicing the tier model list.
> 
> **Honest annotation metrics:** `annotated` counts successful `reinforceFact()` calls, not `recalledMemoryIds.length`. Per-incident **`annotationReasons`** (`noRecalledIds`, `reinforced`, `recalledIdsNoMatch`, `errors`) and **`annotationStatus`** (`partial_no_matches`, `failed_annotation`, `degraded_model_or_parser`) explain zero-annotation outcomes; LLM failures are tracked separately so partial success is not overwritten.
> 
> **CLI:** `extract-reinforcement` prints the reason breakdown and sets non-zero exit codes for real failures, while using exit code `2` for partial success with annotation failures and leaving benign “no memory recall in sessions” as success.
> 
> **Tests:** `reinforcement-zero-annotations.test.ts` covers success, benign no-match, stale IDs, LLM failure, fallback logging, and dry-run/skip behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to reinforcement extraction CLI reporting, LLM fallback resolution, and tests; no auth or core runtime paths.
> 
> **Overview**
> Fixes **extract-reinforcement** looking healthy when many praise incidents produced **zero fact annotations**, and when reinforcement LLM analysis had an **empty fallback chain**.
> 
> **LLM routing:** Analysis fallbacks now come from `resolveReflectionModelAndFallbacks()` (including `llm.fallbackModel` / `distill.fallbackModels` when the tier has a single model), not only slicing the tier model list. Parse failures set `llmAnalysisFailed` and validate JSON as an array.
> 
> **Honest metrics:** `annotated` counts successful `reinforceFact()` calls. Per-incident **`annotationReasons`** and **`annotationStatus`** (`partial_no_matches`, `failed_annotation`, `degraded_model_or_parser`) explain zero-annotation runs; partial fact success is not overwritten by LLM failure.
> 
> **CLI:** Reports reason breakdown, uses exit code **1** for hard failures, **2** for partial success with annotation errors; benign “no memory_recall in sessions” stays success.
> 
> **Tests:** `reinforcement-zero-annotations.test.ts` covers success, benign no-match, stale IDs, LLM failure, fallback logging, and dry-run/skip.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 502468bf355d29b1c6d1074a8e029a382a42d69c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->