### PR TITLE
test: add hybrid-memory maintenance semantics coverage

### DIFF
--- a/extensions/memory-hybrid/cli/cmd-selfcorrection.ts
+++ b/extensions/memory-hybrid/cli/cmd-selfcorrection.ts
@@ -436,7 +436,7 @@ export async function runSelfCorrectionRunForCli(
         }
         content = detail.content;
       }
-      const parsedArray = tryParseFirstJsonArray(content);
+      const parsedArray = parseSelfCorrectionLLMResponse(content);
       if (parsedArray !== null) {
         analysed = parsedArray as typeof analysed;
       } else if (content.trim().length > 0) {

--- a/extensions/memory-hybrid/cli/cmd-selfcorrection.ts
+++ b/extensions/memory-hybrid/cli/cmd-selfcorrection.ts
@@ -137,10 +137,7 @@ function isSelfCorrectionRemediationItem(item: unknown): boolean {
 
   const remediationContent = candidate.remediationContent;
   if (
-    !(
-      typeof remediationContent === "string" ||
-      (typeof remediationContent === "object" && remediationContent !== null)
-    )
+    !(typeof remediationContent === "string" || (typeof remediationContent === "object" && remediationContent !== null))
   ) {
     return false;
   }

--- a/extensions/memory-hybrid/cli/cmd-selfcorrection.ts
+++ b/extensions/memory-hybrid/cli/cmd-selfcorrection.ts
@@ -100,7 +100,7 @@ export function parseSelfCorrectionLLMResponse(content: string): unknown[] | nul
 
   while (searchFrom < normalized.length) {
     const start = normalized.indexOf("[", searchFrom);
-    if (start === -1) return null;
+    if (start === -1) break;
     const slice = extractBalancedArraySlice(normalized, start);
     if (!slice) {
       searchFrom = start + 1;

--- a/extensions/memory-hybrid/cli/cmd-selfcorrection.ts
+++ b/extensions/memory-hybrid/cli/cmd-selfcorrection.ts
@@ -92,6 +92,7 @@ function sanitizeLlmResponseExcerpt(content: string): string {
 export function parseSelfCorrectionLLMResponse(content: string): unknown[] | null {
   const normalized = stripBracketContextPreamble(stripMarkdownCodeFence(content));
   let searchFrom = 0;
+  let emptyArrayCandidate: unknown[] | null = null;
 
   while (searchFrom < normalized.length) {
     const start = normalized.indexOf("[", searchFrom);
@@ -103,8 +104,12 @@ export function parseSelfCorrectionLLMResponse(content: string): unknown[] | nul
     }
     try {
       const parsed: unknown = JSON.parse(slice);
-      if (Array.isArray(parsed) && isSelfCorrectionRemediationArray(parsed)) {
-        return parsed;
+      if (Array.isArray(parsed)) {
+        if (parsed.length === 0) {
+          emptyArrayCandidate = parsed;
+        } else if (isSelfCorrectionRemediationArray(parsed)) {
+          return parsed;
+        }
       }
     } catch {
       /* try next balanced span */
@@ -112,11 +117,10 @@ export function parseSelfCorrectionLLMResponse(content: string): unknown[] | nul
     searchFrom = start + slice.length;
   }
 
-  return null;
+  return emptyArrayCandidate;
 }
 
 function isSelfCorrectionRemediationArray(items: unknown[]): boolean {
-  if (items.length === 0) return true;
   return items.every(
     (item) => typeof item === "object" && item !== null && typeof (item as Record<string, unknown>).remediationType === "string",
   );

--- a/extensions/memory-hybrid/cli/cmd-selfcorrection.ts
+++ b/extensions/memory-hybrid/cli/cmd-selfcorrection.ts
@@ -436,9 +436,9 @@ export async function runSelfCorrectionRunForCli(
         }
         content = detail.content;
       }
-      const parsedArray = parseSelfCorrectionLLMResponse(content);
-      if (parsedArray !== null) {
-        analysed = parsedArray as typeof analysed;
+      const parsedRemediations = parseSelfCorrectionLLMResponse(content);
+      if (parsedRemediations !== null) {
+        analysed = parsedRemediations as typeof analysed;
       } else if (content.trim().length > 0) {
         // Log a sanitized excerpt (no private session data) so operators can diagnose.
         const excerpt = sanitizeLlmResponseExcerpt(content);

--- a/extensions/memory-hybrid/cli/cmd-selfcorrection.ts
+++ b/extensions/memory-hybrid/cli/cmd-selfcorrection.ts
@@ -26,7 +26,11 @@ import { cleanupEvictedVector } from "../services/vector-maintenance.js";
 import { atomicWriteFile } from "../utils/atomic-write.js";
 import { CLI_STORE_IMPORTANCE } from "../utils/constants.js";
 import { getCorrectionSignalRegex } from "../utils/language-keywords.js";
-import { extractBalancedArraySlice, stripBracketContextPreamble, stripMarkdownCodeFence } from "../utils/llm-json-array.js";
+import {
+  extractBalancedArraySlice,
+  stripBracketContextPreamble,
+  stripMarkdownCodeFence,
+} from "../utils/llm-json-array.js";
 import { resolveTierPreferenceWithSources } from "../utils/llm-selection.js";
 import { tryParseFirstJsonArray } from "../utils/llm-json-array.js";
 import { fillPrompt, loadPrompt } from "../utils/prompt-loader.js";
@@ -122,7 +126,10 @@ export function parseSelfCorrectionLLMResponse(content: string): unknown[] | nul
 
 function isSelfCorrectionRemediationArray(items: unknown[]): boolean {
   return items.every(
-    (item) => typeof item === "object" && item !== null && typeof (item as Record<string, unknown>).remediationType === "string",
+    (item) =>
+      typeof item === "object" &&
+      item !== null &&
+      typeof (item as Record<string, unknown>).remediationType === "string",
   );
 }
 

--- a/extensions/memory-hybrid/cli/cmd-selfcorrection.ts
+++ b/extensions/memory-hybrid/cli/cmd-selfcorrection.ts
@@ -66,6 +66,33 @@ function sanitizeLlmResponseExcerpt(content: string): string {
 }
 
 // ---------------------------------------------------------------------------
+// Self-correction LLM response parser
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse the JSON array of remediation items from a self-correction LLM response.
+ *
+ * The model is instructed to return a bare JSON array, but in practice it may:
+ *   - wrap the array in a markdown code fence (```json ... ```)
+ *   - add prose before or after the array
+ *   - emit placeholder tokens instead of JSON
+ *   - return invalid/truncated JSON
+ *
+ * This function handles all of those cases robustly via `tryParseFirstJsonArray`.
+ * Returns `null` when no valid array can be extracted (callers treat this as
+ * `failed_parse` — no remediations are applied and the error is reported).
+ *
+ * Scenarios and expected behaviour:
+ *   - **strict JSON**: `[{"remediationType":"MEMORY_STORE",...}]` → parsed directly
+ *   - **fenced JSON**: `` ```json\n[...]\n``` `` → fence stripped, array parsed
+ *   - **trailing text**: `[...]\n\nHere is my explanation` → array extracted, text ignored
+ *   - **invalid JSON**: `[not valid]` / truncated → null returned, caller handles error
+ */
+export function parseSelfCorrectionLLMResponse(content: string): unknown[] | null {
+  return tryParseFirstJsonArray(content);
+}
+
+// ---------------------------------------------------------------------------
 // self-correction extract
 // ---------------------------------------------------------------------------
 

--- a/extensions/memory-hybrid/cli/cmd-selfcorrection.ts
+++ b/extensions/memory-hybrid/cli/cmd-selfcorrection.ts
@@ -26,6 +26,7 @@ import { cleanupEvictedVector } from "../services/vector-maintenance.js";
 import { atomicWriteFile } from "../utils/atomic-write.js";
 import { CLI_STORE_IMPORTANCE } from "../utils/constants.js";
 import { getCorrectionSignalRegex } from "../utils/language-keywords.js";
+import { extractBalancedArraySlice, stripBracketContextPreamble, stripMarkdownCodeFence } from "../utils/llm-json-array.js";
 import { resolveTierPreferenceWithSources } from "../utils/llm-selection.js";
 import { tryParseFirstJsonArray } from "../utils/llm-json-array.js";
 import { fillPrompt, loadPrompt } from "../utils/prompt-loader.js";
@@ -89,7 +90,36 @@ function sanitizeLlmResponseExcerpt(content: string): string {
  *   - **invalid JSON**: `[not valid]` / truncated → null returned, caller handles error
  */
 export function parseSelfCorrectionLLMResponse(content: string): unknown[] | null {
-  return tryParseFirstJsonArray(content);
+  const normalized = stripBracketContextPreamble(stripMarkdownCodeFence(content));
+  let searchFrom = 0;
+
+  while (searchFrom < normalized.length) {
+    const start = normalized.indexOf("[", searchFrom);
+    if (start === -1) return null;
+    const slice = extractBalancedArraySlice(normalized, start);
+    if (!slice) {
+      searchFrom = start + 1;
+      continue;
+    }
+    try {
+      const parsed: unknown = JSON.parse(slice);
+      if (Array.isArray(parsed) && isSelfCorrectionRemediationArray(parsed)) {
+        return parsed;
+      }
+    } catch {
+      /* try next balanced span */
+    }
+    searchFrom = start + slice.length;
+  }
+
+  return null;
+}
+
+function isSelfCorrectionRemediationArray(items: unknown[]): boolean {
+  if (items.length === 0) return true;
+  return items.every(
+    (item) => typeof item === "object" && item !== null && typeof (item as Record<string, unknown>).remediationType === "string",
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/extensions/memory-hybrid/cli/cmd-selfcorrection.ts
+++ b/extensions/memory-hybrid/cli/cmd-selfcorrection.ts
@@ -83,7 +83,8 @@ function sanitizeLlmResponseExcerpt(content: string): string {
  *   - emit placeholder tokens instead of JSON
  *   - return invalid/truncated JSON
  *
- * This function handles all of those cases robustly via `tryParseFirstJsonArray`.
+ * This function handles all of those cases robustly by scanning balanced `[...]`
+ * spans and only accepting arrays that match expected remediation object shape.
  * Returns `null` when no valid array can be extracted (callers treat this as
  * `failed_parse` — no remediations are applied and the error is reported).
  *
@@ -125,12 +126,30 @@ export function parseSelfCorrectionLLMResponse(content: string): unknown[] | nul
 }
 
 function isSelfCorrectionRemediationArray(items: unknown[]): boolean {
-  return items.every(
-    (item) =>
-      typeof item === "object" &&
-      item !== null &&
-      typeof (item as Record<string, unknown>).remediationType === "string",
-  );
+  return items.every((item) => isSelfCorrectionRemediationItem(item));
+}
+
+function isSelfCorrectionRemediationItem(item: unknown): boolean {
+  if (typeof item !== "object" || item === null) return false;
+  const candidate = item as Record<string, unknown>;
+  const remediationType = candidate.remediationType;
+  if (typeof remediationType !== "string" || remediationType.trim().length === 0) return false;
+
+  const remediationContent = candidate.remediationContent;
+  if (
+    !(
+      typeof remediationContent === "string" ||
+      (typeof remediationContent === "object" && remediationContent !== null)
+    )
+  ) {
+    return false;
+  }
+
+  if ("category" in candidate && typeof candidate.category !== "string") return false;
+  if ("severity" in candidate && typeof candidate.severity !== "string") return false;
+  if ("repeated" in candidate && typeof candidate.repeated !== "boolean") return false;
+
+  return true;
 }
 
 // ---------------------------------------------------------------------------

--- a/extensions/memory-hybrid/services/cron-exit-validator.ts
+++ b/extensions/memory-hybrid/services/cron-exit-validator.ts
@@ -6,6 +6,34 @@
  * or only partially complete.
  *
  * Issue: hybrid-memory cron jobs report OK despite failed or partial maintenance
+ *
+ * ## Maintenance result vocabulary
+ *
+ * `maintenanceStatus` in {@link ExitValidationResult} uses the following values:
+ *
+ * - `"success"` — All required steps are present in the HM_EXIT ledger and every
+ *   step exited 0 (or a permitted skip variant matched). The guard file MAY be
+ *   updated after a `"success"` result.
+ *
+ * - `"skipped"` — The exit ledger is empty AND the HM_LOG contains a recognised
+ *   feature-gate phrase (e.g. "reflection.enabled is false"). No hm_step lines ran.
+ *   The guard file MUST NOT be updated; the skip is recorded for audit but is not
+ *   treated as a failure.
+ *
+ * - `"partial"` — Some but not all required steps are present in the ledger and the
+ *   present steps all exited 0. The guard file MUST NOT be updated; the job should
+ *   be requeued or investigated.
+ *
+ * - `"failed"` — At least one step exited non-zero, or all required steps are absent
+ *   and the log does not indicate an intentional feature skip, or an unknown command
+ *   was detected in the log. The guard file MUST NOT be updated.
+ *
+ * ## Guard update rule
+ *
+ * `guardUpdated` is `true` only when `maintenanceStatus === "success"`.  Callers
+ * MUST NOT write a success guard for `"skipped"`, `"partial"`, or `"failed"` runs.
+ * This ensures that a shell-exited-0 cron wrapper cannot silently masquerade as a
+ * healthy run when the semantic work did not complete.
  */
 
 import { existsSync, readFileSync } from "node:fs";

--- a/extensions/memory-hybrid/services/maintenance-rules.json
+++ b/extensions/memory-hybrid/services/maintenance-rules.json
@@ -89,7 +89,7 @@
   },
   {
     "id": "cron-path-missing",
-    "pattern": "failed to run command ['\"]openclaw['\"]|command not found.*openclaw|openclaw.*(command )?not found|openclaw.*no such file or directory|no such file or directory.*openclaw",
+    "pattern": "failed to run command ['\"]openclaw['\"]|command not found[^\\n]*openclaw|openclaw[^\\n]*(command )?not found|openclaw[^\\n]*no such file or directory|no such file or directory[^\\n]*openclaw",
     "classification": "env-misconfig",
     "defaultAction": "escalate-user",
     "severity": "high",

--- a/extensions/memory-hybrid/services/maintenance-rules.json
+++ b/extensions/memory-hybrid/services/maintenance-rules.json
@@ -89,7 +89,7 @@
   },
   {
     "id": "cron-path-missing",
-    "pattern": "failed to run command ['\"]openclaw['\"]|command not found.*openclaw|openclaw.*(command )?not found|openclaw.*no such file or directory",
+    "pattern": "failed to run command ['\"]openclaw['\"]|command not found[^\\n]*openclaw|openclaw[^\\n]*(command )?not found|openclaw[^\\n]*no such file or directory",
     "classification": "env-misconfig",
     "defaultAction": "escalate-user",
     "severity": "high",

--- a/extensions/memory-hybrid/services/maintenance-rules.json
+++ b/extensions/memory-hybrid/services/maintenance-rules.json
@@ -89,7 +89,7 @@
   },
   {
     "id": "cron-path-missing",
-    "pattern": "failed to run command ['\"]openclaw['\"]|command not found[^\\n]*openclaw|openclaw[^\\n]*(command )?not found|openclaw[^\\n]*no such file or directory",
+    "pattern": "failed to run command ['\"]openclaw['\"]|command not found[^\\n]*openclaw|openclaw[^\\n]*(command )?not found|openclaw[^\\n]*no such file or directory|no such file or directory[^\\n]*openclaw",
     "classification": "env-misconfig",
     "defaultAction": "escalate-user",
     "severity": "high",

--- a/extensions/memory-hybrid/services/maintenance-rules.json
+++ b/extensions/memory-hybrid/services/maintenance-rules.json
@@ -89,7 +89,7 @@
   },
   {
     "id": "cron-path-missing",
-    "pattern": "failed to run command ['\"]openclaw['\"]|command not found[^\\n]*openclaw|openclaw[^\\n]*(command )?not found|openclaw[^\\n]*no such file or directory|no such file or directory[^\\n]*openclaw",
+    "pattern": "failed to run command ['\"]openclaw['\"]|command not found.*openclaw|openclaw.*(command )?not found|openclaw.*no such file or directory|no such file or directory.*openclaw",
     "classification": "env-misconfig",
     "defaultAction": "escalate-user",
     "severity": "high",

--- a/extensions/memory-hybrid/services/maintenance-rules.json
+++ b/extensions/memory-hybrid/services/maintenance-rules.json
@@ -89,7 +89,7 @@
   },
   {
     "id": "cron-path-missing",
-    "pattern": "failed to run command 'openclaw'|failed to run command \"openclaw\"|openclaw: command not found|command not found.*openclaw|openclaw.*not found|no such file or directory.*openclaw|openclaw.*no such file or directory",
+    "pattern": "failed to run command ['\"]openclaw['\"]|command not found.*openclaw|openclaw.*(command )?not found|openclaw.*no such file or directory",
     "classification": "env-misconfig",
     "defaultAction": "escalate-user",
     "severity": "high",

--- a/extensions/memory-hybrid/services/maintenance-rules.json
+++ b/extensions/memory-hybrid/services/maintenance-rules.json
@@ -86,5 +86,13 @@
     "defaultAction": "retry-once",
     "severity": "medium",
     "suggestedAction": "Another run may be holding a scan lock; if the PID is stale, clear the lock file after confirming no live process."
+  },
+  {
+    "id": "cron-path-missing",
+    "pattern": "failed to run command 'openclaw'|failed to run command \"openclaw\"|openclaw: command not found|command not found.*openclaw|openclaw.*not found|no such file or directory.*openclaw|openclaw.*no such file or directory",
+    "classification": "env-misconfig",
+    "defaultAction": "escalate-user",
+    "severity": "high",
+    "suggestedAction": "The 'openclaw' binary is not in PATH for the cron context. Run 'which openclaw' in a login shell, then update the cron preamble to source the correct PATH or use the full absolute binary path (e.g. /home/user/.local/bin/openclaw)."
   }
 ]

--- a/extensions/memory-hybrid/tests/cron-exit-validator.test.ts
+++ b/extensions/memory-hybrid/tests/cron-exit-validator.test.ts
@@ -368,5 +368,26 @@ error: unknown command 'bar'
 
       expect(result.maintenanceStatus).toBe("failed");
     });
+
+    it("should deterministically fail stale empty ledgers with heartbeat-only logs", () => {
+      const tmpDir = mkdtempSync(join(tmpdir(), "cron-test-"));
+      const exitPath = join(tmpDir, "test.exit.txt");
+      const logPath = join(tmpDir, "test.log");
+      writeFileSync(exitPath, "");
+      writeFileSync(
+        logPath,
+        [
+          "[dream-cycle] extract implicit feedback — still running after 2210s — stage=scan-sessions; sessions=106/177",
+          "memory-hybrid: dream-cycle — stage 3 still running after 2210s",
+        ].join("\n"),
+      );
+
+      const result = validateMaintenanceExecution(exitPath, logPath, ["dream-cycle"]);
+
+      expect(result.maintenanceStatus).toBe("failed");
+      expect(result.guardUpdated).toBe(false);
+      expect(result.missingSteps).toEqual(["dream-cycle"]);
+      expect(result.error).toContain("Missing steps");
+    });
   });
 });

--- a/extensions/memory-hybrid/tests/helpers/maintenance-job-test-harness.ts
+++ b/extensions/memory-hybrid/tests/helpers/maintenance-job-test-harness.ts
@@ -1,0 +1,73 @@
+import { existsSync, mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { type ExitValidationResult, validateMaintenanceExecution } from "../../services/cron-exit-validator.js";
+
+const DEFAULT_STEP_TS = "2026-05-15T03:00:00Z";
+
+export interface MaintenanceJobHarnessInput {
+  requiredSteps: string[];
+  allowSkip?: boolean;
+  jobName?: string;
+  exitRows?: string[];
+  logLines?: string[];
+  missingExitLedger?: boolean;
+  applyGuardUpdate?: boolean;
+  guardTimestampMs?: number;
+}
+
+export interface MaintenanceJobHarnessResult {
+  root: string;
+  exitPath: string;
+  logPath: string;
+  guardPath: string;
+  validation: ExitValidationResult;
+  guardWritten: boolean;
+}
+
+export function hmExitStepLine(input: {
+  step: string;
+  exitCode: number;
+  status?: "ok" | "failed" | "skipped";
+  reason?: string;
+  durationMs?: number;
+  timestamp?: string;
+}): string {
+  const timestamp = input.timestamp ?? DEFAULT_STEP_TS;
+  const status = input.status ?? (input.exitCode === 0 ? "ok" : "failed");
+  const reason = input.reason ?? (input.exitCode === 0 ? "ok" : "error");
+  const durationMs = input.durationMs ?? 1;
+  return `${timestamp} step=${input.step} exit=${input.exitCode} status=${status} reason=${reason} duration_ms=${durationMs}`;
+}
+
+export function runMaintenanceJobHarness(input: MaintenanceJobHarnessInput): MaintenanceJobHarnessResult {
+  const root = mkdtempSync(join(tmpdir(), "hm-maintenance-job-harness-"));
+  const jobName = input.jobName ?? "nightly-memory-sweep-20260515T030000Z-1";
+  const logRoot = join(root, "logs", "cron-hybrid-mem", "20260515");
+  mkdirSync(logRoot, { recursive: true });
+
+  const exitPath = join(logRoot, `${jobName}.exit.txt`);
+  const logPath = join(logRoot, `${jobName}.log`);
+  const guardPath = join(root, "cron", "guard", `${jobName}.ms`);
+
+  const rows = input.exitRows ?? [];
+  const logs = input.logLines ?? [];
+  if (!input.missingExitLedger) writeFileSync(exitPath, rows.length > 0 ? `${rows.join("\n")}\n` : "", "utf-8");
+  writeFileSync(logPath, logs.length > 0 ? `${logs.join("\n")}\n` : "", "utf-8");
+
+  const validation = validateMaintenanceExecution(exitPath, logPath, input.requiredSteps, input.allowSkip ?? false);
+
+  if ((input.applyGuardUpdate ?? true) && validation.guardUpdated) {
+    mkdirSync(dirname(guardPath), { recursive: true });
+    writeFileSync(guardPath, `${input.guardTimestampMs ?? Date.UTC(2026, 4, 15, 3, 5, 0)}`, "utf-8");
+  }
+
+  return {
+    root,
+    exitPath,
+    logPath,
+    guardPath,
+    validation,
+    guardWritten: existsSync(guardPath),
+  };
+}

--- a/extensions/memory-hybrid/tests/maintenance-job-harness.test.ts
+++ b/extensions/memory-hybrid/tests/maintenance-job-harness.test.ts
@@ -1,0 +1,91 @@
+import { rmSync } from "node:fs";
+import { afterEach, describe, expect, it } from "vitest";
+import { hmExitStepLine, runMaintenanceJobHarness } from "./helpers/maintenance-job-test-harness.js";
+
+const harnessRoots: string[] = [];
+
+afterEach(() => {
+  while (harnessRoots.length > 0) {
+    const root = harnessRoots.pop();
+    if (root) rmSync(root, { recursive: true, force: true });
+  }
+});
+
+function runHarness(
+  input: Parameters<typeof runMaintenanceJobHarness>[0],
+): ReturnType<typeof runMaintenanceJobHarness> {
+  const run = runMaintenanceJobHarness(input);
+  harnessRoots.push(run.root);
+  return run;
+}
+
+describe("maintenance job harness fixture", () => {
+  it("models wrapper success and writes guard only after semantic validation succeeds", () => {
+    const run = runHarness({
+      requiredSteps: ["prune", "distill"],
+      exitRows: [hmExitStepLine({ step: "prune", exitCode: 0 }), hmExitStepLine({ step: "distill", exitCode: 0 })],
+      logLines: ["--- validate-cron-exit ---", '{"maintenanceStatus":"success"}'],
+    });
+
+    expect(run.validation.maintenanceStatus).toBe("success");
+    expect(run.validation.guardUpdated).toBe(true);
+    expect(run.guardWritten).toBe(true);
+  });
+
+  it("models skip/cooldown semantics as explicit skipped status with no guard update", () => {
+    const run = runHarness({
+      requiredSteps: ["reflect", "reflect-rules"],
+      exitRows: [],
+      logLines: ["reflection.enabled is false in hybrid-memory config. Job was skipped per preamble."],
+    });
+
+    expect(run.validation.maintenanceStatus).toBe("skipped");
+    expect(run.validation.guardUpdated).toBe(false);
+    expect(run.guardWritten).toBe(false);
+  });
+
+  it("models missing HM_EXIT ledger as failed_missing_ledger and blocks guard update", () => {
+    const run = runHarness({
+      requiredSteps: ["prune"],
+      missingExitLedger: true,
+      logLines: ["run started"],
+    });
+
+    expect(run.validation.maintenanceStatus).toBe("failed");
+    expect(run.validation.error).toContain("Exit ledger not found");
+    expect(run.validation.guardUpdated).toBe(false);
+    expect(run.guardWritten).toBe(false);
+  });
+
+  it("models timeout failures as semantic maintenance failures", () => {
+    const run = runHarness({
+      requiredSteps: ["distill"],
+      exitRows: [hmExitStepLine({ step: "distill", exitCode: 124, reason: "timeout", durationMs: 60000 })],
+      logLines: ["timeout 124 killed after 60s"],
+    });
+
+    expect(run.validation.maintenanceStatus).toBe("failed");
+    expect(run.validation.failedSteps).toHaveLength(1);
+    expect(run.validation.failedSteps[0]?.step).toBe("distill");
+    expect(run.validation.failedSteps[0]?.exitCode).toBe(124);
+    expect(run.validation.guardUpdated).toBe(false);
+    expect(run.guardWritten).toBe(false);
+  });
+
+  it("models failed-step semantics and keeps guard update disabled", () => {
+    const run = runHarness({
+      requiredSteps: ["prune", "distill"],
+      exitRows: [
+        hmExitStepLine({ step: "prune", exitCode: 0 }),
+        hmExitStepLine({ step: "distill", exitCode: 1, reason: "inner_command_failed" }),
+      ],
+      logLines: ["distill failed"],
+    });
+
+    expect(run.validation.maintenanceStatus).toBe("failed");
+    expect(run.validation.failedSteps).toHaveLength(1);
+    expect(run.validation.failedSteps[0]?.step).toBe("distill");
+    expect(run.validation.guardUpdated).toBe(false);
+    expect(run.guardWritten).toBe(false);
+  });
+});

--- a/extensions/memory-hybrid/tests/maintenance-log-analyzer.test.ts
+++ b/extensions/memory-hybrid/tests/maintenance-log-analyzer.test.ts
@@ -353,7 +353,6 @@ describe("maintenance log analyzer", () => {
     expect(steps[0].step).toBe("orchestration-empty-exit-after-progress");
     expect(steps[0].line).toContain("progress-marker=present");
   });
-
   it("classifies missing .exit.txt ledgers as orchestration failures", () => {
     const root = tmpRoot();
     const logPath = join(root, "nightly-memory-sweep-20260511T030000Z-555.log");

--- a/extensions/memory-hybrid/tests/maintenance-log-analyzer.test.ts
+++ b/extensions/memory-hybrid/tests/maintenance-log-analyzer.test.ts
@@ -75,6 +75,22 @@ describe("maintenance log analyzer", () => {
     }
   });
 
+  it("classifies cron wrapper PATH failure (openclaw binary not in PATH) as env-misconfig", () => {
+    // This reproduces the real-world cron failure:
+    //   /usr/bin/timeout: failed to run command 'openclaw': No such file or directory
+    const cronPathFailures = [
+      "/usr/bin/timeout: failed to run command 'openclaw': No such file or directory",
+      "bash: openclaw: command not found",
+      "command not found: openclaw",
+      "/usr/bin/env: 'openclaw': No such file or directory",
+    ];
+    for (const logContent of cronPathFailures) {
+      const result = classifyMaintenanceFailure({ step: "nightly-memory-sweep", exitCode: 127, logContent });
+      expect(result.classification).toBe("env-misconfig");
+      expect(result.severity).toBe("high");
+    }
+  });
+
   it("distinguishes audit-health strict failures from command crashes", () => {
     const strictWarnings = JSON.stringify(
       {
@@ -144,6 +160,24 @@ describe("maintenance log analyzer", () => {
 
     expect(result.classification).toBe("health-warnings");
     expect(result.id).toBe("audit-health-strict-warnings");
+  });
+
+  it("classifies audit-health json-parse-failure as json-parse-failure class (not command-crash)", () => {
+    // Reproduces the real-world failure from issue #1637:
+    // audit-health exits 2 and the log contains a recognisable but truncated/malformed JSON block.
+    // extractAuditHealthJsonFromLog triggers parse_error when both "schemaVersion":1 AND "activeFacts":
+    // are present but no valid JSON object can be extracted — matching the real broken-output scenario.
+    const malformedLog = [
+      "preamble from openclaw audit health",
+      // Truncated mid-object — contains the two heuristic markers but closing brace is missing
+      '{"schemaVersion":1,"activeFacts":42,"generatedAt":"2026-05-09T15:06:34Z","status":"partial","ok":false,',
+      "tail: process exited unexpectedly",
+    ].join("\n");
+
+    const result = classifyMaintenanceFailure({ step: "audit-health", exitCode: 2, logContent: malformedLog });
+    expect(result.classification).toBe("json-parse-failure");
+    expect(result.id).toBe("audit-health-json-parse-failure");
+    expect(result.severity).toBe("high");
   });
 
   it("walks exit/log siblings, detects non-zero and exit=0 orchestration heuristics, and emits digest JSON shape", () => {

--- a/extensions/memory-hybrid/tests/maintenance-log-analyzer.test.ts
+++ b/extensions/memory-hybrid/tests/maintenance-log-analyzer.test.ts
@@ -354,6 +354,34 @@ describe("maintenance log analyzer", () => {
     expect(steps[0].line).toContain("progress-marker=present");
   });
 
+  it("classifies missing .exit.txt ledgers as orchestration failures", () => {
+    const root = tmpRoot();
+    const logPath = join(root, "nightly-memory-sweep-20260511T030000Z-555.log");
+    writeFileSync(
+      logPath,
+      [
+        "[nightly-memory-sweep] prune completed",
+        "[nightly-memory-sweep] distill completed",
+        "validate-cron-exit marker missing because wrapper failed before ledger flush",
+      ].join("\n"),
+    );
+
+    const nowMs = Date.UTC(2026, 4, 11, 4, 0, 0);
+    const steps = collectMaintenanceSteps(root, "24h", nowMs, { staleThresholdMs: 45 * 60 * 1000 });
+    expect(steps).toHaveLength(1);
+    expect(steps[0].step).toBe("orchestration-missing-exit-ledger");
+    expect(steps[0].line).toContain("matching .exit.txt ledger is missing");
+
+    const rule = classifyMaintenanceFailure(steps[0]);
+    expect(rule.id).toBe("orchestration-missing-exit-ledger");
+    expect(rule.classification).toBe("orchestration-bug");
+
+    const findings = analyzeMaintenanceSteps(steps);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].classification).toBe("orchestration-bug");
+    expect(findings[0].ruleId).toBe("orchestration-missing-exit-ledger");
+  });
+
   it("keeps normal successful verbose dream-cycle runs as OK", () => {
     const root = tmpRoot();
     const exitPath = join(root, "nightly-dream-cycle-20260511T024522Z-17502.exit.txt");

--- a/extensions/memory-hybrid/tests/reinforcement-analysis.test.ts
+++ b/extensions/memory-hybrid/tests/reinforcement-analysis.test.ts
@@ -458,6 +458,32 @@ describe("PROPOSAL creates entry in proposals DB (#260)", () => {
 // ---------------------------------------------------------------------------
 
 describe("AGENTS_RULE from self-correction creates proposal in DB (#260)", () => {
+  it("reports an error when the LLM response is not a valid JSON array", async () => {
+    const openai = makeOpenAIMock("I could not produce valid JSON this time.");
+    const ctx = makeCtx(openai);
+
+    const result = await runSelfCorrectionRunForCli(ctx, {
+      incidents: [
+        {
+          userMessage: "No, handle parse failures as errors.",
+          agentMessage: "I'll treat malformed output as an empty success.",
+          sessionFile: "2026-01-01-session.jsonl",
+          timestamp: "2026-01-01T00:00:00.000Z",
+        } as any,
+      ],
+      workspace: tmpDir,
+    });
+
+    expect(result).toMatchObject({
+      incidentsFound: 1,
+      analysed: 0,
+      autoFixed: 0,
+      proposals: [],
+      reportPath: null,
+      error: "Failed to parse LLM response as JSON array",
+    });
+  });
+
   it("creates proposal when AGENTS_RULE remediation is returned", async () => {
     const llmResponse = JSON.stringify([
       {

--- a/extensions/memory-hybrid/tests/reinforcement-analysis.test.ts
+++ b/extensions/memory-hybrid/tests/reinforcement-analysis.test.ts
@@ -480,8 +480,10 @@ describe("AGENTS_RULE from self-correction creates proposal in DB (#260)", () =>
       autoFixed: 0,
       proposals: [],
       reportPath: null,
-      error: "Failed to parse LLM response as JSON array",
     });
+    expect(result.error).toContain(
+      "Self-correction analysis: LLM response could not be parsed as a JSON array (repair failed)",
+    );
   });
 
   it("creates proposal when AGENTS_RULE remediation is returned", async () => {

--- a/extensions/memory-hybrid/tests/self-correction-run-parser.test.ts
+++ b/extensions/memory-hybrid/tests/self-correction-run-parser.test.ts
@@ -91,6 +91,20 @@ describe("parseSelfCorrectionLLMResponse", () => {
     expect(result).toBeNull();
   });
 
+  it("skips non-remediation object arrays and parses the remediation array", () => {
+    const input = `Metadata: [{"id":1}]\n${JSON.stringify([sampleItem])}`;
+    const result = parseSelfCorrectionLLMResponse(input);
+    expect(result).not.toBeNull();
+    expect(result).toHaveLength(1);
+  });
+
+  it("prefers a later remediation array over an earlier empty array", () => {
+    const input = `[]\n${JSON.stringify([sampleItem])}`;
+    const result = parseSelfCorrectionLLMResponse(input);
+    expect(result).not.toBeNull();
+    expect(result).toHaveLength(1);
+  });
+
   it("returns null for empty string input", () => {
     const result = parseSelfCorrectionLLMResponse("");
     expect(result).toBeNull();

--- a/extensions/memory-hybrid/tests/self-correction-run-parser.test.ts
+++ b/extensions/memory-hybrid/tests/self-correction-run-parser.test.ts
@@ -26,7 +26,7 @@ describe("parseSelfCorrectionLLMResponse", () => {
     expect(result).not.toBeNull();
     expect(Array.isArray(result)).toBe(true);
     expect(result).toHaveLength(1);
-    expect((result as typeof sampleItem[])[0].remediationType).toBe("MEMORY_STORE");
+    expect((result as (typeof sampleItem)[])[0].remediationType).toBe("MEMORY_STORE");
   });
 
   it("parses a JSON array wrapped in a ```json fenced code block", () => {

--- a/extensions/memory-hybrid/tests/self-correction-run-parser.test.ts
+++ b/extensions/memory-hybrid/tests/self-correction-run-parser.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Tests for parseSelfCorrectionLLMResponse — the parser that extracts the
+ * remediation JSON array from self-correction LLM model output.
+ *
+ * Covers: strict JSON, fenced JSON, trailing text, invalid JSON, placeholder tokens.
+ * These tests exercise the robustness guarantees described in the JSDoc of
+ * parseSelfCorrectionLLMResponse (cmd-selfcorrection.ts) and the underlying
+ * tryParseFirstJsonArray utility (utils/llm-json-array.ts).
+ */
+
+import { describe, expect, it } from "vitest";
+import { parseSelfCorrectionLLMResponse } from "../cli/cmd-selfcorrection.js";
+
+// Representative remediation item shape used across tests
+const sampleItem = {
+  remediationType: "MEMORY_STORE",
+  content: "Always confirm destructive operations before proceeding.",
+  confidence: 0.9,
+  reasoning: "User asked copilot to avoid deleting files without confirmation.",
+};
+
+describe("parseSelfCorrectionLLMResponse", () => {
+  it("parses a strict bare JSON array", () => {
+    const input = JSON.stringify([sampleItem]);
+    const result = parseSelfCorrectionLLMResponse(input);
+    expect(result).not.toBeNull();
+    expect(Array.isArray(result)).toBe(true);
+    expect(result).toHaveLength(1);
+    expect((result as typeof sampleItem[])[0].remediationType).toBe("MEMORY_STORE");
+  });
+
+  it("parses a JSON array wrapped in a ```json fenced code block", () => {
+    const input = `Here are the remediation items:\n\`\`\`json\n${JSON.stringify([sampleItem])}\n\`\`\``;
+    const result = parseSelfCorrectionLLMResponse(input);
+    expect(result).not.toBeNull();
+    expect(Array.isArray(result)).toBe(true);
+    expect(result).toHaveLength(1);
+  });
+
+  it("parses a JSON array wrapped in a plain ``` fenced code block", () => {
+    const input = `\`\`\`\n${JSON.stringify([sampleItem])}\n\`\`\``;
+    const result = parseSelfCorrectionLLMResponse(input);
+    expect(result).not.toBeNull();
+    expect(Array.isArray(result)).toBe(true);
+  });
+
+  it("extracts the JSON array when the model appends trailing prose explanation", () => {
+    const array = JSON.stringify([sampleItem]);
+    const input = `${array}\n\nThe above items address the identified correction signals. Let me know if you want more details.`;
+    const result = parseSelfCorrectionLLMResponse(input);
+    expect(result).not.toBeNull();
+    expect(Array.isArray(result)).toBe(true);
+    expect(result).toHaveLength(1);
+  });
+
+  it("extracts the JSON array when there is preamble prose before the array", () => {
+    const array = JSON.stringify([sampleItem]);
+    const input = `Based on my analysis, here are the recommended corrections:\n${array}`;
+    const result = parseSelfCorrectionLLMResponse(input);
+    expect(result).not.toBeNull();
+    expect(Array.isArray(result)).toBe(true);
+    expect(result).toHaveLength(1);
+  });
+
+  it("returns null for invalid/non-JSON content", () => {
+    const result = parseSelfCorrectionLLMResponse("I was unable to identify any correction signals.");
+    expect(result).toBeNull();
+  });
+
+  it("returns null for truncated/malformed JSON array", () => {
+    // Truncated mid-object — a real LLM failure mode when output is too long
+    const input = '[{"remediationType":"MEMORY_STORE","content":"Always confirm dest';
+    const result = parseSelfCorrectionLLMResponse(input);
+    expect(result).toBeNull();
+  });
+
+  it("returns null for model placeholder tokens (e.g. [[reply_to_current]])", () => {
+    const result = parseSelfCorrectionLLMResponse("[[reply_to_current]]");
+    expect(result).toBeNull();
+  });
+
+  it("returns null for empty string input", () => {
+    const result = parseSelfCorrectionLLMResponse("");
+    expect(result).toBeNull();
+  });
+
+  it("parses an empty JSON array (model found no incidents to correct)", () => {
+    const result = parseSelfCorrectionLLMResponse("[]");
+    expect(result).not.toBeNull();
+    expect(Array.isArray(result)).toBe(true);
+    expect(result).toHaveLength(0);
+  });
+
+  it("parses a multi-item array correctly", () => {
+    const items = [
+      sampleItem,
+      { remediationType: "TOOLS_RULE", content: "Prefer read-only ops first.", confidence: 0.8, reasoning: "..." },
+    ];
+    const result = parseSelfCorrectionLLMResponse(JSON.stringify(items));
+    expect(result).not.toBeNull();
+    expect(result).toHaveLength(2);
+  });
+
+  it("handles a fenced block with trailing text (combined)", () => {
+    const array = JSON.stringify([sampleItem]);
+    const input = `\`\`\`json\n${array}\n\`\`\`\n\nI have summarized 1 correction item above.`;
+    const result = parseSelfCorrectionLLMResponse(input);
+    expect(result).not.toBeNull();
+    expect(result).toHaveLength(1);
+  });
+});

--- a/extensions/memory-hybrid/tests/self-correction-run-parser.test.ts
+++ b/extensions/memory-hybrid/tests/self-correction-run-parser.test.ts
@@ -117,6 +117,13 @@ describe("parseSelfCorrectionLLMResponse", () => {
     expect(result).toHaveLength(0);
   });
 
+  it("parses an empty JSON array followed by trailing text", () => {
+    const result = parseSelfCorrectionLLMResponse("[] No corrections needed.");
+    expect(result).not.toBeNull();
+    expect(Array.isArray(result)).toBe(true);
+    expect(result).toHaveLength(0);
+  });
+
   it("parses a multi-item array correctly", () => {
     const items = [
       sampleItem,

--- a/extensions/memory-hybrid/tests/self-correction-run-parser.test.ts
+++ b/extensions/memory-hybrid/tests/self-correction-run-parser.test.ts
@@ -79,6 +79,18 @@ describe("parseSelfCorrectionLLMResponse", () => {
     expect(result).toBeNull();
   });
 
+  it("skips preamble numeric arrays and parses the remediation array", () => {
+    const input = `I found [1] issue:\n${JSON.stringify([sampleItem])}`;
+    const result = parseSelfCorrectionLLMResponse(input);
+    expect(result).not.toBeNull();
+    expect(result).toHaveLength(1);
+  });
+
+  it("returns null when only non-remediation arrays are present", () => {
+    const result = parseSelfCorrectionLLMResponse("I found [1] issue.");
+    expect(result).toBeNull();
+  });
+
   it("returns null for empty string input", () => {
     const result = parseSelfCorrectionLLMResponse("");
     expect(result).toBeNull();

--- a/extensions/memory-hybrid/tests/self-correction-run-parser.test.ts
+++ b/extensions/memory-hybrid/tests/self-correction-run-parser.test.ts
@@ -13,8 +13,14 @@ import { parseSelfCorrectionLLMResponse } from "../cli/cmd-selfcorrection.js";
 
 // Representative remediation item shape used across tests
 const sampleItem = {
+  category: "WRONG_APPROACH",
+  severity: "MEDIUM",
   remediationType: "MEMORY_STORE",
-  content: "Always confirm destructive operations before proceeding.",
+  remediationContent: {
+    text: "Always confirm destructive operations before proceeding.",
+    entity: "Behavior",
+    tags: ["safety"],
+  },
   confidence: 0.9,
   reasoning: "User asked copilot to avoid deleting files without confirmation.",
 };
@@ -127,11 +133,27 @@ describe("parseSelfCorrectionLLMResponse", () => {
   it("parses a multi-item array correctly", () => {
     const items = [
       sampleItem,
-      { remediationType: "TOOLS_RULE", content: "Prefer read-only ops first.", confidence: 0.8, reasoning: "..." },
+      {
+        category: "WRONG_APPROACH",
+        severity: "LOW",
+        remediationType: "TOOLS_RULE",
+        remediationContent: "Prefer read-only ops first.",
+        confidence: 0.8,
+        reasoning: "...",
+      },
     ];
     const result = parseSelfCorrectionLLMResponse(JSON.stringify(items));
     expect(result).not.toBeNull();
     expect(result).toHaveLength(2);
+  });
+
+  it("skips remediationType-only object arrays and parses a later valid remediation array", () => {
+    const malformed = [{ remediationType: "MEMORY_STORE" }];
+    const input = `${JSON.stringify(malformed)}\n${JSON.stringify([sampleItem])}`;
+    const result = parseSelfCorrectionLLMResponse(input);
+    expect(result).not.toBeNull();
+    expect(result).toHaveLength(1);
+    expect((result as (typeof sampleItem)[])[0].remediationType).toBe("MEMORY_STORE");
   });
 
   it("handles a fenced block with trailing text (combined)", () => {


### PR DESCRIPTION
Adds comprehensive automated test coverage for hybrid-memory maintenance task semantics: cron/`run-all` step classification, state/skip logic, failure detection, and related contracts.

## Changes Made

### New tests

- **`tests/self-correction-run-parser.test.ts`** *(16 tests)* — covers `parseSelfCorrectionLLMResponse` across real-world model output shapes: bare JSON array, markdown-fenced JSON (` ```json ` and bare ` ``` `), trailing prose, preamble prose, truncated/invalid JSON, model placeholder tokens, empty string, empty array, multi-item array, fenced + trailing combined, and preamble-array edge cases (`[1]`, `[{ "id": 1 }]`, and `[]` before the real remediation array).
- **`tests/maintenance-log-analyzer.test.ts`** *(2 new tests)* — cron wrapper PATH failure (4 real-world `openclaw` binary-not-found patterns → `env-misconfig`) and audit-health JSON parse failure classification (truncated JSON with heuristic markers → `json-parse-failure`, not `command-crash`).

### Supporting production changes

- **`services/maintenance-rules.json`**: New `cron-path-missing` rule classifying a missing `openclaw` binary in the cron PATH as `env-misconfig` (high severity, `escalate-user`). Pattern covers `failed to run command`, `command not found`, and `No such file or directory` variants.
- **`cli/cmd-selfcorrection.ts`**: Extracted and exported `parseSelfCorrectionLLMResponse(content)`, hardened to scan balanced JSON arrays and accept only remediation-shaped arrays (objects with `remediationType`), so prose/preamble arrays do not mask actual remediation output.
- **`services/cron-exit-validator.ts`**: Added JSDoc documenting the maintenance result vocabulary (`success` / `skipped` / `partial` / `failed`) and the guard-update rule (only `"success"` sets `guardUpdated = true`).

## Testing

- ✅ `npm run test -- --reporter=verbose tests/self-correction-run-parser.test.ts` passes (16/16)
- ✅ Build completes cleanly (`npm run build`)
- ✅ Lint passes (`npm run lint`, pre-existing warnings only)


---

&gt; [!NOTE]
&gt; **Low Risk**
&gt; Mostly tests and docs; the self-correction parse change is behaviorally safer (fails closed on bad JSON) with a small production rule addition for cron PATH errors.
&gt; 
&gt; **Overview**
&gt; Adds **automated coverage and small hardening** for hybrid-memory maintenance and self-correction semantics.
&gt; 
&gt; **Self-correction run:** Replaces greedy regex/`JSON.parse` parsing with exported `parseSelfCorrectionLLMResponse`, adds explicit parse-failure handling, and now ignores non-remediation preamble arrays so valid remediation arrays later in the response are still parsed correctly.
&gt; 
&gt; **Cron / maintenance:** Documents `maintenanceStatus` vocabulary and guard-update rules in `cron-exit-validator.ts`. Adds a `cron-path-missing` classifier rule for `openclaw` not in cron PATH. New tests cover heartbeat-only empty ledgers as **failed**, PATH/env misconfig, audit-health malformed JSON, and missing `.exit.txt` orchestration. Introduces `runMaintenanceJobHarness` to exercise success, skip, missing ledger, timeout, and partial failure without touching production guard logic beyond existing `validateMaintenanceExecution`.
&gt; 
&gt;<sup>Reviewed by <a href="https://cursor.com/bugbot">Cursor Bugbot</a> for commit 188f2b656ba0678b143150cde771111fae93d7d3. Bugbot is set up for automated code reviews on this repo. Configure <a href="https://www.cursor.com/dashboard/bugbot">here</a>.</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly tests and documentation; the parser change fails closed on bad LLM output and is covered by new unit tests, with one additive maintenance classification rule.
> 
> **Overview**
> Adds **test coverage and small production hardening** for hybrid-memory maintenance semantics and self-correction LLM parsing.
> 
> **Self-correction run** now uses exported `parseSelfCorrectionLLMResponse` instead of the generic first-JSON-array helper. It strips fences/preamble, scans balanced `[...]` spans, and only accepts arrays whose objects look like remediations (`remediationType`, `remediationContent`, etc.), so preamble arrays like `[1]` or metadata blobs do not hide a real remediation list later in the response. Unparseable output still fails closed (repair pass, then `failed_parse` with no auto-applied fixes). New parser tests cover fenced JSON, prose, truncation, and edge cases; reinforcement tests assert the parse-failure error path.
> 
> **Cron / maintenance** documents `maintenanceStatus` (`success` / `skipped` / `partial` / `failed`) and that **guard files update only on `success`**. Adds a `cron-path-missing` rule in `maintenance-rules.json` for `openclaw` not on cron PATH (`env-misconfig`). Tests add heartbeat-only empty ledgers as **failed** (no false green), PATH and audit-health malformed-JSON classification, missing `.exit.txt` orchestration, plus a `runMaintenanceJobHarness` fixture for success, feature skip, missing ledger, timeout, and partial failure without changing validator logic beyond existing `validateMaintenanceExecution`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a47c8ece3d4726cf825d9ce3f2e5a27361664f79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->