### PR TITLE
feat: define category remap policy for legacy forge/episode categories (#1645)

### DIFF
--- a/docs/AUDIT-REMEDIATION-SPIKES.md
+++ b/docs/AUDIT-REMEDIATION-SPIKES.md
@@ -15,11 +15,14 @@ Execute **in order**:
    openclaw hybrid-mem reflect-meta --collapse-implicit-feedback --include-legacy --threshold 0.8 --limit 1000
    ```
 
-2. **Categories** — defaults now include `forge`, `monitoring`, `ops_*`, etc. For legacy rows still tagged `forge_busy` / `forge_dispatch` / `forge_ops`, remap into `forge`:
+2. **Categories** — defaults now include `forge`, `monitoring`, `ops_*`, etc. Apply the legacy remap policy (`forge_* → forge`, `episode → ops_summary`):
 
    ```bash
    openclaw hybrid-mem categories audit
-   openclaw hybrid-mem categories remap --apply   # after configuring mappings for forge_* → forge
+   openclaw hybrid-mem categories remap --from forge_busy --to forge --apply
+   openclaw hybrid-mem categories remap --from forge_dispatch --to forge --apply
+   openclaw hybrid-mem categories remap --from forge_ops --to forge --apply
+   openclaw hybrid-mem categories remap --from episode --to ops_summary --apply
    ```
 
 3. **Re-embed vectorless facts** (after collapse):

--- a/extensions/memory-hybrid/cli/commands/manage/register-storage-graph-audit.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/register-storage-graph-audit.ts
@@ -30,15 +30,6 @@ const LEGACY_CATEGORY_REMAP_POLICY: Readonly<Record<string, string>> = {
   episode: "ops_summary",
 };
 
-function buildLegacyCategoryRemapCommands(categories: readonly string[]): string[] {
-  return categories
-    .filter((category) => Object.hasOwn(LEGACY_CATEGORY_REMAP_POLICY, category))
-    .map(
-      (category) =>
-        `openclaw hybrid-mem categories remap --from ${category} --to ${LEGACY_CATEGORY_REMAP_POLICY[category]} --apply`,
-    );
-}
-
 export function registerManageStorageGraphAudit(mem: Chainable, b: ManageBindings): void {
   const {
     factsDb,
@@ -719,7 +710,10 @@ export function registerManageStorageGraphAudit(mem: Chainable, b: ManageBinding
           console.log(
             `Labels in DB but not in your config (${report.unknown.length}): ${report.unknown.map((u) => u.category).join(", ")}`,
           );
-          const legacyRemapCommands = buildLegacyCategoryRemapCommands(report.unknown.map((u) => u.category));
+          const unknownCategories = new Set(report.unknown.map((u) => u.category));
+          const legacyRemapCommands = Object.entries(LEGACY_CATEGORY_REMAP_POLICY)
+            .filter(([from]) => unknownCategories.has(from))
+            .map(([from, to]) => `openclaw hybrid-mem categories remap --from ${from} --to ${to} --apply`);
           if (legacyRemapCommands.length > 0) {
             console.log("Legacy category remap policy:");
             for (const command of legacyRemapCommands) {

--- a/extensions/memory-hybrid/cli/commands/manage/register-storage-graph-audit.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/register-storage-graph-audit.ts
@@ -23,6 +23,22 @@ import {
   validateSyncEnvelope,
 } from "./storage-stats-helpers.js";
 
+const LEGACY_CATEGORY_REMAP_POLICY: Readonly<Record<string, string>> = {
+  forge_busy: "forge",
+  forge_dispatch: "forge",
+  forge_ops: "forge",
+  episode: "ops_summary",
+};
+
+function buildLegacyCategoryRemapCommands(categories: readonly string[]): string[] {
+  return categories
+    .filter((category) => Object.hasOwn(LEGACY_CATEGORY_REMAP_POLICY, category))
+    .map(
+      (category) =>
+        `openclaw hybrid-mem categories remap --from ${category} --to ${LEGACY_CATEGORY_REMAP_POLICY[category]} --apply`,
+    );
+}
+
 export function registerManageStorageGraphAudit(mem: Chainable, b: ManageBindings): void {
   const {
     factsDb,
@@ -703,6 +719,13 @@ export function registerManageStorageGraphAudit(mem: Chainable, b: ManageBinding
           console.log(
             `Labels in DB but not in your config (${report.unknown.length}): ${report.unknown.map((u) => u.category).join(", ")}`,
           );
+          const legacyRemapCommands = buildLegacyCategoryRemapCommands(report.unknown.map((u) => u.category));
+          if (legacyRemapCommands.length > 0) {
+            console.log("Legacy category remap policy:");
+            for (const command of legacyRemapCommands) {
+              console.log(`  ${command}`);
+            }
+          }
           console.log(
             "Remap into a configured category (dry-run by default), e.g.: openclaw hybrid-mem categories remap --from monitoring --to fact",
           );

--- a/extensions/memory-hybrid/config/utils.ts
+++ b/extensions/memory-hybrid/config/utils.ts
@@ -10,7 +10,7 @@ export const DEFAULT_MEMORY_CATEGORIES = [
   "rule",
   "edict",
   "other",
-  /** Operational / agent categories (audit #1193 — avoids “unknown category” drift on long-lived stores). Remap legacy `forge_*` → `forge` via `categories remap`. */
+  /** Operational / agent categories (audit #1193 — avoids “unknown category” drift on long-lived stores). Remap legacy `forge_*` → `forge` and `episode` → `ops_summary` via `categories remap`. */
   "forge",
   "monitoring",
   "ops_status",

--- a/extensions/memory-hybrid/tests/facts-db.test.ts
+++ b/extensions/memory-hybrid/tests/facts-db.test.ts
@@ -2290,6 +2290,40 @@ describe("FactsDB category drift audit/remap", () => {
     expect(dashboard.total).toBe(1);
     expect(dashboard.facts[0]?.id).toBe(entry.id);
   });
+
+  it("supports legacy forge/episode remap policy end-to-end", () => {
+    const legacyForge = db.store({
+      text: "Legacy forge busy fact",
+      category: "other",
+      importance: 0.7,
+      entity: null,
+      key: null,
+      value: null,
+      source: "test",
+    });
+    const legacyEpisode = db.store({
+      text: "Legacy episode fact",
+      category: "other",
+      importance: 0.7,
+      entity: null,
+      key: null,
+      value: null,
+      source: "test",
+    });
+    db.getRawDb().prepare("UPDATE facts SET category = ? WHERE id = ?").run("forge_busy", legacyForge.id);
+    db.getRawDb().prepare("UPDATE facts SET category = ? WHERE id = ?").run("episode", legacyEpisode.id);
+
+    const report = db.auditCategories(["forge", "ops_summary", "other"], 2);
+    expect(report.unknown.map((row) => row.category)).toEqual(["episode", "forge_busy"]);
+
+    expect(db.remapCategory("forge_busy", "forge", true).changed).toBe(1);
+    expect(db.remapCategory("episode", "ops_summary", true).changed).toBe(1);
+
+    const after = db.auditCategories(["forge", "ops_summary", "other"], 2);
+    expect(after.unknown).toEqual([]);
+    expect(db.getById(legacyForge.id)?.category).toBe("forge");
+    expect(db.getById(legacyEpisode.id)?.category).toBe("ops_summary");
+  });
 });
 
 describe("FactsDB.proceduresCount / proceduresValidatedCount / proceduresPromotedCount", () => {


### PR DESCRIPTION
Issue: https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/1645

Status: draft implementation PR created by Issue Stewardship as Markus/current gh auth.
Protection: keep as draft and `stage/implementing` until Issue Stewardship dispatches/receives implementation and explicitly hands off to PR Stewardship.

Enrichment present on issue: 1
Priority inherited from issue: Low (source labels: priority:low)
Dependencies/blocked labels inherited from issue: none

Implementation PR created by Issue Stewardship. Implementation is now landed on this PR branch.

---

> [!NOTE]
> **Low Risk**
> Focused CLI/docs/test changes for deterministic category hygiene guidance; no schema changes and no behavior changes outside category-audit guidance/remap workflows.
> 
> **Overview**
> This PR now implements the remap policy for legacy category drift by codifying exact operator guidance and validating the remap flow in tests.
> 
> Implemented policy:
> - `forge_busy` → `forge`
> - `forge_dispatch` → `forge`
> - `forge_ops` → `forge`
> - `episode` → `ops_summary`
> 
> **What changed**
> - `categories audit` output now surfaces policy-based remap commands when these legacy labels are detected.
> - Operator runbook docs now include exact safe remap commands for all four legacy labels.
> - Facts DB tests now cover legacy forge/episode audit + remap end-to-end behavior.
> - Related category-policy comment text updated in config defaults documentation/comments.
> 
> **Validation**
> - `npm run build`
> - `npm run test -- --reporter=verbose tests/facts-db.test.ts`
> - `npm run test` (full suite baseline)
> - Parallel validation (code review + CodeQL scan) executed for final changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Operator-facing guidance and CLI output only; category remap behavior was already supported and is covered by new tests with no schema changes.
> 
> **Overview**
> This PR **codifies legacy category drift remediation** so operators and the CLI agree on the same remap targets for long-lived hybrid-memory stores.
> 
> **`categories audit`** now prints **ready-to-run** `categories remap` commands when unknown labels match the legacy policy: `forge_busy`, `forge_dispatch`, and `forge_ops` → **`forge`**, and **`episode`** → **`ops_summary`**. The audit runbook in **`docs/AUDIT-REMEDIATION-SPIKES.md`** lists those four commands explicitly (replacing vague “configure mappings” guidance). Default category docs note the **`episode` → `ops_summary`** remap alongside existing **`forge_*` → `forge`** guidance.
> 
> A **Facts DB test** exercises audit + remap end-to-end for `forge_busy` and `episode`, confirming unknown categories clear after apply.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9de1bb23030c60fcc39971c19eca78a871dbc00d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->