### PR TITLE
fix: upsert expired fact filtering (from orphaned pr-1634)

### DIFF
--- a/extensions/memory-hybrid/cli/active-tasks.ts
+++ b/extensions/memory-hybrid/cli/active-tasks.ts
@@ -866,14 +866,9 @@ export function registerActiveTaskCommands(
           console.warn(`⚠️  Live-state reconcile failed (non-fatal): ${liveErr}`);
         }
       }
-      await renderActiveTaskMarkdownFile(
-        factsDb,
-        ctx.staleMinutes,
-        ctx.activeTaskFilePath,
-        ctx.projection,
-        undefined,
-        { includeCompleted: opts.includeCompleted === true },
-      );
+      await renderActiveTaskMarkdownFile(factsDb, ctx.staleMinutes, ctx.activeTaskFilePath, ctx.projection, undefined, {
+        includeCompleted: opts.includeCompleted === true,
+      });
       console.log(`✅ Wrote ${ctx.activeTaskFilePath}`);
     });
 }

--- a/extensions/memory-hybrid/cli/active-tasks.ts
+++ b/extensions/memory-hybrid/cli/active-tasks.ts
@@ -838,7 +838,8 @@ export function registerActiveTaskCommands(
     .description(
       "Write ACTIVE-TASKS.md projection from facts ledger (no-op when ledger is markdown; use with activeTask.ledger: facts)",
     )
-    .action(async () => {
+    .option("--include-completed", "Include terminal/completed rows for history/audit output")
+    .action(async (opts: { includeCompleted?: boolean }) => {
       if (ctx.ledger !== "facts") {
         console.log(
           "ℹ️  render applies when activeTask.ledger is 'facts'. With markdown ledger, ACTIVE-TASKS.md is already the source.",
@@ -865,7 +866,14 @@ export function registerActiveTaskCommands(
           console.warn(`⚠️  Live-state reconcile failed (non-fatal): ${liveErr}`);
         }
       }
-      await renderActiveTaskMarkdownFile(factsDb, ctx.staleMinutes, ctx.activeTaskFilePath, ctx.projection);
+      await renderActiveTaskMarkdownFile(
+        factsDb,
+        ctx.staleMinutes,
+        ctx.activeTaskFilePath,
+        ctx.projection,
+        undefined,
+        { includeCompleted: opts.includeCompleted === true },
+      );
       console.log(`✅ Wrote ${ctx.activeTaskFilePath}`);
     });
 }

--- a/extensions/memory-hybrid/services/task-ledger-facts.ts
+++ b/extensions/memory-hybrid/services/task-ledger-facts.ts
@@ -907,10 +907,16 @@ export async function upsertProjectTaskKey(
     // entry (which we must not supersede, but an active-task row may still exist), or
     // (c) this is a status write and cache missed (status must not become append-only).
     const facts = factsDb.listFactsByCategory(TASK_LEDGER_CATEGORY, 8000);
+    const nowSec = Math.floor(Date.now() / 1000);
     // Supersede by canonical label to match grouping logic (strips suffixes, normalizes separators).
     // Only supersede facts from the active-task ledger (source:"active-task"), not memory_store.
+    // Exclude expired facts to match projection logic (groupProjectFactsByEntity).
     const same = facts.filter(
-      (f) => f.source === "active-task" && canonicalLabel(f.entity ?? "") === canonical && (f.key ?? "") === key,
+      (f) =>
+        f.source === "active-task" &&
+        canonicalLabel(f.entity ?? "") === canonical &&
+        (f.key ?? "") === key &&
+        !(typeof f.expiresAt === "number" && Number.isFinite(f.expiresAt) && f.expiresAt <= nowSec),
     );
     same.sort((a, b) => b.createdAt - a.createdAt);
     previous = same[0];
@@ -1161,9 +1167,12 @@ export async function applyActiveTaskHygieneFacts(
   const { active } = loadTaskLedgerFromFacts(factsDb);
   const byLabel = new Map(active.map((task) => [task.label, task] as const));
   const latestByEntityKey = new Map<string, MemoryEntry>();
+  const nowSec = Math.floor(Date.now() / 1000);
   // Only index active-task ledger facts, not memory_store project facts.
+  // Exclude expired facts to match projection logic (groupProjectFactsByEntity).
   for (const fact of factsDb.listFactsByCategory(TASK_LEDGER_CATEGORY, 8000)) {
     if (fact.source !== "active-task") continue;
+    if (typeof fact.expiresAt === "number" && Number.isFinite(fact.expiresAt) && fact.expiresAt <= nowSec) continue;
     const entity = fact.entity?.trim().toLowerCase();
     if (!entity) continue;
     const key = (fact.key ?? "").trim();

--- a/extensions/memory-hybrid/services/task-ledger-facts.ts
+++ b/extensions/memory-hybrid/services/task-ledger-facts.ts
@@ -878,7 +878,7 @@ export function buildFactsSectionedMarkdownBody(
 }
 
 export function taskEntityKey(entity: string, key: string): string {
-  return `${entity}\u0000${key}`;
+  return `${canonicalLabel(entity)}\u0000${key.trim()}`;
 }
 
 export async function upsertProjectTaskKey(
@@ -902,9 +902,10 @@ export async function upsertProjectTaskKey(
   // memory_store rows must never be retired by active-task checkpoints.
   if (cached?.source === "active-task") {
     previous = cached;
-  } else if (!opts?.latestByEntityKey || cached) {
+  } else if (!opts?.latestByEntityKey || cached || key === "status") {
     // Query database if: (a) no cache was provided, or (b) cache had a non-active-task
-    // entry (which we must not supersede, but an active-task row may still exist).
+    // entry (which we must not supersede, but an active-task row may still exist), or
+    // (c) this is a status write and cache missed (status must not become append-only).
     const facts = factsDb.listFactsByCategory(TASK_LEDGER_CATEGORY, 8000);
     // Supersede by canonical label to match grouping logic (strips suffixes, normalizes separators).
     // Only supersede facts from the active-task ledger (source:"active-task"), not memory_store.
@@ -1267,15 +1268,17 @@ export async function renderActiveTaskMarkdownFile(
   filePath: string,
   projection: ActiveTaskProjectionConfig,
   logger?: { debug?: (message: string) => void },
+  opts: { includeCompleted?: boolean } = {},
 ): Promise<void> {
   const renderStartMs = Date.now();
+  const includeCompleted = opts.includeCompleted === true;
   let { active, completed, metrics } = loadTaskLedgerFromFactsWithMetrics(
     factsDb,
     8000,
     ACTIVE_TASK_PROJECTION_GLOBAL_SCOPE_FILTER,
   );
   active = applyActiveTaskProjectionFilters(active, projection);
-  completed = applyActiveTaskProjectionFilters(completed, projection);
+  completed = includeCompleted ? applyActiveTaskProjectionFilters(completed, projection) : [];
   active = detectStaleTasks(active, staleMinutes);
 
   const hotRaw = active.filter((t) => !t.stale);
@@ -1316,6 +1319,9 @@ export async function renderActiveTaskMarkdownFile(
     0,
     "",
     "> **Projection** of hybrid-memory `category:project` facts (`activeTask.ledger: facts`). Regenerate via `hybrid-mem active-tasks render`.",
+    includeCompleted
+      ? "> **History mode:** includes terminal rows (`--include-completed`) for audit context."
+      : "> **Default mode:** hides terminal rows; `ACTIVE-TASKS.md` is for active/stale work only. Use `active-tasks render --include-completed` for audit/history.",
     "> **Timestamps:** **Started** / **Updated** use stored fact fields (`started`, `task_started`, `task_updated`, …) or SQLite row times (min / max `createdAt` per task). The render clock is not used. Missing values show as **Unknown** and count as stale under `staleThreshold`.",
     "> **Operators:** Update or close tasks via `memory_store` / project facts; run `hybrid-mem active-tasks reconcile` when session rows are obsolete; then `active-tasks render`. See `docs/ACTIVE-TASKS-PROJECTION.md`.",
     "",

--- a/extensions/memory-hybrid/services/task-ledger/canonical.ts
+++ b/extensions/memory-hybrid/services/task-ledger/canonical.ts
@@ -101,7 +101,10 @@ function factNewerThan(a: MemoryEntry, b: MemoryEntry, aOrder: number, bOrder: n
 export function groupProjectFactsByEntity(facts: MemoryEntry[]): Map<string, Map<string, MemoryEntry>> {
   const byEntity = new Map<string, Map<string, MemoryEntry>>();
   const winnerOrderByEntity = new Map<string, Map<string, number>>();
+  const nowSec = Math.floor(Date.now() / 1000);
   for (const [idx, f] of facts.entries()) {
+    if (typeof f.supersededAt === "number" && Number.isFinite(f.supersededAt)) continue;
+    if (typeof f.expiresAt === "number" && Number.isFinite(f.expiresAt) && f.expiresAt <= nowSec) continue;
     if (!f.entity?.trim()) continue;
     const canonical = factCanonicalLabel(f);
     if (!canonical) continue;

--- a/extensions/memory-hybrid/src/worker/narratives.ts
+++ b/extensions/memory-hybrid/src/worker/narratives.ts
@@ -2,6 +2,8 @@ import type OpenAI from "openai";
 import type { EventLog } from "../../backends/event-log.js";
 import type { NarrativesDB } from "../../backends/narratives-db.js";
 import type { WorkflowStore } from "../../backends/workflow-store.js";
+
+// TODO(issue-1633): Deduplicate stale background-task completion notices after parent review
 import { chatCompleteWithRetry, is500OrWrapped, isAbortOrTransientLlmError } from "../../services/chat.js";
 import { CostFeature } from "../../services/cost-feature-labels.js";
 import { capturePluginError } from "../../services/error-reporter.js";

--- a/extensions/memory-hybrid/src/worker/narratives.ts
+++ b/extensions/memory-hybrid/src/worker/narratives.ts
@@ -3,7 +3,7 @@ import type { EventLog } from "../../backends/event-log.js";
 import type { NarrativesDB } from "../../backends/narratives-db.js";
 import type { WorkflowStore } from "../../backends/workflow-store.js";
 
-// TODO(issue-1633): Deduplicate stale background-task completion notices after parent review
+// TODO(#1633): Deduplicate stale background-task completion notices after parent review
 import { chatCompleteWithRetry, is500OrWrapped, isAbortOrTransientLlmError } from "../../services/chat.js";
 import { CostFeature } from "../../services/cost-feature-labels.js";
 import { capturePluginError } from "../../services/error-reporter.js";

--- a/extensions/memory-hybrid/src/worker/narratives.ts
+++ b/extensions/memory-hybrid/src/worker/narratives.ts
@@ -3,7 +3,6 @@ import type { EventLog } from "../../backends/event-log.js";
 import type { NarrativesDB } from "../../backends/narratives-db.js";
 import type { WorkflowStore } from "../../backends/workflow-store.js";
 
-// TODO(#1633): Deduplicate stale background-task completion notices after parent review
 import { chatCompleteWithRetry, is500OrWrapped, isAbortOrTransientLlmError } from "../../services/chat.js";
 import { CostFeature } from "../../services/cost-feature-labels.js";
 import { capturePluginError } from "../../services/error-reporter.js";

--- a/extensions/memory-hybrid/tests/task-ledger-facts.test.ts
+++ b/extensions/memory-hybrid/tests/task-ledger-facts.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
@@ -116,6 +116,37 @@ describe("task-ledger-facts", () => {
     const t1 = g.get("t1");
     expect(t1?.get("status")?.value).toBe("in_progress");
     expect(t1?.get("title")?.value).toBe("Hello");
+  });
+
+  it("groupProjectFactsByEntity ignores superseded and expired rows when selecting current state", () => {
+    const nowSec = Math.floor(Date.now() / 1000);
+    const rows: MemoryEntry[] = [
+      fact({ id: "s-old", entity: "task-1633", key: "status", value: "in_progress", createdAt: 100 }),
+      fact({
+        id: "s-superseded",
+        entity: "task-1633",
+        key: "status",
+        value: "done",
+        createdAt: 500,
+        supersededAt: nowSec - 5,
+      }),
+      fact({
+        id: "s-expired",
+        entity: "task-1633",
+        key: "status",
+        value: "waiting",
+        createdAt: 600,
+        expiresAt: nowSec - 1,
+      }),
+      fact({ id: "s-current", entity: "task-1633", key: "status", value: "done", createdAt: 300 }),
+      fact({ id: "t1", entity: "task-1633", key: "title", value: "Close stale projection bug", createdAt: 300 }),
+    ];
+    const grouped = groupProjectFactsByEntity(rows);
+    expect(grouped.get("task-1633")?.get("status")?.id).toBe("s-current");
+    const { active, completed } = buildTaskEntriesFromGroupedFacts(grouped);
+    expect(active).toHaveLength(0);
+    expect(completed).toHaveLength(1);
+    expect(completed[0].label).toBe("task-1633");
   });
 
   it("buildTaskEntriesFromGroupedFacts splits active vs terminal", () => {
@@ -612,6 +643,73 @@ describe("task-ledger-facts", () => {
     }
   });
 
+  it("renderActiveTaskMarkdownFile excludes completed rows by default", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "task-ledger-render-default-active-only-"));
+    const db = new FactsDB(join(dir, "facts.db"));
+    try {
+      storeActiveTaskFactRow(db, "active-task-1633", "Active task", "in_progress");
+      storeActiveTaskFactRow(db, "done-task-1633", "Done task", "done");
+
+      const outPath = join(dir, "ACTIVE-TASKS.md");
+      await renderActiveTaskMarkdownFile(
+        db,
+        60,
+        outPath,
+        {
+          mode: "readable",
+          excludeGenericTitle: true,
+          titleMinChars: 0,
+          dedupeBy: "none",
+          sectioned: true,
+        },
+        undefined,
+      );
+
+      const rendered = await readFile(outPath, "utf-8");
+      expect(rendered).toContain("## Active");
+      expect(rendered).toContain("[active-task-1633]");
+      expect(rendered).not.toContain("## Completed");
+      expect(rendered).not.toContain("[done-task-1633]");
+    } finally {
+      db.close();
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("renderActiveTaskMarkdownFile includes completed rows in explicit history mode", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "task-ledger-render-history-"));
+    const db = new FactsDB(join(dir, "facts.db"));
+    try {
+      storeActiveTaskFactRow(db, "active-task-history", "Active task", "in_progress");
+      storeActiveTaskFactRow(db, "done-task-history", "Done task", "done");
+
+      const outPath = join(dir, "ACTIVE-TASKS.md");
+      await renderActiveTaskMarkdownFile(
+        db,
+        60,
+        outPath,
+        {
+          mode: "readable",
+          excludeGenericTitle: true,
+          titleMinChars: 0,
+          dedupeBy: "none",
+          sectioned: true,
+        },
+        undefined,
+        { includeCompleted: true },
+      );
+
+      const rendered = await readFile(outPath, "utf-8");
+      expect(rendered).toContain("## Active");
+      expect(rendered).toContain("[active-task-history]");
+      expect(rendered).toContain("## Completed");
+      expect(rendered).toContain("[done-task-history]");
+    } finally {
+      db.close();
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   it("upsertProjectTaskKey does not supersede cached memory_store rows", async () => {
     const dir = await mkdtemp(join(tmpdir(), "task-ledger-upsert-source-filter-"));
     const db = new FactsDB(join(dir, "facts.db"));
@@ -648,6 +746,46 @@ describe("task-ledger-facts", () => {
         .listFactsByCategory("project", 100)
         .filter((row) => row.entity === "proj-1273" && row.key === "status" && row.source === "active-task");
       expect(activeRows.length).toBeGreaterThanOrEqual(1);
+    } finally {
+      db.close();
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("upsertProjectTaskKey status writes supersede canonical-variant active-task rows even when cache misses", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "task-ledger-upsert-status-canonical-"));
+    const db = new FactsDB(join(dir, "facts.db"));
+    const vectorDb = {
+      hasDuplicate: async () => true,
+      store: async () => {},
+    } as unknown as VectorDB;
+    const embeddings = {
+      modelName: "test-model",
+      embed: async () => new Float32Array([0.1, 0.2, 0.3]),
+    } as unknown as EmbeddingProvider;
+    try {
+      const prior = db.store({
+        category: "project",
+        importance: 0.7,
+        source: "active-task",
+        decayClass: "permanent",
+        entity: "proj-1633 pr queue",
+        key: "status",
+        value: "in_progress",
+        text: "Task [proj-1633 pr queue] status: in_progress",
+      });
+
+      await upsertProjectTaskKey(db, vectorDb, embeddings, "proj-1633", "status", "done", undefined, {
+        latestByEntityKey: new Map<string, MemoryEntry>(),
+      });
+
+      const priorAfter = db.getById(prior.id);
+      expect(priorAfter?.supersededBy).toBeTruthy();
+      expect(priorAfter?.supersededAt).toBeTypeOf("number");
+
+      const { active, completed } = loadTaskLedgerFromFacts(db);
+      expect(active.some((task) => canonicalLabel(task.label) === "proj-1633")).toBe(false);
+      expect(completed.some((task) => canonicalLabel(task.label) === "proj-1633")).toBe(true);
     } finally {
       db.close();
       await rm(dir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
Preserves unique functional work from orphaned branch `pr-1634` (head: `28fe2486`).

## Unique commits (4 total, NOT in main)
- `28fe2486` Fix upsert ignoring expired fact filtering — filter out expired facts in upsertProjectTaskKey and cache-building logic to match projection behavior in groupProjectFactsByEntity
- `1502aac8` fix: keep completed tasks out of active projection  
- `da59f9ba` docs: use issue-linked TODO notation
- `b83a2faf` Add issue-1633 marker comment

## Risks
- Modifies active-task upsert logic; needs regression test pass
- 79 files changed (bulk reformatting/auto-format included)

## Verification required
- npm test for active-task/task-ledger
- CI green

## Next owner
Copilot or manual review before merge

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes active-task ledger write/read paths (status supersession, projection content); wrong expiry/canonical logic could mis-classify tasks, but behavior is covered by new regression tests.
> 
> **Overview**
> This PR tightens the **facts-backed active-task ledger** so projection, upserts, and grouping agree on what counts as “current” state.
> 
> **Projection / CLI:** `active-tasks render` gains `--include-completed`. By default, `ACTIVE-TASKS.md` omits terminal/completed tasks (active + stale only); history/audit output opts in via the flag. Rendered banners document default vs history mode.
> 
> **Consistency fixes:** `groupProjectFactsByEntity` skips **superseded** and **expired** facts when picking winners. The same expiry filter applies when `upsertProjectTaskKey` and hygiene apply build their “latest per entity+key” caches, so stale rows are not superseded or shown as live. **Status** updates always resolve prior active-task rows (even on cache miss) and match **canonical** entity labels via `taskEntityKey`, preventing duplicate in-progress rows and append-only status.
> 
> Vitest coverage adds cases for expired/superseded grouping, default vs `--include-completed` render, and canonical status supersession.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28fe2486c9cd92ff260f32e8f4f8c883776b1972. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->