### PR TITLE
fix

### DIFF
--- a/extensions/memory-hybrid/backends/facts-db/crud.ts
+++ b/extensions/memory-hybrid/backends/facts-db/crud.ts
@@ -428,7 +428,11 @@ export function storeFact(ctx: StoreFactContext, entry: StoreFactInput): StoreFa
   return { entry: loaded, evictedFactId };
 }
 
-/** Update recall_count and last_accessed for facts (bulk UPDATE). */
+/**
+ * Update recall_count and last_accessed for facts (bulk UPDATE).
+ * MUST only be called when full content is injected or explicitly recalled by user.
+ * Index-only exposures must use refreshIndexedFacts() instead (#1559).
+ */
 export function refreshAccessedFacts(db: DatabaseSync, ids: string[]): void {
   if (ids.length === 0) return;
   const nowSec = Math.floor(Date.now() / 1000);
@@ -457,6 +461,27 @@ export function refreshAccessedFacts(db: DatabaseSync, ids: string[]): void {
       db.prepare(
         `UPDATE facts SET recall_count = recall_count + 1, last_accessed = ?, access_count = access_count + 1, last_accessed_at = strftime('%Y-%m-%dT%H:%M:%SZ', ?, 'unixepoch') WHERE id IN (${placeholders})`,
       ).run(nowSec, nowSec, ...batch);
+    }
+  });
+  tx();
+}
+
+/**
+ * Update indexed_count and last_indexed for index-only exposures (#1559).
+ * Does NOT inflate recall_count or last_accessed — these are separate signals.
+ */
+export function refreshIndexedFacts(db: DatabaseSync, ids: string[]): void {
+  if (ids.length === 0) return;
+  const nowSec = Math.floor(Date.now() / 1000);
+  const BATCH_SIZE = 500;
+
+  const tx = createTransaction(db, () => {
+    for (let i = 0; i < ids.length; i += BATCH_SIZE) {
+      const batch = ids.slice(i, i + BATCH_SIZE);
+      const placeholders = batch.map(() => "?").join(",");
+      db.prepare(
+        `UPDATE facts SET indexed_count = indexed_count + 1, last_indexed = ? WHERE id IN (${placeholders})`,
+      ).run(nowSec, ...batch);
     }
   });
   tx();

--- a/extensions/memory-hybrid/backends/facts-db/fact-read-queries.ts
+++ b/extensions/memory-hybrid/backends/facts-db/fact-read-queries.ts
@@ -346,10 +346,19 @@ export function listFacts(
   return rows.map((row) => rowToMemoryEntry(row));
 }
 
-/** Returns true if the fact text looks like a reasoning trace or classifier artifact (#1559). */
-function isLikelyGarbage(entry: MemoryEntry): boolean {
-  const text = entry.text ?? "";
-  const summary = entry.summary ?? "";
+/**
+ * Shared garbage detection utility for consistency across query-time, tiering, and SQL batch operations.
+ * Returns true if the fact text looks like a reasoning trace or classifier artifact (#1559).
+ */
+export function isLikelyGarbage(input: {
+  text: string;
+  summary?: string | null;
+  source?: string | null;
+  category?: string | null;
+  recall_count?: number;
+}): boolean {
+  const text = input.text ?? "";
+  const summary = input.summary ?? "";
   const combined = text + "\n" + summary;
 
   // Reasoning traces embedded in fact content
@@ -359,10 +368,14 @@ function isLikelyGarbage(entry: MemoryEntry): boolean {
   if (/^\[(?:hot-memories|recall|hot\/fact)\]/im.test(combined)) return true;
   // Unhelpful source + long reasoning combo
   if (
-    entry.source === "auto-capture" &&
+    input.source === "auto-capture" &&
     combined.length > 3000 &&
     (/think|reasoning|analyz|process/gi.test(combined) || /\n\n{2,}/.test(combined))
   ) {
+    return true;
+  }
+  // High recall counts for "other" category (self-reinforcing garbage loop)
+  if (input.category === "other" && (input.recall_count ?? 0) > 500) {
     return true;
   }
   return false;
@@ -370,7 +383,16 @@ function isLikelyGarbage(entry: MemoryEntry): boolean {
 
 /** Quality score for HOT injection: 0–1. Garbage facts score 0 and are excluded. */
 function hotQualityScore(entry: MemoryEntry): number {
-  if (isLikelyGarbage(entry)) return 0;
+  if (
+    isLikelyGarbage({
+      text: entry.text,
+      summary: entry.summary,
+      source: entry.source,
+      category: entry.category,
+      recall_count: entry.recallCount,
+    })
+  )
+    return 0;
   const text = entry.text ?? "";
   // Penalise very long unconstrained text (likely full conversation dumps)
   if (text.length > 8000) return 0.3;

--- a/extensions/memory-hybrid/backends/facts-db/fact-read-queries.ts
+++ b/extensions/memory-hybrid/backends/facts-db/fact-read-queries.ts
@@ -356,7 +356,7 @@ function isLikelyGarbage(entry: MemoryEntry): boolean {
   if (/<(?:redacted_)?think(?:ing)?>[\s\S]*?<\/(?:redacted_)?think(?:ing)?>/i.test(combined)) return true;
   // Classifier / capability-hint artifacts
   if (/^Thinking Process:/im.test(combined)) return true;
-  if (/^\[Hot-memories\]|^\[recall\]|^\[hot\/fact\]/im.test(combined)) return true;
+  if (/^\[(?:hot-memories|recall|hot\/fact)\]/im.test(combined)) return true;
   // Unhelpful source + long reasoning combo
   if (
     entry.source === "auto-capture" &&
@@ -391,6 +391,7 @@ export function getHotFacts(db: DatabaseSync, maxTokens: number, scopeFilter?: S
   const results: SearchResult[] = [];
   let usedTokens = 0;
   for (const row of rows) {
+    if (usedTokens >= maxTokens) break;
     const entry = rowToMemoryEntry(row);
     // Apply quality filter: exclude reasoning traces, prompt artifacts, and garbage (#1559)
     const score = hotQualityScore(entry);

--- a/extensions/memory-hybrid/backends/facts-db/fact-read-queries.ts
+++ b/extensions/memory-hybrid/backends/facts-db/fact-read-queries.ts
@@ -356,7 +356,7 @@ function isLikelyGarbage(entry: MemoryEntry): boolean {
   if (/<(?:redacted_)?think(?:ing)?>[\s\S]*?<\/(?:redacted_)?think(?:ing)?>/i.test(combined)) return true;
   // Classifier / capability-hint artifacts
   if (/^Thinking Process:/im.test(text)) return true;
-  if (/^\[Hot-memories\]|^\[recall\]/im.test(text)) return true;
+  if (/^\[Hot-memories\]|^\[recall\]|^\[hot\/fact\]/im.test(text)) return true;
   // Unhelpful source + long reasoning combo
   if (
     entry.source === "auto-capture" &&

--- a/extensions/memory-hybrid/backends/facts-db/fact-read-queries.ts
+++ b/extensions/memory-hybrid/backends/facts-db/fact-read-queries.ts
@@ -360,8 +360,8 @@ function isLikelyGarbage(entry: MemoryEntry): boolean {
   // Unhelpful source + long reasoning combo
   if (
     entry.source === "auto-capture" &&
-    (combined.length > 3000 &&
-      (/think|reasoning|analyz|process/gi.test(combined) || /\n\n{2,}/.test(combined)))
+    combined.length > 3000 &&
+    (/think|reasoning|analyz|process/gi.test(combined) || /\n\n{2,}/.test(combined))
   ) {
     return true;
   }

--- a/extensions/memory-hybrid/backends/facts-db/fact-read-queries.ts
+++ b/extensions/memory-hybrid/backends/facts-db/fact-read-queries.ts
@@ -355,8 +355,8 @@ function isLikelyGarbage(entry: MemoryEntry): boolean {
   // Reasoning traces embedded in fact content
   if (/<(?:redacted_)?think(?:ing)?>[\s\S]*?<\/(?:redacted_)?think(?:ing)?>/i.test(combined)) return true;
   // Classifier / capability-hint artifacts
-  if (/^Thinking Process:/im.test(text)) return true;
-  if (/^\[Hot-memories\]|^\[recall\]|^\[hot\/fact\]/im.test(text)) return true;
+  if (/^Thinking Process:/im.test(combined)) return true;
+  if (/^\[Hot-memories\]|^\[recall\]|^\[hot\/fact\]/im.test(combined)) return true;
   // Unhelpful source + long reasoning combo
   if (
     entry.source === "auto-capture" &&

--- a/extensions/memory-hybrid/backends/facts-db/fact-read-queries.ts
+++ b/extensions/memory-hybrid/backends/facts-db/fact-read-queries.ts
@@ -346,6 +346,37 @@ export function listFacts(
   return rows.map((row) => rowToMemoryEntry(row));
 }
 
+/** Returns true if the fact text looks like a reasoning trace or classifier artifact (#1559). */
+function isLikelyGarbage(entry: MemoryEntry): boolean {
+  const text = entry.text ?? "";
+  const summary = entry.summary ?? "";
+  const combined = text + "\n" + summary;
+
+  // Reasoning traces embedded in fact content
+  if (/<(?:redacted_)?think(?:ing)?>[\s\S]*?<\/(?:redacted_)?think(?:ing)?>/i.test(combined)) return true;
+  // Classifier / capability-hint artifacts
+  if (/^Thinking Process:/im.test(text)) return true;
+  if (/^\[Hot-memories\]|^\[recall\]/im.test(text)) return true;
+  // Unhelpful source + long reasoning combo
+  if (
+    entry.source === "auto-capture" &&
+    (combined.length > 3000 &&
+      (/think|reasoning|analyz|process/gi.test(combined) || /\n\n{2,}/.test(combined)))
+  ) {
+    return true;
+  }
+  return false;
+}
+
+/** Quality score for HOT injection: 0–1. Garbage facts score 0 and are excluded. */
+function hotQualityScore(entry: MemoryEntry): number {
+  if (isLikelyGarbage(entry)) return 0;
+  const text = entry.text ?? "";
+  // Penalise very long unconstrained text (likely full conversation dumps)
+  if (text.length > 8000) return 0.3;
+  return 1.0;
+}
+
 export function getHotFacts(db: DatabaseSync, maxTokens: number, scopeFilter?: ScopeFilter | null): SearchResult[] {
   const nowSec = Math.floor(Date.now() / 1000);
   const { clause: scopeClause, params: scopeParams } = scopeFilterClausePositional(scopeFilter);
@@ -360,14 +391,16 @@ export function getHotFacts(db: DatabaseSync, maxTokens: number, scopeFilter?: S
   const results: SearchResult[] = [];
   let usedTokens = 0;
   for (const row of rows) {
-    if (usedTokens >= maxTokens) break;
     const entry = rowToMemoryEntry(row);
+    // Apply quality filter: exclude reasoning traces, prompt artifacts, and garbage (#1559)
+    const score = hotQualityScore(entry);
+    if (score === 0) continue;
     const tokens = estimateTokensForDisplay(entry.summary || entry.text);
     if (usedTokens + tokens > maxTokens) {
       continue;
     }
     usedTokens += tokens;
-    results.push({ entry, score: 1.0, backend: "sqlite" as const });
+    results.push({ entry, score, backend: "sqlite" as const });
   }
   return results;
 }

--- a/extensions/memory-hybrid/backends/facts-db/fact-read-queries.ts
+++ b/extensions/memory-hybrid/backends/facts-db/fact-read-queries.ts
@@ -367,12 +367,16 @@ export function isLikelyGarbage(input: {
   if (/^Thinking Process:/im.test(combined)) return true;
   if (/^\[(?:hot-memories|recall|hot\/fact)\]/im.test(combined)) return true;
   // Unhelpful source + long reasoning combo
-  if (
-    input.source === "auto-capture" &&
-    combined.length > 3000 &&
-    (/think|reasoning|analyz|process/gi.test(combined) || /\n\n{2,}/.test(combined))
-  ) {
-    return true;
+  // Match reasoning trace patterns more precisely to avoid false positives with common English words
+  if (input.source === "auto-capture" && combined.length > 3000) {
+    // Reasoning-specific phrases that indicate LLM reasoning artifacts
+    const reasoningPhrases =
+      /\b(?:let me think|my reasoning|step[- ]by[- ]step|thought process|reasoning process|analysis process)\b/i;
+    // Multiple paragraph breaks suggesting stream-of-consciousness
+    const multipleBreaks = /\n\n{2,}/;
+    if (reasoningPhrases.test(combined) || multipleBreaks.test(combined)) {
+      return true;
+    }
   }
   // High recall counts for "other" category (self-reinforcing garbage loop)
   if (input.category === "other" && (input.recall_count ?? 0) > 500) {

--- a/extensions/memory-hybrid/backends/facts-db/fact-read-queries.ts
+++ b/extensions/memory-hybrid/backends/facts-db/fact-read-queries.ts
@@ -373,8 +373,8 @@ export function isLikelyGarbage(input: {
     const reasoningPhrases =
       /\b(?:let me think|my reasoning|step[- ]by[- ]step|thought process|reasoning process|analysis process)\b/i;
     // Multiple paragraph breaks suggesting stream-of-consciousness
-    const multipleBreaks = /\n\n{2,}/;
-    if (reasoningPhrases.test(combined) || multipleBreaks.test(combined)) {
+    const multipleBreaks = (combined.match(/\n\n/g) || []).length > 10;
+    if (reasoningPhrases.test(combined) || multipleBreaks) {
       return true;
     }
   }

--- a/extensions/memory-hybrid/backends/facts-db/facts-db-layer1.ts
+++ b/extensions/memory-hybrid/backends/facts-db/facts-db-layer1.ts
@@ -19,6 +19,7 @@ import {
   getDuplicateIdByNormalizedHash,
   hasDuplicateText,
   refreshAccessedFacts as refreshAccessedFactsImpl,
+  refreshIndexedFacts as refreshIndexedFactsImpl,
   statsDailyWrites as statsDailyWritesImpl,
   storeFact,
 } from "./crud.js";
@@ -282,6 +283,11 @@ export class FactsDBLayer1 extends BaseSqliteStore {
   /** Update recall_count and last_accessed for facts (public for progressive disclosure). Bulk UPDATE to avoid N+1. */
   refreshAccessedFacts(ids: string[]): void {
     refreshAccessedFactsImpl(this.liveDb, ids);
+  }
+
+  /** Update indexed_count and last_indexed for index-only exposures (#1559). Does NOT inflate recall_count. */
+  refreshIndexedFacts(ids: string[]): void {
+    refreshIndexedFactsImpl(this.liveDb, ids);
   }
 
   /** Record a memory_recall invocation outcome for hit-rate tracking (Issue #148). */

--- a/extensions/memory-hybrid/backends/facts-db/index.ts
+++ b/extensions/memory-hybrid/backends/facts-db/index.ts
@@ -45,6 +45,7 @@ export {
 export {
   confirmFact,
   decayConfidence,
+  demoteHotGarbageFacts,
   listFactIdsToBeDeletedByDecayRun,
   logRecall,
   promoteScope,

--- a/extensions/memory-hybrid/backends/facts-db/maintenance.ts
+++ b/extensions/memory-hybrid/backends/facts-db/maintenance.ts
@@ -12,6 +12,7 @@ import { createTransaction } from "../../utils/sqlite-transaction.js";
 import { parseTags } from "../../utils/tags.js";
 import type { StoreFactInput } from "./crud.js";
 import { preserveTagsColumnExcludesFromTrimSql } from "./fact-queries.js";
+import { isLikelyGarbage } from "./fact-read-queries.js";
 
 function extractFactIds(rows: Array<{ id: string }>): string[] {
   return rows.map((row) => row.id);
@@ -136,26 +137,6 @@ type HotCandidate = {
   tokens: number;
 };
 
-const HOT_GARBAGE_LONG_TEXT_THRESHOLD = 3000;
-const HOT_GARBAGE_OTHER_RECALL_THRESHOLD = 500;
-
-function isLikelyHotGarbageCandidate(
-  row: Pick<TierCandidate, "text" | "summary" | "source" | "category" | "recall_count">,
-): boolean {
-  const combined = `${row.text}\n${row.summary ?? ""}`;
-  if (/<(?:redacted_)?think(?:ing)?>[\s\S]*?<\/(?:redacted_)?think(?:ing)?>/i.test(combined)) return true;
-  if (/^Thinking Process:/im.test(combined)) return true;
-  if (/^\[(?:hot-memories|recall|hot\/fact)\]/im.test(combined)) return true;
-  if (
-    row.source === "auto-capture" &&
-    combined.length > HOT_GARBAGE_LONG_TEXT_THRESHOLD &&
-    (/think|reasoning|analyz|process/i.test(combined) || /\n\n{2,}/.test(combined))
-  ) {
-    return true;
-  }
-  return row.category === "other" && row.recall_count > HOT_GARBAGE_OTHER_RECALL_THRESHOLD;
-}
-
 function normalizeTieringOptions(opts: TieringOptions): Required<TieringOptions> {
   return {
     inactivePreferenceDays: opts.inactivePreferenceDays,
@@ -228,7 +209,16 @@ function isHotCandidate(
   opts: Required<TieringOptions>,
   flags?: { ignoreStructuralBlock?: boolean; hotByRecallIds?: ReadonlySet<string> },
 ): boolean {
-  if (isLikelyHotGarbageCandidate(row)) return false;
+  if (
+    isLikelyGarbage({
+      text: row.text,
+      summary: row.summary,
+      source: row.source,
+      category: row.category,
+      recall_count: row.recall_count,
+    })
+  )
+    return false;
   if (!flags?.ignoreStructuralBlock && isStructuralCandidate(row, opts)) return false;
   if (hasTag(row.tags, "blocker")) return true;
   if (flags?.hotByRecallIds?.has(row.id)) return true;
@@ -1193,60 +1183,44 @@ export function backfillDecayClasses(db: DatabaseSync): Record<string, number> {
  * Returns the count of facts demoted.
  */
 export function demoteHotGarbageFacts(db: DatabaseSync): number {
-  // Mirrors isLikelyGarbage from fact-read-queries.ts to ensure SQL demotion applies
-  // the same rules used at injection time (fixes #1559).
+  // Uses the shared isLikelyGarbage utility to ensure consistent filtering across
+  // query-time, tiering, and batch demotion operations (fixes #1559).
   const rows = db
     .prepare(
-      `SELECT id, text, summary, source, recall_count, access_count, category
+      `SELECT id, text, summary, source, recall_count, category
        FROM facts
        WHERE tier = 'hot'
          AND superseded_at IS NULL
-         AND id NOT IN (SELECT fact_id FROM verified_facts)
-         AND (
-           -- Reasoning traces (thinking tags) - no source restriction to match isLikelyGarbage
-           (text LIKE '%<thinking>%' OR text LIKE '%</thinking>%' OR
-            text LIKE '%<redacted_thinking>%' OR text LIKE '%</redacted_thinking>%' OR
-            text LIKE '%<think>%' OR text LIKE '%</think>%' OR
-            COALESCE(summary, '') LIKE '%<thinking>%' OR COALESCE(summary, '') LIKE '%</thinking>%' OR
-            COALESCE(summary, '') LIKE '%<redacted_thinking>%' OR COALESCE(summary, '') LIKE '%</redacted_thinking>%' OR
-            COALESCE(summary, '') LIKE '%<think>%' OR COALESCE(summary, '') LIKE '%</think>%')
-           OR
-           -- Classifier / capability-hint artifacts - no source restriction
-           (text LIKE '%Thinking Process:%' OR COALESCE(summary, '') LIKE '%Thinking Process:%')
-           OR
-           -- Hot-memories / recall / hot/fact prefixes - no source restriction (includes missing [Hot-memories])
-           (text LIKE '[Hot-memories]%' OR text LIKE '[recall]%' OR text LIKE '[hot/fact]%' OR
-            COALESCE(summary, '') LIKE '[Hot-memories]%' OR COALESCE(summary, '') LIKE '[recall]%' OR COALESCE(summary, '') LIKE '[hot/fact]%')
-           OR
-           -- Long auto-capture reasoning heuristic (>3000 chars + keywords/patterns)
-           (source = 'auto-capture' AND LENGTH(text || COALESCE(summary, '')) > ${HOT_GARBAGE_LONG_TEXT_THRESHOLD} AND
-            (text LIKE '%think%' OR text LIKE '%reasoning%' OR text LIKE '%analyz%' OR text LIKE '%process%' OR
-             text LIKE '%' || CHAR(10) || CHAR(10) || CHAR(10) || '%' OR
-             COALESCE(summary, '') LIKE '%think%' OR COALESCE(summary, '') LIKE '%reasoning%' OR
-             COALESCE(summary, '') LIKE '%analyz%' OR COALESCE(summary, '') LIKE '%process%' OR
-             COALESCE(summary, '') LIKE '%' || CHAR(10) || CHAR(10) || CHAR(10) || '%'))
-           OR
-           -- Staggeringly high recall counts for "other" category
-           (category = 'other' AND recall_count > ${HOT_GARBAGE_OTHER_RECALL_THRESHOLD})
-         )`,
+         AND id NOT IN (SELECT fact_id FROM verified_facts)`,
     )
     .all() as Array<{
     id: string;
     text: string;
     summary: string | null;
-    source: string;
+    source: string | null;
     recall_count: number;
-    access_count: number;
-    category: string;
+    category: string | null;
   }>;
 
-  if (rows.length === 0) return 0;
+  const garbageIds: string[] = [];
+  for (const row of rows) {
+    if (
+      isLikelyGarbage({
+        text: row.text,
+        summary: row.summary,
+        source: row.source,
+        category: row.category,
+        recall_count: row.recall_count,
+      })
+    ) {
+      garbageIds.push(row.id);
+    }
+  }
 
-  const ids = rows.map((r) => r.id);
+  if (garbageIds.length === 0) return 0;
+
   let totalChanged = 0;
-
-  // Batch updates to respect SQLite's 999 bind variable limit
-  for (const batch of batchedInClauseBinds(ids)) {
+  for (const batch of batchedInClauseBinds(garbageIds)) {
     const placeholders = batch.map(() => "?").join(",");
     const result = db
       .prepare(`UPDATE facts SET tier = 'warm' WHERE id IN (${placeholders}) AND tier = 'hot'`)

--- a/extensions/memory-hybrid/backends/facts-db/maintenance.ts
+++ b/extensions/memory-hybrid/backends/facts-db/maintenance.ts
@@ -1185,7 +1185,11 @@ export function demoteHotGarbageFacts(db: DatabaseSync): number {
              text LIKE '%<thinking>%' OR text LIKE '%<redacted_thinking>%' OR
              text LIKE '%<think>%' || '%</think>%' OR
              text LIKE '%Thinking Process:%' OR
-             text LIKE '%[recall]%' OR text LIKE '%[hot/fact]%'
+             text LIKE '%[recall]%' OR text LIKE '%[hot/fact]%' OR
+             COALESCE(summary, '') LIKE '%<thinking>%' OR COALESCE(summary, '') LIKE '%<redacted_thinking>%' OR
+             COALESCE(summary, '') LIKE '%<think>%' || '%</think>%' OR
+             COALESCE(summary, '') LIKE '%Thinking Process:%' OR
+             COALESCE(summary, '') LIKE '%[recall]%' OR COALESCE(summary, '') LIKE '%[hot/fact]%'
            ))
            OR
            -- Staggeringly high recall counts for "other" category (classic garbage artifacts)

--- a/extensions/memory-hybrid/backends/facts-db/maintenance.ts
+++ b/extensions/memory-hybrid/backends/facts-db/maintenance.ts
@@ -110,6 +110,7 @@ type TierCandidate = {
   tier: MemoryTier;
   text: string;
   summary: string | null;
+  source: string | null;
   category: MemoryCategory | null;
   importance: number;
   key: string | null;
@@ -134,6 +135,23 @@ type HotCandidate = {
   lastAccess: number;
   tokens: number;
 };
+
+function isLikelyHotGarbageCandidate(
+  row: Pick<TierCandidate, "text" | "summary" | "source" | "category" | "recall_count">,
+): boolean {
+  const combined = `${row.text}\n${row.summary ?? ""}`;
+  if (/<(?:redacted_)?think(?:ing)?>[\s\S]*?<\/(?:redacted_)?think(?:ing)?>/i.test(combined)) return true;
+  if (/^Thinking Process:/im.test(combined)) return true;
+  if (/^\[(?:hot-memories|recall|hot\/fact)\]/im.test(combined)) return true;
+  if (
+    row.source === "auto-capture" &&
+    combined.length > 3000 &&
+    (/think|reasoning|analyz|process/i.test(combined) || /\n\n{2,}/.test(combined))
+  ) {
+    return true;
+  }
+  return row.category === "other" && row.recall_count > 500;
+}
 
 function normalizeTieringOptions(opts: TieringOptions): Required<TieringOptions> {
   return {
@@ -207,6 +225,7 @@ function isHotCandidate(
   opts: Required<TieringOptions>,
   flags?: { ignoreStructuralBlock?: boolean; hotByRecallIds?: ReadonlySet<string> },
 ): boolean {
+  if (isLikelyHotGarbageCandidate(row)) return false;
   if (!flags?.ignoreStructuralBlock && isStructuralCandidate(row, opts)) return false;
   if (hasTag(row.tags, "blocker")) return true;
   if (flags?.hotByRecallIds?.has(row.id)) return true;
@@ -295,6 +314,7 @@ export function retierFacts(db: DatabaseSync, opts: TieringOptions, apply = true
   const rows = db
     .prepare(
       `SELECT id, COALESCE(tier, 'warm') as tier, text, summary, category, importance, key, value, decay_class, tags,
+              source,
               COALESCE(recall_count, 0) as recall_count, COALESCE(access_count, 0) as access_count,
               created_at, last_accessed, last_confirmed_at, preserve_until, preserve_tags
          FROM facts

--- a/extensions/memory-hybrid/backends/facts-db/maintenance.ts
+++ b/extensions/memory-hybrid/backends/facts-db/maintenance.ts
@@ -1159,3 +1159,44 @@ export function backfillDecayClasses(db: DatabaseSync): Record<string, number> {
   createTransaction(db, run)();
   return counts;
 }
+
+/**
+ * Demote HOT garbage facts (reasoning traces, prompt artifacts, capability hints)
+ * to warm tier. Fixes the self-reinforcing loop where these artifacts dominated hot tier
+ * via inflated recall_count from repeated index exposure (#1559).
+ *
+ * Returns the count of facts demoted.
+ */
+export function demoteHotGarbageFacts(db: DatabaseSync): number {
+  // Pattern 1: recall_count is suspiciously high (>500) for what should be transient thinking artifacts
+  // Pattern 2: text contains reasoning/think tags (captured by the isLikelyGarbage detector in queries)
+  const rows = db
+    .prepare(
+      `SELECT id, text, summary, source, recall_count, access_count, category
+       FROM facts
+       WHERE tier = 'hot'
+         AND superseded_at IS NULL
+         AND (
+           -- Known garbage patterns
+           (source = 'auto-capture' AND (
+             text LIKE '%<thinking>%' OR text LIKE '%<redacted_thinking>%' OR
+             text LIKE '%<think>%' || '%</think>%' OR
+             text LIKE '%Thinking Process:%' OR
+             text LIKE '%[recall]%' OR text LIKE '%[hot/fact]%'
+           ))
+           OR
+           -- Staggeringly high recall counts for "other" category (classic garbage artifacts)
+           (category = 'other' AND recall_count > 500 AND source = 'auto-capture')
+         )`,
+    )
+    .all() as Array<{ id: string; text: string; summary: string | null; source: string; recall_count: number; access_count: number; category: string }>;
+
+  if (rows.length === 0) return 0;
+
+  const ids = rows.map((r) => r.id);
+  const placeholders = ids.map(() => "?").join(",");
+  const result = db
+    .prepare(`UPDATE facts SET tier = 'warm' WHERE id IN (${placeholders}) AND tier = 'hot'`)
+    .run(...ids);
+  return result.changes;
+}

--- a/extensions/memory-hybrid/backends/facts-db/maintenance.ts
+++ b/extensions/memory-hybrid/backends/facts-db/maintenance.ts
@@ -362,6 +362,8 @@ export function retierFacts(db: DatabaseSync, opts: TieringOptions, apply = true
 }
 
 export function runCompaction(db: DatabaseSync, opts: TieringOptions): RetierReport {
+  // Demote hot garbage facts before retier to prevent them from staying pinned (#1559)
+  demoteHotGarbageFacts(db);
   const report = retierFacts(db, opts, true);
   return report;
 }
@@ -1176,6 +1178,7 @@ export function demoteHotGarbageFacts(db: DatabaseSync): number {
        FROM facts
        WHERE tier = 'hot'
          AND superseded_at IS NULL
+         AND id NOT IN (SELECT fact_id FROM verified_facts)
          AND (
            -- Known garbage patterns
            (source = 'auto-capture' AND (
@@ -1194,9 +1197,16 @@ export function demoteHotGarbageFacts(db: DatabaseSync): number {
   if (rows.length === 0) return 0;
 
   const ids = rows.map((r) => r.id);
-  const placeholders = ids.map(() => "?").join(",");
-  const result = db
-    .prepare(`UPDATE facts SET tier = 'warm' WHERE id IN (${placeholders}) AND tier = 'hot'`)
-    .run(...ids);
-  return result.changes;
+  let totalChanged = 0;
+  
+  // Batch updates to respect SQLite's 999 bind variable limit
+  for (const batch of batchedInClauseBinds(ids)) {
+    const placeholders = batch.map(() => "?").join(",");
+    const result = db
+      .prepare(`UPDATE facts SET tier = 'warm' WHERE id IN (${placeholders}) AND tier = 'hot'`)
+      .run(...batch);
+    totalChanged += Number(result.changes ?? 0);
+  }
+  
+  return totalChanged;
 }

--- a/extensions/memory-hybrid/backends/facts-db/maintenance.ts
+++ b/extensions/memory-hybrid/backends/facts-db/maintenance.ts
@@ -1230,13 +1230,21 @@ export function demoteHotGarbageFacts(db: DatabaseSync): number {
            (category = 'other' AND recall_count > ${HOT_GARBAGE_OTHER_RECALL_THRESHOLD})
          )`,
     )
-    .all() as Array<{ id: string; text: string; summary: string | null; source: string; recall_count: number; access_count: number; category: string }>;
+    .all() as Array<{
+    id: string;
+    text: string;
+    summary: string | null;
+    source: string;
+    recall_count: number;
+    access_count: number;
+    category: string;
+  }>;
 
   if (rows.length === 0) return 0;
 
   const ids = rows.map((r) => r.id);
   let totalChanged = 0;
-  
+
   // Batch updates to respect SQLite's 999 bind variable limit
   for (const batch of batchedInClauseBinds(ids)) {
     const placeholders = batch.map(() => "?").join(",");
@@ -1245,6 +1253,6 @@ export function demoteHotGarbageFacts(db: DatabaseSync): number {
       .run(...batch);
     totalChanged += Number(result.changes ?? 0);
   }
-  
+
   return totalChanged;
 }

--- a/extensions/memory-hybrid/backends/facts-db/maintenance.ts
+++ b/extensions/memory-hybrid/backends/facts-db/maintenance.ts
@@ -136,6 +136,9 @@ type HotCandidate = {
   tokens: number;
 };
 
+const HOT_GARBAGE_LONG_TEXT_THRESHOLD = 3000;
+const HOT_GARBAGE_OTHER_RECALL_THRESHOLD = 500;
+
 function isLikelyHotGarbageCandidate(
   row: Pick<TierCandidate, "text" | "summary" | "source" | "category" | "recall_count">,
 ): boolean {
@@ -145,12 +148,12 @@ function isLikelyHotGarbageCandidate(
   if (/^\[(?:hot-memories|recall|hot\/fact)\]/im.test(combined)) return true;
   if (
     row.source === "auto-capture" &&
-    combined.length > 3000 &&
+    combined.length > HOT_GARBAGE_LONG_TEXT_THRESHOLD &&
     (/think|reasoning|analyz|process/i.test(combined) || /\n\n{2,}/.test(combined))
   ) {
     return true;
   }
-  return row.category === "other" && row.recall_count > 500;
+  return row.category === "other" && row.recall_count > HOT_GARBAGE_OTHER_RECALL_THRESHOLD;
 }
 
 function normalizeTieringOptions(opts: TieringOptions): Required<TieringOptions> {
@@ -1216,7 +1219,7 @@ export function demoteHotGarbageFacts(db: DatabaseSync): number {
             COALESCE(summary, '') LIKE '[Hot-memories]%' OR COALESCE(summary, '') LIKE '[recall]%' OR COALESCE(summary, '') LIKE '[hot/fact]%')
            OR
            -- Long auto-capture reasoning heuristic (>3000 chars + keywords/patterns)
-           (source = 'auto-capture' AND LENGTH(text || COALESCE(summary, '')) > 3000 AND
+           (source = 'auto-capture' AND LENGTH(text || COALESCE(summary, '')) > ${HOT_GARBAGE_LONG_TEXT_THRESHOLD} AND
             (text LIKE '%think%' OR text LIKE '%reasoning%' OR text LIKE '%analyz%' OR text LIKE '%process%' OR
              text LIKE '%' || CHAR(10) || CHAR(10) || CHAR(10) || '%' OR
              COALESCE(summary, '') LIKE '%think%' OR COALESCE(summary, '') LIKE '%reasoning%' OR
@@ -1224,7 +1227,7 @@ export function demoteHotGarbageFacts(db: DatabaseSync): number {
              COALESCE(summary, '') LIKE '%' || CHAR(10) || CHAR(10) || CHAR(10) || '%'))
            OR
            -- Staggeringly high recall counts for "other" category
-           (category = 'other' AND recall_count > 500)
+           (category = 'other' AND recall_count > ${HOT_GARBAGE_OTHER_RECALL_THRESHOLD})
          )`,
     )
     .all() as Array<{ id: string; text: string; summary: string | null; source: string; recall_count: number; access_count: number; category: string }>;

--- a/extensions/memory-hybrid/backends/facts-db/maintenance.ts
+++ b/extensions/memory-hybrid/backends/facts-db/maintenance.ts
@@ -1170,8 +1170,8 @@ export function backfillDecayClasses(db: DatabaseSync): Record<string, number> {
  * Returns the count of facts demoted.
  */
 export function demoteHotGarbageFacts(db: DatabaseSync): number {
-  // Pattern 1: recall_count is suspiciously high (>500) for what should be transient thinking artifacts
-  // Pattern 2: text contains reasoning/think tags (captured by the isLikelyGarbage detector in queries)
+  // Mirrors isLikelyGarbage from fact-read-queries.ts to ensure SQL demotion applies
+  // the same rules used at injection time (fixes #1559).
   const rows = db
     .prepare(
       `SELECT id, text, summary, source, recall_count, access_count, category
@@ -1180,20 +1180,31 @@ export function demoteHotGarbageFacts(db: DatabaseSync): number {
          AND superseded_at IS NULL
          AND id NOT IN (SELECT fact_id FROM verified_facts)
          AND (
-           -- Known garbage patterns
-           (source = 'auto-capture' AND (
-             text LIKE '%<thinking>%' OR text LIKE '%<redacted_thinking>%' OR
-             text LIKE '%<think>%' || '%</think>%' OR
-             text LIKE '%Thinking Process:%' OR
-             text LIKE '%[recall]%' OR text LIKE '%[hot/fact]%' OR
-             COALESCE(summary, '') LIKE '%<thinking>%' OR COALESCE(summary, '') LIKE '%<redacted_thinking>%' OR
-             COALESCE(summary, '') LIKE '%<think>%' || '%</think>%' OR
-             COALESCE(summary, '') LIKE '%Thinking Process:%' OR
-             COALESCE(summary, '') LIKE '%[recall]%' OR COALESCE(summary, '') LIKE '%[hot/fact]%'
-           ))
+           -- Reasoning traces (thinking tags) - no source restriction to match isLikelyGarbage
+           (text LIKE '%<thinking>%' OR text LIKE '%</thinking>%' OR
+            text LIKE '%<redacted_thinking>%' OR text LIKE '%</redacted_thinking>%' OR
+            text LIKE '%<think>%' OR text LIKE '%</think>%' OR
+            COALESCE(summary, '') LIKE '%<thinking>%' OR COALESCE(summary, '') LIKE '%</thinking>%' OR
+            COALESCE(summary, '') LIKE '%<redacted_thinking>%' OR COALESCE(summary, '') LIKE '%</redacted_thinking>%' OR
+            COALESCE(summary, '') LIKE '%<think>%' OR COALESCE(summary, '') LIKE '%</think>%')
            OR
-           -- Staggeringly high recall counts for "other" category (classic garbage artifacts)
-           (category = 'other' AND recall_count > 500 AND source = 'auto-capture')
+           -- Classifier / capability-hint artifacts - no source restriction
+           (text LIKE '%Thinking Process:%' OR COALESCE(summary, '') LIKE '%Thinking Process:%')
+           OR
+           -- Hot-memories / recall / hot/fact prefixes - no source restriction (includes missing [Hot-memories])
+           (text LIKE '[Hot-memories]%' OR text LIKE '[recall]%' OR text LIKE '[hot/fact]%' OR
+            COALESCE(summary, '') LIKE '[Hot-memories]%' OR COALESCE(summary, '') LIKE '[recall]%' OR COALESCE(summary, '') LIKE '[hot/fact]%')
+           OR
+           -- Long auto-capture reasoning heuristic (>3000 chars + keywords/patterns)
+           (source = 'auto-capture' AND LENGTH(text || COALESCE(summary, '')) > 3000 AND
+            (text LIKE '%think%' OR text LIKE '%reasoning%' OR text LIKE '%analyz%' OR text LIKE '%process%' OR
+             text LIKE '%' || CHAR(10) || CHAR(10) || CHAR(10) || '%' OR
+             COALESCE(summary, '') LIKE '%think%' OR COALESCE(summary, '') LIKE '%reasoning%' OR
+             COALESCE(summary, '') LIKE '%analyz%' OR COALESCE(summary, '') LIKE '%process%' OR
+             COALESCE(summary, '') LIKE '%' || CHAR(10) || CHAR(10) || CHAR(10) || '%'))
+           OR
+           -- Staggeringly high recall counts for "other" category
+           (category = 'other' AND recall_count > 500)
          )`,
     )
     .all() as Array<{ id: string; text: string; summary: string | null; source: string; recall_count: number; access_count: number; category: string }>;

--- a/extensions/memory-hybrid/backends/facts-db/row-mapper.ts
+++ b/extensions/memory-hybrid/backends/facts-db/row-mapper.ts
@@ -30,6 +30,8 @@ export function rowToMemoryEntry(row: Record<string, unknown>): MemoryEntry {
     lastAccessed: (row.last_accessed as number) || null,
     accessCount: (row.access_count as number) || 0,
     lastAccessedAt: (row.last_accessed_at as string) || null,
+    indexedCount: (row.indexed_count as number) || 0,
+    lastIndexed: (row.last_indexed as number) || null,
     supersededAt: (row.superseded_at as number) || null,
     supersededBy: (row.superseded_by as string) || null,
     validFrom: (row.valid_from as number) ?? undefined,

--- a/extensions/memory-hybrid/backends/migrations/facts-migrations.ts
+++ b/extensions/memory-hybrid/backends/migrations/facts-migrations.ts
@@ -1369,6 +1369,7 @@ export function runFactsMigrations(db: DatabaseSync): void {
   // Scan cursors and access salience
   migrateScanCursorsTable(db);
   migrateAccessCountAndLastAccessedAt(db);
+  migrateIndexedCountAndLastIndexed(db);
   migrateSupersededAtLookupIndex(db);
 
   // Token-budget tiered trimming (Issue #792)
@@ -1490,4 +1491,15 @@ function migrateTrimBudgetIndex(db: DatabaseSync): void {
     ON facts(superseded_at, importance, created_at, last_accessed)
     WHERE superseded_at IS NULL
   `);
+}
+
+/** Issue #1559: Separate index-only exposure signal from recall_count/last_accessed. */
+function migrateIndexedCountAndLastIndexed(db: DatabaseSync): void {
+  const cols = db.prepare("PRAGMA table_info(facts)").all() as Array<{ name: string }>;
+  if (!cols.some((c) => c.name === "indexed_count")) {
+    db.exec("ALTER TABLE facts ADD COLUMN indexed_count INTEGER NOT NULL DEFAULT 0");
+  }
+  if (!cols.some((c) => c.name === "last_indexed")) {
+    db.exec("ALTER TABLE facts ADD COLUMN last_indexed INTEGER");
+  }
 }

--- a/extensions/memory-hybrid/lifecycle/stage-injection.ts
+++ b/extensions/memory-hybrid/lifecycle/stage-injection.ts
@@ -194,8 +194,19 @@ async function runInjection(
     const rest: typeof candidates = [];
     for (const x of candidates) {
       const recallCount = x.entry.recallCount ?? 0;
-      if (x.entry.decayClass === "permanent" || recallCount >= pinnedRecallThreshold) pinned.push(x);
-      else rest.push(x);
+      // Pin by recall_count ONLY when last_accessed is recent (within 14 days) to prevent
+      // garbage artifacts (high recall_count from repeated index exposure) from being pinned (#1559).
+      const lastAccessed = x.entry.lastAccessed ?? 0;
+      const lastAccessedDaysAgo = lastAccessed > 0 ? (Date.now() / 1000 - lastAccessed) / 86400 : Infinity;
+      const isRecentlyAccessed = lastAccessedDaysAgo < 14;
+      if (
+        x.entry.decayClass === "permanent" ||
+        (recallCount >= pinnedRecallThreshold && isRecentlyAccessed)
+      ) {
+        pinned.push(x);
+      } else {
+        rest.push(x);
+      }
     }
     const pinnedHeader = '<relevant-memories format="progressive_hybrid">\n';
     const pinnedPart: string[] = [];
@@ -253,7 +264,8 @@ async function runInjection(
     lastProgressiveIndexIdsRef.length = 0;
     lastProgressiveIndexIdsRef.push(...indexIds);
     if (pinnedPart.length > 0) ctx.factsDb.refreshAccessedFacts(pinned.map((x) => x.entry.id));
-    if (indexIds.length > 0) ctx.factsDb.refreshAccessedFacts(indexIds);
+    // Index-only exposures must NOT inflate recall_count (#1559)
+    if (indexIds.length > 0) ctx.factsDb.refreshIndexedFacts(indexIds);
     const allIds = [...pinned.map((x) => x.entry.id), ...indexIds];
     if (ambientSeenFacts && allIds.length > 0) ambientSeenFacts.markSeen(allIds);
     if (ctx.cfg.graph.enabled && ctx.cfg.graph.strengthenOnRecall && allIds.length >= 2) {
@@ -296,7 +308,8 @@ async function runInjection(
     }
     lastProgressiveIndexIdsRef.length = 0;
     lastProgressiveIndexIdsRef.push(...indexIds);
-    ctx.factsDb.refreshAccessedFacts(indexIds);
+    // Index-only exposures must NOT inflate recall_count (#1559)
+    ctx.factsDb.refreshIndexedFacts(indexIds);
     if (ambientSeenFacts && indexIds.length > 0) ambientSeenFacts.markSeen(indexIds);
     if (ctx.cfg.graph.enabled && ctx.cfg.graph.strengthenOnRecall && indexIds.length >= 2) {
       strengthenHebbianLinks(indexIds, ctx.factsDb, api.logger);

--- a/extensions/memory-hybrid/lifecycle/stage-injection.ts
+++ b/extensions/memory-hybrid/lifecycle/stage-injection.ts
@@ -301,8 +301,8 @@ async function runInjection(
     if (indexIds.length > 0) ctx.factsDb.refreshIndexedFacts(indexIds);
     const allIds = [...injectedPinnedIds, ...indexIds];
     if (ambientSeenFacts && allIds.length > 0) ambientSeenFacts.markSeen(allIds);
-    if (ctx.cfg.graph.enabled && ctx.cfg.graph.strengthenOnRecall && allIds.length >= 2) {
-      strengthenHebbianLinks(allIds, ctx.factsDb, api.logger);
+    if (ctx.cfg.graph.enabled && ctx.cfg.graph.strengthenOnRecall && injectedPinnedIds.length >= 2) {
+      strengthenHebbianLinks(injectedPinnedIds, ctx.factsDb, api.logger);
     }
     const indexContent = indexLines.join("\n");
     const fullContent =
@@ -347,9 +347,8 @@ async function runInjection(
     // Index-only exposures must NOT inflate recall_count (#1559)
     ctx.factsDb.refreshIndexedFacts(indexIds);
     if (ambientSeenFacts && indexIds.length > 0) ambientSeenFacts.markSeen(indexIds);
-    if (ctx.cfg.graph.enabled && ctx.cfg.graph.strengthenOnRecall && indexIds.length >= 2) {
-      strengthenHebbianLinks(indexIds, ctx.factsDb, api.logger);
-    }
+    // Index-only exposures must NOT strengthen Hebbian links (#1559)
+
     const indexContent = indexLines.join("\n");
     api.logger.info?.(
       `memory-hybrid: progressive disclosure — injecting index of ${indexLines.length} memories (~${indexTokens} tokens)`,

--- a/extensions/memory-hybrid/lifecycle/stage-injection.ts
+++ b/extensions/memory-hybrid/lifecycle/stage-injection.ts
@@ -200,13 +200,13 @@ async function runInjection(
       const lastAccessed = x.entry.lastAccessed ?? 0;
       const lastAccessedDaysAgo = lastAccessed > 0 ? (Date.now() / 1000 - lastAccessed) / 86400 : Infinity;
       const isRecentlyAccessed = lastAccessedDaysAgo < 14;
-      
+
       // Exclude facts with disproportionate index exposure (indexed_count >> recall_count)
       // which indicates garbage that was repeatedly shown in progressive index but never
       // actually recalled (#1559).
       const indexInflationRatio = recallCount > 0 ? indexedCount / recallCount : indexedCount;
       const likelyIndexGarbage = indexInflationRatio > 10 && indexedCount > 50;
-      
+
       if (
         x.entry.decayClass === "permanent" ||
         (recallCount >= pinnedRecallThreshold && isRecentlyAccessed && !likelyIndexGarbage)

--- a/extensions/memory-hybrid/lifecycle/stage-injection.ts
+++ b/extensions/memory-hybrid/lifecycle/stage-injection.ts
@@ -194,14 +194,22 @@ async function runInjection(
     const rest: typeof candidates = [];
     for (const x of candidates) {
       const recallCount = x.entry.recallCount ?? 0;
+      const indexedCount = x.entry.indexedCount ?? 0;
       // Pin by recall_count ONLY when last_accessed is recent (within 14 days) to prevent
       // garbage artifacts (high recall_count from repeated index exposure) from being pinned (#1559).
       const lastAccessed = x.entry.lastAccessed ?? 0;
       const lastAccessedDaysAgo = lastAccessed > 0 ? (Date.now() / 1000 - lastAccessed) / 86400 : Infinity;
       const isRecentlyAccessed = lastAccessedDaysAgo < 14;
+      
+      // Exclude facts with disproportionate index exposure (indexed_count >> recall_count)
+      // which indicates garbage that was repeatedly shown in progressive index but never
+      // actually recalled (#1559).
+      const indexInflationRatio = recallCount > 0 ? indexedCount / recallCount : indexedCount;
+      const likelyIndexGarbage = indexInflationRatio > 10 && indexedCount > 50;
+      
       if (
         x.entry.decayClass === "permanent" ||
-        (recallCount >= pinnedRecallThreshold && isRecentlyAccessed)
+        (recallCount >= pinnedRecallThreshold && isRecentlyAccessed && !likelyIndexGarbage)
       ) {
         pinned.push(x);
       } else {

--- a/extensions/memory-hybrid/lifecycle/stage-injection.ts
+++ b/extensions/memory-hybrid/lifecycle/stage-injection.ts
@@ -218,6 +218,7 @@ async function runInjection(
     }
     const pinnedHeader = '<relevant-memories format="progressive_hybrid">\n';
     const pinnedPart: string[] = [];
+    const injectedPinnedIds: string[] = [];
     let pinnedTokens = estimateTokens(pinnedHeader);
     const pinnedBudget = Math.min(maxTokens, Math.floor(maxTokens * 0.6));
     for (const x of pinned) {
@@ -228,6 +229,7 @@ async function runInjection(
       const lineTokens = estimateTokens(`${line}\n`);
       if (pinnedTokens + lineTokens > pinnedBudget) break;
       pinnedPart.push(line);
+      injectedPinnedIds.push(x.entry.id);
       pinnedTokens += lineTokens;
     }
     const indexIntro =
@@ -242,11 +244,10 @@ async function runInjection(
         `memory-hybrid: progressive index budget exhausted by fixed blocks (indexCap=${indexCap} tokens); no index will be injected`,
       );
       if (pinnedPart.length > 0) {
-        const pinnedIds = pinned.map((x) => x.entry.id);
-        ctx.factsDb.refreshAccessedFacts(pinnedIds);
-        if (ambientSeenFacts) ambientSeenFacts.markSeen(pinnedIds);
-        if (ctx.cfg.graph.enabled && ctx.cfg.graph.strengthenOnRecall && pinnedIds.length >= 2) {
-          strengthenHebbianLinks(pinnedIds, ctx.factsDb, api.logger);
+        ctx.factsDb.refreshAccessedFacts(injectedPinnedIds);
+        if (ambientSeenFacts) ambientSeenFacts.markSeen(injectedPinnedIds);
+        if (ctx.cfg.graph.enabled && ctx.cfg.graph.strengthenOnRecall && injectedPinnedIds.length >= 2) {
+          strengthenHebbianLinks(injectedPinnedIds, ctx.factsDb, api.logger);
         }
         const fullContent = `${pinnedHeader}${pinnedPart.join("\n")}\n</relevant-memories>`;
         api.logger.info?.(
@@ -271,10 +272,10 @@ async function runInjection(
     const { lines: indexLines, ids: indexIds } = buildProgressiveIndex(rest, indexBudget, 1);
     lastProgressiveIndexIdsRef.length = 0;
     lastProgressiveIndexIdsRef.push(...indexIds);
-    if (pinnedPart.length > 0) ctx.factsDb.refreshAccessedFacts(pinned.map((x) => x.entry.id));
+    if (injectedPinnedIds.length > 0) ctx.factsDb.refreshAccessedFacts(injectedPinnedIds);
     // Index-only exposures must NOT inflate recall_count (#1559)
     if (indexIds.length > 0) ctx.factsDb.refreshIndexedFacts(indexIds);
-    const allIds = [...pinned.map((x) => x.entry.id), ...indexIds];
+    const allIds = [...injectedPinnedIds, ...indexIds];
     if (ambientSeenFacts && allIds.length > 0) ambientSeenFacts.markSeen(allIds);
     if (ctx.cfg.graph.enabled && ctx.cfg.graph.strengthenOnRecall && allIds.length >= 2) {
       strengthenHebbianLinks(allIds, ctx.factsDb, api.logger);

--- a/extensions/memory-hybrid/tests/facts-db.test.ts
+++ b/extensions/memory-hybrid/tests/facts-db.test.ts
@@ -720,6 +720,50 @@ describe("FactsDB tiering", () => {
     expect(hot.length).toBeLessThanOrEqual(2);
   });
 
+  it("getHotFacts filters garbage prefixes and down-scores long hot facts", () => {
+    const clean = db.store({
+      text: "Operational runbook summary",
+      category: "fact",
+      importance: 0.8,
+      entity: null,
+      key: null,
+      value: null,
+      source: "test",
+    });
+    const garbage = db.store({
+      text: "Capability hint artifact",
+      summary: "[hot/fact] generated hot-memory wrapper",
+      category: "fact",
+      importance: 0.8,
+      entity: null,
+      key: null,
+      value: null,
+      source: "test",
+    });
+    const long = db.store({
+      text: "longfact ".repeat(1200),
+      category: "fact",
+      importance: 0.8,
+      entity: null,
+      key: null,
+      value: null,
+      source: "test",
+    });
+
+    db.setTier(clean.id, "hot");
+    db.setTier(garbage.id, "hot");
+    db.setTier(long.id, "hot");
+
+    const hot = db.getHotFacts(10_000);
+    const ids = hot.map((row) => row.entry.id);
+
+    expect(ids).toContain(clean.id);
+    expect(ids).toContain(long.id);
+    expect(ids).not.toContain(garbage.id);
+    expect(hot.find((row) => row.entry.id === clean.id)?.score).toBe(1);
+    expect(hot.find((row) => row.entry.id === long.id)?.score).toBe(0.3);
+  });
+
   it("search with tierFilter warm excludes cold", () => {
     const w = db.store({
       text: "Warm preference",
@@ -861,6 +905,23 @@ describe("FactsDB tiering", () => {
 
     expect(counts.hot).toBeGreaterThanOrEqual(1);
     expect(db.getById(fact.id)?.tier).toBe("hot");
+  });
+
+  it("runCompaction keeps garbage artifacts out of HOT after retiering", () => {
+    const garbage = db.store({
+      text: "<thinking>internal reasoning trace</thinking>",
+      category: "fact",
+      importance: 0.8,
+      entity: null,
+      key: null,
+      value: null,
+      source: "test",
+    });
+    for (let i = 0; i < 3; i++) db.refreshAccessedFacts([garbage.id]);
+
+    db.runCompaction({ inactivePreferenceDays: 7, hotMaxTokens: 2000, hotMaxFacts: 50 });
+
+    expect(db.getById(garbage.id)?.tier).toBe("warm");
   });
 
   it("runCompaction moves only inactive unrecalled facts to COLD", () => {

--- a/extensions/memory-hybrid/tests/facts-db.test.ts
+++ b/extensions/memory-hybrid/tests/facts-db.test.ts
@@ -721,6 +721,7 @@ describe("FactsDB tiering", () => {
   });
 
   it("getHotFacts filters garbage prefixes and down-scores long hot facts", () => {
+    const longHotText = "longfact ".repeat(Math.ceil(8001 / "longfact ".length));
     const clean = db.store({
       text: "Operational runbook summary",
       category: "fact",
@@ -741,7 +742,7 @@ describe("FactsDB tiering", () => {
       source: "test",
     });
     const long = db.store({
-      text: "longfact ".repeat(1200),
+      text: longHotText,
       category: "fact",
       importance: 0.8,
       entity: null,

--- a/extensions/memory-hybrid/tests/lifecycle-stage-injection.test.ts
+++ b/extensions/memory-hybrid/tests/lifecycle-stage-injection.test.ts
@@ -78,4 +78,51 @@ describe("runInjectionStage", () => {
 
     expect(capturePluginError).not.toHaveBeenCalled();
   });
+
+  it("refreshes only pinned facts that were actually injected in progressive_hybrid mode", async () => {
+    const short = factsDb.store({
+      text: "Short pinned fact",
+      category: "fact",
+      importance: 0.8,
+      entity: null,
+      key: null,
+      value: null,
+      source: "test",
+    });
+    const oversized = factsDb.store({
+      text: "oversized ".repeat(80),
+      category: "fact",
+      importance: 0.8,
+      entity: null,
+      key: null,
+      value: null,
+      source: "test",
+    });
+    for (let i = 0; i < 3; i++) {
+      factsDb.refreshAccessedFacts([short.id, oversized.id]);
+    }
+
+    const shortEntry = factsDb.getById(short.id);
+    const oversizedEntry = factsDb.getById(oversized.id);
+    expect(shortEntry).toBeDefined();
+    expect(oversizedEntry).toBeDefined();
+
+    const ctx = buildRecallLifecycleContext(tmpDir, factsDb);
+    const api = makeMockStageApi();
+    const recall = makeMinimalRecallResult({
+      injectionFormat: "progressive_hybrid",
+      maxTokens: 40,
+      indexCap: 80,
+      pinnedRecallThreshold: 3,
+      candidates: [
+        { entry: shortEntry!, score: 0.9, backend: "sqlite" },
+        { entry: oversizedEntry!, score: 0.8, backend: "sqlite" },
+      ],
+    });
+
+    await runInjectionStage(recall, api as never, ctx, { prompt: "test" });
+
+    expect(factsDb.getById(short.id)?.recallCount).toBe((shortEntry?.recallCount ?? 0) + 1);
+    expect(factsDb.getById(oversized.id)?.recallCount).toBe(oversizedEntry?.recallCount ?? 0);
+  });
 });

--- a/extensions/memory-hybrid/types/memory.ts
+++ b/extensions/memory-hybrid/types/memory.ts
@@ -35,6 +35,10 @@ export type MemoryEntry = {
   accessCount?: number;
   /** ISO 8601 timestamp of last recall hit (#237). */
   lastAccessedAt?: string | null;
+  /** Number of index-only exposures (does not inflate recall_count). */
+  indexedCount?: number;
+  /** Epoch seconds of last index-only exposure. Separate signal from last_accessed. */
+  lastIndexed?: number | null;
   supersededAt?: number | null;
   supersededBy?: string | null;
   /** When the fact became true in the real world (epoch seconds). */


### PR DESCRIPTION
## Summary
11:Garbage detection improvements — regex, SQL alignment, hot recall loop fixes for #1559

## Verification
- npm test
- CI green

## Next owner
Manual review

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes salience/tiering/injection behavior for all progressive recall paths; wrong heuristics could demote real facts or under-count recall, but scope is memory-hybrid facts DB and injection only.
> 
> **Overview**
> Fixes **#1559**: progressive index exposure was inflating `recall_count` / `last_accessed`, which pinned reasoning traces and prompt artifacts in HOT and reinforced a garbage loop.
> 
> **Separate signals:** Adds `indexed_count` / `last_indexed` (migration + `MemoryEntry`), `refreshIndexedFacts()` for index-only rows, and documents that `refreshAccessedFacts()` is for full injection or explicit recall only. **Injection** uses `refreshIndexedFacts` for progressive/index lines; Hebbian strengthening applies only to actually injected pinned/full content, not index-only IDs. **progressive_hybrid** pinning now requires recent `last_accessed` (14d) and rejects high `indexed_count` vs `recall_count` ratios.
> 
> **Garbage handling:** Shared `isLikelyGarbage()` filters think-tags, classifier artifacts, long auto-capture dumps, and extreme `other` recall counts. HOT reads use `hotQualityScore` (exclude garbage, down-score very long text). Tiering blocks garbage from HOT; `demoteHotGarbageFacts()` runs before compaction retier. Tests cover HOT filtering, compaction demotion, and pinned-only access refresh.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6108336ee0271bba34edd4917fde4d0d494d5ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->