### PR TITLE
fix

### DIFF
--- a/extensions/memory-hybrid/backends/wal.ts
+++ b/extensions/memory-hybrid/backends/wal.ts
@@ -3,8 +3,7 @@
  * Append-only NDJSON format; fsync after each write for durability.
  */
 
-import { mkdirSync } from "node:fs";
-import { existsSync, statSync } from "node:fs";
+import { existsSync, mkdirSync, statSync } from "node:fs";
 import { appendFile, open, readFile, rm, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
 import type { DecayClass } from "../config.js";
@@ -103,7 +102,14 @@ export class WriteAheadLog {
         await prevLock;
         const entries = await this.readAll();
         this.activeIds = new Set(entries.map((e) => e.id));
-      } catch {
+      } catch (err) {
+        capturePluginError(err as Error, {
+          operation: "wal-init",
+          subsystem: "wal",
+        });
+        pluginLogger.warn(
+          `WAL init: failed to load active IDs, continuing with empty in-memory set: ${err instanceof Error ? err.message : String(err)}`,
+        );
         this.activeIds = new Set();
       } finally {
         // biome-ignore lint/style/noNonNullAssertion: Synchronous

--- a/extensions/memory-hybrid/backends/wal.ts
+++ b/extensions/memory-hybrid/backends/wal.ts
@@ -103,7 +103,7 @@ export class WriteAheadLog {
         const entries = await this.readAll();
         this.activeIds = new Set(entries.map((e) => e.id));
       } catch (err) {
-        capturePluginError(err as Error, {
+        capturePluginError(err instanceof Error ? err : new Error(String(err)), {
           operation: "wal-init",
           subsystem: "wal",
         });

--- a/extensions/memory-hybrid/services/error-reporter.ts
+++ b/extensions/memory-hybrid/services/error-reporter.ts
@@ -632,7 +632,13 @@ class GlitchTipReporter {
     this.inFlightReportIds.add(eventId);
     let persisted = false;
     try {
-      await this.ensureQueueLoaded();
+      try {
+        await this.ensureQueueLoaded();
+      } catch (err) {
+        logger.warn?.(
+          `[ErrorReporter] Failed to load pending-report queue: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
       if (this.pendingQueuePath) {
         try {
           await this.enqueuePendingReport(eventId, event);

--- a/extensions/memory-hybrid/services/error-reporter.ts
+++ b/extensions/memory-hybrid/services/error-reporter.ts
@@ -744,7 +744,13 @@ class GlitchTipReporter {
 
       const pruned = this.prunePendingReportsLocked();
       if (pruned > 0) {
-        await this.persistPendingReportsLocked();
+        try {
+          await this.persistPendingReportsLocked();
+        } catch (persistErr) {
+          logger.warn?.(
+            `[ErrorReporter] Failed persisting pruned queue during load (continuing): ${persistErr instanceof Error ? persistErr.message : String(persistErr)}`,
+          );
+        }
         logger.warn?.(`[ErrorReporter] Pruned ${pruned} oldest pending report(s) during queue load`);
       }
 

--- a/extensions/memory-hybrid/services/error-reporter.ts
+++ b/extensions/memory-hybrid/services/error-reporter.ts
@@ -1,3 +1,5 @@
+import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
 import { getEnv } from "../utils/env-manager.js";
 import { compareVersions } from "../utils/version-check.js";
 
@@ -19,6 +21,7 @@ export { compareVersions };
  */
 
 const MAX_BREADCRUMBS = 10;
+const MAX_PENDING_REPORTS = 200;
 
 /**
  * Default GlitchTip DSN for anonymous crash reporting.
@@ -55,6 +58,10 @@ export interface ErrorReporterConfig {
    * When not configured, behavior is identical to today.
    */
   resolvedIssues?: Record<string, string>;
+  /** Optional persistent queue path for pending reports (JSONL). */
+  pendingQueuePath?: string;
+  /** Optional cap for persistent pending reports. Oldest entries are pruned first. */
+  maxPendingReports?: number;
 }
 
 /** Hardcoded DSN for community error reporting (anonymous telemetry) */
@@ -102,6 +109,12 @@ export interface GlitchTipEvent {
   breadcrumbs?: ReportBreadcrumb[];
   user?: { id?: string; username?: string };
   [key: string]: unknown;
+}
+
+interface PendingReportRecord {
+  id: string;
+  event: GlitchTipEvent;
+  enqueuedAt: number;
 }
 
 interface ErrorLike {
@@ -427,11 +440,18 @@ class GlitchTipReporter {
   private readonly environment: string;
   private readonly sampleRate: number;
   private readonly resolvedIssues: Record<string, string>;
+  private readonly pendingQueuePath?: string;
+  private readonly maxPendingReports: number;
   private serverName?: string;
 
   private globalTags: Record<string, string> = {};
   private breadcrumbs: ReportBreadcrumb[] = [];
-  private pendingFetches: Promise<void>[] = [];
+  private pendingFetches = new Set<Promise<void>>();
+  private pendingReports = new Map<string, PendingReportRecord>();
+  private inFlightReportIds = new Set<string>();
+  private queueLoadPromise: Promise<void> | null = null;
+  private queueLoaded = false;
+  private queueWriteLock: Promise<void> = Promise.resolve();
 
   // Current scope — set synchronously during withScope callback
   private currentScopeTags: Record<string, string> = {};
@@ -443,6 +463,8 @@ class GlitchTipReporter {
     environment: string,
     sampleRate: number,
     resolvedIssues?: Record<string, string>,
+    pendingQueuePath?: string,
+    maxPendingReports?: number,
   ) {
     const url = new URL(dsn);
     this.publicKey = url.username;
@@ -457,6 +479,11 @@ class GlitchTipReporter {
     this.environment = environment;
     this.sampleRate = sampleRate;
     this.resolvedIssues = resolvedIssues ?? {};
+    this.pendingQueuePath = pendingQueuePath;
+    this.maxPendingReports =
+      typeof maxPendingReports === "number" && Number.isFinite(maxPendingReports) && maxPendingReports > 0
+        ? Math.floor(maxPendingReports)
+        : MAX_PENDING_REPORTS;
   }
 
   setTag(key: string, value: string): void {
@@ -546,37 +573,219 @@ class GlitchTipReporter {
       return eventId;
     }
 
-    const p = this.send(sanitized).catch(() => {
-      // Fire-and-forget: never throw from error reporter
-    });
-    this.pendingFetches.push(p);
-
-    // Prevent unbounded growth: prune every 20 entries
-    if (this.pendingFetches.length > 20) {
-      this.pendingFetches = this.pendingFetches.slice(-20);
-    }
+    this.trackPending(this.sendWithPersistence(sanitized));
 
     return eventId;
   }
 
+  async initPersistentQueue(): Promise<void> {
+    await this.ensureQueueLoaded();
+    this.retryPendingQueue();
+  }
+
   async flush(timeoutMs: number): Promise<boolean> {
+    await this.ensureQueueLoaded();
+    this.retryPendingQueue();
+
     const pending = [...this.pendingFetches];
-    this.pendingFetches = [];
-    if (pending.length === 0) return true;
+    if (pending.length === 0) return this.pendingReports.size === 0;
     try {
       let timeoutId: NodeJS.Timeout | undefined;
+      let settledWithoutErrors = false;
       await Promise.race([
-        Promise.all(pending).then((result) => {
+        Promise.allSettled(pending).then((results) => {
           if (timeoutId !== undefined) clearTimeout(timeoutId);
-          return result;
+          settledWithoutErrors = results.every((result) => result.status === "fulfilled");
         }),
         new Promise<never>((_, reject) => {
           timeoutId = setTimeout(() => reject(new Error("Flush timeout")), timeoutMs);
         }),
       ]);
-      return true;
+      return settledWithoutErrors && this.pendingReports.size === 0;
     } catch {
       return false;
+    }
+  }
+
+  private trackPending(promise: Promise<void>): void {
+    const tracked = promise.finally(() => {
+      this.pendingFetches.delete(tracked);
+    });
+    this.pendingFetches.add(tracked);
+    // Prevent unhandled-rejection noise while still allowing flush() to observe failures.
+    void tracked.catch(() => {});
+  }
+
+  private retryPendingQueue(): void {
+    if (!this.pendingQueuePath || this.pendingReports.size === 0) return;
+    for (const record of this.pendingReports.values()) {
+      this.trackPending(this.sendPersistedRecord(record));
+    }
+  }
+
+  private async sendWithPersistence(event: GlitchTipEvent): Promise<void> {
+    const eventId =
+      typeof event.event_id === "string" && event.event_id.length > 0 ? event.event_id : generateEventId();
+    event.event_id = eventId;
+
+    if (this.inFlightReportIds.has(eventId)) return;
+    this.inFlightReportIds.add(eventId);
+    let persisted = false;
+    try {
+      await this.ensureQueueLoaded();
+      if (this.pendingQueuePath) {
+        try {
+          await this.enqueuePendingReport(eventId, event);
+          persisted = true;
+        } catch (err) {
+          logger.warn?.(
+            `[ErrorReporter] Failed to persist pending report ${eventId}: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
+      }
+
+      await this.send(event);
+
+      if (persisted) {
+        await this.acknowledgeDelivered(eventId);
+      }
+    } finally {
+      this.inFlightReportIds.delete(eventId);
+    }
+  }
+
+  private async sendPersistedRecord(record: PendingReportRecord): Promise<void> {
+    if (!this.pendingQueuePath) return;
+    const eventId = record.id;
+    if (this.inFlightReportIds.has(eventId)) return;
+
+    this.inFlightReportIds.add(eventId);
+    try {
+      await this.send(record.event);
+      await this.acknowledgeDelivered(eventId);
+    } finally {
+      this.inFlightReportIds.delete(eventId);
+    }
+  }
+
+  private async enqueuePendingReport(eventId: string, event: GlitchTipEvent): Promise<void> {
+    if (!this.pendingQueuePath) return;
+    await this.withQueueLock(async () => {
+      this.pendingReports.set(eventId, { id: eventId, event, enqueuedAt: Date.now() });
+      const pruned = this.prunePendingReportsLocked();
+      await this.persistPendingReportsLocked();
+      if (pruned > 0) {
+        logger.warn?.(`[ErrorReporter] Pruned ${pruned} oldest pending report(s) to keep queue bounded`);
+      }
+    });
+  }
+
+  private async acknowledgeDelivered(eventId: string): Promise<void> {
+    if (!this.pendingQueuePath) return;
+    await this.withQueueLock(async () => {
+      if (!this.pendingReports.delete(eventId)) return;
+      await this.persistPendingReportsLocked();
+    });
+  }
+
+  private async ensureQueueLoaded(): Promise<void> {
+    if (!this.pendingQueuePath || this.queueLoaded) return;
+    if (this.queueLoadPromise) {
+      await this.queueLoadPromise;
+      return;
+    }
+
+    this.queueLoadPromise = (async () => {
+      let content = "";
+      try {
+        content = await readFile(this.pendingQueuePath as string, "utf-8");
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+          logger.warn?.(
+            `[ErrorReporter] Failed reading pending-report queue: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
+      }
+
+      if (content.trim().length > 0) {
+        for (const line of content.split("\n")) {
+          const trimmed = line.trim();
+          if (!trimmed) continue;
+          try {
+            const parsed = JSON.parse(trimmed) as Partial<PendingReportRecord>;
+            if (typeof parsed.id !== "string" || parsed.id.length === 0) continue;
+            if (!parsed.event || typeof parsed.event !== "object") continue;
+            const persistedEventId =
+              typeof parsed.event.event_id === "string" && parsed.event.event_id.length > 0
+                ? parsed.event.event_id
+                : parsed.id;
+            const event = { ...parsed.event, event_id: persistedEventId };
+            this.pendingReports.set(persistedEventId, {
+              id: persistedEventId,
+              event,
+              enqueuedAt: typeof parsed.enqueuedAt === "number" ? parsed.enqueuedAt : Date.now(),
+            });
+          } catch (err) {
+            logger.warn?.(
+              `[ErrorReporter] Failed parsing pending-report queue line, skipping: ${err instanceof Error ? err.message : String(err)}`,
+            );
+          }
+        }
+      }
+
+      const pruned = this.prunePendingReportsLocked();
+      if (pruned > 0) {
+        await this.persistPendingReportsLocked();
+        logger.warn?.(`[ErrorReporter] Pruned ${pruned} oldest pending report(s) during queue load`);
+      }
+
+      this.queueLoaded = true;
+    })().finally(() => {
+      this.queueLoadPromise = null;
+    });
+
+    await this.queueLoadPromise;
+  }
+
+  private prunePendingReportsLocked(): number {
+    let pruned = 0;
+    while (this.pendingReports.size > this.maxPendingReports) {
+      const oldestId = this.pendingReports.keys().next().value as string | undefined;
+      if (!oldestId) break;
+      this.pendingReports.delete(oldestId);
+      pruned++;
+    }
+    return pruned;
+  }
+
+  private async persistPendingReportsLocked(): Promise<void> {
+    if (!this.pendingQueuePath) return;
+
+    if (this.pendingReports.size === 0) {
+      await rm(this.pendingQueuePath, { force: true });
+      return;
+    }
+
+    const dir = dirname(this.pendingQueuePath);
+    await mkdir(dir, { recursive: true });
+    const tmpPath = `${this.pendingQueuePath}.tmp`;
+    const payload = `${[...this.pendingReports.values()].map((record) => JSON.stringify(record)).join("\n")}\n`;
+    await writeFile(tmpPath, payload, "utf-8");
+    await rename(tmpPath, this.pendingQueuePath);
+  }
+
+  private async withQueueLock<T>(op: () => Promise<T>): Promise<T> {
+    const prev = this.queueWriteLock;
+    let releaseLock: () => void;
+    this.queueWriteLock = new Promise((resolve) => {
+      releaseLock = resolve;
+    });
+    await prev;
+    try {
+      return await op();
+    } finally {
+      // biome-ignore lint/style/noNonNullAssertion: Synchronous release initialized in Promise ctor.
+      releaseLock!();
     }
   }
 
@@ -703,10 +912,13 @@ export async function initErrorReporter(
       config.environment || "production",
       config.sampleRate ?? 1.0,
       config.resolvedIssues,
+      config.pendingQueuePath,
+      config.maxPendingReports,
     );
+    await reporter.initPersistentQueue();
   } catch (err) {
     logger.warn?.(
-      "[ErrorReporter] Invalid DSN format, error reporting disabled:",
+      "[ErrorReporter] Failed to initialize reporter, error reporting disabled:",
       err instanceof Error ? err.message : String(err),
     );
     return;

--- a/extensions/memory-hybrid/services/error-reporter.ts
+++ b/extensions/memory-hybrid/services/error-reporter.ts
@@ -700,11 +700,14 @@ class GlitchTipReporter {
       try {
         content = await readFile(this.pendingQueuePath as string, "utf-8");
       } catch (err) {
-        if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
-          logger.warn?.(
-            `[ErrorReporter] Failed reading pending-report queue: ${err instanceof Error ? err.message : String(err)}`,
-          );
+        if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+          this.queueLoaded = true;
+          return;
         }
+        logger.warn?.(
+          `[ErrorReporter] Failed reading pending-report queue: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        throw err;
       }
 
       if (content.trim().length > 0) {

--- a/extensions/memory-hybrid/services/error-reporter.ts
+++ b/extensions/memory-hybrid/services/error-reporter.ts
@@ -918,13 +918,21 @@ export async function initErrorReporter(
       config.pendingQueuePath,
       config.maxPendingReports,
     );
-    await reporter.initPersistentQueue();
   } catch (err) {
     logger.warn?.(
       "[ErrorReporter] Failed to initialize reporter, error reporting disabled:",
       err instanceof Error ? err.message : String(err),
     );
     return;
+  }
+
+  try {
+    await reporter.initPersistentQueue();
+  } catch (err) {
+    logger.warn?.(
+      "[ErrorReporter] Failed to initialize persistent queue (continuing with in-memory only):",
+      err instanceof Error ? err.message : String(err),
+    );
   }
 
   // Bot identity: config first, then OpenClaw context (e.g. api.context?.agentId).

--- a/extensions/memory-hybrid/setup/plugin-service.ts
+++ b/extensions/memory-hybrid/setup/plugin-service.ts
@@ -1,7 +1,6 @@
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, isAbsolute, join } from "node:path";
-import { findPluginRoot } from "../utils/plugin-root.js";
 import type OpenAI from "openai";
 import type { ClawdbotPluginApi } from "openclaw/plugin-sdk/core";
 import { clearRuntimeTimers } from "../api/plugin-runtime.js";
@@ -12,14 +11,13 @@ import type { IssueStore } from "../backends/issue-store.js";
 import type { NarrativesDB } from "../backends/narratives-db.js";
 import type { ProposalsDB } from "../backends/proposals-db.js";
 import type { VectorDB } from "../backends/vector-db.js";
-import type { VerificationStore } from "../services/verification-store.js";
-import type { WorkflowStore } from "../backends/workflow-store.js";
 import type { WriteAheadLog } from "../backends/wal.js";
+import type { WorkflowStore } from "../backends/workflow-store.js";
 import { ensureHybridMemoryWorkspaceSkillIfMissing, loadOpenclawRootForWorkspace } from "../cli/cmd-install.js";
 import type { HybridMemoryConfig, MemoryCategory } from "../config.js";
 import { getCronModelConfig, getDefaultCronModel } from "../config.js";
-import { createDashboardServer } from "../routes/dashboard-server.js";
 import type { DashboardServer } from "../routes/dashboard-server.js";
+import { createDashboardServer } from "../routes/dashboard-server.js";
 import { reconcileActiveTaskInProgressSessions } from "../services/active-task.js";
 import { runAutoClassify } from "../services/auto-classifier.js";
 import { syncCronLastRunFromGuards } from "../services/cron-guard.js";
@@ -42,18 +40,20 @@ import {
   deleteVectorsForFactIds,
   storeCanonicalVectorForFact,
 } from "../services/vector-maintenance.js";
+import type { VerificationStore } from "../services/verification-store.js";
 import { walRemove } from "../services/wal-helpers.js";
 import { parseDuration } from "../utils/duration.js";
 import { getEnv } from "../utils/env-manager.js";
 import { persistCanonicalFactEmbedding } from "../utils/fact-embeddings.js";
 import { getLanguageKeywordsFilePath } from "../utils/language-keywords.js";
+import { findPluginRoot } from "../utils/plugin-root.js";
 import {
-  type VersionCheckCacheEntry,
   fetchLatestPublishedVersion,
   isPluginOutdated,
   isVersionCheckCacheFresh,
   maybeLogOutdatedVersionNudge,
   readVersionCheckCache,
+  type VersionCheckCacheEntry,
   writeVersionCheckCache,
 } from "../utils/plugin-update-check.js";
 import { checkOpenClawVersion } from "../utils/version-check.js";
@@ -171,6 +171,10 @@ export function createPluginService(ctx: PluginServiceContext) {
       const expired = factsDb.countExpired();
       const versionCheckCachePath =
         resolvedSqlitePath === ":memory:" ? null : join(dirname(resolvedSqlitePath), ".latest-plugin-version.json");
+      const errorReportQueuePath =
+        resolvedSqlitePath === ":memory:"
+          ? undefined
+          : join(dirname(resolvedSqlitePath), ".error_reports.pending.jsonl");
       const errorReportingActive = cfg.errorReporting.enabled && cfg.errorReporting.consent;
       let cachedVersionCheck = versionCheckCachePath ? readVersionCheckCache(versionCheckCachePath) : null;
       api.logger.info(
@@ -254,6 +258,7 @@ export function createPluginService(ctx: PluginServiceContext) {
             botId: cfg.errorReporting.botId,
             botName: cfg.errorReporting.botName,
             resolvedIssues: cfg.errorReporting.resolvedIssues,
+            pendingQueuePath: errorReportQueuePath,
           },
           versionInfo.pluginVersion,
           api.logger,
@@ -960,9 +965,12 @@ export function createPluginService(ctx: PluginServiceContext) {
     },
     stop: async () => {
       shuttingDown = true;
-      // Flush any pending error reports before shutdown (non-blocking)
+      // Flush pending error reports with timeout so persisted queue replay can reduce dropped diagnostics.
       if (isErrorReporterActive()) {
-        flushErrorReporter(2000).catch(() => {});
+        const flushed = await flushErrorReporter(2000).catch(() => false);
+        if (!flushed) {
+          api.logger.warn("memory-hybrid: error reporter flush incomplete; pending reports will retry on next startup");
+        }
       }
       clearRuntimeTimers(timers);
       if (dashboardServer) {

--- a/extensions/memory-hybrid/tests/error-reporter-persistence.test.ts
+++ b/extensions/memory-hybrid/tests/error-reporter-persistence.test.ts
@@ -1,0 +1,152 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { setEnv } from "../utils/env-manager.js";
+
+type ErrorReporterModule = typeof import("../services/error-reporter.js");
+
+const fetchMock = vi.fn();
+vi.stubGlobal("fetch", fetchMock);
+
+function readQueueRecords(
+  queuePath: string,
+): Array<{ id: string; event: Record<string, unknown>; enqueuedAt: number }> {
+  if (!existsSync(queuePath)) return [];
+  const content = readFileSync(queuePath, "utf-8").trim();
+  if (!content) return [];
+  return content
+    .split("\n")
+    .map((line) => JSON.parse(line) as { id: string; event: Record<string, unknown>; enqueuedAt: number });
+}
+
+describe("error reporter persistent pending queue", () => {
+  let tempDir: string;
+  let queuePath: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "error-reporter-pending-"));
+    queuePath = join(tempDir, ".error_reports.pending.jsonl");
+    setEnv("ERROR_REPORTING_DSN", undefined);
+    setEnv("OPENCLAW_NODE_NAME", undefined);
+    fetchMock.mockReset();
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+    vi.clearAllMocks();
+  });
+
+  it("persists unsent reports when delivery fails", async () => {
+    fetchMock.mockRejectedValue(new Error("network down"));
+    const reporter = (await import("../services/error-reporter.js")) as ErrorReporterModule;
+
+    await reporter.initErrorReporter(
+      {
+        enabled: true,
+        consent: true,
+        mode: "community",
+        dsn: "https://testkey@example.com/1",
+        maxBreadcrumbs: 0,
+        sampleRate: 1,
+        pendingQueuePath: queuePath,
+      },
+      "test-build",
+    );
+
+    const eventId = reporter.capturePluginError(new Error("Persistent failure test"), {
+      operation: "queue-persist",
+      subsystem: "tests",
+    });
+
+    expect(eventId).toBeTruthy();
+    await expect(reporter.flushErrorReporter(500)).resolves.toBe(false);
+
+    const records = readQueueRecords(queuePath);
+    expect(records).toHaveLength(1);
+    expect(records[0].id).toBe(eventId);
+    expect((records[0].event.event_id as string) ?? "").toBe(eventId);
+  });
+
+  it("replays queued reports on next initialization", async () => {
+    fetchMock.mockRejectedValue(new Error("network down"));
+    let reporter = (await import("../services/error-reporter.js")) as ErrorReporterModule;
+
+    await reporter.initErrorReporter(
+      {
+        enabled: true,
+        consent: true,
+        mode: "community",
+        dsn: "https://testkey@example.com/1",
+        maxBreadcrumbs: 0,
+        sampleRate: 1,
+        pendingQueuePath: queuePath,
+      },
+      "test-build",
+    );
+
+    reporter.capturePluginError(new Error("Replay me after restart"), {
+      operation: "queue-replay",
+      subsystem: "tests",
+    });
+    await expect(reporter.flushErrorReporter(500)).resolves.toBe(false);
+    expect(readQueueRecords(queuePath)).toHaveLength(1);
+
+    vi.resetModules();
+    fetchMock.mockReset();
+    fetchMock.mockResolvedValue({ ok: true, status: 200, text: async () => "" });
+
+    reporter = (await import("../services/error-reporter.js")) as ErrorReporterModule;
+    await reporter.initErrorReporter(
+      {
+        enabled: true,
+        consent: true,
+        mode: "community",
+        dsn: "https://testkey@example.com/1",
+        maxBreadcrumbs: 0,
+        sampleRate: 1,
+        pendingQueuePath: queuePath,
+      },
+      "test-build",
+    );
+
+    await expect(reporter.flushErrorReporter(1000)).resolves.toBe(true);
+    expect(fetchMock).toHaveBeenCalled();
+    expect(readQueueRecords(queuePath)).toHaveLength(0);
+  });
+
+  it("prunes oldest reports when pending queue exceeds cap", async () => {
+    fetchMock.mockRejectedValue(new Error("network down"));
+    const reporter = (await import("../services/error-reporter.js")) as ErrorReporterModule;
+
+    await reporter.initErrorReporter(
+      {
+        enabled: true,
+        consent: true,
+        mode: "community",
+        dsn: "https://testkey@example.com/1",
+        maxBreadcrumbs: 0,
+        sampleRate: 1,
+        pendingQueuePath: queuePath,
+        maxPendingReports: 2,
+      },
+      "test-build",
+    );
+
+    reporter.capturePluginError(new Error("pending-1"), { operation: "queue-prune-1", subsystem: "tests" });
+    reporter.capturePluginError(new Error("pending-2"), { operation: "queue-prune-2", subsystem: "tests" });
+    reporter.capturePluginError(new Error("pending-3"), { operation: "queue-prune-3", subsystem: "tests" });
+
+    await expect(reporter.flushErrorReporter(1000)).resolves.toBe(false);
+    const records = readQueueRecords(queuePath);
+    expect(records).toHaveLength(2);
+    const messages = records
+      .map((record) => {
+        const exception = (record.event.exception as { values?: Array<{ value?: string }> } | undefined)?.values?.[0];
+        return exception?.value ?? "";
+      })
+      .sort();
+    expect(messages).toEqual(["pending-2", "pending-3"]);
+  });
+});

--- a/extensions/memory-hybrid/tests/wal.test.ts
+++ b/extensions/memory-hybrid/tests/wal.test.ts
@@ -57,6 +57,7 @@ import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { _testing } from "../index.js";
+import { pluginLogger } from "../utils/logger.js";
 
 const { WriteAheadLog } = _testing;
 
@@ -93,6 +94,18 @@ describe("WriteAheadLog", () => {
       await nestedWal.init();
       expect(existsSync(join(testDir, "nested", "dir"))).toBe(true);
       await nestedWal.clear(); // cleanup
+    });
+
+    it("logs init load failures instead of silently swallowing them", async () => {
+      const localWal = new WriteAheadLog(walPath, DEFAULT_MAX_AGE_MS);
+      const readAllSpy = vi.spyOn(localWal, "readAll").mockRejectedValue(new Error("simulated init read failure"));
+      const warnSpy = vi.spyOn(pluginLogger, "warn").mockImplementation(() => {});
+
+      await localWal.init();
+
+      expect(readAllSpy).toHaveBeenCalledOnce();
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("WAL init: failed to load active IDs"));
+      warnSpy.mockRestore();
     });
   });
 


### PR DESCRIPTION
## Summary
6:WAL error reporter — queue failure prevention, pending error persistence, init visibility

## Verification
- npm test
- CI green

## Next owner
Manual review

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes telemetry delivery and shutdown timing (disk-backed queue beside the DB); events remain sanitized but failed sends now persist until replay or prune.
> 
> **Overview**
> This PR hardens **crash diagnostics** and **WAL startup** behavior in `memory-hybrid`.
> 
> The GlitchTip error reporter no longer drops in-flight reports when `fetch` fails or shutdown is too fast. It **writes sanitized events to a JSONL queue** next to the SQLite DB (`.error_reports.pending.jsonl`), **replays on startup**, **acks after successful delivery**, and **prunes oldest entries** when over cap (default 200). `flush()` now succeeds only when in-flight work settles **and** the persistent queue is empty; plugin shutdown **awaits flush** and logs if incomplete.
> 
> **WAL `init()`** now reports failures loading active IDs via `capturePluginError` and `pluginLogger.warn` instead of a silent empty set.
> 
> Tests cover queue persist/replay/prune and WAL init warning behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b893f6f92dc272fe470a3def1ba2396ff95782cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->