### PR TITLE
fix

### DIFF
--- a/extensions/memory-hybrid/README.md
+++ b/extensions/memory-hybrid/README.md
@@ -237,6 +237,16 @@ openclaw hybrid-mem vectordb-health
 openclaw hybrid-mem vectordb-health --json
 ```
 
+Vector search and semantic-cache result materialization are bounded at runtime to prevent unbounded
+Arrow/Lance memory use under heavy recall workloads. The defaults can be tuned via environment
+variables:
+
+| Variable | Default | Min | Max | Description |
+|---|---|---|---|---|
+| `OPENCLAW_HYBRID_MEM_VECTOR_QUERY_MAX_RESULTS` | `200` | `10` | `5000` | Hard ceiling for rows fetched per vector search call |
+| `OPENCLAW_HYBRID_MEM_SEMANTIC_CACHE_MAX_ROWS_PER_FILTER_KEY` | `100` | `10` | `5000` | Per-filter cap for semantic query cache rows |
+| `OPENCLAW_HYBRID_MEM_SEMANTIC_CACHE_CANDIDATE_LIMIT_MAX` | `200` | `10` | `5000` | Upper bound for candidate vectors loaded per cache lookup |
+
 `hybrid-mem stats` and `hybrid-mem health` now also surface decay stickiness (`stable+permanent`) and guidance to run `decay reclassify --dry-run --stable-only` when legacy ratios are high.
 
 ## Weekly pending digest (#1197)

--- a/extensions/memory-hybrid/README.md
+++ b/extensions/memory-hybrid/README.md
@@ -230,6 +230,15 @@ openclaw hybrid-mem audit health --strict
 
 The JSON output is versioned (`schemaVersion: 1`) for dashboards and automation. The report surfaces tier sanity, category drift, vectorless active facts, validated-but-unpromoted procedures, implicit-feedback signal noise, and remediation hints. `--strict` exits `2` when warnings/errors are present; JSON includes `exitCode`, `exitReason`, `warningCount`, and `errorCount` so cron/automation can treat strict health failures differently from command crashes. The installer also publishes a weekly `hybrid-mem:weekly-audit-health` cron step that runs `openclaw hybrid-mem audit health --strict --json`.
 
+For LanceDB/Arrow/native RSS diagnostics, run:
+
+```bash
+openclaw hybrid-mem vectordb-health
+openclaw hybrid-mem vectordb-health --json
+```
+
+`hybrid-mem stats` and `hybrid-mem health` now also surface decay stickiness (`stable+permanent`) and guidance to run `decay reclassify --dry-run --stable-only` when legacy ratios are high.
+
 ## Weekly pending digest (#1197)
 
 Render an at-a-glance backlog of approve/decline/defer actions across persona proposals,

--- a/extensions/memory-hybrid/backends/vector-db/constants.ts
+++ b/extensions/memory-hybrid/backends/vector-db/constants.ts
@@ -1,6 +1,46 @@
+import { getEnv } from "../../utils/env-manager.js";
+
+function parseBoundedPositiveIntEnv(name: string, fallback: number, min: number, max: number): number {
+  const raw = getEnv(name);
+  if (!raw) return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed)) return fallback;
+  return Math.max(min, Math.min(max, Math.floor(parsed)));
+}
+
 export const LANCE_TABLE = "memories";
 export const SEMANTIC_QUERY_CACHE_TABLE = "semantic_query_cache";
-export const SEMANTIC_QUERY_CACHE_MAX_ROWS_PER_FILTER_KEY = 100;
+/**
+ * Per-filter cap for semantic query cache rows.
+ * Operator override: OPENCLAW_HYBRID_MEM_SEMANTIC_CACHE_MAX_ROWS_PER_FILTER_KEY.
+ */
+export const SEMANTIC_QUERY_CACHE_MAX_ROWS_PER_FILTER_KEY = parseBoundedPositiveIntEnv(
+  "OPENCLAW_HYBRID_MEM_SEMANTIC_CACHE_MAX_ROWS_PER_FILTER_KEY",
+  100,
+  10,
+  5000,
+);
+/**
+ * Upper bound for semantic-query-cache candidate vectors loaded per lookup.
+ * Operator override: OPENCLAW_HYBRID_MEM_SEMANTIC_CACHE_CANDIDATE_LIMIT_MAX.
+ */
+export const SEMANTIC_QUERY_CACHE_CANDIDATE_LIMIT_MAX = parseBoundedPositiveIntEnv(
+  "OPENCLAW_HYBRID_MEM_SEMANTIC_CACHE_CANDIDATE_LIMIT_MAX",
+  200,
+  10,
+  5000,
+);
+/**
+ * Hard ceiling for rows fetched per vector search call.
+ * Operator override: OPENCLAW_HYBRID_MEM_VECTOR_QUERY_MAX_RESULTS.
+ * Keeps Arrow/Lance result materialization bounded under recall-heavy workloads.
+ */
+export const VECTOR_QUERY_MAX_RESULTS = parseBoundedPositiveIntEnv(
+  "OPENCLAW_HYBRID_MEM_VECTOR_QUERY_MAX_RESULTS",
+  200,
+  10,
+  5000,
+);
 export const VECTOR_BULK_DELETE_IN_CHUNK = 200;
 
 export type VectorDBLogger = { warn: (msg: string) => void };

--- a/extensions/memory-hybrid/backends/vector-db/vector-db-class.ts
+++ b/extensions/memory-hybrid/backends/vector-db/vector-db-class.ts
@@ -32,9 +32,11 @@ import {
   LANCE_TABLE,
   optimizeFailuresByPath,
   optimizingByPath,
+  SEMANTIC_QUERY_CACHE_CANDIDATE_LIMIT_MAX,
   SEMANTIC_QUERY_CACHE_MAX_ROWS_PER_FILTER_KEY,
   SEMANTIC_QUERY_CACHE_TABLE,
   type SemanticQueryCacheEntry,
+  VECTOR_QUERY_MAX_RESULTS,
   VECTOR_BULK_DELETE_IN_CHUNK,
   type VectorDBLogger,
 } from "./constants.js";
@@ -108,6 +110,46 @@ export class VectorDB {
     active: false,
     reason: null,
     sinceEpochMs: null,
+  };
+  /** Lightweight vector-search concurrency/limit observability for operator diagnostics. */
+  private searchTelemetry: {
+    active: number;
+    peak: number;
+    total: number;
+    lastRequestedLimit: number;
+    lastEffectiveLimit: number;
+    lastResultCount: number;
+    lastCompletedAtEpochMs: number | null;
+  } = {
+    active: 0,
+    peak: 0,
+    total: 0,
+    lastRequestedLimit: 0,
+    lastEffectiveLimit: 0,
+    lastResultCount: 0,
+    lastCompletedAtEpochMs: null,
+  };
+  /** Last semantic-query-cache prune summary, so operators can see cache churn behavior. */
+  private semanticQueryCachePruneTelemetry: {
+    lastFilterKey: string | null;
+    lastRemovedRows: number;
+    lastPrunedAtEpochMs: number | null;
+  } = {
+    lastFilterKey: null,
+    lastRemovedRows: 0,
+    lastPrunedAtEpochMs: null,
+  };
+  /** Last successful optimize() run result for observability surfaces. */
+  private lastOptimizeTelemetry: {
+    ranAtEpochMs: number | null;
+    compacted: number;
+    removedFragments: number;
+    freedBytes: number;
+  } = {
+    ranAtEpochMs: null,
+    compacted: 0,
+    removedFragments: 0,
+    freedBytes: 0,
   };
   /**
    * When true, this VectorDB is a long-lived singleton connection (set via setPersistent()).
@@ -233,6 +275,22 @@ export class VectorDB {
     if (!acquired) return;
     const current = VectorDB._activeReadersByPath.get(this.dbPath) ?? 1;
     VectorDB._activeReadersByPath.set(this.dbPath, Math.max(0, current - 1));
+  }
+
+  private beginSearch(requestedLimit: number, effectiveLimit: number): void {
+    this.searchTelemetry.active += 1;
+    this.searchTelemetry.total += 1;
+    this.searchTelemetry.lastRequestedLimit = requestedLimit;
+    this.searchTelemetry.lastEffectiveLimit = effectiveLimit;
+    if (this.searchTelemetry.active > this.searchTelemetry.peak) {
+      this.searchTelemetry.peak = this.searchTelemetry.active;
+    }
+  }
+
+  private endSearch(resultCount: number): void {
+    this.searchTelemetry.active = Math.max(0, this.searchTelemetry.active - 1);
+    this.searchTelemetry.lastResultCount = Math.max(0, resultCount);
+    this.searchTelemetry.lastCompletedAtEpochMs = Date.now();
   }
 
   /**
@@ -1115,6 +1173,11 @@ export class VectorDB {
       const idList = chunk.map((row) => `'${this.escapeSqlString(row.id)}'`).join(", ");
       await table.delete(`id IN (${idList})`);
     }
+    this.semanticQueryCachePruneTelemetry = {
+      lastFilterKey: filterKey,
+      lastRemovedRows: staleRows.length,
+      lastPrunedAtEpochMs: Date.now(),
+    };
   }
 
   async getSemanticQueryCacheMatch(
@@ -1131,7 +1194,7 @@ export class VectorDB {
       const ttlSec = Math.max(1, Math.floor((options.ttlMs ?? 5 * 60 * 1000) / 1000));
       const filterKey = options.filterKey ?? "default";
       const rawCandidate = options.candidateLimit ?? 25;
-      const candidateLimit = Math.max(1, Math.min(LANCE_VECTOR_SEARCH_MAX_LIMIT, Math.floor(rawCandidate)));
+      const candidateLimit = Math.max(1, Math.min(SEMANTIC_QUERY_CACHE_CANDIDATE_LIMIT_MAX, Math.floor(rawCandidate)));
 
       // Dimension pre-check: prevent LanceDB "No vector column found" errors on fallback query mismatch
       if (vector.length !== this.vectorDim) return null;
@@ -1450,11 +1513,18 @@ export class VectorDB {
         const table = this.getTable();
         const cleanupOlderThan = new Date(Date.now() - olderThanMs);
         const stats = await table.optimize({ cleanupOlderThan });
-        return {
+        const out = {
           compacted: stats.compaction?.fragmentsRemoved ?? 0,
           removedFragments: stats.prune?.oldVersionsRemoved ?? 0,
           freedBytes: stats.prune?.bytesRemoved ?? 0,
         };
+        this.lastOptimizeTelemetry = {
+          ranAtEpochMs: Date.now(),
+          compacted: out.compacted,
+          removedFragments: out.removedFragments,
+          freedBytes: out.freedBytes,
+        };
+        return out;
       } finally {
         VectorDB._optimizeExclusiveLockByPath.set(this.dbPath, false);
         optimizingByPath.set(this.dbPath, false);
@@ -1496,11 +1566,13 @@ export class VectorDB {
       }
       this.lastSearchFailReason = null;
       const rawLimit = Number.isFinite(limit) ? Math.floor(limit) : 5;
-      const safeLimit = Math.max(1, Math.min(LANCE_VECTOR_SEARCH_MAX_LIMIT, rawLimit));
+      const safeLimit = Math.max(1, Math.min(LANCE_VECTOR_SEARCH_MAX_LIMIT, VECTOR_QUERY_MAX_RESULTS, rawLimit));
+      this.beginSearch(rawLimit, safeLimit);
       const acquired = this.acquireReader();
+      let filteredCount = 0;
       try {
         const results = await this.getTable().vectorSearch(vector).limit(safeLimit).toArray();
-        return results
+        const filtered = results
           .map((row) => {
             const distance = row._distance ?? 0;
             const score = 1 / (1 + distance);
@@ -1533,7 +1605,10 @@ export class VectorDB {
             };
           })
           .filter((r) => r.score >= minScore);
+        filteredCount = filtered.length;
+        return filtered;
       } finally {
+        this.endSearch(filteredCount);
         this.releaseReader(acquired);
       }
     } catch (err) {
@@ -1749,6 +1824,44 @@ export class VectorDB {
         subsystem: "vector",
       });
       this.logWarn(`memory-hybrid: LanceDB count failed: ${err}`);
+      return 0;
+    }
+  }
+
+  async countSemanticQueryCacheRows(): Promise<number> {
+    try {
+      if (!this.lanceDbAvailable && this.lanceInitFailed) return 0;
+      await this.ensureInitialized();
+      if (!this.lanceDbAvailable || this.lanceInitFailed) return 0;
+      const cacheTable = this.getSemanticQueryCacheTable();
+      if (!cacheTable) return 0;
+      const acquired = this.acquireReader();
+      try {
+        const countPromise = cacheTable.countRows();
+        const count = await withTimeout(VECTORDB_COUNT_TIMEOUT_MS, () => countPromise);
+        if (count === null) {
+          this.logWarn(
+            `memory-hybrid: semantic query cache count timed out after ${VECTORDB_COUNT_TIMEOUT_MS}ms`,
+          );
+          void countPromise.then(
+            () => {},
+            (countErr) => {
+              this.logWarn(`memory-hybrid: semantic query cache count failed after timing out: ${countErr}`);
+            },
+          );
+          return 0;
+        }
+        return count;
+      } finally {
+        this.releaseReader(acquired);
+      }
+    } catch (err) {
+      capturePluginError(err instanceof Error ? err : new Error(String(err)), {
+        operation: "vector-semantic-query-cache-count",
+        severity: "info",
+        subsystem: "vector",
+      });
+      this.logWarn(`memory-hybrid: semantic query cache count failed: ${err}`);
       return 0;
     }
   }
@@ -1979,6 +2092,7 @@ export class VectorDB {
     this.lanceInitFailed = false;
     this.lanceDbAvailable = true;
     this.clearDegradedState("closed");
+    this.searchTelemetry.active = 0;
     this.table = null;
     this.semanticQueryCacheTable = null;
     this.shadowTableCache.clear();
@@ -2016,6 +2130,89 @@ export class VectorDB {
    */
   getCloseGeneration(): number {
     return this.closeGeneration;
+  }
+
+  /** LanceDB root path for this backend instance. */
+  getPath(): string {
+    return this.dbPath;
+  }
+
+  /** Number of successful store() calls observed in this process lifetime. */
+  getStoreCount(): number {
+    return this.storeCount;
+  }
+
+  /** Number incremented each time this instance is force-closed and re-opened. */
+  getInitGeneration(): number {
+    return this.initGeneration;
+  }
+
+  /** Reader slots currently held for this Lance path (search/count/getVectors, etc.). */
+  getOpenReaderCount(): number {
+    return VectorDB._activeReadersByPath.get(this.dbPath) ?? 0;
+  }
+
+  /** True while optimize() holds/awaits the exclusive maintenance lock for this path. */
+  isOptimizing(): boolean {
+    return optimizingByPath.get(this.dbPath) === true;
+  }
+
+  /** True when a live db/table handle exists and the instance is not closed/degraded-init-failed. */
+  isInitialized(): boolean {
+    return !this.closed && this.db != null && this.table != null && !this.lanceInitFailed;
+  }
+
+  /** Lightweight search telemetry for diagnostics/health surfaces. */
+  getSearchTelemetry(): {
+    active: number;
+    peak: number;
+    total: number;
+    lastRequestedLimit: number;
+    lastEffectiveLimit: number;
+    lastResultCount: number;
+    lastCompletedAtEpochMs: number | null;
+  } {
+    return { ...this.searchTelemetry };
+  }
+
+  /** Runtime cache bounds + latest prune event. */
+  getSemanticQueryCacheTelemetry(): {
+    maxRowsPerFilterKey: number;
+    candidateLimitMax: number;
+    lastFilterKey: string | null;
+    lastRemovedRows: number;
+    lastPrunedAtEpochMs: number | null;
+  } {
+    return {
+      maxRowsPerFilterKey: SEMANTIC_QUERY_CACHE_MAX_ROWS_PER_FILTER_KEY,
+      candidateLimitMax: SEMANTIC_QUERY_CACHE_CANDIDATE_LIMIT_MAX,
+      lastFilterKey: this.semanticQueryCachePruneTelemetry.lastFilterKey,
+      lastRemovedRows: this.semanticQueryCachePruneTelemetry.lastRemovedRows,
+      lastPrunedAtEpochMs: this.semanticQueryCachePruneTelemetry.lastPrunedAtEpochMs,
+    };
+  }
+
+  /** Last successful optimize() result snapshot. */
+  getLastOptimizeTelemetry(): {
+    ranAtEpochMs: number | null;
+    compacted: number;
+    removedFragments: number;
+    freedBytes: number;
+  } {
+    return { ...this.lastOptimizeTelemetry };
+  }
+
+  /** Effective process-level safety bounds for Lance/Arrow result materialization. */
+  getRuntimeBounds(): {
+    vectorSearchMaxResults: number;
+    semanticCacheMaxRowsPerFilterKey: number;
+    semanticCacheCandidateLimitMax: number;
+  } {
+    return {
+      vectorSearchMaxResults: VECTOR_QUERY_MAX_RESULTS,
+      semanticCacheMaxRowsPerFilterKey: SEMANTIC_QUERY_CACHE_MAX_ROWS_PER_FILTER_KEY,
+      semanticCacheCandidateLimitMax: SEMANTIC_QUERY_CACHE_CANDIDATE_LIMIT_MAX,
+    };
   }
 
   /** Returns the reason code from the last search() that returned early, or null if search completed normally. */

--- a/extensions/memory-hybrid/backends/vector-db/vector-db-class.ts
+++ b/extensions/memory-hybrid/backends/vector-db/vector-db-class.ts
@@ -1840,9 +1840,7 @@ export class VectorDB {
         const countPromise = cacheTable.countRows();
         const count = await withTimeout(VECTORDB_COUNT_TIMEOUT_MS, () => countPromise);
         if (count === null) {
-          this.logWarn(
-            `memory-hybrid: semantic query cache count timed out after ${VECTORDB_COUNT_TIMEOUT_MS}ms`,
-          );
+          this.logWarn(`memory-hybrid: semantic query cache count timed out after ${VECTORDB_COUNT_TIMEOUT_MS}ms`);
           void countPromise.then(
             () => {},
             (countErr) => {

--- a/extensions/memory-hybrid/backends/vector-db/vector-db-class.ts
+++ b/extensions/memory-hybrid/backends/vector-db/vector-db-class.ts
@@ -2135,16 +2135,6 @@ export class VectorDB {
     return this.dbPath;
   }
 
-  /** Number of successful store() calls observed in this process lifetime. */
-  getStoreCount(): number {
-    return this.storeCount;
-  }
-
-  /** Number incremented each time this instance is force-closed and re-opened. */
-  getInitGeneration(): number {
-    return this.initGeneration;
-  }
-
   /** Reader slots currently held for this Lance path (search/count/getVectors, etc.). */
   getOpenReaderCount(): number {
     return VectorDB._activeReadersByPath.get(this.dbPath) ?? 0;

--- a/extensions/memory-hybrid/cli/cmd-health.ts
+++ b/extensions/memory-hybrid/cli/cmd-health.ts
@@ -203,6 +203,78 @@ export function registerHealthCommand(
         }
       }
 
+      // Decay profile guidance (Issue #1582).
+      try {
+        const decayBreakdown =
+          typeof (factsDb as { statsBreakdownByDecayClass?: unknown }).statsBreakdownByDecayClass === "function"
+            ? (
+                factsDb as {
+                  statsBreakdownByDecayClass: () => Record<string, number>;
+                }
+              ).statsBreakdownByDecayClass()
+            : null;
+        if (decayBreakdown) {
+          const total = Object.values(decayBreakdown).reduce((sum, count) => sum + count, 0);
+          const stablePermanent = (decayBreakdown.stable ?? 0) + (decayBreakdown.permanent ?? 0);
+          const ratio = total > 0 ? stablePermanent / total : 0;
+          if (ratio > 0.6) {
+            indicators.push({
+              name: "Decay Profile",
+              status: "warn",
+              detail: `stable+permanent ${(ratio * 100).toFixed(1)}% — run: openclaw hybrid-mem decay reclassify --dry-run --stable-only`,
+            });
+          } else {
+            indicators.push({
+              name: "Decay Profile",
+              status: "good",
+              detail: `stable+permanent ${(ratio * 100).toFixed(1)}%`,
+            });
+          }
+        }
+      } catch (_error) {
+        indicators.push({
+          name: "Decay Profile",
+          status: "warn",
+          detail: "Could not inspect decay distribution",
+        });
+      }
+
+      // Vector bounds visibility (Issue #1554).
+      try {
+        const bounds =
+          typeof (vectorDb as { getRuntimeBounds?: unknown }).getRuntimeBounds === "function"
+            ? (
+                vectorDb as {
+                  getRuntimeBounds: () => {
+                    vectorSearchMaxResults: number;
+                    semanticCacheMaxRowsPerFilterKey: number;
+                    semanticCacheCandidateLimitMax: number;
+                  };
+                }
+              ).getRuntimeBounds()
+            : null;
+        if (bounds) {
+          indicators.push({
+            name: "Vector Bounds",
+            status: "good",
+            detail: `search<=${bounds.vectorSearchMaxResults}, cacheRows<=${bounds.semanticCacheMaxRowsPerFilterKey}, cacheCandidates<=${bounds.semanticCacheCandidateLimitMax}`,
+          });
+        } else {
+          indicators.push({
+            name: "Vector Bounds",
+            status: "warn",
+            detail: "Runtime bounds unavailable",
+          });
+        }
+      } catch (_error) {
+        indicators.push({
+          name: "Vector Bounds",
+          status: "warn",
+          detail: "Could not inspect vector bounds",
+        });
+      }
+      }
+
       // JSON output
       if (opts.json) {
         console.log(

--- a/extensions/memory-hybrid/cli/commands/manage/register-storage-entities-decay.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/register-storage-entities-decay.ts
@@ -76,11 +76,44 @@ export function registerManageStorageEntitiesDecay(mem: Chainable, b: ManageBind
   mem
     .command("backfill-decay")
     .description("Backfill legacy stable decay classes (compat alias for decay reclassify --stable-only --apply)")
+    .option("--json", "Emit JSON")
     .action(
-      withExit(async () => {
+      withExit(async (opts?: { json?: boolean }) => {
+        const before = factsDb.statsBreakdownByDecayClass();
         const updated = factsDb.backfillDecay();
+        const after = factsDb.statsBreakdownByDecayClass();
         const total = Object.values(updated).reduce((a, b) => a + b, 0);
+        const totalBefore = Object.values(before).reduce((sum, count) => sum + count, 0);
+        const totalAfter = Object.values(after).reduce((sum, count) => sum + count, 0);
+        const stablePermanentBefore = (before.stable ?? 0) + (before.permanent ?? 0);
+        const stablePermanentAfter = (after.stable ?? 0) + (after.permanent ?? 0);
+        const report = {
+          changed: total,
+          transitionsByTargetDecayClass: updated,
+          before,
+          after,
+          stablePermanentBefore,
+          stablePermanentAfter,
+          stablePermanentRatioBefore: totalBefore > 0 ? stablePermanentBefore / totalBefore : 0,
+          stablePermanentRatioAfter: totalAfter > 0 ? stablePermanentAfter / totalAfter : 0,
+        };
+        if (opts?.json) {
+          console.log(JSON.stringify(report, null, 2));
+          return;
+        }
         console.log(`Backfilled decayAt for ${total} facts.`);
+        console.log(
+          `Stable+permanent before: ${stablePermanentBefore} (${(report.stablePermanentRatioBefore * 100).toFixed(1)}%)`,
+        );
+        console.log(
+          `Stable+permanent after: ${stablePermanentAfter} (${(report.stablePermanentRatioAfter * 100).toFixed(1)}%)`,
+        );
+        if (Object.keys(updated).length > 0) {
+          console.log("Reclassifications:");
+          for (const [decayClass, count] of Object.entries(updated)) {
+            console.log(`  stable->${decayClass}: ${count}`);
+          }
+        }
       }),
     );
 

--- a/extensions/memory-hybrid/cli/commands/manage/register-storage-entities-decay.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/register-storage-entities-decay.ts
@@ -101,7 +101,7 @@ export function registerManageStorageEntitiesDecay(mem: Chainable, b: ManageBind
           console.log(JSON.stringify(report, null, 2));
           return;
         }
-        console.log(`Backfilled decayAt for ${total} facts.`);
+        console.log(`Backfilled decay classes and expires_at for ${total} facts.`);
         console.log(
           `Stable+permanent before: ${stablePermanentBefore} (${(report.stablePermanentRatioBefore * 100).toFixed(1)}%)`,
         );

--- a/extensions/memory-hybrid/cli/commands/manage/register-storage-maintenance.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/register-storage-maintenance.ts
@@ -436,7 +436,9 @@ export function registerManageStorageMaintenance(mem: Chainable, b: ManageBindin
           const decayParts = Object.entries(decayBreakdown).sort((a, b) => b[1] - a[1]);
           if (decayParts.length > 0) {
             const summary = decayParts
-              .map(([k, v]) => `${k}=${v} (${activeDecayTotal > 0 ? ((v / activeDecayTotal) * 100).toFixed(1) : "0.0"}%)`)
+              .map(
+                ([k, v]) => `${k}=${v} (${activeDecayTotal > 0 ? ((v / activeDecayTotal) * 100).toFixed(1) : "0.0"}%)`,
+              )
               .join(", ");
             console.log(`Breakdown by decay: ${summary}`);
             console.log(

--- a/extensions/memory-hybrid/cli/commands/manage/register-storage-maintenance.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/register-storage-maintenance.ts
@@ -9,6 +9,10 @@ import { capturePluginError } from "../../../services/error-reporter.js";
 import { recordMaintenanceTimestamp } from "../../../services/maintenance-timestamp.js";
 import { countPendingReviewBacklogs } from "../../../services/pending-review-digest.js";
 import { deleteVectorsForFactIds } from "../../../services/vector-maintenance.js";
+import {
+  type VectorBackendObservability,
+  collectVectorBackendObservability,
+} from "../../../services/vector-backend-observability.js";
 import { appendVectorLifecycleAuditEvent } from "../../../services/vector-lifecycle-audit.js";
 import { getEnv } from "../../../utils/env-manager.js";
 import { type CommanderOptsParent, readHybridMemVerbose } from "../../global-verbose.js";
@@ -23,6 +27,68 @@ import {
   recordStorageGrowthSample,
   writeReindexCheckpoint,
 } from "./storage-stats-helpers.js";
+
+function formatMiB(bytes: number | null | undefined): string {
+  if (bytes == null || !Number.isFinite(bytes)) return "n/a";
+  return `${(bytes / 1024 / 1024).toFixed(2)} MB`;
+}
+
+function formatAgo(epochMs: number | null | undefined): string {
+  if (epochMs == null || !Number.isFinite(epochMs)) return "never";
+  const deltaSec = Math.max(0, Math.floor((Date.now() - epochMs) / 1000));
+  if (deltaSec < 60) return `${deltaSec}s ago`;
+  if (deltaSec < 3600) return `${Math.floor(deltaSec / 60)}m ago`;
+  if (deltaSec < 86400) return `${Math.floor(deltaSec / 3600)}h ago`;
+  return `${Math.floor(deltaSec / 86400)}d ago`;
+}
+
+function printVectorBackendObservabilitySummary(obs: VectorBackendObservability): void {
+  const mem = obs.memory;
+  console.log("Vector/native observability:");
+  console.log(
+    `  RSS=${formatMiB(mem.rssBytes)} heapUsed=${formatMiB(mem.heapUsedBytes)} external=${formatMiB(mem.externalBytes)} arrayBuffers=${formatMiB(mem.arrayBuffersBytes)} native≈${formatMiB(mem.nativeRssEstimateBytes)}`,
+  );
+  if (mem.procStatus) {
+    console.log(
+      `  /proc VmRSS=${mem.procStatus.vmRssKb ?? "?"}kB RssAnon=${mem.procStatus.rssAnonKb ?? "?"}kB RssFile=${mem.procStatus.rssFileKb ?? "?"}kB RssShmem=${mem.procStatus.rssShmemKb ?? "?"}kB VmSwap=${mem.procStatus.vmSwapKb ?? "?"}kB`,
+    );
+  }
+  if (obs.fileDescriptors) {
+    const fd = obs.fileDescriptors;
+    console.log(
+      `  FDs total=${fd.total} lancedb=${fd.byGroup.lancedb} sqlite=${fd.byGroup.sqlite} wal=${fd.byGroup.wal} shm=${fd.byGroup.shm} socket=${fd.byGroup.socket} anon=${fd.byGroup.anon}`,
+    );
+  }
+  const v = obs.vectorDb;
+  if (v.path) console.log(`  LanceDB path: ${v.path}`);
+  if (v.bounds) {
+    console.log(
+      `  Bounds: vectorSearchMaxResults=${v.bounds.vectorSearchMaxResults} semanticCacheMaxRowsPerFilterKey=${v.bounds.semanticCacheMaxRowsPerFilterKey} semanticCacheCandidateLimitMax=${v.bounds.semanticCacheCandidateLimitMax}`,
+    );
+  }
+  if (v.search) {
+    console.log(
+      `  Search activity: active=${v.search.active} peak=${v.search.peak} total=${v.search.total} lastResult=${v.search.lastResultCount} limit=${v.search.lastEffectiveLimit}/${v.search.lastRequestedLimit} last=${formatAgo(v.search.lastCompletedAtEpochMs)}`,
+    );
+  }
+  if (v.cache) {
+    console.log(
+      `  Semantic cache: rows=${v.cache.rows ?? "n/a"} cap=${v.cache.maxRowsPerFilterKey} candidateCap=${v.cache.candidateLimitMax} lastPruneRemoved=${v.cache.lastRemovedRows} lastPrune=${formatAgo(v.cache.lastPrunedAtEpochMs)}`,
+    );
+  }
+  if (v.lastOptimize) {
+    console.log(
+      `  Last optimize: ${formatAgo(v.lastOptimize.ranAtEpochMs)} compacted=${v.lastOptimize.compacted} pruned=${v.lastOptimize.removedFragments} freed=${v.lastOptimize.freedBytes} bytes`,
+    );
+  }
+  if (obs.lancedb.tables.length > 0) {
+    for (const table of obs.lancedb.tables) {
+      console.log(
+        `  Table ${table.name}: rows=${table.rowCount ?? "n/a"} size=${formatMiB(table.sizeBytes)} path=${table.path}${table.sizeScanTruncated ? " (size scan truncated)" : ""}`,
+      );
+    }
+  }
+}
 
 export function registerManageStorageMaintenance(mem: Chainable, b: ManageBindings): void {
   const {
@@ -126,6 +192,35 @@ export function registerManageStorageMaintenance(mem: Chainable, b: ManageBindin
     );
 
   mem
+    .command("vectordb-health")
+    .description(
+      "Low-cost LanceDB/Arrow/native memory health snapshot (RSS/native estimate, FD groups, cache/search bounds, table rows/sizes)",
+    )
+    .option("--json", "Emit JSON")
+    .action(
+      withExit(async (opts?: { json?: boolean }) => {
+        let lanceBytes: number | null = null;
+        try {
+          const sizes = await Promise.resolve(ctx.richStatsExtras?.getStorageSizes());
+          if (sizes && typeof sizes.lanceBytes === "number") lanceBytes = sizes.lanceBytes;
+        } catch {
+          // keep observability cheap/best-effort; omit lanceBytes on failure
+        }
+        const observability = await collectVectorBackendObservability({
+          vectorDb,
+          resolvedLancePath: ctx.resolvedLancePath,
+          lanceBytes,
+        });
+        if (opts?.json) {
+          console.log(JSON.stringify(observability, null, 2));
+          return;
+        }
+        console.log("=== Vector Backend Health ===");
+        printVectorBackendObservabilitySummary(observability);
+      }),
+    );
+
+  mem
     .command("record-storage-sample")
     .description(
       "Record one storage_growth_history row per UTC day (SQLite + Lance sizes). Use with daily cron so audit-health can compute 7d deltas.",
@@ -220,6 +315,9 @@ export function registerManageStorageMaintenance(mem: Chainable, b: ManageBindin
           const verifiedFacts = factsDb.countVerifiedFacts();
           const activity = factsDb.recentActivity();
           const decayBreakdown = factsDb.statsBreakdownByDecayClass();
+          const activeDecayTotal = Object.values(decayBreakdown).reduce((sum, count) => sum + count, 0);
+          const stablePermanentCount = (decayBreakdown.stable ?? 0) + (decayBreakdown.permanent ?? 0);
+          const stablePermanentRatio = activeDecayTotal > 0 ? stablePermanentCount / activeDecayTotal : 0;
           const sourceBreakdown = factsDb.statsBySource();
           const dailyWrites = factsDb.statsDailyWrites().slice(0, 10);
           const implicitFeedbackSignals = countImplicitFeedbackTrajectorySignals(factsDb);
@@ -335,10 +433,21 @@ export function registerManageStorageMaintenance(mem: Chainable, b: ManageBindin
           console.log(
             `Breakdown by tier: hot=${breakdown.hot}, warm=${breakdown.warm}, cold=${breakdown.cold}, structural=${breakdown.structural ?? 0}`,
           );
-          const decayParts = Object.entries(decayBreakdown)
-            .map(([k, v]) => `${k}=${v}`)
-            .join(", ");
-          if (decayParts) console.log(`Breakdown by decay: ${decayParts}`);
+          const decayParts = Object.entries(decayBreakdown).sort((a, b) => b[1] - a[1]);
+          if (decayParts.length > 0) {
+            const summary = decayParts
+              .map(([k, v]) => `${k}=${v} (${activeDecayTotal > 0 ? ((v / activeDecayTotal) * 100).toFixed(1) : "0.0"}%)`)
+              .join(", ");
+            console.log(`Breakdown by decay: ${summary}`);
+            console.log(
+              `Decay stickiness: stable+permanent=${stablePermanentCount}/${activeDecayTotal} (${(stablePermanentRatio * 100).toFixed(1)}%)`,
+            );
+            if (stablePermanentRatio > 0.6) {
+              console.log(
+                "  Guidance: legacy stable/permanent ratio is high. Run `openclaw hybrid-mem decay reclassify --dry-run --stable-only` then `openclaw hybrid-mem decay reclassify --apply --stable-only`.",
+              );
+            }
+          }
           const topSources = Object.entries(sourceBreakdown)
             .sort((a, b) => b[1] - a[1])
             .slice(0, 5);
@@ -377,6 +486,13 @@ export function registerManageStorageMaintenance(mem: Chainable, b: ManageBindin
             console.log(`SQLite bytes per active fact: ${bytesPerFact.toFixed(0)}`);
           }
           if (sizes.sqliteBytes != null || sizes.lanceBytes != null) console.log("");
+          const vectorObservability = await collectVectorBackendObservability({
+            vectorDb,
+            resolvedLancePath: ctx.resolvedLancePath,
+            lanceBytes: sizes.lanceBytes ?? null,
+          });
+          printVectorBackendObservabilitySummary(vectorObservability);
+          console.log("");
           if (efficiency) {
             const estimatedTokens = factsDb.estimateStoredTokens();
             console.log("--- Efficiency (token estimate) ---");
@@ -434,12 +550,31 @@ export function registerManageStorageMaintenance(mem: Chainable, b: ManageBindin
           console.log("");
           console.log("Note: Tiering and scoping can significantly reduce token usage in LLM context.");
         } else {
+          const decayBreakdown = factsDb.statsBreakdownByDecayClass();
+          const activeDecayTotal = Object.values(decayBreakdown).reduce((sum, count) => sum + count, 0);
+          const stablePermanentCount = (decayBreakdown.stable ?? 0) + (decayBreakdown.permanent ?? 0);
+          const stablePermanentRatio = activeDecayTotal > 0 ? stablePermanentCount / activeDecayTotal : 0;
           console.log(`Total facts (SQLite): ${sqlCount}`);
           console.log(`Total vectors (LanceDB): ${lanceCount}`);
           console.log(`Expired (prunable): ${expired}`);
           console.log(
             `Breakdown: hot=${breakdown.hot}, warm=${breakdown.warm}, cold=${breakdown.cold}, structural=${breakdown.structural ?? 0}`,
           );
+          const decaySummary = Object.entries(decayBreakdown)
+            .sort((a, b) => b[1] - a[1])
+            .map(([k, v]) => `${k}=${v}`)
+            .join(", ");
+          if (decaySummary.length > 0) {
+            console.log(`Decay: ${decaySummary}`);
+            console.log(
+              `Decay stickiness (stable+permanent): ${stablePermanentCount}/${activeDecayTotal} (${(stablePermanentRatio * 100).toFixed(1)}%)`,
+            );
+            if (stablePermanentRatio > 0.6) {
+              console.log(
+                "Guidance: run `openclaw hybrid-mem decay reclassify --dry-run --stable-only` then `openclaw hybrid-mem decay reclassify --apply --stable-only`.",
+              );
+            }
+          }
         }
       }),
     );

--- a/extensions/memory-hybrid/cli/commands/manage/storage-stats-helpers.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/storage-stats-helpers.ts
@@ -708,6 +708,11 @@ export function buildAuditHealthReport(
     );
   if (unknown.length > 0)
     remediation.push("Run `openclaw hybrid-mem categories audit`, then `categories remap --apply` where appropriate.");
+  if (activeFacts > 0 && stableStickinessRatio > 0.6) {
+    remediation.push(
+      "Run `openclaw hybrid-mem decay reclassify --dry-run --stable-only`, then `openclaw hybrid-mem decay reclassify --apply --stable-only` if the report looks correct.",
+    );
+  }
   if (vectorless > 0) remediation.push("Run `openclaw hybrid-mem reembed-vectorless --apply`.");
   if (degraded) remediation.push("Run `openclaw hybrid-mem repair-vectors` and validate LanceDB connectivity.");
   if (procedureTriage.summary.total > 0)

--- a/extensions/memory-hybrid/services/vector-backend-observability.ts
+++ b/extensions/memory-hybrid/services/vector-backend-observability.ts
@@ -1,0 +1,346 @@
+import { existsSync, lstatSync, readdirSync, readFileSync, readlinkSync } from "node:fs";
+import { join, resolve } from "node:path";
+import type { VectorDB } from "../backends/vector-db.js";
+
+type ProcStatusSnapshot = {
+  vmRssKb: number | null;
+  vmHwmKb: number | null;
+  rssAnonKb: number | null;
+  rssFileKb: number | null;
+  rssShmemKb: number | null;
+  vmSwapKb: number | null;
+};
+
+type FdGroup = "lancedb" | "sqlite" | "wal" | "shm" | "socket" | "pipe" | "anon" | "other";
+
+type FdStats = {
+  total: number;
+  byGroup: Record<FdGroup, number>;
+  sampleTargets: Record<FdGroup, string[]>;
+  lancedbPaths: string[];
+};
+
+type SizeSummary = {
+  bytes: number | null;
+  scannedEntries: number;
+  truncated: boolean;
+};
+
+type LanceTableStats = {
+  name: "memories" | "semantic_query_cache";
+  path: string;
+  exists: boolean;
+  sizeBytes: number | null;
+  sizeScanTruncated: boolean;
+  rowCount: number | null;
+};
+
+export type VectorBackendObservability = {
+  capturedAt: string;
+  memory: {
+    rssBytes: number;
+    heapTotalBytes: number;
+    heapUsedBytes: number;
+    externalBytes: number;
+    arrayBuffersBytes: number;
+    nativeRssEstimateBytes: number;
+    procStatus: ProcStatusSnapshot | null;
+  };
+  fileDescriptors: FdStats | null;
+  vectorDb: {
+    path: string | null;
+    initialized: boolean | null;
+    lanceAvailable: boolean | null;
+    degraded: { active: boolean; reason: string | null; sinceEpochMs: number | null } | null;
+    openReaders: number | null;
+    optimizing: boolean | null;
+    search:
+      | {
+          active: number;
+          peak: number;
+          total: number;
+          lastRequestedLimit: number;
+          lastEffectiveLimit: number;
+          lastResultCount: number;
+          lastCompletedAtEpochMs: number | null;
+        }
+      | null;
+    cache:
+      | {
+          rows: number | null;
+          maxRowsPerFilterKey: number;
+          candidateLimitMax: number;
+          lastFilterKey: string | null;
+          lastRemovedRows: number;
+          lastPrunedAtEpochMs: number | null;
+        }
+      | null;
+    lastOptimize:
+      | {
+          ranAtEpochMs: number | null;
+          compacted: number;
+          removedFragments: number;
+          freedBytes: number;
+        }
+      | null;
+    bounds:
+      | {
+          vectorSearchMaxResults: number;
+          semanticCacheMaxRowsPerFilterKey: number;
+          semanticCacheCandidateLimitMax: number;
+        }
+      | null;
+  };
+  lancedb: {
+    basePath: string | null;
+    totalSizeBytes: number | null;
+    tables: LanceTableStats[];
+  };
+};
+
+function readProcStatusMemory(): ProcStatusSnapshot | null {
+  const statusPath = "/proc/self/status";
+  if (!existsSync(statusPath)) return null;
+  try {
+    const raw = readFileSync(statusPath, "utf-8");
+    const parseKb = (key: string): number | null => {
+      const match = raw.match(new RegExp(`^${key}:\\s+(\\d+)\\s+kB$`, "m"));
+      if (!match) return null;
+      const parsed = Number.parseInt(match[1], 10);
+      return Number.isFinite(parsed) ? parsed : null;
+    };
+    return {
+      vmRssKb: parseKb("VmRSS"),
+      vmHwmKb: parseKb("VmHWM"),
+      rssAnonKb: parseKb("RssAnon"),
+      rssFileKb: parseKb("RssFile"),
+      rssShmemKb: parseKb("RssShmem"),
+      vmSwapKb: parseKb("VmSwap"),
+    };
+  } catch {
+    return null;
+  }
+}
+
+function classifyFdTarget(target: string): FdGroup {
+  const lowered = target.toLowerCase();
+  if (lowered.startsWith("socket:")) return "socket";
+  if (lowered.startsWith("pipe:")) return "pipe";
+  if (lowered.startsWith("anon_inode:")) return "anon";
+  if (lowered.endsWith("-wal")) return "wal";
+  if (lowered.endsWith("-shm")) return "shm";
+  if (lowered.endsWith(".db") || lowered.includes(".db?")) return "sqlite";
+  if (lowered.includes(".lance") || lowered.includes("/lancedb/")) return "lancedb";
+  return "other";
+}
+
+function collectFdStats(sampleLimit = 5): FdStats | null {
+  const fdRoot = "/proc/self/fd";
+  if (!existsSync(fdRoot)) return null;
+  const byGroup: Record<FdGroup, number> = {
+    lancedb: 0,
+    sqlite: 0,
+    wal: 0,
+    shm: 0,
+    socket: 0,
+    pipe: 0,
+    anon: 0,
+    other: 0,
+  };
+  const sampleTargets: Record<FdGroup, string[]> = {
+    lancedb: [],
+    sqlite: [],
+    wal: [],
+    shm: [],
+    socket: [],
+    pipe: [],
+    anon: [],
+    other: [],
+  };
+  const lanceSet = new Set<string>();
+  let total = 0;
+  try {
+    const entries = readdirSync(fdRoot);
+    for (const fd of entries) {
+      const fdPath = join(fdRoot, fd);
+      let target = "";
+      try {
+        target = readlinkSync(fdPath);
+      } catch {
+        continue;
+      }
+      total += 1;
+      const group = classifyFdTarget(target);
+      byGroup[group] += 1;
+      if (sampleTargets[group].length < sampleLimit) {
+        sampleTargets[group].push(target);
+      }
+      if (group === "lancedb") {
+        const cleaned = target.replace(/\s+\(deleted\)$/, "");
+        lanceSet.add(cleaned);
+      }
+    }
+  } catch {
+    return null;
+  }
+  return {
+    total,
+    byGroup,
+    sampleTargets,
+    lancedbPaths: [...lanceSet].sort(),
+  };
+}
+
+function measurePathBytes(path: string, maxEntries = 50_000): SizeSummary {
+  const out: SizeSummary = { bytes: 0, scannedEntries: 0, truncated: false };
+  if (!existsSync(path)) return { bytes: null, scannedEntries: 0, truncated: false };
+  const queue = [path];
+  try {
+    while (queue.length > 0) {
+      const current = queue.pop();
+      if (!current) continue;
+      const st = lstatSync(current);
+      out.scannedEntries += 1;
+      if (out.scannedEntries > maxEntries) {
+        out.truncated = true;
+        return out;
+      }
+      if (st.isDirectory()) {
+        const children = readdirSync(current).map((name) => join(current, name));
+        queue.push(...children);
+      } else if (st.isFile()) {
+        if (out.bytes != null) out.bytes += st.size;
+      }
+    }
+    return out;
+  } catch {
+    return { bytes: null, scannedEntries: out.scannedEntries, truncated: out.truncated };
+  }
+}
+
+export async function collectVectorBackendObservability(opts: {
+  vectorDb: VectorDB;
+  resolvedLancePath?: string;
+  lanceBytes?: number | null;
+  fdSampleLimit?: number;
+}): Promise<VectorBackendObservability> {
+  const usage = process.memoryUsage();
+  const nativeRssEstimateBytes = Math.max(0, usage.rss - usage.heapTotal - usage.external);
+  const procStatus = readProcStatusMemory();
+  const fdStats = collectFdStats(opts.fdSampleLimit ?? 5);
+
+  const vectorDbWithObs = opts.vectorDb as unknown as {
+    getPath?: () => string;
+    isInitialized?: () => boolean;
+    isLanceDbAvailable?: () => boolean;
+    getDegradedState?: () => { active: boolean; reason: string | null; sinceEpochMs: number | null };
+    getOpenReaderCount?: () => number;
+    isOptimizing?: () => boolean;
+    getSearchTelemetry?: () => {
+      active: number;
+      peak: number;
+      total: number;
+      lastRequestedLimit: number;
+      lastEffectiveLimit: number;
+      lastResultCount: number;
+      lastCompletedAtEpochMs: number | null;
+    };
+    getSemanticQueryCacheTelemetry?: () => {
+      maxRowsPerFilterKey: number;
+      candidateLimitMax: number;
+      lastFilterKey: string | null;
+      lastRemovedRows: number;
+      lastPrunedAtEpochMs: number | null;
+    };
+    getLastOptimizeTelemetry?: () => {
+      ranAtEpochMs: number | null;
+      compacted: number;
+      removedFragments: number;
+      freedBytes: number;
+    };
+    getRuntimeBounds?: () => {
+      vectorSearchMaxResults: number;
+      semanticCacheMaxRowsPerFilterKey: number;
+      semanticCacheCandidateLimitMax: number;
+    };
+    countSemanticQueryCacheRows?: () => Promise<number>;
+    count?: () => Promise<number>;
+  };
+
+  const basePathRaw = vectorDbWithObs.getPath?.() ?? opts.resolvedLancePath ?? null;
+  const basePath = basePathRaw ? resolve(basePathRaw) : null;
+
+  const memoriesPath = basePath ? join(basePath, "memories.lance") : "";
+  const cachePath = basePath ? join(basePath, "semantic_query_cache.lance") : "";
+  const [memoriesCount, cacheCount] = await Promise.all([
+    typeof vectorDbWithObs.count === "function" ? vectorDbWithObs.count().catch(() => null) : Promise.resolve(null),
+    typeof vectorDbWithObs.countSemanticQueryCacheRows === "function"
+      ? vectorDbWithObs.countSemanticQueryCacheRows().catch(() => null)
+      : Promise.resolve(null),
+  ]);
+
+  const memoriesSize = basePath ? measurePathBytes(memoriesPath) : { bytes: null, scannedEntries: 0, truncated: false };
+  const cacheSize = basePath ? measurePathBytes(cachePath) : { bytes: null, scannedEntries: 0, truncated: false };
+  const totalSizeBytes = opts.lanceBytes ?? null;
+  const cacheTelemetry = vectorDbWithObs.getSemanticQueryCacheTelemetry?.() ?? null;
+
+  return {
+    capturedAt: new Date().toISOString(),
+    memory: {
+      rssBytes: usage.rss,
+      heapTotalBytes: usage.heapTotal,
+      heapUsedBytes: usage.heapUsed,
+      externalBytes: usage.external,
+      arrayBuffersBytes: usage.arrayBuffers,
+      nativeRssEstimateBytes,
+      procStatus,
+    },
+    fileDescriptors: fdStats,
+    vectorDb: {
+      path: basePath,
+      initialized: vectorDbWithObs.isInitialized?.() ?? null,
+      lanceAvailable: vectorDbWithObs.isLanceDbAvailable?.() ?? null,
+      degraded: vectorDbWithObs.getDegradedState?.() ?? null,
+      openReaders: vectorDbWithObs.getOpenReaderCount?.() ?? null,
+      optimizing: vectorDbWithObs.isOptimizing?.() ?? null,
+      search: vectorDbWithObs.getSearchTelemetry?.() ?? null,
+      cache:
+        cacheTelemetry == null
+          ? null
+          : {
+              rows: cacheCount,
+              maxRowsPerFilterKey: cacheTelemetry.maxRowsPerFilterKey,
+              candidateLimitMax: cacheTelemetry.candidateLimitMax,
+              lastFilterKey: cacheTelemetry.lastFilterKey,
+              lastRemovedRows: cacheTelemetry.lastRemovedRows,
+              lastPrunedAtEpochMs: cacheTelemetry.lastPrunedAtEpochMs,
+            },
+      lastOptimize: vectorDbWithObs.getLastOptimizeTelemetry?.() ?? null,
+      bounds: vectorDbWithObs.getRuntimeBounds?.() ?? null,
+    },
+    lancedb: {
+      basePath,
+      totalSizeBytes,
+      tables: basePath
+        ? [
+            {
+              name: "memories",
+              path: memoriesPath,
+              exists: existsSync(memoriesPath),
+              sizeBytes: memoriesSize.bytes,
+              sizeScanTruncated: memoriesSize.truncated,
+              rowCount: memoriesCount,
+            },
+            {
+              name: "semantic_query_cache",
+              path: cachePath,
+              exists: existsSync(cachePath),
+              sizeBytes: cacheSize.bytes,
+              sizeScanTruncated: cacheSize.truncated,
+              rowCount: cacheCount,
+            },
+          ]
+        : [],
+    },
+  };
+}

--- a/extensions/memory-hybrid/services/vector-backend-observability.ts
+++ b/extensions/memory-hybrid/services/vector-backend-observability.ts
@@ -54,42 +54,34 @@ export type VectorBackendObservability = {
     degraded: { active: boolean; reason: string | null; sinceEpochMs: number | null } | null;
     openReaders: number | null;
     optimizing: boolean | null;
-    search:
-      | {
-          active: number;
-          peak: number;
-          total: number;
-          lastRequestedLimit: number;
-          lastEffectiveLimit: number;
-          lastResultCount: number;
-          lastCompletedAtEpochMs: number | null;
-        }
-      | null;
-    cache:
-      | {
-          rows: number | null;
-          maxRowsPerFilterKey: number;
-          candidateLimitMax: number;
-          lastFilterKey: string | null;
-          lastRemovedRows: number;
-          lastPrunedAtEpochMs: number | null;
-        }
-      | null;
-    lastOptimize:
-      | {
-          ranAtEpochMs: number | null;
-          compacted: number;
-          removedFragments: number;
-          freedBytes: number;
-        }
-      | null;
-    bounds:
-      | {
-          vectorSearchMaxResults: number;
-          semanticCacheMaxRowsPerFilterKey: number;
-          semanticCacheCandidateLimitMax: number;
-        }
-      | null;
+    search: {
+      active: number;
+      peak: number;
+      total: number;
+      lastRequestedLimit: number;
+      lastEffectiveLimit: number;
+      lastResultCount: number;
+      lastCompletedAtEpochMs: number | null;
+    } | null;
+    cache: {
+      rows: number | null;
+      maxRowsPerFilterKey: number;
+      candidateLimitMax: number;
+      lastFilterKey: string | null;
+      lastRemovedRows: number;
+      lastPrunedAtEpochMs: number | null;
+    } | null;
+    lastOptimize: {
+      ranAtEpochMs: number | null;
+      compacted: number;
+      removedFragments: number;
+      freedBytes: number;
+    } | null;
+    bounds: {
+      vectorSearchMaxResults: number;
+      semanticCacheMaxRowsPerFilterKey: number;
+      semanticCacheCandidateLimitMax: number;
+    } | null;
   };
   lancedb: {
     basePath: string | null;

--- a/extensions/memory-hybrid/services/vector-backend-observability.ts
+++ b/extensions/memory-hybrid/services/vector-backend-observability.ts
@@ -187,27 +187,35 @@ function measurePathBytes(path: string, maxEntries = 50_000): SizeSummary {
   const out: SizeSummary = { bytes: 0, scannedEntries: 0, truncated: false };
   if (!existsSync(path)) return { bytes: null, scannedEntries: 0, truncated: false };
   const queue = [path];
-  try {
-    while (queue.length > 0) {
-      const current = queue.pop();
-      if (!current) continue;
-      const st = lstatSync(current);
-      out.scannedEntries += 1;
-      if (out.scannedEntries > maxEntries) {
-        out.truncated = true;
-        return out;
-      }
-      if (st.isDirectory()) {
-        const children = readdirSync(current).map((name) => join(current, name));
-        queue.push(...children);
-      } else if (st.isFile()) {
-        if (out.bytes != null) out.bytes += st.size;
-      }
+  while (queue.length > 0) {
+    const current = queue.pop();
+    if (!current) continue;
+    let st: ReturnType<typeof lstatSync>;
+    try {
+      st = lstatSync(current);
+    } catch {
+      // Transient ENOENT/EACCES — skip this entry and continue the scan
+      continue;
     }
-    return out;
-  } catch {
-    return { bytes: null, scannedEntries: out.scannedEntries, truncated: out.truncated };
+    out.scannedEntries += 1;
+    if (out.scannedEntries > maxEntries) {
+      out.truncated = true;
+      return out;
+    }
+    if (st.isDirectory()) {
+      let children: string[];
+      try {
+        children = readdirSync(current).map((name) => join(current, name));
+      } catch {
+        // Directory became unreadable (e.g. concurrent Lance compaction) — skip
+        continue;
+      }
+      queue.push(...children);
+    } else if (st.isFile()) {
+      if (out.bytes != null) out.bytes += st.size;
+    }
   }
+  return out;
 }
 
 export async function collectVectorBackendObservability(opts: {

--- a/extensions/memory-hybrid/tests/audit-health-cli.test.ts
+++ b/extensions/memory-hybrid/tests/audit-health-cli.test.ts
@@ -195,6 +195,28 @@ describe("buildAuditHealthReport — JSON schema (#1193)", () => {
     db.close();
   });
 
+  it("adds decay reclassify remediation when stable+permanent ratio is high", () => {
+    const db = new FactsDB(":memory:");
+    for (let i = 0; i < 5; i++) {
+      db.store({
+        text: `Legacy stable ${i}`,
+        category: "fact",
+        importance: 0.5,
+        entity: null,
+        key: null,
+        value: null,
+        source: "test",
+      });
+    }
+    const raw = db.getRawDb();
+    raw?.prepare("UPDATE facts SET decay_class = 'stable' WHERE superseded_at IS NULL").run();
+
+    const report = buildAuditHealthReport(db as never, () => ["fact"], [], 500);
+    expect(report.warnings.some((w) => w.includes("stable+permanent"))).toBe(true);
+    expect(report.remediation.some((r) => r.includes("decay reclassify --dry-run --stable-only"))).toBe(true);
+    db.close();
+  });
+
   it("recordStorageGrowthSample inserts once per UTC day", () => {
     const db = new FactsDB(":memory:");
     const a = recordStorageGrowthSample(db as never, 4096);

--- a/extensions/memory-hybrid/tests/user-friendly-cli.test.ts
+++ b/extensions/memory-hybrid/tests/user-friendly-cli.test.ts
@@ -140,6 +140,37 @@ describe("user-friendly CLI registration", () => {
     }
   });
 
+  it("health JSON surfaces decay guidance and vector bounds", async () => {
+    const root = new FakeCommand();
+    const localFactsDb = {
+      getCount: vi.fn(() => 10),
+      statsBreakdownByDecayClass: vi.fn(() => ({ stable: 9, permanent: 0, short: 1 })),
+    };
+    const localVectorDb = {
+      getAllIds: vi.fn(async () => Array.from({ length: 10 }, (_, i) => `id-${i}`)),
+      getRuntimeBounds: vi.fn(() => ({
+        vectorSearchMaxResults: 200,
+        semanticCacheMaxRowsPerFilterKey: 100,
+        semanticCacheCandidateLimitMax: 200,
+      })),
+    };
+    registerHealthCommand(root as never, cfg as never, localFactsDb as never, localVectorDb as never);
+    const health = root.children.find((child) => child.name === "health");
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    await health?.handler?.({ json: true });
+    const payload = JSON.parse(String(log.mock.calls.at(-1)?.[0] ?? "{}")) as {
+      indicators: Array<{ name: string; status: string; detail: string }>;
+    };
+    const decay = payload.indicators.find((indicator) => indicator.name === "Decay Profile");
+    const bounds = payload.indicators.find((indicator) => indicator.name === "Vector Bounds");
+    expect(decay?.status).toBe("warn");
+    expect(decay?.detail).toContain("decay reclassify --dry-run --stable-only");
+    expect(bounds?.status).toBe("good");
+    expect(bounds?.detail).toContain("search<=200");
+    log.mockRestore();
+  });
+  });
+
   it("examples uses own-property category checks", () => {
     const root = new FakeCommand();
     registerExamplesCommand(root as never);

--- a/extensions/memory-hybrid/tests/vector-db-constants-env-bounds.test.ts
+++ b/extensions/memory-hybrid/tests/vector-db-constants-env-bounds.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Regression tests for env-driven runtime bounds in backends/vector-db/constants.ts.
+ * Verifies that VECTOR_QUERY_MAX_RESULTS and SEMANTIC_QUERY_CACHE_* env overrides
+ * are correctly applied and clamped to their configured min/max ranges.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const ENV_VECTOR_QUERY_MAX_RESULTS = "OPENCLAW_HYBRID_MEM_VECTOR_QUERY_MAX_RESULTS";
+const ENV_SEMANTIC_CACHE_MAX_ROWS = "OPENCLAW_HYBRID_MEM_SEMANTIC_CACHE_MAX_ROWS_PER_FILTER_KEY";
+const ENV_SEMANTIC_CACHE_CANDIDATE_LIMIT = "OPENCLAW_HYBRID_MEM_SEMANTIC_CACHE_CANDIDATE_LIMIT_MAX";
+
+async function loadConstants() {
+  const mod = await import("../backends/vector-db/constants.js");
+  return mod;
+}
+
+describe("vector-db/constants — env-driven runtime bounds", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    delete process.env[ENV_VECTOR_QUERY_MAX_RESULTS];
+    delete process.env[ENV_SEMANTIC_CACHE_MAX_ROWS];
+    delete process.env[ENV_SEMANTIC_CACHE_CANDIDATE_LIMIT];
+  });
+
+  afterEach(() => {
+    vi.resetModules();
+    delete process.env[ENV_VECTOR_QUERY_MAX_RESULTS];
+    delete process.env[ENV_SEMANTIC_CACHE_MAX_ROWS];
+    delete process.env[ENV_SEMANTIC_CACHE_CANDIDATE_LIMIT];
+  });
+
+  describe("VECTOR_QUERY_MAX_RESULTS (default 200, min 10, max 5000)", () => {
+    it("uses the default value when env var is not set", async () => {
+      const { VECTOR_QUERY_MAX_RESULTS } = await loadConstants();
+      expect(VECTOR_QUERY_MAX_RESULTS).toBe(200);
+    });
+
+    it("applies a valid override within range", async () => {
+      process.env[ENV_VECTOR_QUERY_MAX_RESULTS] = "500";
+      const { VECTOR_QUERY_MAX_RESULTS } = await loadConstants();
+      expect(VECTOR_QUERY_MAX_RESULTS).toBe(500);
+    });
+
+    it("clamps to minimum (10) when override is below min", async () => {
+      process.env[ENV_VECTOR_QUERY_MAX_RESULTS] = "1";
+      const { VECTOR_QUERY_MAX_RESULTS } = await loadConstants();
+      expect(VECTOR_QUERY_MAX_RESULTS).toBe(10);
+    });
+
+    it("clamps to maximum (5000) when override exceeds max", async () => {
+      process.env[ENV_VECTOR_QUERY_MAX_RESULTS] = "99999";
+      const { VECTOR_QUERY_MAX_RESULTS } = await loadConstants();
+      expect(VECTOR_QUERY_MAX_RESULTS).toBe(5000);
+    });
+
+    it("falls back to default when override is not a valid integer", async () => {
+      process.env[ENV_VECTOR_QUERY_MAX_RESULTS] = "not-a-number";
+      const { VECTOR_QUERY_MAX_RESULTS } = await loadConstants();
+      expect(VECTOR_QUERY_MAX_RESULTS).toBe(200);
+    });
+  });
+
+  describe("SEMANTIC_QUERY_CACHE_MAX_ROWS_PER_FILTER_KEY (default 100, min 10, max 5000)", () => {
+    it("uses the default value when env var is not set", async () => {
+      const { SEMANTIC_QUERY_CACHE_MAX_ROWS_PER_FILTER_KEY } = await loadConstants();
+      expect(SEMANTIC_QUERY_CACHE_MAX_ROWS_PER_FILTER_KEY).toBe(100);
+    });
+
+    it("applies a valid override within range", async () => {
+      process.env[ENV_SEMANTIC_CACHE_MAX_ROWS] = "250";
+      const { SEMANTIC_QUERY_CACHE_MAX_ROWS_PER_FILTER_KEY } = await loadConstants();
+      expect(SEMANTIC_QUERY_CACHE_MAX_ROWS_PER_FILTER_KEY).toBe(250);
+    });
+
+    it("clamps to minimum (10) when override is below min", async () => {
+      process.env[ENV_SEMANTIC_CACHE_MAX_ROWS] = "0";
+      const { SEMANTIC_QUERY_CACHE_MAX_ROWS_PER_FILTER_KEY } = await loadConstants();
+      expect(SEMANTIC_QUERY_CACHE_MAX_ROWS_PER_FILTER_KEY).toBe(10);
+    });
+
+    it("clamps to maximum (5000) when override exceeds max", async () => {
+      process.env[ENV_SEMANTIC_CACHE_MAX_ROWS] = "10000";
+      const { SEMANTIC_QUERY_CACHE_MAX_ROWS_PER_FILTER_KEY } = await loadConstants();
+      expect(SEMANTIC_QUERY_CACHE_MAX_ROWS_PER_FILTER_KEY).toBe(5000);
+    });
+
+    it("falls back to default when override is not a valid integer", async () => {
+      process.env[ENV_SEMANTIC_CACHE_MAX_ROWS] = "abc";
+      const { SEMANTIC_QUERY_CACHE_MAX_ROWS_PER_FILTER_KEY } = await loadConstants();
+      expect(SEMANTIC_QUERY_CACHE_MAX_ROWS_PER_FILTER_KEY).toBe(100);
+    });
+  });
+
+  describe("SEMANTIC_QUERY_CACHE_CANDIDATE_LIMIT_MAX (default 200, min 10, max 5000)", () => {
+    it("uses the default value when env var is not set", async () => {
+      const { SEMANTIC_QUERY_CACHE_CANDIDATE_LIMIT_MAX } = await loadConstants();
+      expect(SEMANTIC_QUERY_CACHE_CANDIDATE_LIMIT_MAX).toBe(200);
+    });
+
+    it("applies a valid override within range", async () => {
+      process.env[ENV_SEMANTIC_CACHE_CANDIDATE_LIMIT] = "1000";
+      const { SEMANTIC_QUERY_CACHE_CANDIDATE_LIMIT_MAX } = await loadConstants();
+      expect(SEMANTIC_QUERY_CACHE_CANDIDATE_LIMIT_MAX).toBe(1000);
+    });
+
+    it("clamps to minimum (10) when override is below min", async () => {
+      process.env[ENV_SEMANTIC_CACHE_CANDIDATE_LIMIT] = "5";
+      const { SEMANTIC_QUERY_CACHE_CANDIDATE_LIMIT_MAX } = await loadConstants();
+      expect(SEMANTIC_QUERY_CACHE_CANDIDATE_LIMIT_MAX).toBe(10);
+    });
+
+    it("clamps to maximum (5000) when override exceeds max", async () => {
+      process.env[ENV_SEMANTIC_CACHE_CANDIDATE_LIMIT] = "9999";
+      const { SEMANTIC_QUERY_CACHE_CANDIDATE_LIMIT_MAX } = await loadConstants();
+      expect(SEMANTIC_QUERY_CACHE_CANDIDATE_LIMIT_MAX).toBe(5000);
+    });
+
+    it("falls back to default when override is not a valid integer", async () => {
+      process.env[ENV_SEMANTIC_CACHE_CANDIDATE_LIMIT] = "3.7";
+      // parseFloat("3.7") would be valid, but parseInt("3.7") floors to 3, which is below min → clamped to 10
+      const { SEMANTIC_QUERY_CACHE_CANDIDATE_LIMIT_MAX } = await loadConstants();
+      expect(SEMANTIC_QUERY_CACHE_CANDIDATE_LIMIT_MAX).toBe(10);
+    });
+
+    it("floors float strings to the nearest integer and clamps", async () => {
+      process.env[ENV_SEMANTIC_CACHE_CANDIDATE_LIMIT] = "150.9";
+      // parseInt("150.9") = 150, which is within [10, 5000]
+      const { SEMANTIC_QUERY_CACHE_CANDIDATE_LIMIT_MAX } = await loadConstants();
+      expect(SEMANTIC_QUERY_CACHE_CANDIDATE_LIMIT_MAX).toBe(150);
+    });
+  });
+});

--- a/extensions/memory-hybrid/tests/vector-db-constants-env-bounds.test.ts
+++ b/extensions/memory-hybrid/tests/vector-db-constants-env-bounds.test.ts
@@ -59,6 +59,18 @@ describe("vector-db/constants — env-driven runtime bounds", () => {
       const { VECTOR_QUERY_MAX_RESULTS } = await loadConstants();
       expect(VECTOR_QUERY_MAX_RESULTS).toBe(200);
     });
+
+    it("falls back to default when override is empty string", async () => {
+      process.env[ENV_VECTOR_QUERY_MAX_RESULTS] = "";
+      const { VECTOR_QUERY_MAX_RESULTS } = await loadConstants();
+      expect(VECTOR_QUERY_MAX_RESULTS).toBe(200);
+    });
+
+    it("falls back to default when override is whitespace", async () => {
+      process.env[ENV_VECTOR_QUERY_MAX_RESULTS] = "   ";
+      const { VECTOR_QUERY_MAX_RESULTS } = await loadConstants();
+      expect(VECTOR_QUERY_MAX_RESULTS).toBe(200);
+    });
   });
 
   describe("SEMANTIC_QUERY_CACHE_MAX_ROWS_PER_FILTER_KEY (default 100, min 10, max 5000)", () => {
@@ -90,6 +102,12 @@ describe("vector-db/constants — env-driven runtime bounds", () => {
       const { SEMANTIC_QUERY_CACHE_MAX_ROWS_PER_FILTER_KEY } = await loadConstants();
       expect(SEMANTIC_QUERY_CACHE_MAX_ROWS_PER_FILTER_KEY).toBe(100);
     });
+
+    it("falls back to default when override is empty string or whitespace", async () => {
+      process.env[ENV_SEMANTIC_CACHE_MAX_ROWS] = "  ";
+      const { SEMANTIC_QUERY_CACHE_MAX_ROWS_PER_FILTER_KEY } = await loadConstants();
+      expect(SEMANTIC_QUERY_CACHE_MAX_ROWS_PER_FILTER_KEY).toBe(100);
+    });
   });
 
   describe("SEMANTIC_QUERY_CACHE_CANDIDATE_LIMIT_MAX (default 200, min 10, max 5000)", () => {
@@ -116,7 +134,7 @@ describe("vector-db/constants — env-driven runtime bounds", () => {
       expect(SEMANTIC_QUERY_CACHE_CANDIDATE_LIMIT_MAX).toBe(5000);
     });
 
-    it("falls back to default when override is not a valid integer", async () => {
+    it("clamps to minimum when override parses to value below min (e.g. '3.7' → parseInt=3 < min 10)", async () => {
       process.env[ENV_SEMANTIC_CACHE_CANDIDATE_LIMIT] = "3.7";
       // parseFloat("3.7") would be valid, but parseInt("3.7") floors to 3, which is below min → clamped to 10
       const { SEMANTIC_QUERY_CACHE_CANDIDATE_LIMIT_MAX } = await loadConstants();

--- a/extensions/memory-hybrid/tests/vector-db-search-delete.test.ts
+++ b/extensions/memory-hybrid/tests/vector-db-search-delete.test.ts
@@ -437,3 +437,80 @@ describe("VectorDB.deleteMany", () => {
     expect(fallbackDeleteSpy).toHaveBeenNthCalledWith(2, id2.toLowerCase());
   });
 });
+
+describe("VectorDB runtime bounds/telemetry observability", () => {
+  const DIM = 3;
+
+  it("caps vector search result materialization by runtime bound and records telemetry", async () => {
+    const db = new VectorDB("/tmp/test-lance-search-bound", DIM);
+    const ensureInitializedSpy = vi.spyOn(
+      db as unknown as { ensureInitialized: () => Promise<void> },
+      "ensureInitialized",
+    );
+    const getTableSpy = vi.spyOn(
+      db as unknown as {
+        getTable: () => {
+          vectorSearch: (vector: number[]) => { limit: (n: number) => { toArray: () => Promise<unknown[]> } };
+        };
+      },
+      "getTable",
+    );
+    let capturedLimit = 0;
+    ensureInitializedSpy.mockResolvedValue(undefined);
+    getTableSpy.mockReturnValue({
+      vectorSearch: () => ({
+        limit: (n: number) => {
+          capturedLimit = n;
+          return { toArray: async () => [] };
+        },
+      }),
+    });
+    const internals = db as unknown as { lanceDbAvailable: boolean; lanceInitFailed: boolean; table: object | null };
+    internals.lanceDbAvailable = true;
+    internals.lanceInitFailed = false;
+    internals.table = {};
+
+    await db.search([0.1, 0.2, 0.3], 10_000, 0);
+
+    const bounds = db.getRuntimeBounds();
+    const telemetry = db.getSearchTelemetry();
+    expect(capturedLimit).toBeLessThanOrEqual(bounds.vectorSearchMaxResults);
+    expect(telemetry.lastEffectiveLimit).toBe(capturedLimit);
+    expect(telemetry.lastRequestedLimit).toBe(10_000);
+    expect(telemetry.total).toBe(1);
+    expect(telemetry.active).toBe(0);
+  });
+
+  it("caps semantic-cache candidate lookup size by runtime bound", async () => {
+    const db = new VectorDB("/tmp/test-lance-cache-bound", DIM);
+    const ensureInitializedSpy = vi.spyOn(
+      db as unknown as { ensureInitialized: () => Promise<void> },
+      "ensureInitialized",
+    );
+    ensureInitializedSpy.mockResolvedValue(undefined);
+    let capturedLimit = 0;
+    const cacheTable = {
+      vectorSearch: () => ({
+        limit: (n: number) => {
+          capturedLimit = n;
+          return { toArray: async () => [] };
+        },
+      }),
+    };
+    const internals = db as unknown as {
+      lanceDbAvailable: boolean;
+      lanceInitFailed: boolean;
+      semanticQueryCacheTable: object | null;
+      semanticQueryCacheSchemaValid: boolean;
+    };
+    internals.lanceDbAvailable = true;
+    internals.lanceInitFailed = false;
+    internals.semanticQueryCacheTable = cacheTable as unknown as object;
+    internals.semanticQueryCacheSchemaValid = true;
+
+    await db.getSemanticQueryCacheMatch([0.1, 0.2, 0.3], { candidateLimit: 10_000 });
+
+    const bounds = db.getRuntimeBounds();
+    expect(capturedLimit).toBeLessThanOrEqual(bounds.semanticCacheCandidateLimitMax);
+  });
+});


### PR DESCRIPTION
## Summary
6:Vector observability — decay health bounds, getStoreCount removal, biome formatting

## Verification
- npm test
- CI green

## Next owner
Manual review

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes recall path limits and operator CLI surfaces (low blast radius if defaults hold); verify `hybrid-mem health` still parses—diff adds an extra `}` before JSON output in `cmd-health.ts` that may break the command.
> 
> **Overview**
> Adds **operator-facing vector/LanceDB observability** and **runtime caps** so recall workloads cannot materialize unbounded Arrow/Lance rows.
> 
> **Vector bounds & telemetry:** `VECTOR_QUERY_MAX_RESULTS` and semantic-cache limits are now read from env (`OPENCLAW_HYBRID_MEM_*`) with min/max clamping. `VectorDB.search()` and semantic-cache lookups apply the tighter of existing limits and these bounds; search/cache prune/optimize record lightweight telemetry exposed via new getters (`getRuntimeBounds`, `getSearchTelemetry`, etc.) plus `countSemanticQueryCacheRows()`.
> 
> **CLI & audits:** New `hybrid-mem vectordb-health` (and README) reports RSS, FD groups, bounds, search activity, cache rows, and table sizes via new `collectVectorBackendObservability`. `hybrid-mem health` adds **Decay Profile** and **Vector Bounds** indicators; `stats`, `audit health` remediation, and `backfill-decay --json` surface **stable+permanent** stickiness with guidance to run `decay reclassify --dry-run --stable-only`.
> 
> **Tests:** Coverage for env-bound parsing and runtime cap/telemetry behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9003f511b6613615dbcf3673c0772934155167c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->