### PR TITLE
fix: capabilityHints type and default corrections (from orphaned pr1604)

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -118,6 +118,7 @@ Set **`interactiveEnrichment`** to **`fast`** for stable, cost-effective default
 {
   "autoRecall": {
     "enabled": true,
+    "capabilityHints": "session",
     "interactiveEnrichment": "fast",
     "maxTokens": 800,
     "maxPerMemoryChars": 0,
@@ -151,6 +152,7 @@ Set **`interactiveEnrichment`** to **`fast`** for stable, cost-effective default
 | `maxTokens` | `800` | Total tokens injected per turn |
 | `maxPerMemoryChars` | `0` | Truncate each memory to N chars (0 = no truncation) |
 | `injectionFormat` | `"full"` | `full` = `[backend/category] text`, `short` = `category: text`, `minimal` = text only, `progressive` = memory index (agent fetches via `memory_recall`), `progressive_hybrid` = pinned in full + rest as index |
+| `capabilityHints` | `"session"` | Capability-hints cadence: `session` = inject once per session (default), `always` = every prompt, `off` = disable static capability-hints block |
 | `limit` | `10` | Max memories considered for injection |
 | `minScore` | `0.3` | Minimum vector search score (0–1) |
 | `preferLongTerm` | `false` | Boost permanent (×1.2) and stable (×1.1) facts |

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -118,7 +118,7 @@ Set **`interactiveEnrichment`** to **`fast`** for stable, cost-effective default
 {
   "autoRecall": {
     "enabled": true,
-    "capabilityHints": "session",
+    "capabilityHints": "off",
     "interactiveEnrichment": "fast",
     "maxTokens": 800,
     "maxPerMemoryChars": 0,
@@ -152,7 +152,7 @@ Set **`interactiveEnrichment`** to **`fast`** for stable, cost-effective default
 | `maxTokens` | `800` | Total tokens injected per turn |
 | `maxPerMemoryChars` | `0` | Truncate each memory to N chars (0 = no truncation) |
 | `injectionFormat` | `"full"` | `full` = `[backend/category] text`, `short` = `category: text`, `minimal` = text only, `progressive` = memory index (agent fetches via `memory_recall`), `progressive_hybrid` = pinned in full + rest as index |
-| `capabilityHints` | `"session"` | Capability-hints cadence: `session` = inject once per session (default), `always` = every prompt, `off` = disable static capability-hints block |
+| `capabilityHints` | `"off"` | Capability-hints cadence: `off` = disable static capability-hints block (default), `session` = inject once per session, `always` = every prompt |
 | `limit` | `10` | Max memories considered for injection |
 | `minScore` | `0.3` | Minimum vector search score (0–1) |
 | `preferLongTerm` | `false` | Boost permanent (×1.2) and stable (×1.1) facts |

--- a/extensions/memory-hybrid/config/parsers/retrieval.ts
+++ b/extensions/memory-hybrid/config/parsers/retrieval.ts
@@ -146,7 +146,7 @@ export function parseAutoRecallConfig(cfg: Record<string, unknown>): AutoRecallC
       typeof capabilityHintsRaw === "string" &&
       (VALID_CAPABILITY_HINTS as readonly string[]).includes(capabilityHintsRaw)
         ? (capabilityHintsRaw as CapabilityHintsMode)
-        : "session";
+        : "off";
     const scopeFilterRaw = ar.scopeFilter as Record<string, unknown> | undefined;
     const scopeFilter =
       scopeFilterRaw && typeof scopeFilterRaw === "object" && !Array.isArray(scopeFilterRaw)
@@ -216,7 +216,7 @@ export function parseAutoRecallConfig(cfg: Record<string, unknown>): AutoRecallC
   }
   return {
     enabled: arRaw !== false,
-    capabilityHints: "session",
+    capabilityHints: "off",
     recallTiming: "off",
     maxTokens: 800,
     maxPerMemoryChars: 0,

--- a/extensions/memory-hybrid/config/parsers/retrieval.ts
+++ b/extensions/memory-hybrid/config/parsers/retrieval.ts
@@ -4,6 +4,7 @@ import type {
   AutoClassifyConfig,
   AutoRecallConfig,
   AutoRecallInjectionFormat,
+  CapabilityHintsMode,
   ContextualVariantsConfig,
   DocumentGradingConfig,
   EntityLookupConfig,
@@ -139,6 +140,13 @@ export function parseAutoRecallConfig(cfg: Record<string, unknown>): AutoRecallC
           : typeof recallTimingRaw === "string" && (VALID_RECALL_TIMING as readonly string[]).includes(recallTimingRaw)
             ? (recallTimingRaw as (typeof VALID_RECALL_TIMING)[number])
             : "off";
+    const VALID_CAPABILITY_HINTS = ["session", "always", "off"] as const;
+    const capabilityHintsRaw = ar.capabilityHints;
+    const capabilityHints =
+      typeof capabilityHintsRaw === "string" &&
+      (VALID_CAPABILITY_HINTS as readonly string[]).includes(capabilityHintsRaw)
+        ? (capabilityHintsRaw as CapabilityHintsMode)
+        : "session";
     const scopeFilterRaw = ar.scopeFilter as Record<string, unknown> | undefined;
     const scopeFilter =
       scopeFilterRaw && typeof scopeFilterRaw === "object" && !Array.isArray(scopeFilterRaw)
@@ -172,6 +180,7 @@ export function parseAutoRecallConfig(cfg: Record<string, unknown>): AutoRecallC
     };
     return {
       enabled: ar.enabled !== false,
+      capabilityHints,
       recallTiming,
       maxTokens: typeof ar.maxTokens === "number" && ar.maxTokens > 0 ? ar.maxTokens : 800,
       maxPerMemoryChars:
@@ -207,6 +216,7 @@ export function parseAutoRecallConfig(cfg: Record<string, unknown>): AutoRecallC
   }
   return {
     enabled: arRaw !== false,
+    capabilityHints: "session",
     recallTiming: "off",
     maxTokens: 800,
     maxPerMemoryChars: 0,

--- a/extensions/memory-hybrid/config/types/retrieval.ts
+++ b/extensions/memory-hybrid/config/types/retrieval.ts
@@ -1,6 +1,6 @@
 /** Auto-recall injection line format: full = [backend/category] text, short = category: text, minimal = text only, progressive = memory index (agent fetches on demand), progressive_hybrid = pinned in full + rest as index */
 export type AutoRecallInjectionFormat = "full" | "short" | "minimal" | "progressive" | "progressive_hybrid";
-/** Capability hints injection cadence: session = once per session (default), always = every prompt, off = disable hints injection. */
+/** Capability hints injection cadence: session = once per session, always = every prompt, off = disable hints injection (default). */
 export type CapabilityHintsMode = "session" | "always" | "off";
 
 export type AutoClassifyConfig = {
@@ -60,7 +60,7 @@ export type RetrievalDirectivesConfig = {
 /** Auto-recall: enable/disable plus token cap, format, limit, minScore, preferLongTerm, importance/recency, entity lookup, summary, progressive options */
 export type AutoRecallConfig = {
   enabled: boolean;
-  /** Capability hints injection cadence for static memory tools guidance (default: "session"). */
+  /** Capability hints injection cadence for static memory tools guidance (default: "off"). */
   capabilityHints?: CapabilityHintsMode;
   /** Recall timing logs: off = disabled, basic = completed events only, verbose = started+completed with timestamps. */
   recallTiming?: "off" | "basic" | "verbose";

--- a/extensions/memory-hybrid/config/types/retrieval.ts
+++ b/extensions/memory-hybrid/config/types/retrieval.ts
@@ -1,5 +1,7 @@
 /** Auto-recall injection line format: full = [backend/category] text, short = category: text, minimal = text only, progressive = memory index (agent fetches on demand), progressive_hybrid = pinned in full + rest as index */
 export type AutoRecallInjectionFormat = "full" | "short" | "minimal" | "progressive" | "progressive_hybrid";
+/** Capability hints injection cadence: session = once per session (default), always = every prompt, off = disable hints injection. */
+export type CapabilityHintsMode = "session" | "always" | "off";
 
 export type AutoClassifyConfig = {
   enabled: boolean;
@@ -58,6 +60,8 @@ export type RetrievalDirectivesConfig = {
 /** Auto-recall: enable/disable plus token cap, format, limit, minScore, preferLongTerm, importance/recency, entity lookup, summary, progressive options */
 export type AutoRecallConfig = {
   enabled: boolean;
+  /** Capability hints injection cadence for static memory tools guidance (default: "session"). */
+  capabilityHints?: CapabilityHintsMode;
   /** Recall timing logs: off = disabled, basic = completed events only, verbose = started+completed with timestamps. */
   recallTiming?: "off" | "basic" | "verbose";
   maxTokens: number;

--- a/extensions/memory-hybrid/lifecycle/hooks.ts
+++ b/extensions/memory-hybrid/lifecycle/hooks.ts
@@ -268,5 +268,5 @@ export function createLifecycleHooks(ctx: LifecycleContext) {
 
   const dispose = getDispose(staleSweepTimer, sessionState);
 
-  return { onAgentStart, onAgentEnd, onFrustrationDetect, dispose };
+  return { onAgentStart, onAgentEnd, onFrustrationDetect, dispose, sessionState };
 }

--- a/extensions/memory-hybrid/lifecycle/session-state.ts
+++ b/extensions/memory-hybrid/lifecycle/session-state.ts
@@ -55,6 +55,7 @@ export function createSessionState(): SessionState {
   const ambientSeenFactsMap = new Map<string, SessionSeenFacts>();
   const ambientLastEmbeddingMap = new Map<string, number[] | null>();
   const sessionLastActivity = new Map<string, number>();
+  const capabilityHintsSessionsSeen = new Set<string>();
 
   function touchSession(sessionKey: string): void {
     sessionLastActivity.set(sessionKey, Date.now());
@@ -66,6 +67,7 @@ export function createSessionState(): SessionState {
     ambientLastEmbeddingMap.delete(sessionKey);
     frustrationStateMap.delete(sessionKey);
     sessionLastActivity.delete(sessionKey);
+    capabilityHintsSessionsSeen.delete(sessionKey);
     const prefix = `${sessionKey}:`;
     for (const key of authFailureRecallsThisSession.keys()) {
       if (key.startsWith(prefix)) authFailureRecallsThisSession.delete(key);
@@ -100,6 +102,14 @@ export function createSessionState(): SessionState {
         if (value) sessionStartSeen.delete(value);
       }
     }
+    if (capabilityHintsSessionsSeen.size > MAX_TRACKED_SESSIONS) {
+      const excess = capabilityHintsSessionsSeen.size - MAX_TRACKED_SESSIONS;
+      const keys = capabilityHintsSessionsSeen.keys();
+      for (let i = 0; i < excess; i++) {
+        const { value } = keys.next();
+        if (value) capabilityHintsSessionsSeen.delete(value);
+      }
+    }
     if (authFailureRecallsThisSession.size > MAX_TRACKED_SESSIONS * 3) {
       const excess = authFailureRecallsThisSession.size - MAX_TRACKED_SESSIONS * 3;
       const keys = authFailureRecallsThisSession.keys();
@@ -129,6 +139,7 @@ export function createSessionState(): SessionState {
     frustrationStateMap.clear();
     authFailureRecallsThisSession.clear();
     sessionLastActivity.clear();
+    capabilityHintsSessionsSeen.clear();
   };
 
   return {
@@ -138,6 +149,7 @@ export function createSessionState(): SessionState {
     frustrationStateMap,
     authFailureRecallsThisSession,
     sessionLastActivity,
+    capabilityHintsSessionsSeen,
     touchSession,
     clearSessionState,
     pruneSessionMaps,

--- a/extensions/memory-hybrid/lifecycle/types.ts
+++ b/extensions/memory-hybrid/lifecycle/types.ts
@@ -87,6 +87,7 @@ export interface SessionState {
   frustrationStateMap: Map<string, { level: number; turns: FrustrationConversationTurn[] }>;
   authFailureRecallsThisSession: Map<string, number>;
   sessionLastActivity: Map<string, number>;
+  capabilityHintsSessionsSeen: Set<string>;
   touchSession: (sessionKey: string) => void;
   clearSessionState: (sessionKey: string) => void;
   pruneSessionMaps: () => void;

--- a/extensions/memory-hybrid/openclaw.plugin.json
+++ b/extensions/memory-hybrid/openclaw.plugin.json
@@ -777,6 +777,11 @@
                 ],
                 "description": "Structured recall timing logs: false/off=disabled, true/basic=completed events only, verbose=started+completed with timestamps."
               },
+              "capabilityHints": {
+                "type": "string",
+                "enum": ["session", "always", "off"],
+                "description": "Capability hints injection cadence for static memory tools guidance: session = inject once per session start, always = inject on every turn, off = disabled (default: off)."
+              },
               "progressiveMaxCandidates": {
                 "type": "number"
               },

--- a/extensions/memory-hybrid/setup/register-hooks.ts
+++ b/extensions/memory-hybrid/setup/register-hooks.ts
@@ -217,8 +217,6 @@ export function registerLifecycleHooks(ctx: HooksContext, api: ClawdbotPluginApi
   const capabilityHintsMode = ctx.cfg.autoRecall.capabilityHints ?? "off";
   if (ctx.cfg.autoRecall.enabled && ctx.cfg.verbosity !== "silent" && capabilityHintsMode !== "off") {
     let staticMemoryInstructions: string | null = null;
-    const capabilityHintsSessionsSeen = new Set<string>();
-    const MAX_CAPABILITY_HINT_SESSIONS = 200;
 
     // Build once and cache — these never change within a gateway session.
     const buildStaticInstructions = (): string => {
@@ -248,12 +246,9 @@ export function registerLifecycleHooks(ctx: HooksContext, api: ClawdbotPluginApi
       if (capabilityHintsMode === "session") {
         const rApi = withHookResolutionApi(api, hookCtx);
         const sessionKey = resolveSessionKeyFromHookEvent(event, rApi) ?? "default";
-        if (capabilityHintsSessionsSeen.has(sessionKey)) return;
-        capabilityHintsSessionsSeen.add(sessionKey);
-        if (capabilityHintsSessionsSeen.size > MAX_CAPABILITY_HINT_SESSIONS) {
-          const oldest = capabilityHintsSessionsSeen.values().next().value;
-          if (oldest) capabilityHintsSessionsSeen.delete(oldest);
-        }
+        if (hooks.sessionState.capabilityHintsSessionsSeen.has(sessionKey)) return;
+        hooks.sessionState.capabilityHintsSessionsSeen.add(sessionKey);
+        hooks.sessionState.pruneSessionMaps();
       }
       return { prependContext: staticMemoryInstructions };
     });

--- a/extensions/memory-hybrid/setup/register-hooks.ts
+++ b/extensions/memory-hybrid/setup/register-hooks.ts
@@ -10,7 +10,9 @@ import type { ClawdbotPluginApi } from "openclaw/plugin-sdk/core";
 import type { MemoryPluginAPI } from "../api/memory-plugin-api.js";
 import { resolveOpenclawJsonPathForWorkspace } from "../cli/cmd-install.js";
 import { getMemoryCategories } from "../config.js";
+import { withHookResolutionApi } from "../lifecycle/hook-resolution-api.js";
 import { type LifecycleContext, createLifecycleHooks } from "../lifecycle/hooks.js";
+import { resolveSessionKeyFromHookEvent } from "../lifecycle/session-state.js";
 import { capturePluginError } from "../services/error-reporter.js";
 import { buildPostCompactionRecallSnippet } from "../services/post-compaction-recall.js";
 import { runPreConsolidationFlush } from "../services/pre-consolidation-flush.js";
@@ -212,8 +214,11 @@ export function registerLifecycleHooks(ctx: HooksContext, api: ClawdbotPluginApi
   //
   // We ONLY inject when autoRecall is enabled — if the user opted out they don't want hints.
   // Silent mode suppresses all unsolicited output including capability hints (Issue #317).
-  if (ctx.cfg.autoRecall.enabled && ctx.cfg.verbosity !== "silent") {
+  const capabilityHintsMode = ctx.cfg.autoRecall.capabilityHints ?? "session";
+  if (ctx.cfg.autoRecall.enabled && ctx.cfg.verbosity !== "silent" && capabilityHintsMode !== "off") {
     let staticMemoryInstructions: string | null = null;
+    const capabilityHintsSessionsSeen = new Set<string>();
+    const MAX_CAPABILITY_HINT_SESSIONS = 200;
 
     // Build once and cache — these never change within a gateway session.
     const buildStaticInstructions = (): string => {
@@ -236,9 +241,19 @@ export function registerLifecycleHooks(ctx: HooksContext, api: ClawdbotPluginApi
     // the prompt build. When a reliable capability signal for `appendSystemContext`
     // becomes available in the plugin SDK, this hook can be extended to prefer that
     // field without risking duplicate instructions.
-    api.on("before_prompt_build", (): undefined | { prependContext: string } => {
+    api.on("before_prompt_build", (event: unknown, hookCtx: unknown): undefined | { prependContext: string } => {
       if (!staticMemoryInstructions) {
         staticMemoryInstructions = buildStaticInstructions();
+      }
+      if (capabilityHintsMode === "session") {
+        const rApi = withHookResolutionApi(api, hookCtx);
+        const sessionKey = resolveSessionKeyFromHookEvent(event, rApi) ?? "default";
+        if (capabilityHintsSessionsSeen.has(sessionKey)) return;
+        capabilityHintsSessionsSeen.add(sessionKey);
+        if (capabilityHintsSessionsSeen.size > MAX_CAPABILITY_HINT_SESSIONS) {
+          const oldest = capabilityHintsSessionsSeen.values().next().value;
+          if (oldest) capabilityHintsSessionsSeen.delete(oldest);
+        }
       }
       return { prependContext: staticMemoryInstructions };
     });

--- a/extensions/memory-hybrid/setup/register-hooks.ts
+++ b/extensions/memory-hybrid/setup/register-hooks.ts
@@ -213,9 +213,8 @@ export function registerLifecycleHooks(ctx: HooksContext, api: ClawdbotPluginApi
   //     it is supported by all OpenClaw versions and produces the correct runtime behaviour.
   //
   // We ONLY inject when autoRecall is enabled — if the user opted out they don't want hints.
-  // Silent mode suppresses all unsolicited output including capability hints (Issue #317).
   const capabilityHintsMode = ctx.cfg.autoRecall.capabilityHints ?? "off";
-  if (ctx.cfg.autoRecall.enabled && ctx.cfg.verbosity !== "silent" && capabilityHintsMode !== "off") {
+  if (ctx.cfg.autoRecall.enabled && capabilityHintsMode !== "off") {
     let staticMemoryInstructions: string | null = null;
 
     // Build once and cache — these never change within a gateway session.

--- a/extensions/memory-hybrid/setup/register-hooks.ts
+++ b/extensions/memory-hybrid/setup/register-hooks.ts
@@ -214,7 +214,7 @@ export function registerLifecycleHooks(ctx: HooksContext, api: ClawdbotPluginApi
   //
   // We ONLY inject when autoRecall is enabled — if the user opted out they don't want hints.
   // Silent mode suppresses all unsolicited output including capability hints (Issue #317).
-  const capabilityHintsMode = ctx.cfg.autoRecall.capabilityHints ?? "session";
+  const capabilityHintsMode = ctx.cfg.autoRecall.capabilityHints ?? "off";
   if (ctx.cfg.autoRecall.enabled && ctx.cfg.verbosity !== "silent" && capabilityHintsMode !== "off") {
     let staticMemoryInstructions: string | null = null;
     const capabilityHintsSessionsSeen = new Set<string>();

--- a/extensions/memory-hybrid/tests/config.test.ts
+++ b/extensions/memory-hybrid/tests/config.test.ts
@@ -566,14 +566,14 @@ describe("hybridConfigSchema.parse", () => {
     expect(result.autoRecall.interactiveEnrichment).toBe("fast");
   });
 
-  it("defaults autoRecall.capabilityHints to session", () => {
+  it("defaults autoRecall.capabilityHints to off", () => {
     const result = hybridConfigSchema.parse({
       ...validBase,
       autoRecall: {
         enabled: true,
       },
     });
-    expect(result.autoRecall.capabilityHints).toBe("session");
+    expect(result.autoRecall.capabilityHints).toBe("off");
   });
 
   it("parses autoRecall.capabilityHints override", () => {

--- a/extensions/memory-hybrid/tests/config.test.ts
+++ b/extensions/memory-hybrid/tests/config.test.ts
@@ -566,6 +566,36 @@ describe("hybridConfigSchema.parse", () => {
     expect(result.autoRecall.interactiveEnrichment).toBe("fast");
   });
 
+  it("defaults autoRecall.capabilityHints to session", () => {
+    const result = hybridConfigSchema.parse({
+      ...validBase,
+      autoRecall: {
+        enabled: true,
+      },
+    });
+    expect(result.autoRecall.capabilityHints).toBe("session");
+  });
+
+  it("parses autoRecall.capabilityHints override", () => {
+    const always = hybridConfigSchema.parse({
+      ...validBase,
+      autoRecall: {
+        enabled: true,
+        capabilityHints: "always",
+      },
+    });
+    expect(always.autoRecall.capabilityHints).toBe("always");
+
+    const off = hybridConfigSchema.parse({
+      ...validBase,
+      autoRecall: {
+        enabled: true,
+        capabilityHints: "off",
+      },
+    });
+    expect(off.autoRecall.capabilityHints).toBe("off");
+  });
+
   it("parses autoRecall.recallTiming", () => {
     const verbose = hybridConfigSchema.parse({
       ...validBase,

--- a/extensions/memory-hybrid/tests/context-engine.test.ts
+++ b/extensions/memory-hybrid/tests/context-engine.test.ts
@@ -617,9 +617,13 @@ describe("buildContextBlock()", () => {
 
     expect(blockFull).not.toBeNull();
     expect(blockSmall).not.toBeNull();
+    if (blockFull === null || blockSmall === null) {
+      throw new Error("Expected context blocks to be generated");
+    }
 
-    const smallTokens = estimateTokenCount(blockSmall!);
-    expect(smallTokens).toBeLessThanOrEqual(100);
+    const smallTokens = estimateTokenCount(blockSmall);
+    expect(smallTokens).toBeLessThanOrEqual(50);
+>>>>>>> 7cc57e8e (fix: resolve node 24 type errors)
 
     // Ensure blockSmall has fewer entries
     expect(blockSmall!.length).toBeLessThan(blockFull!.length);

--- a/extensions/memory-hybrid/tests/context-engine.test.ts
+++ b/extensions/memory-hybrid/tests/context-engine.test.ts
@@ -622,7 +622,7 @@ describe("buildContextBlock()", () => {
     }
 
     const smallTokens = estimateTokenCount(blockSmall);
-    expect(smallTokens).toBeLessThanOrEqual(50);
+    expect(smallTokens).toBeLessThanOrEqual(100);
 
     // Ensure blockSmall has fewer entries
     expect(blockSmall!.length).toBeLessThan(blockFull!.length);

--- a/extensions/memory-hybrid/tests/context-engine.test.ts
+++ b/extensions/memory-hybrid/tests/context-engine.test.ts
@@ -623,7 +623,6 @@ describe("buildContextBlock()", () => {
 
     const smallTokens = estimateTokenCount(blockSmall);
     expect(smallTokens).toBeLessThanOrEqual(50);
->>>>>>> 7cc57e8e (fix: resolve node 24 type errors)
 
     // Ensure blockSmall has fewer entries
     expect(blockSmall!.length).toBeLessThan(blockFull!.length);

--- a/extensions/memory-hybrid/tests/register-hooks-capability-hints.test.ts
+++ b/extensions/memory-hybrid/tests/register-hooks-capability-hints.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Capability hints injection cadence in registerLifecycleHooks (#1558).
+ */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { FactsDB } from "../backends/facts-db.js";
+import { registerLifecycleHooks } from "../setup/register-hooks.js";
+import { buildPluginApiForRegisterHooks, makeHooksApi } from "./helpers/register-hooks-harness.js";
+
+vi.mock("../lifecycle/stage-capture.js", () => ({
+  runCaptureStage: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../src/worker/narratives.js", () => ({
+  buildDailyNarrative: vi.fn().mockResolvedValue(undefined),
+}));
+
+type PromptBuildHookResult = { prependContext?: string } | undefined;
+
+function invokeBeforePromptBuildHandlers(
+  api: ReturnType<typeof makeHooksApi>,
+  event: Record<string, unknown>,
+): PromptBuildHookResult[] {
+  const handlers = (api.on as ReturnType<typeof vi.fn>).mock.calls
+    .filter((c) => c[0] === "before_prompt_build")
+    .map((c) => c[1] as (ev: unknown, hookCtx: unknown) => PromptBuildHookResult);
+  return handlers.map((handler) => handler(event, {}));
+}
+
+function findCapabilityHints(results: PromptBuildHookResult[]): string | undefined {
+  return results
+    .map((r) => r?.prependContext)
+    .find((text): text is string => typeof text === "string" && text.includes("memory-hybrid: capability hints"));
+}
+
+describe("registerLifecycleHooks capability hints cadence", () => {
+  let tmpDir: string;
+  let factsDb: FactsDB;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "capability-hints-hooks-"));
+    factsDb = new FactsDB(join(tmpDir, "facts.db"));
+  });
+
+  afterEach(() => {
+    factsDb.close();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("injects capability hints only once per session by default", () => {
+    const api = makeHooksApi();
+    const pluginApi = buildPluginApiForRegisterHooks(tmpDir, factsDb, { autoRecall: { enabled: true } });
+    registerLifecycleHooks(pluginApi as never, api as never);
+
+    const first = invokeBeforePromptBuildHandlers(api, { session: { id: "sess-a" } });
+    expect(findCapabilityHints(first)).toBeDefined();
+
+    const second = invokeBeforePromptBuildHandlers(api, { session: { id: "sess-a" } });
+    expect(findCapabilityHints(second)).toBeUndefined();
+
+    const third = invokeBeforePromptBuildHandlers(api, { session: { id: "sess-b" } });
+    expect(findCapabilityHints(third)).toBeDefined();
+  });
+
+  it("supports opt-in always mode to inject capability hints every prompt", () => {
+    const api = makeHooksApi();
+    const pluginApi = buildPluginApiForRegisterHooks(tmpDir, factsDb, {
+      autoRecall: { enabled: true, capabilityHints: "always" },
+    });
+    registerLifecycleHooks(pluginApi as never, api as never);
+
+    const first = invokeBeforePromptBuildHandlers(api, { session: { id: "sess-a" } });
+    const second = invokeBeforePromptBuildHandlers(api, { session: { id: "sess-a" } });
+
+    expect(findCapabilityHints(first)).toBeDefined();
+    expect(findCapabilityHints(second)).toBeDefined();
+  });
+
+  it("supports opt-out mode to disable capability hints injection", () => {
+    const api = makeHooksApi();
+    const pluginApi = buildPluginApiForRegisterHooks(tmpDir, factsDb, {
+      autoRecall: { enabled: true, capabilityHints: "off" },
+    });
+    registerLifecycleHooks(pluginApi as never, api as never);
+
+    const first = invokeBeforePromptBuildHandlers(api, { session: { id: "sess-a" } });
+    const second = invokeBeforePromptBuildHandlers(api, { session: { id: "sess-a" } });
+
+    expect(findCapabilityHints(first)).toBeUndefined();
+    expect(findCapabilityHints(second)).toBeUndefined();
+  });
+});

--- a/extensions/memory-hybrid/tests/register-hooks-capability-hints.test.ts
+++ b/extensions/memory-hybrid/tests/register-hooks-capability-hints.test.ts
@@ -50,19 +50,18 @@ describe("registerLifecycleHooks capability hints cadence", () => {
     rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  it("injects capability hints only once per session by default", () => {
+  it("does not inject capability hints by default", () => {
     const api = makeHooksApi();
     const pluginApi = buildPluginApiForRegisterHooks(tmpDir, factsDb, { autoRecall: { enabled: true } });
     registerLifecycleHooks(pluginApi as never, api as never);
 
     const first = invokeBeforePromptBuildHandlers(api, { session: { id: "sess-a" } });
-    expect(findCapabilityHints(first)).toBeDefined();
-
     const second = invokeBeforePromptBuildHandlers(api, { session: { id: "sess-a" } });
-    expect(findCapabilityHints(second)).toBeUndefined();
-
     const third = invokeBeforePromptBuildHandlers(api, { session: { id: "sess-b" } });
-    expect(findCapabilityHints(third)).toBeDefined();
+
+    expect(findCapabilityHints(first)).toBeUndefined();
+    expect(findCapabilityHints(second)).toBeUndefined();
+    expect(findCapabilityHints(third)).toBeUndefined();
   });
 
   it("supports opt-in always mode to inject capability hints every prompt", () => {
@@ -79,17 +78,19 @@ describe("registerLifecycleHooks capability hints cadence", () => {
     expect(findCapabilityHints(second)).toBeDefined();
   });
 
-  it("supports opt-out mode to disable capability hints injection", () => {
+  it("supports session mode to inject capability hints once per session", () => {
     const api = makeHooksApi();
     const pluginApi = buildPluginApiForRegisterHooks(tmpDir, factsDb, {
-      autoRecall: { enabled: true, capabilityHints: "off" },
+      autoRecall: { enabled: true, capabilityHints: "session" },
     });
     registerLifecycleHooks(pluginApi as never, api as never);
 
     const first = invokeBeforePromptBuildHandlers(api, { session: { id: "sess-a" } });
     const second = invokeBeforePromptBuildHandlers(api, { session: { id: "sess-a" } });
+    const third = invokeBeforePromptBuildHandlers(api, { session: { id: "sess-b" } });
 
-    expect(findCapabilityHints(first)).toBeUndefined();
+    expect(findCapabilityHints(first)).toBeDefined();
     expect(findCapabilityHints(second)).toBeUndefined();
+    expect(findCapabilityHints(third)).toBeDefined();
   });
 });

--- a/extensions/memory-hybrid/tests/stage-capture.test.ts
+++ b/extensions/memory-hybrid/tests/stage-capture.test.ts
@@ -119,6 +119,7 @@ function makeSessionState(): SessionState {
     frustrationStateMap: new Map(),
     authFailureRecallsThisSession: new Map(),
     sessionLastActivity: new Map(),
+    capabilityHintsSessionsSeen: new Set(),
     touchSession: vi.fn(),
     clearSessionState: vi.fn(),
     pruneSessionMaps: vi.fn(),


### PR DESCRIPTION
## Summary
Preserves capabilityHints type/default fixes from orphaned branch `pr1604`.

## Unique commits (7 total, NOT in main)
- `e005a3e9` fix: correct capabilityHints default in type comments from 'session' to 'off'
- `26d7be26` fix: remove verbosity gate from capability hints registration
- `8c29cb4e` Fix: Add missing capabilityHints property to autoRecall schema

## Verification
- npm test
- CI green

## Next owner
Copilot

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Default behavior no longer injects capability hints unless users set `session` or `always`; otherwise limited to prompt prepend logic and session tracking with tests.
> 
> **Overview**
> Adds **`autoRecall.capabilityHints`** (`off` | `session` | `always`, default **`off`**) so static memory-tool guidance in `before_prompt_build` is opt-in instead of tied to **`verbosity !== "silent"`**.
> 
> **`always`** prepends the capability-hints block on every prompt when auto-recall is enabled; **`session`** injects once per resolved session key using new **`capabilityHintsSessionsSeen`** state (pruned/cleared with other session maps). **`off`** registers no hints hook.
> 
> Config parsing, **`CapabilityHintsMode`** types, plugin JSON schema, and **CONFIGURATION.md** are updated; lifecycle hooks expose **`sessionState`** to **`register-hooks`**. Tests cover schema defaults and hook cadence (#1558).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c5f126615b9c747d63e0780849a61faf129d1b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->