### PR TITLE
style: stage recall budget helpers biome formatting (from orphaned pr-1605)

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -120,6 +120,11 @@ Set **`interactiveEnrichment`** to **`fast`** for stable, cost-effective default
     "enabled": true,
     "interactiveEnrichment": "fast",
     "maxTokens": 800,
+    "hotMaxTokens": 200,
+    "narrativeMaxTokens": 160,
+    "procedureMaxTokens": 160,
+    "activeTaskMaxTokens": 160,
+    "staleWarningMaxTokens": 64,
     "maxPerMemoryChars": 0,
     "injectionFormat": "full",
     "limit": 10,
@@ -149,6 +154,11 @@ Set **`interactiveEnrichment`** to **`fast`** for stable, cost-effective default
 | Key | Default | Description |
 |-----|---------|-------------|
 | `maxTokens` | `800` | Total tokens injected per turn |
+| `hotMaxTokens` | dynamic (~25% of interactive budget) | Cap HOT fixed block tokens before recall memories are packed |
+| `narrativeMaxTokens` | dynamic (~20% of interactive budget) | Cap narrative fixed block tokens |
+| `procedureMaxTokens` | dynamic (~20% of interactive budget) | Cap procedure fixed block tokens (applies after `procedures.maxInjectionTokens`) |
+| `activeTaskMaxTokens` | dynamic (min of `activeTask.injectionBudget` and ~20% of interactive budget) | Reserve tokens for active-task injection that runs in a separate hook |
+| `staleWarningMaxTokens` | dynamic (~8% of interactive budget) | Reserve tokens for stale-warning injection in active-task context |
 | `maxPerMemoryChars` | `0` | Truncate each memory to N chars (0 = no truncation) |
 | `injectionFormat` | `"full"` | `full` = `[backend/category] text`, `short` = `category: text`, `minimal` = text only, `progressive` = memory index (agent fetches via `memory_recall`), `progressive_hybrid` = pinned in full + rest as index |
 | `limit` | `10` | Max memories considered for injection |

--- a/extensions/memory-hybrid/cli/commands/manage/register-storage-entities-decay.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/register-storage-entities-decay.ts
@@ -242,6 +242,14 @@ export function registerManageStorageEntitiesDecay(mem: Chainable, b: ManageBind
         console.log(
           `Auto-recall: ${audit.autoRecall.enabled ? `${audit.autoRecall.budgetTokens} token budget` : "disabled"} (format: ${audit.autoRecall.injectionFormat}, hot: ${audit.autoRecall.hotTokens})`,
         );
+        if (audit.autoRecall.enabled) {
+          console.log(
+            `  fixed caps: hot=${audit.autoRecall.fixedBlocks.caps.hotMaxTokens}, narrative=${audit.autoRecall.fixedBlocks.caps.narrativeMaxTokens}, procedures=${audit.autoRecall.fixedBlocks.caps.procedureMaxTokens}, active-task=${audit.autoRecall.fixedBlocks.caps.activeTaskMaxTokens}, stale-warning=${audit.autoRecall.fixedBlocks.caps.staleWarningMaxTokens}`,
+          );
+          console.log(
+            `  fixed estimate: ${audit.autoRecall.fixedBlocks.estimatedTokens.total} tokens, recall headroom: ${audit.autoRecall.fixedBlocks.estimatedTokens.remainingForRecall}${audit.autoRecall.fixedBlocks.estimatedTokens.wouldExhaustRecall ? " (exhausted)" : ""}`,
+          );
+        }
         console.log(
           `Procedures: ${audit.procedures.enabled ? `${audit.procedures.tokens} tokens` : "disabled"} (lines: ${audit.procedures.lines})`,
         );

--- a/extensions/memory-hybrid/config/parsers/retrieval.ts
+++ b/extensions/memory-hybrid/config/parsers/retrieval.ts
@@ -139,6 +139,24 @@ export function parseAutoRecallConfig(cfg: Record<string, unknown>): AutoRecallC
           : typeof recallTimingRaw === "string" && (VALID_RECALL_TIMING as readonly string[]).includes(recallTimingRaw)
             ? (recallTimingRaw as (typeof VALID_RECALL_TIMING)[number])
             : "off";
+    const hotMaxTokens =
+      typeof ar.hotMaxTokens === "number" && ar.hotMaxTokens >= 0 ? Math.floor(ar.hotMaxTokens) : undefined;
+    const narrativeMaxTokens =
+      typeof ar.narrativeMaxTokens === "number" && ar.narrativeMaxTokens >= 0
+        ? Math.floor(ar.narrativeMaxTokens)
+        : undefined;
+    const procedureMaxTokens =
+      typeof ar.procedureMaxTokens === "number" && ar.procedureMaxTokens >= 0
+        ? Math.floor(ar.procedureMaxTokens)
+        : undefined;
+    const activeTaskMaxTokens =
+      typeof ar.activeTaskMaxTokens === "number" && ar.activeTaskMaxTokens >= 0
+        ? Math.floor(ar.activeTaskMaxTokens)
+        : undefined;
+    const staleWarningMaxTokens =
+      typeof ar.staleWarningMaxTokens === "number" && ar.staleWarningMaxTokens >= 0
+        ? Math.floor(ar.staleWarningMaxTokens)
+        : undefined;
     const scopeFilterRaw = ar.scopeFilter as Record<string, unknown> | undefined;
     const scopeFilter =
       scopeFilterRaw && typeof scopeFilterRaw === "object" && !Array.isArray(scopeFilterRaw)
@@ -174,6 +192,11 @@ export function parseAutoRecallConfig(cfg: Record<string, unknown>): AutoRecallC
       enabled: ar.enabled !== false,
       recallTiming,
       maxTokens: typeof ar.maxTokens === "number" && ar.maxTokens > 0 ? ar.maxTokens : 800,
+      hotMaxTokens,
+      narrativeMaxTokens,
+      procedureMaxTokens,
+      activeTaskMaxTokens,
+      staleWarningMaxTokens,
       maxPerMemoryChars:
         typeof ar.maxPerMemoryChars === "number" && ar.maxPerMemoryChars >= 0 ? ar.maxPerMemoryChars : 0,
       injectionFormat: format,
@@ -209,6 +232,11 @@ export function parseAutoRecallConfig(cfg: Record<string, unknown>): AutoRecallC
     enabled: arRaw !== false,
     recallTiming: "off",
     maxTokens: 800,
+    hotMaxTokens: undefined,
+    narrativeMaxTokens: undefined,
+    procedureMaxTokens: undefined,
+    activeTaskMaxTokens: undefined,
+    staleWarningMaxTokens: undefined,
     maxPerMemoryChars: 0,
     injectionFormat: "full",
     limit: 10,

--- a/extensions/memory-hybrid/config/types/retrieval.ts
+++ b/extensions/memory-hybrid/config/types/retrieval.ts
@@ -61,6 +61,19 @@ export type AutoRecallConfig = {
   /** Recall timing logs: off = disabled, basic = completed events only, verbose = started+completed with timestamps. */
   recallTiming?: "off" | "basic" | "verbose";
   maxTokens: number;
+  /** Optional cap for HOT fixed block tokens before recall candidates are packed. */
+  hotMaxTokens?: number;
+  /** Optional cap for narrative fixed block tokens before recall candidates are packed. */
+  narrativeMaxTokens?: number;
+  /** Optional cap for procedural fixed block tokens before recall candidates are packed. */
+  procedureMaxTokens?: number;
+  /**
+   * Optional reserve for active-task context added by other before_agent_start hooks.
+   * This reservation is subtracted from recall packing budget to avoid fixed-block exhaustion.
+   */
+  activeTaskMaxTokens?: number;
+  /** Optional reserve for stale-warning context in active-task injection. */
+  staleWarningMaxTokens?: number;
   maxPerMemoryChars: number;
   injectionFormat: AutoRecallInjectionFormat;
   limit: number;

--- a/extensions/memory-hybrid/lifecycle/stage-recall/run-recall.ts
+++ b/extensions/memory-hybrid/lifecycle/stage-recall/run-recall.ts
@@ -41,6 +41,68 @@ function clipNarrativeText(text: string, maxChars = 360): string {
   return `${text.slice(0, Math.max(0, maxChars - 1)).trimEnd()}…`;
 }
 
+function sanitizeHotFactText(text: string): string {
+  return text
+    .replace(/<redacted_thinking>[\s\S]*?<\/redacted_thinking>/gi, " ")
+    .replace(/<thinking>[\s\S]*?<\/thinking>/gi, " ")
+    .replace(/<reasoning>[\s\S]*?<\/reasoning>/gi, " ")
+    .replace(/<think>[\s\S]*?<\/think>/gi, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function trimBlockToBudget(
+  block: string,
+  maxTokens: number,
+): { text: string; sourceTokens: number; usedTokens: number } {
+  const sourceTokens = block ? estimateTokens(block) : 0;
+  if (!block || sourceTokens === 0 || maxTokens <= 0) {
+    return { text: "", sourceTokens, usedTokens: 0 };
+  }
+  if (sourceTokens <= maxTokens) {
+    return { text: block, sourceTokens, usedTokens: sourceTokens };
+  }
+
+  const trailingNewlines = block.match(/\n+$/)?.[0] ?? "";
+  const core = trailingNewlines.length > 0 ? block.slice(0, -trailingNewlines.length) : block;
+  const lines = core.split("\n");
+  if (lines.length === 0) return { text: "", sourceTokens, usedTokens: 0 };
+
+  const first = lines[0] ?? "";
+  const last = lines[lines.length - 1] ?? "";
+  if (lines.length >= 3 && first.startsWith("<") && last.startsWith("</")) {
+    const middle = lines.slice(1, -1);
+    for (let keep = middle.length; keep >= 0; keep--) {
+      const candidate = [first, ...middle.slice(0, keep), last].join("\n") + trailingNewlines;
+      const candidateTokens = estimateTokens(candidate);
+      if (candidateTokens <= maxTokens) {
+        return { text: candidate, sourceTokens, usedTokens: candidateTokens };
+      }
+    }
+    return { text: "", sourceTokens, usedTokens: 0 };
+  }
+
+  for (let keep = lines.length; keep >= 1; keep--) {
+    const candidate = lines.slice(0, keep).join("\n") + trailingNewlines;
+    const candidateTokens = estimateTokens(candidate);
+    if (candidateTokens <= maxTokens) {
+      return { text: candidate, sourceTokens, usedTokens: candidateTokens };
+    }
+  }
+  return { text: "", sourceTokens, usedTokens: 0 };
+}
+
+type FixedBlockAudit = {
+  block: string;
+  sourceTokens: number;
+  capTokens: number;
+  injectedTokens: number;
+  reserved: boolean;
+  truncated: boolean;
+  suppressed: boolean;
+  reason?: "empty" | "cap" | "budget_exhausted";
+};
+
 export async function runRecall(
   event: unknown,
   api: ClawdbotPluginApi,
@@ -175,11 +237,17 @@ export async function runRecall(
       if (ctx.cfg.memoryTiering.enabled && ctx.cfg.memoryTiering.hotMaxTokens > 0) {
         const hotResults = ctx.factsDb.getHotFacts(ctx.cfg.memoryTiering.hotMaxTokens, scopeFilter);
         if (hotResults.length > 0) {
-          const hotLines = hotResults.map(
-            (r) =>
-              `- [hot/${r.entry.category}] ${(r.entry.summary || r.entry.text).slice(0, 200)}${(r.entry.summary || r.entry.text).length > 200 ? "…" : ""}`,
-          );
-          hotPart = `Hot memories:\n${hotLines.join("\n")}\n\n`;
+          const hotLines = hotResults
+            .map((r) => {
+              const text = sanitizeHotFactText(r.entry.summary || r.entry.text);
+              if (!text) return "";
+              const clipped = `${text.slice(0, 200)}${text.length > 200 ? "…" : ""}`;
+              return `- [hot/${r.entry.category}] ${clipped}`;
+            })
+            .filter(Boolean);
+          if (hotLines.length > 0) {
+            hotPart = `Hot memories:\n${hotLines.join("\n")}\n\n`;
+          }
         }
       }
       const memoryLines = ftsOnly
@@ -291,11 +359,17 @@ export async function runRecall(
     if (ctx.cfg.memoryTiering.enabled && ctx.cfg.memoryTiering.hotMaxTokens > 0) {
       const hotResults = ctx.factsDb.getHotFacts(ctx.cfg.memoryTiering.hotMaxTokens, scopeFilter);
       if (hotResults.length > 0) {
-        const hotLines = hotResults.map(
-          (r) =>
-            `- [hot/${r.entry.category}] ${(r.entry.summary || r.entry.text).slice(0, 200)}${(r.entry.summary || r.entry.text).length > 200 ? "…" : ""}`,
-        );
-        hotBlock = `<hot-memories>\n${hotLines.join("\n")}\n</hot-memories>\n\n`;
+        const hotLines = hotResults
+          .map((r) => {
+            const cleaned = sanitizeHotFactText(r.entry.summary || r.entry.text);
+            if (!cleaned) return "";
+            const clipped = `${cleaned.slice(0, 200)}${cleaned.length > 200 ? "…" : ""}`;
+            return `- [hot/${r.entry.category}] ${clipped}`;
+          })
+          .filter(Boolean);
+        if (hotLines.length > 0) {
+          hotBlock = `<hot-memories>\n${hotLines.join("\n")}\n</hot-memories>\n\n`;
+        }
       }
     }
     recallTiming.phaseCompleted("hot_facts_block", hotFactsStartedAt, { injected: hotBlock.length > 0 });
@@ -702,18 +776,6 @@ export async function runRecall(
       candidates = candidates.slice(0, limit);
     }
 
-    if (candidates.length === 0) {
-      ctx.auditStore?.append({
-        agentId: resolveAgentIdFromHookEvent(event, api) ?? ctx.currentAgentIdRef.value ?? "unknown",
-        action: "recall:empty",
-        outcome: "partial",
-        sessionId: sessionKey,
-        context: { issueBlockInjected: issueBlock.length > 0, narrativeBlockInjected: narrativeBlock.length > 0 },
-      });
-      const combinedContext = issueBlock + narrativeBlock + hotBlock;
-      return completeStage({ kind: "empty", prependContext: combinedContext || undefined });
-    }
-
     const nowSec = Math.floor(Date.now() / 1000);
     const NINETY_DAYS_SEC = 90 * 24 * 3600;
     const boosted = candidates.map((r) => {
@@ -744,23 +806,146 @@ export async function runRecall(
       progressiveIndexMaxTokens,
       progressiveGroupByCategory,
       progressivePinnedRecallCount,
+      hotMaxTokens: hotBlockCapCfg,
+      narrativeMaxTokens: narrativeBlockCapCfg,
+      procedureMaxTokens: procedureBlockCapCfg,
+      activeTaskMaxTokens: activeTaskReserveCapCfg,
+      staleWarningMaxTokens: staleWarningReserveCapCfg,
     } = ctx.cfg.autoRecall;
     // Enforce retrieval.ambientBudgetTokens as a hard total-token cap (#581).
     // autoRecall.maxTokens is a user preference; ambientBudgetTokens is the architectural
     // ceiling — the injected context must not exceed either.
     const totalBudget = interactivePolicy.contextBudgetTokens;
-    // Account for issueBlock, hotBlock, and procedureBlock tokens to ensure total stays within budget
-    const fixedBlocksTokens =
-      estimateTokens(issueBlock) +
-      estimateTokens(narrativeBlock) +
-      estimateTokens(hotBlock) +
-      estimateTokens(procedureBlock);
-    const maxTokens = Math.max(0, totalBudget - fixedBlocksTokens);
+    const issueCapTokens = Math.max(80, Math.floor(totalBudget * 0.15));
+    const narrativeCapTokens =
+      narrativeBlockCapCfg ?? (narrativeBlock.length > 0 ? Math.max(100, Math.floor(totalBudget * 0.2)) : 0);
+    const hotCapTokens = hotBlockCapCfg ?? (hotBlock.length > 0 ? Math.max(100, Math.floor(totalBudget * 0.25)) : 0);
+    const defaultProcedureCap = procedureBlock.length > 0 ? Math.max(100, Math.floor(totalBudget * 0.2)) : 0;
+    const procedureCapTokens =
+      procedureBlockCapCfg ??
+      (ctx.cfg.procedures.enabled
+        ? Math.min(ctx.cfg.procedures.maxInjectionTokens ?? defaultProcedureCap, defaultProcedureCap)
+        : 0);
+    const defaultActiveTaskReserve =
+      ctx.cfg.activeTask.enabled && ctx.cfg.activeTask.injectionBudget > 0
+        ? Math.min(ctx.cfg.activeTask.injectionBudget, Math.max(80, Math.floor(totalBudget * 0.2)))
+        : 0;
+    const activeTaskReserveTokens = activeTaskReserveCapCfg ?? defaultActiveTaskReserve;
+    const defaultStaleReserve =
+      ctx.cfg.activeTask.enabled && ctx.cfg.activeTask.staleWarning.enabled
+        ? Math.max(40, Math.floor(totalBudget * 0.08))
+        : 0;
+    const staleWarningReserveTokens = staleWarningReserveCapCfg ?? defaultStaleReserve;
+
+    let remainingBudget = totalBudget;
+    const fixedBlockAudit: FixedBlockAudit[] = [];
+
+    const capAndTrackBlock = (name: string, block: string, capTokens: number): string => {
+      const cap = Math.max(0, Math.floor(capTokens));
+      const allowed = Math.min(cap, remainingBudget);
+      const { text, sourceTokens, usedTokens } = trimBlockToBudget(block, allowed);
+      const suppressed = sourceTokens > 0 && usedTokens === 0;
+      fixedBlockAudit.push({
+        block: name,
+        sourceTokens,
+        capTokens: cap,
+        injectedTokens: usedTokens,
+        reserved: false,
+        truncated: sourceTokens > usedTokens,
+        suppressed,
+        reason:
+          sourceTokens === 0
+            ? "empty"
+            : usedTokens === 0
+              ? "budget_exhausted"
+              : sourceTokens > usedTokens
+                ? allowed < cap
+                  ? "budget_exhausted"
+                  : "cap"
+                : undefined,
+      });
+      remainingBudget = Math.max(0, remainingBudget - usedTokens);
+      return text;
+    };
+
+    const reserveAndTrackBlock = (name: string, reserveTokens: number, enabled: boolean): void => {
+      const cap = enabled ? Math.max(0, Math.floor(reserveTokens)) : 0;
+      const reserved = Math.min(cap, remainingBudget);
+      fixedBlockAudit.push({
+        block: name,
+        sourceTokens: cap,
+        capTokens: cap,
+        injectedTokens: reserved,
+        reserved: true,
+        truncated: cap > reserved,
+        suppressed: cap > 0 && reserved === 0,
+        reason:
+          cap === 0 ? "empty" : reserved === 0 ? "budget_exhausted" : cap > reserved ? "budget_exhausted" : undefined,
+      });
+      remainingBudget = Math.max(0, remainingBudget - reserved);
+    };
+
+    issueBlock = capAndTrackBlock("issue", issueBlock, issueCapTokens);
+    narrativeBlock = capAndTrackBlock("narrative", narrativeBlock, narrativeCapTokens);
+    hotBlock = capAndTrackBlock("hot", hotBlock, hotCapTokens);
+    procedureBlock = capAndTrackBlock("procedure", procedureBlock, procedureCapTokens);
+    reserveAndTrackBlock("active-task", activeTaskReserveTokens, ctx.cfg.activeTask.enabled);
+    reserveAndTrackBlock(
+      "stale-warning",
+      staleWarningReserveTokens,
+      ctx.cfg.activeTask.enabled && ctx.cfg.activeTask.staleWarning.enabled,
+    );
+
+    const fixedBlocksTokens = totalBudget - remainingBudget;
+    const maxTokens = Math.max(0, remainingBudget);
+    const blockSummary = fixedBlockAudit
+      .map((b) => `${b.block}:${b.injectedTokens}/${b.capTokens}${b.reserved ? "r" : ""}${b.truncated ? "!" : ""}`)
+      .join(", ");
+    api.logger.info?.(
+      `memory-hybrid: context-audit fixed=${fixedBlocksTokens}/${totalBudget} recall=${maxTokens} blocks=[${blockSummary}]`,
+    );
+    ctx.auditStore?.append({
+      agentId: resolveAgentIdFromHookEvent(event, api) ?? ctx.currentAgentIdRef.value ?? "unknown",
+      action: "recall:context-budget",
+      outcome: maxTokens === 0 ? "partial" : "success",
+      sessionId: sessionKey,
+      tokens: fixedBlocksTokens,
+      context: {
+        totalBudget,
+        recallBudget: maxTokens,
+        blocks: fixedBlockAudit,
+      },
+    });
+
     if (maxTokens === 0) {
+      const consumers = fixedBlockAudit
+        .filter((b) => b.injectedTokens > 0)
+        .sort((a, b) => b.injectedTokens - a.injectedTokens)
+        .slice(0, 4)
+        .map((b) => `${b.block}:${b.injectedTokens}`)
+        .join(", ");
       api.logger.warn?.(
-        `memory-hybrid: fixed blocks (${fixedBlocksTokens} tokens) exhausted total budget (${totalBudget} tokens); recall suppressed`,
+        `memory-hybrid: fixed blocks exhausted budget (${fixedBlocksTokens}/${totalBudget} tokens); recall suppressed (consumers: ${consumers || "none"})`,
       );
     }
+
+    if (candidates.length === 0) {
+      ctx.auditStore?.append({
+        agentId: resolveAgentIdFromHookEvent(event, api) ?? ctx.currentAgentIdRef.value ?? "unknown",
+        action: "recall:empty",
+        outcome: "partial",
+        sessionId: sessionKey,
+        context: {
+          issueBlockInjected: issueBlock.length > 0,
+          narrativeBlockInjected: narrativeBlock.length > 0,
+          hotBlockInjected: hotBlock.length > 0,
+          fixedBlocks: fixedBlockAudit,
+        },
+      });
+      const combinedContext = issueBlock + narrativeBlock + hotBlock;
+      return completeStage({ kind: "empty", prependContext: combinedContext || undefined });
+    }
+
     setRecallProbePhase("finalize");
     const indexCap = Math.min(progressiveIndexMaxTokens ?? maxTokens, maxTokens);
     const groupByCategory = progressiveGroupByCategory === true;

--- a/extensions/memory-hybrid/lifecycle/stage-recall/run-recall.ts
+++ b/extensions/memory-hybrid/lifecycle/stage-recall/run-recall.ts
@@ -338,10 +338,13 @@ export async function runRecall(
       );
       const memoryLines = ftsOnly
         .slice(0, degradedLimit)
-        .map(
-          (r) =>
-            `- [${r.backend}/${r.entry.category}] ${(r.entry.summary || r.entry.text).slice(0, 200)}${(r.entry.summary || r.entry.text).length > 200 ? "…" : ""}`,
-        );
+        .map((r) => {
+          const text = sanitizeHotFactText(r.entry.summary || r.entry.text);
+          if (!text) return "";
+          const clipped = `${text.slice(0, 200)}${text.length > 200 ? "…" : ""}`;
+          return `- [${r.backend}/${r.entry.category}] ${clipped}`;
+        })
+        .filter(Boolean);
       const recallBlock = memoryLines.length ? `Recalled (FTS-only):\n${memoryLines.join("\n")}` : "";
       const { text: recallPart } = trimBlockToBudget(recallBlock, remainingBudget);
       const inner = narrativePart + hotPart + recallPart;

--- a/extensions/memory-hybrid/lifecycle/stage-recall/run-recall.ts
+++ b/extensions/memory-hybrid/lifecycle/stage-recall/run-recall.ts
@@ -290,6 +290,7 @@ export async function runRecall(
         narrativeMaxTokens: narrativeBlockCapCfg,
         procedureMaxTokens: procedureBlockCapCfg,
         activeTaskMaxTokens: activeTaskReserveCapCfg,
+        staleWarningMaxTokens: staleWarningReserveCapCfg,
       } = ctx.cfg.autoRecall;
       const hasNarrativesDb = ctx.narrativesDb != null || ctx.eventLog != null;
       const narrativeCapTokens =
@@ -299,6 +300,11 @@ export async function runRecall(
         activeTaskReserveCapCfg ??
         (ctx.cfg.activeTask.enabled && ctx.cfg.activeTask.injectionBudget > 0
           ? Math.min(ctx.cfg.activeTask.injectionBudget, Math.max(80, Math.floor(totalBudget * 0.2)))
+          : 0);
+      const staleWarningReserveTokens =
+        staleWarningReserveCapCfg ??
+        (ctx.cfg.activeTask.enabled && ctx.cfg.activeTask.staleWarning.enabled
+          ? Math.max(40, Math.floor(totalBudget * 0.08))
           : 0);
       const budgetState: BudgetState = {
         remainingBudget: totalBudget,
@@ -341,6 +347,12 @@ export async function runRecall(
         }
       }
       reserveAndTrackBlock("active-task", activeTaskReserveTokens, ctx.cfg.activeTask.enabled, budgetState);
+      reserveAndTrackBlock(
+        "stale-warning",
+        staleWarningReserveTokens,
+        ctx.cfg.activeTask.staleWarning.enabled,
+        budgetState,
+      );
       const memoryLines = ftsOnly
         .slice(0, degradedLimit)
         .map((r) => {
@@ -913,6 +925,7 @@ export async function runRecall(
       narrativeMaxTokens: narrativeBlockCapCfg,
       procedureMaxTokens: procedureBlockCapCfg,
       activeTaskMaxTokens: activeTaskReserveCapCfg,
+      staleWarningMaxTokens: staleWarningReserveCapCfg,
     } = ctx.cfg.autoRecall;
     // Enforce retrieval.ambientBudgetTokens as a hard total-token cap (#581).
     // autoRecall.maxTokens is a user preference; ambientBudgetTokens is the architectural
@@ -933,6 +946,11 @@ export async function runRecall(
         ? Math.min(ctx.cfg.activeTask.injectionBudget, Math.max(80, Math.floor(totalBudget * 0.2)))
         : 0;
     const activeTaskReserveTokens = activeTaskReserveCapCfg ?? defaultActiveTaskReserve;
+    const staleWarningReserveTokens =
+      staleWarningReserveCapCfg ??
+      (ctx.cfg.activeTask.enabled && ctx.cfg.activeTask.staleWarning.enabled
+        ? Math.max(40, Math.floor(totalBudget * 0.08))
+        : 0);
 
     const budgetState: BudgetState = {
       remainingBudget: totalBudget,
@@ -944,6 +962,12 @@ export async function runRecall(
     hotBlock = capAndTrackBlock("hot", hotBlock, hotCapTokens, budgetState);
     procedureBlock = capAndTrackBlock("procedure", procedureBlock, procedureCapTokens, budgetState);
     reserveAndTrackBlock("active-task", activeTaskReserveTokens, ctx.cfg.activeTask.enabled, budgetState);
+    reserveAndTrackBlock(
+      "stale-warning",
+      staleWarningReserveTokens,
+      ctx.cfg.activeTask.staleWarning.enabled,
+      budgetState,
+    );
 
     const fixedBlocksTokens = totalBudget - budgetState.remainingBudget;
     const maxTokens = Math.max(0, budgetState.remainingBudget);

--- a/extensions/memory-hybrid/lifecycle/stage-recall/run-recall.ts
+++ b/extensions/memory-hybrid/lifecycle/stage-recall/run-recall.ts
@@ -243,19 +243,18 @@ export async function runRecall(
         activeTaskMaxTokens: activeTaskReserveCapCfg,
         staleWarningMaxTokens: staleWarningReserveCapCfg,
       } = ctx.cfg.autoRecall;
-      const narrativeCapTokens =
-        narrativeBlockCapCfg ?? Math.max(100, Math.floor(totalBudget * 0.2));
+      const narrativeCapTokens = narrativeBlockCapCfg ?? Math.max(100, Math.floor(totalBudget * 0.2));
       const hotCapTokens = hotBlockCapCfg ?? Math.max(100, Math.floor(totalBudget * 0.25));
-      const activeTaskReserveTokens = activeTaskReserveCapCfg ?? (
-        ctx.cfg.activeTask.enabled && ctx.cfg.activeTask.injectionBudget > 0
+      const activeTaskReserveTokens =
+        activeTaskReserveCapCfg ??
+        (ctx.cfg.activeTask.enabled && ctx.cfg.activeTask.injectionBudget > 0
           ? Math.min(ctx.cfg.activeTask.injectionBudget, Math.max(80, Math.floor(totalBudget * 0.2)))
-          : 0
-      );
-      const staleWarningReserveTokens = staleWarningReserveCapCfg ?? (
-        ctx.cfg.activeTask.enabled && ctx.cfg.activeTask.staleWarning.enabled
+          : 0);
+      const staleWarningReserveTokens =
+        staleWarningReserveCapCfg ??
+        (ctx.cfg.activeTask.enabled && ctx.cfg.activeTask.staleWarning.enabled
           ? Math.max(40, Math.floor(totalBudget * 0.08))
-          : 0
-      );
+          : 0);
       let remainingBudget = totalBudget;
       const fixedBlockAudit: FixedBlockAudit[] = [];
       const capAndTrackBlock = (name: string, block: string, capTokens: number): string => {

--- a/extensions/memory-hybrid/lifecycle/stage-recall/run-recall.ts
+++ b/extensions/memory-hybrid/lifecycle/stage-recall/run-recall.ts
@@ -105,6 +105,66 @@ type FixedBlockAudit = {
   reason?: "empty" | "cap" | "budget_exhausted";
 };
 
+type BudgetState = {
+  remainingBudget: number;
+  audit: FixedBlockAudit[];
+};
+
+function capAndTrackBlock(
+  name: string,
+  block: string,
+  capTokens: number,
+  state: BudgetState,
+): string {
+  const cap = Math.max(0, Math.floor(capTokens));
+  const allowed = Math.min(cap, state.remainingBudget);
+  const { text, sourceTokens, usedTokens } = trimBlockToBudget(block, allowed);
+  const suppressed = sourceTokens > 0 && usedTokens === 0;
+  state.audit.push({
+    block: name,
+    sourceTokens,
+    capTokens: cap,
+    injectedTokens: usedTokens,
+    reserved: false,
+    truncated: sourceTokens > usedTokens,
+    suppressed,
+    reason:
+      sourceTokens === 0
+        ? "empty"
+        : usedTokens === 0
+          ? "budget_exhausted"
+          : sourceTokens > usedTokens
+            ? allowed < cap
+              ? "budget_exhausted"
+              : "cap"
+            : undefined,
+  });
+  state.remainingBudget = Math.max(0, state.remainingBudget - usedTokens);
+  return text;
+}
+
+function reserveAndTrackBlock(
+  name: string,
+  reserveTokens: number,
+  enabled: boolean,
+  state: BudgetState,
+): void {
+  const cap = enabled ? Math.max(0, Math.floor(reserveTokens)) : 0;
+  const reserved = Math.min(cap, state.remainingBudget);
+  state.audit.push({
+    block: name,
+    sourceTokens: cap,
+    capTokens: cap,
+    injectedTokens: reserved,
+    reserved: true,
+    truncated: cap > reserved,
+    suppressed: cap > 0 && reserved === 0,
+    reason:
+      cap === 0 ? "empty" : reserved === 0 ? "budget_exhausted" : cap > reserved ? "budget_exhausted" : undefined,
+  });
+  state.remainingBudget = Math.max(0, state.remainingBudget - reserved);
+}
+
 export async function runRecall(
   event: unknown,
   api: ClawdbotPluginApi,
@@ -251,50 +311,9 @@ export async function runRecall(
         (ctx.cfg.activeTask.enabled && ctx.cfg.activeTask.injectionBudget > 0
           ? Math.min(ctx.cfg.activeTask.injectionBudget, Math.max(80, Math.floor(totalBudget * 0.2)))
           : 0);
-      let remainingBudget = totalBudget;
-      const fixedBlockAudit: FixedBlockAudit[] = [];
-      const capAndTrackBlock = (name: string, block: string, capTokens: number): string => {
-        const cap = Math.max(0, Math.floor(capTokens));
-        const allowed = Math.min(cap, remainingBudget);
-        const { text, sourceTokens, usedTokens } = trimBlockToBudget(block, allowed);
-        const suppressed = sourceTokens > 0 && usedTokens === 0;
-        fixedBlockAudit.push({
-          block: name,
-          sourceTokens,
-          capTokens: cap,
-          injectedTokens: usedTokens,
-          reserved: false,
-          truncated: sourceTokens > usedTokens,
-          suppressed,
-          reason:
-            sourceTokens === 0
-              ? "empty"
-              : usedTokens === 0
-                ? "budget_exhausted"
-                : sourceTokens > usedTokens
-                  ? allowed < cap
-                    ? "budget_exhausted"
-                    : "cap"
-                  : undefined,
-        });
-        remainingBudget = Math.max(0, remainingBudget - usedTokens);
-        return text;
-      };
-      const reserveAndTrackBlock = (name: string, reserveTokens: number, enabled: boolean): void => {
-        const cap = enabled ? Math.max(0, Math.floor(reserveTokens)) : 0;
-        const reserved = Math.min(cap, remainingBudget);
-        fixedBlockAudit.push({
-          block: name,
-          sourceTokens: cap,
-          capTokens: cap,
-          injectedTokens: reserved,
-          reserved: true,
-          truncated: cap > reserved,
-          suppressed: cap > 0 && reserved === 0,
-          reason:
-            cap === 0 ? "empty" : reserved === 0 ? "budget_exhausted" : cap > reserved ? "budget_exhausted" : undefined,
-        });
-        remainingBudget = Math.max(0, remainingBudget - reserved);
+      const budgetState: BudgetState = {
+        remainingBudget: totalBudget,
+        audit: [],
       };
       let narrativePart = "";
       if (ctx.narrativesDb || ctx.eventLog) {
@@ -308,7 +327,7 @@ export async function runRecall(
           if (recentNarratives.length > 0) {
             const narrative = recentNarratives[0];
             const narrativeBlock = `<recent-history-narratives>\n- [${narrative.source}/${formatNarrativeRange(narrative.periodStart, narrative.periodEnd)}] (sessionKey: ${narrative.sessionId})\n${clipNarrativeText(narrative.text)}\n</recent-history-narratives>\n\n`;
-            narrativePart = capAndTrackBlock("narrative", narrativeBlock, narrativeCapTokens);
+            narrativePart = capAndTrackBlock("narrative", narrativeBlock, narrativeCapTokens, budgetState);
           }
         } catch {
           // Non-fatal.
@@ -328,11 +347,11 @@ export async function runRecall(
             .filter(Boolean);
           if (hotLines.length > 0) {
             const hotBlock = `Hot memories:\n${hotLines.join("\n")}\n\n`;
-            hotPart = capAndTrackBlock("hot", hotBlock, hotCapTokens);
+            hotPart = capAndTrackBlock("hot", hotBlock, hotCapTokens, budgetState);
           }
         }
       }
-      reserveAndTrackBlock("active-task", activeTaskReserveTokens, ctx.cfg.activeTask.enabled);
+      reserveAndTrackBlock("active-task", activeTaskReserveTokens, ctx.cfg.activeTask.enabled, budgetState);
       const memoryLines = ftsOnly
         .slice(0, degradedLimit)
         .map((r) => {
@@ -343,29 +362,29 @@ export async function runRecall(
         })
         .filter(Boolean);
       const recallBlock = memoryLines.length ? `Recalled (FTS-only):\n${memoryLines.join("\n")}` : "";
-      const { text: recallPart, usedTokens: recallUsedTokens } = trimBlockToBudget(recallBlock, remainingBudget);
-      remainingBudget = Math.max(0, remainingBudget - recallUsedTokens);
+      const { text: recallPart, usedTokens: recallUsedTokens } = trimBlockToBudget(recallBlock, budgetState.remainingBudget);
+      budgetState.remainingBudget = Math.max(0, budgetState.remainingBudget - recallUsedTokens);
       const inner = narrativePart + hotPart + recallPart;
       const block = inner ? `<recalled-context>\n${inner}\n</recalled-context>` : "";
       const degradedMarker = "<!-- recall degraded: queue -->\n";
       const sessionKey = resolveSessionKey(e, api) ?? currentAgentIdRef.value ?? "default";
-      const fixedBlocksTokens = totalBudget - remainingBudget;
-      const blockSummary = fixedBlockAudit
+      const fixedBlocksTokens = totalBudget - budgetState.remainingBudget;
+      const blockSummary = budgetState.audit
         .map((b) => `${b.block}:${b.injectedTokens}/${b.capTokens}${b.reserved ? "r" : ""}${b.truncated ? "!" : ""}`)
         .join(", ");
       api.logger.info?.(
-        `memory-hybrid: context-audit (degraded) fixed=${fixedBlocksTokens}/${totalBudget} recall=${remainingBudget} blocks=[${blockSummary}]`,
+        `memory-hybrid: context-audit (degraded) fixed=${fixedBlocksTokens}/${totalBudget} recall=${budgetState.remainingBudget} blocks=[${blockSummary}]`,
       );
       ctx.auditStore?.append({
         agentId: resolveAgentIdFromHookEvent(event, api) ?? ctx.currentAgentIdRef.value ?? "unknown",
         action: "recall:context-budget",
-        outcome: remainingBudget === 0 ? "partial" : "success",
+        outcome: budgetState.remainingBudget === 0 ? "partial" : "success",
         sessionId: sessionKey,
         tokens: fixedBlocksTokens,
         context: {
           totalBudget,
-          recallBudget: remainingBudget,
-          blocks: fixedBlockAudit,
+          recallBudget: budgetState.remainingBudget,
+          blocks: budgetState.audit,
           degraded: true,
         },
       });
@@ -923,63 +942,20 @@ export async function runRecall(
         : 0;
     const activeTaskReserveTokens = activeTaskReserveCapCfg ?? defaultActiveTaskReserve;
 
-    let remainingBudget = totalBudget;
-    const fixedBlockAudit: FixedBlockAudit[] = [];
-
-    const capAndTrackBlock = (name: string, block: string, capTokens: number): string => {
-      const cap = Math.max(0, Math.floor(capTokens));
-      const allowed = Math.min(cap, remainingBudget);
-      const { text, sourceTokens, usedTokens } = trimBlockToBudget(block, allowed);
-      const suppressed = sourceTokens > 0 && usedTokens === 0;
-      fixedBlockAudit.push({
-        block: name,
-        sourceTokens,
-        capTokens: cap,
-        injectedTokens: usedTokens,
-        reserved: false,
-        truncated: sourceTokens > usedTokens,
-        suppressed,
-        reason:
-          sourceTokens === 0
-            ? "empty"
-            : usedTokens === 0
-              ? "budget_exhausted"
-              : sourceTokens > usedTokens
-                ? allowed < cap
-                  ? "budget_exhausted"
-                  : "cap"
-                : undefined,
-      });
-      remainingBudget = Math.max(0, remainingBudget - usedTokens);
-      return text;
+    const budgetState: BudgetState = {
+      remainingBudget: totalBudget,
+      audit: [],
     };
 
-    const reserveAndTrackBlock = (name: string, reserveTokens: number, enabled: boolean): void => {
-      const cap = enabled ? Math.max(0, Math.floor(reserveTokens)) : 0;
-      const reserved = Math.min(cap, remainingBudget);
-      fixedBlockAudit.push({
-        block: name,
-        sourceTokens: cap,
-        capTokens: cap,
-        injectedTokens: reserved,
-        reserved: true,
-        truncated: cap > reserved,
-        suppressed: cap > 0 && reserved === 0,
-        reason:
-          cap === 0 ? "empty" : reserved === 0 ? "budget_exhausted" : cap > reserved ? "budget_exhausted" : undefined,
-      });
-      remainingBudget = Math.max(0, remainingBudget - reserved);
-    };
+    issueBlock = capAndTrackBlock("issue", issueBlock, issueCapTokens, budgetState);
+    narrativeBlock = capAndTrackBlock("narrative", narrativeBlock, narrativeCapTokens, budgetState);
+    hotBlock = capAndTrackBlock("hot", hotBlock, hotCapTokens, budgetState);
+    procedureBlock = capAndTrackBlock("procedure", procedureBlock, procedureCapTokens, budgetState);
+    reserveAndTrackBlock("active-task", activeTaskReserveTokens, ctx.cfg.activeTask.enabled, budgetState);
 
-    issueBlock = capAndTrackBlock("issue", issueBlock, issueCapTokens);
-    narrativeBlock = capAndTrackBlock("narrative", narrativeBlock, narrativeCapTokens);
-    hotBlock = capAndTrackBlock("hot", hotBlock, hotCapTokens);
-    procedureBlock = capAndTrackBlock("procedure", procedureBlock, procedureCapTokens);
-    reserveAndTrackBlock("active-task", activeTaskReserveTokens, ctx.cfg.activeTask.enabled);
-
-    const fixedBlocksTokens = totalBudget - remainingBudget;
-    const maxTokens = Math.max(0, remainingBudget);
-    const blockSummary = fixedBlockAudit
+    const fixedBlocksTokens = totalBudget - budgetState.remainingBudget;
+    const maxTokens = Math.max(0, budgetState.remainingBudget);
+    const blockSummary = budgetState.audit
       .map((b) => `${b.block}:${b.injectedTokens}/${b.capTokens}${b.reserved ? "r" : ""}${b.truncated ? "!" : ""}`)
       .join(", ");
     api.logger.info?.(
@@ -994,12 +970,12 @@ export async function runRecall(
       context: {
         totalBudget,
         recallBudget: maxTokens,
-        blocks: fixedBlockAudit,
+        blocks: budgetState.audit,
       },
     });
 
     if (maxTokens === 0) {
-      const consumers = fixedBlockAudit
+      const consumers = budgetState.audit
         .filter((b) => b.injectedTokens > 0)
         .sort((a, b) => b.injectedTokens - a.injectedTokens)
         .slice(0, 4)
@@ -1020,7 +996,7 @@ export async function runRecall(
           issueBlockInjected: issueBlock.length > 0,
           narrativeBlockInjected: narrativeBlock.length > 0,
           hotBlockInjected: hotBlock.length > 0,
-          fixedBlocks: fixedBlockAudit,
+          fixedBlocks: budgetState.audit,
         },
       });
       const combinedContext = issueBlock + narrativeBlock + hotBlock + procedureBlock;

--- a/extensions/memory-hybrid/lifecycle/stage-recall/run-recall.ts
+++ b/extensions/memory-hybrid/lifecycle/stage-recall/run-recall.ts
@@ -70,7 +70,9 @@ function trimBlockToBudget(
 
   const first = lines[0] ?? "";
   const last = lines[lines.length - 1] ?? "";
-  if (lines.length >= 3 && first.startsWith("<") && last.startsWith("</")) {
+  const firstTagMatch = first.match(/^<([^>\s/]+)>$/);
+  const lastTagMatch = last.match(/^<\/([^>\s]+)>$/);
+  if (lines.length >= 3 && firstTagMatch && lastTagMatch && firstTagMatch[1] === lastTagMatch[1]) {
     const middle = lines.slice(1, -1);
     for (let keep = middle.length; keep >= 0; keep--) {
       const candidate = [first, ...middle.slice(0, keep), last].join("\n") + trailingNewlines;
@@ -234,7 +236,71 @@ export async function runRecall(
       await yieldEventLoop();
       const ftsOnly = ctx.factsDb.search(trimmed, degradedLimit, recallOpts);
       const totalBudget = interactivePolicy.contextBudgetTokens;
+      const {
+        hotMaxTokens: hotBlockCapCfg,
+        narrativeMaxTokens: narrativeBlockCapCfg,
+        procedureMaxTokens: procedureBlockCapCfg,
+        activeTaskMaxTokens: activeTaskReserveCapCfg,
+        staleWarningMaxTokens: staleWarningReserveCapCfg,
+      } = ctx.cfg.autoRecall;
+      const narrativeCapTokens =
+        narrativeBlockCapCfg ?? Math.max(100, Math.floor(totalBudget * 0.2));
+      const hotCapTokens = hotBlockCapCfg ?? Math.max(100, Math.floor(totalBudget * 0.25));
+      const activeTaskReserveTokens = activeTaskReserveCapCfg ?? (
+        ctx.cfg.activeTask.enabled && ctx.cfg.activeTask.injectionBudget > 0
+          ? Math.min(ctx.cfg.activeTask.injectionBudget, Math.max(80, Math.floor(totalBudget * 0.2)))
+          : 0
+      );
+      const staleWarningReserveTokens = staleWarningReserveCapCfg ?? (
+        ctx.cfg.activeTask.enabled && ctx.cfg.activeTask.staleWarning.enabled
+          ? Math.max(40, Math.floor(totalBudget * 0.08))
+          : 0
+      );
       let remainingBudget = totalBudget;
+      const fixedBlockAudit: FixedBlockAudit[] = [];
+      const capAndTrackBlock = (name: string, block: string, capTokens: number): string => {
+        const cap = Math.max(0, Math.floor(capTokens));
+        const allowed = Math.min(cap, remainingBudget);
+        const { text, sourceTokens, usedTokens } = trimBlockToBudget(block, allowed);
+        const suppressed = sourceTokens > 0 && usedTokens === 0;
+        fixedBlockAudit.push({
+          block: name,
+          sourceTokens,
+          capTokens: cap,
+          injectedTokens: usedTokens,
+          reserved: false,
+          truncated: sourceTokens > usedTokens,
+          suppressed,
+          reason:
+            sourceTokens === 0
+              ? "empty"
+              : usedTokens === 0
+                ? "budget_exhausted"
+                : sourceTokens > usedTokens
+                  ? allowed < cap
+                    ? "budget_exhausted"
+                    : "cap"
+                  : undefined,
+        });
+        remainingBudget = Math.max(0, remainingBudget - usedTokens);
+        return text;
+      };
+      const reserveAndTrackBlock = (name: string, reserveTokens: number, enabled: boolean): void => {
+        const cap = enabled ? Math.max(0, Math.floor(reserveTokens)) : 0;
+        const reserved = Math.min(cap, remainingBudget);
+        fixedBlockAudit.push({
+          block: name,
+          sourceTokens: cap,
+          capTokens: cap,
+          injectedTokens: reserved,
+          reserved: true,
+          truncated: cap > reserved,
+          suppressed: cap > 0 && reserved === 0,
+          reason:
+            cap === 0 ? "empty" : reserved === 0 ? "budget_exhausted" : cap > reserved ? "budget_exhausted" : undefined,
+        });
+        remainingBudget = Math.max(0, remainingBudget - reserved);
+      };
       let narrativePart = "";
       if (ctx.narrativesDb || ctx.eventLog) {
         try {
@@ -247,10 +313,7 @@ export async function runRecall(
           if (recentNarratives.length > 0) {
             const narrative = recentNarratives[0];
             const narrativeBlock = `<recent-history-narratives>\n- [${narrative.source}/${formatNarrativeRange(narrative.periodStart, narrative.periodEnd)}] (sessionKey: ${narrative.sessionId})\n${clipNarrativeText(narrative.text)}\n</recent-history-narratives>\n\n`;
-            const narrativeCapTokens = Math.max(100, Math.floor(totalBudget * 0.2));
-            const { text } = trimBlockToBudget(narrativeBlock, Math.min(narrativeCapTokens, remainingBudget));
-            narrativePart = text;
-            remainingBudget = Math.max(0, remainingBudget - estimateTokens(text));
+            narrativePart = capAndTrackBlock("narrative", narrativeBlock, narrativeCapTokens);
           }
         } catch {
           // Non-fatal.
@@ -270,13 +333,16 @@ export async function runRecall(
             .filter(Boolean);
           if (hotLines.length > 0) {
             const hotBlock = `Hot memories:\n${hotLines.join("\n")}\n\n`;
-            const hotCapTokens = Math.max(100, Math.floor(totalBudget * 0.25));
-            const { text } = trimBlockToBudget(hotBlock, Math.min(hotCapTokens, remainingBudget));
-            hotPart = text;
-            remainingBudget = Math.max(0, remainingBudget - estimateTokens(text));
+            hotPart = capAndTrackBlock("hot", hotBlock, hotCapTokens);
           }
         }
       }
+      reserveAndTrackBlock("active-task", activeTaskReserveTokens, ctx.cfg.activeTask.enabled);
+      reserveAndTrackBlock(
+        "stale-warning",
+        staleWarningReserveTokens,
+        ctx.cfg.activeTask.enabled && ctx.cfg.activeTask.staleWarning.enabled,
+      );
       const memoryLines = ftsOnly
         .slice(0, degradedLimit)
         .map(
@@ -288,6 +354,27 @@ export async function runRecall(
       const inner = narrativePart + hotPart + recallPart;
       const block = inner ? `<recalled-context>\n${inner}\n</recalled-context>` : "";
       const degradedMarker = "<!-- recall degraded: queue -->\n";
+      const sessionKey = resolveSessionKey(e, api) ?? currentAgentIdRef.value ?? "default";
+      const fixedBlocksTokens = totalBudget - remainingBudget;
+      const blockSummary = fixedBlockAudit
+        .map((b) => `${b.block}:${b.injectedTokens}/${b.capTokens}${b.reserved ? "r" : ""}${b.truncated ? "!" : ""}`)
+        .join(", ");
+      api.logger.info?.(
+        `memory-hybrid: context-audit (degraded) fixed=${fixedBlocksTokens}/${totalBudget} recall=${remainingBudget} blocks=[${blockSummary}]`,
+      );
+      ctx.auditStore?.append({
+        agentId: resolveAgentIdFromHookEvent(event, api) ?? ctx.currentAgentIdRef.value ?? "unknown",
+        action: "recall:context-budget",
+        outcome: remainingBudget === 0 ? "partial" : "success",
+        sessionId: sessionKey,
+        tokens: fixedBlocksTokens,
+        context: {
+          totalBudget,
+          recallBudget: remainingBudget,
+          blocks: fixedBlockAudit,
+          degraded: true,
+        },
+      });
       api.logger.debug?.(
         `memory-hybrid: recall degraded (queue depth ${ctx.recallInFlightRef.value} > ${degradationQueueDepth}), using FTS-only + HOT`,
       );

--- a/extensions/memory-hybrid/lifecycle/stage-recall/run-recall.ts
+++ b/extensions/memory-hybrid/lifecycle/stage-recall/run-recall.ts
@@ -342,7 +342,8 @@ export async function runRecall(
         })
         .filter(Boolean);
       const recallBlock = memoryLines.length ? `Recalled (FTS-only):\n${memoryLines.join("\n")}` : "";
-      const { text: recallPart } = trimBlockToBudget(recallBlock, remainingBudget);
+      const { text: recallPart, usedTokens: recallUsedTokens } = trimBlockToBudget(recallBlock, remainingBudget);
+      remainingBudget = Math.max(0, remainingBudget - recallUsedTokens);
       const inner = narrativePart + hotPart + recallPart;
       const block = inner ? `<recalled-context>\n${inner}\n</recalled-context>` : "";
       const degradedMarker = "<!-- recall degraded: queue -->\n";

--- a/extensions/memory-hybrid/lifecycle/stage-recall/run-recall.ts
+++ b/extensions/memory-hybrid/lifecycle/stage-recall/run-recall.ts
@@ -46,7 +46,6 @@ function sanitizeHotFactText(text: string): string {
     .replace(/<redacted_thinking>[\s\S]*?<\/redacted_thinking>/gi, " ")
     .replace(/<thinking>[\s\S]*?<\/thinking>/gi, " ")
     .replace(/<reasoning>[\s\S]*?<\/reasoning>/gi, " ")
-    .replace(/<think>[\s\S]*?<\/think>/gi, " ")
     .replace(/\s+/g, " ")
     .trim();
 }
@@ -338,11 +337,15 @@ export async function runRecall(
           }
         }
       }
-      reserveAndTrackBlock("active-task", activeTaskReserveTokens, ctx.cfg.activeTask.enabled);
+      reserveAndTrackBlock(
+        "active-task",
+        activeTaskReserveTokens,
+        ctx.cfg.activeTask.enabled && ctx.cfg.verbosity !== "silent",
+      );
       reserveAndTrackBlock(
         "stale-warning",
         staleWarningReserveTokens,
-        ctx.cfg.activeTask.enabled && ctx.cfg.activeTask.staleWarning.enabled,
+        ctx.cfg.activeTask.enabled && ctx.cfg.activeTask.staleWarning.enabled && ctx.cfg.verbosity !== "silent",
       );
       const memoryLines = ftsOnly
         .slice(0, degradedLimit)
@@ -988,11 +991,15 @@ export async function runRecall(
     narrativeBlock = capAndTrackBlock("narrative", narrativeBlock, narrativeCapTokens);
     hotBlock = capAndTrackBlock("hot", hotBlock, hotCapTokens);
     procedureBlock = capAndTrackBlock("procedure", procedureBlock, procedureCapTokens);
-    reserveAndTrackBlock("active-task", activeTaskReserveTokens, ctx.cfg.activeTask.enabled);
+    reserveAndTrackBlock(
+      "active-task",
+      activeTaskReserveTokens,
+      ctx.cfg.activeTask.enabled && ctx.cfg.verbosity !== "silent",
+    );
     reserveAndTrackBlock(
       "stale-warning",
       staleWarningReserveTokens,
-      ctx.cfg.activeTask.enabled && ctx.cfg.activeTask.staleWarning.enabled,
+      ctx.cfg.activeTask.enabled && ctx.cfg.activeTask.staleWarning.enabled && ctx.cfg.verbosity !== "silent",
     );
 
     const fixedBlocksTokens = totalBudget - remainingBudget;
@@ -1041,7 +1048,7 @@ export async function runRecall(
           fixedBlocks: fixedBlockAudit,
         },
       });
-      const combinedContext = issueBlock + narrativeBlock + hotBlock;
+      const combinedContext = issueBlock + narrativeBlock + hotBlock + procedureBlock;
       return completeStage({ kind: "empty", prependContext: combinedContext || undefined });
     }
 

--- a/extensions/memory-hybrid/lifecycle/stage-recall/run-recall.ts
+++ b/extensions/memory-hybrid/lifecycle/stage-recall/run-recall.ts
@@ -233,6 +233,29 @@ export async function runRecall(
       const trimmed = e.prompt.trim();
       await yieldEventLoop();
       const ftsOnly = ctx.factsDb.search(trimmed, degradedLimit, recallOpts);
+      const totalBudget = interactivePolicy.contextBudgetTokens;
+      let remainingBudget = totalBudget;
+      let narrativePart = "";
+      if (ctx.narrativesDb || ctx.eventLog) {
+        try {
+          const recentNarratives = recallNarrativeSummaries({
+            narrativesDb: ctx.narrativesDb,
+            eventLog: ctx.eventLog,
+            query: e.prompt,
+            limit: 1,
+          });
+          if (recentNarratives.length > 0) {
+            const narrative = recentNarratives[0];
+            const narrativeBlock = `<recent-history-narratives>\n- [${narrative.source}/${formatNarrativeRange(narrative.periodStart, narrative.periodEnd)}] (sessionKey: ${narrative.sessionId})\n${clipNarrativeText(narrative.text)}\n</recent-history-narratives>\n\n`;
+            const narrativeCapTokens = Math.max(100, Math.floor(totalBudget * 0.2));
+            const { text } = trimBlockToBudget(narrativeBlock, Math.min(narrativeCapTokens, remainingBudget));
+            narrativePart = text;
+            remainingBudget = Math.max(0, remainingBudget - estimateTokens(text));
+          }
+        } catch {
+          // Non-fatal.
+        }
+      }
       let hotPart = "";
       if (ctx.cfg.memoryTiering.enabled && ctx.cfg.memoryTiering.hotMaxTokens > 0) {
         const hotResults = ctx.factsDb.getHotFacts(ctx.cfg.memoryTiering.hotMaxTokens, scopeFilter);
@@ -246,7 +269,11 @@ export async function runRecall(
             })
             .filter(Boolean);
           if (hotLines.length > 0) {
-            hotPart = `Hot memories:\n${hotLines.join("\n")}\n\n`;
+            const hotBlock = `Hot memories:\n${hotLines.join("\n")}\n\n`;
+            const hotCapTokens = Math.max(100, Math.floor(totalBudget * 0.25));
+            const { text } = trimBlockToBudget(hotBlock, Math.min(hotCapTokens, remainingBudget));
+            hotPart = text;
+            remainingBudget = Math.max(0, remainingBudget - estimateTokens(text));
           }
         }
       }
@@ -256,25 +283,9 @@ export async function runRecall(
           (r) =>
             `- [${r.backend}/${r.entry.category}] ${(r.entry.summary || r.entry.text).slice(0, 200)}${(r.entry.summary || r.entry.text).length > 200 ? "…" : ""}`,
         );
-      let narrativePart = "";
-      if (ctx.narrativesDb || ctx.eventLog) {
-        try {
-          const recentNarratives = recallNarrativeSummaries({
-            narrativesDb: ctx.narrativesDb,
-            eventLog: ctx.eventLog,
-            query: e.prompt,
-            limit: 1,
-          });
-          if (recentNarratives.length > 0) {
-            const narrative = recentNarratives[0];
-            narrativePart = `<recent-history-narratives>\n- [${narrative.source}/${formatNarrativeRange(narrative.periodStart, narrative.periodEnd)}] (sessionKey: ${narrative.sessionId})\n${clipNarrativeText(narrative.text)}\n</recent-history-narratives>\n\n`;
-          }
-        } catch {
-          // Non-fatal.
-        }
-      }
-      const inner =
-        narrativePart + hotPart + (memoryLines.length ? `Recalled (FTS-only):\n${memoryLines.join("\n")}` : "");
+      const recallBlock = memoryLines.length ? `Recalled (FTS-only):\n${memoryLines.join("\n")}` : "";
+      const { text: recallPart } = trimBlockToBudget(recallBlock, remainingBudget);
+      const inner = narrativePart + hotPart + recallPart;
       const block = inner ? `<recalled-context>\n${inner}\n</recalled-context>` : "";
       const degradedMarker = "<!-- recall degraded: queue -->\n";
       api.logger.debug?.(

--- a/extensions/memory-hybrid/lifecycle/stage-recall/run-recall.ts
+++ b/extensions/memory-hybrid/lifecycle/stage-recall/run-recall.ts
@@ -110,12 +110,7 @@ type BudgetState = {
   audit: FixedBlockAudit[];
 };
 
-function capAndTrackBlock(
-  name: string,
-  block: string,
-  capTokens: number,
-  state: BudgetState,
-): string {
+function capAndTrackBlock(name: string, block: string, capTokens: number, state: BudgetState): string {
   const cap = Math.max(0, Math.floor(capTokens));
   const allowed = Math.min(cap, state.remainingBudget);
   const { text, sourceTokens, usedTokens } = trimBlockToBudget(block, allowed);
@@ -143,12 +138,7 @@ function capAndTrackBlock(
   return text;
 }
 
-function reserveAndTrackBlock(
-  name: string,
-  reserveTokens: number,
-  enabled: boolean,
-  state: BudgetState,
-): void {
+function reserveAndTrackBlock(name: string, reserveTokens: number, enabled: boolean, state: BudgetState): void {
   const cap = enabled ? Math.max(0, Math.floor(reserveTokens)) : 0;
   const reserved = Math.min(cap, state.remainingBudget);
   state.audit.push({
@@ -159,8 +149,7 @@ function reserveAndTrackBlock(
     reserved: true,
     truncated: cap > reserved,
     suppressed: cap > 0 && reserved === 0,
-    reason:
-      cap === 0 ? "empty" : reserved === 0 ? "budget_exhausted" : cap > reserved ? "budget_exhausted" : undefined,
+    reason: cap === 0 ? "empty" : reserved === 0 ? "budget_exhausted" : cap > reserved ? "budget_exhausted" : undefined,
   });
   state.remainingBudget = Math.max(0, state.remainingBudget - reserved);
 }
@@ -362,7 +351,10 @@ export async function runRecall(
         })
         .filter(Boolean);
       const recallBlock = memoryLines.length ? `Recalled (FTS-only):\n${memoryLines.join("\n")}` : "";
-      const { text: recallPart, usedTokens: recallUsedTokens } = trimBlockToBudget(recallBlock, budgetState.remainingBudget);
+      const { text: recallPart, usedTokens: recallUsedTokens } = trimBlockToBudget(
+        recallBlock,
+        budgetState.remainingBudget,
+      );
       budgetState.remainingBudget = Math.max(0, budgetState.remainingBudget - recallUsedTokens);
       const inner = narrativePart + hotPart + recallPart;
       const block = inner ? `<recalled-context>\n${inner}\n</recalled-context>` : "";

--- a/extensions/memory-hybrid/lifecycle/stage-recall/run-recall.ts
+++ b/extensions/memory-hybrid/lifecycle/stage-recall/run-recall.ts
@@ -240,7 +240,6 @@ export async function runRecall(
         narrativeMaxTokens: narrativeBlockCapCfg,
         procedureMaxTokens: procedureBlockCapCfg,
         activeTaskMaxTokens: activeTaskReserveCapCfg,
-        staleWarningMaxTokens: staleWarningReserveCapCfg,
       } = ctx.cfg.autoRecall;
       const hasNarrativesDb = ctx.narrativesDb != null || ctx.eventLog != null;
       const narrativeCapTokens =
@@ -250,11 +249,6 @@ export async function runRecall(
         activeTaskReserveCapCfg ??
         (ctx.cfg.activeTask.enabled && ctx.cfg.activeTask.injectionBudget > 0
           ? Math.min(ctx.cfg.activeTask.injectionBudget, Math.max(80, Math.floor(totalBudget * 0.2)))
-          : 0);
-      const staleWarningReserveTokens =
-        staleWarningReserveCapCfg ??
-        (ctx.cfg.activeTask.enabled && ctx.cfg.activeTask.staleWarning.enabled
-          ? Math.max(40, Math.floor(totalBudget * 0.08))
           : 0);
       let remainingBudget = totalBudget;
       const fixedBlockAudit: FixedBlockAudit[] = [];
@@ -341,11 +335,6 @@ export async function runRecall(
         "active-task",
         activeTaskReserveTokens,
         ctx.cfg.activeTask.enabled && ctx.cfg.verbosity !== "silent",
-      );
-      reserveAndTrackBlock(
-        "stale-warning",
-        staleWarningReserveTokens,
-        ctx.cfg.activeTask.enabled && ctx.cfg.activeTask.staleWarning.enabled,
       );
       const memoryLines = ftsOnly
         .slice(0, degradedLimit)
@@ -912,7 +901,6 @@ export async function runRecall(
       narrativeMaxTokens: narrativeBlockCapCfg,
       procedureMaxTokens: procedureBlockCapCfg,
       activeTaskMaxTokens: activeTaskReserveCapCfg,
-      staleWarningMaxTokens: staleWarningReserveCapCfg,
     } = ctx.cfg.autoRecall;
     // Enforce retrieval.ambientBudgetTokens as a hard total-token cap (#581).
     // autoRecall.maxTokens is a user preference; ambientBudgetTokens is the architectural
@@ -933,11 +921,6 @@ export async function runRecall(
         ? Math.min(ctx.cfg.activeTask.injectionBudget, Math.max(80, Math.floor(totalBudget * 0.2)))
         : 0;
     const activeTaskReserveTokens = activeTaskReserveCapCfg ?? defaultActiveTaskReserve;
-    const defaultStaleReserve =
-      ctx.cfg.activeTask.enabled && ctx.cfg.activeTask.staleWarning.enabled
-        ? Math.max(40, Math.floor(totalBudget * 0.08))
-        : 0;
-    const staleWarningReserveTokens = staleWarningReserveCapCfg ?? defaultStaleReserve;
 
     let remainingBudget = totalBudget;
     const fixedBlockAudit: FixedBlockAudit[] = [];
@@ -995,11 +978,6 @@ export async function runRecall(
       "active-task",
       activeTaskReserveTokens,
       ctx.cfg.activeTask.enabled && ctx.cfg.verbosity !== "silent",
-    );
-    reserveAndTrackBlock(
-      "stale-warning",
-      staleWarningReserveTokens,
-      ctx.cfg.activeTask.enabled && ctx.cfg.activeTask.staleWarning.enabled,
     );
 
     const fixedBlocksTokens = totalBudget - remainingBudget;

--- a/extensions/memory-hybrid/lifecycle/stage-recall/run-recall.ts
+++ b/extensions/memory-hybrid/lifecycle/stage-recall/run-recall.ts
@@ -342,6 +342,11 @@ export async function runRecall(
         activeTaskReserveTokens,
         ctx.cfg.activeTask.enabled && ctx.cfg.verbosity !== "silent",
       );
+      reserveAndTrackBlock(
+        "stale-warning",
+        staleWarningReserveTokens,
+        ctx.cfg.activeTask.enabled && ctx.cfg.activeTask.staleWarning.enabled,
+      );
       const memoryLines = ftsOnly
         .slice(0, degradedLimit)
         .map(
@@ -990,6 +995,11 @@ export async function runRecall(
       "active-task",
       activeTaskReserveTokens,
       ctx.cfg.activeTask.enabled && ctx.cfg.verbosity !== "silent",
+    );
+    reserveAndTrackBlock(
+      "stale-warning",
+      staleWarningReserveTokens,
+      ctx.cfg.activeTask.enabled && ctx.cfg.activeTask.staleWarning.enabled,
     );
 
     const fixedBlocksTokens = totalBudget - remainingBudget;

--- a/extensions/memory-hybrid/lifecycle/stage-recall/run-recall.ts
+++ b/extensions/memory-hybrid/lifecycle/stage-recall/run-recall.ts
@@ -334,7 +334,7 @@ export async function runRecall(
       reserveAndTrackBlock(
         "active-task",
         activeTaskReserveTokens,
-        ctx.cfg.activeTask.enabled && ctx.cfg.verbosity !== "silent",
+        ctx.cfg.activeTask.enabled,
       );
       const memoryLines = ftsOnly
         .slice(0, degradedLimit)
@@ -977,7 +977,7 @@ export async function runRecall(
     reserveAndTrackBlock(
       "active-task",
       activeTaskReserveTokens,
-      ctx.cfg.activeTask.enabled && ctx.cfg.verbosity !== "silent",
+      ctx.cfg.activeTask.enabled,
     );
 
     const fixedBlocksTokens = totalBudget - remainingBudget;

--- a/extensions/memory-hybrid/lifecycle/stage-recall/run-recall.ts
+++ b/extensions/memory-hybrid/lifecycle/stage-recall/run-recall.ts
@@ -342,11 +342,6 @@ export async function runRecall(
         activeTaskReserveTokens,
         ctx.cfg.activeTask.enabled && ctx.cfg.verbosity !== "silent",
       );
-      reserveAndTrackBlock(
-        "stale-warning",
-        staleWarningReserveTokens,
-        ctx.cfg.activeTask.enabled && ctx.cfg.activeTask.staleWarning.enabled && ctx.cfg.verbosity !== "silent",
-      );
       const memoryLines = ftsOnly
         .slice(0, degradedLimit)
         .map(
@@ -995,11 +990,6 @@ export async function runRecall(
       "active-task",
       activeTaskReserveTokens,
       ctx.cfg.activeTask.enabled && ctx.cfg.verbosity !== "silent",
-    );
-    reserveAndTrackBlock(
-      "stale-warning",
-      staleWarningReserveTokens,
-      ctx.cfg.activeTask.enabled && ctx.cfg.activeTask.staleWarning.enabled && ctx.cfg.verbosity !== "silent",
     );
 
     const fixedBlocksTokens = totalBudget - remainingBudget;

--- a/extensions/memory-hybrid/lifecycle/stage-recall/run-recall.ts
+++ b/extensions/memory-hybrid/lifecycle/stage-recall/run-recall.ts
@@ -331,11 +331,7 @@ export async function runRecall(
           }
         }
       }
-      reserveAndTrackBlock(
-        "active-task",
-        activeTaskReserveTokens,
-        ctx.cfg.activeTask.enabled,
-      );
+      reserveAndTrackBlock("active-task", activeTaskReserveTokens, ctx.cfg.activeTask.enabled);
       const memoryLines = ftsOnly
         .slice(0, degradedLimit)
         .map((r) => {
@@ -977,11 +973,7 @@ export async function runRecall(
     narrativeBlock = capAndTrackBlock("narrative", narrativeBlock, narrativeCapTokens);
     hotBlock = capAndTrackBlock("hot", hotBlock, hotCapTokens);
     procedureBlock = capAndTrackBlock("procedure", procedureBlock, procedureCapTokens);
-    reserveAndTrackBlock(
-      "active-task",
-      activeTaskReserveTokens,
-      ctx.cfg.activeTask.enabled,
-    );
+    reserveAndTrackBlock("active-task", activeTaskReserveTokens, ctx.cfg.activeTask.enabled);
 
     const fixedBlocksTokens = totalBudget - remainingBudget;
     const maxTokens = Math.max(0, remainingBudget);

--- a/extensions/memory-hybrid/lifecycle/stage-recall/run-recall.ts
+++ b/extensions/memory-hybrid/lifecycle/stage-recall/run-recall.ts
@@ -46,6 +46,7 @@ function sanitizeHotFactText(text: string): string {
     .replace(/<redacted_thinking>[\s\S]*?<\/redacted_thinking>/gi, " ")
     .replace(/<thinking>[\s\S]*?<\/thinking>/gi, " ")
     .replace(/<reasoning>[\s\S]*?<\/reasoning>/gi, " ")
+    .replace(/<think>[\s\S]*?<\/think>/gi, " ")
     .replace(/\s+/g, " ")
     .trim();
 }

--- a/extensions/memory-hybrid/lifecycle/stage-recall/run-recall.ts
+++ b/extensions/memory-hybrid/lifecycle/stage-recall/run-recall.ts
@@ -243,7 +243,9 @@ export async function runRecall(
         activeTaskMaxTokens: activeTaskReserveCapCfg,
         staleWarningMaxTokens: staleWarningReserveCapCfg,
       } = ctx.cfg.autoRecall;
-      const narrativeCapTokens = narrativeBlockCapCfg ?? Math.max(100, Math.floor(totalBudget * 0.2));
+      const hasNarrativesDb = ctx.narrativesDb != null || ctx.eventLog != null;
+      const narrativeCapTokens =
+        narrativeBlockCapCfg ?? (hasNarrativesDb ? Math.max(100, Math.floor(totalBudget * 0.2)) : 0);
       const hotCapTokens = hotBlockCapCfg ?? Math.max(100, Math.floor(totalBudget * 0.25));
       const activeTaskReserveTokens =
         activeTaskReserveCapCfg ??

--- a/extensions/memory-hybrid/openclaw.plugin.json
+++ b/extensions/memory-hybrid/openclaw.plugin.json
@@ -887,6 +887,26 @@
                 "enum": ["fast", "balanced", "full"],
                 "description": "Unified control for interactive auto-recall: fast = lowest latency/cost (no HyDE, no ambient multi-query); balanced = default; full = richer (HyDE + ambient multi when configured)."
               },
+              "hotMaxTokens": {
+                "type": "number",
+                "description": "Optional cap for HOT fixed block tokens before recall candidates are packed."
+              },
+              "narrativeMaxTokens": {
+                "type": "number",
+                "description": "Optional cap for narrative fixed block tokens before recall candidates are packed."
+              },
+              "procedureMaxTokens": {
+                "type": "number",
+                "description": "Optional cap for procedural fixed block tokens before recall candidates are packed."
+              },
+              "activeTaskMaxTokens": {
+                "type": "number",
+                "description": "Optional reserve for active-task context added by other before_agent_start hooks."
+              },
+              "staleWarningMaxTokens": {
+                "type": "number",
+                "description": "Optional reserve for stale-warning context in active-task injection."
+              },
               "authFailure": {
                 "type": "object",
                 "additionalProperties": false,

--- a/extensions/memory-hybrid/services/context-audit.ts
+++ b/extensions/memory-hybrid/services/context-audit.ts
@@ -19,17 +19,19 @@ type ContextAuditResult = {
     injectionFormat: string;
     fixedBlocks: {
       caps: {
-        hotMaxTokens: number;
+        issueMaxTokens: number;
         narrativeMaxTokens: number;
+        hotMaxTokens: number;
         procedureMaxTokens: number;
         activeTaskMaxTokens: number;
         staleWarningMaxTokens: number;
       };
       estimatedTokens: {
+        issue: number;
+        narrative: number;
         hot: number;
         procedures: number;
         activeTasks: number;
-        staleWarning: number;
         total: number;
         remainingForRecall: number;
         wouldExhaustRecall: boolean;
@@ -209,14 +211,16 @@ export async function runContextAudit(opts: {
     }
   }
 
-  const autoRecallBudget = cfg.autoRecall.enabled
+  const baseRecallBudget = cfg.autoRecall.enabled
     ? cfg.autoRecall.injectionFormat === "progressive" || cfg.autoRecall.injectionFormat === "progressive_hybrid"
       ? (cfg.autoRecall.progressiveIndexMaxTokens ?? cfg.autoRecall.maxTokens)
       : cfg.autoRecall.maxTokens
     : 0;
+  const autoRecallBudget = Math.min(baseRecallBudget, cfg.retrieval.ambientBudgetTokens);
+  const issueCapTokens = Math.max(80, Math.floor(autoRecallBudget * 0.15));
+  const narrativeMaxTokens = cfg.autoRecall.narrativeMaxTokens ?? 0;
   const hotMaxTokens =
     cfg.autoRecall.hotMaxTokens ?? (hotTokens > 0 ? Math.max(100, Math.floor(autoRecallBudget * 0.25)) : 0);
-  const narrativeMaxTokens = cfg.autoRecall.narrativeMaxTokens ?? Math.max(100, Math.floor(autoRecallBudget * 0.2));
   const defaultProcedureCap = proceduresTokens > 0 ? Math.max(100, Math.floor(autoRecallBudget * 0.2)) : 0;
   const procedureMaxTokens =
     cfg.autoRecall.procedureMaxTokens ??
@@ -232,11 +236,14 @@ export async function runContextAudit(opts: {
       ? Math.max(40, Math.floor(autoRecallBudget * 0.08))
       : 0);
 
+  const issueEstimateTokens = cfg.ambient.enabled ? issueCapTokens : 0;
+  const narrativeEstimateTokens = narrativeMaxTokens;
   const fixedBlockEstimatedTokens =
+    issueEstimateTokens +
+    narrativeEstimateTokens +
     Math.min(hotTokens, hotMaxTokens) +
     Math.min(proceduresTokens, procedureMaxTokens) +
-    Math.min(activeTasksTokens, activeTaskMaxTokens) +
-    Math.min(staleWarningTokens, staleWarningMaxTokens);
+    Math.min(activeTasksTokens, activeTaskMaxTokens);
   const remainingForRecall = Math.max(0, autoRecallBudget - fixedBlockEstimatedTokens);
   const wouldExhaustRecall = cfg.autoRecall.enabled && autoRecallBudget > 0 && remainingForRecall === 0;
 
@@ -278,17 +285,19 @@ export async function runContextAudit(opts: {
       injectionFormat: cfg.autoRecall.injectionFormat,
       fixedBlocks: {
         caps: {
-          hotMaxTokens,
+          issueMaxTokens: issueCapTokens,
           narrativeMaxTokens,
+          hotMaxTokens,
           procedureMaxTokens,
           activeTaskMaxTokens,
           staleWarningMaxTokens,
         },
         estimatedTokens: {
+          issue: issueEstimateTokens,
+          narrative: narrativeEstimateTokens,
           hot: Math.min(hotTokens, hotMaxTokens),
           procedures: Math.min(proceduresTokens, procedureMaxTokens),
           activeTasks: Math.min(activeTasksTokens, activeTaskMaxTokens),
-          staleWarning: Math.min(staleWarningTokens, staleWarningMaxTokens),
           total: fixedBlockEstimatedTokens,
           remainingForRecall,
           wouldExhaustRecall,

--- a/extensions/memory-hybrid/services/context-audit.ts
+++ b/extensions/memory-hybrid/services/context-audit.ts
@@ -241,8 +241,7 @@ export async function runContextAudit(opts: {
     narrativeEstimateTokens +
     Math.min(hotTokens, hotMaxTokens) +
     Math.min(proceduresTokens, procedureMaxTokens) +
-    Math.min(activeTasksTokens, activeTaskMaxTokens) +
-    Math.min(staleWarningTokens, staleWarningMaxTokens);
+    Math.min(activeTasksTokens, activeTaskMaxTokens);
   const remainingForRecall = Math.max(0, autoRecallBudget - fixedBlockEstimatedTokens);
   const wouldExhaustRecall = cfg.autoRecall.enabled && autoRecallBudget > 0 && remainingForRecall === 0;
 

--- a/extensions/memory-hybrid/services/context-audit.ts
+++ b/extensions/memory-hybrid/services/context-audit.ts
@@ -215,7 +215,7 @@ export async function runContextAudit(opts: {
     ? Math.min(cfg.autoRecall.maxTokens, cfg.retrieval.ambientBudgetTokens)
     : 0;
   const issueCapTokens = Math.max(80, Math.floor(autoRecallBudget * 0.15));
-  const narrativeMaxTokens = cfg.autoRecall.narrativeMaxTokens ?? Math.max(100, Math.floor(autoRecallBudget * 0.2));
+  const narrativeMaxTokens = cfg.autoRecall.narrativeMaxTokens ?? 0;
   const hotMaxTokens =
     cfg.autoRecall.hotMaxTokens ?? (hotTokens > 0 ? Math.max(100, Math.floor(autoRecallBudget * 0.25)) : 0);
   const defaultProcedureCap = proceduresTokens > 0 ? Math.max(100, Math.floor(autoRecallBudget * 0.2)) : 0;

--- a/extensions/memory-hybrid/services/context-audit.ts
+++ b/extensions/memory-hybrid/services/context-audit.ts
@@ -88,7 +88,7 @@ export async function runContextAudit(opts: {
   const workspaceTokens = workspaceFiles.reduce((sum, f) => sum + f.tokens, 0);
 
   let activeTasksTokens = 0;
-  let staleWarningTokens = 0;
+  let _staleWarningTokens = 0;
   let ledgerActiveCount = 0;
   let filteredActiveCount = 0;
   let injectedTaskCount = 0;
@@ -116,7 +116,7 @@ export async function runContextAudit(opts: {
         injectionMaxTasks: cfg.activeTask.injectionMaxTasks,
       });
       activeTasksTokens = bundle.injectedTokens;
-      staleWarningTokens = bundle.parts
+      _staleWarningTokens = bundle.parts
         .filter((part) => /⚠️ STALE ACTIVE TASKS|💡 In-progress tasks with subagents/.test(part))
         .reduce((sum, part) => sum + estimateTokens(part), 0);
       ledgerActiveCount = bundle.ledgerActiveCount;
@@ -215,8 +215,7 @@ export async function runContextAudit(opts: {
     ? Math.min(cfg.autoRecall.maxTokens, cfg.retrieval.ambientBudgetTokens)
     : 0;
   const issueCapTokens = Math.max(80, Math.floor(autoRecallBudget * 0.15));
-  const narrativeMaxTokens =
-    cfg.autoRecall.narrativeMaxTokens ?? Math.max(100, Math.floor(autoRecallBudget * 0.2));
+  const narrativeMaxTokens = cfg.autoRecall.narrativeMaxTokens ?? Math.max(100, Math.floor(autoRecallBudget * 0.2));
   const hotMaxTokens =
     cfg.autoRecall.hotMaxTokens ?? (hotTokens > 0 ? Math.max(100, Math.floor(autoRecallBudget * 0.25)) : 0);
   const defaultProcedureCap = proceduresTokens > 0 ? Math.max(100, Math.floor(autoRecallBudget * 0.2)) : 0;

--- a/extensions/memory-hybrid/services/context-audit.ts
+++ b/extensions/memory-hybrid/services/context-audit.ts
@@ -12,7 +12,30 @@ import { capturePluginError } from "./error-reporter.js";
 import { readActiveTaskRowsFromFacts } from "./task-ledger-facts.js";
 
 type ContextAuditResult = {
-  autoRecall: { enabled: boolean; budgetTokens: number; hotTokens: number; injectionFormat: string };
+  autoRecall: {
+    enabled: boolean;
+    budgetTokens: number;
+    hotTokens: number;
+    injectionFormat: string;
+    fixedBlocks: {
+      caps: {
+        hotMaxTokens: number;
+        narrativeMaxTokens: number;
+        procedureMaxTokens: number;
+        activeTaskMaxTokens: number;
+        staleWarningMaxTokens: number;
+      };
+      estimatedTokens: {
+        hot: number;
+        procedures: number;
+        activeTasks: number;
+        staleWarning: number;
+        total: number;
+        remainingForRecall: number;
+        wouldExhaustRecall: boolean;
+      };
+    };
+  };
   procedures: { enabled: boolean; tokens: number; lines: number };
   activeTasks: {
     enabled: boolean;
@@ -63,6 +86,7 @@ export async function runContextAudit(opts: {
   const workspaceTokens = workspaceFiles.reduce((sum, f) => sum + f.tokens, 0);
 
   let activeTasksTokens = 0;
+  let staleWarningTokens = 0;
   let ledgerActiveCount = 0;
   let filteredActiveCount = 0;
   let injectedTaskCount = 0;
@@ -90,6 +114,9 @@ export async function runContextAudit(opts: {
         injectionMaxTasks: cfg.activeTask.injectionMaxTasks,
       });
       activeTasksTokens = bundle.injectedTokens;
+      staleWarningTokens = bundle.parts
+        .filter((part) => /⚠️ STALE ACTIVE TASKS|💡 In-progress tasks with subagents/.test(part))
+        .reduce((sum, part) => sum + estimateTokens(part), 0);
       ledgerActiveCount = bundle.ledgerActiveCount;
       filteredActiveCount = bundle.filteredActiveCount;
       injectedTaskCount = bundle.injectedTaskCount;
@@ -187,6 +214,31 @@ export async function runContextAudit(opts: {
       ? (cfg.autoRecall.progressiveIndexMaxTokens ?? cfg.autoRecall.maxTokens)
       : cfg.autoRecall.maxTokens
     : 0;
+  const hotMaxTokens =
+    cfg.autoRecall.hotMaxTokens ?? (hotTokens > 0 ? Math.max(100, Math.floor(autoRecallBudget * 0.25)) : 0);
+  const narrativeMaxTokens = cfg.autoRecall.narrativeMaxTokens ?? Math.max(100, Math.floor(autoRecallBudget * 0.2));
+  const defaultProcedureCap = proceduresTokens > 0 ? Math.max(100, Math.floor(autoRecallBudget * 0.2)) : 0;
+  const procedureMaxTokens =
+    cfg.autoRecall.procedureMaxTokens ??
+    (cfg.procedures.enabled ? Math.min(cfg.procedures.maxInjectionTokens, defaultProcedureCap) : 0);
+  const activeTaskMaxTokens =
+    cfg.autoRecall.activeTaskMaxTokens ??
+    (cfg.activeTask.enabled
+      ? Math.min(cfg.activeTask.injectionBudget, Math.max(80, Math.floor(autoRecallBudget * 0.2)))
+      : 0);
+  const staleWarningMaxTokens =
+    cfg.autoRecall.staleWarningMaxTokens ??
+    (cfg.activeTask.enabled && cfg.activeTask.staleWarning.enabled
+      ? Math.max(40, Math.floor(autoRecallBudget * 0.08))
+      : 0);
+
+  const fixedBlockEstimatedTokens =
+    Math.min(hotTokens, hotMaxTokens) +
+    Math.min(proceduresTokens, procedureMaxTokens) +
+    Math.min(activeTasksTokens, activeTaskMaxTokens) +
+    Math.min(staleWarningTokens, staleWarningMaxTokens);
+  const remainingForRecall = Math.max(0, autoRecallBudget - fixedBlockEstimatedTokens);
+  const wouldExhaustRecall = cfg.autoRecall.enabled && autoRecallBudget > 0 && remainingForRecall === 0;
 
   const totalTokens = autoRecallBudget + hotTokens + proceduresTokens + activeTasksTokens + workspaceTokens;
 
@@ -196,6 +248,11 @@ export async function runContextAudit(opts: {
   }
   if (cfg.autoRecall.enabled && autoRecallBudget > 1200) {
     recommendations.push("Lower autoRecall.maxTokens or switch to progressive injection to save context.");
+  }
+  if (wouldExhaustRecall) {
+    recommendations.push(
+      "Fixed block caps consume the full recall budget. Lower hot/narrative/procedure/activeTask caps or increase autoRecall.maxTokens.",
+    );
   }
   if (cfg.activeTask.enabled && activeTasksTokens > cfg.activeTask.injectionBudget) {
     recommendations.push(
@@ -219,6 +276,24 @@ export async function runContextAudit(opts: {
       budgetTokens: autoRecallBudget,
       hotTokens,
       injectionFormat: cfg.autoRecall.injectionFormat,
+      fixedBlocks: {
+        caps: {
+          hotMaxTokens,
+          narrativeMaxTokens,
+          procedureMaxTokens,
+          activeTaskMaxTokens,
+          staleWarningMaxTokens,
+        },
+        estimatedTokens: {
+          hot: Math.min(hotTokens, hotMaxTokens),
+          procedures: Math.min(proceduresTokens, procedureMaxTokens),
+          activeTasks: Math.min(activeTasksTokens, activeTaskMaxTokens),
+          staleWarning: Math.min(staleWarningTokens, staleWarningMaxTokens),
+          total: fixedBlockEstimatedTokens,
+          remainingForRecall,
+          wouldExhaustRecall,
+        },
+      },
     },
     procedures: { enabled: cfg.procedures.enabled, tokens: proceduresTokens, lines: proceduresLines },
     activeTasks: {

--- a/extensions/memory-hybrid/services/context-audit.ts
+++ b/extensions/memory-hybrid/services/context-audit.ts
@@ -238,12 +238,13 @@ export async function runContextAudit(opts: {
   const issueEstimateTokens = cfg.ambient.enabled ? issueCapTokens : 0;
   const narrativeEstimateTokens = narrativeMaxTokens;
   const staleWarningEstimateTokens = staleWarningMaxTokens;
+  const activeTasksTokensWithoutStaleWarning = Math.max(0, activeTasksTokens - _staleWarningTokens);
   const fixedBlockEstimatedTokens =
     issueEstimateTokens +
     narrativeEstimateTokens +
     Math.min(hotTokens, hotMaxTokens) +
     Math.min(proceduresTokens, procedureMaxTokens) +
-    Math.min(activeTasksTokens, activeTaskMaxTokens) +
+    Math.min(activeTasksTokensWithoutStaleWarning, activeTaskMaxTokens) +
     staleWarningEstimateTokens;
   const remainingForRecall = Math.max(0, autoRecallBudget - fixedBlockEstimatedTokens);
   const wouldExhaustRecall = cfg.autoRecall.enabled && autoRecallBudget > 0 && remainingForRecall === 0;

--- a/extensions/memory-hybrid/services/context-audit.ts
+++ b/extensions/memory-hybrid/services/context-audit.ts
@@ -214,8 +214,10 @@ export async function runContextAudit(opts: {
   const autoRecallBudget = cfg.autoRecall.enabled
     ? Math.min(cfg.autoRecall.maxTokens, cfg.retrieval.ambientBudgetTokens)
     : 0;
+  const hasNarrativesDb = cfg.eventLog.enabled;
   const issueCapTokens = Math.max(80, Math.floor(autoRecallBudget * 0.15));
-  const narrativeMaxTokens = cfg.autoRecall.narrativeMaxTokens ?? 0;
+  const narrativeMaxTokens =
+    cfg.autoRecall.narrativeMaxTokens ?? (hasNarrativesDb ? Math.max(100, Math.floor(autoRecallBudget * 0.2)) : 0);
   const hotMaxTokens =
     cfg.autoRecall.hotMaxTokens ?? (hotTokens > 0 ? Math.max(100, Math.floor(autoRecallBudget * 0.25)) : 0);
   const defaultProcedureCap = proceduresTokens > 0 ? Math.max(100, Math.floor(autoRecallBudget * 0.2)) : 0;
@@ -235,12 +237,14 @@ export async function runContextAudit(opts: {
 
   const issueEstimateTokens = cfg.ambient.enabled ? issueCapTokens : 0;
   const narrativeEstimateTokens = narrativeMaxTokens;
+  const staleWarningEstimateTokens = staleWarningMaxTokens;
   const fixedBlockEstimatedTokens =
     issueEstimateTokens +
     narrativeEstimateTokens +
     Math.min(hotTokens, hotMaxTokens) +
     Math.min(proceduresTokens, procedureMaxTokens) +
-    Math.min(activeTasksTokens, activeTaskMaxTokens);
+    Math.min(activeTasksTokens, activeTaskMaxTokens) +
+    staleWarningEstimateTokens;
   const remainingForRecall = Math.max(0, autoRecallBudget - fixedBlockEstimatedTokens);
   const wouldExhaustRecall = cfg.autoRecall.enabled && autoRecallBudget > 0 && remainingForRecall === 0;
 

--- a/extensions/memory-hybrid/services/context-audit.ts
+++ b/extensions/memory-hybrid/services/context-audit.ts
@@ -211,14 +211,11 @@ export async function runContextAudit(opts: {
     }
   }
 
-  const baseRecallBudget = cfg.autoRecall.enabled
-    ? cfg.autoRecall.injectionFormat === "progressive" || cfg.autoRecall.injectionFormat === "progressive_hybrid"
-      ? (cfg.autoRecall.progressiveIndexMaxTokens ?? cfg.autoRecall.maxTokens)
-      : cfg.autoRecall.maxTokens
+  const autoRecallBudget = cfg.autoRecall.enabled
+    ? Math.min(cfg.autoRecall.maxTokens, cfg.retrieval.ambientBudgetTokens)
     : 0;
-  const autoRecallBudget = Math.min(baseRecallBudget, cfg.retrieval.ambientBudgetTokens);
   const issueCapTokens = Math.max(80, Math.floor(autoRecallBudget * 0.15));
-  const narrativeMaxTokens = cfg.autoRecall.narrativeMaxTokens ?? 0;
+  const narrativeMaxTokens = cfg.autoRecall.narrativeMaxTokens ?? Math.max(100, Math.floor(autoRecallBudget * 0.2));
   const hotMaxTokens =
     cfg.autoRecall.hotMaxTokens ?? (hotTokens > 0 ? Math.max(100, Math.floor(autoRecallBudget * 0.25)) : 0);
   const defaultProcedureCap = proceduresTokens > 0 ? Math.max(100, Math.floor(autoRecallBudget * 0.2)) : 0;
@@ -243,7 +240,8 @@ export async function runContextAudit(opts: {
     narrativeEstimateTokens +
     Math.min(hotTokens, hotMaxTokens) +
     Math.min(proceduresTokens, procedureMaxTokens) +
-    Math.min(activeTasksTokens, activeTaskMaxTokens);
+    Math.min(activeTasksTokens, activeTaskMaxTokens) +
+    Math.min(staleWarningTokens, staleWarningMaxTokens);
   const remainingForRecall = Math.max(0, autoRecallBudget - fixedBlockEstimatedTokens);
   const wouldExhaustRecall = cfg.autoRecall.enabled && autoRecallBudget > 0 && remainingForRecall === 0;
 

--- a/extensions/memory-hybrid/services/context-audit.ts
+++ b/extensions/memory-hybrid/services/context-audit.ts
@@ -215,7 +215,9 @@ export async function runContextAudit(opts: {
     ? Math.min(cfg.autoRecall.maxTokens, cfg.retrieval.ambientBudgetTokens)
     : 0;
   const issueCapTokens = Math.max(80, Math.floor(autoRecallBudget * 0.15));
-  const narrativeMaxTokens = cfg.autoRecall.narrativeMaxTokens ?? Math.max(100, Math.floor(autoRecallBudget * 0.2));
+  const hasNarrativesDb = ctx.narrativesDb != null || ctx.eventLog != null;
+  const narrativeMaxTokens =
+    cfg.autoRecall.narrativeMaxTokens ?? (hasNarrativesDb ? Math.max(100, Math.floor(autoRecallBudget * 0.2)) : 0);
   const hotMaxTokens =
     cfg.autoRecall.hotMaxTokens ?? (hotTokens > 0 ? Math.max(100, Math.floor(autoRecallBudget * 0.25)) : 0);
   const defaultProcedureCap = proceduresTokens > 0 ? Math.max(100, Math.floor(autoRecallBudget * 0.2)) : 0;

--- a/extensions/memory-hybrid/services/context-audit.ts
+++ b/extensions/memory-hybrid/services/context-audit.ts
@@ -215,9 +215,8 @@ export async function runContextAudit(opts: {
     ? Math.min(cfg.autoRecall.maxTokens, cfg.retrieval.ambientBudgetTokens)
     : 0;
   const issueCapTokens = Math.max(80, Math.floor(autoRecallBudget * 0.15));
-  const hasNarrativesDb = ctx.narrativesDb != null || ctx.eventLog != null;
   const narrativeMaxTokens =
-    cfg.autoRecall.narrativeMaxTokens ?? (hasNarrativesDb ? Math.max(100, Math.floor(autoRecallBudget * 0.2)) : 0);
+    cfg.autoRecall.narrativeMaxTokens ?? Math.max(100, Math.floor(autoRecallBudget * 0.2));
   const hotMaxTokens =
     cfg.autoRecall.hotMaxTokens ?? (hotTokens > 0 ? Math.max(100, Math.floor(autoRecallBudget * 0.25)) : 0);
   const defaultProcedureCap = proceduresTokens > 0 ? Math.max(100, Math.floor(autoRecallBudget * 0.2)) : 0;

--- a/extensions/memory-hybrid/tests/config.test.ts
+++ b/extensions/memory-hybrid/tests/config.test.ts
@@ -543,6 +543,11 @@ describe("hybridConfigSchema.parse", () => {
         enabled: true,
         interactiveEnrichment: "balanced",
         maxTokens: 500,
+        hotMaxTokens: 120,
+        narrativeMaxTokens: 140,
+        procedureMaxTokens: 90,
+        activeTaskMaxTokens: 200,
+        staleWarningMaxTokens: 80,
         injectionFormat: "short",
         limit: 10,
         minScore: 0.5,
@@ -553,6 +558,11 @@ describe("hybridConfigSchema.parse", () => {
     expect(result.autoRecall.limit).toBe(10);
     expect(result.autoRecall.minScore).toBe(0.5);
     expect(result.autoRecall.interactiveEnrichment).toBe("balanced");
+    expect(result.autoRecall.hotMaxTokens).toBe(120);
+    expect(result.autoRecall.narrativeMaxTokens).toBe(140);
+    expect(result.autoRecall.procedureMaxTokens).toBe(90);
+    expect(result.autoRecall.activeTaskMaxTokens).toBe(200);
+    expect(result.autoRecall.staleWarningMaxTokens).toBe(80);
   });
 
   it("parses autoRecall.interactiveEnrichment", () => {

--- a/extensions/memory-hybrid/tests/context-audit.test.ts
+++ b/extensions/memory-hybrid/tests/context-audit.test.ts
@@ -31,6 +31,8 @@ describe("runContextAudit", () => {
     expect(audit.workspaceFiles.totalTokens).toBeGreaterThan(0);
     expect(audit.workspaceFiles.files.some((f) => f.file === "AGENTS.md")).toBe(true);
     expect(audit.autoRecall.budgetTokens).toBe(cfg.autoRecall.maxTokens);
+    expect(audit.autoRecall.fixedBlocks.caps.hotMaxTokens).toBeGreaterThanOrEqual(0);
+    expect(audit.autoRecall.fixedBlocks.estimatedTokens.remainingForRecall).toBeGreaterThanOrEqual(0);
   });
 
   it("keeps activeTasks.count as a backwards-compatible injected-task alias", async () => {

--- a/extensions/memory-hybrid/tests/context-engine.test.ts
+++ b/extensions/memory-hybrid/tests/context-engine.test.ts
@@ -616,7 +616,7 @@ describe("buildContextBlock()", () => {
     expect(blockFull).not.toBeNull();
     expect(blockSmall).not.toBeNull();
 
-    const smallTokens = estimateTokenCount(blockSmall!);
+    const smallTokens = estimateTokenCount(blockSmall ?? "");
     expect(smallTokens).toBeLessThanOrEqual(50);
 
     // Ensure blockSmall has fewer entries

--- a/extensions/memory-hybrid/tests/lifecycle-stage-recall.test.ts
+++ b/extensions/memory-hybrid/tests/lifecycle-stage-recall.test.ts
@@ -11,6 +11,7 @@ import { FactsDB } from "../backends/facts-db.js";
 import { runRecallStage } from "../lifecycle/stage-recall.js";
 import { INTERACTIVE_RECALL_STAGE_TIMEOUT_MS } from "../services/retrieval-mode-policy.js";
 import * as recallPipeline from "../services/recall-pipeline.js";
+import { estimateTokens } from "../utils/text.js";
 import {
   buildRecallLifecycleContext,
   makeMockStageApi,
@@ -163,5 +164,142 @@ describe("runRecallStage", () => {
       expect(result.result.candidates.some((c) => c.entry.id === "pipe-1")).toBe(true);
     }
     expect(ctx.recallInFlightRef.value).toBe(0);
+  });
+
+  it("caps hot fixed block tokens and keeps recall budget available", async () => {
+    const ctx = buildRecallLifecycleContext(tmpDir, factsDb, {
+      memoryTiering: { enabled: true, hotMaxTokens: 2000 },
+      autoRecall: {
+        hotMaxTokens: 40,
+        narrativeMaxTokens: 200,
+        procedureMaxTokens: 200,
+        activeTaskMaxTokens: 0,
+        staleWarningMaxTokens: 0,
+      },
+    });
+    vi.mocked(recallPipeline.runRecallPipelineQuery).mockResolvedValue([
+      {
+        entry: {
+          id: "pipe-hot-cap",
+          text: "pipeline hit",
+          category: "fact",
+          importance: 0.8,
+          entity: null,
+          key: null,
+          value: null,
+          source: "conversation",
+          createdAt: 1,
+          decayClass: "stable",
+          expiresAt: null,
+          lastConfirmedAt: 0,
+          confidence: 1,
+          scope: "global",
+        },
+        score: 0.95,
+        backend: "sqlite",
+      },
+    ]);
+    vi.spyOn(factsDb, "getHotFacts").mockReturnValue([
+      {
+        entry: {
+          id: "hot-1",
+          text: "<think>internal chain</think> deployment api key rotates weekly with strict rollback checks ".repeat(
+            8,
+          ),
+          category: "project",
+          importance: 0.9,
+          entity: null,
+          key: null,
+          value: null,
+          source: "conversation",
+          createdAt: 1,
+          decayClass: "stable",
+          expiresAt: null,
+          lastConfirmedAt: 0,
+          confidence: 1,
+          scope: "global",
+        },
+        score: 1,
+        backend: "sqlite",
+      },
+    ]);
+
+    const sessionState = makeRecallSessionState();
+    const api = makeMockStageApi();
+    const result = await runRecallStage({ prompt: "deployment plan context" }, api as never, ctx, sessionState);
+
+    expect(result?.kind).toBe("full");
+    if (result?.kind === "full") {
+      expect(result.result.maxTokens).toBeGreaterThan(0);
+      expect(estimateTokens(result.result.hotBlock)).toBeLessThanOrEqual(40);
+      expect(result.result.hotBlock).not.toContain("<think>");
+    }
+  });
+
+  it("logs fixed-block consumers when recall budget is exhausted", async () => {
+    const ctx = buildRecallLifecycleContext(tmpDir, factsDb, {
+      memoryTiering: { enabled: true, hotMaxTokens: 2000 },
+      activeTask: { enabled: true, ledger: "facts", injectionBudget: 500, staleWarning: { enabled: true } },
+      autoRecall: {
+        maxTokens: 120,
+        hotMaxTokens: 80,
+        narrativeMaxTokens: 80,
+        procedureMaxTokens: 80,
+        activeTaskMaxTokens: 80,
+        staleWarningMaxTokens: 40,
+      },
+    });
+    vi.mocked(recallPipeline.runRecallPipelineQuery).mockResolvedValue([
+      {
+        entry: {
+          id: "pipe-exhausted",
+          text: "pipeline hit",
+          category: "fact",
+          importance: 0.8,
+          entity: null,
+          key: null,
+          value: null,
+          source: "conversation",
+          createdAt: 1,
+          decayClass: "stable",
+          expiresAt: null,
+          lastConfirmedAt: 0,
+          confidence: 1,
+          scope: "global",
+        },
+        score: 0.95,
+        backend: "sqlite",
+      },
+    ]);
+    vi.spyOn(factsDb, "getHotFacts").mockReturnValue([
+      {
+        entry: {
+          id: "hot-2",
+          text: "critical deploy context ".repeat(80),
+          category: "project",
+          importance: 0.9,
+          entity: null,
+          key: null,
+          value: null,
+          source: "conversation",
+          createdAt: 1,
+          decayClass: "stable",
+          expiresAt: null,
+          lastConfirmedAt: 0,
+          confidence: 1,
+          scope: "global",
+        },
+        score: 1,
+        backend: "sqlite",
+      },
+    ]);
+
+    const sessionState = makeRecallSessionState();
+    const api = makeMockStageApi();
+    const result = await runRecallStage({ prompt: "deploy now with context" }, api as never, ctx, sessionState);
+
+    expect(result?.kind).toBe("full");
+    expect(api.logger.warn).toHaveBeenCalledWith(expect.stringContaining("consumers:"));
+    expect(api.logger.warn).toHaveBeenCalledWith(expect.stringContaining("active-task"));
   });
 });


### PR DESCRIPTION
## Summary
Style-only: biome formatting of stage recall budget helpers from orphaned branch `pr-1605`.

## Unique commits (5 total, NOT in main)
- `ae6c8d9f` style: format stage recall budget helpers

## Next owner
Manual (style-only, low priority)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes what gets injected each turn and can suppress recall when caps are tight; mitigated by defaults, reservations, and context-audit reporting.
> 
> **Overview**
> Adds **per-block token budgeting** for auto-recall so fixed injection slices (issues, narratives, HOT, procedures) and **reserved headroom** for active-task / stale-warning hooks no longer crowd out semantic recall.
> 
> New optional `autoRecall` settings (`hotMaxTokens`, `narrativeMaxTokens`, `procedureMaxTokens`, `activeTaskMaxTokens`, `staleWarningMaxTokens`) are parsed, documented, and exposed in the plugin schema. **`run-recall`** now caps or reserves each block against `contextBudgetTokens`, trims XML-wrapped blocks line-wise when over cap, logs **`recall:context-budget`** audit events, and warns with top consumers when recall headroom hits zero. HOT/FTS lines are **sanitized** (thinking/reasoning tags stripped). **Degraded (FTS-only)** recall uses the same budget model.
> 
> **`context-audit`** (CLI + service) reports fixed-block caps, estimated token use, and remaining recall headroom; auto-recall budget in audit aligns with `min(maxTokens, ambientBudgetTokens)`.
> 
> Tests cover config parsing, context audit fields, hot cap behavior, and exhausted-budget warnings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da70bfb12d424913be7d659a0ea66c773aa1dac5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->