### PR TITLE
fix: strict closure guard for duplicate/superseded decisions (from closed pr-1611)

### DIFF
--- a/extensions/memory-hybrid/services/duplicate-closure-guard.ts
+++ b/extensions/memory-hybrid/services/duplicate-closure-guard.ts
@@ -64,7 +64,7 @@ export function evaluateStrictDuplicateClosureGuard(candidates: ClosureCandidate
     } satisfies ClosureAssessment;
   });
 
-  const decision: ClosureDecision = assessments.every((item) => item.decision === "safe")
+  const decision: ClosureDecision = assessments.length > 0 && assessments.every((item) => item.decision === "safe")
     ? "safe"
     : "needs-reconciliation";
 

--- a/extensions/memory-hybrid/services/duplicate-closure-guard.ts
+++ b/extensions/memory-hybrid/services/duplicate-closure-guard.ts
@@ -1,0 +1,75 @@
+export type ClosureDecision = "safe" | "needs-reconciliation";
+
+export type ImplementationClass = "implementation" | "docs" | "workflow" | "mixed" | "unknown";
+
+export interface ClosureCandidate {
+  candidateRef: string;
+  replacementRef?: string | null;
+  sameIssueScope: boolean;
+  replacementState: "open" | "merged" | "closed-unmerged" | "missing";
+  replacementBranchRecoverable: boolean;
+  hasScopeCoverageNote: boolean;
+  implementationClassCompatibility: boolean;
+  hasFileOverlap: boolean;
+  hasSemanticCoverageNote: boolean;
+  hasEvidenceCommentText: boolean;
+}
+
+export interface ClosureAssessment {
+  candidateRef: string;
+  replacementRef?: string | null;
+  decision: ClosureDecision;
+  reasons: string[];
+}
+
+export interface ClosureGuardResult {
+  decision: ClosureDecision;
+  assessments: ClosureAssessment[];
+}
+
+export function evaluateStrictDuplicateClosureGuard(candidates: ClosureCandidate[]): ClosureGuardResult {
+  const assessments = candidates.map((candidate) => {
+    const reasons: string[] = [];
+
+    if (!candidate.sameIssueScope) {
+      reasons.push("different_issue_scope");
+    }
+    if (!candidate.replacementRef) {
+      reasons.push("missing_explicit_replacement");
+    }
+    if (!(candidate.replacementState === "open" || candidate.replacementState === "merged")) {
+      reasons.push("replacement_not_open_or_merged");
+    }
+    if (!candidate.replacementBranchRecoverable) {
+      reasons.push("replacement_branch_not_recoverable");
+    }
+    if (!candidate.hasScopeCoverageNote) {
+      reasons.push("missing_scope_coverage_note");
+    }
+    if (!candidate.implementationClassCompatibility) {
+      reasons.push("implementation_class_incompatible");
+    }
+    if (!candidate.hasFileOverlap && !candidate.hasSemanticCoverageNote) {
+      reasons.push("no_overlap_without_semantic_coverage");
+    }
+    if (!candidate.hasEvidenceCommentText) {
+      reasons.push("missing_individual_evidence_comment");
+    }
+
+    return {
+      candidateRef: candidate.candidateRef,
+      replacementRef: candidate.replacementRef,
+      decision: reasons.length === 0 ? "safe" : "needs-reconciliation",
+      reasons,
+    } satisfies ClosureAssessment;
+  });
+
+  const decision: ClosureDecision = assessments.every((item) => item.decision === "safe")
+    ? "safe"
+    : "needs-reconciliation";
+
+  return {
+    decision,
+    assessments,
+  };
+}

--- a/extensions/memory-hybrid/services/duplicate-closure-guard.ts
+++ b/extensions/memory-hybrid/services/duplicate-closure-guard.ts
@@ -1,6 +1,12 @@
-export type ClosureDecision = "safe" | "needs-reconciliation";
+import type {
+  DuplicateClosureDecision,
+  DuplicateClosureAssessment,
+  DuplicateClosureGuardProof,
+} from "../types/issue-types.js";
 
-export type ImplementationClass = "implementation" | "docs" | "workflow" | "mixed" | "unknown";
+export type ClosureDecision = DuplicateClosureDecision;
+export type ClosureAssessment = DuplicateClosureAssessment;
+export type ClosureGuardResult = DuplicateClosureGuardProof;
 
 export interface ClosureCandidate {
   candidateRef: string;
@@ -13,18 +19,6 @@ export interface ClosureCandidate {
   hasFileOverlap: boolean;
   hasSemanticCoverageNote: boolean;
   hasEvidenceCommentText: boolean;
-}
-
-export interface ClosureAssessment {
-  candidateRef: string;
-  replacementRef?: string | null;
-  decision: ClosureDecision;
-  reasons: string[];
-}
-
-export interface ClosureGuardResult {
-  decision: ClosureDecision;
-  assessments: ClosureAssessment[];
 }
 
 export function evaluateStrictDuplicateClosureGuard(candidates: ClosureCandidate[]): ClosureGuardResult {
@@ -64,9 +58,8 @@ export function evaluateStrictDuplicateClosureGuard(candidates: ClosureCandidate
     } satisfies ClosureAssessment;
   });
 
-  const decision: ClosureDecision = assessments.length > 0 && assessments.every((item) => item.decision === "safe")
-    ? "safe"
-    : "needs-reconciliation";
+  const decision: ClosureDecision =
+    assessments.length > 0 && assessments.every((item) => item.decision === "safe") ? "safe" : "needs-reconciliation";
 
   return {
     decision,

--- a/extensions/memory-hybrid/tests/duplicate-closure-guard.test.ts
+++ b/extensions/memory-hybrid/tests/duplicate-closure-guard.test.ts
@@ -1,9 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import {
-  type ClosureCandidate,
-  evaluateStrictDuplicateClosureGuard,
-} from "../services/duplicate-closure-guard.js";
+import { type ClosureCandidate, evaluateStrictDuplicateClosureGuard } from "../services/duplicate-closure-guard.js";
 
 function baseCandidate(overrides: Partial<ClosureCandidate> = {}): ClosureCandidate {
   return {

--- a/extensions/memory-hybrid/tests/duplicate-closure-guard.test.ts
+++ b/extensions/memory-hybrid/tests/duplicate-closure-guard.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  type ClosureCandidate,
+  evaluateStrictDuplicateClosureGuard,
+} from "../services/duplicate-closure-guard.js";
+
+function baseCandidate(overrides: Partial<ClosureCandidate> = {}): ClosureCandidate {
+  return {
+    candidateRef: "#1593",
+    replacementRef: "#1600",
+    sameIssueScope: true,
+    replacementState: "merged",
+    replacementBranchRecoverable: true,
+    hasScopeCoverageNote: true,
+    implementationClassCompatibility: true,
+    hasFileOverlap: true,
+    hasSemanticCoverageNote: false,
+    hasEvidenceCommentText: true,
+    ...overrides,
+  };
+}
+
+describe("evaluateStrictDuplicateClosureGuard", () => {
+  it("marks same-title different issue scope unsafe (#1560 vs #1561 style)", () => {
+    const result = evaluateStrictDuplicateClosureGuard([
+      baseCandidate({
+        candidateRef: "#1561",
+        replacementRef: "#1560",
+        sameIssueScope: false,
+      }),
+    ]);
+
+    expect(result.decision).toBe("needs-reconciliation");
+    expect(result.assessments[0]?.reasons).toContain("different_issue_scope");
+  });
+
+  it("marks zero file overlap unsafe without semantic evidence", () => {
+    const result = evaluateStrictDuplicateClosureGuard([
+      baseCandidate({
+        hasFileOverlap: false,
+        hasSemanticCoverageNote: false,
+      }),
+    ]);
+
+    expect(result.decision).toBe("needs-reconciliation");
+    expect(result.assessments[0]?.reasons).toContain("no_overlap_without_semantic_coverage");
+  });
+
+  it("marks docs/workflow-only replacement unsafe for implementation candidate", () => {
+    const result = evaluateStrictDuplicateClosureGuard([
+      baseCandidate({
+        implementationClassCompatibility: false,
+      }),
+    ]);
+
+    expect(result.decision).toBe("needs-reconciliation");
+    expect(result.assessments[0]?.reasons).toContain("implementation_class_incompatible");
+  });
+
+  it("marks deleted/missing replacement branch unsafe", () => {
+    const result = evaluateStrictDuplicateClosureGuard([
+      baseCandidate({
+        replacementBranchRecoverable: false,
+      }),
+    ]);
+
+    expect(result.decision).toBe("needs-reconciliation");
+    expect(result.assessments[0]?.reasons).toContain("replacement_branch_not_recoverable");
+  });
+
+  it("marks missing evidence comment unsafe", () => {
+    const result = evaluateStrictDuplicateClosureGuard([
+      baseCandidate({
+        hasEvidenceCommentText: false,
+      }),
+    ]);
+
+    expect(result.decision).toBe("needs-reconciliation");
+    expect(result.assessments[0]?.reasons).toContain("missing_individual_evidence_comment");
+  });
+
+  it("marks valid same-issue same-files merged replacement with full proof as safe", () => {
+    const result = evaluateStrictDuplicateClosureGuard([
+      baseCandidate({
+        candidateRef: "#1609",
+        replacementRef: "#1610",
+        sameIssueScope: true,
+        replacementState: "merged",
+        replacementBranchRecoverable: true,
+        hasScopeCoverageNote: true,
+        implementationClassCompatibility: true,
+        hasFileOverlap: true,
+        hasSemanticCoverageNote: false,
+        hasEvidenceCommentText: true,
+      }),
+    ]);
+
+    expect(result.decision).toBe("safe");
+    expect(result.assessments[0]?.reasons).toHaveLength(0);
+  });
+});

--- a/extensions/memory-hybrid/types/issue-types.ts
+++ b/extensions/memory-hybrid/types/issue-types.ts
@@ -52,7 +52,7 @@ export type DuplicateClosureDecision = "safe" | "needs-reconciliation";
 
 export interface DuplicateClosureAssessment {
   candidateRef: string;
-  replacementRef?: string;
+  replacementRef?: string | null;
   decision: DuplicateClosureDecision;
   reasons: string[];
 }

--- a/extensions/memory-hybrid/types/issue-types.ts
+++ b/extensions/memory-hybrid/types/issue-types.ts
@@ -47,3 +47,17 @@ export const ISSUE_TRANSITIONS: Record<IssueStatus, IssueStatus[]> = {
   verified: [],
   "wont-fix": ["open"],
 };
+
+export type DuplicateClosureDecision = "safe" | "needs-reconciliation";
+
+export interface DuplicateClosureAssessment {
+  candidateRef: string;
+  replacementRef?: string;
+  decision: DuplicateClosureDecision;
+  reasons: string[];
+}
+
+export interface DuplicateClosureGuardProof {
+  decision: DuplicateClosureDecision;
+  assessments: DuplicateClosureAssessment[];
+}


### PR DESCRIPTION
## Summary
Preserves functional work from closed PR branch `fix/strict-duplicate-closure-guard-1611` (PR #1614, #1615 closed).

## Unique commits (2 total, NOT in main)
- `3ae2c07d` fix: prevent empty candidates from yielding safe decision
- `23e3a38a` feat(duplicates): add strict closure guard proof model

## Verification
- npm test

## Next owner
Manual

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Isolated new service, types, and tests in memory-hybrid with no call-site integration yet; wrong future wiring could block legitimate duplicate closures.
> 
> **Overview**
> Adds a **strict duplicate/superseded closure guard** in `memory-hybrid` so closing a candidate as a duplicate only yields **`safe`** when every supplied candidate passes a fixed proof checklist; otherwise the aggregate result is **`needs-reconciliation`**.
> 
> New types in `issue-types` (`DuplicateClosureGuardProof`, per-candidate assessments with machine-readable **reasons**) back `evaluateStrictDuplicateClosureGuard`, which takes precomputed `ClosureCandidate` facts (scope, replacement ref/state, branch recoverability, coverage notes, file/semantic overlap, evidence comment). **Vitest** covers common failure modes (different scope, no overlap without semantic note, class mismatch, bad branch, missing evidence) and one fully satisfied **safe** path. Wiring into live duplicate-close flows is **not** in this diff—this is the guard + proof model + tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd43150bfe07e400a9fd47b7933756d5b569c5f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->