### PR TITLE
perf: SQL-level category filter for project-fact queries (from closed pr-1594)

### DIFF
--- a/extensions/memory-hybrid/backends/facts-db/fact-read-queries.ts
+++ b/extensions/memory-hybrid/backends/facts-db/fact-read-queries.ts
@@ -263,6 +263,67 @@ export function getAll(
   return rows.map((row) => rowToMemoryEntry(row));
 }
 
+/**
+ * SQL-level project-fact query (category='project', non-superseded, non-expired).
+ * Used by active-task injection to avoid loading all facts then filtering in JS.
+ * Returns latest fact per entity+key via the same grouping logic as `groupProjectFactsByEntity`.
+ *
+ * Columns selected: id, category, entity, key, value, text, importance, source,
+ * decay_class, scope, scope_target, created_at, valid_from, valid_until,
+ * superseded_at, expires_at, tags, embedding_model (needed for task reconstruction).
+ */
+export function getProjectFacts(
+  db: DatabaseSync,
+  options?: {
+    limit?: number;
+    scopeFilter?: ScopeFilter | null;
+  },
+): MemoryEntry[] {
+  const nowSec = Math.floor(Date.now() / 1000);
+  const { limit = 8000, scopeFilter } = options ?? {};
+  const { clause: scopeClause, params: scopeParams } = scopeFilterClausePositional(scopeFilter);
+  const params = [...[nowSec], ...scopeParams];
+  const rows = db
+    .prepare(
+      `SELECT id, category, entity, key, value, text, importance, source,
+              decay_class, scope, scope_target, created_at, valid_from, valid_until,
+              superseded_at, expires_at, tags, embedding_model
+       FROM facts
+       WHERE (expires_at IS NULL OR expires_at > ?)
+         AND category = 'project'
+         AND superseded_at IS NULL
+         ${scopeClause}
+       ORDER BY created_at DESC
+       LIMIT ?`,
+    )
+    .all(...params, limit) as Array<Record<string, unknown>>;
+  return rows.map((row) => rowToMemoryEntry(row));
+}
+
+/** SQL-level max created_at for project facts (category='project', non-superseded, non-expired). */
+export function getMaxCreatedAtByProjectFacts(
+  db: DatabaseSync,
+  scopeFilter?: ScopeFilter | null,
+): number | null {
+  const nowSec = Math.floor(Date.now() / 1000);
+  const { clause: scopeClause, params: scopeParams } = scopeFilterClausePositional(scopeFilter);
+  const params = [...[nowSec], ...scopeParams];
+  const row = db
+    .prepare(
+      `SELECT MAX(created_at) as max_created_at
+       FROM facts
+       WHERE (expires_at IS NULL OR expires_at > ?)
+         AND category = 'project'
+         AND superseded_at IS NULL
+         ${scopeClause}`,
+    )
+    .get(...params) as Record<string, unknown> | undefined;
+  if (!row) return null;
+  const maxCreatedAt = row.max_created_at;
+  if (typeof maxCreatedAt === "number" && Number.isFinite(maxCreatedAt)) return maxCreatedAt;
+  return null;
+}
+
 export function getCount(db: DatabaseSync, options?: { includeSuperseded?: boolean }): number {
   const nowSec = Math.floor(Date.now() / 1000);
   const { includeSuperseded = false } = options ?? {};

--- a/extensions/memory-hybrid/backends/facts-db/facts-db-layer2.ts
+++ b/extensions/memory-hybrid/backends/facts-db/facts-db-layer2.ts
@@ -13,6 +13,8 @@ import {
   getByCategory as getByCategoryImpl,
   getCount as getCountImpl,
   getMaxCreatedAtByCategory as getMaxCreatedAtByCategoryImpl,
+  getMaxCreatedAtByProjectFacts as getMaxCreatedAtByProjectFactsImpl,
+  getProjectFacts as getProjectFactsImpl,
   getRecentFacts as getRecentFactsImpl,
   getUnattemptedOtherFacts as getUnattemptedOtherFactsImpl,
   listDirectives as listDirectivesImpl,
@@ -502,6 +504,23 @@ export class FactsDBLayer2 extends FactsDBLayer1 {
   /** Get maximum created_at timestamp for non-superseded facts in a category. */
   getMaxCreatedAtByCategory(category: string): number | null {
     return getMaxCreatedAtByCategoryImpl(this.liveDb, category);
+  }
+
+  /**
+   * SQL-level project-fact query (category='project', non-superseded, non-expired).
+   * Used by active-task injection to avoid loading all facts then filtering in JS.
+   * Applies scope filter and limit at DB level.
+   */
+  getProjectFacts(options?: {
+    limit?: number;
+    scopeFilter?: ScopeFilter | null;
+  }): MemoryEntry[] {
+    return getProjectFactsImpl(this.liveDb, options);
+  }
+
+  /** SQL-level max created_at for project facts (category='project', non-superseded, non-expired). */
+  getMaxCreatedAtByProjectFacts(scopeFilter?: ScopeFilter | null): number | null {
+    return getMaxCreatedAtByProjectFactsImpl(this.liveDb, scopeFilter);
   }
 
   updateCategory(id: string, category: string): boolean {

--- a/extensions/memory-hybrid/services/task-ledger-facts.ts
+++ b/extensions/memory-hybrid/services/task-ledger-facts.ts
@@ -216,13 +216,20 @@ export function loadTaskLedgerFromFacts(
 ): {
   active: ActiveTaskEntry[];
   completed: ActiveTaskEntry[];
+  /** Milliseconds spent in SQL fetch + grouping (excludes caller-level staleness detection). */
+  loadMs: number;
+  /** Number of rows returned by the SQL query. */
+  sqlRowsScanned: number;
 } {
-  const facts = factsDb
-    .getAll({ scopeFilter })
-    .filter((fact) => fact.category === TASK_LEDGER_CATEGORY)
-    .slice(0, factLimit);
+  const t0 = Date.now();
+  // SQL-level category filter instead of getAll + in-memory filter (#1553)
+  const facts = factsDb.getProjectFacts({ limit: factLimit, scopeFilter });
+  const sqlMs = Date.now() - t0;
   const grouped = groupProjectFactsByEntity(facts);
-  return buildTaskEntriesFromGroupedFacts(grouped);
+  const { active, completed } = buildTaskEntriesFromGroupedFacts(grouped);
+  const elapsed = Date.now() - t0;
+  void sqlMs; // intentionally held for potential future per-phase breakdown
+  return { active, completed, loadMs: elapsed, sqlRowsScanned: facts.length };
 }
 
 export function readActiveTaskRowsFromFacts(
@@ -230,10 +237,10 @@ export function readActiveTaskRowsFromFacts(
   staleMinutes: number,
   scopeFilter?: ScopeFilter | null,
 ): { active: ActiveTaskEntry[]; completed: ActiveTaskEntry[]; latestProjectFactSec: number | null } {
-  const { active, completed } = loadTaskLedgerFromFacts(factsDb, 8000, scopeFilter);
-  const staleActive = detectStaleTasks(active, staleMinutes);
+  const result = loadTaskLedgerFromFacts(factsDb, 8000, scopeFilter);
+  const staleActive = detectStaleTasks(result.active, staleMinutes);
   const latestProjectFactSec = getLatestProjectFactCreatedAtSec(factsDb, scopeFilter);
-  return { active: staleActive, completed, latestProjectFactSec };
+  return { active: staleActive, completed: result.completed, latestProjectFactSec };
 }
 
 export function getActiveTaskProjectionStaleMarkerPath(filePath: string): string {
@@ -299,18 +306,8 @@ export async function clearActiveTaskProjectionStale(filePath: string): Promise<
 }
 
 export function getLatestProjectFactCreatedAtSec(factsDb: FactsDB, scopeFilter?: ScopeFilter | null): number | null {
-  const projectFacts = factsDb
-    .getAll({ scopeFilter })
-    .filter((fact) => fact.category === TASK_LEDGER_CATEGORY)
-    .slice(0, 8000);
-  if (projectFacts.length === 0) return null;
-  let maxSec = Number.NEGATIVE_INFINITY;
-  for (const fact of projectFacts) {
-    if (typeof fact.createdAt === "number" && Number.isFinite(fact.createdAt)) {
-      maxSec = Math.max(maxSec, fact.createdAt);
-    }
-  }
-  return maxSec === Number.NEGATIVE_INFINITY ? null : maxSec;
+  // SQL-level max; avoids loading all project facts just to find the latest timestamp (#1553)
+  return factsDb.getMaxCreatedAtByProjectFacts(scopeFilter);
 }
 
 function toIsoOrNull(unixSeconds: number | null): string | null {


### PR DESCRIPTION
## Summary
Preserves perf improvement from closed PR branch `feat/1553-task-ledger-sql-filter` (PR #1594 closed).

## Unique commits (1 total, NOT in main)
- `3e54e43b` perf: SQL-level category filter for project-fact queries (#1553)

## Verification
- npm test

## Next owner
Manual

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-path optimization with equivalent filters (project category, expiry, superseded, scope); no auth or write-path changes.
> 
> **Overview**
> Moves **active-task / project-fact** reads off `getAll` + in-memory `category === 'project'` filtering and onto **SQL-scoped** queries in the facts DB.
> 
> New **`getProjectFacts`** returns non-expired, non-superseded `category='project'` rows with optional **scope filter** and **LIMIT** (default 8000), selecting only columns needed for task reconstruction. **`getMaxCreatedAtByProjectFacts`** computes the latest `created_at` for the same filter set without loading rows. **`FactsDB`** exposes both on layer 2.
> 
> **`loadTaskLedgerFromFacts`** now calls `getProjectFacts`; **`getLatestProjectFactCreatedAtSec`** uses the SQL max helper. The loader also returns **`loadMs`** and **`sqlRowsScanned`** for timing/row-count observability. Grouping and task entry building stay in JS unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e54e43b4f2341014f686ffcfda30da8fab5d0a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->