### PR TITLE
fix: enforce generated skill byte limit (from closed pr-1543)

### DIFF
--- a/extensions/memory-hybrid/config/skill-size-limits.ts
+++ b/extensions/memory-hybrid/config/skill-size-limits.ts
@@ -9,15 +9,6 @@
 /** OpenClaw loader hard cap for a single SKILL.md file. */
 export const MAX_SKILL_FILE_BYTES = 256_000;
 
-/** Safer generator target that leaves room for future loader metadata changes. */
-export const MAX_SKILL_FILE_BYTES_SAFE = 200_000;
-
-/** Initial cap for generated procedure recipe sidecars. */
-export const MAX_RECIPE_FILE_BYTES = 256_000;
-
-/** Initial cap for optional generated sidecars. */
-export const MAX_SKILL_SIDECAR_BYTES = 128_000;
-
 export function utf8ByteLength(value: string): number {
   return Buffer.byteLength(value, "utf8");
 }

--- a/extensions/memory-hybrid/config/skill-size-limits.ts
+++ b/extensions/memory-hybrid/config/skill-size-limits.ts
@@ -1,0 +1,23 @@
+/**
+ * Generated skill size limits.
+ *
+ * OpenClaw's workspace skill loader skips SKILL.md files above 256 KB. Keep
+ * this hard cap aligned with that external loader contract and enforce it
+ * before generated procedure skills are written.
+ */
+
+/** OpenClaw loader hard cap for a single SKILL.md file. */
+export const MAX_SKILL_FILE_BYTES = 256_000;
+
+/** Safer generator target that leaves room for future loader metadata changes. */
+export const MAX_SKILL_FILE_BYTES_SAFE = 200_000;
+
+/** Initial cap for generated procedure recipe sidecars. */
+export const MAX_RECIPE_FILE_BYTES = 256_000;
+
+/** Initial cap for optional generated sidecars. */
+export const MAX_SKILL_SIDECAR_BYTES = 128_000;
+
+export function utf8ByteLength(value: string): number {
+  return Buffer.byteLength(value, "utf8");
+}

--- a/extensions/memory-hybrid/services/procedure-skill-generator.ts
+++ b/extensions/memory-hybrid/services/procedure-skill-generator.ts
@@ -6,6 +6,7 @@ import { existsSync, mkdirSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import type { FactsDB } from "../backends/facts-db.js";
 import type { GenerateAutoSkillsResult } from "../cli/register.js";
+import { MAX_SKILL_FILE_BYTES, utf8ByteLength } from "../config/skill-size-limits.js";
 import type { MemoryEntry, MemoryScope, ProcedureEntry, ScopeFilter } from "../types/memory.js";
 import { SKILL_COMPLETE_MARKER, atomicWriteSkillDir } from "../utils/atomic-write.js";
 import { resolveWorkspacePath, toWorkspaceRelativePath } from "../utils/path.js";
@@ -592,6 +593,13 @@ function writeDraftSkill(
     proposalMetadataJson: string;
   },
 ): void {
+  const skillBytes = utf8ByteLength(draft.skillMd);
+  if (skillBytes > MAX_SKILL_FILE_BYTES) {
+    throw new Error(
+      `Generated SKILL.md exceeds OpenClaw loader byte limit (${skillBytes} > ${MAX_SKILL_FILE_BYTES}); refusing to write oversized auto-skill`,
+    );
+  }
+
   // Write all sidecar files atomically (temp dir → rename). SKILL.md is
   // written last among content files so it is the final content write before
   // the completion marker.

--- a/extensions/memory-hybrid/services/skill-validator.ts
+++ b/extensions/memory-hybrid/services/skill-validator.ts
@@ -22,6 +22,7 @@ import {
   getSectionTaxonomy,
   type SectionTaxonomyOverrides,
 } from "../config/skill-sections.js";
+import { MAX_SKILL_FILE_BYTES, utf8ByteLength } from "../config/skill-size-limits.js";
 export {
   CATEGORY_FRONTMATTER_KEYS,
   DEFAULT_REQUIRED_SECTIONS,
@@ -29,6 +30,7 @@ export {
   getSectionTaxonomy,
   type SectionTaxonomyOverrides,
 } from "../config/skill-sections.js";
+export { MAX_SKILL_FILE_BYTES } from "../config/skill-size-limits.js";
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -268,6 +270,13 @@ export class SkillValidator {
     const violations: string[] = [];
     const normalizedSkillContent = stripLeadingHtmlComments(skillContent);
     const lines = normalizedSkillContent.split("\n");
+    const skillBytes = utf8ByteLength(normalizedSkillContent);
+
+    if (skillBytes > MAX_SKILL_FILE_BYTES) {
+      violations.push(
+        `Skill exceeds OpenClaw loader byte limit (${skillBytes} > ${MAX_SKILL_FILE_BYTES}). Shrink SKILL.md or move deterministic detail into bounded sidecars.`,
+      );
+    }
 
     if (lines.length > MAX_SKILL_LINES) {
       violations.push(

--- a/extensions/memory-hybrid/services/skill-validator.ts
+++ b/extensions/memory-hybrid/services/skill-validator.ts
@@ -270,7 +270,7 @@ export class SkillValidator {
     const violations: string[] = [];
     const normalizedSkillContent = stripLeadingHtmlComments(skillContent);
     const lines = normalizedSkillContent.split("\n");
-    const skillBytes = utf8ByteLength(normalizedSkillContent);
+    const skillBytes = utf8ByteLength(skillContent);
 
     if (skillBytes > MAX_SKILL_FILE_BYTES) {
       violations.push(

--- a/extensions/memory-hybrid/tests/crystallization.test.ts
+++ b/extensions/memory-hybrid/tests/crystallization.test.ts
@@ -974,6 +974,15 @@ ${extra.extraBody ?? ""}`;
     expect(result.violations.some((v: string) => v.includes("loader byte limit"))).toBe(true);
   });
 
+  it("includes leading HTML comments in byte limit check (guards against loader rejection after injectInstallMetadata)", () => {
+    const htmlComment = "<!-- openclaw:skill-proposal id=test-123 pattern_id=pat-456 evidence_hash=ev-789 output_path=/tmp/test -->\n";
+    const baseContent = compactValidSkill({ extraBody: "\n" + "a".repeat(MAX_SKILL_FILE_BYTES - 500) });
+    const contentWithHtml = htmlComment + baseContent;
+    const result = validator.validate(contentWithHtml);
+    expect(result.valid).toBe(false);
+    expect(result.violations.some((v: string) => v.includes("loader byte limit"))).toBe(true);
+  });
+
   it("denies eval() in code block", () => {
     const content = compactValidSkill({
       workflow: [

--- a/extensions/memory-hybrid/tests/crystallization.test.ts
+++ b/extensions/memory-hybrid/tests/crystallization.test.ts
@@ -11,6 +11,7 @@ import { DatabaseSync } from "node:sqlite";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { SkillProposalValidationResult } from "../services/generated-skill-validation.js";
+import { MAX_SKILL_FILE_BYTES } from "../config/skill-size-limits.js";
 import { _testing } from "../index.js";
 
 const {
@@ -964,6 +965,13 @@ ${extra.extraBody ?? ""}`;
   it("does not require related tools/skills section", () => {
     const result = validator.validate(compactValidSkill({ includeRelated: false }));
     expect(result.valid).toBe(true);
+  });
+
+  it("rejects SKILL.md content above the OpenClaw loader byte limit even when line count is low", () => {
+    const content = compactValidSkill({ extraBody: "\n" + "a".repeat(MAX_SKILL_FILE_BYTES + 1) });
+    const result = validator.validate(content);
+    expect(result.valid).toBe(false);
+    expect(result.violations.some((v: string) => v.includes("loader byte limit"))).toBe(true);
   });
 
   it("denies eval() in code block", () => {

--- a/extensions/memory-hybrid/tests/crystallization.test.ts
+++ b/extensions/memory-hybrid/tests/crystallization.test.ts
@@ -975,8 +975,9 @@ ${extra.extraBody ?? ""}`;
   });
 
   it("includes leading HTML comments in byte limit check (guards against loader rejection after injectInstallMetadata)", () => {
-    const htmlComment = "<!-- openclaw:skill-proposal id=test-123 pattern_id=pat-456 evidence_hash=ev-789 output_path=/tmp/test -->\n";
-    const baseContent = compactValidSkill({ extraBody: "\n" + "a".repeat(MAX_SKILL_FILE_BYTES - 500) });
+    const htmlComment =
+      "<!-- openclaw:skill-proposal id=test-123 pattern_id=pat-456 evidence_hash=ev-789 output_path=/tmp/test -->\n";
+    const baseContent = compactValidSkill({ extraBody: "\n" + "a".repeat(MAX_SKILL_FILE_BYTES - 900) });
     const contentWithHtml = htmlComment + baseContent;
     const result = validator.validate(contentWithHtml);
     expect(result.valid).toBe(false);

--- a/extensions/memory-hybrid/tests/procedure-skill-generator.test.ts
+++ b/extensions/memory-hybrid/tests/procedure-skill-generator.test.ts
@@ -215,7 +215,9 @@ describe("generateAutoSkills", () => {
 
     expect(result.generated).toBe(0);
     expect(result.skipped).toBe(1);
-    expect(result.decisions?.[0]?.reasons.some((reason) => reason.includes("skill_static_validation_failed"))).toBe(true);
+    expect(result.decisions?.[0]?.reasons.some((reason) => reason.includes("skill_static_validation_failed"))).toBe(
+      true,
+    );
     expect(existsSync(join(skillsDir, "validate-huge-generated-skill-output"))).toBe(false);
     expect(db.getProcedureById(proc.id)?.promotedToSkill).toBe(0);
   });

--- a/extensions/memory-hybrid/tests/procedure-skill-generator.test.ts
+++ b/extensions/memory-hybrid/tests/procedure-skill-generator.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join, relative } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { FactsDB } from "../backends/facts-db.js";
+import { MAX_SKILL_FILE_BYTES } from "../config/skill-size-limits.js";
 import { generateAutoSkillForProcedure, generateAutoSkills } from "../services/procedure-skill-generator.js";
 import { getEnv, setEnv } from "../utils/env-manager.js";
 import { SKILL_COMPLETE_MARKER } from "../utils/atomic-write.js";
@@ -173,6 +174,50 @@ describe("generateAutoSkills", () => {
     expect(updated?.promotedToSkill).toBe(1);
     expect(updated?.skillPath).toContain("check-moltbook-notifications");
     expect(updated?.skillState).toBe("experimental");
+  });
+
+  it("does not write or mark promoted when generated SKILL.md would exceed the loader byte limit", () => {
+    const hugeSummary = "Verify bounded output " + "a".repeat(Math.ceil(MAX_SKILL_FILE_BYTES / 2));
+    const proc = db.upsertProcedure({
+      taskPattern: "Validate huge generated skill output",
+      recipeJson: JSON.stringify([
+        { tool: "read", args: { path: "status.json" }, summary: hugeSummary },
+        { tool: "exec", args: { command: "npm test" }, summary: hugeSummary },
+        { tool: "read", args: { path: "report.json" }, summary: hugeSummary },
+      ]),
+      procedureType: "positive",
+      successCount: 3,
+      confidence: 0.9,
+      sourceSessionId: "huge-s1",
+      ttlDays: 30,
+    });
+    recordDistinctSuccesses(proc.id);
+
+    const previousWorkspace = getEnv("OPENCLAW_WORKSPACE");
+    setEnv("OPENCLAW_WORKSPACE", tmpDir);
+    let result: ReturnType<typeof generateAutoSkills>;
+    try {
+      result = generateAutoSkills(
+        db,
+        {
+          skillsAutoPath: skillsDir,
+          validationThreshold: 3,
+          skillTTLDays: 30,
+          apply: true,
+          policy: "auto-safe",
+        },
+        { info: () => {}, warn: () => {} },
+      );
+    } finally {
+      if (previousWorkspace !== undefined) setEnv("OPENCLAW_WORKSPACE", previousWorkspace);
+      else setEnv("OPENCLAW_WORKSPACE", undefined);
+    }
+
+    expect(result.generated).toBe(0);
+    expect(result.skipped).toBe(1);
+    expect(result.decisions[0]?.reasons.some((reason) => reason.includes("skill_static_validation_failed"))).toBe(true);
+    expect(existsSync(join(skillsDir, "validate-huge-generated-skill-output"))).toBe(false);
+    expect(db.getProcedureById(proc.id)?.promotedToSkill).toBe(0);
   });
 
   it("keeps collision-adjusted draft metadata aligned with the output directory", () => {

--- a/extensions/memory-hybrid/tests/procedure-skill-generator.test.ts
+++ b/extensions/memory-hybrid/tests/procedure-skill-generator.test.ts
@@ -215,7 +215,7 @@ describe("generateAutoSkills", () => {
 
     expect(result.generated).toBe(0);
     expect(result.skipped).toBe(1);
-    expect(result.decisions[0]?.reasons.some((reason) => reason.includes("skill_static_validation_failed"))).toBe(true);
+    expect(result.decisions?.[0]?.reasons.some((reason) => reason.includes("skill_static_validation_failed"))).toBe(true);
     expect(existsSync(join(skillsDir, "validate-huge-generated-skill-output"))).toBe(false);
     expect(db.getProcedureById(proc.id)?.promotedToSkill).toBe(0);
   });


### PR DESCRIPTION
## Summary
Preserves functional work from closed PR branch `fix/1537-skill-byte-limit-guard` (PR #1543 closed).

## Unique commits (3 total, NOT in main)
- `d2a50a24` style: format generated skill byte-limit changes
- `734973c3` test: handle optional generator decisions
- `7fd47645` fix: enforce generated skill byte limit

## Verification
- npm test

## Next owner
Manual

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive size checks on generated skills with tests; no auth or runtime behavior changes beyond blocking oversized writes.
> 
> **Overview**
> Adds a shared **256 KB UTF-8 byte cap** for generated `SKILL.md` files (matching OpenClaw’s workspace skill loader) via `skill-size-limits.ts`.
> 
> **`SkillValidator`** now fails validation when content exceeds the limit (byte count includes leading HTML comments). **`writeDraftSkill`** in the procedure skill generator refuses to write oversized drafts and throws before atomic write.
> 
> New tests cover validator rejection (including HTML-comment inflation) and batch auto-skill generation skipping promotion when static validation fails for oversized output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44679d73b5988941faaeb31ec315f2a2cb72d944. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->