### PR TITLE
feat: active-task ledger live-state reconciliation placeholder (from closed pr-1627)

### DIFF
--- a/extensions/memory-hybrid/services/task-ledger/canonical.ts
+++ b/extensions/memory-hybrid/services/task-ledger/canonical.ts
@@ -47,9 +47,39 @@ export function activeTaskProvenance(canonical: string, existing?: string | null
   return JSON.stringify(base);
 }
 
+/** Deterministic tie-break for two facts with equal createdAt.
+ *
+ *  Rules:
+ *  1. For the `status` key, terminal status wins over non-terminal when timestamps are equal.
+ *     This prevents a stale "in_progress" from persisting when a terminal "done"/"closed" update
+ *     lands in the same second/millisecond bucket.
+ *  2. In all other cases, newer id wins (lexicographic: later ids are "greater").
+ *     This gives a stable total order without depending on insertion/iteration order.
+ *
+ *  Returns a positive number if `b" is preferred (b wins), negative if `a` wins, 0 if identical.
+ */
+function factTieBreak(a: MemoryEntry, b: MemoryEntry, key: string): number {
+  if (a.createdAt === b.createdAt) {
+    // Rule 1: status terminal-vs-nonterminal tie-break
+    if (key === "status") {
+      const aTerminal = isTerminalFactStatus(a.value ?? "") ? 1 : 0;
+      const bTerminal = isTerminalFactStatus(b.value ?? "") ? 1 : 0;
+      if (aTerminal !== bTerminal) return bTerminal - aTerminal; // terminal (1) wins
+    }
+    // Rule 2: lexicographic id tie-break (stable, later id = newer fact)
+    return b.id.localeCompare(a.id);
+  }
+  return 0; // caller already compared createdAt; this is only for equal timestamps
+}
+
 /** Latest value per entity+key from non-superseded project facts.
  *  Entity labels are normalized via factCanonicalLabel() (provenance-aware + trim + toLowerCase + suffix/separator cleanup)
- *  so that case-variant entries (e.g. "Humanizer" / "humanizer") are merged into one group. */
+ *  so that case-variant entries (e.g. "Humanizer" / "humanizer") are merged into one group.
+ *
+ *  Selection is deterministic: newer createdAt wins, and when timestamps are equal a stable
+ *  tie-break (id + status-terminal override for the `status` key) ensures no stale fact
+ *  can shadow a newer terminal update.
+ */
 export function groupProjectFactsByEntity(facts: MemoryEntry[]): Map<string, Map<string, MemoryEntry>> {
   const byEntity = new Map<string, Map<string, MemoryEntry>>();
   for (const f of facts) {
@@ -63,8 +93,17 @@ export function groupProjectFactsByEntity(facts: MemoryEntry[]): Map<string, Map
       byEntity.set(canonical, km);
     }
     const prev = km.get(k);
-    if (!prev || f.createdAt > prev.createdAt) {
+    if (!prev) {
       km.set(k, f);
+    } else if (f.createdAt > prev.createdAt) {
+      km.set(k, f);
+    } else if (f.createdAt === prev.createdAt) {
+      // Same timestamp: apply deterministic tie-break
+      const prefer = factTieBreak(prev, f, k);
+      if (prefer > 0) {
+        km.set(k, f);
+      }
+      // If prefer <= 0, keep prev (prev is strictly preferred or identical)
     }
   }
   return byEntity;


### PR DESCRIPTION
## Summary
Preserves placeholder work from closed PR branch `feat/1625-active-task-refresh-live-state` (PR #1627 closed).

## Unique commits (2 total, NOT in main)
- `0926706e` feat(1625): active-task ledger live-state reconciliation — placeholder
- `5c7f9434` fix(1624): add deterministic tie-break in groupProjectFactsByEntity (shared with fix/1624)

## Note
Commit 5c7f9434 is also in `fix/1624-active-task-renderer-stale-status`. Both branches are being preserved.

## Verification
- npm test

## Next owner
Manual

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes canonical fact selection used for active-task projection and pre-finalization checks; wrong tie-break logic could still show stale task status, but scope is small and behavior is more deterministic than before.
> 
> **Overview**
> When two project facts share the same `createdAt` for an entity+key, **`groupProjectFactsByEntity`** no longer leaves the winner undefined (iteration-order dependent). It applies a new **`factTieBreak`**: for **`status`**, a terminal value (`done`, `closed`, etc.) beats non-terminal so a same-bucket terminal update is not shadowed by stale `in_progress`; otherwise the fact with the lexicographically greater **`id`** wins.
> 
> This affects how the active-task ledger and pre-finalization guard pick the latest fact per key when timestamps collide.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0926706e01735f969520a5f16ebade459dd15c66. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->