### PR TITLE
fix: deterministic tie-break in groupProjectFactsByEntity (from closed pr-1626)

### DIFF
--- a/extensions/memory-hybrid/services/task-ledger/canonical.ts
+++ b/extensions/memory-hybrid/services/task-ledger/canonical.ts
@@ -47,9 +47,39 @@ export function activeTaskProvenance(canonical: string, existing?: string | null
   return JSON.stringify(base);
 }
 
+/** Deterministic tie-break for two facts with equal createdAt.
+ *
+ *  Rules:
+ *  1. For the `status` key, terminal status wins over non-terminal when timestamps are equal.
+ *     This prevents a stale "in_progress" from persisting when a terminal "done"/"closed" update
+ *     lands in the same second/millisecond bucket.
+ *  2. In all other cases, newer id wins (lexicographic: later ids are "greater").
+ *     This gives a stable total order without depending on insertion/iteration order.
+ *
+ *  Returns a positive number if `b" is preferred (b wins), negative if `a` wins, 0 if identical.
+ */
+function factTieBreak(a: MemoryEntry, b: MemoryEntry, key: string): number {
+  if (a.createdAt === b.createdAt) {
+    // Rule 1: status terminal-vs-nonterminal tie-break
+    if (key === "status") {
+      const aTerminal = isTerminalFactStatus(a.value ?? "") ? 1 : 0;
+      const bTerminal = isTerminalFactStatus(b.value ?? "") ? 1 : 0;
+      if (aTerminal !== bTerminal) return bTerminal - aTerminal; // terminal (1) wins
+    }
+    // Rule 2: lexicographic id tie-break (stable, later id = newer fact)
+    return b.id.localeCompare(a.id);
+  }
+  return 0; // caller already compared createdAt; this is only for equal timestamps
+}
+
 /** Latest value per entity+key from non-superseded project facts.
  *  Entity labels are normalized via factCanonicalLabel() (provenance-aware + trim + toLowerCase + suffix/separator cleanup)
- *  so that case-variant entries (e.g. "Humanizer" / "humanizer") are merged into one group. */
+ *  so that case-variant entries (e.g. "Humanizer" / "humanizer") are merged into one group.
+ *
+ *  Selection is deterministic: newer createdAt wins, and when timestamps are equal a stable
+ *  tie-break (id + status-terminal override for the `status` key) ensures no stale fact
+ *  can shadow a newer terminal update.
+ */
 export function groupProjectFactsByEntity(facts: MemoryEntry[]): Map<string, Map<string, MemoryEntry>> {
   const byEntity = new Map<string, Map<string, MemoryEntry>>();
   for (const f of facts) {
@@ -63,8 +93,17 @@ export function groupProjectFactsByEntity(facts: MemoryEntry[]): Map<string, Map
       byEntity.set(canonical, km);
     }
     const prev = km.get(k);
-    if (!prev || f.createdAt > prev.createdAt) {
+    if (!prev) {
       km.set(k, f);
+    } else if (f.createdAt > prev.createdAt) {
+      km.set(k, f);
+    } else if (f.createdAt === prev.createdAt) {
+      // Same timestamp: apply deterministic tie-break
+      const prefer = factTieBreak(prev, f, k);
+      if (prefer > 0) {
+        km.set(k, f);
+      }
+      // If prefer <= 0, keep prev (prev is strictly preferred or identical)
     }
   }
   return byEntity;

--- a/extensions/memory-hybrid/services/task-ledger/canonical.ts
+++ b/extensions/memory-hybrid/services/task-ledger/canonical.ts
@@ -62,8 +62,8 @@ function factTieBreak(a: MemoryEntry, b: MemoryEntry, key: string): number {
   if (a.createdAt === b.createdAt) {
     // Rule 1: status terminal-vs-nonterminal tie-break
     if (key === "status") {
-      const aTerminal = isTerminalFactStatus(a.value ?? "") ? 1 : 0;
-      const bTerminal = isTerminalFactStatus(b.value ?? "") ? 1 : 0;
+      const aTerminal = isTerminalFactStatus(a.value ?? a.text ?? "") ? 1 : 0;
+      const bTerminal = isTerminalFactStatus(b.value ?? b.text ?? "") ? 1 : 0;
       if (aTerminal !== bTerminal) return bTerminal - aTerminal; // terminal (1) wins
     }
     // Rule 2: lexicographic id tie-break (stable, later id = newer fact)


### PR DESCRIPTION
## Summary
Preserves functional work from closed PR branch `fix/1624-active-task-renderer-stale-status` (PR #1626 closed).

## Unique commits (1 total, NOT in main)
- `5c7f9434` fix(1624): add deterministic tie-break in groupProjectFactsByEntity

## Verification
- npm test

## Next owner
Manual

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized canonical grouping logic for task-ledger facts; improves consistency of active-task status without touching auth, persistence APIs, or broad refactors.
> 
> **Overview**
> **`groupProjectFactsByEntity`** no longer treats “newer `createdAt`” as the only winner when collapsing project facts per entity/key. It now applies a **deterministic tie-break** when two facts share the same timestamp.
> 
> For the **`status`** key, a **terminal** status (`done`, `closed`, etc.) beats a non-terminal one at equal time—so a stale `in_progress` cannot win over a same-bucket terminal update. For all other keys (and as a fallback), the fact with the **lexicographically greater `id`** wins, giving a stable order independent of array iteration order.
> 
> Selection logic is split into explicit branches (no fact / strictly newer / equal timestamp) instead of a single `!prev || newer` check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d277228605fa95684195fcc1250f2cff6ac6ecd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->