### PR TITLE
chore: CI workflow updates for conventional commits (from closed pr-1572)

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -15,6 +15,7 @@ permissions:
   contents: read
   pull-requests: write
   issues: write
+  statuses: write
 
 jobs:
   size-label:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -114,6 +114,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
+          wip: true
           types: |
             feat
             fix

--- a/docs/1559.md
+++ b/docs/1559.md
@@ -1,0 +1,58 @@
+# Issue #1559: fix: hot/progressive recall self-reinforces garbage memories via recall-count pinning
+
+Status: WIP scaffold PR only — implementation pending.
+
+## Source Issue
+
+- Issue: #1559
+- URL: https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/1559
+- State at time of writing: OPEN
+- Labels at time of writing: bug, priority:high
+
+## Issue Body
+
+### Summary
+
+Hot-memory and progressive recall form a self-reinforcing loop: showing a fact in a progressive index refreshes its access count, which promotes it to the hot tier on the next prompt, which increases its recall_count, which causes `progressive_hybrid` to pin it in full. Garbage memories (raw `think` artifacts, stale errors, prompt fragments) enter this loop and become sticky.
+
+### Evidence
+
+**Code:**
+- `lifecycle/stage-injection.ts:220-222`: progressive-hybrid calls `ctx.factsDb.refreshAccessedFacts(pinnedIds)` and `refreshAccessedFacts(indexIds)` — counting both pinned full injection and index-only listing
+- `lifecycle/stage-injection.ts:163-188`: `progressive_hybrid` pins any candidate with `recallCount >= progressivePinnedRecallCount` into full text — recall_count is inflated by index exposure
+- `backends/facts-db/fact-read-queries.ts:314`: HOT orders by `COALESCE(last_accessed, last_confirmed_at, created_at) DESC` — recently indexed facts get priority
+- `lifecycle/stage-recall.ts:280-298`: HOT block injects `getHotFacts()` results directly, with no content-quality filter
+
+**DB evidence (Maeve live facts.db):**
+- Fact `1094ccf6...` text: `think Thinking Process...` — recall_count 2464
+- Fact `76a882f8...` text: `think Thinking Process...` — recall_count 2644
+- Fact `8bbab2ff...` text: `<think>The guard check...` — recall_count 4133
+- These appear verbatim in `<hot-memories>` block in prompts
+
+**Loop:** fact shown in index → `refreshAccessedFacts` → hot tier → shown in HOT block → recall_count++ → pinned in full → even higher recall_count → stays pinned.
+
+### Impact
+
+- Garbage memories become more prominent over time, not less.
+- Context budget is consumed by low-quality hot memories that crowd out relevant recall.
+- The system amplifies its own mistakes: showing a bad memory makes it more likely to be shown again.
+
+### Acceptance criteria
+
+- `refreshAccessedFacts` must not be called for index-only exposures (only when full content is injected or explicitly recalled by the user).
+- HOT retrieval must apply quality filters to exclude known garbage: reasoning traces, prompt artifacts, capability hints, classifier outputs.
+- `progressivePinnedRecallCount` threshold must not count index-only exposures; require full-content injection.
+- Add `indexed_count` / `last_indexed` as separate signals from `recall_count` / `last_accessed`.
+- Add a maintenance cleanup to demote existing high-recall-count reasoning traces from HOT.
+
+### Fix direction
+
+- Add a `last_indexed` field; `refreshAccessedFacts` should update `last_indexed` only, not `last_accessed`.
+- When pinning by recall_count, require `last_accessed` to be recent, not just `recall_count`.
+- Add quality filter in `getHotFacts()`: `source != 'auto-capture'` OR content not matching reasoning/prompt-artifact patterns.
+- Cap `hotMaxTokens` and add per-fact quality scoring before HOT injection.
+
+
+## Stewardship Notes
+
+This placeholder document exists to create a draft PR branch for Issue Stewardship tracking. The implementation work remains pending and should replace or extend this scaffold with the actual fix and verification evidence.


### PR DESCRIPTION
## Summary
Preserves CI workflow work from closed PR branch `issue-1559-fix-hot-progressive-recall-self-reinforces-garbage-memories-via-recall` (PR #1572 closed).

## Unique commits (3 total, NOT in main)
- `0674e3ef` ci: allow semantic PR check to write statuses
- `3ad0e12d` ci(pr-checks): allow draft PR titles in conventional-commits check
- `7d601920` docs(issue-1559): scaffold stewardship PR and clarify issue metadata snapshot

## Verification
- CI checks pass

## Next owner
Manual (CI-only)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow permission and semantic-PR config tweaks plus a non-executable docs scaffold; no application logic changes.
> 
> **Overview**
> Updates **PR Checks** so the conventional-commit validator can post commit statuses and accept **WIP/draft** PR titles via `wip: true` on `amannn/action-semantic-pull-request`, plus workflow **`statuses: write`** permission.
> 
> Also adds **`docs/1559.md`**, a stewardship placeholder for issue #1559 (hot/progressive recall loop); it documents the bug and acceptance criteria but states **implementation is still pending**—no runtime/memory code changes in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0674e3ef3de91a2bd3cc1496fb6d2ada0ec47d2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->