### PR TITLE
chore: CI conventional commits workflow updates (from closed pr-1568)

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -114,6 +114,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
+          wip: true
           types: |
             feat
             fix
@@ -126,6 +127,7 @@ jobs:
             build
             ci
             revert
+            WIP
 
   changed-files-summary:
     name: Changed Files Summary

--- a/docs/1552.md
+++ b/docs/1552.md
@@ -1,0 +1,81 @@
+# Issue #1552: fix: stale and duplicate active-task rows are still injected into prompts
+
+Status: WIP scaffold PR only — implementation pending.
+
+## Source Issue
+
+- Issue: #1552
+- URL: https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/1552
+- State: OPEN
+- Priority label: priority:high
+- Labels: bug, priority:high, issue/stage/enriching
+
+## Acceptance Criteria / Issue Body
+
+## Summary
+
+Active-task prompt injection still includes stale and duplicate task rows even though prior fixes were expected to suppress stale tasks. This causes noisy prompts, repeated hygiene chatter, and likely amplifies memory/recall pressure.
+
+## Evidence observed on Maeve
+
+Gateway logs during normal prompt construction:
+
+```text
+memory-hybrid: injecting 100 active task(s) from category:project facts (87 stale)
+```
+
+The injected active-task context still included duplicate/case-variant rows such as:
+
+```text
+[Hybrid-memory] ... (In progress)
+  Next: Closed as duplicate of canonical [hybrid-memory] ...
+
+[Hybrid-Memory PR Queue] ... (In progress)
+  Next: Closed stale duplicate. Canonical PR #1549 work is tracked by [hybrid-memory].
+```
+
+This is contradictory: tasks whose latest/next text says they are closed duplicates are still being projected/injected as active/in-progress.
+
+## Suspected causes
+
+- Project fact supersession/latest-state selection may be mixing old `status=in_progress` with newer `next=closed duplicate` facts.
+- Status normalization may not treat `closed`, `done`, `completed`, `cancelled`, etc. consistently across projection and injection.
+- Case-variant task entities (`hybrid-memory`, `Hybrid-memory`, `Hybrid-Memory PR Queue`) may not canonicalize before active-row selection.
+- Injection may count stale rows even when they should be omitted or collapsed.
+- Active-task projection/injection may be using a generated markdown snapshot or fact query that does not apply the same filters.
+
+## Why this matters
+
+This is not just cosmetic. It has operational impact:
+
+- Prompts get polluted with stale rows.
+- Hygiene jobs repeatedly report/close the same duplicates.
+- LLMs act on stale task state instead of live GitHub/PR state.
+- More active rows trigger more recall/projection work.
+- Memory pressure investigation showed this happening alongside high native RSS.
+
+## Acceptance criteria
+
+- Stale tasks should not be injected into prompt context by default.
+- Duplicate/case-variant task entities should collapse to one canonical entity.
+- If latest canonical status is `done`, `closed`, `completed`, `cancelled`, or `abandoned`, the task must not appear as active/in-progress.
+- If a row is injected despite being stale, it must be explicitly marked stale and should be capped to a tiny number for operator awareness.
+- Add regression tests covering:
+  - old `status=in_progress` + newer `status=done/closed`
+  - newer `next=closed duplicate` but old active status
+  - case variants of same entity
+  - stale task cutoff
+- Logs should report both candidates and actually injected count, e.g. `active candidates=100, injected=13, staleSkipped=87, duplicatesCollapsed=5`.
+
+## Suggested fix direction
+
+- Introduce a single shared active-task selection function used by both projection and injection.
+- Normalize entity IDs for canonical comparison, while preserving display title.
+- Normalize terminal statuses.
+- Resolve latest facts per `(entity,key)` before constructing task rows.
+- Do not use `next` text as a pseudo-status; require explicit status facts and ensure checkpoint writes them.
+
+
+## Stewardship Notes
+
+This placeholder document exists to create a draft PR branch for Issue Stewardship tracking. The implementation work remains pending and should replace or extend this scaffold with the actual fix and verification evidence.

--- a/docs/1552.md
+++ b/docs/1552.md
@@ -4,19 +4,18 @@ Status: WIP scaffold PR only — implementation pending.
 
 ## Source Issue
 
+<!-- Snapshot at scaffold creation time; refer to the linked issue for current state. -->
+
 - Issue: #1552
 - URL: https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/1552
-- State: OPEN
-- Priority label: priority:high
-- Labels: bug, priority:high, issue/stage/enriching
 
-## Acceptance Criteria / Issue Body
+## Issue Body
 
-## Summary
+### Summary
 
 Active-task prompt injection still includes stale and duplicate task rows even though prior fixes were expected to suppress stale tasks. This causes noisy prompts, repeated hygiene chatter, and likely amplifies memory/recall pressure.
 
-## Evidence observed on Maeve
+### Evidence observed on Maeve
 
 Gateway logs during normal prompt construction:
 
@@ -36,7 +35,7 @@ The injected active-task context still included duplicate/case-variant rows such
 
 This is contradictory: tasks whose latest/next text says they are closed duplicates are still being projected/injected as active/in-progress.
 
-## Suspected causes
+### Suspected causes
 
 - Project fact supersession/latest-state selection may be mixing old `status=in_progress` with newer `next=closed duplicate` facts.
 - Status normalization may not treat `closed`, `done`, `completed`, `cancelled`, etc. consistently across projection and injection.
@@ -44,7 +43,7 @@ This is contradictory: tasks whose latest/next text says they are closed duplica
 - Injection may count stale rows even when they should be omitted or collapsed.
 - Active-task projection/injection may be using a generated markdown snapshot or fact query that does not apply the same filters.
 
-## Why this matters
+### Why this matters
 
 This is not just cosmetic. It has operational impact:
 
@@ -54,7 +53,7 @@ This is not just cosmetic. It has operational impact:
 - More active rows trigger more recall/projection work.
 - Memory pressure investigation showed this happening alongside high native RSS.
 
-## Acceptance criteria
+### Acceptance criteria
 
 - Stale tasks should not be injected into prompt context by default.
 - Duplicate/case-variant task entities should collapse to one canonical entity.
@@ -67,7 +66,7 @@ This is not just cosmetic. It has operational impact:
   - stale task cutoff
 - Logs should report both candidates and actually injected count, e.g. `active candidates=100, injected=13, staleSkipped=87, duplicatesCollapsed=5`.
 
-## Suggested fix direction
+### Suggested fix direction
 
 - Introduce a single shared active-task selection function used by both projection and injection.
 - Normalize entity IDs for canonical comparison, while preserving display title.


### PR DESCRIPTION
## Summary
Preserves CI workflow work from closed PR branch `issue-1552-fix-stale-and-duplicate-active-task-rows-are-still-injected-into-promp` (PR #1568 closed).

## Unique commits (3 total, NOT in main)
- `25d117c1` ci: add WIP type and wip option to conventional-commits check
- `5bba20c0` docs: fix heading hierarchy and remove stale metadata in 1552.md
- `7a99ce1e` docs: scaffold issue #1552 stewardship PR

## Verification
- CI checks

## Next owner
Manual (CI/docs-only)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI title rules and documentation scaffolding; no authentication, data handling, or active-task injection logic is modified.
> 
> **Overview**
> Updates **PR title validation** in `pr-checks.yml` so work-in-progress PRs can pass conventional-commit checks: enables the action’s **`wip: true`** option and adds **`WIP`** to the allowed semantic types alongside the existing list.
> 
> Adds **`docs/1552.md`**, a stewardship placeholder for issue #1552 that captures the stale/duplicate active-task injection problem, evidence, acceptance criteria, and suggested fix direction. The doc states **implementation is still pending**—no runtime/memory-hybrid code changes in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25d117c1ea7f37280c557c2932638ccb72bcdeb4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->