### PR TITLE
Audit orphan branch: orphan/pr1591-preserve

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,4 +159,3 @@ Plugin source and manifest: [extensions/memory-hybrid/README.md](extensions/memo
 ## License
 
 MIT ([LICENSE](LICENSE))
-# No-op commit to refresh CI status

--- a/README.md
+++ b/README.md
@@ -159,3 +159,4 @@ Plugin source and manifest: [extensions/memory-hybrid/README.md](extensions/memo
 ## License
 
 MIT ([LICENSE](LICENSE))
+# No-op commit to refresh CI status

--- a/docs/CREDENTIALS.md
+++ b/docs/CREDENTIALS.md
@@ -10,13 +10,13 @@ The hybrid-memory plugin supports an **opt-in credential store** for structured 
 
 ## Dual-mode: Vault vs memory
 
-- **Vault disabled (default):** Credentials are stored in memory like the live version: both **distil** (session distillation, extract-daily) and **store** (memory_store tool, `openclaw hybrid-mem store`) write credential-like content into the hybrid memory (SQLite + LanceDB). This matches the existing “store everything in memory” behavior.
+- **Vault disabled/unavailable (default):** Credential-like content is **blocked** from ordinary memory storage. `memory_store`, `openclaw hybrid-mem store`, session distillation, and extract-daily will skip credential-like inputs and instruct operators to enable the credential vault.
 - **Vault enabled:** When the secure credential vault is enabled (see below), credential-like content is **not** written into memory or the database. Instead:
   - The secret is stored only in the encrypted vault.
   - A **pointer** fact is stored in memory (e.g. “Credential for home-assistant (token) — stored in secure vault. Use credential_get(service=\"home-assistant\") to retrieve.”) so the agent knows the credential exists and how to retrieve it.
   - Recall and search return the pointer, not the secret; the agent uses `credential_get` when it needs the value.
 
-So: **no vault** → credentials live in memory/facts (live behavior). **Vault on** → credentials live only in the vault; memory holds pointers only.
+So: **no vault** → credentials are not stored in ordinary memory. **Vault on** → credentials live only in the vault; memory holds pointers only.
 
 Dual-mode applies to: **memory_store** tool, **openclaw hybrid-mem store** (CLI and scripts such as session distillation), and **openclaw hybrid-mem extract-daily**.
 

--- a/docs/SESSION-DISTILLATION.md
+++ b/docs/SESSION-DISTILLATION.md
@@ -51,7 +51,7 @@ So in one sentence: **it re-reads conversation logs in a chosen window (full or 
 
 ## Overview
 
-Session distillation is a **batch fact-extraction pipeline** that **indexes and processes old session logs and historical memories**: it runs over historical OpenClaw session transcripts, extracts durable facts (and credentials when present), and stores them in the right place in **one run**. Facts go to hybrid memory (SQLite + LanceDB); credentials are routed automatically—to the **Secure Credential Vault** (plus a pointer in memory) when the vault is enabled, or to memory when it is not. No separate “facts” vs “credentials” distillation runs are needed. It complements the hybrid memory system's real-time auto-capture by retrospectively analyzing chat history.
+Session distillation is a **batch fact-extraction pipeline** that **indexes and processes old session logs and historical memories**: it runs over historical OpenClaw session transcripts, extracts durable facts (and credentials when present), and stores them in the right place in **one run**. Facts go to hybrid memory (SQLite + LanceDB); credentials are routed automatically—to the **Secure Credential Vault** (plus a pointer in memory) when the vault is enabled, and are skipped when the vault is disabled or unavailable. No separate “facts” vs “credentials” distillation runs are needed. It complements the hybrid memory system's real-time auto-capture by retrospectively analyzing chat history.
 
 **Model choice:** The pipeline uses whatever chat model the **OpenClaw gateway** provides; configure **`llm.heavy`** (see [LLM-AND-PROVIDERS.md](LLM-AND-PROVIDERS.md)) for an ordered preference list (e.g. Gemini for 1M+ context, then Claude/OpenAI). Long-context models allow large batches (~500k tokens per batch); others use 80k. You can pass `--model M` to override for a run or spawn the distillation sub-agent with a specific model (see [Running the Pipeline](#running-the-pipeline-manually) and [Nightly Cron Setup](#nightly-cron-setup)).
 
@@ -303,7 +303,7 @@ Use `openclaw hybrid-mem distill-window` at the start of the job to get `mode`, 
 1. **Get the window:** Run `openclaw hybrid-mem distill-window --json`. Parse `mode`, `startDate`, `endDate`, `mtimeDays`.
 2. Find session JSONL files in that window (e.g. `find ... -mtime -<mtimeDays>`).
 3. Extract conversational text (e.g. via `scripts/distill-sessions/extract-text.sh`).
-4. Extract facts with the LLM (Gemini or other), dedupe against memory_recall, store net new facts via memory_store. Extracted credentials are routed the same way as in real time: to the secure vault (plus a pointer in memory) when the vault is enabled, or to memory when it is not.
+4. Extract facts with the LLM (Gemini or other), dedupe against memory_recall, store net new facts via memory_store. Extracted credentials are routed the same way as in real time: to the secure vault (plus a pointer in memory) when the vault is enabled, and skipped when the vault is disabled or unavailable.
 5. Log a short summary to `nightly-logs/YYYY-MM-DD.md`.
 6. **Always** run `openclaw hybrid-mem record-distill` at the end so the next run uses the correct window.
 
@@ -317,7 +317,7 @@ Run the nightly memory distillation pipeline.
 1. Get the window: run `openclaw hybrid-mem distill-window --json`. Parse the JSON (mode, startDate, endDate, mtimeDays).
 2. Find session files in that window: e.g. find ~/.openclaw/agents/main/sessions/ -name '*.jsonl' -not -name '*.deleted.*' -mtime -<mtimeDays> (use mtimeDays from step 1).
 3. Extract text using scripts/distill-sessions/extract-text.sh (or equivalent) for those files.
-4. Extract facts from the text using the LLM (category, entity, key, value, source date). For each fact, check memory_recall for similar — skip if already stored. Store only net new facts via memory_store, prefixed with [YYYY-MM-DD]. Credentials extracted from sessions are routed like in real time: to the secure vault (plus a pointer in memory) when the vault is enabled, or to memory when it is not.
+4. Extract facts from the text using the LLM (category, entity, key, value, source date). For each fact, check memory_recall for similar — skip if already stored. Store only net new facts via memory_store, prefixed with [YYYY-MM-DD]. Credentials extracted from sessions are routed like in real time: to the secure vault (plus a pointer in memory) when the vault is enabled, and skipped when the vault is disabled or unavailable.
 5. Write a brief summary to scripts/distill-sessions/nightly-logs/YYYY-MM-DD.md (sessions scanned, facts extracted, new stored).
 6. Run openclaw hybrid-mem record-distill so the next run uses the correct incremental window.
 

--- a/extensions/memory-hybrid/cli/cmd-distill.ts
+++ b/extensions/memory-hybrid/cli/cmd-distill.ts
@@ -625,82 +625,86 @@ export async function runDistillForCli(
     let skipped = 0;
     for (const fact of allFacts) {
       const isCred = isCredentialLike(fact.text, fact.entity ?? null, fact.key ?? null, fact.value);
-      if (isCred && cfg.credentials.enabled && credentialsDb) {
-        const parsed = tryParseCredentialForVault(fact.text, fact.entity ?? null, fact.key ?? null, fact.value, {
-          requirePatternMatch: cfg.credentials.autoCapture?.requirePatternMatch === true,
-        });
-        if (parsed) {
-          if (!opts.dryRun) {
-            let storedInVault = false;
-            try {
-              const credStoreResult = credentialsDb.storeIfNew({
-                service: parsed.service,
-                type: parsed.type as any,
-                value: parsed.secretValue,
-                url: parsed.url,
-                notes: parsed.notes,
-              });
-              if (!credStoreResult) {
-                continue;
-              }
-              storedInVault = true;
-              const pointerText = `Credential for ${parsed.service} (${parsed.type}) — stored in vault.`;
-              const storeResult = factsDb.storeWithResult({
-                text: pointerText,
-                category: "technical",
-                importance: BATCH_STORE_IMPORTANCE,
-                entity: "Credentials",
-                key: parsed.service,
-                value: `${VAULT_POINTER_PREFIX}${parsed.service}:${parsed.type}`,
-                source: "distillation",
-                sourceDate: sourceDateSec(fact.source_date),
-              });
-              const entry = storeResult.entry;
-              // CRITICAL FIX (#2): Delete vector for evicted fact to prevent orphaned vectors
-              await cleanupEvictedVector({
-                vectorDb: vectorDb,
-                evictedFactId: storeResult.evictedFactId,
-                logger: sink,
-                context: "distill",
-              });
+      if (isCred) {
+        if (cfg.credentials.enabled && credentialsDb) {
+          const parsed = tryParseCredentialForVault(fact.text, fact.entity ?? null, fact.key ?? null, fact.value, {
+            requirePatternMatch: cfg.credentials.autoCapture?.requirePatternMatch === true,
+          });
+          if (parsed) {
+            if (!opts.dryRun) {
+              let storedInVault = false;
               try {
-                const vector = await embeddings.embed(pointerText);
-                factsDb.setEmbeddingModel(entry.id, embeddings.modelName);
-                if (!(await vectorDb.hasDuplicate(vector, DISTILL_DEDUP_THRESHOLD))) {
-                  await vectorDb.store({
-                    text: pointerText,
-                    vector,
-                    importance: BATCH_STORE_IMPORTANCE,
-                    category: "technical",
-                    id: entry.id,
-                  });
-                }
-              } catch (err) {
-                capturePluginError(err as Error, {
-                  subsystem: "cli",
-                  operation: "runDistillForCli:credential-vector-store",
+                const credStoreResult = credentialsDb.storeIfNew({
+                  service: parsed.service,
+                  type: parsed.type as any,
+                  value: parsed.secretValue,
+                  url: parsed.url,
+                  notes: parsed.notes,
                 });
-              }
-              stored++;
-              if (opts.verbose) sink.log(`  stored credential: ${parsed.service}`);
-            } catch (err) {
-              if (storedInVault) {
+                if (!credStoreResult) {
+                  continue;
+                }
+                storedInVault = true;
+                const pointerText = `Credential for ${parsed.service} (${parsed.type}) — stored in vault.`;
+                const storeResult = factsDb.storeWithResult({
+                  text: pointerText,
+                  category: "technical",
+                  importance: BATCH_STORE_IMPORTANCE,
+                  entity: "Credentials",
+                  key: parsed.service,
+                  value: `${VAULT_POINTER_PREFIX}${parsed.service}:${parsed.type}`,
+                  source: "distillation",
+                  sourceDate: sourceDateSec(fact.source_date),
+                });
+                const entry = storeResult.entry;
+                // CRITICAL FIX (#2): Delete vector for evicted fact to prevent orphaned vectors
+                await cleanupEvictedVector({
+                  vectorDb: vectorDb,
+                  evictedFactId: storeResult.evictedFactId,
+                  logger: sink,
+                  context: "distill",
+                });
                 try {
-                  credentialsDb.delete(parsed.service, parsed.type as any);
-                } catch (cleanupErr) {
-                  if (opts.verbose)
-                    sink.log(`  failed to clean up orphaned credential for ${parsed.service}: ${cleanupErr}`);
-                  capturePluginError(cleanupErr as Error, {
+                  const vector = await embeddings.embed(pointerText);
+                  factsDb.setEmbeddingModel(entry.id, embeddings.modelName);
+                  if (!(await vectorDb.hasDuplicate(vector, DISTILL_DEDUP_THRESHOLD))) {
+                    await vectorDb.store({
+                      text: pointerText,
+                      vector,
+                      importance: BATCH_STORE_IMPORTANCE,
+                      category: "technical",
+                      id: entry.id,
+                    });
+                  }
+                } catch (err) {
+                  capturePluginError(err as Error, {
                     subsystem: "cli",
-                    operation: "runDistillForCli:credential-compensating-delete",
+                    operation: "runDistillForCli:credential-vector-store",
                   });
                 }
+                stored++;
+                if (opts.verbose) sink.log(`  stored credential: ${parsed.service}`);
+              } catch (err) {
+                if (storedInVault) {
+                  try {
+                    credentialsDb.delete(parsed.service, parsed.type as any);
+                  } catch (cleanupErr) {
+                    if (opts.verbose)
+                      sink.log(`  failed to clean up orphaned credential for ${parsed.service}: ${cleanupErr}`);
+                    capturePluginError(cleanupErr as Error, {
+                      subsystem: "cli",
+                      operation: "runDistillForCli:credential-compensating-delete",
+                    });
+                  }
+                }
+                capturePluginError(err as Error, { subsystem: "cli", operation: "runDistillForCli:credential-store" });
               }
-              capturePluginError(err as Error, { subsystem: "cli", operation: "runDistillForCli:credential-store" });
             }
+            continue;
           }
           continue;
         }
+        if (opts.verbose) sink.log("  skipped credential-like fact: vault disabled or unavailable");
         continue;
       }
       if (factsDb.hasDuplicate(fact.text, "distillation")) {

--- a/extensions/memory-hybrid/cli/cmd-distill.ts
+++ b/extensions/memory-hybrid/cli/cmd-distill.ts
@@ -5,18 +5,17 @@
  * Extracted from handlers.ts.
  */
 
-import { existsSync, mkdirSync, readFileSync, readdirSync, statSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { basename, dirname, join } from "node:path";
-
+import type { MemoryCategory } from "../config.js";
 import {
+  describeMaintenanceFallbackPolicy,
   getCronModelConfig,
   getDefaultCronModel,
-  describeMaintenanceFallbackPolicy,
+  isValidCategory,
   resolveReflectionModelAndFallbacks,
 } from "../config.js";
-import { isValidCategory } from "../config.js";
-import type { MemoryCategory } from "../config.js";
 import {
   ADAPTIVE_MODEL_LIMITS_VERSION,
   adaptiveFailureShrinkRatios,
@@ -26,7 +25,7 @@ import {
   recordAdaptiveSuccess,
   saveAdaptiveModelLimits,
 } from "../services/adaptive-model-limits.js";
-import { VAULT_POINTER_PREFIX, isCredentialLike, tryParseCredentialForVault } from "../services/auto-capture.js";
+import { isCredentialLike, tryParseCredentialForVault, VAULT_POINTER_PREFIX } from "../services/auto-capture.js";
 import {
   chatCompleteWithRetryDetailed,
   distillBatchTokenLimit,
@@ -40,6 +39,7 @@ import {
 import { CostFeature } from "../services/cost-feature-labels.js";
 import { capturePluginError } from "../services/error-reporter.js";
 import { preFilterSessions } from "../services/session-pre-filter.js";
+import { cleanupEvictedVector } from "../services/vector-maintenance.js";
 import { BATCH_STORE_IMPORTANCE, DISTILL_DEDUP_THRESHOLD } from "../utils/constants.js";
 import { getEnv } from "../utils/env-manager.js";
 import { resolveTierPreferenceWithSources } from "../utils/llm-selection.js";
@@ -47,12 +47,11 @@ import { loadPrompt } from "../utils/prompt-loader.js";
 import { extractTags } from "../utils/tags.js";
 import { chunkSessionText, estimateTokens } from "../utils/text.js";
 import { getMaxMtime } from "./cmd-extract.js";
-import { extractTextFromSessionJsonl } from "./distill-session-jsonl.js";
 import { buildPreFilterConfig, createProgressReporter } from "./cmd-install.js";
+import { extractTextFromSessionJsonl } from "./distill-session-jsonl.js";
 import type { HandlerContext } from "./handlers.js";
 import { acquireScanSlot, clearScanLock } from "./shared.js";
 import type { DistillCliResult, DistillCliSink, DistillWindowResult, RecordDistillResult } from "./types.js";
-import { cleanupEvictedVector } from "../services/vector-maintenance.js";
 
 // Constants used only by distill functions
 const FULL_DISTILL_MAX_DAYS = 90;
@@ -636,7 +635,7 @@ export async function runDistillForCli(
               try {
                 const credStoreResult = credentialsDb.storeIfNew({
                   service: parsed.service,
-                  type: parsed.type as any,
+                  type: parsed.type,
                   value: parsed.secretValue,
                   url: parsed.url,
                   notes: parsed.notes,
@@ -687,7 +686,7 @@ export async function runDistillForCli(
               } catch (err) {
                 if (storedInVault) {
                   try {
-                    credentialsDb.delete(parsed.service, parsed.type as any);
+                    credentialsDb.delete(parsed.service, parsed.type);
                   } catch (cleanupErr) {
                     if (opts.verbose)
                       sink.log(`  failed to clean up orphaned credential for ${parsed.service}: ${cleanupErr}`);

--- a/extensions/memory-hybrid/cli/cmd-extract-daily.ts
+++ b/extensions/memory-hybrid/cli/cmd-extract-daily.ts
@@ -4,9 +4,9 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import type { MemoryCategory } from "../config.js";
 import { getCronModelConfig, getDefaultCronModel } from "../config.js";
-import { VAULT_POINTER_PREFIX, isCredentialLike, tryParseCredentialForVault } from "../services/auto-capture.js";
+import { isCredentialLike, tryParseCredentialForVault, VAULT_POINTER_PREFIX } from "../services/auto-capture.js";
+import { classifyMemoryOperationsBatch, type MemoryClassification } from "../services/classification.js";
 import { validateScopedClassificationTarget } from "../services/classification-scope.js";
-import { type MemoryClassification, classifyMemoryOperationsBatch } from "../services/classification.js";
 import { capturePluginError } from "../services/error-reporter.js";
 import { extractStructuredFields } from "../services/fact-extraction.js";
 import { cleanupEvictedVector, deleteVectorForFactId } from "../services/vector-maintenance.js";
@@ -203,7 +203,7 @@ export async function runExtractDailyForCli(
               try {
                 const stored = credentialsDb.storeIfNew({
                   service: parsed.service,
-                  type: parsed.type as any,
+                  type: parsed.type,
                   value: parsed.secretValue,
                   url: parsed.url,
                   notes: parsed.notes,
@@ -212,7 +212,7 @@ export async function runExtractDailyForCli(
                   continue;
                 }
                 storedInVault = true;
-                const pointerText = `Credential for ${parsed.service} (${parsed.type}) — stored in secure vault. Use credential_get(service="${parsed.service}") to retrieve.`;
+                const pointerText = `Credential for ${parsed.service} (${parsed.type}) — stored in secure vault. Use credential_get(service="${parsed.service}", type="${parsed.type}") to retrieve.`;
                 const sourceDateSec = Math.floor(new Date(dateStr).getTime() / 1000);
                 const pointerStoreResult = factsDb.storeWithResult({
                   text: pointerText,
@@ -255,7 +255,7 @@ export async function runExtractDailyForCli(
               } catch (err) {
                 if (storedInVault) {
                   try {
-                    credentialsDb.delete(parsed.service, parsed.type as any);
+                    credentialsDb.delete(parsed.service, parsed.type);
                   } catch (cleanupErr) {
                     sink.warn(
                       `memory-hybrid: Failed to clean up orphaned credential for ${parsed.service}: ${cleanupErr}`,

--- a/extensions/memory-hybrid/cli/cmd-extract-daily.ts
+++ b/extensions/memory-hybrid/cli/cmd-extract-daily.ts
@@ -278,6 +278,8 @@ export async function runExtractDailyForCli(
           // isCredentialLike but vault parse failed — skip this line entirely.
           continue;
         }
+        if (opts.verbose) sink.log("  skipped credential-like line: vault disabled or unavailable");
+        continue;
       }
       if (!extracted.entity && !extracted.key && category !== "decision") continue;
       totalExtracted++;

--- a/extensions/memory-hybrid/cli/cmd-store.ts
+++ b/extensions/memory-hybrid/cli/cmd-store.ts
@@ -7,18 +7,18 @@
 
 import type { MemoryCategory } from "../config.js";
 import { getCronModelConfig, getDefaultCronModel } from "../config.js";
-import { VAULT_POINTER_PREFIX, isCredentialLike, tryParseCredentialForVault } from "../services/auto-capture.js";
+import { isCredentialLike, tryParseCredentialForVault, VAULT_POINTER_PREFIX } from "../services/auto-capture.js";
 import { classifyMemoryOperation } from "../services/classification.js";
 import { validateScopedClassificationTarget } from "../services/classification-scope.js";
 import { capturePluginError } from "../services/error-reporter.js";
 import { extractStructuredFields } from "../services/fact-extraction.js";
+import { cleanupEvictedVector, deleteVectorForFactId } from "../services/vector-maintenance.js";
 import { findSimilarByEmbedding } from "../services/vector-search.js";
 import { CLI_STORE_IMPORTANCE } from "../utils/constants.js";
 import { parseSourceDate } from "../utils/dates.js";
 import { extractTags } from "../utils/tags.js";
 import type { HandlerContext } from "./handlers.js";
 import type { StoreCliOpts, StoreCliResult } from "./types.js";
-import { cleanupEvictedVector, deleteVectorForFactId } from "../services/vector-maintenance.js";
 
 /**
  * Infer which identity file a rule or suggestion should target (#260).
@@ -58,7 +58,7 @@ export async function runStoreForCli(
         try {
           const stored = credentialsDb.storeIfNew({
             service: parsed.service,
-            type: parsed.type as any,
+            type: parsed.type,
             value: parsed.secretValue,
             url: parsed.url,
             notes: parsed.notes,
@@ -74,7 +74,7 @@ export async function runStoreForCli(
         // Step 2: Write pointer to factsDb
         let pointerEntry: any;
         try {
-          const pointerText = `Credential for ${parsed.service} (${parsed.type}) — stored in secure vault. Use credential_get(service="${parsed.service}") to retrieve.`;
+          const pointerText = `Credential for ${parsed.service} (${parsed.type}) — stored in secure vault. Use credential_get(service="${parsed.service}", type="${parsed.type}") to retrieve.`;
           const pointerValue = `${VAULT_POINTER_PREFIX}${parsed.service}:${parsed.type}`;
           const storeResult = factsDb.storeWithResult({
             text: pointerText,
@@ -114,8 +114,7 @@ export async function runStoreForCli(
         } catch (err) {
           // Compensating delete: vault write succeeded but pointer write failed
           try {
-            // biome-ignore lint/suspicious/noExplicitAny: credential type from parsed input
-            credentialsDb.delete(parsed.service, parsed.type as any);
+            credentialsDb.delete(parsed.service, parsed.type);
           } catch (cleanupErr) {
             log.warn(`memory-hybrid: Failed to clean up orphaned credential for ${parsed.service}: ${cleanupErr}`);
             capturePluginError(cleanupErr as Error, {

--- a/extensions/memory-hybrid/cli/cmd-store.ts
+++ b/extensions/memory-hybrid/cli/cmd-store.ts
@@ -48,86 +48,89 @@ export async function runStoreForCli(
   const key = opts.key ?? extracted.key ?? null;
   const value = opts.value ?? extracted.value ?? null;
 
-  if (cfg.credentials.enabled && credentialsDb && isCredentialLike(text, entity, key, value)) {
-    const parsed = tryParseCredentialForVault(text, entity, key, value, {
-      requirePatternMatch: cfg.credentials.autoCapture?.requirePatternMatch === true,
-    });
-    if (parsed) {
-      // Step 1: Write to vault (use storeIfNew to avoid overwriting user-managed credentials)
-      try {
-        const stored = credentialsDb.storeIfNew({
-          service: parsed.service,
-          type: parsed.type as any,
-          value: parsed.secretValue,
-          url: parsed.url,
-          notes: parsed.notes,
-        });
-        if (!stored) {
-          return { outcome: "credential_skipped_duplicate", service: parsed.service, type: parsed.type };
-        }
-      } catch (err) {
-        capturePluginError(err as Error, { subsystem: "cli", operation: "runStoreForCli:credential-vault-store" });
-        return { outcome: "credential_vault_error" };
-      }
-
-      // Step 2: Write pointer to factsDb
-      let pointerEntry: any;
-      try {
-        const pointerText = `Credential for ${parsed.service} (${parsed.type}) — stored in secure vault. Use credential_get(service="${parsed.service}") to retrieve.`;
-        const pointerValue = `${VAULT_POINTER_PREFIX}${parsed.service}:${parsed.type}`;
-        const storeResult = factsDb.storeWithResult({
-          text: pointerText,
-          category: "technical" as MemoryCategory,
-          importance: CLI_STORE_IMPORTANCE,
-          entity: "Credentials",
-          key: parsed.service,
-          value: pointerValue,
-          source: "cli",
-          sourceDate,
-          tags: ["auth", ...extractTags(pointerText, "Credentials")],
-        });
-        pointerEntry = storeResult.entry;
-        // CRITICAL FIX (#2): Delete vector for evicted fact to prevent orphaned vectors
-        await cleanupEvictedVector({
-          vectorDb: vectorDb,
-          evictedFactId: storeResult.evictedFactId,
-          logger: log,
-          context: "cli-store",
-        });
+  if (isCredentialLike(text, entity, key, value)) {
+    if (cfg.credentials.enabled && credentialsDb) {
+      const parsed = tryParseCredentialForVault(text, entity, key, value, {
+        requirePatternMatch: cfg.credentials.autoCapture?.requirePatternMatch === true,
+      });
+      if (parsed) {
+        // Step 1: Write to vault (use storeIfNew to avoid overwriting user-managed credentials)
         try {
-          const vector = await embeddings.embed(pointerText);
-          factsDb.setEmbeddingModel(pointerEntry.id, embeddings.modelName);
-          if (!(await vectorDb.hasDuplicate(vector))) {
-            await vectorDb.store({
-              text: pointerText,
-              vector,
-              importance: CLI_STORE_IMPORTANCE,
-              category: "technical",
-              id: pointerEntry.id,
-            });
+          const stored = credentialsDb.storeIfNew({
+            service: parsed.service,
+            type: parsed.type as any,
+            value: parsed.secretValue,
+            url: parsed.url,
+            notes: parsed.notes,
+          });
+          if (!stored) {
+            return { outcome: "credential_skipped_duplicate", service: parsed.service, type: parsed.type };
           }
         } catch (err) {
-          log.warn(`memory-hybrid: vector store failed: ${err}`);
-          capturePluginError(err as Error, { subsystem: "cli", operation: "runStoreForCli:vector-store" });
+          capturePluginError(err as Error, { subsystem: "cli", operation: "runStoreForCli:credential-vault-store" });
+          return { outcome: "credential_vault_error" };
         }
-      } catch (err) {
-        // Compensating delete: vault write succeeded but pointer write failed
+
+        // Step 2: Write pointer to factsDb
+        let pointerEntry: any;
         try {
-          // biome-ignore lint/suspicious/noExplicitAny: credential type from parsed input
-          credentialsDb.delete(parsed.service, parsed.type as any);
-        } catch (cleanupErr) {
-          log.warn(`memory-hybrid: Failed to clean up orphaned credential for ${parsed.service}: ${cleanupErr}`);
-          capturePluginError(cleanupErr as Error, {
-            subsystem: "cli",
-            operation: "runStoreForCli:credential-compensating-delete",
+          const pointerText = `Credential for ${parsed.service} (${parsed.type}) — stored in secure vault. Use credential_get(service="${parsed.service}") to retrieve.`;
+          const pointerValue = `${VAULT_POINTER_PREFIX}${parsed.service}:${parsed.type}`;
+          const storeResult = factsDb.storeWithResult({
+            text: pointerText,
+            category: "technical" as MemoryCategory,
+            importance: CLI_STORE_IMPORTANCE,
+            entity: "Credentials",
+            key: parsed.service,
+            value: pointerValue,
+            source: "cli",
+            sourceDate,
+            tags: ["auth", ...extractTags(pointerText, "Credentials")],
           });
+          pointerEntry = storeResult.entry;
+          // CRITICAL FIX (#2): Delete vector for evicted fact to prevent orphaned vectors
+          await cleanupEvictedVector({
+            vectorDb: vectorDb,
+            evictedFactId: storeResult.evictedFactId,
+            logger: log,
+            context: "cli-store",
+          });
+          try {
+            const vector = await embeddings.embed(pointerText);
+            factsDb.setEmbeddingModel(pointerEntry.id, embeddings.modelName);
+            if (!(await vectorDb.hasDuplicate(vector))) {
+              await vectorDb.store({
+                text: pointerText,
+                vector,
+                importance: CLI_STORE_IMPORTANCE,
+                category: "technical",
+                id: pointerEntry.id,
+              });
+            }
+          } catch (err) {
+            log.warn(`memory-hybrid: vector store failed: ${err}`);
+            capturePluginError(err as Error, { subsystem: "cli", operation: "runStoreForCli:vector-store" });
+          }
+        } catch (err) {
+          // Compensating delete: vault write succeeded but pointer write failed
+          try {
+            // biome-ignore lint/suspicious/noExplicitAny: credential type from parsed input
+            credentialsDb.delete(parsed.service, parsed.type as any);
+          } catch (cleanupErr) {
+            log.warn(`memory-hybrid: Failed to clean up orphaned credential for ${parsed.service}: ${cleanupErr}`);
+            capturePluginError(cleanupErr as Error, {
+              subsystem: "cli",
+              operation: "runStoreForCli:credential-compensating-delete",
+            });
+          }
+          capturePluginError(err as Error, { subsystem: "cli", operation: "runStoreForCli:credential-db-store" });
+          return { outcome: "credential_db_error" };
         }
-        capturePluginError(err as Error, { subsystem: "cli", operation: "runStoreForCli:credential-db-store" });
-        return { outcome: "credential_db_error" };
+        return { outcome: "credential", id: pointerEntry.id, service: parsed.service, type: parsed.type };
       }
-      return { outcome: "credential", id: pointerEntry.id, service: parsed.service, type: parsed.type };
+      return { outcome: "credential_parse_error" };
     }
-    return { outcome: "credential_parse_error" };
+    return { outcome: "credential_blocked_no_vault" };
   }
 
   const tags = opts.tags

--- a/extensions/memory-hybrid/cli/commands/manage/register-corrections.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/register-corrections.ts
@@ -144,6 +144,8 @@ export function registerManageCorrections(mem: Chainable, b: ManageBindings): vo
             console.log(`Credential stored: ${res.service} (${res.type}), id=${res.id}`);
           } else if (res.outcome === "credential_skipped_duplicate") {
             console.log(`Credential already in vault (skipped): ${res.service} (${res.type})`);
+          } else if (res.outcome === "credential_blocked_no_vault") {
+            console.log("Credential-like content blocked: enable credentials vault to store secrets securely.");
           } else if (res.outcome === "credential_parse_error") {
             console.log("Credential parse error (skipped).");
           } else if (res.outcome === "credential_vault_error") {

--- a/extensions/memory-hybrid/cli/types.ts
+++ b/extensions/memory-hybrid/cli/types.ts
@@ -34,6 +34,7 @@ export type StoreCliResult =
   | { outcome: "duplicate" }
   | { outcome: "credential"; id: string; service: string; type: string }
   | { outcome: "credential_skipped_duplicate"; service: string; type: string }
+  | { outcome: "credential_blocked_no_vault" }
   | { outcome: "credential_parse_error" }
   | { outcome: "credential_vault_error" }
   | { outcome: "credential_db_error" }

--- a/extensions/memory-hybrid/lifecycle/stage-capture/run-capture.ts
+++ b/extensions/memory-hybrid/lifecycle/stage-capture/run-capture.ts
@@ -16,9 +16,9 @@ import {
   resolveCaptureProvenance,
 } from "../../services/capture-provenance.js";
 import {
-  type MemoryClassification,
   classifyMemoryOperation,
   classifyMemoryOperationsBatch,
+  type MemoryClassification,
 } from "../../services/classification.js";
 import { validateScopedClassificationTarget } from "../../services/classification-scope.js";
 import { extractCredentialsFromToolCalls } from "../../services/credential-scanner.js";
@@ -28,8 +28,8 @@ import { extractStructuredFields } from "../../services/fact-extraction.js";
 import { formatQualityLoopEntry, runHumanizerScore } from "../../services/humanizer-score.js";
 import { cleanupEvictedVector, deleteVectorForFactId } from "../../services/vector-maintenance.js";
 import type { MemoryEntry } from "../../types/memory.js";
-import { CLI_STORE_IMPORTANCE } from "../../utils/constants.js";
 import { atomicWriteFile } from "../../utils/atomic-write.js";
+import { CLI_STORE_IMPORTANCE } from "../../utils/constants.js";
 import { persistCanonicalFactEmbedding } from "../../utils/fact-embeddings.js";
 import { extractTags } from "../../utils/tags.js";
 import { truncateForStorage } from "../../utils/text.js";
@@ -900,106 +900,31 @@ export async function runCapture(
             .join(" ");
           const creds = extractCredentialsFromToolCalls(argsToScan || args);
           for (const cred of creds) {
-            if (ctx.credentialsDb) {
-              const stored = ctx.credentialsDb.storeIfNew({
-                service: cred.service,
-                type: cred.type,
-                value: cred.value,
-                url: cred.url,
-                notes: cred.notes,
+            if (!ctx.credentialsDb) {
+              api.logger.warn(
+                `memory-hybrid: skipped tool-call credential auto-capture for ${cred.service} (${cred.type}) because the credential vault is unavailable`,
+              );
+              ctx.auditStore?.append({
+                agentId: resolveAgentIdFromHookEvent(event, api) ?? ctx.currentAgentIdRef.value ?? "unknown",
+                action: "tool-call-credential:blocked-no-vault",
+                target: cred.service,
+                outcome: "skipped",
+                sessionId: sessionKey,
+                context: { service: cred.service, type: cred.type, url: cred.url },
               });
-              if (stored && logCaptures) {
-                api.logger.info(`memory-hybrid: auto-captured credential for ${cred.service} (${cred.type})`);
-              }
-            } else {
-              const text = `Credential for ${cred.service} (${cred.type})${cred.url ? ` — ${cred.url}` : ""}${cred.notes ? `. ${cred.notes}` : ""}.`;
-              const storeResult = ctx.factsDb.storeWithResult({
-                text,
-                category: "technical" as MemoryCategory,
-                importance: 0.9,
-                entity: "Credentials",
-                key: cred.service,
-                value: cred.value,
-                source: "conversation",
-                decayClass: "permanent",
-                tags: ["auth", "credential"],
-              });
-              const entry = storeResult.entry;
-              // Guard: skip post-store ops when pre-store guard blocked the write (#1560, #1561)
-              if (!storeResult.skipped) {
-                // CRITICAL FIX (#2): Delete vector for evicted fact to prevent orphaned vectors
-                await cleanupEvictedVector({
-                  vectorDb: ctx.vectorDb,
-                  evictedFactId: storeResult.evictedFactId,
-                  logger: api.logger,
-                  context: "stage-capture",
-                });
-                if (ctx.cfg.retrieval.strategies.includes("semantic")) {
-                  try {
-                    if (storeResult.embeddingStale) {
-                      // Merge case: re-embed the merged text to keep the vector in sync.
-                      // If embed fails, the vector encodes stale pre-merge text; nightly re-index will repair.
-                      const mergedVector = await ctx.embeddings.embed(entry.text);
-                      ctx.factsDb.setEmbeddingModel(entry.id, ctx.embeddings.modelName);
-                      await ctx.vectorDb.store({
-                        text: entry.text,
-                        vector: mergedVector,
-                        importance: 0.9,
-                        category: "technical",
-                        id: entry.id,
-                      });
-                      persistCanonicalFactEmbedding(
-                        ctx.factsDb,
-                        entry.id,
-                        ctx.embeddings.modelName,
-                        mergedVector,
-                        "auto-capture-fact-embeddings",
-                        "auto-capture",
-                        api.logger.warn?.bind(api.logger),
-                      );
-                    } else {
-                      const vector = await ctx.embeddings.embed(entry.text);
-                      ctx.factsDb.setEmbeddingModel(entry.id, ctx.embeddings.modelName);
-                      if (!(await ctx.vectorDb.hasDuplicate(vector))) {
-                        await ctx.vectorDb.store({
-                          text: entry.text,
-                          vector,
-                          importance: 0.9,
-                          category: "technical",
-                          id: entry.id,
-                        });
-                        persistCanonicalFactEmbedding(
-                          ctx.factsDb,
-                          entry.id,
-                          ctx.embeddings.modelName,
-                          vector,
-                          "auto-capture-fact-embeddings",
-                          "auto-capture",
-                          api.logger.warn?.bind(api.logger),
-                        );
-                      }
-                    }
-                  } catch (err) {
-                    const asErr = err instanceof Error ? err : new Error(String(err));
-                    if (!isOllamaCircuitBreakerOpen(asErr)) {
-                      capturePluginError(asErr, {
-                        operation: storeResult.embeddingStale
-                          ? "tool-call-credential-stale-vector-update"
-                          : "tool-call-credential-vector-store",
-                        subsystem: "credentials",
-                      });
-                    }
-                    api.logger.warn(
-                      storeResult.embeddingStale
-                        ? `memory-hybrid: stale vector re-embed failed for merged credential fact ${entry.id.slice(0, 8)} — nightly re-index will repair: ${err}`
-                        : `memory-hybrid: vector store for credential fact failed: ${err}`,
-                    );
-                  }
-                }
-                if (logCaptures) {
-                  api.logger.info(`memory-hybrid: auto-captured credential for ${cred.service} (${cred.type})`);
-                }
-              } // close if (!storeResult.skipped) guard (#1560, #1561)
+              continue;
+            }
+            const stored = ctx.credentialsDb.storeIfNew({
+              service: cred.service,
+              type: cred.type,
+              value: cred.value,
+              url: cred.url,
+              notes: cred.notes,
+            });
+            if (stored && logCaptures) {
+              api.logger.info(`memory-hybrid: auto-captured credential for ${cred.service} (${cred.type})`);
+            }
+>>>>>>> 6598532b (fix: block credential capture without vault)
             }
           }
         }

--- a/extensions/memory-hybrid/tests/cli-store-rollback.test.ts
+++ b/extensions/memory-hybrid/tests/cli-store-rollback.test.ts
@@ -252,3 +252,19 @@ describe("runStoreForCli credential parse failure", () => {
     expect(vaultList.length).toBe(0);
   });
 });
+
+describe("runStoreForCli credential blocked when vault unavailable", () => {
+  it("returns credential_blocked_no_vault when vault is disabled", async () => {
+    mockCtx.cfg.credentials.enabled = false;
+    const opts: StoreCliOpts = {
+      text: "OpenAI API Key: sk-testAbCdEfGh1234IjKlMnOpQrSt",
+      category: "technical",
+    };
+
+    const result: StoreCliResult = await runStoreForCli(mockCtx, opts, { warn: vi.fn() });
+    expect(result.outcome).toBe("credential_blocked_no_vault");
+
+    expect(credentialsDb.list()).toHaveLength(0);
+    expect(factsDb.getAll()).toHaveLength(0);
+  });
+});

--- a/extensions/memory-hybrid/tests/plugin-e2e.test.ts
+++ b/extensions/memory-hybrid/tests/plugin-e2e.test.ts
@@ -328,6 +328,28 @@ describe("Store and recall e2e (real FactsDB + VectorDB, mock embeddings)", () =
     expect(texts.some((t) => t.includes("banana server port 9999"))).toBe(true);
   });
 
+  it("memory_store blocks credential-like content when vault is disabled", async () => {
+    registerTools(buildE2EContext({ tmpDir, factsDb, vectorDb, cfg, api }) as never, api as never);
+
+    const storeTool = api.getTool("memory_store");
+    const recallTool = api.getTool("memory_recall");
+
+    const result = (await storeTool?.execute("call-cred-block", {
+      text: "OpenAI API Key: sk-testAbCdEfGh1234IjKlMnOpQrSt",
+      category: "technical",
+      importance: 0.9,
+    })) as { content?: { type: string; text: string }[]; details?: { action?: string } };
+
+    expect(result.details?.action).toBe("credential_blocked_no_vault");
+    expect(result.content?.[0]?.text).toContain("blocked");
+
+    const recallResult = (await recallTool?.execute("call-cred-block-recall", {
+      query: "OpenAI API Key",
+      limit: 5,
+    })) as { details?: { count?: number } };
+    expect(recallResult.details?.count ?? 0).toBe(0);
+  });
+
   it("memory_recall exposes constrained-recall mode with filter and rank explanation", async () => {
     registerTools(buildE2EContext({ tmpDir, factsDb, vectorDb, cfg, api }) as never, api as never);
 

--- a/extensions/memory-hybrid/tools/memory/register-store-tools.ts
+++ b/extensions/memory-hybrid/tools/memory/register-store-tools.ts
@@ -292,112 +292,121 @@ export function registerStoreTools(runtime: MemoryToolRuntime): void {
             }
           };
 
-          // Dual-mode credentials: vault enabled → store in vault + pointer in memory; vault disabled → store in memory (live behavior).
-          // When vault is enabled, credential-like content that fails to parse must not be written to memory (see docs/CREDENTIALS.md).
-          if (cfg.credentials.enabled && credentialsDb && isCredentialLike(textToStore, entity, key, value)) {
-            const parsed = tryParseCredentialForVault(textToStore, entity, key, value, {
-              requirePatternMatch: cfg.credentials.autoCapture?.requirePatternMatch === true,
-            });
-            if (parsed) {
-              const stored = credentialsDb.storeIfNew({
-                service: parsed.service,
-                type: parsed.type,
-                value: parsed.secretValue,
-                url: parsed.url,
-                notes: parsed.notes,
+          if (isCredentialLike(textToStore, entity, key, value)) {
+            if (cfg.credentials.enabled && credentialsDb) {
+              const parsed = tryParseCredentialForVault(textToStore, entity, key, value, {
+                requirePatternMatch: cfg.credentials.autoCapture?.requirePatternMatch === true,
               });
-              if (!stored) {
-                return {
-                  content: [
-                    { type: "text", text: `Credential already in vault for ${parsed.service} (${parsed.type}).` },
-                  ],
-                  details: { action: "credential_skipped_duplicate", service: parsed.service, type: parsed.type },
-                };
-              }
-              const pointerText = `Credential for ${parsed.service} (${parsed.type}) — stored in secure vault. Use credential_get(service="${parsed.service}", type="${parsed.type}") to retrieve.`;
-              const pointerValue = `${VAULT_POINTER_PREFIX}${parsed.service}:${parsed.type}`;
-              const pointerStoreResult = factsDb.storeWithResult({
-                text: pointerText,
-                why,
-                category: "technical" as MemoryCategory,
-                importance,
-                entity: "Credentials",
-                key: parsed.service,
-                value: pointerValue,
-                source: "conversation",
-                decayClass: paramDecayClass ?? "permanent",
-                tags: ["auth", ...extractTags(pointerText, "Credentials")],
-                provenanceSession: provenanceSessionId,
-                extractionMethod: "active",
-                extractionConfidence: importance,
-              });
-              const pointerEntry = pointerStoreResult.entry;
-              await cleanupEvictedVector({
-                vectorDb,
-                evictedFactId: pointerStoreResult.evictedFactId,
-                logger: api.logger,
-                context: "memory-store-credential-pointer",
-              });
-              recordActiveStoreProvenance(pointerEntry.id, pointerText);
-              try {
-                addOperationBreadcrumb("vector", "store-credential-pointer");
-                const vector = await embedCallWithTimeoutAndRetry(
-                  () => embeddings.embed(pointerText),
-                  "memory-tools:store-credential-pointer",
-                );
-                await storeActiveCanonicalVector({
-                  factId: pointerEntry.id,
+              if (parsed) {
+                const stored = credentialsDb.storeIfNew({
+                  service: parsed.service,
+                  type: parsed.type,
+                  value: parsed.secretValue,
+                  url: parsed.url,
+                  notes: parsed.notes,
+                });
+                if (!stored) {
+                  return {
+                    content: [
+                      { type: "text", text: `Credential already in vault for ${parsed.service} (${parsed.type}).` },
+                    ],
+                    details: { action: "credential_skipped_duplicate", service: parsed.service, type: parsed.type },
+                  };
+                }
+                const pointerText = `Credential for ${parsed.service} (${parsed.type}) — stored in secure vault. Use credential_get(service="${parsed.service}", type="${parsed.type}") to retrieve.`;
+                const pointerValue = `${VAULT_POINTER_PREFIX}${parsed.service}:${parsed.type}`;
+                const pointerStoreResult = factsDb.storeWithResult({
                   text: pointerText,
                   why,
-                  vector,
+                  category: "technical" as MemoryCategory,
                   importance,
-                  category: "technical",
+                  entity: "Credentials",
+                  key: parsed.service,
+                  value: pointerValue,
+                  source: "conversation",
+                  decayClass: paramDecayClass ?? "permanent",
+                  tags: ["auth", ...extractTags(pointerText, "Credentials")],
+                  provenanceSession: provenanceSessionId,
+                  extractionMethod: "active",
+                  extractionConfidence: importance,
                 });
-                await storeRegistryEmbeddings({
-                  factsDb,
-                  embeddingRegistry,
-                  embeddings,
-                  factId: pointerEntry.id,
-                  text: pointerText,
-                  vector,
+                const pointerEntry = pointerStoreResult.entry;
+                await cleanupEvictedVector({
+                  vectorDb,
+                  evictedFactId: pointerStoreResult.evictedFactId,
                   logger: api.logger,
-                  operation: "store-credential-pointer",
+                  context: "memory-store-credential-pointer",
                 });
-              } catch (err) {
-                // AllEmbeddingProvidersFailed is expected when no providers are configured — don't report to Sentry.
-                if (!(err instanceof AllEmbeddingProvidersFailed)) {
-                  capturePluginError(err instanceof Error ? err : new Error(String(err)), {
-                    subsystem: "vector",
-                    operation: "store-credential-pointer",
-                    phase: "runtime",
-                    backend: "lancedb",
+                recordActiveStoreProvenance(pointerEntry.id, pointerText);
+                try {
+                  addOperationBreadcrumb("vector", "store-credential-pointer");
+                  const vector = await embedCallWithTimeoutAndRetry(
+                    () => embeddings.embed(pointerText),
+                    "memory-tools:store-credential-pointer",
+                  );
+                  await storeActiveCanonicalVector({
+                    factId: pointerEntry.id,
+                    text: pointerText,
+                    why,
+                    vector,
+                    importance,
+                    category: "technical",
                   });
+                  await storeRegistryEmbeddings({
+                    factsDb,
+                    embeddingRegistry,
+                    embeddings,
+                    factId: pointerEntry.id,
+                    text: pointerText,
+                    vector,
+                    logger: api.logger,
+                    operation: "store-credential-pointer",
+                  });
+                } catch (err) {
+                  // AllEmbeddingProvidersFailed is expected when no providers are configured — don't report to Sentry.
+                  if (!(err instanceof AllEmbeddingProvidersFailed)) {
+                    capturePluginError(err instanceof Error ? err : new Error(String(err)), {
+                      subsystem: "vector",
+                      operation: "store-credential-pointer",
+                      phase: "runtime",
+                      backend: "lancedb",
+                    });
+                  }
+                  api.logger.warn(`memory-hybrid: vector store failed: ${err}`);
                 }
-                api.logger.warn(`memory-hybrid: vector store failed: ${err}`);
+                return {
+                  content: [
+                    {
+                      type: "text",
+                      text: `Credential stored in vault for ${parsed.service} (${parsed.type}). Pointer saved in memory.`,
+                    },
+                  ],
+                  details: {
+                    action: "credential_vault",
+                    id: pointerEntry.id,
+                    service: parsed.service,
+                    type: parsed.type,
+                  },
+                };
               }
               return {
                 content: [
                   {
                     type: "text",
-                    text: `Credential stored in vault for ${parsed.service} (${parsed.type}). Pointer saved in memory.`,
+                    text: "Credential-like content detected but could not be parsed as a structured credential; not stored (vault is enabled).",
                   },
                 ],
-                details: {
-                  action: "credential_vault",
-                  id: pointerEntry.id,
-                  service: parsed.service,
-                  type: parsed.type,
-                },
+                details: { action: "credential_skipped" },
               };
             }
             return {
               content: [
                 {
                   type: "text",
-                  text: "Credential-like content detected but could not be parsed as a structured credential; not stored (vault is enabled).",
+                  text: "Credential-like content detected. Ordinary memory storage is blocked while the credential vault is disabled or unavailable. Enable credentials vault and retry.",
                 },
               ],
-              details: { action: "credential_skipped" },
+              details: { action: "credential_blocked_no_vault" },
             };
           }
 


### PR DESCRIPTION
## Orphan Branch Audit PR

**Branch:** `orphan/pr1591-preserve`
**Issue association:** Likely #1578 (credential-like fallback security fix)
**Commit count ahead of main:** 5
**Divergence:** diverged (5 ahead, 26 behind main)

### Commit history
1. `chore(issue-1578): start implementation branch`
2. `fix(security): block credential-like fallback to ordinary memory` (issue #1578)
3. `ci: refresh status [skip ci footer]`
4. `fix: block credential capture without vault (resolved conflict)`
5. `Remove accidentally committed CI refresh comment from README`

### Changed files
CLI tools (cmd-distill, cmd-store), lifecycle stage-capture, register-store-tools, docs, tests.

### Analysis
The canonical PR #1591 (issue-1578) was merged. This branch contains 5 commits that diverge from both main and the consolidated PR #1682 head. Some work may be unique/earlier implementation of the credential-blocking feature. Value assessment: **uncertain**.

### Action
- PR created for audit record
- Evidence comment posted
- Awaiting assessment: close/delete if no unique value vs merged canonical work

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes secret handling across store, distill, extract-daily, and auto-capture paths; incorrect behavior could leak or drop credentials. The unresolved merge marker in run-capture.ts is a ship-blocking syntax issue.
> 
> **Overview**
> **Stops credential-like secrets from landing in ordinary hybrid memory when the credential vault is off or unavailable** — aligning runtime behavior with updated docs (`CREDENTIALS.md`, `SESSION-DISTILLATION.md`).
> 
> **`memory_store`**, **`openclaw hybrid-mem store`**, **session distill**, and **extract-daily** now detect credential-like input first: with vault enabled they still route to the vault plus pointer facts; otherwise they **skip** and return **`credential_blocked_no_vault`** (CLI messaging and tests added). **Lifecycle tool-call auto-capture** no longer writes detected secrets into SQLite/LanceDB when `credentialsDb` is missing — it logs, audits, and skips instead.
> 
> Minor cleanups include typed credential `delete` calls and pointer text that mentions `credential_get` **type**.
> 
> **Review note:** `extensions/memory-hybrid/lifecycle/stage-capture/run-capture.ts` still contains a stray **`>>>>>>> 6598532b`** merge marker in the diff/context — that must be removed before merge or the file will not compile.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 495d0675792413fd45b04596003264fd4aba0ee7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->