### PR TITLE
fix: nightly-dream-cycle continuous verification reports 12/12 uncertain with 12 errors but job still passes (#1705)

### DIFF
--- a/extensions/memory-hybrid/cli/commands/manage/dream-cycle-followup.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/dream-cycle-followup.ts
@@ -1,6 +1,7 @@
 /** Dream-cycle follow-up progress formatting and verbose stage runner. */
 
 import type { ExtractImplicitFeedbackProgressSnapshot } from "../../cmd-feedback.js";
+import type { VerificationCycleResult } from "../../../services/continuous-verifier.js";
 import { runMaintenanceHeartbeat } from "./maintenance-heartbeat.js";
 
 export type FollowUpProgressSupplier = () => string | undefined;
@@ -10,6 +11,12 @@ export interface RunVerboseFollowUpOptions {
   heartbeatIntervalMs?: number;
   stageIndex?: number;
   stageTotal?: number;
+}
+
+export interface ContinuousVerificationAssessment {
+  status: "healthy" | "degraded";
+  shouldFailPipeline: boolean;
+  summary?: string;
 }
 
 export function formatExtractImplicitFeedbackProgress(
@@ -38,6 +45,26 @@ export function formatExtractImplicitFeedbackProgress(
   }
 
   return parts.join("; ");
+}
+
+export function assessContinuousVerificationResult(
+  result: VerificationCycleResult,
+): ContinuousVerificationAssessment {
+  if (result.errors > 0) {
+    return {
+      status: "degraded",
+      shouldFailPipeline: true,
+      summary: `${result.errors}/${result.checked} verification check(s) errored`,
+    };
+  }
+  if (result.checked > 0 && result.confirmed === 0 && result.stale === 0) {
+    return {
+      status: "degraded",
+      shouldFailPipeline: true,
+      summary: `all ${result.checked} verification check(s) were uncertain`,
+    };
+  }
+  return { status: "healthy", shouldFailPipeline: false };
 }
 
 export async function runVerboseFollowUp<T>(

--- a/extensions/memory-hybrid/cli/commands/manage/dream-cycle-followup.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/dream-cycle-followup.ts
@@ -47,9 +47,7 @@ export function formatExtractImplicitFeedbackProgress(
   return parts.join("; ");
 }
 
-export function assessContinuousVerificationResult(
-  result: VerificationCycleResult,
-): ContinuousVerificationAssessment {
+export function assessContinuousVerificationResult(result: VerificationCycleResult): ContinuousVerificationAssessment {
   if (result.errors > 0) {
     return {
       status: "degraded",

--- a/extensions/memory-hybrid/cli/commands/manage/dream-cycle-followup.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/dream-cycle-followup.ts
@@ -49,9 +49,10 @@ export function formatExtractImplicitFeedbackProgress(
 
 export function assessContinuousVerificationResult(result: VerificationCycleResult): ContinuousVerificationAssessment {
   if (result.errors > 0) {
-    const summary = result.checked === 0
-      ? `infrastructure error prevented verification (${result.errors} error(s))`
-      : `${result.errors}/${result.checked} verification check(s) errored`;
+    const summary =
+      result.checked === 0
+        ? `infrastructure error prevented verification (${result.errors} error(s))`
+        : `${result.errors}/${result.checked} verification check(s) errored`;
     return {
       status: "degraded",
       shouldFailPipeline: true,

--- a/extensions/memory-hybrid/cli/commands/manage/dream-cycle-followup.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/dream-cycle-followup.ts
@@ -49,10 +49,13 @@ export function formatExtractImplicitFeedbackProgress(
 
 export function assessContinuousVerificationResult(result: VerificationCycleResult): ContinuousVerificationAssessment {
   if (result.errors > 0) {
+    const summary = result.checked === 0
+      ? `infrastructure error prevented verification (${result.errors} error(s))`
+      : `${result.errors}/${result.checked} verification check(s) errored`;
     return {
       status: "degraded",
       shouldFailPipeline: true,
-      summary: `${result.errors}/${result.checked} verification check(s) errored`,
+      summary,
     };
   }
   if (result.checked > 0 && result.confirmed === 0 && result.stale === 0) {

--- a/extensions/memory-hybrid/cli/commands/manage/register-reflection-pipeline.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/register-reflection-pipeline.ts
@@ -631,7 +631,7 @@ export function registerManageReflectionPipeline(mem: Chainable, b: ManageBindin
                 });
                 // Keep running the remaining follow-up stages for observability, but make the
                 // standalone CLI exit non-zero once the pipeline completes.
-                process.exitCode = 1;
+                process.exitCode = 2;
               }
             }
           }

--- a/extensions/memory-hybrid/cli/commands/manage/register-reflection-pipeline.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/register-reflection-pipeline.ts
@@ -16,6 +16,7 @@ import type {
 } from "../../../backends/facts-db/contradictions.js";
 
 import {
+  assessContinuousVerificationResult,
   formatExtractImplicitFeedbackProgress,
   runVerboseFollowUp,
   type RunVerboseFollowUpOptions,
@@ -611,6 +612,28 @@ export function registerManageReflectionPipeline(mem: Chainable, b: ManageBindin
             console.log(`  Stale: ${verificationRes.stale}`);
             console.log(`  Uncertain: ${verificationRes.uncertain}`);
             console.log(`  Errors: ${verificationRes.errors}`);
+            if (verificationRes.errorSummaries.length > 0) {
+              console.log("  Error summary:");
+              for (const summary of verificationRes.errorSummaries) {
+                console.log(`    - ${summary}`);
+              }
+            }
+            const verificationAssessment = assessContinuousVerificationResult(verificationRes);
+            if (verificationAssessment.status !== "healthy") {
+              console.log(`  Status: ${verificationAssessment.status.toUpperCase()}`);
+              if (verificationAssessment.summary) {
+                console.log(`  Warning: ${verificationAssessment.summary}`);
+              }
+              if (verificationAssessment.shouldFailPipeline) {
+                followUpFailures.push({
+                  phase: "continuous verification",
+                  error: verificationAssessment.summary ?? "verification follow-up degraded",
+                });
+                // Keep running the remaining follow-up stages for observability, but make the
+                // standalone CLI exit non-zero once the pipeline completes.
+                process.exitCode = 1;
+              }
+            }
           }
 
           // Extract implicit feedback signals as part of nightly cycle

--- a/extensions/memory-hybrid/services/continuous-verifier.ts
+++ b/extensions/memory-hybrid/services/continuous-verifier.ts
@@ -26,6 +26,7 @@ export interface VerificationCycleResult {
   stale: number;
   uncertain: number;
   errors: number;
+  errorSummaries: string[];
 }
 
 export interface ContinuousVerifierOptions {
@@ -85,11 +86,25 @@ const DEFAULT_TIMEOUT_MS = 15_000;
 const RECENT_FACTS_DAYS = 90;
 const MAX_CONTEXT_PER_ENTITY = 20;
 const MAX_CONTEXT_CHARS_PER_FACT = 500;
+const MAX_ERROR_SUMMARIES = 5;
+const MAX_ERROR_SUMMARY_LENGTH = 160;
 // Confidence assigned to facts the LLM determines are stale. Kept below 0.3
 // so that natural decay cycles will eventually remove them, while still
 // preventing immediate deletion (threshold is < 0.1). Previously 0.5, which
 // was misleadingly high — stale facts should not appear reliable in recall.
 const STALE_CONFIDENCE = 0.2;
+
+function compactVerificationError(err: unknown): string {
+  const raw = err instanceof Error ? err.message : String(err);
+  const compact = raw.replace(/\s+/g, " ").trim() || "unknown error";
+  if (compact.length <= MAX_ERROR_SUMMARY_LENGTH) return compact;
+  return `${compact.slice(0, MAX_ERROR_SUMMARY_LENGTH - 3)}...`;
+}
+
+function recordVerificationError(result: VerificationCycleResult, prefix: string, err: unknown): void {
+  if (result.errorSummaries.length >= MAX_ERROR_SUMMARIES) return;
+  result.errorSummaries.push(`${prefix}: ${compactVerificationError(err)}`);
+}
 
 export class ContinuousVerifier {
   private readonly store: VerificationStore;
@@ -162,6 +177,7 @@ export class ContinuousVerifier {
       stale: 0,
       uncertain: 0,
       errors: 0,
+      errorSummaries: [],
     };
 
     if (this.cycleDays !== undefined && this.lastRunDate !== null) {
@@ -178,6 +194,7 @@ export class ContinuousVerifier {
         operation: "listDueForReverification",
       });
       result.errors++;
+      recordVerificationError(result, "listDueForReverification", err);
       return result;
     }
 
@@ -233,6 +250,7 @@ export class ContinuousVerifier {
             metadata: { factId: fact.factId },
           });
           result.errors++;
+          recordVerificationError(result, `fact=${fact.factId.slice(0, 8)}…`, err);
           outcome = "UNCERTAIN";
         }
 
@@ -266,6 +284,7 @@ export class ContinuousVerifier {
           metadata: { factId: fact.factId },
         });
         result.errors++;
+        recordVerificationError(result, `fact=${fact.factId.slice(0, 8)}…`, err);
       }
     }
 

--- a/extensions/memory-hybrid/setup/cli-context/cli-services.ts
+++ b/extensions/memory-hybrid/setup/cli-context/cli-services.ts
@@ -393,7 +393,7 @@ export function buildCliContextServices(
     },
     runContinuousVerification: async (opts?: { verbose?: boolean }) => {
       if (!verificationStore || !cfg.verification.enabled || !cfg.verification.continuousVerification) {
-        return { checked: 0, confirmed: 0, stale: 0, uncertain: 0, errors: 0 };
+        return { checked: 0, confirmed: 0, stale: 0, uncertain: 0, errors: 0, errorSummaries: [] };
       }
       const verbose = !!opts?.verbose;
       return runVerificationCycle(verificationStore, factsDb, openai, {

--- a/extensions/memory-hybrid/tests/continuous-verifier.test.ts
+++ b/extensions/memory-hybrid/tests/continuous-verifier.test.ts
@@ -240,7 +240,7 @@ describe("ContinuousVerifier.runCycle — empty due list", () => {
     // Add a fresh fact (not yet due)
     await store.verify("fact-fresh", "Fresh fact", "agent");
     const result = await verifier.runCycle();
-    expect(result).toEqual({ checked: 0, confirmed: 0, stale: 0, uncertain: 0, errors: 0 });
+    expect(result).toEqual({ checked: 0, confirmed: 0, stale: 0, uncertain: 0, errors: 0, errorSummaries: [] });
   });
 });
 
@@ -388,6 +388,52 @@ describe("ContinuousVerifier.runCycle — error handling", () => {
     expect(result.checked).toBe(2);
     expect(result.errors).toBe(1);
     expect(result.confirmed).toBe(1);
+    expect(result.errorSummaries).toHaveLength(1);
+    expect(result.errorSummaries[0]).toContain("fact=fact-err");
+    expect(result.errorSummaries[0]).toContain("transient error");
+  });
+
+  it("records compact summaries when every verification call errors", async () => {
+    const mockOpenAI = makeMockOpenAI(new Error("provider timeout while checking fact"));
+    const verifier = new ContinuousVerifier(store, factsDb, mockOpenAI as never);
+
+    const alpha = factsDb.store({
+      text: "Primary API endpoint is api.internal",
+      category: "technical",
+      importance: 0.8,
+      entity: "api",
+      key: "endpoint",
+      value: "api.internal",
+      source: "test",
+    });
+    const beta = factsDb.store({
+      text: "API region is eu-north-1",
+      category: "technical",
+      importance: 0.7,
+      entity: "api",
+      key: "region",
+      value: "eu-north-1",
+      source: "test",
+    });
+
+    const ids = [
+      await store.verify(alpha.id, "Primary API endpoint is api.internal", "agent"),
+      await store.verify(beta.id, "API region is eu-north-1", "agent"),
+    ];
+    const db = (store as unknown as { db: import("node:sqlite").DatabaseSync }).db;
+    for (const id of ids) {
+      db.prepare(`UPDATE verified_facts SET next_verification = '2020-01-01T00:00:00.000Z' WHERE id = ?`).run(id);
+    }
+
+    const result = await verifier.runCycle();
+    expect(result.checked).toBe(2);
+    expect(result.confirmed).toBe(0);
+    expect(result.stale).toBe(0);
+    expect(result.uncertain).toBe(2);
+    expect(result.errors).toBe(2);
+    expect(result.errorSummaries).toHaveLength(2);
+    expect(result.errorSummaries[0]).toContain("provider timeout while checking fact");
+    expect(result.errorSummaries[1]).toContain("provider timeout while checking fact");
   });
 
   it("no-op on STALE when underlying fact is not in FactsDB (no crash)", async () => {
@@ -510,7 +556,7 @@ describe("runVerificationCycle", () => {
   it("returns the same result as runCycle for empty due list", async () => {
     const mockOpenAI = makeMockOpenAI("CONFIRMED");
     const result = await runVerificationCycle(store, factsDb, mockOpenAI as never);
-    expect(result).toEqual({ checked: 0, confirmed: 0, stale: 0, uncertain: 0, errors: 0 });
+    expect(result).toEqual({ checked: 0, confirmed: 0, stale: 0, uncertain: 0, errors: 0, errorSummaries: [] });
   });
 
   it("passes verificationModel option to the verifier", async () => {

--- a/extensions/memory-hybrid/tests/dream-cycle-followup-logging.test.ts
+++ b/extensions/memory-hybrid/tests/dream-cycle-followup-logging.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { runVerboseFollowUp } from "../cli/commands/manage/dream-cycle-followup.js";
+import {
+  assessContinuousVerificationResult,
+  runVerboseFollowUp,
+} from "../cli/commands/manage/dream-cycle-followup.js";
 
 describe("dream-cycle follow-up heartbeat logging", () => {
   afterEach(() => {
@@ -59,5 +62,41 @@ describe("dream-cycle follow-up heartbeat logging", () => {
 
     expect(logs.some((l) => l.includes("stage 2/6 extract implicit feedback — start"))).toBe(true);
     expect(logs.some((l) => l.includes("stage 2/6 extract implicit feedback — complete in"))).toBe(true);
+  });
+
+  it("treats all-uncertain verification results as degraded", () => {
+    const assessment = assessContinuousVerificationResult({
+      checked: 12,
+      confirmed: 0,
+      stale: 0,
+      uncertain: 12,
+      errors: 0,
+      errorSummaries: [],
+    });
+
+    expect(assessment.status).toBe("degraded");
+    expect(assessment.shouldFailPipeline).toBe(true);
+    expect(assessment.summary).toContain("all 12 verification check(s) were uncertain");
+  });
+
+  it("treats verification errors as degraded even when outcomes are uncertain", () => {
+    const assessment = assessContinuousVerificationResult({
+      checked: 5,
+      confirmed: 0,
+      stale: 0,
+      uncertain: 5,
+      errors: 5,
+      errorSummaries: [
+        "fact=abc12345…: provider timeout",
+        "fact=def67890…: provider timeout",
+        "fact=ghi54321…: provider timeout",
+        "fact=jkl98765…: provider timeout",
+        "fact=mno24680…: provider timeout",
+      ],
+    });
+
+    expect(assessment.status).toBe("degraded");
+    expect(assessment.shouldFailPipeline).toBe(true);
+    expect(assessment.summary).toContain("5/5 verification check(s) errored");
   });
 });

--- a/extensions/memory-hybrid/tests/dream-cycle-followup-logging.test.ts
+++ b/extensions/memory-hybrid/tests/dream-cycle-followup-logging.test.ts
@@ -1,9 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import {
-  assessContinuousVerificationResult,
-  runVerboseFollowUp,
-} from "../cli/commands/manage/dream-cycle-followup.js";
+import { assessContinuousVerificationResult, runVerboseFollowUp } from "../cli/commands/manage/dream-cycle-followup.js";
 
 describe("dream-cycle follow-up heartbeat logging", () => {
   afterEach(() => {


### PR DESCRIPTION
Issue: https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/1705

Status: draft implementation PR created by Issue Stewardship as Markus/current gh auth.
Protection: keep as draft and `stage/implementing` until Issue Stewardship dispatches/receives implementation and explicitly hands off to PR Stewardship.

Enrichment present on issue: 1
Priority inherited from issue: High (source labels: priority:high)
Dependencies/blocked labels inherited from issue: none

Implementation PR created by Issue Stewardship. Detailed enrichment should be attached to the issue before Copilot implementation dispatch.

## Changes Made

- Treat degraded continuous verification as non-healthy during `dream-cycle` follow-up execution.
- Mark the nightly pipeline for non-zero exit when continuous verification reports any verification errors.
- Mark the nightly pipeline for non-zero exit when all checked facts are uncertain (no confirmed or stale outcomes).
- Include compact verification error summaries in dream-cycle logging so per-fact failures are visible without dumping full error output.
- Update focused tests to cover all-uncertain and all-error verification outcomes and verify they are not treated as fully healthy success.

## Validation

- ✅ `npm run test -- --reporter=verbose tests/continuous-verifier.test.ts tests/dream-cycle-followup-logging.test.ts tests/cron-exit-validator.test.ts tests/validate-cron-exit-cli-1225.test.ts tests/maintenance-log-analyzer.test.ts`
- ✅ `npm run build`
- ✅ `npm run lint` (existing warnings only)

---

> [!NOTE]
><sup><a href="https://cursor.com/bugbot">Cursor Bugbot</a> is generating a summary for commit 39dc0dd. Configure <a href="https://www.cursor.com/dashboard/bugbot">here</a>.</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Nightly maintenance exit semantics change (exit 2 on bad verification) but scope is limited to dream-cycle follow-up and logging; no auth or data-model changes.
> 
> **Overview**
> Fixes **dream-cycle** reporting success when continuous verification is effectively a failure (e.g. all uncertain with underlying errors).
> 
> **Continuous verifier** now returns **`errorSummaries`** (compact, capped messages) whenever listing due facts or per-fact checks fail, without changing the existing per-fact error counting behavior.
> 
> **`assessContinuousVerificationResult`** classifies a cycle as **degraded** when there are any errors, or when every checked fact is uncertain with zero confirmed/stale. The dream-cycle follow-up logs status, warnings, and error lines, records the phase in **`followUpFailures`**, and sets **`process.exitCode = 2`** while still running later follow-up stages for observability.
> 
> Tests cover assessment rules and error summary recording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7512f9cbe8ae0dd6b0842a1e945e81fd3824de86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->