### PR TITLE
WIP: self-correction-run has empty fallback chain — single model is sole execution path (#1715)

### DIFF
--- a/extensions/memory-hybrid/cli/cmd-selfcorrection.ts
+++ b/extensions/memory-hybrid/cli/cmd-selfcorrection.ts
@@ -14,7 +14,7 @@ import { existsSync, lstatSync, readFileSync, rmSync, writeFileSync } from "node
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 
-import { getCronModelConfig, getDefaultCronModel, getLLMModelPreference } from "../config.js";
+import { getCronModelConfig, getDefaultCronModel, resolveReflectionModelAndFallbacks } from "../config.js";
 import { chatCompleteWithAdaptiveMaintenanceRetry } from "../services/adaptive-maintenance-llm.js";
 import { distillMaxOutputTokens } from "../services/chat.js";
 import { CostFeature } from "../services/cost-feature-labels.js";
@@ -312,18 +312,17 @@ export async function runSelfCorrectionRunForCli(
     const prompt = fillPrompt(loadPrompt("self-correction-analyze"), {
       incidents_json: JSON.stringify(incidents),
     });
-    const heavyPref = getLLMModelPreference(getCronModelConfig(cfg), "heavy");
+    const heavyResolved = resolveReflectionModelAndFallbacks(cfg, "heavy");
     const heavyPrefWithSources = resolveTierPreferenceWithSources(cfg, "heavy");
-    const model = opts.model ?? heavyPref[0] ?? getDefaultCronModel(getCronModelConfig(cfg), "heavy");
+    const model = opts.model ?? heavyResolved.defaultModel ?? getDefaultCronModel(getCronModelConfig(cfg), "heavy");
     const modelSource = opts.model
       ? "--model"
       : heavyPrefWithSources.models[0] === model
         ? (heavyPrefWithSources.sources[0] ?? "built-in")
         : "built-in";
-    const scFallbackCandidates = [
-      ...(opts.model ? heavyPref : heavyPref.slice(1)),
-      ...(cfg.llm ? [] : (cfg.distill?.fallbackModels ?? [])),
-    ];
+    const scFallbackCandidates = opts.model
+      ? [heavyResolved.defaultModel, ...(heavyResolved.fallbackModels ?? [])]
+      : (heavyResolved.fallbackModels ?? []);
     const scFallbackModels = [...new Set(scFallbackCandidates.filter((m) => m !== model))];
     let analysed: Array<{
       category: string;

--- a/extensions/memory-hybrid/tests/cmd-selfcorrection-json-parse.test.ts
+++ b/extensions/memory-hybrid/tests/cmd-selfcorrection-json-parse.test.ts
@@ -330,6 +330,31 @@ describe("self-correction-run — JSON parsing robustness (#1637)", () => {
     expect(res.status).toBe("success_analyzed");
   });
 
+  it("#1715: uses heavy-tier fallback chain when llm.heavy has a single model", async () => {
+    const ctx = makeCtx(makeOpenAIMock("[]"));
+    (ctx.cfg as any).llm = {
+      default: ["default-model"],
+      heavy: ["heavy-primary"],
+    };
+    (ctx.cfg as any).distill = {
+      fallbackModels: ["heavy-fallback-1", "heavy-fallback-2"],
+    };
+
+    const res = await runSelfCorrectionRunForCli(ctx, {
+      incidents: [SAMPLE_INCIDENT],
+      workspace: tmpDir,
+      dryRun: true,
+    });
+
+    expect(res.error).toBeUndefined();
+    const infoCalls = ((ctx.logger.info as any).mock?.calls ?? []).flat();
+    expect(
+      infoCalls.some((line: unknown) =>
+        String(line).includes("fallback chain = [heavy-fallback-1, heavy-fallback-2]"),
+      ),
+    ).toBe(true);
+  });
+
   it("uses configured fallback chain when model is overridden via --model", async () => {
     const ctx = makeCtx(makeOpenAIMock("[]"));
     (ctx.cfg as any).llm = {

--- a/extensions/memory-hybrid/tests/cmd-selfcorrection-json-parse.test.ts
+++ b/extensions/memory-hybrid/tests/cmd-selfcorrection-json-parse.test.ts
@@ -349,9 +349,7 @@ describe("self-correction-run — JSON parsing robustness (#1637)", () => {
     expect(res.error).toBeUndefined();
     const infoCalls = ((ctx.logger.info as any).mock?.calls ?? []).flat();
     expect(
-      infoCalls.some((line: unknown) =>
-        String(line).includes("fallback chain = [heavy-fallback-1, heavy-fallback-2]"),
-      ),
+      infoCalls.some((line: unknown) => String(line).includes("fallback chain = [heavy-fallback-1, heavy-fallback-2]")),
     ).toBe(true);
   });
 


### PR DESCRIPTION
Issue: https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/1715

Status: draft implementation PR created by Issue Stewardship as Markus/current gh auth.  
Protection: keep as draft and `stage/implementing` until Issue Stewardship dispatches/receives implementation and explicitly hands off to PR Stewardship.

Enrichment present on issue: 0  
Priority inherited from issue: High (source labels: priority:high)  
Dependencies/blocked labels inherited from issue: none

Implementation PR created by Issue Stewardship. Detailed enrichment should be attached to the issue before Copilot implementation dispatch.

---

> [!NOTE]
> **Medium Risk**
> Changes maintenance/heavy-tier LLM routing for self-correction-run; affects reliability and cost of nightly/operator runs, not auth or data stores.
>
> **Overview**
> This PR now includes implementation changes in `extensions/memory-hybrid/cli/cmd-selfcorrection.ts` to prevent an empty fallback chain when `llm.heavy` has a single model.
>
> The run path now uses `resolveReflectionModelAndFallbacks(cfg, "heavy")` for self-correction model/fallback resolution, aligning it with the shared maintenance fallback behavior already used by related flows.
>
> This ensures analyze / repair / rewrite-tools paths that call `chatCompleteWithAdaptiveMaintenanceRetry` receive configured fallback models consistently, while preserving explicit `--model` override behavior and existing logging/adaptive retry flows.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes maintenance/heavy-tier LLM routing for nightly self-correction runs, affecting reliability and cost on failure—not auth or data stores.
> 
> **Overview**
> **Self-correction-run** no longer builds an empty LLM fallback list when `llm.heavy` lists only one model. Model selection now goes through `resolveReflectionModelAndFallbacks(cfg, "heavy")`, matching other maintenance flows so analyze, JSON repair, and rewrite-tools calls to `chatCompleteWithAdaptiveMaintenanceRetry` get `distill.fallbackModels` (and related policy) instead of stopping at the sole primary.
> 
> Fallback assembly is simplified: without `--model`, fallbacks come from the resolved heavy chain; with `--model`, the override is primary and configured heavy fallbacks still apply. A regression test asserts the logged fallback chain when heavy has a single entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e04b0d614a8e72d2393b43f877dc1c526e8f7053. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->