### PR TITLE
fix(glitchtip): prevent closed SQLite handle in background tasks

### DIFF
--- a/extensions/memory-hybrid/lifecycle/hooks.ts
+++ b/extensions/memory-hybrid/lifecycle/hooks.ts
@@ -33,6 +33,14 @@ import type { LifecycleContext } from "./types.js";
 
 export type { LifecycleContext } from "./types.js";
 
+function isStaleLifecycleGeneration(ctx: LifecycleContext): boolean {
+  return (
+    typeof ctx.registrationGeneration === "number" &&
+    ctx.currentRegistrationGenerationRef !== undefined &&
+    ctx.currentRegistrationGenerationRef.value !== ctx.registrationGeneration
+  );
+}
+
 export function createLifecycleHooks(ctx: LifecycleContext) {
   const sessionState = createSessionState();
   const staleSweepTimer = createStaleSweepTimer(sessionState);
@@ -69,6 +77,7 @@ export function createLifecycleHooks(ctx: LifecycleContext) {
         }
         try {
           const recallStageResult = await runRecallStage(event, rApi, ctx, sessionState);
+          if (isStaleLifecycleGeneration(ctx)) return undefined;
           if (!recallStageResult) {
             if (capturedFirstRecallBegin) {
               recordStartupMemoryCheckpoint({
@@ -115,6 +124,7 @@ export function createLifecycleHooks(ctx: LifecycleContext) {
             return recallStageResult.prependContext ? { prependContext: recallStageResult.prependContext } : undefined;
           }
           const inj = await runInjectionStage(recallStageResult.result, rApi, ctx, event);
+          if (isStaleLifecycleGeneration(ctx)) return undefined;
           if (capturedFirstRecallBegin) {
             recordStartupMemoryCheckpoint({
               logger: api.logger,
@@ -240,6 +250,7 @@ export function createLifecycleHooks(ctx: LifecycleContext) {
       }
 
       await runCaptureStage(event, rApi, ctx, sessionState);
+      if (isStaleLifecycleGeneration(ctx)) return;
       const sessionId = sessionState.resolveSessionKey(event, rApi) ?? ctx.currentAgentIdRef.value ?? "default";
       if (ctx.cfg.goalStewardship?.enabled) {
         try {
@@ -273,6 +284,7 @@ export function createLifecycleHooks(ctx: LifecycleContext) {
           api.logger.debug?.(`memory-hybrid: goal session summary failed (non-fatal): ${String(err)}`);
         }
       }
+      if (isStaleLifecycleGeneration(ctx)) return;
 
       try {
         await buildDailyNarrative({
@@ -301,6 +313,7 @@ export function createLifecycleHooks(ctx: LifecycleContext) {
           api.logger.warn(`memory-hybrid: session narrative build failed: ${String(err)}`);
         }
       }
+      if (isStaleLifecycleGeneration(ctx)) return;
 
       if (ev?.success !== false) {
         try {

--- a/extensions/memory-hybrid/lifecycle/hooks.ts
+++ b/extensions/memory-hybrid/lifecycle/hooks.ts
@@ -30,16 +30,9 @@ import { runSetupStage } from "./stage-setup.js";
 import { formatPreFinalizationGuardMessage, evaluatePreFinalizationGuard } from "../services/pre-finalization-guard.js";
 import { TASK_LEDGER_CATEGORY } from "../services/task-ledger-facts.js";
 import type { LifecycleContext } from "./types.js";
+import { isStaleLifecycleGeneration } from "../utils/lifecycle-generation.js";
 
 export type { LifecycleContext } from "./types.js";
-
-function isStaleLifecycleGeneration(ctx: LifecycleContext): boolean {
-  return (
-    typeof ctx.registrationGeneration === "number" &&
-    ctx.currentRegistrationGenerationRef !== undefined &&
-    ctx.currentRegistrationGenerationRef.value !== ctx.registrationGeneration
-  );
-}
 
 export function createLifecycleHooks(ctx: LifecycleContext) {
   const sessionState = createSessionState();
@@ -296,6 +289,8 @@ export function createLifecycleHooks(ctx: LifecycleContext) {
           model: getDefaultCronModel(getCronModelConfig(ctx.cfg), "nano"),
           logger: api.logger,
           fallbackModels: [],
+          registrationGeneration: ctx.registrationGeneration,
+          currentRegistrationGenerationRef: ctx.currentRegistrationGenerationRef,
         });
       } catch (err) {
         const transient = isAbortOrTransientLlmError(err);

--- a/extensions/memory-hybrid/lifecycle/hooks.ts
+++ b/extensions/memory-hybrid/lifecycle/hooks.ts
@@ -242,9 +242,11 @@ export function createLifecycleHooks(ctx: LifecycleContext) {
         }
       }
 
+      if (isStaleLifecycleGeneration(ctx)) return;
       await runCaptureStage(event, rApi, ctx, sessionState);
       if (isStaleLifecycleGeneration(ctx)) return;
       const sessionId = sessionState.resolveSessionKey(event, rApi) ?? ctx.currentAgentIdRef.value ?? "default";
+      if (isStaleLifecycleGeneration(ctx)) return;
       if (ctx.cfg.goalStewardship?.enabled) {
         try {
           const { listActiveGoals, resolveGoalsDir } = await import("../services/goal-stewardship.js");

--- a/extensions/memory-hybrid/lifecycle/hooks.ts
+++ b/extensions/memory-hybrid/lifecycle/hooks.ts
@@ -70,7 +70,12 @@ export function createLifecycleHooks(ctx: LifecycleContext) {
         }
         try {
           const recallStageResult = await runRecallStage(event, rApi, ctx, sessionState);
-          if (isStaleLifecycleGeneration(ctx)) return undefined;
+          if (isStaleLifecycleGeneration(ctx)) {
+            if (capturedFirstRecallBegin) {
+              firstRecallCheckpointCaptured = false;
+            }
+            return undefined;
+          }
           if (!recallStageResult) {
             if (capturedFirstRecallBegin) {
               recordStartupMemoryCheckpoint({
@@ -117,7 +122,12 @@ export function createLifecycleHooks(ctx: LifecycleContext) {
             return recallStageResult.prependContext ? { prependContext: recallStageResult.prependContext } : undefined;
           }
           const inj = await runInjectionStage(recallStageResult.result, rApi, ctx, event);
-          if (isStaleLifecycleGeneration(ctx)) return undefined;
+          if (isStaleLifecycleGeneration(ctx)) {
+            if (capturedFirstRecallBegin) {
+              firstRecallCheckpointCaptured = false;
+            }
+            return undefined;
+          }
           if (capturedFirstRecallBegin) {
             recordStartupMemoryCheckpoint({
               logger: api.logger,
@@ -187,6 +197,8 @@ export function createLifecycleHooks(ctx: LifecycleContext) {
     api.on("agent_end", async (event: unknown, hookCtx: unknown) => {
       const rApi = withHookResolutionApi(api, hookCtx);
       const ev = event as { messages?: unknown[]; success?: boolean };
+
+      if (isStaleLifecycleGeneration(ctx)) return;
 
       // Issue #742: extract tool names from messages and record via WorkflowTracker
       // so crystallization can detect patterns from the traces table.

--- a/extensions/memory-hybrid/lifecycle/stage-recall/run-recall.ts
+++ b/extensions/memory-hybrid/lifecycle/stage-recall/run-recall.ts
@@ -28,6 +28,7 @@ import { resolveAgentIdFromHookEvent } from "../resolve-agent-id.js";
 import { yieldEventLoop } from "../../utils/event-loop-yield.js";
 import { estimateTokens, sanitizeRecallFactText } from "../../utils/text.js";
 import type { LifecycleContext, RecallResult, RecallStageResult, SessionState } from "../types.js";
+import { isStaleLifecycleGeneration } from "../../utils/lifecycle-generation.js";
 
 function emptyRecallStage(): RecallStageResult {
   return { kind: "empty", prependContext: undefined };
@@ -45,11 +46,7 @@ function isLifecycleSqliteShutdownError(err: unknown, ctx: LifecycleContext): bo
   if (typeof ctx.factsDb.isOpen === "function" && !ctx.factsDb.isOpen()) {
     return true;
   }
-  return (
-    typeof ctx.registrationGeneration === "number" &&
-    ctx.currentRegistrationGenerationRef !== undefined &&
-    ctx.currentRegistrationGenerationRef.value !== ctx.registrationGeneration
-  );
+  return isStaleLifecycleGeneration(ctx);
 }
 
 function clipNarrativeText(text: string, maxChars = 360): string {

--- a/extensions/memory-hybrid/lifecycle/stage-recall/run-recall.ts
+++ b/extensions/memory-hybrid/lifecycle/stage-recall/run-recall.ts
@@ -37,6 +37,21 @@ function recallAborted(signal: AbortSignal | undefined): boolean {
   return signal?.aborted === true;
 }
 
+function isLifecycleSqliteShutdownError(err: unknown, ctx: LifecycleContext): boolean {
+  const message = err instanceof Error ? err.message : String(err);
+  if (!/not open|connection is not open|database is not open/i.test(message)) {
+    return false;
+  }
+  if (typeof ctx.factsDb.isOpen === "function" && !ctx.factsDb.isOpen()) {
+    return true;
+  }
+  return (
+    typeof ctx.registrationGeneration === "number" &&
+    ctx.currentRegistrationGenerationRef !== undefined &&
+    ctx.currentRegistrationGenerationRef.value !== ctx.registrationGeneration
+  );
+}
+
 function clipNarrativeText(text: string, maxChars = 360): string {
   if (text.length <= maxChars) return text;
   return `${text.slice(0, Math.max(0, maxChars - 1)).trimEnd()}…`;
@@ -1048,6 +1063,10 @@ export async function runRecall(
     };
     return completeStage({ kind: "full", result });
   } catch (err) {
+    if (isLifecycleSqliteShutdownError(err, ctx)) {
+      setRecallProbePhase("skip:shutdown");
+      return completeStage(emptyRecallStage());
+    }
     if (!recallStageCompleted) {
       recallTiming.phaseCompleted("recall_stage_run", recallStageStartedAt, {
         ...(recallStageFields ?? {}),

--- a/extensions/memory-hybrid/lifecycle/types.ts
+++ b/extensions/memory-hybrid/lifecycle/types.ts
@@ -77,6 +77,10 @@ export interface LifecycleContext {
   recallInFlightRef: { value: number };
   /** Updated when interactive auto-recall runs; read after compaction to re-inject recall (#957). */
   lastAutoRecallPromptRef: { value: string | null };
+  /** Registration generation that owns this lifecycle context; used to detect stale in-flight hooks. */
+  registrationGeneration?: number;
+  /** Shared current generation ref; differs from registrationGeneration after plugin re-registration. */
+  currentRegistrationGenerationRef?: { value: number };
 }
 
 /** Per-session state shared across stages (owned by dispatcher). */

--- a/extensions/memory-hybrid/setup/register-hooks.ts
+++ b/extensions/memory-hybrid/setup/register-hooks.ts
@@ -177,6 +177,8 @@ export function registerLifecycleHooks(ctx: HooksContext, api: ClawdbotPluginApi
       issueStore: ctx.issueStore,
       recallInFlightRef: ctx.recallInFlightRef,
       lastAutoRecallPromptRef: ctx.lastAutoRecallPromptRef,
+      registrationGeneration,
+      currentRegistrationGenerationRef,
     };
   } catch (err) {
     capturePluginError(err instanceof Error ? err : new Error(String(err)), {

--- a/extensions/memory-hybrid/src/worker/narratives.ts
+++ b/extensions/memory-hybrid/src/worker/narratives.ts
@@ -44,10 +44,17 @@ function normalizeNarrative(raw: string): string {
   return raw.replace(/\r\n?/g, "\n").trim();
 }
 
+function isDatabaseNotOpenError(err: unknown): boolean {
+  const message = err instanceof Error ? err.message : String(err);
+  return /not open|connection is not open|database is not open/i.test(message);
+}
+
 export async function buildDailyNarrative(params: BuildDailyNarrativeParams): Promise<boolean> {
   const { sessionId, eventLog, workflowStore, narrativesDb, openai, model, logger, fallbackModels } = params;
   if (!eventLog || !narrativesDb) return false;
   if (!eventLog.isOpen()) return false; // session already disposed
+  if (!narrativesDb.isOpen()) return false;
+  if (workflowStore && !workflowStore.isOpen()) return false;
 
   try {
     const events = eventLog.getBySession(sessionId, MAX_EVENTS_FOR_PROMPT);
@@ -97,7 +104,6 @@ export async function buildDailyNarrative(params: BuildDailyNarrativeParams): Pr
       workflows: workflowsBlock || "none",
       max_chars: String(DEFAULT_MAX_NARRATIVE_CHARS),
     });
-
     const raw = await chatCompleteWithRetry({
       model,
       content: prompt,
@@ -111,6 +117,7 @@ export async function buildDailyNarrative(params: BuildDailyNarrativeParams): Pr
     });
     const normalized = normalizeNarrative(raw);
     if (!normalized || normalized === "NO_NARRATIVE") return false;
+    if (!narrativesDb.isOpen()) return false;
     narrativesDb.store({
       sessionId,
       periodStart,
@@ -119,13 +126,27 @@ export async function buildDailyNarrative(params: BuildDailyNarrativeParams): Pr
       narrativeText: clip(normalized, DEFAULT_MAX_NARRATIVE_CHARS),
     });
     // Keep narrative storage bounded.
-    narrativesDb.pruneOlderThan(30);
+    try {
+      if (narrativesDb.isOpen()) {
+        narrativesDb.pruneOlderThan(30);
+      }
+    } catch (err) {
+      if (!isDatabaseNotOpenError(err)) {
+        throw err;
+      }
+    }
     logger.info?.(
       `memory-hybrid: stored session narrative for ${sessionId} (transcript file: ${sessionTranscriptFilename(sessionId)})`,
     );
     return true;
   } catch (err) {
     const asError = err instanceof Error ? err : new Error(String(err));
+    if (
+      isDatabaseNotOpenError(asError) &&
+      (!eventLog.isOpen() || !narrativesDb.isOpen() || (workflowStore !== null && !workflowStore.isOpen()))
+    ) {
+      return false;
+    }
     const transient = isAbortOrTransientLlmError(err) || is500OrWrapped(asError);
     if (!transient) {
       capturePluginError(asError, {

--- a/extensions/memory-hybrid/src/worker/narratives.ts
+++ b/extensions/memory-hybrid/src/worker/narratives.ts
@@ -28,6 +28,8 @@ export interface BuildDailyNarrativeParams {
   model: string;
   logger: { info?: (msg: string) => void; warn: (msg: string) => void };
   fallbackModels?: string[];
+  registrationGeneration?: number;
+  currentRegistrationGenerationRef?: { value: number };
 }
 
 function toSec(iso: string): number {
@@ -50,7 +52,18 @@ function isDatabaseNotOpenError(err: unknown): boolean {
 }
 
 export async function buildDailyNarrative(params: BuildDailyNarrativeParams): Promise<boolean> {
-  const { sessionId, eventLog, workflowStore, narrativesDb, openai, model, logger, fallbackModels } = params;
+  const {
+    sessionId,
+    eventLog,
+    workflowStore,
+    narrativesDb,
+    openai,
+    model,
+    logger,
+    fallbackModels,
+    registrationGeneration,
+    currentRegistrationGenerationRef,
+  } = params;
   if (!eventLog || !narrativesDb) return false;
   if (!eventLog.isOpen()) return false; // session already disposed
   if (!narrativesDb.isOpen()) return false;
@@ -118,6 +131,13 @@ export async function buildDailyNarrative(params: BuildDailyNarrativeParams): Pr
     const normalized = normalizeNarrative(raw);
     if (!normalized || normalized === "NO_NARRATIVE") return false;
     if (!narrativesDb.isOpen()) return false;
+    if (
+      typeof registrationGeneration === "number" &&
+      currentRegistrationGenerationRef !== undefined &&
+      currentRegistrationGenerationRef.value !== registrationGeneration
+    ) {
+      return false;
+    }
     narrativesDb.store({
       sessionId,
       periodStart,

--- a/extensions/memory-hybrid/tests/lifecycle-stage-recall.test.ts
+++ b/extensions/memory-hybrid/tests/lifecycle-stage-recall.test.ts
@@ -113,7 +113,9 @@ describe("runRecallStage", () => {
 
   it("returns empty instead of throwing when FactsDB closes during teardown", async () => {
     const ctx = buildRecallLifecycleContext(tmpDir, factsDb);
-    vi.mocked(recallPipeline.runRecallPipelineQuery).mockRejectedValue(new Error("The database connection is not open"));
+    vi.mocked(recallPipeline.runRecallPipelineQuery).mockRejectedValue(
+      new Error("The database connection is not open"),
+    );
     factsDb.permanentClose();
     const sessionState = makeRecallSessionState();
     const api = makeMockStageApi();

--- a/extensions/memory-hybrid/tests/lifecycle-stage-recall.test.ts
+++ b/extensions/memory-hybrid/tests/lifecycle-stage-recall.test.ts
@@ -111,6 +111,19 @@ describe("runRecallStage", () => {
     expect(ctx.recallInFlightRef.value).toBe(0);
   });
 
+  it("returns empty instead of throwing when FactsDB closes during teardown", async () => {
+    const ctx = buildRecallLifecycleContext(tmpDir, factsDb);
+    vi.mocked(recallPipeline.runRecallPipelineQuery).mockRejectedValue(new Error("The database connection is not open"));
+    factsDb.permanentClose();
+    const sessionState = makeRecallSessionState();
+    const api = makeMockStageApi();
+
+    const result = await runRecallStage({ prompt: "find credentials for github api" }, api as never, ctx, sessionState);
+
+    expect(result).toEqual({ kind: "empty", prependContext: undefined });
+    expect(ctx.recallInFlightRef.value).toBe(0);
+  });
+
   it("returns null when stage wall-clock timeout fires", async () => {
     vi.useFakeTimers();
     const ctx = buildRecallLifecycleContext(tmpDir, factsDb);

--- a/extensions/memory-hybrid/tests/narratives-worker.test.ts
+++ b/extensions/memory-hybrid/tests/narratives-worker.test.ts
@@ -163,4 +163,40 @@ describe("buildDailyNarrative", () => {
     expect(String(info.mock.calls[0]?.[0])).toMatch(/narrative skipped/i);
     expect(narrativesDb.listRecent(5, "session").length).toBe(0);
   });
+
+  it("skips narrative persistence when the narratives DB closes during the async LLM call", async () => {
+    eventLog.append({
+      sessionId: "s-close",
+      timestamp: "2026-03-22T10:00:00.000Z",
+      eventType: "action_taken",
+      content: { action: "session_start" },
+    });
+    eventLog.append({
+      sessionId: "s-close",
+      timestamp: "2026-03-22T10:05:00.000Z",
+      eventType: "decision_made",
+      content: { decision: "switch strategy" },
+    });
+
+    vi.spyOn(chatModule, "chatCompleteWithRetry").mockImplementation(async () => {
+      narrativesDb.permanentClose();
+      return "**Context** Goal.\n**Chronicle** Step-by-step.\n**Decisions** Next action.";
+    });
+    const captureSpy = vi.spyOn(errorReporter, "capturePluginError");
+    const warn = vi.fn();
+
+    const stored = await buildDailyNarrative({
+      sessionId: "s-close",
+      eventLog,
+      workflowStore,
+      narrativesDb,
+      openai: {} as never,
+      model: "test-model",
+      logger: { warn, info: vi.fn() },
+    });
+
+    expect(stored).toBe(false);
+    expect(warn).not.toHaveBeenCalled();
+    expect(captureSpy).not.toHaveBeenCalled();
+  });
 });

--- a/extensions/memory-hybrid/tests/plugin-lifecycle-registration.test.ts
+++ b/extensions/memory-hybrid/tests/plugin-lifecycle-registration.test.ts
@@ -10,6 +10,7 @@ import { FactsDB } from "../backends/facts-db.js";
 import { resetStartupMemoryAttributionForTests } from "../services/startup-memory-attribution.js";
 import { runCaptureStage } from "../lifecycle/stage-capture.js";
 import { registerLifecycleHooks } from "../setup/register-hooks.js";
+import { buildDailyNarrative } from "../src/worker/narratives.js";
 import { buildGuardTestConfig, buildGuardTestLifecycleContext } from "./helpers/lifecycle-hook-harness.js";
 
 vi.mock("../lifecycle/stage-capture.js", () => ({
@@ -153,6 +154,72 @@ describe("registerLifecycleHooks", () => {
     for (const unsubscribe of unsubscribers) {
       expect(unsubscribe).toHaveBeenCalledTimes(1);
     }
+  });
+
+  it("skips post-await agent_end work when the lifecycle generation goes stale mid-flight", async () => {
+    const lifecycleCtx = buildGuardTestLifecycleContext(tmpDir, factsDb);
+    const cfg = buildGuardTestConfig(tmpDir);
+    const currentRegistrationGenerationRef = { value: 1 };
+    let releaseCapture: (() => void) | undefined;
+    vi.mocked(runCaptureStage).mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseCapture = resolve;
+        }),
+    );
+    const narrativeMock = vi.mocked(buildDailyNarrative);
+    narrativeMock.mockClear();
+
+    const api = {
+      on: vi.fn(),
+      logger: { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() },
+      context: { sessionId: "e2e-session", sessionKey: "e2e-session", agentId: "e2e-agent" },
+    };
+
+    const pluginApi = {
+      ...lifecycleCtx,
+      cfg,
+      embeddingRegistry: null,
+      credentialsDb: null,
+      aliasDb: null,
+      wal: null,
+      proposalsDb: null,
+      eventLog: null,
+      narrativesDb: null,
+      workflowStore: null,
+      issueStore: null,
+      crystallizationStore: null,
+      toolProposalStore: null,
+      verificationStore: null,
+      variantQueue: null,
+      pythonBridge: null,
+      apitapStore: null,
+      auditStore: null,
+      agentHealthStore: null,
+      provenanceService: null,
+      timers: { proposalsPruneTimer: { value: null } },
+      buildToolScopeFilter: () => undefined,
+      runReflection: vi.fn(),
+      runReflectionRules: vi.fn(),
+      runReflectionMeta: vi.fn(),
+      registrationGeneration: 1,
+      currentRegistrationGenerationRef,
+    };
+
+    registerLifecycleHooks(pluginApi as never, api as never);
+    const agentEndHandler = (api.on as ReturnType<typeof vi.fn>).mock.calls.find((c) => c[0] === "agent_end")?.[1] as
+      | ((event: unknown, hookCtx: unknown) => Promise<unknown>)
+      | undefined;
+
+    const pending = agentEndHandler?.(
+      { messages: [], success: true, sessionKey: "e2e-session", sessionId: "e2e-session" },
+      { sessionKey: "e2e-session", sessionId: "e2e-session", agentId: "e2e-agent" },
+    );
+    currentRegistrationGenerationRef.value = 2;
+    releaseCapture?.();
+    await pending;
+
+    expect(narrativeMock).not.toHaveBeenCalled();
   });
 
   it("logs first agent_end compaction checkpoint with subsystem attribution", async () => {

--- a/extensions/memory-hybrid/utils/lifecycle-generation.ts
+++ b/extensions/memory-hybrid/utils/lifecycle-generation.ts
@@ -1,0 +1,18 @@
+/**
+ * Shared utility for lifecycle generation staleness checks.
+ * Used across hooks.ts and stage-recall/run-recall.ts to avoid duplication.
+ */
+
+import type { LifecycleContext } from "../lifecycle/types.js";
+
+/**
+ * Returns true if the lifecycle generation is stale (plugin has been re-registered).
+ * This prevents stale in-flight work from writing to databases that are being torn down.
+ */
+export function isStaleLifecycleGeneration(ctx: LifecycleContext): boolean {
+  return (
+    typeof ctx.registrationGeneration === "number" &&
+    ctx.currentRegistrationGenerationRef !== undefined &&
+    ctx.currentRegistrationGenerationRef.value !== ctx.registrationGeneration
+  );
+}


### PR DESCRIPTION
Issue: https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/1686

Status: implementation added on this PR.
Protection: keep `stage/implementing` until Issue Stewardship dispatches/receives implementation and explicitly hands off to PR Stewardship.

Enrichment present on issue: 1
Priority inherited from issue: Medium (source labels: priority:medium)
Dependencies/blocked labels inherited from issue: none

Implementation PR created by Issue Stewardship. Detailed enrichment should be attached to the issue before Copilot implementation dispatch.


---

> [!NOTE]
> **Medium Risk**
> Targets plugin lifecycle and concurrent DB access during recall/narrative hooks; wrong sequencing could drop narratives, break auto-recall, or leak handles, but scope is localized to teardown/race handling.
> 
> **Overview**
> This PR now implements the teardown/race fix for <a href="https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/1686">#1686</a> (GlitchTip **HYBRID-MEMORY-440**).
> 
> The implementation prevents **use-after-close on SQLite** during **async narrative work** and **auto-recall** after plugin reload, CLI teardown, or signal-driven shutdown by:
> 
> - adding **generation/stale-hook guards** so in-flight lifecycle work stops once a newer plugin registration takes ownership
> - making **auto-recall fail open** when teardown leaves `FactsDB` or related SQLite access permanently closed, returning an empty recall result instead of surfacing shutdown-time errors
> - making `buildDailyNarrative` **skip persistence safely** if `EventLog`, `WorkflowStore`, or `NarrativesDB` close during the async LLM gap
> - adding focused tests covering **stale `agent_end` continuation**, **recall during teardown**, and **narrative close-during-await**
> 
> `BaseSqliteStore.close()` can still reopen handles on later `liveDb` access, while teardown uses **`permanentClose()`** via `closeOldDatabases` (including `narrativesDb`), so stale hook/tool closures must not keep using old handles. This implementation keeps the fix scoped to teardown sequencing and stale-generation handling without changing normal steady-state behavior.
> 
> <sup>Reviewed by <a href="https://cursor.com/bugbot">Cursor Bugbot</a> for commit d2a8981b680b6281598ae6f6517086fae0aaa228. Bugbot is set up for automated code reviews on this repo. Configure <a href="https://www.cursor.com/dashboard/bugbot">here</a>.</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes concurrent lifecycle/DB behavior during reload and teardown; mis-ordered guards could skip narratives or recall, but scope is limited to shutdown races with new tests.
> 
> **Overview**
> This PR hardens **memory-hybrid** lifecycle hooks against **plugin re-registration and SQLite teardown**, addressing use-after-close when async work (auto-recall, session narratives) outlives a closed DB (#1686).
> 
> A shared **`isStaleLifecycleGeneration`** check ties each hook’s `LifecycleContext` to a **registration generation**; **`before_agent_start`** recall/injection and **`agent_end`** steps bail out (and reset first-recall checkpoints) once a newer registration owns the plugin. **`runRecall`** maps closed-connection errors (or stale generation) to an **empty recall** instead of throwing. **`buildDailyNarrative`** verifies stores are open before/after the LLM call, skips **store/prune** when generation is stale or DBs close mid-await, and treats “database not open” as a quiet skip rather than GlitchTip noise.
> 
> **`register-hooks`** wires generation refs into the lifecycle context; tests cover **FactsDB close during recall**, **narratives DB close during LLM**, and **stale `agent_end` after capture**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f83e30f90ecf0fb829d58c1565ab6da6a5ad918. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->