### PR TITLE
WIP: nightly-dream-cycle continuous verification reports 12/12 uncertain with 12 errors but job still passes (#1705)

### DIFF
--- a/extensions/memory-hybrid/cli/commands/manage/dream-cycle-followup.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/dream-cycle-followup.ts
@@ -15,6 +15,7 @@ export interface RunVerboseFollowUpOptions {
 
 export interface ContinuousVerificationAssessment {
   status: "healthy" | "degraded";
+  reason: "healthy" | "errors_present" | "all_uncertain";
   shouldFailPipeline: boolean;
   summary?: string;
 }
@@ -55,6 +56,7 @@ export function assessContinuousVerificationResult(result: VerificationCycleResu
         : `${result.errors}/${result.checked} verification check(s) errored`;
     return {
       status: "degraded",
+      reason: "errors_present",
       shouldFailPipeline: true,
       summary,
     };
@@ -62,11 +64,27 @@ export function assessContinuousVerificationResult(result: VerificationCycleResu
   if (result.checked > 0 && result.confirmed === 0 && result.stale === 0) {
     return {
       status: "degraded",
+      reason: "all_uncertain",
       shouldFailPipeline: true,
       summary: `all ${result.checked} verification check(s) were uncertain`,
     };
   }
-  return { status: "healthy", shouldFailPipeline: false };
+  return { status: "healthy", reason: "healthy", shouldFailPipeline: false };
+}
+
+export function formatContinuousVerificationAssessmentLine(
+  result: VerificationCycleResult,
+  assessment: ContinuousVerificationAssessment,
+): string {
+  return [
+    `status=${assessment.status}`,
+    `reason=${assessment.reason}`,
+    `checked=${result.checked}`,
+    `confirmed=${result.confirmed}`,
+    `stale=${result.stale}`,
+    `uncertain=${result.uncertain}`,
+    `errors=${result.errors}`,
+  ].join(" ");
 }
 
 export async function runVerboseFollowUp<T>(

--- a/extensions/memory-hybrid/cli/commands/manage/register-reflection-pipeline.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/register-reflection-pipeline.ts
@@ -17,6 +17,7 @@ import type {
 
 import {
   assessContinuousVerificationResult,
+  formatContinuousVerificationAssessmentLine,
   formatExtractImplicitFeedbackProgress,
   runVerboseFollowUp,
   type RunVerboseFollowUpOptions,
@@ -621,6 +622,9 @@ export function registerManageReflectionPipeline(mem: Chainable, b: ManageBindin
             const verificationAssessment = assessContinuousVerificationResult(verificationRes);
             if (verificationAssessment.status !== "healthy") {
               console.log(`  Status: ${verificationAssessment.status.toUpperCase()}`);
+              console.log(
+                `  Machine status: ${formatContinuousVerificationAssessmentLine(verificationRes, verificationAssessment)}`,
+              );
               if (verificationAssessment.summary) {
                 console.log(`  Warning: ${verificationAssessment.summary}`);
               }

--- a/extensions/memory-hybrid/tests/dream-cycle-followup-logging.test.ts
+++ b/extensions/memory-hybrid/tests/dream-cycle-followup-logging.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { assessContinuousVerificationResult, runVerboseFollowUp } from "../cli/commands/manage/dream-cycle-followup.js";
+import {
+  assessContinuousVerificationResult,
+  formatContinuousVerificationAssessmentLine,
+  runVerboseFollowUp,
+} from "../cli/commands/manage/dream-cycle-followup.js";
 
 describe("dream-cycle follow-up heartbeat logging", () => {
   afterEach(() => {
@@ -72,6 +76,7 @@ describe("dream-cycle follow-up heartbeat logging", () => {
     });
 
     expect(assessment.status).toBe("degraded");
+    expect(assessment.reason).toBe("all_uncertain");
     expect(assessment.shouldFailPipeline).toBe(true);
     expect(assessment.summary).toContain("all 12 verification check(s) were uncertain");
   });
@@ -93,7 +98,23 @@ describe("dream-cycle follow-up heartbeat logging", () => {
     });
 
     expect(assessment.status).toBe("degraded");
+    expect(assessment.reason).toBe("errors_present");
     expect(assessment.shouldFailPipeline).toBe(true);
     expect(assessment.summary).toContain("5/5 verification check(s) errored");
+  });
+
+  it("emits machine-readable degraded verification status details", () => {
+    const result = {
+      checked: 5,
+      confirmed: 0,
+      stale: 0,
+      uncertain: 5,
+      errors: 5,
+      errorSummaries: ["fact=abc12345…: provider timeout"],
+    };
+    const assessment = assessContinuousVerificationResult(result);
+    expect(formatContinuousVerificationAssessmentLine(result, assessment)).toBe(
+      "status=degraded reason=errors_present checked=5 confirmed=0 stale=0 uncertain=5 errors=5",
+    );
   });
 });


### PR DESCRIPTION
Issue: https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/1705

Status: draft implementation PR created by Issue Stewardship as Markus/current gh auth.
Protection: keep as draft and `stage/implementing` until Issue Stewardship dispatches/receives implementation and explicitly hands off to PR Stewardship.

Enrichment present on issue: 1
Priority inherited from issue: High (source labels: priority:high)
Dependencies/blocked labels inherited from issue: none

Implementation updates landed on this branch:

- Continuous verification follow-up now emits a machine-readable degraded status line when verification is not healthy, including status, reason, and counters (`checked/confirmed/stale/uncertain/errors`).
- Added explicit degraded reason classification in assessment logic (`errors_present`, `all_uncertain`) to distinguish error-driven degradation from all-uncertain outcomes.
- Kept failure semantics for degraded verification intact (`shouldFailPipeline: true` for error/all-uncertain degraded states).

Tests updated:

- Extended `extensions/memory-hybrid/tests/dream-cycle-followup-logging.test.ts` to assert degraded reason classification and machine-readable status formatting output.

Validation performed:

- `npm run test -- --reporter=verbose tests/dream-cycle-followup-logging.test.ts`
- `npm run build`
- parallel validation (Code Review + CodeQL) completed with no actionable findings.

---

> [!NOTE]
> <sup><a href="https://cursor.com/bugbot">Cursor Bugbot</a> is generating a summary for commit 4030b4a473429381b9c14873a19912d55a33d1d4. Configure <a href="https://www.cursor.com/dashboard/bugbot">here</a>.</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging and assessment metadata only; pipeline failure semantics are unchanged.
> 
> **Overview**
> Continuous verification follow-up now classifies degraded outcomes with an explicit **`reason`** (`errors_present`, `all_uncertain`, or `healthy`) on **`ContinuousVerificationAssessment`**, and exposes a single **machine-readable status line** via **`formatContinuousVerificationAssessmentLine`** (status, reason, and `checked` / `confirmed` / `stale` / `uncertain` / `errors` counters).
> 
> The dream-cycle reflection pipeline logs that line as **`Machine status:`** when verification is not healthy, so nightly runs can distinguish error-driven degradation from all-uncertain results without parsing prose warnings. **`shouldFailPipeline`** behavior for degraded states is unchanged.
> 
> Tests in **`dream-cycle-followup-logging.test.ts`** assert the new **`reason`** values and the formatted machine status string.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc56a3d66747572885fff4d16b2158183f5f4509. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->