### PR TITLE
fix(cron): surface reembed-vectorless failure reasons in maintenance validation (#1731)

### DIFF
--- a/extensions/memory-hybrid/services/cron-exit-validator.ts
+++ b/extensions/memory-hybrid/services/cron-exit-validator.ts
@@ -286,6 +286,10 @@ export function validateMaintenanceExecution(
     }
   }
 
+  for (const step of failedSteps) {
+    if (!step.failureReason && step.reason) step.failureReason = step.reason;
+  }
+
   if (logPath && failedSteps.some((s) => s.step === "audit-health")) {
     for (const step of failedSteps) {
       if (step.step !== "audit-health") continue;

--- a/extensions/memory-hybrid/tests/cron-exit-validator.test.ts
+++ b/extensions/memory-hybrid/tests/cron-exit-validator.test.ts
@@ -142,6 +142,22 @@ error: unknown command 'bar'
       expect(result.failedSteps[0].exitCode).toBe(1);
     });
 
+    it("should surface HM_EXIT failure reasons for non-zero steps", () => {
+      const tmpDir = mkdtempSync(join(tmpdir(), "cron-test-"));
+      const exitPath = join(tmpDir, "test.exit.txt");
+      writeFileSync(
+        exitPath,
+        "2024-05-08T02:01:00Z step=reembed-vectorless exit=1 status=failed reason=failed_embedding_provider_5xx duration_ms=420000\n",
+      );
+
+      const result = validateMaintenanceExecution(exitPath, undefined, ["reembed-vectorless"]);
+
+      expect(result.maintenanceStatus).toBe("failed");
+      expect(result.failedSteps).toHaveLength(1);
+      expect(result.failedSteps[0].failureReason).toBe("failed_embedding_provider_5xx");
+      expect(result.error).toContain("failed_embedding_provider_5xx");
+    });
+
     it("should annotate audit-health strict failures with a machine-readable reason", () => {
       const tmpDir = mkdtempSync(join(tmpdir(), "cron-test-"));
       const exitPath = join(tmpDir, "test.exit.txt");

--- a/extensions/memory-hybrid/tests/maintenance-job-harness.test.ts
+++ b/extensions/memory-hybrid/tests/maintenance-job-harness.test.ts
@@ -88,4 +88,29 @@ describe("maintenance job harness fixture", () => {
     expect(run.validation.guardUpdated).toBe(false);
     expect(run.guardWritten).toBe(false);
   });
+
+  it("models monthly-consolidation stopping before enrich-entities after reembed-vectorless provider failure", () => {
+    const run = runHarness({
+      requiredSteps: ["consolidate", "build-languages", "backfill-decay", "reembed-vectorless", "enrich-entities"],
+      jobName: "monthly-consolidation-20260529T162810Z-10883",
+      exitRows: [
+        hmExitStepLine({ step: "consolidate", exitCode: 0 }),
+        hmExitStepLine({ step: "build-languages", exitCode: 0 }),
+        hmExitStepLine({ step: "backfill-decay", exitCode: 0 }),
+        hmExitStepLine({ step: "reembed-vectorless", exitCode: 1, reason: "failed_embedding_provider_5xx" }),
+      ],
+      logLines: ['{"maintenanceStatus":"failed","guardUpdated":false}'],
+    });
+
+    expect(run.validation.maintenanceStatus).toBe("failed");
+    expect(run.validation.missingSteps).toEqual(["enrich-entities"]);
+    expect(run.validation.failedSteps).toHaveLength(1);
+    expect(run.validation.failedSteps[0]?.step).toBe("reembed-vectorless");
+    expect(run.validation.failedSteps[0]?.exitCode).toBe(1);
+    expect(run.validation.failedSteps[0]?.failureReason).toBe("failed_embedding_provider_5xx");
+    expect(run.validation.error).toContain("Missing steps: enrich-entities");
+    expect(run.validation.error).toContain("Failed steps: reembed-vectorless (exit=1 failed_embedding_provider_5xx)");
+    expect(run.validation.guardUpdated).toBe(false);
+    expect(run.guardWritten).toBe(false);
+  });
 });


### PR DESCRIPTION
<!-- issue-stewardship-pr issue:1731 -->
Closes #1731
Issue: https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/1731

Status: draft implementation PR created by Issue Stewardship as Markus/current gh auth.
Protection: keep as draft and `stage/implementing` until Issue Stewardship dispatches/receives implementation and explicitly hands off to PR Stewardship.

Enrichment present on issue: 0
Priority inherited from issue: High (source labels: priority:high)
Dependencies/blocked labels inherited from issue: none

Implementation PR created by Issue Stewardship. Detailed enrichment should be attached to the issue before Copilot implementation dispatch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small validator mapping plus tests; no auth, data, or guard-success rule changes beyond clearer failure reporting.
> 
> **Overview**
> Maintenance exit validation now **propagates HM_EXIT `reason` into `failureReason`** for any failed step that does not already have a dedicated inference path (audit-health and dream-cycle behavior unchanged). Failed-step summaries and `validateMaintenanceExecution` error text therefore include machine-readable reasons such as **`failed_embedding_provider_5xx`** for **`reembed-vectorless`**, not only exit codes.
> 
> Tests cover a direct validator case on extended `step=` ledger lines and a **monthly-consolidation** harness where provider failure stops the job before later required steps, asserting both missing downstream steps and the surfaced failure reason in the aggregate error.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12263ca3d783118b42f04257bed3cd4639fa5f78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->