### PR TITLE
WIP: fix: v2026.5.310 async register() breaks OpenClaw plugin load (register must be synchronous) (#1773)

### DIFF
--- a/extensions/memory-hybrid/setup/register-plugin.ts
+++ b/extensions/memory-hybrid/setup/register-plugin.ts
@@ -39,11 +39,9 @@ import {
 } from "./provider-router.js";
 import { getHybridMemoryRegistrationState } from "./hybrid-memory-generation-state.js";
 import {
-  blockReloadTeardownBeforeOpen,
   drainOldBootstrap,
   drainOldRecall,
   schedulePluginTeardown,
-  TEARDOWN_WAIT_MS,
 } from "./hybrid-memory-reload-coordinator.js";
 import { registerContextEngineBestEffort } from "./register-context-engine.js";
 import { registerLifecycleHooks } from "./register-hooks.js";
@@ -285,15 +283,6 @@ function runMemoryHybridRegisterImpl(api: ClawdbotPluginApi): void {
       });
     }
     runtimeRef.value = null;
-  }
-
-  if (old && !reuseDatabases) {
-    // Wait for teardown to complete before opening new DB handles (#802).
-    // Bounded wait: drains (3s + 2s) + buffer fit within TEARDOWN_WAIT_MS.
-    const drained = blockReloadTeardownBeforeOpen(TEARDOWN_WAIT_MS);
-    if (!drained) {
-      throw new Error("memory-hybrid: reload teardown did not drain before opening new databases");
-    }
   }
 
   let dbContext: ReturnType<typeof initializeDatabases>;

--- a/extensions/memory-hybrid/tests/cli-help-hang.test.ts
+++ b/extensions/memory-hybrid/tests/cli-help-hang.test.ts
@@ -42,7 +42,7 @@ describe("hybrid-mem help invocations", () => {
     rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  it("openclaw hybrid-mem --help registers CLI only (no DB bootstrap, no tools/services)", async () => {
+  it("openclaw hybrid-mem --help registers CLI only (no DB bootstrap, no tools/services)", () => {
     process.argv = ["node", "openclaw", "hybrid-mem", "--help"];
     const api = makeMockApi();
     const sqlitePath = join(tmpDir, "facts.db");
@@ -59,14 +59,14 @@ describe("hybrid-mem help invocations", () => {
       resolvePath: (p: string) => (p.startsWith("/") || /^[A-Z]:/.test(p) ? p : join(tmpDir, p)),
     };
 
-    await expect(memoryHybridPlugin.register(mockApi as never)).resolves.toBeUndefined();
+    expect(memoryHybridPlugin.register(mockApi as never)).toBeUndefined();
     expect(existsSync(sqlitePath)).toBe(false);
     expect(api.registerCli).toHaveBeenCalled();
     expect(api.registerTool).not.toHaveBeenCalled();
     expect(api.registerService).not.toHaveBeenCalled();
   });
 
-  it("openclaw hybrid-mem verify --help registers CLI only (no DB bootstrap, no tools/services)", async () => {
+  it("openclaw hybrid-mem verify --help registers CLI only (no DB bootstrap, no tools/services)", () => {
     process.argv = ["node", "openclaw", "hybrid-mem", "verify", "--help"];
     const api = makeMockApi();
     const sqlitePath = join(tmpDir, "facts.db");
@@ -83,14 +83,14 @@ describe("hybrid-mem help invocations", () => {
       resolvePath: (p: string) => (p.startsWith("/") || /^[A-Z]:/.test(p) ? p : join(tmpDir, p)),
     };
 
-    await expect(memoryHybridPlugin.register(mockApi as never)).resolves.toBeUndefined();
+    expect(memoryHybridPlugin.register(mockApi as never)).toBeUndefined();
     expect(existsSync(sqlitePath)).toBe(false);
     expect(api.registerCli).toHaveBeenCalled();
     expect(api.registerTool).not.toHaveBeenCalled();
     expect(api.registerService).not.toHaveBeenCalled();
   });
 
-  it("openclaw hybrid-mem store -- --help uses full registration (not help fast-path)", async () => {
+  it("openclaw hybrid-mem store -- --help uses full registration (not help fast-path)", () => {
     process.argv = ["node", "openclaw", "hybrid-mem", "store", "--", "--help"];
     const api = makeMockApi();
     const sqlitePath = join(tmpDir, "facts.db");
@@ -107,12 +107,12 @@ describe("hybrid-mem help invocations", () => {
       resolvePath: (p: string) => (p.startsWith("/") || /^[A-Z]:/.test(p) ? p : join(tmpDir, p)),
     };
 
-    await expect(memoryHybridPlugin.register(mockApi as never)).resolves.toBeUndefined();
+    expect(memoryHybridPlugin.register(mockApi as never)).toBeUndefined();
     expect(api.registerTool).toHaveBeenCalled();
     expect(api.registerService).toHaveBeenCalled();
   });
 
-  it("help is deterministic even with invalid/unresolvable plugin config", async () => {
+  it("help is deterministic even with invalid/unresolvable plugin config", () => {
     process.argv = ["node", "openclaw", "hybrid-mem", "--help"];
     const api = makeMockApi();
     const mockApi = {
@@ -124,7 +124,7 @@ describe("hybrid-mem help invocations", () => {
       resolvePath: (p: string) => (p.startsWith("/") || /^[A-Z]:/.test(p) ? p : join(tmpDir, p)),
     };
 
-    await expect(memoryHybridPlugin.register(mockApi as never)).resolves.toBeUndefined();
+    expect(memoryHybridPlugin.register(mockApi as never)).toBeUndefined();
     expect(api.registerCli).toHaveBeenCalled();
     expect(api.registerTool).not.toHaveBeenCalled();
     expect(api.registerService).not.toHaveBeenCalled();

--- a/extensions/memory-hybrid/tests/plugin-e2e.test.ts
+++ b/extensions/memory-hybrid/tests/plugin-e2e.test.ts
@@ -42,7 +42,11 @@ function makeMockApi() {
     registerService: vi.fn((svc) => {
       registeredService = svc;
     }),
-    _stopRegisteredService: () => registeredService?.stop?.(),
+    _stopRegisteredService: async () => {
+      const serviceToStop = registeredService;
+      registeredService = null;
+      await serviceToStop?.stop?.();
+    },
     registerCli: vi.fn(),
     registerLifecycleHook: vi.fn(),
     registerHttpRoute: vi.fn(),

--- a/extensions/memory-hybrid/tests/plugin-e2e.test.ts
+++ b/extensions/memory-hybrid/tests/plugin-e2e.test.ts
@@ -163,7 +163,7 @@ describe("Plugin registration e2e", () => {
     expect(result).not.toBeInstanceOf(Promise);
   });
 
-  it("register() does not throw and core memory tools are registered", async () => {
+  it("register() does not throw and core memory tools are registered", () => {
     const pluginConfig = getMinimalConfig({
       sqlitePath: join(tmpDir, "facts.db"),
       lanceDbPath: join(tmpDir, "lancedb"),
@@ -174,7 +174,7 @@ describe("Plugin registration e2e", () => {
       registrationMode: "full" as const,
       resolvePath: (p: string) => (p.startsWith("/") || /^[A-Z]:/.test(p) ? p : join(tmpDir, p)),
     };
-    await expect(memoryHybridPlugin.register(mockApi as never)).resolves.toBeUndefined();
+    expect(memoryHybridPlugin.register(mockApi as never)).toBeUndefined();
 
     expect(mockApi.getTool("memory_store")).toBeDefined();
     expect(mockApi.getTool("memory_recall")).toBeDefined();

--- a/extensions/memory-hybrid/tests/plugin-e2e.test.ts
+++ b/extensions/memory-hybrid/tests/plugin-e2e.test.ts
@@ -144,8 +144,8 @@ describe("Plugin registration e2e", () => {
     resetPluginRegistrationStateForTests();
   });
 
-  afterEach(() => {
-    api._stopRegisteredService?.();
+  afterEach(async () => {
+    await api._stopRegisteredService?.();
     rmSync(tmpDir, { recursive: true, force: true });
     resetPluginRegistrationStateForTests();
   });
@@ -256,10 +256,10 @@ describe("Store and recall e2e (real FactsDB + VectorDB, mock embeddings)", () =
     api = makeMockApi();
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     vectorDb.close();
     factsDb.close();
-    api._stopRegisteredService?.();
+    await api._stopRegisteredService?.();
     rmSync(tmpDir, { recursive: true, force: true });
   });
 
@@ -449,8 +449,8 @@ describe("Init-databases e2e", () => {
     api = makeMockApi();
   });
 
-  afterEach(() => {
-    api._stopRegisteredService?.();
+  afterEach(async () => {
+    await api._stopRegisteredService?.();
     rmSync(tmpDir, { recursive: true, force: true });
   });
 
@@ -524,10 +524,10 @@ describe("Core and common flows e2e", () => {
     api = makeMockApi();
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     vectorDb.close();
     factsDb.close();
-    api._stopRegisteredService?.();
+    await api._stopRegisteredService?.();
     rmSync(tmpDir, { recursive: true, force: true });
   });
 
@@ -750,10 +750,10 @@ describe("Advanced features e2e", () => {
     api = makeMockApi();
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     vectorDb.close();
     factsDb.close();
-    api._stopRegisteredService?.();
+    await api._stopRegisteredService?.();
     rmSync(tmpDir, { recursive: true, force: true });
   });
 

--- a/extensions/memory-hybrid/tests/service-marker-cli-registration.test.ts
+++ b/extensions/memory-hybrid/tests/service-marker-cli-registration.test.ts
@@ -17,7 +17,7 @@ describe("CLI registration with service markers (Issue #1209 regression)", () =>
     process.env = { ...originalEnv };
   });
 
-  it("should register CLI metadata even when OPENCLAW_SERVICE_KIND is present", async () => {
+  it("should register CLI metadata even when OPENCLAW_SERVICE_KIND is present", () => {
     // Set service marker that would leak from gateway/service context
     process.env.OPENCLAW_SERVICE_KIND = "gateway";
 
@@ -46,7 +46,7 @@ describe("CLI registration with service markers (Issue #1209 regression)", () =>
     };
 
     // Call register with cli-metadata mode
-    await memoryHybridPlugin.register(mockApi as any);
+    expect(memoryHybridPlugin.register(mockApi as any)).toBeUndefined();
 
     // Verify CLI was registered despite service marker being present
     expect(cliRegistered).toBe(true);
@@ -54,7 +54,7 @@ describe("CLI registration with service markers (Issue #1209 regression)", () =>
     expect(cliDescriptors[0].name).toBe("hybrid-mem");
   });
 
-  it("should register CLI metadata even when OPENCLAW_SERVICE_MARKER is present", async () => {
+  it("should register CLI metadata even when OPENCLAW_SERVICE_MARKER is present", () => {
     // Set service marker
     process.env.OPENCLAW_SERVICE_MARKER = "1";
 
@@ -78,12 +78,12 @@ describe("CLI registration with service markers (Issue #1209 regression)", () =>
       context: undefined,
     };
 
-    await memoryHybridPlugin.register(mockApi as any);
+    expect(memoryHybridPlugin.register(mockApi as any)).toBeUndefined();
 
     expect(cliRegistered).toBe(true);
   });
 
-  it("should register CLI metadata when both service markers are present", async () => {
+  it("should register CLI metadata when both service markers are present", () => {
     // Set both markers (worst case scenario from leaked cron environment)
     process.env.OPENCLAW_SERVICE_KIND = "gateway";
     process.env.OPENCLAW_SERVICE_MARKER = "1";
@@ -108,12 +108,12 @@ describe("CLI registration with service markers (Issue #1209 regression)", () =>
       context: undefined,
     };
 
-    await memoryHybridPlugin.register(mockApi as any);
+    expect(memoryHybridPlugin.register(mockApi as any)).toBeUndefined();
 
     expect(cliRegistered).toBe(true);
   });
 
-  it("should still register CLI metadata when OPENCLAW_SKIP_HYBRID_MEMORY_CLI is present (shouldn't be set in normal cron)", async () => {
+  it("should still register CLI metadata when OPENCLAW_SKIP_HYBRID_MEMORY_CLI is present (shouldn't be set in normal cron)", () => {
     // This env var is specifically for skipping hybrid-mem CLI, but during cli-metadata
     // registration phase, even this should not prevent registration
     process.env.OPENCLAW_SKIP_HYBRID_MEMORY_CLI = "1";
@@ -138,7 +138,7 @@ describe("CLI registration with service markers (Issue #1209 regression)", () =>
       context: undefined,
     };
 
-    await memoryHybridPlugin.register(mockApi as any);
+    expect(memoryHybridPlugin.register(mockApi as any)).toBeUndefined();
 
     // Even with skip flag, CLI metadata should register
     // (the skip flag should only affect full registration, not metadata)


### PR DESCRIPTION
Closes #1773

Issue: https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/1773

Status: draft implementation PR created by Issue Stewardship as Markus/current gh auth.
Protection: keep as draft and `stage/implementing` until Issue Stewardship dispatches/receives implementation and explicitly hands off to PR Stewardship.

Enrichment present on issue: 0
Priority inherited from issue: High (source labels: priority:high)
Dependencies/blocked labels inherited from issue: none

Implementation PR created by Issue Stewardship. Detailed enrichment should be attached to the issue before Copilot implementation dispatch.


---

> [!NOTE]
> **Medium Risk**
> Includes a production runtime change in `setup/register-plugin.ts` in addition to test updates.
>
> **Overview**
> Fixes a deadlock introduced when `register()` was made synchronous: `blockReloadTeardownBeforeOpen()` used `Atomics.wait` in the Node.js main thread, which blocks **all** JS execution including microtasks and Promise callbacks. Since the teardown chain scheduled by `schedulePluginTeardown` relies on `.then()`/`.finally()` microtasks to signal completion, both sides waited on each other permanently. After `TEARDOWN_WAIT_MS` (6 s) the guard threw `"memory-hybrid: reload teardown did not drain before opening new databases"`, failing 6 CI tests in `comprehensive-e2e` and `plugin-e2e`.
>
> **Production change (`setup/register-plugin.ts`)**
> Removes the `blockReloadTeardownBeforeOpen(TEARDOWN_WAIT_MS)` guard and its now-unused imports (`blockReloadTeardownBeforeOpen`, `TEARDOWN_WAIT_MS`) from `runMemoryHybridRegister`. `schedulePluginTeardown` is preserved — async drain + DB close still runs fire-and-forget after `register()` returns. New DB handles are independent of old ones; existing stale-error guards (`shouldSuppressStaleLifecycleError` etc.) protect against in-flight errors on closed connections.
>
> **Test changes (`tests/`)**
> Updates **memory-hybrid** Vitest suites so they treat `memoryHybridPlugin.register()` as **synchronous**, matching OpenClaw's plugin contract. Help-path and CLI-metadata tests drop `async`/`await` and replace `await expect(...).resolves.toBeUndefined()` with direct `expect(...register(...)).toBeUndefined()`. Service-marker regression tests assert the same synchronous return.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes to registration assertions and teardown; no production behavior modified in this diff.
> 
> **Overview**
> Updates **memory-hybrid** Vitest suites so they match OpenClaw’s **synchronous** `memoryHybridPlugin.register()` contract: help-path, registration, and service-marker CLI tests no longer `async`/`await` registration and instead assert `register(...)` returns **`undefined`** (not a `Promise`).
> 
> In **plugin e2e** mocks, `_stopRegisteredService` is now **async**—it clears the registered service reference before `await`ing `stop()`—and multiple `afterEach` hooks **`await`** that cleanup so teardown doesn’t race the next test.
> 
> These are test-harness changes aligned with **#1773** (sync `register()`); they do not change production registration logic in the files shown in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9be1a09d3e171aba26df22704f09766c16808d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->