### PR TITLE
WIP: [Job20 QA] add actionable unresolved buckets to resolve-contradictions output (#1781)

### DIFF
--- a/extensions/memory-hybrid/backends/facts-db/contradictions.ts
+++ b/extensions/memory-hybrid/backends/facts-db/contradictions.ts
@@ -925,7 +925,7 @@ export async function resolveContradictionsAutonomously(
         if (applied) decisionsApplied++;
       }
       continue;
-    } else if (lww.eligible && isFactVerified(db, contradiction.factIdOld)) {
+    } else if (isFactVerified(db, contradiction.factIdOld)) {
       reviewItem.suggestedReason = "Older fact is verified; leaving for manual review.";
     }
 

--- a/extensions/memory-hybrid/cli/commands/manage/register-reflection-pipeline.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/register-reflection-pipeline.ts
@@ -1144,15 +1144,13 @@ export function registerManageReflectionPipeline(mem: Chainable, b: ManageBindin
             }
           }
           if (res.ambiguous.length > 0) {
-            let unresolvedBuckets:
-              | {
-                  safeDeterministic: number;
-                  possibleEntityReuse: number;
-                  olderVerified: number;
-                  humanRequired: number;
-                  otherManual: number;
-                }
-              | null = null;
+            let unresolvedBuckets: {
+              safeDeterministic: number;
+              possibleEntityReuse: number;
+              olderVerified: number;
+              humanRequired: number;
+              otherManual: number;
+            } | null = null;
             try {
               const preview = await ctx.runResolveContradictionsAuto({
                 dryRun: true,
@@ -1255,10 +1253,12 @@ export function registerManageReflectionPipeline(mem: Chainable, b: ManageBindin
             if (!details) {
               console.log("  3. Easier scan: openclaw hybrid-mem resolve-contradictions --details");
             }
+            let nextStepNumber = 4;
             if (unresolvedBuckets?.safeDeterministic && unresolvedBuckets.safeDeterministic > 0) {
               console.log(
-                `  4. Apply deterministic safe bucket (${unresolvedBuckets.safeDeterministic}): openclaw hybrid-mem resolve-contradictions --auto --apply`,
+                `  ${nextStepNumber}. Apply deterministic safe bucket (${unresolvedBuckets.safeDeterministic}): openclaw hybrid-mem resolve-contradictions --auto --apply`,
               );
+              nextStepNumber++;
             }
             const hasProjectStatePairs = res.ambiguous.some((a) => {
               const newF = factsDb.getById(a.factIdNew);
@@ -1270,7 +1270,7 @@ export function registerManageReflectionPipeline(mem: Chainable, b: ManageBindin
             });
             if (hasProjectStatePairs) {
               console.log(
-                "  5. Auto-resolve project-state: openclaw hybrid-mem resolve-contradictions --project-state-lww --dry-run",
+                `  ${nextStepNumber}. Auto-resolve project-state: openclaw hybrid-mem resolve-contradictions --project-state-lww --dry-run`,
               );
             }
           }

--- a/extensions/memory-hybrid/cli/commands/manage/register-reflection-pipeline.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/register-reflection-pipeline.ts
@@ -24,6 +24,8 @@ import {
 } from "./dream-cycle-followup.js";
 import { runMaintenanceHeartbeat } from "./maintenance-heartbeat.js";
 
+const CONTRADICTION_BUCKET_PREVIEW_TARGET_RATE = 0.8;
+
 function writeContradictionReviewFile(outputPath: string, items: ContradictionReviewItem[]): void {
   const content = `${items.map((item) => JSON.stringify(item)).join("\n")}${items.length > 0 ? "\n" : ""}`;
   writeFileSync(outputPath, content, "utf-8");
@@ -1142,6 +1144,58 @@ export function registerManageReflectionPipeline(mem: Chainable, b: ManageBindin
             }
           }
           if (res.ambiguous.length > 0) {
+            let unresolvedBuckets:
+              | {
+                  safeDeterministic: number;
+                  possibleEntityReuse: number;
+                  olderVerified: number;
+                  humanRequired: number;
+                  otherManual: number;
+                }
+              | null = null;
+            try {
+              const preview = await ctx.runResolveContradictionsAuto({
+                dryRun: true,
+                targetRate: CONTRADICTION_BUCKET_PREVIEW_TARGET_RATE,
+              });
+              let possibleEntityReuse = 0;
+              let olderVerified = 0;
+              let humanRequired = 0;
+              let otherManual = 0;
+              for (const item of preview.reviewItems) {
+                if (item.possibleOverloadedEntity) {
+                  possibleEntityReuse++;
+                  continue;
+                }
+                const reason = item.suggestedReason.toLowerCase();
+                if (reason.includes("older fact is verified")) {
+                  olderVerified++;
+                  continue;
+                }
+                if (reason.includes("no safe deterministic resolution matched")) {
+                  humanRequired++;
+                  continue;
+                }
+                otherManual++;
+              }
+              unresolvedBuckets = {
+                safeDeterministic: preview.deterministic,
+                possibleEntityReuse,
+                olderVerified,
+                humanRequired,
+                otherManual,
+              };
+            } catch (err) {
+              capturePluginError(err instanceof Error ? err : new Error(String(err)), {
+                subsystem: "cli",
+                operation: "resolve-contradictions-bucket-preview",
+              });
+              const message = err instanceof Error ? err.message : String(err);
+              console.error(
+                `Warning: could not generate unresolved_by_reason bucket preview (${message}). Check database state and rerun if needed.`,
+              );
+            }
+
             const trunc = (s: string | null | undefined, n: number): string => {
               if (s == null || s === "") return "(empty)";
               const t = s.replace(/\s+/g, " ").trim();
@@ -1175,6 +1229,16 @@ export function registerManageReflectionPipeline(mem: Chainable, b: ManageBindin
             if (!verbose && !details && res.ambiguous.length > 10) {
               console.log(`  ...and ${res.ambiguous.length - 10} more`);
             }
+            if (unresolvedBuckets) {
+              console.log("unresolved_by_reason:");
+              console.log(`  safe_deterministic_auto=${unresolvedBuckets.safeDeterministic}`);
+              console.log(`  possible_entity_reuse=${unresolvedBuckets.possibleEntityReuse}`);
+              console.log(`  older_verified=${unresolvedBuckets.olderVerified}`);
+              console.log(`  human_required=${unresolvedBuckets.humanRequired}`);
+              if (unresolvedBuckets.otherManual > 0) {
+                console.log(`  other_manual=${unresolvedBuckets.otherManual}`);
+              }
+            }
             console.log("");
             console.log(
               "What this means: each line is two stored facts with the same entity and key but different values. " +
@@ -1191,6 +1255,11 @@ export function registerManageReflectionPipeline(mem: Chainable, b: ManageBindin
             if (!details) {
               console.log("  3. Easier scan: openclaw hybrid-mem resolve-contradictions --details");
             }
+            if (unresolvedBuckets?.safeDeterministic && unresolvedBuckets.safeDeterministic > 0) {
+              console.log(
+                `  4. Apply deterministic safe bucket (${unresolvedBuckets.safeDeterministic}): openclaw hybrid-mem resolve-contradictions --auto --apply`,
+              );
+            }
             const hasProjectStatePairs = res.ambiguous.some((a) => {
               const newF = factsDb.getById(a.factIdNew);
               const oldF = factsDb.getById(a.factIdOld);
@@ -1201,7 +1270,7 @@ export function registerManageReflectionPipeline(mem: Chainable, b: ManageBindin
             });
             if (hasProjectStatePairs) {
               console.log(
-                "  4. Auto-resolve project-state: openclaw hybrid-mem resolve-contradictions --project-state-lww --dry-run",
+                "  5. Auto-resolve project-state: openclaw hybrid-mem resolve-contradictions --project-state-lww --dry-run",
               );
             }
           }

--- a/extensions/memory-hybrid/docs/contradiction-detection.md
+++ b/extensions/memory-hybrid/docs/contradiction-detection.md
@@ -101,6 +101,13 @@ Contradicted facts naturally rank lower due to reduced confidence, which flows t
    - From an explicit user store (`source = 'conversation'` or `'cli'`)
 3. Returns **ambiguous** pairs for future LLM resolution (#143 Dream Cycle).
 
+When ambiguous pairs remain, the CLI now also prints `unresolved_by_reason` buckets so operators can quickly see:
+
+- how many pairs are in the deterministic safe bucket (`--auto --apply`)
+- likely entity-reuse conflicts
+- verified-older-fact conflicts
+- genuinely human-required conflicts
+
 ### Return value
 
 ```typescript

--- a/extensions/memory-hybrid/tests/resolve-contradictions-cli.test.ts
+++ b/extensions/memory-hybrid/tests/resolve-contradictions-cli.test.ts
@@ -449,4 +449,42 @@ describe("resolve-contradictions CLI contract mode", () => {
     expect(lines).toContain("  - Contradiction c-2: already resolved.");
     expect(lines).toContain("  - Contradiction c-3: row not found.");
   });
+
+  it("prints unresolved ambiguity buckets with deterministic actionable count", async () => {
+    const runResolveContradictions = vi.fn().mockResolvedValue({
+      autoResolved: [],
+      ambiguous: [{ contradictionId: "c-1", factIdNew: "new-1", factIdOld: "old-1" }],
+    });
+    const runResolveContradictionsAuto = vi.fn().mockResolvedValue({
+      total: 1,
+      deterministic: 1,
+      llm: 0,
+      merged: 0,
+      manualReview: 0,
+      applied: false,
+      decisionsApplied: 0,
+      targetRate: 0.8,
+      achievedRate: 1,
+      targetMet: true,
+      reviewItems: [],
+    });
+    const mem = makeProgram(makeBindings({ runResolveContradictions, runResolveContradictionsAuto }));
+    const lines: string[] = [];
+    vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+      lines.push(args.map((a) => String(a)).join(" "));
+    });
+
+    await mem.parseAsync(["resolve-contradictions"], { from: "user" });
+
+    expect(lines).toContain("unresolved_by_reason:");
+    expect(lines).toContain("  safe_deterministic_auto=1");
+    expect(lines).toContain("  possible_entity_reuse=0");
+    expect(lines).toContain("  older_verified=0");
+    expect(lines).toContain("  human_required=0");
+    expect(
+      lines.some((l) =>
+        l.includes("Apply deterministic safe bucket (1): openclaw hybrid-mem resolve-contradictions --auto --apply"),
+      ),
+    ).toBe(true);
+  });
 });


### PR DESCRIPTION
Issue: https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/1781

Status: draft implementation completed on the existing PR branch.
Protection: keep as draft and `stage/implementing` until explicit handoff to PR Stewardship.

Enrichment present on issue: 0
Priority inherited from issue: High (source labels: priority:high)
Dependencies/blocked labels inherited from issue: none

## What was implemented

Focused implementation for the ambiguity backlog in `resolve-contradictions`:

- Added actionable `unresolved_by_reason` bucket reporting in default `resolve-contradictions` output.
- Added deterministic-safe bucket guidance with an explicit next-step command:
  - `openclaw hybrid-mem resolve-contradictions --auto --apply`
- Kept existing behavior outside issue scope; this extends reporting/actionability rather than broadening resolution semantics.
- Added targeted test coverage for unresolved bucket output:
  - `extensions/memory-hybrid/tests/resolve-contradictions-cli.test.ts`
- Updated related docs:
  - `extensions/memory-hybrid/docs/contradiction-detection.md`

## Validation

- `npm run test -- --reporter=verbose tests/resolve-contradictions-cli.test.ts`
- `npm run test -- --reporter=verbose tests/contradiction-detection.test.ts`
- `npm run build`
- Parallel validation run (Code Review + CodeQL)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Reporting and a narrow reason-label tweak on the contradiction CLI; resolution apply paths are unchanged except clearer operator guidance.
> 
> **Overview**
> When **`resolve-contradictions`** still has ambiguous pairs, the CLI now runs a **dry-run autonomous preview** and prints **`unresolved_by_reason`** counts (deterministic-safe, entity-reuse, verified-older, human-required, other) plus a **numbered next step** to run **`--auto --apply`** when the safe bucket is non-empty.
> 
> In **`resolveContradictionsAutonomously`**, pairs whose **older fact is verified** always get the manual-review reason **without requiring project-state LWW eligibility**, so verified conflicts bucket correctly in that preview.
> 
> Docs and a **CLI test** cover the new output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 508c1208e2e377fa91f990ffd1358af935ee62f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->