### PR TITLE
fix: weekly-persona-proposals masks generate-proposals LLM failure as SUCCESS with zero proposals

### DIFF
--- a/extensions/memory-hybrid/cli/cmd-extract-proposals.ts
+++ b/extensions/memory-hybrid/cli/cmd-extract-proposals.ts
@@ -177,11 +177,10 @@ export async function runGenerateProposalsForCli(
     rawResponse = detail.content;
   } catch (err) {
     const errMsg = err instanceof Error ? err.message : String(err);
-    const attemptedFallbacks = JSON.stringify(fallbackModels);
-    const failureMessage = `memory-hybrid: generate-proposals failed after model=${model}, fallbacks=${attemptedFallbacks}: ${errMsg}`;
-    console.error(
-      `memory-hybrid: generate-proposals LLM call failed (model=${model}, fallbacks=${attemptedFallbacks}): ${errMsg}`,
-    );
+    const failureMessage = `memory-hybrid: generate-proposals LLM call failed (model=${model}, fallbacks=${JSON.stringify(
+      fallbackModels,
+    )}): ${errMsg}`;
+    console.error(failureMessage);
     capturePluginError(err instanceof Error ? err : new Error(String(err)), {
       subsystem: "cli",
       operation: "runGenerateProposalsForCli:llm",

--- a/extensions/memory-hybrid/cli/cmd-extract-proposals.ts
+++ b/extensions/memory-hybrid/cli/cmd-extract-proposals.ts
@@ -177,16 +177,16 @@ export async function runGenerateProposalsForCli(
     rawResponse = detail.content;
   } catch (err) {
     const errMsg = err instanceof Error ? err.message : String(err);
+    const attemptedFallbacks = JSON.stringify(fallbackModels);
+    const failureMessage = `memory-hybrid: generate-proposals failed after model=${model}, fallbacks=${attemptedFallbacks}: ${errMsg}`;
     console.error(
-      `memory-hybrid: generate-proposals LLM call failed (model=${model}, fallbacks=${JSON.stringify(
-        fallbackModels,
-      )}): ${errMsg}`,
+      `memory-hybrid: generate-proposals LLM call failed (model=${model}, fallbacks=${attemptedFallbacks}): ${errMsg}`,
     );
     capturePluginError(err instanceof Error ? err : new Error(String(err)), {
       subsystem: "cli",
       operation: "runGenerateProposalsForCli:llm",
     });
-    return { created: 0 };
+    throw new Error(failureMessage);
   }
   let items: Array<{
     targetFile: string;

--- a/extensions/memory-hybrid/tests/generate-proposals-cli-status.test.ts
+++ b/extensions/memory-hybrid/tests/generate-proposals-cli-status.test.ts
@@ -1,0 +1,70 @@
+import { Command } from "commander";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { registerDistillCommands, type DistillContext } from "../cli/distill.js";
+
+function makeDistillContext(
+  overrides: Partial<DistillContext> & Required<Pick<DistillContext, "runGenerateProposals">>,
+): DistillContext {
+  return {
+    runDistillWindow: vi.fn(async () => ({ mode: "full", startDate: "2026-01-01", endDate: "2026-01-02", mtimeDays: 1 })),
+    runRecordDistill: vi.fn(async () => ({ timestamp: "2026-01-01T00:00:00.000Z", path: ".distill_last_run" })),
+    runExtractDaily: vi.fn(async () => ({ dryRun: false, totalExtracted: 0, totalStored: 0, daysBack: 7 })),
+    runExtractProcedures: vi.fn(async () => ({
+      dryRun: false,
+      sessionsScanned: 0,
+      proceduresStored: 0,
+      positiveCount: 0,
+      negativeCount: 0,
+    })),
+    runGenerateAutoSkills: vi.fn(async () => ({ dryRun: false, generated: 0, skipped: 0, paths: [] })),
+    runDistill: vi.fn(async () => ({ dryRun: false, factsExtracted: 0, sessionsScanned: 0, stored: 0, dedupSkipped: 0 })),
+    runExtractDirectives: vi.fn(async () => ({ incidents: [], sessionsScanned: 0 })),
+    runExtractReinforcement: vi.fn(async () => ({ incidents: [], sessionsScanned: 0, annotationStatus: "ok" })),
+    runGenerateProposals: overrides.runGenerateProposals,
+    ...overrides,
+  } as DistillContext;
+}
+
+describe("generate-proposals CLI status", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    process.exitCode = undefined;
+  });
+
+  it("keeps healthy zero-proposal runs successful", async () => {
+    const mem = new Command("hybrid-mem");
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    registerDistillCommands(
+      mem,
+      makeDistillContext({
+        runGenerateProposals: vi.fn(async () => ({ created: 0 })),
+      }),
+    );
+
+    await mem.parseAsync(["generate-proposals"], { from: "user" });
+
+    expect(logSpy).toHaveBeenCalledWith("\nCreated 0 proposal(s).");
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it("does not report healthy zero-proposal success when generation fails", async () => {
+    const mem = new Command("hybrid-mem");
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    registerDistillCommands(
+      mem,
+      makeDistillContext({
+        runGenerateProposals: vi.fn(async () => {
+          throw new Error("memory-hybrid: generate-proposals LLM call failed");
+        }),
+      }),
+    );
+
+    await expect(mem.parseAsync(["generate-proposals"], { from: "user" })).rejects.toThrow(
+      "memory-hybrid: generate-proposals LLM call failed",
+    );
+    expect(logSpy).not.toHaveBeenCalledWith("\nCreated 0 proposal(s).");
+  });
+});

--- a/extensions/memory-hybrid/tests/generate-proposals-cli-status.test.ts
+++ b/extensions/memory-hybrid/tests/generate-proposals-cli-status.test.ts
@@ -1,5 +1,5 @@
 import { Command } from "commander";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { registerDistillCommands, type DistillContext } from "../cli/distill.js";
 
 function makeDistillContext(
@@ -26,14 +26,19 @@ function makeDistillContext(
 }
 
 describe("generate-proposals CLI status", () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
   afterEach(() => {
     vi.restoreAllMocks();
     process.exitCode = undefined;
   });
 
-  it("keeps healthy zero-proposal runs successful", async () => {
+  it("should exit successfully when zero proposals are generated", async () => {
     const mem = new Command("hybrid-mem");
-    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
 
     registerDistillCommands(
       mem,
@@ -48,9 +53,8 @@ describe("generate-proposals CLI status", () => {
     expect(process.exitCode).toBeUndefined();
   });
 
-  it("does not report healthy zero-proposal success when generation fails", async () => {
+  it("should throw error when proposal generation fails", async () => {
     const mem = new Command("hybrid-mem");
-    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     vi.spyOn(console, "error").mockImplementation(() => {});
 
     registerDistillCommands(

--- a/extensions/memory-hybrid/tests/generate-proposals-cli-status.test.ts
+++ b/extensions/memory-hybrid/tests/generate-proposals-cli-status.test.ts
@@ -5,8 +5,15 @@ import { registerDistillCommands, type DistillContext } from "../cli/distill.js"
 function makeDistillContext(
   overrides: Partial<DistillContext> & Required<Pick<DistillContext, "runGenerateProposals">>,
 ): DistillContext {
+  const { runGenerateProposals, ...contextOverrides } = overrides;
+
   return {
-    runDistillWindow: vi.fn(async () => ({ mode: "full", startDate: "2026-01-01", endDate: "2026-01-02", mtimeDays: 1 })),
+    runDistillWindow: vi.fn(async () => ({
+      mode: "full",
+      startDate: "2026-01-01",
+      endDate: "2026-01-02",
+      mtimeDays: 1,
+    })),
     runRecordDistill: vi.fn(async () => ({ timestamp: "2026-01-01T00:00:00.000Z", path: ".distill_last_run" })),
     runExtractDaily: vi.fn(async () => ({ dryRun: false, totalExtracted: 0, totalStored: 0, daysBack: 7 })),
     runExtractProcedures: vi.fn(async () => ({
@@ -17,11 +24,17 @@ function makeDistillContext(
       negativeCount: 0,
     })),
     runGenerateAutoSkills: vi.fn(async () => ({ dryRun: false, generated: 0, skipped: 0, paths: [] })),
-    runDistill: vi.fn(async () => ({ dryRun: false, factsExtracted: 0, sessionsScanned: 0, stored: 0, dedupSkipped: 0 })),
+    runDistill: vi.fn(async () => ({
+      dryRun: false,
+      factsExtracted: 0,
+      sessionsScanned: 0,
+      stored: 0,
+      dedupSkipped: 0,
+    })),
     runExtractDirectives: vi.fn(async () => ({ incidents: [], sessionsScanned: 0 })),
     runExtractReinforcement: vi.fn(async () => ({ incidents: [], sessionsScanned: 0, annotationStatus: "ok" })),
-    runGenerateProposals: overrides.runGenerateProposals,
-    ...overrides,
+    ...contextOverrides,
+    runGenerateProposals,
   } as DistillContext;
 }
 


### PR DESCRIPTION
<!-- issue-stewardship-pr issue:1787 -->
Refs #1787

Issue: https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/1787

Status: draft implementation PR created by Issue Stewardship as Markus/current gh auth.
Protection: keep as draft and `stage/implementing` until Issue Stewardship dispatches/receives implementation and explicitly hands off to PR Stewardship.

Enrichment present on issue: 0  
Priority inherited from issue: Critical (source labels: priority:critical)  
Dependencies/blocked labels inherited from issue: none

Implementation PR created by Issue Stewardship. Detailed enrichment should be attached to the issue before Copilot implementation dispatch.

### Implementation update

Implemented the issue behavior fix on this branch:

- Updated `runGenerateProposalsForCli` (`extensions/memory-hybrid/cli/cmd-extract-proposals.ts`) so an LLM call failure no longer returns `{ created: 0 }`.
- The command now logs the failure (including model and fallback chain) and throws, allowing cron/maintenance wrappers to surface a non-success outcome instead of masking it as a healthy zero-proposal run.
- Added focused tests in `extensions/memory-hybrid/tests/generate-proposals-cli-status.test.ts` to distinguish:
  - healthy zero-proposal success (`Created 0 proposal(s)`), and
  - failed zero-proposal generation (error path, no false healthy-success message).

### Validation

- Targeted tests for the new behavior pass.
- Related maintenance test pass.
- Build passes.

---

&gt; [!NOTE]
&gt;<sup><a href="https://cursor.com/bugbot">Cursor Bugbot</a> may still show an earlier commit summary in this draft PR view.</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrows error handling for one CLI path; improves observability for weekly persona/cron jobs without touching auth or data stores.
> 
> **Overview**
> **`generate-proposals` no longer treats LLM failures as a successful zero-proposal run.** When the proposals LLM call fails, `runGenerateProposalsForCli` still logs (with model and fallback chain) and reports the error, but now **throws** with that message instead of returning `{ created: 0 }`, so cron and maintenance wrappers can fail visibly.
> 
> New CLI tests cover the **`generate-proposals`** distill command: a healthy run with zero proposals still prints `Created 0 proposal(s)` and exits cleanly, while a thrown failure does not print that success line.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6baf9b1ec6a22bc32cc977ee82a6ecc9ad0c7709. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

