### PR TITLE
fix(dream-cycle): exit 0 on core success despite follow-up failure; durable stage artifacts

### DIFF
--- a/extensions/memory-hybrid/services/dream-cycle.ts
+++ b/extensions/memory-hybrid/services/dream-cycle.ts
@@ -143,6 +143,17 @@ const MIN_PATTERNS_FOR_RULES = 3;
 export const DEFAULT_MAX_EVENTS_PER_CONSOLIDATION = 200;
 const DREAM_STAGE_HEARTBEAT_MS = 60_000;
 const EPISODIC_PROGRESS_HEARTBEAT_MS = 60_000;
+/** Maximum characters used from the stage label in artifact filenames (Issue #1827). */
+const STAGE_LABEL_MAX_LENGTH = 60;
+
+/**
+ * Returns a run identifier string that encodes the UTC timestamp and process PID,
+ * suitable for directory names and artifact fields (Issue #1827).
+ * Format: `YYYYMMDDTHHmmss`Z-`<pid>` e.g. `20260602T061400Z-12345`.
+ */
+export function makeDreamCycleRunId(): string {
+  return `${new Date().toISOString().replace(/[:.]/g, "").slice(0, 15)}Z-${process.pid}`;
+}
 const EPISODIC_PROGRESS_GROUP_INTERVAL = 25;
 const SKIP_CONSOLIDATION_TEXT_PATTERNS = new Set([
   "heartbeat",
@@ -616,7 +627,7 @@ export async function runDreamCycle(
   logger.info("memory-hybrid: dream-cycle — starting nightly cycle");
   const cycleStartedAt = Date.now();
   const v = !!config.verbose;
-  const runId = `${new Date().toISOString().replace(/[:.]/g, "").slice(0, 15)}Z-${process.pid}`;
+  const runId = makeDreamCycleRunId();
   // Ensure stage artifact dir exists when configured.
   if (config.stageArtifactDir) {
     try {
@@ -632,7 +643,7 @@ export async function runDreamCycle(
         .replace(/[^a-zA-Z0-9]+/g, "-")
         .replace(/^-|-$/g, "")
         .toLowerCase()
-        .slice(0, 60);
+        .slice(0, STAGE_LABEL_MAX_LENGTH);
       const filename = `stage-${String(stageNumber).padStart(2, "0")}-${sanitized}.json`;
       const filePath = join(config.stageArtifactDir, filename);
       writeFileSync(filePath, JSON.stringify({ runId, stage: label, stageNumber, ...payload }, null, 2));

--- a/extensions/memory-hybrid/services/dream-cycle.ts
+++ b/extensions/memory-hybrid/services/dream-cycle.ts
@@ -10,7 +10,7 @@
  * Self-contained — does not require an active agent session.
  */
 
-import { mkdirSync, writeFileSync } from "node:fs";
+import { mkdirSync } from "node:fs";
 import { join } from "node:path";
 import type OpenAI from "openai";
 import type { EventLog, EventLogEntry, EventType } from "../backends/event-log.js";
@@ -18,6 +18,7 @@ import type { FactsDB } from "../backends/facts-db.js";
 import type { VectorDB } from "../backends/vector-db.js";
 import type { MemoryCategory, MemoryEntry } from "../types/memory.js";
 import { CONSOLIDATED_FACT_DECAY_CLASS } from "../utils/consolidation-controls.js";
+import { atomicWriteFile } from "../utils/atomic-write.js";
 import type { EmbeddingProvider } from "./embeddings.js";
 import { capturePluginError } from "./error-reporter.js";
 import { writeMemoryIndex } from "./memory-index.js";
@@ -149,10 +150,10 @@ const STAGE_LABEL_MAX_LENGTH = 60;
 /**
  * Returns a run identifier string that encodes the UTC timestamp and process PID,
  * suitable for directory names and artifact fields (Issue #1827).
- * Format: `YYYYMMDDTHHmmss`Z-`<pid>` e.g. `20260602T061400Z-12345`.
+ * Format: `YYYYMMDDTHHmmssZ<pid>` e.g. `20260602T061400Z12345`.
  */
 export function makeDreamCycleRunId(): string {
-  return `${new Date().toISOString().replace(/[:.]/g, "").slice(0, 15)}Z-${process.pid}`;
+  return `${new Date().toISOString().replace(/[-:]/g, "").replace(/\.\d{3}Z$/, "Z")}${process.pid}`;
 }
 const EPISODIC_PROGRESS_GROUP_INTERVAL = 25;
 const SKIP_CONSOLIDATION_TEXT_PATTERNS = new Set([
@@ -646,7 +647,7 @@ export async function runDreamCycle(
         .slice(0, STAGE_LABEL_MAX_LENGTH);
       const filename = `stage-${String(stageNumber).padStart(2, "0")}-${sanitized}.json`;
       const filePath = join(config.stageArtifactDir, filename);
-      writeFileSync(filePath, JSON.stringify({ runId, stage: label, stageNumber, ...payload }, null, 2));
+      atomicWriteFile(filePath, JSON.stringify({ runId, stage: label, stageNumber, ...payload }, null, 2));
     } catch {
       // Artifact write failures are non-fatal.
     }
@@ -657,7 +658,7 @@ export async function runDreamCycle(
     opts?: { heartbeat?: boolean; progressSupplier?: () => string | undefined },
   ): {
     complete: (summary?: string) => void;
-    fail: (err: unknown) => void;
+    fail: (err: unknown, summary?: string) => void;
   } => {
     const stageNumber = ++stageCounter;
     const startedAt = Date.now();
@@ -692,7 +693,7 @@ export async function runDreamCycle(
           ...(summary != null ? { summary } : {}),
         });
       },
-      fail: (err: unknown) => {
+      fail: (err: unknown, summary?: string) => {
         clearHeartbeat();
         const elapsedSec = Math.floor((Date.now() - startedAt) / 1000);
         logger.warn(`memory-hybrid: dream-cycle — stage ${stageNumber} failed after ${elapsedSec}s: ${label}: ${err}`);
@@ -702,6 +703,7 @@ export async function runDreamCycle(
           completedAt: new Date().toISOString(),
           elapsedSec,
           error: String(err),
+          ...(summary != null ? { summary } : {}),
         });
       },
     };
@@ -722,6 +724,7 @@ export async function runDreamCycle(
 
   // ── Stage 1: Core pruning / decay / graph-vector maintenance ─────────────
   const stageCore = beginStage("core prune/decay/link/vector maintenance");
+  let stageCoreError: unknown;
   let factsPruned = 0;
   let factsDecayed = 0;
   if (config.pruneMode === "expired" || config.pruneMode === "both") {
@@ -739,6 +742,7 @@ export async function runDreamCycle(
         );
       }
     } catch (err) {
+      stageCoreError ??= err;
       logger.warn(`memory-hybrid: dream-cycle — pruneExpired failed: ${err}`);
       capturePluginError(err instanceof Error ? err : new Error(String(err)), {
         operation: "dream-cycle-prune-expired",
@@ -769,6 +773,7 @@ export async function runDreamCycle(
         );
       }
     } catch (err) {
+      stageCoreError ??= err;
       logger.warn(`memory-hybrid: dream-cycle — reclassifyDecayClasses failed: ${err}`);
       capturePluginError(err instanceof Error ? err : new Error(String(err)), {
         operation: "dream-cycle-reclassify-decay",
@@ -794,6 +799,7 @@ export async function runDreamCycle(
         );
       }
     } catch (err) {
+      stageCoreError ??= err;
       logger.warn(`memory-hybrid: dream-cycle — decayConfidence failed: ${err}`);
       capturePluginError(err instanceof Error ? err : new Error(String(err)), {
         operation: "dream-cycle-decay",
@@ -810,6 +816,7 @@ export async function runDreamCycle(
       logger.info(`memory-hybrid: dream-cycle — pruned ${linksPruned} orphaned link(s)`);
     }
   } catch (err) {
+    stageCoreError ??= err;
     logger.warn(`memory-hybrid: dream-cycle — pruneOrphanedLinks failed: ${err}`);
     capturePluginError(err instanceof Error ? err : new Error(String(err)), {
       operation: "dream-cycle-prune-orphaned-links",
@@ -829,6 +836,7 @@ export async function runDreamCycle(
         logger.info(`memory-hybrid: dream-cycle — refreshed fact degrees for ${result.updated} facts`);
       }
     } catch (err) {
+      stageCoreError ??= err;
       logger.warn(`memory-hybrid: dream-cycle — refreshFactDegrees failed: ${err}`);
       capturePluginError(err instanceof Error ? err : new Error(String(err)), {
         operation: "dream-cycle-refresh-degrees",
@@ -874,6 +882,7 @@ export async function runDreamCycle(
       }
     }
   } catch (err) {
+    stageCoreError ??= err;
     logger.warn(`memory-hybrid: dream-cycle — vector reconciliation failed: ${err}`);
     capturePluginError(err instanceof Error ? err : new Error(String(err)), {
       operation: "dream-cycle-vector-reconcile",
@@ -881,14 +890,18 @@ export async function runDreamCycle(
     });
   }
   vectorReconcileStep.complete(`removed=${orphanVectorsRemoved}`);
-  stageCore.complete(
-    `factsPruned=${factsPruned}, factsDecayed=${factsDecayed}, linksPruned=${linksPruned}, decayReclassified=${decayReclassified}, orphanVectorsRemoved=${orphanVectorsRemoved}`,
-  );
+  {
+    const summary =
+      `factsPruned=${factsPruned}, factsDecayed=${factsDecayed}, linksPruned=${linksPruned}, decayReclassified=${decayReclassified}, orphanVectorsRemoved=${orphanVectorsRemoved}`;
+    if (stageCoreError === undefined) stageCore.complete(summary);
+    else stageCore.fail(stageCoreError, summary);
+  }
 
   // ── Stage 2: Episodic consolidation + event log maintenance ──────────────
   let eventsConsolidated = 0;
   let factsCreated = 0;
   let eventLogPhase = "consolidation";
+  let stageEventLogError: unknown;
   const stageEventLog = beginStage("episodic consolidation + event log maintenance", {
     heartbeat: true,
     progressSupplier: () =>
@@ -910,6 +923,7 @@ export async function runDreamCycle(
       eventsConsolidated = consolidationResult.eventsConsolidated;
       factsCreated = consolidationResult.factsCreated;
     } catch (err) {
+      stageEventLogError ??= err;
       logger.warn(`memory-hybrid: dream-cycle — consolidation step failed: ${err}`);
       capturePluginError(err instanceof Error ? err : new Error(String(err)), {
         operation: "dream-cycle-consolidation",
@@ -931,6 +945,7 @@ export async function runDreamCycle(
         );
       }
     } catch (err) {
+      stageEventLogError ??= err;
       logger.warn(`memory-hybrid: dream-cycle — archiveConsolidated failed: ${err}`);
       capturePluginError(err instanceof Error ? err : new Error(String(err)), {
         operation: "dream-cycle-archive",
@@ -950,6 +965,7 @@ export async function runDreamCycle(
         );
       }
     } catch (err) {
+      stageEventLogError ??= err;
       logger.warn(`memory-hybrid: dream-cycle — archiveOld failed: ${err}`);
       capturePluginError(err instanceof Error ? err : new Error(String(err)), {
         operation: "dream-cycle-archive-old",
@@ -957,10 +973,15 @@ export async function runDreamCycle(
       });
     }
   }
-  stageEventLog.complete(`eventsConsolidated=${eventsConsolidated}, factsCreated=${factsCreated}`);
+  {
+    const summary = `eventsConsolidated=${eventsConsolidated}, factsCreated=${factsCreated}`;
+    if (stageEventLogError === undefined) stageEventLog.complete(summary);
+    else stageEventLog.fail(stageEventLogError, summary);
+  }
 
   // ── Stage 3: Reflection (patterns) ────────────────────────────────────────
   let patternsFound = 0;
+  let stageReflectionError: unknown;
   const stageReflection = beginStage("reflection (patterns)", {
     heartbeat: true,
     progressSupplier: () => `phase=extract-patterns; patternsStored=${patternsFound}`,
@@ -990,13 +1011,18 @@ export async function runDreamCycle(
     patternsFound = reflectionResult.patternsStored;
     logger.info(`memory-hybrid: dream-cycle — reflection complete: ${patternsFound} patterns stored`);
   } catch (err) {
+    stageReflectionError ??= err;
     logger.warn(`memory-hybrid: dream-cycle — reflection step failed: ${err}`);
     capturePluginError(err instanceof Error ? err : new Error(String(err)), {
       operation: "dream-cycle-reflect",
       subsystem: "reflection",
     });
   }
-  stageReflection.complete(`patternsStored=${patternsFound}`);
+  {
+    const summary = `patternsStored=${patternsFound}`;
+    if (stageReflectionError === undefined) stageReflection.complete(summary);
+    else stageReflection.fail(stageReflectionError, summary);
+  }
 
   const livePatternCountForRules = countActivePatternFactsForMaintenance(factsDb);
   const patternGateForRules = Math.max(patternsFound, livePatternCountForRules);
@@ -1006,6 +1032,7 @@ export async function runDreamCycle(
   let reflectionRulesDiagnostics: DreamCycleResult["reflectionRulesDiagnostics"];
   const enableReflectionRules = config.enableReflectionRules !== false; // default: true
   if (enableReflectionRules && patternGateForRules >= MIN_PATTERNS_FOR_RULES) {
+    let stageReflectRulesError: unknown;
     const stageReflectRules = beginStage("reflect-rules", {
       heartbeat: true,
       progressSupplier: () => `phase=extract-rules; rulesStored=${rulesGenerated}`,
@@ -1026,6 +1053,7 @@ export async function runDreamCycle(
         `memory-hybrid: dream-cycle — reflect-rules complete: ${rulesGenerated} rules stored (status=${rulesResult.diagnostics.status}${rulesResult.diagnostics.zeroRulesReason ? `, zero_rules_reason=${rulesResult.diagnostics.zeroRulesReason}` : ""})`,
       );
     } catch (err) {
+      stageReflectRulesError ??= err;
       logger.warn(`memory-hybrid: dream-cycle — reflect-rules step failed: ${err}`);
       capturePluginError(err instanceof Error ? err : new Error(String(err)), {
         operation: "dream-cycle-reflect-rules",
@@ -1042,7 +1070,11 @@ export async function runDreamCycle(
         status: "degraded",
       };
     }
-    stageReflectRules.complete(`rulesStored=${rulesGenerated}`);
+    {
+      const summary = `rulesStored=${rulesGenerated}`;
+      if (stageReflectRulesError === undefined) stageReflectRules.complete(summary);
+      else stageReflectRules.fail(stageReflectRulesError, summary);
+    }
   } else if (!enableReflectionRules) {
     reflectionRulesDiagnostics = {
       modelResponseChars: 0,
@@ -1076,6 +1108,7 @@ export async function runDreamCycle(
   }
 
   // ── Stage 5: Refresh memory awareness index ───────────────────────────────
+  let stageMemoryIndexError: unknown;
   const stageMemoryIndex = beginStage("MEMORY_INDEX.md refresh", {
     heartbeat: true,
     progressSupplier: () => "phase=refresh-index",
@@ -1093,18 +1126,21 @@ export async function runDreamCycle(
       logger,
     );
   } catch (err) {
+    stageMemoryIndexError ??= err;
     logger.warn(`memory-hybrid: dream-cycle — memory index update failed: ${err}`);
     capturePluginError(err instanceof Error ? err : new Error(String(err)), {
       operation: "dream-cycle-memory-index",
       subsystem: "reflection",
     });
   }
-  stageMemoryIndex.complete();
+  if (stageMemoryIndexError === undefined) stageMemoryIndex.complete();
+  else stageMemoryIndex.fail(stageMemoryIndexError);
 
   // ── Stage 6: Operational table/index cleanup ──────────────────────────────
   let logRowsPruned = 0;
   let vacuumRan = false;
   let walCheckpointRan = false;
+  let stageOperationalError: unknown;
   const stageOperational = beginStage("prune operational logs + FTS optimize + optional vacuum", {
     heartbeat: true,
     progressSupplier: () =>
@@ -1119,6 +1155,7 @@ export async function runDreamCycle(
         );
       }
     } catch (err) {
+      stageOperationalError ??= err;
       logger.warn(`memory-hybrid: dream-cycle — pruneLogTables failed: ${err}`);
       capturePluginError(err instanceof Error ? err : new Error(String(err)), {
         operation: "dream-cycle-prune-log-tables",
@@ -1133,6 +1170,7 @@ export async function runDreamCycle(
     factsDb.optimizeFts();
     logger.info("memory-hybrid: dream-cycle — FTS5 index optimized");
   } catch (err) {
+    stageOperationalError ??= err;
     logger.warn(`memory-hybrid: dream-cycle — optimizeFts failed: ${err}`);
     capturePluginError(err instanceof Error ? err : new Error(String(err)), {
       operation: "dream-cycle-optimize-fts",
@@ -1164,6 +1202,7 @@ export async function runDreamCycle(
         );
       }
     } catch (err) {
+      stageOperationalError ??= err;
       logger.warn(`memory-hybrid: dream-cycle — vacuumAndCheckpoint failed: ${err}`);
       capturePluginError(err instanceof Error ? err : new Error(String(err)), {
         operation: "dream-cycle-vacuum",
@@ -1172,9 +1211,12 @@ export async function runDreamCycle(
     }
     vacuumStep.complete(`vacuumRan=${vacuumRan ? "yes" : "no"}, walCheckpointRan=${walCheckpointRan ? "yes" : "no"}`);
   }
-  stageOperational.complete(
-    `logRowsPruned=${logRowsPruned}, vacuumRan=${vacuumRan ? "yes" : "no"}, walCheckpointRan=${walCheckpointRan ? "yes" : "no"}`,
-  );
+  {
+    const summary =
+      `logRowsPruned=${logRowsPruned}, vacuumRan=${vacuumRan ? "yes" : "no"}, walCheckpointRan=${walCheckpointRan ? "yes" : "no"}`;
+    if (stageOperationalError === undefined) stageOperational.complete(summary);
+    else stageOperational.fail(stageOperationalError, summary);
+  }
 
   // ── Step 6: Digest summary ───────────────────────────────────────────────
   const digestSummary = buildDigestSummary({

--- a/extensions/memory-hybrid/services/dream-cycle.ts
+++ b/extensions/memory-hybrid/services/dream-cycle.ts
@@ -96,6 +96,12 @@ export interface DreamCycleConfig {
    * When unset (default), no artifact files are written.
    */
   stageArtifactDir?: string;
+  /**
+   * Run identifier for this dream cycle execution (Issue #1827).
+   * When unset, a new run ID is generated. When set, the provided ID is used
+   * for both the directory name and artifact `runId` field to ensure consistency.
+   */
+  runId?: string;
 }
 
 /** Result returned by a single dream cycle run. */
@@ -628,7 +634,7 @@ export async function runDreamCycle(
   logger.info("memory-hybrid: dream-cycle — starting nightly cycle");
   const cycleStartedAt = Date.now();
   const v = !!config.verbose;
-  const runId = makeDreamCycleRunId();
+  const runId = config.runId ?? makeDreamCycleRunId();
   // Ensure stage artifact dir exists when configured.
   if (config.stageArtifactDir) {
     try {

--- a/extensions/memory-hybrid/services/dream-cycle.ts
+++ b/extensions/memory-hybrid/services/dream-cycle.ts
@@ -156,10 +156,10 @@ const STAGE_LABEL_MAX_LENGTH = 60;
 /**
  * Returns a run identifier string that encodes the UTC timestamp and process PID,
  * suitable for directory names and artifact fields (Issue #1827).
- * Format: `YYYYMMDDTHHmmssZ<pid>` e.g. `20260602T061400Z12345`.
+ * Format: `YYYYMMDDTHHmmssZ-<pid>` e.g. `20260602T061400Z-12345`.
  */
 export function makeDreamCycleRunId(): string {
-  return `${new Date().toISOString().replace(/[-:]/g, "").replace(/\.\d{3}Z$/, "Z")}${process.pid}`;
+  return `${new Date().toISOString().replace(/[-:]/g, "").replace(/\.\d{3}Z$/, "Z")}-${process.pid}`;
 }
 const EPISODIC_PROGRESS_GROUP_INTERVAL = 25;
 const SKIP_CONSOLIDATION_TEXT_PATTERNS = new Set([

--- a/extensions/memory-hybrid/services/dream-cycle.ts
+++ b/extensions/memory-hybrid/services/dream-cycle.ts
@@ -10,6 +10,8 @@
  * Self-contained — does not require an active agent session.
  */
 
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 import type OpenAI from "openai";
 import type { EventLog, EventLogEntry, EventType } from "../backends/event-log.js";
 import type { FactsDB } from "../backends/facts-db.js";
@@ -86,6 +88,13 @@ export interface DreamCycleConfig {
    * Default: true (enabled for backward compatibility).
    */
   enableReflectionRules?: boolean;
+  /**
+   * Directory where per-stage durable JSON artifacts are written (Issue #1827).
+   * Each stage writes `stage-NN-<label>.json` with started/succeeded/failed status,
+   * timing, and summary. Created automatically if it does not exist.
+   * When unset (default), no artifact files are written.
+   */
+  stageArtifactDir?: string;
 }
 
 /** Result returned by a single dream cycle run. */
@@ -607,6 +616,30 @@ export async function runDreamCycle(
   logger.info("memory-hybrid: dream-cycle — starting nightly cycle");
   const cycleStartedAt = Date.now();
   const v = !!config.verbose;
+  const runId = `${new Date().toISOString().replace(/[:.]/g, "").slice(0, 15)}Z-${process.pid}`;
+  // Ensure stage artifact dir exists when configured.
+  if (config.stageArtifactDir) {
+    try {
+      mkdirSync(config.stageArtifactDir, { recursive: true });
+    } catch {
+      // Non-fatal: artifact writes below will also fail gracefully.
+    }
+  }
+  const writeStageArtifact = (stageNumber: number, label: string, payload: Record<string, unknown>): void => {
+    if (!config.stageArtifactDir) return;
+    try {
+      const sanitized = label
+        .replace(/[^a-zA-Z0-9]+/g, "-")
+        .replace(/^-|-$/g, "")
+        .toLowerCase()
+        .slice(0, 60);
+      const filename = `stage-${String(stageNumber).padStart(2, "0")}-${sanitized}.json`;
+      const filePath = join(config.stageArtifactDir, filename);
+      writeFileSync(filePath, JSON.stringify({ runId, stage: label, stageNumber, ...payload }, null, 2));
+    } catch {
+      // Artifact write failures are non-fatal.
+    }
+  };
   let stageCounter = 0;
   const beginStage = (
     label: string,
@@ -618,6 +651,7 @@ export async function runDreamCycle(
     const stageNumber = ++stageCounter;
     const startedAt = Date.now();
     logger.info(`memory-hybrid: dream-cycle — stage ${stageNumber} start: ${label}`);
+    writeStageArtifact(stageNumber, label, { status: "started", startedAt: new Date(startedAt).toISOString() });
     let heartbeat: ReturnType<typeof setInterval> | undefined;
     if (v && opts?.heartbeat === true) {
       heartbeat = setInterval(() => {
@@ -639,11 +673,25 @@ export async function runDreamCycle(
         logger.info(
           `memory-hybrid: dream-cycle — stage ${stageNumber} complete in ${elapsedSec}s: ${label}${summary ? `; ${summary}` : ""}`,
         );
+        writeStageArtifact(stageNumber, label, {
+          status: "succeeded",
+          startedAt: new Date(startedAt).toISOString(),
+          completedAt: new Date().toISOString(),
+          elapsedSec,
+          ...(summary != null ? { summary } : {}),
+        });
       },
       fail: (err: unknown) => {
         clearHeartbeat();
         const elapsedSec = Math.floor((Date.now() - startedAt) / 1000);
         logger.warn(`memory-hybrid: dream-cycle — stage ${stageNumber} failed after ${elapsedSec}s: ${label}: ${err}`);
+        writeStageArtifact(stageNumber, label, {
+          status: "failed",
+          startedAt: new Date(startedAt).toISOString(),
+          completedAt: new Date().toISOString(),
+          elapsedSec,
+          error: String(err),
+        });
       },
     };
   };

--- a/extensions/memory-hybrid/setup/cli-context/cli-services.ts
+++ b/extensions/memory-hybrid/setup/cli-context/cli-services.ts
@@ -8,7 +8,7 @@ import { getMemoryCategories, resolveReflectionModelAndFallbacks } from "../../c
 import { runClassifyForCli } from "../../services/auto-classifier.js";
 import { runConsolidate } from "../../services/consolidation.js";
 import { type VerificationCycleResult, runVerificationCycle } from "../../services/continuous-verifier.js";
-import { type DreamCycleResult, runDreamCycle } from "../../services/dream-cycle.js";
+import { type DreamCycleResult, makeDreamCycleRunId, runDreamCycle } from "../../services/dream-cycle.js";
 import { runEntityEnrichmentForCli } from "../../services/entity-enrichment-cli.js";
 import { runExport } from "../../services/export-memory.js";
 import { runFindDuplicates } from "../../services/find-duplicates.js";
@@ -416,8 +416,7 @@ export function buildCliContextServices(
               return process.env.HYBRID_MEM_DREAM_STAGE_DIR.trim();
             }
             const openclawHome = process.env.OPENCLAW_HOME?.trim() || join(homedir(), ".openclaw");
-            const runId = `${new Date().toISOString().replace(/[:.]/g, "").slice(0, 15)}Z-${process.pid}`;
-            return join(openclawHome, "logs", "dream-cycle", `run-${runId}`);
+            return join(openclawHome, "logs", "dream-cycle", `run-${makeDreamCycleRunId()}`);
           })(),
         },
         logSink,

--- a/extensions/memory-hybrid/setup/cli-context/cli-services.ts
+++ b/extensions/memory-hybrid/setup/cli-context/cli-services.ts
@@ -18,6 +18,7 @@ import { runPreConsolidationFlush } from "../../services/pre-consolidation-flush
 import { adjudicateContradictionWithLlm } from "../../services/contradiction-adjudicator.js";
 import { runReflection, runReflectionMeta, runReflectionRules } from "../../services/reflection.js";
 import { parseSourceDate } from "../../utils/dates.js";
+import { getEnv } from "../../utils/env-manager.js";
 import { resolveTierPreferenceWithSources } from "../../utils/llm-selection.js";
 import { pluginLogger } from "../../utils/logger.js";
 import { versionInfo } from "../../versionInfo.js";
@@ -382,6 +383,7 @@ export function buildCliContextServices(
           `memory-hybrid: dream-cycle — WAL flush done (committed=${flush.committed}, skipped=${flush.skipped})`,
         );
       }
+      const runId = makeDreamCycleRunId();
       return runDreamCycle(
         factsDb,
         vectorDb,
@@ -411,12 +413,14 @@ export function buildCliContextServices(
             allow: cfg.nightlyCycle.consolidationEventTypeAllow,
             deny: cfg.nightlyCycle.consolidationEventTypeDeny,
           },
+          runId,
           stageArtifactDir: (() => {
-            if (process.env.HYBRID_MEM_DREAM_STAGE_DIR?.trim()) {
-              return process.env.HYBRID_MEM_DREAM_STAGE_DIR.trim();
+            const envDir = getEnv("HYBRID_MEM_DREAM_STAGE_DIR");
+            if (envDir?.trim()) {
+              return envDir.trim();
             }
-            const openclawHome = process.env.OPENCLAW_HOME?.trim() || join(homedir(), ".openclaw");
-            return join(openclawHome, "logs", "dream-cycle", `run${makeDreamCycleRunId()}`);
+            const openclawHome = getEnv("OPENCLAW_HOME")?.trim() || join(homedir(), ".openclaw");
+            return join(openclawHome, "logs", "dream-cycle", `run${runId}`);
           })(),
         },
         logSink,

--- a/extensions/memory-hybrid/setup/cli-context/cli-services.ts
+++ b/extensions/memory-hybrid/setup/cli-context/cli-services.ts
@@ -1,4 +1,5 @@
 import { dirname, join } from "node:path";
+import { homedir } from "node:os";
 import type { ClawdbotPluginApi } from "openclaw/plugin-sdk/core";
 import type { HandlerContext } from "../../cli/handlers.js";
 import type { HybridMemCliContext } from "../../cli/register.js";
@@ -410,6 +411,14 @@ export function buildCliContextServices(
             allow: cfg.nightlyCycle.consolidationEventTypeAllow,
             deny: cfg.nightlyCycle.consolidationEventTypeDeny,
           },
+          stageArtifactDir: (() => {
+            if (process.env.HYBRID_MEM_DREAM_STAGE_DIR?.trim()) {
+              return process.env.HYBRID_MEM_DREAM_STAGE_DIR.trim();
+            }
+            const openclawHome = process.env.OPENCLAW_HOME?.trim() || join(homedir(), ".openclaw");
+            const runId = `${new Date().toISOString().replace(/[:.]/g, "").slice(0, 15)}Z-${process.pid}`;
+            return join(openclawHome, "logs", "dream-cycle", `run-${runId}`);
+          })(),
         },
         logSink,
         provenanceService,

--- a/extensions/memory-hybrid/setup/cli-context/cli-services.ts
+++ b/extensions/memory-hybrid/setup/cli-context/cli-services.ts
@@ -420,7 +420,7 @@ export function buildCliContextServices(
               return envDir.trim();
             }
             const openclawHome = getEnv("OPENCLAW_HOME")?.trim() || join(homedir(), ".openclaw");
-            return join(openclawHome, "logs", "dream-cycle", `run${runId}`);
+            return join(openclawHome, "logs", "dream-cycle", `run-${runId}`);
           })(),
         },
         logSink,

--- a/extensions/memory-hybrid/setup/cli-context/cli-services.ts
+++ b/extensions/memory-hybrid/setup/cli-context/cli-services.ts
@@ -417,7 +417,7 @@ export function buildCliContextServices(
           stageArtifactDir: (() => {
             const envDir = getEnv("HYBRID_MEM_DREAM_STAGE_DIR");
             if (envDir?.trim()) {
-              return envDir.trim();
+              return join(envDir.trim(), `run-${runId}`);
             }
             const openclawHome = getEnv("OPENCLAW_HOME")?.trim() || join(homedir(), ".openclaw");
             return join(openclawHome, "logs", "dream-cycle", `run-${runId}`);

--- a/extensions/memory-hybrid/setup/cli-context/cli-services.ts
+++ b/extensions/memory-hybrid/setup/cli-context/cli-services.ts
@@ -416,7 +416,7 @@ export function buildCliContextServices(
               return process.env.HYBRID_MEM_DREAM_STAGE_DIR.trim();
             }
             const openclawHome = process.env.OPENCLAW_HOME?.trim() || join(homedir(), ".openclaw");
-            return join(openclawHome, "logs", "dream-cycle", `run-${makeDreamCycleRunId()}`);
+            return join(openclawHome, "logs", "dream-cycle", `run${makeDreamCycleRunId()}`);
           })(),
         },
         logSink,

--- a/extensions/memory-hybrid/tests/dream-cycle.test.ts
+++ b/extensions/memory-hybrid/tests/dream-cycle.test.ts
@@ -25,6 +25,7 @@ import {
   type DreamCycleConfig,
   extractEventText,
   groupEventsByEntity,
+  makeDreamCycleRunId,
   runDreamCycle,
   runEpisodicConsolidation,
   shouldSkipEpisodicConsolidation,
@@ -950,8 +951,7 @@ describe("runDreamCycle", () => {
         expect(artifact).toHaveProperty("stage");
         expect(artifact).toHaveProperty("stageNumber");
         expect(artifact).toHaveProperty("status");
-        // All stages should have succeeded
-        expect(artifact.status).toBe("succeeded");
+        expect(["succeeded", "failed"]).toContain(artifact.status);
         expect(artifact).toHaveProperty("startedAt");
         expect(artifact).toHaveProperty("completedAt");
       }
@@ -1007,6 +1007,58 @@ describe("runDreamCycle", () => {
       silentLogger,
     );
     expect(result.skipped).toBe(false);
+  });
+
+  it("uses a sortable path-safe dream-cycle run ID", () => {
+    expect(makeDreamCycleRunId()).toMatch(/^\d{8}T\d{6}Z\d+$/);
+  });
+
+  it("preserves successful earlier stage artifacts when a later stage reports failure", async () => {
+    const artifactDir = mkdtempSync(join(tmpdir(), "dream-artifacts-"));
+    const pruneLogTables = vi.spyOn(factsDb, "pruneLogTables").mockImplementation(() => {
+      throw new Error("prune-log-tables boom");
+    });
+    try {
+      const openaiStub = {
+        chat: { completions: { create: vi.fn().mockRejectedValue(new Error("no key")) } },
+      } as never;
+      const embeddingsStub = { embed: vi.fn().mockRejectedValue(new Error("no key")) } as never;
+      const vectorDbStub = {
+        getAllIds: vi.fn().mockResolvedValue([]),
+        isLanceDbAvailable: vi.fn().mockReturnValue(false),
+      } as never;
+
+      await runDreamCycle(
+        factsDb,
+        vectorDbStub,
+        embeddingsStub,
+        openaiStub,
+        null,
+        { ...baseConfig, stageArtifactDir: artifactDir },
+        silentLogger,
+      );
+
+      const artifacts = Object.fromEntries(
+        (await import("node:fs"))
+          .readdirSync(artifactDir)
+          .filter((f) => f.endsWith(".json"))
+          .map((f) => {
+            const artifact = JSON.parse(readFileSync(join(artifactDir, f), "utf-8"));
+            return [artifact.stage as string, artifact];
+          }),
+      );
+
+      expect(artifacts["core prune/decay/link/vector maintenance"]).toMatchObject({
+        status: "succeeded",
+      });
+      expect(artifacts["prune operational logs + FTS optimize + optional vacuum"]).toMatchObject({
+        status: "failed",
+        error: expect.stringContaining("prune-log-tables boom"),
+      });
+    } finally {
+      pruneLogTables.mockRestore();
+      rmSync(artifactDir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/extensions/memory-hybrid/tests/dream-cycle.test.ts
+++ b/extensions/memory-hybrid/tests/dream-cycle.test.ts
@@ -1010,7 +1010,7 @@ describe("runDreamCycle", () => {
   });
 
   it("uses a sortable path-safe dream-cycle run ID", () => {
-    expect(makeDreamCycleRunId()).toMatch(/^\d{8}T\d{6}Z\d+$/);
+    expect(makeDreamCycleRunId()).toMatch(/^\d{8}T\d{6}Z-\d+$/);
   });
 
   it("preserves successful earlier stage artifacts when a later stage reports failure", async () => {

--- a/extensions/memory-hybrid/tests/dream-cycle.test.ts
+++ b/extensions/memory-hybrid/tests/dream-cycle.test.ts
@@ -919,6 +919,95 @@ describe("runDreamCycle", () => {
 
     expect(warn).not.toHaveBeenCalledWith(expect.stringContaining("active SQLite fact(s) without vectors"));
   });
+
+  it("writes per-stage JSON artifacts when stageArtifactDir is configured", async () => {
+    const artifactDir = mkdtempSync(join(tmpdir(), "dream-artifacts-"));
+    try {
+      const openaiStub = {
+        chat: { completions: { create: vi.fn().mockRejectedValue(new Error("no key")) } },
+      } as never;
+      const embeddingsStub = { embed: vi.fn().mockRejectedValue(new Error("no key")) } as never;
+
+      await runDreamCycle(
+        factsDb,
+        {} as never,
+        embeddingsStub,
+        openaiStub,
+        null,
+        { ...baseConfig, stageArtifactDir: artifactDir },
+        silentLogger,
+      );
+
+      const { readdirSync } = await import("node:fs");
+      const files = readdirSync(artifactDir)
+        .filter((f) => f.endsWith(".json"))
+        .sort();
+      expect(files.length).toBeGreaterThan(0);
+      // Each file is a valid JSON object with required fields
+      for (const f of files) {
+        const artifact = JSON.parse(readFileSync(join(artifactDir, f), "utf-8"));
+        expect(artifact).toHaveProperty("runId");
+        expect(artifact).toHaveProperty("stage");
+        expect(artifact).toHaveProperty("stageNumber");
+        expect(artifact).toHaveProperty("status");
+        // All stages should have succeeded
+        expect(artifact.status).toBe("succeeded");
+        expect(artifact).toHaveProperty("startedAt");
+        expect(artifact).toHaveProperty("completedAt");
+      }
+    } finally {
+      rmSync(artifactDir, { recursive: true, force: true });
+    }
+  });
+
+  it("stage artifact 'started' entry is overwritten with final status on completion", async () => {
+    const artifactDir = mkdtempSync(join(tmpdir(), "dream-artifacts-"));
+    try {
+      const openaiStub = {
+        chat: { completions: { create: vi.fn().mockRejectedValue(new Error("no key")) } },
+      } as never;
+      const embeddingsStub = { embed: vi.fn().mockRejectedValue(new Error("no key")) } as never;
+
+      await runDreamCycle(
+        factsDb,
+        {} as never,
+        embeddingsStub,
+        openaiStub,
+        null,
+        { ...baseConfig, stageArtifactDir: artifactDir },
+        silentLogger,
+      );
+
+      const { readdirSync } = await import("node:fs");
+      const files = readdirSync(artifactDir).filter((f) => f.endsWith(".json"));
+      // No artifact should be stuck in 'started' — each should be succeeded or failed
+      for (const f of files) {
+        const artifact = JSON.parse(readFileSync(join(artifactDir, f), "utf-8"));
+        expect(artifact.status).not.toBe("started");
+      }
+    } finally {
+      rmSync(artifactDir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not write artifacts when stageArtifactDir is not set", async () => {
+    const openaiStub = {
+      chat: { completions: { create: vi.fn().mockRejectedValue(new Error("no key")) } },
+    } as never;
+    const embeddingsStub = { embed: vi.fn().mockRejectedValue(new Error("no key")) } as never;
+
+    // Should complete without throwing even without artifact dir
+    const result = await runDreamCycle(
+      factsDb,
+      {} as never,
+      embeddingsStub,
+      openaiStub,
+      null,
+      baseConfig,
+      silentLogger,
+    );
+    expect(result.skipped).toBe(false);
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Acceptance criteria: dream-cycle exits 0 when core pipeline succeeds even if follow-ups fail; continuous-verification errors do not cause exit 2; each stage writes durable artifacts.

## Changes Made

### Exit semantics fix
Removed `process.exitCode = 2` from the continuous-verification follow-up failure block in `register-reflection-pipeline.ts`. Follow-up failures are still collected and printed in the final run summary, but a successful core pipeline now exits 0. Follow-up and core outcomes are fully isolated.

### Durable per-stage artifacts
`DreamCycleConfig` gains an optional `stageArtifactDir` field. The `beginStage` helper in `runDreamCycle` now writes a `stage-NN-<label>.json` artifact at each stage boundary:
- **`status: "started"`** is written immediately at stage begin, so partial evidence survives a crash or hard kill
- **`status: "succeeded"`** (with `elapsedSec`, `summary`) or **`status: "failed"`** (with `error`) overwrites the file on completion
- Artifact writes are non-fatal; I/O errors are silently swallowed so they cannot affect pipeline outcome

### CLI wiring
`cli-services.ts` computes a per-run artifact directory at `OPENCLAW_HOME/logs/dream-cycle/run-<timestamp>-<pid>` by default, or uses the `HYBRID_MEM_DREAM_STAGE_DIR` environment variable as an override. The directory is created automatically.

### Shared helper
`makeDreamCycleRunId()` is exported from `services/dream-cycle.ts` (format: `YYYYMMDDTHHmmssZ-<pid>`) and used in both the service and the CLI wrapper to ensure a consistent run ID format. `STAGE_LABEL_MAX_LENGTH = 60` is named as a constant.

## Testing

- ✅ 3 new tests in `dream-cycle.test.ts`: artifact files are written with the correct JSON schema; `started` status is always overwritten with a final status on completion; function is a no-op when `stageArtifactDir` is unset
- ✅ All 66 dream-cycle tests pass
- ✅ Lint and format checks pass for all modified files

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability and non-fatal file writes around an existing pipeline; stage failure marking is logging/artifacts only and does not change core prune/consolidation behavior beyond reporting.
> 
> **Overview**
> Adds **durable per-stage JSON artifacts** for the nightly dream cycle so operators can see what ran after crashes or partial failures.
> 
> **Dream cycle service:** Optional `stageArtifactDir` and `runId` on config; shared `makeDreamCycleRunId()` (`YYYYMMDDTHHmmssZ-<pid>`). Each pipeline stage writes `stage-NN-<sanitized-label>.json` via atomic write with `started` at begin and `succeeded` or `failed` (timing, summary, error) on finish. Sub-step errors inside a stage are aggregated so `complete` vs `fail` reflects whether any step in that stage threw. Artifact I/O failures are non-fatal.
> 
> **CLI:** Dream-cycle invocations pass a consistent `runId` and default artifact directory under `OPENCLAW_HOME/logs/dream-cycle/run-<runId>`, overridable with `HYBRID_MEM_DREAM_STAGE_DIR`.
> 
> **Tests:** Coverage for artifact schema, final status overwriting `started`, no writes when dir unset, run ID format, and earlier stages staying `succeeded` when a later stage fails.
> 
> *Note: PR description also mentions exit-code changes for follow-up steps; those are not in the provided diff.*
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a98d6356705bc83f116eb1d6367dfb0604b5b5c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->