### PR TITLE
fix(vm-memory): guarantee memory-diagnostics-live.json is never 0-byte (#1828)

### DIFF
--- a/extensions/memory-hybrid/cli/commands/manage/register-agents-audit-runall.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/register-agents-audit-runall.ts
@@ -12,10 +12,7 @@ import { countActivePatternFactsForMaintenance } from "../../../services/reflect
 import { deleteVectorsForFactIds } from "../../../services/vector-maintenance.js";
 import { getLanguageKeywordsFilePath } from "../../../utils/language-keywords.js";
 import { type CommanderOptsParent, readHybridMemVerbose } from "../../global-verbose.js";
-import {
-  registerScanMaintenanceOverrideOptions,
-  scanMaintenanceOverridePayload,
-} from "../../maintenance-overrides.js";
+import { registerScanMaintenanceOverrideOptions, scanMaintenanceOverridePayload } from "../../maintenance-overrides.js";
 import { type Chainable, withExit } from "../../shared.js";
 import type { ManageBindings } from "./bindings.js";
 
@@ -113,7 +110,11 @@ export function registerManageAgentsAuditRunall(mem: Chainable, b: ManageBinding
       .option("--dry-run", "List steps that would run without executing")
       .option("-v, --verbose", "Show detailed output for each step"),
   ).action(
-      withExit(async (opts?: { dryRun?: boolean; verbose?: boolean; force?: boolean; full?: boolean }, cmd?: CommanderOptsParent) => {
+    withExit(
+      async (
+        opts?: { dryRun?: boolean; verbose?: boolean; force?: boolean; full?: boolean },
+        cmd?: CommanderOptsParent,
+      ) => {
         const dryRun = !!opts?.dryRun;
         const verbose = !!opts?.verbose || readHybridMemVerbose(cmd);
         const scanOverrides = scanMaintenanceOverridePayload(opts);
@@ -377,6 +378,7 @@ export function registerManageAgentsAuditRunall(mem: Chainable, b: ManageBinding
           }
         }
         log("run-all complete.");
-      }),
-    );
+      },
+    ),
+  );
 }

--- a/extensions/memory-hybrid/cli/commands/manage/register-self-correction-feedback.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/register-self-correction-feedback.ts
@@ -1,9 +1,6 @@
 import { capturePluginError } from "../../../services/error-reporter.js";
 import { type CommanderOptsParent, readHybridMemVerbose } from "../../global-verbose.js";
-import {
-  registerScanMaintenanceOverrideOptions,
-  scanMaintenanceOverridePayload,
-} from "../../maintenance-overrides.js";
+import { registerScanMaintenanceOverrideOptions, scanMaintenanceOverridePayload } from "../../maintenance-overrides.js";
 import { type Chainable, SCAN_MIN_INTERVAL_MS, withExit } from "../../shared.js";
 import type { ManageBindings } from "./bindings.js";
 
@@ -70,86 +67,86 @@ export function registerManageSelfCorrectionFeedback(mem: Chainable, b: ManageBi
       .option("--no-apply-tools", "Skip TOOLS.md updates (memory-only)")
       .option("-v, --verbose", "Log progress before LLM analysis (plugin logger); respects hybrid-mem -v"),
   ).action(
-      withExit(
-        async (
-          opts?: {
-            extractPath?: string;
-            workspace?: string;
-            dryRun?: boolean;
-            model?: string;
-            approve?: boolean;
-            applyTools?: boolean;
-            full?: boolean;
-            force?: boolean;
-            verbose?: boolean;
-          },
-          cmd?: CommanderOptsParent,
-        ) => {
-          const extractPath = opts?.extractPath;
-          const workspace = opts?.workspace;
-          const dryRun = !!opts?.dryRun;
-          const model = opts?.model?.trim() || undefined;
-          const approve = !!opts?.approve;
-          const verbose = !!opts?.verbose || readHybridMemVerbose(cmd);
-          let res;
-          try {
-            res = await runSelfCorrectionRun({
-              extractPath,
-              workspace,
-              dryRun,
-              model,
-              approve,
-              applyTools: opts?.applyTools,
-              ...scanMaintenanceOverridePayload(opts),
-              verbose,
-            });
-          } catch (err) {
-            capturePluginError(err instanceof Error ? err : new Error(String(err)), {
-              subsystem: "cli",
-              operation: "self-correction-run",
-            });
-            throw err;
-          }
-          if (res.error) {
-            console.error(`Error: ${res.error}${res.status ? ` status=${res.status}` : ""}`);
-            process.exitCode = 1;
-            return;
-          }
-          if (res.skipped) {
-            const thresholdH = Math.round(SCAN_MIN_INTERVAL_MS / 3_600_000);
-            if (res.status === "skipped_concurrency") {
-              console.log(`Skipping self-correction-run: scan already in progress. status=skipped_concurrency`);
-            } else {
-              console.log(
-                `Skipping self-correction-run: cooldown active (last run < ${thresholdH}h ago). Use --force (or --full) to override. status=skipped_cooldown`,
-              );
-            }
-            return;
-          }
-          console.log(
-            `Self-correction run complete: ${res.incidentsFound} incidents found, ${res.analysed} analysed, ${res.autoFixed} auto-fixed ${dryRun ? "(dry-run)" : ""}${res.status ? ` status=${res.status}` : ""}`,
-          );
-          if (res.proposals.length > 0) {
-            console.log(`Proposals (${res.proposals.length}):`);
-            for (const p of res.proposals) {
-              console.log(`  - ${p}`);
-            }
-          }
-          if (res.reportPath) {
-            console.log(`Report: ${res.reportPath}`);
-          }
-          if (res.toolsSuggestions && res.toolsSuggestions.length > 0) {
-            console.log(`TOOLS.md suggestions (${res.toolsSuggestions.length}):`);
-            for (const s of res.toolsSuggestions) {
-              console.log(`  - ${s}`);
-            }
-          }
-          if (res.toolsApplied != null && res.toolsApplied > 0) {
-            console.log(`TOOLS.md updates applied: ${res.toolsApplied}`);
-          }
+    withExit(
+      async (
+        opts?: {
+          extractPath?: string;
+          workspace?: string;
+          dryRun?: boolean;
+          model?: string;
+          approve?: boolean;
+          applyTools?: boolean;
+          full?: boolean;
+          force?: boolean;
+          verbose?: boolean;
         },
-      ),
-    );
+        cmd?: CommanderOptsParent,
+      ) => {
+        const extractPath = opts?.extractPath;
+        const workspace = opts?.workspace;
+        const dryRun = !!opts?.dryRun;
+        const model = opts?.model?.trim() || undefined;
+        const approve = !!opts?.approve;
+        const verbose = !!opts?.verbose || readHybridMemVerbose(cmd);
+        let res;
+        try {
+          res = await runSelfCorrectionRun({
+            extractPath,
+            workspace,
+            dryRun,
+            model,
+            approve,
+            applyTools: opts?.applyTools,
+            ...scanMaintenanceOverridePayload(opts),
+            verbose,
+          });
+        } catch (err) {
+          capturePluginError(err instanceof Error ? err : new Error(String(err)), {
+            subsystem: "cli",
+            operation: "self-correction-run",
+          });
+          throw err;
+        }
+        if (res.error) {
+          console.error(`Error: ${res.error}${res.status ? ` status=${res.status}` : ""}`);
+          process.exitCode = 1;
+          return;
+        }
+        if (res.skipped) {
+          const thresholdH = Math.round(SCAN_MIN_INTERVAL_MS / 3_600_000);
+          if (res.status === "skipped_concurrency") {
+            console.log(`Skipping self-correction-run: scan already in progress. status=skipped_concurrency`);
+          } else {
+            console.log(
+              `Skipping self-correction-run: cooldown active (last run < ${thresholdH}h ago). Use --force (or --full) to override. status=skipped_cooldown`,
+            );
+          }
+          return;
+        }
+        console.log(
+          `Self-correction run complete: ${res.incidentsFound} incidents found, ${res.analysed} analysed, ${res.autoFixed} auto-fixed ${dryRun ? "(dry-run)" : ""}${res.status ? ` status=${res.status}` : ""}`,
+        );
+        if (res.proposals.length > 0) {
+          console.log(`Proposals (${res.proposals.length}):`);
+          for (const p of res.proposals) {
+            console.log(`  - ${p}`);
+          }
+        }
+        if (res.reportPath) {
+          console.log(`Report: ${res.reportPath}`);
+        }
+        if (res.toolsSuggestions && res.toolsSuggestions.length > 0) {
+          console.log(`TOOLS.md suggestions (${res.toolsSuggestions.length}):`);
+          for (const s of res.toolsSuggestions) {
+            console.log(`  - ${s}`);
+          }
+        }
+        if (res.toolsApplied != null && res.toolsApplied > 0) {
+          console.log(`TOOLS.md updates applied: ${res.toolsApplied}`);
+        }
+      },
+    ),
+  );
 
   if (runExtractImplicitFeedback) {
     registerScanMaintenanceOverrideOptions(
@@ -164,65 +161,65 @@ export function registerManageSelfCorrectionFeedback(mem: Chainable, b: ManageBi
         .option("--no-trajectories", "Skip trajectory building")
         .option("--no-closed-loop", "Skip closed-loop analysis"),
     ).action(
-        withExit(
-          async (
-            opts?: {
-              days?: string;
-              dryRun?: boolean;
-              full?: boolean;
-              force?: boolean;
-              verbose?: boolean;
-              trajectories?: boolean;
-              closedLoop?: boolean;
-            },
-            cmd?: CommanderOptsParent,
-          ) => {
-            const days = opts?.days ? Number.parseInt(opts.days, 10) : 3;
-            const dryRun = !!opts?.dryRun;
-            const verbose = !!opts?.verbose || readHybridMemVerbose(cmd);
-            const includeTrajectories = opts?.trajectories !== false;
-            const includeClosedLoop = opts?.closedLoop !== false;
-            let res;
-            try {
-              res = await runExtractImplicitFeedback({
-                days,
-                dryRun,
-                ...scanMaintenanceOverridePayload(opts),
-                verbose,
-                includeTrajectories,
-                includeClosedLoop,
-              });
-            } catch (err) {
-              capturePluginError(err instanceof Error ? err : new Error(String(err)), {
-                subsystem: "cli",
-                operation: "extract-implicit",
-              });
-              throw err;
-            }
-            console.log(
-              `Extract-implicit complete: ${res.signalsExtracted} signals from ${res.sessionsScanned} sessions ${dryRun ? "(dry-run)" : ""}`,
-            );
-            console.log(`  Sessions visited: ${res.sessionsVisited}`);
-            console.log(`  Sessions processed: ${res.sessionsProcessed}`);
-            console.log(`  Sessions skipped: ${res.sessionsSkipped}`);
-            if (res.sessionsDeferred > 0) {
-              console.log(`  Sessions deferred: ${res.sessionsDeferred}`);
-              console.log(
-                `  Backlog estimate: ${res.backlogSignalsEstimate} signals, ${res.backlogTrajectoriesEstimate} trajectories`,
-              );
-            }
-            console.log(`  Positive signals: ${res.positiveCount}`);
-            console.log(`  Negative signals: ${res.negativeCount}`);
-            console.log(`  Trajectories built: ${res.trajectoriesBuilt}`);
-            if (res.partial) {
-              console.log(`  Partial run: yes (${res.partialReason ?? "capped"})`);
-            }
-            if (res.closedLoopReport) {
-              console.log(`\n${res.closedLoopReport}`);
-            }
+      withExit(
+        async (
+          opts?: {
+            days?: string;
+            dryRun?: boolean;
+            full?: boolean;
+            force?: boolean;
+            verbose?: boolean;
+            trajectories?: boolean;
+            closedLoop?: boolean;
           },
-        ),
-      );
+          cmd?: CommanderOptsParent,
+        ) => {
+          const days = opts?.days ? Number.parseInt(opts.days, 10) : 3;
+          const dryRun = !!opts?.dryRun;
+          const verbose = !!opts?.verbose || readHybridMemVerbose(cmd);
+          const includeTrajectories = opts?.trajectories !== false;
+          const includeClosedLoop = opts?.closedLoop !== false;
+          let res;
+          try {
+            res = await runExtractImplicitFeedback({
+              days,
+              dryRun,
+              ...scanMaintenanceOverridePayload(opts),
+              verbose,
+              includeTrajectories,
+              includeClosedLoop,
+            });
+          } catch (err) {
+            capturePluginError(err instanceof Error ? err : new Error(String(err)), {
+              subsystem: "cli",
+              operation: "extract-implicit",
+            });
+            throw err;
+          }
+          console.log(
+            `Extract-implicit complete: ${res.signalsExtracted} signals from ${res.sessionsScanned} sessions ${dryRun ? "(dry-run)" : ""}`,
+          );
+          console.log(`  Sessions visited: ${res.sessionsVisited}`);
+          console.log(`  Sessions processed: ${res.sessionsProcessed}`);
+          console.log(`  Sessions skipped: ${res.sessionsSkipped}`);
+          if (res.sessionsDeferred > 0) {
+            console.log(`  Sessions deferred: ${res.sessionsDeferred}`);
+            console.log(
+              `  Backlog estimate: ${res.backlogSignalsEstimate} signals, ${res.backlogTrajectoriesEstimate} trajectories`,
+            );
+          }
+          console.log(`  Positive signals: ${res.positiveCount}`);
+          console.log(`  Negative signals: ${res.negativeCount}`);
+          console.log(`  Trajectories built: ${res.trajectoriesBuilt}`);
+          if (res.partial) {
+            console.log(`  Partial run: yes (${res.partialReason ?? "capped"})`);
+          }
+          if (res.closedLoopReport) {
+            console.log(`\n${res.closedLoopReport}`);
+          }
+        },
+      ),
+    );
   }
 
   // ----- cross-agent-learning (Issue #263 — Phase 2) -----

--- a/extensions/memory-hybrid/cli/maintenance-overrides.ts
+++ b/extensions/memory-hybrid/cli/maintenance-overrides.ts
@@ -25,9 +25,7 @@ export type ScanMaintenanceOverrides = {
  * `--full` is the legacy name for watermark + cooldown bypass on extraction commands.
  * `--force` is the preferred umbrella flag (same effect for scan commands).
  */
-export function resolveScanMaintenanceOverrides(
-  opts?: ScanMaintenanceOverrideInput | null,
-): ScanMaintenanceOverrides {
+export function resolveScanMaintenanceOverrides(opts?: ScanMaintenanceOverrideInput | null): ScanMaintenanceOverrides {
   const forced = opts?.force === true || opts?.full === true;
   return {
     bypassScanCooldown: forced,
@@ -40,10 +38,7 @@ export function registerScanMaintenanceOverrideOptions<
   T extends { option(flags: string, desc?: string, defaultValue?: unknown): T },
 >(cmd: T): T {
   return cmd
-    .option(
-      "--force",
-      "Bypass maintenance guards for this run (23h scan cooldown and incremental watermark)",
-    )
+    .option("--force", "Bypass maintenance guards for this run (23h scan cooldown and incremental watermark)")
     .option("--full", "Alias for --force on scan commands (legacy; prefer --force)");
 }
 

--- a/extensions/memory-hybrid/services/gateway-memory-diagnostics.ts
+++ b/extensions/memory-hybrid/services/gateway-memory-diagnostics.ts
@@ -85,7 +85,8 @@ function activeRequestCount(): number {
 function readV8HeapSpaces(): GatewayMemoryDiagnostics["v8"] {
   try {
     const stats = v8.getHeapStatistics();
-    const spaces = v8.getHeapSpaceStatistics?.()
+    const spaces = v8
+      .getHeapSpaceStatistics?.()
       ?.map((s) => ({ spaceName: s.space_name, spaceUsedSize: s.space_used_size }))
       .sort((a, b) => b.spaceUsedSize - a.spaceUsedSize)
       .slice(0, 5);
@@ -146,10 +147,14 @@ function buildLeakHints(opts: {
     hints.push("plugin_reregister_full_teardown_despite_reuse_policy: check bootstrapSettledRef or config drift");
   }
   if (nativeMb > 2048 && opts.reregisterMetrics.databaseReuses > 0) {
-    hints.push("native_rss_high_with_db_reuse: likely Lance/Rust allocator or OpenClaw plugin module reload (not Lance close/reopen)");
+    hints.push(
+      "native_rss_high_with_db_reuse: likely Lance/Rust allocator or OpenClaw plugin module reload (not Lance close/reopen)",
+    );
   }
   if (opts.reregisterMetrics.fullTeardowns >= 3) {
-    hints.push("repeated_lance_sqlite_teardown: each full re-register can retain ~500MB-2GB native RSS until process restart");
+    hints.push(
+      "repeated_lance_sqlite_teardown: each full re-register can retain ~500MB-2GB native RSS until process restart",
+    );
   }
   return hints;
 }

--- a/extensions/memory-hybrid/services/vm-memory-incident-capture.ts
+++ b/extensions/memory-hybrid/services/vm-memory-incident-capture.ts
@@ -1,0 +1,424 @@
+/**
+ * VM Memory Incident Capture — Issue #1828
+ *
+ * Guarantees that `memory-diagnostics-live.json` inside an incident bundle is
+ * never left at 0 bytes. When the live-diagnostics command fails, times out,
+ * or produces non-JSON output the file is replaced with a structured failure
+ * envelope so operators always have actionable JSON to inspect.
+ *
+ * Design:
+ *  1. All writes go through a temp-file + atomic rename so a mid-write crash
+ *     cannot leave the destination empty.
+ *  2. On any capture failure a well-typed failure object is written instead.
+ *  3. After bundle assembly a manifest file records each artifact size and
+ *     warns about empty or missing critical files.
+ */
+
+import { existsSync, mkdirSync, readdirSync, renameSync, statSync, unlinkSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { execFile } from "../utils/process-runner.js";
+import { getEnv } from "../utils/env-manager.js";
+import { capturePluginError } from "./error-reporter.js";
+
+/**
+ * Promisified wrapper around execFile that correctly preserves the full
+ * `(err, stdout, stderr)` callback signature.  Using an explicit wrapper
+ * instead of `util.promisify` avoids losing the `util.promisify.custom`
+ * symbol when the function is replaced by test doubles.
+ */
+function runCommand(
+  command: string,
+  args: string[],
+  timeoutMs: number,
+): Promise<{ stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    execFile(command, args, { encoding: "utf-8", timeout: timeoutMs }, (err, stdout, stderr) => {
+      if (err) {
+        // Attach stdout/stderr to the error so callers can inspect them.
+        const augmented = Object.assign(err, {
+          stdout: stdout as string,
+          stderr: stderr as string,
+        });
+        reject(augmented);
+      } else {
+        resolve({ stdout: stdout as string, stderr: (stderr ?? "") as string });
+      }
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Written when live diagnostics were captured successfully. */
+export interface LiveDiagnosticsSuccess {
+  ok: true;
+  timestamp: string;
+  exitCode: 0;
+  /** The raw parsed JSON output from the diagnostics command. */
+  diagnostics: unknown;
+}
+
+/**
+ * Written when live diagnostics could not be captured. Always valid JSON and
+ * always non-empty — this is the primary guarantee of Issue #1828.
+ */
+export interface LiveDiagnosticsFailure {
+  ok: false;
+  status: "command_failed" | "timeout" | "invalid_json" | "empty_output" | "spawn_error";
+  /** Human-readable error description. */
+  error: string;
+  /** Process exit code (−1 when the process never started or was killed). */
+  exitCode: number;
+  /** True when the command exceeded `timeoutMs`. */
+  timedOut: boolean;
+  /** Captured stderr, if any. */
+  stderr?: string;
+  /** Fallback memory snapshot taken from process.memoryUsage() at failure time. */
+  fallbackMemory?: FallbackMemory;
+  timestamp: string;
+}
+
+export type LiveDiagnosticsResult = LiveDiagnosticsSuccess | LiveDiagnosticsFailure;
+
+/** Lightweight memory snapshot captured in-process as a fallback. */
+export interface FallbackMemory {
+  rssBytes: number;
+  heapTotalBytes: number;
+  heapUsedBytes: number;
+}
+
+/** Per-file metadata entry in the incident manifest. */
+export interface IncidentArtifactInfo {
+  /** Filename relative to the bundle directory. */
+  filename: string;
+  /** File size in bytes (−1 when the file does not exist). */
+  size: number;
+  /** True when the file does not exist on disk. */
+  missing: boolean;
+  /** True when the file exists but contains no bytes. */
+  empty: boolean;
+  /** True for artifacts whose absence degrades incident diagnosis significantly. */
+  critical: boolean;
+}
+
+/** Written as `incident-manifest.json` in the bundle directory. */
+export interface IncidentManifest {
+  timestamp: string;
+  bundleDir: string;
+  artifacts: IncidentArtifactInfo[];
+  /** Human-readable warning strings for empty or missing critical artifacts. */
+  warnings: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Default critical artifacts
+// ---------------------------------------------------------------------------
+
+/** Files that are expected in every incident bundle and flagged when missing/empty. */
+export const DEFAULT_CRITICAL_ARTIFACTS = [
+  "memory-diagnostics-live.json",
+  "snapshot.json",
+  "leak-report.json",
+] as const;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Atomically writes `content` to `destPath` by writing to a sibling temp file
+ * first, then renaming. Guarantees `destPath` is never partially written.
+ */
+function atomicWrite(destPath: string, content: string): void {
+  const tmpPath = `${destPath}.tmp-${process.pid}-${Date.now()}`;
+  mkdirSync(dirname(destPath), { recursive: true });
+  try {
+    writeFileSync(tmpPath, content, "utf-8");
+    renameSync(tmpPath, destPath);
+  } catch (err) {
+    try {
+      if (existsSync(tmpPath)) unlinkSync(tmpPath);
+    } catch {
+      // best-effort temp cleanup
+    }
+    throw err;
+  }
+}
+
+function captureFallbackMemory(): FallbackMemory {
+  const m = process.memoryUsage();
+  return { rssBytes: m.rss, heapTotalBytes: m.heapTotal, heapUsedBytes: m.heapUsed };
+}
+
+// ---------------------------------------------------------------------------
+// Core capture function
+// ---------------------------------------------------------------------------
+
+export interface CaptureLiveDiagnosticsOptions {
+  /** Path to the executable (e.g. `"node"`, `"/usr/bin/python3"`). */
+  command: string;
+  /** Arguments passed to the executable. */
+  args?: string[];
+  /** Milliseconds before the child process is killed (default: 30 000). */
+  timeoutMs?: number;
+  /**
+   * When true the in-process RSS/heap snapshot is included in failure envelopes
+   * (default: true).
+   */
+  includeFallbackMemory?: boolean;
+}
+
+/**
+ * Runs a live-diagnostics command and writes its JSON output to `destPath`.
+ *
+ * Guarantees:
+ * - `destPath` is **never** left at 0 bytes.
+ * - On any capture failure a structured failure envelope is written instead of
+ *   leaving an empty file.
+ * - All writes are atomic (temp-file + rename).
+ *
+ * @returns The result object that was serialised to `destPath`.
+ */
+export async function captureLiveDiagnosticsToFile(
+  destPath: string,
+  opts: CaptureLiveDiagnosticsOptions,
+): Promise<LiveDiagnosticsResult> {
+  const { command, args = [], timeoutMs = 30_000, includeFallbackMemory = true } = opts;
+  const timestamp = new Date().toISOString();
+
+  let result: LiveDiagnosticsResult;
+
+  try {
+    const { stdout, stderr } = await runCommand(command, args, timeoutMs);
+
+    const trimmed = stdout.trim();
+
+    if (!trimmed) {
+      const failure: LiveDiagnosticsFailure = {
+        ok: false,
+        status: "empty_output",
+        error: "Diagnostics command produced no output",
+        exitCode: 0,
+        timedOut: false,
+        ...(stderr?.trim() ? { stderr: stderr.trim() } : {}),
+        ...(includeFallbackMemory ? { fallbackMemory: captureFallbackMemory() } : {}),
+        timestamp,
+      };
+      result = failure;
+    } else {
+      let parsedResult: LiveDiagnosticsResult;
+      try {
+        const parsed = JSON.parse(trimmed);
+        parsedResult = {
+          ok: true,
+          timestamp,
+          exitCode: 0,
+          diagnostics: parsed,
+        } satisfies LiveDiagnosticsSuccess;
+      } catch (parseErr) {
+        parsedResult = {
+          ok: false,
+          status: "invalid_json",
+          error: `Diagnostics command output was not valid JSON: ${String(parseErr)}`,
+          exitCode: 0,
+          timedOut: false,
+          ...(stderr?.trim() ? { stderr: stderr.trim() } : {}),
+          ...(includeFallbackMemory ? { fallbackMemory: captureFallbackMemory() } : {}),
+          timestamp,
+        } satisfies LiveDiagnosticsFailure;
+      }
+      result = parsedResult;
+    }
+  } catch (err: unknown) {
+    // execFile rejects on non-zero exit or timeout
+    const isTimeout =
+      (err as NodeJS.ErrnoException)?.code === "ETIMEDOUT" ||
+      (err as { killed?: boolean })?.killed === true ||
+      (typeof (err as { signal?: string })?.signal === "string" &&
+        (err as { signal: string }).signal === "SIGTERM");
+
+    const exitCode =
+      typeof (err as { code?: unknown })?.code === "number"
+        ? ((err as { code: number }).code as number)
+        : -1;
+
+    const stderr =
+      typeof (err as { stderr?: string })?.stderr === "string"
+        ? ((err as { stderr: string }).stderr.trim() as string)
+        : undefined;
+
+    const failure: LiveDiagnosticsFailure = {
+      ok: false,
+      status: isTimeout ? "timeout" : "command_failed",
+      error: err instanceof Error ? err.message : String(err),
+      exitCode,
+      timedOut: isTimeout,
+      ...(stderr ? { stderr } : {}),
+      ...(includeFallbackMemory ? { fallbackMemory: captureFallbackMemory() } : {}),
+      timestamp,
+    };
+    result = failure;
+  }
+
+  try {
+    atomicWrite(destPath, JSON.stringify(result, null, 2));
+  } catch (writeErr) {
+    capturePluginError(writeErr instanceof Error ? writeErr : new Error(String(writeErr)), {
+      subsystem: "vm-memory-incident",
+      operation: "write-live-diagnostics",
+    });
+    // Re-throw: the caller needs to know the write failed.
+    throw writeErr;
+  }
+
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Zero-byte repair helper
+// ---------------------------------------------------------------------------
+
+/**
+ * If `filePath` exists and is 0 bytes, replace it with a structured failure
+ * envelope so the bundle never contains empty JSON files.
+ *
+ * @returns `true` when a repair was performed, `false` otherwise.
+ */
+export function repairZeroByteIncidentFile(
+  filePath: string,
+  context?: { command?: string; reason?: string },
+): boolean {
+  if (!existsSync(filePath)) return false;
+  let size: number;
+  try {
+    size = statSync(filePath).size;
+  } catch {
+    return false;
+  }
+  if (size !== 0) return false;
+
+  const envelope: LiveDiagnosticsFailure = {
+    ok: false,
+    status: "empty_output",
+    error:
+      context?.reason ??
+      "Artifact was 0 bytes at bundle assembly time; capture command likely crashed or was killed before writing output.",
+    exitCode: -1,
+    timedOut: false,
+    fallbackMemory: captureFallbackMemory(),
+    timestamp: new Date().toISOString(),
+  };
+
+  try {
+    atomicWrite(filePath, JSON.stringify(envelope, null, 2));
+    return true;
+  } catch (err) {
+    capturePluginError(err instanceof Error ? err : new Error(String(err)), {
+      subsystem: "vm-memory-incident",
+      operation: "repair-zero-byte",
+    });
+    return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Incident manifest
+// ---------------------------------------------------------------------------
+
+export interface WriteIncidentManifestOptions {
+  /**
+   * Filenames that should exist in the bundle (checked for empty/missing).
+   * Defaults to {@link DEFAULT_CRITICAL_ARTIFACTS}.
+   */
+  criticalFiles?: readonly string[];
+}
+
+/**
+ * Writes `incident-manifest.json` to `bundleDir`, listing every file's size
+ * and flagging empty or missing critical artifacts.
+ *
+ * @returns The manifest that was written.
+ */
+export function writeIncidentManifest(
+  bundleDir: string,
+  opts?: WriteIncidentManifestOptions,
+): IncidentManifest {
+  const criticalSet = new Set<string>(opts?.criticalFiles ?? DEFAULT_CRITICAL_ARTIFACTS);
+
+  // Collect all filenames from the directory (excluding the manifest itself).
+  const dirFiles = new Set<string>();
+  if (existsSync(bundleDir)) {
+    try {
+      for (const entry of readdirSync(bundleDir, { withFileTypes: true })) {
+        if (entry.isFile() && entry.name !== "incident-manifest.json") {
+          dirFiles.add(entry.name);
+        }
+      }
+    } catch {
+      // If we can't read the dir, continue with an empty set
+    }
+  }
+
+  // Union of existing files and expected critical files.
+  const allFiles = new Set([...dirFiles, ...criticalSet]);
+
+  const artifacts: IncidentArtifactInfo[] = [];
+  const warnings: string[] = [];
+
+  for (const filename of [...allFiles].sort()) {
+    const fullPath = join(bundleDir, filename);
+    const missing = !existsSync(fullPath);
+    let size = -1;
+    if (!missing) {
+      try {
+        size = statSync(fullPath).size;
+      } catch {
+        size = -1;
+      }
+    }
+    const empty = !missing && size === 0;
+    const critical = criticalSet.has(filename);
+
+    artifacts.push({ filename, size, missing, empty, critical });
+
+    if (critical && missing) {
+      warnings.push(`Critical artifact missing: ${filename}`);
+    } else if (critical && empty) {
+      warnings.push(`Critical artifact is empty (0 bytes): ${filename}`);
+    }
+  }
+
+  const manifest: IncidentManifest = {
+    timestamp: new Date().toISOString(),
+    bundleDir,
+    artifacts,
+    warnings,
+  };
+
+  try {
+    atomicWrite(join(bundleDir, "incident-manifest.json"), JSON.stringify(manifest, null, 2));
+  } catch (err) {
+    capturePluginError(err instanceof Error ? err : new Error(String(err)), {
+      subsystem: "vm-memory-incident",
+      operation: "write-manifest",
+    });
+  }
+
+  return manifest;
+}
+
+// ---------------------------------------------------------------------------
+// Convenience: resolve the incident bundle directory
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the root directory for VM memory incident bundles, honouring the
+ * `OPENCLAW_HOME` environment variable.
+ */
+export function resolveIncidentBundleRoot(): string {
+  const home = getEnv("OPENCLAW_HOME")?.trim() || join(homedir(), ".openclaw");
+  return join(home, "logs", "vm-memory-incidents");
+}

--- a/extensions/memory-hybrid/services/vm-memory-incident-capture.ts
+++ b/extensions/memory-hybrid/services/vm-memory-incident-capture.ts
@@ -140,9 +140,10 @@ function captureFallbackMemory(): FallbackMemory {
 }
 
 function isTimeoutError(err: unknown): boolean {
+  const errObj = err as NodeJS.ErrnoException & { killed?: boolean };
   return (
-    (err as NodeJS.ErrnoException)?.code === "ETIMEDOUT" ||
-    (err as { killed?: boolean })?.killed === true
+    errObj?.code === "ETIMEDOUT" ||
+    (errObj?.killed === true && errObj?.code !== "ERR_CHILD_PROCESS_STDIO_MAXBUFFER")
   );
 }
 

--- a/extensions/memory-hybrid/services/vm-memory-incident-capture.ts
+++ b/extensions/memory-hybrid/services/vm-memory-incident-capture.ts
@@ -14,6 +14,7 @@
  *     warns about empty or missing critical files.
  */
 
+import { randomBytes } from "node:crypto";
 import { existsSync, mkdirSync, readdirSync, renameSync, statSync, unlinkSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
@@ -133,7 +134,7 @@ export const DEFAULT_CRITICAL_ARTIFACTS = [
  * first, then renaming. Guarantees `destPath` is never partially written.
  */
 function atomicWrite(destPath: string, content: string): void {
-  const tmpPath = `${destPath}.tmp-${process.pid}-${Date.now()}`;
+  const tmpPath = `${destPath}.tmp-${process.pid}-${randomBytes(8).toString("hex")}`;
   mkdirSync(dirname(destPath), { recursive: true });
   try {
     writeFileSync(tmpPath, content, "utf-8");
@@ -151,6 +152,15 @@ function atomicWrite(destPath: string, content: string): void {
 function captureFallbackMemory(): FallbackMemory {
   const m = process.memoryUsage();
   return { rssBytes: m.rss, heapTotalBytes: m.heapTotal, heapUsedBytes: m.heapUsed };
+}
+
+function isTimeoutError(err: unknown): boolean {
+  return (
+    (err as NodeJS.ErrnoException)?.code === "ETIMEDOUT" ||
+    (err as { killed?: boolean })?.killed === true ||
+    (typeof (err as { signal?: string })?.signal === "string" &&
+      (err as { signal: string }).signal === "SIGTERM")
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -197,13 +207,14 @@ export async function captureLiveDiagnosticsToFile(
     const trimmed = stdout.trim();
 
     if (!trimmed) {
+      const trimmedStderr = stderr?.trim();
       const failure: LiveDiagnosticsFailure = {
         ok: false,
         status: "empty_output",
         error: "Diagnostics command produced no output",
         exitCode: 0,
         timedOut: false,
-        ...(stderr?.trim() ? { stderr: stderr.trim() } : {}),
+        ...(trimmedStderr ? { stderr: trimmedStderr } : {}),
         ...(includeFallbackMemory ? { fallbackMemory: captureFallbackMemory() } : {}),
         timestamp,
       };
@@ -219,13 +230,14 @@ export async function captureLiveDiagnosticsToFile(
           diagnostics: parsed,
         } satisfies LiveDiagnosticsSuccess;
       } catch (parseErr) {
+        const trimmedStderr = stderr?.trim();
         parsedResult = {
           ok: false,
           status: "invalid_json",
           error: `Diagnostics command output was not valid JSON: ${String(parseErr)}`,
           exitCode: 0,
           timedOut: false,
-          ...(stderr?.trim() ? { stderr: stderr.trim() } : {}),
+          ...(trimmedStderr ? { stderr: trimmedStderr } : {}),
           ...(includeFallbackMemory ? { fallbackMemory: captureFallbackMemory() } : {}),
           timestamp,
         } satisfies LiveDiagnosticsFailure;
@@ -234,11 +246,7 @@ export async function captureLiveDiagnosticsToFile(
     }
   } catch (err: unknown) {
     // execFile rejects on non-zero exit or timeout
-    const isTimeout =
-      (err as NodeJS.ErrnoException)?.code === "ETIMEDOUT" ||
-      (err as { killed?: boolean })?.killed === true ||
-      (typeof (err as { signal?: string })?.signal === "string" &&
-        (err as { signal: string }).signal === "SIGTERM");
+    const timedOut = isTimeoutError(err);
 
     const exitCode =
       typeof (err as { code?: unknown })?.code === "number"
@@ -252,10 +260,10 @@ export async function captureLiveDiagnosticsToFile(
 
     const failure: LiveDiagnosticsFailure = {
       ok: false,
-      status: isTimeout ? "timeout" : "command_failed",
+      status: timedOut ? "timeout" : "command_failed",
       error: err instanceof Error ? err.message : String(err),
       exitCode,
-      timedOut: isTimeout,
+      timedOut,
       ...(stderr ? { stderr } : {}),
       ...(includeFallbackMemory ? { fallbackMemory: captureFallbackMemory() } : {}),
       timestamp,

--- a/extensions/memory-hybrid/services/vm-memory-incident-capture.ts
+++ b/extensions/memory-hybrid/services/vm-memory-incident-capture.ts
@@ -14,13 +14,13 @@
  *     warns about empty or missing critical files.
  */
 
-import { randomBytes } from "node:crypto";
-import { existsSync, mkdirSync, readdirSync, renameSync, statSync, unlinkSync, writeFileSync } from "node:fs";
+import { existsSync, readdirSync, statSync } from "node:fs";
 import { homedir } from "node:os";
-import { dirname, join } from "node:path";
+import { join } from "node:path";
 import { execFile } from "../utils/process-runner.js";
 import { getEnv } from "../utils/env-manager.js";
 import { capturePluginError } from "./error-reporter.js";
+import { atomicWriteFile } from "../utils/atomic-write.js";
 
 /**
  * Promisified wrapper around execFile that correctly preserves the full
@@ -28,11 +28,7 @@ import { capturePluginError } from "./error-reporter.js";
  * instead of `util.promisify` avoids losing the `util.promisify.custom`
  * symbol when the function is replaced by test doubles.
  */
-function runCommand(
-  command: string,
-  args: string[],
-  timeoutMs: number,
-): Promise<{ stdout: string; stderr: string }> {
+function runCommand(command: string, args: string[], timeoutMs: number): Promise<{ stdout: string; stderr: string }> {
   return new Promise((resolve, reject) => {
     execFile(command, args, { encoding: "utf-8", timeout: timeoutMs }, (err, stdout, stderr) => {
       if (err) {
@@ -130,23 +126,12 @@ export const DEFAULT_CRITICAL_ARTIFACTS = [
 // ---------------------------------------------------------------------------
 
 /**
- * Atomically writes `content` to `destPath` by writing to a sibling temp file
- * first, then renaming. Guarantees `destPath` is never partially written.
+ * Atomically writes `content` to `destPath` using the shared crash-safe helper.
+ * Keeping this as a tiny local wrapper documents the invariant for this module
+ * without duplicating temp-file/rename semantics.
  */
 function atomicWrite(destPath: string, content: string): void {
-  const tmpPath = `${destPath}.tmp-${process.pid}-${randomBytes(8).toString("hex")}`;
-  mkdirSync(dirname(destPath), { recursive: true });
-  try {
-    writeFileSync(tmpPath, content, "utf-8");
-    renameSync(tmpPath, destPath);
-  } catch (err) {
-    try {
-      if (existsSync(tmpPath)) unlinkSync(tmpPath);
-    } catch {
-      // best-effort temp cleanup
-    }
-    throw err;
-  }
+  atomicWriteFile(destPath, content);
 }
 
 function captureFallbackMemory(): FallbackMemory {
@@ -158,9 +143,14 @@ function isTimeoutError(err: unknown): boolean {
   return (
     (err as NodeJS.ErrnoException)?.code === "ETIMEDOUT" ||
     (err as { killed?: boolean })?.killed === true ||
-    (typeof (err as { signal?: string })?.signal === "string" &&
-      (err as { signal: string }).signal === "SIGTERM")
+    (typeof (err as { signal?: string })?.signal === "string" && (err as { signal: string }).signal === "SIGTERM")
   );
+}
+
+function isSpawnError(err: unknown): boolean {
+  const code = (err as NodeJS.ErrnoException)?.code;
+  if (typeof code !== "string") return false;
+  return ["ENOENT", "EACCES", "EPERM", "ENOTDIR", "ELOOP"].includes(code);
 }
 
 // ---------------------------------------------------------------------------
@@ -249,9 +239,7 @@ export async function captureLiveDiagnosticsToFile(
     const timedOut = isTimeoutError(err);
 
     const exitCode =
-      typeof (err as { code?: unknown })?.code === "number"
-        ? ((err as { code: number }).code as number)
-        : -1;
+      typeof (err as { code?: unknown })?.code === "number" ? ((err as { code: number }).code as number) : -1;
 
     const stderr =
       typeof (err as { stderr?: string })?.stderr === "string"
@@ -260,7 +248,7 @@ export async function captureLiveDiagnosticsToFile(
 
     const failure: LiveDiagnosticsFailure = {
       ok: false,
-      status: timedOut ? "timeout" : "command_failed",
+      status: timedOut ? "timeout" : isSpawnError(err) ? "spawn_error" : "command_failed",
       error: err instanceof Error ? err.message : String(err),
       exitCode,
       timedOut,
@@ -295,10 +283,7 @@ export async function captureLiveDiagnosticsToFile(
  *
  * @returns `true` when a repair was performed, `false` otherwise.
  */
-export function repairZeroByteIncidentFile(
-  filePath: string,
-  context?: { command?: string; reason?: string },
-): boolean {
+export function repairZeroByteIncidentFile(filePath: string, context?: { command?: string; reason?: string }): boolean {
   if (!existsSync(filePath)) return false;
   let size: number;
   try {
@@ -350,10 +335,7 @@ export interface WriteIncidentManifestOptions {
  *
  * @returns The manifest that was written.
  */
-export function writeIncidentManifest(
-  bundleDir: string,
-  opts?: WriteIncidentManifestOptions,
-): IncidentManifest {
+export function writeIncidentManifest(bundleDir: string, opts?: WriteIncidentManifestOptions): IncidentManifest {
   const criticalSet = new Set<string>(opts?.criticalFiles ?? DEFAULT_CRITICAL_ARTIFACTS);
 
   // Collect all filenames from the directory (excluding the manifest itself).

--- a/extensions/memory-hybrid/services/vm-memory-incident-capture.ts
+++ b/extensions/memory-hybrid/services/vm-memory-incident-capture.ts
@@ -142,8 +142,7 @@ function captureFallbackMemory(): FallbackMemory {
 function isTimeoutError(err: unknown): boolean {
   return (
     (err as NodeJS.ErrnoException)?.code === "ETIMEDOUT" ||
-    (err as { killed?: boolean })?.killed === true ||
-    (typeof (err as { signal?: string })?.signal === "string" && (err as { signal: string }).signal === "SIGTERM")
+    (err as { killed?: boolean })?.killed === true
   );
 }
 

--- a/extensions/memory-hybrid/tests/generate-proposals-scope-filter.test.ts
+++ b/extensions/memory-hybrid/tests/generate-proposals-scope-filter.test.ts
@@ -95,9 +95,7 @@ describe("generate-proposals — requireScopeFilter (#1809)", () => {
       expect((caughtError as Error).message).not.toContain("autoRecall.scopeFilter is not set");
     }
 
-    expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining("autoRecall.scopeFilter is not set"),
-    );
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("autoRecall.scopeFilter is not set"));
   });
 
   it("throws when requireScopeFilter=true, scopeFilter absent, and non-global scoped facts exist", async () => {
@@ -107,9 +105,9 @@ describe("generate-proposals — requireScopeFilter (#1809)", () => {
 
     const ctx = makeCtx(db, proposalsDb, { requireScopeFilter: true });
 
-    await expect(
-      runGenerateProposalsForCli(ctx, { dryRun: false }, { resolvePath: (f) => f }),
-    ).rejects.toThrow("autoRecall.scopeFilter is not set");
+    await expect(runGenerateProposalsForCli(ctx, { dryRun: false }, { resolvePath: (f) => f })).rejects.toThrow(
+      "autoRecall.scopeFilter is not set",
+    );
   });
 
   it("does not throw when requireScopeFilter=true but all facts are global scope", async () => {

--- a/extensions/memory-hybrid/tests/public-api-routes.test.ts
+++ b/extensions/memory-hybrid/tests/public-api-routes.test.ts
@@ -482,7 +482,10 @@ describe("registerPublicApiRoutes", () => {
     const { api, routes } = makeApi();
     registerPublicApiRoutes({ cfg: makeCfg(true), factsDb, narrativesDb }, api);
     const route = routes.find((r) => r.path === `${PUBLIC_API_PREFIX}${PUBLIC_API_PATHS.processMemory}`)!;
-    const res = await invokeNodeHttpRoute(route.handler, fakeReq(`${PUBLIC_API_PREFIX}${PUBLIC_API_PATHS.processMemory}`));
+    const res = await invokeNodeHttpRoute(
+      route.handler,
+      fakeReq(`${PUBLIC_API_PREFIX}${PUBLIC_API_PATHS.processMemory}`),
+    );
     expect(res.status).toBe(200);
     const body = JSON.parse(res.body);
     expect(body.process.rssBytes).toBeGreaterThan(0);

--- a/extensions/memory-hybrid/tests/resolve-facts-db-pragmas.test.ts
+++ b/extensions/memory-hybrid/tests/resolve-facts-db-pragmas.test.ts
@@ -30,7 +30,7 @@ describe("resolveFactsDbPragmas", () => {
     setEnv("OPENCLAW_FACTS_CACHE_SIZE_KB", "524288"); // 512GB request
     setEnv("OPENCLAW_FACTS_MMAP_SIZE", String(2 * 1024 * 1024 * 1024)); // 2GB
     const p = resolveFactsDbPragmas(dbPath);
-    expect(p.cacheSizeKb).toBeLessThanOrEqual(Math.ceil((10 * 1024 * 1024) / 1024 * 1.5));
+    expect(p.cacheSizeKb).toBeLessThanOrEqual(Math.ceil(((10 * 1024 * 1024) / 1024) * 1.5));
     expect(p.mmapSizeBytes).toBeLessThanOrEqual(10 * 1024 * 1024 + 64 * 1024 * 1024);
   });
 });

--- a/extensions/memory-hybrid/tests/vm-memory-incident-capture.test.ts
+++ b/extensions/memory-hybrid/tests/vm-memory-incident-capture.test.ts
@@ -11,7 +11,6 @@
  */
 
 import { existsSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
-import { execFileSync } from "node:child_process";
 import { randomBytes } from "node:crypto";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -27,7 +26,8 @@ import {
   type LiveDiagnosticsFailure,
   type LiveDiagnosticsSuccess,
 } from "../services/vm-memory-incident-capture.js";
-import { setEnv } from "../utils/env-manager.js";
+import { getEnv, setEnv } from "../utils/env-manager.js";
+import { execFileSync } from "../utils/process-runner.js";
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -438,7 +438,7 @@ describe("writeIncidentManifest", () => {
 // ---------------------------------------------------------------------------
 
 describe("resolveIncidentBundleRoot", () => {
-  const originalHome = process.env.OPENCLAW_HOME;
+  const originalHome = getEnv("OPENCLAW_HOME");
 
   afterEach(() => {
     setEnv("OPENCLAW_HOME", originalHome);
@@ -486,7 +486,7 @@ describe("vm-memory-collect-diagnostics.sh", () => {
       env: {
         ...process.env,
         OPENCLAW_HOME: openclawHome,
-        PATH: `${binDir}:${process.env.PATH ?? ""}`,
+        PATH: `${binDir}:${getEnv("PATH") ?? ""}`,
       },
       stdio: "pipe",
       timeout: 20_000,

--- a/extensions/memory-hybrid/tests/vm-memory-incident-capture.test.ts
+++ b/extensions/memory-hybrid/tests/vm-memory-incident-capture.test.ts
@@ -11,6 +11,7 @@
  */
 
 import { existsSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
 import { randomBytes } from "node:crypto";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -59,11 +60,7 @@ function fileSize(path: string): number {
 }
 
 /** Matches the (error, stdout, stderr) execFile callback signature. */
-type ExecFileCallback = (
-  error: Error | null,
-  stdout: string,
-  stderr: string,
-) => void;
+type ExecFileCallback = (error: Error | null, stdout: string, stderr: string) => void;
 
 /** Constructs a fake execFile error with attached stdout/stderr and exit code. */
 function makeExecError(
@@ -81,9 +78,7 @@ function makeExecError(
 
 // We vi.mock the entire module to intercept execFile calls.
 vi.mock("../utils/process-runner.js", async () => {
-  const actual = await vi.importActual<typeof import("../utils/process-runner.js")>(
-    "../utils/process-runner.js",
-  );
+  const actual = await vi.importActual<typeof import("../utils/process-runner.js")>("../utils/process-runner.js");
   return {
     ...actual,
     execFile: vi.fn(actual.execFile),
@@ -160,6 +155,28 @@ describe("captureLiveDiagnosticsToFile — success", () => {
 // ---------------------------------------------------------------------------
 
 describe("captureLiveDiagnosticsToFile — command failure", () => {
+  it("classifies executable spawn errors as spawn_error", async () => {
+    const fakeError = makeExecError("spawn fake-diagnostic ENOENT", "ENOENT", "");
+
+    execFileMock.mockImplementation((_cmd, _args, _opts, cb: ExecFileCallback) => {
+      cb(fakeError, "", "");
+    });
+
+    const destPath = join(tmpDir, "memory-diagnostics-live.json");
+    const result = await captureLiveDiagnosticsToFile(destPath, {
+      command: "missing-diagnostic-binary",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(fileSize(destPath)).toBeGreaterThan(0);
+
+    const written = readJsonFile<LiveDiagnosticsFailure>(destPath);
+    expect(written.ok).toBe(false);
+    expect(written.status).toBe("spawn_error");
+    expect(written.exitCode).toBe(-1);
+    expect(written.timedOut).toBe(false);
+  });
+
   it("writes a non-empty failure envelope when the command exits non-zero", async () => {
     const fakeError = makeExecError("Command exited with code 1", 1, "Fatal: out of memory");
 
@@ -361,9 +378,7 @@ describe("writeIncidentManifest", () => {
     const diagArtifact = manifest.artifacts.find((a) => a.filename === "memory-diagnostics-live.json");
     expect(diagArtifact?.empty).toBe(true);
     expect(diagArtifact?.critical).toBe(true);
-    expect(manifest.warnings).toContain(
-      "Critical artifact is empty (0 bytes): memory-diagnostics-live.json",
-    );
+    expect(manifest.warnings).toContain("Critical artifact is empty (0 bytes): memory-diagnostics-live.json");
   });
 
   it("flags missing critical artifacts as warnings", () => {
@@ -439,5 +454,58 @@ describe("resolveIncidentBundleRoot", () => {
     const root = resolveIncidentBundleRoot();
     expect(root).toMatch(/vm-memory-incidents$/);
     expect(root).toMatch(/\.openclaw/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// vm-memory-collect-diagnostics.sh integration guard
+// ---------------------------------------------------------------------------
+
+describe("vm-memory-collect-diagnostics.sh", () => {
+  it("writes a non-empty failure envelope and manifest when live HTTP diagnostics fail", () => {
+    const repoRoot = join(import.meta.dirname, "..", "..", "..");
+    const scriptPath = join(repoRoot, "scripts", "vm-memory-collect-diagnostics.sh");
+    const openclawHome = join(tmpDir, "openclaw-home");
+    const incidentDir = join(openclawHome, "logs", "vm-memory-incidents", "test-incident");
+    const binDir = join(tmpDir, "bin");
+    mkdirSync(binDir, { recursive: true });
+    mkdirSync(join(openclawHome, ".secrets"), { recursive: true });
+    writeFileSync(join(openclawHome, ".secrets", "gateway-token"), "test-token", "utf-8");
+
+    // Keep the test hermetic and fast: the real script shells out to systemctl,
+    // journalctl, and optionally openclaw, so shadow them with harmless stubs.
+    for (const name of ["systemctl", "journalctl", "openclaw"]) {
+      writeFileSync(join(binDir, name), "#!/usr/bin/env bash\nexit 1\n", { encoding: "utf-8", mode: 0o755 });
+    }
+    writeFileSync(join(binDir, "curl"), "#!/usr/bin/env bash\necho 'simulated connection refused' >&2\nexit 7\n", {
+      encoding: "utf-8",
+      mode: 0o755,
+    });
+
+    execFileSync("/bin/bash", [scriptPath, incidentDir], {
+      env: {
+        ...process.env,
+        OPENCLAW_HOME: openclawHome,
+        PATH: `${binDir}:${process.env.PATH ?? ""}`,
+      },
+      stdio: "pipe",
+      timeout: 20_000,
+    });
+
+    const livePath = join(incidentDir, "memory-diagnostics-live.json");
+    expect(fileSize(livePath)).toBeGreaterThan(0);
+    const live = readJsonFile<LiveDiagnosticsFailure>(livePath);
+    expect(live).toMatchObject({
+      ok: false,
+      status: "command_failed",
+      exitCode: 7,
+      timedOut: false,
+    });
+    expect(live.stderr).toContain("simulated connection refused");
+
+    const manifest = readJsonFile<IncidentManifest>(join(incidentDir, "incident-manifest.json"));
+    const liveArtifact = manifest.artifacts.find((a) => a.filename === "memory-diagnostics-live.json");
+    expect(liveArtifact?.empty).toBe(false);
+    expect(manifest.warnings).not.toContain("Critical artifact is empty (0 bytes): memory-diagnostics-live.json");
   });
 });

--- a/extensions/memory-hybrid/tests/vm-memory-incident-capture.test.ts
+++ b/extensions/memory-hybrid/tests/vm-memory-incident-capture.test.ts
@@ -11,6 +11,7 @@
  */
 
 import { existsSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { randomBytes } from "node:crypto";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -43,7 +44,7 @@ const FAKE_DIAGNOSTICS = {
 // ---------------------------------------------------------------------------
 
 function makeTmpDir(prefix: string): string {
-  const dir = join(tmpdir(), `${prefix}-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+  const dir = join(tmpdir(), `${prefix}-${Date.now()}-${randomBytes(8).toString("hex")}`);
   mkdirSync(dir, { recursive: true });
   return dir;
 }
@@ -55,6 +56,23 @@ function readJsonFile<T>(path: string): T {
 
 function fileSize(path: string): number {
   return statSync(path).size;
+}
+
+/** Matches the (error, stdout, stderr) execFile callback signature. */
+type ExecFileCallback = (
+  error: Error | null,
+  stdout: string,
+  stderr: string,
+) => void;
+
+/** Constructs a fake execFile error with attached stdout/stderr and exit code. */
+function makeExecError(
+  message: string,
+  code: number | string,
+  stderr: string,
+  killed = false,
+): Error & { code: number | string; killed: boolean; signal: string | null; stderr: string } {
+  return Object.assign(new Error(message), { code, killed, signal: null as string | null, stderr });
 }
 
 // ---------------------------------------------------------------------------
@@ -96,7 +114,7 @@ afterEach(() => {
 
 describe("captureLiveDiagnosticsToFile — success", () => {
   it("writes valid non-empty JSON when the command succeeds", async () => {
-    execFileMock.mockImplementation((_cmd, _args, _opts, cb: (...args: unknown[]) => void) => {
+    execFileMock.mockImplementation((_cmd, _args, _opts, cb: ExecFileCallback) => {
       cb(null, JSON.stringify(FAKE_DIAGNOSTICS), "");
     });
 
@@ -116,7 +134,7 @@ describe("captureLiveDiagnosticsToFile — success", () => {
   });
 
   it("fixture: successful diagnostics object matches expected shape", async () => {
-    execFileMock.mockImplementation((_cmd, _args, _opts, cb: (...args: unknown[]) => void) => {
+    execFileMock.mockImplementation((_cmd, _args, _opts, cb: ExecFileCallback) => {
       cb(null, JSON.stringify(FAKE_DIAGNOSTICS), "");
     });
 
@@ -143,14 +161,9 @@ describe("captureLiveDiagnosticsToFile — success", () => {
 
 describe("captureLiveDiagnosticsToFile — command failure", () => {
   it("writes a non-empty failure envelope when the command exits non-zero", async () => {
-    const fakeError = Object.assign(new Error("Command exited with code 1"), {
-      code: 1,
-      killed: false,
-      signal: null,
-      stderr: "Fatal: out of memory",
-    });
+    const fakeError = makeExecError("Command exited with code 1", 1, "Fatal: out of memory");
 
-    execFileMock.mockImplementation((_cmd, _args, _opts, cb: (...args: unknown[]) => void) => {
+    execFileMock.mockImplementation((_cmd, _args, _opts, cb: ExecFileCallback) => {
       cb(fakeError, "", "Fatal: out of memory");
     });
 
@@ -173,14 +186,9 @@ describe("captureLiveDiagnosticsToFile — command failure", () => {
   });
 
   it("fixture: failed diagnostics object matches expected shape", async () => {
-    const fakeError = Object.assign(new Error("exit code 2"), {
-      code: 2,
-      killed: false,
-      signal: null,
-      stderr: "diagnostics tool crashed",
-    });
+    const fakeError = makeExecError("exit code 2", 2, "diagnostics tool crashed");
 
-    execFileMock.mockImplementation((_cmd, _args, _opts, cb: (...args: unknown[]) => void) => {
+    execFileMock.mockImplementation((_cmd, _args, _opts, cb: ExecFileCallback) => {
       cb(fakeError, "", "diagnostics tool crashed");
     });
 
@@ -207,14 +215,11 @@ describe("captureLiveDiagnosticsToFile — command failure", () => {
 
 describe("captureLiveDiagnosticsToFile — timeout", () => {
   it("writes a non-empty failure envelope with timedOut: true when the command is killed", async () => {
-    const timeoutError = Object.assign(new Error("Command timed out"), {
-      code: "ETIMEDOUT",
-      killed: true,
+    const timeoutError = Object.assign(makeExecError("Command timed out", "ETIMEDOUT", "", true), {
       signal: "SIGTERM",
-      stderr: "",
     });
 
-    execFileMock.mockImplementation((_cmd, _args, _opts, cb: (...args: unknown[]) => void) => {
+    execFileMock.mockImplementation((_cmd, _args, _opts, cb: ExecFileCallback) => {
       cb(timeoutError, "", "");
     });
 
@@ -241,7 +246,7 @@ describe("captureLiveDiagnosticsToFile — timeout", () => {
 
 describe("captureLiveDiagnosticsToFile — invalid output", () => {
   it("writes a failure envelope when the command produces non-JSON output", async () => {
-    execFileMock.mockImplementation((_cmd, _args, _opts, cb: (...args: unknown[]) => void) => {
+    execFileMock.mockImplementation((_cmd, _args, _opts, cb: ExecFileCallback) => {
       cb(null, "not json at all <<<>>>", "");
     });
 
@@ -260,7 +265,7 @@ describe("captureLiveDiagnosticsToFile — invalid output", () => {
   });
 
   it("writes a failure envelope when the command produces empty output", async () => {
-    execFileMock.mockImplementation((_cmd, _args, _opts, cb: (...args: unknown[]) => void) => {
+    execFileMock.mockImplementation((_cmd, _args, _opts, cb: ExecFileCallback) => {
       cb(null, "   \n\t  ", "");
     });
 

--- a/extensions/memory-hybrid/tests/vm-memory-incident-capture.test.ts
+++ b/extensions/memory-hybrid/tests/vm-memory-incident-capture.test.ts
@@ -1,0 +1,438 @@
+/**
+ * Tests for vm-memory-incident-capture (Issue #1828).
+ *
+ * Covers:
+ *  - Successful capture writes valid non-empty JSON
+ *  - Command failure writes a structured failure envelope (never 0 bytes)
+ *  - Command timeout writes a failure envelope with timedOut: true
+ *  - Invalid (non-JSON) command output is represented as failure
+ *  - Existing 0-byte file is repaired to a non-empty failure envelope
+ *  - Incident manifest lists artifacts, sizes, and flags empty/missing critical files
+ */
+
+import { existsSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { MockInstance } from "vitest";
+import {
+  DEFAULT_CRITICAL_ARTIFACTS,
+  captureLiveDiagnosticsToFile,
+  repairZeroByteIncidentFile,
+  resolveIncidentBundleRoot,
+  writeIncidentManifest,
+  type IncidentManifest,
+  type LiveDiagnosticsFailure,
+  type LiveDiagnosticsSuccess,
+} from "../services/vm-memory-incident-capture.js";
+import { setEnv } from "../utils/env-manager.js";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const FAKE_DIAGNOSTICS = {
+  rssBytes: 1_073_741_824,
+  heapTotalBytes: 512_000_000,
+  heapUsedBytes: 400_000_000,
+  gcStats: { collections: 12 },
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeTmpDir(prefix: string): string {
+  const dir = join(tmpdir(), `${prefix}-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function readJsonFile<T>(path: string): T {
+  const raw = readFileSync(path, "utf-8");
+  return JSON.parse(raw) as T;
+}
+
+function fileSize(path: string): number {
+  return statSync(path).size;
+}
+
+// ---------------------------------------------------------------------------
+// Mock process-runner so we don't spawn real child processes
+// ---------------------------------------------------------------------------
+
+// We vi.mock the entire module to intercept execFile calls.
+vi.mock("../utils/process-runner.js", async () => {
+  const actual = await vi.importActual<typeof import("../utils/process-runner.js")>(
+    "../utils/process-runner.js",
+  );
+  return {
+    ...actual,
+    execFile: vi.fn(actual.execFile),
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+let tmpDir: string;
+let execFileMock: MockInstance;
+
+beforeEach(async () => {
+  tmpDir = makeTmpDir("vm-incident-test");
+  const runner = await import("../utils/process-runner.js");
+  execFileMock = vi.mocked(runner.execFile);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// captureLiveDiagnosticsToFile — success path
+// ---------------------------------------------------------------------------
+
+describe("captureLiveDiagnosticsToFile — success", () => {
+  it("writes valid non-empty JSON when the command succeeds", async () => {
+    execFileMock.mockImplementation((_cmd, _args, _opts, cb: (...args: unknown[]) => void) => {
+      cb(null, JSON.stringify(FAKE_DIAGNOSTICS), "");
+    });
+
+    const destPath = join(tmpDir, "memory-diagnostics-live.json");
+    const result = await captureLiveDiagnosticsToFile(destPath, {
+      command: "fake-diagnostic",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(fileSize(destPath)).toBeGreaterThan(0);
+
+    const written = readJsonFile<LiveDiagnosticsSuccess>(destPath);
+    expect(written.ok).toBe(true);
+    expect(written.exitCode).toBe(0);
+    expect(written.diagnostics).toMatchObject(FAKE_DIAGNOSTICS);
+    expect(written.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it("fixture: successful diagnostics object matches expected shape", async () => {
+    execFileMock.mockImplementation((_cmd, _args, _opts, cb: (...args: unknown[]) => void) => {
+      cb(null, JSON.stringify(FAKE_DIAGNOSTICS), "");
+    });
+
+    const destPath = join(tmpDir, "memory-diagnostics-live.json");
+    await captureLiveDiagnosticsToFile(destPath, { command: "fake-diagnostic" });
+
+    const written = readJsonFile<LiveDiagnosticsSuccess>(destPath);
+    expect(written).toMatchObject({
+      ok: true,
+      exitCode: 0,
+      diagnostics: {
+        rssBytes: 1_073_741_824,
+        heapTotalBytes: 512_000_000,
+        heapUsedBytes: 400_000_000,
+        gcStats: { collections: 12 },
+      },
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// captureLiveDiagnosticsToFile — command failure
+// ---------------------------------------------------------------------------
+
+describe("captureLiveDiagnosticsToFile — command failure", () => {
+  it("writes a non-empty failure envelope when the command exits non-zero", async () => {
+    const fakeError = Object.assign(new Error("Command exited with code 1"), {
+      code: 1,
+      killed: false,
+      signal: null,
+      stderr: "Fatal: out of memory",
+    });
+
+    execFileMock.mockImplementation((_cmd, _args, _opts, cb: (...args: unknown[]) => void) => {
+      cb(fakeError, "", "Fatal: out of memory");
+    });
+
+    const destPath = join(tmpDir, "memory-diagnostics-live.json");
+    const result = await captureLiveDiagnosticsToFile(destPath, {
+      command: "fake-diagnostic",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(fileSize(destPath)).toBeGreaterThan(0);
+
+    const written = readJsonFile<LiveDiagnosticsFailure>(destPath);
+    expect(written.ok).toBe(false);
+    expect(written.status).toBe("command_failed");
+    expect(written.timedOut).toBe(false);
+    expect(written.stderr).toBe("Fatal: out of memory");
+    expect(written.fallbackMemory).toBeDefined();
+    expect(written.fallbackMemory?.rssBytes).toBeGreaterThan(0);
+    expect(written.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it("fixture: failed diagnostics object matches expected shape", async () => {
+    const fakeError = Object.assign(new Error("exit code 2"), {
+      code: 2,
+      killed: false,
+      signal: null,
+      stderr: "diagnostics tool crashed",
+    });
+
+    execFileMock.mockImplementation((_cmd, _args, _opts, cb: (...args: unknown[]) => void) => {
+      cb(fakeError, "", "diagnostics tool crashed");
+    });
+
+    const destPath = join(tmpDir, "memory-diagnostics-live.json");
+    await captureLiveDiagnosticsToFile(destPath, { command: "fake-diagnostic" });
+
+    const written = readJsonFile<LiveDiagnosticsFailure>(destPath);
+    expect(written).toMatchObject({
+      ok: false,
+      status: "command_failed",
+      timedOut: false,
+      stderr: "diagnostics tool crashed",
+    });
+    expect(written.fallbackMemory).toBeDefined();
+    expect(typeof written.fallbackMemory?.rssBytes).toBe("number");
+    expect(typeof written.fallbackMemory?.heapTotalBytes).toBe("number");
+    expect(typeof written.fallbackMemory?.heapUsedBytes).toBe("number");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// captureLiveDiagnosticsToFile — timeout
+// ---------------------------------------------------------------------------
+
+describe("captureLiveDiagnosticsToFile — timeout", () => {
+  it("writes a non-empty failure envelope with timedOut: true when the command is killed", async () => {
+    const timeoutError = Object.assign(new Error("Command timed out"), {
+      code: "ETIMEDOUT",
+      killed: true,
+      signal: "SIGTERM",
+      stderr: "",
+    });
+
+    execFileMock.mockImplementation((_cmd, _args, _opts, cb: (...args: unknown[]) => void) => {
+      cb(timeoutError, "", "");
+    });
+
+    const destPath = join(tmpDir, "memory-diagnostics-live.json");
+    const result = await captureLiveDiagnosticsToFile(destPath, {
+      command: "fake-diagnostic",
+      timeoutMs: 100,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(fileSize(destPath)).toBeGreaterThan(0);
+
+    const written = readJsonFile<LiveDiagnosticsFailure>(destPath);
+    expect(written.ok).toBe(false);
+    expect(written.status).toBe("timeout");
+    expect(written.timedOut).toBe(true);
+    expect(written.fallbackMemory).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// captureLiveDiagnosticsToFile — invalid JSON output
+// ---------------------------------------------------------------------------
+
+describe("captureLiveDiagnosticsToFile — invalid output", () => {
+  it("writes a failure envelope when the command produces non-JSON output", async () => {
+    execFileMock.mockImplementation((_cmd, _args, _opts, cb: (...args: unknown[]) => void) => {
+      cb(null, "not json at all <<<>>>", "");
+    });
+
+    const destPath = join(tmpDir, "memory-diagnostics-live.json");
+    const result = await captureLiveDiagnosticsToFile(destPath, {
+      command: "fake-diagnostic",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(fileSize(destPath)).toBeGreaterThan(0);
+
+    const written = readJsonFile<LiveDiagnosticsFailure>(destPath);
+    expect(written.ok).toBe(false);
+    expect(written.status).toBe("invalid_json");
+    expect(written.timedOut).toBe(false);
+  });
+
+  it("writes a failure envelope when the command produces empty output", async () => {
+    execFileMock.mockImplementation((_cmd, _args, _opts, cb: (...args: unknown[]) => void) => {
+      cb(null, "   \n\t  ", "");
+    });
+
+    const destPath = join(tmpDir, "memory-diagnostics-live.json");
+    const result = await captureLiveDiagnosticsToFile(destPath, {
+      command: "fake-diagnostic",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(fileSize(destPath)).toBeGreaterThan(0);
+
+    const written = readJsonFile<LiveDiagnosticsFailure>(destPath);
+    expect(written.ok).toBe(false);
+    expect(written.status).toBe("empty_output");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// repairZeroByteIncidentFile
+// ---------------------------------------------------------------------------
+
+describe("repairZeroByteIncidentFile", () => {
+  it("replaces a 0-byte file with a structured failure envelope", () => {
+    const filePath = join(tmpDir, "memory-diagnostics-live.json");
+    writeFileSync(filePath, "", "utf-8");
+    expect(fileSize(filePath)).toBe(0);
+
+    const repaired = repairZeroByteIncidentFile(filePath, {
+      reason: "capture command was killed before writing output",
+    });
+
+    expect(repaired).toBe(true);
+    expect(fileSize(filePath)).toBeGreaterThan(0);
+
+    const written = readJsonFile<LiveDiagnosticsFailure>(filePath);
+    expect(written.ok).toBe(false);
+    expect(written.status).toBe("empty_output");
+    expect(written.error).toContain("capture command was killed");
+    expect(written.fallbackMemory).toBeDefined();
+  });
+
+  it("does not modify a file that already has content", () => {
+    const filePath = join(tmpDir, "memory-diagnostics-live.json");
+    const original = JSON.stringify({ ok: true, diagnostics: { x: 1 } });
+    writeFileSync(filePath, original, "utf-8");
+
+    const repaired = repairZeroByteIncidentFile(filePath);
+
+    expect(repaired).toBe(false);
+    expect(readFileSync(filePath, "utf-8")).toBe(original);
+  });
+
+  it("returns false when the file does not exist", () => {
+    const missing = join(tmpDir, "does-not-exist.json");
+    expect(repairZeroByteIncidentFile(missing)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// writeIncidentManifest
+// ---------------------------------------------------------------------------
+
+describe("writeIncidentManifest", () => {
+  it("writes incident-manifest.json with artifact sizes", () => {
+    const bundleDir = join(tmpDir, "bundle1");
+    mkdirSync(bundleDir, { recursive: true });
+
+    // Write some artifacts
+    writeFileSync(join(bundleDir, "snapshot.json"), JSON.stringify({ rss: 1 }), "utf-8");
+    writeFileSync(join(bundleDir, "ps-gateway.txt"), "pid 1234\n", "utf-8");
+    // Leave memory-diagnostics-live.json empty (the problem case)
+    writeFileSync(join(bundleDir, "memory-diagnostics-live.json"), "", "utf-8");
+
+    writeIncidentManifest(bundleDir);
+
+    expect(existsSync(join(bundleDir, "incident-manifest.json"))).toBe(true);
+
+    const stored = readJsonFile<IncidentManifest>(join(bundleDir, "incident-manifest.json"));
+    expect(stored.bundleDir).toBe(bundleDir);
+    expect(stored.warnings.length).toBeGreaterThan(0);
+    expect(stored.warnings.some((w) => w.includes("memory-diagnostics-live.json"))).toBe(true);
+  });
+
+  it("flags empty critical artifacts as warnings", () => {
+    const bundleDir = join(tmpDir, "bundle2");
+    mkdirSync(bundleDir, { recursive: true });
+
+    // Empty memory-diagnostics-live.json
+    writeFileSync(join(bundleDir, "memory-diagnostics-live.json"), "", "utf-8");
+
+    const manifest = writeIncidentManifest(bundleDir);
+
+    const diagArtifact = manifest.artifacts.find((a) => a.filename === "memory-diagnostics-live.json");
+    expect(diagArtifact?.empty).toBe(true);
+    expect(diagArtifact?.critical).toBe(true);
+    expect(manifest.warnings).toContain(
+      "Critical artifact is empty (0 bytes): memory-diagnostics-live.json",
+    );
+  });
+
+  it("flags missing critical artifacts as warnings", () => {
+    const bundleDir = join(tmpDir, "bundle3");
+    mkdirSync(bundleDir, { recursive: true });
+
+    // No files — just an empty directory
+    const manifest = writeIncidentManifest(bundleDir);
+
+    expect(manifest.warnings.some((w) => w.includes("memory-diagnostics-live.json"))).toBe(true);
+    const diagArtifact = manifest.artifacts.find((a) => a.filename === "memory-diagnostics-live.json");
+    expect(diagArtifact?.missing).toBe(true);
+    expect(diagArtifact?.size).toBe(-1);
+  });
+
+  it("reports no warnings when all critical artifacts are present and non-empty", () => {
+    const bundleDir = join(tmpDir, "bundle4");
+    mkdirSync(bundleDir, { recursive: true });
+
+    for (const name of DEFAULT_CRITICAL_ARTIFACTS) {
+      writeFileSync(join(bundleDir, name), JSON.stringify({ ok: true }), "utf-8");
+    }
+
+    const manifest = writeIncidentManifest(bundleDir);
+    expect(manifest.warnings).toHaveLength(0);
+  });
+
+  it("records correct file sizes in the artifact list", () => {
+    const bundleDir = join(tmpDir, "bundle5");
+    mkdirSync(bundleDir, { recursive: true });
+
+    const content = JSON.stringify({ heap: 123_456 });
+    writeFileSync(join(bundleDir, "memory-diagnostics-live.json"), content, "utf-8");
+
+    const manifest = writeIncidentManifest(bundleDir);
+    const artifact = manifest.artifacts.find((a) => a.filename === "memory-diagnostics-live.json");
+    expect(artifact?.size).toBe(Buffer.byteLength(content, "utf-8"));
+    expect(artifact?.empty).toBe(false);
+    expect(artifact?.missing).toBe(false);
+  });
+
+  it("accepts custom critical file list", () => {
+    const bundleDir = join(tmpDir, "bundle6");
+    mkdirSync(bundleDir, { recursive: true });
+    writeFileSync(join(bundleDir, "custom-artifact.json"), "", "utf-8");
+
+    const manifest = writeIncidentManifest(bundleDir, {
+      criticalFiles: ["custom-artifact.json"],
+    });
+
+    expect(manifest.warnings).toContain("Critical artifact is empty (0 bytes): custom-artifact.json");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveIncidentBundleRoot
+// ---------------------------------------------------------------------------
+
+describe("resolveIncidentBundleRoot", () => {
+  const originalHome = process.env.OPENCLAW_HOME;
+
+  afterEach(() => {
+    setEnv("OPENCLAW_HOME", originalHome);
+  });
+
+  it("uses OPENCLAW_HOME when set", () => {
+    setEnv("OPENCLAW_HOME", "/custom/openclaw");
+    expect(resolveIncidentBundleRoot()).toBe("/custom/openclaw/logs/vm-memory-incidents");
+  });
+
+  it("falls back to ~/.openclaw when OPENCLAW_HOME is not set", () => {
+    setEnv("OPENCLAW_HOME", undefined);
+    const root = resolveIncidentBundleRoot();
+    expect(root).toMatch(/vm-memory-incidents$/);
+    expect(root).toMatch(/\.openclaw/);
+  });
+});

--- a/extensions/memory-hybrid/tools/public-api-routes.ts
+++ b/extensions/memory-hybrid/tools/public-api-routes.ts
@@ -5,10 +5,7 @@ import type { FactsDB } from "../backends/facts-db.js";
 import type { NarrativesDB } from "../backends/narratives-db.js";
 import type { VectorDB } from "../backends/vector-db.js";
 import type { ActiveTaskProjectionConfig } from "../config.js";
-import {
-  buildGatewayMemoryDiagnostics,
-  buildProcessMemorySnapshot,
-} from "../services/gateway-memory-diagnostics.js";
+import { buildGatewayMemoryDiagnostics, buildProcessMemorySnapshot } from "../services/gateway-memory-diagnostics.js";
 import { buildPublicExportBundle } from "../services/public-export-bundle.js";
 import {
   getActiveTaskProjectionStatus,

--- a/extensions/memory-hybrid/utils/process-runner.ts
+++ b/extensions/memory-hybrid/utils/process-runner.ts
@@ -1,5 +1,6 @@
 import {
   execFile as cpExecFile,
+  execFileSync as cpExecFileSync,
   execSync as cpExecSync,
   spawn as cpSpawn,
   spawnSync as cpSpawnSync,
@@ -12,6 +13,7 @@ import type * as cp from "node:child_process";
 
 export const execSync = cpExecSync;
 export const execFile = cpExecFile;
+export const execFileSync = cpExecFileSync;
 export const spawn = cpSpawn;
 export const spawnSync = cpSpawnSync;
 

--- a/scripts/vm-memory-collect-diagnostics.sh
+++ b/scripts/vm-memory-collect-diagnostics.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+# Deep diagnostic bundle for a memory alert incident directory.
+# Usage: vm-memory-collect-diagnostics.sh /path/to/incident-dir
+set -euo pipefail
+
+INCIDENT_DIR="${1:?incident directory required}"
+export HOME="${HOME:-$(getent passwd "$(id -un)" | cut -d: -f6)}"
+export OPENCLAW_HOME="${OPENCLAW_HOME:-$HOME/.openclaw}"
+export XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"
+PORT="${OPENCLAW_GATEWAY_PORT:-18789}"
+JOURNAL_LINES="${VM_MEMORY_JOURNAL_LINES:-800}"
+HEAP_SNAPSHOT="${VM_MEMORY_HEAP_SNAPSHOT:-0}"
+TOKFILE="${GATEWAY_TOKEN_FILE:-$OPENCLAW_HOME/.secrets/gateway-token}"
+LOG="$OPENCLAW_HOME/logs/vm-memory-collect-diagnostics.log"
+LIVE_DEST="$INCIDENT_DIR/memory-diagnostics-live.json"
+MANIFEST_DEST="$INCIDENT_DIR/incident-manifest.json"
+
+mkdir -p "$INCIDENT_DIR" "$(dirname "$LOG")"
+log() { echo "[$(date -Iseconds)] $*" >>"$LOG"; }
+
+json_escape_env_writer() {
+	STATUS="$1" ERROR_TEXT="$2" EXIT_CODE="$3" TIMED_OUT="$4" STDERR_FILE="${5:-}" node <<'NODE'
+const fs = require('node:fs');
+const stderrFile = process.env.STDERR_FILE || '';
+let stderr = '';
+if (stderrFile && fs.existsSync(stderrFile)) stderr = fs.readFileSync(stderrFile, 'utf8').trim();
+const mem = process.memoryUsage();
+const envelope = {
+  ok: false,
+  status: process.env.STATUS,
+  error: process.env.ERROR_TEXT,
+  exitCode: Number(process.env.EXIT_CODE || '-1'),
+  timedOut: process.env.TIMED_OUT === 'true',
+  timestamp: new Date().toISOString(),
+  fallbackMemory: {
+    rssBytes: mem.rss,
+    heapTotalBytes: mem.heapTotal,
+    heapUsedBytes: mem.heapUsed,
+  },
+};
+if (stderr) envelope.stderr = stderr.slice(0, 8192);
+process.stdout.write(JSON.stringify(envelope, null, 2) + '\n');
+NODE
+}
+
+atomic_write_text() {
+	local dest="$1"
+	local tmp="${dest}.tmp-$$-$RANDOM"
+	cat >"$tmp"
+	mv -f "$tmp" "$dest"
+}
+
+write_failure() {
+	local status="$1" error_text="$2" exit_code="$3" timed_out="$4" stderr_file="${5:-}"
+	json_escape_env_writer "$status" "$error_text" "$exit_code" "$timed_out" "$stderr_file" | atomic_write_text "$LIVE_DEST"
+}
+
+validate_non_empty_json() {
+	local path="$1"
+	[[ -s "$path" ]] || return 2
+	node -e 'const fs=require("node:fs"); JSON.parse(fs.readFileSync(process.argv[1], "utf8"));' "$path" >/dev/null 2>&1
+}
+
+write_manifest() {
+	MANIFEST_DEST="$MANIFEST_DEST" INCIDENT_DIR="$INCIDENT_DIR" node <<'NODE'
+const fs = require('node:fs');
+const path = require('node:path');
+const dir = process.env.INCIDENT_DIR;
+const manifestPath = process.env.MANIFEST_DEST;
+const critical = new Set(['memory-diagnostics-live.json', 'snapshot.json', 'leak-report.json']);
+const names = new Set([...critical]);
+try {
+  for (const ent of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (ent.isFile() && ent.name !== path.basename(manifestPath)) names.add(ent.name);
+  }
+} catch {}
+const artifacts = [];
+const warnings = [];
+for (const filename of [...names].sort()) {
+  const full = path.join(dir, filename);
+  let missing = !fs.existsSync(full);
+  let size = -1;
+  if (!missing) {
+    try { size = fs.statSync(full).size; } catch { missing = true; }
+  }
+  const empty = !missing && size === 0;
+  const item = { filename, size, missing, empty, critical: critical.has(filename) };
+  artifacts.push(item);
+  if (item.critical && item.missing) warnings.push(`Critical artifact missing: ${filename}`);
+  else if (item.critical && item.empty) warnings.push(`Critical artifact is empty (0 bytes): ${filename}`);
+}
+const manifest = { timestamp: new Date().toISOString(), bundleDir: dir, artifacts, warnings };
+const tmp = `${manifestPath}.tmp-${process.pid}-${Math.random().toString(16).slice(2)}`;
+fs.writeFileSync(tmp, JSON.stringify(manifest, null, 2) + '\n', 'utf8');
+fs.renameSync(tmp, manifestPath);
+NODE
+}
+
+log "collect start dir=$INCIDENT_DIR"
+
+# Gateway journal
+if systemctl --user is-active --quiet openclaw-gateway.service 2>/dev/null; then
+	journalctl --user -u openclaw-gateway.service -n "$JOURNAL_LINES" --no-pager \
+		>"$INCIDENT_DIR/journal-gateway.txt" 2>/dev/null || true
+	systemctl --user show openclaw-gateway.service -p MainPID,MemoryCurrent,MemoryPeak,MemoryMax,ActiveState \
+		>"$INCIDENT_DIR/systemd-gateway.txt" 2>/dev/null || true
+fi
+
+# Live HTTP diagnostics from hybrid-memory. Never redirect curl directly to the final
+# artifact: curl creates/truncates the destination before it knows whether the gateway
+# will return valid JSON. Capture to a temp file, validate, then atomically promote.
+if [[ -r "$TOKFILE" ]]; then
+	TOK="$(tr -d '\n\r' <"$TOKFILE")"
+	QUERY=""
+	if [[ "$HEAP_SNAPSHOT" == "1" ]]; then
+		QUERY="?heapSnapshot=1"
+	fi
+	tmp_live="${LIVE_DEST}.tmp-$$-$RANDOM"
+	tmp_err="${LIVE_DEST}.stderr-$$-$RANDOM"
+	if curl -fsS -m 30 -H "Authorization: Bearer $TOK" \
+		"http://127.0.0.1:${PORT}/plugins/memory-public/memory-diagnostics${QUERY}" \
+		>"$tmp_live" 2>"$tmp_err"; then
+		if validate_non_empty_json "$tmp_live"; then
+			mv -f "$tmp_live" "$LIVE_DEST"
+			log "memory-diagnostics HTTP ok heap=$HEAP_SNAPSHOT"
+		elif [[ ! -s "$tmp_live" ]]; then
+			write_failure "empty_output" "memory-diagnostics endpoint returned an empty response" 0 false "$tmp_err"
+			log "memory-diagnostics HTTP returned empty output"
+		else
+			write_failure "invalid_json" "memory-diagnostics endpoint returned non-JSON output" 0 false "$tmp_err"
+			log "memory-diagnostics HTTP returned invalid JSON"
+		fi
+	else
+		code=$?
+		status="command_failed"
+		timed_out="false"
+		if [[ "$code" == "28" ]]; then
+			status="timeout"
+			timed_out="true"
+		fi
+		write_failure "$status" "memory-diagnostics HTTP request failed" "$code" "$timed_out" "$tmp_err"
+		log "memory-diagnostics HTTP failed exit=$code status=$status"
+	fi
+	rm -f "$tmp_live" "$tmp_err"
+else
+	write_failure "command_failed" "gateway token file is not readable: $TOKFILE" -1 false ""
+	log "memory-diagnostics skipped: token file not readable"
+fi
+
+# Process list (gateway family)
+ps ax -o pid,ppid,etimes,rss,vsz,comm,args 2>/dev/null | grep -E 'openclaw|gateway|PID' \
+	>"$INCIDENT_DIR/ps-gateway.txt" || true
+
+# Cgroup memory files
+CG="/sys/fs/cgroup/user.slice/user-$(id -u).slice/user@$(id -u).service/app.slice/openclaw-gateway.service"
+if [[ -d "$CG" ]]; then
+	{
+		echo "memory.current=$(cat "$CG/memory.current" 2>/dev/null || echo n/a)"
+		echo "memory.peak=$(cat "$CG/memory.peak" 2>/dev/null || echo n/a)"
+		echo "memory.max=$(cat "$CG/memory.max" 2>/dev/null || echo n/a)"
+	} >"$INCIDENT_DIR/cgroup-memory.txt"
+fi
+
+# Tail recent snapshot / hint logs
+for f in vm-memory-snapshot.jsonl vm-memory-leak-hints.jsonl vm-memory-alerts.jsonl; do
+	p="$OPENCLAW_HOME/logs/$f"
+	if [[ -f "$p" ]]; then
+		tail -n 48 "$p" >"$INCIDENT_DIR/recent-${f%.jsonl}.tail" 2>/dev/null || true
+	fi
+done
+
+# openclaw diagnostics export (best-effort; may need Node 22+)
+if command -v openclaw >/dev/null 2>&1; then
+	timeout 120 openclaw gateway diagnostics export \
+		--output "$INCIDENT_DIR/openclaw-diagnostics.zip" \
+		--timeout 15000 \
+		>>"$LOG" 2>&1 || log "openclaw diagnostics export skipped/failed"
+fi
+
+write_manifest
+log "collect done dir=$INCIDENT_DIR"

--- a/scripts/vm-memory-collect-diagnostics.sh
+++ b/scripts/vm-memory-collect-diagnostics.sh
@@ -52,7 +52,10 @@ atomic_write_text() {
 
 write_failure() {
 	local status="$1" error_text="$2" exit_code="$3" timed_out="$4" stderr_file="${5:-}"
-	json_escape_env_writer "$status" "$error_text" "$exit_code" "$timed_out" "$stderr_file" | atomic_write_text "$LIVE_DEST"
+	local tmp="${LIVE_DEST}.tmp-$$-$RANDOM"
+	json_escape_env_writer "$status" "$error_text" "$exit_code" "$timed_out" "$stderr_file" >"$tmp"
+	[[ -s "$tmp" ]] || { rm -f "$tmp"; return 1; }
+	mv -f "$tmp" "$LIVE_DEST"
 }
 
 validate_non_empty_json() {


### PR DESCRIPTION
Closes #1828

Issue: https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/1828

Guarantees that `memory-diagnostics-live.json` inside a VM memory incident bundle is never left at 0 bytes. When the live-diagnostics command fails, times out, or produces non-JSON output, the file is replaced with a structured failure envelope so operators always have actionable JSON to inspect.

## Changes Made

### New service: `services/vm-memory-incident-capture.ts`

- **`captureLiveDiagnosticsToFile`** — runs the live-diagnostics command and writes its JSON output to `memory-diagnostics-live.json` via atomic temp-file + rename. On any failure (non-zero exit, timeout, invalid/empty output) it writes a structured `LiveDiagnosticsFailure` envelope containing `{ ok: false, status, error, exitCode, timedOut, stderr?, fallbackMemory, timestamp }` — the file is **never** left at 0 bytes.
- **`repairZeroByteIncidentFile`** — retroactively replaces an existing 0-byte file with a failure envelope for bundles assembled before this fix.
- **`writeIncidentManifest`** — scans the bundle directory, records per-artifact sizes, and flags empty or missing critical artifacts as warnings in `incident-manifest.json`.
- **`resolveIncidentBundleRoot`** — resolves the bundle root directory, honouring `OPENCLAW_HOME`.

All writes are atomic (temp-file + `renameSync`) so a mid-write crash cannot leave the destination empty or partially written.

### New tests: `tests/vm-memory-incident-capture.test.ts`

18 tests covering all acceptance criteria:
- Success path: valid non-empty JSON written; fixture shape verified
- Command failure: structured failure envelope written with `status: "command_failed"`
- Timeout: failure envelope with `timedOut: true` and `status: "timeout"`
- Invalid JSON output: `status: "invalid_json"` envelope
- Empty/whitespace-only output: `status: "empty_output"` envelope
- `repairZeroByteIncidentFile`: repairs 0-byte files, leaves non-empty files untouched
- `writeIncidentManifest`: artifact sizing, empty/missing critical-file warnings, custom critical file list
- `resolveIncidentBundleRoot`: `OPENCLAW_HOME` override and `~/.openclaw` fallback

## Testing

- ✅ All 18 tests pass (`npm run test -- tests/vm-memory-incident-capture.test.ts`)
- ✅ New files pass lint (`npx biome lint`)
- ✅ CodeQL: 0 alerts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Operational diagnostics and incident bundle I/O only; no auth, data migration, or production API behavior changes beyond safer artifact writes.
> 
> **Overview**
> This PR fixes VM memory incident bundles so **`memory-diagnostics-live.json` is never left at 0 bytes** when live diagnostics fail (#1828).
> 
> A new **`vm-memory-incident-capture`** service atomically writes successful diagnostics or a typed **`LiveDiagnosticsFailure`** envelope (command failure, timeout, invalid/empty JSON, spawn errors) with optional in-process **`fallbackMemory`**. It also adds **`repairZeroByteIncidentFile`** for legacy empty files and **`writeIncidentManifest`** to record artifact sizes and warn on missing/empty critical files (`memory-diagnostics-live.json`, `snapshot.json`, `leak-report.json`).
> 
> **`scripts/vm-memory-collect-diagnostics.sh`** is new: it gathers gateway journal, cgroup/ps snapshots, and live HTTP diagnostics via curl into a temp file, validates JSON, then promotes atomically—or writes the same failure envelope pattern in bash/node. **`execFileSync`** is exported from **`process-runner`** for the shell integration test.
> 
> The rest of the diff is **formatting** (CLI `withExit` wrapping, import lines, test expectations) with no behavioral change to maintenance or public API routes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f61447b9ceb327b693c7441d5c1fcd728c4e6f02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->