### PR TITLE
WIP: stage dream-cycle maintenance artifacts and resumable follow-ups (#1827)

### DIFF
--- a/.github/issue-stewardship/placeholders/issue-1827.md
+++ b/.github/issue-stewardship/placeholders/issue-1827.md
@@ -1,0 +1,17 @@
+---
+issue: 1827
+repo: markus-lassfolk/openclaw-hybrid-memory
+created_by: issue-stewardship
+status: placeholder
+---
+
+# Issue Stewardship Placeholder for #1827
+
+This file exists only to make the draft implementation PR non-empty while
+Copilot/Forge is dispatched to implement the actual issue scope.
+
+Issue: https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/1827
+Branch: issue-1827-dream-cycle-maintenance-run-is-monolithic-and-lo
+
+The PR must remain draft + `stage/implementing` until implementation lands and
+Issue Stewardship posts an explicit handoff marker.


### PR DESCRIPTION
Issue: https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/1827

Status: draft implementation PR created by Issue Stewardship as Markus/current gh auth.
Protection: keep as draft and `stage/implementing` until Issue Stewardship dispatches/receives implementation and explicitly hands off to PR Stewardship.

Enrichment present on issue: 0
Priority inherited from issue: High (source labels: priority:high)
Dependencies/blocked labels inherited from issue: none

## Implementation update

This PR now implements the issue scope for making dream-cycle maintenance less monolithic and preserving actionable failure artifacts:

- Added per-stage dream-cycle artifacts (`started`, `succeeded`, `failed`, `skipped`) as durable JSON files.
- Added compact per-run stage log output (`stages.log`) for operator diagnostics.
- Added `dream-cycle` CLI options:
  - `--run-id`
  - `--artifact-dir`
  - `--resume`
  - `--from-stage`
- Implemented safe resume semantics so failed follow-up stages can be retried without rerunning already-successful core mutation stages.
- Improved failure semantics so core success and follow-up degradation are distinguishable via stage artifacts and follow-up failure reporting.
- Bounded continuous-verification context loading with a capped recent-facts query to reduce context pressure in large datasets.
- Updated docs (README) with artifact and resume usage examples.
- Added focused tests covering:
  - follow-up failure after core success writes correct artifacts
  - resume from continuous-verification without rerunning core
  - continuous-verifier behavior remains validated with new context cap path

## Validation

- `npm run lint` (passes; existing repository warnings remain)
- `npm run build` (passes)
- `npm run test` (passes)

---

&gt; [!NOTE]
&gt;<sup><a href="https://cursor.com/bugbot">Cursor Bugbot</a> is generating a summary for commit d1b3941e9875161318cfdedbd087568289b2b6d4. Configure <a href="https://www.cursor.com/dashboard/bugbot">here</a>.</sup>