### PR TITLE
fix: JSON mode and reflect-meta format retry for reflect-rules (#1801)

### DIFF
--- a/extensions/memory-hybrid/cli/commands/manage/register-reflection-pipeline.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/register-reflection-pipeline.ts
@@ -490,6 +490,14 @@ export function registerManageReflectionPipeline(mem: Chainable, b: ManageBindin
         console.log(
           `Reflection (meta) complete: extracted ${res.metaExtracted} meta-patterns, stored ${res.metaStored} ${dryRun ? "(dry-run)" : ""}`,
         );
+        if (res.diagnostics) {
+          const zeroReason = res.diagnostics.zeroMetasReason
+            ? ` zero_metas_reason=${res.diagnostics.zeroMetasReason}`
+            : "";
+          console.log(
+            `Reflection (meta) diagnostics: model_response_chars=${res.diagnostics.modelResponseChars} parse_success=${res.diagnostics.parseSuccess} parsed_candidates=${res.diagnostics.parsedCandidates} rejected_length=${res.diagnostics.rejectedLength} stored=${res.diagnostics.stored} status=${res.diagnostics.status}${zeroReason}`,
+          );
+        }
       },
     ),
   );
@@ -1180,8 +1188,7 @@ export function registerManageReflectionPipeline(mem: Chainable, b: ManageBindin
           const totalConsidered = autoResolvedCount + ambiguousCount;
           const noProgress = totalConsidered > 0 && autoResolvedCount === 0;
           const degradedThresholdEnabled = degradedAmbiguousThreshold > 0;
-          const degraded =
-            degradedThresholdEnabled && noProgress && ambiguousCount >= degradedAmbiguousThreshold;
+          const degraded = degradedThresholdEnabled && noProgress && ambiguousCount >= degradedAmbiguousThreshold;
           const exitCode = degraded ? 2 : 0;
           const summary = {
             mode: "default",

--- a/extensions/memory-hybrid/services/adaptive-maintenance-llm.ts
+++ b/extensions/memory-hybrid/services/adaptive-maintenance-llm.ts
@@ -41,6 +41,8 @@ export type AdaptiveMaintenanceLlmOptions = {
   logger: MaintenanceLlmLogger;
   adaptiveStatePath?: string;
   enabled?: boolean;
+  /** OpenAI chat.completions response_format (chat wire API only). */
+  responseFormat?: { type: "json_object" };
 };
 
 function emptyState(): AdaptiveModelLimitsStateV1 {
@@ -119,6 +121,7 @@ export async function chatCompleteWithAdaptiveMaintenanceRetry(
       fallbackModels,
       label: opts.label,
       feature: opts.feature,
+      responseFormat: opts.responseFormat,
     });
     if (enabled) {
       const usedModel = detail.modelUsed;

--- a/extensions/memory-hybrid/services/chat.ts
+++ b/extensions/memory-hybrid/services/chat.ts
@@ -449,6 +449,8 @@ export async function chatComplete(opts: {
   feature?: string;
   /** Force a specific wire API surface ("chat" or "responses"). When unset, resolved from the model's provider prefix. */
   wireApi?: WireApi;
+  /** OpenAI chat.completions response_format (chat wire API only). */
+  responseFormat?: { type: "json_object" };
 }): Promise<string> {
   const {
     model,
@@ -459,6 +461,7 @@ export async function chatComplete(opts: {
     signal,
     feature,
     wireApi: wireApiOverride,
+    responseFormat,
   } = opts;
   const effectiveMaxTokens = maxTokens ?? distillMaxOutputTokens(model);
   const controller = new AbortController();
@@ -497,6 +500,9 @@ export async function chatComplete(opts: {
     };
     if (!shouldOmitSamplingParams(model)) {
       body.temperature = temperature;
+    }
+    if (responseFormat) {
+      body.response_format = responseFormat;
     }
     const doCreate = () =>
       opts.openai.chat.completions.create(body as unknown as Parameters<OpenAI["chat"]["completions"]["create"]>[0], {
@@ -856,6 +862,8 @@ export async function chatCompleteWithRetryDetailed(opts: {
   pendingWarnings?: PendingLLMWarnings;
   /** Feature label for cost tracking. Passed to chatComplete which wraps the call in withCostFeature(). */
   feature?: string;
+  /** OpenAI chat.completions response_format (chat wire API only). */
+  responseFormat?: { type: "json_object" };
 }): Promise<ChatCompleteWithRetryDetails> {
   const {
     fallbackModels = [],

--- a/extensions/memory-hybrid/services/reflection.ts
+++ b/extensions/memory-hybrid/services/reflection.ts
@@ -51,7 +51,14 @@ import {
 
 export { dotProductSimilarity, normalizeVector, parsePatternsFromReflectionResponse } from "./reflection/shared.js";
 
-import { stripThinkingWrapperBlocks } from "../utils/llm-json-array.js";
+import {
+  classifyZeroMetasReason,
+  classifyZeroRulesReason,
+  parseMetasFromModelResponse,
+  parseRulesFromModelResponse,
+  REFLECTION_META_JSON_INSTRUCTION,
+  REFLECTION_RULES_JSON_INSTRUCTION,
+} from "./reflection/structured-output.js";
 import { cleanupEvictedVector } from "./vector-maintenance.js";
 
 /** Non-superseded, non-expired pattern facts (same filter as reflection dedupe corpus). */
@@ -97,36 +104,6 @@ export interface ReflectionRulesDiagnostics {
   stored: number;
   zeroRulesReason?: string;
   status: "ok" | "partial" | "degraded";
-}
-
-// Accepted model phrases when "0 rules" is a valid no-op rather than parse failure.
-// Anchored to start-of-string but allows leading whitespace so phrases like
-// "No actionable rules detected from ..." are correctly classified.
-// Only accepts single-line no-op responses; multiline outputs must be parsed for RULE lines.
-const VALID_NO_RULES_PATTERN =
-  /^\s*(no\s+(actionable\s+)?rules?|no rules (detected|identified)|unable to extract rules|insufficient information for rules)[^\n\r]*$/i;
-const LOW_CONFIDENCE_PREFIX_PATTERN =
-  /^\s*(?:\[(?:low[-\s]?confidence)\]|\((?:low[-\s]?confidence)\)|low[-\s]?confidence\s*[:\-])\s*/i;
-const EXPLICIT_CONFIDENCE_PREFIX_PATTERN =
-  /^\s*(?:\[|\()?\s*confidence\s*[:=]\s*(?<value>0(?:\.\d+)?|1(?:\.0+)?)\s*(?:\]|\))?\s*/i;
-const REFLECTION_RULE_MIN_CONFIDENCE = 0.5;
-
-const THINKING_WRAPPER_TAGS_PATTERN = /<\/?(?:redacted_thinking|thinking|reasoning|think)>/gi;
-
-function stripThinkingWrapperTagsKeepContent(s: string): string {
-  return s.replace(THINKING_WRAPPER_TAGS_PATTERN, "").trim();
-}
-
-function extractThinkingWrapperContents(s: string): string[] {
-  const matches = s.matchAll(
-    /<(?:redacted_thinking|thinking|reasoning|think)>([\s\S]*?)<\/(?:redacted_thinking|thinking|reasoning|think)>/gi,
-  );
-  const contents: string[] = [];
-  for (const match of matches) {
-    const content = match[1]?.trim();
-    if (content) contents.push(content);
-  }
-  return contents;
 }
 
 function derivePreMergeText(mergedText: string, appendedText: string): string | null {
@@ -276,6 +253,17 @@ function reusedExistingStoreEntry(
 interface ReflectionMetaResult {
   metaExtracted: number;
   metaStored: number;
+  diagnostics?: ReflectionMetaDiagnostics;
+}
+
+export interface ReflectionMetaDiagnostics {
+  modelResponseChars: number;
+  parseSuccess: boolean;
+  parsedCandidates: number;
+  rejectedLength: number;
+  stored: number;
+  zeroMetasReason?: string;
+  status: "ok" | "partial" | "degraded";
 }
 
 /**
@@ -1188,10 +1176,11 @@ export async function runReflectionRules(
     return { rulesExtracted: 0, rulesStored: 0, diagnostics };
   }
   const patternsBlock = patterns.map((p, i) => `${i + 1}. ${p}`).join("\n");
-  const prompt = fillPrompt(loadPrompt("reflection-rules"), { patterns: patternsBlock });
+  const prompt =
+    fillPrompt(loadPrompt("reflection-rules"), { patterns: patternsBlock }) + REFLECTION_RULES_JSON_INSTRUCTION;
   if (opts.verbose) {
     logger.info(
-      `memory-hybrid: reflect-rules — LLM call (${prompt.length} chars, ${patterns.length} patterns, model=${opts.model})`,
+      `memory-hybrid: reflect-rules — LLM call (${prompt.length} chars, ${patterns.length} patterns, model=${opts.model}, jsonMode=true)`,
     );
   }
   let rawResponse: string;
@@ -1211,6 +1200,7 @@ export async function runReflectionRules(
       logger,
       adaptiveStatePath: opts.adaptiveStatePath,
       enabled: adaptiveEnabled,
+      responseFormat: { type: "json_object" },
     });
     modelUsed = detail.modelUsed;
     if (detail.modelUsed !== opts.model) {
@@ -1227,103 +1217,14 @@ export async function runReflectionRules(
     });
     throw err instanceof Error ? err : new Error(String(err));
   }
-  const trimmedResponse = rawResponse.trim();
-  const strippedResponse = stripThinkingWrapperBlocks(trimmedResponse);
-  const wrapperContents = extractThinkingWrapperContents(trimmedResponse);
-  const responseForParsing = strippedResponse.length > 0 ? strippedResponse : trimmedResponse;
-  const rules: string[] = [];
-  let rejectedLowConfidence = 0;
-  let rejectedLength = 0;
-  let parseableLines = 0;
-  for (const line of responseForParsing.split(/\n/)) {
-    const m = line.match(/^\s*RULE:\s*(.+)/);
-    if (!m) continue;
-    parseableLines++;
-    let text = m[1].trim();
-    if (LOW_CONFIDENCE_PREFIX_PATTERN.test(text)) {
-      rejectedLowConfidence++;
-      continue;
-    }
-    const confidencePrefix = text.match(EXPLICIT_CONFIDENCE_PREFIX_PATTERN);
-    if (confidencePrefix?.groups?.value) {
-      const confidence = Number.parseFloat(confidencePrefix.groups.value);
-      text = text.slice(confidencePrefix[0].length).trim();
-      if (Number.isFinite(confidence) && confidence < REFLECTION_RULE_MIN_CONFIDENCE) {
-        rejectedLowConfidence++;
-        continue;
-      }
-    }
-    if (text.length >= REFLECTION_RULE_MIN_CHARS && text.length <= REFLECTION_RULE_MAX_CHARS) {
-      rules.push(text);
-    } else {
-      rejectedLength++;
-    }
-  }
-  for (const wrapperContent of wrapperContents) {
-    for (const line of wrapperContent.split(/\n/)) {
-      const m = line.match(/^\s*RULE:\s*(.+)/);
-      if (!m) continue;
-      parseableLines++;
-      let text = m[1].trim();
-      if (LOW_CONFIDENCE_PREFIX_PATTERN.test(text)) {
-        rejectedLowConfidence++;
-        continue;
-      }
-      const confidencePrefix = text.match(EXPLICIT_CONFIDENCE_PREFIX_PATTERN);
-      if (confidencePrefix?.groups?.value) {
-        const confidence = Number.parseFloat(confidencePrefix.groups.value);
-        text = text.slice(confidencePrefix[0].length).trim();
-        if (Number.isFinite(confidence) && confidence < REFLECTION_RULE_MIN_CONFIDENCE) {
-          rejectedLowConfidence++;
-          continue;
-        }
-      }
-      if (text.length >= REFLECTION_RULE_MIN_CHARS && text.length <= REFLECTION_RULE_MAX_CHARS) {
-        rules.push(text);
-      } else {
-        rejectedLength++;
-      }
-    }
-  }
-  const seenInBatch = new Set<string>();
-  const uniqueRules: string[] = [];
-  let rejectedDuplicates = 0;
-  for (const r of rules) {
-    const key = r.toLowerCase().replace(/\s+/g, " ");
-    if (seenInBatch.has(key)) {
-      rejectedDuplicates++;
-      continue;
-    }
-    seenInBatch.add(key);
-    uniqueRules.push(r);
-  }
-  const wrapperTagStrippedResponse = stripThinkingWrapperTagsKeepContent(trimmedResponse);
-  const noRulesClassificationResponse = strippedResponse.length > 0 ? strippedResponse : wrapperTagStrippedResponse;
-  const containsRuleLineInResponse =
-    /(?:^|\n)\s*RULE:/i.test(noRulesClassificationResponse) ||
-    wrapperContents.some((content) => /(?:^|\n)\s*RULE:/i.test(content));
-  const looksLikeValidNoRules =
-    !containsRuleLineInResponse &&
-    (VALID_NO_RULES_PATTERN.test(noRulesClassificationResponse) ||
-      wrapperContents.some((content) => VALID_NO_RULES_PATTERN.test(content)));
-  const parseSuccess = parseableLines > 0 || looksLikeValidNoRules;
+  const parseResult = parseRulesFromModelResponse(rawResponse);
+  const uniqueRules = parseResult.rules;
+  const { parseableLines, rejectedLowConfidence, rejectedLength, rejectedDuplicates, parseSuccess, parsedFromJson } =
+    parseResult;
   const modelResponseChars = rawResponse.length;
   if (uniqueRules.length === 0) {
     logger.info("memory-hybrid: reflect-rules — 0 rules extracted from LLM");
-    const zeroRulesReason =
-      parseableLines > 0 && rejectedDuplicates > 0 && rejectedLowConfidence === 0 && rejectedLength === 0
-        ? "all_candidates_duplicate"
-        : parseableLines > 0 && rejectedLowConfidence > 0 && rejectedDuplicates === 0 && rejectedLength === 0
-          ? "all_candidates_rejected_low_confidence"
-          : parseableLines > 0 && rejectedLength > 0 && rejectedLowConfidence === 0 && rejectedDuplicates === 0
-            ? "all_candidates_rejected_length"
-            : parseableLines > 0
-              ? "all_candidates_rejected"
-              : looksLikeValidNoRules
-                ? "valid_no_actionable_rules"
-                : noRulesClassificationResponse.length === 0
-                  ? "empty_model_response"
-                  : "invalid_response_format";
+    const zeroRulesReason = classifyZeroRulesReason(parseResult, rawResponse.trim().length);
     const diagnostics: ReflectionRulesDiagnostics = {
       modelResponseChars,
       parseSuccess,
@@ -1347,7 +1248,8 @@ export async function runReflectionRules(
         `rejected_duplicates=${diagnostics.rejectedDuplicates} ` +
         `rejected_low_confidence=${diagnostics.rejectedLowConfidence} ` +
         `stored=${diagnostics.stored} ` +
-        `status=${diagnostics.status} zero_rules_reason=${diagnostics.zeroRulesReason}`,
+        `status=${diagnostics.status} zero_rules_reason=${diagnostics.zeroRulesReason}` +
+        (parsedFromJson ? " parsed_from=json" : ""),
     );
     // Format retry (#1824): when the model returned an unusable response format and fallbacks are
     // available, retry with the next model in the chain before giving up.
@@ -1377,6 +1279,10 @@ export async function runReflectionRules(
       throw new Error(`memory-hybrid: reflect-rules — model=${modelUsed} failure_type=${zeroRulesReason}`);
     }
     return { rulesExtracted: uniqueRules.length, rulesStored: 0, diagnostics };
+  }
+
+  if (parsedFromJson && opts.verbose) {
+    logger.info("memory-hybrid: reflect-rules — parsed rules from JSON response");
   }
 
   logger.info(
@@ -1909,13 +1815,15 @@ export async function runReflectionMeta(
     return { metaExtracted: 0, metaStored: 0 };
   }
   const patternsBlock = patterns.map((p, i) => `${i + 1}. ${p}`).join("\n");
-  const prompt = fillPrompt(loadPrompt("reflection-meta"), { patterns: patternsBlock });
+  const prompt =
+    fillPrompt(loadPrompt("reflection-meta"), { patterns: patternsBlock }) + REFLECTION_META_JSON_INSTRUCTION;
   if (opts.verbose) {
     logger.info(
-      `memory-hybrid: reflect-meta — LLM call (${prompt.length} chars, ${patterns.length} patterns, model=${opts.model})`,
+      `memory-hybrid: reflect-meta — LLM call (${prompt.length} chars, ${patterns.length} patterns, model=${opts.model}, jsonMode=true)`,
     );
   }
   let rawResponse: string;
+  let modelUsed: string;
   try {
     const adaptiveEnabled = (getEnv("OPENCLAW_HYBRID_MEM_ADAPTIVE_DISTILL") ?? "").trim() !== "0";
     const detail = await chatCompleteWithAdaptiveMaintenanceRetry({
@@ -1931,7 +1839,9 @@ export async function runReflectionMeta(
       logger,
       adaptiveStatePath: opts.adaptiveStatePath,
       enabled: adaptiveEnabled,
+      responseFormat: { type: "json_object" },
     });
+    modelUsed = detail.modelUsed;
     if (detail.modelUsed !== opts.model) {
       logger.info(`memory-hybrid: reflect-meta — used fallback model ${detail.modelUsed}`);
     }
@@ -1944,26 +1854,67 @@ export async function runReflectionMeta(
       subsystem: "openai",
       retryAttempt,
     });
-    return { metaExtracted: 0, metaStored: 0 };
+    throw err instanceof Error ? err : new Error(String(err));
   }
-  const metas: string[] = [];
-  for (const line of rawResponse.split(/\n/)) {
-    const m = line.match(/^\s*META:\s*(.+)/);
-    if (!m) continue;
-    const text = m[1].trim();
-    if (text.length >= REFLECTION_META_MIN_CHARS && text.length <= REFLECTION_META_MAX_CHARS) metas.push(text);
-  }
-  const seenInBatch = new Set<string>();
-  const uniqueMetas: string[] = [];
-  for (const x of metas) {
-    const key = x.toLowerCase().replace(/\s+/g, " ");
-    if (seenInBatch.has(key)) continue;
-    seenInBatch.add(key);
-    uniqueMetas.push(x);
-  }
+  const parseResult = parseMetasFromModelResponse(rawResponse);
+  const uniqueMetas = parseResult.metas;
+  const modelResponseChars = rawResponse.length;
   if (uniqueMetas.length === 0) {
     logger.info("memory-hybrid: reflect-meta — 0 meta-patterns extracted from LLM");
-    return { metaExtracted: metas.length, metaStored: 0 };
+    const zeroMetasReason = classifyZeroMetasReason(parseResult, rawResponse.trim().length);
+    const diagnostics: ReflectionMetaDiagnostics = {
+      modelResponseChars,
+      parseSuccess: parseResult.parseSuccess,
+      parsedCandidates: parseResult.parseableLines,
+      rejectedLength: parseResult.rejectedLength,
+      stored: 0,
+      zeroMetasReason,
+      status:
+        zeroMetasReason === "invalid_response_format" || zeroMetasReason === "empty_model_response"
+          ? "degraded"
+          : zeroMetasReason === "valid_no_actionable_metas"
+            ? "ok"
+            : "partial",
+    };
+    logger.info(
+      "memory-hybrid: reflect-meta — diagnostics: " +
+        `model_response_chars=${diagnostics.modelResponseChars} ` +
+        `parse_success=${diagnostics.parseSuccess} ` +
+        `parsed_candidates=${diagnostics.parsedCandidates} ` +
+        `rejected_length=${diagnostics.rejectedLength} ` +
+        `stored=${diagnostics.stored} ` +
+        `status=${diagnostics.status} zero_metas_reason=${diagnostics.zeroMetasReason}` +
+        (parseResult.parsedFromJson ? " parsed_from=json" : ""),
+    );
+    if (
+      (zeroMetasReason === "invalid_response_format" || zeroMetasReason === "empty_model_response") &&
+      opts.fallbackModels?.length
+    ) {
+      const remainingFallbacks = opts.fallbackModels.filter((m) => m !== modelUsed);
+      if (remainingFallbacks.length > 0) {
+        const [fallbackModel, ...nextFallbacks] = remainingFallbacks;
+        logger.warn(
+          `memory-hybrid: reflect-meta — ${modelUsed} returned ${zeroMetasReason}, retrying with fallback model ${fallbackModel}`,
+        );
+        return runReflectionMeta(
+          factsDb,
+          vectorDb,
+          embeddings,
+          openai,
+          { ...opts, model: fallbackModel, fallbackModels: nextFallbacks, modelSource: "format-retry-fallback" },
+          logger,
+          provenanceService,
+        );
+      }
+    }
+    if (zeroMetasReason === "invalid_response_format" || zeroMetasReason === "empty_model_response") {
+      throw new Error(`memory-hybrid: reflect-meta — model=${modelUsed} failure_type=${zeroMetasReason}`);
+    }
+    return { metaExtracted: parseResult.parseableLines, metaStored: 0, diagnostics };
+  }
+
+  if (parseResult.parsedFromJson && opts.verbose) {
+    logger.info("memory-hybrid: reflect-meta — parsed meta-patterns from JSON response");
   }
 
   logger.info(
@@ -2378,5 +2329,16 @@ export async function runReflectionMeta(
     );
   }
 
-  return { metaExtracted: metas.length, metaStored: stored };
+  return {
+    metaExtracted: uniqueMetas.length,
+    metaStored: stored,
+    diagnostics: {
+      modelResponseChars,
+      parseSuccess: true,
+      parsedCandidates: parseResult.parseableLines,
+      rejectedLength: parseResult.rejectedLength,
+      stored,
+      status: "ok",
+    },
+  };
 }

--- a/extensions/memory-hybrid/services/reflection.ts
+++ b/extensions/memory-hybrid/services/reflection.ts
@@ -1910,7 +1910,7 @@ export async function runReflectionMeta(
     if (zeroMetasReason === "invalid_response_format" || zeroMetasReason === "empty_model_response") {
       throw new Error(`memory-hybrid: reflect-meta — model=${modelUsed} failure_type=${zeroMetasReason}`);
     }
-    return { metaExtracted: parseResult.parseableLines, metaStored: 0, diagnostics };
+    return { metaExtracted: uniqueMetas.length, metaStored: 0, diagnostics };
   }
 
   if (parseResult.parsedFromJson && opts.verbose) {

--- a/extensions/memory-hybrid/services/reflection/structured-output.ts
+++ b/extensions/memory-hybrid/services/reflection/structured-output.ts
@@ -262,7 +262,7 @@ export function parseRulesFromModelResponse(rawResponse: string): ReflectionRule
       };
     }
   }
-  
+
   const lineParse = parseRuleLines(responseForParsing);
   if (!jsonObject) {
     rules = lineParse.rules;
@@ -276,6 +276,24 @@ export function parseRulesFromModelResponse(rawResponse: string): ReflectionRule
     rules.push(...lineParse.rules);
   }
   for (const wrapperContent of wrapperContents) {
+    const wrapperJsonObject = tryParseJsonObject(wrapperContent);
+    if (wrapperJsonObject && !parsedFromJson) {
+      parsedFromJson = true;
+      const jsonRules = readStringArrayField(wrapperJsonObject, "rules");
+      parseableLines += jsonRules.length;
+      for (const candidate of jsonRules) {
+        const normalized = normalizeRuleCandidate(candidate);
+        if (normalized.rejectedLowConfidence) {
+          rejectedLowConfidence++;
+          continue;
+        }
+        if (normalized.rejectedLength) {
+          rejectedLength++;
+          continue;
+        }
+        rules.push(normalized.text);
+      }
+    }
     const wrapperParse = parseRuleLines(wrapperContent);
     parseableLines += wrapperParse.parseableLines;
     rejectedLowConfidence += wrapperParse.rejectedLowConfidence;
@@ -355,6 +373,19 @@ export function parseMetasFromModelResponse(rawResponse: string): ReflectionMeta
   }
 
   for (const wrapperContent of extractThinkingWrapperContents(trimmedResponse)) {
+    const wrapperJsonObject = tryParseJsonObject(wrapperContent);
+    if (wrapperJsonObject && !parsedFromJson) {
+      parsedFromJson = true;
+      const jsonMetas = readStringArrayField(wrapperJsonObject, "metas");
+      parseableLines += jsonMetas.length;
+      for (const candidate of jsonMetas) {
+        if (candidate.length >= REFLECTION_META_MIN_CHARS && candidate.length <= REFLECTION_META_MAX_CHARS) {
+          metas.push(candidate);
+        } else {
+          rejectedLength++;
+        }
+      }
+    }
     const wrapperParse = parseMetaLines(wrapperContent);
     metas.push(...wrapperParse.metas);
     parseableLines += wrapperParse.parseableLines;

--- a/extensions/memory-hybrid/services/reflection/structured-output.ts
+++ b/extensions/memory-hybrid/services/reflection/structured-output.ts
@@ -293,6 +293,18 @@ export function parseRulesFromModelResponse(rawResponse: string): ReflectionRule
         }
         rules.push(normalized.text);
       }
+      if (rules.length === 0 && readBooleanField(wrapperJsonObject, "noAction") && parseableLines === 0) {
+        return {
+          rules: [],
+          parseableLines: 0,
+          rejectedLowConfidence: 0,
+          rejectedLength: 0,
+          rejectedDuplicates: 0,
+          looksLikeValidNoRules: true,
+          parseSuccess: true,
+          parsedFromJson: true,
+        };
+      }
     }
     const wrapperParse = parseRuleLines(wrapperContent);
     parseableLines += wrapperParse.parseableLines;
@@ -384,6 +396,17 @@ export function parseMetasFromModelResponse(rawResponse: string): ReflectionMeta
         } else {
           rejectedLength++;
         }
+      }
+      if (metas.length === 0 && readBooleanField(wrapperJsonObject, "noAction") && parseableLines === 0) {
+        return {
+          metas: [],
+          parseableLines: 0,
+          rejectedLength: 0,
+          rejectedDuplicates: 0,
+          looksLikeValidNoMetas: true,
+          parseSuccess: true,
+          parsedFromJson: true,
+        };
       }
     }
     const wrapperParse = parseMetaLines(wrapperContent);

--- a/extensions/memory-hybrid/services/reflection/structured-output.ts
+++ b/extensions/memory-hybrid/services/reflection/structured-output.ts
@@ -261,19 +261,26 @@ export function parseRulesFromModelResponse(rawResponse: string): ReflectionRule
         parsedFromJson: true,
       };
     }
-  } else {
-    const lineParse = parseRuleLines(responseForParsing);
+  }
+  
+  const lineParse = parseRuleLines(responseForParsing);
+  if (!jsonObject) {
     rules = lineParse.rules;
     parseableLines = lineParse.parseableLines;
     rejectedLowConfidence = lineParse.rejectedLowConfidence;
     rejectedLength = lineParse.rejectedLength;
-    for (const wrapperContent of wrapperContents) {
-      const wrapperParse = parseRuleLines(wrapperContent);
-      parseableLines += wrapperParse.parseableLines;
-      rejectedLowConfidence += wrapperParse.rejectedLowConfidence;
-      rejectedLength += wrapperParse.rejectedLength;
-      rules.push(...wrapperParse.rules);
-    }
+  } else {
+    parseableLines += lineParse.parseableLines;
+    rejectedLowConfidence += lineParse.rejectedLowConfidence;
+    rejectedLength += lineParse.rejectedLength;
+    rules.push(...lineParse.rules);
+  }
+  for (const wrapperContent of wrapperContents) {
+    const wrapperParse = parseRuleLines(wrapperContent);
+    parseableLines += wrapperParse.parseableLines;
+    rejectedLowConfidence += wrapperParse.rejectedLowConfidence;
+    rejectedLength += wrapperParse.rejectedLength;
+    rules.push(...wrapperParse.rules);
   }
 
   const { unique, rejectedDuplicates } = dedupeStrings(rules);
@@ -334,18 +341,24 @@ export function parseMetasFromModelResponse(rawResponse: string): ReflectionMeta
         parsedFromJson: true,
       };
     }
-  } else {
-    const lineParse = parseMetaLines(responseForParsing);
+  }
+
+  const lineParse = parseMetaLines(responseForParsing);
+  if (!jsonObject) {
     metas = lineParse.metas;
     parseableLines = lineParse.parseableLines;
     rejectedLength = lineParse.rejectedLength;
+  } else {
+    parseableLines += lineParse.parseableLines;
+    rejectedLength += lineParse.rejectedLength;
+    metas.push(...lineParse.metas);
+  }
 
-    for (const wrapperContent of extractThinkingWrapperContents(trimmedResponse)) {
-      const wrapperParse = parseMetaLines(wrapperContent);
-      metas.push(...wrapperParse.metas);
-      parseableLines += wrapperParse.parseableLines;
-      rejectedLength += wrapperParse.rejectedLength;
-    }
+  for (const wrapperContent of extractThinkingWrapperContents(trimmedResponse)) {
+    const wrapperParse = parseMetaLines(wrapperContent);
+    metas.push(...wrapperParse.metas);
+    parseableLines += wrapperParse.parseableLines;
+    rejectedLength += wrapperParse.rejectedLength;
   }
 
   const { unique, rejectedDuplicates } = dedupeStrings(metas);

--- a/extensions/memory-hybrid/services/reflection/structured-output.ts
+++ b/extensions/memory-hybrid/services/reflection/structured-output.ts
@@ -1,0 +1,409 @@
+/**
+ * Structured JSON output parsing for reflect-rules and reflect-meta (#1801).
+ * JSON mode is requested via chat response_format; line-based RULE:/META: parsing remains as fallback.
+ */
+
+import { stripMarkdownCodeFence, stripThinkingWrapperBlocks } from "../../utils/llm-json-array.js";
+import { REFLECTION_META_MAX_CHARS } from "../../utils/constants.js";
+import { REFLECTION_META_MIN_CHARS, REFLECTION_RULE_MAX_CHARS, REFLECTION_RULE_MIN_CHARS } from "./shared.js";
+
+export const REFLECTION_RULES_JSON_INSTRUCTION = `
+
+Respond with JSON only (no markdown fences). Use this schema:
+{"rules":["<imperative one-line rule>", "..."],"noAction":false}
+When there are no actionable rules, return {"rules":[],"noAction":true}.
+Each rule must be a single imperative line under 80 characters.`;
+
+export const REFLECTION_META_JSON_INSTRUCTION = `
+
+Respond with JSON only (no markdown fences). Use this schema:
+{"metas":["<1-2 sentence meta-pattern>", "..."],"noAction":false}
+When there are no meta-patterns, return {"metas":[],"noAction":true}.
+Each meta-pattern must be 1-2 sentences synthesizing themes across the patterns.`;
+
+const VALID_NO_RULES_PATTERN =
+  /^\s*(no\s+(actionable\s+)?rules?|no rules (detected|identified)|unable to extract rules|insufficient information for rules)[^\n\r]*$/i;
+const VALID_NO_META_PATTERN =
+  /^\s*(no\s+(actionable\s+)?meta[-\s]?patterns?|no meta[-\s]?patterns (detected|identified)|unable to extract meta|insufficient information for meta)[^\n\r]*$/i;
+const LOW_CONFIDENCE_PREFIX_PATTERN =
+  /^\s*(?:\[(?:low[-\s]?confidence)\]|\((?:low[-\s]?confidence)\)|low[-\s]?confidence\s*[:\-])\s*/i;
+const EXPLICIT_CONFIDENCE_PREFIX_PATTERN =
+  /^\s*(?:\[|\()?\s*confidence\s*[:=]\s*(?<value>0(?:\.\d+)?|1(?:\.0+)?)\s*(?:\]|\))?\s*/i;
+const REFLECTION_RULE_MIN_CONFIDENCE = 0.5;
+
+export type ReflectionRulesParseResult = {
+  rules: string[];
+  parseableLines: number;
+  rejectedLowConfidence: number;
+  rejectedLength: number;
+  rejectedDuplicates: number;
+  looksLikeValidNoRules: boolean;
+  parseSuccess: boolean;
+  parsedFromJson: boolean;
+};
+
+export type ReflectionMetaParseResult = {
+  metas: string[];
+  parseableLines: number;
+  rejectedLength: number;
+  rejectedDuplicates: number;
+  looksLikeValidNoMetas: boolean;
+  parseSuccess: boolean;
+  parsedFromJson: boolean;
+};
+
+function tryParseJsonObject(raw: string): Record<string, unknown> | null {
+  const stripped = stripThinkingWrapperBlocks(stripMarkdownCodeFence(raw.trim()));
+  if (!stripped) return null;
+  try {
+    const parsed: unknown = JSON.parse(stripped);
+    return typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : null;
+  } catch {
+    const start = stripped.indexOf("{");
+    if (start === -1) return null;
+    let depth = 0;
+    let inString = false;
+    let afterBackslash = false;
+    for (let i = start; i < stripped.length; i++) {
+      const c = stripped.charAt(i);
+      if (inString) {
+        if (afterBackslash) {
+          afterBackslash = false;
+          continue;
+        }
+        if (c === "\\") {
+          afterBackslash = true;
+          continue;
+        }
+        if (c === '"') {
+          inString = false;
+          continue;
+        }
+        continue;
+      }
+      if (c === '"') {
+        inString = true;
+        continue;
+      }
+      if (c === "{") depth++;
+      else if (c === "}") {
+        depth--;
+        if (depth === 0) {
+          try {
+            const parsed: unknown = JSON.parse(stripped.slice(start, i + 1));
+            return typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)
+              ? (parsed as Record<string, unknown>)
+              : null;
+          } catch {
+            return null;
+          }
+        }
+      }
+    }
+    return null;
+  }
+}
+
+function readStringArrayField(obj: Record<string, unknown>, key: string): string[] {
+  const value = obj[key];
+  if (!Array.isArray(value)) return [];
+  return value
+    .filter((item): item is string => typeof item === "string")
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+function readBooleanField(obj: Record<string, unknown>, key: string): boolean {
+  return obj[key] === true;
+}
+
+function normalizeRuleCandidate(text: string): {
+  text: string;
+  rejectedLowConfidence: boolean;
+  rejectedLength: boolean;
+} {
+  let candidate = text.trim();
+  if (LOW_CONFIDENCE_PREFIX_PATTERN.test(candidate)) {
+    return { text: candidate, rejectedLowConfidence: true, rejectedLength: false };
+  }
+  const confidencePrefix = candidate.match(EXPLICIT_CONFIDENCE_PREFIX_PATTERN);
+  if (confidencePrefix?.groups?.value) {
+    const confidence = Number.parseFloat(confidencePrefix.groups.value);
+    candidate = candidate.slice(confidencePrefix[0].length).trim();
+    if (Number.isFinite(confidence) && confidence < REFLECTION_RULE_MIN_CONFIDENCE) {
+      return { text: candidate, rejectedLowConfidence: true, rejectedLength: false };
+    }
+  }
+  if (candidate.length >= REFLECTION_RULE_MIN_CHARS && candidate.length <= REFLECTION_RULE_MAX_CHARS) {
+    return { text: candidate, rejectedLowConfidence: false, rejectedLength: false };
+  }
+  return { text: candidate, rejectedLowConfidence: false, rejectedLength: true };
+}
+
+function dedupeStrings(items: string[]): { unique: string[]; rejectedDuplicates: number } {
+  const seenInBatch = new Set<string>();
+  const unique: string[] = [];
+  let rejectedDuplicates = 0;
+  for (const item of items) {
+    const key = item.toLowerCase().replace(/\s+/g, " ");
+    if (seenInBatch.has(key)) {
+      rejectedDuplicates++;
+      continue;
+    }
+    seenInBatch.add(key);
+    unique.push(item);
+  }
+  return { unique, rejectedDuplicates };
+}
+
+function parseRuleLines(text: string): {
+  rules: string[];
+  parseableLines: number;
+  rejectedLowConfidence: number;
+  rejectedLength: number;
+} {
+  const rules: string[] = [];
+  let parseableLines = 0;
+  let rejectedLowConfidence = 0;
+  let rejectedLength = 0;
+  for (const line of text.split(/\n/)) {
+    const m = line.match(/^\s*RULE:\s*(.+)/);
+    if (!m) continue;
+    parseableLines++;
+    const normalized = normalizeRuleCandidate(m[1]);
+    if (normalized.rejectedLowConfidence) {
+      rejectedLowConfidence++;
+      continue;
+    }
+    if (normalized.rejectedLength) {
+      rejectedLength++;
+      continue;
+    }
+    rules.push(normalized.text);
+  }
+  return { rules, parseableLines, rejectedLowConfidence, rejectedLength };
+}
+
+function parseMetaLines(text: string): {
+  metas: string[];
+  parseableLines: number;
+  rejectedLength: number;
+} {
+  const metas: string[] = [];
+  let parseableLines = 0;
+  let rejectedLength = 0;
+  for (const line of text.split(/\n/)) {
+    const m = line.match(/^\s*META:\s*(.+)/);
+    if (!m) continue;
+    parseableLines++;
+    const candidate = m[1].trim();
+    if (candidate.length >= REFLECTION_META_MIN_CHARS && candidate.length <= REFLECTION_META_MAX_CHARS) {
+      metas.push(candidate);
+    } else {
+      rejectedLength++;
+    }
+  }
+  return { metas, parseableLines, rejectedLength };
+}
+
+function extractThinkingWrapperContents(s: string): string[] {
+  const matches = s.matchAll(
+    /<(?:redacted_thinking|thinking|reasoning|think)>([\s\S]*?)<\/(?:redacted_thinking|thinking|reasoning|think)>/gi,
+  );
+  const contents: string[] = [];
+  for (const match of matches) {
+    const content = match[1]?.trim();
+    if (content) contents.push(content);
+  }
+  return contents;
+}
+
+export function parseRulesFromModelResponse(rawResponse: string): ReflectionRulesParseResult {
+  const trimmedResponse = rawResponse.trim();
+  const strippedResponse = stripThinkingWrapperBlocks(trimmedResponse);
+  const wrapperContents = extractThinkingWrapperContents(trimmedResponse);
+  const responseForParsing = strippedResponse.length > 0 ? strippedResponse : trimmedResponse;
+
+  let rules: string[] = [];
+  let parseableLines = 0;
+  let rejectedLowConfidence = 0;
+  let rejectedLength = 0;
+  let parsedFromJson = false;
+
+  const jsonObject = tryParseJsonObject(responseForParsing);
+  if (jsonObject) {
+    parsedFromJson = true;
+    const jsonRules = readStringArrayField(jsonObject, "rules");
+    parseableLines = jsonRules.length;
+    for (const candidate of jsonRules) {
+      const normalized = normalizeRuleCandidate(candidate);
+      if (normalized.rejectedLowConfidence) {
+        rejectedLowConfidence++;
+        continue;
+      }
+      if (normalized.rejectedLength) {
+        rejectedLength++;
+        continue;
+      }
+      rules.push(normalized.text);
+    }
+    if (rules.length === 0 && readBooleanField(jsonObject, "noAction")) {
+      return {
+        rules: [],
+        parseableLines: 0,
+        rejectedLowConfidence: 0,
+        rejectedLength: 0,
+        rejectedDuplicates: 0,
+        looksLikeValidNoRules: true,
+        parseSuccess: true,
+        parsedFromJson: true,
+      };
+    }
+  } else {
+    const lineParse = parseRuleLines(responseForParsing);
+    rules = lineParse.rules;
+    parseableLines = lineParse.parseableLines;
+    rejectedLowConfidence = lineParse.rejectedLowConfidence;
+    rejectedLength = lineParse.rejectedLength;
+    for (const wrapperContent of wrapperContents) {
+      const wrapperParse = parseRuleLines(wrapperContent);
+      parseableLines += wrapperParse.parseableLines;
+      rejectedLowConfidence += wrapperParse.rejectedLowConfidence;
+      rejectedLength += wrapperParse.rejectedLength;
+      rules.push(...wrapperParse.rules);
+    }
+  }
+
+  const { unique, rejectedDuplicates } = dedupeStrings(rules);
+  const noRulesClassificationResponse = strippedResponse.length > 0 ? strippedResponse : trimmedResponse;
+  const containsRuleLineInResponse =
+    parsedFromJson ||
+    /(?:^|\n)\s*RULE:/i.test(noRulesClassificationResponse) ||
+    wrapperContents.some((content) => /(?:^|\n)\s*RULE:/i.test(content));
+  const looksLikeValidNoRules =
+    unique.length === 0 &&
+    !containsRuleLineInResponse &&
+    (VALID_NO_RULES_PATTERN.test(noRulesClassificationResponse) ||
+      wrapperContents.some((content) => VALID_NO_RULES_PATTERN.test(content)));
+  const parseSuccess = parseableLines > 0 || looksLikeValidNoRules;
+
+  return {
+    rules: unique,
+    parseableLines,
+    rejectedLowConfidence,
+    rejectedLength,
+    rejectedDuplicates,
+    looksLikeValidNoRules,
+    parseSuccess,
+    parsedFromJson,
+  };
+}
+
+export function parseMetasFromModelResponse(rawResponse: string): ReflectionMetaParseResult {
+  const trimmedResponse = rawResponse.trim();
+  const strippedResponse = stripThinkingWrapperBlocks(trimmedResponse);
+  const responseForParsing = strippedResponse.length > 0 ? strippedResponse : trimmedResponse;
+
+  let metas: string[] = [];
+  let parseableLines = 0;
+  let rejectedLength = 0;
+  let parsedFromJson = false;
+
+  const jsonObject = tryParseJsonObject(responseForParsing);
+  if (jsonObject) {
+    parsedFromJson = true;
+    const jsonMetas = readStringArrayField(jsonObject, "metas");
+    parseableLines = jsonMetas.length;
+    for (const candidate of jsonMetas) {
+      if (candidate.length >= REFLECTION_META_MIN_CHARS && candidate.length <= REFLECTION_META_MAX_CHARS) {
+        metas.push(candidate);
+      } else {
+        rejectedLength++;
+      }
+    }
+    if (metas.length === 0 && readBooleanField(jsonObject, "noAction")) {
+      return {
+        metas: [],
+        parseableLines: 0,
+        rejectedLength: 0,
+        rejectedDuplicates: 0,
+        looksLikeValidNoMetas: true,
+        parseSuccess: true,
+        parsedFromJson: true,
+      };
+    }
+  } else {
+    const lineParse = parseMetaLines(responseForParsing);
+    metas = lineParse.metas;
+    parseableLines = lineParse.parseableLines;
+    rejectedLength = lineParse.rejectedLength;
+  }
+
+  const { unique, rejectedDuplicates } = dedupeStrings(metas);
+  const looksLikeValidNoMetas =
+    unique.length === 0 &&
+    !parsedFromJson &&
+    !/(?:^|\n)\s*META:/i.test(responseForParsing) &&
+    VALID_NO_META_PATTERN.test(responseForParsing);
+  const parseSuccess = parseableLines > 0 || looksLikeValidNoMetas;
+
+  return {
+    metas: unique,
+    parseableLines,
+    rejectedLength,
+    rejectedDuplicates,
+    looksLikeValidNoMetas,
+    parseSuccess,
+    parsedFromJson,
+  };
+}
+
+export function classifyZeroRulesReason(
+  parse: Pick<
+    ReflectionRulesParseResult,
+    "parseableLines" | "rejectedDuplicates" | "rejectedLowConfidence" | "rejectedLength" | "looksLikeValidNoRules"
+  >,
+  responseLength: number,
+): string {
+  if (parse.looksLikeValidNoRules) return "valid_no_actionable_rules";
+  if (responseLength === 0) return "empty_model_response";
+  if (
+    parse.parseableLines > 0 &&
+    parse.rejectedDuplicates > 0 &&
+    parse.rejectedLowConfidence === 0 &&
+    parse.rejectedLength === 0
+  ) {
+    return "all_candidates_duplicate";
+  }
+  if (
+    parse.parseableLines > 0 &&
+    parse.rejectedLowConfidence > 0 &&
+    parse.rejectedDuplicates === 0 &&
+    parse.rejectedLength === 0
+  ) {
+    return "all_candidates_rejected_low_confidence";
+  }
+  if (
+    parse.parseableLines > 0 &&
+    parse.rejectedLength > 0 &&
+    parse.rejectedLowConfidence === 0 &&
+    parse.rejectedDuplicates === 0
+  ) {
+    return "all_candidates_rejected_length";
+  }
+  if (parse.parseableLines > 0) return "all_candidates_rejected";
+  return "invalid_response_format";
+}
+
+export function classifyZeroMetasReason(
+  parse: Pick<ReflectionMetaParseResult, "parseableLines" | "rejectedLength" | "looksLikeValidNoMetas">,
+  responseLength: number,
+): string {
+  if (parse.looksLikeValidNoMetas) return "valid_no_actionable_metas";
+  if (responseLength === 0) return "empty_model_response";
+  if (parse.parseableLines > 0 && parse.rejectedLength > 0) return "all_candidates_rejected_length";
+  if (parse.parseableLines > 0) return "all_candidates_rejected";
+  return "invalid_response_format";
+}

--- a/extensions/memory-hybrid/services/reflection/structured-output.ts
+++ b/extensions/memory-hybrid/services/reflection/structured-output.ts
@@ -339,6 +339,13 @@ export function parseMetasFromModelResponse(rawResponse: string): ReflectionMeta
     metas = lineParse.metas;
     parseableLines = lineParse.parseableLines;
     rejectedLength = lineParse.rejectedLength;
+
+    for (const wrapperContent of extractThinkingWrapperContents(trimmedResponse)) {
+      const wrapperParse = parseMetaLines(wrapperContent);
+      metas.push(...wrapperParse.metas);
+      parseableLines += wrapperParse.parseableLines;
+      rejectedLength += wrapperParse.rejectedLength;
+    }
   }
 
   const { unique, rejectedDuplicates } = dedupeStrings(metas);

--- a/extensions/memory-hybrid/services/reflection/structured-output.ts
+++ b/extensions/memory-hybrid/services/reflection/structured-output.ts
@@ -249,7 +249,7 @@ export function parseRulesFromModelResponse(rawResponse: string): ReflectionRule
       }
       rules.push(normalized.text);
     }
-    if (rules.length === 0 && readBooleanField(jsonObject, "noAction")) {
+    if (rules.length === 0 && readBooleanField(jsonObject, "noAction") && parseableLines === 0) {
       return {
         rules: [],
         parseableLines: 0,
@@ -323,7 +323,7 @@ export function parseMetasFromModelResponse(rawResponse: string): ReflectionMeta
         rejectedLength++;
       }
     }
-    if (metas.length === 0 && readBooleanField(jsonObject, "noAction")) {
+    if (metas.length === 0 && readBooleanField(jsonObject, "noAction") && parseableLines === 0) {
       return {
         metas: [],
         parseableLines: 0,

--- a/extensions/memory-hybrid/tests/reflect-meta-format-retry.test.ts
+++ b/extensions/memory-hybrid/tests/reflect-meta-format-retry.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it, vi } from "vitest";
+import { runReflectionMeta } from "../services/reflection.js";
+import type { MemoryEntry } from "../types/memory.js";
+
+function makeEntry(overrides: Partial<MemoryEntry> = {}): MemoryEntry {
+  return {
+    id: overrides.id ?? "fact-1",
+    text: overrides.text ?? "User prefers TypeScript over JavaScript for type safety",
+    category: overrides.category ?? "preference",
+    importance: overrides.importance ?? 0.7,
+    entity: overrides.entity ?? null,
+    key: overrides.key ?? null,
+    value: overrides.value ?? null,
+    source: overrides.source ?? "test",
+    createdAt: overrides.createdAt ?? Date.now(),
+    decayClass: overrides.decayClass ?? "stable",
+    expiresAt: overrides.expiresAt ?? null,
+    lastConfirmedAt: overrides.lastConfirmedAt ?? Date.now(),
+    confidence: overrides.confidence ?? 0.7,
+    tags: overrides.tags,
+    supersededAt: overrides.supersededAt ?? null,
+    scope: overrides.scope ?? "global",
+    scopeTarget: overrides.scopeTarget ?? null,
+  };
+}
+
+const metaText =
+  "User consistently prefers functional composition with strong emphasis on explicit types and small focused modules";
+
+const patternEntries = [
+  makeEntry({
+    id: "p1",
+    category: "pattern",
+    text: "User consistently prefers functional composition over object-oriented patterns",
+  }),
+  makeEntry({
+    id: "p2",
+    category: "pattern",
+    text: "User values type safety and always enables TypeScript strict mode in projects",
+  }),
+  makeEntry({
+    id: "p3",
+    category: "pattern",
+    text: "User prefers small focused functions under twenty lines with clear single responsibility",
+  }),
+];
+
+describe("runReflectionMeta format retry (#1801)", () => {
+  it("retries with fallback model when primary returns invalid_response_format", async () => {
+    let callIndex = 0;
+    const responses = ["Some prose without META lines or JSON", JSON.stringify({ metas: [metaText], noAction: false })];
+    const factsDb = {
+      getByCategory: (cat: string) => (cat === "pattern" ? patternEntries : []),
+      storeWithResult: vi.fn((storeArgs: { text: string }) => ({
+        skipped: false as const,
+        evictedFactId: null,
+        embeddingStale: false,
+        newlyStored: true,
+        preMergeText: null,
+        entry: makeEntry({ id: "meta-1", category: "pattern", text: storeArgs.text, tags: ["meta"] }),
+      })),
+      setEmbeddingModel: () => undefined,
+    };
+    const vectorDb = {
+      store: async () => undefined,
+      getVectorDim: () => 2,
+      getVectorsByFactIds: async () => new Map(),
+    };
+    const embeddings = { embed: async () => [1, 0], modelName: "test-model" };
+    const openai = {
+      chat: {
+        completions: {
+          create: async (body: { response_format?: { type: string } }) => {
+            expect(body.response_format).toEqual({ type: "json_object" });
+            return { choices: [{ message: { content: responses[callIndex++] ?? "" } }] };
+          },
+        },
+      },
+    };
+    const logger = { info: () => undefined, warn: vi.fn() };
+
+    const res = await runReflectionMeta(
+      factsDb as never,
+      vectorDb as never,
+      embeddings as never,
+      openai as never,
+      { dryRun: false, model: "primary-model", fallbackModels: ["fallback-model"] },
+      logger,
+    );
+
+    expect(callIndex).toBe(2);
+    expect(res.metaStored).toBe(1);
+    expect(res.diagnostics?.status).toBe("ok");
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("invalid_response_format"));
+  });
+
+  it("throws when primary and fallback both return invalid_response_format", async () => {
+    let callIndex = 0;
+    const responses = ["Still no JSON or META lines", "Also invalid prose"];
+    const factsDb = {
+      getByCategory: (cat: string) => (cat === "pattern" ? patternEntries : []),
+      setEmbeddingModel: () => undefined,
+    };
+    const vectorDb = {
+      store: async () => undefined,
+      getVectorDim: () => 2,
+      getVectorsByFactIds: async () => new Map(),
+    };
+    const embeddings = { embed: async () => [1, 0], modelName: "test-model" };
+    const openai = {
+      chat: {
+        completions: {
+          create: async () => ({
+            choices: [{ message: { content: responses[callIndex++] ?? "" } }],
+          }),
+        },
+      },
+    };
+    await expect(
+      runReflectionMeta(
+        factsDb as never,
+        vectorDb as never,
+        embeddings as never,
+        openai as never,
+        { dryRun: false, model: "primary-model", fallbackModels: ["fallback-model"] },
+        { info: () => undefined, warn: () => undefined },
+      ),
+    ).rejects.toThrow("failure_type=invalid_response_format");
+  });
+
+  it("rethrows LLM API failures instead of returning zero silently", async () => {
+    const factsDb = {
+      getByCategory: (cat: string) => (cat === "pattern" ? patternEntries : []),
+    };
+    const vectorDb = {
+      store: async () => undefined,
+      getVectorDim: () => 2,
+      getVectorsByFactIds: async () => new Map(),
+    };
+    const embeddings = { embed: async () => [1, 0], modelName: "test-model" };
+    const openai = {
+      chat: {
+        completions: {
+          create: async () => {
+            throw new Error("provider unavailable");
+          },
+        },
+      },
+    };
+    await expect(
+      runReflectionMeta(
+        factsDb as never,
+        vectorDb as never,
+        embeddings as never,
+        openai as never,
+        { dryRun: false, model: "primary-model" },
+        { info: () => undefined, warn: () => undefined },
+      ),
+    ).rejects.toThrow("provider unavailable");
+  });
+});

--- a/extensions/memory-hybrid/tests/reflection-structured-output.test.ts
+++ b/extensions/memory-hybrid/tests/reflection-structured-output.test.ts
@@ -43,6 +43,15 @@ describe("parseRulesFromModelResponse (#1801)", () => {
     expect(res.rules).toHaveLength(1);
   });
 
+  it("parses JSON inside thinking wrappers", () => {
+    const res = parseRulesFromModelResponse(
+      `<thinking>${JSON.stringify({ rules: ["Never hardcode credentials in source code"], noAction: false })}</thinking>`,
+    );
+    expect(res.parsedFromJson).toBe(true);
+    expect(res.rules).toHaveLength(1);
+    expect(res.rules[0]).toBe("Never hardcode credentials in source code");
+  });
+
   it("classifies prose-only response as invalid_response_format", () => {
     const raw = "Some prose without RULE lines or JSON";
     const res = parseRulesFromModelResponse(raw);
@@ -70,6 +79,15 @@ describe("parseMetasFromModelResponse (#1801)", () => {
   it("classifies invalid prose as invalid_response_format", () => {
     const res = parseMetasFromModelResponse("Some prose without META lines or JSON");
     expect(classifyZeroMetasReason(res, 40)).toBe("invalid_response_format");
+  });
+
+  it("parses JSON inside thinking wrappers", () => {
+    const text = "User demonstrates strong preference for immutability and functional patterns across multiple domains";
+    const res = parseMetasFromModelResponse(
+      `<thinking>${JSON.stringify({ metas: [text], noAction: false })}</thinking>`,
+    );
+    expect(res.parsedFromJson).toBe(true);
+    expect(res.metas).toEqual([text]);
   });
 });
 

--- a/extensions/memory-hybrid/tests/reflection-structured-output.test.ts
+++ b/extensions/memory-hybrid/tests/reflection-structured-output.test.ts
@@ -57,6 +57,15 @@ describe("parseRulesFromModelResponse (#1801)", () => {
     const res = parseRulesFromModelResponse(raw);
     expect(classifyZeroRulesReason(res, raw.length)).toBe("invalid_response_format");
   });
+
+  it("accepts JSON noAction inside thinking wrapper (bug #6ff54c2a)", () => {
+    const res = parseRulesFromModelResponse(`<thinking>${JSON.stringify({ rules: [], noAction: true })}</thinking>`);
+    expect(res.parsedFromJson).toBe(true);
+    expect(res.rules).toHaveLength(0);
+    expect(res.looksLikeValidNoRules).toBe(true);
+    expect(res.parseSuccess).toBe(true);
+    expect(classifyZeroRulesReason(res, 50)).toBe("valid_no_actionable_rules");
+  });
 });
 
 describe("parseMetasFromModelResponse (#1801)", () => {
@@ -95,5 +104,14 @@ describe("classifyZeroMetasReason", () => {
   it("returns valid_no_actionable_metas for JSON noAction", () => {
     const res = parseMetasFromModelResponse(JSON.stringify({ metas: [], noAction: true }));
     expect(classifyZeroMetasReason(res, 18)).toBe("valid_no_actionable_metas");
+  });
+
+  it("accepts JSON noAction inside thinking wrapper (bug #6ff54c2a)", () => {
+    const res = parseMetasFromModelResponse(`<thinking>${JSON.stringify({ metas: [], noAction: true })}</thinking>`);
+    expect(res.parsedFromJson).toBe(true);
+    expect(res.metas).toHaveLength(0);
+    expect(res.looksLikeValidNoMetas).toBe(true);
+    expect(res.parseSuccess).toBe(true);
+    expect(classifyZeroMetasReason(res, 50)).toBe("valid_no_actionable_metas");
   });
 });

--- a/extensions/memory-hybrid/tests/reflection-structured-output.test.ts
+++ b/extensions/memory-hybrid/tests/reflection-structured-output.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import {
+  classifyZeroMetasReason,
+  classifyZeroRulesReason,
+  parseMetasFromModelResponse,
+  parseRulesFromModelResponse,
+} from "../services/reflection/structured-output.js";
+
+describe("parseRulesFromModelResponse (#1801)", () => {
+  it("parses rules from JSON object response", () => {
+    const res = parseRulesFromModelResponse(
+      JSON.stringify({
+        rules: ["Always prefer explicit TypeScript types for public APIs"],
+        noAction: false,
+      }),
+    );
+    expect(res.parsedFromJson).toBe(true);
+    expect(res.rules).toHaveLength(1);
+    expect(res.parseSuccess).toBe(true);
+  });
+
+  it("accepts JSON noAction when there are no rules", () => {
+    const res = parseRulesFromModelResponse(JSON.stringify({ rules: [], noAction: true }));
+    expect(res.parsedFromJson).toBe(true);
+    expect(res.rules).toHaveLength(0);
+    expect(res.looksLikeValidNoRules).toBe(true);
+    expect(classifyZeroRulesReason(res, 20)).toBe("valid_no_actionable_rules");
+  });
+
+  it("falls back to RULE: line parsing when JSON is absent", () => {
+    const res = parseRulesFromModelResponse(
+      "RULE: Never commit secrets to version control\nRULE: Prefer small focused functions",
+    );
+    expect(res.parsedFromJson).toBe(false);
+    expect(res.rules).toHaveLength(2);
+  });
+
+  it("strips thinking wrappers before JSON parse", () => {
+    const res = parseRulesFromModelResponse(
+      `<thinking>draft</thinking>${JSON.stringify({ rules: ["Always validate cron exit ledgers"], noAction: false })}`,
+    );
+    expect(res.parsedFromJson).toBe(true);
+    expect(res.rules).toHaveLength(1);
+  });
+
+  it("classifies prose-only response as invalid_response_format", () => {
+    const raw = "Some prose without RULE lines or JSON";
+    const res = parseRulesFromModelResponse(raw);
+    expect(classifyZeroRulesReason(res, raw.length)).toBe("invalid_response_format");
+  });
+});
+
+describe("parseMetasFromModelResponse (#1801)", () => {
+  it("parses metas from JSON object response", () => {
+    const text =
+      "User consistently prefers functional composition with strong emphasis on explicit types and small focused modules";
+    const res = parseMetasFromModelResponse(JSON.stringify({ metas: [text], noAction: false }));
+    expect(res.parsedFromJson).toBe(true);
+    expect(res.metas).toEqual([text]);
+  });
+
+  it("falls back to META: line parsing", () => {
+    const text =
+      "User consistently prefers functional composition with strong emphasis on explicit types and small focused modules";
+    const res = parseMetasFromModelResponse(`META: ${text}`);
+    expect(res.parsedFromJson).toBe(false);
+    expect(res.metas).toEqual([text]);
+  });
+
+  it("classifies invalid prose as invalid_response_format", () => {
+    const res = parseMetasFromModelResponse("Some prose without META lines or JSON");
+    expect(classifyZeroMetasReason(res, 40)).toBe("invalid_response_format");
+  });
+});
+
+describe("classifyZeroMetasReason", () => {
+  it("returns valid_no_actionable_metas for JSON noAction", () => {
+    const res = parseMetasFromModelResponse(JSON.stringify({ metas: [], noAction: true }));
+    expect(classifyZeroMetasReason(res, 18)).toBe("valid_no_actionable_metas");
+  });
+});


### PR DESCRIPTION
## Summary
- Adds structured JSON output (`response_format: json_object`) for `reflect-rules` and `reflect-meta` LLM calls, with prompt schema instructions and parsing that falls back to legacy `RULE:` / `META:` line formats.
- Aligns `reflect-meta` failure semantics with `reflect-rules`: format retry through the maintenance fallback chain, non-zero exit when all models return unusable output, and rethrow on upstream LLM API failures (no silent zero-result success).
- Exposes `reflect-meta` diagnostics in CLI output for easier cron/log triage.

Fixes #1801

## Context
PRs #1815 and #1847 addressed empty fallback chains, non-zero exits on `invalid_response_format`, and `validate-cron-exit` semantic detection. This PR closes the remaining gaps from the issue:
- Structured output / JSON mode for MiniMax-heavy reflection commands
- Same format-retry and hard-failure behavior for `reflect-meta`

## Test plan
- [x] `npm test -- tests/reflection-structured-output.test.ts tests/reflect-meta-format-retry.test.ts` (12 tests)
- [ ] Run `openclaw hybrid-mem reflect-rules --verbose` against a MiniMax-primary config and confirm JSON parse or fallback retry
- [ ] Run `openclaw hybrid-mem reflect-meta --verbose` and confirm diagnostics + non-zero exit on invalid format exhaustion


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes nightly maintenance LLM contracts and reflect-meta failure/exit behavior (throws vs silent success), which can affect cron validation; parsing still has line-format fallback to limit breakage.
> 
> **Overview**
> Adds **structured JSON output** (`response_format: json_object`) for **`reflect-rules`** and **`reflect-meta`**, with schema instructions appended to prompts and a new **`structured-output`** module that parses JSON first and **falls back** to legacy `RULE:` / `META:` lines (including thinking-wrapper handling).
> 
> **`reflect-meta`** is brought in line with **`reflect-rules`**: format-retry through the maintenance fallback chain, **throws** on exhausted invalid/empty responses and on upstream LLM failures (no silent zero-result), plus **diagnostics** (`zero_metas_reason`, parse stats) logged and printed from the CLI.
> 
> The chat stack (**`chatComplete`**, retry, adaptive maintenance**) now accepts optional **`responseFormat`** on the chat wire API only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b33cd1416c7739c0218b4334c198cdd1339c84e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->