### PR TITLE
fix(resolve-contradictions): progress metrics and degraded exit for --auto mode (#1805)

### DIFF
--- a/extensions/memory-hybrid/backends/facts-db/contradictions.ts
+++ b/extensions/memory-hybrid/backends/facts-db/contradictions.ts
@@ -907,8 +907,8 @@ export async function resolveContradictionsAutonomously(
       reviewItem.suggestedStrategy = "project-state-lww";
       reviewItem.suggestedConfidence = 1;
       reviewItem.suggestedReason = "Trusted newer project-state fact supersedes the stale value.";
+      deterministic++;
       if (!dryRun) {
-        deterministic++;
         const applied = persistContradictionDecision(db, getById, supersede, {
           contradictionId: contradiction.id,
           keptFactId: contradiction.factIdNew,
@@ -941,8 +941,8 @@ export async function resolveContradictionsAutonomously(
           reviewItem.suggestedStrategy = "llm-adjudication";
           reviewItem.suggestedConfidence = confidence;
           reviewItem.suggestedReason = llmDecision.reason?.trim() || "LLM adjudication approved the resolution.";
+          llmResolved++;
           if (!dryRun) {
-            llmResolved++;
             const keepNew = llmDecision.decision === "keep_new";
             const applied = persistContradictionDecision(db, getById, supersede, {
               contradictionId: contradiction.id,

--- a/extensions/memory-hybrid/backends/facts-db/contradictions.ts
+++ b/extensions/memory-hybrid/backends/facts-db/contradictions.ts
@@ -907,8 +907,8 @@ export async function resolveContradictionsAutonomously(
       reviewItem.suggestedStrategy = "project-state-lww";
       reviewItem.suggestedConfidence = 1;
       reviewItem.suggestedReason = "Trusted newer project-state fact supersedes the stale value.";
-      deterministic++;
       if (!dryRun) {
+        deterministic++;
         const applied = persistContradictionDecision(db, getById, supersede, {
           contradictionId: contradiction.id,
           keptFactId: contradiction.factIdNew,
@@ -941,8 +941,8 @@ export async function resolveContradictionsAutonomously(
           reviewItem.suggestedStrategy = "llm-adjudication";
           reviewItem.suggestedConfidence = confidence;
           reviewItem.suggestedReason = llmDecision.reason?.trim() || "LLM adjudication approved the resolution.";
-          llmResolved++;
           if (!dryRun) {
+            llmResolved++;
             const keepNew = llmDecision.decision === "keep_new";
             const applied = persistContradictionDecision(db, getById, supersede, {
               contradictionId: contradiction.id,

--- a/extensions/memory-hybrid/cli/commands/manage/register-reflection-pipeline.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/register-reflection-pipeline.ts
@@ -1170,6 +1170,9 @@ export function registerManageReflectionPipeline(mem: Chainable, b: ManageBindin
               previousConsecutiveNoProgressRuns: previousConsecutive,
             });
             persistConsecutiveNoProgressState(metrics, evaluation);
+            if (exportReview) {
+              writeContradictionReviewFile(exportReview, res.reviewItems);
+            }
             logContradictionProgressOutcome({
               mode: "auto",
               metrics,
@@ -1197,10 +1200,11 @@ export function registerManageReflectionPipeline(mem: Chainable, b: ManageBindin
                   `contradiction-auto target-missed achieved=${res.achievedRate.toFixed(3)} target=${res.targetRate.toFixed(2)}`,
                 );
               }
-            }
-            if (exportReview) {
-              writeContradictionReviewFile(exportReview, res.reviewItems);
-              console.log(`manual-review exported: ${res.reviewItems.length} item(s) -> ${exportReview}`);
+              if (exportReview) {
+                console.log(`manual-review exported: ${res.reviewItems.length} item(s) -> ${exportReview}`);
+              }
+            } else if (exportReview) {
+              console.error(`manual-review exported: ${res.reviewItems.length} item(s) -> ${exportReview}`);
             }
             if (jsonMode) {
               return;

--- a/extensions/memory-hybrid/cli/commands/manage/register-reflection-pipeline.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/register-reflection-pipeline.ts
@@ -1190,13 +1190,14 @@ export function registerManageReflectionPipeline(mem: Chainable, b: ManageBindin
                 );
               }
             }
-            if (jsonMode) {
-              return;
-            }
             if (exportReview) {
               writeContradictionReviewFile(exportReview, res.reviewItems);
               console.log(`manual-review exported: ${res.reviewItems.length} item(s) -> ${exportReview}`);
-            } else if (res.reviewItems.length > 0) {
+            }
+            if (jsonMode) {
+              return;
+            }
+            if (!exportReview && res.reviewItems.length > 0) {
               console.log(
                 `Manual review remaining: ${res.reviewItems.length}. Export with --export-review <path> for stable JSONL.`,
               );

--- a/extensions/memory-hybrid/cli/commands/manage/register-reflection-pipeline.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/register-reflection-pipeline.ts
@@ -1148,14 +1148,6 @@ export function registerManageReflectionPipeline(mem: Chainable, b: ManageBindin
               throw err;
             }
 
-            console.log(
-              `contradiction-auto summary total=${res.total} deterministic=${res.deterministic} llm=${res.llm} merged=${res.merged} manual_review=${res.manualReview} applied=${res.applied} target=${res.targetRate.toFixed(2)} achieved=${res.achievedRate.toFixed(3)}`,
-            );
-            if (!res.targetMet) {
-              console.log(
-                `contradiction-auto target-missed achieved=${res.achievedRate.toFixed(3)} target=${res.targetRate.toFixed(2)}`,
-              );
-            }
             const autoResolvedCount = res.deterministic + res.llm + res.merged;
             const ambiguousCount = res.manualReview;
             const metrics = {
@@ -1188,6 +1180,19 @@ export function registerManageReflectionPipeline(mem: Chainable, b: ManageBindin
                     : undefined,
               },
             });
+            if (!jsonMode) {
+              console.log(
+                `contradiction-auto summary total=${res.total} deterministic=${res.deterministic} llm=${res.llm} merged=${res.merged} manual_review=${res.manualReview} applied=${res.applied} target=${res.targetRate.toFixed(2)} achieved=${res.achievedRate.toFixed(3)}`,
+              );
+              if (!res.targetMet) {
+                console.log(
+                  `contradiction-auto target-missed achieved=${res.achievedRate.toFixed(3)} target=${res.targetRate.toFixed(2)}`,
+                );
+              }
+            }
+            if (jsonMode) {
+              return;
+            }
             if (exportReview) {
               writeContradictionReviewFile(exportReview, res.reviewItems);
               console.log(`manual-review exported: ${res.reviewItems.length} item(s) -> ${exportReview}`);

--- a/extensions/memory-hybrid/cli/commands/manage/register-reflection-pipeline.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/register-reflection-pipeline.ts
@@ -28,10 +28,52 @@ import {
   type RunVerboseFollowUpOptions,
   runVerboseFollowUp,
 } from "./dream-cycle-followup.js";
+import {
+  DEFAULT_AMBIGUOUS_BACKLOG_DEGRADED_THRESHOLD,
+  DEFAULT_DEGRADED_CONSECUTIVE_THRESHOLD,
+  buildContradictionProgressJsonSummary,
+  evaluateContradictionProgress,
+  formatContradictionProgressSummaryLine,
+  persistConsecutiveNoProgressState,
+  readConsecutiveNoProgressRuns,
+  type ContradictionProgressJsonSummary,
+} from "../../../services/contradiction-progress-summary.js";
 import { runMaintenanceHeartbeat } from "./maintenance-heartbeat.js";
 
 const CONTRADICTION_BUCKET_PREVIEW_TARGET_RATE = 0.8;
-const DEFAULT_AMBIGUOUS_BACKLOG_DEGRADED_THRESHOLD = 200;
+
+function logContradictionProgressOutcome(params: {
+  mode: "default" | "auto";
+  metrics: { autoResolved: number; ambiguous: number; totalConsidered: number };
+  evaluation: ReturnType<typeof evaluateContradictionProgress>;
+  jsonMode: boolean;
+  suggestions?: ContradictionProgressJsonSummary["suggestions"];
+}): void {
+  const { mode, metrics, evaluation, jsonMode, suggestions } = params;
+  if (evaluation.exitCode !== 0) process.exitCode = evaluation.exitCode;
+  if (jsonMode) {
+    console.log(
+      JSON.stringify(
+        buildContradictionProgressJsonSummary(mode, metrics, evaluation, suggestions ? { suggestions } : undefined),
+      ),
+    );
+    return;
+  }
+  console.log(formatContradictionProgressSummaryLine(mode, metrics, evaluation));
+  if (evaluation.degraded) {
+    console.log(
+      `Backlog alert: ambiguous=${metrics.ambiguous} with auto-resolved=0 meets or exceeds degraded threshold ${evaluation.degradedAmbiguousThreshold} for ${evaluation.consecutiveNoProgressRuns} consecutive run(s) (exit code 2).`,
+    );
+  } else if (
+    evaluation.noProgress &&
+    evaluation.degradedThresholdEnabled &&
+    metrics.ambiguous >= evaluation.degradedAmbiguousThreshold
+  ) {
+    console.log(
+      `Backlog monitor: ambiguous=${metrics.ambiguous} with auto-resolved=0; consecutive no-progress runs=${evaluation.consecutiveNoProgressRuns}/${evaluation.degradedConsecutiveThreshold} before degraded exit.`,
+    );
+  }
+}
 
 function writeContradictionReviewFile(outputPath: string, items: ContradictionReviewItem[]): void {
   const content = `${items.map((item) => JSON.stringify(item)).join("\n")}${items.length > 0 ? "\n" : ""}`;
@@ -931,6 +973,11 @@ export function registerManageReflectionPipeline(mem: Chainable, b: ManageBindin
       "Set degraded exit threshold when ambiguous backlog is large and no pairs were auto-resolved (0 disables)",
       String(DEFAULT_AMBIGUOUS_BACKLOG_DEGRADED_THRESHOLD),
     )
+    .option(
+      "--degraded-consecutive-threshold <n>",
+      "Require this many consecutive no-progress runs before degraded exit (default 1; 0 uses 1)",
+      String(DEFAULT_DEGRADED_CONSECUTIVE_THRESHOLD),
+    )
     .action(
       withExit(
         async (
@@ -948,6 +995,7 @@ export function registerManageReflectionPipeline(mem: Chainable, b: ManageBindin
             model?: string;
             json?: boolean;
             degradedAmbiguousThreshold?: string;
+            degradedConsecutiveThreshold?: string;
           },
           cmd?: CommanderOptsParent,
         ) => {
@@ -967,18 +1015,27 @@ export function registerManageReflectionPipeline(mem: Chainable, b: ManageBindin
             opts?.degradedAmbiguousThreshold ?? String(DEFAULT_AMBIGUOUS_BACKLOG_DEGRADED_THRESHOLD),
             10,
           );
+          const degradedConsecutiveThreshold = Number.parseInt(
+            opts?.degradedConsecutiveThreshold ?? String(DEFAULT_DEGRADED_CONSECUTIVE_THRESHOLD),
+            10,
+          );
 
           if (dryRun && apply) {
             throw new Error("--dry-run and --apply are mutually exclusive");
           }
-          if (jsonMode && (auto || projectStateLww || dryRun || apply || applyReview)) {
-            throw new Error("--json is only supported in default resolve-contradictions mode");
+          if (jsonMode && (projectStateLww || dryRun || apply || applyReview)) {
+            throw new Error(
+              "--json is only supported in default or --auto resolve-contradictions mode (not LWW/dry-run/apply-review)",
+            );
           }
           if (Number.isNaN(targetRate) || targetRate <= 0 || targetRate > 1) {
             throw new Error("--target-rate must be a number between 0 and 1");
           }
           if (Number.isNaN(degradedAmbiguousThreshold) || degradedAmbiguousThreshold < 0) {
             throw new Error("--degraded-ambiguous-threshold must be an integer >= 0");
+          }
+          if (Number.isNaN(degradedConsecutiveThreshold) || degradedConsecutiveThreshold < 0) {
+            throw new Error("--degraded-consecutive-threshold must be an integer >= 0");
           }
           if (applyReview && (auto || projectStateLww || dryRun || apply || exportReview || llm || model)) {
             throw new Error(
@@ -1099,6 +1156,38 @@ export function registerManageReflectionPipeline(mem: Chainable, b: ManageBindin
                 `contradiction-auto target-missed achieved=${res.achievedRate.toFixed(3)} target=${res.targetRate.toFixed(2)}`,
               );
             }
+            const autoResolvedCount = res.deterministic + res.llm + res.merged;
+            const ambiguousCount = res.manualReview;
+            const metrics = {
+              autoResolved: autoResolvedCount,
+              ambiguous: ambiguousCount,
+              totalConsidered: res.total,
+            };
+            const previousConsecutive = readConsecutiveNoProgressRuns();
+            const evaluation = evaluateContradictionProgress(metrics, {
+              degradedAmbiguousThreshold,
+              degradedConsecutiveThreshold,
+              previousConsecutiveNoProgressRuns: previousConsecutive,
+            });
+            persistConsecutiveNoProgressState(metrics, evaluation);
+            logContradictionProgressOutcome({
+              mode: "auto",
+              metrics,
+              evaluation,
+              jsonMode,
+              suggestions: {
+                details: "openclaw hybrid-mem resolve-contradictions --auto --details",
+                projectStateLwwDryRun: "openclaw hybrid-mem resolve-contradictions --project-state-lww --dry-run",
+                autoApply:
+                  autoResolvedCount > 0
+                    ? "openclaw hybrid-mem resolve-contradictions --auto --apply"
+                    : undefined,
+                exportReview:
+                  ambiguousCount > 0
+                    ? "openclaw hybrid-mem resolve-contradictions --auto --dry-run --export-review <path>"
+                    : undefined,
+              },
+            });
             if (exportReview) {
               writeContradictionReviewFile(exportReview, res.reviewItems);
               console.log(`manual-review exported: ${res.reviewItems.length} item(s) -> ${exportReview}`);
@@ -1177,41 +1266,26 @@ export function registerManageReflectionPipeline(mem: Chainable, b: ManageBindin
           }
           const autoResolvedCount = res.autoResolved.length;
           const ambiguousCount = res.ambiguous.length;
-          const totalConsidered = autoResolvedCount + ambiguousCount;
-          const noProgress = totalConsidered > 0 && autoResolvedCount === 0;
-          const degradedThresholdEnabled = degradedAmbiguousThreshold > 0;
-          const degraded =
-            degradedThresholdEnabled && noProgress && ambiguousCount >= degradedAmbiguousThreshold;
-          const exitCode = degraded ? 2 : 0;
-          const summary = {
-            mode: "default",
+          const metrics = {
             autoResolved: autoResolvedCount,
             ambiguous: ambiguousCount,
-            totalConsidered,
-            resolutionRate: totalConsidered === 0 ? 1 : autoResolvedCount / totalConsidered,
-            noProgress,
-            degradedThresholdEnabled,
-            degradedAmbiguousThreshold,
-            degraded,
-            exitCode,
-            exitReason: degraded ? "ambiguous_backlog_no_progress" : "success",
-            suggestions: {
-              details: "openclaw hybrid-mem resolve-contradictions --details",
-              projectStateLwwDryRun: "openclaw hybrid-mem resolve-contradictions --project-state-lww --dry-run",
-            },
+            totalConsidered: autoResolvedCount + ambiguousCount,
           };
-          if (exitCode !== 0) process.exitCode = exitCode;
+          const previousConsecutive = readConsecutiveNoProgressRuns();
+          const evaluation = evaluateContradictionProgress(metrics, {
+            degradedAmbiguousThreshold,
+            degradedConsecutiveThreshold,
+            previousConsecutiveNoProgressRuns: previousConsecutive,
+          });
+          persistConsecutiveNoProgressState(metrics, evaluation);
+          logContradictionProgressOutcome({
+            mode: "default",
+            metrics,
+            evaluation,
+            jsonMode,
+          });
           if (jsonMode) {
-            console.log(JSON.stringify(summary));
             return;
-          }
-          console.log(
-            `resolve-contradictions summary auto_resolved=${autoResolvedCount} ambiguous=${ambiguousCount} no_progress=${noProgress ? 1 : 0} degraded=${degraded ? 1 : 0} threshold_enabled=${degradedThresholdEnabled ? 1 : 0} threshold=${degradedAmbiguousThreshold}`,
-          );
-          if (degraded) {
-            console.log(
-              `Backlog alert: ambiguous=${ambiguousCount} with auto-resolved=0 meets or exceeds degraded threshold ${degradedAmbiguousThreshold} (exit code 2).`,
-            );
           }
           if (verbose && res.autoResolved.length > 0) {
             console.log("Auto-resolved (--verbose):");

--- a/extensions/memory-hybrid/cli/install/cron-jobs.ts
+++ b/extensions/memory-hybrid/cli/install/cron-jobs.ts
@@ -210,7 +210,7 @@ const MAINTENANCE_CRON_JOBS: Array<
         { name: "prune", cmd: "openclaw hybrid-mem prune --verbose" },
         { name: "distill", cmd: "openclaw hybrid-mem distill --days 1 --verbose" },
         { name: "extract-daily", cmd: "openclaw hybrid-mem extract-daily --days 7 --verbose", optional: true },
-        { name: "resolve-contradictions", cmd: "openclaw hybrid-mem resolve-contradictions --auto --verbose" },
+        { name: "resolve-contradictions", cmd: "openclaw hybrid-mem resolve-contradictions --auto --verbose --degraded-consecutive-threshold 3" },
         { name: "enrich-entities", cmd: "openclaw hybrid-mem enrich-entities --limit 200 --verbose" },
       ],
     }),

--- a/extensions/memory-hybrid/docs/contradiction-detection.md
+++ b/extensions/memory-hybrid/docs/contradiction-detection.md
@@ -127,12 +127,12 @@ When ambiguous pairs remain, the CLI now also prints `unresolved_by_reason` buck
 
 Every run prints a summary with total contradictions, deterministic/LLM/manual counts, target rate, and achieved rate so nightly maintenance does not hide leftover backlog.
 
-Default `resolve-contradictions` now also emits an actionable summary line (`auto_resolved`, `ambiguous`, `no_progress`, `degraded`, `threshold`). For cron/automation, use `--json` to get a structured payload with `exitReason` and recommended follow-up commands. When ambiguous backlog is large and no pairs were auto-resolved, the command exits degraded (`exitCode=2`); tune or disable this guard with `--degraded-ambiguous-threshold <n>` (`0` disables).
+Default `resolve-contradictions` and `--auto` both emit an actionable progress summary (`mode`, `auto_resolved`, `ambiguous`, `no_progress`, `degraded`, `threshold`, `consecutive`). For cron/automation, use `--json` to get a structured payload with `exitReason`, consecutive-run counters, and recommended follow-up commands. When ambiguous backlog is large and no pairs were auto-resolved for `--degraded-consecutive-threshold` runs in a row, the command exits degraded (`exitCode=2`); tune with `--degraded-ambiguous-threshold <n>` (default `200`, `0` disables) and `--degraded-consecutive-threshold <m>` (default `1`; nightly cron uses `3`).
 
 Summary log format (single line):
 
 ```text
-resolve-contradictions summary auto_resolved=<n> ambiguous=<n> no_progress=<0|1> degraded=<0|1> threshold_enabled=<0|1> threshold=<n>
+resolve-contradictions summary mode=<default|auto> auto_resolved=<n> ambiguous=<n> no_progress=<0|1> degraded=<0|1> threshold_enabled=<0|1> threshold=<n> consecutive=<run-count> consecutive_threshold=<m>
 ```
 
 Use `--json` when possible; the text summary is intended as a lightweight fallback for log scrapers.

--- a/extensions/memory-hybrid/services/contradiction-progress-summary.ts
+++ b/extensions/memory-hybrid/services/contradiction-progress-summary.ts
@@ -1,7 +1,8 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { getEnv } from "../utils/env-manager.js";
+import { atomicWriteFile } from "../utils/atomic-write.js";
 
 export const DEFAULT_AMBIGUOUS_BACKLOG_DEGRADED_THRESHOLD = 200;
 export const DEFAULT_DEGRADED_CONSECUTIVE_THRESHOLD = 1;
@@ -68,8 +69,8 @@ export function persistConsecutiveNoProgressState(
   openclawHome?: string,
 ): void {
   const statePath = resolveStatePath(openclawHome);
-  mkdirSync(join(statePath, ".."), { recursive: true });
-  writeFileSync(
+  mkdirSync(dirname(statePath), { recursive: true });
+  atomicWriteFile(
     statePath,
     `${JSON.stringify(
       {
@@ -81,7 +82,6 @@ export function persistConsecutiveNoProgressState(
       null,
       2,
     )}\n`,
-    "utf-8",
   );
 }
 

--- a/extensions/memory-hybrid/services/contradiction-progress-summary.ts
+++ b/extensions/memory-hybrid/services/contradiction-progress-summary.ts
@@ -1,0 +1,151 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export const DEFAULT_AMBIGUOUS_BACKLOG_DEGRADED_THRESHOLD = 200;
+export const DEFAULT_DEGRADED_CONSECUTIVE_THRESHOLD = 1;
+
+export interface ContradictionProgressMetrics {
+  autoResolved: number;
+  ambiguous: number;
+  totalConsidered: number;
+}
+
+export interface ContradictionProgressEvaluation {
+  noProgress: boolean;
+  degradedThresholdEnabled: boolean;
+  degradedAmbiguousThreshold: number;
+  degradedConsecutiveThreshold: number;
+  consecutiveNoProgressRuns: number;
+  degraded: boolean;
+  exitCode: number;
+  exitReason: string;
+  resolutionRate: number;
+}
+
+export interface ContradictionProgressJsonSummary extends ContradictionProgressEvaluation {
+  mode: "default" | "auto";
+  autoResolved: number;
+  ambiguous: number;
+  totalConsidered: number;
+  suggestions: {
+    details: string;
+    projectStateLwwDryRun: string;
+    autoApply?: string;
+    exportReview?: string;
+  };
+}
+
+interface PersistedNoProgressState {
+  consecutiveNoProgressRuns: number;
+  lastAmbiguous: number;
+  lastAutoResolved: number;
+  updatedAt: string;
+}
+
+function resolveStatePath(openclawHome?: string): string {
+  const root = openclawHome ?? process.env.OPENCLAW_HOME ?? join(homedir(), ".openclaw");
+  return join(root, "cron", "guard", "resolve-contradictions-no-progress.json");
+}
+
+export function readConsecutiveNoProgressRuns(openclawHome?: string): number {
+  const statePath = resolveStatePath(openclawHome);
+  if (!existsSync(statePath)) return 0;
+  try {
+    const parsed = JSON.parse(readFileSync(statePath, "utf-8")) as Partial<PersistedNoProgressState>;
+    return typeof parsed.consecutiveNoProgressRuns === "number" && parsed.consecutiveNoProgressRuns >= 0
+      ? parsed.consecutiveNoProgressRuns
+      : 0;
+  } catch {
+    return 0;
+  }
+}
+
+export function persistConsecutiveNoProgressState(
+  metrics: ContradictionProgressMetrics,
+  evaluation: Pick<ContradictionProgressEvaluation, "consecutiveNoProgressRuns">,
+  openclawHome?: string,
+): void {
+  const statePath = resolveStatePath(openclawHome);
+  mkdirSync(join(statePath, ".."), { recursive: true });
+  writeFileSync(
+    statePath,
+    `${JSON.stringify(
+      {
+        consecutiveNoProgressRuns: evaluation.consecutiveNoProgressRuns,
+        lastAmbiguous: metrics.ambiguous,
+        lastAutoResolved: metrics.autoResolved,
+        updatedAt: new Date().toISOString(),
+      } satisfies PersistedNoProgressState,
+      null,
+      2,
+    )}\n`,
+    "utf-8",
+  );
+}
+
+export function evaluateContradictionProgress(
+  metrics: ContradictionProgressMetrics,
+  opts: {
+    degradedAmbiguousThreshold: number;
+    degradedConsecutiveThreshold: number;
+    previousConsecutiveNoProgressRuns?: number;
+  },
+): ContradictionProgressEvaluation {
+  const { degradedAmbiguousThreshold, degradedConsecutiveThreshold } = opts;
+  const previousConsecutiveNoProgressRuns = opts.previousConsecutiveNoProgressRuns ?? 0;
+  const totalConsidered = metrics.totalConsidered;
+  const noProgress = totalConsidered > 0 && metrics.autoResolved === 0;
+  const degradedThresholdEnabled = degradedAmbiguousThreshold > 0;
+  const thresholdExceeded = degradedThresholdEnabled && metrics.ambiguous >= degradedAmbiguousThreshold;
+  const consecutiveNoProgressRuns =
+    noProgress && thresholdExceeded ? previousConsecutiveNoProgressRuns + 1 : 0;
+  const consecutiveRequired = degradedConsecutiveThreshold > 0 ? degradedConsecutiveThreshold : 1;
+  const degraded = thresholdExceeded && noProgress && consecutiveNoProgressRuns >= consecutiveRequired;
+  const exitCode = degraded ? 2 : 0;
+  const exitReason = degraded
+    ? "ambiguous_backlog_no_progress"
+    : noProgress && thresholdExceeded
+      ? "ambiguous_backlog_monitoring"
+      : "success";
+
+  return {
+    noProgress,
+    degradedThresholdEnabled,
+    degradedAmbiguousThreshold,
+    degradedConsecutiveThreshold,
+    consecutiveNoProgressRuns,
+    degraded,
+    exitCode,
+    exitReason,
+    resolutionRate: totalConsidered === 0 ? 1 : metrics.autoResolved / totalConsidered,
+  };
+}
+
+export function formatContradictionProgressSummaryLine(
+  mode: "default" | "auto",
+  metrics: ContradictionProgressMetrics,
+  evaluation: ContradictionProgressEvaluation,
+): string {
+  return `resolve-contradictions summary mode=${mode} auto_resolved=${metrics.autoResolved} ambiguous=${metrics.ambiguous} no_progress=${evaluation.noProgress ? 1 : 0} degraded=${evaluation.degraded ? 1 : 0} threshold_enabled=${evaluation.degradedThresholdEnabled ? 1 : 0} threshold=${evaluation.degradedAmbiguousThreshold} consecutive=${evaluation.consecutiveNoProgressRuns} consecutive_threshold=${evaluation.degradedConsecutiveThreshold}`;
+}
+
+export function buildContradictionProgressJsonSummary(
+  mode: "default" | "auto",
+  metrics: ContradictionProgressMetrics,
+  evaluation: ContradictionProgressEvaluation,
+  extra?: Partial<Pick<ContradictionProgressJsonSummary, "suggestions">>,
+): ContradictionProgressJsonSummary {
+  const suggestions = extra?.suggestions ?? {
+    details: "openclaw hybrid-mem resolve-contradictions --details",
+    projectStateLwwDryRun: "openclaw hybrid-mem resolve-contradictions --project-state-lww --dry-run",
+  };
+  return {
+    mode,
+    autoResolved: metrics.autoResolved,
+    ambiguous: metrics.ambiguous,
+    totalConsidered: metrics.totalConsidered,
+    ...evaluation,
+    suggestions,
+  };
+}

--- a/extensions/memory-hybrid/services/contradiction-progress-summary.ts
+++ b/extensions/memory-hybrid/services/contradiction-progress-summary.ts
@@ -1,6 +1,7 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { getEnv } from "../utils/env-manager.js";
 
 export const DEFAULT_AMBIGUOUS_BACKLOG_DEGRADED_THRESHOLD = 200;
 export const DEFAULT_DEGRADED_CONSECUTIVE_THRESHOLD = 1;
@@ -44,7 +45,7 @@ interface PersistedNoProgressState {
 }
 
 function resolveStatePath(openclawHome?: string): string {
-  const root = openclawHome ?? process.env.OPENCLAW_HOME ?? join(homedir(), ".openclaw");
+  const root = openclawHome ?? getEnv("OPENCLAW_HOME") ?? join(homedir(), ".openclaw");
   return join(root, "cron", "guard", "resolve-contradictions-no-progress.json");
 }
 

--- a/extensions/memory-hybrid/services/contradiction-progress-summary.ts
+++ b/extensions/memory-hybrid/services/contradiction-progress-summary.ts
@@ -114,7 +114,7 @@ export function evaluateContradictionProgress(
     noProgress,
     degradedThresholdEnabled,
     degradedAmbiguousThreshold,
-    degradedConsecutiveThreshold,
+    degradedConsecutiveThreshold: consecutiveRequired,
     consecutiveNoProgressRuns,
     degraded,
     exitCode,

--- a/extensions/memory-hybrid/tests/contradiction-progress-summary.test.ts
+++ b/extensions/memory-hybrid/tests/contradiction-progress-summary.test.ts
@@ -1,0 +1,96 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  evaluateContradictionProgress,
+  persistConsecutiveNoProgressState,
+  readConsecutiveNoProgressRuns,
+} from "../services/contradiction-progress-summary.js";
+
+describe("contradiction-progress-summary", () => {
+  let stateDir = "";
+
+  afterEach(() => {
+    if (stateDir) {
+      rmSync(stateDir, { recursive: true, force: true });
+      stateDir = "";
+    }
+  });
+
+  function tempOpenclawHome(): string {
+    stateDir = mkdtempSync(join(tmpdir(), "hm-contradiction-progress-"));
+    return stateDir;
+  }
+
+  it("requires consecutive no-progress runs before degraded exit", () => {
+    const home = tempOpenclawHome();
+    const metrics = { autoResolved: 0, ambiguous: 250, totalConsidered: 250 };
+
+    const first = evaluateContradictionProgress(metrics, {
+      degradedAmbiguousThreshold: 200,
+      degradedConsecutiveThreshold: 3,
+      previousConsecutiveNoProgressRuns: readConsecutiveNoProgressRuns(home),
+    });
+    expect(first.degraded).toBe(false);
+    expect(first.consecutiveNoProgressRuns).toBe(1);
+    persistConsecutiveNoProgressState(metrics, first, home);
+
+    const second = evaluateContradictionProgress(metrics, {
+      degradedAmbiguousThreshold: 200,
+      degradedConsecutiveThreshold: 3,
+      previousConsecutiveNoProgressRuns: readConsecutiveNoProgressRuns(home),
+    });
+    expect(second.degraded).toBe(false);
+    expect(second.consecutiveNoProgressRuns).toBe(2);
+    persistConsecutiveNoProgressState(metrics, second, home);
+
+    const third = evaluateContradictionProgress(metrics, {
+      degradedAmbiguousThreshold: 200,
+      degradedConsecutiveThreshold: 3,
+      previousConsecutiveNoProgressRuns: readConsecutiveNoProgressRuns(home),
+    });
+    expect(third.degraded).toBe(true);
+    expect(third.exitCode).toBe(2);
+    expect(third.exitReason).toBe("ambiguous_backlog_no_progress");
+  });
+
+  it("resets consecutive counter when auto-resolved progress is made", () => {
+    const home = tempOpenclawHome();
+    const stuck = { autoResolved: 0, ambiguous: 250, totalConsidered: 250 };
+    const first = evaluateContradictionProgress(stuck, {
+      degradedAmbiguousThreshold: 200,
+      degradedConsecutiveThreshold: 3,
+      previousConsecutiveNoProgressRuns: 0,
+    });
+    persistConsecutiveNoProgressState(stuck, first, home);
+    expect(readConsecutiveNoProgressRuns(home)).toBe(1);
+
+    const progress = { autoResolved: 3, ambiguous: 247, totalConsidered: 250 };
+    const recovered = evaluateContradictionProgress(progress, {
+      degradedAmbiguousThreshold: 200,
+      degradedConsecutiveThreshold: 3,
+      previousConsecutiveNoProgressRuns: readConsecutiveNoProgressRuns(home),
+    });
+    expect(recovered.noProgress).toBe(false);
+    expect(recovered.consecutiveNoProgressRuns).toBe(0);
+    persistConsecutiveNoProgressState(progress, recovered, home);
+    expect(readConsecutiveNoProgressRuns(home)).toBe(0);
+  });
+
+  it("persists state to openclaw cron guard directory", () => {
+    const home = tempOpenclawHome();
+    const metrics = { autoResolved: 0, ambiguous: 5, totalConsidered: 5 };
+    const evaluation = evaluateContradictionProgress(metrics, {
+      degradedAmbiguousThreshold: 1,
+      degradedConsecutiveThreshold: 1,
+      previousConsecutiveNoProgressRuns: 0,
+    });
+    persistConsecutiveNoProgressState(metrics, evaluation, home);
+
+    const raw = readFileSync(join(home, "cron", "guard", "resolve-contradictions-no-progress.json"), "utf-8");
+    const parsed = JSON.parse(raw) as { consecutiveNoProgressRuns: number; lastAmbiguous: number };
+    expect(parsed.consecutiveNoProgressRuns).toBe(1);
+    expect(parsed.lastAmbiguous).toBe(5);
+  });
+});

--- a/extensions/memory-hybrid/tests/contradiction-progress-summary.test.ts
+++ b/extensions/memory-hybrid/tests/contradiction-progress-summary.test.ts
@@ -93,4 +93,19 @@ describe("contradiction-progress-summary", () => {
     expect(parsed.consecutiveNoProgressRuns).toBe(1);
     expect(parsed.lastAmbiguous).toBe(5);
   });
+
+  it("treats degradedConsecutiveThreshold=0 as 1 in returned value", () => {
+    const metrics = { autoResolved: 0, ambiguous: 250, totalConsidered: 250 };
+
+    const evaluation = evaluateContradictionProgress(metrics, {
+      degradedAmbiguousThreshold: 200,
+      degradedConsecutiveThreshold: 0,
+      previousConsecutiveNoProgressRuns: 0,
+    });
+
+    expect(evaluation.degradedConsecutiveThreshold).toBe(1);
+    expect(evaluation.consecutiveNoProgressRuns).toBe(1);
+    expect(evaluation.degraded).toBe(true);
+    expect(evaluation.exitCode).toBe(2);
+  });
 });

--- a/extensions/memory-hybrid/tests/resolve-contradictions-cli.test.ts
+++ b/extensions/memory-hybrid/tests/resolve-contradictions-cli.test.ts
@@ -713,9 +713,9 @@ describe("resolve-contradictions CLI contract mode", () => {
     await mem.parseAsync(["resolve-contradictions", "--degraded-ambiguous-threshold", "1"], { from: "user" });
 
     expect(process.exitCode).toBe(2);
-    expect(lines.some((l) => l.includes("resolve-contradictions summary mode=default auto_resolved=0 ambiguous=2"))).toBe(
-      true,
-    );
+    expect(
+      lines.some((l) => l.includes("resolve-contradictions summary mode=default auto_resolved=0 ambiguous=2")),
+    ).toBe(true);
     expect(
       lines.some((l) =>
         l.includes("Backlog alert: ambiguous=2 with auto-resolved=0 meets or exceeds degraded threshold 1"),
@@ -724,79 +724,95 @@ describe("resolve-contradictions CLI contract mode", () => {
   });
 
   it("emits resolve-contradictions JSON summary for cron validation", async () => {
-    const runResolveContradictions = vi.fn().mockResolvedValue({
-      autoResolved: [],
-      ambiguous: [{ contradictionId: "c-1", factIdNew: "new-1", factIdOld: "old-1" }],
-    });
-    const mem = makeProgram(makeBindings({ runResolveContradictions }));
-    const lines: string[] = [];
-    vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
-      lines.push(args.map((a) => String(a)).join(" "));
-    });
+    const tmpHome = mkdtempSync(join(tmpdir(), "openclaw-test-"));
+    const originalHome = process.env.OPENCLAW_HOME;
+    try {
+      process.env.OPENCLAW_HOME = tmpHome;
+      const runResolveContradictions = vi.fn().mockResolvedValue({
+        autoResolved: [],
+        ambiguous: [{ contradictionId: "c-1", factIdNew: "new-1", factIdOld: "old-1" }],
+      });
+      const mem = makeProgram(makeBindings({ runResolveContradictions }));
+      const lines: string[] = [];
+      vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+        lines.push(args.map((a) => String(a)).join(" "));
+      });
 
-    await mem.parseAsync(
-      ["resolve-contradictions", "--json", "--degraded-ambiguous-threshold", "1"],
-      { from: "user" },
-    );
+      await mem.parseAsync(["resolve-contradictions", "--json", "--degraded-ambiguous-threshold", "1"], {
+        from: "user",
+      });
 
-    const jsonLine = lines.find((line) => line.trim().startsWith("{"));
-    expect(jsonLine).toBeTruthy();
-    const summary = JSON.parse(jsonLine as string);
-    expect(summary).toMatchObject({
-      mode: "default",
-      autoResolved: 0,
-      ambiguous: 1,
-      noProgress: true,
-      degraded: true,
-      exitCode: 2,
-      exitReason: "ambiguous_backlog_no_progress",
-      consecutiveNoProgressRuns: 1,
-      suggestions: {
-        details: "openclaw hybrid-mem resolve-contradictions --details",
-        projectStateLwwDryRun: "openclaw hybrid-mem resolve-contradictions --project-state-lww --dry-run",
-      },
-    });
+      const jsonLine = lines.find((line) => line.trim().startsWith("{"));
+      expect(jsonLine).toBeTruthy();
+      const summary = JSON.parse(jsonLine as string);
+      expect(summary).toMatchObject({
+        mode: "default",
+        autoResolved: 0,
+        ambiguous: 1,
+        noProgress: true,
+        degraded: true,
+        exitCode: 2,
+        exitReason: "ambiguous_backlog_no_progress",
+        consecutiveNoProgressRuns: 1,
+        suggestions: {
+          details: "openclaw hybrid-mem resolve-contradictions --details",
+          projectStateLwwDryRun: "openclaw hybrid-mem resolve-contradictions --project-state-lww --dry-run",
+        },
+      });
+    } finally {
+      if (originalHome !== undefined) process.env.OPENCLAW_HOME = originalHome;
+      else Reflect.deleteProperty(process.env, "OPENCLAW_HOME");
+      rmSync(tmpHome, { recursive: true, force: true });
+    }
   });
 
   it("marks auto mode backlog with no progress as degraded for cron validation", async () => {
-    const runResolveContradictionsAuto = vi.fn().mockResolvedValue({
-      total: 222,
-      deterministic: 0,
-      llm: 0,
-      merged: 0,
-      manualReview: 222,
-      applied: false,
-      decisionsApplied: 0,
-      targetRate: 0.8,
-      achievedRate: 0,
-      targetMet: false,
-      reviewItems: [],
-    });
-    const mem = makeProgram(makeBindings({ runResolveContradictionsAuto }));
-    const lines: string[] = [];
-    vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
-      lines.push(args.map((a) => String(a)).join(" "));
-    });
+    const tmpHome = mkdtempSync(join(tmpdir(), "openclaw-test-"));
+    const originalHome = process.env.OPENCLAW_HOME;
+    try {
+      process.env.OPENCLAW_HOME = tmpHome;
+      const runResolveContradictionsAuto = vi.fn().mockResolvedValue({
+        total: 222,
+        deterministic: 0,
+        llm: 0,
+        merged: 0,
+        manualReview: 222,
+        applied: false,
+        decisionsApplied: 0,
+        targetRate: 0.8,
+        achievedRate: 0,
+        targetMet: false,
+        reviewItems: [],
+      });
+      const mem = makeProgram(makeBindings({ runResolveContradictionsAuto }));
+      const lines: string[] = [];
+      vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+        lines.push(args.map((a) => String(a)).join(" "));
+      });
 
-    await mem.parseAsync(
-      ["resolve-contradictions", "--auto", "--json", "--degraded-ambiguous-threshold", "200"],
-      { from: "user" },
-    );
+      await mem.parseAsync(["resolve-contradictions", "--auto", "--json", "--degraded-ambiguous-threshold", "200"], {
+        from: "user",
+      });
 
-    const jsonLine = lines.find((line) => line.trim().startsWith("{"));
-    expect(jsonLine).toBeTruthy();
-    const summary = JSON.parse(jsonLine as string);
-    expect(summary).toMatchObject({
-      mode: "auto",
-      autoResolved: 0,
-      ambiguous: 222,
-      noProgress: true,
-      degraded: true,
-      exitCode: 2,
-      exitReason: "ambiguous_backlog_no_progress",
-    });
-    expect(process.exitCode).toBe(2);
-    expect(lines.some((l) => l.includes("contradiction-auto summary total=222"))).toBe(true);
+      const jsonLine = lines.find((line) => line.trim().startsWith("{"));
+      expect(jsonLine).toBeTruthy();
+      const summary = JSON.parse(jsonLine as string);
+      expect(summary).toMatchObject({
+        mode: "auto",
+        autoResolved: 0,
+        ambiguous: 222,
+        noProgress: true,
+        degraded: true,
+        exitCode: 2,
+        exitReason: "ambiguous_backlog_no_progress",
+      });
+      expect(process.exitCode).toBe(2);
+      expect(lines.some((l) => l.includes("contradiction-auto summary total=222"))).toBe(false);
+    } finally {
+      if (originalHome !== undefined) process.env.OPENCLAW_HOME = originalHome;
+      else Reflect.deleteProperty(process.env, "OPENCLAW_HOME");
+      rmSync(tmpHome, { recursive: true, force: true });
+    }
   });
 
   it("reports noProgress=false when no contradictions are considered", async () => {

--- a/extensions/memory-hybrid/tests/resolve-contradictions-cli.test.ts
+++ b/extensions/memory-hybrid/tests/resolve-contradictions-cli.test.ts
@@ -333,19 +333,16 @@ describe("resolve-contradictions CLI contract mode", () => {
     );
   });
 
-  it("rejects --json in non-default resolve modes", async () => {
+  it("rejects --json in LWW and dry-run contract modes", async () => {
     const mem = makeProgram(makeBindings());
     vi.spyOn(console, "error").mockImplementation(() => undefined);
 
-    await expect(mem.parseAsync(["resolve-contradictions", "--auto", "--json"], { from: "user" })).rejects.toThrow(
-      "--json is only supported in default resolve-contradictions mode",
-    );
     await expect(mem.parseAsync(["resolve-contradictions", "--dry-run", "--json"], { from: "user" })).rejects.toThrow(
-      "--json is only supported in default resolve-contradictions mode",
+      "--json is only supported in default or --auto resolve-contradictions mode",
     );
     await expect(
       mem.parseAsync(["resolve-contradictions", "--project-state-lww", "--json"], { from: "user" }),
-    ).rejects.toThrow("--json is only supported in default resolve-contradictions mode");
+    ).rejects.toThrow("--json is only supported in default or --auto resolve-contradictions mode");
   });
 
   it("supports --auto dry-run, summary reporting, and review export", async () => {
@@ -716,7 +713,9 @@ describe("resolve-contradictions CLI contract mode", () => {
     await mem.parseAsync(["resolve-contradictions", "--degraded-ambiguous-threshold", "1"], { from: "user" });
 
     expect(process.exitCode).toBe(2);
-    expect(lines.some((l) => l.includes("resolve-contradictions summary auto_resolved=0 ambiguous=2"))).toBe(true);
+    expect(lines.some((l) => l.includes("resolve-contradictions summary mode=default auto_resolved=0 ambiguous=2"))).toBe(
+      true,
+    );
     expect(
       lines.some((l) =>
         l.includes("Backlog alert: ambiguous=2 with auto-resolved=0 meets or exceeds degraded threshold 1"),
@@ -751,11 +750,53 @@ describe("resolve-contradictions CLI contract mode", () => {
       degraded: true,
       exitCode: 2,
       exitReason: "ambiguous_backlog_no_progress",
+      consecutiveNoProgressRuns: 1,
       suggestions: {
         details: "openclaw hybrid-mem resolve-contradictions --details",
         projectStateLwwDryRun: "openclaw hybrid-mem resolve-contradictions --project-state-lww --dry-run",
       },
     });
+  });
+
+  it("marks auto mode backlog with no progress as degraded for cron validation", async () => {
+    const runResolveContradictionsAuto = vi.fn().mockResolvedValue({
+      total: 222,
+      deterministic: 0,
+      llm: 0,
+      merged: 0,
+      manualReview: 222,
+      applied: false,
+      decisionsApplied: 0,
+      targetRate: 0.8,
+      achievedRate: 0,
+      targetMet: false,
+      reviewItems: [],
+    });
+    const mem = makeProgram(makeBindings({ runResolveContradictionsAuto }));
+    const lines: string[] = [];
+    vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+      lines.push(args.map((a) => String(a)).join(" "));
+    });
+
+    await mem.parseAsync(
+      ["resolve-contradictions", "--auto", "--json", "--degraded-ambiguous-threshold", "200"],
+      { from: "user" },
+    );
+
+    const jsonLine = lines.find((line) => line.trim().startsWith("{"));
+    expect(jsonLine).toBeTruthy();
+    const summary = JSON.parse(jsonLine as string);
+    expect(summary).toMatchObject({
+      mode: "auto",
+      autoResolved: 0,
+      ambiguous: 222,
+      noProgress: true,
+      degraded: true,
+      exitCode: 2,
+      exitReason: "ambiguous_backlog_no_progress",
+    });
+    expect(process.exitCode).toBe(2);
+    expect(lines.some((l) => l.includes("contradiction-auto summary total=222"))).toBe(true);
   });
 
   it("reports noProgress=false when no contradictions are considered", async () => {

--- a/extensions/memory-hybrid/tests/resolve-contradictions-cli.test.ts
+++ b/extensions/memory-hybrid/tests/resolve-contradictions-cli.test.ts
@@ -825,38 +825,56 @@ describe("resolve-contradictions CLI contract mode", () => {
   });
 
   it("reports noProgress=false when no contradictions are considered", async () => {
-    const runResolveContradictions = vi.fn().mockResolvedValue({ autoResolved: [], ambiguous: [] });
-    const mem = makeProgram(makeBindings({ runResolveContradictions }));
-    const lines: string[] = [];
-    vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
-      lines.push(args.map((a) => String(a)).join(" "));
-    });
+    const tmpHome = mkdtempSync(join(tmpdir(), "openclaw-test-"));
+    const originalHome = process.env.OPENCLAW_HOME;
+    try {
+      process.env.OPENCLAW_HOME = tmpHome;
+      const runResolveContradictions = vi.fn().mockResolvedValue({ autoResolved: [], ambiguous: [] });
+      const mem = makeProgram(makeBindings({ runResolveContradictions }));
+      const lines: string[] = [];
+      vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+        lines.push(args.map((a) => String(a)).join(" "));
+      });
 
-    await mem.parseAsync(["resolve-contradictions", "--json"], { from: "user" });
+      await mem.parseAsync(["resolve-contradictions", "--json"], { from: "user" });
 
-    const jsonLine = lines.find((line) => line.trim().startsWith("{"));
-    expect(jsonLine).toBeTruthy();
-    const summary = JSON.parse(jsonLine as string);
-    expect(summary.noProgress).toBe(false);
-    expect(summary.degraded).toBe(false);
+      const jsonLine = lines.find((line) => line.trim().startsWith("{"));
+      expect(jsonLine).toBeTruthy();
+      const summary = JSON.parse(jsonLine as string);
+      expect(summary.noProgress).toBe(false);
+      expect(summary.degraded).toBe(false);
+    } finally {
+      if (originalHome !== undefined) process.env.OPENCLAW_HOME = originalHome;
+      else Reflect.deleteProperty(process.env, "OPENCLAW_HOME");
+      rmSync(tmpHome, { recursive: true, force: true });
+    }
   });
 
   it("reports noProgress=true when contradictions are considered with zero auto-resolves", async () => {
-    const runResolveContradictions = vi.fn().mockResolvedValue({
-      autoResolved: [],
-      ambiguous: [{ contradictionId: "c-1", factIdNew: "new-1", factIdOld: "old-1" }],
-    });
-    const mem = makeProgram(makeBindings({ runResolveContradictions }));
-    const lines: string[] = [];
-    vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
-      lines.push(args.map((a) => String(a)).join(" "));
-    });
+    const tmpHome = mkdtempSync(join(tmpdir(), "openclaw-test-"));
+    const originalHome = process.env.OPENCLAW_HOME;
+    try {
+      process.env.OPENCLAW_HOME = tmpHome;
+      const runResolveContradictions = vi.fn().mockResolvedValue({
+        autoResolved: [],
+        ambiguous: [{ contradictionId: "c-1", factIdNew: "new-1", factIdOld: "old-1" }],
+      });
+      const mem = makeProgram(makeBindings({ runResolveContradictions }));
+      const lines: string[] = [];
+      vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+        lines.push(args.map((a) => String(a)).join(" "));
+      });
 
-    await mem.parseAsync(["resolve-contradictions", "--json"], { from: "user" });
+      await mem.parseAsync(["resolve-contradictions", "--json"], { from: "user" });
 
-    const jsonLine = lines.find((line) => line.trim().startsWith("{"));
-    expect(jsonLine).toBeTruthy();
-    const summary = JSON.parse(jsonLine as string);
-    expect(summary.noProgress).toBe(true);
+      const jsonLine = lines.find((line) => line.trim().startsWith("{"));
+      expect(jsonLine).toBeTruthy();
+      const summary = JSON.parse(jsonLine as string);
+      expect(summary.noProgress).toBe(true);
+    } finally {
+      if (originalHome !== undefined) process.env.OPENCLAW_HOME = originalHome;
+      else Reflect.deleteProperty(process.env, "OPENCLAW_HOME");
+      rmSync(tmpHome, { recursive: true, force: true });
+    }
   });
 });

--- a/extensions/memory-hybrid/tests/resolve-contradictions-cli.test.ts
+++ b/extensions/memory-hybrid/tests/resolve-contradictions-cli.test.ts
@@ -684,43 +684,52 @@ describe("resolve-contradictions CLI contract mode", () => {
   });
 
   it("marks large ambiguous backlog with no progress as degraded", async () => {
-    const runResolveContradictions = vi.fn().mockResolvedValue({
-      autoResolved: [],
-      ambiguous: [
-        { contradictionId: "c-1", factIdNew: "new-1", factIdOld: "old-1" },
-        { contradictionId: "c-2", factIdNew: "new-2", factIdOld: "old-2" },
-      ],
-    });
-    const runResolveContradictionsAuto = vi.fn().mockResolvedValue({
-      total: 2,
-      deterministic: 0,
-      llm: 0,
-      merged: 0,
-      manualReview: 2,
-      applied: false,
-      decisionsApplied: 0,
-      targetRate: 0.8,
-      achievedRate: 0,
-      targetMet: false,
-      reviewItems: [],
-    });
-    const mem = makeProgram(makeBindings({ runResolveContradictions, runResolveContradictionsAuto }));
-    const lines: string[] = [];
-    vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
-      lines.push(args.map((a) => String(a)).join(" "));
-    });
+    const tmpHome = mkdtempSync(join(tmpdir(), "openclaw-test-"));
+    const originalHome = process.env.OPENCLAW_HOME;
+    try {
+      process.env.OPENCLAW_HOME = tmpHome;
+      const runResolveContradictions = vi.fn().mockResolvedValue({
+        autoResolved: [],
+        ambiguous: [
+          { contradictionId: "c-1", factIdNew: "new-1", factIdOld: "old-1" },
+          { contradictionId: "c-2", factIdNew: "new-2", factIdOld: "old-2" },
+        ],
+      });
+      const runResolveContradictionsAuto = vi.fn().mockResolvedValue({
+        total: 2,
+        deterministic: 0,
+        llm: 0,
+        merged: 0,
+        manualReview: 2,
+        applied: false,
+        decisionsApplied: 0,
+        targetRate: 0.8,
+        achievedRate: 0,
+        targetMet: false,
+        reviewItems: [],
+      });
+      const mem = makeProgram(makeBindings({ runResolveContradictions, runResolveContradictionsAuto }));
+      const lines: string[] = [];
+      vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+        lines.push(args.map((a) => String(a)).join(" "));
+      });
 
-    await mem.parseAsync(["resolve-contradictions", "--degraded-ambiguous-threshold", "1"], { from: "user" });
+      await mem.parseAsync(["resolve-contradictions", "--degraded-ambiguous-threshold", "1"], { from: "user" });
 
-    expect(process.exitCode).toBe(2);
-    expect(
-      lines.some((l) => l.includes("resolve-contradictions summary mode=default auto_resolved=0 ambiguous=2")),
-    ).toBe(true);
-    expect(
-      lines.some((l) =>
-        l.includes("Backlog alert: ambiguous=2 with auto-resolved=0 meets or exceeds degraded threshold 1"),
-      ),
-    ).toBe(true);
+      expect(process.exitCode).toBe(2);
+      expect(
+        lines.some((l) => l.includes("resolve-contradictions summary mode=default auto_resolved=0 ambiguous=2")),
+      ).toBe(true);
+      expect(
+        lines.some((l) =>
+          l.includes("Backlog alert: ambiguous=2 with auto-resolved=0 meets or exceeds degraded threshold 1"),
+        ),
+      ).toBe(true);
+    } finally {
+      if (originalHome !== undefined) process.env.OPENCLAW_HOME = originalHome;
+      else Reflect.deleteProperty(process.env, "OPENCLAW_HOME");
+      rmSync(tmpHome, { recursive: true, force: true });
+    }
   });
 
   it("emits resolve-contradictions JSON summary for cron validation", async () => {


### PR DESCRIPTION
## Summary
- Closes the remaining gap from #1805 after #1813: nightly `resolve-contradictions --auto` now emits the same actionable progress summary/JSON and can exit degraded when a large ambiguous backlog makes no progress across consecutive runs.
- Adds shared progress evaluation in `contradiction-progress-summary.ts` with persisted consecutive no-progress state under `~/.openclaw/cron/guard/resolve-contradictions-no-progress.json`.
- Adds `--degraded-consecutive-threshold <m>` (default `1`; nightly cron now uses `3`) alongside existing `--degraded-ambiguous-threshold <n>` (default `200`).
- Enables `--json` in `--auto` mode for cron validation; LWW/dry-run/apply-review modes still reject `--json`.

## Why
#1813 fixed default mode only, but production cron runs `resolve-contradictions --auto --verbose`, so large ambiguous backlogs still exited 0 and looked successful.

## Test plan
- [x] `npm test -- contradiction-progress-summary`
- [ ] `npm test -- resolve-contradictions-cli` (requires Node with `node:sqlite`; local runner on Node 20 failed to load suite)
- [ ] Manual: run `openclaw hybrid-mem resolve-contradictions --auto --json --degraded-ambiguous-threshold 200` against a DB with large ambiguous backlog and verify `exitCode=2` after consecutive threshold is met
- [ ] Manual: verify nightly cron step records non-zero exit in `HM_EXIT` after three consecutive stuck runs

Fixes #1805

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI/cron observability and exit-code behavior for maintenance; no auth or data-model changes beyond a small guard state file.
> 
> **Overview**
> Extends the **resolve-contradictions** degraded-backlog guard so **default** and **`--auto`** paths share one progress pipeline: metrics, text/JSON summaries, exit code 2, and follow-up suggestions.
> 
> A new **`contradiction-progress-summary`** module evaluates no-progress runs, formats the unified summary line (`mode`, `consecutive`, `consecutive_threshold`), and **persists** consecutive no-progress counts under `~/.openclaw/cron/guard/resolve-contradictions-no-progress.json`. Degraded exit now needs both a large ambiguous backlog with zero auto-resolves **and** enough **consecutive** stuck runs via **`--degraded-consecutive-threshold`** (default `1`; nightly cron uses `3`). **`--json`** is allowed in **`--auto`** for cron validation; LWW/dry-run/apply-review still reject it.
> 
> Docs and tests cover the new behavior and CLI contracts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa4ed2f244d0086f6f9b20afcb04020e2feffa07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->