### PR TITLE
fix: restore maintenance-tier fallback policy for generate-proposals (#1824)

### DIFF
--- a/extensions/memory-hybrid/cli/cmd-extract-proposals.ts
+++ b/extensions/memory-hybrid/cli/cmd-extract-proposals.ts
@@ -162,9 +162,15 @@ export async function runGenerateProposalsForCli(
     insights: insightsBlock,
     identity_files: identityFilesBlock,
   });
-  const { defaultModel: model, fallbackModels: resolvedFallbacks } = resolveReflectionModelAndFallbacks(cfg, "heavy");
+  const { defaultModel: model, fallbackModels: resolvedFallbacks } = resolveReflectionModelAndFallbacks(
+    cfg,
+    "maintenance",
+  );
   const fallbackModels = resolvedFallbacks ?? [];
   const allModels = [model, ...fallbackModels];
+  ctx.logger.info?.(
+    `memory-hybrid: generate-proposals fallback chain = [${fallbackModels.length > 0 ? fallbackModels.join(", ") : ""}]`,
+  );
   let items:
     | Array<{
         targetFile: string;
@@ -181,7 +187,7 @@ export async function runGenerateProposalsForCli(
     try {
       const detail = await chatCompleteWithAdaptiveMaintenanceRetry({
         model: tryModel,
-        modelSource: modelIdx === 0 ? "heavy" : "fallback",
+        modelSource: modelIdx === 0 ? "maintenance" : "fallback",
         content: prompt,
         temperature: 0.3,
         maxTokens: 4000,

--- a/extensions/memory-hybrid/tests/generate-proposals-scope-filter.test.ts
+++ b/extensions/memory-hybrid/tests/generate-proposals-scope-filter.test.ts
@@ -157,7 +157,7 @@ describe("generate-proposals — requireScopeFilter (#1809)", () => {
     }
   });
 
-  it("includes llm.fallbackModel for heavy generate-proposals fallback chain", async () => {
+  it("includes llm.fallbackModel for maintenance generate-proposals fallback chain", async () => {
     const db = new FactsDB(":memory:");
     const proposalsDb = new ProposalsDB(":memory:");
     insertScopedPattern(db, "global", null, "global pattern");
@@ -166,8 +166,9 @@ describe("generate-proposals — requireScopeFilter (#1809)", () => {
     const ctx = makeCtx(db, proposalsDb, {
       configOverrides: {
         llm: {
+          maintenance: ["minimax/minimax-m1"],
           default: ["openai/gpt-4.1-mini"],
-          heavy: ["minimax/minimax-m1"],
+          heavy: ["openai/gpt-5.4"],
           fallbackModel: "openai/gpt-4.1-mini",
         },
       },
@@ -181,10 +182,38 @@ describe("generate-proposals — requireScopeFilter (#1809)", () => {
       chatSpy.mockRestore();
     }
   });
+
+  it("#1824: uses maintenance safety-net fallback when single maintenance model has no configured fallbacks", async () => {
+    const db = new FactsDB(":memory:");
+    const proposalsDb = new ProposalsDB(":memory:");
+    insertScopedPattern(db, "global", null, "global pattern");
+    const chatSpy = vi.spyOn(chatService, "chatCompleteWithRetryDetailed").mockRejectedValue(new Error("forced failure"));
+
+    const ctx = makeCtx(db, proposalsDb, {
+      configOverrides: {
+        llm: {
+          maintenance: ["minimax/MiniMax-M2.7-highspeed"],
+          default: ["minimax/MiniMax-M2.7-highspeed", "openai/gpt-4.1-mini"],
+          heavy: ["openai/gpt-5.4"],
+        },
+      },
+    });
+
+    try {
+      await expect(runGenerateProposalsForCli(ctx, { dryRun: false }, { resolvePath: (f) => f })).rejects.toThrow(
+        /models tried:.*openai\/gpt-4\.1-mini/,
+      );
+      expect(ctx.logger.info).toHaveBeenCalledWith(
+        expect.stringContaining("generate-proposals fallback chain = [openai/gpt-4.1-mini]"),
+      );
+    } finally {
+      chatSpy.mockRestore();
+    }
+  });
 });
 
 describe("generate-proposals — JSON retry (#1824)", () => {
-  function makeCtxWithTwoHeavyModels(
+  function makeCtxWithMaintenanceFallbackModels(
     db: InstanceType<typeof FactsDB>,
     proposalsDb: InstanceType<typeof ProposalsDB>,
     openai: unknown,
@@ -203,7 +232,11 @@ describe("generate-proposals — JSON retry (#1824)", () => {
       autoRecall: { scopeFilter: undefined },
       identityReflection: { enabled: false },
       identityPromotion: { enabled: false },
-      llm: { maintenance: ["primary-model"], default: ["primary-model"], heavy: ["primary-model", "fallback-model"] },
+      llm: {
+        maintenance: ["primary-model"],
+        default: ["primary-model", "fallback-model"],
+        heavy: ["openai/gpt-5.4"],
+      },
     } as unknown as HybridMemoryConfig;
 
     return {
@@ -248,7 +281,7 @@ describe("generate-proposals — JSON retry (#1824)", () => {
       },
     };
 
-    const ctx = makeCtxWithTwoHeavyModels(db, proposalsDb, openai);
+    const ctx = makeCtxWithMaintenanceFallbackModels(db, proposalsDb, openai);
     const result = await runGenerateProposalsForCli(ctx, { dryRun: false }, { resolvePath: (f) => f });
 
     expect(openai.chat.completions.create).toHaveBeenCalledTimes(2);
@@ -277,7 +310,7 @@ describe("generate-proposals — JSON retry (#1824)", () => {
       },
     };
 
-    const ctx = makeCtxWithTwoHeavyModels(db, proposalsDb, openai);
+    const ctx = makeCtxWithMaintenanceFallbackModels(db, proposalsDb, openai);
 
     await expect(runGenerateProposalsForCli(ctx, { dryRun: false }, { resolvePath: (f) => f })).rejects.toThrow(
       "all models failed",
@@ -307,7 +340,7 @@ describe("generate-proposals — JSON retry (#1824)", () => {
       },
     };
 
-    const ctx = makeCtxWithTwoHeavyModels(db, proposalsDb, openai);
+    const ctx = makeCtxWithMaintenanceFallbackModels(db, proposalsDb, openai);
     const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
     try {
       let thrown: Error | null = null;
@@ -348,7 +381,7 @@ describe("generate-proposals — JSON retry (#1824)", () => {
       },
     };
 
-    const ctx = makeCtxWithTwoHeavyModels(db, proposalsDb, openai);
+    const ctx = makeCtxWithMaintenanceFallbackModels(db, proposalsDb, openai);
     let thrown: Error | null = null;
     try {
       await runGenerateProposalsForCli(ctx, { dryRun: false, verbose: true }, { resolvePath: (f) => f });


### PR DESCRIPTION
## Summary

Issue #1824 was largely implemented in PR #1847, but PR #1819 (#1803) regressed `generate-proposals` back to the **heavy** tier. That bypassed the maintenance fallback safety-net that appends a cheap JSON-safe model when the chain would otherwise be empty (the exact MiniMax highspeed single-point-of-failure scenario from QA).

This PR restores maintenance-tier model resolution for `generate-proposals`, logs the resolved fallback chain up front, and adds regression coverage for the safety-net path.

## Changes

- **`cmd-extract-proposals.ts`**: resolve models via `resolveReflectionModelAndFallbacks(cfg, "maintenance")` again; log `generate-proposals fallback chain = [...]` before LLM attempts
- **`generate-proposals-scope-filter.test.ts`**: update fallback-chain tests for maintenance tier; add `#1824` safety-net test for single MiniMax maintenance model

## Acceptance criteria (#1824)

- [x] `reflect-rules` and `generate-proposals` show a non-empty fallback chain by default (maintenance safety-net restored for generate-proposals)
- [x] Invalid JSON from first model retries on fallback (already on main; tests retained)
- [x] All models fail → non-zero exit / guard not updated (already on main via throws + validate-cron-exit)
- [x] Tests cover malformed JSON + fallback success (extended with maintenance safety-net case)

Fixes #1824

## Test plan

- [x] `npm test -- --run tests/config.test.ts -t "1824"`
- [ ] CI: `generate-proposals-scope-filter.test.ts` (requires Node >=22 for `node:sqlite`)


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to cron proposal LLM tier selection and observability; no auth, data, or persistence logic changes beyond existing generate-proposals flow.
> 
> **Overview**
> **`generate-proposals`** again resolves its LLM chain through the **maintenance** tier (not **heavy**), so the maintenance fallback safety-net applies when only a single fast maintenance model is configured. **`modelSource`** on adaptive maintenance calls is aligned to `maintenance` / `fallback`, and an **info** log records the resolved fallback chain before any model is tried.
> 
> Tests now assert maintenance-tier fallback behavior (including **`llm.fallbackModel`** and the **#1824** safety-net path that appends a cheap default model), and JSON-retry helpers were renamed/retuned to use maintenance + default fallbacks instead of a two-model heavy chain.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f73a2696df9fd48c2609a71130de80cf3db2f39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->