### PR TITLE
fix: classify benign SDK/Codex warnings in maintenance analyzer (#1833)

### DIFF
--- a/extensions/memory-hybrid/README.md
+++ b/extensions/memory-hybrid/README.md
@@ -299,7 +299,7 @@ openclaw hybrid-mem analyze-maintenance-logs --since 7d --format json --out /tmp
 openclaw hybrid-mem analyze-maintenance-logs --since 24h --auto-fix --glitchtip --strict
 ```
 
-Rules are data-driven in [`services/maintenance-rules.json`](services/maintenance-rules.json), so operators can inspect or extend classifications without changing analyzer code. Findings are persisted in `maintenance-findings.db` table `maintenance_finding`, enabling week-over-week trend output for `--since 7d` / `--trend` runs. The digest collapses repeated fingerprints into `New` vs `Still failing`, suppresses stale historical fingerprints outside the current window from the primary findings, and avoids re-reporting already GlitchTip-reported fingerprints on every analyzer run.
+Rules are data-driven in [`services/maintenance-rules.json`](services/maintenance-rules.json), so operators can inspect or extend classifications without changing analyzer code. Findings are persisted in `maintenance-findings.db` table `maintenance_finding`, enabling week-over-week trend output for `--since 7d` / `--trend` runs. The digest collapses repeated fingerprints into `New` vs `Still failing`, suppresses stale historical fingerprints outside the current window from the primary findings, and avoids re-reporting already GlitchTip-reported fingerprints on every analyzer run. Known benign compatibility notices (for example missing `registerContextEngine` on older SDKs and Codex project-local config warnings) are collected in `noiseWarnings[]` and excluded from primary failure counts by default (#1833).
 
 The installer registers `hybrid-mem:maintenance-log-analyzer` to run after the nightly chain and announce the rendered digest to the operator.
 

--- a/extensions/memory-hybrid/cli/commands/manage/register-analyze-maintenance-logs.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/register-analyze-maintenance-logs.ts
@@ -20,6 +20,7 @@ import {
   writeMaintenanceAnalysisOutput,
   type MaintenanceLogStep,
 } from "../../../services/maintenance-log-analyzer.js";
+import { isBenignNoiseOnlyMaintenanceStep } from "../../../services/maintenance-benign-noise.js";
 import { type Chainable, withExit } from "../../shared.js";
 import type { ManageBindings } from "./bindings.js";
 
@@ -146,6 +147,7 @@ export async function runAnalyzeMaintenanceLogs(
     findings: reportFindings,
     findingsPath: persistedFindings.length > 0 && opts?.noPersist !== true ? findingsPath : undefined,
     historicalStaleSuppressed: summarized.historicalStaleSuppressed,
+    benignNoiseSuppressed: steps.filter((step) => step.exitCode !== 0 && isBenignNoiseOnlyMaintenanceStep(step)).length,
     includeTrend: opts?.trend === true || since.endsWith("d") || since.endsWith("w"),
   });
   writeMaintenanceAnalysisOutput(report, format, outPath);

--- a/extensions/memory-hybrid/services/context-engine.ts
+++ b/extensions/memory-hybrid/services/context-engine.ts
@@ -580,6 +580,8 @@ export class HybridMemoryContextEngine implements MinimalContextEngine {
 // Registration helper (feature-detected)
 // ---------------------------------------------------------------------------
 
+let loggedMissingRegisterContextEngine = false;
+
 /**
  * Attempt to register HybridMemoryContextEngine with the OpenClaw plugin SDK.
  *
@@ -604,7 +606,12 @@ export async function registerHybridContextEngine(opts: ContextEngineOptions): P
     };
 
     if (typeof registerContextEngine !== "function") {
-      opts.logger.debug?.("memory-hybrid: registerContextEngine not found in SDK; skipping ContextEngine registration");
+      if (!loggedMissingRegisterContextEngine) {
+        loggedMissingRegisterContextEngine = true;
+        opts.logger.debug?.(
+          "memory-hybrid: registerContextEngine not found in SDK; skipping ContextEngine registration",
+        );
+      }
       return false;
     }
 

--- a/extensions/memory-hybrid/services/maintenance-benign-noise.ts
+++ b/extensions/memory-hybrid/services/maintenance-benign-noise.ts
@@ -1,0 +1,126 @@
+import { createHash } from "node:crypto";
+
+export interface MaintenanceBenignNoisePattern {
+  id: string;
+  /** Human-readable label for digest output. */
+  label: string;
+  pattern: RegExp;
+}
+
+/** Known benign maintenance log lines that should not inflate failure analysis (#1833). */
+export const MAINTENANCE_BENIGN_NOISE_PATTERNS: MaintenanceBenignNoisePattern[] = [
+  {
+    id: "register-context-engine-missing",
+    label: "registerContextEngine not found in SDK (compatibility notice)",
+    pattern: /registerContextEngine not found in SDK; skipping ContextEngine registration/i,
+  },
+  {
+    id: "codex-unsupported-project-local-config",
+    label: "Codex app-server ignored unsupported project-local config keys",
+    pattern:
+      /codex_app_server:\s*Ignored unsupported project-local config keys in .*\.codex\/config\.toml:\s*(?:model_provider|model_providers|profiles)/i,
+  },
+];
+
+export interface MaintenanceNoiseWarning {
+  patternId: string;
+  fingerprint: string;
+  classification: "benign_noise";
+  label: string;
+  job: string;
+  step: string;
+  logPath: string;
+  occurrenceCount: number;
+  excerpt: string;
+}
+
+export function maintenanceBenignNoiseFingerprint(patternId: string): string {
+  return createHash("sha256").update(`benign_noise\0${patternId}`).digest("hex").slice(0, 16);
+}
+
+export function lineMatchesMaintenanceBenignNoise(line: string): MaintenanceBenignNoisePattern | null {
+  const trimmed = line.trim();
+  if (!trimmed) return null;
+  for (const entry of MAINTENANCE_BENIGN_NOISE_PATTERNS) {
+    if (entry.pattern.test(trimmed)) return entry;
+  }
+  return null;
+}
+
+export function logContainsMaintenanceBenignNoise(text: string): boolean {
+  if (!text) return false;
+  return text.split("\n").some((line) => lineMatchesMaintenanceBenignNoise(line) !== null);
+}
+
+/** Remove known benign noise lines before classifying or excerpting actionable failures. */
+export function sanitizeMaintenanceLogText(text: string): string {
+  if (!text) return "";
+  return text
+    .split("\n")
+    .filter((line) => lineMatchesMaintenanceBenignNoise(line) === null)
+    .join("\n");
+}
+
+const ACTIONABLE_FAILURE_SIGNAL =
+  /error|fail|exception|unauthorized|429|busy|timeout|killed|cannot find module|guard|stopped early|ENOSPC|SQLITE_BUSY|still running after|validate-cron-exit|orchestration anomaly|empty exit ledger/i;
+const BENIGN_COUNTER_SIGNAL =
+  /\b(no|without|zero)\s+(errors?|failures?)\b|\berrors?\s*[:=]\s*0\b|\bfailures?\s*[:=]\s*0\b|\b0\s+errors?\b|\b0\s+failures?\b|\berrorcount\s*[:=]\s*0\b/gi;
+
+export function textHasActionableFailureSignal(text: string): boolean {
+  const sanitized = sanitizeMaintenanceLogText(text);
+  if (!sanitized.trim()) return false;
+  if (!ACTIONABLE_FAILURE_SIGNAL.test(sanitized)) return false;
+  return ACTIONABLE_FAILURE_SIGNAL.test(sanitized.replace(BENIGN_COUNTER_SIGNAL, " "));
+}
+
+export function stepHasActionableFailureSignal(input: { line?: string; logContent?: string }): boolean {
+  return textHasActionableFailureSignal(`${input.line ?? ""}\n${input.logContent ?? ""}`);
+}
+
+export function isBenignNoiseOnlyMaintenanceStep(input: {
+  exitCode: number;
+  line?: string;
+  logContent?: string;
+}): boolean {
+  if (input.exitCode === 0) return logContainsMaintenanceBenignNoise(`${input.line ?? ""}\n${input.logContent ?? ""}`);
+  const combined = `${input.line ?? ""}\n${input.logContent ?? ""}`;
+  if (!logContainsMaintenanceBenignNoise(combined)) return false;
+  return !stepHasActionableFailureSignal(input);
+}
+
+export function collectMaintenanceNoiseWarnings(
+  steps: Array<{ job: string; step: string; logPath: string; line?: string; logContent?: string }>,
+): MaintenanceNoiseWarning[] {
+  const byKey = new Map<string, MaintenanceNoiseWarning>();
+
+  for (const step of steps) {
+    const lines = `${step.line ?? ""}\n${step.logContent ?? ""}`.split("\n");
+    for (const rawLine of lines) {
+      const match = lineMatchesMaintenanceBenignNoise(rawLine);
+      if (!match) continue;
+      const key = `${match.id}\0${step.job}\0${step.step}\0${step.logPath}`;
+      const existing = byKey.get(key);
+      if (existing) {
+        existing.occurrenceCount += 1;
+        continue;
+      }
+      byKey.set(key, {
+        patternId: match.id,
+        fingerprint: maintenanceBenignNoiseFingerprint(match.id),
+        classification: "benign_noise",
+        label: match.label,
+        job: step.job,
+        step: step.step,
+        logPath: step.logPath,
+        occurrenceCount: 1,
+        excerpt: rawLine.trim().slice(0, 500),
+      });
+    }
+  }
+
+  return [...byKey.values()].sort((a, b) => {
+    if (a.patternId !== b.patternId) return a.patternId.localeCompare(b.patternId);
+    if (a.job !== b.job) return a.job.localeCompare(b.job);
+    return a.step.localeCompare(b.step);
+  });
+}

--- a/extensions/memory-hybrid/services/maintenance-benign-noise.ts
+++ b/extensions/memory-hybrid/services/maintenance-benign-noise.ts
@@ -82,7 +82,6 @@ export function isBenignNoiseOnlyMaintenanceStep(input: {
   line?: string;
   logContent?: string;
 }): boolean {
-  if (input.exitCode === 0) return logContainsMaintenanceBenignNoise(`${input.line ?? ""}\n${input.logContent ?? ""}`);
   const combined = `${input.line ?? ""}\n${input.logContent ?? ""}`;
   if (!logContainsMaintenanceBenignNoise(combined)) return false;
   return !stepHasActionableFailureSignal(input);

--- a/extensions/memory-hybrid/services/maintenance-log-analyzer.ts
+++ b/extensions/memory-hybrid/services/maintenance-log-analyzer.ts
@@ -6,6 +6,12 @@ import { DatabaseSync } from "node:sqlite";
 import { extractAuditHealthJsonFromLog } from "./audit-health-json.js";
 import { normalizeExitStepName } from "./cron-exit-validator.js";
 import { capturePluginError } from "./error-reporter.js";
+import {
+  collectMaintenanceNoiseWarnings,
+  isBenignNoiseOnlyMaintenanceStep,
+  sanitizeMaintenanceLogText,
+  type MaintenanceNoiseWarning,
+} from "./maintenance-benign-noise.js";
 
 export type MaintenanceClassification =
   | "env-misconfig"
@@ -88,12 +94,15 @@ export interface MaintenanceAnalysisReport {
   totalSteps: number;
   successfulSteps: number;
   findings: MaintenanceFinding[];
+  /** Known benign compatibility/config warnings suppressed from primary failure counts (#1833). */
+  noiseWarnings: MaintenanceNoiseWarning[];
   summary: {
     jobsOk: number;
     jobsWithFindings: number;
     newFindings: number;
     stillFailing: number;
     historicalStaleSuppressed: number;
+    benignNoiseSuppressed: number;
     byClassification: Record<string, number>;
     byAction: Record<string, number>;
     weekOverWeek?: Array<{ classification: string; currentWeek: number; previousWeek: number; delta: number }>;
@@ -496,7 +505,9 @@ export function classifyMaintenanceFailure(input: {
   const auditRule = classifyAuditHealthFailure(input.step, input.exitCode, input.logContent);
   if (auditRule) return auditRule;
 
-  const text = `${input.step ?? ""}\nexit=${input.exitCode ?? ""}\n${input.line ?? ""}\n${input.logContent ?? ""}`;
+  const text = sanitizeMaintenanceLogText(
+    `${input.step ?? ""}\nexit=${input.exitCode ?? ""}\n${input.line ?? ""}\n${input.logContent ?? ""}`,
+  );
   for (const rule of input.rules ?? RULES) {
     if (new RegExp(rule.pattern, "ims").test(text)) return rule;
   }
@@ -652,15 +663,18 @@ function excerptFor(logContent: string, line: string): string {
   const benignSignal =
     /\b(no|without|zero)\s+(errors?|failures?)\b|\berrors?\s*[:=]\s*0\b|\bfailures?\s*[:=]\s*0\b|\b0\s+errors?\b|\b0\s+failures?\b|\berrorcount\s*[:=]\s*0\b/gi;
   const hasActionableFailureSignal = (candidate: string): boolean => {
-    if (!failureSignal.test(candidate)) return false;
+    const sanitized = sanitizeMaintenanceLogText(candidate);
+    if (!failureSignal.test(sanitized)) return false;
 
     // Keep real failures even when the same log line also includes a benign
     // zero-error/zero-failure counter. Suppress only lines whose failure-like
     // text disappears after removing the benign phrases.
-    return failureSignal.test(candidate.replace(benignSignal, " "));
+    return failureSignal.test(sanitized.replace(benignSignal, " "));
   };
-  const interesting = logContent.split("\n").filter(hasActionableFailureSignal).slice(-8).join("\n");
-  return (interesting || line || logContent.slice(0, 1000)).slice(0, 1800);
+  const sanitizedLog = sanitizeMaintenanceLogText(logContent);
+  const sanitizedLine = sanitizeMaintenanceLogText(line);
+  const interesting = sanitizedLog.split("\n").filter(hasActionableFailureSignal).slice(-8).join("\n");
+  return (interesting || sanitizedLine || sanitizedLog.slice(0, 1000)).slice(0, 1800);
 }
 
 function fingerprintFor(step: MaintenanceLogStep, rule: MaintenanceRule): string {
@@ -700,6 +714,7 @@ export function analyzeMaintenanceSteps(
   const zeroExitHeuristicSeen = new Set<string>();
   for (const step of steps) {
     if (step.exitCode !== 0) {
+      if (isBenignNoiseOnlyMaintenanceStep(step)) continue;
       findings.push(findingFromStep(step));
       continue;
     }
@@ -1022,6 +1037,33 @@ function renderFindingSection(title: string, findings: MaintenanceFinding[]): st
   return lines;
 }
 
+function renderNoiseWarningSection(noiseWarnings: MaintenanceNoiseWarning[]): string[] {
+  const lines = ["", "### Benign noise (suppressed from failure counts)", ""];
+  if (noiseWarnings.length === 0) {
+    lines.push("None.");
+    return lines;
+  }
+
+  const byPattern = new Map<string, { label: string; count: number; jobs: Set<string> }>();
+  for (const warning of noiseWarnings) {
+    const bucket = byPattern.get(warning.patternId) ?? {
+      label: warning.label,
+      count: 0,
+      jobs: new Set<string>(),
+    };
+    bucket.count += warning.occurrenceCount;
+    bucket.jobs.add(warning.job);
+    byPattern.set(warning.patternId, bucket);
+  }
+
+  for (const [patternId, bucket] of [...byPattern.entries()].sort((a, b) => a[0].localeCompare(b[0]))) {
+    lines.push(
+      `- \`${patternId}\` — ${bucket.label}: ${bucket.count} occurrence(s) across ${bucket.jobs.size} job(s).`,
+    );
+  }
+  return lines;
+}
+
 export function renderMaintenanceDigestMarkdown(report: Omit<MaintenanceAnalysisReport, "digestMd">): string {
   const okJobs = report.summary.jobsOk;
   const totalJobs = okJobs + report.summary.jobsWithFindings;
@@ -1040,6 +1082,7 @@ export function renderMaintenanceDigestMarkdown(report: Omit<MaintenanceAnalysis
         `Suppressed ${report.summary.historicalStaleSuppressed} older historical fingerprint(s) that are outside the current reporting window.`,
       );
     }
+    lines.push(...renderNoiseWarningSection(report.noiseWarnings));
   } else {
     lines.push(...renderFindingSection("New", newFindings.slice(0, 20)));
     lines.push(...renderFindingSection("Still failing", stillFailing.slice(0, 20)));
@@ -1054,6 +1097,7 @@ export function renderMaintenanceDigestMarkdown(report: Omit<MaintenanceAnalysis
     const actualShown = Math.min(newFindings.length, 20) + Math.min(stillFailing.length, 20);
     const hiddenCount = Math.max(0, report.findings.length - actualShown);
     if (hiddenCount > 0) lines.push("", `… and ${hiddenCount} more findings.`);
+    lines.push(...renderNoiseWarningSection(report.noiseWarnings));
   }
   const trend = report.summary.weekOverWeek ?? [];
   if (trend.length > 0) {
@@ -1072,9 +1116,11 @@ export function buildMaintenanceAnalysisReport(opts: {
   since?: string;
   steps: MaintenanceLogStep[];
   findings: MaintenanceFinding[];
+  noiseWarnings?: MaintenanceNoiseWarning[];
   findingsPath?: string;
   includeTrend?: boolean;
   historicalStaleSuppressed?: number;
+  benignNoiseSuppressed?: number;
 }): MaintenanceAnalysisReport {
   const jobs = new Set(opts.steps.map((s) => s.job));
   const failedJobs = new Set(opts.findings.map((f) => f.job));
@@ -1086,6 +1132,7 @@ export function buildMaintenanceAnalysisReport(opts: {
     incr(byClassification, f.classification);
     incr(byAction, f.actionTaken);
   }
+  const noiseWarnings = opts.noiseWarnings ?? collectMaintenanceNoiseWarnings(opts.steps);
   const base = {
     schemaVersion: 1 as const,
     generatedAt: new Date().toISOString(),
@@ -1094,12 +1141,14 @@ export function buildMaintenanceAnalysisReport(opts: {
     totalSteps: opts.steps.length,
     successfulSteps: opts.steps.filter((s) => s.exitCode === 0).length,
     findings: opts.findings,
+    noiseWarnings,
     summary: {
       jobsOk: [...jobs].filter((j) => !failedJobs.has(j)).length,
       jobsWithFindings: failedJobs.size,
       newFindings,
       stillFailing,
       historicalStaleSuppressed: opts.historicalStaleSuppressed ?? 0,
+      benignNoiseSuppressed: opts.benignNoiseSuppressed ?? 0,
       byClassification,
       byAction,
       weekOverWeek: opts.includeTrend && opts.findingsPath ? weekOverWeekTrend(opts.findingsPath) : undefined,

--- a/extensions/memory-hybrid/tests/maintenance-benign-noise.test.ts
+++ b/extensions/memory-hybrid/tests/maintenance-benign-noise.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  collectMaintenanceNoiseWarnings,
+  isBenignNoiseOnlyMaintenanceStep,
+  sanitizeMaintenanceLogText,
+  stepHasActionableFailureSignal,
+} from "../services/maintenance-benign-noise.js";
+
+describe("maintenance-benign-noise", () => {
+  const registerContextEngineLine =
+    "memory-hybrid: registerContextEngine not found in SDK; skipping ContextEngine registration";
+  const codexConfigLine =
+    "ERROR codex_app_server: Ignored unsupported project-local config keys in /mnt/openclaw/.openclaw/workspace/.codex/config.toml: model_provider, model_providers, profiles.";
+
+  it("sanitizes known benign warning lines from log text", () => {
+    const sanitized = sanitizeMaintenanceLogText([registerContextEngineLine, "real progress line"].join("\n"));
+    expect(sanitized).not.toContain("registerContextEngine");
+    expect(sanitized).toContain("real progress line");
+  });
+
+  it("treats benign-only non-zero steps as noise-only", () => {
+    expect(
+      isBenignNoiseOnlyMaintenanceStep({
+        exitCode: 1,
+        logContent: codexConfigLine,
+      }),
+    ).toBe(true);
+    expect(
+      isBenignNoiseOnlyMaintenanceStep({
+        exitCode: 1,
+        logContent: `${codexConfigLine}\nUnhandled exception: parser timeout`,
+      }),
+    ).toBe(false);
+  });
+
+  it("detects actionable failure signals after benign stripping", () => {
+    expect(stepHasActionableFailureSignal({ logContent: registerContextEngineLine })).toBe(false);
+    expect(stepHasActionableFailureSignal({ logContent: "Unhandled exception: parser timeout" })).toBe(true);
+  });
+
+  it("aggregates noise warnings by pattern/job/step/log path", () => {
+    const warnings = collectMaintenanceNoiseWarnings([
+      {
+        job: "weekly-reflection",
+        step: "reflect",
+        logPath: "/tmp/a.log",
+        logContent: [registerContextEngineLine, registerContextEngineLine].join("\n"),
+      },
+      {
+        job: "nightly-memory-sweep",
+        step: "extract-daily",
+        logPath: "/tmp/b.log",
+        logContent: codexConfigLine,
+      },
+    ]);
+
+    expect(warnings).toHaveLength(2);
+    expect(warnings.find((w) => w.patternId === "register-context-engine-missing")?.occurrenceCount).toBe(2);
+    expect(warnings.find((w) => w.patternId === "codex-unsupported-project-local-config")?.classification).toBe(
+      "benign_noise",
+    );
+  });
+});

--- a/extensions/memory-hybrid/tests/maintenance-log-analyzer.test.ts
+++ b/extensions/memory-hybrid/tests/maintenance-log-analyzer.test.ts
@@ -139,6 +139,75 @@ describe("maintenance log analyzer", () => {
     expect(finding.logExcerpt).not.toContain("summary: errorCount=0 warningCount=0");
   });
 
+  it("collects benign SDK and Codex warnings in noiseWarnings without actionable findings", () => {
+    const steps = [
+      {
+        occurredAt: Math.floor(Date.now() / 1000),
+        iso: new Date().toISOString(),
+        job: "weekly-reflection",
+        step: "reflect",
+        exitCode: 0,
+        exitPath: "/tmp/reflect.exit.txt",
+        line: "reflect exit=0",
+        logPath: "/tmp/reflect.log",
+        logContent: [
+          "memory-hybrid: registerContextEngine not found in SDK; skipping ContextEngine registration",
+          "[agent/embedded] codex app-server stderr: ERROR codex_app_server: Ignored unsupported project-local config keys in /mnt/openclaw/.openclaw/workspace/.codex/config.toml: model_provider, model_providers, profiles. If you want these settings to apply, manually set them in your user-level config.toml.",
+        ].join("\n"),
+      },
+    ];
+
+    const findings = analyzeMaintenanceSteps(steps);
+    expect(findings).toHaveLength(0);
+
+    const report = buildMaintenanceAnalysisReport({ since: "24h", steps, findings });
+    expect(report.noiseWarnings).toHaveLength(2);
+    expect(report.noiseWarnings.map((w) => w.patternId)).toEqual(
+      expect.arrayContaining(["register-context-engine-missing", "codex-unsupported-project-local-config"]),
+    );
+    expect(report.noiseWarnings.every((w) => w.classification === "benign_noise")).toBe(true);
+    expect(report.digestMd).toContain("Benign noise (suppressed from failure counts)");
+    expect(report.digestMd).toContain("register-context-engine-missing");
+  });
+
+  it("suppresses benign-noise-only non-zero steps but keeps co-occurring actionable failures", () => {
+    const benignOnly = analyzeMaintenanceSteps([
+      {
+        occurredAt: Math.floor(Date.now() / 1000),
+        iso: new Date().toISOString(),
+        job: "weekly-reflection",
+        step: "reflect",
+        exitCode: 1,
+        exitPath: "/tmp/reflect.exit.txt",
+        line: "reflect exit=1",
+        logPath: "/tmp/reflect.log",
+        logContent:
+          "ERROR codex_app_server: Ignored unsupported project-local config keys in /mnt/openclaw/.openclaw/workspace/.codex/config.toml: model_provider, model_providers, profiles.",
+      },
+    ]);
+    expect(benignOnly).toHaveLength(0);
+
+    const actionable = analyzeMaintenanceSteps([
+      {
+        occurredAt: Math.floor(Date.now() / 1000),
+        iso: new Date().toISOString(),
+        job: "weekly-reflection",
+        step: "reflect",
+        exitCode: 1,
+        exitPath: "/tmp/reflect.exit.txt",
+        line: "reflect exit=1",
+        logPath: "/tmp/reflect.log",
+        logContent: [
+          "ERROR codex_app_server: Ignored unsupported project-local config keys in /mnt/openclaw/.openclaw/workspace/.codex/config.toml: model_provider, model_providers, profiles.",
+          "Unhandled exception: parser timeout",
+        ].join("\n"),
+      },
+    ]);
+    expect(actionable).toHaveLength(1);
+    expect(actionable[0]?.logExcerpt).toContain("Unhandled exception: parser timeout");
+    expect(actionable[0]?.logExcerpt).not.toContain("codex_app_server");
+  });
+
   it("classifies cron wrapper PATH failure (openclaw binary not in PATH) as env-misconfig", () => {
     // This reproduces the real-world cron failure:
     //   /usr/bin/timeout: failed to run command 'openclaw': No such file or directory


### PR DESCRIPTION
## Summary
- Adds `maintenance-benign-noise.ts` with known fingerprints for missing `registerContextEngine` SDK notices and Codex project-local config warnings
- Maintenance analyzer now strips benign lines before classification/excerpting, suppresses benign-only non-zero steps from primary `findings`, and reports them in `noiseWarnings[]`
- Markdown digest includes a **Benign noise (suppressed from failure counts)** section; JSON output includes `noiseWarnings` and `summary.benignNoiseSuppressed`
- Logs missing `registerContextEngine` at debug **once per process** instead of on every registration attempt

Fixes #1833

## Acceptance criteria
- [x] Analyzer separates benign noise from actionable failures (`noiseWarnings[]` vs `findings[]`)
- [x] Codex ignored-config warning does not inflate primary failure counts when it is the only error-shaped signal
- [x] `registerContextEngine not found` handled at debug-once (existing debug level + per-process guard)
- [x] Co-occurring real failures (e.g. parser timeout) remain actionable

## Test plan
- [x] `npm test -- --run maintenance-benign-noise.test.ts`
- [x] Added analyzer tests for noise collection, benign-only suppression, and co-occurring actionable failures
- [ ] Full `maintenance-log-analyzer.test.ts` suite (requires Node with `node:sqlite`)


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Operator-facing maintenance classification and digest output only; behavior is covered by new unit tests and does not touch auth, data stores, or runtime memory paths.
> 
> **Overview**
> Maintenance log analysis now treats known **compatibility/config warnings** (missing `registerContextEngine` on older SDKs, Codex ignored project-local config keys) as **benign noise** instead of inflating failure counts.
> 
> A new **`maintenance-benign-noise`** layer strips those lines before rule matching and excerpts, skips **non-zero steps** that only contain benign signals, and surfaces them separately as **`noiseWarnings[]`** with **`summary.benignNoiseSuppressed`** in JSON and a **Benign noise (suppressed from failure counts)** section in the markdown digest. **Real failures** that appear alongside benign lines (e.g. parser timeout) still become actionable findings, with excerpts that omit the noise.
> 
> **Context engine** registration logs the missing-SDK message at **debug once per process**. README documents the behavior (#1833).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1ee73485f0b6e43aed6e539df74e56e353932cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->