### PR TITLE
fix(vector-db): close re-index lock TOCTOU before LanceDB writes (#1841)

### DIFF
--- a/extensions/memory-hybrid/backends/vector-db/runtime-locks.ts
+++ b/extensions/memory-hybrid/backends/vector-db/runtime-locks.ts
@@ -1,3 +1,9 @@
+/**
+ * Module-level cooperative locks for LanceDB readers, optimize exclusivity, and re-index
+ * exclusion. Refcount maps use `.get(path) ?? 0` intentionally: updates run in synchronous
+ * JS blocks (no await between read and write), which is safe on Node's single-threaded model.
+ * Async callers must re-check immediately before mutating LanceDB (#1841).
+ */
 export const activeReadersByPath = new Map<string, number>();
 export const optimizeExclusiveLockByPath = new Map<string, boolean>();
 export const reindexExclusiveLockByPath = new Map<string, number>();
@@ -37,4 +43,28 @@ export function decrementReindexLockCount(dbPath: string): void {
     return;
   }
   reindexExclusiveLockByPath.set(dbPath, next);
+}
+
+/** Returns true when a re-index operation currently holds the cooperative re-index lock. */
+export function isReindexLockHeld(dbPath: string): boolean {
+  return getReindexLockCount(dbPath) > 0;
+}
+
+/**
+ * Wait until no re-index lock is held. Re-validates synchronously after each drain so a lock
+ * acquired during an await does not leave callers proceeding into LanceDB mutations (#1841).
+ */
+export async function waitForReindexLockClear(dbPath: string, maxWaitMs = 30_000): Promise<void> {
+  const started = Date.now();
+  for (;;) {
+    while (isReindexLockHeld(dbPath)) {
+      if (Date.now() - started > maxWaitMs) {
+        throw new Error(
+          `VectorDB operation blocked by active re-index lock for >${maxWaitMs}ms. Retry after re-index completes.`,
+        );
+      }
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+    if (!isReindexLockHeld(dbPath)) return;
+  }
 }

--- a/extensions/memory-hybrid/backends/vector-db/runtime-locks.ts
+++ b/extensions/memory-hybrid/backends/vector-db/runtime-locks.ts
@@ -65,4 +65,3 @@ export async function waitForReindexLockClear(dbPath: string, maxWaitMs = 30_000
     await new Promise((resolve) => setTimeout(resolve, 50));
   }
 }
-}

--- a/extensions/memory-hybrid/backends/vector-db/runtime-locks.ts
+++ b/extensions/memory-hybrid/backends/vector-db/runtime-locks.ts
@@ -56,15 +56,13 @@ export function isReindexLockHeld(dbPath: string): boolean {
  */
 export async function waitForReindexLockClear(dbPath: string, maxWaitMs = 30_000): Promise<void> {
   const started = Date.now();
-  for (;;) {
-    while (isReindexLockHeld(dbPath)) {
-      if (Date.now() - started > maxWaitMs) {
-        throw new Error(
-          `VectorDB operation blocked by active re-index lock for >${maxWaitMs}ms. Retry after re-index completes.`,
-        );
-      }
-      await new Promise((resolve) => setTimeout(resolve, 50));
+  while (isReindexLockHeld(dbPath)) {
+    if (Date.now() - started > maxWaitMs) {
+      throw new Error(
+        `VectorDB operation blocked by active re-index lock for >${maxWaitMs}ms. Retry after re-index completes.`,
+      );
     }
-    if (!isReindexLockHeld(dbPath)) return;
+    await new Promise((resolve) => setTimeout(resolve, 50));
   }
+}
 }

--- a/extensions/memory-hybrid/backends/vector-db/vector-db-class.ts
+++ b/extensions/memory-hybrid/backends/vector-db/vector-db-class.ts
@@ -50,9 +50,11 @@ import {
   incrementActiveReaderCount,
   incrementReindexLockCount,
   isOptimizeLocked,
+  isReindexLockHeld,
   optimizeExclusiveLockByPath,
   reindexExclusiveLockByPath,
   setOptimizeLock,
+  waitForReindexLockClear,
 } from "./runtime-locks.js";
 
 export class VectorDB {
@@ -228,15 +230,7 @@ export class VectorDB {
   }
 
   private async waitForReindexLockRelease(maxWaitMs = 30_000): Promise<void> {
-    const started = Date.now();
-    while (getReindexLockCount(this.dbPath) > 0) {
-      if (Date.now() - started > maxWaitMs) {
-        throw new Error(
-          `VectorDB operation blocked by active re-index lock for >${maxWaitMs}ms. Retry after re-index completes.`,
-        );
-      }
-      await new Promise((resolve) => setTimeout(resolve, 50));
-    }
+    await waitForReindexLockClear(this.dbPath, maxWaitMs);
   }
 
   async runWithReindexLock<T>(fn: () => Promise<T>): Promise<T> {
@@ -1359,10 +1353,20 @@ export class VectorDB {
     let lastErr: unknown;
     for (let attempt = 1; attempt <= maxAttempts; attempt++) {
       try {
+        await this.waitForReindexLockRelease();
+        if (isReindexLockHeld(this.dbPath)) {
+          throw new Error("VectorDB write blocked by active re-index lock");
+        }
         return await fn();
       } catch (err) {
         lastErr = err;
-        if (!this.isRetryableCommitConflictError(err) || attempt >= maxAttempts) throw err;
+        if (
+          !this.isRetryableCommitConflictError(err) &&
+          !(err instanceof Error && err.message.includes("re-index lock"))
+        ) {
+          throw err;
+        }
+        if (attempt >= maxAttempts) throw err;
         const delayMs = this.getWriteConflictRetryDelayMs(attempt);
         this.logWarn(
           `memory-hybrid: ${operation} hit retryable commit conflict (attempt ${attempt}/${maxAttempts}) — retrying in ${delayMs}ms`,

--- a/extensions/memory-hybrid/backends/vector-db/vector-db-class.ts
+++ b/extensions/memory-hybrid/backends/vector-db/vector-db-class.ts
@@ -1336,6 +1336,11 @@ export class VectorDB {
     return /retryable commit conflict/i.test(msg);
   }
 
+  /** TOCTOU guard after waitForReindexLockRelease; distinct from max-wait timeout errors. */
+  private isRetryableReindexLockBlockError(err: unknown): boolean {
+    return err instanceof Error && err.message === "VectorDB write blocked by active re-index lock";
+  }
+
   private async sleep(ms: number): Promise<void> {
     await new Promise((resolve) => setTimeout(resolve, ms));
   }
@@ -1360,16 +1365,14 @@ export class VectorDB {
         return await fn();
       } catch (err) {
         lastErr = err;
-        if (
-          !this.isRetryableCommitConflictError(err) &&
-          !(err instanceof Error && err.message.includes("re-index lock"))
-        ) {
-          throw err;
-        }
+        const isCommitConflict = this.isRetryableCommitConflictError(err);
+        const isReindexBlock = this.isRetryableReindexLockBlockError(err);
+        if (!isCommitConflict && !isReindexBlock) throw err;
         if (attempt >= maxAttempts) throw err;
         const delayMs = this.getWriteConflictRetryDelayMs(attempt);
+        const reason = isReindexBlock ? "re-index lock block" : "retryable commit conflict";
         this.logWarn(
-          `memory-hybrid: ${operation} hit retryable commit conflict (attempt ${attempt}/${maxAttempts}) — retrying in ${delayMs}ms`,
+          `memory-hybrid: ${operation} hit ${reason} (attempt ${attempt}/${maxAttempts}) — retrying in ${delayMs}ms`,
         );
         await this.sleep(delayMs);
       }

--- a/extensions/memory-hybrid/tests/runtime-locks.test.ts
+++ b/extensions/memory-hybrid/tests/runtime-locks.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  decrementReindexLockCount,
+  getReindexLockCount,
+  incrementReindexLockCount,
+  isReindexLockHeld,
+  reindexExclusiveLockByPath,
+  waitForReindexLockClear,
+} from "../backends/vector-db/runtime-locks.js";
+
+describe("runtime-locks re-index cooperative lock (#1841)", () => {
+  const dbPath = "/tmp/runtime-locks-test-db";
+
+  afterEach(() => {
+    reindexExclusiveLockByPath.delete(dbPath);
+    vi.useRealTimers();
+  });
+
+  it("tracks nested re-index holders via refcount helpers", () => {
+    expect(getReindexLockCount(dbPath)).toBe(0);
+    expect(isReindexLockHeld(dbPath)).toBe(false);
+
+    incrementReindexLockCount(dbPath);
+    incrementReindexLockCount(dbPath);
+    expect(getReindexLockCount(dbPath)).toBe(2);
+    expect(isReindexLockHeld(dbPath)).toBe(true);
+
+    decrementReindexLockCount(dbPath);
+    expect(getReindexLockCount(dbPath)).toBe(1);
+
+    decrementReindexLockCount(dbPath);
+    expect(getReindexLockCount(dbPath)).toBe(0);
+    expect(isReindexLockHeld(dbPath)).toBe(false);
+  });
+
+  it("waitForReindexLockClear resolves immediately when no lock is held", async () => {
+    await expect(waitForReindexLockClear(dbPath, 100)).resolves.toBeUndefined();
+  });
+
+  it("waitForReindexLockClear waits until the re-index lock is released", async () => {
+    vi.useFakeTimers();
+    incrementReindexLockCount(dbPath);
+
+    const waiting = waitForReindexLockClear(dbPath, 1_000);
+    let settled = false;
+    void waiting.then(() => {
+      settled = true;
+    });
+
+    await vi.advanceTimersByTimeAsync(40);
+    expect(settled).toBe(false);
+
+    decrementReindexLockCount(dbPath);
+    await vi.advanceTimersByTimeAsync(60);
+    await waiting;
+    expect(settled).toBe(true);
+  });
+
+  it("waitForReindexLockClear re-checks after drain when lock is re-acquired during await", async () => {
+    vi.useFakeTimers();
+    incrementReindexLockCount(dbPath);
+
+    const waiting = waitForReindexLockClear(dbPath, 1_000);
+
+    decrementReindexLockCount(dbPath);
+    incrementReindexLockCount(dbPath);
+
+    await vi.advanceTimersByTimeAsync(50);
+    expect(isReindexLockHeld(dbPath)).toBe(true);
+
+    decrementReindexLockCount(dbPath);
+    await vi.advanceTimersByTimeAsync(50);
+    await waiting;
+    expect(isReindexLockHeld(dbPath)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
Investigation for similarity-sweep issue #1841 (from #1836):

- **`reindexExclusiveLockByPath.get(dbPath) ?? 0` is intentional** — module-level cooperative refcount for re-index exclusion, safe for synchronous increment/decrement on Node's event loop.
- **Real gap was async TOCTOU** — `waitForReindexLockRelease()` could return while `store()` / `optimize()` still had `await ensureInitialized()` (and other yields) before the LanceDB mutation, allowing a re-index to start in between.

This PR closes that window by:
- Adding `waitForReindexLockClear()` with post-drain synchronous re-check
- Re-checking immediately before each write attempt inside `withRetryableWriteConflictRetry()` (store/delete/optimize path)
- Documenting the lock design in `runtime-locks.ts`

Fixes #1841

## Test plan
- [x] `npm test -- --run runtime-locks.test.ts`
- [x] `npm test -- --run vector-db-write-conflict.test.ts`


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes write-path concurrency against re-index for store/delete/optimize; mistakes could cause spurious retries or rare write/re-index overlap, but scope is narrow and covered by new lock tests.
> 
> **Overview**
> Closes an **async TOCTOU** where `waitForReindexLockRelease()` could finish while a write still had `await` gaps (e.g. init) before the actual LanceDB mutation, letting re-index start in between (#1841).
> 
> **`runtime-locks.ts`** now exposes `isReindexLockHeld`, shared `waitForReindexLockClear()` (re-checks synchronously after each poll drain), and documents the cooperative refcount model. **`VectorDB`** delegates waiting to that helper and, inside **`withRetryableWriteConflictRetry`**, waits for the lock, then **re-checks immediately** before `store` / `delete` / `optimize` — treating a post-wait lock as a **retryable** condition alongside commit conflicts. New **`runtime-locks.test.ts`** covers refcounting and re-acquire-during-await behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74e9c1853bc421a92282986e96efd493a5374566. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->