### PR TITLE
fix(active-task): narrow stale signal delete error handling (#1842)

### DIFF
--- a/extensions/memory-hybrid/services/active-task.ts
+++ b/extensions/memory-hybrid/services/active-task.ts
@@ -51,13 +51,29 @@ export function resolveActiveTaskReadPath(filePath: string): string | null {
 export const STALE_CORRUPT_SIGNAL_MS = 5 * 60 * 1000;
 const MAX_TASK_SIGNAL_BYTES = 256 * 1024;
 
-async function tryDeleteStaleCorruptSignalFile(filePath: string): Promise<void> {
+/** Best-effort cleanup for stale corrupt/orphan signal files (#812, #1842). Exported for tests. */
+export async function tryDeleteStaleCorruptSignalFile(filePath: string): Promise<void> {
+  let mtimeMs: number;
   try {
     const s = await stat(filePath);
-    if (Date.now() - s.mtimeMs <= STALE_CORRUPT_SIGNAL_MS) return;
+    mtimeMs = s.mtimeMs;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return;
+    pluginLogger.warn?.(
+      `memory-hybrid: failed to stat stale corrupt task signal for cleanup (${filePath}): ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return;
+  }
+
+  if (Date.now() - mtimeMs <= STALE_CORRUPT_SIGNAL_MS) return;
+
+  try {
     await unlink(filePath);
-  } catch {
-    // ENOENT or other — ignore
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return;
+    pluginLogger.warn?.(
+      `memory-hybrid: failed to delete stale corrupt task signal (${filePath}): ${err instanceof Error ? err.message : String(err)}`,
+    );
   }
 }
 

--- a/extensions/memory-hybrid/services/active-task.ts
+++ b/extensions/memory-hybrid/services/active-task.ts
@@ -59,7 +59,7 @@ export async function tryDeleteStaleCorruptSignalFile(filePath: string): Promise
     mtimeMs = s.mtimeMs;
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === "ENOENT") return;
-    pluginLogger.warn?.(
+    pluginLogger.warn(
       `memory-hybrid: failed to stat stale corrupt task signal for cleanup (${filePath}): ${err instanceof Error ? err.message : String(err)}`,
     );
     return;
@@ -71,7 +71,7 @@ export async function tryDeleteStaleCorruptSignalFile(filePath: string): Promise
     await unlink(filePath);
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === "ENOENT") return;
-    pluginLogger.warn?.(
+    pluginLogger.warn(
       `memory-hybrid: failed to delete stale corrupt task signal (${filePath}): ${err instanceof Error ? err.message : String(err)}`,
     );
   }

--- a/extensions/memory-hybrid/tests/active-task.test.ts
+++ b/extensions/memory-hybrid/tests/active-task.test.ts
@@ -1431,7 +1431,7 @@ describe("writeTaskSignal / readPendingSignals / deleteSignal", () => {
   });
 
   it("warns on non-ENOENT stale corrupt signal delete failures without throwing", async () => {
-    const { initPluginLogger, resetPluginLogger } = await import("../utils/logger.js");
+    const { initPluginLogger, restoreDefaultLogger } = await import("../utils/logger.js");
     const warn = vi.fn();
     initPluginLogger({ info: vi.fn(), warn, error: vi.fn() });
     try {
@@ -1442,11 +1442,11 @@ describe("writeTaskSignal / readPendingSignals / deleteSignal", () => {
       await expect(tryDeleteStaleCorruptSignalFile(signalsDir)).resolves.toBeUndefined();
       expect(warn).toHaveBeenCalledWith(expect.stringContaining("failed to delete stale corrupt task signal"));
     } finally {
-      resetPluginLogger();
+      restoreDefaultLogger();
     }
   });
 
-  it("tryDeleteStaleCorruptSignalFile ignores ENOENT on delete races", async () => {
+  it("tryDeleteStaleCorruptSignalFile ignores ENOENT when file is already gone before stat", async () => {
     const { writeFile: fsWrite, mkdir: fsMkdir, utimes, unlink: fsUnlink } = await import("node:fs/promises");
     const signalsDir = join(tmpDir, "task-signals");
     await fsMkdir(signalsDir, { recursive: true });

--- a/extensions/memory-hybrid/tests/active-task.test.ts
+++ b/extensions/memory-hybrid/tests/active-task.test.ts
@@ -3,10 +3,10 @@
  * Tests for ACTIVE-TASKS.md working memory service and CLI commands.
  */
 
-import { chmod, mkdir, mkdtemp, readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, readdir, readFile, rm, stat, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   type ActiveTaskContext,
   runActiveTaskAdd,
@@ -33,6 +33,7 @@ import {
   readPendingSignals,
   reconcileActiveTaskInProgressSessions,
   STALE_CORRUPT_SIGNAL_MS,
+  tryDeleteStaleCorruptSignalFile,
   serializeActiveTaskFile,
   serializeTaskEntry,
   type TaskSignal,
@@ -1427,6 +1428,34 @@ describe("writeTaskSignal / readPendingSignals / deleteSignal", () => {
     await utimes(tmpPath, old, old);
     await readPendingSignals(tmpDir);
     await expect(readFile(tmpPath, "utf-8")).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("warns on non-ENOENT stale corrupt signal delete failures without throwing", async () => {
+    const { initPluginLogger, resetPluginLogger } = await import("../utils/logger.js");
+    const warn = vi.fn();
+    initPluginLogger({ info: vi.fn(), warn, error: vi.fn() });
+    try {
+      const signalsDir = join(tmpDir, "task-signals");
+      await mkdir(signalsDir, { recursive: true });
+      const old = new Date(Date.now() - STALE_CORRUPT_SIGNAL_MS - 60_000);
+      await utimes(signalsDir, old, old);
+      await expect(tryDeleteStaleCorruptSignalFile(signalsDir)).resolves.toBeUndefined();
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining("failed to delete stale corrupt task signal"));
+    } finally {
+      resetPluginLogger();
+    }
+  });
+
+  it("tryDeleteStaleCorruptSignalFile ignores ENOENT on delete races", async () => {
+    const { writeFile: fsWrite, mkdir: fsMkdir, utimes, unlink: fsUnlink } = await import("node:fs/promises");
+    const signalsDir = join(tmpDir, "task-signals");
+    await fsMkdir(signalsDir, { recursive: true });
+    const badPath = join(signalsDir, "race-delete.json");
+    await fsWrite(badPath, "{", "utf-8");
+    const old = new Date(Date.now() - STALE_CORRUPT_SIGNAL_MS - 60_000);
+    await utimes(badPath, old, old);
+    await fsUnlink(badPath);
+    await expect(tryDeleteStaleCorruptSignalFile(badPath)).resolves.toBeUndefined();
   });
 
   it("ignores non-JSON files in signals dir", async () => {


### PR DESCRIPTION
## Summary
Similarity-sweep issue #1842 flagged a broad `catch { // ENOENT or other — ignore }` in `tryDeleteStaleCorruptSignalFile`.

**Investigation:** The cleanup helper is intentionally best-effort (issue #812) and should not abort `readPendingSignals`, but swallowing *all* errors hid real permission/path failures.

This PR aligns with `deleteSignal()` semantics:
- **ENOENT** on stat/unlink → ignore (idempotent / race-safe)
- **Other errors** → `pluginLogger.warn` and continue (still non-fatal for signal ingestion)

Fixes #1842

## Test plan
- [x] Existing stale corrupt JSON / orphan temp cleanup tests still pass
- [x] New test: non-ENOENT delete failure emits warning without throwing
- [x] New test: ENOENT after race is ignored


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to optional filesystem cleanup during signal ingestion; behavior stays best-effort with added observability only.
> 
> **Overview**
> Tightens **best-effort** stale corrupt/orphan task-signal cleanup in `tryDeleteStaleCorruptSignalFile`: the helper is now **exported** for direct testing, and empty `catch` blocks are replaced with explicit handling—**ENOENT** on `stat`/`unlink` is ignored (races/idempotency), while other failures log **`pluginLogger.warn`** without aborting `readPendingSignals`.
> 
> Tests cover a non-ENOENT delete failure (warn, no throw) and ENOENT when the file disappears before `stat`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f93a9b6f86da999d6e18955b22ec6303970090f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->