### PR TITLE
fix(task-ledger): warn on malformed handoff JSON instead of silent catch (#1845)

### DIFF
--- a/extensions/memory-hybrid/services/active-task.ts
+++ b/extensions/memory-hybrid/services/active-task.ts
@@ -214,12 +214,12 @@ export function parseHandoffRef(value: string, context?: string): ActiveTaskHand
   try {
     const parsed = JSON.parse(value) as unknown;
     if (!isHandoffRef(parsed)) {
-      pluginLogger.warn?.(`memory-hybrid: invalid active-task handoff JSON for ${label}: shape validation failed`);
+      pluginLogger.warn(`memory-hybrid: invalid active-task handoff JSON for ${label}: shape validation failed`);
       return null;
     }
     return parsed;
   } catch (err) {
-    pluginLogger.warn?.(
+    pluginLogger.warn(
       `memory-hybrid: failed to parse active-task handoff JSON for ${label}: ${err instanceof Error ? err.message : String(err)}`,
     );
     return null;

--- a/extensions/memory-hybrid/services/active-task.ts
+++ b/extensions/memory-hybrid/services/active-task.ts
@@ -199,7 +199,7 @@ function parseTaskBlock(header: string, lines: string[]): ActiveTaskEntry | null
         entry.relatedGoal = value || undefined;
         break;
       case "handoff":
-        entry.handoff = parseHandoffRef(value) ?? undefined;
+        entry.handoff = parseHandoffRef(value, entry.label) ?? undefined;
         break;
     }
   }
@@ -207,13 +207,21 @@ function parseTaskBlock(header: string, lines: string[]): ActiveTaskEntry | null
   return entry as ActiveTaskEntry;
 }
 
-function parseHandoffRef(value: string): ActiveTaskHandoffRef | null {
+/** Parse persisted handoff JSON into a typed ref; logs malformed values (#1845). */
+export function parseHandoffRef(value: string, context?: string): ActiveTaskHandoffRef | null {
   if (!value) return null;
+  const label = context?.trim() || "task";
   try {
     const parsed = JSON.parse(value) as unknown;
-    if (!isHandoffRef(parsed)) return null;
+    if (!isHandoffRef(parsed)) {
+      pluginLogger.warn?.(`memory-hybrid: invalid active-task handoff JSON for ${label}: shape validation failed`);
+      return null;
+    }
     return parsed;
-  } catch {
+  } catch (err) {
+    pluginLogger.warn?.(
+      `memory-hybrid: failed to parse active-task handoff JSON for ${label}: ${err instanceof Error ? err.message : String(err)}`,
+    );
     return null;
   }
 }

--- a/extensions/memory-hybrid/services/task-ledger-facts.ts
+++ b/extensions/memory-hybrid/services/task-ledger-facts.ts
@@ -23,6 +23,7 @@ import {
   isNonActionableSubagentPlaceholderTask,
   normalizePlaceholderTaskNext,
   OMITTED_CAP_NOTE,
+  parseHandoffRef,
   type PendingTaskSignal,
   readPendingSignals,
   serializeActiveTaskFile,
@@ -170,11 +171,7 @@ export function buildTaskEntriesFromGroupedFacts(byEntity: Map<string, Map<strin
     const updated = resolveTaskUpdated(f, bounds);
     let handoff: ActiveTaskEntry["handoff"];
     if (f.handoff?.trim()) {
-      try {
-        handoff = JSON.parse(f.handoff.trim());
-      } catch {
-        // Ignore parse errors
-      }
+      handoff = parseHandoffRef(f.handoff.trim(), entity) ?? undefined;
     }
     const entry: ActiveTaskEntry = {
       label: entity,

--- a/extensions/memory-hybrid/tests/task-ledger-facts.test.ts
+++ b/extensions/memory-hybrid/tests/task-ledger-facts.test.ts
@@ -11,6 +11,7 @@ import type { VectorDB } from "../backends/vector-db.js";
 import type { ActiveTaskProjectionConfig } from "../config.js";
 import { type ActiveTaskEntry, UNKNOWN_ACTIVE_TASK_TIME } from "../services/active-task.js";
 import type { EmbeddingProvider } from "../services/embeddings.js";
+import { initPluginLogger, resetPluginLogger } from "../utils/logger.js";
 import {
   applyActiveTaskHygieneFacts,
   applyActiveTaskProjectionFilters,
@@ -166,6 +167,58 @@ describe("task-ledger-facts", () => {
     expect(completed).toHaveLength(1);
     expect(completed[0].label).toBe("done-task");
     expect(completed[0].status).toBe("Done");
+  });
+
+  it("buildTaskEntriesFromGroupedFacts parses valid handoff JSON and warns on malformed handoff facts", () => {
+    const warn = vi.fn();
+    initPluginLogger({ info: vi.fn(), warn, error: vi.fn() });
+    try {
+      const validHandoff = JSON.stringify({
+        schema: "octave/task-handoff@v1",
+        artifactId: "artifact-1",
+        signal: "completed",
+        agent: "worker",
+        timestamp: "2026-01-01T00:00:00.000Z",
+        checksum: "abc123",
+      });
+
+      const valid = new Map<string, MemoryEntry>();
+      valid.set("status", fact({ id: "s1", entity: "task-valid", key: "status", value: "in_progress", createdAt: 1 }));
+      valid.set("title", fact({ id: "t1", entity: "task-valid", key: "title", value: "Valid handoff", createdAt: 1 }));
+      valid.set(
+        "handoff",
+        fact({ id: "h1", entity: "task-valid", key: "handoff", value: validHandoff, createdAt: 1 }),
+      );
+
+      const invalid = new Map<string, MemoryEntry>();
+      invalid.set(
+        "status",
+        fact({ id: "s2", entity: "task-invalid", key: "status", value: "in_progress", createdAt: 1 }),
+      );
+      invalid.set(
+        "title",
+        fact({ id: "t2", entity: "task-invalid", key: "title", value: "Bad handoff", createdAt: 1 }),
+      );
+      invalid.set(
+        "handoff",
+        fact({ id: "h2", entity: "task-invalid", key: "handoff", value: "{not-json", createdAt: 1 }),
+      );
+
+      const grouped = new Map<string, Map<string, MemoryEntry>>([
+        ["task-valid", valid],
+        ["task-invalid", invalid],
+      ]);
+      const { active } = buildTaskEntriesFromGroupedFacts(grouped);
+
+      expect(active.find((task) => task.label === "task-valid")?.handoff).toMatchObject({
+        artifactId: "artifact-1",
+        signal: "completed",
+      });
+      expect(active.find((task) => task.label === "task-invalid")?.handoff).toBeUndefined();
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining("failed to parse active-task handoff JSON for task-invalid"));
+    } finally {
+      resetPluginLogger();
+    }
   });
 
   it("derives Started/Updated from fact row createdAt when string fields absent", () => {


### PR DESCRIPTION
## Summary
Similarity-sweep issue #1845 flagged a broad `catch { // Ignore parse errors }` when parsing `handoff` facts in `buildTaskEntriesFromGroupedFacts`.

**Investigation:** Handoff parsing is intentionally best-effort — malformed handoff facts must not break task ledger loading. Silently swallowing all parse/shape failures hid corrupt fact data.

This PR:
- Exports and reuses `parseHandoffRef()` from `active-task.ts` (typed shape validation via `isHandoffRef`)
- Logs `pluginLogger.warn` on JSON parse failures and invalid handoff shapes (includes task entity context)
- Keeps `handoff` undefined on failure so projection/injection continue

Fixes #1845

## Test plan
- [x] Added `buildTaskEntriesFromGroupedFacts parses valid handoff JSON and warns on malformed handoff facts`
- [ ] Full `task-ledger-facts.test.ts` suite (requires Node with `node:sqlite`)


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Best-effort parsing behavior is unchanged; only adds logging and shared validation for observability of corrupt handoff facts.
> 
> **Overview**
> **Handoff fact parsing** is centralized on exported `parseHandoffRef()` so both **ACTIVE-TASKS.md** parsing and **facts-backed** `buildTaskEntriesFromGroupedFacts` use the same typed validation (`isHandoffRef`) instead of a silent `JSON.parse` catch in the ledger path.
> 
> Malformed or invalid-shape `handoff` values now emit **`pluginLogger.warn`** with task/entity context (#1845); **`handoff` stays undefined** on failure so projection and injection keep working.
> 
> A unit test covers valid handoff JSON vs malformed facts and expects the warn path for bad JSON.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e189f24ab151637fae06430cf3c9053c07a35fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->