### PR TITLE
fix(wal): complete fsync fallback errors and preserve error causes (#1846)

### DIFF
--- a/extensions/memory-hybrid/backends/wal.ts
+++ b/extensions/memory-hybrid/backends/wal.ts
@@ -132,14 +132,15 @@ export class WriteAheadLog {
     try {
       // "a+" read+append so fdatasync works on more filesystems than read-only or append-only edge cases (issue #854).
       fh = await open(this.walPath, "a+");
-      await fh.datasync();
-    } catch (err) {
-      const code = (err as NodeJS.ErrnoException).code;
-      if (code === "EPERM" || code === "EINVAL") {
+      try {
+        await fh.datasync();
+        return;
+      } catch (datasyncErr) {
+        const code = (datasyncErr as NodeJS.ErrnoException).code;
+        if (code !== "EPERM" && code !== "EINVAL") throw datasyncErr;
         // Intentional fail-fast when neither datasync nor fsync can persist WAL writes (#7, #1846).
         // Some filesystems (e.g. NTFS via WSL2) reject fdatasync; reopen and try fsync() as fallback.
-        const datasyncErr = err;
-        await fh?.close().catch(() => {});
+        await fh.close().catch(() => {});
         fh = undefined;
         try {
           fh = await open(this.walPath, "a+");
@@ -158,12 +159,16 @@ export class WriteAheadLog {
             );
             this.fsyncWarnEmitted = true;
           }
-          throw new Error(`WAL fsync unavailable (${code}): datasync and fsync fallback both failed`, {
+          const causes = [datasyncErr, fsyncErr].filter((e): e is Error => e instanceof Error);
+          const err = new Error(`WAL fsync unavailable (${code}): datasync and fsync fallback both failed`, {
             cause: fsyncErr instanceof Error ? fsyncErr : datasyncErr,
           });
+          if (causes.length > 1) {
+            (err as Error & { causes: Error[] }).causes = causes;
+          }
+          throw err;
         }
       }
-      throw err;
     } finally {
       await fh?.close();
     }

--- a/extensions/memory-hybrid/backends/wal.ts
+++ b/extensions/memory-hybrid/backends/wal.ts
@@ -142,8 +142,8 @@ export class WriteAheadLog {
         // Some filesystems (e.g. NTFS via WSL2) reject fdatasync; reopen and try fsync() as fallback.
         await fh.close().catch(() => {});
         fh = undefined;
+        fh = await open(this.walPath, "a+");
         try {
-          fh = await open(this.walPath, "a+");
           await fh.sync();
           if (!this.fsyncWarnEmitted) {
             pluginLogger.warn(
@@ -152,16 +152,16 @@ export class WriteAheadLog {
             this.fsyncWarnEmitted = true;
           }
           return;
-        } catch (fsyncErr) {
+        } catch (syncErr) {
           if (!this.fsyncWarnEmitted) {
             pluginLogger.error(
               `[WAL] CRITICAL: Both datasync() and fsync() failed (${code}) — WAL durability unavailable on this filesystem. Data loss may occur on crash. Consider moving the database to a POSIX-compliant filesystem.`,
             );
             this.fsyncWarnEmitted = true;
           }
-          const causes = [datasyncErr, fsyncErr].filter((e): e is Error => e instanceof Error);
+          const causes = [datasyncErr, syncErr].filter((e): e is Error => e instanceof Error);
           const err = new Error(`WAL fsync unavailable (${code}): datasync and fsync fallback both failed`, {
-            cause: fsyncErr instanceof Error ? fsyncErr : datasyncErr,
+            cause: syncErr instanceof Error ? syncErr : datasyncErr,
           });
           if (causes.length > 1) {
             (err as Error & { causes: Error[] }).causes = causes;

--- a/extensions/memory-hybrid/backends/wal.ts
+++ b/extensions/memory-hybrid/backends/wal.ts
@@ -142,7 +142,11 @@ export class WriteAheadLog {
         // Some filesystems (e.g. NTFS via WSL2) reject fdatasync; reopen and try fsync() as fallback.
         await fh.close().catch(() => {});
         fh = undefined;
-        fh = await open(this.walPath, "a+");
+        try {
+          fh = await open(this.walPath, "a+");
+        } catch (openErr) {
+          throw openErr;
+        }
         try {
           await fh.sync();
           if (!this.fsyncWarnEmitted) {

--- a/extensions/memory-hybrid/backends/wal.ts
+++ b/extensions/memory-hybrid/backends/wal.ts
@@ -136,14 +136,21 @@ export class WriteAheadLog {
     } catch (err) {
       const code = (err as NodeJS.ErrnoException).code;
       if (code === "EPERM" || code === "EINVAL") {
-        // CRITICAL FIX (#7): Some filesystems (e.g. NTFS via WSL2) reject fdatasync/fsync.
-        // Instead of silently degrading durability forever, try fsync() as a fallback.
-        // If both fail, throw an error so operators know their WAL has no crash safety.
+        // Intentional fail-fast when neither datasync nor fsync can persist WAL writes (#7, #1846).
+        // Some filesystems (e.g. NTFS via WSL2) reject fdatasync; reopen and try fsync() as fallback.
+        const datasyncErr = err;
+        await fh?.close().catch(() => {});
+        fh = undefined;
         try {
-          if (!fh) {
-            throw new Error(`fallback fsync could not open WAL file after datasync() failed with ${code}`);
+          fh = await open(this.walPath, "a+");
+          await fh.sync();
+          if (!this.fsyncWarnEmitted) {
+            pluginLogger.warn(
+              `[WAL] datasync() unsupported (${code}), using fsync() fallback — durability available but may be slower`,
+            );
+            this.fsyncWarnEmitted = true;
           }
-          await fh.sync(); // Try fsync() instead of datasync()
+          return;
         } catch (fsyncErr) {
           if (!this.fsyncWarnEmitted) {
             pluginLogger.error(
@@ -151,21 +158,12 @@ export class WriteAheadLog {
             );
             this.fsyncWarnEmitted = true;
           }
-          // Throw so the write operation fails fast rather than silently losing crash safety.
-          throw new Error(
-            `WAL fsync unavailable: ${code}: ${fsyncErr instanceof Error ? fsyncErr.message : String(fsyncErr)}`,
-          );
+          throw new Error(`WAL fsync unavailable (${code}): datasync and fsync fallback both failed`, {
+            cause: fsyncErr instanceof Error ? fsyncErr : datasyncErr,
+          });
         }
-        // fsync() succeeded as fallback
-        if (!this.fsyncWarnEmitted) {
-          pluginLogger.warn(
-            `[WAL] datasync() unsupported (${code}), using fsync() fallback — durability available but may be slower`,
-          );
-          this.fsyncWarnEmitted = true;
-        }
-      } else {
-        throw err;
       }
+      throw err;
     } finally {
       await fh?.close();
     }
@@ -189,7 +187,7 @@ export class WriteAheadLog {
         operation: "wal-write",
         subsystem: "wal",
       });
-      throw new Error(`WAL write failed: ${err}`);
+      throw new Error(`WAL write failed: ${err instanceof Error ? err.message : String(err)}`, { cause: err });
     } finally {
       // biome-ignore lint/style/noNonNullAssertion: Synchronous
       releaseLock!();
@@ -284,7 +282,7 @@ export class WriteAheadLog {
         operation: "wal-remove",
         subsystem: "wal",
       });
-      throw new Error(`WAL remove failed: ${err}`);
+      throw new Error(`WAL remove failed: ${err instanceof Error ? err.message : String(err)}`, { cause: err });
     } finally {
       // biome-ignore lint/style/noNonNullAssertion: Synchronous
       releaseLock!();
@@ -300,7 +298,7 @@ export class WriteAheadLog {
         operation: "wal-clear",
         subsystem: "wal",
       });
-      throw new Error(`WAL clear failed: ${err}`);
+      throw new Error(`WAL clear failed: ${err instanceof Error ? err.message : String(err)}`, { cause: err });
     }
   }
 

--- a/extensions/memory-hybrid/tests/wal.test.ts
+++ b/extensions/memory-hybrid/tests/wal.test.ts
@@ -694,6 +694,25 @@ describe("WriteAheadLog", () => {
       // fh was opened (open() succeeded) so close() must have been called.
       expect(closedHandleCount.value).toBeGreaterThan(before);
     });
+
+    it("chains fsync durability failures through write() error cause (#1846)", async () => {
+      const epermError = Object.assign(new Error("operation not permitted"), { code: "EPERM" });
+      const syncFail = Object.assign(new Error("sync unsupported"), { code: "EPERM" });
+      fsyncError.value = epermError;
+      syncError.value = syncFail;
+      const entry = {
+        id: randomUUID(),
+        timestamp: Date.now(),
+        operation: "store" as const,
+        data: { text: "cause-check double-fail", category: "general", importance: 0.5, source: "test" },
+      };
+
+      await expect(wal.write(entry)).rejects.toSatisfy((err: unknown) => {
+        if (!(err instanceof Error)) return false;
+        const durabilityErr = err.cause;
+        return durabilityErr instanceof Error && /WAL fsync unavailable \(EPERM\)/.test(durabilityErr.message);
+      });
+    });
   });
 
   describe("idempotency and crash recovery simulation", () => {


### PR DESCRIPTION
## Summary
Similarity-sweep issue #1846 flagged the `// CRITICAL FIX` throw path in `fsyncAfterWrite()`.

**Investigation:** Failing WAL writes when neither `datasync()` nor `fsync()` can persist is **intentional** (#7) — operators must not believe crash durability exists on unsupported filesystems (e.g. NTFS via WSL2). The sweep finding was valid, however: the fallback path was incomplete (dead `!fh` branch, no reopen) and errors were rethrown without `cause` chains.

This PR:
- Closes the first handle and **reopens** the WAL file before `fsync()` fallback after `EPERM`/`EINVAL` datasync failures
- Throws a structured `WAL fsync unavailable (...)` error with `{ cause }` when both paths fail
- Preserves underlying errors via `{ cause: err }` in `write()` / `remove()` / `_clearInternal()` wrappers

Fixes #1846

## Test plan
- [x] Existing WAL fsync fallback tests updated/retained in `wal.test.ts`
- [x] Added `#1846` error-cause chaining assertion
- [ ] Full `wal.test.ts` suite (requires Node with `node:sqlite` import chain)


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes crash-safety and error behavior on the WAL hot path; intentional fail-fast when sync is unavailable remains, but mis-handled fallback could affect durability on edge filesystems.
> 
> **Overview**
> Hardens **WAL post-write durability** in `fsyncAfterWrite()` when `datasync()` fails with `EPERM`/`EINVAL`: the file handle is **closed and the WAL is reopened** before the `fsync()` fallback, fixing an incomplete fallback path. If both sync paths fail, the code still **fails fast** (by design) but now throws a clearer `WAL fsync unavailable (...)` error with **`{ cause }`** (and optional `causes`).
> 
> **`write()`**, **`remove()`**, and **`_clearInternal()`** now rethrow with **`{ cause: err }`** so operators can trace fsync failures through the wrapper. A new test asserts that double-fail durability errors surface on **`write()`** via **`error.cause`** (#1846).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c53b4bfbd7a7224507f133790dc26c6048b412e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->