### PR TITLE
fix: re-arm Workboard sync after plugin hot-reload (#1893)

### DIFF
--- a/extensions/memory-hybrid/api/plugin-runtime.ts
+++ b/extensions/memory-hybrid/api/plugin-runtime.ts
@@ -149,6 +149,8 @@ export interface PluginRuntime {
     maintenanceStartupTimeout: { value: ReturnType<typeof setTimeout> | null };
     /** Workboard bidirectional sync timer. */
     workboardSync?: { value: ReturnType<typeof setInterval> | null };
+    /** Plugin service shutdown flag (Issue #1893 re-arm abort guard). */
+    shuttingDownRef: { value: boolean };
   };
 }
 
@@ -166,6 +168,7 @@ export function createTimers(): PluginRuntime["timers"] {
     watchdogTimer: { value: null },
     maintenanceTick: { value: null },
     maintenanceStartupTimeout: { value: null },
+    shuttingDownRef: { value: false },
   };
 }
 

--- a/extensions/memory-hybrid/setup/plugin-service.ts
+++ b/extensions/memory-hybrid/setup/plugin-service.ts
@@ -568,7 +568,7 @@ export function createPluginService(ctx: PluginServiceContext) {
           cfg,
           api,
           timers: timers as PluginRuntime["timers"],
-          shouldAbort: () => shuttingDown,
+          shouldAbort: () => timers.shuttingDownRef.value,
           connectLabel: "startup",
         });
       }
@@ -1001,6 +1001,7 @@ export function createPluginService(ctx: PluginServiceContext) {
     },
     stop: async () => {
       shuttingDown = true;
+      timers.shuttingDownRef.value = true;
       // Flush pending error reports with timeout so persisted queue replay can reduce dropped diagnostics.
       if (isErrorReporterActive()) {
         const flushed = await flushErrorReporter(2000).catch(() => false);

--- a/extensions/memory-hybrid/setup/plugin-service.ts
+++ b/extensions/memory-hybrid/setup/plugin-service.ts
@@ -172,6 +172,7 @@ export function createPluginService(ctx: PluginServiceContext) {
     id: PLUGIN_ID,
     _getVersionCheckPromise: () => versionCheckPromise,
     start: async () => {
+      timers.shuttingDownRef.value = false;
       // Issue #422: surface missing Python deps early; deferred from register() for lighter CLI (issue #1111).
       if (pythonBridge) {
         const { ok, missing, spawnError } = pythonBridge.checkDependencies();

--- a/extensions/memory-hybrid/setup/plugin-service.ts
+++ b/extensions/memory-hybrid/setup/plugin-service.ts
@@ -5,7 +5,7 @@ import { resolveDreamCycleLogDir } from "../utils/dream-cycle-paths.js";
 import { nowIso } from "../utils/dates.js";
 import type OpenAI from "openai";
 import type { ClawdbotPluginApi } from "openclaw/plugin-sdk/core";
-import { clearRuntimeTimers } from "../api/plugin-runtime.js";
+import { clearRuntimeTimers, type PluginRuntime } from "../api/plugin-runtime.js";
 import type { CredentialsDB } from "../backends/credentials-db.js";
 import type { EdictStore } from "../backends/edict-store.js";
 import type { FactsDB } from "../backends/facts-db.js";
@@ -560,94 +560,17 @@ export function createPluginService(ctx: PluginServiceContext) {
 
       // Workboard integration: start adapter for bidirectional task/goal sync
       if (cfg.workboard?.enabled) {
-        try {
-          const { createWorkboardAdapter } = await import("../services/workboard-adapter.js");
-          const { loadTaskLedgerFromFacts } = await import("../services/task-ledger-facts.js");
-          const { listGoals } = await import("../services/goal-registry.js");
-          const { applyWorkboardTaskStatusUpdate, applyWorkboardGoalStatusUpdate } = await import(
-            "../services/workboard-facts-sync.js"
-          );
-
-          const workspaceRoot = process.env.OPENCLAW_WORKSPACE ?? join(homedir(), ".openclaw", "workspace");
-          const goalsDir = cfg.goalStewardship?.enabled
-            ? resolveGoalsDir(workspaceRoot, cfg.goalStewardship.goalsDir)
-            : undefined;
-
-          const gatewayToken = process.env.OPENCLAW_GATEWAY_TOKEN ?? undefined;
-
-          const adapter = createWorkboardAdapter({
-            cfg: {
-              ...cfg.workboard,
-              syncGoals: cfg.workboard.syncGoals && !!goalsDir,
-            },
-            loadTasks: () => loadTaskLedgerFromFacts(factsDb),
-            loadGoals: async () => {
-              if (!goalsDir) return [];
-              try {
-                return await listGoals(goalsDir);
-              } catch {
-                return [];
-              }
-            },
-            updateTaskStatus: (label, newStatus) =>
-              applyWorkboardTaskStatusUpdate(
-                factsDb,
-                vectorDb,
-                embeddings,
-                label,
-                newStatus as import("../services/active-task.js").ActiveTaskStatus,
-                api.logger,
-              ),
-            updateGoalStatus: goalsDir
-              ? (goalId, newStatus) =>
-                  applyWorkboardGoalStatusUpdate(
-                    goalsDir,
-                    goalId,
-                    newStatus as import("../services/goal-stewardship-types.js").GoalStatus,
-                  )
-              : undefined,
-            gatewayToken,
-            verbose: uiIntegrationVerbose,
-          });
-
-          const available = await adapter.isAvailable();
-          if (available) {
-            api.logger.info("memory-hybrid: Workboard adapter connected — starting initial sync");
-            const result = await adapter.sync();
-            if (result.errors.length > 0) {
-              api.logger.warn(`memory-hybrid: Workboard initial sync had errors: ${result.errors.join("; ")}`);
-            }
-
-            // Recurring sync timer
-            const intervalMs = cfg.workboard.syncIntervalMinutes * 60 * 1000;
-            (timers as Record<string, unknown>).workboardSync = {
-              value: setInterval(() => {
-                if (shuttingDown) return;
-                adapter.sync().then((syncResult) => {
-                  if (syncResult.errors.length > 0) {
-                    api.logger.warn?.(
-                      `memory-hybrid: Workboard sync tick errors: ${syncResult.errors.slice(0, 5).join("; ")}`,
-                    );
-                  }
-                }).catch((err) => {
-                  api.logger.warn?.(`memory-hybrid: Workboard sync tick failed: ${err}`);
-                });
-              }, intervalMs),
-            };
-          } else {
-            api.logger.info(
-              "memory-hybrid: Workboard plugin not reachable — sync disabled (will retry on next maintenance cycle)",
-            );
-          }
-        } catch (err) {
-          api.logger.warn?.(
-            `memory-hybrid: Workboard adapter startup failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`,
-          );
-          capturePluginError(err instanceof Error ? err : new Error(String(err)), {
-            subsystem: "plugin-service",
-            operation: "workboard-adapter-start",
-          });
-        }
+        const { armWorkboardIntegration } = await import("./workboard-integration.js");
+        await armWorkboardIntegration({
+          factsDb,
+          vectorDb,
+          embeddings,
+          cfg,
+          api,
+          timers: timers as PluginRuntime["timers"],
+          shouldAbort: () => shuttingDown,
+          connectLabel: "startup",
+        });
       }
 
       // Issue #309: Mission Control dashboard HTTP server

--- a/extensions/memory-hybrid/setup/register-plugin.ts
+++ b/extensions/memory-hybrid/setup/register-plugin.ts
@@ -692,18 +692,24 @@ function runMemoryHybridRegisterImpl(api: ClawdbotPluginApi): void {
 
   // Issue #1893: OpenClaw does not re-run plugin-service.start() on hot reload; re-arm Workboard sync.
   if (wasReregister && cfg.workboard?.enabled) {
-    void import("./workboard-integration.js").then(({ scheduleWorkboardIntegrationAfterReregister }) => {
-      scheduleWorkboardIntegrationAfterReregister({
-        factsDb: runtime.factsDb,
-        vectorDb: runtime.vectorDb,
-        embeddings: runtime.embeddings,
-        cfg: runtime.cfg,
-        api: logApi,
-        timers: runtime.timers,
-        shouldAbort: () =>
-          registrationGenerationRef.value !== registrationGeneration || runtime.timers.shuttingDownRef.value,
+    void import("./workboard-integration.js")
+      .then(({ scheduleWorkboardIntegrationAfterReregister }) => {
+        scheduleWorkboardIntegrationAfterReregister({
+          factsDb: runtime.factsDb,
+          vectorDb: runtime.vectorDb,
+          embeddings: runtime.embeddings,
+          cfg: runtime.cfg,
+          api: logApi,
+          timers: runtime.timers,
+          shouldAbort: () =>
+            registrationGenerationRef.value !== registrationGeneration || runtime.timers.shuttingDownRef.value,
+        });
+      })
+      .catch((err) => {
+        logApi.logger.warn?.(
+          `memory-hybrid: Workboard re-register arm failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`,
+        );
       });
-    });
   }
 
   // Issue #281 -- Verify cron health on boot

--- a/extensions/memory-hybrid/setup/register-plugin.ts
+++ b/extensions/memory-hybrid/setup/register-plugin.ts
@@ -700,6 +700,7 @@ function runMemoryHybridRegisterImpl(api: ClawdbotPluginApi): void {
         cfg: runtime.cfg,
         api: logApi,
         timers: runtime.timers,
+        shouldAbort: () => registrationGenerationRef.value !== registrationGeneration,
       });
     });
   }

--- a/extensions/memory-hybrid/setup/register-plugin.ts
+++ b/extensions/memory-hybrid/setup/register-plugin.ts
@@ -646,6 +646,8 @@ function runMemoryHybridRegisterImpl(api: ClawdbotPluginApi): void {
 
   // Service
 
+  const wasReregister = old != null;
+
   try {
     api.registerService(
       createPluginService({
@@ -686,6 +688,20 @@ function runMemoryHybridRegisterImpl(api: ClawdbotPluginApi): void {
       operation: "plugin-register:service",
     });
     throw err;
+  }
+
+  // Issue #1893: OpenClaw does not re-run plugin-service.start() on hot reload; re-arm Workboard sync.
+  if (wasReregister && cfg.workboard?.enabled) {
+    void import("./workboard-integration.js").then(({ scheduleWorkboardIntegrationAfterReregister }) => {
+      scheduleWorkboardIntegrationAfterReregister({
+        factsDb: runtime.factsDb,
+        vectorDb: runtime.vectorDb,
+        embeddings: runtime.embeddings,
+        cfg: runtime.cfg,
+        api: logApi,
+        timers: runtime.timers,
+      });
+    });
   }
 
   // Issue #281 -- Verify cron health on boot

--- a/extensions/memory-hybrid/setup/register-plugin.ts
+++ b/extensions/memory-hybrid/setup/register-plugin.ts
@@ -700,7 +700,8 @@ function runMemoryHybridRegisterImpl(api: ClawdbotPluginApi): void {
         cfg: runtime.cfg,
         api: logApi,
         timers: runtime.timers,
-        shouldAbort: () => registrationGenerationRef.value !== registrationGeneration,
+        shouldAbort: () =>
+          registrationGenerationRef.value !== registrationGeneration || runtime.timers.shuttingDownRef.value,
       });
     });
   }

--- a/extensions/memory-hybrid/setup/workboard-integration.ts
+++ b/extensions/memory-hybrid/setup/workboard-integration.ts
@@ -1,0 +1,149 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type { ClawdbotPluginApi } from "openclaw/plugin-sdk/core";
+import type { PluginRuntime } from "../api/plugin-runtime.js";
+import type { FactsDB } from "../backends/facts-db.js";
+import type { VectorDB } from "../backends/vector-db.js";
+import type { HybridMemoryConfig } from "../config.js";
+import { capturePluginError } from "../services/error-reporter.js";
+import { resolveGoalsDir } from "../services/goal-stewardship.js";
+import type { EmbeddingProvider } from "../services/embeddings.js";
+import { integrationVerbose } from "../utils/integration-trace.js";
+
+export type WorkboardIntegrationContext = {
+  factsDb: FactsDB;
+  vectorDb: VectorDB;
+  embeddings: EmbeddingProvider;
+  cfg: HybridMemoryConfig;
+  api: ClawdbotPluginApi;
+  timers: PluginRuntime["timers"];
+  /** When true, skip arming (plugin service shutdown). */
+  shouldAbort?: () => boolean;
+  /** Log label for connect/sync (e.g. startup, re-register). */
+  connectLabel?: string;
+};
+
+function clearWorkboardSyncTimer(timers: PluginRuntime["timers"]): void {
+  if (timers.workboardSync?.value) {
+    clearInterval(timers.workboardSync.value);
+    timers.workboardSync.value = null;
+  }
+}
+
+/**
+ * Connect Workboard adapter, run an initial sync, and arm the recurring sync interval.
+ * Safe to call after hot-reload when plugin-service.start() is not re-invoked.
+ */
+export async function armWorkboardIntegration(ctx: WorkboardIntegrationContext): Promise<void> {
+  const { factsDb, vectorDb, embeddings, cfg, api, timers, shouldAbort, connectLabel = "startup" } = ctx;
+
+  if (!cfg.workboard?.enabled) return;
+  if (shouldAbort?.()) return;
+
+  const uiIntegrationVerbose = integrationVerbose(cfg);
+
+  try {
+    const { createWorkboardAdapter } = await import("../services/workboard-adapter.js");
+    const { loadTaskLedgerFromFacts } = await import("../services/task-ledger-facts.js");
+    const { listGoals } = await import("../services/goal-registry.js");
+    const { applyWorkboardTaskStatusUpdate, applyWorkboardGoalStatusUpdate } = await import(
+      "../services/workboard-facts-sync.js"
+    );
+
+    const workspaceRoot = process.env.OPENCLAW_WORKSPACE ?? join(homedir(), ".openclaw", "workspace");
+    const goalsDir = cfg.goalStewardship?.enabled
+      ? resolveGoalsDir(workspaceRoot, cfg.goalStewardship.goalsDir)
+      : undefined;
+
+    const gatewayToken = process.env.OPENCLAW_GATEWAY_TOKEN ?? undefined;
+
+    const adapter = createWorkboardAdapter({
+      cfg: {
+        ...cfg.workboard,
+        syncGoals: cfg.workboard.syncGoals && !!goalsDir,
+      },
+      loadTasks: () => loadTaskLedgerFromFacts(factsDb),
+      loadGoals: async () => {
+        if (!goalsDir) return [];
+        try {
+          return await listGoals(goalsDir);
+        } catch {
+          return [];
+        }
+      },
+      updateTaskStatus: (label, newStatus) =>
+        applyWorkboardTaskStatusUpdate(
+          factsDb,
+          vectorDb,
+          embeddings,
+          label,
+          newStatus as import("../services/active-task.js").ActiveTaskStatus,
+          api.logger,
+        ),
+      updateGoalStatus: goalsDir
+        ? (goalId, newStatus) =>
+            applyWorkboardGoalStatusUpdate(
+              goalsDir,
+              goalId,
+              newStatus as import("../services/goal-stewardship-types.js").GoalStatus,
+            )
+        : undefined,
+      gatewayToken,
+      verbose: uiIntegrationVerbose,
+    });
+
+    const available = await adapter.isAvailable();
+    if (!available) {
+      api.logger.info?.(
+        `memory-hybrid: Workboard plugin not reachable (${connectLabel}) — sync not armed`,
+      );
+      return;
+    }
+
+    clearWorkboardSyncTimer(timers);
+
+    api.logger.info(`memory-hybrid: Workboard adapter connected (${connectLabel}) — starting sync`);
+    const result = await adapter.sync();
+    if (result.errors.length > 0) {
+      api.logger.warn(
+        `memory-hybrid: Workboard sync errors (${connectLabel}): ${result.errors.slice(0, 5).join("; ")}`,
+      );
+    }
+
+    const intervalMs = cfg.workboard.syncIntervalMinutes * 60 * 1000;
+    timers.workboardSync = {
+      value: setInterval(() => {
+        if (shouldAbort?.()) return;
+        api.logger.info?.("memory-hybrid: workboard sync tick");
+        adapter
+          .sync()
+          .then((syncResult) => {
+            if (syncResult.errors.length > 0) {
+              api.logger.warn?.(
+                `memory-hybrid: Workboard sync tick errors: ${syncResult.errors.slice(0, 5).join("; ")}`,
+              );
+            }
+          })
+          .catch((err) => {
+            api.logger.warn?.(`memory-hybrid: Workboard sync tick failed: ${err}`);
+          });
+      }, intervalMs),
+    };
+    api.logger.info?.(
+      `memory-hybrid: Workboard sync loop started (every ${cfg.workboard.syncIntervalMinutes} min)`,
+    );
+  } catch (err) {
+    api.logger.warn?.(
+      `memory-hybrid: Workboard adapter startup failed (${connectLabel}, non-fatal): ${err instanceof Error ? err.message : String(err)}`,
+    );
+    capturePluginError(err instanceof Error ? err : new Error(String(err)), {
+      subsystem: "plugin-service",
+      operation: "workboard-adapter-start",
+    });
+  }
+}
+
+/** Fire-and-forget re-arm after hot reload cleared timers without re-running plugin-service.start(). */
+export function scheduleWorkboardIntegrationAfterReregister(ctx: WorkboardIntegrationContext): void {
+  void armWorkboardIntegration({ ...ctx, connectLabel: "re-register" });
+}

--- a/extensions/memory-hybrid/setup/workboard-integration.ts
+++ b/extensions/memory-hybrid/setup/workboard-integration.ts
@@ -39,6 +39,8 @@ export async function armWorkboardIntegration(ctx: WorkboardIntegrationContext):
 
   if (!cfg.workboard?.enabled) return;
   if (shouldAbort?.()) return;
+  
+  const checkSuperseded = () => shouldAbort?.() ?? false;
 
   const uiIntegrationVerbose = integrationVerbose(cfg);
 
@@ -100,10 +102,19 @@ export async function armWorkboardIntegration(ctx: WorkboardIntegrationContext):
       return;
     }
 
+    if (checkSuperseded()) {
+      api.logger.debug?.(`memory-hybrid: Workboard arm superseded after isAvailable (${connectLabel})`);
+      return;
+    }
+
     clearWorkboardSyncTimer(timers);
 
     api.logger.info(`memory-hybrid: Workboard adapter connected (${connectLabel}) — starting sync`);
     const result = await adapter.sync();
+    if (checkSuperseded()) {
+      api.logger.debug?.(`memory-hybrid: Workboard arm superseded after sync (${connectLabel})`);
+      return;
+    }
     if (result.errors.length > 0) {
       api.logger.warn(
         `memory-hybrid: Workboard sync errors (${connectLabel}): ${result.errors.slice(0, 5).join("; ")}`,

--- a/extensions/memory-hybrid/setup/workboard-integration.ts
+++ b/extensions/memory-hybrid/setup/workboard-integration.ts
@@ -42,7 +42,7 @@ export async function armWorkboardIntegration(ctx: WorkboardIntegrationContext):
   
   const checkSuperseded = () => shouldAbort?.() ?? false;
 
-  const uiIntegrationVerbose = integrationVerbose(cfg);
+  const uiIntegrationVerbose = integrationVerbose(cfg.verbosity);
 
   try {
     const { createWorkboardAdapter } = await import("../services/workboard-adapter.js");
@@ -156,5 +156,6 @@ export async function armWorkboardIntegration(ctx: WorkboardIntegrationContext):
 
 /** Fire-and-forget re-arm after hot reload cleared timers without re-running plugin-service.start(). */
 export function scheduleWorkboardIntegrationAfterReregister(ctx: WorkboardIntegrationContext): void {
+  if (ctx.shouldAbort?.()) return;
   void armWorkboardIntegration({ ...ctx, connectLabel: "re-register" });
 }

--- a/extensions/memory-hybrid/tests/plugin-runtime.test.ts
+++ b/extensions/memory-hybrid/tests/plugin-runtime.test.ts
@@ -31,10 +31,14 @@ describe("createTimers", () => {
     expect(a.classifyTimer).not.toBe(b.classifyTimer);
   });
 
-  it("all timer refs start null", () => {
+  it("all timer refs start null except shuttingDownRef", () => {
     const t = createTimers();
     for (const key of Object.keys(t) as Array<keyof typeof t>) {
-      expect(t[key].value).toBeNull();
+      if (key === "shuttingDownRef") {
+        expect(t[key].value).toBe(false);
+      } else {
+        expect(t[key].value).toBeNull();
+      }
     }
   });
 

--- a/extensions/memory-hybrid/tests/workboard-integration.test.ts
+++ b/extensions/memory-hybrid/tests/workboard-integration.test.ts
@@ -71,8 +71,7 @@ describe("workboard-integration", () => {
     expect(sync).toHaveBeenCalledTimes(1);
     expect(timers.workboardSync?.value).not.toBeNull();
 
-    vi.advanceTimersByTime(5 * 60 * 1000);
-    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
     expect(sync).toHaveBeenCalledTimes(2);
   });
 

--- a/extensions/memory-hybrid/tests/workboard-integration.test.ts
+++ b/extensions/memory-hybrid/tests/workboard-integration.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { PluginRuntime } from "../api/plugin-runtime.js";
+import { createTimers } from "../api/plugin-runtime.js";
+import type { HybridMemoryConfig } from "../config.js";
+import { armWorkboardIntegration } from "../setup/workboard-integration.js";
+
+function minimalWorkboardCfg(): HybridMemoryConfig {
+  return {
+    workboard: {
+      enabled: true,
+      syncTasks: true,
+      syncGoals: false,
+      bidirectional: true,
+      gatewayUrl: "http://127.0.0.1:18789",
+      syncIntervalMinutes: 5,
+      cardTag: "hybrid-memory",
+      columns: {},
+    },
+    goalStewardship: { enabled: false },
+  } as unknown as HybridMemoryConfig;
+}
+
+function mockLogger() {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  };
+}
+
+describe("workboard-integration", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("arms workboard sync interval when adapter is available", async () => {
+    const sync = vi.fn().mockResolvedValue({
+      cardsCreated: 2,
+      cardsUpdated: 0,
+      cardsRemoved: 0,
+      pullChanges: 0,
+      errors: [],
+    });
+    const isAvailable = vi.fn().mockResolvedValue(true);
+
+    vi.spyOn(await import("../services/workboard-adapter.js"), "createWorkboardAdapter").mockReturnValue({
+      isAvailable,
+      sync,
+    } as never);
+
+    const timers = createTimers() as PluginRuntime["timers"];
+    const logger = mockLogger();
+
+    await armWorkboardIntegration({
+      factsDb: {} as never,
+      vectorDb: {} as never,
+      embeddings: {} as never,
+      cfg: minimalWorkboardCfg(),
+      api: { logger } as never,
+      timers,
+      connectLabel: "test",
+    });
+
+    expect(isAvailable).toHaveBeenCalled();
+    expect(sync).toHaveBeenCalledTimes(1);
+    expect(timers.workboardSync?.value).not.toBeNull();
+
+    vi.advanceTimersByTime(5 * 60 * 1000);
+    await Promise.resolve();
+    expect(sync).toHaveBeenCalledTimes(2);
+  });
+
+  it("re-arms interval after prior timer was cleared (hot-reload simulation)", async () => {
+    const sync = vi.fn().mockResolvedValue({
+      cardsCreated: 0,
+      cardsUpdated: 0,
+      cardsRemoved: 0,
+      pullChanges: 0,
+      errors: [],
+    });
+    const isAvailable = vi.fn().mockResolvedValue(true);
+
+    vi.spyOn(await import("../services/workboard-adapter.js"), "createWorkboardAdapter").mockReturnValue({
+      isAvailable,
+      sync,
+    } as never);
+
+    const timers = createTimers() as PluginRuntime["timers"];
+    const logger = mockLogger();
+    const ctx = {
+      factsDb: {} as never,
+      vectorDb: {} as never,
+      embeddings: {} as never,
+      cfg: minimalWorkboardCfg(),
+      api: { logger } as never,
+      timers,
+      connectLabel: "startup",
+    };
+
+    await armWorkboardIntegration(ctx);
+    const firstInterval = timers.workboardSync?.value;
+    expect(firstInterval).not.toBeNull();
+
+    if (timers.workboardSync?.value) {
+      clearInterval(timers.workboardSync.value);
+      timers.workboardSync.value = null;
+    }
+
+    await armWorkboardIntegration({ ...ctx, connectLabel: "re-register" });
+    expect(timers.workboardSync?.value).not.toBeNull();
+    expect(timers.workboardSync?.value).not.toBe(firstInterval);
+    expect(logger.info).toHaveBeenCalledWith(
+      "memory-hybrid: Workboard adapter connected (re-register) — starting sync",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Extracts Workboard connect/sync/interval logic into `setup/workboard-integration.ts`.
- Calls `scheduleWorkboardIntegrationAfterReregister()` from `register-plugin.ts` when hybrid-memory hot-reloads (`old` runtime existed).
- Keeps `plugin-service.start()` using the same helper for first boot.

Fixes the gap where `clearRuntimeTimers()` on re-register stops the Workboard sync loop, but OpenClaw `registerService()` does not invoke `plugin-service.start()` again for an existing service id.

Closes #1893

## Root cause

| Step | What happens |
|------|----------------|
| Gateway boot | `plugin-service.start()` arms `workboardSync` interval |
| Hot reload | `register-plugin` clears old timers including `workboardSync` |
| Re-register | `registerService` early-returns → `start()` never runs again |
| Result | New active tasks stay in facts ledger but never push to Workboard |

## Test plan

- [x] `npm test -- tests/workboard-integration.test.ts` (2 tests: arm interval; re-arm after clear)
- [ ] After merge + publish: trigger a plugin re-register on Maeve and confirm `workboard sync tick` resumes without gateway restart
- [ ] Confirm new active tasks appear on Workboard within one sync interval

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to Workboard integration and timer lifecycle; guards reduce race risk on reload/shutdown without changing core memory or auth paths.
> 
> **Overview**
> Fixes Workboard bidirectional sync stopping after hybrid-memory **hot reload**: re-register clears `workboardSync` via `clearRuntimeTimers()`, but OpenClaw does not call `plugin-service.start()` again for an existing service id.
> 
> Workboard connect/sync/interval logic moves into **`setup/workboard-integration.ts`** (`armWorkboardIntegration`, `scheduleWorkboardIntegrationAfterReregister`). First boot still arms sync from `plugin-service.start()`; on re-register, **`register-plugin.ts`** fire-and-forgets re-arm when a prior runtime existed and Workboard is enabled.
> 
> Adds **`timers.shuttingDownRef`** (reset on start, set on stop) so sync ticks and in-flight re-arm abort during shutdown. Re-register uses **`shouldAbort`** when registration generation changes or shutdown is in progress, with supersede checks after `isAvailable` and initial sync.
> 
> Tests cover interval arming and re-arm after timer clear (hot-reload simulation).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9b7b7f0d6e21a78cc382b39044a5a4be3a81b46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->