### PR TITLE
fix(goal-stewardship): read heartbeat text from event.prompt (#1895)

### DIFF
--- a/extensions/memory-hybrid/lifecycle/stage-goal-stewardship.ts
+++ b/extensions/memory-hybrid/lifecycle/stage-goal-stewardship.ts
@@ -35,10 +35,19 @@ export function registerGoalStewardshipInjection(
   api.on("before_agent_start", async (event: unknown, hookCtx: unknown) => {
     try {
       const userText = extractLastUserMessageText(event);
-      if (!userText || !matchesHeartbeat(userText, gs)) return undefined;
+      if (!userText) {
+        api.logger?.debug?.(
+          "memory-hybrid: goal stewardship skipped — no user text in hook event (expected event.prompt or messages)",
+        );
+        return undefined;
+      }
+      if (!matchesHeartbeat(userText, gs)) return undefined;
       const resolvedApi = withHookResolutionApi(api, hookCtx);
       const sessionKey = resolveSessionKeyFromHookEvent(event, resolvedApi);
-      if (isSubagentSession(sessionKey ?? undefined)) return undefined;
+      if (isSubagentSession(sessionKey ?? undefined)) {
+        api.logger?.info?.("memory-hybrid: goal stewardship skipped — subagent session");
+        return undefined;
+      }
 
       const goals = await listActiveGoals(goalsDir);
 
@@ -68,7 +77,10 @@ export function registerGoalStewardshipInjection(
         }
       }
 
-      if (goals.length === 0) return undefined;
+      if (goals.length === 0) {
+        api.logger?.info?.("memory-hybrid: goal stewardship skipped — no active goals");
+        return undefined;
+      }
 
       if (isGlobalRateLimited(gs.globalLimits.maxDispatchesPerHour, goalsDir)) {
         api.logger?.warn?.("memory-hybrid: goal stewardship skipped — global dispatch rate limit");
@@ -93,7 +105,12 @@ export function registerGoalStewardshipInjection(
         suggestHeavyDirective: gs.triageSuggestHeavyDirective,
         triageHeavy,
       });
-      if (!built) return undefined;
+      if (!built) {
+        api.logger?.info?.(
+          "memory-hybrid: goal stewardship skipped — no candidate goals past cooldown/budget filters",
+        );
+        return undefined;
+      }
 
       api.logger?.info?.(
         `memory-hybrid: goal stewardship bundle (${built.goalsIncluded.length} goal(s), heavyHint=${built.suggestHeavy})`,

--- a/extensions/memory-hybrid/tests/extract-last-user-message.test.ts
+++ b/extensions/memory-hybrid/tests/extract-last-user-message.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { extractLastUserMessageText } from "../utils/extract-last-user-message.js";
+
+describe("extractLastUserMessageText", () => {
+  it("returns event.prompt when present (agent heartbeat / before_agent_start)", () => {
+    expect(
+      extractLastUserMessageText({
+        prompt: "Read HEARTBEAT.md if it exists. Workspace ok. Reply HEARTBEAT_OK.",
+      }),
+    ).toBe("Read HEARTBEAT.md if it exists. Workspace ok. Reply HEARTBEAT_OK.");
+  });
+
+  it("prefers prompt over messages when both are set", () => {
+    expect(
+      extractLastUserMessageText({
+        prompt: "cron heartbeat — assess goals",
+        messages: [{ role: "user", content: "older message without heartbeat keyword" }],
+      }),
+    ).toBe("cron heartbeat — assess goals");
+  });
+
+  it("falls back to last user message in messages array", () => {
+    expect(
+      extractLastUserMessageText({
+        messages: [
+          { role: "assistant", content: "ok" },
+          { role: "user", content: "scheduled ping" },
+        ],
+      }),
+    ).toBe("scheduled ping");
+  });
+
+  it("extracts text blocks from structured message content", () => {
+    expect(
+      extractLastUserMessageText({
+        messages: [
+          {
+            role: "user",
+            content: [
+              { type: "text", text: "line one" },
+              { type: "text", text: "line two" },
+            ],
+          },
+        ],
+      }),
+    ).toBe("line one\nline two");
+  });
+
+  it("returns undefined when prompt is blank and messages are absent", () => {
+    expect(extractLastUserMessageText({ prompt: "   " })).toBeUndefined();
+    expect(extractLastUserMessageText({})).toBeUndefined();
+  });
+});

--- a/extensions/memory-hybrid/tests/goal-stewardship-integration.test.ts
+++ b/extensions/memory-hybrid/tests/goal-stewardship-integration.test.ts
@@ -102,6 +102,44 @@ describe("goal stewardship integration (mock plugin API)", () => {
     expect(prep).toContain("integration_goal");
   });
 
+  it("before_agent_start injects stewardship when heartbeat text is only in event.prompt (#1895)", async () => {
+    const cfg = parseCfg();
+    const ctx = minimalLifecycleContext(cfg);
+    const api = createMockPluginApi();
+    registerGoalStewardshipInjection(api as unknown as ClawdbotPluginApi, ctx, goalsDir, undefined);
+
+    await createGoal(
+      goalsDir,
+      {
+        label: "prompt_heartbeat_goal",
+        description: "test",
+        acceptanceCriteria: ["criterion one"],
+        cooldownMinutes: 1,
+      },
+      { ...defaults, cooldownMinutes: 1 },
+    );
+    const goals = await listGoals(goalsDir);
+    const g0 = goals[0];
+    expect(g0).toBeDefined();
+    if (!g0) throw new Error("fixture: expected one goal");
+    const old = new Date(Date.now() - 10 * 60 * 1000).toISOString();
+    await updateGoal(
+      goalsDir,
+      g0.id,
+      { lastAssessedAt: old },
+      { timestamp: new Date().toISOString(), action: "test", detail: "cooldown", actor: "user" },
+    );
+
+    const event = {
+      prompt: "Read HEARTBEAT.md if it exists. Workspace ok. Reply HEARTBEAT_OK.",
+    };
+    const result = await api.emitFirstResult("before_agent_start", event);
+    expect(result && typeof result === "object" && "prependContext" in result).toBe(true);
+    const prep = (result as { prependContext?: string }).prependContext ?? "";
+    expect(prep).toContain("<goal-stewardship-bundle>");
+    expect(prep).toContain("prompt_heartbeat_goal");
+  });
+
   it("before_agent_start returns undefined without heartbeat keyword", async () => {
     const cfg = parseCfg();
     const ctx = minimalLifecycleContext(cfg);

--- a/extensions/memory-hybrid/utils/extract-last-user-message.ts
+++ b/extensions/memory-hybrid/utils/extract-last-user-message.ts
@@ -1,13 +1,17 @@
 /**
- * Extract plain-text content of the last user message from a hook event payload.
- * Handles both string content and array-of-blocks content (e.g. `{type:"text", text:"…"}`).
+ * Extract plain-text user turn text from a before_agent_start hook event.
+ *
+ * OpenClaw delivers the current turn via `event.prompt` (agent heartbeat, cron
+ * agentTurn, interactive chat). Some callers also populate `event.messages`;
+ * prompt takes precedence when both are present (#1895).
+ *
+ * Handles string content and array-of-blocks content in messages
+ * (e.g. `{type:"text", text:"…"}`).
  */
 
-export function extractLastUserMessageText(event: unknown): string | undefined {
-  const e = event as { messages?: unknown[] };
-  if (!e?.messages || !Array.isArray(e.messages)) return undefined;
-  for (let i = e.messages.length - 1; i >= 0; i--) {
-    const m = e.messages[i] as { role?: string; content?: unknown };
+function extractFromMessages(messages: unknown[]): string | undefined {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const m = messages[i] as { role?: string; content?: unknown };
     if (m?.role !== "user") continue;
     const c = m.content;
     if (typeof c === "string") return c;
@@ -19,6 +23,18 @@ export function extractLastUserMessageText(event: unknown): string | undefined {
       }
       if (parts.length > 0) return parts.join("\n");
     }
+  }
+  return undefined;
+}
+
+export function extractLastUserMessageText(event: unknown): string | undefined {
+  const e = event as { prompt?: string; messages?: unknown[] };
+  if (typeof e?.prompt === "string") {
+    const trimmed = e.prompt.trim();
+    if (trimmed.length > 0) return e.prompt;
+  }
+  if (e?.messages && Array.isArray(e.messages)) {
+    return extractFromMessages(e.messages);
   }
   return undefined;
 }


### PR DESCRIPTION
## Summary

- **Root cause:** Goal stewardship (and active-task heartbeat hygiene) used `extractLastUserMessageText`, which only scanned `event.messages`. OpenClaw agent heartbeat ticks deliver the turn via `event.prompt` on `before_agent_start` — the same field auto-recall, frustration detection, and auth-failure recall already use. Heartbeat text containing `HEARTBEAT` never reached `matchesHeartbeat`, so `_stewardship_rr.json` never advanced and goals stayed at `assessmentCount=0`.
- **Fix:** `extractLastUserMessageText` now reads `event.prompt` first, then falls back to the last user message in `event.messages`.
- **Diagnostics:** INFO logs when a heartbeat-matched turn is skipped (subagent session, no active goals, no candidates past cooldown).
- **Tests:** Unit coverage for prompt/messages precedence; integration test reproducing prompt-only agent heartbeat.

Fixes #1895

## Test plan

- [x] `npm test -- --run tests/extract-last-user-message.test.ts tests/goal-stewardship-integration.test.ts tests/goal-stewardship-heartbeat.test.ts tests/heartbeat-facts-ledger.test.ts` (38 passed)
- [ ] Deploy to Maeve and confirm main-agent heartbeat advances `_stewardship_rr.json` `updatedAt` and goal `assessmentCount` without a hand-written cron
- [ ] Gateway logs show `goal stewardship bundle` on heartbeat turns with active goals

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow hook-event parsing fix with tests; may change behavior for any caller that sets both prompt and messages (prompt now wins).
> 
> **Overview**
> Agent heartbeat turns were not triggering goal stewardship because user text was only read from `event.messages`, while OpenClaw puts the turn in **`event.prompt`**. **`extractLastUserMessageText`** now uses non-empty `prompt` first, then the existing last-user-message logic in `messages` (including structured text blocks).
> 
> Goal stewardship **`before_agent_start`** now logs when a heartbeat-matched turn is skipped (missing text, subagent session, no active goals, no candidates after cooldown/budget). Unit tests cover prompt precedence and fallbacks; an integration test asserts stewardship injection for prompt-only HEARTBEAT-style events.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e049d19e1a4ce92022b2270cd36252b753e7b65b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->