### PR TITLE
fix(memory_store): stop dropping facts on broad credential word matches (#1896)

### DIFF
--- a/extensions/memory-hybrid/cli/cmd-distill.ts
+++ b/extensions/memory-hybrid/cli/cmd-distill.ts
@@ -28,7 +28,7 @@ import {
   recordAdaptiveSuccess,
   saveAdaptiveModelLimits,
 } from "../services/adaptive-model-limits.js";
-import { tryParseCredentialForVault } from "../services/auto-capture.js";
+import { tryParseCredentialForVault, isStructuredCredentialCandidate } from "../services/auto-capture.js";
 import {
   buildCredentialPointerText,
   ensureCredentialVaultPointer,
@@ -805,6 +805,18 @@ export async function runDistillForCli(
         if (opts.verbose) sink.log("  skipped credential-like fact: vault disabled or unavailable");
         continue;
       }
+
+      // When requirePatternMatch rejects vault parsing but the input is still credential-like,
+      // skip ordinary storage to prevent plaintext secrets in facts.db (#1896).
+      if (
+        !parsed &&
+        cfg.credentials.autoCapture?.requirePatternMatch === true &&
+        isStructuredCredentialCandidate(fact.text, fact.entity ?? null, fact.key ?? null, fact.value)
+      ) {
+        if (opts.verbose) sink.log("  skipped credential-like fact: blocked by requirePatternMatch");
+        continue;
+      }
+
       if (factsDb.hasDuplicate(fact.text, "distillation")) {
         skipped++;
         continue;

--- a/extensions/memory-hybrid/cli/cmd-distill.ts
+++ b/extensions/memory-hybrid/cli/cmd-distill.ts
@@ -28,7 +28,7 @@ import {
   recordAdaptiveSuccess,
   saveAdaptiveModelLimits,
 } from "../services/adaptive-model-limits.js";
-import { isCredentialLike, tryParseCredentialForVault } from "../services/auto-capture.js";
+import { tryParseCredentialForVault } from "../services/auto-capture.js";
 import {
   buildCredentialPointerText,
   ensureCredentialVaultPointer,
@@ -719,13 +719,11 @@ export async function runDistillForCli(
     let stored = 0;
     let skipped = 0;
     for (const fact of allFacts) {
-      const isCred = isCredentialLike(fact.text, fact.entity ?? null, fact.key ?? null, fact.value);
-      if (isCred) {
+      const parsed = tryParseCredentialForVault(fact.text, fact.entity ?? null, fact.key ?? null, fact.value, {
+        requirePatternMatch: cfg.credentials.autoCapture?.requirePatternMatch === true,
+      });
+      if (parsed) {
         if (cfg.credentials.enabled && credentialsDb) {
-          const parsed = tryParseCredentialForVault(fact.text, fact.entity ?? null, fact.key ?? null, fact.value, {
-            requirePatternMatch: cfg.credentials.autoCapture?.requirePatternMatch === true,
-          });
-          if (parsed) {
             if (!opts.dryRun) {
               let storedInVault = false;
               try {
@@ -803,8 +801,6 @@ export async function runDistillForCli(
               }
             }
             continue;
-          }
-          continue;
         }
         if (opts.verbose) sink.log("  skipped credential-like fact: vault disabled or unavailable");
         continue;

--- a/extensions/memory-hybrid/cli/cmd-distill.ts
+++ b/extensions/memory-hybrid/cli/cmd-distill.ts
@@ -724,83 +724,81 @@ export async function runDistillForCli(
       });
       if (parsed) {
         if (cfg.credentials.enabled && credentialsDb) {
-            if (!opts.dryRun) {
-              let storedInVault = false;
+          let storedInVault = false;
+          try {
+            const credStoreResult = credentialsDb.storeIfNew({
+              service: parsed.service,
+              type: parsed.type,
+              value: parsed.secretValue,
+              url: parsed.url,
+              notes: parsed.notes,
+            });
+            storedInVault = credStoreResult;
+            const pointer = ensureCredentialVaultPointer(factsDb, parsed.service, parsed.type, "distillation", {
+              importance: BATCH_STORE_IMPORTANCE,
+              sourceDate: sourceDateSec(fact.source_date),
+            });
+            if (!pointer.ok) {
+              if (storedInVault) {
+                rollbackVaultCredentialWrite(credentialsDb, parsed.service, parsed.type);
+              }
+              continue;
+            }
+            if (
+              abortCredentialVaultWriteOnPointerDedupe(
+                storedInVault,
+                pointer,
+                credentialsDb,
+                parsed.service,
+                parsed.type,
+              )
+            ) {
+              continue;
+            }
+            const entry = pointer.entry;
+            const pointerText = buildCredentialPointerText(parsed.service, parsed.type);
+            // CRITICAL FIX (#2): Delete vector for evicted fact to prevent orphaned vectors
+            await cleanupEvictedVector({
+              vectorDb: vectorDb,
+              evictedFactId: pointer.evictedFactId,
+              logger: sink,
+              context: "distill",
+            });
+            if (pointer.newlyStored || pointer.embeddingStale) {
               try {
-                const credStoreResult = credentialsDb.storeIfNew({
-                  service: parsed.service,
-                  type: parsed.type,
-                  value: parsed.secretValue,
-                  url: parsed.url,
-                  notes: parsed.notes,
-                });
-                storedInVault = credStoreResult;
-                const pointer = ensureCredentialVaultPointer(factsDb, parsed.service, parsed.type, "distillation", {
-                  importance: BATCH_STORE_IMPORTANCE,
-                  sourceDate: sourceDateSec(fact.source_date),
-                });
-                if (!pointer.ok) {
-                  if (storedInVault) {
-                    rollbackVaultCredentialWrite(credentialsDb, parsed.service, parsed.type);
-                  }
-                  continue;
-                }
-                if (
-                  abortCredentialVaultWriteOnPointerDedupe(
-                    storedInVault,
-                    pointer,
-                    credentialsDb,
-                    parsed.service,
-                    parsed.type,
-                  )
-                ) {
-                  continue;
-                }
-                const entry = pointer.entry;
-                const pointerText = buildCredentialPointerText(parsed.service, parsed.type);
-                // CRITICAL FIX (#2): Delete vector for evicted fact to prevent orphaned vectors
-                await cleanupEvictedVector({
-                  vectorDb: vectorDb,
-                  evictedFactId: pointer.evictedFactId,
-                  logger: sink,
-                  context: "distill",
-                });
-                if (pointer.newlyStored || pointer.embeddingStale) {
-                  try {
-                    const vector = await embeddings.embed(pointerText);
-                    factsDb.setEmbeddingModel(entry.id, embeddings.modelName);
-                    if (!(await vectorDb.hasDuplicate(vector, DISTILL_DEDUP_THRESHOLD))) {
-                      await vectorDb.store({
-                        text: pointerText,
-                        vector,
-                        importance: BATCH_STORE_IMPORTANCE,
-                        category: "technical",
-                        id: entry.id,
-                      });
-                    }
-                  } catch (err) {
-                    capturePluginError(err as Error, {
-                      subsystem: "cli",
-                      operation: "runDistillForCli:credential-vector-store",
-                    });
-                  }
-                }
-                stored++;
-                if (opts.verbose) sink.log(`  stored credential: ${parsed.service}`);
-              } catch (err) {
-                if (storedInVault) {
-                  rollbackVaultCredentialWrite(credentialsDb, parsed.service, parsed.type, (message, cleanupErr) => {
-                    if (opts.verbose) sink.log(`  ${message}: ${cleanupErr}`);
-                    capturePluginError(cleanupErr as Error, {
-                      subsystem: "cli",
-                      operation: "runDistillForCli:credential-compensating-delete",
-                    });
+                const vector = await embeddings.embed(pointerText);
+                factsDb.setEmbeddingModel(entry.id, embeddings.modelName);
+                if (!(await vectorDb.hasDuplicate(vector, DISTILL_DEDUP_THRESHOLD))) {
+                  await vectorDb.store({
+                    text: pointerText,
+                    vector,
+                    importance: BATCH_STORE_IMPORTANCE,
+                    category: "technical",
+                    id: entry.id,
                   });
                 }
-                capturePluginError(err as Error, { subsystem: "cli", operation: "runDistillForCli:credential-store" });
+              } catch (err) {
+                capturePluginError(err as Error, {
+                  subsystem: "cli",
+                  operation: "runDistillForCli:credential-vector-store",
+                });
               }
             }
-            continue;
+            stored++;
+            if (opts.verbose) sink.log(`  stored credential: ${parsed.service}`);
+          } catch (err) {
+            if (storedInVault) {
+              rollbackVaultCredentialWrite(credentialsDb, parsed.service, parsed.type, (message, cleanupErr) => {
+                if (opts.verbose) sink.log(`  ${message}: ${cleanupErr}`);
+                capturePluginError(cleanupErr as Error, {
+                  subsystem: "cli",
+                  operation: "runDistillForCli:credential-compensating-delete",
+                });
+              });
+            }
+            capturePluginError(err as Error, { subsystem: "cli", operation: "runDistillForCli:credential-store" });
+          }
+          continue;
         }
         if (opts.verbose) sink.log("  skipped credential-like fact: vault disabled or unavailable");
         continue;

--- a/extensions/memory-hybrid/cli/cmd-extract-daily.ts
+++ b/extensions/memory-hybrid/cli/cmd-extract-daily.ts
@@ -4,7 +4,7 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import type { MemoryCategory } from "../config.js";
 import { getCronModelConfig, getDefaultCronModel } from "../config.js";
-import { tryParseCredentialForVault } from "../services/auto-capture.js";
+import { tryParseCredentialForVault, isStructuredCredentialCandidate } from "../services/auto-capture.js";
 import {
   buildCredentialPointerText,
   ensureCredentialVaultPointer,
@@ -298,6 +298,18 @@ export async function runExtractDailyForCli(
         if (opts.verbose) sink.log("  skipped credential-like line: vault disabled or unavailable");
         continue;
       }
+
+      // When requirePatternMatch rejects vault parsing but the input is still credential-like,
+      // skip ordinary storage to prevent plaintext secrets in facts.db (#1896).
+      if (
+        !parsed &&
+        cfg.credentials.autoCapture?.requirePatternMatch === true &&
+        isStructuredCredentialCandidate(trimmed, extracted.entity, extracted.key, extracted.value)
+      ) {
+        if (opts.verbose) sink.log("  skipped credential-like line: blocked by requirePatternMatch");
+        continue;
+      }
+
       if (!extracted.entity && !extracted.key && category !== "decision") continue;
       totalExtracted++;
       if (opts.dryRun) {

--- a/extensions/memory-hybrid/cli/cmd-extract-daily.ts
+++ b/extensions/memory-hybrid/cli/cmd-extract-daily.ts
@@ -4,7 +4,7 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import type { MemoryCategory } from "../config.js";
 import { getCronModelConfig, getDefaultCronModel } from "../config.js";
-import { isCredentialLike, tryParseCredentialForVault } from "../services/auto-capture.js";
+import { tryParseCredentialForVault } from "../services/auto-capture.js";
 import {
   buildCredentialPointerText,
   ensureCredentialVaultPointer,
@@ -213,91 +213,86 @@ export async function runExtractDailyForCli(
       if (trimmed.length < 15 || trimmed.length > 500) continue;
       const category = ctx.detectCategory(trimmed);
       const extracted = extractStructuredFields(trimmed, category);
-      if (isCredentialLike(trimmed, extracted.entity, extracted.key, extracted.value)) {
+      const parsed = tryParseCredentialForVault(trimmed, extracted.entity, extracted.key, extracted.value, {
+        requirePatternMatch: cfg.credentials.autoCapture?.requirePatternMatch === true,
+      });
+      if (parsed) {
         if (cfg.credentials.enabled && credentialsDb) {
-          const parsed = tryParseCredentialForVault(trimmed, extracted.entity, extracted.key, extracted.value, {
-            requirePatternMatch: cfg.credentials.autoCapture?.requirePatternMatch === true,
-          });
-          if (parsed) {
-            totalExtracted++;
-            if (!opts.dryRun) {
-              let storedInVault = false;
-              try {
-                storedInVault = credentialsDb.storeIfNew({
-                  service: parsed.service,
-                  type: parsed.type,
-                  value: parsed.secretValue,
-                  url: parsed.url,
-                  notes: parsed.notes,
-                });
-                const sourceDateSec = Math.floor(new Date(dateStr).getTime() / 1000);
-                const pointer = ensureCredentialVaultPointer(
-                  factsDb,
-                  parsed.service,
-                  parsed.type,
-                  `daily-scan:${dateStr}`,
-                  {
-                    importance: BATCH_STORE_IMPORTANCE,
-                    sourceDate: sourceDateSec,
-                  },
-                );
-                if (!pointer.ok) {
-                  if (storedInVault) {
-                    rollbackVaultCredentialWrite(credentialsDb, parsed.service, parsed.type);
-                  }
-                  continue;
-                }
-                if (
-                  abortCredentialVaultWriteOnPointerDedupe(
-                    storedInVault,
-                    pointer,
-                    credentialsDb,
-                    parsed.service,
-                    parsed.type,
-                  )
-                ) {
-                  continue;
-                }
-                const pointerEntry = pointer.entry;
-                await cleanupEvictedVector({
-                  vectorDb,
-                  evictedFactId: pointer.evictedFactId,
-                  logger: sink,
-                  context: "extract-daily-credential-pointer",
-                });
-                if (pointer.newlyStored || pointer.embeddingStale) {
-                  const pointerText = buildCredentialPointerText(parsed.service, parsed.type);
-                  try {
-                    const vector = await embeddings.embed(pointerText);
-                    factsDb.setEmbeddingModel(pointerEntry.id, embeddings.modelName);
-                    if (!(await vectorDb.hasDuplicate(vector))) {
-                      await vectorDb.store({
-                        text: pointerText,
-                        vector,
-                        importance: BATCH_STORE_IMPORTANCE,
-                        category: "technical",
-                        id: pointerEntry.id,
-                      });
-                    }
-                  } catch (err) {
-                    recordVectorFailure(err, "runExtractDailyForCli:vector-store");
-                  }
-                }
-                totalStored++;
-              } catch (err) {
+          totalExtracted++;
+          if (!opts.dryRun) {
+            let storedInVault = false;
+            try {
+              storedInVault = credentialsDb.storeIfNew({
+                service: parsed.service,
+                type: parsed.type,
+                value: parsed.secretValue,
+                url: parsed.url,
+                notes: parsed.notes,
+              });
+              const sourceDateSec = Math.floor(new Date(dateStr).getTime() / 1000);
+              const pointer = ensureCredentialVaultPointer(
+                factsDb,
+                parsed.service,
+                parsed.type,
+                `daily-scan:${dateStr}`,
+                {
+                  importance: BATCH_STORE_IMPORTANCE,
+                  sourceDate: sourceDateSec,
+                },
+              );
+              if (!pointer.ok) {
                 if (storedInVault) {
                   rollbackVaultCredentialWrite(credentialsDb, parsed.service, parsed.type);
                 }
-                capturePluginError(err as Error, {
-                  subsystem: "cli",
-                  operation: "runExtractDailyForCli:credential-store",
-                });
+                continue;
               }
+              if (
+                abortCredentialVaultWriteOnPointerDedupe(
+                  storedInVault,
+                  pointer,
+                  credentialsDb,
+                  parsed.service,
+                  parsed.type,
+                )
+              ) {
+                continue;
+              }
+              const pointerEntry = pointer.entry;
+              await cleanupEvictedVector({
+                vectorDb,
+                evictedFactId: pointer.evictedFactId,
+                logger: sink,
+                context: "extract-daily-credential-pointer",
+              });
+              if (pointer.newlyStored || pointer.embeddingStale) {
+                const pointerText = buildCredentialPointerText(parsed.service, parsed.type);
+                try {
+                  const vector = await embeddings.embed(pointerText);
+                  factsDb.setEmbeddingModel(pointerEntry.id, embeddings.modelName);
+                  if (!(await vectorDb.hasDuplicate(vector))) {
+                    await vectorDb.store({
+                      text: pointerText,
+                      vector,
+                      importance: BATCH_STORE_IMPORTANCE,
+                      category: "technical",
+                      id: pointerEntry.id,
+                    });
+                  }
+                } catch (err) {
+                  recordVectorFailure(err, "runExtractDailyForCli:vector-store");
+                }
+              }
+              totalStored++;
+            } catch (err) {
+              if (storedInVault) {
+                rollbackVaultCredentialWrite(credentialsDb, parsed.service, parsed.type);
+              }
+              capturePluginError(err as Error, {
+                subsystem: "cli",
+                operation: "runExtractDailyForCli:credential-store",
+              });
             }
-            // Skip normal fact-storage path — this line has been handled as a credential.
-            continue;
           }
-          // isCredentialLike but vault parse failed — skip this line entirely.
           continue;
         }
         if (opts.verbose) sink.log("  skipped credential-like line: vault disabled or unavailable");

--- a/extensions/memory-hybrid/cli/cmd-store.ts
+++ b/extensions/memory-hybrid/cli/cmd-store.ts
@@ -7,7 +7,7 @@
 
 import type { MemoryCategory } from "../config.js";
 import { getCronModelConfig, getDefaultCronModel } from "../config.js";
-import { isCredentialLike, tryParseCredentialForVault } from "../services/auto-capture.js";
+import { tryParseCredentialForVault } from "../services/auto-capture.js";
 import {
   buildCredentialPointerText,
   ensureCredentialVaultPointer,
@@ -66,12 +66,12 @@ export async function runStoreForCli(
   const entity = opts.entity ?? extracted.entity ?? null;
   const key = opts.key ?? extracted.key ?? null;
   const value = opts.value ?? extracted.value ?? null;
-  if (isCredentialLike(text, entity, key, value)) {
+  const parsedCredential = tryParseCredentialForVault(text, entity, key, value, {
+    requirePatternMatch: cfg.credentials.autoCapture?.requirePatternMatch === true,
+  });
+  if (parsedCredential) {
+    const parsed = parsedCredential;
     if (cfg.credentials.enabled && credentialsDb) {
-      const parsed = tryParseCredentialForVault(text, entity, key, value, {
-        requirePatternMatch: cfg.credentials.autoCapture?.requirePatternMatch === true,
-      });
-      if (parsed) {
         let storedInVault = false;
         try {
           storedInVault = credentialsDb.storeIfNew({
@@ -154,8 +154,6 @@ export async function runStoreForCli(
           return { outcome: "credential_db_error" };
         }
         return { outcome: "credential", id: pointerEntry.id, service: parsed.service, type: parsed.type };
-      }
-      return { outcome: "credential_parse_error" };
     }
     return { outcome: "credential_blocked_no_vault" };
   }

--- a/extensions/memory-hybrid/cli/cmd-store.ts
+++ b/extensions/memory-hybrid/cli/cmd-store.ts
@@ -7,7 +7,7 @@
 
 import type { MemoryCategory } from "../config.js";
 import { getCronModelConfig, getDefaultCronModel } from "../config.js";
-import { tryParseCredentialForVault } from "../services/auto-capture.js";
+import { tryParseCredentialForVault, isStructuredCredentialCandidate } from "../services/auto-capture.js";
 import {
   buildCredentialPointerText,
   ensureCredentialVaultPointer,
@@ -155,6 +155,16 @@ export async function runStoreForCli(
         }
         return { outcome: "credential", id: pointerEntry.id, service: parsed.service, type: parsed.type };
     }
+    return { outcome: "credential_blocked_no_vault" };
+  }
+
+  // When requirePatternMatch rejects vault parsing but the input is still credential-like,
+  // block ordinary storage to prevent plaintext secrets in facts.db (#1896).
+  if (
+    !parsedCredential &&
+    cfg.credentials.autoCapture?.requirePatternMatch === true &&
+    isStructuredCredentialCandidate(text, entity, key, value)
+  ) {
     return { outcome: "credential_blocked_no_vault" };
   }
 

--- a/extensions/memory-hybrid/cli/cmd-store.ts
+++ b/extensions/memory-hybrid/cli/cmd-store.ts
@@ -72,88 +72,88 @@ export async function runStoreForCli(
   if (parsedCredential) {
     const parsed = parsedCredential;
     if (cfg.credentials.enabled && credentialsDb) {
-        let storedInVault = false;
-        try {
-          storedInVault = credentialsDb.storeIfNew({
-            service: parsed.service,
-            type: parsed.type,
-            value: parsed.secretValue,
-            url: parsed.url,
-            notes: parsed.notes,
-          });
-        } catch (err) {
-          capturePluginError(err as Error, { subsystem: "cli", operation: "runStoreForCli:credential-vault-store" });
-          return { outcome: "credential_vault_error" };
-        }
+      let storedInVault = false;
+      try {
+        storedInVault = credentialsDb.storeIfNew({
+          service: parsed.service,
+          type: parsed.type,
+          value: parsed.secretValue,
+          url: parsed.url,
+          notes: parsed.notes,
+        });
+      } catch (err) {
+        capturePluginError(err as Error, { subsystem: "cli", operation: "runStoreForCli:credential-vault-store" });
+        return { outcome: "credential_vault_error" };
+      }
 
-        let pointerEntry: MemoryEntry;
-        try {
-          const pointer = ensureCredentialVaultPointer(factsDb, parsed.service, parsed.type, "cli", {
-            importance: CLI_STORE_IMPORTANCE,
-            sourceDate,
-          });
-          if (!pointer.ok) {
-            if (storedInVault) {
-              rollbackVaultCredentialWrite(credentialsDb, parsed.service, parsed.type, (msg, err) =>
-                log.warn(`memory-hybrid: ${msg}: ${err}`),
-              );
-            }
-            return { outcome: "noop", reason: "artifact text rejected by pre-store guard" };
-          }
-          pointerEntry = pointer.entry;
-          if (
-            abortCredentialVaultWriteOnPointerDedupe(storedInVault, pointer, credentialsDb, parsed.service, parsed.type)
-          ) {
-            return {
-              outcome: "credential_skipped_duplicate",
-              service: parsed.service,
-              type: parsed.type,
-            };
-          }
-          await cleanupEvictedVector({
-            vectorDb: vectorDb,
-            evictedFactId: pointer.evictedFactId,
-            logger: log,
-            context: "cli-store",
-          });
-          if (pointer.newlyStored || pointer.embeddingStale) {
-            const pointerText = buildCredentialPointerText(parsed.service, parsed.type);
-            try {
-              const vector = await embeddings.embed(pointerText);
-              factsDb.setEmbeddingModel(pointerEntry.id, embeddings.modelName);
-              if (!(await vectorDb.hasDuplicate(vector))) {
-                await vectorDb.store({
-                  text: pointerText,
-                  vector,
-                  importance: CLI_STORE_IMPORTANCE,
-                  category: "technical",
-                  id: pointerEntry.id,
-                });
-              }
-              persistCanonicalFactEmbedding(
-                factsDb,
-                pointerEntry.id,
-                embeddings.modelName,
-                vector,
-                "runStoreForCli:pointer-fact-embeddings",
-                "cli",
-                log.warn,
-              );
-            } catch (err) {
-              log.warn(`memory-hybrid: vector store failed: ${err}`);
-              capturePluginError(err as Error, { subsystem: "cli", operation: "runStoreForCli:vector-store" });
-            }
-          }
-        } catch (err) {
+      let pointerEntry: MemoryEntry;
+      try {
+        const pointer = ensureCredentialVaultPointer(factsDb, parsed.service, parsed.type, "cli", {
+          importance: CLI_STORE_IMPORTANCE,
+          sourceDate,
+        });
+        if (!pointer.ok) {
           if (storedInVault) {
-            rollbackVaultCredentialWrite(credentialsDb, parsed.service, parsed.type, (msg, cleanupErr) =>
-              log.warn(`memory-hybrid: ${msg}: ${cleanupErr}`),
+            rollbackVaultCredentialWrite(credentialsDb, parsed.service, parsed.type, (msg, err) =>
+              log.warn(`memory-hybrid: ${msg}: ${err}`),
             );
           }
-          capturePluginError(err as Error, { subsystem: "cli", operation: "runStoreForCli:credential-db-store" });
-          return { outcome: "credential_db_error" };
+          return { outcome: "noop", reason: "artifact text rejected by pre-store guard" };
         }
-        return { outcome: "credential", id: pointerEntry.id, service: parsed.service, type: parsed.type };
+        pointerEntry = pointer.entry;
+        if (
+          abortCredentialVaultWriteOnPointerDedupe(storedInVault, pointer, credentialsDb, parsed.service, parsed.type)
+        ) {
+          return {
+            outcome: "credential_skipped_duplicate",
+            service: parsed.service,
+            type: parsed.type,
+          };
+        }
+        await cleanupEvictedVector({
+          vectorDb: vectorDb,
+          evictedFactId: pointer.evictedFactId,
+          logger: log,
+          context: "cli-store",
+        });
+        if (pointer.newlyStored || pointer.embeddingStale) {
+          const pointerText = buildCredentialPointerText(parsed.service, parsed.type);
+          try {
+            const vector = await embeddings.embed(pointerText);
+            factsDb.setEmbeddingModel(pointerEntry.id, embeddings.modelName);
+            if (!(await vectorDb.hasDuplicate(vector))) {
+              await vectorDb.store({
+                text: pointerText,
+                vector,
+                importance: CLI_STORE_IMPORTANCE,
+                category: "technical",
+                id: pointerEntry.id,
+              });
+            }
+            persistCanonicalFactEmbedding(
+              factsDb,
+              pointerEntry.id,
+              embeddings.modelName,
+              vector,
+              "runStoreForCli:pointer-fact-embeddings",
+              "cli",
+              log.warn,
+            );
+          } catch (err) {
+            log.warn(`memory-hybrid: vector store failed: ${err}`);
+            capturePluginError(err as Error, { subsystem: "cli", operation: "runStoreForCli:vector-store" });
+          }
+        }
+      } catch (err) {
+        if (storedInVault) {
+          rollbackVaultCredentialWrite(credentialsDb, parsed.service, parsed.type, (msg, cleanupErr) =>
+            log.warn(`memory-hybrid: ${msg}: ${cleanupErr}`),
+          );
+        }
+        capturePluginError(err as Error, { subsystem: "cli", operation: "runStoreForCli:credential-db-store" });
+        return { outcome: "credential_db_error" };
+      }
+      return { outcome: "credential", id: pointerEntry.id, service: parsed.service, type: parsed.type };
     }
     return { outcome: "credential_blocked_no_vault" };
   }
@@ -165,7 +165,7 @@ export async function runStoreForCli(
     cfg.credentials.autoCapture?.requirePatternMatch === true &&
     isStructuredCredentialCandidate(text, entity, key, value)
   ) {
-    return { outcome: "credential_blocked_no_vault" };
+    return { outcome: "credential_blocked_require_pattern_match" };
   }
 
   const tags = opts.tags

--- a/extensions/memory-hybrid/cli/commands/manage/register-corrections.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/register-corrections.ts
@@ -146,6 +146,10 @@ export function registerManageCorrections(mem: Chainable, b: ManageBindings): vo
             console.log(`Credential already in vault (skipped): ${res.service} (${res.type})`);
           } else if (res.outcome === "credential_blocked_no_vault") {
             console.log("Credential-like content blocked: enable credentials vault to store secrets securely.");
+          } else if (res.outcome === "credential_blocked_require_pattern_match") {
+            console.log(
+              "Credential-like content blocked: no recognizable secret pattern found (requirePatternMatch is enabled).",
+            );
           } else if (res.outcome === "credential_parse_error") {
             console.log("Credential parse error (skipped).");
           } else if (res.outcome === "credential_vault_error") {

--- a/extensions/memory-hybrid/cli/types.ts
+++ b/extensions/memory-hybrid/cli/types.ts
@@ -35,6 +35,7 @@ export type StoreCliResult =
   | { outcome: "credential"; id: string; service: string; type: string }
   | { outcome: "credential_skipped_duplicate"; service: string; type: string }
   | { outcome: "credential_blocked_no_vault" }
+  | { outcome: "credential_blocked_require_pattern_match" }
   | { outcome: "credential_parse_error" }
   | { outcome: "credential_vault_error" }
   | { outcome: "credential_db_error" }

--- a/extensions/memory-hybrid/services/auto-capture.ts
+++ b/extensions/memory-hybrid/services/auto-capture.ts
@@ -136,7 +136,8 @@ export function tryParseCredentialForVault(
   // If a match exists, it IS the credential — use its value.
   // Only fall back to the structured value param when no pattern matched.
   const secretFromMatch = match?.secretValue ?? null;
-  const secretFromParam = value && value.length >= 8 ? value : null;
+  const secretFromParam =
+    value && value.length >= 8 && !value.startsWith(VAULT_POINTER_PREFIX) ? value : null;
   const secretValue = secretFromMatch ?? secretFromParam ?? null;
   if (!secretValue) return null;
   const typeFromPattern = (match?.type ?? "other") as "token" | "password" | "api_key" | "ssh" | "bearer" | "other";

--- a/extensions/memory-hybrid/services/auto-capture.ts
+++ b/extensions/memory-hybrid/services/auto-capture.ts
@@ -77,8 +77,11 @@ export function extractCredentialMatch(text: string): { type: string; secretValu
   return null;
 }
 
-/** True if content should be treated as a credential (store in vault when enabled, else in memory). */
-export function isCredentialLike(
+/**
+ * Narrow credential signal: structured fields or extractable secret patterns.
+ * Used for vault routing — does not match broad English words alone (#1896).
+ */
+export function isStructuredCredentialCandidate(
   text: string,
   entity?: string | null,
   key?: string | null,
@@ -89,7 +92,17 @@ export function isCredentialLike(
   const e = (entity ?? "").toLowerCase();
   if (["api_key", "password", "token", "secret", "bearer"].some((x) => k.includes(x) || e.includes(x))) return true;
   if (value && value.length >= 8 && /^(eyJ|sk-|ghp_|gho_|xox[baprs]-)/i.test(value)) return true;
-  return CREDENTIAL_PATTERNS.some((p) => p.regex.test(text)) || CAPTURE_FILTER_PATTERNS.some((r) => r.test(text));
+  return CREDENTIAL_PATTERNS.some((p) => p.regex.test(text));
+}
+
+/** True if content looks credential-related (broad or narrow). Used by auto-capture filters, not vault gating. */
+export function isCredentialLike(
+  text: string,
+  entity?: string | null,
+  key?: string | null,
+  value?: string | null,
+): boolean {
+  return isStructuredCredentialCandidate(text, entity, key, value) || CAPTURE_FILTER_PATTERNS.some((r) => r.test(text));
 }
 
 export const VAULT_POINTER_PREFIX = "vault:";
@@ -114,7 +127,7 @@ export function tryParseCredentialForVault(
   url?: string;
   notes?: string;
 } | null {
-  if (!isCredentialLike(text, entity, key, value)) return null;
+  if (!isStructuredCredentialCandidate(text, entity, key, value)) return null;
   const match = extractCredentialMatch(text);
   if (options?.requirePatternMatch && !match) return null;
   // Prefer the secret extracted from a regex pattern match over the structured value param.

--- a/extensions/memory-hybrid/tests/auto-capture-pure.test.ts
+++ b/extensions/memory-hybrid/tests/auto-capture-pure.test.ts
@@ -339,6 +339,16 @@ describe("tryParseCredentialForVault", () => {
     expect(result).toBeNull();
   });
 
+  it("returns null when structured value is an existing vault pointer", () => {
+    const result = tryParseCredentialForVault(
+      "stored credential reference",
+      "openai",
+      "api_key",
+      `${VAULT_POINTER_PREFIX}openai:api_key`,
+    );
+    expect(result).toBeNull();
+  });
+
   it("includes notes field containing original text when text is short enough", () => {
     const text = `github token: ${GHP_TOKEN}`;
     const result = tryParseCredentialForVault(text, null, null, null);

--- a/extensions/memory-hybrid/tests/auto-capture-pure.test.ts
+++ b/extensions/memory-hybrid/tests/auto-capture-pure.test.ts
@@ -269,6 +269,18 @@ describe("isCredentialLike", () => {
     expect(isCredentialLike("the user prefers dark mode in VS Code", null, null, null)).toBe(false);
   });
 
+  it("isCredentialLike is true for broad-only token wording but structured candidate is false (#1896)", () => {
+    const text = "M3 has 5.1B tokens monthly budget";
+    expect(isCredentialLike(text, "minimax-quota", null, null)).toBe(true);
+    expect(tryParseCredentialForVault(text, "minimax-quota", null, null)).toBeNull();
+  });
+
+  it("stores broad api-key prose without narrow secret as non-vault candidate (#1896)", () => {
+    const text = "the API key is used for service auth";
+    expect(isCredentialLike(text, null, null, null)).toBe(true);
+    expect(tryParseCredentialForVault(text, null, null, null)).toBeNull();
+  });
+
   it("returns false when value is too short (< 8 chars)", () => {
     // "sk-abc" (6 chars) fails the sk- credential pattern (requires 20+ alphanum after prefix)
     // and also fails the value length guard (< 8 chars), so isCredentialLike returns false.

--- a/extensions/memory-hybrid/tests/cli-store-rollback.test.ts
+++ b/extensions/memory-hybrid/tests/cli-store-rollback.test.ts
@@ -358,8 +358,37 @@ describe("runStoreForCli credential_skipped_duplicate", () => {
 // Parse failure
 // ---------------------------------------------------------------------------
 
+describe("runStoreForCli credential broad-only text (#1896)", () => {
+  it("stores ordinary memory when text is broad-sensitive but has no extractable secret", async () => {
+    const opts: StoreCliOpts = {
+      text: "M3 has 5.1B tokens monthly budget",
+      category: "technical",
+      entity: "minimax-quota",
+    };
+
+    const result = await runStoreForCli(mockCtx, opts, { warn: vi.fn() });
+
+    expect(result.outcome).toBe("stored");
+    if (result.outcome === "stored") {
+      expect(factsDb.getById(result.id)?.text).toContain("tokens monthly budget");
+    }
+    expect(credentialsDb.list()).toHaveLength(0);
+  });
+
+  it("stores api-key prose without a narrow secret pattern as ordinary memory", async () => {
+    const opts: StoreCliOpts = {
+      text: "the API key is used for service auth",
+      category: "technical",
+    };
+
+    const result = await runStoreForCli(mockCtx, opts, { warn: vi.fn() });
+    expect(result.outcome).toBe("stored");
+    expect(credentialsDb.list()).toHaveLength(0);
+  });
+});
+
 describe("runStoreForCli credential parse failure", () => {
-  it("returns credential_parse_error when credential-like text cannot be parsed to vault format", async () => {
+  it("stores as ordinary memory when structured fields suggest credential but secret is invalid", async () => {
     // This text matches isCredentialLike but tryParseCredentialForVault returns null
     // because the secret value is too short or doesn't match patterns
     const opts: StoreCliOpts = {
@@ -372,11 +401,10 @@ describe("runStoreForCli credential parse failure", () => {
 
     const result: StoreCliResult = await runStoreForCli(mockCtx, opts, { warn: vi.fn() });
 
-    expect(result.outcome).toBe("credential_parse_error");
+    expect(result.outcome).toBe("stored");
 
-    // Verify nothing stored in vault
-    const vaultList = credentialsDb.list();
-    expect(vaultList.length).toBe(0);
+    expect(credentialsDb.list().length).toBe(0);
+    expect(factsDb.getAll().length).toBeGreaterThan(0);
   });
 });
 

--- a/extensions/memory-hybrid/tests/plugin-e2e.test.ts
+++ b/extensions/memory-hybrid/tests/plugin-e2e.test.ts
@@ -373,6 +373,32 @@ describe("Store and recall e2e (real FactsDB + VectorDB, mock embeddings)", () =
     expect(recallResult.details?.count ?? 0).toBe(0);
   });
 
+  it("memory_store stores technical token-budget facts that only match broad patterns (#1896)", async () => {
+    registerTools(buildE2EContext({ tmpDir, factsDb, vectorDb, cfg, api }) as never, api as never);
+
+    const storeTool = api.getTool("memory_store");
+    const recallTool = api.getTool("memory_recall");
+
+    const storeResult = (await storeTool?.execute("call-token-budget", {
+      text: "M3 has 5.1B tokens monthly budget",
+      entity: "minimax-quota",
+      category: "technical",
+      importance: 0.9,
+    })) as { details?: { action?: string; id?: string } };
+
+    expect(storeResult.details?.action).toBe("created");
+    expect(storeResult.details?.id).toBeTruthy();
+
+    const recallResult = (await recallTool?.execute("call-token-budget-recall", {
+      query: "minimax quota token budget",
+      limit: 5,
+    })) as { details?: { count?: number; memories?: { text: string }[] } };
+
+    expect(recallResult.details?.count).toBeGreaterThanOrEqual(1);
+    const texts = (recallResult.details?.memories ?? []).map((m) => m.text);
+    expect(texts.some((t) => t.includes("tokens monthly budget"))).toBe(true);
+  });
+
   it("memory_recall exposes constrained-recall mode with filter and rank explanation", async () => {
     registerTools(buildE2EContext({ tmpDir, factsDb, vectorDb, cfg, api }) as never, api as never);
 

--- a/extensions/memory-hybrid/tools/memory/register-store-tools.ts
+++ b/extensions/memory-hybrid/tools/memory/register-store-tools.ts
@@ -18,7 +18,7 @@ import {
   getMemoryCategories,
   isCompactVerbosity,
 } from "../../config.js";
-import { isCredentialLike, tryParseCredentialForVault } from "../../services/auto-capture.js";
+import { tryParseCredentialForVault } from "../../services/auto-capture.js";
 import {
   buildCredentialPointerText,
   ensureCredentialVaultPointer,
@@ -376,146 +376,173 @@ export function registerStoreTools(runtime: MemoryToolRuntime): void {
             }
           };
 
-          if (isCredentialLike(textToStore, entity, key, value)) {
+          const parsedCredential = tryParseCredentialForVault(textToStore, entity, key, value, {
+            requirePatternMatch: cfg.credentials.autoCapture?.requirePatternMatch === true,
+          });
+          if (parsedCredential) {
+            const parsed = parsedCredential;
             if (cfg.credentials.enabled && credentialsDb) {
-              const parsed = tryParseCredentialForVault(textToStore, entity, key, value, {
-                requirePatternMatch: cfg.credentials.autoCapture?.requirePatternMatch === true,
-              });
-              if (parsed) {
-                let storedInVault = false;
-                try {
-                  storedInVault = credentialsDb.storeIfNew({
-                    service: parsed.service,
-                    type: parsed.type,
-                    value: parsed.secretValue,
-                    url: parsed.url,
-                    notes: parsed.notes,
-                  });
-                } catch (err) {
-                  capturePluginError(err instanceof Error ? err : new Error(String(err)), {
-                    subsystem: "memory-tools",
-                    operation: "memory-store:credential-vault-store",
-                  });
-                  return {
-                    content: [{ type: "text", text: "Credential vault store failed." }],
-                    details: { action: "credential_vault_error" },
-                  };
-                }
+              let storedInVault = false;
+              try {
+                storedInVault = credentialsDb.storeIfNew({
+                  service: parsed.service,
+                  type: parsed.type,
+                  value: parsed.secretValue,
+                  url: parsed.url,
+                  notes: parsed.notes,
+                });
+              } catch (err) {
+                capturePluginError(err instanceof Error ? err : new Error(String(err)), {
+                  subsystem: "memory-tools",
+                  operation: "memory-store:credential-vault-store",
+                });
+                auditAppend({
+                  agentId: agentIdForAudit(),
+                  action: "memory_store",
+                  outcome: "failed",
+                  error: "credential vault store failed",
+                  sessionId: api.context?.sessionId ?? undefined,
+                });
+                return {
+                  content: [{ type: "text", text: "Credential vault store failed." }],
+                  details: { action: "credential_vault_error" },
+                };
+              }
 
-                const pointer = ensureCredentialVaultPointer(factsDb, parsed.service, parsed.type, "conversation", {
-                  why: whyStored,
-                  importance,
-                  decayClass: paramDecayClass ?? "permanent",
-                  provenanceSession: provenanceSessionId,
-                  extractionMethod: "active",
-                  extractionConfidence: importance,
+              const pointer = ensureCredentialVaultPointer(factsDb, parsed.service, parsed.type, "conversation", {
+                why: whyStored,
+                importance,
+                decayClass: paramDecayClass ?? "permanent",
+                provenanceSession: provenanceSessionId,
+                extractionMethod: "active",
+                extractionConfidence: importance,
+              });
+              if (!pointer.ok) {
+                if (storedInVault) {
+                  rollbackVaultCredentialWrite(credentialsDb, parsed.service, parsed.type);
+                }
+                auditAppend({
+                  agentId: agentIdForAudit(),
+                  action: "memory_store",
+                  outcome: "failed",
+                  error: "credential rejected by pre-store guard",
+                  sessionId: api.context?.sessionId ?? undefined,
                 });
-                if (!pointer.ok) {
-                  if (storedInVault) {
-                    rollbackVaultCredentialWrite(credentialsDb, parsed.service, parsed.type);
-                  }
-                  return {
-                    content: [{ type: "text", text: "Credential-like content rejected by pre-store guard." }],
-                    details: { action: "credential_rejected_artifact" },
-                  };
-                }
-                const pointerEntry = pointer.entry;
-                if (
-                  abortCredentialVaultWriteOnPointerDedupe(
-                    storedInVault,
-                    pointer,
-                    credentialsDb,
-                    parsed.service,
-                    parsed.type,
-                  )
-                ) {
-                  return {
-                    content: [
-                      {
-                        type: "text",
-                        text: `Credential already in vault for ${parsed.service} (${parsed.type}).`,
-                      },
-                    ],
-                    details: {
-                      action: "credential_skipped_duplicate",
-                      id: pointerEntry.id,
-                      service: parsed.service,
-                      type: parsed.type,
-                    },
-                  };
-                }
-                await cleanupEvictedVector({
-                  vectorDb,
-                  evictedFactId: pointer.evictedFactId,
-                  logger: api.logger,
-                  context: "memory-store-credential-pointer",
+                return {
+                  content: [{ type: "text", text: "Credential-like content rejected by pre-store guard." }],
+                  details: { action: "credential_rejected_artifact" },
+                };
+              }
+              const pointerEntry = pointer.entry;
+              if (
+                abortCredentialVaultWriteOnPointerDedupe(
+                  storedInVault,
+                  pointer,
+                  credentialsDb,
+                  parsed.service,
+                  parsed.type,
+                )
+              ) {
+                auditAppend({
+                  agentId: agentIdForAudit(),
+                  action: "memory_store",
+                  target: `memory #${pointerEntry.id}`,
+                  outcome: "partial",
+                  sessionId: api.context?.sessionId ?? undefined,
+                  context: { credentialDuplicate: true, service: parsed.service },
                 });
-                const pointerText = buildCredentialPointerText(parsed.service, parsed.type);
-                if (pointer.newlyStored) {
-                  recordActiveStoreProvenance(pointerEntry.id, pointerText);
-                }
-                if (pointer.newlyStored || pointer.embeddingStale) {
-                  try {
-                    addOperationBreadcrumb("vector", "store-credential-pointer");
-                    const vector = await embedCallWithTimeoutAndRetry(
-                      () => embeddings.embed(pointerText),
-                      "memory-tools:store-credential-pointer",
-                    );
-                    await storeActiveCanonicalVector({
-                      factId: pointerEntry.id,
-                      text: pointerText,
-                      why: whyStored,
-                      vector,
-                      importance,
-                      category: "technical",
-                    });
-                    await storeRegistryEmbeddings({
-                      factsDb,
-                      embeddingRegistry,
-                      embeddings,
-                      factId: pointerEntry.id,
-                      text: pointerText,
-                      vector,
-                      logger: api.logger,
-                      operation: "store-credential-pointer",
-                    });
-                  } catch (err) {
-                    if (!(err instanceof AllEmbeddingProvidersFailed)) {
-                      capturePluginError(err instanceof Error ? err : new Error(String(err)), {
-                        subsystem: "vector",
-                        operation: "store-credential-pointer",
-                        phase: "runtime",
-                        backend: "lancedb",
-                      });
-                    }
-                    api.logger.warn(`memory-hybrid: vector store failed: ${err}`);
-                  }
-                }
                 return {
                   content: [
                     {
                       type: "text",
-                      text: `Credential stored in vault for ${parsed.service} (${parsed.type}). Pointer saved in memory.`,
+                      text: `Credential already in vault for ${parsed.service} (${parsed.type}).`,
                     },
                   ],
                   details: {
-                    action: "credential_vault",
+                    action: "credential_skipped_duplicate",
                     id: pointerEntry.id,
                     service: parsed.service,
                     type: parsed.type,
                   },
                 };
               }
+              await cleanupEvictedVector({
+                vectorDb,
+                evictedFactId: pointer.evictedFactId,
+                logger: api.logger,
+                context: "memory-store-credential-pointer",
+              });
+              const pointerText = buildCredentialPointerText(parsed.service, parsed.type);
+              if (pointer.newlyStored) {
+                recordActiveStoreProvenance(pointerEntry.id, pointerText);
+              }
+              if (pointer.newlyStored || pointer.embeddingStale) {
+                try {
+                  addOperationBreadcrumb("vector", "store-credential-pointer");
+                  const vector = await embedCallWithTimeoutAndRetry(
+                    () => embeddings.embed(pointerText),
+                    "memory-tools:store-credential-pointer",
+                  );
+                  await storeActiveCanonicalVector({
+                    factId: pointerEntry.id,
+                    text: pointerText,
+                    why: whyStored,
+                    vector,
+                    importance,
+                    category: "technical",
+                  });
+                  await storeRegistryEmbeddings({
+                    factsDb,
+                    embeddingRegistry,
+                    embeddings,
+                    factId: pointerEntry.id,
+                    text: pointerText,
+                    vector,
+                    logger: api.logger,
+                    operation: "store-credential-pointer",
+                  });
+                } catch (err) {
+                  if (!(err instanceof AllEmbeddingProvidersFailed)) {
+                    capturePluginError(err instanceof Error ? err : new Error(String(err)), {
+                      subsystem: "vector",
+                      operation: "store-credential-pointer",
+                      phase: "runtime",
+                      backend: "lancedb",
+                    });
+                  }
+                  api.logger.warn(`memory-hybrid: vector store failed: ${err}`);
+                }
+              }
+              auditAppend({
+                agentId: agentIdForAudit(),
+                action: "memory_store",
+                target: `memory #${pointerEntry.id}`,
+                outcome: "partial",
+                sessionId: api.context?.sessionId ?? undefined,
+                context: { category: "technical", credentialType: parsed.type, service: parsed.service },
+              });
               return {
                 content: [
                   {
                     type: "text",
-                    text: "Credential-like content detected but could not be parsed as a structured credential; not stored (vault is enabled).",
+                    text: `Credential stored in vault for ${parsed.service} (${parsed.type}). Pointer saved in memory.`,
                   },
                 ],
-                details: { action: "credential_skipped" },
+                details: {
+                  action: "credential_vault",
+                  id: pointerEntry.id,
+                  service: parsed.service,
+                  type: parsed.type,
+                },
               };
             }
+            auditAppend({
+              agentId: agentIdForAudit(),
+              action: "memory_store",
+              outcome: "failed",
+              error: "credential vault disabled or unavailable",
+              sessionId: api.context?.sessionId ?? undefined,
+            });
             return {
               content: [
                 {

--- a/extensions/memory-hybrid/tools/memory/register-store-tools.ts
+++ b/extensions/memory-hybrid/tools/memory/register-store-tools.ts
@@ -18,7 +18,7 @@ import {
   getMemoryCategories,
   isCompactVerbosity,
 } from "../../config.js";
-import { tryParseCredentialForVault } from "../../services/auto-capture.js";
+import { tryParseCredentialForVault, isStructuredCredentialCandidate } from "../../services/auto-capture.js";
 import {
   buildCredentialPointerText,
   ensureCredentialVaultPointer,
@@ -541,6 +541,31 @@ export function registerStoreTools(runtime: MemoryToolRuntime): void {
               action: "memory_store",
               outcome: "failed",
               error: "credential vault disabled or unavailable",
+              sessionId: api.context?.sessionId ?? undefined,
+            });
+            return {
+              content: [
+                {
+                  type: "text",
+                  text: "Credential-like content detected. Ordinary memory storage is blocked while the credential vault is disabled or unavailable. Enable credentials vault and retry.",
+                },
+              ],
+              details: { action: "credential_blocked_no_vault" },
+            };
+          }
+
+          // When requirePatternMatch rejects vault parsing but the input is still credential-like,
+          // block ordinary storage to prevent plaintext secrets in facts.db (#1896).
+          if (
+            !parsedCredential &&
+            cfg.credentials.autoCapture?.requirePatternMatch === true &&
+            isStructuredCredentialCandidate(textToStore, entity, key, value)
+          ) {
+            auditAppend({
+              agentId: agentIdForAudit(),
+              action: "memory_store",
+              outcome: "failed",
+              error: "credential-like content blocked by requirePatternMatch",
               sessionId: api.context?.sessionId ?? undefined,
             });
             return {

--- a/extensions/memory-hybrid/tools/memory/register-store-tools.ts
+++ b/extensions/memory-hybrid/tools/memory/register-store-tools.ts
@@ -572,10 +572,10 @@ export function registerStoreTools(runtime: MemoryToolRuntime): void {
               content: [
                 {
                   type: "text",
-                  text: "Credential-like content detected. Ordinary memory storage is blocked while the credential vault is disabled or unavailable. Enable credentials vault and retry.",
+                  text: "Credential-like content detected but no recognizable secret pattern was found (requirePatternMatch is enabled). Store using a known credential format or disable requirePatternMatch.",
                 },
               ],
-              details: { action: "credential_blocked_no_vault" },
+              details: { action: "credential_blocked_require_pattern_match" },
             };
           }
 


### PR DESCRIPTION
## Summary

- **Root cause:** `memory_store` gated on `isCredentialLike()`, which ORs broad `CAPTURE_FILTER_PATTERNS` (including `/token/i`) with narrow secret extractors. When broad matched but `tryParseCredentialForVault` could not extract a real secret, the fact was silently dropped with `credential_skipped` — while audit often still showed success elsewhere.
- **Fix (Option A):** Introduce `isStructuredCredentialCandidate()` for vault routing (entity/key heuristics + `CREDENTIAL_PATTERNS` only). `tryParseCredentialForVault` and all store paths (`memory_store`, CLI store, distill, extract-daily) now divert to vault **only** when narrow parsing succeeds; otherwise they continue to ordinary fact storage. Broad patterns remain for auto-capture filtering (`shouldCapture`).
- **Audit:** Credential vault writes log `partial`; vault-disabled real secrets log `failed`; ordinary fact persistence continues to log `success`.

Fixes #1896

## Test plan

- [x] `npm test -- --run tests/auto-capture-pure.test.ts tests/cli-store-rollback.test.ts tests/plugin-e2e.test.ts tests/credential-validation.test.ts tests/credentials-auto-capture.test.ts` (159 passed)
- [x] Regression: `"M3 has 5.1B tokens monthly budget"` stores and recalls
- [x] Regression: `"the API key is used for service auth"` stores as ordinary memory
- [x] Regression: real `sk-...` keys still blocked without vault / diverted with vault enabled
- [ ] Maeve: `memory_store` MiniMax quota fact persists in `facts.db` with vault enabled

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes credential routing across multiple store entry points and secret-handling edge cases (requirePatternMatch, vault pointers); behavior is well covered by tests but affects security-sensitive storage paths.
> 
> **Overview**
> Fixes **#1896** where facts were dropped when broad patterns (e.g. `/token/i`) matched but no real secret could be extracted.
> 
> **Credential detection split:** Adds `isStructuredCredentialCandidate()` for vault routing (structured fields + `CREDENTIAL_PATTERNS` only). `isCredentialLike()` still includes broad `CAPTURE_FILTER_PATTERNS` for auto-capture filters. `tryParseCredentialForVault` gates on the narrow helper and ignores structured values that are already `vault:` pointers.
> 
> **Store paths** (`memory_store`, CLI store, distill, extract-daily) now call `tryParseCredentialForVault` first and only divert to the vault when parsing succeeds; otherwise they continue to normal fact storage instead of `credential_skipped` / silent skip. With **`requirePatternMatch`** enabled, structured-but-unparsed credential-like input is blocked from `facts.db` via `credential_blocked_require_pattern_match` (CLI + tool messaging).
> 
> **Tests** cover token-budget / API-key prose storing as memory, vault pointer rejection, and updated parse-failure expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51581b3cd62a9709c0a0c8ae3615f1081fcaa291. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->