### PR TITLE
fix(cron): verify/install use OpenClaw SQLite cron store (#1923)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- **#1923 OpenClaw 6.8+ cron store:** `verify`, `verify --fix`, install, maintenance inventory, dashboard, cron guard sync, and active-task wake scheduling now read/write the live OpenClaw cron store (`~/.openclaw/state/openclaw.sqlite`) when legacy `jobs.json` has been migrated, instead of creating a transient JSON file that OpenClaw immediately archives.
+
 ---
 
 ## [2026.6.160] - 2026-06-16

--- a/extensions/memory-hybrid/cli/commands/manage/register-maintenance-health.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/register-maintenance-health.ts
@@ -1,7 +1,6 @@
 /**
  * Maintenance inventory, status, and cron-health subcommands (Issue #281).
  */
-import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
@@ -12,6 +11,7 @@ import {
   renderMaintenanceInventoryText,
 } from "../../../services/maintenance-inventory.js";
 import { formatTimestampUtcFromMs } from "../../../utils/dates.js";
+import { readOpenClawCronStore, describeCronStoreLocation } from "../../../services/openclaw-cron-store.js";
 import { type Chainable, relativeTime, withExit } from "../../shared.js";
 
 export function registerMaintenanceHealthCommands(maintenance: Chainable, cfg: HybridMemoryConfig): void {
@@ -50,7 +50,7 @@ export function registerMaintenanceHealthCommands(maintenance: Chainable, cfg: H
     .option("--json", "Output as JSON")
     .action(
       withExit(async (opts?: { json?: boolean }) => {
-        const cronStorePath = join(homedir(), ".openclaw", "cron", "jobs.json");
+        const openclawDir = join(homedir(), ".openclaw");
         const staleThresholdMs = (cfg.maintenance?.cronReliability?.staleThresholdHours ?? 28) * 60 * 60 * 1000;
         const nightlyCronExpr = cfg.maintenance?.cronReliability?.nightlyCron ?? "0 3 * * *";
         const weeklyBackupCronExpr = cfg.maintenance?.cronReliability?.weeklyBackupCron ?? "0 4 * * 0";
@@ -95,14 +95,10 @@ export function registerMaintenanceHealthCommands(maintenance: Chainable, cfg: H
         const results: JobStatus[] = [];
 
         let cronStore: { jobs?: unknown[] } = { jobs: [] };
-        if (existsSync(cronStorePath)) {
-          try {
-            cronStore = JSON.parse(readFileSync(cronStorePath, "utf-8")) as {
-              jobs?: unknown[];
-            };
-          } catch {
-            // corrupt store — treat all as missing
-          }
+        try {
+          cronStore = readOpenClawCronStore(openclawDir).store;
+        } catch {
+          // corrupt store — treat all as missing
         }
 
         const jobs = Array.isArray(cronStore.jobs) ? (cronStore.jobs as Array<Record<string, unknown>>) : [];
@@ -189,7 +185,7 @@ export function registerMaintenanceHealthCommands(maintenance: Chainable, cfg: H
 
         console.log("Memory Maintenance Status (Issue #281)");
         console.log("========================================");
-        console.log(`Cron store: ${cronStorePath}`);
+        console.log(`Cron store: ${describeCronStoreLocation(openclawDir)}`);
         console.log(`Stale threshold (daily): ${cfg.maintenance?.cronReliability?.staleThresholdHours ?? 28}h`);
         console.log("");
 
@@ -228,23 +224,21 @@ export function registerMaintenanceHealthCommands(maintenance: Chainable, cfg: H
     )
     .action(
       withExit(async () => {
-        const cronStorePath = join(homedir(), ".openclaw", "cron", "jobs.json");
+        const openclawDir = join(homedir(), ".openclaw");
         const staleThresholdMs = (cfg.maintenance?.cronReliability?.staleThresholdHours ?? 28) * 60 * 60 * 1000;
         const useConsolidatedCron = cfg.maintenance?.orchestrator?.consolidatedCronJobs !== false;
         const criticalJobs = useConsolidatedCron ? ["hybrid-mem:maintenance-nightly"] : ["hybrid-mem:nightly-distill"];
 
         let cronStore: { jobs?: unknown[] } = { jobs: [] };
-        if (existsSync(cronStorePath)) {
-          try {
-            cronStore = JSON.parse(readFileSync(cronStorePath, "utf-8")) as {
-              jobs?: unknown[];
-            };
-          } catch {
-            console.warn("⚠ Could not read cron store — skipping health check.");
+        try {
+          const snapshot = readOpenClawCronStore(openclawDir);
+          cronStore = snapshot.store;
+          if ((snapshot.store.jobs?.length ?? 0) === 0 && snapshot.backend === "json") {
+            console.warn("⚠ Cron store not found — maintenance jobs not installed. Run: hybrid-mem install");
             return;
           }
-        } else {
-          console.warn("⚠ Cron store not found — maintenance jobs not installed. Run: hybrid-mem install");
+        } catch {
+          console.warn("⚠ Could not read cron store — skipping health check.");
           return;
         }
 

--- a/extensions/memory-hybrid/cli/commands/manage/register-maintenance-health.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/register-maintenance-health.ts
@@ -233,10 +233,6 @@ export function registerMaintenanceHealthCommands(maintenance: Chainable, cfg: H
         try {
           const snapshot = readOpenClawCronStore(openclawDir);
           cronStore = snapshot.store;
-          if ((snapshot.store.jobs?.length ?? 0) === 0 && snapshot.backend === "json") {
-            console.warn("⚠ Cron store not found — maintenance jobs not installed. Run: hybrid-mem install");
-            return;
-          }
         } catch {
           console.warn("⚠ Could not read cron store — skipping health check.");
           return;

--- a/extensions/memory-hybrid/cli/install/cron-jobs.ts
+++ b/extensions/memory-hybrid/cli/install/cron-jobs.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { mkdirSync } from "node:fs";
 import { join } from "node:path";
 
 import type { DigestWeeklyDeliveryConfig } from "../../config.js";
@@ -11,6 +11,10 @@ import {
 } from "../../services/cron-job-bash-harness.js";
 import { findDeprecatedHybridMemCronTokens } from "../../services/deprecated-cron-commands.js";
 import { capturePluginError } from "../../services/error-reporter.js";
+import {
+  readOpenClawCronStore,
+  writeOpenClawCronStore,
+} from "../../services/openclaw-cron-store.js";
 import {
   extractCronStoreJobModel,
   readAgentsPrimaryModelFromOpenclawJsonPath,
@@ -28,12 +32,8 @@ export function ensureGoalStewardshipHeartbeatCronJob(
   openclawDir: string,
   options: { heartbeatPatterns: string[] },
 ): { added: boolean; normalized: boolean; skippedReason?: string } {
-  const cronDir = join(openclawDir, "cron");
-  const cronStorePath = join(cronDir, "jobs.json");
-  mkdirSync(cronDir, { recursive: true });
-  const store: { jobs?: unknown[] } = existsSync(cronStorePath)
-    ? (JSON.parse(readFileSync(cronStorePath, "utf-8")) as { jobs?: unknown[] })
-    : {};
+  const cronSnapshot = readOpenClawCronStore(openclawDir);
+  const store = cronSnapshot.store;
   if (!Array.isArray(store.jobs)) store.jobs = [];
   const jobsArr = store.jobs as Array<Record<string, unknown>>;
   const existing = jobsArr.find(
@@ -68,10 +68,7 @@ export function ensureGoalStewardshipHeartbeatCronJob(
         text: desiredMessage,
       },
     });
-    const payload = JSON.stringify(store, null, 2);
-    const tmpPath = `${cronStorePath}.${process.pid}.${Date.now()}.tmp`;
-    writeFileSync(tmpPath, payload, "utf-8");
-    renameSync(tmpPath, cronStorePath);
+    writeOpenClawCronStore(openclawDir, store, cronSnapshot.backend);
     return { added: true, normalized: false };
   }
 
@@ -146,10 +143,7 @@ export function ensureGoalStewardshipHeartbeatCronJob(
 
   if (!changed) return { added: false, normalized: false };
 
-  const nextPayload = JSON.stringify(store, null, 2);
-  const tmpPath = `${cronStorePath}.${process.pid}.${Date.now()}.tmp`;
-  writeFileSync(tmpPath, nextPayload, "utf-8");
-  renameSync(tmpPath, cronStorePath);
+  writeOpenClawCronStore(openclawDir, store, cronSnapshot.backend);
   return { added: false, normalized: true };
 }
 
@@ -764,9 +758,9 @@ export function ensureMaintenanceCronJobs(
   const normalized: string[] = [];
   const openclawConfigPath = join(openclawDir, "openclaw.json");
   const agentPrimary = readAgentsPrimaryModelFromOpenclawJsonPath(openclawConfigPath);
-  const cronDir = join(openclawDir, "cron");
-  const cronStorePath = join(cronDir, "jobs.json");
-  mkdirSync(cronDir, { recursive: true });
+  const cronSnapshot = readOpenClawCronStore(openclawDir);
+  const store = cronSnapshot.store;
+  mkdirSync(join(openclawDir, "cron"), { recursive: true });
   try {
     mkdirSync(join(openclawDir, "logs", "cron-hybrid-mem"), { recursive: true });
   } catch (err) {
@@ -776,9 +770,6 @@ export function ensureMaintenanceCronJobs(
       severity: "info",
     });
   }
-  const store: { jobs?: unknown[] } = existsSync(cronStorePath)
-    ? (JSON.parse(readFileSync(cronStorePath, "utf-8")) as { jobs?: unknown[] })
-    : {};
   if (!Array.isArray(store.jobs)) store.jobs = [];
   const jobsArr = store.jobs as Array<Record<string, unknown>>;
   let jobsChanged = false;
@@ -1056,10 +1047,7 @@ export function ensureMaintenanceCronJobs(
     }
   }
   if (jobsChanged) {
-    const payload = JSON.stringify(store, null, 2);
-    const tmpPath = `${cronStorePath}.${process.pid}.${Date.now()}.tmp`;
-    writeFileSync(tmpPath, payload, "utf-8");
-    renameSync(tmpPath, cronStorePath);
+    writeOpenClawCronStore(openclawDir, store, cronSnapshot.backend);
   }
   return { added, normalized };
 }

--- a/extensions/memory-hybrid/cli/verify/sections/config-cron.ts
+++ b/extensions/memory-hybrid/cli/verify/sections/config-cron.ts
@@ -23,6 +23,10 @@ import {
 import { resolveMaintenanceSummaryPath } from "../../../services/maintenance-artifact-paths.js";
 import { capturePluginError } from "../../../services/error-reporter.js";
 import {
+  describeCronStoreLocation,
+  readOpenClawCronStore,
+} from "../../../services/openclaw-cron-store.js";
+import {
   analyzeCronJobsAgainstHeartbeatPatterns,
   extractCronJobMessageEntries,
   getHeartbeatMatchersForVerify,
@@ -39,9 +43,9 @@ import {
   isConsolidatedMaintenanceCronEnabled,
   readConsolidatedCronJobsFlag,
 } from "../../install/cron-jobs.js";
-import { approxIntervalMs, relativeTime } from "../../shared.js";
-
 import type { VerifyRunState } from "../verify-run-state.js";
+
+import { approxIntervalMs, relativeTime } from "../../shared.js";
 
 /** Former standalone cron jobs — now config-gated orchestrator modules (not separate cron entries). */
 const CONSOLIDATED_FORMER_STANDALONE_MODULES: Array<{
@@ -200,7 +204,9 @@ export async function runVerifyConfigCronSection(state: VerifyRunState): Promise
   }
 
   // Job name regex patterns for matching (use normalized name so "Weekly Reflection" etc. match)
-  const cronStorePath = join(openclawDir, "cron", "jobs.json");
+  const cronStoreSnapshot = readOpenClawCronStore(openclawDir);
+  const cronStoreLabel = describeCronStoreLocation(openclawDir, cronStoreSnapshot.backend);
+  const cronStoreHasJobs = (cronStoreSnapshot.store.jobs?.length ?? 0) > 0;
   const nightlyMemorySweepRe = /nightly[- ]?memory[- ]?sweep|memory distillation.*nightly|nightly.*memory.*distill/i;
   const weeklyReflectionRe = /weekly[- ]?reflection|memory reflection|pattern synthesis/i;
   const extractProceduresRe = /extract[- ]?procedures|weekly[- ]?extract[- ]?procedures|procedural memory/i;
@@ -227,14 +233,12 @@ export async function runVerifyConfigCronSection(state: VerifyRunState): Promise
     log(`  Heartbeat patterns compiled: ${matchers.length} matcher(s)${patternsHint}.`);
     log("  See docs/GOAL-STEWARDSHIP-OPERATOR.md (Heartbeat scheduling checklist).");
     try {
-      if (!existsSync(cronStorePath)) {
+      if (!cronStoreHasJobs) {
         log(
-          `${WARN} Cannot confirm heartbeat cron: ${cronStorePath} not found. Run \`openclaw hybrid-mem verify --fix\` to seed maintenance jobs, then add a small heartbeat job whose message matches one of the patterns above.`,
+          `${WARN} Cannot confirm heartbeat cron: no jobs in OpenClaw cron store (${cronStoreLabel}). Run \`openclaw hybrid-mem verify --fix\` to seed maintenance jobs, then add a small heartbeat job whose message matches one of the patterns above.`,
         );
       } else {
-        const raw = readFileSync(cronStorePath, "utf-8");
-        const store = JSON.parse(raw) as { jobs?: unknown[] };
-        const entries = extractCronJobMessageEntries(store);
+        const entries = extractCronJobMessageEntries(cronStoreSnapshot.store);
         const h = analyzeCronJobsAgainstHeartbeatPatterns(matchers, entries);
         const withText = entries.filter((e) => e.text.length > 0).length;
         if (entries.length === 0) {
@@ -442,10 +446,9 @@ export async function runVerifyConfigCronSection(state: VerifyRunState): Promise
     return "ok";
   }
 
-  if (existsSync(cronStorePath)) {
+  if (cronStoreHasJobs) {
     try {
-      const raw = readFileSync(cronStorePath, "utf-8");
-      const store = JSON.parse(raw) as Record<string, unknown>;
+      const store = cronStoreSnapshot.store as Record<string, unknown>;
       const jobs = store.jobs;
       if (Array.isArray(jobs)) {
         for (const j of jobs) {
@@ -578,8 +581,8 @@ export async function runVerifyConfigCronSection(state: VerifyRunState): Promise
 
   cronLog(
     useConsolidatedCron
-      ? "\nScheduled maintenance (consolidated orchestrator — ~/.openclaw/cron/jobs.json):"
-      : "\nScheduled jobs (cron store at ~/.openclaw/cron/jobs.json):",
+      ? `\nScheduled maintenance (consolidated orchestrator — ${cronStoreLabel}):`
+      : `\nScheduled jobs (OpenClaw cron store at ${cronStoreLabel}):`,
   );
   if (useConsolidatedCron) {
     cronLog(
@@ -744,14 +747,12 @@ export async function runVerifyConfigCronSection(state: VerifyRunState): Promise
   // Issue #965 — isolated hybrid-mem cron runs must not request a different provider family than
   // agents.defaults.model.primary or OpenClaw may throw LiveSessionModelSwitchError.
   try {
-    if (openclawConfigRead.root && existsSync(cronStorePath)) {
+    if (openclawConfigRead.root && cronStoreHasJobs) {
       const root = openclawConfigRead.root;
       const agentPrimary = readEffectiveAgentChatPrimaryFromOpenclawJsonRoot(root);
       if (agentPrimary) {
         const agentFam = inferModelProviderPrefix(agentPrimary);
-        const rawStore = readFileSync(cronStorePath, "utf-8");
-        const store = JSON.parse(rawStore) as { jobs?: unknown[] };
-        const jobs = Array.isArray(store.jobs) ? store.jobs : [];
+        const jobs = Array.isArray(cronStoreSnapshot.store.jobs) ? cronStoreSnapshot.store.jobs : [];
         const WARN = noEmoji ? "[WARN]" : "⚠️";
         for (const j of jobs) {
           if (typeof j !== "object" || j === null) continue;

--- a/extensions/memory-hybrid/cli/verify/sections/config-cron.ts
+++ b/extensions/memory-hybrid/cli/verify/sections/config-cron.ts
@@ -204,7 +204,18 @@ export async function runVerifyConfigCronSection(state: VerifyRunState): Promise
   }
 
   // Job name regex patterns for matching (use normalized name so "Weekly Reflection" etc. match)
-  const cronStoreSnapshot = readOpenClawCronStore(openclawDir);
+  let cronStoreSnapshot;
+  try {
+    cronStoreSnapshot = readOpenClawCronStore(openclawDir);
+  } catch (err) {
+    const FAIL = noEmoji ? "[FAIL]" : "❌";
+    log(`\n${FAIL} Cron store read failed: ${err instanceof Error ? err.message : String(err)}`);
+    state.issues.push(`Cron store read error: ${err instanceof Error ? err.message : String(err)}`);
+    state.fixes.push(
+      "Fix corrupt cron JSON: restore from backup or delete the file to start fresh. See docs/TROUBLESHOOTING.md.",
+    );
+    return;
+  }
   const cronStoreLabel = describeCronStoreLocation(openclawDir, cronStoreSnapshot.backend);
   const cronStoreHasJobs = (cronStoreSnapshot.store.jobs?.length ?? 0) > 0;
   const nightlyMemorySweepRe = /nightly[- ]?memory[- ]?sweep|memory distillation.*nightly|nightly.*memory.*distill/i;

--- a/extensions/memory-hybrid/cli/verify/sections/reconcile.ts
+++ b/extensions/memory-hybrid/cli/verify/sections/reconcile.ts
@@ -19,6 +19,7 @@ import { appendVectorLifecycleAuditEvent } from "../../../services/vector-lifecy
 import { findOrphanVectorIds, reconcileOrphanVectors } from "../../../services/vector-maintenance.js";
 import { PLUGIN_ID } from "../../../utils/constants.js";
 import { nowIso, formatTimestampUtcFromMs } from "../../../utils/dates.js";
+import { describeCronStoreLocation } from "../../../services/openclaw-cron-store.js";
 import { ensureGoalStewardshipHeartbeatCronJob, ensureMaintenanceCronJobs } from "../../cmd-install.js";
 import { readConsolidatedCronJobsFlag } from "../../install/cron-jobs.js";
 
@@ -328,8 +329,7 @@ export async function runVerifyReconcileSection(state: VerifyRunState): Promise<
         }
 
         // Add cron jobs (same logic as install)
-        const cronDir = join(openclawDir, "cron");
-        const cronStorePath = join(cronDir, "jobs.json");
+        const cronStorePath = describeCronStoreLocation(openclawDir);
 
         try {
           const scheduleOverrides: Record<string, string> = {};

--- a/extensions/memory-hybrid/routes/dashboard/collectors.ts
+++ b/extensions/memory-hybrid/routes/dashboard/collectors.ts
@@ -28,6 +28,7 @@ import type { VectorDB } from "../../backends/vector-db.js";
 import type { WorkflowStore } from "../../backends/workflow-store.js";
 import type { EvolutionStats } from "../../services/evolution-stats.js";
 import { collectEvolutionStats } from "../../services/evolution-stats.js";
+import { readOpenClawCronStore } from "../../services/openclaw-cron-store.js";
 import type { VerificationStore } from "../../services/verification-store.js";
 import { getDirSize, getFileSizeAsync, readJsonFile } from "../../utils/fs.js";
 import { formatTimestampUtc, nowIso } from "../../utils/dates.js";
@@ -524,11 +525,9 @@ async function collectMemoryStats(ctx: DashboardContext): Promise<MemoryStats> {
 
 async function collectCronJobs(): Promise<CronJobStatus[]> {
   const openclawDir = join(homedir(), ".openclaw");
-  const cronStorePath = join(openclawDir, "cron", "jobs.json");
-  if (!existsSync(cronStorePath)) return [];
   try {
-    const store = await readJsonFile<{ jobs?: unknown[] }>(cronStorePath);
-    if (!store || !Array.isArray(store.jobs)) return [];
+    const { store } = readOpenClawCronStore(openclawDir);
+    if (!Array.isArray(store.jobs)) return [];
     return store.jobs
       .filter((j): j is Record<string, unknown> => typeof j === "object" && j !== null)
       .map((job) => {

--- a/extensions/memory-hybrid/services/active-task-checkpoint.ts
+++ b/extensions/memory-hybrid/services/active-task-checkpoint.ts
@@ -18,6 +18,7 @@ import {
   activeTaskRenderGoalsOpts,
 } from "./task-ledger-facts.js";
 import { buildGuardPrefix } from "./cron-guard.js";
+import { describeCronStoreLocation, readOpenClawCronStore, writeOpenClawCronStore } from "./openclaw-cron-store.js";
 import type { EmbeddingProvider } from "./embeddings.js";
 
 const ACTIVE_TASK_WAKE_JOB_PREFIX = "hybrid-mem:active-task-wake:";
@@ -389,19 +390,15 @@ async function disableActiveTaskWakeJobsForEntity(
 ): Promise<{ jobsPath: string; disabled: number }> {
   const openclawDir = resolveOpenclawDir(openclawDirOverride);
   return withCronJobsLock(openclawDir, () => {
-    const cronDir = join(openclawDir, "cron");
-    const jobsPath = join(cronDir, "jobs.json");
-    if (!existsSync(jobsPath)) {
-      return { jobsPath, disabled: 0 };
-    }
-
-    let store: { jobs?: unknown[] };
+    const jobsPath = describeCronStoreLocation(openclawDir);
+    let snapshot: ReturnType<typeof readOpenClawCronStore>;
     try {
-      store = JSON.parse(readFileSync(jobsPath, "utf-8")) as { jobs?: unknown[] };
+      snapshot = readOpenClawCronStore(openclawDir);
     } catch (err) {
-      throw new Error(`failed to parse ${jobsPath}: ${String(err)}`);
+      throw new Error(`failed to read OpenClaw cron store at ${jobsPath}: ${String(err)}`);
     }
 
+    const store = snapshot.store;
     if (!Array.isArray(store.jobs)) {
       return { jobsPath, disabled: 0 };
     }
@@ -412,10 +409,7 @@ async function disableActiveTaskWakeJobsForEntity(
       return { jobsPath, disabled: 0 };
     }
 
-    const payload = JSON.stringify(store, null, 2);
-    const tmpPath = `${jobsPath}.${process.pid}.${Date.now()}.tmp`;
-    writeFileSync(tmpPath, payload, "utf-8");
-    renameSync(tmpPath, jobsPath);
+    writeOpenClawCronStore(openclawDir, store, snapshot.backend);
     return { jobsPath, disabled };
   });
 }
@@ -487,17 +481,9 @@ async function scheduleActiveTaskWakeReminder(
 ): Promise<ActiveTaskWakeScheduleResult> {
   const openclawDir = resolveOpenclawDir(input.openclawDir);
   return withCronJobsLock(openclawDir, () => {
-    const cronDir = join(openclawDir, "cron");
-    const jobsPath = join(cronDir, "jobs.json");
-
-    let store: { jobs?: unknown[] } = {};
-    if (existsSync(jobsPath)) {
-      try {
-        store = JSON.parse(readFileSync(jobsPath, "utf-8")) as { jobs?: unknown[] };
-      } catch (err) {
-        throw new Error(`failed to parse ${jobsPath}: ${String(err)}`);
-      }
-    }
+    const jobsPath = describeCronStoreLocation(openclawDir);
+    const snapshot = readOpenClawCronStore(openclawDir);
+    const store = snapshot.store;
 
     if (!Array.isArray(store.jobs)) {
       store.jobs = [];
@@ -563,10 +549,7 @@ async function scheduleActiveTaskWakeReminder(
       jobs.push(job);
     }
 
-    const payload = JSON.stringify(store, null, 2);
-    const tmpPath = `${jobsPath}.${process.pid}.${Date.now()}.tmp`;
-    writeFileSync(tmpPath, payload, "utf-8");
-    renameSync(tmpPath, jobsPath);
+    writeOpenClawCronStore(openclawDir, store, snapshot.backend);
 
     return {
       scheduled: true,

--- a/extensions/memory-hybrid/services/cron-guard.ts
+++ b/extensions/memory-hybrid/services/cron-guard.ts
@@ -19,9 +19,11 @@
  *   runner processes the queue on startup.
  */
 
-import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, readdirSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
+
+import { readOpenClawCronStore, writeOpenClawCronStore } from "./openclaw-cron-store.js";
 
 /** Subdirectory (relative to openclawDir) where guard files are kept. */
 export const GUARD_SUBDIR = join("cron", "guard");
@@ -121,19 +123,16 @@ type Logger = { info: (s: string) => void; warn: (s: string) => void };
 export function syncCronLastRunFromGuards(logger: Logger, openclawDir?: string): void {
   const dir = openclawDir ?? join(homedir(), ".openclaw");
   const guardDir = getGuardDir(dir);
-  const cronStorePath = join(dir, "cron", "jobs.json");
 
-  if (!existsSync(cronStorePath)) return;
-
-  let store: { jobs?: unknown[] };
+  let snapshot: ReturnType<typeof readOpenClawCronStore>;
   try {
-    store = JSON.parse(readFileSync(cronStorePath, "utf-8")) as { jobs?: unknown[] };
+    snapshot = readOpenClawCronStore(dir);
   } catch {
     return;
   }
-  if (!Array.isArray(store.jobs)) return;
+  if (!Array.isArray(snapshot.store.jobs) || snapshot.store.jobs.length === 0) return;
 
-  const jobs = store.jobs as Array<Record<string, unknown>>;
+  const jobs = snapshot.store.jobs as Array<Record<string, unknown>>;
 
   // Collect guard timestamps keyed by jobName (normalized: spaces → hyphens).
   // The persistent files take precedence over legacy /tmp/ files.
@@ -194,10 +193,10 @@ export function syncCronLastRunFromGuards(logger: Logger, openclawDir?: string):
 
   if (synced > 0) {
     try {
-      writeFileSync(cronStorePath, JSON.stringify(store, null, 2), "utf-8");
+      writeOpenClawCronStore(dir, snapshot.store, snapshot.backend);
       logger.info(`memory-hybrid: synced lastRunAtMs for ${synced} cron job(s) from persistent guard files`);
     } catch (err) {
-      logger.warn(`memory-hybrid: failed to write cron guard sync to jobs.json: ${err}`);
+      logger.warn(`memory-hybrid: failed to write cron guard sync to OpenClaw cron store: ${err}`);
     }
   }
 }

--- a/extensions/memory-hybrid/services/maintenance-inventory.ts
+++ b/extensions/memory-hybrid/services/maintenance-inventory.ts
@@ -3,7 +3,7 @@ import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { basename, join } from "node:path";
 
 import { relativeTime } from "../cli/shared.js";
-import { describeCronStoreLocation, readOpenClawCronStore, resolveLegacyCronJobsPath } from "./openclaw-cron-store.js";
+import { describeCronStoreLocation, readOpenClawCronStore } from "./openclaw-cron-store.js";
 import { getGuardFilePath, readGuardTimestampMs } from "./cron-guard.js";
 import { readExitLedger, validateMaintenanceExecution } from "./cron-exit-validator.js";
 import { HYBRID_MEM_CRON_DEFAULT_JOB_STEPS } from "./hybrid-mem-cron-default-job-steps.js";
@@ -712,7 +712,7 @@ export function collectMaintenanceInventory(
   openclawDir: string,
   options: MaintenanceInventoryOptions = {},
 ): MaintenanceInventoryReport {
-  const cronStorePath = resolveLegacyCronJobsPath(openclawDir);
+  const cronStorePath = describeCronStoreLocation(openclawDir);
   const logRoot = join(openclawDir, "logs", "cron-hybrid-mem");
   const crontab =
     options.crontabText !== undefined || options.crontabError !== undefined

--- a/extensions/memory-hybrid/services/maintenance-inventory.ts
+++ b/extensions/memory-hybrid/services/maintenance-inventory.ts
@@ -3,6 +3,7 @@ import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { basename, join } from "node:path";
 
 import { relativeTime } from "../cli/shared.js";
+import { describeCronStoreLocation, readOpenClawCronStore, resolveLegacyCronJobsPath } from "./openclaw-cron-store.js";
 import { getGuardFilePath, readGuardTimestampMs } from "./cron-guard.js";
 import { readExitLedger, validateMaintenanceExecution } from "./cron-exit-validator.js";
 import { HYBRID_MEM_CRON_DEFAULT_JOB_STEPS } from "./hybrid-mem-cron-default-job-steps.js";
@@ -545,6 +546,7 @@ function parseGatewayJobs(
   rawJobs: unknown[],
   artifacts: Map<string, MaintenanceArtifacts>,
 ): MaintenanceInventoryJob[] {
+  const cronStoreDisplayPath = describeCronStoreLocation(openclawDir);
   const jobsByInventoryId = new Map<string, MaintenanceInventoryJob>();
   const rawPluginJobIdByInventoryId = new Map<string, string | undefined>();
   for (const rawJob of rawJobs) {
@@ -601,7 +603,7 @@ function parseGatewayJobs(
       scheduleKind: schedule.scheduleKind,
       timezone: schedule.timezone,
       prompt,
-      sourceRef: join(openclawDir, "cron", "jobs.json"),
+      sourceRef: cronStoreDisplayPath,
       guardPath,
       lastRunAt: lastRun.lastRunAt,
       lastRunSource: lastRun.lastRunSource,
@@ -710,7 +712,7 @@ export function collectMaintenanceInventory(
   openclawDir: string,
   options: MaintenanceInventoryOptions = {},
 ): MaintenanceInventoryReport {
-  const cronStorePath = join(openclawDir, "cron", "jobs.json");
+  const cronStorePath = resolveLegacyCronJobsPath(openclawDir);
   const logRoot = join(openclawDir, "logs", "cron-hybrid-mem");
   const crontab =
     options.crontabText !== undefined || options.crontabError !== undefined
@@ -728,13 +730,20 @@ export function collectMaintenanceInventory(
   let cronStoreStatus: CronStoreStatus = "missing";
   let cronStoreError: string | undefined;
   let cronStoreJobs: unknown[] = [];
-  const cronStoreText =
-    options.cronStoreText ?? (existsSync(cronStorePath) ? readFileSync(cronStorePath, "utf-8") : undefined);
-  if (cronStoreText != null) {
+  if (options.cronStoreText != null) {
     try {
-      const parsed = JSON.parse(cronStoreText) as { jobs?: unknown[] };
+      const parsed = JSON.parse(options.cronStoreText) as { jobs?: unknown[] };
       cronStoreJobs = Array.isArray(parsed.jobs) ? parsed.jobs : [];
       cronStoreStatus = "present";
+    } catch (error) {
+      cronStoreStatus = "invalid";
+      cronStoreError = error instanceof Error ? error.message : String(error);
+    }
+  } else {
+    try {
+      const snapshot = readOpenClawCronStore(openclawDir);
+      cronStoreJobs = Array.isArray(snapshot.store.jobs) ? snapshot.store.jobs : [];
+      cronStoreStatus = cronStoreJobs.length > 0 || snapshot.backend === "sqlite" ? "present" : "missing";
     } catch (error) {
       cronStoreStatus = "invalid";
       cronStoreError = error instanceof Error ? error.message : String(error);

--- a/extensions/memory-hybrid/services/openclaw-cron-store.ts
+++ b/extensions/memory-hybrid/services/openclaw-cron-store.ts
@@ -125,11 +125,21 @@ function mergeJobFromSqliteRow(row: {
   schedule_expr: string | null;
   job_id: string;
   name: string;
+  last_run_at_ms: number | null;
+  next_run_at_ms: number | null;
+  last_run_status: string | null;
 }): Record<string, unknown> {
   const config = parseJsonObject(row.job_json, {});
   const state = parseJsonObject(row.state_json, {});
   if (typeof state.lastRunStatus === "string" && state.lastStatus == null) {
     state.lastStatus = state.lastRunStatus;
+  }
+  // Indexed columns are authoritative for runtime fields (state_json can lag).
+  if (row.last_run_at_ms != null) state.lastRunAtMs = row.last_run_at_ms;
+  if (row.next_run_at_ms != null) state.nextRunAtMs = row.next_run_at_ms;
+  if (row.last_run_status != null) {
+    state.lastRunStatus = row.last_run_status;
+    if (state.lastStatus == null) state.lastStatus = row.last_run_status;
   }
   const job: Record<string, unknown> = { ...config, state };
   if (job.id == null && row.job_id) job.id = row.job_id;
@@ -160,7 +170,8 @@ function readCronStoreFromSqlite(sqlitePath: string, storeKey: string): OpenClaw
     if (!sqliteHasCronJobsTable(db)) return { version: 1, jobs: [] };
     const rows = db
       .prepare(
-        `SELECT job_id, name, enabled, schedule_expr, job_json, state_json
+        `SELECT job_id, name, enabled, schedule_expr, job_json, state_json,
+                last_run_at_ms, next_run_at_ms, last_run_status
          FROM cron_jobs
          WHERE store_key = ?
          ORDER BY sort_order ASC, updated_at ASC, job_id ASC`,
@@ -172,6 +183,9 @@ function readCronStoreFromSqlite(sqlitePath: string, storeKey: string): OpenClaw
       schedule_expr: string | null;
       job_json: string;
       state_json: string | null;
+      last_run_at_ms: number | null;
+      next_run_at_ms: number | null;
+      last_run_status: string | null;
     }>;
     return {
       version: 1,

--- a/extensions/memory-hybrid/services/openclaw-cron-store.ts
+++ b/extensions/memory-hybrid/services/openclaw-cron-store.ts
@@ -134,7 +134,8 @@ function mergeJobFromSqliteRow(row: {
   const job: Record<string, unknown> = { ...config, state };
   if (job.id == null && row.job_id) job.id = row.job_id;
   if (job.name == null && row.name) job.name = row.name;
-  if (job.enabled === undefined) job.enabled = row.enabled !== 0;
+  // SQLite indexed column is authoritative for enabled (job_json can lag).
+  job.enabled = row.enabled !== 0;
   if (job.schedule == null && row.schedule_expr) {
     job.schedule = { kind: "cron", expr: row.schedule_expr };
   }
@@ -143,7 +144,12 @@ function mergeJobFromSqliteRow(row: {
 
 function readCronStoreFromJson(legacyPath: string): OpenClawCronStoreFile {
   if (!existsSync(legacyPath)) return { version: 1, jobs: [] };
-  const parsed = JSON.parse(readFileSync(legacyPath, "utf-8")) as OpenClawCronStoreFile;
+  let parsed: OpenClawCronStoreFile;
+  try {
+    parsed = JSON.parse(readFileSync(legacyPath, "utf-8")) as OpenClawCronStoreFile;
+  } catch (err) {
+    throw new Error(`failed to parse cron store at ${legacyPath}: ${err instanceof Error ? err.message : String(err)}`);
+  }
   if (!Array.isArray(parsed.jobs)) parsed.jobs = [];
   return parsed;
 }
@@ -533,6 +539,20 @@ function writeCronStoreToJson(legacyPath: string, store: OpenClawCronStoreFile):
   renameSync(tmpPath, legacyPath);
 }
 
+function cronJobRowId(rawJob: Record<string, unknown>): string {
+  return String(rawJob.id ?? rawJob.pluginJobId ?? rawJob.name ?? "").trim();
+}
+
+function loadExistingSqliteCronRows(db: DatabaseSync, storeKey: string): Map<string, Record<string, unknown>> {
+  const rows = db.prepare(`SELECT * FROM cron_jobs WHERE store_key = ?`).all(storeKey) as Array<Record<string, unknown>>;
+  const out = new Map<string, Record<string, unknown>>();
+  for (const row of rows) {
+    const jobId = String(row.job_id ?? "");
+    if (jobId) out.set(jobId, row);
+  }
+  return out;
+}
+
 function writeCronStoreToSqlite(sqlitePath: string, storeKey: string, store: OpenClawCronStoreFile): void {
   mkdirSync(dirname(sqlitePath), { recursive: true });
   const db = new DatabaseSync(sqlitePath);
@@ -540,21 +560,49 @@ function writeCronStoreToSqlite(sqlitePath: string, storeKey: string, store: Ope
     if (!sqliteHasCronJobsTable(db)) {
       throw new Error("cron_jobs table missing in OpenClaw state database");
     }
+    const existingByJobId = loadExistingSqliteCronRows(db, storeKey);
     const jobs = Array.isArray(store.jobs) ? (store.jobs as Array<Record<string, unknown>>) : [];
+    const incomingIds = new Set<string>();
+    const rowsToInsert: Array<Record<string, string | number | null>> = [];
+
+    let sortOrder = 0;
+    for (const rawJob of jobs) {
+      if (typeof rawJob !== "object" || rawJob === null) continue;
+      const jobId = cronJobRowId(rawJob);
+      if (!jobId) {
+        throw new Error("Refusing to persist cron store with a job missing id/pluginJobId/name");
+      }
+      incomingIds.add(jobId);
+      const row = bindCronJobInsertRow(storeKey, rawJob, sortOrder);
+      if (row) {
+        rowsToInsert.push(row);
+        sortOrder += 1;
+        continue;
+      }
+      const preserved = existingByJobId.get(jobId);
+      if (preserved) {
+        rowsToInsert.push(preserved as Record<string, string | number | null>);
+        sortOrder += 1;
+        continue;
+      }
+      throw new Error(
+        `Job normalization failed for ${JSON.stringify(rawJob).slice(0, 200)}; refusing to drop job from SQLite store`,
+      );
+    }
+
+    // Keep DB rows not represented in the in-memory store (defensive — full reads should include all jobs).
+    for (const [jobId, preserved] of existingByJobId) {
+      if (!incomingIds.has(jobId)) {
+        rowsToInsert.push(preserved as Record<string, string | number | null>);
+        sortOrder += 1;
+      }
+    }
+
     const tx = createTransaction(db, () => {
       db.prepare(`DELETE FROM cron_jobs WHERE store_key = ?`).run(storeKey);
       const insert = db.prepare(CRON_JOBS_INSERT_SQL);
-      let sortOrder = 0;
-      for (const rawJob of jobs) {
-        if (typeof rawJob !== "object" || rawJob === null) continue;
-        const row = bindCronJobInsertRow(storeKey, rawJob, sortOrder);
-        if (!row) {
-          throw new Error(
-            `Job normalization failed for ${JSON.stringify(rawJob).slice(0, 200)}; refusing to drop job from SQLite store`,
-          );
-        }
+      for (const row of rowsToInsert) {
         insert.run(row);
-        sortOrder += 1;
       }
     }, "IMMEDIATE");
     tx();

--- a/extensions/memory-hybrid/services/openclaw-cron-store.ts
+++ b/extensions/memory-hybrid/services/openclaw-cron-store.ts
@@ -1,0 +1,592 @@
+/**
+ * Read/write OpenClaw cron job stores — legacy JSON (~/.openclaw/cron/jobs.json) and
+ * SQLite (~/.openclaw/state/openclaw.sqlite) used by OpenClaw 2026.6.8+.
+ *
+ * Issue #1923: verify/install must target the live store, not a deprecated JSON file
+ * that OpenClaw migrates away on load.
+ */
+
+import { existsSync, mkdirSync, readFileSync, readdirSync, renameSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+
+import { createTransaction } from "../utils/sqlite-transaction.js";
+
+export type CronStoreBackend = "json" | "sqlite";
+
+export type OpenClawCronStoreFile = {
+  version?: number;
+  jobs?: unknown[];
+};
+
+export type OpenClawCronStoreSnapshot = {
+  store: OpenClawCronStoreFile;
+  backend: CronStoreBackend;
+  /** Human-facing path shown in CLI output. */
+  displayPath: string;
+  /** Legacy logical partition key (resolved jobs.json path). */
+  legacyStorePath: string;
+};
+
+/** Default legacy cron store path (logical partition key in SQLite). */
+export function resolveLegacyCronJobsPath(openclawDir: string): string {
+  return join(openclawDir, "cron", "jobs.json");
+}
+
+/** Shared OpenClaw state database (cron rows live here on 2026.6.8+). */
+export function resolveOpenClawStateSqlitePath(openclawDir: string): string {
+  return join(openclawDir, "state", "openclaw.sqlite");
+}
+
+/** Partition key OpenClaw uses in cron_jobs.store_key (resolved legacy jobs.json path). */
+export function cronStorePartitionKey(legacyStorePath: string): string {
+  return resolve(legacyStorePath);
+}
+
+function sqliteHasCronJobsTable(db: DatabaseSync): boolean {
+  const row = db.prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name='cron_jobs'`).get();
+  return row != null;
+}
+
+function countSqliteCronRows(db: DatabaseSync, storeKey: string): number {
+  const row = db.prepare(`SELECT COUNT(*) AS c FROM cron_jobs WHERE store_key = ?`).get(storeKey) as
+    | { c: number }
+    | undefined;
+  return row?.c ?? 0;
+}
+
+function hasMigratedLegacyCronFile(openclawDir: string): boolean {
+  const cronDir = join(openclawDir, "cron");
+  if (!existsSync(cronDir)) return false;
+  try {
+    return readdirSync(cronDir).some((f) => /^jobs\.json\.migrated(\.\d+)?$/.test(f));
+  } catch {
+    return false;
+  }
+}
+
+/** Choose JSON vs SQLite backend for read/write on this host. */
+export function detectCronStoreBackend(openclawDir: string): CronStoreBackend {
+  const legacyPath = resolveLegacyCronJobsPath(openclawDir);
+  const sqlitePath = resolveOpenClawStateSqlitePath(openclawDir);
+
+  if (!existsSync(sqlitePath)) {
+    return "json";
+  }
+
+  try {
+    const db = new DatabaseSync(sqlitePath, { readOnly: true });
+    try {
+      if (!sqliteHasCronJobsTable(db)) return "json";
+      const storeKey = cronStorePartitionKey(legacyPath);
+      if (countSqliteCronRows(db, storeKey) > 0) return "sqlite";
+      if (existsSync(legacyPath)) return "json";
+      // Migrated or fresh 6.8+ host: jobs.json absent, SQLite is canonical.
+      if (hasMigratedLegacyCronFile(openclawDir)) return "sqlite";
+      return "sqlite";
+    } finally {
+      db.close();
+    }
+  } catch {
+    return existsSync(legacyPath) ? "json" : "json";
+  }
+}
+
+export function describeCronStoreLocation(openclawDir: string, backend?: CronStoreBackend): string {
+  const resolved = backend ?? detectCronStoreBackend(openclawDir);
+  if (resolved === "sqlite") {
+    return resolveOpenClawStateSqlitePath(openclawDir);
+  }
+  return resolveLegacyCronJobsPath(openclawDir);
+}
+
+function parseJsonObject(raw: string | null | undefined, fallback: Record<string, unknown>): Record<string, unknown> {
+  if (!raw?.trim()) return fallback;
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    return typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+function mergeJobFromSqliteRow(row: {
+  job_json: string;
+  state_json: string | null;
+  enabled: number;
+  schedule_expr: string | null;
+  job_id: string;
+  name: string;
+}): Record<string, unknown> {
+  const config = parseJsonObject(row.job_json, {});
+  const state = parseJsonObject(row.state_json, {});
+  const job: Record<string, unknown> = { ...config, state };
+  if (job.id == null && row.job_id) job.id = row.job_id;
+  if (job.name == null && row.name) job.name = row.name;
+  if (job.enabled === undefined) job.enabled = row.enabled !== 0;
+  if (job.schedule == null && row.schedule_expr) {
+    job.schedule = { kind: "cron", expr: row.schedule_expr };
+  }
+  return job;
+}
+
+function readCronStoreFromJson(legacyPath: string): OpenClawCronStoreFile {
+  if (!existsSync(legacyPath)) return { version: 1, jobs: [] };
+  const parsed = JSON.parse(readFileSync(legacyPath, "utf-8")) as OpenClawCronStoreFile;
+  if (!Array.isArray(parsed.jobs)) parsed.jobs = [];
+  return parsed;
+}
+
+function readCronStoreFromSqlite(sqlitePath: string, storeKey: string): OpenClawCronStoreFile {
+  const db = new DatabaseSync(sqlitePath, { readOnly: true });
+  try {
+    if (!sqliteHasCronJobsTable(db)) return { version: 1, jobs: [] };
+    const rows = db
+      .prepare(
+        `SELECT job_id, name, enabled, schedule_expr, job_json, state_json
+         FROM cron_jobs
+         WHERE store_key = ?
+         ORDER BY sort_order ASC, updated_at ASC, job_id ASC`,
+      )
+      .all(storeKey) as Array<{
+      job_id: string;
+      name: string;
+      enabled: number;
+      schedule_expr: string | null;
+      job_json: string;
+      state_json: string | null;
+    }>;
+    return {
+      version: 1,
+      jobs: rows.map((row) => mergeJobFromSqliteRow(row)),
+    };
+  } finally {
+    db.close();
+  }
+}
+
+/** Load cron jobs from the live store (SQLite when migrated, else legacy JSON). */
+export function readOpenClawCronStore(openclawDir: string): OpenClawCronStoreSnapshot {
+  const legacyStorePath = resolveLegacyCronJobsPath(openclawDir);
+  const backend = detectCronStoreBackend(openclawDir);
+  const displayPath = describeCronStoreLocation(openclawDir, backend);
+  const store =
+    backend === "sqlite"
+      ? readCronStoreFromSqlite(resolveOpenClawStateSqlitePath(openclawDir), cronStorePartitionKey(legacyStorePath))
+      : readCronStoreFromJson(legacyStorePath);
+  if (!Array.isArray(store.jobs)) store.jobs = [];
+  return { store, backend, displayPath, legacyStorePath };
+}
+
+function boolToInt(v: boolean | undefined | null): number | null {
+  if (v == null) return null;
+  return v ? 1 : 0;
+}
+
+function numOrNull(v: unknown): number | null {
+  return typeof v === "number" && Number.isFinite(v) ? v : null;
+}
+
+function strOrNull(v: unknown): string | null {
+  return typeof v === "string" && v.length > 0 ? v : null;
+}
+
+function stripJobRuntimeFields(job: Record<string, unknown>): Record<string, unknown> {
+  const { state: _state, updatedAtMs: _updatedAtMs, ...rest } = job;
+  return { ...rest, state: {} };
+}
+
+function resolvePayload(job: Record<string, unknown>): Record<string, unknown> | null {
+  const payload = job.payload;
+  if (typeof payload === "object" && payload !== null && !Array.isArray(payload)) {
+    return payload as Record<string, unknown>;
+  }
+  if (typeof job.message === "string") {
+    return {
+      kind: "agentTurn",
+      message: job.message,
+      ...(typeof job.model === "string" ? { model: job.model } : {}),
+    };
+  }
+  if (typeof job.text === "string") {
+    return { kind: "systemEvent", text: job.text };
+  }
+  return null;
+}
+
+function bindScheduleColumns(schedule: unknown): {
+  schedule_kind: string;
+  schedule_expr: string | null;
+  schedule_tz: string | null;
+  every_ms: number | null;
+  anchor_ms: number | null;
+  at: string | null;
+  stagger_ms: number | null;
+} {
+  if (typeof schedule === "string") {
+    return {
+      schedule_kind: "cron",
+      schedule_expr: schedule,
+      schedule_tz: null,
+      every_ms: null,
+      anchor_ms: null,
+      at: null,
+      stagger_ms: null,
+    };
+  }
+  if (typeof schedule === "object" && schedule !== null && !Array.isArray(schedule)) {
+    const s = schedule as Record<string, unknown>;
+    if (s.kind === "at" && typeof s.at === "string") {
+      return {
+        schedule_kind: "at",
+        at: s.at,
+        schedule_expr: null,
+        schedule_tz: null,
+        every_ms: null,
+        anchor_ms: null,
+        stagger_ms: null,
+      };
+    }
+    if (s.kind === "every" && typeof s.everyMs === "number") {
+      return {
+        schedule_kind: "every",
+        every_ms: s.everyMs,
+        anchor_ms: typeof s.anchorMs === "number" ? s.anchorMs : null,
+        schedule_expr: null,
+        schedule_tz: null,
+        at: null,
+        stagger_ms: null,
+      };
+    }
+    if (s.kind === "cron" && typeof s.expr === "string") {
+      return {
+        schedule_kind: "cron",
+        schedule_expr: s.expr,
+        schedule_tz: typeof s.tz === "string" ? s.tz : null,
+        stagger_ms: typeof s.staggerMs === "number" ? s.staggerMs : null,
+        every_ms: null,
+        anchor_ms: null,
+        at: null,
+      };
+    }
+  }
+  return {
+    schedule_kind: "manual",
+    schedule_expr: null,
+    schedule_tz: null,
+    every_ms: null,
+    anchor_ms: null,
+    at: null,
+    stagger_ms: null,
+  };
+}
+
+function bindPayloadColumns(payload: Record<string, unknown>): {
+  payload_kind: string;
+  payload_message: string | null;
+  payload_model: string | null;
+  payload_fallbacks_json: string | null;
+  payload_thinking: string | null;
+  payload_timeout_seconds: number | null;
+  payload_allow_unsafe_external_content: number | null;
+  payload_external_content_source_json: string | null;
+  payload_light_context: number | null;
+  payload_tools_allow_json: string | null;
+} {
+  const kind = String(payload.kind ?? "agentTurn");
+  if (kind === "systemEvent") {
+    const text = typeof payload.text === "string" ? payload.text : typeof payload.message === "string" ? payload.message : null;
+    return {
+      payload_kind: "systemEvent",
+      payload_message: text,
+      payload_model: null,
+      payload_fallbacks_json: null,
+      payload_thinking: null,
+      payload_timeout_seconds: null,
+      payload_allow_unsafe_external_content: null,
+      payload_external_content_source_json: null,
+      payload_light_context: null,
+      payload_tools_allow_json: null,
+    };
+  }
+  if (kind === "command") {
+    const { timeoutSeconds, ...rest } = payload;
+    return {
+      payload_kind: "command",
+      payload_message: JSON.stringify(rest),
+      payload_model: null,
+      payload_fallbacks_json: null,
+      payload_thinking: null,
+      payload_timeout_seconds: numOrNull(timeoutSeconds),
+      payload_allow_unsafe_external_content: null,
+      payload_external_content_source_json: null,
+      payload_light_context: null,
+      payload_tools_allow_json: null,
+    };
+  }
+  return {
+    payload_kind: "agentTurn",
+    payload_message: typeof payload.message === "string" ? payload.message : null,
+    payload_model: typeof payload.model === "string" ? payload.model : null,
+    payload_fallbacks_json: Array.isArray(payload.fallbacks) ? JSON.stringify(payload.fallbacks) : null,
+    payload_thinking: typeof payload.thinking === "string" ? payload.thinking : null,
+    payload_timeout_seconds: numOrNull(payload.timeoutSeconds),
+    payload_allow_unsafe_external_content: boolToInt(payload.allowUnsafeExternalContent as boolean | undefined),
+    payload_external_content_source_json:
+      payload.externalContentSource != null ? JSON.stringify(payload.externalContentSource) : null,
+    payload_light_context: boolToInt(payload.lightContext as boolean | undefined),
+    payload_tools_allow_json: Array.isArray(payload.toolsAllow) ? JSON.stringify(payload.toolsAllow) : null,
+  };
+}
+
+function bindDeliveryColumns(delivery: unknown): Record<string, string | number | null> {
+  if (typeof delivery !== "object" || delivery === null || Array.isArray(delivery)) {
+    return {
+      delivery_mode: null,
+      delivery_channel: null,
+      delivery_to: null,
+      delivery_thread_id: null,
+      delivery_account_id: null,
+      delivery_best_effort: null,
+      delivery_completion_mode: null,
+      delivery_completion_to: null,
+      failure_delivery_mode: null,
+      failure_delivery_channel: null,
+      failure_delivery_to: null,
+      failure_delivery_account_id: null,
+    };
+  }
+  const d = delivery as Record<string, unknown>;
+  const failure = d.failureDestination as Record<string, unknown> | undefined;
+  return {
+    delivery_mode: typeof d.mode === "string" ? d.mode : null,
+    delivery_channel: typeof d.channel === "string" ? d.channel : null,
+    delivery_to: typeof d.to === "string" ? d.to : null,
+    delivery_thread_id: d.threadId != null ? String(d.threadId) : null,
+    delivery_account_id: typeof d.accountId === "string" ? d.accountId : null,
+    delivery_best_effort: boolToInt(d.bestEffort as boolean | undefined),
+    delivery_completion_mode:
+      typeof (d.completionDestination as Record<string, unknown> | undefined)?.mode === "string"
+        ? String((d.completionDestination as Record<string, unknown>).mode)
+        : null,
+    delivery_completion_to:
+      typeof (d.completionDestination as Record<string, unknown> | undefined)?.to === "string"
+        ? String((d.completionDestination as Record<string, unknown>).to)
+        : null,
+    failure_delivery_mode: failure && Object.hasOwn(failure, "mode") ? String(failure.mode ?? "") : null,
+    failure_delivery_channel: failure && Object.hasOwn(failure, "channel") ? String(failure.channel ?? "") : null,
+    failure_delivery_to: failure && Object.hasOwn(failure, "to") ? String(failure.to ?? "") : null,
+    failure_delivery_account_id:
+      failure && Object.hasOwn(failure, "accountId") ? String(failure.accountId ?? "") : null,
+  };
+}
+
+function bindStateColumns(state: Record<string, unknown>): Record<string, string | number | null> {
+  const lastStatus =
+    typeof state.lastRunStatus === "string"
+      ? state.lastRunStatus
+      : typeof state.lastStatus === "string"
+        ? state.lastStatus
+        : null;
+  return {
+    next_run_at_ms: numOrNull(state.nextRunAtMs),
+    running_at_ms: numOrNull(state.runningAtMs),
+    last_run_at_ms: numOrNull(state.lastRunAtMs),
+    last_run_status: lastStatus,
+    last_error: typeof state.lastError === "string" ? state.lastError : null,
+    last_duration_ms: numOrNull(state.lastDurationMs),
+    consecutive_errors: numOrNull(state.consecutiveErrors),
+    consecutive_skipped: numOrNull(state.consecutiveSkipped),
+    schedule_error_count: numOrNull(state.scheduleErrorCount),
+    last_delivery_status: typeof state.lastDeliveryStatus === "string" ? state.lastDeliveryStatus : null,
+    last_delivery_error: typeof state.lastDeliveryError === "string" ? state.lastDeliveryError : null,
+    last_delivered: boolToInt(state.lastDelivered as boolean | undefined),
+    last_failure_alert_at_ms: numOrNull(state.lastFailureAlertAtMs),
+  };
+}
+
+function normalizeJobRecord(raw: Record<string, unknown>): Record<string, unknown> | null {
+  const id = String(raw.id ?? raw.pluginJobId ?? raw.name ?? "").trim();
+  if (!id) return null;
+  const now = Date.now();
+  const state =
+    typeof raw.state === "object" && raw.state !== null && !Array.isArray(raw.state)
+      ? (raw.state as Record<string, unknown>)
+      : {};
+  const payload = resolvePayload(raw);
+  if (!payload) return null;
+  const schedule = raw.schedule ?? { kind: "manual" };
+  return {
+    ...raw,
+    id,
+    name: String(raw.name ?? id),
+    enabled: raw.enabled !== false,
+    schedule,
+    sessionTarget: raw.sessionTarget ?? "main",
+    wakeMode: raw.wakeMode ?? "now",
+    payload,
+    delivery: raw.delivery ?? { mode: "none" },
+    createdAtMs: numOrNull(raw.createdAtMs) ?? now,
+    updatedAtMs: numOrNull(raw.updatedAtMs) ?? now,
+    state,
+  };
+}
+
+const CRON_JOBS_INSERT_SQL = `
+INSERT INTO cron_jobs (
+  store_key, job_id, name, description, enabled, delete_after_run, created_at_ms, updated_at,
+  agent_id, session_key, session_target, wake_mode,
+  schedule_kind, schedule_expr, schedule_tz, every_ms, anchor_ms, at, stagger_ms,
+  payload_kind, payload_message, payload_model, payload_fallbacks_json, payload_thinking,
+  payload_timeout_seconds, payload_allow_unsafe_external_content, payload_external_content_source_json,
+  payload_light_context, payload_tools_allow_json,
+  delivery_mode, delivery_channel, delivery_to, delivery_thread_id, delivery_account_id,
+  delivery_best_effort, delivery_completion_mode, delivery_completion_to,
+  failure_delivery_mode, failure_delivery_channel, failure_delivery_to, failure_delivery_account_id,
+  failure_alert_disabled, failure_alert_after, failure_alert_channel, failure_alert_to,
+  failure_alert_cooldown_ms, failure_alert_include_skipped, failure_alert_mode, failure_alert_account_id,
+  next_run_at_ms, running_at_ms, last_run_at_ms, last_run_status, last_error, last_duration_ms,
+  consecutive_errors, consecutive_skipped, schedule_error_count, last_delivery_status, last_delivery_error,
+  last_delivered, last_failure_alert_at_ms, state_json, runtime_updated_at_ms, schedule_identity, sort_order, job_json
+) VALUES (
+  @store_key, @job_id, @name, @description, @enabled, @delete_after_run, @created_at_ms, @updated_at,
+  @agent_id, @session_key, @session_target, @wake_mode,
+  @schedule_kind, @schedule_expr, @schedule_tz, @every_ms, @anchor_ms, @at, @stagger_ms,
+  @payload_kind, @payload_message, @payload_model, @payload_fallbacks_json, @payload_thinking,
+  @payload_timeout_seconds, @payload_allow_unsafe_external_content, @payload_external_content_source_json,
+  @payload_light_context, @payload_tools_allow_json,
+  @delivery_mode, @delivery_channel, @delivery_to, @delivery_thread_id, @delivery_account_id,
+  @delivery_best_effort, @delivery_completion_mode, @delivery_completion_to,
+  @failure_delivery_mode, @failure_delivery_channel, @failure_delivery_to, @failure_delivery_account_id,
+  @failure_alert_disabled, @failure_alert_after, @failure_alert_channel, @failure_alert_to,
+  @failure_alert_cooldown_ms, @failure_alert_include_skipped, @failure_alert_mode, @failure_alert_account_id,
+  @next_run_at_ms, @running_at_ms, @last_run_at_ms, @last_run_status, @last_error, @last_duration_ms,
+  @consecutive_errors, @consecutive_skipped, @schedule_error_count, @last_delivery_status, @last_delivery_error,
+  @last_delivered, @last_failure_alert_at_ms, @state_json, @runtime_updated_at_ms, @schedule_identity, @sort_order, @job_json
+)`;
+
+function bindCronJobInsertRow(
+  storeKey: string,
+  rawJob: Record<string, unknown>,
+  sortOrder: number,
+): Record<string, string | number | null> | null {
+  const job = normalizeJobRecord(rawJob);
+  if (!job) return null;
+  const payload = job.payload as Record<string, unknown>;
+  const state = job.state as Record<string, unknown>;
+  const scheduleCols = bindScheduleColumns(job.schedule);
+  const payloadCols = bindPayloadColumns(payload);
+  if (!payloadCols.payload_message) return null;
+  const deliveryCols = bindDeliveryColumns(job.delivery);
+  const stateCols = bindStateColumns(state);
+  const updatedAtMs = numOrNull(job.updatedAtMs) ?? Date.now();
+  const createdAtMs = numOrNull(job.createdAtMs) ?? updatedAtMs;
+  return {
+    store_key: storeKey,
+    job_id: String(job.id),
+    name: String(job.name),
+    description: strOrNull(job.description),
+    enabled: job.enabled === false ? 0 : 1,
+    delete_after_run: boolToInt(job.deleteAfterRun as boolean | undefined),
+    created_at_ms: createdAtMs,
+    updated_at: updatedAtMs,
+    agent_id: strOrNull(job.agentId),
+    session_key: strOrNull(job.sessionKey),
+    session_target: String(job.sessionTarget ?? "main"),
+    wake_mode: String(job.wakeMode ?? "now"),
+    ...scheduleCols,
+    ...payloadCols,
+    ...deliveryCols,
+    failure_alert_disabled: null,
+    failure_alert_after: null,
+    failure_alert_channel: null,
+    failure_alert_to: null,
+    failure_alert_cooldown_ms: null,
+    failure_alert_include_skipped: null,
+    failure_alert_mode: null,
+    failure_alert_account_id: null,
+    ...stateCols,
+    state_json: JSON.stringify(state),
+    runtime_updated_at_ms: updatedAtMs,
+    schedule_identity: null,
+    sort_order: sortOrder,
+    job_json: JSON.stringify(stripJobRuntimeFields(job)),
+  };
+}
+
+function writeCronStoreToJson(legacyPath: string, store: OpenClawCronStoreFile): void {
+  mkdirSync(dirname(legacyPath), { recursive: true });
+  const payload = JSON.stringify(store, null, 2);
+  const tmpPath = `${legacyPath}.${process.pid}.${Date.now()}.tmp`;
+  writeFileSync(tmpPath, payload, "utf-8");
+  renameSync(tmpPath, legacyPath);
+}
+
+function writeCronStoreToSqlite(sqlitePath: string, storeKey: string, store: OpenClawCronStoreFile): void {
+  mkdirSync(dirname(sqlitePath), { recursive: true });
+  const db = new DatabaseSync(sqlitePath);
+  try {
+    if (!sqliteHasCronJobsTable(db)) {
+      throw new Error("cron_jobs table missing in OpenClaw state database");
+    }
+    const jobs = Array.isArray(store.jobs) ? (store.jobs as Array<Record<string, unknown>>) : [];
+    const tx = createTransaction(db, () => {
+      db.prepare(`DELETE FROM cron_jobs WHERE store_key = ?`).run(storeKey);
+      const insert = db.prepare(CRON_JOBS_INSERT_SQL);
+      let sortOrder = 0;
+      for (const rawJob of jobs) {
+        if (typeof rawJob !== "object" || rawJob === null) continue;
+        const row = bindCronJobInsertRow(storeKey, rawJob, sortOrder);
+        if (!row) continue;
+        insert.run(row);
+        sortOrder += 1;
+      }
+    }, "IMMEDIATE");
+    tx();
+  } finally {
+    db.close();
+  }
+}
+
+/** Persist cron jobs to the live store (SQLite when migrated, else legacy JSON). */
+export function writeOpenClawCronStore(
+  openclawDir: string,
+  store: OpenClawCronStoreFile,
+  backend?: CronStoreBackend,
+): { backend: CronStoreBackend; displayPath: string } {
+  const resolvedBackend = backend ?? detectCronStoreBackend(openclawDir);
+  const legacyStorePath = resolveLegacyCronJobsPath(openclawDir);
+  const displayPath = describeCronStoreLocation(openclawDir, resolvedBackend);
+  if (!Array.isArray(store.jobs)) store.jobs = [];
+
+  if (resolvedBackend === "sqlite") {
+    try {
+      writeCronStoreToSqlite(
+        resolveOpenClawStateSqlitePath(openclawDir),
+        cronStorePartitionKey(legacyStorePath),
+        store,
+      );
+      return { backend: "sqlite", displayPath };
+    } catch {
+      // Host may be mid-upgrade — fall back to JSON if SQLite is not ready.
+    }
+  }
+
+  writeCronStoreToJson(legacyStorePath, store);
+  return { backend: "json", displayPath: legacyStorePath };
+}
+
+/** Convenience: load store, mutate jobs array in place, then persist. */
+export function withOpenClawCronStore<T>(
+  openclawDir: string,
+  mutate: (ctx: { store: OpenClawCronStoreFile; jobs: Array<Record<string, unknown>>; snapshot: OpenClawCronStoreSnapshot }) => T,
+): T {
+  const snapshot = readOpenClawCronStore(openclawDir);
+  if (!Array.isArray(snapshot.store.jobs)) snapshot.store.jobs = [];
+  const jobs = snapshot.store.jobs as Array<Record<string, unknown>>;
+  const result = mutate({ store: snapshot.store, jobs, snapshot });
+  writeOpenClawCronStore(openclawDir, snapshot.store, snapshot.backend);
+  return result;
+}

--- a/extensions/memory-hybrid/services/openclaw-cron-store.ts
+++ b/extensions/memory-hybrid/services/openclaw-cron-store.ts
@@ -589,6 +589,42 @@ function writeCronStoreToSqlite(sqlitePath: string, storeKey: string, store: Ope
       incomingIds.add(jobId);
       const row = bindCronJobInsertRow(storeKey, rawJob, sortOrder);
       if (row) {
+        const existing = existingByJobId.get(jobId);
+        if (existing) {
+          const existingRuntimeTs = numOrNull(existing.runtime_updated_at_ms);
+          const newRuntimeTs = numOrNull(row.runtime_updated_at_ms);
+          if (existingRuntimeTs != null && (newRuntimeTs == null || existingRuntimeTs > newRuntimeTs)) {
+            row.runtime_updated_at_ms = existingRuntimeTs;
+            row.next_run_at_ms = existing.next_run_at_ms as number | null;
+            row.running_at_ms = existing.running_at_ms as number | null;
+            row.last_run_at_ms = existing.last_run_at_ms as number | null;
+            row.last_run_status = existing.last_run_status as string | null;
+            row.last_error = existing.last_error as string | null;
+            row.last_duration_ms = existing.last_duration_ms as number | null;
+            row.consecutive_errors = existing.consecutive_errors as number | null;
+            row.consecutive_skipped = existing.consecutive_skipped as number | null;
+            row.schedule_error_count = existing.schedule_error_count as number | null;
+            row.last_delivery_status = existing.last_delivery_status as string | null;
+            row.last_delivery_error = existing.last_delivery_error as string | null;
+            row.last_delivered = existing.last_delivered as number | null;
+            row.last_failure_alert_at_ms = existing.last_failure_alert_at_ms as number | null;
+            const stateJson = parseJsonObject(String(row.state_json ?? "{}"), {});
+            if (row.next_run_at_ms != null) stateJson.nextRunAtMs = row.next_run_at_ms;
+            if (row.running_at_ms != null) stateJson.runningAtMs = row.running_at_ms;
+            if (row.last_run_at_ms != null) stateJson.lastRunAtMs = row.last_run_at_ms;
+            if (row.last_run_status != null) stateJson.lastRunStatus = row.last_run_status;
+            if (row.last_error != null) stateJson.lastError = row.last_error;
+            if (row.last_duration_ms != null) stateJson.lastDurationMs = row.last_duration_ms;
+            if (row.consecutive_errors != null) stateJson.consecutiveErrors = row.consecutive_errors;
+            if (row.consecutive_skipped != null) stateJson.consecutiveSkipped = row.consecutive_skipped;
+            if (row.schedule_error_count != null) stateJson.scheduleErrorCount = row.schedule_error_count;
+            if (row.last_delivery_status != null) stateJson.lastDeliveryStatus = row.last_delivery_status;
+            if (row.last_delivery_error != null) stateJson.lastDeliveryError = row.last_delivery_error;
+            if (row.last_delivered != null) stateJson.lastDelivered = row.last_delivered !== 0;
+            if (row.last_failure_alert_at_ms != null) stateJson.lastFailureAlertAtMs = row.last_failure_alert_at_ms;
+            row.state_json = JSON.stringify(stateJson);
+          }
+        }
         rowsToInsert.push(row);
         sortOrder += 1;
         continue;

--- a/extensions/memory-hybrid/services/openclaw-cron-store.ts
+++ b/extensions/memory-hybrid/services/openclaw-cron-store.ts
@@ -128,6 +128,9 @@ function mergeJobFromSqliteRow(row: {
 }): Record<string, unknown> {
   const config = parseJsonObject(row.job_json, {});
   const state = parseJsonObject(row.state_json, {});
+  if (typeof state.lastRunStatus === "string" && state.lastStatus == null) {
+    state.lastStatus = state.lastRunStatus;
+  }
   const job: Record<string, unknown> = { ...config, state };
   if (job.id == null && row.job_id) job.id = row.job_id;
   if (job.name == null && row.name) job.name = row.name;

--- a/extensions/memory-hybrid/services/openclaw-cron-store.ts
+++ b/extensions/memory-hybrid/services/openclaw-cron-store.ts
@@ -539,7 +539,11 @@ function writeCronStoreToSqlite(sqlitePath: string, storeKey: string, store: Ope
       for (const rawJob of jobs) {
         if (typeof rawJob !== "object" || rawJob === null) continue;
         const row = bindCronJobInsertRow(storeKey, rawJob, sortOrder);
-        if (!row) continue;
+        if (!row) {
+          throw new Error(
+            `Job normalization failed for ${JSON.stringify(rawJob).slice(0, 200)}; refusing to drop job from SQLite store`,
+          );
+        }
         insert.run(row);
         sortOrder += 1;
       }
@@ -569,8 +573,8 @@ export function writeOpenClawCronStore(
         store,
       );
       return { backend: "sqlite", displayPath };
-    } catch {
-      // Host may be mid-upgrade — fall back to JSON if SQLite is not ready.
+    } catch (err) {
+      throw new Error(`SQLite write failed on migrated host: ${err instanceof Error ? err.message : String(err)}`);
     }
   }
 

--- a/extensions/memory-hybrid/services/openclaw-cron-store.ts
+++ b/extensions/memory-hybrid/services/openclaw-cron-store.ts
@@ -77,7 +77,11 @@ export function detectCronStoreBackend(openclawDir: string): CronStoreBackend {
   try {
     const db = new DatabaseSync(sqlitePath, { readOnly: true });
     try {
-      if (!sqliteHasCronJobsTable(db)) return "json";
+      if (!sqliteHasCronJobsTable(db)) {
+        // DB exists but table missing; check if we're on a migrated host.
+        if (hasMigratedLegacyCronFile(openclawDir)) return "sqlite";
+        return "json";
+      }
       const storeKey = cronStorePartitionKey(legacyPath);
       if (countSqliteCronRows(db, storeKey) > 0) return "sqlite";
       if (existsSync(legacyPath)) return "json";
@@ -88,7 +92,9 @@ export function detectCronStoreBackend(openclawDir: string): CronStoreBackend {
       db.close();
     }
   } catch {
-    return existsSync(legacyPath) ? "json" : "json";
+    // DB exists but can't be opened; check if we're on a migrated host.
+    if (hasMigratedLegacyCronFile(openclawDir)) return "sqlite";
+    return existsSync(legacyPath) ? "json" : "sqlite";
   }
 }
 

--- a/extensions/memory-hybrid/setup/cli-context/register-help.ts
+++ b/extensions/memory-hybrid/setup/cli-context/register-help.ts
@@ -232,7 +232,7 @@ function buildRichStatsExtras(ctx: HandlerContext): NonNullable<HybridMemCliCont
         store = readOpenClawCronStore(owHome).store;
       } catch (err) {
         capturePluginError(err instanceof Error ? err : new Error(String(err)), {
-          operation: "stats-read-jobs-json",
+          operation: "stats-read-cron-store",
           severity: "info",
           subsystem: "cli",
         });

--- a/extensions/memory-hybrid/setup/cli-context/register-help.ts
+++ b/extensions/memory-hybrid/setup/cli-context/register-help.ts
@@ -18,6 +18,7 @@ import { applyApprovedProposal, getProposalExpiryError } from "../../cli/proposa
 import type { HybridMemCliContext } from "../../cli/register.js";
 import { getCronModelConfig, getDefaultCronModel, hybridConfigSchema } from "../../config.js";
 import { readGuardTimestampMs } from "../../services/cron-guard.js";
+import { readOpenClawCronStore } from "../../services/openclaw-cron-store.js";
 import { capturePluginError } from "../../services/error-reporter.js";
 import { runPersonaProposalTriage, validatePersonaPolicy } from "../../services/persona-proposal-triage.js";
 import { syncProposalWithdrawnInChangeFeed } from "../../services/change-feed-emit.js";
@@ -226,11 +227,9 @@ function buildRichStatsExtras(ctx: HandlerContext): NonNullable<HybridMemCliCont
     getCronJobsStatus: () => {
       const owHome =
         process.env.OPENCLAW_HOME?.trim() || join(process.env.HOME ?? process.env.USERPROFILE ?? "", ".openclaw");
-      const cronStorePath = join(owHome, "cron", "jobs.json");
-      if (!existsSync(cronStorePath)) return [];
       let store: { jobs?: unknown[] };
       try {
-        store = JSON.parse(readFileSync(cronStorePath, "utf-8")) as { jobs?: unknown[] };
+        store = readOpenClawCronStore(owHome).store;
       } catch (err) {
         capturePluginError(err instanceof Error ? err : new Error(String(err)), {
           operation: "stats-read-jobs-json",

--- a/extensions/memory-hybrid/tests/openclaw-cron-store.test.ts
+++ b/extensions/memory-hybrid/tests/openclaw-cron-store.test.ts
@@ -159,6 +159,73 @@ describe("openclaw-cron-store (#1923)", () => {
     const job = snapshot.store.jobs?.[0] as Record<string, unknown>;
     expect(job.pluginJobId ?? job.id).toBe("hybrid-mem:maintenance-nightly");
     expect((job.state as { lastRunStatus?: string }).lastRunStatus).toBe("ok");
+    expect((job.state as { lastStatus?: string }).lastStatus).toBe("ok");
+  });
+
+  it("uses SQLite enabled column over stale job_json", () => {
+    homeDir = mkdtempSync(join(tmpdir(), "oc-cron-store-"));
+    const openclawDir = join(homeDir, ".openclaw");
+    const legacyPath = resolveLegacyCronJobsPath(openclawDir);
+    const sqlitePath = resolveOpenClawStateSqlitePath(openclawDir);
+    mkdirSync(join(openclawDir, "state"), { recursive: true });
+    const db = new DatabaseSync(sqlitePath);
+    db.exec(CRON_JOBS_DDL);
+    const storeKey = cronStorePartitionKey(legacyPath);
+    db.prepare(
+      `INSERT INTO cron_jobs (
+        store_key, job_id, name, enabled, created_at_ms, updated_at, session_target, wake_mode,
+        schedule_kind, schedule_expr, payload_kind, payload_message, delivery_mode,
+        state_json, sort_order, job_json
+      ) VALUES (?, ?, ?, 0, ?, ?, 'main', 'now', 'cron', '0 2 * * *', 'agentTurn', 'msg', 'none', '{}', 0, ?)`,
+    ).run(
+      storeKey,
+      "hybrid-mem:maintenance-nightly",
+      "maintenance-nightly",
+      Date.now(),
+      Date.now(),
+      JSON.stringify({ id: "hybrid-mem:maintenance-nightly", enabled: true, payload: { kind: "agentTurn", message: "msg" } }),
+    );
+    db.close();
+
+    const snapshot = readOpenClawCronStore(openclawDir);
+    const job = snapshot.store.jobs?.[0] as Record<string, unknown>;
+    expect(job.enabled).toBe(false);
+  });
+
+  it("preserves existing SQLite rows when an in-memory job cannot be re-normalized", () => {
+    homeDir = mkdtempSync(join(tmpdir(), "oc-cron-store-"));
+    const openclawDir = join(homeDir, ".openclaw");
+    seedSqliteCronJob(openclawDir, {
+      id: "external:custom-job",
+      name: "external-custom",
+      enabled: true,
+      payload: { kind: "command", argv: ["echo", "hello"] },
+    });
+    seedSqliteCronJob(openclawDir, {
+      id: "hybrid-mem:maintenance-nightly",
+      pluginJobId: "hybrid-mem:maintenance-nightly",
+      name: "maintenance-nightly",
+      schedule: { kind: "cron", expr: "5 2 * * *" },
+      sessionTarget: "isolated",
+      payload: { kind: "agentTurn", message: "openclaw hybrid-mem maintenance nightly --verbose" },
+    });
+
+    const snapshot = readOpenClawCronStore(openclawDir);
+    expect(snapshot.store.jobs?.length).toBe(2);
+    const jobs = snapshot.store.jobs as Array<Record<string, unknown>>;
+    const nightly = jobs.find((j) => j.id === "hybrid-mem:maintenance-nightly");
+    expect(nightly).toBeTruthy();
+    const state = (nightly?.state as Record<string, unknown>) ?? {};
+    state.lastRunAtMs = Date.now();
+    const external = jobs.find((j) => j.id === "external:custom-job");
+    expect(external).toBeTruthy();
+    // Simulate a lossy in-memory shape that cannot round-trip through bindCronJobInsertRow.
+    delete external!.payload;
+
+    writeOpenClawCronStore(openclawDir, { jobs }, snapshot.backend);
+    const after = readOpenClawCronStore(openclawDir);
+    expect(after.store.jobs?.length).toBe(2);
+    expect(after.store.jobs?.some((j) => (j as { id?: string }).id === "external:custom-job")).toBe(true);
   });
 
   it("reads legacy jobs.json when SQLite has no rows", () => {

--- a/extensions/memory-hybrid/tests/openclaw-cron-store.test.ts
+++ b/extensions/memory-hybrid/tests/openclaw-cron-store.test.ts
@@ -290,4 +290,67 @@ describe("openclaw-cron-store (#1923)", () => {
     const reread = readOpenClawCronStore(openclawDir);
     expect(reread.store.jobs?.length).toBe(1);
   });
+
+  it("preserves fresher gateway runtime state when writing config updates (#1923)", () => {
+    homeDir = mkdtempSync(join(tmpdir(), "oc-cron-store-"));
+    const openclawDir = join(homeDir, ".openclaw");
+    const legacyPath = resolveLegacyCronJobsPath(openclawDir);
+    const sqlitePath = resolveOpenClawStateSqlitePath(openclawDir);
+    mkdirSync(join(openclawDir, "state"), { recursive: true });
+    const db = new DatabaseSync(sqlitePath);
+    db.exec(CRON_JOBS_DDL);
+    const storeKey = cronStorePartitionKey(legacyPath);
+
+    const gatewayRuntimeTimestamp = Date.now() + 10_000;
+    const oldInMemoryTimestamp = Date.now();
+    db.prepare(
+      `INSERT INTO cron_jobs (
+        store_key, job_id, name, enabled, created_at_ms, updated_at, session_target, wake_mode,
+        schedule_kind, schedule_expr, payload_kind, payload_message, delivery_mode,
+        last_run_at_ms, next_run_at_ms, last_run_status, consecutive_errors,
+        state_json, runtime_updated_at_ms, sort_order, job_json
+      ) VALUES (?, ?, ?, 1, ?, ?, 'main', 'now', 'cron', '0 2 * * *', 'agentTurn', 'old message', 'none', ?, ?, ?, ?, '{}', ?, 0, ?)`,
+    ).run(
+      storeKey,
+      "test-job",
+      "Test Job",
+      Date.now(),
+      Date.now(),
+      1_700_000_000_000,
+      1_700_100_000_000,
+      "success",
+      5,
+      gatewayRuntimeTimestamp,
+      JSON.stringify({ id: "test-job", payload: { kind: "agentTurn", message: "old message" } }),
+    );
+    db.close();
+
+    const snapshot = readOpenClawCronStore(openclawDir);
+    expect(snapshot.store.jobs?.length).toBe(1);
+    const jobs = snapshot.store.jobs as Array<Record<string, unknown>>;
+    const job = jobs[0];
+
+    const gatewayLastRunAt = (job.state as { lastRunAtMs?: number }).lastRunAtMs;
+    const gatewayNextRunAt = (job.state as { nextRunAtMs?: number }).nextRunAtMs;
+    expect(gatewayLastRunAt).toBe(1_700_000_000_000);
+    expect(gatewayNextRunAt).toBe(1_700_100_000_000);
+
+    job.payload = { kind: "agentTurn", message: "updated message" };
+    job.updatedAtMs = oldInMemoryTimestamp;
+    (job.state as Record<string, unknown>).lastRunAtMs = 1_699_000_000_000;
+    (job.state as Record<string, unknown>).nextRunAtMs = 1_699_100_000_000;
+    (job.state as Record<string, unknown>).consecutiveErrors = 0;
+
+    writeOpenClawCronStore(openclawDir, { jobs }, snapshot.backend);
+
+    const after = readOpenClawCronStore(openclawDir);
+    const updatedJob = (after.store.jobs as Array<Record<string, unknown>>)[0];
+    const updatedPayload = updatedJob.payload as { message?: string };
+    expect(updatedPayload.message).toBe("updated message");
+
+    const updatedState = updatedJob.state as Record<string, unknown>;
+    expect(updatedState.lastRunAtMs).toBe(1_700_000_000_000);
+    expect(updatedState.nextRunAtMs).toBe(1_700_100_000_000);
+    expect(updatedState.consecutiveErrors).toBe(5);
+  });
 });

--- a/extensions/memory-hybrid/tests/openclaw-cron-store.test.ts
+++ b/extensions/memory-hybrid/tests/openclaw-cron-store.test.ts
@@ -1,0 +1,226 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  cronStorePartitionKey,
+  detectCronStoreBackend,
+  readOpenClawCronStore,
+  resolveLegacyCronJobsPath,
+  resolveOpenClawStateSqlitePath,
+  writeOpenClawCronStore,
+} from "../services/openclaw-cron-store.js";
+
+const CRON_JOBS_DDL = `
+CREATE TABLE IF NOT EXISTS cron_jobs (
+  store_key TEXT NOT NULL,
+  job_id TEXT NOT NULL,
+  name TEXT NOT NULL DEFAULT '',
+  description TEXT,
+  enabled INTEGER NOT NULL DEFAULT 1,
+  delete_after_run INTEGER,
+  created_at_ms INTEGER NOT NULL DEFAULT 0,
+  updated_at INTEGER NOT NULL DEFAULT 0,
+  agent_id TEXT,
+  session_key TEXT,
+  session_target TEXT NOT NULL DEFAULT 'main',
+  wake_mode TEXT NOT NULL DEFAULT 'now',
+  schedule_kind TEXT NOT NULL DEFAULT 'manual',
+  schedule_expr TEXT,
+  schedule_tz TEXT,
+  every_ms INTEGER,
+  anchor_ms INTEGER,
+  at TEXT,
+  stagger_ms INTEGER,
+  payload_kind TEXT NOT NULL DEFAULT 'agentTurn',
+  payload_message TEXT,
+  payload_model TEXT,
+  payload_fallbacks_json TEXT,
+  payload_thinking TEXT,
+  payload_timeout_seconds INTEGER,
+  payload_allow_unsafe_external_content INTEGER,
+  payload_external_content_source_json TEXT,
+  payload_light_context INTEGER,
+  payload_tools_allow_json TEXT,
+  delivery_mode TEXT,
+  delivery_channel TEXT,
+  delivery_to TEXT,
+  delivery_thread_id TEXT,
+  delivery_account_id TEXT,
+  delivery_best_effort INTEGER,
+  delivery_completion_mode TEXT,
+  delivery_completion_to TEXT,
+  failure_delivery_mode TEXT,
+  failure_delivery_channel TEXT,
+  failure_delivery_to TEXT,
+  failure_delivery_account_id TEXT,
+  failure_alert_disabled INTEGER,
+  failure_alert_after INTEGER,
+  failure_alert_channel TEXT,
+  failure_alert_to TEXT,
+  failure_alert_cooldown_ms INTEGER,
+  failure_alert_include_skipped INTEGER,
+  failure_alert_mode TEXT,
+  failure_alert_account_id TEXT,
+  next_run_at_ms INTEGER,
+  running_at_ms INTEGER,
+  last_run_at_ms INTEGER,
+  last_run_status TEXT,
+  last_error TEXT,
+  last_duration_ms INTEGER,
+  consecutive_errors INTEGER,
+  consecutive_skipped INTEGER,
+  schedule_error_count INTEGER,
+  last_delivery_status TEXT,
+  last_delivery_error TEXT,
+  last_delivered INTEGER,
+  last_failure_alert_at_ms INTEGER,
+  state_json TEXT NOT NULL DEFAULT '{}',
+  runtime_updated_at_ms INTEGER,
+  schedule_identity TEXT,
+  sort_order INTEGER NOT NULL DEFAULT 0,
+  job_json TEXT NOT NULL DEFAULT '{}',
+  PRIMARY KEY (store_key, job_id)
+);
+`;
+
+function seedSqliteCronJob(
+  openclawDir: string,
+  job: Record<string, unknown>,
+  state: Record<string, unknown> = { lastRunAtMs: 1_700_000_000_000, lastRunStatus: "ok" },
+): void {
+  const legacyPath = resolveLegacyCronJobsPath(openclawDir);
+  const sqlitePath = resolveOpenClawStateSqlitePath(openclawDir);
+  mkdirSync(join(openclawDir, "state"), { recursive: true });
+  const db = new DatabaseSync(sqlitePath);
+  try {
+    db.exec(CRON_JOBS_DDL);
+    const storeKey = cronStorePartitionKey(legacyPath);
+    const id = String(job.id ?? job.pluginJobId ?? "test-job");
+    const payload = (job.payload as Record<string, unknown> | undefined) ?? {
+      kind: "agentTurn",
+      message: String(job.message ?? "cron heartbeat test"),
+    };
+    db.prepare(
+      `INSERT INTO cron_jobs (
+        store_key, job_id, name, enabled, created_at_ms, updated_at, session_target, wake_mode,
+        schedule_kind, schedule_expr, payload_kind, payload_message, delivery_mode,
+        last_run_at_ms, last_run_status, state_json, runtime_updated_at_ms, sort_order, job_json
+      ) VALUES (?, ?, ?, 1, ?, ?, ?, 'now', 'cron', ?, ?, ?, 'none', ?, 'ok', ?, ?, 0, ?)`,
+    ).run(
+      storeKey,
+      id,
+      String(job.name ?? id),
+      Date.now(),
+      Date.now(),
+      String(job.sessionTarget ?? "main"),
+      typeof (job.schedule as { expr?: string } | undefined)?.expr === "string"
+        ? (job.schedule as { expr: string }).expr
+        : "5 2 * * *",
+      String(payload.kind ?? "agentTurn"),
+      String(payload.message ?? payload.text ?? ""),
+      state.lastRunAtMs ?? null,
+      JSON.stringify(state),
+      Date.now(),
+      JSON.stringify({ ...job, state: {} }),
+    );
+  } finally {
+    db.close();
+  }
+}
+
+describe("openclaw-cron-store (#1923)", () => {
+  let homeDir: string | null = null;
+
+  afterEach(() => {
+    if (homeDir) {
+      rmSync(homeDir, { recursive: true, force: true });
+      homeDir = null;
+    }
+  });
+
+  it("detects SQLite backend when jobs.json is absent but cron_jobs rows exist", () => {
+    homeDir = mkdtempSync(join(tmpdir(), "oc-cron-store-"));
+    const openclawDir = join(homeDir, ".openclaw");
+    seedSqliteCronJob(openclawDir, {
+      id: "hybrid-mem:maintenance-nightly",
+      pluginJobId: "hybrid-mem:maintenance-nightly",
+      name: "maintenance-nightly",
+      schedule: { kind: "cron", expr: "5 2 * * *" },
+      sessionTarget: "isolated",
+      payload: { kind: "agentTurn", message: "openclaw hybrid-mem maintenance nightly --verbose" },
+    });
+    expect(detectCronStoreBackend(openclawDir)).toBe("sqlite");
+    const snapshot = readOpenClawCronStore(openclawDir);
+    expect(snapshot.backend).toBe("sqlite");
+    expect(snapshot.store.jobs?.length).toBe(1);
+    const job = snapshot.store.jobs?.[0] as Record<string, unknown>;
+    expect(job.pluginJobId ?? job.id).toBe("hybrid-mem:maintenance-nightly");
+    expect((job.state as { lastRunStatus?: string }).lastRunStatus).toBe("ok");
+  });
+
+  it("reads legacy jobs.json when SQLite has no rows", () => {
+    homeDir = mkdtempSync(join(tmpdir(), "oc-cron-store-"));
+    const openclawDir = join(homeDir, ".openclaw");
+    mkdirSync(join(openclawDir, "cron"), { recursive: true });
+    writeFileSync(
+      resolveLegacyCronJobsPath(openclawDir),
+      JSON.stringify({
+        jobs: [
+          {
+            id: "hybrid-mem:maintenance-nightly",
+            pluginJobId: "hybrid-mem:maintenance-nightly",
+            name: "maintenance-nightly",
+            enabled: true,
+            schedule: { kind: "cron", expr: "0 2 * * *" },
+            payload: { kind: "agentTurn", message: "legacy job" },
+          },
+        ],
+      }),
+      "utf-8",
+    );
+    expect(detectCronStoreBackend(openclawDir)).toBe("json");
+    const snapshot = readOpenClawCronStore(openclawDir);
+    expect(snapshot.backend).toBe("json");
+    expect((snapshot.store.jobs?.[0] as { name?: string }).name).toBe("maintenance-nightly");
+  });
+
+  it("writes maintenance jobs to SQLite without creating jobs.json", () => {
+    homeDir = mkdtempSync(join(tmpdir(), "oc-cron-store-"));
+    const openclawDir = join(homeDir, ".openclaw");
+    mkdirSync(join(openclawDir, "state"), { recursive: true });
+    const sqlitePath = resolveOpenClawStateSqlitePath(openclawDir);
+    const db = new DatabaseSync(sqlitePath);
+    db.exec(CRON_JOBS_DDL);
+    db.close();
+
+    writeOpenClawCronStore(
+      openclawDir,
+      {
+        jobs: [
+          {
+            id: "hybrid-mem:maintenance-nightly",
+            pluginJobId: "hybrid-mem:maintenance-nightly",
+            name: "maintenance-nightly",
+            enabled: true,
+            sessionTarget: "isolated",
+            wakeMode: "now",
+            schedule: { kind: "cron", expr: "5 2 * * *" },
+            delivery: { mode: "none" },
+            payload: { kind: "agentTurn", message: "openclaw hybrid-mem maintenance nightly --verbose" },
+          },
+        ],
+      },
+      "sqlite",
+    );
+
+    expect(detectCronStoreBackend(openclawDir)).toBe("sqlite");
+    const legacyPath = resolveLegacyCronJobsPath(openclawDir);
+    const { existsSync } = require("node:fs") as typeof import("node:fs");
+    expect(existsSync(legacyPath)).toBe(false);
+    const reread = readOpenClawCronStore(openclawDir);
+    expect(reread.store.jobs?.length).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `openclaw-cron-store.ts` to read/write cron jobs from the live store: SQLite (`~/.openclaw/state/openclaw.sqlite`) on OpenClaw 2026.6.8+ migrated hosts, legacy `~/.openclaw/cron/jobs.json` otherwise.
- Updates `verify`, `verify --fix`, `ensureMaintenanceCronJobs`, goal-stewardship heartbeat installer, cron guard sync, maintenance inventory/status, dashboard collectors, and active-task wake scheduling to use the shared helper.
- Fixes false negatives where `maintenance-nightly` and heartbeat jobs existed in SQLite but verify reported them missing; fixes `--fix` creating transient `jobs.json` that OpenClaw immediately migrated away.

## Related issues

Closes #1923

## Test plan

- [x] `npm test -- openclaw-cron-store.test.ts verify-consolidated-cron.test.ts goal-stewardship-heartbeat-cron-installer.test.ts cron-lastrun-state.test.ts`
- [ ] On OpenClaw 6.8+ host with migrated cron (no `jobs.json`): `openclaw hybrid-mem verify` shows `maintenance-nightly` present and heartbeat confirmed when jobs exist in SQLite
- [ ] `openclaw hybrid-mem verify --fix` upserts jobs without creating `jobs.json`
- [ ] Pre-6.8 host with only `jobs.json` still passes verify/install (regression)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared cron persistence across verify, install, and runtime sync; SQLite write path is complex but guarded by tests and runtime-state preservation logic.
> 
> **Overview**
> Fixes **#1923** by routing hybrid-mem cron I/O through a new **`openclaw-cron-store`** helper instead of hard-coding `~/.openclaw/cron/jobs.json`. On OpenClaw **2026.6.8+** hosts where cron lives in **`~/.openclaw/state/openclaw.sqlite`**, verify, install, maintenance health/inventory, dashboard collectors, cron guard sync, and active-task wake scheduling now read and write the **live** store—so jobs are no longer reported missing and `--fix` no longer creates a transient JSON file OpenClaw archives.
> 
> The helper **auto-detects** JSON vs SQLite (migrated `jobs.json.migrated.*`, `cron_jobs` rows), exposes **`describeCronStoreLocation`** for CLI messaging, and on SQLite writes **merges indexed runtime fields** (last/next run, errors) so plugin updates do not clobber fresher gateway state. Legacy hosts with only `jobs.json` keep the same behavior.
> 
> Adds **`openclaw-cron-store.test.ts`** and a **CHANGELOG** entry under Unreleased.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 195c8443c6c725d5a094f471f4afd318ed689ca9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->