### PR TITLE
fix(workboard): map OpenClaw 6.8 card API and unwrap create responses

### DIFF
--- a/extensions/memory-hybrid/backends/credentials-db.ts
+++ b/extensions/memory-hybrid/backends/credentials-db.ts
@@ -262,9 +262,9 @@ export class CredentialsDB extends BaseSqliteStore {
       this.liveDb,
       () => {
         for (const service of [...new Set(invalidRows.map((r) => r.service))]) {
-          const serviceRows = this.liveDb
-            .prepare("SELECT * FROM credentials WHERE service = ?")
-            .all(service) as Array<Record<string, unknown>>;
+          const serviceRows = this.liveDb.prepare("SELECT * FROM credentials WHERE service = ?").all(service) as Array<
+            Record<string, unknown>
+          >;
           const typesPresent = new Set(serviceRows.map((r) => String(r.type)));
 
           for (const row of serviceRows) {
@@ -300,9 +300,7 @@ export class CredentialsDB extends BaseSqliteStore {
                   .get(service, plan.siblingType) as { notes: string | null } | undefined;
                 const existingNotes = targetRow?.notes?.trim() || "";
                 const legacyEndpointNote = `[Legacy endpoint: ${plan.endpointUrl}]`;
-                const updatedNotes = existingNotes
-                  ? `${existingNotes} ${legacyEndpointNote}`
-                  : legacyEndpointNote;
+                const updatedNotes = existingNotes ? `${existingNotes} ${legacyEndpointNote}` : legacyEndpointNote;
                 this.liveDb
                   .prepare("UPDATE credentials SET notes = ?, updated = ? WHERE service = ? AND type = ?")
                   .run(updatedNotes, now, service, plan.siblingType);
@@ -324,9 +322,7 @@ export class CredentialsDB extends BaseSqliteStore {
                   .get(service) as { notes: string | null } | undefined;
                 const existingNotes = targetRow?.notes?.trim() || "";
                 const legacyEndpointNote = `[Legacy endpoint: ${plan.endpointUrl}]`;
-                const updatedNotes = existingNotes
-                  ? `${existingNotes} ${legacyEndpointNote}`
-                  : legacyEndpointNote;
+                const updatedNotes = existingNotes ? `${existingNotes} ${legacyEndpointNote}` : legacyEndpointNote;
                 this.liveDb
                   .prepare("UPDATE credentials SET notes = ?, updated = ? WHERE service = ? AND type = 'other'")
                   .run(updatedNotes, now, service);
@@ -363,9 +359,7 @@ export class CredentialsDB extends BaseSqliteStore {
 
         // Drop any remaining unsupported types that were not handled above.
         this.liveDb
-          .prepare(
-            `DELETE FROM credentials WHERE type NOT IN (${CREDENTIAL_TYPES.map(() => "?").join(", ")})`,
-          )
+          .prepare(`DELETE FROM credentials WHERE type NOT IN (${CREDENTIAL_TYPES.map(() => "?").join(", ")})`)
           .run(...CREDENTIAL_TYPES);
       },
       "IMMEDIATE",

--- a/extensions/memory-hybrid/backends/facts-db/contradictions.ts
+++ b/extensions/memory-hybrid/backends/facts-db/contradictions.ts
@@ -1334,19 +1334,12 @@ export function detectEpisodeFailureContradictions(
     params.push(...scope.params);
   }
   const rows = db
-    .prepare(
-      `SELECT id, text, value FROM facts WHERE ${conditions.join(" AND ")} ORDER BY created_at DESC LIMIT 20`,
-    )
+    .prepare(`SELECT id, text, value FROM facts WHERE ${conditions.join(" AND ")} ORDER BY created_at DESC LIMIT 20`)
     .all(...params) as Array<{ id: string; text: string; value: string | null }>;
 
   const out: Array<{ factId: string; score: number; heuristicSignals: string[]; preview: string }> = [];
   for (const row of rows) {
-    const { score, heuristicSignals } = scoreFactContradiction(
-      eventText,
-      eventText,
-      row.text ?? "",
-      row.value ?? "",
-    );
+    const { score, heuristicSignals } = scoreFactContradiction(eventText, eventText, row.text ?? "", row.value ?? "");
     if (score >= 0.3) {
       out.push({
         factId: row.id,

--- a/extensions/memory-hybrid/backends/facts-db/facts-db-layer3.ts
+++ b/extensions/memory-hybrid/backends/facts-db/facts-db-layer3.ts
@@ -503,9 +503,7 @@ export class FactsDB extends FactsDBLayer2 {
     return recordEpisodeImpl(this.liveDb, input, false).episode;
   }
 
-  recordEpisodeWithCausalLinks(
-    input: Parameters<typeof recordEpisodeImpl>[1],
-  ): ReturnType<typeof recordEpisodeImpl> {
+  recordEpisodeWithCausalLinks(input: Parameters<typeof recordEpisodeImpl>[1]): ReturnType<typeof recordEpisodeImpl> {
     return recordEpisodeImpl(this.liveDb, input, true);
   }
 

--- a/extensions/memory-hybrid/backends/facts-db/scope-sql.ts
+++ b/extensions/memory-hybrid/backends/facts-db/scope-sql.ts
@@ -26,10 +26,10 @@ export function scopedRowMatchesFilter(
 }
 
 /** Scope SQL for episode causal candidate queries: global-only source → global candidates; scoped → global + compatible scope. */
-export function episodeCandidateScopeClause(episode: {
-  scope?: MemoryScope | null;
-  scopeTarget?: string | null;
-}): { clause: string; params: SQLInputValue[] } {
+export function episodeCandidateScopeClause(episode: { scope?: MemoryScope | null; scopeTarget?: string | null }): {
+  clause: string;
+  params: SQLInputValue[];
+} {
   const scope = episode.scope ?? "global";
   if (scope === "global") {
     return { clause: " AND scope = 'global'", params: [] };

--- a/extensions/memory-hybrid/backends/migrations/facts-migrations.ts
+++ b/extensions/memory-hybrid/backends/migrations/facts-migrations.ts
@@ -1697,15 +1697,9 @@ function migrateEpisodeCausalLinksTable(db: DatabaseSync): void {
       FOREIGN KEY (target_episode_id) REFERENCES episodes(id) ON DELETE CASCADE
     )
   `);
-  db.exec(
-    "CREATE INDEX IF NOT EXISTS idx_ecl_source ON episode_causal_links(source_episode_id)",
-  );
-  db.exec(
-    "CREATE INDEX IF NOT EXISTS idx_ecl_target ON episode_causal_links(target_episode_id, confidence DESC)",
-  );
-  db.exec(
-    "CREATE INDEX IF NOT EXISTS idx_ecl_reinforced ON episode_causal_links(last_reinforced_at)",
-  );
+  db.exec("CREATE INDEX IF NOT EXISTS idx_ecl_source ON episode_causal_links(source_episode_id)");
+  db.exec("CREATE INDEX IF NOT EXISTS idx_ecl_target ON episode_causal_links(target_episode_id, confidence DESC)");
+  db.exec("CREATE INDEX IF NOT EXISTS idx_ecl_reinforced ON episode_causal_links(last_reinforced_at)");
 }
 
 function migrateEpisodeCausalLinksLastDecayAt(db: DatabaseSync): void {

--- a/extensions/memory-hybrid/cli/cmd-bootstrap.ts
+++ b/extensions/memory-hybrid/cli/cmd-bootstrap.ts
@@ -40,9 +40,7 @@ export function registerBootstrapCommand(
           return;
         }
         if (!opts.force && existsSync(configPath)) {
-          console.error(
-            `Config already exists at ${configPath}. Re-run with --force to apply preset "${preset}".`,
-          );
+          console.error(`Config already exists at ${configPath}. Re-run with --force to apply preset "${preset}".`);
           process.exitCode = 1;
           return;
         }

--- a/extensions/memory-hybrid/cli/cmd-credentials.ts
+++ b/extensions/memory-hybrid/cli/cmd-credentials.ts
@@ -14,7 +14,12 @@ import { dirname, join } from "node:path";
 
 import type { CredentialType } from "../config.js";
 import { CREDENTIAL_REDACTION_MIGRATION_FLAG, migrateCredentialsToVault } from "../services/credential-migration.js";
-import { auditCredentialType, auditCredentialValue, auditServiceName, normalizeServiceForDedup } from "../services/credential-validation.js";
+import {
+  auditCredentialType,
+  auditCredentialValue,
+  auditServiceName,
+  normalizeServiceForDedup,
+} from "../services/credential-validation.js";
 import { capturePluginError } from "../services/error-reporter.js";
 import type { HandlerContext } from "./handlers.js";
 import type {
@@ -215,7 +220,11 @@ export function runCredentialsAuditForCli(ctx: HandlerContext): CredentialsAudit
   for (const row of list) {
     const value = row.value;
     const updated = row.updated;
-    const flags = [...auditCredentialType(row.type), ...auditCredentialValue(value, row.type), ...auditServiceName(row.service)];
+    const flags = [
+      ...auditCredentialType(row.type),
+      ...auditCredentialValue(value, row.type),
+      ...auditServiceName(row.service),
+    ];
     const normKey = `${normalizeServiceForDedup(row.service)}:${row.type}`;
     if (!valueToEntries.has(value)) valueToEntries.set(value, []);
     valueToEntries.get(value)?.push({ service: row.service, type: row.type, updated });

--- a/extensions/memory-hybrid/cli/cmd-doctor.ts
+++ b/extensions/memory-hybrid/cli/cmd-doctor.ts
@@ -404,8 +404,7 @@ export function registerDoctorCommand(
 
       try {
         const signals = getRecallSignalsSnapshot(factsDb.getRawDb(), 7);
-        const status =
-          signals.autoSnoozeCandidates > 0 || signals.neverReferencedSurfaced > 0 ? "warn" : "pass";
+        const status = signals.autoSnoozeCandidates > 0 || signals.neverReferencedSurfaced > 0 ? "warn" : "pass";
         checks.push({
           name: "Recall feedback",
           status,

--- a/extensions/memory-hybrid/cli/cmd-user-friendly.ts
+++ b/extensions/memory-hybrid/cli/cmd-user-friendly.ts
@@ -30,7 +30,9 @@ export interface UserFriendlyContext {
     key: string,
     value: string,
   ) => { ok: boolean; error?: string } | Promise<{ ok: boolean; error?: string }>;
-  runConfigMode?: (mode: string) => { ok: boolean; error?: string; message?: string } | Promise<{ ok: boolean; error?: string; message?: string }>;
+  runConfigMode?: (
+    mode: string,
+  ) => { ok: boolean; error?: string; message?: string } | Promise<{ ok: boolean; error?: string; message?: string }>;
   runInstall?: (opts: { dryRun: boolean }) => Promise<{ ok: boolean }>;
   runMine?: (path: string) => Promise<void>;
 }
@@ -75,9 +77,11 @@ export function registerUserFriendlyCommands(mem: Chainable, ctx: UserFriendlyCo
   registerIfMissing(mem, "bootstrap", () =>
     registerBootstrapCommand(mem, ctx.cfg, ctx.factsDb, {
       runConfigMode: ctx.runConfigMode,
-      runInstall: ctx.runInstall ? async () => {
-        await ctx.runInstall!({ dryRun: false });
-      } : undefined,
+      runInstall: ctx.runInstall
+        ? async () => {
+            await ctx.runInstall!({ dryRun: false });
+          }
+        : undefined,
       runMine: ctx.runMine,
     }),
   );

--- a/extensions/memory-hybrid/cli/install/cron-jobs.ts
+++ b/extensions/memory-hybrid/cli/install/cron-jobs.ts
@@ -11,10 +11,7 @@ import {
 } from "../../services/cron-job-bash-harness.js";
 import { findDeprecatedHybridMemCronTokens } from "../../services/deprecated-cron-commands.js";
 import { capturePluginError } from "../../services/error-reporter.js";
-import {
-  readOpenClawCronStore,
-  writeOpenClawCronStore,
-} from "../../services/openclaw-cron-store.js";
+import { readOpenClawCronStore, writeOpenClawCronStore } from "../../services/openclaw-cron-store.js";
 import {
   extractCronStoreJobModel,
   readAgentsPrimaryModelFromOpenclawJsonPath,

--- a/extensions/memory-hybrid/cli/install/embedding-detect.ts
+++ b/extensions/memory-hybrid/cli/install/embedding-detect.ts
@@ -75,11 +75,7 @@ export function detectRecommendedEmbeddingSetup(
     return {
       provider: "ollama",
       model: "nomic-embed-text",
-      source: ollamaHost
-        ? "OLLAMA_HOST"
-        : existsSync(join(homedir(), ".ollama"))
-          ? "~/.ollama"
-          : "ollama --version",
+      source: ollamaHost ? "OLLAMA_HOST" : existsSync(join(homedir(), ".ollama")) ? "~/.ollama" : "ollama --version",
       reason: "Detected a local Ollama installation or endpoint hint.",
     };
   }

--- a/extensions/memory-hybrid/cli/verify/sections/config-cron.ts
+++ b/extensions/memory-hybrid/cli/verify/sections/config-cron.ts
@@ -14,7 +14,10 @@ import { dirname, join } from "node:path";
 import type { CredentialType, HybridMemoryConfig } from "../../../config.js";
 import { readGuardTimestampMs } from "../../../services/cron-guard.js";
 import { listMaintenanceSteps } from "../../../services/maintenance-orchestrator.js";
-import { HYBRID_MEM_CRON_ENV_SANITIZER_MARKER, maintenanceCronExpectsSummaryArtifact } from "../../../services/cron-job-bash-harness.js";
+import {
+  HYBRID_MEM_CRON_ENV_SANITIZER_MARKER,
+  maintenanceCronExpectsSummaryArtifact,
+} from "../../../services/cron-job-bash-harness.js";
 import {
   collectRecentHmExitLedgerPaths,
   findDeprecatedHybridMemCronTokens,
@@ -22,10 +25,7 @@ import {
 } from "../../../services/deprecated-cron-commands.js";
 import { resolveMaintenanceSummaryPath } from "../../../services/maintenance-artifact-paths.js";
 import { capturePluginError } from "../../../services/error-reporter.js";
-import {
-  describeCronStoreLocation,
-  readOpenClawCronStore,
-} from "../../../services/openclaw-cron-store.js";
+import { describeCronStoreLocation, readOpenClawCronStore } from "../../../services/openclaw-cron-store.js";
 import {
   analyzeCronJobsAgainstHeartbeatPatterns,
   extractCronJobMessageEntries,

--- a/extensions/memory-hybrid/config/parsers/features.ts
+++ b/extensions/memory-hybrid/config/parsers/features.ts
@@ -1277,6 +1277,7 @@ export function parseWorkboardConfig(cfg: Record<string, unknown>): WorkboardCon
   const columnsRaw = raw.columns as Record<string, unknown> | undefined;
   const columns: WorkboardColumnMapping = {
     taskInProgress: parseColumnName(columnsRaw?.taskInProgress, DEFAULT_WORKBOARD_COLUMNS.taskInProgress),
+    taskWaiting: parseColumnName(columnsRaw?.taskWaiting, DEFAULT_WORKBOARD_COLUMNS.taskWaiting),
     taskDone: parseColumnName(columnsRaw?.taskDone, DEFAULT_WORKBOARD_COLUMNS.taskDone),
     taskFailed: parseNullableColumnName(columnsRaw?.taskFailed, DEFAULT_WORKBOARD_COLUMNS.taskFailed),
     taskStale: parseNullableColumnName(columnsRaw?.taskStale, DEFAULT_WORKBOARD_COLUMNS.taskStale),

--- a/extensions/memory-hybrid/config/parsers/features.ts
+++ b/extensions/memory-hybrid/config/parsers/features.ts
@@ -1196,9 +1196,7 @@ export function parseLifecycleConfig(cfg: Record<string, unknown>): LifecycleAda
     fragmentEmbedding: {
       enabled: fragmentRaw?.enabled === true,
       minChars:
-        typeof fragmentRaw?.minChars === "number" && fragmentRaw.minChars > 0
-          ? Math.floor(fragmentRaw.minChars)
-          : 6000,
+        typeof fragmentRaw?.minChars === "number" && fragmentRaw.minChars > 0 ? Math.floor(fragmentRaw.minChars) : 6000,
     },
   };
 }

--- a/extensions/memory-hybrid/config/parsers/maintenance.ts
+++ b/extensions/memory-hybrid/config/parsers/maintenance.ts
@@ -190,29 +190,21 @@ function parseWorkerLeasesConfig(raw: unknown) {
       ? {
           enabled: quietRaw.enabled === true,
           start:
-            typeof quietRaw.start === "string" && quietRaw.start.trim().length > 0
-              ? quietRaw.start.trim()
-              : "01:00",
-          end:
-            typeof quietRaw.end === "string" && quietRaw.end.trim().length > 0 ? quietRaw.end.trim() : "06:00",
-          tz:
-            typeof quietRaw.tz === "string" && quietRaw.tz.trim().length > 0 ? quietRaw.tz.trim() : "UTC",
+            typeof quietRaw.start === "string" && quietRaw.start.trim().length > 0 ? quietRaw.start.trim() : "01:00",
+          end: typeof quietRaw.end === "string" && quietRaw.end.trim().length > 0 ? quietRaw.end.trim() : "06:00",
+          tz: typeof quietRaw.tz === "string" && quietRaw.tz.trim().length > 0 ? quietRaw.tz.trim() : "UTC",
         }
       : undefined;
   return {
     enabled: o.enabled === true,
     defaultTtlSeconds:
-      typeof o.defaultTtlSeconds === "number" && o.defaultTtlSeconds > 0
-        ? Math.floor(o.defaultTtlSeconds)
-        : 120,
+      typeof o.defaultTtlSeconds === "number" && o.defaultTtlSeconds > 0 ? Math.floor(o.defaultTtlSeconds) : 120,
     heartbeatIntervalSeconds:
       typeof o.heartbeatIntervalSeconds === "number" && o.heartbeatIntervalSeconds > 0
         ? Math.floor(o.heartbeatIntervalSeconds)
         : 30,
     ...(quietWindow ? { quietWindow } : {}),
-    ...(typeof o.contextUsageThreshold === "number" &&
-    o.contextUsageThreshold >= 0 &&
-    o.contextUsageThreshold <= 1
+    ...(typeof o.contextUsageThreshold === "number" && o.contextUsageThreshold >= 0 && o.contextUsageThreshold <= 1
       ? { contextUsageThreshold: o.contextUsageThreshold }
       : {}),
   };

--- a/extensions/memory-hybrid/config/parsers/retrieval.ts
+++ b/extensions/memory-hybrid/config/parsers/retrieval.ts
@@ -20,7 +20,9 @@ import type {
 export const MIN_QE_TIMEOUT_MS = 10_000;
 export const MIN_RERANK_TIMEOUT_MS = 5_000;
 
-function parseIntentRouterConfig(retrievalRaw: Record<string, unknown> | undefined): import("../types/retrieval.js").IntentRouterConfig {
+function parseIntentRouterConfig(
+  retrievalRaw: Record<string, unknown> | undefined,
+): import("../types/retrieval.js").IntentRouterConfig {
   const raw = retrievalRaw?.intentRouter as Record<string, unknown> | undefined;
   return {
     enabled: raw?.enabled !== false,
@@ -34,7 +36,9 @@ function parseIntentRouterConfig(retrievalRaw: Record<string, unknown> | undefin
   };
 }
 
-function parseCompositeScoreConfig(retrievalRaw: Record<string, unknown> | undefined): import("../types/retrieval.js").CompositeScoreConfig {
+function parseCompositeScoreConfig(
+  retrievalRaw: Record<string, unknown> | undefined,
+): import("../types/retrieval.js").CompositeScoreConfig {
   const raw = retrievalRaw?.compositeScore as Record<string, unknown> | undefined;
   const v = raw?.v === 2 ? 2 : 1;
   return {
@@ -44,7 +48,9 @@ function parseCompositeScoreConfig(retrievalRaw: Record<string, unknown> | undef
   };
 }
 
-function parseRetrievalDiversityConfig(retrievalRaw: Record<string, unknown> | undefined): import("../types/retrieval.js").RetrievalDiversityConfig {
+function parseRetrievalDiversityConfig(
+  retrievalRaw: Record<string, unknown> | undefined,
+): import("../types/retrieval.js").RetrievalDiversityConfig {
   const raw = retrievalRaw?.diversity as Record<string, unknown> | undefined;
   return {
     enabled: raw?.enabled === true,
@@ -52,7 +58,9 @@ function parseRetrievalDiversityConfig(retrievalRaw: Record<string, unknown> | u
   };
 }
 
-function parseRetrievalBypassConfig(retrievalRaw: Record<string, unknown> | undefined): import("../types/retrieval.js").RetrievalBypassConfig {
+function parseRetrievalBypassConfig(
+  retrievalRaw: Record<string, unknown> | undefined,
+): import("../types/retrieval.js").RetrievalBypassConfig {
   const raw = retrievalRaw?.bypass as Record<string, unknown> | undefined;
   return {
     enabled: raw?.enabled === true,
@@ -61,7 +69,9 @@ function parseRetrievalBypassConfig(retrievalRaw: Record<string, unknown> | unde
   };
 }
 
-function parseCrossEncoderConfig(retrievalRaw: Record<string, unknown> | undefined): import("../types/retrieval.js").CrossEncoderRerankConfig {
+function parseCrossEncoderConfig(
+  retrievalRaw: Record<string, unknown> | undefined,
+): import("../types/retrieval.js").CrossEncoderRerankConfig {
   const raw = retrievalRaw?.crossEncoder as Record<string, unknown> | undefined;
   return {
     endpoint: typeof raw?.endpoint === "string" ? raw.endpoint : undefined,
@@ -70,7 +80,9 @@ function parseCrossEncoderConfig(retrievalRaw: Record<string, unknown> | undefin
   };
 }
 
-function parseContextBoundaryConfig(retrievalRaw: Record<string, unknown> | undefined): import("../types/retrieval.js").ContextBoundaryConfig {
+function parseContextBoundaryConfig(
+  retrievalRaw: Record<string, unknown> | undefined,
+): import("../types/retrieval.js").ContextBoundaryConfig {
   const raw = retrievalRaw?.contextBoundary as Record<string, unknown> | undefined;
   const vf = raw?.vaultFactsMaxTokens as Record<string, unknown> | undefined;
   return {
@@ -87,7 +99,9 @@ function parseContextBoundaryConfig(retrievalRaw: Record<string, unknown> | unde
   };
 }
 
-function parseRecallFeedbackConfig(retrievalRaw: Record<string, unknown> | undefined): import("../types/retrieval.js").RecallFeedbackConfig {
+function parseRecallFeedbackConfig(
+  retrievalRaw: Record<string, unknown> | undefined,
+): import("../types/retrieval.js").RecallFeedbackConfig {
   const raw = retrievalRaw?.recallFeedback as Record<string, unknown> | undefined;
   const nudge = raw?.nudge as Record<string, unknown> | undefined;
   return {

--- a/extensions/memory-hybrid/config/types/workboard.ts
+++ b/extensions/memory-hybrid/config/types/workboard.ts
@@ -37,6 +37,8 @@ export type WorkboardConfig = {
 
 export type WorkboardColumnMapping = {
   taskInProgress: string;
+  /** Workboard column for Waiting tasks (OpenClaw slug, e.g. scheduled). */
+  taskWaiting: string;
   taskDone: string;
   taskFailed: string | null;
   taskStale: string | null;
@@ -47,16 +49,18 @@ export type WorkboardColumnMapping = {
   goalCompleted: string;
 };
 
+/** OpenClaw 6.8 Workboard status slugs — not legacy Kanban display labels. */
 export const DEFAULT_WORKBOARD_COLUMNS: WorkboardColumnMapping = {
-  taskInProgress: "In Progress",
-  taskDone: "Done",
-  taskFailed: "Failed",
-  taskStale: "Backlog",
-  taskParked: "Backlog",
-  goalActive: "In Progress",
-  goalBlocked: "Blocked",
-  goalStalled: "Backlog",
-  goalCompleted: "Done",
+  taskInProgress: "running",
+  taskWaiting: "scheduled",
+  taskDone: "done",
+  taskFailed: "blocked",
+  taskStale: "backlog",
+  taskParked: "backlog",
+  goalActive: "running",
+  goalBlocked: "blocked",
+  goalStalled: "backlog",
+  goalCompleted: "done",
 };
 
 export const DEFAULT_WORKBOARD_CONFIG: WorkboardConfig = {

--- a/extensions/memory-hybrid/lifecycle/stage-goal-stewardship.ts
+++ b/extensions/memory-hybrid/lifecycle/stage-goal-stewardship.ts
@@ -106,9 +106,7 @@ export function registerGoalStewardshipInjection(
         triageHeavy,
       });
       if (!built) {
-        api.logger?.info?.(
-          "memory-hybrid: goal stewardship skipped — no candidate goals past cooldown/budget filters",
-        );
+        api.logger?.info?.("memory-hybrid: goal stewardship skipped — no candidate goals past cooldown/budget filters");
         return undefined;
       }
 

--- a/extensions/memory-hybrid/lifecycle/stage-injection.ts
+++ b/extensions/memory-hybrid/lifecycle/stage-injection.ts
@@ -21,10 +21,7 @@ import {
 } from "../services/recalled-context-assembler.js";
 import { logRecallEvent } from "../services/recall-events.js";
 import { recordInjectionAttribution } from "../services/injection-attribution-store.js";
-import {
-  attributeInjectionToTurn,
-  segmentTranscriptIntoTurns,
-} from "../services/per-turn-attribution.js";
+import { attributeInjectionToTurn, segmentTranscriptIntoTurns } from "../services/per-turn-attribution.js";
 import { scanInjectionFilter, type InjectionFilterMode } from "../services/injection-filter.js";
 import { emitRecallVerboseLog } from "../services/recall-verbose-log.js";
 import { createRecallSpan, createRecallTimingLogger } from "../services/recall-timing.js";
@@ -204,8 +201,7 @@ async function runInjection(
   } = r;
   const recalledAmbient = issueBlock + narrativeBlock + hotBlock;
 
-  const injectionFilterMode: InjectionFilterMode =
-    ctx.cfg.retrieval?.contextBoundary?.injectionFilter ?? "audit";
+  const injectionFilterMode: InjectionFilterMode = ctx.cfg.retrieval?.contextBoundary?.injectionFilter ?? "audit";
   let injectionFilteredCount = 0;
 
   const vaultHandles =

--- a/extensions/memory-hybrid/openclaw.plugin.json
+++ b/extensions/memory-hybrid/openclaw.plugin.json
@@ -2614,31 +2614,35 @@
             "properties": {
               "taskInProgress": {
                 "type": "string",
-                "description": "Column for in-progress tasks. Default: In Progress."
+                "description": "Workboard status slug for in-progress tasks. Default: running."
               },
-              "taskDone": { "type": "string", "description": "Column for completed tasks. Default: Done." },
+              "taskWaiting": {
+                "type": "string",
+                "description": "Workboard status slug for waiting tasks. Default: scheduled."
+              },
+              "taskDone": { "type": "string", "description": "Workboard status slug for completed tasks. Default: done." },
               "taskFailed": {
                 "type": ["string", "null"],
-                "description": "Column for failed tasks (null to skip). Default: Failed."
+                "description": "Workboard status slug for failed tasks (null to skip). Default: blocked."
               },
               "taskStale": {
                 "type": ["string", "null"],
-                "description": "Column for stale tasks (null to skip). Default: Backlog."
+                "description": "Workboard status slug for stale tasks (null to skip). Default: backlog."
               },
               "taskParked": {
                 "type": ["string", "null"],
-                "description": "Column for parked tasks (null to skip). Default: Backlog."
+                "description": "Workboard status slug for parked tasks (null to skip). Default: backlog."
               },
-              "goalActive": { "type": "string", "description": "Column for active goals. Default: In Progress." },
+              "goalActive": { "type": "string", "description": "Workboard status slug for active goals. Default: running." },
               "goalBlocked": {
                 "type": ["string", "null"],
-                "description": "Column for blocked goals (null to skip). Default: Blocked."
+                "description": "Workboard status slug for blocked goals (null to skip). Default: blocked."
               },
               "goalStalled": {
                 "type": ["string", "null"],
-                "description": "Column for stalled goals (null to skip). Default: Backlog."
+                "description": "Workboard status slug for stalled goals (null to skip). Default: backlog."
               },
-              "goalCompleted": { "type": "string", "description": "Column for completed goals. Default: Done." }
+              "goalCompleted": { "type": "string", "description": "Workboard status slug for completed goals. Default: done." }
             },
             "description": "Workboard column mapping for hybrid-memory statuses."
           }

--- a/extensions/memory-hybrid/openclaw.plugin.json
+++ b/extensions/memory-hybrid/openclaw.plugin.json
@@ -2620,7 +2620,10 @@
                 "type": "string",
                 "description": "Workboard status slug for waiting tasks. Default: scheduled."
               },
-              "taskDone": { "type": "string", "description": "Workboard status slug for completed tasks. Default: done." },
+              "taskDone": {
+                "type": "string",
+                "description": "Workboard status slug for completed tasks. Default: done."
+              },
               "taskFailed": {
                 "type": ["string", "null"],
                 "description": "Workboard status slug for failed tasks (null to skip). Default: blocked."
@@ -2633,7 +2636,10 @@
                 "type": ["string", "null"],
                 "description": "Workboard status slug for parked tasks (null to skip). Default: backlog."
               },
-              "goalActive": { "type": "string", "description": "Workboard status slug for active goals. Default: running." },
+              "goalActive": {
+                "type": "string",
+                "description": "Workboard status slug for active goals. Default: running."
+              },
               "goalBlocked": {
                 "type": ["string", "null"],
                 "description": "Workboard status slug for blocked goals (null to skip). Default: blocked."
@@ -2642,7 +2648,10 @@
                 "type": ["string", "null"],
                 "description": "Workboard status slug for stalled goals (null to skip). Default: backlog."
               },
-              "goalCompleted": { "type": "string", "description": "Workboard status slug for completed goals. Default: done." }
+              "goalCompleted": {
+                "type": "string",
+                "description": "Workboard status slug for completed goals. Default: done."
+              }
             },
             "description": "Workboard column mapping for hybrid-memory statuses."
           }

--- a/extensions/memory-hybrid/services/auto-capture.ts
+++ b/extensions/memory-hybrid/services/auto-capture.ts
@@ -136,8 +136,7 @@ export function tryParseCredentialForVault(
   // If a match exists, it IS the credential — use its value.
   // Only fall back to the structured value param when no pattern matched.
   const secretFromMatch = match?.secretValue ?? null;
-  const secretFromParam =
-    value && value.length >= 8 && !value.startsWith(VAULT_POINTER_PREFIX) ? value : null;
+  const secretFromParam = value && value.length >= 8 && !value.startsWith(VAULT_POINTER_PREFIX) ? value : null;
   const secretValue = secretFromMatch ?? secretFromParam ?? null;
   if (!secretValue) return null;
   const typeFromPattern = (match?.type ?? "other") as "token" | "password" | "api_key" | "ssh" | "bearer" | "other";

--- a/extensions/memory-hybrid/services/capture-dedup.ts
+++ b/extensions/memory-hybrid/services/capture-dedup.ts
@@ -49,8 +49,6 @@ export function checkCaptureDedupWindow(
     )
     .get(hash, cutoff, scope, scopeTarget, scopeTarget, scopeTarget) as { id: string } | undefined;
   if (!row) return { skip: false };
-  db.prepare(
-    `UPDATE facts SET duplicate_count = COALESCE(duplicate_count, 0) + 1 WHERE id = ?`,
-  ).run(row.id);
+  db.prepare(`UPDATE facts SET duplicate_count = COALESCE(duplicate_count, 0) + 1 WHERE id = ?`).run(row.id);
   return { skip: true, existingId: row.id };
 }

--- a/extensions/memory-hybrid/services/composite-score.ts
+++ b/extensions/memory-hybrid/services/composite-score.ts
@@ -83,9 +83,7 @@ export function computeCompositeScore(
 ): number {
   const weights = getIntentWeights(input.intent);
   const base =
-    input.searchScore * weights.search +
-    input.recencyScore * weights.recency +
-    input.confidence * weights.confidence;
+    input.searchScore * weights.search + input.recencyScore * weights.recency + input.confidence * weights.confidence;
 
   if (config.version === 1) {
     return base;

--- a/extensions/memory-hybrid/services/contamination-guard.ts
+++ b/extensions/memory-hybrid/services/contamination-guard.ts
@@ -23,10 +23,7 @@ function extractNamedEntities(text: string): string[] {
 }
 
 /** Layer 1: every named entity in draft must appear in ≥1 source fact. */
-export function checkEntityContamination(
-  draft: string,
-  sourceTexts: string[],
-): ContaminationCheckResult {
+export function checkEntityContamination(draft: string, sourceTexts: string[]): ContaminationCheckResult {
   const entities = extractNamedEntities(draft);
   if (entities.length === 0) return { allowed: true, layer: "deterministic" };
   const corpus = sourceTexts.join("\n").toLowerCase();

--- a/extensions/memory-hybrid/services/cross-encoder-reranker.ts
+++ b/extensions/memory-hybrid/services/cross-encoder-reranker.ts
@@ -24,10 +24,7 @@ export function positionAwareAlpha(rankIndex: number): number {
 }
 
 /** Blend reranked order with pre-rerank scores using position-aware α. */
-export function blendRerankScores(
-  facts: ScoredFact[],
-  rerankScores: Map<string, number>,
-): ScoredFact[] {
+export function blendRerankScores(facts: ScoredFact[], rerankScores: Map<string, number>): ScoredFact[] {
   return facts
     .map((fact, index) => {
       const rerankScore = rerankScores.get(fact.factId) ?? fact.finalScore;

--- a/extensions/memory-hybrid/services/diversity.ts
+++ b/extensions/memory-hybrid/services/diversity.ts
@@ -59,9 +59,7 @@ export function applyDiversityDemotion<T extends { text: string }>(
   const demoted: T[] = [];
 
   for (const item of ranked) {
-    const tooSimilar = kept.some(
-      (k) => jaccardBigramSimilarity(k.text, item.text) > config.maxSimilarity,
-    );
+    const tooSimilar = kept.some((k) => jaccardBigramSimilarity(k.text, item.text) > config.maxSimilarity);
     if (tooSimilar && demoted.length < maxDemote) {
       demoted.push(item);
     } else {

--- a/extensions/memory-hybrid/services/dream-cycle.ts
+++ b/extensions/memory-hybrid/services/dream-cycle.ts
@@ -1053,20 +1053,17 @@ export async function runDreamCycle(
       logger.warn(
         `memory-hybrid: dream-cycle — ${repair.pairsFailed} contradiction pair(s) could not be repaired; will retry next dream cycle`,
       );
-      capturePluginError(
-        new Error(`contradiction repair partial failure: ${repair.pairsFailed} pair(s) unresolved`),
-        {
-          subsystem: "maintenance",
-          operation: "contradiction-repair-partial",
-          phase: "dream-cycle",
-          severity: "warning",
-          tags: {
-            pairs_failed: repair.pairsFailed,
-            pairs_fallback: repair.pairsFallback,
-            pairs_repaired: repair.pairsRepaired,
-          },
+      capturePluginError(new Error(`contradiction repair partial failure: ${repair.pairsFailed} pair(s) unresolved`), {
+        subsystem: "maintenance",
+        operation: "contradiction-repair-partial",
+        phase: "dream-cycle",
+        severity: "warning",
+        tags: {
+          pairs_failed: repair.pairsFailed,
+          pairs_fallback: repair.pairsFallback,
+          pairs_repaired: repair.pairsRepaired,
         },
-      );
+      });
     }
   } catch (err) {
     capturePluginError(err instanceof Error ? err : new Error(String(err)), {

--- a/extensions/memory-hybrid/services/episode-causal-inference.ts
+++ b/extensions/memory-hybrid/services/episode-causal-inference.ts
@@ -181,8 +181,8 @@ export function inferCausalLinks(db: DatabaseSync, newEpisode: Episode): InferCa
       `SELECT * FROM episodes WHERE created_at >= ? AND id != ? AND timestamp <= ?${scopeClause} ORDER BY timestamp DESC LIMIT ?`,
     )
     .all(sinceSec, newEpisode.id, newEpisode.timestamp, ...scopeParams, MAX_CANDIDATES * 2) as Array<
-      Record<string, unknown>
-    >;
+    Record<string, unknown>
+  >;
 
   const advisory: CausalLinkCandidate[] = [];
   const persisted: CausalLinkCandidate[] = [];
@@ -237,9 +237,7 @@ export function inferCausalLinks(db: DatabaseSync, newEpisode: Episode): InferCa
 export function decayEpisodeCausalLinks(db: DatabaseSync): { updated: number; deleted: number } {
   const nowSec = Math.floor(Date.now() / 1000);
   const rows = db
-    .prepare(
-      "SELECT id, confidence, last_reinforced_at, last_decay_at, created_at FROM episode_causal_links",
-    )
+    .prepare("SELECT id, confidence, last_reinforced_at, last_decay_at, created_at FROM episode_causal_links")
     .all() as Array<{
     id: string;
     confidence: number;

--- a/extensions/memory-hybrid/services/evolution-pass.ts
+++ b/extensions/memory-hybrid/services/evolution-pass.ts
@@ -71,12 +71,7 @@ export async function runEvolutionPass(
       db.prepare(
         `INSERT INTO maintenance_runs (job, started_at, ended_at, status, items_processed, metadata_json)
          VALUES ('evolution-pass', ?, ?, 'ran', ?, ?)`,
-      ).run(
-        now,
-        now,
-        evolved,
-        JSON.stringify({ scanned: rows.length, neighborsUpdated, llmCalls }),
-      );
+      ).run(now, now, evolved, JSON.stringify({ scanned: rows.length, neighborsUpdated, llmCalls }));
     }
     return { scanned: rows.length, evolved, neighborsUpdated, llmCalls };
   }

--- a/extensions/memory-hybrid/services/evolution-stats.ts
+++ b/extensions/memory-hybrid/services/evolution-stats.ts
@@ -46,9 +46,7 @@ export function collectEvolutionStats(db: DatabaseSync): EvolutionStats | null {
            ORDER BY started_at DESC
            LIMIT 1`,
         )
-        .get() as
-        | { started_at: number; items_processed: number; metadata_json: string | null }
-        | undefined;
+        .get() as { started_at: number; items_processed: number; metadata_json: string | null } | undefined;
       if (lastRun) {
         lastEvolutionPassAt = formatTimestampUtc(lastRun.started_at);
         qualityEvolvedLastPass = lastRun.items_processed ?? null;

--- a/extensions/memory-hybrid/services/feature-telemetry.ts
+++ b/extensions/memory-hybrid/services/feature-telemetry.ts
@@ -25,10 +25,7 @@ function sanitize(value: string): string {
 }
 
 function formatEvent(event: FeatureTelemetryEvent): string {
-  const parts = [
-    `feature=${sanitize(event.feature)}`,
-    `op=${sanitize(event.operation)}`,
-  ];
+  const parts = [`feature=${sanitize(event.feature)}`, `op=${sanitize(event.operation)}`];
   if (event.outcome) parts.push(`outcome=${event.outcome}`);
   if (event.durationMs != null) parts.push(`duration_ms=${event.durationMs}`);
   if (event.warnBudgetMs != null) parts.push(`budget_ms=${event.warnBudgetMs}`);

--- a/extensions/memory-hybrid/services/fragment-recall.ts
+++ b/extensions/memory-hybrid/services/fragment-recall.ts
@@ -6,11 +6,7 @@ import type { FactsDB } from "../backends/facts-db.js";
 import type { VaultHandle } from "./vault-registry.js";
 import type { MemoryEntry, SearchResult } from "../types/memory.js";
 
-export function resolveFactsDbForEntry(
-  entry: MemoryEntry,
-  defaultDb: FactsDB,
-  vaultHandles?: VaultHandle[],
-): FactsDB {
+export function resolveFactsDbForEntry(entry: MemoryEntry, defaultDb: FactsDB, vaultHandles?: VaultHandle[]): FactsDB {
   if (!vaultHandles || vaultHandles.length <= 1) return defaultDb;
   for (const handle of vaultHandles) {
     if (handle.factsDb.getById(entry.id)) return handle.factsDb;
@@ -41,27 +37,14 @@ export function preferFragmentsOverParents(candidates: SearchResult[]): SearchRe
 }
 
 /** Text shown in recall / injection when a fragment child is selected. */
-export function formatFragmentRecallText(
-  entry: MemoryEntry,
-  parent: MemoryEntry | null,
-  useSummary: boolean,
-): string {
+export function formatFragmentRecallText(entry: MemoryEntry, parent: MemoryEntry | null, useSummary: boolean): string {
   const body = useSummary && entry.summary?.trim() ? entry.summary : entry.text;
   if (!isFragmentEntry(entry) || !parent) return body;
-  const parentTitle =
-    parent.summary?.trim() ||
-    parent.text
-      .slice(0, 160)
-      .replace(/\s+/g, " ")
-      .trim();
+  const parentTitle = parent.summary?.trim() || parent.text.slice(0, 160).replace(/\s+/g, " ").trim();
   return `[§ ${parentTitle}]\n${body}`;
 }
 
-export function resolveRecallInjectionText(
-  entry: MemoryEntry,
-  factsDb: FactsDB,
-  useSummary: boolean,
-): string {
+export function resolveRecallInjectionText(entry: MemoryEntry, factsDb: FactsDB, useSummary: boolean): string {
   if (!isFragmentEntry(entry)) {
     return useSummary && entry.summary?.trim() ? entry.summary : entry.text;
   }
@@ -78,9 +61,7 @@ export function applyFragmentRecallPostProcess(
   let results = preferFragmentsOverParents(candidates);
   const boost = opts?.fragmentScoreBoost ?? 1.05;
   if (boost !== 1) {
-    results = results.map((r) =>
-      isFragmentEntry(r.entry) ? { ...r, score: r.score * boost } : r,
-    );
+    results = results.map((r) => (isFragmentEntry(r.entry) ? { ...r, score: r.score * boost } : r));
     results.sort((a, b) => b.score - a.score);
   }
   return results;

--- a/extensions/memory-hybrid/services/fts-search.ts
+++ b/extensions/memory-hybrid/services/fts-search.ts
@@ -231,7 +231,12 @@ export function searchFts(
         }
         if (tagFilter?.trim()) {
           filterSql += " AND (',' || COALESCE(tags,'') || ',') LIKE ? ESCAPE '\\'";
-          filterParams.push(`%,${tagFilter.toLowerCase().trim().replace(/[%_\\]/g, '\\$&')},%`);
+          filterParams.push(
+            `%,${tagFilter
+              .toLowerCase()
+              .trim()
+              .replace(/[%_\\]/g, "\\$&")},%`,
+          );
         }
         allFiltered.push(
           ...(db.prepare(filterSql).all(...filterParams) as Array<{

--- a/extensions/memory-hybrid/services/injection-filter.ts
+++ b/extensions/memory-hybrid/services/injection-filter.ts
@@ -37,13 +37,7 @@ const LAYER3 = [
 ];
 
 /** Layer 4 — delimiter injection. */
-const LAYER4 = [
-  /<\/context>/i,
-  /\n\nHuman\s*:/i,
-  /<\/recalled-context>/i,
-  /<\/vault-context>/i,
-  /<\/memory-context>/i,
-];
+const LAYER4 = [/<\/context>/i, /\n\nHuman\s*:/i, /<\/recalled-context>/i, /<\/vault-context>/i, /<\/memory-context>/i];
 
 /** Layer 5 — unicode obfuscation (zero-width, RTL, homoglyphs inside Latin words). */
 const ZERO_WIDTH = /[\u200B\u200C\u200D\uFEFF]/;

--- a/extensions/memory-hybrid/services/intent-classifier.ts
+++ b/extensions/memory-hybrid/services/intent-classifier.ts
@@ -16,13 +16,7 @@ export type IntentClassification = {
   source: "heuristic" | "llm" | "explicit";
 };
 
-const WHY_PATTERNS = [
-  /\bwhy\b/i,
-  /\bbecause\b/i,
-  /\bcaused\b/i,
-  /\breason\b/i,
-  /\bhow come\b/i,
-];
+const WHY_PATTERNS = [/\bwhy\b/i, /\bbecause\b/i, /\bcaused\b/i, /\breason\b/i, /\bhow come\b/i];
 
 const WHEN_PATTERNS = [
   /\bwhen\b/i,
@@ -170,11 +164,7 @@ export async function classifyQueryIntent(
   const heuristic = classifyIntentHeuristic(query);
   let result = heuristic;
 
-  if (
-    config.llmRefinement &&
-    heuristic.confidence < config.heuristicThreshold &&
-    opts?.openai
-  ) {
+  if (config.llmRefinement && heuristic.confidence < config.heuristicThreshold && opts?.openai) {
     try {
       const response = await chatComplete({
         model: config.model ?? "openai/gpt-4.1-nano",

--- a/extensions/memory-hybrid/services/maintenance-audit-journal.ts
+++ b/extensions/memory-hybrid/services/maintenance-audit-journal.ts
@@ -24,12 +24,7 @@ export type OrchestratorStepJournalInput = {
   semanticOutcome?: string;
 };
 
-export type MaintenanceRunStatus =
-  | "ran"
-  | "skipped:quiet"
-  | "skipped:rate"
-  | "skipped:lease"
-  | "failed";
+export type MaintenanceRunStatus = "ran" | "skipped:quiet" | "skipped:rate" | "skipped:lease" | "failed";
 
 export type MaintenanceRunInput = {
   job: string;
@@ -95,10 +90,7 @@ export function getLastRunForJob(db: DatabaseSync, job: string): MaintenanceRunR
 }
 
 /** Map orchestrator step outcome to journal status. */
-export function mapStepToMaintenanceRunStatus(
-  status: OrchestratorStepStatus,
-  summary: string,
-): MaintenanceRunStatus {
+export function mapStepToMaintenanceRunStatus(status: OrchestratorStepStatus, summary: string): MaintenanceRunStatus {
   if (status === "ok") {
     const lower = summary.toLowerCase();
     if (lower.includes("dry-run")) return "skipped:quiet";

--- a/extensions/memory-hybrid/services/memory-evolution.ts
+++ b/extensions/memory-hybrid/services/memory-evolution.ts
@@ -151,8 +151,7 @@ function applyHeuristicUpdate(
   const merged = [...new Set([...existing, ...keywords])];
   if (merged.length === existing.length && neighbor.summary?.trim()) return false;
   const summary =
-    neighbor.summary?.trim() ||
-    (context.summary?.trim() ? context.summary.slice(0, 240) : context.text.slice(0, 240));
+    neighbor.summary?.trim() || (context.summary?.trim() ? context.summary.slice(0, 240) : context.text.slice(0, 240));
   const reason = `neighbor_evolution:${context.id}:${evolutionCfg.mode}`;
   updateNeighbor.run(JSON.stringify(merged), summary, reason, neighbor.id);
   return true;
@@ -167,10 +166,7 @@ export async function runMemoryEvolutionPass(
   const result: MemoryEvolutionResult = { linksScanned: 0, neighborsUpdated: 0, llmCalls: 0 };
   if (!evolutionCfg.enabled) return result;
 
-  const llmBudget = Math.min(
-    evolutionCfg.dailyLlmCallCap,
-    opts.llmCallsBudget ?? evolutionCfg.dailyLlmCallCap,
-  );
+  const llmBudget = Math.min(evolutionCfg.dailyLlmCallCap, opts.llmCallsBudget ?? evolutionCfg.dailyLlmCallCap);
   const useLlm = evolutionCfg.mode === "llm" && Boolean(opts.openai && opts.model);
 
   const sinceSec = Math.floor(Date.now() / 1000) - 7 * 86_400;

--- a/extensions/memory-hybrid/services/multi-vault-retrieval.ts
+++ b/extensions/memory-hybrid/services/multi-vault-retrieval.ts
@@ -6,10 +6,7 @@ import type { DatabaseSync } from "node:sqlite";
 import type { FactsDB } from "../backends/facts-db.js";
 import type { VectorDB } from "../backends/vector-db.js";
 import type { MemoryEntry } from "../types/memory.js";
-import {
-  runExplicitDeepRetrieval,
-  type RetrievalPipelineOptions,
-} from "./retrieval-orchestrator.js";
+import { runExplicitDeepRetrieval, type RetrievalPipelineOptions } from "./retrieval-orchestrator.js";
 import type { FusedResult } from "./rrf-fusion.js";
 import type { VaultHandle } from "./vault-registry.js";
 
@@ -96,14 +93,7 @@ export async function runMultiVaultExplicitDeepRetrieval(
   const slices = await Promise.all(
     handles.map(async (h) => ({
       vaultName: h.name,
-      slice: await runExplicitDeepRetrieval(
-        query,
-        queryVector,
-        h.factsDb.getRawDb(),
-        h.vectorDb,
-        h.factsDb,
-        options,
-      ),
+      slice: await runExplicitDeepRetrieval(query, queryVector, h.factsDb.getRawDb(), h.vectorDb, h.factsDb, options),
     })),
   );
   return mergeOrchestratorSlices(slices);

--- a/extensions/memory-hybrid/services/openclaw-cron-store.ts
+++ b/extensions/memory-hybrid/services/openclaw-cron-store.ts
@@ -326,7 +326,8 @@ function bindPayloadColumns(payload: Record<string, unknown>): {
 } {
   const kind = String(payload.kind ?? "agentTurn");
   if (kind === "systemEvent") {
-    const text = typeof payload.text === "string" ? payload.text : typeof payload.message === "string" ? payload.message : null;
+    const text =
+      typeof payload.text === "string" ? payload.text : typeof payload.message === "string" ? payload.message : null;
     return {
       payload_kind: "systemEvent",
       payload_message: text,
@@ -558,7 +559,9 @@ function cronJobRowId(rawJob: Record<string, unknown>): string {
 }
 
 function loadExistingSqliteCronRows(db: DatabaseSync, storeKey: string): Map<string, Record<string, unknown>> {
-  const rows = db.prepare(`SELECT * FROM cron_jobs WHERE store_key = ?`).all(storeKey) as Array<Record<string, unknown>>;
+  const rows = db.prepare(`SELECT * FROM cron_jobs WHERE store_key = ?`).all(storeKey) as Array<
+    Record<string, unknown>
+  >;
   const out = new Map<string, Record<string, unknown>>();
   for (const row of rows) {
     const jobId = String(row.job_id ?? "");
@@ -648,13 +651,17 @@ function writeCronStoreToSqlite(sqlitePath: string, storeKey: string, store: Ope
       }
     }
 
-    const tx = createTransaction(db, () => {
-      db.prepare(`DELETE FROM cron_jobs WHERE store_key = ?`).run(storeKey);
-      const insert = db.prepare(CRON_JOBS_INSERT_SQL);
-      for (const row of rowsToInsert) {
-        insert.run(row);
-      }
-    }, "IMMEDIATE");
+    const tx = createTransaction(
+      db,
+      () => {
+        db.prepare(`DELETE FROM cron_jobs WHERE store_key = ?`).run(storeKey);
+        const insert = db.prepare(CRON_JOBS_INSERT_SQL);
+        for (const row of rowsToInsert) {
+          insert.run(row);
+        }
+      },
+      "IMMEDIATE",
+    );
     tx();
   } finally {
     db.close();
@@ -692,7 +699,11 @@ export function writeOpenClawCronStore(
 /** Convenience: load store, mutate jobs array in place, then persist. */
 export function withOpenClawCronStore<T>(
   openclawDir: string,
-  mutate: (ctx: { store: OpenClawCronStoreFile; jobs: Array<Record<string, unknown>>; snapshot: OpenClawCronStoreSnapshot }) => T,
+  mutate: (ctx: {
+    store: OpenClawCronStoreFile;
+    jobs: Array<Record<string, unknown>>;
+    snapshot: OpenClawCronStoreSnapshot;
+  }) => T,
 ): T {
   const snapshot = readOpenClawCronStore(openclawDir);
   if (!Array.isArray(snapshot.store.jobs)) snapshot.store.jobs = [];

--- a/extensions/memory-hybrid/services/passive-observer.ts
+++ b/extensions/memory-hybrid/services/passive-observer.ts
@@ -731,7 +731,13 @@ export async function runPassiveObserver(
         }
 
         const dedupWindow = opts.dedupWindowMinutes ?? 30;
-        const dedupInput = { text: storedText, entity: null, key: null, scope: identity ? "global" : "session", scopeTarget: identity ? null : sessionId };
+        const dedupInput = {
+          text: storedText,
+          entity: null,
+          key: null,
+          scope: identity ? "global" : "session",
+          scopeTarget: identity ? null : sessionId,
+        };
 
         const storeWithDedupCheck = createTransaction(
           factsDb.getRawDb(),

--- a/extensions/memory-hybrid/services/per-turn-attribution.ts
+++ b/extensions/memory-hybrid/services/per-turn-attribution.ts
@@ -15,9 +15,7 @@ export type TurnAttribution = {
 };
 
 /** Segment messages into turns for attribution. Falls back to single turn on uncertainty. */
-export function segmentTranscriptIntoTurns(
-  messages: Array<{ role?: string; content?: unknown }>,
-): ConversationTurn[] {
+export function segmentTranscriptIntoTurns(messages: Array<{ role?: string; content?: unknown }>): ConversationTurn[] {
   const turns: ConversationTurn[] = [];
   let idx = 0;
   for (const msg of messages) {
@@ -44,10 +42,7 @@ export function segmentTranscriptIntoTurns(
 }
 
 /** Attribute injected fact ids to the user turn that triggered injection (pre-response). */
-export function attributeInjectionToTurn(
-  turns: ConversationTurn[],
-  injectedFactIds: string[],
-): TurnAttribution {
+export function attributeInjectionToTurn(turns: ConversationTurn[], injectedFactIds: string[]): TurnAttribution {
   if (injectedFactIds.length === 0) {
     return { turnIndex: 0, injectedFactIds: [], referencedFactIds: [] };
   }
@@ -55,7 +50,7 @@ export function attributeInjectionToTurn(
   for (const t of turns) {
     if (t.role === "user") lastUser = t.index;
   }
-  const targetTurn = lastUser >= 0 ? lastUser : turns[turns.length - 1]?.index ?? 0;
+  const targetTurn = lastUser >= 0 ? lastUser : (turns[turns.length - 1]?.index ?? 0);
   return { turnIndex: targetTurn, injectedFactIds, referencedFactIds: [] };
 }
 

--- a/extensions/memory-hybrid/services/quiet-window.ts
+++ b/extensions/memory-hybrid/services/quiet-window.ts
@@ -34,10 +34,7 @@ export function localMinutesInTimeZone(at: Date, timeZone: string): number {
 }
 
 /** Returns true when wall-clock time in `qw.tz` is inside [start, end). */
-export function isInQuietWindowAt(
-  qw: NonNullable<WorkerLeasesConfig["quietWindow"]>,
-  at: Date,
-): boolean {
+export function isInQuietWindowAt(qw: NonNullable<WorkerLeasesConfig["quietWindow"]>, at: Date): boolean {
   if (!qw.enabled) return false;
   const startMin = parseHmToMinutes(qw.start);
   const endMin = parseHmToMinutes(qw.end);
@@ -54,10 +51,7 @@ export function isInQuietWindowAt(
  * Epoch seconds when the quiet window ends after `at`.
  * Scans forward minute-by-minute using the same TZ logic as `isInQuietWindowAt`.
  */
-export function quietWindowEndEpochSecAt(
-  qw: NonNullable<WorkerLeasesConfig["quietWindow"]>,
-  at: Date,
-): number | null {
+export function quietWindowEndEpochSecAt(qw: NonNullable<WorkerLeasesConfig["quietWindow"]>, at: Date): number | null {
   if (!qw.enabled || !isInQuietWindowAt(qw, at)) return null;
 
   const startMs = at.getTime();

--- a/extensions/memory-hybrid/services/recall-signals.ts
+++ b/extensions/memory-hybrid/services/recall-signals.ts
@@ -126,10 +126,7 @@ export function aggregateRecallStats(db: DatabaseSync, windowDays = 30): Map<str
 }
 
 /** Map confirmed access (full injection / explicit recall) onto recall-event surface stats. */
-export function enrichReferenceCountsFromFacts(
-  db: DatabaseSync,
-  stats: Map<string, FactRecallStats>,
-): void {
+export function enrichReferenceCountsFromFacts(db: DatabaseSync, stats: Map<string, FactRecallStats>): void {
   const factIds = [...stats.keys()];
   if (factIds.length === 0) return;
 

--- a/extensions/memory-hybrid/services/recall-verbose-log.ts
+++ b/extensions/memory-hybrid/services/recall-verbose-log.ts
@@ -43,10 +43,7 @@ export function getHmVerboseLevel(): typeof verboseLevel {
   return verboseLevel;
 }
 
-export function emitRecallVerboseLog(
-  event: RecallVerboseEvent,
-  logger?: { debug?: (msg: string) => void },
-): void {
+export function emitRecallVerboseLog(event: RecallVerboseEvent, logger?: { debug?: (msg: string) => void }): void {
   if (verboseLevel === "off") return;
   const payload = { ts: nowIso(), ...event };
   const line = JSON.stringify(payload);

--- a/extensions/memory-hybrid/services/recalled-context-assembler.ts
+++ b/extensions/memory-hybrid/services/recalled-context-assembler.ts
@@ -98,8 +98,7 @@ export function finalizeInjectionMemoryContent(
   const vaultBudget = boundary?.vaultFactsMaxTokens?.balanced ?? 200;
   const vaultHandles =
     ctx.cfg.retrieval?.multiVaultFanOut === true && ctx.resolveAllVaults ? ctx.resolveAllVaults() : [];
-  const factsDbs =
-    vaultHandles.length > 0 ? vaultHandles.map((handle) => handle.factsDb) : [ctx.factsDb];
+  const factsDbs = vaultHandles.length > 0 ? vaultHandles.map((handle) => handle.factsDb) : [ctx.factsDb];
   let spoBlock = "";
   if (vaultBudget > 0 && prompt.trim()) {
     const triples = resolveVaultFactsTriplesMulti(factsDbs, prompt);

--- a/extensions/memory-hybrid/services/reflection.ts
+++ b/extensions/memory-hybrid/services/reflection.ts
@@ -781,10 +781,15 @@ export async function runReflection(
     }
 
     const sourceTexts = recentFacts.map((f) => f.text);
-    const guard = await runContaminationGuard(patternText, sourceTexts, existingPatternFacts.map((f) => f.text), {
-      openai,
-      skipLlm: true,
-    });
+    const guard = await runContaminationGuard(
+      patternText,
+      sourceTexts,
+      existingPatternFacts.map((f) => f.text),
+      {
+        openai,
+        skipLlm: true,
+      },
+    );
     if (!guard.allowed) {
       quarantineSynthesisDraft(factsDb.getRawDb(), patternText, guard, sourceTexts);
       duplicatesSkipped++;

--- a/extensions/memory-hybrid/services/retrieval-v2.ts
+++ b/extensions/memory-hybrid/services/retrieval-v2.ts
@@ -126,9 +126,7 @@ export async function applyRetrievalV2(opts: ApplyRetrievalV2Opts): Promise<Retr
   const v1Order = opts.results.map((r) => r.entry.id);
   const compositeCfg = opts.config.compositeScore;
   const recallStats =
-    opts.factsDb && compositeCfg.version === 2
-      ? aggregateRecallStats(opts.factsDb.getRawDb(), 30)
-      : null;
+    opts.factsDb && compositeCfg.version === 2 ? aggregateRecallStats(opts.factsDb.getRawDb(), 30) : null;
   let finalResults: SearchResult[];
   let demotedCount = 0;
 
@@ -147,9 +145,7 @@ export async function applyRetrievalV2(opts: ApplyRetrievalV2Opts): Promise<Retr
         (entry as MemoryEntry & { revisionCount?: number }).revisionCount ?? 0,
         (entry as MemoryEntry & { duplicateCount?: number }).duplicateCount ?? 0,
       ),
-      crossDomainBoost: recallStats
-        ? computeCrossDomainBoost(recallStats.get(r.entry.id)?.distinctQueries ?? 0, 3)
-        : 0,
+      crossDomainBoost: recallStats ? computeCrossDomainBoost(recallStats.get(r.entry.id)?.distinctQueries ?? 0, 3) : 0,
       intent: intent.intent,
       focusMultiplier: topicMatchMultiplier(entry.text, opts.focusTopic),
     };

--- a/extensions/memory-hybrid/services/transcript-importers/index.ts
+++ b/extensions/memory-hybrid/services/transcript-importers/index.ts
@@ -91,7 +91,9 @@ export function parseChatGptExport(raw: string): ParsedConversation[] {
       if (!item || typeof item !== "object") continue;
       const conv = item as Record<string, unknown>;
       const title = String(conv.title ?? "ChatGPT conversation");
-      const mapping = conv.mapping as Record<string, { message?: { author?: { role?: string }; content?: { parts?: string[] } } }> | undefined;
+      const mapping = conv.mapping as
+        | Record<string, { message?: { author?: { role?: string }; content?: { parts?: string[] } } }>
+        | undefined;
       const messages: TranscriptMessage[] = [];
       if (mapping) {
         for (const node of Object.values(mapping)) {
@@ -163,7 +165,11 @@ const SECRET_PATTERNS: Array<{ name: string; regex: RegExp }> = [
 ];
 
 /** Redact common secret patterns before mine ingest. */
-export function redactSecretsInText(text: string): { text: string; redacted: number; categories: Record<string, number> } {
+export function redactSecretsInText(text: string): {
+  text: string;
+  redacted: number;
+  categories: Record<string, number>;
+} {
   let out = text;
   let redacted = 0;
   const categories: Record<string, number> = {};

--- a/extensions/memory-hybrid/services/vault-context.ts
+++ b/extensions/memory-hybrid/services/vault-context.ts
@@ -40,16 +40,8 @@ export function buildVaultContextBlock(options: VaultContextOptions): string {
     const suffix = meta.length > 0 ? ` [${meta.join(", ")}]` : "";
     return `  - ${f.text}${suffix}`;
   });
-  const relLines = (options.relationships ?? []).map(
-    (r) => `  - ${r.subjectId} ${r.edgeType} ${r.objectId}`,
-  );
-  const inner = [
-    "<vault-context>",
-    `<instruction>${instruction}</instruction>`,
-    "<facts>",
-    ...factLines,
-    "</facts>",
-  ];
+  const relLines = (options.relationships ?? []).map((r) => `  - ${r.subjectId} ${r.edgeType} ${r.objectId}`);
+  const inner = ["<vault-context>", `<instruction>${instruction}</instruction>`, "<facts>", ...factLines, "</facts>"];
   if (relLines.length > 0) {
     inner.push("<relationships>", ...relLines, "</relationships>");
   }
@@ -80,10 +72,7 @@ export function extractPromptNgrams(prompt: string, maxGram = 3): string[] {
 }
 
 /** Match known entity names against prompt (proper noun + ngram paths). */
-export function matchEntitiesInPrompt(
-  prompt: string,
-  knownEntities: string[],
-): string[] {
+export function matchEntitiesInPrompt(prompt: string, knownEntities: string[]): string[] {
   const lower = prompt.toLowerCase();
   const matched = new Set<string>();
   for (const entity of knownEntities) {

--- a/extensions/memory-hybrid/services/vault-facts-resolver.ts
+++ b/extensions/memory-hybrid/services/vault-facts-resolver.ts
@@ -10,9 +10,7 @@ type ContactRow = { id: string; display_name: string; primary_org_id: string | n
 
 function loadOrgRows(db: ReturnType<FactsDB["getRawDb"]>): OrgRow[] {
   try {
-    return db
-      .prepare(`SELECT id, display_name FROM organizations ORDER BY display_name LIMIT 200`)
-      .all() as OrgRow[];
+    return db.prepare(`SELECT id, display_name FROM organizations ORDER BY display_name LIMIT 200`).all() as OrgRow[];
   } catch {
     return [];
   }
@@ -29,20 +27,13 @@ function loadContactRows(db: ReturnType<FactsDB["getRawDb"]>): ContactRow[] {
 }
 
 /** Build SPO triples for entities mentioned in the user prompt. */
-export function resolveVaultFactsTriples(
-  factsDb: FactsDB,
-  prompt: string,
-  maxTriples = 20,
-): SpoTriple[] {
+export function resolveVaultFactsTriples(factsDb: FactsDB, prompt: string, maxTriples = 20): SpoTriple[] {
   const db = factsDb.getRawDb();
   const orgRows = loadOrgRows(db);
   const contactRows = loadContactRows(db);
   if (orgRows.length === 0 && contactRows.length === 0) return [];
 
-  const knownEntities = [
-    ...orgRows.map((o) => o.display_name),
-    ...contactRows.map((c) => c.display_name),
-  ];
+  const knownEntities = [...orgRows.map((o) => o.display_name), ...contactRows.map((c) => c.display_name)];
   const matched = matchEntitiesInPrompt(prompt, knownEntities);
   if (matched.length === 0) return [];
 
@@ -79,11 +70,7 @@ export function resolveVaultFactsTriples(
 }
 
 /** Merge SPO triples from multiple vault facts DBs (multi-vault fan-out). */
-export function resolveVaultFactsTriplesMulti(
-  factsDbs: FactsDB[],
-  prompt: string,
-  maxTriples = 20,
-): SpoTriple[] {
+export function resolveVaultFactsTriplesMulti(factsDbs: FactsDB[], prompt: string, maxTriples = 20): SpoTriple[] {
   if (factsDbs.length === 0) return [];
   const seen = new Set<string>();
   const merged: SpoTriple[] = [];

--- a/extensions/memory-hybrid/services/vault-registry.ts
+++ b/extensions/memory-hybrid/services/vault-registry.ts
@@ -58,16 +58,8 @@ export function createVaultRegistry(opts: {
   defaultWal: WriteAheadLog | null;
   vectorDim: number;
 }): VaultRegistry {
-  const {
-    cfg,
-    api,
-    defaultFactsDb,
-    defaultVectorDb,
-    defaultSqlitePath,
-    defaultLancePath,
-    defaultWal,
-    vectorDim,
-  } = opts;
+  const { cfg, api, defaultFactsDb, defaultVectorDb, defaultSqlitePath, defaultLancePath, defaultWal, vectorDim } =
+    opts;
   const cache = new Map<string, VaultHandle>();
   const walCache = new Map<string, WriteAheadLog>();
   const walEnabled = cfg.wal?.enabled === true;

--- a/extensions/memory-hybrid/services/workboard-adapter.ts
+++ b/extensions/memory-hybrid/services/workboard-adapter.ts
@@ -23,11 +23,8 @@ import {
   taskExternalId,
   taskToCard,
 } from "./workboard-card-mapper.js";
-import {
-  type WorkboardRpcCard,
-  type WorkboardRpcClient,
-  createWorkboardRpcClient,
-} from "./workboard-rpc-client.js";
+import { type WorkboardRpcCard, type WorkboardRpcClient, createWorkboardRpcClient } from "./workboard-rpc-client.js";
+import { tryToWorkboardStatusSlug } from "./workboard-status-slugs.js";
 
 export type TaskLoader = () => { active: ActiveTaskEntry[]; completed: ActiveTaskEntry[] };
 export type GoalLoader = () => Goal[] | Promise<Goal[]>;
@@ -191,8 +188,10 @@ async function upsertCard(
   const existingCard = existing.get(payload.externalId);
 
   if (existingCard) {
+    const existingCardColumnSlug = tryToWorkboardStatusSlug(existingCard.column);
+    const payloadColumnSlug = tryToWorkboardStatusSlug(payload.column);
     const needsUpdate =
-      existingCard.column !== payload.column ||
+      existingCardColumnSlug !== payloadColumnSlug ||
       existingCard.title !== payload.title ||
       existingCard.description !== payload.description;
 
@@ -280,7 +279,9 @@ async function pullChanges(
         );
         continue;
       }
-      if (card.column === expectedColumn) {
+      const cardColumnSlug = tryToWorkboardStatusSlug(card.column);
+      const expectedColumnSlug = tryToWorkboardStatusSlug(expectedColumn);
+      if (cardColumnSlug === expectedColumnSlug) {
         traceIntegration(
           verbose,
           `workboard sync [${syncRunId}] pull noop task ${extId} — column "${card.column}" matches memory`,
@@ -333,7 +334,9 @@ async function pullChanges(
         );
         continue;
       }
-      if (card.column === expectedColumn) {
+      const cardColumnSlug = tryToWorkboardStatusSlug(card.column);
+      const expectedColumnSlug = tryToWorkboardStatusSlug(expectedColumn);
+      if (cardColumnSlug === expectedColumnSlug) {
         traceIntegration(
           verbose,
           `workboard sync [${syncRunId}] pull noop goal ${extId} — column "${card.column}" matches memory`,

--- a/extensions/memory-hybrid/services/workboard-adapter.ts
+++ b/extensions/memory-hybrid/services/workboard-adapter.ts
@@ -19,12 +19,13 @@ import {
   goalExternalId,
   goalToCard,
   isHybridMemoryCard,
+  normalizeWorkboardNotes,
   parseExternalId,
   taskExternalId,
   taskToCard,
+  workboardColumnsEquivalent,
 } from "./workboard-card-mapper.js";
 import { type WorkboardRpcCard, type WorkboardRpcClient, createWorkboardRpcClient } from "./workboard-rpc-client.js";
-import { tryToWorkboardStatusSlug } from "./workboard-status-slugs.js";
 
 export type TaskLoader = () => { active: ActiveTaskEntry[]; completed: ActiveTaskEntry[] };
 export type GoalLoader = () => Goal[] | Promise<Goal[]>;
@@ -188,12 +189,10 @@ async function upsertCard(
   const existingCard = existing.get(payload.externalId);
 
   if (existingCard) {
-    const existingCardColumnSlug = tryToWorkboardStatusSlug(existingCard.column);
-    const payloadColumnSlug = tryToWorkboardStatusSlug(payload.column);
     const needsUpdate =
-      existingCardColumnSlug !== payloadColumnSlug ||
+      !workboardColumnsEquivalent(existingCard.column, payload.column) ||
       existingCard.title !== payload.title ||
-      existingCard.description !== payload.description;
+      normalizeWorkboardNotes(existingCard.description) !== normalizeWorkboardNotes(payload.description);
 
     if (needsUpdate) {
       const updated = await client.updateCard(existingCard.id, {
@@ -279,9 +278,7 @@ async function pullChanges(
         );
         continue;
       }
-      const cardColumnSlug = tryToWorkboardStatusSlug(card.column);
-      const expectedColumnSlug = tryToWorkboardStatusSlug(expectedColumn);
-      if (cardColumnSlug === expectedColumnSlug) {
+      if (workboardColumnsEquivalent(card.column, expectedColumn)) {
         traceIntegration(
           verbose,
           `workboard sync [${syncRunId}] pull noop task ${extId} — column "${card.column}" matches memory`,
@@ -334,9 +331,7 @@ async function pullChanges(
         );
         continue;
       }
-      const cardColumnSlug = tryToWorkboardStatusSlug(card.column);
-      const expectedColumnSlug = tryToWorkboardStatusSlug(expectedColumn);
-      if (cardColumnSlug === expectedColumnSlug) {
+      if (workboardColumnsEquivalent(card.column, expectedColumn)) {
         traceIntegration(
           verbose,
           `workboard sync [${syncRunId}] pull noop goal ${extId} — column "${card.column}" matches memory`,

--- a/extensions/memory-hybrid/services/workboard-card-mapper.ts
+++ b/extensions/memory-hybrid/services/workboard-card-mapper.ts
@@ -6,6 +6,7 @@
 import type { ActiveTaskEntry, ActiveTaskStatus } from "./active-task.js";
 import type { Goal, GoalStatus } from "./goal-stewardship-types.js";
 import type { WorkboardColumnMapping } from "../config/types/workboard.js";
+import { toWorkboardStatusSlug } from "./workboard-status-slugs.js";
 
 export type WorkboardCardPayload = {
   title: string;
@@ -80,7 +81,7 @@ export function taskToCard(
 
   return {
     title: `[Task] ${task.label}`,
-    column,
+    column: toWorkboardStatusSlug(column),
     description: descParts.join("\n") || undefined,
     tags: [cardTag],
     externalId: taskExternalId(task.label),
@@ -110,7 +111,7 @@ export function goalToCard(goal: Goal, columns: WorkboardColumnMapping, cardTag:
 
   return {
     title: `[Goal] ${goal.label}`,
-    column,
+    column: toWorkboardStatusSlug(column),
     description: descParts.join("\n") || undefined,
     tags: [cardTag, `priority:${goal.priority}`],
     externalId: goalExternalId(goal.id),

--- a/extensions/memory-hybrid/services/workboard-card-mapper.ts
+++ b/extensions/memory-hybrid/services/workboard-card-mapper.ts
@@ -6,7 +6,7 @@
 import type { ActiveTaskEntry, ActiveTaskStatus } from "./active-task.js";
 import type { Goal, GoalStatus } from "./goal-stewardship-types.js";
 import type { WorkboardColumnMapping } from "../config/types/workboard.js";
-import { toWorkboardStatusSlug } from "./workboard-status-slugs.js";
+import { toWorkboardStatusSlug, tryToWorkboardStatusSlug } from "./workboard-status-slugs.js";
 
 export type WorkboardCardPayload = {
   title: string;
@@ -168,8 +168,10 @@ function goalStatusToColumn(status: GoalStatus, columns: WorkboardColumnMapping)
 }
 
 export function columnToTaskStatus(column: string, columns: WorkboardColumnMapping): ActiveTaskStatus | null {
-  const lower = column.toLowerCase();
-  const match = (col: string | null) => col?.toLowerCase() === lower;
+  const normalizedColumn = tryToWorkboardStatusSlug(column);
+  if (!normalizedColumn) return null;
+
+  const match = (col: string | null) => col && toWorkboardStatusSlug(col) === normalizedColumn;
 
   if (match(columns.taskInProgress)) return "In progress";
   if (match(columns.taskWaiting)) return "Waiting";
@@ -181,8 +183,10 @@ export function columnToTaskStatus(column: string, columns: WorkboardColumnMappi
 }
 
 export function columnToGoalStatus(column: string, columns: WorkboardColumnMapping): GoalStatus | null {
-  const lower = column.toLowerCase();
-  const match = (col: string | null) => col?.toLowerCase() === lower;
+  const normalizedColumn = tryToWorkboardStatusSlug(column);
+  if (!normalizedColumn) return null;
+
+  const match = (col: string | null) => col && toWorkboardStatusSlug(col) === normalizedColumn;
 
   if (match(columns.goalActive)) return "active";
   if (match(columns.goalCompleted)) return "completed";

--- a/extensions/memory-hybrid/services/workboard-card-mapper.ts
+++ b/extensions/memory-hybrid/services/workboard-card-mapper.ts
@@ -25,7 +25,7 @@ export type WorkboardCardRecord = {
   description?: string;
   tags?: string[];
   externalId?: string;
-  metadata?: Record<string, string>;
+  metadata?: Record<string, unknown>;
   updatedAt?: string;
 };
 
@@ -40,11 +40,25 @@ export function goalExternalId(goalId: string): string {
   return `${GOAL_EXTERNAL_PREFIX}${goalId}`;
 }
 
-export function resolveWorkboardExternalId(card: WorkboardCardRecord): string | undefined {
+export function resolveWorkboardExternalId(card: {
+  externalId?: string;
+  metadata?: Record<string, unknown>;
+}): string | undefined {
   const meta = card.metadata as { automation?: { idempotencyKey?: string } } | undefined;
   const key = meta?.automation?.idempotencyKey;
   if (typeof key === "string" && key.length > 0) return key;
   return card.externalId;
+}
+
+export function normalizeWorkboardNotes(notes?: string): string | undefined {
+  return notes ? notes : undefined;
+}
+
+export function workboardColumnsEquivalent(a: string, b: string): boolean {
+  const slugA = tryToWorkboardStatusSlug(a);
+  const slugB = tryToWorkboardStatusSlug(b);
+  if (slugA !== null && slugB !== null) return slugA === slugB;
+  return a === b;
 }
 
 export function isHybridMemoryCard(card: WorkboardCardRecord): boolean {

--- a/extensions/memory-hybrid/services/workboard-card-mapper.ts
+++ b/extensions/memory-hybrid/services/workboard-card-mapper.ts
@@ -133,8 +133,9 @@ function taskStatusToColumn(
 
   switch (status) {
     case "In progress":
-    case "Waiting":
       return columns.taskInProgress;
+    case "Waiting":
+      return columns.taskWaiting;
     case "Stalled":
       return columns.taskStale;
     case "Done":
@@ -170,6 +171,7 @@ export function columnToTaskStatus(column: string, columns: WorkboardColumnMappi
   const match = (col: string | null) => col?.toLowerCase() === lower;
 
   if (match(columns.taskInProgress)) return "In progress";
+  if (match(columns.taskWaiting)) return "Waiting";
   if (match(columns.taskDone)) return "Done";
   if (match(columns.taskFailed)) return "Failed";
   if (match(columns.taskStale)) return "Stalled";

--- a/extensions/memory-hybrid/services/workboard-card-mapper.ts
+++ b/extensions/memory-hybrid/services/workboard-card-mapper.ts
@@ -39,8 +39,16 @@ export function goalExternalId(goalId: string): string {
   return `${GOAL_EXTERNAL_PREFIX}${goalId}`;
 }
 
+export function resolveWorkboardExternalId(card: WorkboardCardRecord): string | undefined {
+  const meta = card.metadata as { automation?: { idempotencyKey?: string } } | undefined;
+  const key = meta?.automation?.idempotencyKey;
+  if (typeof key === "string" && key.length > 0) return key;
+  return card.externalId;
+}
+
 export function isHybridMemoryCard(card: WorkboardCardRecord): boolean {
-  return !!card.externalId?.startsWith(TASK_EXTERNAL_PREFIX) || !!card.externalId?.startsWith(GOAL_EXTERNAL_PREFIX);
+  const extId = resolveWorkboardExternalId(card);
+  return !!extId?.startsWith(TASK_EXTERNAL_PREFIX) || !!extId?.startsWith(GOAL_EXTERNAL_PREFIX);
 }
 
 export function parseExternalId(

--- a/extensions/memory-hybrid/services/workboard-rpc-client.ts
+++ b/extensions/memory-hybrid/services/workboard-rpc-client.ts
@@ -8,6 +8,7 @@
 
 import { spawn } from "../utils/process-runner.js";
 import { pluginLogger } from "../utils/logger.js";
+import { toWorkboardStatusSlug } from "./workboard-status-slugs.js";
 
 export type WorkboardRpcCard = {
   id: string;
@@ -138,7 +139,7 @@ function mapWorkboardCreateParams(card: {
 }): Record<string, unknown> {
   const params: Record<string, unknown> = {
     title: card.title,
-    status: card.column,
+    status: toWorkboardStatusSlug(card.column),
   };
   if (card.description) params.notes = card.description;
   if (card.tags?.length) params.labels = card.tags;
@@ -156,7 +157,7 @@ function mapWorkboardUpdatePatch(patch: {
 }): Record<string, unknown> {
   const out: Record<string, unknown> = {};
   if (patch.title !== undefined) out.title = patch.title;
-  if (patch.column !== undefined) out.status = patch.column;
+  if (patch.column !== undefined) out.status = toWorkboardStatusSlug(patch.column);
   if (patch.description !== undefined) out.notes = patch.description;
   if (patch.tags !== undefined) out.labels = patch.tags;
   if (patch.metadata !== undefined) out.metadata = patch.metadata;

--- a/extensions/memory-hybrid/services/workboard-rpc-client.ts
+++ b/extensions/memory-hybrid/services/workboard-rpc-client.ts
@@ -143,6 +143,7 @@ function mapWorkboardCreateParams(card: {
   if (card.description) params.notes = card.description;
   if (card.tags?.length) params.labels = card.tags;
   if (card.externalId) params.idempotencyKey = card.externalId;
+  if (card.metadata) params.metadata = card.metadata;
   return params;
 }
 
@@ -218,6 +219,7 @@ export function createWorkboardHttpRpcClient(gatewayUrl: string, token?: string)
     async listCards(opts) {
       const params: Record<string, unknown> = {};
       if (opts?.column) params.status = opts.column;
+      if (opts?.tag) params.labels = [opts.tag];
       const result = await rpc("workboard.cards.list", params);
       return filterCardsByTag(normalizeWorkboardCardsResult(result), opts?.tag);
     },
@@ -346,6 +348,7 @@ export function createWorkboardGatewayCliRpcClient(token?: string): WorkboardRpc
     async listCards(opts) {
       const params: Record<string, unknown> = {};
       if (opts?.column) params.status = opts.column;
+      if (opts?.tag) params.labels = [opts.tag];
       const result = await rpc("workboard.cards.list", params);
       return filterCardsByTag(normalizeWorkboardCardsResult(result), opts?.tag);
     },

--- a/extensions/memory-hybrid/services/workboard-rpc-client.ts
+++ b/extensions/memory-hybrid/services/workboard-rpc-client.ts
@@ -300,6 +300,14 @@ async function runWorkboardGatewayCliCall(
       });
       child.on("close", (code) => {
         clearTimeout(timer);
+        if (code !== 0) {
+          const detail = (stderr || stdout).trim();
+          pluginLogger.warn(
+            `memory-hybrid: workboard gateway call ${method} failed${detail ? `: ${detail.slice(0, 200)}` : ""}`,
+          );
+          resolve(null);
+          return;
+        }
         const out = stdout.trim();
         if (out.startsWith("{") || out.startsWith("[")) {
           try {
@@ -308,14 +316,6 @@ async function runWorkboardGatewayCliCall(
           } catch {
             /* fall through */
           }
-        }
-        if (code !== 0) {
-          const detail = (stderr || stdout).trim();
-          pluginLogger.warn(
-            `memory-hybrid: workboard gateway call ${method} failed${detail ? `: ${detail.slice(0, 200)}` : ""}`,
-          );
-          resolve(null);
-          return;
         }
         if (!out) {
           resolve(null);

--- a/extensions/memory-hybrid/services/workboard-rpc-client.ts
+++ b/extensions/memory-hybrid/services/workboard-rpc-client.ts
@@ -288,8 +288,18 @@ async function runWorkboardGatewayCliCall(
     return await new Promise((resolve) => {
       let stdout = "";
       let stderr = "";
+      let settled = false;
       const child = spawn("openclaw", args, { env });
-      const timer = setTimeout(() => child.kill("SIGTERM"), REQUEST_TIMEOUT_MS + 5000);
+      const timer = setTimeout(() => {
+        if (!settled) {
+          settled = true;
+          pluginLogger.warn(
+            `memory-hybrid: workboard gateway call ${method} timed out after ${REQUEST_TIMEOUT_MS + 5000}ms`,
+          );
+          child.kill("SIGTERM");
+          resolve(null);
+        }
+      }, REQUEST_TIMEOUT_MS + 5000);
       child.stdout?.on("data", (chunk) => {
         stdout += String(chunk);
       });
@@ -297,37 +307,43 @@ async function runWorkboardGatewayCliCall(
         stderr += String(chunk);
       });
       child.on("error", (err) => {
-        clearTimeout(timer);
-        pluginLogger.warn(`memory-hybrid: workboard gateway call ${method} failed: ${err.message}`);
-        resolve(null);
+        if (!settled) {
+          settled = true;
+          clearTimeout(timer);
+          pluginLogger.warn(`memory-hybrid: workboard gateway call ${method} failed: ${err.message}`);
+          resolve(null);
+        }
       });
       child.on("close", (code) => {
-        clearTimeout(timer);
-        if (code !== 0) {
-          const detail = (stderr || stdout).trim();
-          pluginLogger.warn(
-            `memory-hybrid: workboard gateway call ${method} failed${detail ? `: ${detail.slice(0, 200)}` : ""}`,
-          );
-          resolve(null);
-          return;
-        }
-        const out = stdout.trim();
-        if (out.startsWith("{") || out.startsWith("[")) {
+        if (!settled) {
+          settled = true;
+          clearTimeout(timer);
+          if (code !== 0) {
+            const detail = (stderr || stdout).trim();
+            pluginLogger.warn(
+              `memory-hybrid: workboard gateway call ${method} failed${detail ? `: ${detail.slice(0, 200)}` : ""}`,
+            );
+            resolve(null);
+            return;
+          }
+          const out = stdout.trim();
+          if (out.startsWith("{") || out.startsWith("[")) {
+            try {
+              resolve(JSON.parse(out));
+              return;
+            } catch {
+              /* fall through */
+            }
+          }
+          if (!out) {
+            resolve(null);
+            return;
+          }
           try {
             resolve(JSON.parse(out));
-            return;
           } catch {
-            /* fall through */
+            resolve(null);
           }
-        }
-        if (!out) {
-          resolve(null);
-          return;
-        }
-        try {
-          resolve(JSON.parse(out));
-        } catch {
-          resolve(null);
         }
       });
     });

--- a/extensions/memory-hybrid/services/workboard-rpc-client.ts
+++ b/extensions/memory-hybrid/services/workboard-rpc-client.ts
@@ -79,11 +79,13 @@ export function normalizeWorkboardCardFromApi(raw: unknown): WorkboardRpcCard | 
   const column = typeof api.status === "string" ? api.status : typeof api.column === "string" ? api.column : "";
   const tags = Array.isArray(api.labels) ? api.labels : Array.isArray(api.tags) ? api.tags : undefined;
   const externalId = workboardApiExternalId(api);
+  const rawNotes = typeof api.notes === "string" ? api.notes : api.description;
+  const description = rawNotes ? rawNotes : undefined;
   return {
     id: api.id,
     title: typeof api.title === "string" ? api.title : "",
     column,
-    description: typeof api.notes === "string" ? api.notes : api.description,
+    description,
     tags,
     externalId,
     metadata: api.metadata,

--- a/extensions/memory-hybrid/services/workboard-rpc-client.ts
+++ b/extensions/memory-hybrid/services/workboard-rpc-client.ts
@@ -6,7 +6,7 @@
  * a direct plugin-to-plugin API if that becomes available.
  */
 
-import { spawnSync } from "../utils/process-runner.js";
+import { spawn } from "../utils/process-runner.js";
 import { pluginLogger } from "../utils/logger.js";
 
 export type WorkboardRpcCard = {
@@ -16,7 +16,7 @@ export type WorkboardRpcCard = {
   description?: string;
   tags?: string[];
   externalId?: string;
-  metadata?: Record<string, string>;
+  metadata?: Record<string, unknown>;
   createdAt?: string;
   updatedAt?: string;
 };
@@ -46,24 +46,77 @@ export interface WorkboardRpcClient {
   isAvailable(): Promise<boolean>;
 }
 
-const REQUEST_TIMEOUT_MS = 10_000;
+const REQUEST_TIMEOUT_MS = 25_000;
+
+type WorkboardApiCard = {
+  id?: string;
+  title?: string;
+  status?: string;
+  column?: string;
+  notes?: string;
+  description?: string;
+  labels?: string[];
+  tags?: string[];
+  externalId?: string;
+  metadata?: { automation?: { idempotencyKey?: string } } & Record<string, unknown>;
+  createdAt?: number | string;
+  updatedAt?: number | string;
+};
+
+function workboardApiExternalId(card: WorkboardApiCard): string | undefined {
+  const key = card.metadata?.automation?.idempotencyKey;
+  if (typeof key === "string" && key.length > 0) return key;
+  if (typeof card.externalId === "string" && card.externalId.length > 0) return card.externalId;
+  return undefined;
+}
+
+/** Map OpenClaw Workboard card JSON (status/labels/notes) to hybrid-memory RPC shape. */
+export function normalizeWorkboardCardFromApi(raw: unknown): WorkboardRpcCard | null {
+  if (typeof raw !== "object" || raw === null) return null;
+  const api = raw as WorkboardApiCard;
+  if (typeof api.id !== "string" || typeof api.title !== "string") return null;
+  const column = typeof api.status === "string" ? api.status : typeof api.column === "string" ? api.column : "";
+  const tags = Array.isArray(api.labels) ? api.labels : Array.isArray(api.tags) ? api.tags : undefined;
+  const externalId = workboardApiExternalId(api);
+  return {
+    id: api.id,
+    title: api.title,
+    column,
+    description: typeof api.notes === "string" ? api.notes : api.description,
+    tags,
+    externalId,
+    metadata: api.metadata,
+    createdAt: typeof api.createdAt === "number" ? String(api.createdAt) : api.createdAt,
+    updatedAt: typeof api.updatedAt === "number" ? String(api.updatedAt) : api.updatedAt,
+  };
+}
 
 function normalizeWorkboardCardsResult(result: unknown): WorkboardRpcCard[] {
-  if (Array.isArray(result)) return result as WorkboardRpcCard[];
+  if (Array.isArray(result)) {
+    return result.map((card) => normalizeWorkboardCardFromApi(card)).filter((c): c is WorkboardRpcCard => c != null);
+  }
   if (typeof result === "object" && result !== null) {
-    const obj = result as { cards?: WorkboardRpcCard[]; result?: { cards?: WorkboardRpcCard[] } };
-    if (Array.isArray(obj.cards)) return obj.cards;
-    if (obj.result && Array.isArray(obj.result.cards)) return obj.result.cards;
+    const obj = result as { cards?: unknown[]; result?: { cards?: unknown[] } };
+    const rawCards = Array.isArray(obj.cards)
+      ? obj.cards
+      : obj.result && Array.isArray(obj.result.cards)
+        ? obj.result.cards
+        : [];
+    return rawCards.map((card) => normalizeWorkboardCardFromApi(card)).filter((c): c is WorkboardRpcCard => c != null);
   }
   return [];
 }
 
 function normalizeWorkboardCardResult(result: unknown): WorkboardRpcCard | null {
   if (typeof result !== "object" || result === null) return null;
-  const obj = result as WorkboardRpcCard & { result?: WorkboardRpcCard };
-  if (typeof obj.id === "string") return obj;
-  if (obj.result && typeof obj.result.id === "string") return obj.result;
-  return null;
+  const obj = result as { card?: unknown; result?: { card?: unknown; id?: string } };
+  if (obj.card) return normalizeWorkboardCardFromApi(obj.card);
+  if (obj.result && typeof obj.result === "object" && obj.result !== null) {
+    const nested = obj.result as { card?: unknown; id?: string };
+    if (nested.card) return normalizeWorkboardCardFromApi(nested.card);
+    if (typeof nested.id === "string") return normalizeWorkboardCardFromApi(nested);
+  }
+  return normalizeWorkboardCardFromApi(obj);
 }
 
 function normalizeWorkboardDeleteResult(result: unknown): boolean {
@@ -75,10 +128,49 @@ function normalizeWorkboardDeleteResult(result: unknown): boolean {
   return false;
 }
 
+function mapWorkboardCreateParams(card: {
+  title: string;
+  column: string;
+  description?: string;
+  tags?: string[];
+  externalId?: string;
+  metadata?: Record<string, string>;
+}): Record<string, unknown> {
+  const params: Record<string, unknown> = {
+    title: card.title,
+    status: card.column,
+  };
+  if (card.description) params.notes = card.description;
+  if (card.tags?.length) params.labels = card.tags;
+  if (card.externalId) params.idempotencyKey = card.externalId;
+  return params;
+}
+
+function mapWorkboardUpdatePatch(patch: {
+  title?: string;
+  column?: string;
+  description?: string;
+  tags?: string[];
+  metadata?: Record<string, string>;
+}): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  if (patch.title !== undefined) out.title = patch.title;
+  if (patch.column !== undefined) out.status = patch.column;
+  if (patch.description !== undefined) out.notes = patch.description;
+  if (patch.tags !== undefined) out.labels = patch.tags;
+  if (patch.metadata !== undefined) out.metadata = patch.metadata;
+  return out;
+}
+
+function filterCardsByTag(cards: WorkboardRpcCard[], tag?: string): WorkboardRpcCard[] {
+  if (!tag) return cards;
+  return cards.filter((c) => c.tags?.includes(tag));
+}
+
 export function createWorkboardHttpRpcClient(gatewayUrl: string, token?: string): WorkboardRpcClient {
   const baseUrl = gatewayUrl.replace(/\/+$/, "");
 
-  async function rpc<T>(method: string, params: Record<string, unknown> = {}): Promise<T | null> {
+  async function rpc(method: string, params: Record<string, unknown> = {}): Promise<unknown | null> {
     const url = `${baseUrl}/rpc/${method}`;
     const headers: Record<string, string> = { "Content-Type": "application/json" };
     if (token) headers.Authorization = `Bearer ${token}`;
@@ -103,13 +195,13 @@ export function createWorkboardHttpRpcClient(gatewayUrl: string, token?: string)
         return null;
       }
 
-      const json = (await response.json()) as { result?: T; error?: string };
+      const json = (await response.json()) as { result?: unknown; error?: string };
       if (json.error) {
         pluginLogger.warn(`memory-hybrid: workboard RPC ${method} error: ${json.error}`);
         return null;
       }
 
-      return json.result ?? (json as unknown as T);
+      return json.result ?? json;
     } catch (err) {
       if (err instanceof Error && err.name === "AbortError") {
         pluginLogger.warn(`memory-hybrid: workboard RPC ${method} timed out after ${REQUEST_TIMEOUT_MS}ms`);
@@ -125,23 +217,24 @@ export function createWorkboardHttpRpcClient(gatewayUrl: string, token?: string)
   return {
     async listCards(opts) {
       const params: Record<string, unknown> = {};
-      if (opts?.tag) params.tag = opts.tag;
-      if (opts?.column) params.column = opts.column;
-      const result = await rpc<{ cards: WorkboardRpcCard[] }>("workboard.cards.list", params);
-      return result?.cards ?? [];
+      if (opts?.column) params.status = opts.column;
+      const result = await rpc("workboard.cards.list", params);
+      return filterCardsByTag(normalizeWorkboardCardsResult(result), opts?.tag);
     },
 
     async createCard(card) {
-      return rpc<WorkboardRpcCard>("workboard.cards.create", card);
+      const result = await rpc("workboard.cards.create", mapWorkboardCreateParams(card));
+      return normalizeWorkboardCardResult(result);
     },
 
     async updateCard(cardId, patch) {
-      return rpc<WorkboardRpcCard>("workboard.cards.update", { id: cardId, ...patch });
+      const result = await rpc("workboard.cards.update", { id: cardId, ...mapWorkboardUpdatePatch(patch) });
+      return normalizeWorkboardCardResult(result);
     },
 
     async deleteCard(cardId) {
-      const result = await rpc<{ deleted: boolean }>("workboard.cards.delete", { id: cardId });
-      return result?.deleted ?? false;
+      const result = await rpc("workboard.cards.delete", { id: cardId });
+      return normalizeWorkboardDeleteResult(result);
     },
 
     async findByExternalId(externalId) {
@@ -171,7 +264,11 @@ export function createWorkboardHttpRpcClient(gatewayUrl: string, token?: string)
   };
 }
 
-function runWorkboardGatewayCliCall(method: string, params: Record<string, unknown>, token?: string): unknown | null {
+async function runWorkboardGatewayCliCall(
+  method: string,
+  params: Record<string, unknown>,
+  token?: string,
+): Promise<unknown | null> {
   const args = [
     "gateway",
     "call",
@@ -182,24 +279,55 @@ function runWorkboardGatewayCliCall(method: string, params: Record<string, unkno
     "--timeout",
     String(REQUEST_TIMEOUT_MS),
   ];
+  const env = token ? { ...process.env, OPENCLAW_GATEWAY_TOKEN: token } : process.env;
 
   try {
-    const env = token ? { ...process.env, OPENCLAW_GATEWAY_TOKEN: token } : process.env;
-    const result = spawnSync("openclaw", args, {
-      encoding: "utf-8",
-      env,
-      timeout: REQUEST_TIMEOUT_MS + 2000,
+    return await new Promise((resolve) => {
+      let stdout = "";
+      let stderr = "";
+      const child = spawn("openclaw", args, { env });
+      const timer = setTimeout(() => child.kill("SIGTERM"), REQUEST_TIMEOUT_MS + 5000);
+      child.stdout?.on("data", (chunk) => {
+        stdout += String(chunk);
+      });
+      child.stderr?.on("data", (chunk) => {
+        stderr += String(chunk);
+      });
+      child.on("error", (err) => {
+        clearTimeout(timer);
+        pluginLogger.warn(`memory-hybrid: workboard gateway call ${method} failed: ${err.message}`);
+        resolve(null);
+      });
+      child.on("close", (code) => {
+        clearTimeout(timer);
+        const out = stdout.trim();
+        if (out.startsWith("{") || out.startsWith("[")) {
+          try {
+            resolve(JSON.parse(out));
+            return;
+          } catch {
+            /* fall through */
+          }
+        }
+        if (code !== 0) {
+          const detail = (stderr || stdout).trim();
+          pluginLogger.warn(
+            `memory-hybrid: workboard gateway call ${method} failed${detail ? `: ${detail.slice(0, 200)}` : ""}`,
+          );
+          resolve(null);
+          return;
+        }
+        if (!out) {
+          resolve(null);
+          return;
+        }
+        try {
+          resolve(JSON.parse(out));
+        } catch {
+          resolve(null);
+        }
+      });
     });
-    if (result.error || result.status !== 0) {
-      const detail = (result.stderr || result.stdout || "").trim();
-      pluginLogger.warn(
-        `memory-hybrid: workboard gateway call ${method} failed${detail ? `: ${detail.slice(0, 200)}` : ""}`,
-      );
-      return null;
-    }
-    const stdout = result.stdout.trim();
-    if (!stdout) return null;
-    return JSON.parse(stdout) as unknown;
   } catch (err) {
     pluginLogger.warn(
       `memory-hybrid: workboard gateway call ${method} failed: ${err instanceof Error ? err.message : String(err)}`,
@@ -217,19 +345,18 @@ export function createWorkboardGatewayCliRpcClient(token?: string): WorkboardRpc
   return {
     async listCards(opts) {
       const params: Record<string, unknown> = {};
-      if (opts?.tag) params.tag = opts.tag;
-      if (opts?.column) params.column = opts.column;
+      if (opts?.column) params.status = opts.column;
       const result = await rpc("workboard.cards.list", params);
-      return normalizeWorkboardCardsResult(result);
+      return filterCardsByTag(normalizeWorkboardCardsResult(result), opts?.tag);
     },
 
     async createCard(card) {
-      const result = await rpc("workboard.cards.create", card);
+      const result = await rpc("workboard.cards.create", mapWorkboardCreateParams(card));
       return normalizeWorkboardCardResult(result);
     },
 
     async updateCard(cardId, patch) {
-      const result = await rpc("workboard.cards.update", { id: cardId, ...patch });
+      const result = await rpc("workboard.cards.update", { id: cardId, ...mapWorkboardUpdatePatch(patch) });
       return normalizeWorkboardCardResult(result);
     },
 
@@ -244,8 +371,7 @@ export function createWorkboardGatewayCliRpcClient(token?: string): WorkboardRpc
     },
 
     async isAvailable() {
-      const result = runWorkboardGatewayCliCall("workboard.cards.list", {}, token);
-      return result != null;
+      return (await runWorkboardGatewayCliCall("workboard.cards.list", {}, token)) != null;
     },
   };
 }

--- a/extensions/memory-hybrid/services/workboard-rpc-client.ts
+++ b/extensions/memory-hybrid/services/workboard-rpc-client.ts
@@ -75,13 +75,13 @@ function workboardApiExternalId(card: WorkboardApiCard): string | undefined {
 export function normalizeWorkboardCardFromApi(raw: unknown): WorkboardRpcCard | null {
   if (typeof raw !== "object" || raw === null) return null;
   const api = raw as WorkboardApiCard;
-  if (typeof api.id !== "string" || typeof api.title !== "string") return null;
+  if (typeof api.id !== "string") return null;
   const column = typeof api.status === "string" ? api.status : typeof api.column === "string" ? api.column : "";
   const tags = Array.isArray(api.labels) ? api.labels : Array.isArray(api.tags) ? api.tags : undefined;
   const externalId = workboardApiExternalId(api);
   return {
     id: api.id,
-    title: api.title,
+    title: typeof api.title === "string" ? api.title : "",
     column,
     description: typeof api.notes === "string" ? api.notes : api.description,
     tags,
@@ -219,7 +219,7 @@ export function createWorkboardHttpRpcClient(gatewayUrl: string, token?: string)
   return {
     async listCards(opts) {
       const params: Record<string, unknown> = {};
-      if (opts?.column) params.status = opts.column;
+      if (opts?.column) params.status = toWorkboardStatusSlug(opts.column);
       if (opts?.tag) params.labels = [opts.tag];
       const result = await rpc("workboard.cards.list", params);
       return filterCardsByTag(normalizeWorkboardCardsResult(result), opts?.tag);
@@ -348,7 +348,7 @@ export function createWorkboardGatewayCliRpcClient(token?: string): WorkboardRpc
   return {
     async listCards(opts) {
       const params: Record<string, unknown> = {};
-      if (opts?.column) params.status = opts.column;
+      if (opts?.column) params.status = toWorkboardStatusSlug(opts.column);
       if (opts?.tag) params.labels = [opts.tag];
       const result = await rpc("workboard.cards.list", params);
       return filterCardsByTag(normalizeWorkboardCardsResult(result), opts?.tag);

--- a/extensions/memory-hybrid/services/workboard-status-slugs.ts
+++ b/extensions/memory-hybrid/services/workboard-status-slugs.ts
@@ -45,10 +45,13 @@ export function isValidWorkboardStatusSlug(value: string): value is WorkboardSta
 }
 
 /** Map configured column name (slug or legacy label) to a Workboard API status slug. */
-export function toWorkboardStatusSlug(column: string): WorkboardStatusSlug {
-  const lower = column.trim().toLowerCase();
-  if (SLUG_SET.has(lower)) return lower as WorkboardStatusSlug;
-  return LEGACY_COLUMN_TO_SLUG[lower] ?? "backlog";
+export function toWorkboardStatusSlug(column: string): string {
+  const trimmed = column.trim();
+  const lower = trimmed.toLowerCase();
+  if (SLUG_SET.has(lower)) return lower;
+  const mapped = LEGACY_COLUMN_TO_SLUG[lower];
+  if (mapped) return mapped;
+  return trimmed;
 }
 
 /** Map column name (slug or legacy label) to slug, returning null if unrecognized. */

--- a/extensions/memory-hybrid/services/workboard-status-slugs.ts
+++ b/extensions/memory-hybrid/services/workboard-status-slugs.ts
@@ -50,3 +50,10 @@ export function toWorkboardStatusSlug(column: string): WorkboardStatusSlug {
   if (SLUG_SET.has(lower)) return lower as WorkboardStatusSlug;
   return LEGACY_COLUMN_TO_SLUG[lower] ?? "backlog";
 }
+
+/** Map column name (slug or legacy label) to slug, returning null if unrecognized. */
+export function tryToWorkboardStatusSlug(column: string): WorkboardStatusSlug | null {
+  const lower = column.trim().toLowerCase();
+  if (SLUG_SET.has(lower)) return lower as WorkboardStatusSlug;
+  return LEGACY_COLUMN_TO_SLUG[lower] ?? null;
+}

--- a/extensions/memory-hybrid/services/workboard-status-slugs.ts
+++ b/extensions/memory-hybrid/services/workboard-status-slugs.ts
@@ -1,0 +1,52 @@
+/**
+ * OpenClaw Workboard card status slugs (OpenClaw 6.8+).
+ * @see workboard.cards.create / workboard.cards.update `status` field
+ */
+
+export const WORKBOARD_STATUS_SLUGS = [
+  "triage",
+  "backlog",
+  "todo",
+  "scheduled",
+  "ready",
+  "running",
+  "review",
+  "blocked",
+  "done",
+] as const;
+
+export type WorkboardStatusSlug = (typeof WORKBOARD_STATUS_SLUGS)[number];
+
+const SLUG_SET = new Set<string>(WORKBOARD_STATUS_SLUGS);
+
+/** Legacy display names and aliases → Workboard status slug. */
+const LEGACY_COLUMN_TO_SLUG: Record<string, WorkboardStatusSlug> = {
+  "in progress": "running",
+  in_progress: "running",
+  active: "running",
+  running: "running",
+  waiting: "scheduled",
+  scheduled: "scheduled",
+  backlog: "backlog",
+  stalled: "backlog",
+  parked: "backlog",
+  done: "done",
+  completed: "done",
+  failed: "blocked",
+  blocked: "blocked",
+  review: "review",
+  ready: "ready",
+  todo: "todo",
+  triage: "triage",
+};
+
+export function isValidWorkboardStatusSlug(value: string): value is WorkboardStatusSlug {
+  return SLUG_SET.has(value.toLowerCase());
+}
+
+/** Map configured column name (slug or legacy label) to a Workboard API status slug. */
+export function toWorkboardStatusSlug(column: string): WorkboardStatusSlug {
+  const lower = column.trim().toLowerCase();
+  if (SLUG_SET.has(lower)) return lower as WorkboardStatusSlug;
+  return LEGACY_COLUMN_TO_SLUG[lower] ?? "backlog";
+}

--- a/extensions/memory-hybrid/services/worker-lease.ts
+++ b/extensions/memory-hybrid/services/worker-lease.ts
@@ -65,9 +65,7 @@ export function estimateContextUsage(db: DatabaseSync): number {
     const now = nowSec();
     const windowSec = 300;
     const row = db
-      .prepare(
-        `SELECT COUNT(*) AS cnt FROM facts WHERE created_at >= ? AND superseded_at IS NULL`,
-      )
+      .prepare(`SELECT COUNT(*) AS cnt FROM facts WHERE created_at >= ? AND superseded_at IS NULL`)
       .get(now - windowSec) as { cnt: number } | undefined;
     const recent = row?.cnt ?? 0;
     // Saturate at 20 writes/5min → usage 1.0
@@ -126,12 +124,8 @@ export function acquireLease(
   db.exec("BEGIN IMMEDIATE");
   try {
     const existing = db
-      .prepare(
-        "SELECT owner_session_id, expires_at, last_heartbeat_at FROM worker_leases WHERE worker_id = ?",
-      )
-      .get(workerId) as
-      | { owner_session_id: string; expires_at: number; last_heartbeat_at: number }
-      | undefined;
+      .prepare("SELECT owner_session_id, expires_at, last_heartbeat_at FROM worker_leases WHERE worker_id = ?")
+      .get(workerId) as { owner_session_id: string; expires_at: number; last_heartbeat_at: number } | undefined;
 
     if (existing) {
       const expired = existing.expires_at <= now;
@@ -142,16 +136,7 @@ export function acquireLease(
       db.prepare(
         `UPDATE worker_leases SET owner_session_id = ?, pid = ?, host = ?, acquired_at = ?, last_heartbeat_at = ?, expires_at = ?, state_json = ?
          WHERE worker_id = ?`,
-      ).run(
-        ownerSessionId,
-        pid,
-        host,
-        now,
-        now,
-        expiresAt,
-        opts.stateJson ?? null,
-        workerId,
-      );
+      ).run(ownerSessionId, pid, host, now, now, expiresAt, opts.stateJson ?? null, workerId);
     } else {
       db.prepare(
         `INSERT INTO worker_leases (worker_id, owner_session_id, pid, host, acquired_at, last_heartbeat_at, expires_at, state_json)
@@ -191,9 +176,9 @@ export function heartbeatLease(
   const now = nowSec();
   db.exec("BEGIN IMMEDIATE");
   try {
-    const row = db
-      .prepare("SELECT owner_session_id FROM worker_leases WHERE worker_id = ?")
-      .get(workerId) as { owner_session_id: string } | undefined;
+    const row = db.prepare("SELECT owner_session_id FROM worker_leases WHERE worker_id = ?").get(workerId) as
+      | { owner_session_id: string }
+      | undefined;
     if (!row || row.owner_session_id !== ownerSessionId) {
       db.exec("ROLLBACK");
       return false;
@@ -248,9 +233,7 @@ export function releaseAllLeasesForSession(db: DatabaseSync, ownerSessionId: str
 }
 
 export function listWorkerLeases(db: DatabaseSync): WorkerLeaseRow[] {
-  const rows = db.prepare("SELECT * FROM worker_leases ORDER BY worker_id").all() as Array<
-    Record<string, unknown>
-  >;
+  const rows = db.prepare("SELECT * FROM worker_leases ORDER BY worker_id").all() as Array<Record<string, unknown>>;
   return rows.map((r) => ({
     workerId: r.worker_id as string,
     ownerSessionId: r.owner_session_id as string,

--- a/extensions/memory-hybrid/setup/workboard-integration.ts
+++ b/extensions/memory-hybrid/setup/workboard-integration.ts
@@ -39,7 +39,7 @@ export async function armWorkboardIntegration(ctx: WorkboardIntegrationContext):
 
   if (!cfg.workboard?.enabled) return;
   if (shouldAbort?.()) return;
-  
+
   const checkSuperseded = () => shouldAbort?.() ?? false;
 
   const uiIntegrationVerbose = integrationVerbose(cfg.verbosity);
@@ -96,9 +96,7 @@ export async function armWorkboardIntegration(ctx: WorkboardIntegrationContext):
 
     const available = await adapter.isAvailable();
     if (!available) {
-      api.logger.info?.(
-        `memory-hybrid: Workboard plugin not reachable (${connectLabel}) — sync not armed`,
-      );
+      api.logger.info?.(`memory-hybrid: Workboard plugin not reachable (${connectLabel}) — sync not armed`);
       return;
     }
 
@@ -140,9 +138,7 @@ export async function armWorkboardIntegration(ctx: WorkboardIntegrationContext):
           });
       }, intervalMs),
     };
-    api.logger.info?.(
-      `memory-hybrid: Workboard sync loop started (every ${cfg.workboard.syncIntervalMinutes} min)`,
-    );
+    api.logger.info?.(`memory-hybrid: Workboard sync loop started (every ${cfg.workboard.syncIntervalMinutes} min)`);
   } catch (err) {
     api.logger.warn?.(
       `memory-hybrid: Workboard adapter startup failed (${connectLabel}, non-fatal): ${err instanceof Error ? err.message : String(err)}`,

--- a/extensions/memory-hybrid/tests/cron-jobs-superseded.test.ts
+++ b/extensions/memory-hybrid/tests/cron-jobs-superseded.test.ts
@@ -25,9 +25,9 @@ describe("consolidated cron superseded job keys (#1925)", () => {
         "workshop-approval-reminder",
       ),
     ).toBe(false);
-    expect(
-      shouldDisableJobUnderConsolidatedOrchestrator("hybrid-mem:nightly-distill", "nightly-memory-sweep"),
-    ).toBe(true);
+    expect(shouldDisableJobUnderConsolidatedOrchestrator("hybrid-mem:nightly-distill", "nightly-memory-sweep")).toBe(
+      true,
+    );
     expect(shouldDisableJobUnderConsolidatedOrchestrator("hybrid-mem:maintenance-nightly")).toBe(false);
     expect(shouldDisableJobUnderConsolidatedOrchestrator("hybrid-mem:unknown-job")).toBe(false);
   });

--- a/extensions/memory-hybrid/tests/epic-1918.test.ts
+++ b/extensions/memory-hybrid/tests/epic-1918.test.ts
@@ -29,7 +29,12 @@ import { computeCrossDomainBoost, isNeverReferencedCandidate } from "../services
 import { buildMemoryNudge, resetNudgeState } from "../services/memory-nudge.js";
 import { validateVaultPath } from "../config/vaults.js";
 import { positionAwareAlpha, blendRerankScores } from "../services/cross-encoder-reranker.js";
-import { resetRecallStats, recordRecallStageTiming, getRecallStatsSnapshot, recordBypassDecision } from "../services/recall-timing-stats.js";
+import {
+  resetRecallStats,
+  recordRecallStageTiming,
+  getRecallStatsSnapshot,
+  recordBypassDecision,
+} from "../services/recall-timing-stats.js";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -68,7 +73,10 @@ describe("composite score (#1910)", () => {
       intent: "GENERAL" as const,
     };
     const v2NoPin = computeCompositeScore(base, { version: 2, pinBoostDefault: 0.3, pinBoostCap: 1 });
-    const v2Pin = computeCompositeScore({ ...base, pinBoost: 0.3 }, { version: 2, pinBoostDefault: 0.3, pinBoostCap: 1 });
+    const v2Pin = computeCompositeScore(
+      { ...base, pinBoost: 0.3 },
+      { version: 2, pinBoostDefault: 0.3, pinBoostCap: 1 },
+    );
     expect(v2Pin).toBeGreaterThan(v2NoPin);
   });
 
@@ -97,7 +105,10 @@ describe("diversity (#1910)", () => {
 
 describe("BM25 bypass (#1910)", () => {
   it("bypasses when top score and gap are strong", () => {
-    const fts = [{ entry: { id: "a", text: "x" }, score: 0.9, backend: "sqlite" as const }, { entry: { id: "b", text: "y" }, score: 0.5, backend: "sqlite" as const }];
+    const fts = [
+      { entry: { id: "a", text: "x" }, score: 0.9, backend: "sqlite" as const },
+      { entry: { id: "b", text: "y" }, score: 0.5, backend: "sqlite" as const },
+    ];
     const d = evaluateBm25Bypass(fts, { enabled: true, bm25MinScore: 0.85, bm25MinGap: 0.15 }, false);
     expect(d.bypass).toBe(true);
   });
@@ -290,9 +301,9 @@ describe("transcript importers (#1915)", () => {
 describe("pin quota (#1911)", () => {
   it("exports default quota constant", () => {
     expect(DEFAULT_PIN_QUOTA).toBe(10);
-    expect(checkPinQuota({ getRawDb: () => ({ prepare: () => ({ get: () => ({ cnt: 10 }) }) }) } as never, 10).allowed).toBe(
-      false,
-    );
+    expect(
+      checkPinQuota({ getRawDb: () => ({ prepare: () => ({ get: () => ({ cnt: 10 }) }) }) } as never, 10).allowed,
+    ).toBe(false);
   });
 });
 

--- a/extensions/memory-hybrid/tests/evolution-pass.test.ts
+++ b/extensions/memory-hybrid/tests/evolution-pass.test.ts
@@ -37,7 +37,9 @@ describe("runEvolutionPass (#1914)", () => {
     expect(result.scanned).toBeGreaterThanOrEqual(1);
     expect(result.evolved).toBeGreaterThanOrEqual(1);
 
-    const row = db.prepare("SELECT quality_score, evolution_reason, revision_count FROM facts WHERE id = ?").get(fact.id) as {
+    const row = db
+      .prepare("SELECT quality_score, evolution_reason, revision_count FROM facts WHERE id = ?")
+      .get(fact.id) as {
       quality_score: number;
       evolution_reason: string;
       revision_count: number;

--- a/extensions/memory-hybrid/tests/feature-telemetry.test.ts
+++ b/extensions/memory-hybrid/tests/feature-telemetry.test.ts
@@ -5,14 +5,17 @@ describe("feature-telemetry", () => {
   it("warns when duration exceeds budget", () => {
     const warn = vi.fn();
     const info = vi.fn();
-    emitFeatureTelemetry({ warn, info }, {
-      feature: "recall",
-      operation: "memory_recall",
-      durationMs: 200,
-      warnBudgetMs: 150,
-      outcome: "ok",
-      fields: { mode: "hybrid" },
-    });
+    emitFeatureTelemetry(
+      { warn, info },
+      {
+        feature: "recall",
+        operation: "memory_recall",
+        durationMs: 200,
+        warnBudgetMs: 150,
+        outcome: "ok",
+        fields: { mode: "hybrid" },
+      },
+    );
     expect(warn).toHaveBeenCalledTimes(1);
     expect(info).not.toHaveBeenCalled();
     expect(warn.mock.calls[0]?.[0]).toContain("feature-telemetry");
@@ -22,13 +25,16 @@ describe("feature-telemetry", () => {
   it("info when within budget", () => {
     const warn = vi.fn();
     const info = vi.fn();
-    emitFeatureTelemetry({ warn, info }, {
-      feature: "recall",
-      operation: "memory_recall",
-      durationMs: 50,
-      warnBudgetMs: 150,
-      outcome: "ok",
-    });
+    emitFeatureTelemetry(
+      { warn, info },
+      {
+        feature: "recall",
+        operation: "memory_recall",
+        durationMs: 50,
+        warnBudgetMs: 150,
+        outcome: "ok",
+      },
+    );
     expect(info).toHaveBeenCalledTimes(1);
     expect(warn).not.toHaveBeenCalled();
   });
@@ -36,14 +42,17 @@ describe("feature-telemetry", () => {
   it("does not warn when contradiction detection succeeds with hits (#1902)", () => {
     const warn = vi.fn();
     const info = vi.fn();
-    emitFeatureTelemetry({ warn, info }, {
-      feature: "contradiction",
-      operation: "memory_store_detect",
-      durationMs: 5,
-      warnBudgetMs: 20,
-      outcome: "ok",
-      fields: { hit_count: 2 },
-    });
+    emitFeatureTelemetry(
+      { warn, info },
+      {
+        feature: "contradiction",
+        operation: "memory_store_detect",
+        durationMs: 5,
+        warnBudgetMs: 20,
+        outcome: "ok",
+        fields: { hit_count: 2 },
+      },
+    );
     expect(info).toHaveBeenCalledTimes(1);
     expect(warn).not.toHaveBeenCalled();
   });

--- a/extensions/memory-hybrid/tests/issues-1901-1904.test.ts
+++ b/extensions/memory-hybrid/tests/issues-1901-1904.test.ts
@@ -6,12 +6,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { _testing } from "../index.js";
-import {
-  acquireLease,
-  heartbeatLease,
-  releaseAllLeasesForSession,
-  releaseLease,
-} from "../services/worker-lease.js";
+import { acquireLease, heartbeatLease, releaseAllLeasesForSession, releaseLease } from "../services/worker-lease.js";
 import { searchFts } from "../services/fts-search.js";
 import { buildEpisodeCausalChain, decayEpisodeCausalLinks } from "../services/episode-causal-inference.js";
 import { scoreFactContradiction, repairUndetectedContradictions } from "../backends/facts-db/contradictions.js";
@@ -100,12 +95,7 @@ describe("recall mode config (#1901 risk 3)", () => {
 
 describe("contradiction surface (#1902)", () => {
   it("scores entity+key value mismatch with heuristic signals", () => {
-    const score = scoreFactContradiction(
-      "timeout is 30 seconds",
-      "30",
-      "timeout is 60 seconds",
-      "60",
-    );
+    const score = scoreFactContradiction("timeout is 30 seconds", "30", "timeout is 60 seconds", "60");
     expect(score.score).toBeGreaterThan(0);
     expect(score.heuristicSignals).toContain("numeric_conflict");
   });
@@ -159,11 +149,7 @@ describe("contradiction surface (#1902)", () => {
       source: "conversation",
     });
 
-    const repair = repairUndetectedContradictions(
-      db.getRawDb(),
-      (a, b, t, s) => db.createLink(a, b, t, s ?? 1.0),
-      50,
-    );
+    const repair = repairUndetectedContradictions(db.getRawDb(), (a, b, t, s) => db.createLink(a, b, t, s ?? 1.0), 50);
     expect(repair.pairsRepaired).toBeGreaterThan(0);
     expect(repair.pairsFailed).toBe(0);
     expect(repair.pairsFallback).toBe(0);
@@ -242,23 +228,25 @@ describe("episode causal chain (#1903)", () => {
       importance: 0.8,
     }).episode;
     raw.prepare("DELETE FROM episode_causal_links").run();
-    raw.prepare(
-      `INSERT INTO episode_causal_links (id, source_episode_id, target_episode_id, confidence, score_breakdown, last_reinforced_at, created_at)
+    raw
+      .prepare(
+        `INSERT INTO episode_causal_links (id, source_episode_id, target_episode_id, confidence, score_breakdown, last_reinforced_at, created_at)
        VALUES (?, ?, ?, ?, ?, NULL, ?)`,
-    ).run("link-1", source.id, target.id, 0.5, "{}", now - 86400);
+      )
+      .run("link-1", source.id, target.id, 0.5, "{}", now - 86400);
 
     const first = decayEpisodeCausalLinks(raw);
     expect(first.updated + first.deleted).toBeGreaterThan(0);
-    const afterFirst = raw
-      .prepare("SELECT confidence FROM episode_causal_links WHERE id = ?")
-      .get("link-1") as { confidence: number };
+    const afterFirst = raw.prepare("SELECT confidence FROM episode_causal_links WHERE id = ?").get("link-1") as {
+      confidence: number;
+    };
     const confAfterFirst = afterFirst.confidence;
 
     const second = decayEpisodeCausalLinks(raw);
     expect(second.updated).toBe(0);
-    const afterSecond = raw
-      .prepare("SELECT confidence FROM episode_causal_links WHERE id = ?")
-      .get("link-1") as { confidence: number };
+    const afterSecond = raw.prepare("SELECT confidence FROM episode_causal_links WHERE id = ?").get("link-1") as {
+      confidence: number;
+    };
     expect(afterSecond.confidence).toBeCloseTo(confAfterFirst, 5);
   });
 
@@ -273,13 +261,7 @@ describe("episode causal chain (#1903)", () => {
       importance: 0.8,
     }).episode;
 
-    const chain = buildEpisodeCausalChain(
-      db.getRawDb(),
-      scoped.id,
-      5,
-      false,
-      globalOnlyScopeFilter(),
-    );
+    const chain = buildEpisodeCausalChain(db.getRawDb(), scoped.id, 5, false, globalOnlyScopeFilter());
     expect(chain).toEqual([]);
     expect(scopedRowMatchesFilter("session", "secret-session", undefined)).toBe(false);
   });

--- a/extensions/memory-hybrid/tests/memory-evolution-fragments.test.ts
+++ b/extensions/memory-hybrid/tests/memory-evolution-fragments.test.ts
@@ -164,7 +164,10 @@ describe("indexFactFragments (#1914)", () => {
     });
 
     expect(result.fragmentsStored).toBeGreaterThan(1);
-    const childCount = factsDb.getRawDb().prepare("SELECT COUNT(*) AS c FROM facts WHERE parent_fact_id = ?").get(parent.id) as {
+    const childCount = factsDb
+      .getRawDb()
+      .prepare("SELECT COUNT(*) AS c FROM facts WHERE parent_fact_id = ?")
+      .get(parent.id) as {
       c: number;
     };
     expect(childCount.c).toBeGreaterThan(1);

--- a/extensions/memory-hybrid/tests/openclaw-cron-store.test.ts
+++ b/extensions/memory-hybrid/tests/openclaw-cron-store.test.ts
@@ -183,7 +183,11 @@ describe("openclaw-cron-store (#1923)", () => {
       "maintenance-nightly",
       Date.now(),
       Date.now(),
-      JSON.stringify({ id: "hybrid-mem:maintenance-nightly", enabled: true, payload: { kind: "agentTurn", message: "msg" } }),
+      JSON.stringify({
+        id: "hybrid-mem:maintenance-nightly",
+        enabled: true,
+        payload: { kind: "agentTurn", message: "msg" },
+      }),
     );
     db.close();
 

--- a/extensions/memory-hybrid/tests/perf/recall-benchmark.ts
+++ b/extensions/memory-hybrid/tests/perf/recall-benchmark.ts
@@ -75,12 +75,7 @@ export function seedCorpusFacts(factsDb: FactsDB, rows: CorpusRow[]): Map<string
 }
 
 /** Compute average NDCG@k using FTS5 ranking against seeded corpus facts. */
-export function measureFtsNdcg(
-  factsDb: FactsDB,
-  rows: CorpusRow[],
-  idMap: Map<string, string>,
-  k = 5,
-): number {
+export function measureFtsNdcg(factsDb: FactsDB, rows: CorpusRow[], idMap: Map<string, string>, k = 5): number {
   const db = factsDb.getRawDb();
   let sum = 0;
   let counted = 0;

--- a/extensions/memory-hybrid/tests/recall-signals.test.ts
+++ b/extensions/memory-hybrid/tests/recall-signals.test.ts
@@ -4,11 +4,7 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { _testing } from "../index.js";
 import { insertRecallEvent } from "../services/recall-events.js";
-import {
-  aggregateRecallStats,
-  getSnoozeCandidates,
-  isNeverReferencedCandidate,
-} from "../services/recall-signals.js";
+import { aggregateRecallStats, getSnoozeCandidates, isNeverReferencedCandidate } from "../services/recall-signals.js";
 
 const { FactsDB } = _testing;
 

--- a/extensions/memory-hybrid/tests/vault-facts-resolver.test.ts
+++ b/extensions/memory-hybrid/tests/vault-facts-resolver.test.ts
@@ -7,10 +7,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { FactsDB } from "../backends/facts-db.js";
-import {
-  resolveVaultFactsTriples,
-  resolveVaultFactsTriplesMulti,
-} from "../services/vault-facts-resolver.js";
+import { resolveVaultFactsTriples, resolveVaultFactsTriplesMulti } from "../services/vault-facts-resolver.js";
 
 describe("resolveVaultFactsTriplesMulti", () => {
   let tmpDir: string;
@@ -61,10 +58,7 @@ describe("resolveVaultFactsTriplesMulti", () => {
     const defaultTriples = resolveVaultFactsTriples(defaultDb, "Tell me about Acme Corporation");
     expect(defaultTriples).toEqual([]);
 
-    const merged = resolveVaultFactsTriplesMulti(
-      [defaultDb, secondaryDb],
-      "Tell me about Acme Corporation",
-    );
+    const merged = resolveVaultFactsTriplesMulti([defaultDb, secondaryDb], "Tell me about Acme Corporation");
     expect(merged.some((t) => t.subject === "Acme Corporation" && t.predicate === "deadline")).toBe(true);
   });
 });

--- a/extensions/memory-hybrid/tests/vault-resolve.test.ts
+++ b/extensions/memory-hybrid/tests/vault-resolve.test.ts
@@ -19,8 +19,20 @@ function mockRuntime(overrides: Partial<MemoryToolRuntime> = {}): MemoryToolRunt
       lancePath: "",
     }),
     resolveAllVaults: () => [
-      { name: "default", factsDb: {} as MemoryToolRuntime["factsDb"], vectorDb: {} as MemoryToolRuntime["vectorDb"], sqlitePath: "", lancePath: "" },
-      { name: "work", factsDb: {} as MemoryToolRuntime["factsDb"], vectorDb: {} as MemoryToolRuntime["vectorDb"], sqlitePath: "", lancePath: "" },
+      {
+        name: "default",
+        factsDb: {} as MemoryToolRuntime["factsDb"],
+        vectorDb: {} as MemoryToolRuntime["vectorDb"],
+        sqlitePath: "",
+        lancePath: "",
+      },
+      {
+        name: "work",
+        factsDb: {} as MemoryToolRuntime["factsDb"],
+        vectorDb: {} as MemoryToolRuntime["vectorDb"],
+        sqlitePath: "",
+        lancePath: "",
+      },
     ],
     ...overrides,
   } as MemoryToolRuntime;

--- a/extensions/memory-hybrid/tests/vault-wal.test.ts
+++ b/extensions/memory-hybrid/tests/vault-wal.test.ts
@@ -7,8 +7,6 @@ import { resolveVaultWalPath } from "../config/vaults.js";
 
 describe("resolveVaultWalPath (#1917)", () => {
   it("derives sibling .wal from sqlite path", () => {
-    expect(resolveVaultWalPath("/home/user/.openclaw/work/project.db")).toBe(
-      "/home/user/.openclaw/work/project.wal",
-    );
+    expect(resolveVaultWalPath("/home/user/.openclaw/work/project.db")).toBe("/home/user/.openclaw/work/project.wal");
   });
 });

--- a/extensions/memory-hybrid/tests/workboard-adapter.test.ts
+++ b/extensions/memory-hybrid/tests/workboard-adapter.test.ts
@@ -31,9 +31,7 @@ describe("workboard adapter stale card removal", () => {
     };
     const client = mockClient([taskCard]);
 
-    vi.spyOn(await import("../services/workboard-rpc-client.js"), "createWorkboardRpcClient").mockReturnValue(
-      client,
-    );
+    vi.spyOn(await import("../services/workboard-rpc-client.js"), "createWorkboardRpcClient").mockReturnValue(client);
 
     const adapter = createWorkboardAdapter({
       cfg: {
@@ -64,9 +62,7 @@ describe("workboard adapter stale card removal", () => {
     };
     const client = mockClient([taskCard]);
 
-    vi.spyOn(await import("../services/workboard-rpc-client.js"), "createWorkboardRpcClient").mockReturnValue(
-      client,
-    );
+    vi.spyOn(await import("../services/workboard-rpc-client.js"), "createWorkboardRpcClient").mockReturnValue(client);
 
     const adapter = createWorkboardAdapter({
       cfg: {
@@ -97,9 +93,7 @@ describe("workboard adapter stale card removal", () => {
     };
     const client = mockClient([goalCard]);
 
-    vi.spyOn(await import("../services/workboard-rpc-client.js"), "createWorkboardRpcClient").mockReturnValue(
-      client,
-    );
+    vi.spyOn(await import("../services/workboard-rpc-client.js"), "createWorkboardRpcClient").mockReturnValue(client);
 
     const adapter = createWorkboardAdapter({
       cfg: {
@@ -154,9 +148,7 @@ describe("workboard adapter bidirectional sync", () => {
       isAvailable: vi.fn(async () => true),
     } as WorkboardRpcClient;
 
-    vi.spyOn(await import("../services/workboard-rpc-client.js"), "createWorkboardRpcClient").mockReturnValue(
-      client,
-    );
+    vi.spyOn(await import("../services/workboard-rpc-client.js"), "createWorkboardRpcClient").mockReturnValue(client);
 
     const adapter = createWorkboardAdapter({
       cfg: {

--- a/extensions/memory-hybrid/tests/workboard-card-mapper.test.ts
+++ b/extensions/memory-hybrid/tests/workboard-card-mapper.test.ts
@@ -63,24 +63,24 @@ describe("workboard-card-mapper", () => {
       const card = taskToCard(makeTask(), DEFAULT_WORKBOARD_COLUMNS, TAG);
       expect(card).not.toBeNull();
       expect(card!.title).toBe("[Task] test-task");
-      expect(card!.column).toBe("In Progress");
+      expect(card!.column).toBe("running");
       expect(card!.externalId).toBe("hm-task:test-task");
       expect(card!.tags).toContain(TAG);
     });
 
     it("maps a done task", () => {
       const card = taskToCard(makeTask({ status: "Done" }), DEFAULT_WORKBOARD_COLUMNS, TAG);
-      expect(card!.column).toBe("Done");
+      expect(card!.column).toBe("done");
     });
 
     it("maps a failed task", () => {
       const card = taskToCard(makeTask({ status: "Failed" }), DEFAULT_WORKBOARD_COLUMNS, TAG);
-      expect(card!.column).toBe("Failed");
+      expect(card!.column).toBe("blocked");
     });
 
     it("maps a stale task to Backlog", () => {
       const card = taskToCard(makeTask({ stale: true }), DEFAULT_WORKBOARD_COLUMNS, TAG);
-      expect(card!.column).toBe("Backlog");
+      expect(card!.column).toBe("backlog");
     });
 
     it("includes branch and next in description", () => {
@@ -95,19 +95,19 @@ describe("workboard-card-mapper", () => {
       const card = goalToCard(makeGoal(), DEFAULT_WORKBOARD_COLUMNS, TAG);
       expect(card).not.toBeNull();
       expect(card!.title).toBe("[Goal] Ship feature X");
-      expect(card!.column).toBe("In Progress");
+      expect(card!.column).toBe("running");
       expect(card!.externalId).toBe("hm-goal:goal-1");
       expect(card!.tags).toContain("priority:high");
     });
 
     it("maps a blocked goal", () => {
       const card = goalToCard(makeGoal({ status: "blocked" }), DEFAULT_WORKBOARD_COLUMNS, TAG);
-      expect(card!.column).toBe("Blocked");
+      expect(card!.column).toBe("blocked");
     });
 
     it("maps a completed goal", () => {
       const card = goalToCard(makeGoal({ status: "completed" }), DEFAULT_WORKBOARD_COLUMNS, TAG);
-      expect(card!.column).toBe("Done");
+      expect(card!.column).toBe("done");
     });
 
     it("includes acceptance criteria and blockers in description", () => {
@@ -144,18 +144,19 @@ describe("workboard-card-mapper", () => {
 
   describe("column-to-status mapping", () => {
     it("maps columns back to task statuses", () => {
-      expect(columnToTaskStatus("In Progress", DEFAULT_WORKBOARD_COLUMNS)).toBe("In progress");
-      expect(columnToTaskStatus("Done", DEFAULT_WORKBOARD_COLUMNS)).toBe("Done");
-      expect(columnToTaskStatus("Failed", DEFAULT_WORKBOARD_COLUMNS)).toBe("Failed");
-      expect(columnToTaskStatus("Backlog", DEFAULT_WORKBOARD_COLUMNS)).toBe("Stalled");
+      expect(columnToTaskStatus("running", DEFAULT_WORKBOARD_COLUMNS)).toBe("In progress");
+      expect(columnToTaskStatus("scheduled", DEFAULT_WORKBOARD_COLUMNS)).toBe("Waiting");
+      expect(columnToTaskStatus("done", DEFAULT_WORKBOARD_COLUMNS)).toBe("Done");
+      expect(columnToTaskStatus("blocked", DEFAULT_WORKBOARD_COLUMNS)).toBe("Failed");
+      expect(columnToTaskStatus("backlog", DEFAULT_WORKBOARD_COLUMNS)).toBe("Stalled");
       expect(columnToTaskStatus("Unknown Column", DEFAULT_WORKBOARD_COLUMNS)).toBeNull();
     });
 
     it("maps columns back to goal statuses", () => {
-      expect(columnToGoalStatus("In Progress", DEFAULT_WORKBOARD_COLUMNS)).toBe("active");
-      expect(columnToGoalStatus("Done", DEFAULT_WORKBOARD_COLUMNS)).toBe("completed");
-      expect(columnToGoalStatus("Blocked", DEFAULT_WORKBOARD_COLUMNS)).toBe("blocked");
-      expect(columnToGoalStatus("Backlog", DEFAULT_WORKBOARD_COLUMNS)).toBe("stalled");
+      expect(columnToGoalStatus("running", DEFAULT_WORKBOARD_COLUMNS)).toBe("active");
+      expect(columnToGoalStatus("done", DEFAULT_WORKBOARD_COLUMNS)).toBe("completed");
+      expect(columnToGoalStatus("blocked", DEFAULT_WORKBOARD_COLUMNS)).toBe("blocked");
+      expect(columnToGoalStatus("backlog", DEFAULT_WORKBOARD_COLUMNS)).toBe("stalled");
       expect(columnToGoalStatus("Unknown Column", DEFAULT_WORKBOARD_COLUMNS)).toBeNull();
     });
   });

--- a/extensions/memory-hybrid/tests/workboard-rpc-client.test.ts
+++ b/extensions/memory-hybrid/tests/workboard-rpc-client.test.ts
@@ -1,85 +1,119 @@
+import { EventEmitter } from "node:events";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-const { spawnSyncMock } = vi.hoisted(() => ({
-  spawnSyncMock: vi.fn(),
+const { spawnMock } = vi.hoisted(() => ({
+  spawnMock: vi.fn(),
 }));
 
 vi.mock("../utils/process-runner.js", () => ({
-  spawnSync: spawnSyncMock,
+  spawn: spawnMock,
 }));
 
 import {
   createWorkboardGatewayCliRpcClient,
   createWorkboardHttpRpcClient,
   createWorkboardRpcClient,
+  normalizeWorkboardCardFromApi,
 } from "../services/workboard-rpc-client.js";
+
+function mockSpawnJson(stdout: unknown, exitCode = 0, stderr = "") {
+  spawnMock.mockImplementation(() => {
+    const child = new EventEmitter() as EventEmitter & {
+      stdout: EventEmitter;
+      stderr: EventEmitter;
+      kill: ReturnType<typeof vi.fn>;
+    };
+    child.stdout = new EventEmitter();
+    child.stderr = new EventEmitter();
+    child.kill = vi.fn();
+    setTimeout(() => {
+      if (stderr) child.stderr.emit("data", stderr);
+      child.stdout.emit("data", JSON.stringify(stdout));
+      child.emit("close", exitCode);
+    }, 0);
+    return child;
+  });
+}
+
+describe("normalizeWorkboardCardFromApi", () => {
+  it("maps OpenClaw workboard status/labels/notes and idempotencyKey", () => {
+    const card = normalizeWorkboardCardFromApi({
+      id: "c1",
+      title: "[Task] foo",
+      status: "backlog",
+      labels: ["hybrid-memory"],
+      notes: "hello",
+      metadata: { automation: { idempotencyKey: "hm-task:foo" } },
+    });
+    expect(card).toEqual({
+      id: "c1",
+      title: "[Task] foo",
+      column: "backlog",
+      description: "hello",
+      tags: ["hybrid-memory"],
+      externalId: "hm-task:foo",
+      metadata: { automation: { idempotencyKey: "hm-task:foo" } },
+      createdAt: undefined,
+      updatedAt: undefined,
+    });
+  });
+});
 
 describe("workboard-rpc-client (#1925)", () => {
   afterEach(() => {
     vi.restoreAllMocks();
-    spawnSyncMock.mockReset();
+    spawnMock.mockReset();
   });
 
   it("createWorkboardRpcClient falls back to gateway CLI when HTTP /rpc returns 404", async () => {
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response("not found", { status: 404 }) as Response,
-    );
-    spawnSyncMock.mockReturnValue({
-      status: 0,
-      stdout: JSON.stringify({ cards: [{ id: "c1", title: "Task", column: "todo" }] }),
-      stderr: "",
-      pid: 1,
-      output: [null, "", ""],
-      signal: null,
-      error: undefined,
-    });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("not found", { status: 404 }) as Response);
+    mockSpawnJson({ cards: [{ id: "c1", title: "Task", status: "todo" }] });
 
     const client = createWorkboardRpcClient("http://127.0.0.1:18789");
     expect(await client.isAvailable()).toBe(true);
     const cards = await client.listCards();
     expect(cards).toHaveLength(1);
     expect(cards[0]?.id).toBe("c1");
-    expect(spawnSyncMock).toHaveBeenCalled();
-    const args = spawnSyncMock.mock.calls[0]?.[1] as string[];
+    expect(cards[0]?.column).toBe("todo");
+    expect(spawnMock).toHaveBeenCalled();
+    const args = spawnMock.mock.calls[0]?.[1] as string[];
     expect(args).toContain("gateway");
     expect(args).toContain("workboard.cards.list");
-    expect(args).not.toContain("--token");
   });
 
   it("createWorkboardGatewayCliRpcClient passes token via OPENCLAW_GATEWAY_TOKEN env", async () => {
-    spawnSyncMock.mockReturnValue({
-      status: 0,
-      stdout: JSON.stringify({ cards: [] }),
-      stderr: "",
-      pid: 1,
-      output: [null, "", ""],
-      signal: null,
-      error: undefined,
-    });
+    mockSpawnJson({ cards: [] });
 
     const client = createWorkboardGatewayCliRpcClient("secret-token");
     await client.isAvailable();
-    const env = spawnSyncMock.mock.calls[0]?.[2]?.env as NodeJS.ProcessEnv;
+    const env = spawnMock.mock.calls[0]?.[2]?.env as NodeJS.ProcessEnv;
     expect(env.OPENCLAW_GATEWAY_TOKEN).toBe("secret-token");
-    const args = spawnSyncMock.mock.calls[0]?.[1] as string[];
-    expect(args).not.toContain("--token");
   });
 
-  it("createWorkboardGatewayCliRpcClient parses cards from gateway call JSON", async () => {
-    spawnSyncMock.mockReturnValue({
-      status: 0,
-      stdout: JSON.stringify({ result: { cards: [{ id: "g1", title: "Goal", column: "done" }] } }),
-      stderr: "",
-      pid: 1,
-      output: [null, "", ""],
-      signal: null,
-      error: undefined,
+  it("createWorkboardGatewayCliRpcClient unwraps { card } on create", async () => {
+    mockSpawnJson({
+      card: {
+        id: "new1",
+        title: "[Task] x",
+        status: "backlog",
+        labels: ["hybrid-memory"],
+        metadata: { automation: { idempotencyKey: "hm-task:x" } },
+      },
     });
 
     const client = createWorkboardGatewayCliRpcClient();
-    const cards = await client.listCards();
-    expect(cards).toHaveLength(1);
-    expect(cards[0]?.column).toBe("done");
+    const created = await client.createCard({
+      title: "[Task] x",
+      column: "backlog",
+      tags: ["hybrid-memory"],
+      externalId: "hm-task:x",
+    });
+    expect(created?.id).toBe("new1");
+    expect(created?.externalId).toBe("hm-task:x");
+    const params = JSON.parse((spawnMock.mock.calls[0]?.[1] as string[])[4]);
+    expect(params.status).toBe("backlog");
+    expect(params.idempotencyKey).toBe("hm-task:x");
+    expect(params.labels).toEqual(["hybrid-memory"]);
   });
 
   it("createWorkboardHttpRpcClient uses HTTP when available", async () => {

--- a/extensions/memory-hybrid/tests/workboard-status-slugs.test.ts
+++ b/extensions/memory-hybrid/tests/workboard-status-slugs.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { isValidWorkboardStatusSlug, toWorkboardStatusSlug } from "../services/workboard-status-slugs.js";
+
+describe("workboard-status-slugs", () => {
+  it("passes through valid slugs", () => {
+    expect(toWorkboardStatusSlug("running")).toBe("running");
+    expect(toWorkboardStatusSlug("DONE")).toBe("done");
+    expect(isValidWorkboardStatusSlug("backlog")).toBe(true);
+  });
+
+  it("maps legacy display labels to slugs", () => {
+    expect(toWorkboardStatusSlug("In Progress")).toBe("running");
+    expect(toWorkboardStatusSlug("Waiting")).toBe("scheduled");
+    expect(toWorkboardStatusSlug("Backlog")).toBe("backlog");
+    expect(toWorkboardStatusSlug("Failed")).toBe("blocked");
+    expect(toWorkboardStatusSlug("Blocked")).toBe("blocked");
+  });
+});

--- a/extensions/memory-hybrid/tests/workboard-status-slugs.test.ts
+++ b/extensions/memory-hybrid/tests/workboard-status-slugs.test.ts
@@ -15,4 +15,8 @@ describe("workboard-status-slugs", () => {
     expect(toWorkboardStatusSlug("Failed")).toBe("blocked");
     expect(toWorkboardStatusSlug("Blocked")).toBe("blocked");
   });
+
+  it("passes through unrecognized custom column names", () => {
+    expect(toWorkboardStatusSlug("My Custom Lane")).toBe("My Custom Lane");
+  });
 });

--- a/extensions/memory-hybrid/tools/memory/helpers.ts
+++ b/extensions/memory-hybrid/tools/memory/helpers.ts
@@ -65,6 +65,10 @@ export async function storeRegistryEmbeddings({
   operation: string;
 }): Promise<void> {
   if (!embeddingRegistry) return;
+  if (!factsDb) {
+    logger.warn(`memory-hybrid: fact_embeddings store skipped (${operation}) — factsDb unavailable`);
+    return;
+  }
   const vectors = new Map<string, Float32Array>();
   if (vector && vector.length > 0) {
     vectors.set(embeddings.modelName, toFloat32Array(vector));

--- a/extensions/memory-hybrid/tools/memory/register-episode-tools.ts
+++ b/extensions/memory-hybrid/tools/memory/register-episode-tools.ts
@@ -230,13 +230,7 @@ export function registerEpisodeTools(runtime: MemoryToolRuntime): void {
         if (!episodeId) throw new Error("episodeId is required");
         const depth = typeof params.depth === "number" && params.depth > 0 ? Math.min(10, Math.floor(params.depth)) : 5;
         const includeExplicitOnly = params.includeExplicitOnly === true;
-        const chain = buildEpisodeCausalChain(
-          factsDb.getRawDb(),
-          episodeId,
-          depth,
-          includeExplicitOnly,
-          scopeFilter,
-        );
+        const chain = buildEpisodeCausalChain(factsDb.getRawDb(), episodeId, depth, includeExplicitOnly, scopeFilter);
         return {
           content: [
             {

--- a/extensions/memory-hybrid/tools/memory/register-recall-tools.ts
+++ b/extensions/memory-hybrid/tools/memory/register-recall-tools.ts
@@ -517,16 +517,16 @@ export function registerRecallTools(runtime: MemoryToolRuntime): void {
       retrievalMode,
       includeSuperseded = false,
       asOf: asOfParam,
-        includeCold = false,
-        userId,
-        agentId,
-        sessionId,
-        confirmCrossTenantScope,
-        expandGraph: expandGraphParam,
-        expandDepth: expandDepthParam,
-        mode: recallModeParam,
-        vault: vaultParam,
-      } = params as {
+      includeCold = false,
+      userId,
+      agentId,
+      sessionId,
+      confirmCrossTenantScope,
+      expandGraph: expandGraphParam,
+      expandDepth: expandDepthParam,
+      mode: recallModeParam,
+      vault: vaultParam,
+    } = params as {
       query?: string;
       id?: string | number;
       limit?: number;
@@ -733,8 +733,7 @@ export function registerRecallTools(runtime: MemoryToolRuntime): void {
         scopeFilter,
       });
       if (!includeCold && results.length > 0) {
-        const coldFilterOpts =
-          asOfSec != null || scopeFilter ? { asOf: asOfSec, scopeFilter } : undefined;
+        const coldFilterOpts = asOfSec != null || scopeFilter ? { asOf: asOfSec, scopeFilter } : undefined;
         results = results.filter((r) => {
           const full = recallFactsDb.getById(r.entry.id, coldFilterOpts);
           return full && full.tier !== "cold";
@@ -843,11 +842,7 @@ export function registerRecallTools(runtime: MemoryToolRuntime): void {
     let results: SearchResult[] = [];
     try {
       const useLegacyTagShortcut = Boolean(tag && !shouldUseConstrainedMode && recallMode !== "semantic");
-      const rrfStrategies = resolveRecallRrfStrategies(
-        recallMode,
-        cfg.retrieval.strategies,
-        useLegacyTagShortcut,
-      );
+      const rrfStrategies = resolveRecallRrfStrategies(recallMode, cfg.retrieval.strategies, useLegacyTagShortcut);
       const rrfConfig = { ...cfg.retrieval, strategies: rrfStrategies };
       // interactive-recall uses a different policy with its own vector prep; skip for other modes
       const effectivePolicy =
@@ -882,98 +877,105 @@ export function registerRecallTools(runtime: MemoryToolRuntime): void {
         }
       }
       if (!recallFallback) {
-      const queryExpander =
-        cfg.queryExpansion?.enabled && rrfStrategies.includes("semantic")
-          ? new QueryExpander(cfg.queryExpansion, openai)
-          : null;
-      const embedFn =
-        queryVector != null
-          ? (text: string) =>
-              embedCallWithTimeoutAndRetry(() => embeddings.embed(text), "memory-tools:rrf-deep-retrieval")
-          : null;
-      const rrfOutput =
-        vaultHandles.length > 1
-          ? await runMultiVaultExplicitDeepRetrieval(query, queryVector, vaultHandles, {
-              config: rrfConfig,
-              ...(effectiveMode !== "interactive-recall" && effectivePolicy
-                ? { policy: effectivePolicy }
-                : effectiveMode === "interactive-recall"
-                  ? { mode: effectiveMode as "interactive-recall" }
-                  : {}),
-              ...(useLegacyTagShortcut ? { tagFilter: tag ?? undefined } : {}),
-              ...(constrainedFilters ? { constrainedFilters } : {}),
-              includeSuperseded,
-              scopeFilter,
-              asOf: asOfSec ?? undefined,
-              graphHubDegreeCap: cfg.graph.hubDegreeCap,
-              graphHubScorePenalty: cfg.graph.hubScorePenalty,
-              aliasDb: cfg.aliases?.enabled ? aliasDb : null,
-              clustersConfig: cfg.clusters,
-              embeddingRegistry: embeddingRegistry ?? null,
-              factsDbForEmbeddings: recallFactsDb,
-              queryExpander: queryExpander ?? null,
-              embedFn,
-              rerankingConfig: cfg.reranking,
-              rerankingOpenai: openai,
-              adaptiveOpenai: cfg.documentGrading?.enabled ? openai : undefined,
-              documentGradingConfig: cfg.documentGrading,
-              issueStore: issueStore ?? null,
-              ...(entityLayerFactIds?.length ? { entityLayerCandidateIds: entityLayerFactIds } : {}),
-              warmTierOnly: !includeCold && cfg.memoryTiering.enabled,
-            })
-          : await runExplicitDeepRetrieval(query, queryVector, recallFactsDb.getRawDb(), recallVectorDb, recallFactsDb, {
-              config: rrfConfig,
-              ...(effectiveMode !== "interactive-recall" && effectivePolicy
-                ? { policy: effectivePolicy }
-                : effectiveMode === "interactive-recall"
-                  ? { mode: effectiveMode as "interactive-recall" }
-                  : {}),
-              ...(useLegacyTagShortcut ? { tagFilter: tag ?? undefined } : {}),
-              ...(constrainedFilters ? { constrainedFilters } : {}),
-              includeSuperseded,
-              scopeFilter,
-              asOf: asOfSec ?? undefined,
-              graphHubDegreeCap: cfg.graph.hubDegreeCap,
-              graphHubScorePenalty: cfg.graph.hubScorePenalty,
-              aliasDb: cfg.aliases?.enabled ? aliasDb : null,
-              clustersConfig: cfg.clusters,
-              embeddingRegistry: embeddingRegistry ?? null,
-              factsDbForEmbeddings: recallFactsDb,
-              queryExpander: queryExpander ?? null,
-              embedFn,
-              rerankingConfig: cfg.reranking,
-              rerankingOpenai: openai,
-              adaptiveOpenai: cfg.documentGrading?.enabled ? openai : undefined,
-              documentGradingConfig: cfg.documentGrading,
-              issueStore: issueStore ?? null,
-              ...(entityLayerFactIds?.length ? { entityLayerCandidateIds: entityLayerFactIds } : {}),
-              warmTierOnly: !includeCold && cfg.memoryTiering.enabled,
-            });
+        const queryExpander =
+          cfg.queryExpansion?.enabled && rrfStrategies.includes("semantic")
+            ? new QueryExpander(cfg.queryExpansion, openai)
+            : null;
+        const embedFn =
+          queryVector != null
+            ? (text: string) =>
+                embedCallWithTimeoutAndRetry(() => embeddings.embed(text), "memory-tools:rrf-deep-retrieval")
+            : null;
+        const rrfOutput =
+          vaultHandles.length > 1
+            ? await runMultiVaultExplicitDeepRetrieval(query, queryVector, vaultHandles, {
+                config: rrfConfig,
+                ...(effectiveMode !== "interactive-recall" && effectivePolicy
+                  ? { policy: effectivePolicy }
+                  : effectiveMode === "interactive-recall"
+                    ? { mode: effectiveMode as "interactive-recall" }
+                    : {}),
+                ...(useLegacyTagShortcut ? { tagFilter: tag ?? undefined } : {}),
+                ...(constrainedFilters ? { constrainedFilters } : {}),
+                includeSuperseded,
+                scopeFilter,
+                asOf: asOfSec ?? undefined,
+                graphHubDegreeCap: cfg.graph.hubDegreeCap,
+                graphHubScorePenalty: cfg.graph.hubScorePenalty,
+                aliasDb: cfg.aliases?.enabled ? aliasDb : null,
+                clustersConfig: cfg.clusters,
+                embeddingRegistry: embeddingRegistry ?? null,
+                factsDbForEmbeddings: recallFactsDb,
+                queryExpander: queryExpander ?? null,
+                embedFn,
+                rerankingConfig: cfg.reranking,
+                rerankingOpenai: openai,
+                adaptiveOpenai: cfg.documentGrading?.enabled ? openai : undefined,
+                documentGradingConfig: cfg.documentGrading,
+                issueStore: issueStore ?? null,
+                ...(entityLayerFactIds?.length ? { entityLayerCandidateIds: entityLayerFactIds } : {}),
+                warmTierOnly: !includeCold && cfg.memoryTiering.enabled,
+              })
+            : await runExplicitDeepRetrieval(
+                query,
+                queryVector,
+                recallFactsDb.getRawDb(),
+                recallVectorDb,
+                recallFactsDb,
+                {
+                  config: rrfConfig,
+                  ...(effectiveMode !== "interactive-recall" && effectivePolicy
+                    ? { policy: effectivePolicy }
+                    : effectiveMode === "interactive-recall"
+                      ? { mode: effectiveMode as "interactive-recall" }
+                      : {}),
+                  ...(useLegacyTagShortcut ? { tagFilter: tag ?? undefined } : {}),
+                  ...(constrainedFilters ? { constrainedFilters } : {}),
+                  includeSuperseded,
+                  scopeFilter,
+                  asOf: asOfSec ?? undefined,
+                  graphHubDegreeCap: cfg.graph.hubDegreeCap,
+                  graphHubScorePenalty: cfg.graph.hubScorePenalty,
+                  aliasDb: cfg.aliases?.enabled ? aliasDb : null,
+                  clustersConfig: cfg.clusters,
+                  embeddingRegistry: embeddingRegistry ?? null,
+                  factsDbForEmbeddings: recallFactsDb,
+                  queryExpander: queryExpander ?? null,
+                  embedFn,
+                  rerankingConfig: cfg.reranking,
+                  rerankingOpenai: openai,
+                  adaptiveOpenai: cfg.documentGrading?.enabled ? openai : undefined,
+                  documentGradingConfig: cfg.documentGrading,
+                  issueStore: issueStore ?? null,
+                  ...(entityLayerFactIds?.length ? { entityLayerCandidateIds: entityLayerFactIds } : {}),
+                  warmTierOnly: !includeCold && cfg.memoryTiering.enabled,
+                },
+              );
 
-      // Merge entity-lookup results first, then append RRF results (deduped).
-      // When packed is non-empty, only include fused results whose factId was packed
-      // (avoids including items beyond the token budget). Fall back to the full fused
-      // list when packed is empty (e.g. budget too small to pack any).
-      // Use a factId→entry Map so entry lookup never depends on loop index alignment.
-      const seenIds = new Set<string>(entityResults.map((r) => r.entry.id));
-      results = [...entityResults];
-      const entryByFactId = new Map<string, MemoryEntry>();
-      for (let i = 0; i < rrfOutput.fused.length; i++) {
-        const e = rrfOutput.entries[i];
-        if (e) entryByFactId.set(rrfOutput.fused[i].factId, e);
-      }
-      const packedFactIdSet = rrfOutput.packed.length > 0 ? new Set(rrfOutput.packedFactIds) : null;
-      for (const fusedResult of rrfOutput.fused) {
-        if (packedFactIdSet && !packedFactIdSet.has(fusedResult.factId)) continue;
-        if (seenIds.has(fusedResult.factId)) continue;
-        const entry = entryByFactId.get(fusedResult.factId);
-        if (entry) {
-          results.push({ entry, score: fusedResult.finalScore, backend: "sqlite" });
-          seenIds.add(fusedResult.factId);
+        // Merge entity-lookup results first, then append RRF results (deduped).
+        // When packed is non-empty, only include fused results whose factId was packed
+        // (avoids including items beyond the token budget). Fall back to the full fused
+        // list when packed is empty (e.g. budget too small to pack any).
+        // Use a factId→entry Map so entry lookup never depends on loop index alignment.
+        const seenIds = new Set<string>(entityResults.map((r) => r.entry.id));
+        results = [...entityResults];
+        const entryByFactId = new Map<string, MemoryEntry>();
+        for (let i = 0; i < rrfOutput.fused.length; i++) {
+          const e = rrfOutput.entries[i];
+          if (e) entryByFactId.set(rrfOutput.fused[i].factId, e);
         }
-      }
-      results.sort((a, b) => b.score - a.score);
-      results = results.slice(0, limit);
+        const packedFactIdSet = rrfOutput.packed.length > 0 ? new Set(rrfOutput.packedFactIds) : null;
+        for (const fusedResult of rrfOutput.fused) {
+          if (packedFactIdSet && !packedFactIdSet.has(fusedResult.factId)) continue;
+          if (seenIds.has(fusedResult.factId)) continue;
+          const entry = entryByFactId.get(fusedResult.factId);
+          if (entry) {
+            results.push({ entry, score: fusedResult.finalScore, backend: "sqlite" });
+            seenIds.add(fusedResult.factId);
+          }
+        }
+        results.sort((a, b) => b.score - a.score);
+        results = results.slice(0, limit);
       }
     } catch (err) {
       capturePluginError(err instanceof Error ? err : new Error(String(err)), {
@@ -1252,9 +1254,7 @@ export function registerRecallTools(runtime: MemoryToolRuntime): void {
           return { content: [{ type: "text", text: "Provide a query." }], details: { count: 0 } };
         }
         const limit =
-          typeof params.limit === "number" && params.limit > 0
-            ? Math.min(100, Math.floor(params.limit))
-            : 10;
+          typeof params.limit === "number" && params.limit > 0 ? Math.min(100, Math.floor(params.limit)) : 10;
         const entity = typeof params.entity === "string" ? params.entity.trim() : undefined;
         const tag = Array.isArray(params.tags) && params.tags.length > 0 ? String(params.tags[0]) : undefined;
         const scopeFilter = buildToolScopeFilter({}, currentAgentIdRef.value, cfg);

--- a/extensions/memory-hybrid/tools/memory/register-store-tools.ts
+++ b/extensions/memory-hybrid/tools/memory/register-store-tools.ts
@@ -35,7 +35,11 @@ import { storeAliases } from "../../services/retrieval-aliases.js";
 import { validateScopedClassificationTarget } from "../../services/classification-scope.js";
 import { shouldAutoVerify } from "../../services/verification-store.js";
 import { cleanupEvictedVector, deleteVectorForFactId } from "../../services/vector-maintenance.js";
-import { isWalWriteFailure, walRemove as walRemoveEntry, walWrite as walWriteEntry } from "../../services/wal-helpers.js";
+import {
+  isWalWriteFailure,
+  walRemove as walRemoveEntry,
+  walWrite as walWriteEntry,
+} from "../../services/wal-helpers.js";
 import type { MemoryEntry } from "../../types/memory.js";
 import { MEMORY_SCOPES } from "../../types/memory.js";
 import { detectFutureDate } from "../../utils/date-detector.js";
@@ -703,7 +707,8 @@ export function registerStoreTools(runtime: MemoryToolRuntime): void {
                   warnMessage: `memory-hybrid: blocked cross-scope or unknown memory_store UPDATE target ${classification.targetId}`,
                 });
                 if (oldFact) {
-                  const walEntryId = await walWriteEntry(storeWal,
+                  const walEntryId = await walWriteEntry(
+                    storeWal,
                     "update",
                     {
                       text: textToStore,
@@ -758,7 +763,7 @@ export function registerStoreTools(runtime: MemoryToolRuntime): void {
                     updateStoreResult.newlyStored === false &&
                     !updateStoreResult.embeddingStale
                   ) {
-                    if (walEntryId) await walRemoveEntry(storeWal,walEntryId, api.logger);
+                    if (walEntryId) await walRemoveEntry(storeWal, walEntryId, api.logger);
                     return {
                       content: [
                         {
@@ -794,7 +799,7 @@ export function registerStoreTools(runtime: MemoryToolRuntime): void {
                     } catch (err) {
                       api.logger.warn(`memory-hybrid: UPDATE merge vector refresh failed: ${err}`);
                     }
-                    if (walEntryId) await walRemoveEntry(storeWal,walEntryId, api.logger);
+                    if (walEntryId) await walRemoveEntry(storeWal, walEntryId, api.logger);
                     return {
                       content: [
                         {
@@ -872,7 +877,7 @@ export function registerStoreTools(runtime: MemoryToolRuntime): void {
                     api.logger.info?.(
                       `memory-hybrid: UPDATE — superseded ${classification.targetId} with ${newEntry.id}: ${classification.reason}`,
                     );
-                    if (walEntryId) await walRemoveEntry(storeWal,walEntryId, api.logger);
+                    if (walEntryId) await walRemoveEntry(storeWal, walEntryId, api.logger);
                     return {
                       content: [
                         {
@@ -892,7 +897,7 @@ export function registerStoreTools(runtime: MemoryToolRuntime): void {
                     };
                   }
                   // WAL cleanup for skipped update path
-                  if (walEntryId) await walRemoveEntry(storeWal,walEntryId, api.logger);
+                  if (walEntryId) await walRemoveEntry(storeWal, walEntryId, api.logger);
                   return {
                     content: [
                       {
@@ -919,7 +924,8 @@ export function registerStoreTools(runtime: MemoryToolRuntime): void {
 
           // Scope was resolved above (before classify-before-write) for WAL and classification consistency.
 
-          const walEntryId = await walWriteEntry(storeWal,
+          const walEntryId = await walWriteEntry(
+            storeWal,
             "store",
             {
               text: textToStore,
@@ -973,7 +979,7 @@ export function registerStoreTools(runtime: MemoryToolRuntime): void {
           });
           const entry = storeResult.entry;
           if (!storeResult.skipped && storeResult.newlyStored === false && !storeResult.embeddingStale) {
-            if (walEntryId) await walRemoveEntry(storeWal,walEntryId, api.logger);
+            if (walEntryId) await walRemoveEntry(storeWal, walEntryId, api.logger);
             return {
               content: [
                 {
@@ -1039,7 +1045,11 @@ export function registerStoreTools(runtime: MemoryToolRuntime): void {
               api.logger.warn(`memory-hybrid: vector store failed: ${err}`);
             }
 
-            if (storeResult.newlyStored && cfg.lifecycle.fragmentEmbedding.enabled && textToStore.length >= cfg.lifecycle.fragmentEmbedding.minChars) {
+            if (
+              storeResult.newlyStored &&
+              cfg.lifecycle.fragmentEmbedding.enabled &&
+              textToStore.length >= cfg.lifecycle.fragmentEmbedding.minChars
+            ) {
               setImmediate(() => {
                 void import("../../services/fragment-embedding.js")
                   .then(({ indexFactFragments }) =>
@@ -1271,7 +1281,7 @@ export function registerStoreTools(runtime: MemoryToolRuntime): void {
               context: { category },
             });
 
-            if (walEntryId) await walRemoveEntry(storeWal,walEntryId, api.logger);
+            if (walEntryId) await walRemoveEntry(storeWal, walEntryId, api.logger);
             return {
               content: [
                 {
@@ -1305,7 +1315,7 @@ export function registerStoreTools(runtime: MemoryToolRuntime): void {
             };
           }
           // WAL cleanup and return for skipped store path (Bug fix #1560, #1561)
-          if (walEntryId) await walRemoveEntry(storeWal,walEntryId, api.logger);
+          if (walEntryId) await walRemoveEntry(storeWal, walEntryId, api.logger);
           return {
             content: [
               {
@@ -1343,7 +1353,9 @@ export function registerStoreTools(runtime: MemoryToolRuntime): void {
       description:
         "Returns facts flagged with contradictions — useful for reviewing uncertain or conflicting knowledge.",
       parameters: Type.Object({
-        since: Type.Optional(Type.String({ description: "ISO8601 timestamp cursor — only contradictions after this time." })),
+        since: Type.Optional(
+          Type.String({ description: "ISO8601 timestamp cursor — only contradictions after this time." }),
+        ),
         entity: Type.Optional(Type.String({ description: "Filter to contradictions involving this entity." })),
         limit: Type.Optional(Type.Number({ description: "Max results (default 50, max 200)." })),
         resolved: Type.Optional(
@@ -1355,8 +1367,7 @@ export function registerStoreTools(runtime: MemoryToolRuntime): void {
         const rows = factsDb.queryContradictionSurface({
           since: typeof params.since === "string" ? params.since : undefined,
           entity: typeof params.entity === "string" ? params.entity : undefined,
-          limit:
-            typeof params.limit === "number" && params.limit > 0 ? Math.min(200, Math.floor(params.limit)) : 50,
+          limit: typeof params.limit === "number" && params.limit > 0 ? Math.min(200, Math.floor(params.limit)) : 50,
           resolved: typeof params.resolved === "boolean" ? params.resolved : undefined,
           scopeFilter,
         });
@@ -1369,8 +1380,7 @@ export function registerStoreTools(runtime: MemoryToolRuntime): void {
                   ? "No contradictions found."
                   : rows
                       .map(
-                        (r) =>
-                          `- [${r.score.toFixed(2)}] ${r.preview} (new=${r.factId}, old=${r.contradictingFactId})`,
+                        (r) => `- [${r.score.toFixed(2)}] ${r.preview} (new=${r.factId}, old=${r.contradictingFactId})`,
                       )
                       .join("\n"),
             },

--- a/extensions/memory-hybrid/tools/memory/register-store-tools.ts
+++ b/extensions/memory-hybrid/tools/memory/register-store-tools.ts
@@ -504,7 +504,7 @@ export function registerStoreTools(runtime: MemoryToolRuntime): void {
                     category: "technical",
                   });
                   await storeRegistryEmbeddings({
-                    storeFactsDb,
+                    factsDb: storeFactsDb,
                     embeddingRegistry,
                     embeddings,
                     factId: pointerEntry.id,
@@ -848,7 +848,7 @@ export function registerStoreTools(runtime: MemoryToolRuntime): void {
                         });
                       }
                       await storeRegistryEmbeddings({
-                        storeFactsDb,
+                        factsDb: storeFactsDb,
                         embeddingRegistry,
                         embeddings,
                         factId: newEntry.id,
@@ -1026,7 +1026,7 @@ export function registerStoreTools(runtime: MemoryToolRuntime): void {
                 });
               }
               await storeRegistryEmbeddings({
-                storeFactsDb,
+                factsDb: storeFactsDb,
                 embeddingRegistry,
                 embeddings,
                 factId: entry.id,


### PR DESCRIPTION
## Summary

Fixes Workboard sync logging `Failed to create card for hm-task:…` / `hm-goal:…` on OpenClaw 6.8+ (#1927).

- Map create/update params: `column`→`status`, `description`→`notes`, `tags`→`labels`, `externalId`→`idempotencyKey`
- Normalize list/create responses: `status`→`column`, `labels`→`tags`, read external id from `metadata.automation.idempotencyKey`
- Unwrap `{ card }` wrapper in `normalizeWorkboardCardResult` so successful creates are recognized
- Replace `spawnSync` gateway CLI calls with async `spawn` to avoid blocking the gateway event loop (#1925 CLI fallback path)
- `resolveWorkboardExternalId()` in card mapper for consistent idempotency key lookup

## Verification

- `npm test -- workboard-rpc-client.test.ts` — 5 tests pass
- Maeve local patch (copied dist to installed `openclaw-hybrid-memory@2026.6.170`): after gateway restart, startup sync had ~12 create failures during initial burst, then zero ongoing flood (previously continuous every few seconds)

## Test plan

- [x] Unit tests for API normalization and CLI client mocks
- [x] Manual `openclaw gateway call workboard.cards.create` with idempotencyKey
- [x] Gateway journal: no sustained `Failed to create card` after sync settles

## Follow-up (separate issue)

Pull/update path still maps some ledger statuses (e.g. `Stalled`) to invalid Workboard `status` values — causes `workboard.cards.update` errors, not covered here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default Workboard column mappings and bidirectional sync semantics; misconfiguration could mis-route task/goal statuses until configs are updated, though legacy label→slug mapping mitigates some cases.
> 
> **Overview**
> Aligns hybrid-memory **Workboard** sync with OpenClaw **6.8+** card RPCs so create/list/update stop failing on mismatched field names and unrecognized create responses (#1927).
> 
> The RPC client now sends **`status` / `notes` / `labels` / `idempotencyKey`** instead of legacy `column` / `description` / `tags` / `externalId`, normalizes API cards back (`status`→`column`, `labels`→`tags`, id from `metadata.automation.idempotencyKey`), and unwraps **`{ card }`** on create. Gateway fallback uses **async `spawn`** (replacing `spawnSync`) with a longer timeout.
> 
> **Status slugs** replace Kanban display labels: new `workboard-status-slugs` helpers, default column config (`running`, `scheduled`, `done`, etc.), dedicated **`taskWaiting`→`scheduled`**, and slug-aware **column equivalence** for push/pull sync. Card mapper resolves external IDs consistently and maps outgoing columns through `toWorkboardStatusSlug`.
> 
> Smaller fixes: **`storeRegistryEmbeddings`** guards missing `factsDb` and uses the correct `factsDb` argument name; plugin schema documents slug-based columns. Remaining diff is mostly formatting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c69fed31044e4d12014adc6d86b61f3dd94874bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->