### PR TITLE
fix(workboard): map OpenClaw 6.8 RPC fields to stop create-card sync flood (#1927)

### DIFF
--- a/extensions/memory-hybrid/services/workboard-rpc-client.ts
+++ b/extensions/memory-hybrid/services/workboard-rpc-client.ts
@@ -6,7 +6,7 @@
  * a direct plugin-to-plugin API if that becomes available.
  */
 
-import { spawnSync } from "../utils/process-runner.js";
+import { spawn } from "../utils/process-runner.js";
 import { pluginLogger } from "../utils/logger.js";
 
 export type WorkboardRpcCard = {
@@ -48,21 +48,122 @@ export interface WorkboardRpcClient {
 
 const REQUEST_TIMEOUT_MS = 10_000;
 
-function normalizeWorkboardCardsResult(result: unknown): WorkboardRpcCard[] {
-  if (Array.isArray(result)) return result as WorkboardRpcCard[];
-  if (typeof result === "object" && result !== null) {
-    const obj = result as { cards?: WorkboardRpcCard[]; result?: { cards?: WorkboardRpcCard[] } };
-    if (Array.isArray(obj.cards)) return obj.cards;
-    if (obj.result && Array.isArray(obj.result.cards)) return obj.result.cards;
+type WorkboardApiCardRaw = {
+  id: string;
+  title: string;
+  status?: string;
+  column?: string;
+  notes?: string;
+  description?: string;
+  labels?: string[];
+  tags?: string[];
+  externalId?: string;
+  idempotencyKey?: string;
+  metadata?: Record<string, unknown>;
+  createdAt?: string;
+  updatedAt?: string;
+};
+
+function extractWorkboardExternalId(raw: WorkboardApiCardRaw): string | undefined {
+  if (typeof raw.idempotencyKey === "string" && raw.idempotencyKey) return raw.idempotencyKey;
+  if (typeof raw.externalId === "string" && raw.externalId) return raw.externalId;
+  const automation = raw.metadata?.automation;
+  if (typeof automation === "object" && automation !== null) {
+    const key = (automation as { idempotencyKey?: unknown }).idempotencyKey;
+    if (typeof key === "string" && key) return key;
   }
-  return [];
+  return undefined;
+}
+
+/** Map OpenClaw 6.8 Workboard API cards to hybrid-memory's internal card shape (#1927). */
+export function normalizeWorkboardApiCard(raw: unknown): WorkboardRpcCard | null {
+  if (typeof raw !== "object" || raw === null) return null;
+  const card = raw as WorkboardApiCardRaw;
+  if (typeof card.id !== "string" || typeof card.title !== "string") return null;
+
+  const metadata: Record<string, string> | undefined =
+    card.metadata && typeof card.metadata === "object"
+      ? Object.fromEntries(
+          Object.entries(card.metadata).flatMap(([key, value]) =>
+            typeof value === "string" ? [[key, value]] : [],
+          ),
+        )
+      : undefined;
+
+  return {
+    id: card.id,
+    title: card.title,
+    column: card.status ?? card.column ?? "",
+    description: card.notes ?? card.description,
+    tags: card.labels ?? card.tags,
+    externalId: extractWorkboardExternalId(card),
+    metadata: metadata && Object.keys(metadata).length > 0 ? metadata : undefined,
+    createdAt: card.createdAt,
+    updatedAt: card.updatedAt,
+  };
+}
+
+function toWorkboardApiListParams(opts?: { tag?: string; column?: string }): Record<string, unknown> {
+  const params: Record<string, unknown> = {};
+  if (opts?.tag) params.label = opts.tag;
+  if (opts?.column) params.status = opts.column;
+  return params;
+}
+
+function toWorkboardApiCreateParams(card: {
+  title: string;
+  column: string;
+  description?: string;
+  tags?: string[];
+  externalId?: string;
+  metadata?: Record<string, string>;
+}): Record<string, unknown> {
+  const params: Record<string, unknown> = { title: card.title, status: card.column };
+  if (card.description) params.notes = card.description;
+  if (card.tags?.length) params.labels = card.tags;
+  if (card.externalId) params.idempotencyKey = card.externalId;
+  if (card.metadata) params.metadata = card.metadata;
+  return params;
+}
+
+function toWorkboardApiUpdateParams(patch: {
+  title?: string;
+  column?: string;
+  description?: string;
+  tags?: string[];
+  metadata?: Record<string, string>;
+}): Record<string, unknown> {
+  const params: Record<string, unknown> = {};
+  if (patch.title !== undefined) params.title = patch.title;
+  if (patch.column !== undefined) params.status = patch.column;
+  if (patch.description !== undefined) params.notes = patch.description;
+  if (patch.tags !== undefined) params.labels = patch.tags;
+  if (patch.metadata !== undefined) params.metadata = patch.metadata;
+  return params;
+}
+
+function normalizeWorkboardCardsResult(result: unknown): WorkboardRpcCard[] {
+  let cards: unknown[] = [];
+  if (Array.isArray(result)) {
+    cards = result;
+  } else if (typeof result === "object" && result !== null) {
+    const obj = result as { cards?: unknown[]; result?: { cards?: unknown[] } };
+    if (Array.isArray(obj.cards)) cards = obj.cards;
+    else if (obj.result && Array.isArray(obj.result.cards)) cards = obj.result.cards;
+  }
+  return cards.map(normalizeWorkboardApiCard).filter((card): card is WorkboardRpcCard => card !== null);
 }
 
 function normalizeWorkboardCardResult(result: unknown): WorkboardRpcCard | null {
   if (typeof result !== "object" || result === null) return null;
-  const obj = result as WorkboardRpcCard & { result?: WorkboardRpcCard };
-  if (typeof obj.id === "string") return obj;
-  if (obj.result && typeof obj.result.id === "string") return obj.result;
+  const obj = result as { card?: unknown; result?: unknown; id?: string };
+  if (obj.card) return normalizeWorkboardApiCard(obj.card);
+  if (typeof obj.id === "string") return normalizeWorkboardApiCard(obj);
+  if (obj.result && typeof obj.result === "object" && obj.result !== null) {
+    const inner = obj.result as { card?: unknown; id?: string };
+    if (inner.card) return normalizeWorkboardApiCard(inner.card);
+    if (typeof inner.id === "string") return normalizeWorkboardApiCard(inner);
+  }
   return null;
 }
 
@@ -124,19 +225,21 @@ export function createWorkboardHttpRpcClient(gatewayUrl: string, token?: string)
 
   return {
     async listCards(opts) {
-      const params: Record<string, unknown> = {};
-      if (opts?.tag) params.tag = opts.tag;
-      if (opts?.column) params.column = opts.column;
-      const result = await rpc<{ cards: WorkboardRpcCard[] }>("workboard.cards.list", params);
-      return result?.cards ?? [];
+      const result = await rpc<unknown>("workboard.cards.list", toWorkboardApiListParams(opts));
+      return normalizeWorkboardCardsResult(result);
     },
 
     async createCard(card) {
-      return rpc<WorkboardRpcCard>("workboard.cards.create", card);
+      const result = await rpc<unknown>("workboard.cards.create", toWorkboardApiCreateParams(card));
+      return normalizeWorkboardCardResult(result);
     },
 
     async updateCard(cardId, patch) {
-      return rpc<WorkboardRpcCard>("workboard.cards.update", { id: cardId, ...patch });
+      const result = await rpc<unknown>("workboard.cards.update", {
+        id: cardId,
+        ...toWorkboardApiUpdateParams(patch),
+      });
+      return normalizeWorkboardCardResult(result);
     },
 
     async deleteCard(cardId) {
@@ -171,7 +274,11 @@ export function createWorkboardHttpRpcClient(gatewayUrl: string, token?: string)
   };
 }
 
-function runWorkboardGatewayCliCall(method: string, params: Record<string, unknown>, token?: string): unknown | null {
+function runWorkboardGatewayCliCall(
+  method: string,
+  params: Record<string, unknown>,
+  token?: string,
+): Promise<unknown | null> {
   const args = [
     "gateway",
     "call",
@@ -183,29 +290,69 @@ function runWorkboardGatewayCliCall(method: string, params: Record<string, unkno
     String(REQUEST_TIMEOUT_MS),
   ];
 
-  try {
-    const env = token ? { ...process.env, OPENCLAW_GATEWAY_TOKEN: token } : process.env;
-    const result = spawnSync("openclaw", args, {
-      encoding: "utf-8",
-      env,
-      timeout: REQUEST_TIMEOUT_MS + 2000,
-    });
-    if (result.error || result.status !== 0) {
-      const detail = (result.stderr || result.stdout || "").trim();
+  return new Promise((resolve) => {
+    try {
+      const env = token ? { ...process.env, OPENCLAW_GATEWAY_TOKEN: token } : process.env;
+      const child = spawn("openclaw", args, { env });
+      let stdout = "";
+      let stderr = "";
+      let settled = false;
+
+      const finish = (value: unknown | null) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timeout);
+        resolve(value);
+      };
+
+      const timeout = setTimeout(() => {
+        child.kill();
+        pluginLogger.warn(`memory-hybrid: workboard gateway call ${method} timed out after ${REQUEST_TIMEOUT_MS}ms`);
+        finish(null);
+      }, REQUEST_TIMEOUT_MS + 2000);
+
+      child.stdout?.on("data", (chunk: string | Buffer) => {
+        stdout += chunk.toString();
+      });
+      child.stderr?.on("data", (chunk: string | Buffer) => {
+        stderr += chunk.toString();
+      });
+      child.on("error", (err) => {
+        pluginLogger.warn(
+          `memory-hybrid: workboard gateway call ${method} failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        finish(null);
+      });
+      child.on("close", (code) => {
+        if (code !== 0) {
+          const detail = (stderr || stdout).trim();
+          pluginLogger.warn(
+            `memory-hybrid: workboard gateway call ${method} failed${detail ? `: ${detail.slice(0, 200)}` : ""}`,
+          );
+          finish(null);
+          return;
+        }
+        const trimmed = stdout.trim();
+        if (!trimmed) {
+          finish(null);
+          return;
+        }
+        try {
+          finish(JSON.parse(trimmed) as unknown);
+        } catch (err) {
+          pluginLogger.warn(
+            `memory-hybrid: workboard gateway call ${method} failed: ${err instanceof Error ? err.message : String(err)}`,
+          );
+          finish(null);
+        }
+      });
+    } catch (err) {
       pluginLogger.warn(
-        `memory-hybrid: workboard gateway call ${method} failed${detail ? `: ${detail.slice(0, 200)}` : ""}`,
+        `memory-hybrid: workboard gateway call ${method} failed: ${err instanceof Error ? err.message : String(err)}`,
       );
-      return null;
+      resolve(null);
     }
-    const stdout = result.stdout.trim();
-    if (!stdout) return null;
-    return JSON.parse(stdout) as unknown;
-  } catch (err) {
-    pluginLogger.warn(
-      `memory-hybrid: workboard gateway call ${method} failed: ${err instanceof Error ? err.message : String(err)}`,
-    );
-    return null;
-  }
+  });
 }
 
 /** Gateway RPC via `openclaw gateway call` (OpenClaw 6.8+ when HTTP /rpc/* is unavailable). */
@@ -216,20 +363,20 @@ export function createWorkboardGatewayCliRpcClient(token?: string): WorkboardRpc
 
   return {
     async listCards(opts) {
-      const params: Record<string, unknown> = {};
-      if (opts?.tag) params.tag = opts.tag;
-      if (opts?.column) params.column = opts.column;
-      const result = await rpc("workboard.cards.list", params);
+      const result = await rpc("workboard.cards.list", toWorkboardApiListParams(opts));
       return normalizeWorkboardCardsResult(result);
     },
 
     async createCard(card) {
-      const result = await rpc("workboard.cards.create", card);
+      const result = await rpc("workboard.cards.create", toWorkboardApiCreateParams(card));
       return normalizeWorkboardCardResult(result);
     },
 
     async updateCard(cardId, patch) {
-      const result = await rpc("workboard.cards.update", { id: cardId, ...patch });
+      const result = await rpc("workboard.cards.update", {
+        id: cardId,
+        ...toWorkboardApiUpdateParams(patch),
+      });
       return normalizeWorkboardCardResult(result);
     },
 
@@ -244,7 +391,7 @@ export function createWorkboardGatewayCliRpcClient(token?: string): WorkboardRpc
     },
 
     async isAvailable() {
-      const result = runWorkboardGatewayCliCall("workboard.cards.list", {}, token);
+      const result = await runWorkboardGatewayCliCall("workboard.cards.list", {}, token);
       return result != null;
     },
   };

--- a/extensions/memory-hybrid/tests/workboard-rpc-client.test.ts
+++ b/extensions/memory-hybrid/tests/workboard-rpc-client.test.ts
@@ -1,80 +1,77 @@
+import { EventEmitter } from "node:events";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-const { spawnSyncMock } = vi.hoisted(() => ({
-  spawnSyncMock: vi.fn(),
+const { spawnMock } = vi.hoisted(() => ({
+  spawnMock: vi.fn(),
 }));
 
 vi.mock("../utils/process-runner.js", () => ({
-  spawnSync: spawnSyncMock,
+  spawn: spawnMock,
 }));
 
 import {
   createWorkboardGatewayCliRpcClient,
   createWorkboardHttpRpcClient,
   createWorkboardRpcClient,
+  normalizeWorkboardApiCard,
 } from "../services/workboard-rpc-client.js";
+
+function mockSpawnSuccess(stdout: unknown) {
+  spawnMock.mockImplementation(() => {
+    const child = new EventEmitter() as EventEmitter & {
+      stdout: EventEmitter;
+      stderr: EventEmitter;
+      kill: ReturnType<typeof vi.fn>;
+    };
+    child.stdout = new EventEmitter();
+    child.stderr = new EventEmitter();
+    child.kill = vi.fn();
+    setImmediate(() => {
+      child.stdout.emit("data", JSON.stringify(stdout));
+      child.emit("close", 0);
+    });
+    return child;
+  });
+}
 
 describe("workboard-rpc-client (#1925)", () => {
   afterEach(() => {
     vi.restoreAllMocks();
-    spawnSyncMock.mockReset();
+    spawnMock.mockReset();
   });
 
   it("createWorkboardRpcClient falls back to gateway CLI when HTTP /rpc returns 404", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response("not found", { status: 404 }) as Response,
     );
-    spawnSyncMock.mockReturnValue({
-      status: 0,
-      stdout: JSON.stringify({ cards: [{ id: "c1", title: "Task", column: "todo" }] }),
-      stderr: "",
-      pid: 1,
-      output: [null, "", ""],
-      signal: null,
-      error: undefined,
-    });
+    mockSpawnSuccess({ cards: [{ id: "c1", title: "Task", status: "todo" }] });
 
     const client = createWorkboardRpcClient("http://127.0.0.1:18789");
     expect(await client.isAvailable()).toBe(true);
     const cards = await client.listCards();
     expect(cards).toHaveLength(1);
     expect(cards[0]?.id).toBe("c1");
-    expect(spawnSyncMock).toHaveBeenCalled();
-    const args = spawnSyncMock.mock.calls[0]?.[1] as string[];
+    expect(cards[0]?.column).toBe("todo");
+    expect(spawnMock).toHaveBeenCalled();
+    const args = spawnMock.mock.calls[0]?.[1] as string[];
     expect(args).toContain("gateway");
     expect(args).toContain("workboard.cards.list");
     expect(args).not.toContain("--token");
   });
 
   it("createWorkboardGatewayCliRpcClient passes token via OPENCLAW_GATEWAY_TOKEN env", async () => {
-    spawnSyncMock.mockReturnValue({
-      status: 0,
-      stdout: JSON.stringify({ cards: [] }),
-      stderr: "",
-      pid: 1,
-      output: [null, "", ""],
-      signal: null,
-      error: undefined,
-    });
+    mockSpawnSuccess({ cards: [] });
 
     const client = createWorkboardGatewayCliRpcClient("secret-token");
     await client.isAvailable();
-    const env = spawnSyncMock.mock.calls[0]?.[2]?.env as NodeJS.ProcessEnv;
+    const env = spawnMock.mock.calls[0]?.[2]?.env as NodeJS.ProcessEnv;
     expect(env.OPENCLAW_GATEWAY_TOKEN).toBe("secret-token");
-    const args = spawnSyncMock.mock.calls[0]?.[1] as string[];
+    const args = spawnMock.mock.calls[0]?.[1] as string[];
     expect(args).not.toContain("--token");
   });
 
   it("createWorkboardGatewayCliRpcClient parses cards from gateway call JSON", async () => {
-    spawnSyncMock.mockReturnValue({
-      status: 0,
-      stdout: JSON.stringify({ result: { cards: [{ id: "g1", title: "Goal", column: "done" }] } }),
-      stderr: "",
-      pid: 1,
-      output: [null, "", ""],
-      signal: null,
-      error: undefined,
-    });
+    mockSpawnSuccess({ result: { cards: [{ id: "g1", title: "Goal", status: "done" }] } });
 
     const client = createWorkboardGatewayCliRpcClient();
     const cards = await client.listCards();
@@ -89,5 +86,115 @@ describe("workboard-rpc-client (#1925)", () => {
 
     const client = createWorkboardHttpRpcClient("http://127.0.0.1:18789");
     expect(await client.isAvailable()).toBe(true);
+  });
+});
+
+describe("workboard-rpc-client (#1927)", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    spawnMock.mockReset();
+  });
+
+  it("normalizeWorkboardApiCard maps OpenClaw 6.8 fields to hybrid-memory shape", () => {
+    const card = normalizeWorkboardApiCard({
+      id: "wb-1",
+      title: "[Task] demo",
+      status: "In Progress",
+      notes: "Do the thing",
+      labels: ["hybrid-memory"],
+      metadata: {
+        automation: { idempotencyKey: "hm-task:demo" },
+        type: "active-task",
+      },
+    });
+
+    expect(card).toEqual({
+      id: "wb-1",
+      title: "[Task] demo",
+      column: "In Progress",
+      description: "Do the thing",
+      tags: ["hybrid-memory"],
+      externalId: "hm-task:demo",
+      metadata: { type: "active-task" },
+      createdAt: undefined,
+      updatedAt: undefined,
+    });
+  });
+
+  it("createWorkboardGatewayCliRpcClient maps create params to Workboard API fields", async () => {
+    mockSpawnSuccess({
+      card: {
+        id: "wb-2",
+        title: "[Goal] ship",
+        status: "Active",
+        labels: ["hybrid-memory"],
+        metadata: { automation: { idempotencyKey: "hm-goal:g1" } },
+      },
+    });
+
+    const client = createWorkboardGatewayCliRpcClient();
+    const created = await client.createCard({
+      title: "[Goal] ship",
+      column: "Active",
+      description: "Ship it",
+      tags: ["hybrid-memory"],
+      externalId: "hm-goal:g1",
+    });
+
+    expect(created?.id).toBe("wb-2");
+    expect(created?.externalId).toBe("hm-goal:g1");
+    const args = spawnMock.mock.calls[0]?.[1] as string[];
+    const paramsIndex = args.indexOf("--params");
+    const params = JSON.parse(args[paramsIndex + 1] ?? "{}") as Record<string, unknown>;
+    expect(params).toEqual({
+      title: "[Goal] ship",
+      status: "Active",
+      notes: "Ship it",
+      labels: ["hybrid-memory"],
+      idempotencyKey: "hm-goal:g1",
+    });
+  });
+
+  it("createWorkboardGatewayCliRpcClient finds cards by metadata.automation.idempotencyKey", async () => {
+    mockSpawnSuccess({
+      cards: [
+        {
+          id: "wb-3",
+          title: "[Task] existing",
+          status: "Done",
+          metadata: { automation: { idempotencyKey: "hm-task:existing" } },
+        },
+      ],
+    });
+
+    const client = createWorkboardGatewayCliRpcClient();
+    const found = await client.findByExternalId("hm-task:existing");
+    expect(found?.id).toBe("wb-3");
+    expect(found?.column).toBe("Done");
+  });
+
+  it("createWorkboardGatewayCliRpcClient unwraps { card } create responses", async () => {
+    mockSpawnSuccess({
+      card: { id: "wb-4", title: "Created", status: "todo", idempotencyKey: "hm-task:new" },
+    });
+
+    const client = createWorkboardGatewayCliRpcClient();
+    const created = await client.createCard({
+      title: "Created",
+      column: "todo",
+      externalId: "hm-task:new",
+    });
+
+    expect(created).toEqual({
+      id: "wb-4",
+      title: "Created",
+      column: "todo",
+      description: undefined,
+      tags: undefined,
+      externalId: "hm-task:new",
+      metadata: undefined,
+      createdAt: undefined,
+      updatedAt: undefined,
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Map hybrid-memory card fields to OpenClaw 6.8 Workboard API shape on create/update/list (`status`, `notes`, `labels`, `idempotencyKey`).
- Normalize API responses back to the internal adapter shape, including `{ card }` unwrap and `metadata.automation.idempotencyKey` → `externalId`.
- Replace synchronous `spawnSync` gateway CLI calls with async `spawn` to avoid blocking the gateway event loop.

Fixes #1927.

## Test plan
- [x] `npm test -- tests/workboard-rpc-client.test.ts tests/workboard-adapter.test.ts`
- [ ] Deploy to Maeve (OpenClaw 6.8+) and confirm startup sync no longer floods `Failed to create card for hm-task:...` / `hm-goal:...`
- [ ] Confirm subsequent sync ticks report `created=0` when cards already exist

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes integration with external Workboard sync and idempotency matching; mis-mapping could still cause duplicate creates or missed updates, though scope is limited to the RPC client layer with solid test coverage.
> 
> **Overview**
> Fixes Workboard sync repeatedly trying to create cards on OpenClaw 6.8+ by translating hybrid-memory’s card model to the **6.8 API** on the way out and normalizing API payloads back on the way in.
> 
> **Outbound mapping** for list/create/update: `column`→`status`, `description`→`notes`, `tags`→`labels`, `externalId`→`idempotencyKey`, and list filters `tag`/`column`→`label`/`status`.
> 
> **Inbound normalization** via `normalizeWorkboardApiCard`: reverses those fields, unwraps `{ card }` / nested `result` shapes, and sets `externalId` from `idempotencyKey`, `externalId`, or `metadata.automation.idempotencyKey` so `findByExternalId` can skip duplicate creates.
> 
> **Gateway CLI** no longer uses synchronous `spawnSync`; it uses async `spawn` with stream collection, timeouts, and kill-on-timeout to avoid blocking the gateway event loop. Tests mock `spawn` and cover the new mapping behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 724333db700c9c0c64feb51ad3a3d3d40e9d9917. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->