### PR TITLE
fix: 2026.6.241 hotfix for registration, contract, and Workboard startup (#1938–#1940)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ---
 
+## [2026.6.241] - 2026-06-24
+
+### Fixed
+
+- **Gateway registration regression (#1938):** `hasBoundMemoryToolHelpers()` rejected pre-bound memory tool contexts when `wal` was present, causing `registerMemoryTools: Missing required legacy helper functions` on cold gateway start in **2026.6.240**. Bound helpers are now authoritative; legacy mode is detected only when those helpers are missing.
+- **Crystallization tool contract (#1939):** Added `memory_crystallize_restore` to `contracts.tools` / `AGENT_TOOL_CONTRACT_NAMES` so OpenClaw 6.x no longer warns about an undeclared runtime tool.
+- **Workboard cold-start probe (#1940):** Deferred the initial Workboard availability probe by 60s and retry up to 3 times with 15s backoff so sync arms after other gateway plugins finish loading, without requiring a manual re-register.
+
+### Changed
+
+- Version set to **2026.6.241**.
+
+---
+
 ## [2026.6.240] - 2026-06-24
 
 ### Fixed

--- a/docs/ERROR-REPORTING.md
+++ b/docs/ERROR-REPORTING.md
@@ -366,7 +366,7 @@ const issues: MaintenanceTelemetryIssue[] = [
 
 await reportMaintenanceFailureIssues(issues, {
   cfg: config,
-  pluginVersion: "2026.6.240",
+  pluginVersion: "2026.6.241",
   logger: console,
 });
 ```

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -6,7 +6,7 @@ nav_order: 1
 ---
 # Quick Start - Hybrid Memory Plugin
 
-Get an agent that **remembers you** and **gets better at giving the right context** over time - in about 10 minutes. For full configuration options see [CONFIGURATION.md](CONFIGURATION.md); for architecture background see [ARCHITECTURE.md](ARCHITECTURE.md). For low-cost production rollout, see [COST-OPTIMIZATION-PLAYBOOK.md](COST-OPTIMIZATION-PLAYBOOK.md). After install, see [release notes 2026.6.240](../release-notes/release-notes-2026.6.240.md) for recent maintenance guard and recall fixes.
+Get an agent that **remembers you** and **gets better at giving the right context** over time - in about 10 minutes. For full configuration options see [CONFIGURATION.md](CONFIGURATION.md); for architecture background see [ARCHITECTURE.md](ARCHITECTURE.md). For low-cost production rollout, see [COST-OPTIMIZATION-PLAYBOOK.md](COST-OPTIMIZATION-PLAYBOOK.md). After install, see [release notes 2026.6.241](../release-notes/release-notes-2026.6.241.md) for recent hotfix and maintenance notes.
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -124,7 +124,7 @@ Hybrid Memory gives your OpenClaw agent **persistent memory** without turning me
 | [Credits & attribution](CREDITS-AND-ATTRIBUTION) | Sources, lineage, and what this repository adds |
 | [Contributor onboarding](CONTRIBUTOR-ONBOARDING) | First-contribution path, quality bar, and high-impact starter areas |
 | [Similar-sweep PR process](SIMILAR-SWEEP-PR) | Contributor merge order and module-split conventions during sweep batches |
-| [Release notes 2026.6.240](../release-notes/release-notes-2026.6.240.md) | Latest release highlights and upgrade notes |
+| [Release notes 2026.6.241](../release-notes/release-notes-2026.6.241.md) | Latest release highlights and upgrade notes |
 
 ---
 

--- a/extensions/memory-hybrid/api/plugin-runtime.ts
+++ b/extensions/memory-hybrid/api/plugin-runtime.ts
@@ -154,6 +154,8 @@ export interface PluginRuntime {
     maintenanceStartupTimeout: { value: ReturnType<typeof setTimeout> | null };
     /** Workboard bidirectional sync timer. */
     workboardSync?: { value: ReturnType<typeof setInterval> | null };
+    /** Deferred Workboard cold-start probe (#1940). */
+    workboardStartupTimeout?: { value: ReturnType<typeof setTimeout> | null };
     /** Plugin service shutdown flag (Issue #1893 re-arm abort guard). */
     shuttingDownRef: { value: boolean };
   };
@@ -229,5 +231,9 @@ export function clearRuntimeTimers(timers: PluginRuntime["timers"]): void {
   if (timers.workboardSync?.value) {
     clearInterval(timers.workboardSync.value);
     timers.workboardSync.value = null;
+  }
+  if (timers.workboardStartupTimeout?.value) {
+    clearTimeout(timers.workboardStartupTimeout.value);
+    timers.workboardStartupTimeout.value = null;
   }
 }

--- a/extensions/memory-hybrid/contracts/agent-tool-names.ts
+++ b/extensions/memory-hybrid/contracts/agent-tool-names.ts
@@ -28,6 +28,7 @@ export const AGENT_TOOL_CONTRACT_NAMES = [
   "memory_crystallize_approve",
   "memory_crystallize_list",
   "memory_crystallize_reject",
+  "memory_crystallize_restore",
   "memory_crystallize_skills_rescan",
   "memory_directory",
   "memory_edict_stats",

--- a/extensions/memory-hybrid/openclaw.plugin.json
+++ b/extensions/memory-hybrid/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "openclaw-hybrid-memory",
   "kind": "memory",
-  "version": "2026.6.240",
+  "version": "2026.6.241",
   "contracts": {
     "tools": [
       "active_task_checkpoint",
@@ -29,6 +29,7 @@
       "memory_crystallize_approve",
       "memory_crystallize_list",
       "memory_crystallize_reject",
+      "memory_crystallize_restore",
       "memory_crystallize_skills_rescan",
       "memory_directory",
       "memory_edict_stats",

--- a/extensions/memory-hybrid/package-lock.json
+++ b/extensions/memory-hybrid/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openclaw-hybrid-memory",
-  "version": "2026.6.240",
+  "version": "2026.6.241",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openclaw-hybrid-memory",
-      "version": "2026.6.240",
+      "version": "2026.6.241",
       "hasInstallScript": true,
       "dependencies": {
         "@lancedb/lancedb": "^0.30.0",

--- a/extensions/memory-hybrid/package.json
+++ b/extensions/memory-hybrid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-hybrid-memory",
-  "version": "2026.6.240",
+  "version": "2026.6.241",
   "type": "module",
   "description": "Give your OpenClaw agent lasting memory: structured facts, semantic search, auto-capture & recall, decay, optional credential vault. Part of Hybrid Memory v3.",
   "files": [

--- a/extensions/memory-hybrid/setup/plugin-service.ts
+++ b/extensions/memory-hybrid/setup/plugin-service.ts
@@ -571,10 +571,10 @@ export function createPluginService(ctx: PluginServiceContext) {
         }
       }
 
-      // Workboard integration: start adapter for bidirectional task/goal sync
+      // Workboard integration: defer probe on cold start (#1940), then retry before arming sync
       if (cfg.workboard?.enabled) {
-        const { armWorkboardIntegration } = await import("./workboard-integration.js");
-        await armWorkboardIntegration({
+        const { scheduleWorkboardStartupIntegration } = await import("./workboard-integration.js");
+        scheduleWorkboardStartupIntegration({
           factsDb,
           vectorDb,
           embeddings,

--- a/extensions/memory-hybrid/setup/plugin-service.ts
+++ b/extensions/memory-hybrid/setup/plugin-service.ts
@@ -573,7 +573,12 @@ export function createPluginService(ctx: PluginServiceContext) {
 
       // Workboard integration: defer probe on cold start (#1940), then retry before arming sync
       if (cfg.workboard?.enabled) {
-        const { scheduleWorkboardStartupIntegration } = await import("./workboard-integration.js");
+        const {
+          scheduleWorkboardStartupIntegration,
+          captureWorkboardBootRegistrationGeneration,
+          createWorkboardStartupShouldAbort,
+        } = await import("./workboard-integration.js");
+        const bootRegistrationGeneration = captureWorkboardBootRegistrationGeneration();
         scheduleWorkboardStartupIntegration({
           factsDb,
           vectorDb,
@@ -581,7 +586,7 @@ export function createPluginService(ctx: PluginServiceContext) {
           cfg,
           api,
           timers: timers as PluginRuntime["timers"],
-          shouldAbort: () => timers.shuttingDownRef.value,
+          shouldAbort: createWorkboardStartupShouldAbort(bootRegistrationGeneration, timers.shuttingDownRef),
           connectLabel: "startup",
         });
       }

--- a/extensions/memory-hybrid/setup/workboard-integration.ts
+++ b/extensions/memory-hybrid/setup/workboard-integration.ts
@@ -23,11 +23,60 @@ export type WorkboardIntegrationContext = {
   connectLabel?: string;
 };
 
+export const WORKBOARD_STARTUP_DEFER_MS = 60_000;
+export const WORKBOARD_STARTUP_PROBE_MAX_ATTEMPTS = 3;
+export const WORKBOARD_STARTUP_PROBE_BACKOFF_MS = 15_000;
+
 function clearWorkboardSyncTimer(timers: PluginRuntime["timers"]): void {
   if (timers.workboardSync?.value) {
     clearInterval(timers.workboardSync.value);
     timers.workboardSync.value = null;
   }
+}
+
+function clearWorkboardStartupTimer(timers: PluginRuntime["timers"]): void {
+  if (timers.workboardStartupTimeout?.value) {
+    clearTimeout(timers.workboardStartupTimeout.value);
+    timers.workboardStartupTimeout.value = null;
+  }
+}
+
+async function sleepMs(ms: number, shouldAbort?: () => boolean): Promise<void> {
+  if (ms <= 0) return;
+  await new Promise<void>((resolve) => {
+    setTimeout(() => resolve(), ms);
+  });
+  if (shouldAbort?.()) {
+    throw new Error("aborted");
+  }
+}
+
+async function probeWorkboardAdapterAvailable(
+  adapter: { isAvailable(): Promise<boolean> },
+  opts: {
+    maxAttempts: number;
+    backoffMs: number;
+    shouldAbort?: () => boolean;
+    logger: { debug?: (msg: string) => void };
+    connectLabel: string;
+  },
+): Promise<boolean> {
+  for (let attempt = 1; attempt <= opts.maxAttempts; attempt++) {
+    if (opts.shouldAbort?.()) return false;
+    const available = await adapter.isAvailable();
+    if (available) return true;
+    if (attempt < opts.maxAttempts) {
+      opts.logger.debug?.(
+        `memory-hybrid: Workboard probe attempt ${attempt}/${opts.maxAttempts} failed (${opts.connectLabel}) — retrying in ${opts.backoffMs}ms`,
+      );
+      try {
+        await sleepMs(opts.backoffMs, opts.shouldAbort);
+      } catch {
+        return false;
+      }
+    }
+  }
+  return false;
 }
 
 /**
@@ -94,7 +143,15 @@ export async function armWorkboardIntegration(ctx: WorkboardIntegrationContext):
       verbose: uiIntegrationVerbose,
     });
 
-    const available = await adapter.isAvailable();
+    const probeAttempts = connectLabel === "startup" ? WORKBOARD_STARTUP_PROBE_MAX_ATTEMPTS : 1;
+    const probeBackoff = connectLabel === "startup" ? WORKBOARD_STARTUP_PROBE_BACKOFF_MS : 0;
+    const available = await probeWorkboardAdapterAvailable(adapter, {
+      maxAttempts: probeAttempts,
+      backoffMs: probeBackoff,
+      shouldAbort: checkSuperseded,
+      logger: api.logger,
+      connectLabel,
+    });
     if (!available) {
       api.logger.info?.(`memory-hybrid: Workboard plugin not reachable (${connectLabel}) — sync not armed`);
       return;
@@ -148,6 +205,24 @@ export async function armWorkboardIntegration(ctx: WorkboardIntegrationContext):
       operation: "workboard-adapter-start",
     });
   }
+}
+
+/** Defer cold-start Workboard probe until other gateway plugins finish loading (#1940). */
+export function scheduleWorkboardStartupIntegration(ctx: WorkboardIntegrationContext): void {
+  const { cfg, api, timers, shouldAbort } = ctx;
+  if (!cfg.workboard?.enabled) return;
+  if (shouldAbort?.()) return;
+
+  clearWorkboardStartupTimer(timers);
+  api.logger.debug?.(
+    `memory-hybrid: Workboard startup probe deferred ${WORKBOARD_STARTUP_DEFER_MS}ms (cold gateway start)`,
+  );
+  timers.workboardStartupTimeout = {
+    value: setTimeout(() => {
+      timers.workboardStartupTimeout!.value = null;
+      void armWorkboardIntegration({ ...ctx, connectLabel: "startup" });
+    }, WORKBOARD_STARTUP_DEFER_MS),
+  };
 }
 
 /** Fire-and-forget re-arm after hot reload cleared timers without re-running plugin-service.start(). */

--- a/extensions/memory-hybrid/setup/workboard-integration.ts
+++ b/extensions/memory-hybrid/setup/workboard-integration.ts
@@ -9,6 +9,8 @@ import { capturePluginError } from "../services/error-reporter.js";
 import { resolveGoalsDir } from "../services/goal-stewardship.js";
 import type { EmbeddingProvider } from "../services/embeddings.js";
 import { integrationVerbose } from "../utils/integration-trace.js";
+import { isRegistrationSuperseded } from "../utils/registration-superseded.js";
+import { getHybridMemoryRegistrationState } from "./hybrid-memory-generation-state.js";
 
 export type WorkboardIntegrationContext = {
   factsDb: FactsDB;
@@ -26,6 +28,30 @@ export type WorkboardIntegrationContext = {
 export const WORKBOARD_STARTUP_DEFER_MS = 60_000;
 export const WORKBOARD_STARTUP_PROBE_MAX_ATTEMPTS = 3;
 export const WORKBOARD_STARTUP_PROBE_BACKOFF_MS = 15_000;
+
+/** First plugin-service cold start in this process — used to compute remaining defer on re-register. */
+let workboardGatewayColdStartAtMs: number | null = null;
+
+export function markWorkboardGatewayColdStart(): void {
+  if (workboardGatewayColdStartAtMs == null) {
+    workboardGatewayColdStartAtMs = Date.now();
+  }
+}
+
+/** @internal test helper */
+export function resetWorkboardGatewayColdStartForTests(): void {
+  workboardGatewayColdStartAtMs = null;
+}
+
+export function resolveWorkboardDeferMs(nowMs: number = Date.now()): number {
+  if (workboardGatewayColdStartAtMs == null) return 0;
+  const elapsed = nowMs - workboardGatewayColdStartAtMs;
+  return Math.max(0, WORKBOARD_STARTUP_DEFER_MS - elapsed);
+}
+
+function usesColdStartProbeStrategy(connectLabel: string): boolean {
+  return connectLabel === "startup" || connectLabel === "re-register";
+}
 
 function clearWorkboardSyncTimer(timers: PluginRuntime["timers"]): void {
   if (timers.workboardSync?.value) {
@@ -143,8 +169,10 @@ export async function armWorkboardIntegration(ctx: WorkboardIntegrationContext):
       verbose: uiIntegrationVerbose,
     });
 
-    const probeAttempts = connectLabel === "startup" ? WORKBOARD_STARTUP_PROBE_MAX_ATTEMPTS : 1;
-    const probeBackoff = connectLabel === "startup" ? WORKBOARD_STARTUP_PROBE_BACKOFF_MS : 0;
+    const probeAttempts = usesColdStartProbeStrategy(connectLabel)
+      ? WORKBOARD_STARTUP_PROBE_MAX_ATTEMPTS
+      : 1;
+    const probeBackoff = usesColdStartProbeStrategy(connectLabel) ? WORKBOARD_STARTUP_PROBE_BACKOFF_MS : 0;
     const available = await probeWorkboardAdapterAvailable(adapter, {
       maxAttempts: probeAttempts,
       backoffMs: probeBackoff,
@@ -207,26 +235,55 @@ export async function armWorkboardIntegration(ctx: WorkboardIntegrationContext):
   }
 }
 
-/** Defer cold-start Workboard probe until other gateway plugins finish loading (#1940). */
-export function scheduleWorkboardStartupIntegration(ctx: WorkboardIntegrationContext): void {
+/** Defer Workboard probe until other gateway plugins finish loading (#1940). */
+function scheduleWorkboardDeferredIntegration(ctx: WorkboardIntegrationContext, connectLabel: string): void {
   const { cfg, api, timers, shouldAbort } = ctx;
   if (!cfg.workboard?.enabled) return;
   if (shouldAbort?.()) return;
 
+  const deferMs = resolveWorkboardDeferMs();
   clearWorkboardStartupTimer(timers);
+
+  if (deferMs <= 0) {
+    void armWorkboardIntegration({ ...ctx, connectLabel });
+    return;
+  }
+
   api.logger.debug?.(
-    `memory-hybrid: Workboard startup probe deferred ${WORKBOARD_STARTUP_DEFER_MS}ms (cold gateway start)`,
+    `memory-hybrid: Workboard ${connectLabel} probe deferred ${deferMs}ms (cold gateway start)`,
   );
   timers.workboardStartupTimeout = {
     value: setTimeout(() => {
       timers.workboardStartupTimeout!.value = null;
-      void armWorkboardIntegration({ ...ctx, connectLabel: "startup" });
-    }, WORKBOARD_STARTUP_DEFER_MS),
+      if (shouldAbort?.()) return;
+      void armWorkboardIntegration({ ...ctx, connectLabel });
+    }, deferMs),
   };
+}
+
+/** Defer cold-start Workboard probe until other gateway plugins finish loading (#1940). */
+export function scheduleWorkboardStartupIntegration(ctx: WorkboardIntegrationContext): void {
+  markWorkboardGatewayColdStart();
+  scheduleWorkboardDeferredIntegration(ctx, "startup");
 }
 
 /** Fire-and-forget re-arm after hot reload cleared timers without re-running plugin-service.start(). */
 export function scheduleWorkboardIntegrationAfterReregister(ctx: WorkboardIntegrationContext): void {
   if (ctx.shouldAbort?.()) return;
-  void armWorkboardIntegration({ ...ctx, connectLabel: "re-register" });
+  scheduleWorkboardDeferredIntegration(ctx, "re-register");
+}
+
+/** Build shouldAbort for plugin-service cold start (shutdown + registration generation). */
+export function createWorkboardStartupShouldAbort(
+  bootRegistrationGeneration: number,
+  shuttingDownRef: { value: boolean },
+): () => boolean {
+  return () =>
+    shuttingDownRef.value ||
+    isRegistrationSuperseded(bootRegistrationGeneration);
+}
+
+/** Capture the registration generation when plugin-service.start() schedules Workboard. */
+export function captureWorkboardBootRegistrationGeneration(): number {
+  return getHybridMemoryRegistrationState().registrationGenerationRef.value;
 }

--- a/extensions/memory-hybrid/tests/memory-helpers.test.ts
+++ b/extensions/memory-hybrid/tests/memory-helpers.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it, vi } from "vitest";
+import { hasBoundMemoryToolHelpers, resolveMemoryToolsContext } from "../tools/memory/helpers.js";
+
+describe("hasBoundMemoryToolHelpers (#1938)", () => {
+  const boundHelpers = {
+    buildToolScopeFilter: vi.fn(),
+    walWrite: vi.fn(),
+    walRemove: vi.fn(),
+    findSimilarByEmbedding: vi.fn(),
+  };
+
+  it("accepts pre-bound helpers when wal is also present on the context", () => {
+    const ctx = { wal: { kind: "wal" }, ...boundHelpers };
+    expect(hasBoundMemoryToolHelpers(ctx)).toBe(true);
+    expect(() => resolveMemoryToolsContext(ctx)).not.toThrow();
+  });
+
+  it("rejects legacy context without bound helpers even when wal is present", () => {
+    const legacyCtx = { wal: { kind: "wal" }, factsDb: {} };
+    expect(hasBoundMemoryToolHelpers(legacyCtx)).toBe(false);
+    expect(() => resolveMemoryToolsContext(legacyCtx)).toThrow(
+      "registerMemoryTools: Missing required legacy helper functions for memory tools initialization.",
+    );
+  });
+});

--- a/extensions/memory-hybrid/tests/tool-installers.test.ts
+++ b/extensions/memory-hybrid/tests/tool-installers.test.ts
@@ -1,6 +1,7 @@
 // @ts-nocheck
 import { describe, expect, it, vi } from "vitest";
 import { toolInstallers } from "../setup/tool-installers.js";
+import { hasBoundMemoryToolHelpers, resolveMemoryToolsContext } from "../tools/memory/helpers.js";
 import type { MemoryToolsContext } from "../tools/memory-tools.js";
 
 describe("tool installers", () => {
@@ -91,13 +92,19 @@ describe("tool installers", () => {
       "pendingLLMWarnings",
       "progressiveIndexBySession",
       "provenanceService",
+      "resolveAllVaults",
+      "resolveVault",
+      "resolveVaultWal",
       "variantQueue",
       "vectorDb",
       "verificationStore",
+      "wal",
       "walRemove",
       "walWrite",
     ]);
-    expect(selected).not.toHaveProperty("wal");
+    expect(selected.wal).toBe(wal);
+    expect(hasBoundMemoryToolHelpers(selected)).toBe(true);
+    expect(() => resolveMemoryToolsContext(selected)).not.toThrow();
     expect(selected.issueStore).toEqual({ kind: "issues" });
     expect(selected).not.toHaveProperty("workflowStore");
 

--- a/extensions/memory-hybrid/tests/workboard-integration.test.ts
+++ b/extensions/memory-hybrid/tests/workboard-integration.test.ts
@@ -5,7 +5,12 @@ import type { HybridMemoryConfig } from "../config.js";
 import {
   WORKBOARD_STARTUP_DEFER_MS,
   WORKBOARD_STARTUP_PROBE_BACKOFF_MS,
+  WORKBOARD_STARTUP_PROBE_MAX_ATTEMPTS,
   armWorkboardIntegration,
+  markWorkboardGatewayColdStart,
+  resetWorkboardGatewayColdStartForTests,
+  resolveWorkboardDeferMs,
+  scheduleWorkboardIntegrationAfterReregister,
   scheduleWorkboardStartupIntegration,
 } from "../setup/workboard-integration.js";
 
@@ -37,6 +42,7 @@ function mockLogger() {
 describe("workboard-integration", () => {
   beforeEach(() => {
     vi.useFakeTimers();
+    resetWorkboardGatewayColdStartForTests();
   });
 
   afterEach(() => {
@@ -203,5 +209,131 @@ describe("workboard-integration", () => {
 
     expect(isAvailable).toHaveBeenCalled();
     expect(sync).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-register within cold-start defer window reschedules remaining defer (#1940)", async () => {
+    const sync = vi.fn().mockResolvedValue({
+      cardsCreated: 0,
+      cardsUpdated: 0,
+      cardsRemoved: 0,
+      pullChanges: 0,
+      errors: [],
+    });
+    const isAvailable = vi.fn().mockResolvedValue(true);
+
+    vi.spyOn(await import("../services/workboard-adapter.js"), "createWorkboardAdapter").mockReturnValue({
+      isAvailable,
+      sync,
+    } as never);
+
+    const timers = createTimers() as PluginRuntime["timers"];
+    const logger = mockLogger();
+    const ctx = {
+      factsDb: {} as never,
+      vectorDb: {} as never,
+      embeddings: {} as never,
+      cfg: minimalWorkboardCfg(),
+      api: { logger } as never,
+      timers,
+      connectLabel: "startup",
+    };
+
+    markWorkboardGatewayColdStart();
+    scheduleWorkboardStartupIntegration(ctx);
+    await vi.advanceTimersByTimeAsync(20_000);
+    expect(isAvailable).not.toHaveBeenCalled();
+
+    scheduleWorkboardIntegrationAfterReregister({ ...ctx, connectLabel: "re-register" });
+    expect(resolveWorkboardDeferMs()).toBe(WORKBOARD_STARTUP_DEFER_MS - 20_000);
+
+    await vi.advanceTimersByTimeAsync(WORKBOARD_STARTUP_DEFER_MS - 20_000 - 1);
+    expect(isAvailable).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    await Promise.resolve();
+
+    expect(isAvailable).toHaveBeenCalled();
+    expect(sync).toHaveBeenCalledTimes(1);
+    expect(logger.info).toHaveBeenCalledWith(
+      "memory-hybrid: Workboard adapter connected (re-register) — starting sync",
+    );
+  });
+
+  it("re-register probe retries before giving up (#1940)", async () => {
+    const sync = vi.fn().mockResolvedValue({
+      cardsCreated: 0,
+      cardsUpdated: 0,
+      cardsRemoved: 0,
+      pullChanges: 0,
+      errors: [],
+    });
+    const isAvailable = vi
+      .fn()
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true);
+
+    vi.spyOn(await import("../services/workboard-adapter.js"), "createWorkboardAdapter").mockReturnValue({
+      isAvailable,
+      sync,
+    } as never);
+
+    const timers = createTimers() as PluginRuntime["timers"];
+    const logger = mockLogger();
+
+    const armPromise = armWorkboardIntegration({
+      factsDb: {} as never,
+      vectorDb: {} as never,
+      embeddings: {} as never,
+      cfg: minimalWorkboardCfg(),
+      api: { logger } as never,
+      timers,
+      connectLabel: "re-register",
+    });
+
+    await vi.advanceTimersByTimeAsync(WORKBOARD_STARTUP_PROBE_BACKOFF_MS);
+    await vi.advanceTimersByTimeAsync(WORKBOARD_STARTUP_PROBE_BACKOFF_MS);
+    await armPromise;
+
+    expect(isAvailable).toHaveBeenCalledTimes(WORKBOARD_STARTUP_PROBE_MAX_ATTEMPTS);
+    expect(sync).toHaveBeenCalledTimes(1);
+  });
+
+  it("aborts deferred startup arm when registration generation is superseded", async () => {
+    const sync = vi.fn().mockResolvedValue({
+      cardsCreated: 0,
+      cardsUpdated: 0,
+      cardsRemoved: 0,
+      pullChanges: 0,
+      errors: [],
+    });
+    const isAvailable = vi.fn().mockResolvedValue(true);
+
+    vi.spyOn(await import("../services/workboard-adapter.js"), "createWorkboardAdapter").mockReturnValue({
+      isAvailable,
+      sync,
+    } as never);
+
+    const timers = createTimers() as PluginRuntime["timers"];
+    const logger = mockLogger();
+    let superseded = false;
+
+    scheduleWorkboardStartupIntegration({
+      factsDb: {} as never,
+      vectorDb: {} as never,
+      embeddings: {} as never,
+      cfg: minimalWorkboardCfg(),
+      api: { logger } as never,
+      timers,
+      shouldAbort: () => superseded,
+      connectLabel: "startup",
+    });
+
+    superseded = true;
+    await vi.advanceTimersByTimeAsync(WORKBOARD_STARTUP_DEFER_MS);
+    await Promise.resolve();
+
+    expect(isAvailable).not.toHaveBeenCalled();
+    expect(sync).not.toHaveBeenCalled();
   });
 });

--- a/extensions/memory-hybrid/tests/workboard-integration.test.ts
+++ b/extensions/memory-hybrid/tests/workboard-integration.test.ts
@@ -2,7 +2,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { PluginRuntime } from "../api/plugin-runtime.js";
 import { createTimers } from "../api/plugin-runtime.js";
 import type { HybridMemoryConfig } from "../config.js";
-import { armWorkboardIntegration } from "../setup/workboard-integration.js";
+import {
+  WORKBOARD_STARTUP_DEFER_MS,
+  WORKBOARD_STARTUP_PROBE_BACKOFF_MS,
+  armWorkboardIntegration,
+  scheduleWorkboardStartupIntegration,
+} from "../setup/workboard-integration.js";
 
 function minimalWorkboardCfg(): HybridMemoryConfig {
   return {
@@ -117,5 +122,86 @@ describe("workboard-integration", () => {
     expect(logger.info).toHaveBeenCalledWith(
       "memory-hybrid: Workboard adapter connected (re-register) — starting sync",
     );
+  });
+
+  it("retries startup probe before giving up (#1940)", async () => {
+    const sync = vi.fn().mockResolvedValue({
+      cardsCreated: 0,
+      cardsUpdated: 0,
+      cardsRemoved: 0,
+      pullChanges: 0,
+      errors: [],
+    });
+    const isAvailable = vi
+      .fn()
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true);
+
+    vi.spyOn(await import("../services/workboard-adapter.js"), "createWorkboardAdapter").mockReturnValue({
+      isAvailable,
+      sync,
+    } as never);
+
+    const timers = createTimers() as PluginRuntime["timers"];
+    const logger = mockLogger();
+
+    const armPromise = armWorkboardIntegration({
+      factsDb: {} as never,
+      vectorDb: {} as never,
+      embeddings: {} as never,
+      cfg: minimalWorkboardCfg(),
+      api: { logger } as never,
+      timers,
+      connectLabel: "startup",
+    });
+
+    await vi.advanceTimersByTimeAsync(WORKBOARD_STARTUP_PROBE_BACKOFF_MS);
+    await vi.advanceTimersByTimeAsync(WORKBOARD_STARTUP_PROBE_BACKOFF_MS);
+    await armPromise;
+
+    expect(isAvailable).toHaveBeenCalledTimes(3);
+    expect(sync).toHaveBeenCalledTimes(1);
+    expect(timers.workboardSync?.value).not.toBeNull();
+  });
+
+  it("defers startup arm until cold-start delay elapses (#1940)", async () => {
+    const sync = vi.fn().mockResolvedValue({
+      cardsCreated: 0,
+      cardsUpdated: 0,
+      cardsRemoved: 0,
+      pullChanges: 0,
+      errors: [],
+    });
+    const isAvailable = vi.fn().mockResolvedValue(true);
+
+    vi.spyOn(await import("../services/workboard-adapter.js"), "createWorkboardAdapter").mockReturnValue({
+      isAvailable,
+      sync,
+    } as never);
+
+    const timers = createTimers() as PluginRuntime["timers"];
+    const logger = mockLogger();
+    const ctx = {
+      factsDb: {} as never,
+      vectorDb: {} as never,
+      embeddings: {} as never,
+      cfg: minimalWorkboardCfg(),
+      api: { logger } as never,
+      timers,
+      connectLabel: "startup",
+    };
+
+    scheduleWorkboardStartupIntegration(ctx);
+    expect(isAvailable).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(WORKBOARD_STARTUP_DEFER_MS - 1);
+    expect(isAvailable).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    await Promise.resolve();
+
+    expect(isAvailable).toHaveBeenCalled();
+    expect(sync).toHaveBeenCalledTimes(1);
   });
 });

--- a/extensions/memory-hybrid/tools/memory/helpers.ts
+++ b/extensions/memory-hybrid/tools/memory/helpers.ts
@@ -31,13 +31,15 @@ export function hasBoundMemoryToolHelpers(
   ctx: MemoryToolsContext | LegacyMemoryToolsContext,
 ): ctx is MemoryToolsContext {
   const maybe = ctx as Partial<MemoryToolsContext> & { wal?: unknown };
-  const hasAllNewHelpers =
+  // Bound helpers on the context are authoritative; legacy mode passes them as separate
+  // registerMemoryTools args instead. MemoryToolsContext may include wal alongside bound
+  // walWrite/walRemove (e.g. selectMemoryCoreToolsContext for vault routing).
+  return (
     typeof maybe.buildToolScopeFilter === "function" &&
     typeof maybe.walWrite === "function" &&
     typeof maybe.walRemove === "function" &&
-    typeof maybe.findSimilarByEmbedding === "function";
-  const hasLegacyWal = typeof maybe.wal === "object" && maybe.wal !== null;
-  return hasAllNewHelpers && !hasLegacyWal;
+    typeof maybe.findSimilarByEmbedding === "function"
+  );
 }
 
 export function isEdictWriteToolEnabled(): boolean {

--- a/packages/openclaw-hybrid-memory-install/package.json
+++ b/packages/openclaw-hybrid-memory-install/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-hybrid-memory-install",
-  "version": "2026.6.240",
+  "version": "2026.6.241",
   "description": "Standalone installer for openclaw-hybrid-memory. Use when OpenClaw config validation fails.",
   "bin": {
     "openclaw-hybrid-memory-install": "./install.js"

--- a/release-notes/release-notes-2026.6.241.md
+++ b/release-notes/release-notes-2026.6.241.md
@@ -1,0 +1,29 @@
+# Release notes — OpenClaw Hybrid Memory **2026.6.241**
+
+**Release date:** 2026-06-24  
+**Since:** [2026.6.240](CHANGELOG.md#20266240---2026-06-24)  
+**Full changelog:** [CHANGELOG.md](../CHANGELOG.md) — section **[2026.6.241]**
+
+## Highlights
+
+Hotfix release for three bugs surfaced during the **2026.6.240** upgrade on Maeve:
+
+- [#1938](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/1938) — gateway registration failed with `Missing required legacy helper functions`
+- [#1939](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/1939) — `memory_crystallize_restore` missing from `contracts.tools`
+- [#1940](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/1940) — Workboard startup probe timed out during cold gateway start
+
+### What changed
+
+- Fixed `hasBoundMemoryToolHelpers()` so `wal` on a pre-bound context no longer forces legacy mode.
+- Declared `memory_crystallize_restore` in the plugin contract manifest.
+- Deferred Workboard cold-start probe (60s) with retry/backoff before arming sync.
+
+### After upgrading
+
+```bash
+openclaw plugins update openclaw-hybrid-memory@2026.6.241
+systemctl --user restart openclaw-gateway
+openclaw hybrid-mem verify
+```
+
+Within ~2 minutes of a cold restart with Workboard enabled, the journal should show `Workboard adapter connected (startup)` without requiring a manual CLI re-register.


### PR DESCRIPTION
## Summary
- Fix gateway registration regression in **2026.6.240** where `hasBoundMemoryToolHelpers()` rejected pre-bound memory tool contexts when `wal` was present (#1938)
- Add missing `memory_crystallize_restore` to `contracts.tools` / `AGENT_TOOL_CONTRACT_NAMES` (#1939)
- Defer Workboard cold-start probe (60s) and retry availability up to 3 times with 15s backoff so sync arms without manual re-register (#1940)
- Bump version to **2026.6.241** with release notes and CHANGELOG

## Test plan
- [x] `npm test -- tests/memory-helpers.test.ts tests/tool-installers.test.ts`
- [x] `npm test -- tests/agent-tool-contracts.test.ts`
- [x] `npm test -- tests/workboard-integration.test.ts`
- [x] `npm run verify:gate`
- [ ] Cold-restart gateway on Maeve with Workboard enabled — journal shows `Workboard adapter connected (startup)` within ~2 min
- [ ] `openclaw hybrid-mem verify` passes without `memory_crystallize_restore` contract warning

Fixes #1938, #1939, #1940

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes gateway plugin registration and cold-start Workboard timing on a critical startup path, but scope is narrow regression fixes with added unit tests rather than new behavior.
> 
> **Overview**
> Hotfix **2026.6.241** addressing three regressions from **2026.6.240**.
> 
> **Gateway memory registration (#1938):** `hasBoundMemoryToolHelpers()` no longer treats a `wal` field on the context as legacy-only. Pre-bound `walWrite` / `walRemove` / etc. are authoritative again, so cold gateway start does not fail with missing legacy helper errors when vault routing includes `wal`.
> 
> **Tool contract (#1939):** `memory_crystallize_restore` is added to `contracts.tools` and `AGENT_TOOL_CONTRACT_NAMES` so OpenClaw stops warning about an undeclared runtime tool.
> 
> **Workboard cold start (#1940):** Startup uses `scheduleWorkboardStartupIntegration` with a **60s** defer, then up to **3** availability probes with **15s** backoff before arming sync; `workboardStartupTimeout` is cleared on shutdown. Re-register path keeps a single immediate probe.
> 
> Version and docs bump to **2026.6.241** with release notes; regression tests cover helpers, tool-installer context selection, and Workboard scheduling/probes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d3c64d583e73531cd3d8d79cc40b7e5739a4c6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->