### PR TITLE
fix(release): correct version to 2026.6.250

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ---
 
+## [2026.6.250] - 2026-06-25
+
+### Fixed
+
+- **Maintenance nightly abort on degraded contradiction backlog (#1942):** `resolve-contradictions` no longer throws when the ambiguous backlog crosses the degraded threshold, so `maintenance-nightly` continues through downstream steps and cron guard files advance while operators still receive degraded telemetry.
+- **Monitoring-only maintenance signals:** Introduced non-blocking `semantic=monitoring` for operational signals (degraded contradiction backlog, transient `record-storage-sample` unavailability) that surface in validation without aborting the orchestrator or blocking guard advancement.
+- **`reflect-rules` tolerated flake:** Orchestrator runner no longer treats tolerated `invalid_response_format` flakes (non-empty model response) as fatal semantic failures.
+- **Legacy cron `resolve-contradictions` exit code:** Standalone CLI preserves shell exit `2` on degraded backlog; cron wrappers (`HM_JOB` set) keep shell exit `0` so `nightly-memory-sweep` does not abort under `set -e`.
+
+### Changed
+
+- Version set to **2026.6.250** (replaces invalid npm version `2026.250`).
+
+---
+
 ## [2026.6.241] - 2026-06-24
 
 ### Fixed

--- a/docs/ERROR-REPORTING.md
+++ b/docs/ERROR-REPORTING.md
@@ -366,7 +366,7 @@ const issues: MaintenanceTelemetryIssue[] = [
 
 await reportMaintenanceFailureIssues(issues, {
   cfg: config,
-  pluginVersion: "2026.6.241",
+  pluginVersion: "2026.6.250",
   logger: console,
 });
 ```

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -6,7 +6,7 @@ nav_order: 1
 ---
 # Quick Start - Hybrid Memory Plugin
 
-Get an agent that **remembers you** and **gets better at giving the right context** over time - in about 10 minutes. For full configuration options see [CONFIGURATION.md](CONFIGURATION.md); for architecture background see [ARCHITECTURE.md](ARCHITECTURE.md). For low-cost production rollout, see [COST-OPTIMIZATION-PLAYBOOK.md](COST-OPTIMIZATION-PLAYBOOK.md). After install, see [release notes 2026.6.241](../release-notes/release-notes-2026.6.241.md) for recent hotfix and maintenance notes.
+Get an agent that **remembers you** and **gets better at giving the right context** over time - in about 10 minutes. For full configuration options see [CONFIGURATION.md](CONFIGURATION.md); for architecture background see [ARCHITECTURE.md](ARCHITECTURE.md). For low-cost production rollout, see [COST-OPTIMIZATION-PLAYBOOK.md](COST-OPTIMIZATION-PLAYBOOK.md). After install, see [release notes 2026.6.250](../release-notes/release-notes-2026.6.250.md) for recent hotfix and maintenance notes.
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -124,7 +124,7 @@ Hybrid Memory gives your OpenClaw agent **persistent memory** without turning me
 | [Credits & attribution](CREDITS-AND-ATTRIBUTION) | Sources, lineage, and what this repository adds |
 | [Contributor onboarding](CONTRIBUTOR-ONBOARDING) | First-contribution path, quality bar, and high-impact starter areas |
 | [Similar-sweep PR process](SIMILAR-SWEEP-PR) | Contributor merge order and module-split conventions during sweep batches |
-| [Release notes 2026.6.241](../release-notes/release-notes-2026.6.241.md) | Latest release highlights and upgrade notes |
+| [Release notes 2026.6.250](../release-notes/release-notes-2026.6.250.md) | Latest release highlights and upgrade notes |
 
 ---
 

--- a/extensions/memory-hybrid/openclaw.plugin.json
+++ b/extensions/memory-hybrid/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "openclaw-hybrid-memory",
   "kind": "memory",
-  "version": "2026.250",
+  "version": "2026.6.250",
   "contracts": {
     "tools": [
       "active_task_checkpoint",

--- a/extensions/memory-hybrid/package-lock.json
+++ b/extensions/memory-hybrid/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openclaw-hybrid-memory",
-  "version": "2026.250",
+  "version": "2026.6.250",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openclaw-hybrid-memory",
-      "version": "2026.250",
+      "version": "2026.6.250",
       "hasInstallScript": true,
       "dependencies": {
         "@lancedb/lancedb": "^0.30.0",

--- a/extensions/memory-hybrid/package.json
+++ b/extensions/memory-hybrid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-hybrid-memory",
-  "version": "2026.250",
+  "version": "2026.6.250",
   "type": "module",
   "description": "Give your OpenClaw agent lasting memory: structured facts, semantic search, auto-capture & recall, decay, optional credential vault. Part of Hybrid Memory v3.",
   "files": [

--- a/packages/openclaw-hybrid-memory-install/package.json
+++ b/packages/openclaw-hybrid-memory-install/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-hybrid-memory-install",
-  "version": "2026.250",
+  "version": "2026.6.250",
   "description": "Standalone installer for openclaw-hybrid-memory. Use when OpenClaw config validation fails.",
   "bin": {
     "openclaw-hybrid-memory-install": "./install.js"

--- a/release-notes/release-notes-2026.6.250.md
+++ b/release-notes/release-notes-2026.6.250.md
@@ -1,0 +1,26 @@
+# Release notes — OpenClaw Hybrid Memory **2026.6.250**
+
+**Release date:** 2026-06-25  
+**Since:** [2026.6.241](CHANGELOG.md#20266241---2026-06-24)  
+**Full changelog:** [CHANGELOG.md](../CHANGELOG.md) — section **[2026.6.250]**
+
+## Highlights
+
+Maintenance hotfix for [#1942](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/1942): nightly `maintenance-nightly` was failing every night once the contradiction ambiguity backlog crossed the degraded threshold, starving all downstream maintenance steps.
+
+### What changed
+
+- Degraded contradiction backlog is a **monitoring signal**, not a fatal step failure — the orchestrator continues and cron guard files advance.
+- Cron validation distinguishes monitoring-only issues from guard-blocking degraded outcomes.
+- `reflect-rules` no longer fails on tolerated `invalid_response_format` flakes.
+- Legacy `nightly-memory-sweep` `resolve-contradictions` CLI keeps shell exit `0` under cron wrappers while standalone runs still exit `2` on degraded backlog.
+
+### After upgrading
+
+```bash
+openclaw plugins update openclaw-hybrid-memory@2026.6.250
+systemctl --user restart openclaw-gateway
+openclaw hybrid-mem verify
+```
+
+Confirm the next `maintenance-nightly` run completes past `resolve-contradictions` and updates `~/.openclaw/cron/guard/maintenance-nightly.ms`.


### PR DESCRIPTION
## Summary
- Replace invalid npm semver `2026.250` with `2026.6.250` in package manifests
- Add release notes and changelog entry for 2026.6.250
- Update docs to reference the correct version
- Failed `v2026.250` GitHub release and tag were already deleted

## Test plan
- [ ] CI passes on main after merge
- [ ] Release workflow tags `v2026.6.250` and publishes to npm successfully