### PR TITLE
fix(contradictions): per-fact PR ref counting for entity-reuse heuristic (#1945)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ---
 
+## [2026.6.251] - 2026-06-25
+
+### Fixed
+
+- **Project-state LWW entity-reuse heuristic (#1945):** Count distinct PR/issue refs per fact instead of across both facts in a pair, so legitimate project-state transitions (e.g. `status` / `next` mentioning different PRs in old vs new values) no longer false-positive as `possible-entity-reuse` and block LWW supersede.
+
+### Changed
+
+- Version set to **2026.6.251**.
+
+---
+
 ## [2026.6.250] - 2026-06-25
 
 ### Fixed

--- a/docs/ERROR-REPORTING.md
+++ b/docs/ERROR-REPORTING.md
@@ -366,7 +366,7 @@ const issues: MaintenanceTelemetryIssue[] = [
 
 await reportMaintenanceFailureIssues(issues, {
   cfg: config,
-  pluginVersion: "2026.6.250",
+  pluginVersion: "2026.6.251",
   logger: console,
 });
 ```

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -6,7 +6,7 @@ nav_order: 1
 ---
 # Quick Start - Hybrid Memory Plugin
 
-Get an agent that **remembers you** and **gets better at giving the right context** over time - in about 10 minutes. For full configuration options see [CONFIGURATION.md](CONFIGURATION.md); for architecture background see [ARCHITECTURE.md](ARCHITECTURE.md). For low-cost production rollout, see [COST-OPTIMIZATION-PLAYBOOK.md](COST-OPTIMIZATION-PLAYBOOK.md). After install, see [release notes 2026.6.250](../release-notes/release-notes-2026.6.250.md) for recent hotfix and maintenance notes.
+Get an agent that **remembers you** and **gets better at giving the right context** over time - in about 10 minutes. For full configuration options see [CONFIGURATION.md](CONFIGURATION.md); for architecture background see [ARCHITECTURE.md](ARCHITECTURE.md). For low-cost production rollout, see [COST-OPTIMIZATION-PLAYBOOK.md](COST-OPTIMIZATION-PLAYBOOK.md). After install, see [release notes 2026.6.251](../release-notes/release-notes-2026.6.251.md) for recent hotfix and maintenance notes.
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -124,7 +124,7 @@ Hybrid Memory gives your OpenClaw agent **persistent memory** without turning me
 | [Credits & attribution](CREDITS-AND-ATTRIBUTION) | Sources, lineage, and what this repository adds |
 | [Contributor onboarding](CONTRIBUTOR-ONBOARDING) | First-contribution path, quality bar, and high-impact starter areas |
 | [Similar-sweep PR process](SIMILAR-SWEEP-PR) | Contributor merge order and module-split conventions during sweep batches |
-| [Release notes 2026.6.250](../release-notes/release-notes-2026.6.250.md) | Latest release highlights and upgrade notes |
+| [Release notes 2026.6.251](../release-notes/release-notes-2026.6.251.md) | Latest release highlights and upgrade notes |
 
 ---
 

--- a/extensions/memory-hybrid/backends/facts-db/contradictions.ts
+++ b/extensions/memory-hybrid/backends/facts-db/contradictions.ts
@@ -700,11 +700,17 @@ function extractRefNumbers(text: string): Set<string> {
   return new Set(matches ?? []);
 }
 
-/** Heuristic: flag if multiple distinct PR/issue numbers appear across the two facts. */
+function countDistinctRefsInFact(fact: MemoryEntry): number {
+  const text = `${fact.value ?? ""} ${fact.text ?? ""}`;
+  return extractRefNumbers(text).size;
+}
+
+/** Heuristic: flag if either fact alone references too many distinct PR/issue numbers. */
 function isPossiblyOverloadedEntity(newFact: MemoryEntry, oldFact: MemoryEntry): boolean {
-  const combined = `${newFact.value ?? ""} ${newFact.text ?? ""} ${oldFact.value ?? ""} ${oldFact.text ?? ""}`;
-  const refs = extractRefNumbers(combined);
-  return refs.size > MAX_EXPECTED_REFS_PER_ENTITY;
+  return (
+    countDistinctRefsInFact(newFact) > MAX_EXPECTED_REFS_PER_ENTITY ||
+    countDistinctRefsInFact(oldFact) > MAX_EXPECTED_REFS_PER_ENTITY
+  );
 }
 
 function truncateExcerpt(s: string, maxLen: number): string {

--- a/extensions/memory-hybrid/openclaw.plugin.json
+++ b/extensions/memory-hybrid/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "openclaw-hybrid-memory",
   "kind": "memory",
-  "version": "2026.6.250",
+  "version": "2026.6.251",
   "contracts": {
     "tools": [
       "active_task_checkpoint",

--- a/extensions/memory-hybrid/package-lock.json
+++ b/extensions/memory-hybrid/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openclaw-hybrid-memory",
-  "version": "2026.6.250",
+  "version": "2026.6.251",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openclaw-hybrid-memory",
-      "version": "2026.6.250",
+      "version": "2026.6.251",
       "hasInstallScript": true,
       "dependencies": {
         "@lancedb/lancedb": "^0.30.0",

--- a/extensions/memory-hybrid/package.json
+++ b/extensions/memory-hybrid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-hybrid-memory",
-  "version": "2026.6.250",
+  "version": "2026.6.251",
   "type": "module",
   "description": "Give your OpenClaw agent lasting memory: structured facts, semantic search, auto-capture & recall, decay, optional credential vault. Part of Hybrid Memory v3.",
   "files": [

--- a/extensions/memory-hybrid/tests/project-state-lww.test.ts
+++ b/extensions/memory-hybrid/tests/project-state-lww.test.ts
@@ -228,6 +228,35 @@ describe("project-state-lww: non-project facts are not touched", () => {
 // 4. Overloaded task entity is flagged in the LWW report
 // ---------------------------------------------------------------------------
 describe("project-state-lww: overloaded entity detection", () => {
+  it("does not flag when refs are split across facts but each fact stays within threshold", () => {
+    const older = storeProjectFact({
+      entity: "hybrid-memory / next",
+      key: "next",
+      value: "merge PR #1597 next",
+      text: "Queue head: PR #1596",
+      confidence: 1.0,
+    });
+    const newer = storeProjectFact({
+      entity: "hybrid-memory / next",
+      key: "next",
+      value: "merge PR #1600 next",
+      text: "Updated queue: PR #1599",
+      confidence: 1.0,
+      createdAtOffset: 30,
+    });
+
+    db.recordContradiction(newer.id, older.id);
+
+    const result = db.resolveContradictionsProjectStateLww({ dryRun: true });
+    const candidate = result.groups
+      .flatMap((g) => g.candidates)
+      .find((c) => c.factIdNew === newer.id || c.factIdOld === older.id);
+
+    expect(candidate).toBeDefined();
+    expect(candidate?.possibleOverloadedEntity).toBe(false);
+    expect(candidate?.action).toBe("supersede");
+  });
+
   it("flags when entity/key values reference many distinct PR/issue numbers", () => {
     const older = storeProjectFact({
       entity: "hybrid-memory-issue-1272-pr",

--- a/packages/openclaw-hybrid-memory-install/package.json
+++ b/packages/openclaw-hybrid-memory-install/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-hybrid-memory-install",
-  "version": "2026.6.250",
+  "version": "2026.6.251",
   "description": "Standalone installer for openclaw-hybrid-memory. Use when OpenClaw config validation fails.",
   "bin": {
     "openclaw-hybrid-memory-install": "./install.js"

--- a/release-notes/release-notes-2026.6.251.md
+++ b/release-notes/release-notes-2026.6.251.md
@@ -1,0 +1,28 @@
+# Release notes — OpenClaw Hybrid Memory **2026.6.251**
+
+**Release date:** 2026-06-25  
+**Since:** [2026.6.250](CHANGELOG.md#20266250---2026-06-25)  
+**Full changelog:** [CHANGELOG.md](../CHANGELOG.md) — section **[2026.6.251]**
+
+## Highlights
+
+Fix for [#1945](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/1945): `resolve-contradictions --project-state-lww` was blocking all qualifying candidates because the `possible-entity-reuse` heuristic summed PR/issue refs across both facts in a pair.
+
+### What changed
+
+- Count distinct `#NNNN` refs **per fact**; flag only when either fact alone exceeds the threshold.
+- Legitimate project-state `status` / `next` transitions that mention different PRs in old vs new values can now qualify for LWW supersede again.
+
+### After upgrading
+
+```bash
+openclaw plugins update openclaw-hybrid-memory@2026.6.251
+systemctl --user restart openclaw-gateway
+openclaw hybrid-mem verify
+```
+
+Re-run a dry-run to confirm candidates now qualify:
+
+```bash
+openclaw hybrid-mem quality contradictions --project-state-lww --dry-run --verbose
+```


### PR DESCRIPTION
## Summary
- Fixes the `possible-entity-reuse` heuristic that blocked all 73 project-state LWW candidates on real installations ([#1945](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/1945)).
- Count distinct `#NNNN` refs **per fact** instead of concatenating both facts; a pair is flagged only when either fact alone exceeds `MAX_EXPECTED_REFS_PER_ENTITY`.
- Adds regression coverage for split-ref project-state pairs that should qualify for LWW supersede.

## Root cause
`isPossiblyOverloadedEntity` summed PR/issue refs across old + new fact text/value. Legitimate status/`next` transitions often mention different PRs in each version, producing 3+ combined refs and forcing manual review even when each fact independently stays within the threshold.

## Test plan
- [x] `npm test -- project-state-lww.test.ts` (18/18 pass)
- [ ] On a host with project-state backlog: `openclaw hybrid-mem quality contradictions --project-state-lww --dry-run --verbose` and confirm non-zero `would supersede` where refs are split across facts
- [ ] Confirm pairs where a **single** fact mentions 3+ distinct refs still show `[!] possible-entity-reuse`

Fixes #1945