### PR TITLE
fix(maintenance): project-state LWW + distill vector dedupe (#1945, #1947)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ---
 
+## [2026.6.252] - 2026-06-25
+
+### Fixed
+
+- **Project-state LWW entity-reuse heuristic (#1945):** Count distinct PR/issue refs per fact instead of across both facts in a pair, so legitimate project-state transitions no longer false-positive as `possible-entity-reuse`.
+- **Distill vector dedupe (#1947):** Wire LanceDB neighbour candidates into `storeWithResult`, restore `hasDuplicate` fallback when vector search degrades, pass structured fields into the lexical pre-check, and allow distillation project facts to vector-dedupe across entity slug drift while preserving the #1276 guard for other sources.
+
+### Changed
+
+- Version set to **2026.6.252**.
+
+---
+
 ## [2026.6.250] - 2026-06-25
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,68 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ---
 
+## [2026.6.256] - 2026-06-25
+
+### Fixed
+
+- **GraphQL auth:** Anonymous mutations (`{ deleteFact(...) }`) now require `dashboard.token`.
+- **GraphQL pruneFacts:** Requires valid `olderThan`; no longer deletes all facts when omitted or unparsed.
+- **GraphQL mutations:** Index LanceDB on create/import/update; delete vectors on supersede/delete; publish subscription events.
+- **GraphQL queries:** `search`/`semanticSearch` scope filter; `entityFacts`/`relatedFacts` active-only; `graph` includes `memory_links`.
+- **Crystallization tool:** `getRawDb()` required only when worker leases are enabled.
+
+---
+
+## [2026.6.255] - 2026-06-25
+
+### Fixed
+
+- **Mission Control write auth:** Optional `dashboard.token` requires Bearer/`X-Dashboard-Token` on verify/forget/workshop/GraphQL POST routes.
+- **Distill vector dedupe (degraded):** Scoped neighbour filtering before unscoped `hasDuplicate`; unscoped hits no longer skip writes.
+- **GraphQL updateFact:** Artifact/reasoning-trace text always rejected; legacy source bypass no longer skips text guard.
+- **Auto-capture WAL:** Dedup-window peek before WAL write avoids orphan WAL entries on skip.
+- **Dashboard forget/GraphQL delete:** LanceDB vectors removed when facts are forgotten or deleted.
+- **Passive observer:** Session-scoped vector dedupe validates live facts before treating matches as duplicates.
+- **GraphQL expiry filters:** `facts`/`search` compare `expiresAt` in unix seconds (not milliseconds).
+- **GraphQL updateFact:** Removes LanceDB vector for superseded fact id after in-place edit.
+
+### Changed
+
+- **Pre-store guard:** Artifact/reasoning-trace text blocked even when `allowPreStoreGuardBypass` is set (category/source bypass unchanged).
+- **GraphQL auth:** `dashboard.token` required only for mutations; read-only queries work without a token.
+
+---
+
+## [2026.6.254] - 2026-06-25
+
+### Fixed
+
+- **memory_store WAL routing:** Use bound `walWrite`/`walRemove` helpers when the default WAL handle is null (fixes test regressions and legacy tool registration paths).
+- **Capture dedup window:** Gracefully skip SQLite transaction wrapper when `factsDb.getRawDb()` is unavailable (passive-observer, stage-capture, maintenance CLI mocks).
+- **Config guards:** Optional-chain `lifecycle.fragmentEmbedding`, `provenance`, and `verification` in memory_store.
+- **Live MiniMax tests:** Opt-in via `RUN_LIVE_MINIMAX_TESTS=1`; update ceiling probes and fetch timeouts.
+
+### Changed
+
+- Version set to **2026.6.254**.
+
+---
+
+## [2026.6.253] - 2026-06-25
+
+### Fixed
+
+- **Distill dedupe QA (#1945, #1947):** Restore `vectorDb.hasDuplicate` when `fuzzyDedupe` is disabled; redact maintenance-private text before the lexical pre-check; increment `skipped` when `storeWithResult` returns `skipped`.
+- **Distill vector fallback:** Skip useless `hasDuplicate` when LanceDB schema is invalid (it always returns false); only use the fallback when schema is valid.
+- **Distillation entity drift:** Require compatible entity slugs (prefix relationship) for vector dedupe — same key alone is no longer enough across unrelated projects.
+- **Project-state LWW overload heuristic:** Flag asymmetric ref splits (e.g. 2+1) while still allowing symmetric 2+2 queue drift (#1945).
+
+### Changed
+
+- Version set to **2026.6.253**.
+
+---
+
 ## [2026.6.252] - 2026-06-25
 
 ### Fixed

--- a/docs/ERROR-REPORTING.md
+++ b/docs/ERROR-REPORTING.md
@@ -366,7 +366,7 @@ const issues: MaintenanceTelemetryIssue[] = [
 
 await reportMaintenanceFailureIssues(issues, {
   cfg: config,
-  pluginVersion: "2026.6.250",
+  pluginVersion: "2026.6.252",
   logger: console,
 });
 ```

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -6,7 +6,7 @@ nav_order: 1
 ---
 # Quick Start - Hybrid Memory Plugin
 
-Get an agent that **remembers you** and **gets better at giving the right context** over time - in about 10 minutes. For full configuration options see [CONFIGURATION.md](CONFIGURATION.md); for architecture background see [ARCHITECTURE.md](ARCHITECTURE.md). For low-cost production rollout, see [COST-OPTIMIZATION-PLAYBOOK.md](COST-OPTIMIZATION-PLAYBOOK.md). After install, see [release notes 2026.6.250](../release-notes/release-notes-2026.6.250.md) for recent hotfix and maintenance notes.
+Get an agent that **remembers you** and **gets better at giving the right context** over time - in about 10 minutes. For full configuration options see [CONFIGURATION.md](CONFIGURATION.md); for architecture background see [ARCHITECTURE.md](ARCHITECTURE.md). For low-cost production rollout, see [COST-OPTIMIZATION-PLAYBOOK.md](COST-OPTIMIZATION-PLAYBOOK.md). After install, see [release notes 2026.6.252](../release-notes/release-notes-2026.6.252.md) for recent hotfix and maintenance notes.
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -124,7 +124,7 @@ Hybrid Memory gives your OpenClaw agent **persistent memory** without turning me
 | [Credits & attribution](CREDITS-AND-ATTRIBUTION) | Sources, lineage, and what this repository adds |
 | [Contributor onboarding](CONTRIBUTOR-ONBOARDING) | First-contribution path, quality bar, and high-impact starter areas |
 | [Similar-sweep PR process](SIMILAR-SWEEP-PR) | Contributor merge order and module-split conventions during sweep batches |
-| [Release notes 2026.6.250](../release-notes/release-notes-2026.6.250.md) | Latest release highlights and upgrade notes |
+| [Release notes 2026.6.252](../release-notes/release-notes-2026.6.252.md) | Latest release highlights and upgrade notes |
 
 ---
 

--- a/extensions/memory-hybrid/backends/facts-db/contradictions.ts
+++ b/extensions/memory-hybrid/backends/facts-db/contradictions.ts
@@ -700,11 +700,17 @@ function extractRefNumbers(text: string): Set<string> {
   return new Set(matches ?? []);
 }
 
-/** Heuristic: flag if multiple distinct PR/issue numbers appear across the two facts. */
+function countDistinctRefsInFact(fact: MemoryEntry): number {
+  const text = `${fact.value ?? ""} ${fact.text ?? ""}`;
+  return extractRefNumbers(text).size;
+}
+
+/** Heuristic: flag if either fact alone references too many distinct PR/issue numbers. */
 function isPossiblyOverloadedEntity(newFact: MemoryEntry, oldFact: MemoryEntry): boolean {
-  const combined = `${newFact.value ?? ""} ${newFact.text ?? ""} ${oldFact.value ?? ""} ${oldFact.text ?? ""}`;
-  const refs = extractRefNumbers(combined);
-  return refs.size > MAX_EXPECTED_REFS_PER_ENTITY;
+  return (
+    countDistinctRefsInFact(newFact) > MAX_EXPECTED_REFS_PER_ENTITY ||
+    countDistinctRefsInFact(oldFact) > MAX_EXPECTED_REFS_PER_ENTITY
+  );
 }
 
 function truncateExcerpt(s: string, maxLen: number): string {

--- a/extensions/memory-hybrid/backends/facts-db/contradictions.ts
+++ b/extensions/memory-hybrid/backends/facts-db/contradictions.ts
@@ -705,12 +705,30 @@ function countDistinctRefsInFact(fact: MemoryEntry): number {
   return extractRefNumbers(text).size;
 }
 
-/** Heuristic: flag if either fact alone references too many distinct PR/issue numbers. */
+function countCombinedDistinctRefs(newFact: MemoryEntry, oldFact: MemoryEntry): number {
+  const text = `${newFact.value ?? ""} ${newFact.text ?? ""} ${oldFact.value ?? ""} ${oldFact.text ?? ""}`;
+  return extractRefNumbers(text).size;
+}
+
+/**
+ * Heuristic: flag entity reuse when refs exceed per-fact or asymmetric combined thresholds.
+ * Allows 2+2 disjoint queue drift for LWW (#1945) while still flagging 2+1 style overload.
+ */
 function isPossiblyOverloadedEntity(newFact: MemoryEntry, oldFact: MemoryEntry): boolean {
-  return (
-    countDistinctRefsInFact(newFact) > MAX_EXPECTED_REFS_PER_ENTITY ||
-    countDistinctRefsInFact(oldFact) > MAX_EXPECTED_REFS_PER_ENTITY
-  );
+  const newCount = countDistinctRefsInFact(newFact);
+  const oldCount = countDistinctRefsInFact(oldFact);
+  if (newCount > MAX_EXPECTED_REFS_PER_ENTITY || oldCount > MAX_EXPECTED_REFS_PER_ENTITY) {
+    return true;
+  }
+  const combined = countCombinedDistinctRefs(newFact, oldFact);
+  if (combined <= MAX_EXPECTED_REFS_PER_ENTITY) {
+    return false;
+  }
+  // Both facts at capacity with disjoint refs (typical queue drift) — allow LWW (#1945).
+  if (newCount >= MAX_EXPECTED_REFS_PER_ENTITY && oldCount >= MAX_EXPECTED_REFS_PER_ENTITY) {
+    return false;
+  }
+  return true;
 }
 
 function truncateExcerpt(s: string, maxLen: number): string {

--- a/extensions/memory-hybrid/backends/facts-db/crud.ts
+++ b/extensions/memory-hybrid/backends/facts-db/crud.ts
@@ -250,11 +250,20 @@ export function storeFact(ctx: StoreFactContext, entry: StoreFactInput): StoreFa
 
   const entryCategory = entry.category ?? "";
   const entrySource = entry.source ?? "";
+  if (isPromptArtifactOrReasoningTrace(entry.text)) {
+    return {
+      skipped: true,
+      rejected: true,
+      evictedFactId: null,
+      embeddingStale: false,
+      newlyStored: false,
+      preMergeText: null,
+      entry: createSkippedStorePlaceholder(entry),
+    };
+  }
   if (
     !ctx.allowPreStoreGuardBypass &&
-    (BLOCKED_CATEGORIES.has(entryCategory) ||
-      BLOCKED_SOURCES.has(entrySource) ||
-      isPromptArtifactOrReasoningTrace(entry.text))
+    (BLOCKED_CATEGORIES.has(entryCategory) || BLOCKED_SOURCES.has(entrySource))
   ) {
     return {
       skipped: true,

--- a/extensions/memory-hybrid/cli/cmd-distill.ts
+++ b/extensions/memory-hybrid/cli/cmd-distill.ts
@@ -71,71 +71,14 @@ import type { MaintenanceJobRun } from "../services/maintenance-job-run/job-run.
 import { resolveScanMaintenanceOverrides } from "./maintenance-overrides.js";
 import { acquireScanSlot, clearScanLock } from "./shared.js";
 import type { DistillCliResult, DistillCliSink, DistillWindowResult, RecordDistillResult } from "./types.js";
+import {
+  classifyStoreDedupeMode,
+  resolveDistillVectorCandidates,
+} from "./vector-dedupe-helpers.js";
 
 // Constants used only by distill functions
 const FULL_DISTILL_MAX_DAYS = 90;
 const INCREMENTAL_MIN_DAYS = 3;
-const VECTOR_CANDIDATE_LIMIT = 10;
-const VECTOR_CANDIDATE_OVERFETCH_LIMIT = 50;
-const VECTOR_CANDIDATE_MIN_SCORE = 0;
-
-function getVectorSearchFailReason(vectorDb: unknown): string | null {
-  const getter = (vectorDb as { getLastSearchFailReason?: unknown }).getLastSearchFailReason;
-  if (typeof getter !== "function") return null;
-  try {
-    const reason = getter.call(vectorDb);
-    return typeof reason === "string" && reason.length > 0 ? reason : null;
-  } catch {
-    return null;
-  }
-}
-
-function isLiveFact(candidate: { supersededAt?: number | null; expiresAt?: number | null }): boolean {
-  const nowSec = Math.floor(Date.now() / 1000);
-  return candidate.supersededAt == null && (candidate.expiresAt == null || candidate.expiresAt > nowSec);
-}
-
-/** Filter LanceDB neighbours to live distillation facts for write-time dedupe (#1947). */
-export function filterDistillVectorCandidates(
-  neighbors: Array<{ entry: { id: string }; score: number }>,
-  factsDb: {
-    getById: (
-      id: string,
-    ) => {
-      supersededAt?: number | null;
-      expiresAt?: number | null;
-      source?: string | null;
-      embeddingModel?: string | null;
-      scope?: string | null;
-      scopeTarget?: string | null;
-    } | null;
-  },
-  embeddingModelName: string | null,
-  candidateScope = "global",
-  candidateScopeTarget: string | null = null,
-): Array<{ id: string; score: number }> {
-  return neighbors
-    .map((candidate) => ({
-      id: candidate.entry.id,
-      score: candidate.score,
-    }))
-    .filter(
-      (candidate) =>
-        typeof candidate.id === "string" && candidate.id.length > 0 && Number.isFinite(candidate.score),
-    )
-    .filter((candidate) => {
-      const live = factsDb.getById(candidate.id);
-      return (
-        live != null &&
-        isLiveFact(live) &&
-        live.source === "distillation" &&
-        (live.scope ?? "global") === candidateScope &&
-        (live.scope === "global" ? null : (live.scopeTarget ?? null)) === candidateScopeTarget &&
-        (embeddingModelName == null || live.embeddingModel == null || live.embeddingModel === embeddingModelName)
-      );
-    })
-    .slice(0, VECTOR_CANDIDATE_LIMIT);
-}
 
 export function gatherSessionFiles(opts: {
   all?: boolean;
@@ -779,6 +722,11 @@ export async function runDistillForCli(
     };
     let stored = 0;
     let skipped = 0;
+    const fuzzyDedupeEnabled = cfg.store.fuzzyDedupe === true;
+    let vectorSearchDegraded = false;
+    let vectorDedupeStores = 0;
+    let lexicalOnlyDedupeStores = 0;
+    let usedHasDuplicateFallback = false;
     for (const fact of allFacts) {
       const parsed = tryParseCredentialForVault(fact.text, fact.entity ?? null, fact.key ?? null, fact.value, {
         requirePatternMatch: cfg.credentials.autoCapture?.requirePatternMatch === true,
@@ -876,7 +824,12 @@ export async function runDistillForCli(
         continue;
       }
 
-      if (factsDb.hasDuplicate(fact.text, "distillation")) {
+      const category = (isValidCategory(fact.category) ? fact.category : "other") as MemoryCategory;
+      const entity = fact.entity ?? null;
+      const key = fact.key ?? null;
+      const factValue = fact.value ?? null;
+
+      if (factsDb.hasDuplicate(fact.text, "distillation", { category, entity, key, value: factValue })) {
         skipped++;
         continue;
       }
@@ -884,46 +837,58 @@ export async function runDistillForCli(
         const redactedText = redactMaintenancePrivateText(fact.text);
         const redactedValue = fact.value ? redactMaintenancePrivateText(fact.value) : redactedText.slice(0, 200);
         const vector = await embeddings.embed(redactedText);
-        let vectorCandidates: Array<{ id: string; score: number }> | undefined;
-        if (cfg.store?.fuzzyDedupe ?? true) {
-          try {
-            const embeddingModelName =
-              typeof embeddings.modelName === "string" && embeddings.modelName.trim().length > 0
-                ? embeddings.modelName
-                : null;
-            const neighbors = await vectorDb.search(
-              vector,
-              VECTOR_CANDIDATE_OVERFETCH_LIMIT,
-              VECTOR_CANDIDATE_MIN_SCORE,
-            );
-            if (!getVectorSearchFailReason(vectorDb)) {
-              vectorCandidates = filterDistillVectorCandidates(neighbors, factsDb, embeddingModelName);
-            }
-          } catch (err) {
-            capturePluginError(err instanceof Error ? err : new Error(String(err)), {
-              subsystem: "cli",
-              operation: "runDistillForCli:vector-candidates",
-            });
-          }
+        const embeddingModelName =
+          typeof embeddings.modelName === "string" && embeddings.modelName.trim().length > 0
+            ? embeddings.modelName
+            : null;
+        const vectorResolve = await resolveDistillVectorCandidates({
+          fuzzyDedupe: fuzzyDedupeEnabled,
+          vector,
+          vectorDb,
+          factsDb,
+          embeddingModelName,
+        });
+        vectorSearchDegraded = vectorSearchDegraded || vectorResolve.vectorSearchDegraded;
+        if (vectorResolve.usedHasDuplicateFallback) {
+          usedHasDuplicateFallback = true;
+        }
+        if (vectorResolve.skipAsDuplicate) {
+          skipped++;
+          continue;
         }
         const storeResult = factsDb.storeWithResult(
           {
             text: redactedText,
-            category: (isValidCategory(fact.category) ? fact.category : "other") as MemoryCategory,
+            category,
             importance: BATCH_STORE_IMPORTANCE,
-            entity: fact.entity ?? null,
-            key: fact.key ?? null,
+            entity,
+            key,
             value: redactedValue,
             source: "distillation",
             sourceDate: sourceDateSec(fact.source_date),
             tags: fact.tags?.length ? fact.tags : extractTags(redactedText, fact.entity ?? undefined),
           },
           {
-            vectorCandidates,
+            vectorCandidates: vectorResolve.vectorCandidates,
             warnContext: "distill",
             suppressVectorFallbackWarning: true,
           },
         );
+        const factDedupeMode = classifyStoreDedupeMode({
+          fuzzyDedupe: fuzzyDedupeEnabled,
+          vectorSearchDegraded: vectorResolve.vectorSearchDegraded,
+          vectorCandidates: vectorResolve.vectorCandidates,
+          usedHasDuplicateFallback: vectorResolve.usedHasDuplicateFallback,
+          skipAsDuplicate: vectorResolve.skipAsDuplicate,
+        });
+        if (factDedupeMode === "vector") {
+          vectorDedupeStores++;
+        } else if (factDedupeMode === "mixed") {
+          vectorDedupeStores++;
+          lexicalOnlyDedupeStores++;
+        } else {
+          lexicalOnlyDedupeStores++;
+        }
         if (storeResult.skipped) {
           continue;
         }
@@ -978,6 +943,18 @@ export async function runDistillForCli(
     } else if (batchFailures > 0) {
       sink.warn(`memory-hybrid: distill partial failure: ${batchFailures} batch(es) failed; scan cursor not advanced`);
     }
+    const dedupeDegraded = vectorSearchDegraded;
+    const distillDedupeMode =
+      vectorDedupeStores > 0 && lexicalOnlyDedupeStores > 0
+        ? "mixed"
+        : vectorDedupeStores > 0
+          ? "vector"
+          : "lexical-only";
+    if (dedupeDegraded && !opts.dryRun) {
+      sink.warn(
+        `memory-hybrid: distill DEGRADED — vector neighbour search unavailable${usedHasDuplicateFallback ? "; used hasDuplicate fallback where applicable" : ""}`,
+      );
+    }
     return withDistillJobRun({
       sessionsScanned: filesToProcess.length,
       factsExtracted: allFacts.length,
@@ -987,6 +964,8 @@ export async function runDistillForCli(
       semanticEmpty,
       partialFailure: batchFailures > 0,
       batchFailures,
+      dedupeDegraded,
+      distillDedupeMode,
     });
   } finally {
     if (shouldAcquireLock && !opts.dryRun) clearScanLock(SCAN_TYPE);

--- a/extensions/memory-hybrid/cli/cmd-distill.ts
+++ b/extensions/memory-hybrid/cli/cmd-distill.ts
@@ -75,6 +75,67 @@ import type { DistillCliResult, DistillCliSink, DistillWindowResult, RecordDisti
 // Constants used only by distill functions
 const FULL_DISTILL_MAX_DAYS = 90;
 const INCREMENTAL_MIN_DAYS = 3;
+const VECTOR_CANDIDATE_LIMIT = 10;
+const VECTOR_CANDIDATE_OVERFETCH_LIMIT = 50;
+const VECTOR_CANDIDATE_MIN_SCORE = 0;
+
+function getVectorSearchFailReason(vectorDb: unknown): string | null {
+  const getter = (vectorDb as { getLastSearchFailReason?: unknown }).getLastSearchFailReason;
+  if (typeof getter !== "function") return null;
+  try {
+    const reason = getter.call(vectorDb);
+    return typeof reason === "string" && reason.length > 0 ? reason : null;
+  } catch {
+    return null;
+  }
+}
+
+function isLiveFact(candidate: { supersededAt?: number | null; expiresAt?: number | null }): boolean {
+  const nowSec = Math.floor(Date.now() / 1000);
+  return candidate.supersededAt == null && (candidate.expiresAt == null || candidate.expiresAt > nowSec);
+}
+
+/** Filter LanceDB neighbours to live distillation facts for write-time dedupe (#1947). */
+export function filterDistillVectorCandidates(
+  neighbors: Array<{ entry: { id: string }; score: number }>,
+  factsDb: {
+    getById: (
+      id: string,
+    ) => {
+      supersededAt?: number | null;
+      expiresAt?: number | null;
+      source?: string | null;
+      embeddingModel?: string | null;
+      scope?: string | null;
+      scopeTarget?: string | null;
+    } | null;
+  },
+  embeddingModelName: string | null,
+  candidateScope = "global",
+  candidateScopeTarget: string | null = null,
+): Array<{ id: string; score: number }> {
+  return neighbors
+    .map((candidate) => ({
+      id: candidate.entry.id,
+      score: candidate.score,
+    }))
+    .filter(
+      (candidate) =>
+        typeof candidate.id === "string" && candidate.id.length > 0 && Number.isFinite(candidate.score),
+    )
+    .filter((candidate) => {
+      const live = factsDb.getById(candidate.id);
+      return (
+        live != null &&
+        isLiveFact(live) &&
+        live.source === "distillation" &&
+        (live.scope ?? "global") === candidateScope &&
+        (live.scope === "global" ? null : (live.scopeTarget ?? null)) === candidateScopeTarget &&
+        (embeddingModelName == null || live.embeddingModel == null || live.embeddingModel === embeddingModelName)
+      );
+    })
+    .slice(0, VECTOR_CANDIDATE_LIMIT);
+}
 
 export function gatherSessionFiles(opts: {
   all?: boolean;
@@ -823,21 +884,46 @@ export async function runDistillForCli(
         const redactedText = redactMaintenancePrivateText(fact.text);
         const redactedValue = fact.value ? redactMaintenancePrivateText(fact.value) : redactedText.slice(0, 200);
         const vector = await embeddings.embed(redactedText);
-        if (await vectorDb.hasDuplicate(vector, DISTILL_DEDUP_THRESHOLD)) {
-          skipped++;
-          continue;
+        let vectorCandidates: Array<{ id: string; score: number }> | undefined;
+        if (cfg.store?.fuzzyDedupe ?? true) {
+          try {
+            const embeddingModelName =
+              typeof embeddings.modelName === "string" && embeddings.modelName.trim().length > 0
+                ? embeddings.modelName
+                : null;
+            const neighbors = await vectorDb.search(
+              vector,
+              VECTOR_CANDIDATE_OVERFETCH_LIMIT,
+              VECTOR_CANDIDATE_MIN_SCORE,
+            );
+            if (!getVectorSearchFailReason(vectorDb)) {
+              vectorCandidates = filterDistillVectorCandidates(neighbors, factsDb, embeddingModelName);
+            }
+          } catch (err) {
+            capturePluginError(err instanceof Error ? err : new Error(String(err)), {
+              subsystem: "cli",
+              operation: "runDistillForCli:vector-candidates",
+            });
+          }
         }
-        const storeResult = factsDb.storeWithResult({
-          text: redactedText,
-          category: (isValidCategory(fact.category) ? fact.category : "other") as MemoryCategory,
-          importance: BATCH_STORE_IMPORTANCE,
-          entity: fact.entity ?? null,
-          key: fact.key ?? null,
-          value: redactedValue,
-          source: "distillation",
-          sourceDate: sourceDateSec(fact.source_date),
-          tags: fact.tags?.length ? fact.tags : extractTags(redactedText, fact.entity ?? undefined),
-        });
+        const storeResult = factsDb.storeWithResult(
+          {
+            text: redactedText,
+            category: (isValidCategory(fact.category) ? fact.category : "other") as MemoryCategory,
+            importance: BATCH_STORE_IMPORTANCE,
+            entity: fact.entity ?? null,
+            key: fact.key ?? null,
+            value: redactedValue,
+            source: "distillation",
+            sourceDate: sourceDateSec(fact.source_date),
+            tags: fact.tags?.length ? fact.tags : extractTags(redactedText, fact.entity ?? undefined),
+          },
+          {
+            vectorCandidates,
+            warnContext: "distill",
+            suppressVectorFallbackWarning: true,
+          },
+        );
         if (storeResult.skipped) {
           continue;
         }

--- a/extensions/memory-hybrid/cli/cmd-distill.ts
+++ b/extensions/memory-hybrid/cli/cmd-distill.ts
@@ -827,15 +827,21 @@ export async function runDistillForCli(
       const category = (isValidCategory(fact.category) ? fact.category : "other") as MemoryCategory;
       const entity = fact.entity ?? null;
       const key = fact.key ?? null;
-      const factValue = fact.value ?? null;
+      const redactedText = redactMaintenancePrivateText(fact.text);
+      const redactedValue = fact.value ? redactMaintenancePrivateText(fact.value) : redactedText.slice(0, 200);
 
-      if (factsDb.hasDuplicate(fact.text, "distillation", { category, entity, key, value: factValue })) {
+      if (
+        factsDb.hasDuplicate(redactedText, "distillation", {
+          category,
+          entity,
+          key,
+          value: redactedValue,
+        })
+      ) {
         skipped++;
         continue;
       }
       try {
-        const redactedText = redactMaintenancePrivateText(fact.text);
-        const redactedValue = fact.value ? redactMaintenancePrivateText(fact.value) : redactedText.slice(0, 200);
         const vector = await embeddings.embed(redactedText);
         const embeddingModelName =
           typeof embeddings.modelName === "string" && embeddings.modelName.trim().length > 0
@@ -853,6 +859,10 @@ export async function runDistillForCli(
           usedHasDuplicateFallback = true;
         }
         if (vectorResolve.skipAsDuplicate) {
+          skipped++;
+          continue;
+        }
+        if (!fuzzyDedupeEnabled && (await vectorDb.hasDuplicate(vector, DISTILL_DEDUP_THRESHOLD))) {
           skipped++;
           continue;
         }
@@ -890,6 +900,7 @@ export async function runDistillForCli(
           lexicalOnlyDedupeStores++;
         }
         if (storeResult.skipped) {
+          skipped++;
           continue;
         }
         if (storeResult.newlyStored === false && !storeResult.embeddingStale) {

--- a/extensions/memory-hybrid/cli/cmd-extract-directives.ts
+++ b/extensions/memory-hybrid/cli/cmd-extract-directives.ts
@@ -18,10 +18,14 @@ import { acquireScanSlot, clearScanLock } from "./shared.js";
 
 import { resolveExtractSessionFilePaths } from "../services/extract-session-paths.js";
 import { getMaxMtime } from "./cmd-extract-sessions.js";
-
-const VECTOR_CANDIDATE_LIMIT = 10;
-const VECTOR_CANDIDATE_OVERFETCH_LIMIT = 50;
-const VECTOR_CANDIDATE_MIN_SCORE = 0;
+import {
+  VECTOR_CANDIDATE_LIMIT,
+  VECTOR_CANDIDATE_MIN_SCORE,
+  VECTOR_CANDIDATE_OVERFETCH_LIMIT,
+  getVectorSearchFailReason,
+  isLiveFact,
+  mapValidVectorCandidates,
+} from "./vector-dedupe-helpers.js";
 
 /**
  * Identifies transient/retryable store errors (SQLite busy, network issues) vs permanent errors.
@@ -49,22 +53,6 @@ function isRetryableStoreError(err: unknown): boolean {
 
   // All other errors (TypeError, schema bugs, programming errors) are permanent
   return false;
-}
-
-function getVectorSearchFailReason(vectorDb: unknown): string | null {
-  const getter = (vectorDb as { getLastSearchFailReason?: unknown }).getLastSearchFailReason;
-  if (typeof getter !== "function") return null;
-  try {
-    const reason = getter.call(vectorDb);
-    return typeof reason === "string" && reason.length > 0 ? reason : null;
-  } catch {
-    return null;
-  }
-}
-
-function isLiveFact(candidate: { supersededAt?: number | null; expiresAt?: number | null }): boolean {
-  const nowSec = Math.floor(Date.now() / 1000);
-  return candidate.supersededAt == null && (candidate.expiresAt == null || candidate.expiresAt > nowSec);
 }
 
 export async function runExtractDirectivesForCli(
@@ -199,7 +187,7 @@ export async function runExtractDirectivesForCli(
           let vectorCandidates: Array<{ id: string; score: number }> | undefined;
           try {
             vector = await embeddings.embed(incident.extractedRule);
-            if (cfg.store?.fuzzyDedupe ?? true) {
+            if (cfg.store.fuzzyDedupe === true) {
               const sourceScope = "global";
               const sourceScopeTarget = null;
               const embeddingModelName =
@@ -212,26 +200,18 @@ export async function runExtractDirectivesForCli(
                 VECTOR_CANDIDATE_MIN_SCORE,
               );
               if (!getVectorSearchFailReason(vectorDb)) {
-                vectorCandidates = neighbors
-                  .map((candidate) => ({
-                    id: candidate.entry.id,
-                    score: candidate.score,
-                  }))
-                  .filter(
-                    (candidate) =>
-                      typeof candidate.id === "string" && candidate.id.length > 0 && Number.isFinite(candidate.score),
-                  )
+                vectorCandidates = mapValidVectorCandidates(neighbors)
                   .filter((candidate) => {
-                    const fact = factsDb.getById(candidate.id);
+                    const liveFact = factsDb.getById(candidate.id);
                     return (
-                      fact != null &&
-                      isLiveFact(fact) &&
-                      fact.source.startsWith("directive:") &&
-                      (fact.scope ?? "global") === sourceScope &&
-                      (fact.scope === "global" ? null : (fact.scopeTarget ?? null)) === sourceScopeTarget &&
+                      liveFact != null &&
+                      isLiveFact(liveFact) &&
+                      liveFact.source.startsWith("directive:") &&
+                      (liveFact.scope ?? "global") === sourceScope &&
+                      (liveFact.scope === "global" ? null : (liveFact.scopeTarget ?? null)) === sourceScopeTarget &&
                       (embeddingModelName == null ||
-                        fact.embeddingModel == null ||
-                        fact.embeddingModel === embeddingModelName)
+                        liveFact.embeddingModel == null ||
+                        liveFact.embeddingModel === embeddingModelName)
                     );
                   })
                   .slice(0, VECTOR_CANDIDATE_LIMIT);
@@ -245,7 +225,7 @@ export async function runExtractDirectivesForCli(
           }
           const usedLexicalOnlyFallback = shouldReportVectorDedupeFallback({
             source,
-            fuzzyDedupe: cfg.store?.fuzzyDedupe ?? true,
+            fuzzyDedupe: cfg.store.fuzzyDedupe === true,
             storeConfig: cfg.store,
             vectorCandidates,
           });

--- a/extensions/memory-hybrid/cli/commands/manage/maintenance-step-runners.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/maintenance-step-runners.ts
@@ -347,6 +347,7 @@ export function buildCliMaintenanceRunners(
   });
 
   set("evolution-pass", async () => {
+    if (typeof b.factsDb.getRawDb !== "function") return "skipped (factsDb unavailable)";
     const { runEvolutionPass } = await import("../../../services/evolution-pass.js");
     const { resolveReflectionModelAndFallbacks } = await import("../../../config/index.js");
     const { defaultModel, fallbackModels } = resolveReflectionModelAndFallbacks(b.cfg, "maintenance");
@@ -933,7 +934,8 @@ export function buildPluginCycleRunners(deps: PluginCycleRunnerDeps): Map<string
     );
   }
 
-  runners.set("evolution-pass", async () => {
+  runners.  set("evolution-pass", async () => {
+    if (typeof deps.factsDb.getRawDb !== "function") return "skipped (factsDb unavailable)";
     const { runEvolutionPass } = await import("../../../services/evolution-pass.js");
     const { resolveReflectionModelAndFallbacks } = await import("../../../config/index.js");
     const { defaultModel, fallbackModels } = resolveReflectionModelAndFallbacks(deps.cfg, "maintenance");

--- a/extensions/memory-hybrid/cli/commands/manage/register-agents-audit-runall.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/register-agents-audit-runall.ts
@@ -45,7 +45,7 @@ export function registerRunAllCommand(mem: Chainable, b: ManageBindings, command
             openclawDir,
             logger: { info: (m) => console.log(m), warn: (m) => console.warn(m) },
             oneTimeMarkerExists: (path) => existsSync(join(memoryDir, path)),
-            journalDb: b.factsDb.getRawDb(),
+            journalDb: typeof b.factsDb.getRawDb === "function" ? b.factsDb.getRawDb() : undefined,
           },
           {
             tiers: ["cycle", "nightly"],

--- a/extensions/memory-hybrid/cli/types.ts
+++ b/extensions/memory-hybrid/cli/types.ts
@@ -235,6 +235,8 @@ export type DistillCliResult = {
   batchFailures?: number;
   jobRunId?: string;
   semanticOutcome?: string;
+  dedupeDegraded?: boolean;
+  distillDedupeMode?: "vector" | "lexical-only" | "mixed";
 };
 export type DistillCliSink = {
   log: (s: string) => void;

--- a/extensions/memory-hybrid/cli/vector-dedupe-helpers.ts
+++ b/extensions/memory-hybrid/cli/vector-dedupe-helpers.ts
@@ -1,0 +1,155 @@
+import { DISTILL_DEDUP_THRESHOLD } from "../utils/constants.js";
+
+export const VECTOR_CANDIDATE_LIMIT = 10;
+export const VECTOR_CANDIDATE_OVERFETCH_LIMIT = 50;
+export const VECTOR_CANDIDATE_MIN_SCORE = 0;
+
+export type VectorNeighbor = { entry: { id: string }; score: number };
+export type VectorCandidate = { id: string; score: number };
+
+export type VectorCandidateFact = {
+  supersededAt?: number | null;
+  expiresAt?: number | null;
+  source?: string | null;
+  embeddingModel?: string | null;
+  scope?: string | null;
+  scopeTarget?: string | null;
+};
+
+export function getVectorSearchFailReason(vectorDb: unknown): string | null {
+  const getter = (vectorDb as { getLastSearchFailReason?: unknown }).getLastSearchFailReason;
+  if (typeof getter !== "function") return null;
+  try {
+    const reason = getter.call(vectorDb);
+    return typeof reason === "string" && reason.length > 0 ? reason : null;
+  } catch {
+    return null;
+  }
+}
+
+export function isLiveFact(candidate: { supersededAt?: number | null; expiresAt?: number | null }): boolean {
+  const nowSec = Math.floor(Date.now() / 1000);
+  return candidate.supersededAt == null && (candidate.expiresAt == null || candidate.expiresAt > nowSec);
+}
+
+export function mapValidVectorCandidates(neighbors: VectorNeighbor[]): VectorCandidate[] {
+  return neighbors
+    .map((candidate) => ({
+      id: candidate.entry.id,
+      score: candidate.score,
+    }))
+    .filter(
+      (candidate) =>
+        typeof candidate.id === "string" && candidate.id.length > 0 && Number.isFinite(candidate.score),
+    );
+}
+
+/** Filter LanceDB neighbours to live distillation facts for write-time dedupe (#1947). */
+export function filterDistillVectorCandidates(
+  neighbors: VectorNeighbor[],
+  factsDb: { getById: (id: string) => VectorCandidateFact | null },
+  embeddingModelName: string | null,
+  candidateScope = "global",
+  candidateScopeTarget: string | null = null,
+): VectorCandidate[] {
+  return mapValidVectorCandidates(neighbors)
+    .filter((candidate) => {
+      const live = factsDb.getById(candidate.id);
+      return (
+        live != null &&
+        isLiveFact(live) &&
+        live.source === "distillation" &&
+        (live.scope ?? "global") === candidateScope &&
+        (live.scope === "global" ? null : (live.scopeTarget ?? null)) === candidateScopeTarget &&
+        (embeddingModelName == null || live.embeddingModel == null || live.embeddingModel === embeddingModelName)
+      );
+    })
+    .slice(0, VECTOR_CANDIDATE_LIMIT);
+}
+
+export type ResolveDistillVectorCandidatesResult = {
+  vectorCandidates?: VectorCandidate[];
+  vectorSearchDegraded: boolean;
+  usedHasDuplicateFallback: boolean;
+  skipAsDuplicate: boolean;
+};
+
+type VectorDbForDistillDedupe = {
+  search: (vector: number[], limit: number, minScore: number) => Promise<VectorNeighbor[]>;
+  hasDuplicate: (vector: number[], threshold?: number) => Promise<boolean>;
+};
+
+/** Pre-compute vector neighbours for distill store, with LanceDB fallback when search is degraded (#1947). */
+export async function resolveDistillVectorCandidates(input: {
+  fuzzyDedupe: boolean;
+  vector: number[];
+  vectorDb: VectorDbForDistillDedupe;
+  factsDb: { getById: (id: string) => VectorCandidateFact | null };
+  embeddingModelName: string | null;
+  candidateScope?: string;
+  candidateScopeTarget?: string | null;
+  duplicateThreshold?: number;
+}): Promise<ResolveDistillVectorCandidatesResult> {
+  const none: ResolveDistillVectorCandidatesResult = {
+    vectorSearchDegraded: false,
+    usedHasDuplicateFallback: false,
+    skipAsDuplicate: false,
+  };
+  if (!input.fuzzyDedupe) return none;
+
+  const threshold = input.duplicateThreshold ?? DISTILL_DEDUP_THRESHOLD;
+  const scope = input.candidateScope ?? "global";
+  const scopeTarget = input.candidateScopeTarget ?? null;
+
+  try {
+    const neighbors = await input.vectorDb.search(
+      input.vector,
+      VECTOR_CANDIDATE_OVERFETCH_LIMIT,
+      VECTOR_CANDIDATE_MIN_SCORE,
+    );
+    const searchFailReason = getVectorSearchFailReason(input.vectorDb);
+    if (searchFailReason) {
+      const skipAsDuplicate = await input.vectorDb.hasDuplicate(input.vector, threshold);
+      return {
+        vectorSearchDegraded: true,
+        usedHasDuplicateFallback: true,
+        skipAsDuplicate,
+      };
+    }
+    return {
+      vectorCandidates: filterDistillVectorCandidates(
+        neighbors,
+        input.factsDb,
+        input.embeddingModelName,
+        scope,
+        scopeTarget,
+      ),
+      vectorSearchDegraded: false,
+      usedHasDuplicateFallback: false,
+      skipAsDuplicate: false,
+    };
+  } catch {
+    const skipAsDuplicate = await input.vectorDb.hasDuplicate(input.vector, threshold);
+    return {
+      vectorSearchDegraded: true,
+      usedHasDuplicateFallback: true,
+      skipAsDuplicate,
+    };
+  }
+}
+
+export type StoreDedupeMode = "vector" | "lexical-only" | "mixed";
+
+export function classifyStoreDedupeMode(input: {
+  fuzzyDedupe: boolean;
+  vectorSearchDegraded: boolean;
+  vectorCandidates?: ReadonlyArray<VectorCandidate>;
+  usedHasDuplicateFallback: boolean;
+  skipAsDuplicate: boolean;
+}): StoreDedupeMode {
+  if (!input.fuzzyDedupe) return "lexical-only";
+  if (input.skipAsDuplicate && input.usedHasDuplicateFallback) return "mixed";
+  if (input.vectorSearchDegraded) return "lexical-only";
+  if (input.vectorCandidates && input.vectorCandidates.length > 0) return "vector";
+  return "lexical-only";
+}

--- a/extensions/memory-hybrid/cli/vector-dedupe-helpers.ts
+++ b/extensions/memory-hybrid/cli/vector-dedupe-helpers.ts
@@ -1,3 +1,4 @@
+import { capturePluginError } from "../services/error-reporter.js";
 import { DISTILL_DEDUP_THRESHOLD } from "../utils/constants.js";
 
 export const VECTOR_CANDIDATE_LIMIT = 10;
@@ -14,6 +15,7 @@ export type VectorCandidateFact = {
   embeddingModel?: string | null;
   scope?: string | null;
   scopeTarget?: string | null;
+  category?: string | null;
 };
 
 export function getVectorSearchFailReason(vectorDb: unknown): string | null {
@@ -24,6 +26,16 @@ export function getVectorSearchFailReason(vectorDb: unknown): string | null {
     return typeof reason === "string" && reason.length > 0 ? reason : null;
   } catch {
     return null;
+  }
+}
+
+function isVectorSchemaValid(vectorDb: unknown): boolean {
+  const checker = (vectorDb as { isMemoriesVectorSchemaValid?: unknown }).isMemoriesVectorSchemaValid;
+  if (typeof checker !== "function") return true;
+  try {
+    return checker.call(vectorDb) !== false;
+  } catch {
+    return true;
   }
 }
 
@@ -51,6 +63,7 @@ export function filterDistillVectorCandidates(
   embeddingModelName: string | null,
   candidateScope = "global",
   candidateScopeTarget: string | null = null,
+  candidateCategory: string | null = null,
 ): VectorCandidate[] {
   return mapValidVectorCandidates(neighbors)
     .filter((candidate) => {
@@ -59,6 +72,8 @@ export function filterDistillVectorCandidates(
         live != null &&
         isLiveFact(live) &&
         live.source === "distillation" &&
+        (candidateCategory == null ||
+          (live.category ?? "").trim().toLowerCase() === candidateCategory.trim().toLowerCase()) &&
         (live.scope ?? "global") === candidateScope &&
         (live.scope === "global" ? null : (live.scopeTarget ?? null)) === candidateScopeTarget &&
         (embeddingModelName == null || live.embeddingModel == null || live.embeddingModel === embeddingModelName)
@@ -78,6 +93,46 @@ type VectorDbForDistillDedupe = {
   search: (vector: number[], limit: number, minScore: number) => Promise<VectorNeighbor[]>;
   hasDuplicate: (vector: number[], threshold?: number) => Promise<boolean>;
 };
+
+async function tryHasDuplicateFallback(input: {
+  vectorDb: VectorDbForDistillDedupe;
+  vector: number[];
+  threshold: number;
+  neighbors: VectorNeighbor[];
+  factsDb: { getById: (id: string) => VectorCandidateFact | null };
+  embeddingModelName: string | null;
+  candidateScope: string;
+  candidateScopeTarget: string | null;
+}): Promise<{
+  skipAsDuplicate: boolean;
+  usedHasDuplicateFallback: boolean;
+  vectorCandidates?: VectorCandidate[];
+}> {
+  if (!isVectorSchemaValid(input.vectorDb)) {
+    // hasDuplicate() also returns false when schema is invalid — skip the useless call.
+    return { skipAsDuplicate: false, usedHasDuplicateFallback: false };
+  }
+  const scopedFromNeighbors = filterDistillVectorCandidates(
+    input.neighbors,
+    input.factsDb,
+    input.embeddingModelName,
+    input.candidateScope,
+    input.candidateScopeTarget,
+  );
+  if (scopedFromNeighbors.length > 0) {
+    return {
+      skipAsDuplicate: false,
+      usedHasDuplicateFallback: true,
+      vectorCandidates: scopedFromNeighbors,
+    };
+  }
+  const hasGlobalDuplicate = await input.vectorDb.hasDuplicate(input.vector, input.threshold);
+  if (!hasGlobalDuplicate) {
+    return { skipAsDuplicate: false, usedHasDuplicateFallback: true };
+  }
+  // Unscoped hasDuplicate alone must not skip distill writes — fall back to lexical dedupe at store time.
+  return { skipAsDuplicate: false, usedHasDuplicateFallback: true };
+}
 
 /** Pre-compute vector neighbours for distill store, with LanceDB fallback when search is degraded (#1947). */
 export async function resolveDistillVectorCandidates(input: {
@@ -109,11 +164,21 @@ export async function resolveDistillVectorCandidates(input: {
     );
     const searchFailReason = getVectorSearchFailReason(input.vectorDb);
     if (searchFailReason) {
-      const skipAsDuplicate = await input.vectorDb.hasDuplicate(input.vector, threshold);
+      const fallback = await tryHasDuplicateFallback({
+        vectorDb: input.vectorDb,
+        vector: input.vector,
+        threshold,
+        neighbors,
+        factsDb: input.factsDb,
+        embeddingModelName: input.embeddingModelName,
+        candidateScope: scope,
+        candidateScopeTarget: scopeTarget,
+      });
       return {
         vectorSearchDegraded: true,
-        usedHasDuplicateFallback: true,
-        skipAsDuplicate,
+        usedHasDuplicateFallback: fallback.usedHasDuplicateFallback,
+        skipAsDuplicate: fallback.skipAsDuplicate,
+        vectorCandidates: fallback.vectorCandidates,
       };
     }
     return {
@@ -128,12 +193,27 @@ export async function resolveDistillVectorCandidates(input: {
       usedHasDuplicateFallback: false,
       skipAsDuplicate: false,
     };
-  } catch {
-    const skipAsDuplicate = await input.vectorDb.hasDuplicate(input.vector, threshold);
+  } catch (err) {
+    capturePluginError(err as Error, {
+      subsystem: "cli",
+      operation: "resolveDistillVectorCandidates:search",
+      severity: "info",
+    });
+    const fallback = await tryHasDuplicateFallback({
+      vectorDb: input.vectorDb,
+      vector: input.vector,
+      threshold,
+      neighbors: [],
+      factsDb: input.factsDb,
+      embeddingModelName: input.embeddingModelName,
+      candidateScope: scope,
+      candidateScopeTarget: scopeTarget,
+    });
     return {
       vectorSearchDegraded: true,
-      usedHasDuplicateFallback: true,
-      skipAsDuplicate,
+      usedHasDuplicateFallback: fallback.usedHasDuplicateFallback,
+      skipAsDuplicate: fallback.skipAsDuplicate,
+      vectorCandidates: fallback.vectorCandidates,
     };
   }
 }

--- a/extensions/memory-hybrid/config/parsers/features.ts
+++ b/extensions/memory-hybrid/config/parsers/features.ts
@@ -941,9 +941,11 @@ export function parseCostTrackingConfig(cfg: Record<string, unknown>): CostTrack
 
 export function parseDashboardConfig(cfg: Record<string, unknown>): DashboardConfig {
   const raw = cfg.dashboard as Record<string, unknown> | undefined;
+  const token = typeof raw?.token === "string" && raw.token.trim().length > 0 ? raw.token.trim() : undefined;
   return {
     enabled: raw?.enabled !== false,
     port: typeof raw?.port === "number" && raw.port >= 1024 && raw.port <= 65535 ? Math.floor(raw.port) : 7700,
+    token,
     gitRepo: typeof raw?.gitRepo === "string" ? raw.gitRepo : undefined,
   };
 }

--- a/extensions/memory-hybrid/config/types/features.ts
+++ b/extensions/memory-hybrid/config/types/features.ts
@@ -437,6 +437,8 @@ export type DashboardConfig = {
   enabled: boolean;
   /** Port for the dashboard HTTP server (default: 7700). */
   port: number;
+  /** Optional bearer token for dashboard write APIs (verify/forget/workshop/GraphQL mutations). */
+  token?: string;
   /** Optional owner/repo for GitHub queries (e.g. "markus-lassfolk/openclaw-hybrid-memory"). */
   gitRepo?: string;
 };

--- a/extensions/memory-hybrid/lifecycle/stage-capture/run-capture.ts
+++ b/extensions/memory-hybrid/lifecycle/stage-capture/run-capture.ts
@@ -11,7 +11,7 @@ import { getCronModelConfig, getDefaultCronModel } from "../../config/index.js";
 import type { MemoryCategory } from "../../config.js";
 import "../../config.js";
 import { detectCredentialPatterns } from "../../services/auto-capture.js";
-import { checkCaptureDedupWindow, computeCaptureDedupHash } from "../../services/capture-dedup.js";
+import { runCaptureStoreWithDedupWindow, peekCaptureDedupWindow } from "../../services/capture-dedup.js";
 import {
   abortCredentialVaultWriteOnPointerDedupe,
   buildCredentialPointerText,
@@ -43,7 +43,6 @@ import { CLI_STORE_IMPORTANCE } from "../../utils/constants.js";
 import { persistCanonicalFactEmbedding } from "../../utils/fact-embeddings.js";
 import { isStaleLifecycleGeneration } from "../../utils/lifecycle-generation.js";
 import { isRecallContextSuperseded, shouldSuppressStaleLifecycleError } from "../../utils/registration-superseded.js";
-import { createTransaction } from "../../utils/sqlite-transaction.js";
 import { extractTags } from "../../utils/tags.js";
 import { isSubstantiveMemoryText, prepareMemoryTextForStorage } from "../../services/recalled-context-assembler.js";
 import { resolveAgentIdFromHookEvent } from "../resolve-agent-id.js";
@@ -707,6 +706,31 @@ export async function runCapture(
               }
             }
           }
+          const dedupWindow = ctx.cfg.store.dedupWindowMinutes ?? 30;
+          const dedupInput = {
+            text: textToStore,
+            entity: extracted.entity,
+            key: extracted.key,
+            scope: "global",
+            scopeTarget: null,
+          };
+          const rawDbForDedup =
+            typeof ctx.factsDb.getRawDb === "function" ? ctx.factsDb.getRawDb() : null;
+          if (rawDbForDedup && dedupWindow > 0) {
+            const peek = peekCaptureDedupWindow(rawDbForDedup, dedupInput, dedupWindow);
+            if (peek.skip) {
+              ctx.auditStore?.append({
+                agentId: resolveAgentIdFromHookEvent(event, api) ?? ctx.currentAgentIdRef.value ?? "unknown",
+                action: "auto-capture:dedup-window",
+                target: textToStore.slice(0, 80),
+                outcome: "skipped",
+                sessionId: captureProvenance.sessionId ?? undefined,
+                context: { category, existingId: peek.existingId },
+              });
+              continue;
+            }
+          }
+
           const walEntryId = await ctx.walWrite(
             "store",
             {
@@ -733,26 +757,12 @@ export async function runCapture(
             continue;
           }
 
-          const dedupWindow = ctx.cfg.store.dedupWindowMinutes ?? 30;
-          const dedupInput = {
-            text: textToStore,
-            entity: extracted.entity,
-            key: extracted.key,
-            scope: "global",
-            scopeTarget: null,
-          };
-
-          const storeWithDedupCheck = createTransaction(
-            ctx.factsDb.getRawDb(),
-            () => {
-              if (dedupWindow > 0) {
-                const dedupCheck = checkCaptureDedupWindow(ctx.factsDb.getRawDb(), dedupInput, dedupWindow);
-                if (dedupCheck.skip) {
-                  return { skipped: true, dedupExistingId: dedupCheck.existingId };
-                }
-              }
-
-              const storeResult = ctx.factsDb.storeWithResult({
+          const txResult = runCaptureStoreWithDedupWindow(
+            ctx.factsDb,
+            dedupWindow,
+            dedupInput,
+            () =>
+              ctx.factsDb.storeWithResult({
                 text: textToStore,
                 category,
                 importance: CLI_STORE_IMPORTANCE,
@@ -766,22 +776,8 @@ export async function runCapture(
                 sourceTurn: candidate.sourceTurn,
                 extractionMethod: getAutoCaptureExtractionMethod(candidate.role, captureProvenance),
                 extractionConfidence: getAutoCaptureExtractionConfidence(candidate.role),
-              });
-
-              if (!storeResult.skipped && dedupWindow > 0) {
-                const dedupHash = computeCaptureDedupHash(dedupInput);
-                ctx.factsDb
-                  .getRawDb()
-                  .prepare("UPDATE facts SET content_dedup_hash = ? WHERE id = ?")
-                  .run(dedupHash, storeResult.entry.id);
-              }
-
-              return { skipped: false, storeResult };
-            },
-            "IMMEDIATE",
+              }),
           );
-
-          const txResult = storeWithDedupCheck();
           if (txResult.skipped) {
             if (walEntryId) await ctx.walRemove(walEntryId, api.logger);
             ctx.auditStore?.append({

--- a/extensions/memory-hybrid/lifecycle/stage-frustration.ts
+++ b/extensions/memory-hybrid/lifecycle/stage-frustration.ts
@@ -100,7 +100,7 @@ export function registerFrustrationHandlers(
       }
 
       const implicitSignals = exportAsImplicitSignals(frustrationResult);
-      if (implicitSignals.length > 0) {
+      if (implicitSignals.length > 0 && typeof ctx.factsDb.getRawDb === "function") {
         try {
           const rawDb = ctx.factsDb.getRawDb();
           const insert = rawDb.prepare(`

--- a/extensions/memory-hybrid/openclaw.plugin.json
+++ b/extensions/memory-hybrid/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "openclaw-hybrid-memory",
   "kind": "memory",
-  "version": "2026.6.252",
+  "version": "2026.6.256",
   "contracts": {
     "tools": [
       "active_task_checkpoint",

--- a/extensions/memory-hybrid/openclaw.plugin.json
+++ b/extensions/memory-hybrid/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "openclaw-hybrid-memory",
   "kind": "memory",
-  "version": "2026.6.250",
+  "version": "2026.6.252",
   "contracts": {
     "tools": [
       "active_task_checkpoint",

--- a/extensions/memory-hybrid/package-lock.json
+++ b/extensions/memory-hybrid/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openclaw-hybrid-memory",
-  "version": "2026.6.250",
+  "version": "2026.6.252",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openclaw-hybrid-memory",
-      "version": "2026.6.250",
+      "version": "2026.6.252",
       "hasInstallScript": true,
       "dependencies": {
         "@lancedb/lancedb": "^0.30.0",

--- a/extensions/memory-hybrid/package.json
+++ b/extensions/memory-hybrid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-hybrid-memory",
-  "version": "2026.6.250",
+  "version": "2026.6.252",
   "type": "module",
   "description": "Give your OpenClaw agent lasting memory: structured facts, semantic search, auto-capture & recall, decay, optional credential vault. Part of Hybrid Memory v3.",
   "files": [

--- a/extensions/memory-hybrid/package.json
+++ b/extensions/memory-hybrid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-hybrid-memory",
-  "version": "2026.6.252",
+  "version": "2026.6.256",
   "type": "module",
   "description": "Give your OpenClaw agent lasting memory: structured facts, semantic search, auto-capture & recall, decay, optional credential vault. Part of Hybrid Memory v3.",
   "files": [

--- a/extensions/memory-hybrid/routes/dashboard-server.ts
+++ b/extensions/memory-hybrid/routes/dashboard-server.ts
@@ -1,2 +1,2 @@
-export { createDashboardServer, type DashboardServer } from "./dashboard/server.js";
+export { createDashboardServer, graphqlBodyIsMutation, isDashboardWriteAuthorized, type DashboardServer } from "./dashboard/server.js";
 export { collectStatus, collectForgeState } from "./dashboard/collectors.js";

--- a/extensions/memory-hybrid/routes/dashboard/collectors.ts
+++ b/extensions/memory-hybrid/routes/dashboard/collectors.ts
@@ -34,6 +34,7 @@ import type { VerificationStore } from "../../services/verification-store.js";
 import { getDirSize, getFileSizeAsync, readJsonFile } from "../../utils/fs.js";
 import { formatTimestampUtc, nowIso } from "../../utils/dates.js";
 import { pluginLogger } from "../../utils/logger.js";
+import { deleteVectorForFactId } from "../../services/vector-maintenance.js";
 import { isValidGhRepoArg } from "../../utils/gh-repo-arg.js";
 import { execFile as execFileCb } from "../../utils/process-runner.js";
 
@@ -1225,12 +1226,12 @@ export function collectMemoryViewerLinks(ctx: DashboardContext, limit = 5000): M
 }
 
 /** Perform a fact action (verify / forget) and return result. */
-export function performFactAction(
+export async function performFactAction(
   ctx: DashboardContext,
   action: "verify" | "forget",
   factId: string,
   body: Record<string, unknown>,
-): { ok: boolean; message: string } {
+): Promise<{ ok: boolean; message: string }> {
   try {
     const factsDb = ctx.factsDb;
     const fact = factsDb.getById(factId);
@@ -1248,6 +1249,14 @@ export function performFactAction(
     try {
       const ok = factsDb.supersede(factId, null);
       if (!ok) return { ok: false, message: `Could not supersede fact ${factId}` };
+      if (ctx.vectorDb) {
+        await deleteVectorForFactId({
+          vectorDb: ctx.vectorDb,
+          factId,
+          logger: ctx.logger ?? pluginLogger,
+          context: "dashboard-forget",
+        });
+      }
     } catch {
       return { ok: false, message: `Could not forget fact ${factId}` };
     }

--- a/extensions/memory-hybrid/routes/dashboard/server.ts
+++ b/extensions/memory-hybrid/routes/dashboard/server.ts
@@ -7,7 +7,7 @@
  *   GET /api/status — JSON data for all dashboard sections
  */
 
-import type { Server } from "node:http";
+import type { IncomingMessage, Server, ServerResponse } from "node:http";
 import { createServer } from "node:http";
 import { createRequire } from "node:module";
 import { promisify } from "node:util";
@@ -86,6 +86,58 @@ function workshopCtx(ctx: DashboardContext): WorkshopDashboardContext | null {
     changeFeed: ctx.changeFeed ?? null,
     dreamCycleLogDir: ctx.dreamCycleLogDir,
   };
+}
+
+function extractDashboardAuthToken(req: IncomingMessage): string | null {
+  const bearer = req.headers.authorization;
+  if (typeof bearer === "string" && bearer.startsWith("Bearer ")) {
+    const token = bearer.slice("Bearer ".length).trim();
+    if (token) return token;
+  }
+  const header = req.headers["x-dashboard-token"];
+  if (typeof header === "string" && header.trim()) return header.trim();
+  if (Array.isArray(header) && typeof header[0] === "string" && header[0].trim()) return header[0].trim();
+  return null;
+}
+
+/** When `dashboard.token` is configured, require Bearer or X-Dashboard-Token on write routes. */
+export function isDashboardWriteAuthorized(req: IncomingMessage, ctx: DashboardContext): boolean {
+  const expected = ctx.hybridCfg?.dashboard?.token?.trim();
+  if (!expected) return true;
+  return extractDashboardAuthToken(req) === expected;
+}
+
+function rejectUnauthorizedDashboardWrite(res: ServerResponse): void {
+  res.writeHead(401, { "Content-Type": "application/json" });
+  res.end(JSON.stringify({ error: "Unauthorized" }));
+}
+
+const GRAPHQL_MUTATION_ROOT_FIELDS = [
+  "createFact",
+  "updateFact",
+  "deleteFact",
+  "supersedeFact",
+  "createLink",
+  "deleteLink",
+  "importFacts",
+  "pruneFacts",
+  "consolidateFacts",
+  "recomputeEmbeddings",
+] as const;
+
+/** Detect named and anonymous GraphQL mutations for dashboard.token auth. */
+export function graphqlBodyIsMutation(body: unknown): boolean {
+  if (typeof body !== "object" || body == null) return false;
+  const query = (body as { query?: unknown }).query;
+  if (typeof query !== "string") return false;
+  const trimmed = query.replace(/^\s*(#[^\n]*\n)*/m, "").trimStart();
+  if (trimmed.startsWith("mutation") || /\bmutation\b/.test(trimmed.slice(0, 500))) return true;
+  if (trimmed.startsWith("{")) {
+    for (const field of GRAPHQL_MUTATION_ROOT_FIELDS) {
+      if (new RegExp(`\\b${field}\\s*\\(`).test(trimmed)) return true;
+    }
+  }
+  return false;
 }
 
 export interface DashboardServer {
@@ -609,6 +661,10 @@ export async function createDashboardServer(ctx: DashboardContext, port: number)
 
     // POST /api/viewer/facts/:id/verify
     if (req.method === "POST" && pathname.match(/^\/api\/viewer\/facts\/[^/]+\/verify$/)) {
+      if (!isDashboardWriteAuthorized(req, ctx)) {
+        rejectUnauthorizedDashboardWrite(res);
+        return;
+      }
       const factIdRaw = pathname.split("/")[4];
       const factId = parseUrlPathSegment(factIdRaw ?? "");
       if (!factId) {
@@ -618,8 +674,8 @@ export async function createDashboardServer(ctx: DashboardContext, port: number)
       }
 
       readJsonBody(req, MAX_DASHBOARD_JSON_BODY_BYTES)
-        .then((parsed) => {
-          const result = performFactAction(ctx, "verify", factId, parsed);
+        .then(async (parsed) => {
+          const result = await performFactAction(ctx, "verify", factId, parsed);
           res.writeHead(result.ok ? 200 : 400, { "Content-Type": "application/json" });
           res.end(JSON.stringify(result));
         })
@@ -637,6 +693,10 @@ export async function createDashboardServer(ctx: DashboardContext, port: number)
 
     // POST /api/viewer/facts/:id/forget
     if (req.method === "POST" && pathname.match(/^\/api\/viewer\/facts\/[^/]+\/forget$/)) {
+      if (!isDashboardWriteAuthorized(req, ctx)) {
+        rejectUnauthorizedDashboardWrite(res);
+        return;
+      }
       const factIdRaw = pathname.split("/")[4];
       const factId = parseUrlPathSegment(factIdRaw ?? "");
       if (!factId) {
@@ -647,19 +707,19 @@ export async function createDashboardServer(ctx: DashboardContext, port: number)
 
       // Drain any body (defensive) and enforce size.
       readJsonBody(req, MAX_DASHBOARD_JSON_BODY_BYTES)
-        .then(() => {
-          const result = performFactAction(ctx, "forget", factId, {});
+        .then(async () => {
+          const result = await performFactAction(ctx, "forget", factId, {});
           res.writeHead(result.ok ? 200 : 400, { "Content-Type": "application/json" });
           res.end(JSON.stringify(result));
         })
-        .catch((err: unknown) => {
+        .catch(async (err: unknown) => {
           if (err instanceof Error && err.message === "Request body too large") {
             res.writeHead(413, { "Content-Type": "application/json" });
             res.end(JSON.stringify({ error: "PayloadTooLarge" }));
             return;
           }
           // Body content is ignored for forget; malformed JSON should not block the action.
-          const result = performFactAction(ctx, "forget", factId, {});
+          const result = await performFactAction(ctx, "forget", factId, {});
           res.writeHead(result.ok ? 200 : 400, { "Content-Type": "application/json" });
           res.end(JSON.stringify(result));
         });
@@ -758,6 +818,10 @@ export async function createDashboardServer(ctx: DashboardContext, port: number)
     }
 
     if (pathname === "/api/workshop/changes/revert" && wctx && req.method === "POST") {
+      if (!isDashboardWriteAuthorized(req, ctx)) {
+        rejectUnauthorizedDashboardWrite(res);
+        return;
+      }
       readJsonBody(req, MAX_DASHBOARD_JSON_BODY_BYTES)
         .then((body) => {
           const id = typeof body.id === "string" ? body.id.trim() : "";
@@ -798,6 +862,10 @@ export async function createDashboardServer(ctx: DashboardContext, port: number)
         return;
       }
       if (req.method === "POST" && actionMatch) {
+        if (!isDashboardWriteAuthorized(req, ctx)) {
+          rejectUnauthorizedDashboardWrite(res);
+          return;
+        }
         const id = parseUrlPathSegment(actionMatch[1] ?? "");
         const action = actionMatch[2];
         if (!id) {
@@ -873,6 +941,10 @@ export async function createDashboardServer(ctx: DashboardContext, port: number)
       // Handle GraphQL API requests using the shared Yoga server created at dashboard startup.
       try {
         const graphQlBody = await readJsonBody(req, MAX_DASHBOARD_JSON_BODY_BYTES);
+        if (graphqlBodyIsMutation(graphQlBody) && !isDashboardWriteAuthorized(req, ctx)) {
+          rejectUnauthorizedDashboardWrite(res);
+          return;
+        }
         const headers = new Headers();
         for (const [name, value] of Object.entries(req.headers)) {
           if (typeof value === "string") headers.set(name, value);

--- a/extensions/memory-hybrid/routes/graphql-pubsub.ts
+++ b/extensions/memory-hybrid/routes/graphql-pubsub.ts
@@ -1,0 +1,64 @@
+import { createPubSub } from "graphql-yoga";
+
+type FactSubscriptionPayload = { fact: unknown; category?: string; scope?: string };
+type FactUpdatedPayload = { fact: unknown; factId?: string; category?: string };
+type FactDeletedPayload = { id: string; category?: string };
+type LinkCreatedPayload = { link: unknown; sourceId?: string; targetId?: string };
+type StatsUpdatedPayload = { stats: unknown };
+
+export const graphqlPubSub = createPubSub<{
+  factCreated: [FactSubscriptionPayload];
+  factUpdated: [FactUpdatedPayload];
+  factDeleted: [FactDeletedPayload];
+  linkCreated: [LinkCreatedPayload];
+  statsUpdated: [StatsUpdatedPayload];
+}>();
+
+function recordValue(value: unknown, key: string): unknown {
+  return value && typeof value === "object" ? (value as Record<string, unknown>)[key] : undefined;
+}
+
+function factCategory(fact: unknown, fallback?: string): string | undefined {
+  return typeof recordValue(fact, "category") === "string" ? (recordValue(fact, "category") as string) : fallback;
+}
+
+function factScope(fact: unknown, fallback?: string): string | undefined {
+  return typeof recordValue(fact, "scope") === "string" ? (recordValue(fact, "scope") as string) : fallback;
+}
+
+function factId(fact: unknown): string | undefined {
+  return typeof recordValue(fact, "id") === "string" ? (recordValue(fact, "id") as string) : undefined;
+}
+
+function linkEndpoint(link: unknown, key: "sourceId" | "targetId", fallback?: string): string | undefined {
+  const direct = recordValue(link, key);
+  return typeof direct === "string" ? direct : fallback;
+}
+
+export function notifyGraphqlFactCreated(fact: unknown, category?: string, scope?: string): void {
+  graphqlPubSub.publish("factCreated", {
+    fact,
+    category: category ?? factCategory(fact),
+    scope: scope ?? factScope(fact),
+  });
+}
+
+export function notifyGraphqlFactUpdated(fact: unknown): void {
+  graphqlPubSub.publish("factUpdated", { fact, factId: factId(fact), category: factCategory(fact) });
+}
+
+export function notifyGraphqlFactDeleted(id: string, category?: string): void {
+  graphqlPubSub.publish("factDeleted", { id, category });
+}
+
+export function notifyGraphqlLinkCreated(link: unknown): void {
+  graphqlPubSub.publish("linkCreated", {
+    link,
+    sourceId: linkEndpoint(link, "sourceId"),
+    targetId: linkEndpoint(link, "targetId"),
+  });
+}
+
+export function notifyGraphqlStatsUpdated(stats: unknown): void {
+  graphqlPubSub.publish("statsUpdated", { stats });
+}

--- a/extensions/memory-hybrid/routes/graphql-resolvers.ts
+++ b/extensions/memory-hybrid/routes/graphql-resolvers.ts
@@ -7,9 +7,19 @@ import { isPreStoreGuardBlocked } from "../backends/facts-db/crud.js";
 import type { VectorDB } from "../backends/vector-db.js";
 import { DECAY_CLASSES, type DecayClass } from "../config.js";
 import type { MemoryLinkType } from "../backends/facts-db/types.js";
+import { isPromptArtifactOrReasoningTrace } from "../services/capture-utils.js";
 import type { MemoryEntry } from "../types/memory.js";
-import { cleanupEvictedVector } from "../services/vector-maintenance.js";
+import type { EmbeddingProvider } from "../services/embeddings/types.js";
+import { capturePluginError } from "../services/error-reporter.js";
+import { cleanupEvictedVector, deleteVectorForFactId } from "../services/vector-maintenance.js";
+import { persistCanonicalFactEmbedding } from "../utils/fact-embeddings.js";
 import { pluginLogger } from "../utils/logger.js";
+import {
+  notifyGraphqlFactCreated,
+  notifyGraphqlFactDeleted,
+  notifyGraphqlFactUpdated,
+  notifyGraphqlLinkCreated,
+} from "./graphql-pubsub.js";
 
 export type GraphQLContext = {
   factsDb: FactsDB;
@@ -42,6 +52,63 @@ function asNumber(value: unknown): number | undefined {
 
 function asStringArray(value: unknown): string[] | undefined {
   return Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : undefined;
+}
+
+function getGraphqlEmbeddings(context: GraphQLContext): EmbeddingProvider | undefined {
+  const candidate = context.pluginContext?.embeddings;
+  if (
+    candidate &&
+    typeof candidate === "object" &&
+    typeof (candidate as EmbeddingProvider).embed === "function" &&
+    typeof (candidate as EmbeddingProvider).modelName === "string"
+  ) {
+    return candidate as EmbeddingProvider;
+  }
+  return undefined;
+}
+
+function parsePruneOlderThan(value: unknown): number {
+  const asNum = asNumber(value);
+  if (asNum !== undefined) return asNum;
+  if (typeof value === "string" && value.trim()) {
+    const ms = Date.parse(value);
+    if (Number.isFinite(ms)) return Math.floor(ms / 1000);
+  }
+  throw new Error("pruneFacts requires valid olderThan (unix seconds or ISO DateTime)");
+}
+
+async function indexGraphqlFactVector(context: GraphQLContext, entry: MemoryEntry): Promise<void> {
+  const embeddings = getGraphqlEmbeddings(context);
+  if (!context.vectorDb || !embeddings) return;
+  try {
+    const vector = await embeddings.embed(entry.text);
+    context.factsDb.setEmbeddingModel(entry.id, embeddings.modelName);
+    if (!(await context.vectorDb.hasDuplicate(vector))) {
+      await context.vectorDb.store({
+        text: entry.text,
+        vector,
+        importance: entry.importance,
+        category: entry.category,
+        id: entry.id,
+      });
+    }
+    persistCanonicalFactEmbedding(
+      context.factsDb,
+      entry.id,
+      embeddings.modelName,
+      vector,
+      "graphql-mutation-index",
+      "graphql",
+      (msg) => pluginLogger.warn(msg),
+    );
+  } catch (err) {
+    capturePluginError(err instanceof Error ? err : new Error(String(err)), {
+      subsystem: "graphql",
+      operation: "indexGraphqlFactVector",
+      factId: entry.id,
+    });
+    pluginLogger.warn(`memory-hybrid: GraphQL vector index failed for ${entry.id}: ${err}`);
+  }
 }
 
 function allFacts(factsDb: FactsDB, includeSuperseded = false): MemoryEntry[] {
@@ -83,12 +150,14 @@ function searchFacts(
   const tags = asStringArray(input.tags);
   const minImportance = asNumber(input.minImportance);
   const minConfidence = asNumber(input.minConfidence);
+  const scope = asString(input.scope);
   const includeSuperseded = input.includeSuperseded === true;
   const includeExpired = input.includeExpired === true;
-  const now = Date.now();
+  const nowSec = Math.floor(Date.now() / 1000);
 
   let facts = allFacts(context.factsDb, includeSuperseded);
-  if (!includeExpired) facts = facts.filter((fact) => fact.expiresAt == null || fact.expiresAt > now);
+  if (!includeExpired) facts = facts.filter((fact) => isActiveFact(fact, nowSec));
+  if (scope) facts = facts.filter((fact) => fact.scope === scope);
   if (categories?.length) facts = facts.filter((fact) => categories.includes(fact.category));
   if (tags?.length) facts = facts.filter((fact) => tags.some((tag) => fact.tags?.includes(tag)));
   if (minImportance !== undefined) facts = facts.filter((fact) => fact.importance >= minImportance);
@@ -194,14 +263,14 @@ export const resolvers: GraphQLResolvers = {
       const scope = asString(input.scope);
       const includeSuperseded = input.includeSuperseded === true;
       const includeExpired = input.includeExpired === true;
-      const now = Date.now();
+      const nowSec = Math.floor(Date.now() / 1000);
 
       let facts = allFacts(context.factsDb, includeSuperseded);
       if (category) facts = facts.filter((fact) => fact.category === category);
       if (decayClass) facts = facts.filter((fact) => fact.decayClass === decayClass);
       if (tags?.length) facts = facts.filter((fact) => tags.some((tag) => fact.tags?.includes(tag)));
       if (scope) facts = facts.filter((fact) => fact.scope === scope);
-      if (!includeExpired) facts = facts.filter((fact) => fact.expiresAt == null || fact.expiresAt > now);
+      if (!includeExpired) facts = facts.filter((fact) => isActiveFact(fact, nowSec));
       return facts.sort((a, b) => b.createdAt - a.createdAt).slice(offset, offset + limit);
     },
 
@@ -236,11 +305,29 @@ export const resolvers: GraphQLResolvers = {
       const factId = asString(input.factId);
       if (!factId) return [];
       const maxDepth = Math.max(1, Math.min(5, asNumber(input.maxDepth) ?? 1));
-      return context.factsDb
-        .getConnectedFactIds([factId], maxDepth)
-        .filter((id) => id !== factId)
+      const linkTypes = asStringArray(input.linkTypes);
+      const nowSec = Math.floor(Date.now() / 1000);
+      let neighborIds: string[];
+      if (linkTypes?.length) {
+        neighborIds = [
+          ...new Set(
+            getAllLinks(context.factsDb)
+              .filter(
+                (link) =>
+                  linkTypes.includes(link.linkType) &&
+                  (link.sourceId === factId || link.targetId === factId),
+              )
+              .flatMap((link) => [link.sourceId, link.targetId]),
+          ),
+        ].filter((id) => id !== factId);
+      } else {
+        neighborIds = context.factsDb
+          .getConnectedFactIds([factId], maxDepth)
+          .filter((id) => id !== factId);
+      }
+      return neighborIds
         .map((id) => context.factsDb.getById(id))
-        .filter((fact): fact is MemoryEntry => fact !== null);
+        .filter((fact): fact is MemoryEntry => fact != null && isActiveFact(fact, nowSec));
     },
 
     entityFacts: (_parent, args, context) => {
@@ -248,7 +335,10 @@ export const resolvers: GraphQLResolvers = {
       const entity = asString(input.entity);
       const key = asString(input.key);
       if (!entity) return [];
-      return allFacts(context.factsDb).filter((fact) => fact.entity === entity && (!key || fact.key === key));
+      const nowSec = Math.floor(Date.now() / 1000);
+      return allFacts(context.factsDb).filter(
+        (fact) => fact.entity === entity && (!key || fact.key === key) && isActiveFact(fact, nowSec),
+      );
     },
 
     graph: (_parent, args, context) => {
@@ -262,6 +352,23 @@ export const resolvers: GraphQLResolvers = {
       if (decayClasses?.length) facts = facts.filter((fact) => decayClasses.includes(fact.decayClass));
       if (minImportance !== undefined) facts = facts.filter((fact) => fact.importance >= minImportance);
       if (scope) facts = facts.filter((fact) => fact.scope === scope);
+      const factIds = new Set(facts.map((fact) => fact.id));
+      const linkEdges = getAllLinks(context.factsDb)
+        .filter((link) => factIds.has(link.sourceId) && factIds.has(link.targetId))
+        .map((link) => ({
+          source: link.sourceId,
+          target: link.targetId,
+          linkType: link.linkType,
+          weight: link.weight,
+        }));
+      const supersedeEdges = facts
+        .filter((fact) => fact.supersededBy)
+        .map((fact) => ({
+          source: fact.id,
+          target: fact.supersededBy as string,
+          linkType: "superseded_by",
+          weight: 1,
+        }));
       return {
         nodes: facts.map((fact) => ({
           id: fact.id,
@@ -272,14 +379,7 @@ export const resolvers: GraphQLResolvers = {
           decayClass: fact.decayClass,
           factCount: 1,
         })),
-        edges: facts
-          .filter((fact) => fact.supersededBy)
-          .map((fact) => ({
-            source: fact.id,
-            target: fact.supersededBy as string,
-            linkType: "superseded_by",
-            weight: 1,
-          })),
+        edges: [...linkEdges, ...supersedeEdges],
       };
     },
 
@@ -305,8 +405,11 @@ export const resolvers: GraphQLResolvers = {
         factsByCategory: [...byCategory].map(([category, count]) => ({ category, count })),
         factsByDecayClass: [...byDecay].map(([decayClass, count]) => ({ decayClass, count })),
         totalEpisodes: 0,
-        totalLinks: 0,
-        databaseSizeBytes: 0,
+        totalLinks: getAllLinks(context.factsDb).length,
+        databaseSizeBytes:
+          typeof context.factsDb.estimateStorageBytes === "function"
+            ? context.factsDb.estimateStorageBytes().sqliteBytes
+            : 0,
         oldestFactDate: facts.length ? Math.min(...facts.map((fact) => fact.createdAt)) : null,
         newestFactDate: facts.length ? Math.max(...facts.map((fact) => fact.createdAt)) : null,
       };
@@ -321,6 +424,10 @@ export const resolvers: GraphQLResolvers = {
         throw new Error("Fact rejected: artifact or reasoning trace text cannot be stored");
       }
       await cleanupGraphqlEviction(context, result.evictedFactId);
+      if (result.newlyStored) {
+        await indexGraphqlFactVector(context, result.entry);
+        notifyGraphqlFactCreated(result.entry, result.entry.category, result.entry.scope);
+      }
       return result.entry;
     },
 
@@ -331,6 +438,9 @@ export const resolvers: GraphQLResolvers = {
       const existing = context.factsDb.getById(id);
       if (!existing) throw new Error(`Fact not found: ${id}`);
       const updatedText = asString(input.text) ?? existing.text;
+      if (isPromptArtifactOrReasoningTrace(updatedText)) {
+        throw new Error("Fact rejected: artifact or reasoning trace text cannot be stored");
+      }
       const result = context.factsDb.storeWithResult(
         {
           text: updatedText,
@@ -352,17 +462,41 @@ export const resolvers: GraphQLResolvers = {
       // Skip supersede if store was rejected (artifact text) or deduped to an existing row
       if (result.entry.id !== "" && result.newlyStored) {
         context.factsDb.supersede(existing.id, result.entry.id);
+        if (context.vectorDb) {
+          await deleteVectorForFactId({
+            vectorDb: context.vectorDb,
+            factId: existing.id,
+            logger: pluginLogger,
+            context: "graphql-update-supersede",
+          });
+        }
+        await indexGraphqlFactVector(context, result.entry);
+        notifyGraphqlFactUpdated(result.entry);
       }
       await cleanupGraphqlEviction(context, result.evictedFactId);
       return result.entry;
     },
 
-    deleteFact: (_parent, args, context) => {
+    deleteFact: async (_parent, args, context) => {
       const id = asString(asRecord(args).id);
-      return id ? context.factsDb.delete(id) : false;
+      if (!id) return false;
+      const existing = context.factsDb.getById(id);
+      const deleted = context.factsDb.delete(id);
+      if (deleted && context.vectorDb) {
+        await deleteVectorForFactId({
+          vectorDb: context.vectorDb,
+          factId: id,
+          logger: pluginLogger,
+          context: "graphql-delete-fact",
+        });
+      }
+      if (deleted) {
+        notifyGraphqlFactDeleted(id, existing?.category);
+      }
+      return deleted;
     },
 
-    supersedeFact: (_parent, args, context) => {
+    supersedeFact: async (_parent, args, context) => {
       const input = asRecord(args);
       const oldFactId = asString(input.oldFactId);
       const newFactId = asString(input.newFactId);
@@ -373,6 +507,15 @@ export const resolvers: GraphQLResolvers = {
       if (!newFact) throw new Error(`Fact not found: ${newFactId}`);
       const applied = context.factsDb.supersede(oldFactId, newFactId);
       if (!applied) throw new Error(`Fact supersede did not apply: ${oldFactId}`);
+      if (context.vectorDb) {
+        await deleteVectorForFactId({
+          vectorDb: context.vectorDb,
+          factId: oldFactId,
+          logger: pluginLogger,
+          context: "graphql-supersede",
+        });
+      }
+      notifyGraphqlFactUpdated(newFact);
       return newFact;
     },
 
@@ -385,7 +528,9 @@ export const resolvers: GraphQLResolvers = {
       if (!sourceId || !targetId) throw new Error("Missing link endpoint");
       if (!isMemoryLinkType(linkType)) throw new Error(`Unsupported link type: ${linkType}`);
       const id = context.factsDb.createLink(sourceId, targetId, linkType, weight);
-      return getAllLinks(context.factsDb).find((link) => link.id === id);
+      const link = getAllLinks(context.factsDb).find((entry) => entry.id === id);
+      if (link) notifyGraphqlLinkCreated(link);
+      return link;
     },
     deleteLink: (_parent, args, context) => {
       const id = asString(asRecord(args).id);
@@ -410,28 +555,48 @@ export const resolvers: GraphQLResolvers = {
         const result = context.factsDb.storeWithResult(input);
         if (result.entry.id !== "" && result.newlyStored) {
           stored.push(result.entry);
+          await indexGraphqlFactVector(context, result.entry);
+          notifyGraphqlFactCreated(result.entry, result.entry.category, result.entry.scope);
         }
         await cleanupGraphqlEviction(context, result.evictedFactId);
       }
       return stored;
     },
 
-    pruneFacts: (_parent, args, context) => {
+    pruneFacts: async (_parent, args, context) => {
       const input = asRecord(args);
-      const olderThan = asNumber(input.olderThan);
+      if (input.olderThan == null) {
+        throw new Error("pruneFacts requires olderThan (unix seconds or ISO DateTime)");
+      }
+      const olderThan = parsePruneOlderThan(input.olderThan);
       const category = asString(input.category);
       const toDelete = allFacts(context.factsDb).filter(
-        (fact) => (olderThan === undefined || fact.createdAt < olderThan) && (!category || fact.category === category),
+        (fact) => fact.createdAt < olderThan && (!category || fact.category === category),
       );
       let deleted = 0;
       for (const fact of toDelete) {
-        if (context.factsDb.delete(fact.id)) deleted++;
+        if (context.factsDb.delete(fact.id)) {
+          deleted++;
+          notifyGraphqlFactDeleted(fact.id, fact.category);
+          if (context.vectorDb) {
+            await deleteVectorForFactId({
+              vectorDb: context.vectorDb,
+              factId: fact.id,
+              logger: pluginLogger,
+              context: "graphql-prune-facts",
+            });
+          }
+        }
       }
       return deleted;
     },
 
-    consolidateFacts: () => null,
-    recomputeEmbeddings: () => null,
+    consolidateFacts: () => {
+      throw new Error("consolidateFacts is not implemented; use maintenance CLI consolidate instead");
+    },
+    recomputeEmbeddings: () => {
+      throw new Error("recomputeEmbeddings is not implemented; use the reindex CLI command instead");
+    },
   },
 
   Fact: {

--- a/extensions/memory-hybrid/routes/graphql-server.ts
+++ b/extensions/memory-hybrid/routes/graphql-server.ts
@@ -8,10 +8,11 @@ interface MemoryPluginContext {
   [key: string]: unknown;
 }
 
-import { createSchema, createYoga, createPubSub } from "graphql-yoga";
+import { createSchema, createYoga } from "graphql-yoga";
 import type { FactsDB } from "../backends/facts-db.js";
 import type { VectorDB } from "../backends/vector-db.js";
 import { graphqlSchema } from "./graphql-schema.js";
+import { graphqlPubSub } from "./graphql-pubsub.js";
 import { pluginLogger } from "../utils/logger.js";
 import { resolvers, type GraphQLContext } from "./graphql-resolvers.js";
 
@@ -21,14 +22,7 @@ type FactDeletedPayload = { id: string; category?: string };
 type LinkCreatedPayload = { link: unknown; sourceId?: string; targetId?: string };
 type StatsUpdatedPayload = { stats: unknown };
 
-// PubSub for subscriptions
-const pubSub = createPubSub<{
-  factCreated: [FactSubscriptionPayload];
-  factUpdated: [FactUpdatedPayload];
-  factDeleted: [FactDeletedPayload];
-  linkCreated: [LinkCreatedPayload];
-  statsUpdated: [StatsUpdatedPayload];
-}>();
+const pubSub = graphqlPubSub;
 
 function recordValue(value: unknown, key: string): unknown {
   return value && typeof value === "object" ? (value as Record<string, unknown>)[key] : undefined;
@@ -260,7 +254,7 @@ subscription WatchNewFacts {
  * Publish fact created event
  */
 export function publishFactCreated(
-  pubSub: ReturnType<typeof createPubSub>,
+  pubSub: typeof graphqlPubSub,
   fact: unknown,
   category?: string,
   scope?: string,
@@ -271,21 +265,21 @@ export function publishFactCreated(
 /**
  * Publish fact updated event
  */
-export function publishFactUpdated(pubSub: ReturnType<typeof createPubSub>, fact: unknown) {
+export function publishFactUpdated(pubSub: typeof graphqlPubSub, fact: unknown) {
   pubSub.publish("factUpdated", { fact, factId: factId(fact), category: factCategory(fact) });
 }
 
 /**
  * Publish fact deleted event
  */
-export function publishFactDeleted(pubSub: ReturnType<typeof createPubSub>, id: string, category?: string) {
+export function publishFactDeleted(pubSub: typeof graphqlPubSub, id: string, category?: string) {
   pubSub.publish("factDeleted", { id, category });
 }
 
 /**
  * Publish stats updated event
  */
-export function publishLinkCreated(pubSub: ReturnType<typeof createPubSub>, link: unknown) {
+export function publishLinkCreated(pubSub: typeof graphqlPubSub, link: unknown) {
   pubSub.publish("linkCreated", {
     link,
     sourceId: linkEndpoint(link, "sourceId"),
@@ -293,6 +287,6 @@ export function publishLinkCreated(pubSub: ReturnType<typeof createPubSub>, link
   });
 }
 
-export function publishStatsUpdated(pubSub: ReturnType<typeof createPubSub>, stats: unknown) {
+export function publishStatsUpdated(pubSub: typeof graphqlPubSub, stats: unknown) {
   pubSub.publish("statsUpdated", { stats });
 }

--- a/extensions/memory-hybrid/services/capture-dedup.ts
+++ b/extensions/memory-hybrid/services/capture-dedup.ts
@@ -5,6 +5,8 @@
 import { createHash } from "node:crypto";
 import type { DatabaseSync } from "node:sqlite";
 
+import { createTransaction } from "../utils/sqlite-transaction.js";
+
 export type CaptureDedupInput = {
   text: string;
   entity?: string | null;
@@ -25,11 +27,8 @@ export function computeCaptureDedupHash(input: CaptureDedupInput): string {
   return createHash("sha256").update(payload).digest("hex");
 }
 
-/**
- * When an identical hash exists within the window for the same scope, bump duplicate_count
- * on the existing row and return skip=true. Otherwise returns skip=false.
- */
-export function checkCaptureDedupWindow(
+/** Read-only dedup window probe — does not bump duplicate_count. */
+export function peekCaptureDedupWindow(
   db: DatabaseSync,
   input: CaptureDedupInput,
   windowMinutes: number,
@@ -49,6 +48,58 @@ export function checkCaptureDedupWindow(
     )
     .get(hash, cutoff, scope, scopeTarget, scopeTarget, scopeTarget) as { id: string } | undefined;
   if (!row) return { skip: false };
-  db.prepare(`UPDATE facts SET duplicate_count = COALESCE(duplicate_count, 0) + 1 WHERE id = ?`).run(row.id);
   return { skip: true, existingId: row.id };
+}
+
+/**
+ * When an identical hash exists within the window for the same scope, bump duplicate_count
+ * on the existing row and return skip=true. Otherwise returns skip=false.
+ */
+export function checkCaptureDedupWindow(
+  db: DatabaseSync,
+  input: CaptureDedupInput,
+  windowMinutes: number,
+): { skip: boolean; existingId?: string } {
+  const peek = peekCaptureDedupWindow(db, input, windowMinutes);
+  if (!peek.skip || !peek.existingId) return peek;
+  db.prepare(`UPDATE facts SET duplicate_count = COALESCE(duplicate_count, 0) + 1 WHERE id = ?`).run(peek.existingId);
+  return peek;
+}
+
+export type CaptureStoreDedupResult<TStoreResult extends { skipped?: boolean; entry: { id: string } }> =
+  | { skipped: true; dedupExistingId?: string }
+  | { skipped: false; storeResult: TStoreResult };
+
+/**
+ * Store with optional observation dedup window (#1913).
+ * When factsDb has no getRawDb(), skips the transaction wrapper and dedup hash write.
+ */
+export function runCaptureStoreWithDedupWindow<TStoreResult extends { skipped?: boolean; entry: { id: string } }>(
+  factsDb: { getRawDb?: () => DatabaseSync },
+  dedupWindowMinutes: number,
+  dedupInput: CaptureDedupInput,
+  store: () => TStoreResult,
+): CaptureStoreDedupResult<TStoreResult> {
+  const execute = (): CaptureStoreDedupResult<TStoreResult> => {
+    const rawDb = typeof factsDb.getRawDb === "function" ? factsDb.getRawDb() : null;
+    if (rawDb && dedupWindowMinutes > 0) {
+      const dedupCheck = checkCaptureDedupWindow(rawDb, dedupInput, dedupWindowMinutes);
+      if (dedupCheck.skip) {
+        return { skipped: true, dedupExistingId: dedupCheck.existingId };
+      }
+    }
+    const storeResult = store();
+    if (rawDb && dedupWindowMinutes > 0 && !storeResult.skipped) {
+      rawDb
+        .prepare("UPDATE facts SET content_dedup_hash = ? WHERE id = ?")
+        .run(computeCaptureDedupHash(dedupInput), storeResult.entry.id);
+    }
+    return { skipped: false, storeResult };
+  };
+
+  const rawDb = typeof factsDb.getRawDb === "function" ? factsDb.getRawDb() : null;
+  if (rawDb) {
+    return createTransaction(rawDb, execute, "IMMEDIATE")();
+  }
+  return execute();
 }

--- a/extensions/memory-hybrid/services/dedupe-policy.ts
+++ b/extensions/memory-hybrid/services/dedupe-policy.ts
@@ -29,6 +29,15 @@ function globToRegExp(pattern: string): RegExp {
   return new RegExp(`^${escaped}$`);
 }
 
+/** Distillation re-extractions may drift entity slug within the same project namespace (#1947). */
+function entitiesCompatibleForDistillation(candidateEntity: string, matchedEntity: string | null): boolean {
+  if (!matchedEntity) return false;
+  const a = candidateEntity.trim();
+  const b = matchedEntity.trim();
+  if (a === b) return true;
+  return a.startsWith(`${b}-`) || b.startsWith(`${a}-`);
+}
+
 function normalizeProfile(sourcePattern: string, raw?: StoreConfig["defaultProfile"]): Partial<ResolvedDedupeProfile> {
   const partial: Partial<ResolvedDedupeProfile> = { sourcePattern };
   if (typeof raw?.vectorThreshold === "number" && raw.vectorThreshold > 0 && raw.vectorThreshold <= 1) {
@@ -209,6 +218,48 @@ function resolveVectorDuplicateCandidate(
   return bestVec;
 }
 
+function resolveProjectVectorDuplicateCandidate(
+  profile: ResolvedDedupeProfile,
+  ctx: ApplyDedupeContext,
+  entity: string,
+  key: string,
+  candidateSource: string,
+): { id: string; score: number } | null {
+  if (
+    profile.vectorThreshold == null ||
+    profile.vectorThreshold <= 0 ||
+    profile.vectorThreshold > 1 ||
+    !ctx.vectorCandidates ||
+    ctx.vectorCandidates.length === 0
+  ) {
+    return null;
+  }
+  const ranked = [...ctx.vectorCandidates]
+    .filter((cand) => typeof cand.score === "number" && cand.score >= profile.vectorThreshold!)
+    .sort((a, b) => b.score - a.score);
+  for (const vectorDup of ranked) {
+    const matched = ctx.db
+      .prepare("SELECT entity, key, category FROM facts WHERE id = ? AND superseded_at IS NULL LIMIT 1")
+      .get(vectorDup.id) as { entity: string | null; key: string | null; category: string | null } | undefined;
+    if (!matched || matched.category?.trim().toLowerCase() !== "project") {
+      continue;
+    }
+    const matchedEntity = matched.entity?.trim() ?? null;
+    const matchedKey = matched.key?.trim() ?? null;
+    const sameKey = matchedKey === key;
+    const sameEntityAndKey = matchedEntity === entity && sameKey;
+    if (
+      sameEntityAndKey ||
+      (candidateSource === "distillation" &&
+        sameKey &&
+        entitiesCompatibleForDistillation(entity, matchedEntity))
+    ) {
+      return vectorDup;
+    }
+  }
+  return null;
+}
+
 /**
  * Decide how a candidate fact should be handled before insert.
  * Side-effect free (no SQL writes).
@@ -271,21 +322,9 @@ export function applyDedupe(
     if (existing) {
       return mapOnDuplicate(profile, existing.id, "exact");
     }
-    const vectorDup = resolveVectorDuplicateCandidate(profile, ctx);
+    const vectorDup = resolveProjectVectorDuplicateCandidate(profile, ctx, entity, key, candidate.source);
     if (vectorDup) {
-      const matched = ctx.db
-        .prepare("SELECT entity, key FROM facts WHERE id = ? AND superseded_at IS NULL LIMIT 1")
-        .get(vectorDup.id) as { entity: string | null; key: string | null } | undefined;
-      if (!matched) {
-        return { action: "store" };
-      }
-      // Distillation re-extractions may drift entity slug while keeping the same key (#1947).
-      // Active-task projection still requires exact entity+key for other sources (#1276).
-      const sameKey = matched.key === key;
-      const sameEntityAndKey = matched.entity === entity && sameKey;
-      if (sameEntityAndKey || (candidate.source === "distillation" && sameKey)) {
-        return mapOnDuplicate(profile, vectorDup.id, "vector");
-      }
+      return mapOnDuplicate(profile, vectorDup.id, "vector");
     }
     return { action: "store" };
   }

--- a/extensions/memory-hybrid/services/dedupe-policy.ts
+++ b/extensions/memory-hybrid/services/dedupe-policy.ts
@@ -60,6 +60,9 @@ export function resolveDedupeProfile(source: string | null | undefined, store: S
   if (profiles[sourceKey]) {
     const normalized = normalizeProfile(sourceKey, profiles[sourceKey]);
     const merged = { ...base, ...normalized };
+    if (sourceKey === "distillation" && normalized.vectorThreshold === undefined) {
+      merged.vectorThreshold = DISTILL_DEDUP_THRESHOLD;
+    }
     // If user configured a source-specific profile without explicit onDuplicate, default to "store"
     if (normalized.onDuplicate === undefined) {
       merged.onDuplicate = "store";
@@ -72,7 +75,6 @@ export function resolveDedupeProfile(source: string | null | undefined, store: S
     if (globToRegExp(pattern).test(sourceKey)) {
       const normalized = normalizeProfile(pattern, profile);
       const merged = { ...base, ...normalized };
-      // If user configured a glob profile without explicit onDuplicate, default to "store"
       if (normalized.onDuplicate === undefined) {
         merged.onDuplicate = "store";
       }
@@ -274,7 +276,14 @@ export function applyDedupe(
       const matched = ctx.db
         .prepare("SELECT entity, key FROM facts WHERE id = ? AND superseded_at IS NULL LIMIT 1")
         .get(vectorDup.id) as { entity: string | null; key: string | null } | undefined;
-      if (matched?.entity === entity && matched?.key === key) {
+      if (!matched) {
+        return { action: "store" };
+      }
+      // Distillation re-extractions may drift entity slug while keeping the same key (#1947).
+      // Active-task projection still requires exact entity+key for other sources (#1276).
+      const sameKey = matched.key === key;
+      const sameEntityAndKey = matched.entity === entity && sameKey;
+      if (sameEntityAndKey || (candidate.source === "distillation" && sameKey)) {
         return mapOnDuplicate(profile, vectorDup.id, "vector");
       }
     }

--- a/extensions/memory-hybrid/services/dedupe-policy.ts
+++ b/extensions/memory-hybrid/services/dedupe-policy.ts
@@ -1,6 +1,7 @@
 import type { DatabaseSync } from "node:sqlite";
 
 import type { StoreConfig, StoreDedupeAction, StoreOverflowAction } from "../config/types/core.js";
+import { DISTILL_DEDUP_THRESHOLD } from "../utils/constants.js";
 import { normalizedHash } from "../utils/tags.js";
 
 export type ResolvedDedupeProfile = {
@@ -77,6 +78,10 @@ export function resolveDedupeProfile(source: string | null | undefined, store: S
       }
       return merged;
     }
+  }
+
+  if (sourceKey === "distillation") {
+    return { ...base, vectorThreshold: DISTILL_DEDUP_THRESHOLD };
   }
 
   return base;
@@ -176,6 +181,32 @@ function tokenJaccard(a: Set<string>, b: Set<string>): number {
 const JACCARD_LOOKBACK_SEC = 120 * 24 * 60 * 60;
 const JACCARD_ROW_LIMIT = 200;
 
+function resolveVectorDuplicateCandidate(
+  profile: ResolvedDedupeProfile,
+  ctx: ApplyDedupeContext,
+): { id: string; score: number } | null {
+  if (
+    profile.vectorThreshold == null ||
+    profile.vectorThreshold <= 0 ||
+    profile.vectorThreshold > 1 ||
+    !ctx.vectorCandidates ||
+    ctx.vectorCandidates.length === 0
+  ) {
+    return null;
+  }
+  let bestVec: { id: string; score: number } | null = null;
+  for (const cand of ctx.vectorCandidates) {
+    if (
+      typeof cand.score === "number" &&
+      cand.score >= profile.vectorThreshold &&
+      (bestVec === null || cand.score > bestVec.score)
+    ) {
+      bestVec = { id: cand.id, score: cand.score };
+    }
+  }
+  return bestVec;
+}
+
 /**
  * Decide how a candidate fact should be handled before insert.
  * Side-effect free (no SQL writes).
@@ -238,6 +269,15 @@ export function applyDedupe(
     if (existing) {
       return mapOnDuplicate(profile, existing.id, "exact");
     }
+    const vectorDup = resolveVectorDuplicateCandidate(profile, ctx);
+    if (vectorDup) {
+      const matched = ctx.db
+        .prepare("SELECT entity, key FROM facts WHERE id = ? AND superseded_at IS NULL LIMIT 1")
+        .get(vectorDup.id) as { entity: string | null; key: string | null } | undefined;
+      if (matched?.entity === entity && matched?.key === key) {
+        return mapOnDuplicate(profile, vectorDup.id, "vector");
+      }
+    }
     return { action: "store" };
   }
 
@@ -299,16 +339,7 @@ export function applyDedupe(
     ctx.vectorCandidates &&
     ctx.vectorCandidates.length > 0
   ) {
-    let bestVec: { id: string; score: number } | null = null;
-    for (const cand of ctx.vectorCandidates) {
-      if (
-        typeof cand.score === "number" &&
-        cand.score >= profile.vectorThreshold &&
-        (bestVec === null || cand.score > bestVec.score)
-      ) {
-        bestVec = { id: cand.id, score: cand.score };
-      }
-    }
+    const bestVec = resolveVectorDuplicateCandidate(profile, ctx);
     if (bestVec) {
       return mapOnDuplicate(profile, bestVec.id, "vector");
     }

--- a/extensions/memory-hybrid/services/passive-observer.ts
+++ b/extensions/memory-hybrid/services/passive-observer.ts
@@ -36,9 +36,8 @@ import {
 } from "./recalled-context-assembler.js";
 import type { ProvenanceService } from "./provenance.js";
 import { cleanupEvictedVector } from "./vector-maintenance.js";
-import { checkCaptureDedupWindow, computeCaptureDedupHash } from "./capture-dedup.js";
+import { runCaptureStoreWithDedupWindow } from "./capture-dedup.js";
 import { dotProductSimilarity, normalizeVector } from "./reflection.js";
-import { createTransaction } from "../utils/sqlite-transaction.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -603,6 +602,7 @@ export async function runPassiveObserver(
         if (!storedText || !isSubstantiveMemoryText(storedText)) continue;
         const storedCategory =
           (prepareMemoryMetadataForStorage(fact.category) as MemoryCategory | undefined) ?? fact.category;
+        const identity = isIdentityFact(storedText, opts.agentName);
 
         // Embed new fact for dedup check
         let vec: number[];
@@ -629,6 +629,8 @@ export async function runPassiveObserver(
         // While OpenAI embeddings are pre-normalized, Ollama and some other providers return
         // unnormalized vectors, causing the L2 distance to be scaled by vector magnitude.
         const normalizedVec = normalizeVector(vec);
+        const dedupScope = identity ? "global" : "session";
+        const dedupScopeTarget = identity ? null : sessionId;
 
         // Dedup check via LanceDB ANN search — O(log n) instead of O(n*m) brute-force.
         // Replaces the old recentVectors[] linear scan and eliminates the embedBatch()
@@ -637,16 +639,26 @@ export async function runPassiveObserver(
         try {
           const dupeResults = await vectorDb.search(normalizedVec, 1, similarityThreshold);
           if (dupeResults.length > 0) {
-            isDuplicate = true;
-            // Confidence reinforcement: boost the matched fact instead of silently skipping (Issue #147)
-            if (reinforcementEnabled && !opts.dryRun) {
-              const matchedId = dupeResults[0].entry.id;
-              if (matchedId) {
-                try {
-                  const boosted = factsDb.boostConfidence(matchedId, passiveBoost, maxConfidence);
-                  if (boosted) result.factsReinforced++;
-                } catch {
-                  // Non-fatal — don't fail passive observer because of boost error
+            const matchedId = dupeResults[0].entry.id;
+            const matched = matchedId ? factsDb.getById(matchedId) : null;
+            const nowSec = Math.floor(Date.now() / 1000);
+            const scopeMatches =
+              matched != null &&
+              matched.supersededAt == null &&
+              (matched.expiresAt == null || matched.expiresAt > nowSec) &&
+              (matched.scope ?? "global") === dedupScope &&
+              (dedupScope === "global" ? null : (matched.scopeTarget ?? null)) === dedupScopeTarget;
+            if (scopeMatches) {
+              isDuplicate = true;
+              // Confidence reinforcement: boost the matched fact instead of silently skipping (Issue #147)
+              if (reinforcementEnabled && !opts.dryRun) {
+                if (matchedId) {
+                  try {
+                    const boosted = factsDb.boostConfidence(matchedId, passiveBoost, maxConfidence);
+                    if (boosted) result.factsReinforced++;
+                  } catch {
+                    // Non-fatal — don't fail passive observer because of boost error
+                  }
                 }
               }
             }
@@ -725,7 +737,6 @@ export async function runPassiveObserver(
 
         // Identity fact promotion (Issue #306): if this fact describes the agent itself,
         // store it as global/permanent so it persists across sessions.
-        const identity = isIdentityFact(storedText, opts.agentName);
         if (identity) {
           logger.info(`passive-observer: promoting identity fact to global/permanent: "${storedText.slice(0, 60)}..."`);
         }
@@ -735,21 +746,16 @@ export async function runPassiveObserver(
           text: storedText,
           entity: null,
           key: null,
-          scope: identity ? "global" : "session",
-          scopeTarget: identity ? null : sessionId,
+          scope: dedupScope,
+          scopeTarget: dedupScopeTarget,
         };
 
-        const storeWithDedupCheck = createTransaction(
-          factsDb.getRawDb(),
-          () => {
-            if (dedupWindow > 0 && typeof factsDb.getRawDb === "function") {
-              const dedupCheck = checkCaptureDedupWindow(factsDb.getRawDb(), dedupInput, dedupWindow);
-              if (dedupCheck.skip) {
-                return { skipped: true };
-              }
-            }
-
-            const storeResult = factsDb.storeWithResult({
+        const txResult = runCaptureStoreWithDedupWindow(
+          factsDb,
+          dedupWindow,
+          dedupInput,
+          () =>
+            factsDb.storeWithResult({
               text: storedText,
               category: storedCategory,
               importance: identity ? Math.max(fact.importance, 0.9) : fact.importance,
@@ -765,22 +771,8 @@ export async function runPassiveObserver(
               provenanceSession: sessionId,
               extractionMethod: "passive",
               extractionConfidence: fact.importance,
-            });
-
-            if (!storeResult.skipped && storeResult.newlyStored !== false && dedupWindow > 0) {
-              const dedupHash = computeCaptureDedupHash(dedupInput);
-              factsDb
-                .getRawDb()
-                .prepare("UPDATE facts SET content_dedup_hash = ? WHERE id = ?")
-                .run(dedupHash, storeResult.entry.id);
-            }
-
-            return { skipped: false, storeResult };
-          },
-          "IMMEDIATE",
+            }),
         );
-
-        const txResult = storeWithDedupCheck();
         if (txResult.skipped) {
           continue;
         }

--- a/extensions/memory-hybrid/setup/plugin-service.ts
+++ b/extensions/memory-hybrid/setup/plugin-service.ts
@@ -619,6 +619,9 @@ export function createPluginService(ctx: PluginServiceContext) {
               toolProposalStore: toolProposalStore ?? null,
               dreamCycleLogDir: resolveDreamCycleLogDir(),
               changeFeed: changeFeed ?? null,
+              cfg,
+              embeddings,
+              embeddingRegistry,
             },
             cfg.dashboard.port,
           );

--- a/extensions/memory-hybrid/tests/capture-dedup-window.test.ts
+++ b/extensions/memory-hybrid/tests/capture-dedup-window.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it, vi } from "vitest";
+import { runCaptureStoreWithDedupWindow } from "../services/capture-dedup.js";
+
+describe("runCaptureStoreWithDedupWindow", () => {
+  it("stores without a transaction when factsDb has no getRawDb()", () => {
+    const storeWithResult = vi.fn().mockReturnValue({
+      skipped: false,
+      entry: { id: "fact-1" },
+    });
+    const factsDb = { storeWithResult };
+
+    const result = runCaptureStoreWithDedupWindow(
+      factsDb,
+      30,
+      { text: "hello", scope: "global", scopeTarget: null },
+      () => storeWithResult({ text: "hello" }),
+    );
+
+    expect(result.skipped).toBe(false);
+    expect(storeWithResult).toHaveBeenCalledOnce();
+  });
+});

--- a/extensions/memory-hybrid/tests/dashboard-server.test.ts
+++ b/extensions/memory-hybrid/tests/dashboard-server.test.ts
@@ -31,7 +31,7 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { parseDashboardConfig } from "../config/parsers/features.js";
 import { _testing } from "../index.js";
-import { collectStatus, createDashboardServer } from "../routes/dashboard-server.js";
+import { collectStatus, createDashboardServer, graphqlBodyIsMutation } from "../routes/dashboard-server.js";
 import * as fsUtils from "../utils/fs.js";
 
 const { FactsDB, VectorDB } = _testing;
@@ -164,6 +164,18 @@ describe("parseDashboardConfig", () => {
   it("enabled=false disables the server", () => {
     const cfg = parseDashboardConfig({ dashboard: { enabled: false } });
     expect(cfg.enabled).toBe(false);
+  });
+
+  it("parses optional dashboard token", () => {
+    const cfg = parseDashboardConfig({ dashboard: { token: "  secret-token  " } });
+    expect(cfg.token).toBe("secret-token");
+  });
+
+  it("graphqlBodyIsMutation detects named and anonymous mutations", () => {
+    expect(graphqlBodyIsMutation({ query: "{ __typename }" })).toBe(false);
+    expect(graphqlBodyIsMutation({ query: "mutation { deleteFact(id: \"x\") }" })).toBe(true);
+    expect(graphqlBodyIsMutation({ query: '{ deleteFact(id: "x") }' })).toBe(true);
+    expect(graphqlBodyIsMutation({ query: "query { facts { id } }" })).toBe(false);
   });
 });
 
@@ -526,10 +538,21 @@ describe("Memory Viewer API (Issue #1023)", () => {
     });
   }
 
-  async function apiPost(port: number, path: string, body: string) {
+  async function apiPost(
+    port: number,
+    path: string,
+    body: string,
+    extraHeaders: Record<string, string> = {},
+  ) {
     return new Promise<{ status: number; body: string }>((resolve) => {
       const req = request(
-        { hostname: "127.0.0.1", port, path, method: "POST", headers: { "Content-Type": "application/json" } },
+        {
+          hostname: "127.0.0.1",
+          port,
+          path,
+          method: "POST",
+          headers: { "Content-Type": "application/json", ...extraHeaders },
+        },
         (res) => {
           let data = "";
           res.on("data", (c: Buffer) => {
@@ -802,6 +825,25 @@ describe("Memory Viewer API (Issue #1023)", () => {
     });
   });
 
+  it("POST /api/viewer/facts/:id/forget deletes the LanceDB vector", async () => {
+    await withServer(async (ctx, port) => {
+      const entry = ctx.factsDb.store({ text: "To forget vector", category: "fact", source: "test" });
+      const vector = new Array(VECTOR_DIM).fill(0.1);
+      await ctx.vectorDb.store({
+        text: entry.text,
+        vector,
+        importance: 0.5,
+        category: "fact",
+        id: entry.id,
+      });
+      const deleteSpy = vi.spyOn(ctx.vectorDb, "delete").mockResolvedValue(true);
+      const { status, body } = await apiPost(port, `/api/viewer/facts/${entry.id}/forget`, "{}");
+      expect(status).toBe(200);
+      expect(JSON.parse(body).ok).toBe(true);
+      expect(deleteSpy).toHaveBeenCalledWith(entry.id);
+    });
+  });
+
   it("POST /api/viewer/facts/:id/forget forgets a fact", async () => {
     await withServer(async (ctx, port) => {
       ctx.factsDb.store({ text: "To forget", category: "fact", source: "test" });
@@ -813,6 +855,73 @@ describe("Memory Viewer API (Issue #1023)", () => {
       expect(status).toBe(200);
       expect(JSON.parse(body).ok).toBe(true);
     });
+  });
+
+  it("POST forget returns 401 when dashboard.token is configured and missing", async () => {
+    const td = mkdtempSync(join(tmpdir(), "dashboard-auth-forget-"));
+    try {
+      const ctx = await makeContextWithStores(td);
+      ctx.hybridCfg = { dashboard: { enabled: true, port: 7700, token: "test-secret" } };
+      const srv = await createDashboardServer(ctx, 0);
+      try {
+        const entry = ctx.factsDb.store({ text: "Auth forget", category: "fact", source: "test" });
+        const unauthorized = await apiPost(srv.port, `/api/viewer/facts/${entry.id}/forget`, "{}");
+        expect(unauthorized.status).toBe(401);
+        const authorized = await apiPost(srv.port, `/api/viewer/facts/${entry.id}/forget`, "{}", {
+          Authorization: "Bearer test-secret",
+        });
+        expect(authorized.status).toBe(200);
+        expect(JSON.parse(authorized.body).ok).toBe(true);
+      } finally {
+        closeAll(ctx);
+        srv.close();
+      }
+    } finally {
+      rmSync(td, { recursive: true, force: true });
+    }
+  });
+
+  it("POST /graphql allows read-only queries without dashboard.token", async () => {
+    const td = mkdtempSync(join(tmpdir(), "dashboard-auth-gql-read-"));
+    try {
+      const ctx = await makeContextWithStores(td);
+      ctx.hybridCfg = { dashboard: { enabled: true, port: 7700, token: "test-secret" } };
+      const srv = await createDashboardServer(ctx, 0);
+      try {
+        const query = JSON.stringify({ query: "{ __typename }" });
+        const res = await apiPost(srv.port, "/graphql", query);
+        expect(res.status).not.toBe(401);
+      } finally {
+        closeAll(ctx);
+        srv.close();
+      }
+    } finally {
+      rmSync(td, { recursive: true, force: true });
+    }
+  });
+
+  it("POST /graphql anonymous deleteFact returns 401 when dashboard.token is set", async () => {
+    const td = mkdtempSync(join(tmpdir(), "dashboard-auth-gql-mut-"));
+    try {
+      const ctx = await makeContextWithStores(td);
+      ctx.hybridCfg = { dashboard: { enabled: true, port: 7700, token: "test-secret" } };
+      const srv = await createDashboardServer(ctx, 0);
+      try {
+        const entry = ctx.factsDb.store({ text: "GQL delete", category: "fact", source: "test" });
+        const query = JSON.stringify({ query: `{ deleteFact(id: "${entry.id}") }` });
+        const unauthorized = await apiPost(srv.port, "/graphql", query);
+        expect(unauthorized.status).toBe(401);
+        const authorized = await apiPost(srv.port, "/graphql", query, {
+          Authorization: "Bearer test-secret",
+        });
+        expect(authorized.status).not.toBe(401);
+      } finally {
+        closeAll(ctx);
+        srv.close();
+      }
+    } finally {
+      rmSync(td, { recursive: true, force: true });
+    }
   });
 
   it("POST /api/viewer/facts/:id/forget accepts malformed JSON bodies", async () => {

--- a/extensions/memory-hybrid/tests/dedupe-policy.test.ts
+++ b/extensions/memory-hybrid/tests/dedupe-policy.test.ts
@@ -29,6 +29,11 @@ describe("dedupe policy", () => {
     expect(profile.vectorThreshold).toBe(0.95);
     expect(profile.lexicalJaccard).toBe(0.9);
   });
+
+  it("uses distill cosine threshold for distillation source (#1947)", () => {
+    const profile = resolveDedupeProfile("distillation", parseStoreConfig({ store: {} }));
+    expect(profile.vectorThreshold).toBe(0.85);
+  });
 });
 
 import { mkdtempSync, rmSync } from "node:fs";
@@ -361,6 +366,43 @@ describe("FactsDB sourceProfiles write path", () => {
       );
       expect(stored.id).toBe(original.id);
       expect((stored.recallCount ?? 0) - initialRecall).toBeGreaterThanOrEqual(1);
+      expect(db.count()).toBe(1);
+    } finally {
+      db.close();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("honours vectorCandidates for keyed project distillation facts (#1947)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "dedupe-profile-distill-project-"));
+    const db = new FactsDB(join(dir, "facts.db"), {
+      fuzzyDedupe: true,
+      storeConfig: { fuzzyDedupe: true },
+    });
+    try {
+      const original = db.store({
+        text: "PR stewardship queue prioritizes merge-ready PRs before new feature work",
+        category: "project",
+        importance: 0.8,
+        entity: "hybrid-memory-pr-stewardship",
+        key: "next",
+        value: "merge PR #1600",
+        source: "distillation",
+      });
+      const stored = db.storeWithResult(
+        {
+          text: "PR stewardship queue should prioritize merge-ready pull requests before feature work",
+          category: "project",
+          importance: 0.8,
+          entity: "hybrid-memory-pr-stewardship",
+          key: "next",
+          value: "merge PR #1600 next",
+          source: "distillation",
+        },
+        { vectorCandidates: [{ id: original.id, score: 0.88 }] },
+      );
+      expect(stored.newlyStored).toBe(false);
+      expect(stored.entry.id).toBe(original.id);
       expect(db.count()).toBe(1);
     } finally {
       db.close();

--- a/extensions/memory-hybrid/tests/dedupe-policy.test.ts
+++ b/extensions/memory-hybrid/tests/dedupe-policy.test.ts
@@ -34,6 +34,13 @@ describe("dedupe policy", () => {
     const profile = resolveDedupeProfile("distillation", parseStoreConfig({ store: {} }));
     expect(profile.vectorThreshold).toBe(0.85);
   });
+
+  it("applies distill threshold to custom distillation profiles without vectorThreshold", () => {
+    const store = parseStoreConfig({
+      store: { sourceProfiles: { distillation: { onDuplicate: "skip" } } },
+    });
+    expect(resolveDedupeProfile("distillation", store).vectorThreshold).toBe(0.85);
+  });
 });
 
 import { mkdtempSync, rmSync } from "node:fs";
@@ -395,6 +402,43 @@ describe("FactsDB sourceProfiles write path", () => {
           category: "project",
           importance: 0.8,
           entity: "hybrid-memory-pr-stewardship",
+          key: "next",
+          value: "merge PR #1600 next",
+          source: "distillation",
+        },
+        { vectorCandidates: [{ id: original.id, score: 0.88 }] },
+      );
+      expect(stored.newlyStored).toBe(false);
+      expect(stored.entry.id).toBe(original.id);
+      expect(db.count()).toBe(1);
+    } finally {
+      db.close();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("honours vectorCandidates for distillation project facts with entity slug drift (#1947)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "dedupe-profile-distill-project-"));
+    const db = new FactsDB(join(dir, "facts.db"), {
+      fuzzyDedupe: true,
+      storeConfig: { fuzzyDedupe: true },
+    });
+    try {
+      const original = db.store({
+        text: "PR stewardship queue prioritizes merge-ready PRs before new feature work",
+        category: "project",
+        importance: 0.8,
+        entity: "hybrid-memory-pr-stewardship",
+        key: "next",
+        value: "merge PR #1600",
+        source: "distillation",
+      });
+      const stored = db.storeWithResult(
+        {
+          text: "PR stewardship queue should prioritize merge-ready pull requests before feature work",
+          category: "project",
+          importance: 0.8,
+          entity: "hybrid-memory-pr-stewardship-current-state",
           key: "next",
           value: "merge PR #1600 next",
           source: "distillation",

--- a/extensions/memory-hybrid/tests/distill-vector-dedupe.test.ts
+++ b/extensions/memory-hybrid/tests/distill-vector-dedupe.test.ts
@@ -1,0 +1,135 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { filterDistillVectorCandidates } from "../cli/cmd-distill.js";
+import { applyDedupe, resolveDedupeProfile } from "../services/dedupe-policy.js";
+import { DISTILL_DEDUP_THRESHOLD } from "../utils/constants.js";
+import { _testing } from "../index.js";
+
+const { FactsDB } = _testing;
+
+describe("distill vector dedupe (#1947)", () => {
+  let dir: string;
+  let db: FactsDB;
+
+  afterEach(() => {
+    if (db) db.close();
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("uses the distill cosine threshold in the default dedupe profile", () => {
+    const profile = resolveDedupeProfile("distillation", { fuzzyDedupe: true });
+    expect(profile.vectorThreshold).toBe(DISTILL_DEDUP_THRESHOLD);
+  });
+
+  it("filterDistillVectorCandidates keeps live distillation neighbours only", () => {
+    dir = mkdtempSync(join(tmpdir(), "distill-vector-dedupe-"));
+    db = new FactsDB(join(dir, "facts.db"));
+    const original = db.store({
+      text: "Hybrid memory nightly maintenance resolves contradictions automatically",
+      category: "project",
+      importance: 0.8,
+      entity: "hybrid-memory",
+      key: "status",
+      value: "in_progress",
+      source: "distillation",
+    });
+    const otherSource = db.store({
+      text: "Hybrid memory nightly maintenance resolves contradictions automatically",
+      category: "project",
+      importance: 0.8,
+      entity: "hybrid-memory",
+      key: "status",
+      value: "done",
+      source: "conversation",
+    });
+
+    const filtered = filterDistillVectorCandidates(
+      [
+        { entry: { id: original.id }, score: 0.91 },
+        { entry: { id: otherSource.id }, score: 0.99 },
+        { entry: { id: "missing-id" }, score: 0.95 },
+      ],
+      db,
+      null,
+    );
+
+    expect(filtered).toEqual([{ id: original.id, score: 0.91 }]);
+  });
+
+  it("applyDedupe skips distillation near-duplicates from vectorCandidates", () => {
+    dir = mkdtempSync(join(tmpdir(), "distill-vector-dedupe-"));
+    db = new FactsDB(join(dir, "facts.db"));
+    const original = db.store({
+      text: "PR stewardship queue prioritizes merge-ready PRs before new feature work",
+      category: "project",
+      importance: 0.8,
+      entity: "hybrid-memory-pr-stewardship",
+      key: "next",
+      value: "merge PR #1600",
+      source: "distillation",
+    });
+    const profile = resolveDedupeProfile("distillation", { fuzzyDedupe: true });
+    const dedupe = applyDedupe(
+      profile,
+      {
+        text: "PR stewardship queue should prioritize merge-ready pull requests before feature work",
+        source: "distillation",
+        scope: "global",
+        scopeTarget: null,
+        category: "project",
+        entity: "hybrid-memory-pr-stewardship",
+        key: "next",
+        value: "merge PR #1600 next",
+      },
+      {
+        db: db.getRawDb(),
+        nowSec: Math.floor(Date.now() / 1000),
+        fuzzyDedupe: true,
+        vectorCandidates: [{ id: original.id, score: 0.88 }],
+      },
+    );
+
+    expect(dedupe.action).toBe("skip");
+    if (dedupe.action === "skip") {
+      expect(dedupe.existingId).toBe(original.id);
+      expect(dedupe.reason).toBe("vector");
+    }
+  });
+
+  it("skips near-duplicate distillation facts via vectorCandidates in storeWithResult", () => {
+    dir = mkdtempSync(join(tmpdir(), "distill-vector-dedupe-"));
+    db = new FactsDB(join(dir, "facts.db"), {
+      fuzzyDedupe: true,
+      storeConfig: { fuzzyDedupe: true },
+    });
+    const original = db.store({
+      text: "PR stewardship queue prioritizes merge-ready PRs before new feature work",
+      category: "project",
+      importance: 0.8,
+      entity: "hybrid-memory-pr-stewardship",
+      key: "next",
+      value: "merge PR #1600",
+      source: "distillation",
+    });
+
+    const result = db.storeWithResult(
+      {
+        text: "PR stewardship queue should prioritize merge-ready pull requests before feature work",
+        category: "project",
+        importance: 0.8,
+        entity: "hybrid-memory-pr-stewardship",
+        key: "next",
+        value: "merge PR #1600 next",
+        source: "distillation",
+      },
+      { vectorCandidates: [{ id: original.id, score: 0.88 }] },
+    );
+
+    expect(result.newlyStored).toBe(false);
+    expect(result.entry.id).toBe(original.id);
+    expect(db.count()).toBe(1);
+  });
+});

--- a/extensions/memory-hybrid/tests/distill-vector-dedupe.test.ts
+++ b/extensions/memory-hybrid/tests/distill-vector-dedupe.test.ts
@@ -175,6 +175,42 @@ describe("distill vector dedupe (#1947)", () => {
     expect(db.count()).toBe(1);
   });
 
+  it("does not vector-dedupe distillation project facts across unrelated entities with the same key", () => {
+    dir = mkdtempSync(join(tmpdir(), "distill-vector-dedupe-"));
+    db = new FactsDB(join(dir, "facts.db"));
+    const original = db.store({
+      text: "Hybrid memory maintenance resolves contradictions automatically",
+      category: "project",
+      importance: 0.8,
+      entity: "hybrid-memory",
+      key: "status",
+      value: "in_progress",
+      source: "distillation",
+    });
+    const profile = resolveDedupeProfile("distillation", { fuzzyDedupe: true });
+    const dedupe = applyDedupe(
+      profile,
+      {
+        text: "Humanizer pipeline maintenance resolves contradictions automatically overnight",
+        source: "distillation",
+        scope: "global",
+        scopeTarget: null,
+        category: "project",
+        entity: "humanizer",
+        key: "status",
+        value: "in_progress",
+      },
+      {
+        db: db.getRawDb(),
+        nowSec: Math.floor(Date.now() / 1000),
+        fuzzyDedupe: true,
+        vectorCandidates: [{ id: original.id, score: 0.95 }],
+      },
+    );
+
+    expect(dedupe.action).toBe("store");
+  });
+
   it("does not vector-dedupe distillation project facts across different keys", () => {
     dir = mkdtempSync(join(tmpdir(), "distill-vector-dedupe-"));
     db = new FactsDB(join(dir, "facts.db"));
@@ -208,6 +244,41 @@ describe("distill vector dedupe (#1947)", () => {
       },
     );
 
+    expect(dedupe.action).toBe("store");
+  });
+
+  it("does not vector-dedupe when entity slugs share only a shallow prefix", () => {
+    dir = mkdtempSync(join(tmpdir(), "distill-vector-dedupe-prefix-"));
+    db = new FactsDB(join(dir, "facts.db"));
+    const original = db.store({
+      text: "Hybrid memory maintenance resolves contradictions automatically",
+      category: "project",
+      importance: 0.8,
+      entity: "hybrid-memory-maintenance",
+      key: "status",
+      value: "in_progress",
+      source: "distillation",
+    });
+    const profile = resolveDedupeProfile("distillation", { fuzzyDedupe: true });
+    const dedupe = applyDedupe(
+      profile,
+      {
+        text: "Hybrid memory other project maintenance resolves contradictions automatically overnight",
+        source: "distillation",
+        scope: "global",
+        scopeTarget: null,
+        category: "project",
+        entity: "hybrid-memory-other-project",
+        key: "status",
+        value: "in_progress",
+      },
+      {
+        db: db.getRawDb(),
+        nowSec: Math.floor(Date.now() / 1000),
+        fuzzyDedupe: true,
+        vectorCandidates: [{ id: original.id, score: 0.95 }],
+      },
+    );
     expect(dedupe.action).toBe("store");
   });
 

--- a/extensions/memory-hybrid/tests/distill-vector-dedupe.test.ts
+++ b/extensions/memory-hybrid/tests/distill-vector-dedupe.test.ts
@@ -3,7 +3,10 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
-import { filterDistillVectorCandidates } from "../cli/cmd-distill.js";
+import {
+  filterDistillVectorCandidates,
+  resolveDistillVectorCandidates,
+} from "../cli/vector-dedupe-helpers.js";
 import { applyDedupe, resolveDedupeProfile } from "../services/dedupe-policy.js";
 import { DISTILL_DEDUP_THRESHOLD } from "../utils/constants.js";
 import { _testing } from "../index.js";
@@ -12,7 +15,7 @@ const { FactsDB } = _testing;
 
 describe("distill vector dedupe (#1947)", () => {
   let dir: string;
-  let db: FactsDB;
+  let db: InstanceType<typeof FactsDB>;
 
   afterEach(() => {
     if (db) db.close();
@@ -99,6 +102,45 @@ describe("distill vector dedupe (#1947)", () => {
     }
   });
 
+  it("applyDedupe skips distillation near-duplicates even when entity slug drifted", () => {
+    dir = mkdtempSync(join(tmpdir(), "distill-vector-dedupe-"));
+    db = new FactsDB(join(dir, "facts.db"));
+    const original = db.store({
+      text: "PR stewardship queue prioritizes merge-ready PRs before new feature work",
+      category: "project",
+      importance: 0.8,
+      entity: "hybrid-memory-pr-stewardship",
+      key: "next",
+      value: "merge PR #1600",
+      source: "distillation",
+    });
+    const profile = resolveDedupeProfile("distillation", { fuzzyDedupe: true });
+    const dedupe = applyDedupe(
+      profile,
+      {
+        text: "PR stewardship queue should prioritize merge-ready pull requests before feature work",
+        source: "distillation",
+        scope: "global",
+        scopeTarget: null,
+        category: "project",
+        entity: "hybrid-memory-pr-stewardship-current-state",
+        key: "next",
+        value: "merge PR #1600 next",
+      },
+      {
+        db: db.getRawDb(),
+        nowSec: Math.floor(Date.now() / 1000),
+        fuzzyDedupe: true,
+        vectorCandidates: [{ id: original.id, score: 0.88 }],
+      },
+    );
+
+    expect(dedupe.action).toBe("skip");
+    if (dedupe.action === "skip") {
+      expect(dedupe.existingId).toBe(original.id);
+    }
+  });
+
   it("skips near-duplicate distillation facts via vectorCandidates in storeWithResult", () => {
     dir = mkdtempSync(join(tmpdir(), "distill-vector-dedupe-"));
     db = new FactsDB(join(dir, "facts.db"), {
@@ -120,7 +162,7 @@ describe("distill vector dedupe (#1947)", () => {
         text: "PR stewardship queue should prioritize merge-ready pull requests before feature work",
         category: "project",
         importance: 0.8,
-        entity: "hybrid-memory-pr-stewardship",
+        entity: "hybrid-memory-pr-stewardship-current-state",
         key: "next",
         value: "merge PR #1600 next",
         source: "distillation",
@@ -131,5 +173,70 @@ describe("distill vector dedupe (#1947)", () => {
     expect(result.newlyStored).toBe(false);
     expect(result.entry.id).toBe(original.id);
     expect(db.count()).toBe(1);
+  });
+
+  it("does not vector-dedupe distillation project facts across different keys", () => {
+    dir = mkdtempSync(join(tmpdir(), "distill-vector-dedupe-"));
+    db = new FactsDB(join(dir, "facts.db"));
+    const original = db.store({
+      text: "Hybrid memory maintenance resolves contradictions automatically",
+      category: "project",
+      importance: 0.8,
+      entity: "hybrid-memory",
+      key: "status",
+      value: "in_progress",
+      source: "distillation",
+    });
+    const profile = resolveDedupeProfile("distillation", { fuzzyDedupe: true });
+    const dedupe = applyDedupe(
+      profile,
+      {
+        text: "Hybrid memory maintenance resolves contradictions automatically overnight",
+        source: "distillation",
+        scope: "global",
+        scopeTarget: null,
+        category: "project",
+        entity: "hybrid-memory-current-state",
+        key: "next",
+        value: "resolve contradictions",
+      },
+      {
+        db: db.getRawDb(),
+        nowSec: Math.floor(Date.now() / 1000),
+        fuzzyDedupe: true,
+        vectorCandidates: [{ id: original.id, score: 0.95 }],
+      },
+    );
+
+    expect(dedupe.action).toBe("store");
+  });
+
+  it("resolveDistillVectorCandidates returns filtered candidates for storeWithResult wiring", async () => {
+    dir = mkdtempSync(join(tmpdir(), "distill-vector-dedupe-"));
+    db = new FactsDB(join(dir, "facts.db"));
+    const original = db.store({
+      text: "Hybrid memory nightly maintenance resolves contradictions automatically",
+      category: "project",
+      importance: 0.8,
+      entity: "hybrid-memory",
+      key: "status",
+      value: "in_progress",
+      source: "distillation",
+    });
+
+    const result = await resolveDistillVectorCandidates({
+      fuzzyDedupe: true,
+      vector: [0.1, 0.2, 0.3],
+      vectorDb: {
+        search: async () => [{ entry: { id: original.id }, score: 0.91 }],
+        hasDuplicate: async () => false,
+      },
+      factsDb: db,
+      embeddingModelName: null,
+    });
+
+    expect(result.vectorSearchDegraded).toBe(false);
+    expect(result.vectorCandidates).toEqual([{ id: original.id, score: 0.91 }]);
+    expect(result.skipAsDuplicate).toBe(false);
   });
 });

--- a/extensions/memory-hybrid/tests/m27-live-catalog-limits.test.ts
+++ b/extensions/memory-hybrid/tests/m27-live-catalog-limits.test.ts
@@ -13,7 +13,8 @@ import {
 } from "../services/model-capabilities.js";
 
 const apiKey = process.env.MINIMAX_API_KEY?.trim();
-const live = apiKey ? describe : describe.skip;
+const runLiveMiniMax = apiKey && process.env.RUN_LIVE_MINIMAX_TESTS === "1";
+const live = runLiveMiniMax ? describe : describe.skip;
 
 const BASE_URL = "https://api.minimax.io/v1";
 const BLOCK = "word ";
@@ -23,7 +24,7 @@ function fillerForTargetTokens(targetTokens: number): string {
   return `Reply only: OK\n\n${BLOCK.repeat(Math.ceil(approxChars / BLOCK.length))}`;
 }
 
-async function chatCompletion(body: Record<string, unknown>) {
+async function chatCompletion(body: Record<string, unknown>, timeoutMs = 120_000) {
   const res = await fetch(`${BASE_URL}/chat/completions`, {
     method: "POST",
     headers: {
@@ -31,6 +32,7 @@ async function chatCompletion(body: Record<string, unknown>) {
       "Content-Type": "application/json",
     },
     body: JSON.stringify(body),
+    signal: AbortSignal.timeout(timeoutMs),
   });
   const json = (await res.json()) as {
     usage?: { prompt_tokens?: number; completion_tokens?: number };
@@ -91,23 +93,29 @@ live("live MiniMax M2.7 catalog limits", () => {
     }
   }, 600_000);
 
-  it("distill batch 150k input + 128k output budget succeeds; 200k input fails", async () => {
-    const ok = await chatCompletion({
-      model: "MiniMax-M2.7",
-      messages: [{ role: "user", content: fillerForTargetTokens(150_000) }],
-      max_completion_tokens: 128_000,
-      thinking: { type: "disabled" },
-    });
+  it("distill batch 150k input + 128k output budget succeeds; input above API ceiling fails", async () => {
+    const ok = await chatCompletion(
+      {
+        model: "MiniMax-M2.7",
+        messages: [{ role: "user", content: fillerForTargetTokens(150_000) }],
+        max_completion_tokens: 128_000,
+        thinking: { type: "disabled" },
+      },
+      540_000,
+    );
     expect(ok.status).toBe(200);
     expect(ok.json.usage?.prompt_tokens).toBeGreaterThan(110_000);
     expect(ok.json.usage?.prompt_tokens).toBeLessThanOrEqual(150_000);
 
-    const fail = await chatCompletion({
-      model: "MiniMax-M2.7",
-      messages: [{ role: "user", content: fillerForTargetTokens(200_000) }],
-      max_completion_tokens: 128_000,
-      thinking: { type: "disabled" },
-    });
+    const fail = await chatCompletion(
+      {
+        model: "MiniMax-M2.7",
+        messages: [{ role: "user", content: fillerForTargetTokens(328_000) }],
+        max_completion_tokens: 128_000,
+        thinking: { type: "disabled" },
+      },
+      540_000,
+    );
     expect(fail.status).toBe(400);
     expect(fail.json.error?.message ?? fail.json.base_resp?.status_msg ?? "").toMatch(/context window exceeds limit/i);
   }, 600_000);

--- a/extensions/memory-hybrid/tests/m3-live-catalog-limits.test.ts
+++ b/extensions/memory-hybrid/tests/m3-live-catalog-limits.test.ts
@@ -12,7 +12,8 @@ import {
 } from "../services/model-capabilities.js";
 
 const apiKey = process.env.MINIMAX_API_KEY?.trim();
-const live = apiKey ? describe : describe.skip;
+const runLiveMiniMax = apiKey && process.env.RUN_LIVE_MINIMAX_TESTS === "1";
+const live = runLiveMiniMax ? describe : describe.skip;
 
 const BASE_URL = "https://api.minimax.io/v1";
 const WIRE_MODEL = "MiniMax-M3";
@@ -24,7 +25,7 @@ function fillerForTargetTokens(targetTokens: number): string {
   return `Reply only: OK\n\n${BLOCK.repeat(Math.ceil(approxChars / BLOCK.length))}`;
 }
 
-async function chatCompletion(body: Record<string, unknown>) {
+async function chatCompletion(body: Record<string, unknown>, timeoutMs = 120_000) {
   const res = await fetch(`${BASE_URL}/chat/completions`, {
     method: "POST",
     headers: {
@@ -32,6 +33,7 @@ async function chatCompletion(body: Record<string, unknown>) {
       "Content-Type": "application/json",
     },
     body: JSON.stringify(body),
+    signal: AbortSignal.timeout(timeoutMs),
   });
   const json = (await res.json()) as {
     usage?: { prompt_tokens?: number; completion_tokens?: number; total_tokens?: number };
@@ -64,26 +66,32 @@ live("live MiniMax M3 catalog limits", () => {
     expect(json.choices?.[0]?.finish_reason).toBe("stop");
   }, 60_000);
 
-  it("input ceiling is ~524169 prompt tokens (655k target ok, 656k target rejected)", async () => {
-    const ok = await chatCompletion({
-      model: WIRE_MODEL,
-      messages: [{ role: "user", content: fillerForTargetTokens(655_000) }],
-      max_completion_tokens: 8,
-      thinking: { type: "disabled" },
-    });
+  it("input ceiling is ~524169 prompt tokens (655k target ok, oversize target rejected)", async () => {
+    const ok = await chatCompletion(
+      {
+        model: WIRE_MODEL,
+        messages: [{ role: "user", content: fillerForTargetTokens(655_000) }],
+        max_completion_tokens: 8,
+        thinking: { type: "disabled" },
+      },
+      300_000,
+    );
     expect(ok.status).toBe(200);
     expect(ok.json.usage?.prompt_tokens).toBeGreaterThanOrEqual(524_000);
     expect(ok.json.usage?.prompt_tokens).toBeLessThanOrEqual(524_288);
 
-    const fail = await chatCompletion({
-      model: WIRE_MODEL,
-      messages: [{ role: "user", content: fillerForTargetTokens(656_000) }],
-      max_completion_tokens: 8,
-      thinking: { type: "disabled" },
-    });
+    const fail = await chatCompletion(
+      {
+        model: WIRE_MODEL,
+        messages: [{ role: "user", content: fillerForTargetTokens(700_000) }],
+        max_completion_tokens: 8,
+        thinking: { type: "disabled" },
+      },
+      300_000,
+    );
     expect(fail.status).toBe(400);
-    expect(fail.json.error?.message ?? fail.json.base_resp?.status_msg ?? "").toMatch(/invalid params/i);
-  }, 300_000);
+    expect(fail.json.error?.message ?? fail.json.base_resp?.status_msg ?? "").toMatch(/invalid params|context window exceeds limit/i);
+  }, 600_000);
 
   it("rejects provider-prefixed model id on direct api.minimax.io (gateway strips prefix)", async () => {
     const { status, json } = await chatCompletion({

--- a/extensions/memory-hybrid/tests/memory-journey-e2e.test.ts
+++ b/extensions/memory-hybrid/tests/memory-journey-e2e.test.ts
@@ -296,7 +296,7 @@ describe("Memory journey e2e — full register() stack", () => {
     expect(runtimeRef.value?.factsDb).toBeDefined();
     expect(api.getTool("memory_store")).toBeDefined();
     expect(api.getTool("memory_recall")).toBeDefined();
-  });
+  }, 120_000);
 
   it("memory_recall query path finds stored facts via FTS (deterministic strategies)", async () => {
     await registerJourney({ retrieval: { strategies: ["fts5"] } });

--- a/extensions/memory-hybrid/tests/memory-store-event-log.test.ts
+++ b/extensions/memory-hybrid/tests/memory-store-event-log.test.ts
@@ -252,7 +252,7 @@ describe("memory_store event_log integration", () => {
     factsDb.storeWithResult = vi.fn().mockReturnValue({
       entry: { id: "", text: "", createdAt: 0 },
       evictedFactId: null,
-      rejected: true,
+      skipped: true,
     });
 
     registerMemoryTools(

--- a/extensions/memory-hybrid/tests/passive-observer.test.ts
+++ b/extensions/memory-hybrid/tests/passive-observer.test.ts
@@ -481,7 +481,15 @@ describe("runPassiveObserver", () => {
     // vectorDb.search returns a match — signals the fact is a duplicate
     const matchResult = [{ entry: { id: "existing-fact-id" }, score: 0.95 }];
     const vectorDb = makeVectorDb(matchResult);
-    const factsDb = makeFactsDb({ detectContradictions: vi.fn(), setEmbeddingModel: vi.fn() });
+    const factsDb = makeFactsDb({
+      detectContradictions: vi.fn(),
+      setEmbeddingModel: vi.fn(),
+      getById: vi.fn().mockImplementation((id: string) =>
+        id === "existing-fact-id"
+          ? { id, scope: "session", scopeTarget: "dedup-test", supersededAt: null, expiresAt: null }
+          : null,
+      ),
+    });
 
     const cfg = makeConfig({ sessionsDir });
     const result = await runPassiveObserver(
@@ -719,6 +727,11 @@ describe("runPassiveObserver — LanceDB dedup (Issue #499)", () => {
     const vectorDb = makeVectorDb(matchResult);
     const factsDb = makeFactsDb({
       boostConfidence: vi.fn().mockReturnValue(true),
+      getById: vi.fn().mockImplementation((id: string) =>
+        id === matchedFactId
+          ? { id, scope: "session", scopeTarget: "reinforce-test", supersededAt: null, expiresAt: null }
+          : null,
+      ),
     });
     const cfg = makeConfig({ sessionsDir });
 

--- a/extensions/memory-hybrid/tests/pr1332-remediation.test.ts
+++ b/extensions/memory-hybrid/tests/pr1332-remediation.test.ts
@@ -128,6 +128,137 @@ describe("PR #1332 unresolved feedback remediation", () => {
     expect(context.factsDb.supersede).toHaveBeenCalledWith(existing.id, replacement.id);
   });
 
+  it("rejects GraphQL updateFact when new text is an artifact/reasoning trace", async () => {
+    const existing = {
+      id: "legacy-compact",
+      text: "old compact text",
+      category: "fact",
+      importance: 0.5,
+      confidence: 0.9,
+      decayClass: "normal",
+      source: "compact",
+      tags: [],
+      entity: null,
+      key: null,
+      value: null,
+      scope: "global",
+      scopeTarget: null,
+      expiresAt: null,
+    };
+    const context = {
+      factsDb: {
+        getById: vi.fn((id: string) => (id === existing.id ? existing : null)),
+        storeWithResult: vi.fn(),
+        supersede: vi.fn(),
+      },
+    } as unknown as ResolverContext;
+
+    await expect(
+      resolvers.Mutation.updateFact(
+        null,
+        { input: { id: existing.id, text: "NOOP | duplicate fact" } } as ResolverArgs,
+        context,
+      ),
+    ).rejects.toThrow(/artifact or reasoning trace/);
+    expect(context.factsDb.storeWithResult).not.toHaveBeenCalled();
+  });
+
+  it("GraphQL facts query treats expiresAt as unix seconds", () => {
+    const nowSec = Math.floor(Date.now() / 1000);
+    const base = {
+      category: "fact",
+      importance: 0.5,
+      confidence: 1,
+      decayClass: "normal",
+      source: "test",
+      tags: [],
+      entity: null,
+      key: null,
+      value: null,
+      scope: "global",
+      scopeTarget: null,
+      supersededAt: null,
+      supersededBy: null,
+      createdAt: nowSec,
+    };
+    const active = { ...base, id: "active", text: "still valid", expiresAt: nowSec + 3600 };
+    const expired = { ...base, id: "expired", text: "past ttl", expiresAt: nowSec - 60 };
+    const context = {
+      factsDb: {
+        getAll: vi.fn(() => [active, expired]),
+      },
+    } as unknown as ResolverContext;
+
+    const rows = resolvers.Query.facts(null, {}, context) as Array<{ id: string }>;
+    expect(rows.map((row) => row.id)).toEqual(["active"]);
+  });
+
+  it("GraphQL updateFact deletes vector for superseded fact id", async () => {
+    const existing = {
+      id: "old",
+      text: "old text",
+      category: "fact",
+      importance: 0.5,
+      confidence: 0.9,
+      decayClass: "normal",
+      source: "graphql",
+      tags: [],
+      entity: null,
+      key: null,
+      value: null,
+      scope: "global",
+      scopeTarget: null,
+      expiresAt: null,
+    };
+    const replacement = { ...existing, id: "new", text: "new text" };
+    const vectorDb = { delete: vi.fn().mockResolvedValue(true) };
+    const context = {
+      factsDb: {
+        getById: vi.fn((id: string) => (id === existing.id ? existing : null)),
+        storeWithResult: vi.fn(() => ({ entry: replacement, skipped: false, newlyStored: true })),
+        supersede: vi.fn(() => true),
+      },
+      vectorDb,
+    } as unknown as ResolverContext;
+
+    await resolvers.Mutation.updateFact(
+      null,
+      { input: { id: existing.id, text: "new text" } } as ResolverArgs,
+      context,
+    );
+
+    expect(vectorDb.delete).toHaveBeenCalledWith(existing.id);
+  });
+
+  it("GraphQL supersedeFact deletes vector for superseded fact id", async () => {
+    const oldFact = { id: "old", text: "old", category: "fact" };
+    const newFact = { id: "new", text: "new", category: "fact" };
+    const vectorDb = { delete: vi.fn().mockResolvedValue(true) };
+    const context = {
+      factsDb: {
+        getById: vi.fn((id: string) => (id === "old" ? oldFact : id === "new" ? newFact : null)),
+        supersede: vi.fn(() => true),
+      },
+      vectorDb,
+    } as unknown as ResolverContext;
+
+    await resolvers.Mutation.supersedeFact(
+      null,
+      { oldFactId: "old", newFactId: "new" } as ResolverArgs,
+      context,
+    );
+
+    expect(vectorDb.delete).toHaveBeenCalledWith("old");
+  });
+
+  it("GraphQL pruneFacts requires olderThan", async () => {
+    const context = {
+      factsDb: { getAll: vi.fn(() => []), delete: vi.fn() },
+    } as unknown as ResolverContext;
+
+    await expect(resolvers.Mutation.pruneFacts(null, {} as ResolverArgs, context)).rejects.toThrow(/olderThan/);
+  });
+
   it("prevalidates GraphQL importFacts before storing guarded facts", async () => {
     const storeWithResult = vi.fn((input: { text: string }) => ({
       entry: { id: input.text, text: input.text },
@@ -157,7 +288,7 @@ describe("PR #1332 unresolved feedback remediation", () => {
     expect(vectorDb.delete).toHaveBeenCalledWith("evicted");
   });
 
-  it("fails GraphQL supersede mutation when the old fact is missing or already superseded", () => {
+  it("fails GraphQL supersede mutation when the old fact is missing or already superseded", async () => {
     const facts = new Map([
       ["new", { id: "new", text: "new" }],
       ["old", { id: "old", text: "old" }],
@@ -169,16 +300,16 @@ describe("PR #1332 unresolved feedback remediation", () => {
       },
     } as unknown as ResolverContext;
 
-    expect(() =>
+    await expect(
       resolvers.Mutation.supersedeFact(null, { oldFactId: "missing", newFactId: "new" } as ResolverArgs, context),
-    ).toThrow(/missing/);
-    expect(() =>
+    ).rejects.toThrow(/missing/);
+    await expect(
       resolvers.Mutation.supersedeFact(null, { oldFactId: "old", newFactId: "new" } as ResolverArgs, context),
-    ).not.toThrow();
+    ).resolves.toBeDefined();
     context.factsDb.supersede = vi.fn(() => false) as never;
-    expect(() =>
+    await expect(
       resolvers.Mutation.supersedeFact(null, { oldFactId: "old", newFactId: "new" } as ResolverArgs, context),
-    ).toThrow(/did not apply/);
+    ).rejects.toThrow(/did not apply/);
   });
 
   it("does not treat an OpenAI key as Google provider configuration", async () => {

--- a/extensions/memory-hybrid/tests/project-state-lww.test.ts
+++ b/extensions/memory-hybrid/tests/project-state-lww.test.ts
@@ -257,6 +257,34 @@ describe("project-state-lww: overloaded entity detection", () => {
     expect(candidate?.action).toBe("supersede");
   });
 
+  it("flags when refs are asymmetrically split across facts (2+1)", () => {
+    const older = storeProjectFact({
+      entity: "hybrid-memory / next",
+      key: "next",
+      value: "merge PR #1597 next",
+      text: "Queue head: PR #1596 and PR #1597",
+      confidence: 1.0,
+    });
+    const newer = storeProjectFact({
+      entity: "hybrid-memory / next",
+      key: "next",
+      value: "merge next",
+      text: "Updated queue: PR #1599",
+      confidence: 1.0,
+      createdAtOffset: 30,
+    });
+
+    db.recordContradiction(newer.id, older.id);
+
+    const result = db.resolveContradictionsProjectStateLww({ dryRun: true });
+    const candidate = result.groups
+      .flatMap((g) => g.candidates)
+      .find((c) => c.factIdNew === newer.id || c.factIdOld === older.id);
+
+    expect(candidate).toBeDefined();
+    expect(candidate?.possibleOverloadedEntity).toBe(true);
+  });
+
   it("flags when entity/key values reference many distinct PR/issue numbers", () => {
     const older = storeProjectFact({
       entity: "hybrid-memory-issue-1272-pr",

--- a/extensions/memory-hybrid/tests/project-state-lww.test.ts
+++ b/extensions/memory-hybrid/tests/project-state-lww.test.ts
@@ -288,6 +288,35 @@ describe("project-state-lww: overloaded entity detection", () => {
     expect(candidate).toBeDefined();
     expect(candidate?.possibleOverloadedEntity).toBe(true);
   });
+
+  it("still flags when a single fact alone references many distinct PR/issue numbers", () => {
+    const older = storeProjectFact({
+      entity: "agent:pr-steward:subagent:abc",
+      key: "status",
+      value: "in_progress",
+      text: "Task status: in_progress",
+      confidence: 1.0,
+    });
+    const newer = storeProjectFact({
+      entity: "agent:pr-steward:subagent:abc",
+      key: "status",
+      value: "done",
+      text: "Subagent session done. Completed: rebased PRs #1597, #1596, #1600, #1599, #1571, #1565 onto main",
+      confidence: 1.0,
+      createdAtOffset: 30,
+    });
+
+    db.recordContradiction(newer.id, older.id);
+
+    const result = db.resolveContradictionsProjectStateLww({ dryRun: true });
+    const candidate = result.groups
+      .flatMap((g) => g.candidates)
+      .find((c) => c.factIdNew === newer.id || c.factIdOld === older.id);
+
+    expect(candidate).toBeDefined();
+    expect(candidate?.possibleOverloadedEntity).toBe(true);
+    expect(candidate?.action).toBe("manual-review");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/extensions/memory-hybrid/tests/project-state-lww.test.ts
+++ b/extensions/memory-hybrid/tests/project-state-lww.test.ts
@@ -228,6 +228,35 @@ describe("project-state-lww: non-project facts are not touched", () => {
 // 4. Overloaded task entity is flagged in the LWW report
 // ---------------------------------------------------------------------------
 describe("project-state-lww: overloaded entity detection", () => {
+  it("does not flag when refs are split across facts but each fact stays within threshold", () => {
+    const older = storeProjectFact({
+      entity: "hybrid-memory / next",
+      key: "next",
+      value: "merge PR #1597 next",
+      text: "Queue head: PR #1596",
+      confidence: 1.0,
+    });
+    const newer = storeProjectFact({
+      entity: "hybrid-memory / next",
+      key: "next",
+      value: "merge PR #1600 next",
+      text: "Updated queue: PR #1599",
+      confidence: 1.0,
+      createdAtOffset: 30,
+    });
+
+    db.recordContradiction(newer.id, older.id);
+
+    const result = db.resolveContradictionsProjectStateLww({ dryRun: true });
+    const candidate = result.groups
+      .flatMap((g) => g.candidates)
+      .find((c) => c.factIdNew === newer.id || c.factIdOld === older.id);
+
+    expect(candidate).toBeDefined();
+    expect(candidate?.possibleOverloadedEntity).toBe(false);
+    expect(candidate?.action).toBe("supersede");
+  });
+
   it("flags when entity/key values reference many distinct PR/issue numbers", () => {
     const older = storeProjectFact({
       entity: "hybrid-memory-issue-1272-pr",

--- a/extensions/memory-hybrid/tests/publish-dist-procedure-skill-generator.test.ts
+++ b/extensions/memory-hybrid/tests/publish-dist-procedure-skill-generator.test.ts
@@ -60,7 +60,7 @@ describe.skipIf(!distExists)("publish dist procedure-skill-generator", () => {
       expect(typeof genMod.generateAutoSkills).toBe("function");
       expect(typeof factsMod.FactsDB).toBe("function");
     }
-  });
+  }, 60_000);
 
   it("dist skill-creator-validator accepts generated frontmatter and rejects illegal one (#1545)", async () => {
     const { quickValidateSkillMarkdown } = await import(

--- a/extensions/memory-hybrid/tests/vector-dedupe-helpers.test.ts
+++ b/extensions/memory-hybrid/tests/vector-dedupe-helpers.test.ts
@@ -1,0 +1,112 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  classifyStoreDedupeMode,
+  filterDistillVectorCandidates,
+  resolveDistillVectorCandidates,
+} from "../cli/vector-dedupe-helpers.js";
+import { DISTILL_DEDUP_THRESHOLD } from "../utils/constants.js";
+import { _testing } from "../index.js";
+
+const { FactsDB } = _testing;
+
+describe("vector-dedupe-helpers", () => {
+  let dir: string;
+  let db: InstanceType<typeof FactsDB>;
+
+  afterEach(() => {
+    if (db) db.close();
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("resolveDistillVectorCandidates falls back to hasDuplicate when vector search is degraded", async () => {
+    const vectorDb = {
+      search: vi.fn(),
+      hasDuplicate: vi.fn().mockResolvedValue(true),
+      getLastSearchFailReason: vi.fn().mockReturnValue("schema_invalid"),
+    };
+
+    const result = await resolveDistillVectorCandidates({
+      fuzzyDedupe: true,
+      vector: [0.1, 0.2],
+      vectorDb,
+      factsDb: { getById: () => null },
+      embeddingModelName: "test-embedding",
+    });
+
+    expect(vectorDb.search).toHaveBeenCalledOnce();
+    expect(vectorDb.hasDuplicate).toHaveBeenCalledWith([0.1, 0.2], DISTILL_DEDUP_THRESHOLD);
+    expect(result.skipAsDuplicate).toBe(true);
+    expect(result.vectorSearchDegraded).toBe(true);
+    expect(result.usedHasDuplicateFallback).toBe(true);
+  });
+
+  it("resolveDistillVectorCandidates skips vector work when fuzzyDedupe is disabled", async () => {
+    const vectorDb = {
+      search: vi.fn(),
+      hasDuplicate: vi.fn(),
+    };
+
+    const result = await resolveDistillVectorCandidates({
+      fuzzyDedupe: false,
+      vector: [0.1],
+      vectorDb,
+      factsDb: { getById: () => null },
+      embeddingModelName: null,
+    });
+
+    expect(vectorDb.search).not.toHaveBeenCalled();
+    expect(result.skipAsDuplicate).toBe(false);
+    expect(result.vectorCandidates).toBeUndefined();
+  });
+
+  it("filterDistillVectorCandidates respects scoped neighbours", () => {
+    dir = mkdtempSync(join(tmpdir(), "vector-dedupe-helpers-"));
+    db = new FactsDB(join(dir, "facts.db"));
+    const scoped = db.store({
+      text: "Scoped distill fact",
+      category: "project",
+      importance: 0.8,
+      entity: "hybrid-memory",
+      key: "status",
+      value: "in_progress",
+      source: "distillation",
+      scope: "agent",
+      scopeTarget: "main",
+    });
+
+    const filtered = filterDistillVectorCandidates(
+      [{ entry: { id: scoped.id }, score: 0.92 }],
+      db,
+      null,
+      "agent",
+      "main",
+    );
+
+    expect(filtered).toEqual([{ id: scoped.id, score: 0.92 }]);
+    expect(filterDistillVectorCandidates([{ entry: { id: scoped.id }, score: 0.92 }], db, null)).toEqual([]);
+  });
+
+  it("classifyStoreDedupeMode distinguishes vector and degraded lexical paths", () => {
+    expect(
+      classifyStoreDedupeMode({
+        fuzzyDedupe: true,
+        vectorSearchDegraded: false,
+        vectorCandidates: [{ id: "a", score: 0.9 }],
+        usedHasDuplicateFallback: false,
+        skipAsDuplicate: false,
+      }),
+    ).toBe("vector");
+    expect(
+      classifyStoreDedupeMode({
+        fuzzyDedupe: true,
+        vectorSearchDegraded: true,
+        usedHasDuplicateFallback: true,
+        skipAsDuplicate: true,
+      }),
+    ).toBe("mixed");
+  });
+});

--- a/extensions/memory-hybrid/tests/vector-dedupe-helpers.test.ts
+++ b/extensions/memory-hybrid/tests/vector-dedupe-helpers.test.ts
@@ -22,11 +22,35 @@ describe("vector-dedupe-helpers", () => {
     if (dir) rmSync(dir, { recursive: true, force: true });
   });
 
-  it("resolveDistillVectorCandidates falls back to hasDuplicate when vector search is degraded", async () => {
+  it("resolveDistillVectorCandidates skips hasDuplicate when vector schema is invalid", async () => {
     const vectorDb = {
-      search: vi.fn(),
+      search: vi.fn().mockResolvedValue([]),
       hasDuplicate: vi.fn().mockResolvedValue(true),
       getLastSearchFailReason: vi.fn().mockReturnValue("schema_invalid"),
+      isMemoriesVectorSchemaValid: vi.fn().mockReturnValue(false),
+    };
+
+    const result = await resolveDistillVectorCandidates({
+      fuzzyDedupe: true,
+      vector: [0.1, 0.2],
+      vectorDb,
+      factsDb: { getById: () => null },
+      embeddingModelName: "test-embedding",
+    });
+
+    expect(vectorDb.search).toHaveBeenCalledOnce();
+    expect(vectorDb.hasDuplicate).not.toHaveBeenCalled();
+    expect(result.skipAsDuplicate).toBe(false);
+    expect(result.vectorSearchDegraded).toBe(true);
+    expect(result.usedHasDuplicateFallback).toBe(false);
+  });
+
+  it("resolveDistillVectorCandidates falls back to hasDuplicate when vector search is degraded but schema is valid", async () => {
+    const vectorDb = {
+      search: vi.fn().mockResolvedValue([]),
+      hasDuplicate: vi.fn().mockResolvedValue(true),
+      getLastSearchFailReason: vi.fn().mockReturnValue("lance_error"),
+      isMemoriesVectorSchemaValid: vi.fn().mockReturnValue(true),
     };
 
     const result = await resolveDistillVectorCandidates({
@@ -39,9 +63,41 @@ describe("vector-dedupe-helpers", () => {
 
     expect(vectorDb.search).toHaveBeenCalledOnce();
     expect(vectorDb.hasDuplicate).toHaveBeenCalledWith([0.1, 0.2], DISTILL_DEDUP_THRESHOLD);
-    expect(result.skipAsDuplicate).toBe(true);
+    expect(result.skipAsDuplicate).toBe(false);
     expect(result.vectorSearchDegraded).toBe(true);
     expect(result.usedHasDuplicateFallback).toBe(true);
+  });
+
+  it("resolveDistillVectorCandidates uses scoped neighbours when search is degraded", async () => {
+    dir = mkdtempSync(join(tmpdir(), "vector-dedupe-degraded-"));
+    db = new FactsDB(join(dir, "facts.db"));
+    const scoped = db.store({
+      text: "Scoped distill fact",
+      category: "project",
+      importance: 0.8,
+      entity: "hybrid-memory",
+      key: "status",
+      value: "in_progress",
+      source: "distillation",
+    });
+    const vectorDb = {
+      search: vi.fn().mockResolvedValue([{ entry: { id: scoped.id }, score: 0.93 }]),
+      hasDuplicate: vi.fn().mockResolvedValue(true),
+      getLastSearchFailReason: vi.fn().mockReturnValue("lance_error"),
+      isMemoriesVectorSchemaValid: vi.fn().mockReturnValue(true),
+    };
+
+    const result = await resolveDistillVectorCandidates({
+      fuzzyDedupe: true,
+      vector: [0.1, 0.2],
+      vectorDb,
+      factsDb: db,
+      embeddingModelName: null,
+    });
+
+    expect(result.skipAsDuplicate).toBe(false);
+    expect(result.vectorCandidates).toEqual([{ id: scoped.id, score: 0.93 }]);
+    expect(vectorDb.hasDuplicate).not.toHaveBeenCalled();
   });
 
   it("resolveDistillVectorCandidates skips vector work when fuzzyDedupe is disabled", async () => {

--- a/extensions/memory-hybrid/tools/crystallization-tools.ts
+++ b/extensions/memory-hybrid/tools/crystallization-tools.ts
@@ -22,6 +22,7 @@ import { BROADCAST_CHANGE_SESSION_KEY } from "../services/change-feed-emit.js";
 import type { ChangeFeed } from "../services/change-feed.js";
 import { capturePluginError } from "../services/error-reporter.js";
 import { summarizeSkillProposalValidation } from "../services/generated-skill-validation.js";
+import { resolveWorkerLeasesConfig } from "../services/worker-lease.js";
 
 interface CrystallizationToolsContext {
   crystallizationStore: CrystallizationStore;
@@ -55,15 +56,31 @@ export function registerCrystallizationTools(ctx: CrystallizationToolsContext, a
           cfg.crystallization,
           changeFeedEmit,
         );
+        const workerLeases = resolveWorkerLeasesConfig(cfg.maintenance.orchestrator?.workerLeases);
+        const rawDb =
+          workerLeases.enabled && typeof factsDb.getRawDb === "function" ? factsDb.getRawDb() : null;
+        if (workerLeases.enabled && !rawDb) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: "Crystallization unavailable: facts database is not initialized for worker leases.",
+              },
+            ],
+            details: { error: "facts_db_unavailable", proposed: 0, skipped: 0, reasons: [] },
+          };
+        }
         // Issue: skill proposal lifecycle — tool-triggered crystallization should never install directly.
         const result = proposer.runCycle({
           autoApproveOverride: false,
-          leaseContext: {
-            db: factsDb.getRawDb(),
-            ownerSessionId: `plugin-${process.pid}`,
-            workerLeases: cfg.maintenance.orchestrator?.workerLeases,
-            logger: api.logger,
-          },
+          leaseContext: rawDb
+            ? {
+                db: rawDb,
+                ownerSessionId: `plugin-${process.pid}`,
+                workerLeases: cfg.maintenance.orchestrator?.workerLeases,
+                logger: api.logger,
+              }
+            : undefined,
         });
 
         const lines: string[] = [];

--- a/extensions/memory-hybrid/tools/memory/register-recall-tools.ts
+++ b/extensions/memory-hybrid/tools/memory/register-recall-tools.ts
@@ -498,13 +498,16 @@ export function registerRecallTools(runtime: MemoryToolRuntime): void {
       scopeFilter?: ScopeFilter;
     },
   ): SearchResult[] {
-    const ftsHits = searchFts(factsDb.getRawDb(), query, {
-      limit: recallLimit,
-      entityFilter: opts.entity,
-      tagFilter: opts.tag,
-      includeSuperseded: opts.includeSuperseded,
-      asOf: opts.asOfSec,
-    });
+    const ftsHits =
+      typeof factsDb.getRawDb === "function"
+        ? searchFts(factsDb.getRawDb(), query, {
+            limit: recallLimit,
+            entityFilter: opts.entity,
+            tagFilter: opts.tag,
+            includeSuperseded: opts.includeSuperseded,
+            asOf: opts.asOfSec,
+          })
+        : [];
     const out: SearchResult[] = [];
     for (const hit of ftsHits) {
       const getByIdOpts =
@@ -1320,6 +1323,12 @@ export function registerRecallTools(runtime: MemoryToolRuntime): void {
       async execute() {
         const workerLeases = resolveWorkerLeasesConfig(cfg.maintenance.orchestrator?.workerLeases);
         const now = Math.floor(Date.now() / 1000);
+        if (typeof factsDb.getRawDb !== "function") {
+          return {
+            content: [{ type: "text", text: "Worker lease status unavailable (factsDb has no raw DB handle)." }],
+            details: { workers: [] },
+          };
+        }
         const leases = listWorkerLeases(factsDb.getRawDb());
         const workers = leases.map((l) => {
           const quietEnd = isInQuietWindow(workerLeases) ? quietWindowEndEpochSec(workerLeases) : null;

--- a/extensions/memory-hybrid/tools/memory/register-store-tools.ts
+++ b/extensions/memory-hybrid/tools/memory/register-store-tools.ts
@@ -84,7 +84,34 @@ export function registerStoreTools(runtime: MemoryToolRuntime): void {
     storeRegistryEmbeddings,
     isEdictWriteToolEnabled,
     sanitizeScopeParam,
+    wal,
+    walWrite,
+    walRemove,
   } = runtime;
+
+  const writeStoreWal = (
+    storeWal: ReturnType<typeof resolveToolVaultWal>,
+    operation: "store" | "update",
+    data: Record<string, unknown>,
+    supersedeTargetId?: string,
+  ) => {
+    if (storeWal != null && storeWal !== wal) {
+      return walWriteEntry(storeWal, operation, data, api.logger, supersedeTargetId);
+    }
+    return walWrite(operation, data, api.logger, supersedeTargetId);
+  };
+
+  const removeStoreWal = (storeWal: ReturnType<typeof resolveToolVaultWal>, id: string) => {
+    if (storeWal != null && storeWal !== wal) {
+      return walRemoveEntry(storeWal, id, api.logger);
+    }
+    return walRemove(id, api.logger);
+  };
+
+  const storeWalWriteFailed = (storeWal: ReturnType<typeof resolveToolVaultWal>, walEntryId: string | null) => {
+    const walRef = storeWal != null && storeWal !== wal ? storeWal : wal;
+    return isWalWriteFailure(walRef, walEntryId);
+  };
 
   const walWriteFailedResponse = () => ({
     content: [
@@ -262,7 +289,7 @@ export function registerStoreTools(runtime: MemoryToolRuntime): void {
 
           const provenanceSessionId = api.context?.sessionId ?? null;
           const recordActiveStoreProvenance = (factId: string, sourceText?: string) => {
-            if (!provenanceService || !cfg.provenance.enabled) return;
+            if (!provenanceService || cfg.provenance?.enabled !== true) return;
             try {
               provenanceService.addEdge(factId, {
                 edgeType: "DERIVED_FROM",
@@ -366,7 +393,7 @@ export function registerStoreTools(runtime: MemoryToolRuntime): void {
             autoKey?: string | null,
             autoValue?: string | null,
           ) => {
-            if (!cfg.verification.enabled || !verificationStore) return;
+            if (!cfg.verification?.enabled || !verificationStore) return;
             const shouldEnroll =
               explicitVerificationTier === "critical" ||
               (cfg.verification.autoClassify &&
@@ -708,7 +735,7 @@ export function registerStoreTools(runtime: MemoryToolRuntime): void {
                   warnMessage: `memory-hybrid: blocked cross-scope or unknown memory_store UPDATE target ${classification.targetId}`,
                 });
                 if (oldFact) {
-                  const walEntryId = await walWriteEntry(
+                  const walEntryId = await writeStoreWal(
                     storeWal,
                     "update",
                     {
@@ -728,10 +755,9 @@ export function registerStoreTools(runtime: MemoryToolRuntime): void {
                       scope,
                       scopeTarget,
                     },
-                    api.logger,
                     classification.targetId,
                   );
-                  if (isWalWriteFailure(storeWal, walEntryId)) {
+                  if (storeWalWriteFailed(storeWal, walEntryId)) {
                     return walWriteFailedResponse();
                   }
 
@@ -764,7 +790,7 @@ export function registerStoreTools(runtime: MemoryToolRuntime): void {
                     updateStoreResult.newlyStored === false &&
                     !updateStoreResult.embeddingStale
                   ) {
-                    if (walEntryId) await walRemoveEntry(storeWal, walEntryId, api.logger);
+                    if (walEntryId) await removeStoreWal(storeWal, walEntryId);
                     return {
                       content: [
                         {
@@ -800,7 +826,7 @@ export function registerStoreTools(runtime: MemoryToolRuntime): void {
                     } catch (err) {
                       api.logger.warn(`memory-hybrid: UPDATE merge vector refresh failed: ${err}`);
                     }
-                    if (walEntryId) await walRemoveEntry(storeWal, walEntryId, api.logger);
+                    if (walEntryId) await removeStoreWal(storeWal, walEntryId);
                     return {
                       content: [
                         {
@@ -878,7 +904,7 @@ export function registerStoreTools(runtime: MemoryToolRuntime): void {
                     api.logger.info?.(
                       `memory-hybrid: UPDATE — superseded ${classification.targetId} with ${newEntry.id}: ${classification.reason}`,
                     );
-                    if (walEntryId) await walRemoveEntry(storeWal, walEntryId, api.logger);
+                    if (walEntryId) await removeStoreWal(storeWal, walEntryId);
                     return {
                       content: [
                         {
@@ -898,7 +924,7 @@ export function registerStoreTools(runtime: MemoryToolRuntime): void {
                     };
                   }
                   // WAL cleanup for skipped update path
-                  if (walEntryId) await walRemoveEntry(storeWal, walEntryId, api.logger);
+                  if (walEntryId) await removeStoreWal(storeWal, walEntryId);
                   return {
                     content: [
                       {
@@ -925,7 +951,7 @@ export function registerStoreTools(runtime: MemoryToolRuntime): void {
 
           // Scope was resolved above (before classify-before-write) for WAL and classification consistency.
 
-          const walEntryId = await walWriteEntry(
+          const walEntryId = await writeStoreWal(
             storeWal,
             "store",
             {
@@ -945,9 +971,8 @@ export function registerStoreTools(runtime: MemoryToolRuntime): void {
               scope,
               scopeTarget,
             },
-            api.logger,
           );
-          if (isWalWriteFailure(storeWal, walEntryId)) {
+          if (storeWalWriteFailed(storeWal, walEntryId)) {
             return walWriteFailedResponse();
           }
           const decayFreezeUntil =
@@ -980,7 +1005,7 @@ export function registerStoreTools(runtime: MemoryToolRuntime): void {
           });
           const entry = storeResult.entry;
           if (!storeResult.skipped && storeResult.newlyStored === false && !storeResult.embeddingStale) {
-            if (walEntryId) await walRemoveEntry(storeWal, walEntryId, api.logger);
+            if (walEntryId) await removeStoreWal(storeWal, walEntryId);
             return {
               content: [
                 {
@@ -1048,8 +1073,8 @@ export function registerStoreTools(runtime: MemoryToolRuntime): void {
 
             if (
               storeResult.newlyStored &&
-              cfg.lifecycle.fragmentEmbedding.enabled &&
-              textToStore.length >= cfg.lifecycle.fragmentEmbedding.minChars
+              cfg.lifecycle?.fragmentEmbedding?.enabled === true &&
+              textToStore.length >= (cfg.lifecycle?.fragmentEmbedding?.minChars ?? 6000)
             ) {
               setImmediate(() => {
                 void import("../../services/fragment-embedding.js")
@@ -1059,7 +1084,7 @@ export function registerStoreTools(runtime: MemoryToolRuntime): void {
                       vectorDb: storeVectorDb,
                       embeddings,
                       parentFact: entry,
-                      cfg: cfg.lifecycle.fragmentEmbedding,
+                      cfg: cfg.lifecycle!.fragmentEmbedding!,
                       logger: api.logger,
                     }),
                   )
@@ -1282,7 +1307,7 @@ export function registerStoreTools(runtime: MemoryToolRuntime): void {
               context: { category },
             });
 
-            if (walEntryId) await walRemoveEntry(storeWal, walEntryId, api.logger);
+            if (walEntryId) await removeStoreWal(storeWal, walEntryId);
             return {
               content: [
                 {
@@ -1316,7 +1341,7 @@ export function registerStoreTools(runtime: MemoryToolRuntime): void {
             };
           }
           // WAL cleanup and return for skipped store path (Bug fix #1560, #1561)
-          if (walEntryId) await walRemoveEntry(storeWal, walEntryId, api.logger);
+          if (walEntryId) await removeStoreWal(storeWal, walEntryId);
           return {
             content: [
               {

--- a/packages/openclaw-hybrid-memory-install/package.json
+++ b/packages/openclaw-hybrid-memory-install/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-hybrid-memory-install",
-  "version": "2026.6.250",
+  "version": "2026.6.252",
   "description": "Standalone installer for openclaw-hybrid-memory. Use when OpenClaw config validation fails.",
   "bin": {
     "openclaw-hybrid-memory-install": "./install.js"

--- a/packages/openclaw-hybrid-memory-install/package.json
+++ b/packages/openclaw-hybrid-memory-install/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-hybrid-memory-install",
-  "version": "2026.6.252",
+  "version": "2026.6.254",
   "description": "Standalone installer for openclaw-hybrid-memory. Use when OpenClaw config validation fails.",
   "bin": {
     "openclaw-hybrid-memory-install": "./install.js"

--- a/release-notes/release-notes-2026.6.252.md
+++ b/release-notes/release-notes-2026.6.252.md
@@ -1,0 +1,30 @@
+# Release notes — OpenClaw Hybrid Memory **2026.6.252**
+
+**Release date:** 2026-06-25  
+**Since:** [2026.6.250](CHANGELOG.md#20266250---2026-06-25)  
+**Full changelog:** [CHANGELOG.md](../CHANGELOG.md) — section **[2026.6.252]**
+
+## Highlights
+
+Combined maintenance release for [#1945](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/1945) and [#1947](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/1947).
+
+### What changed
+
+- **Project-state LWW:** Per-fact PR/issue ref counting stops split-ref false positives on `possible-entity-reuse`.
+- **Distill dedupe:** LanceDB neighbour candidates now reach `applyDedupe`; degraded vector search falls back to `hasDuplicate`; distillation project facts can vector-dedupe across entity slug drift.
+- **Observability:** Distill reports `dedupeDegraded` / `distillDedupeMode` when vector search is unavailable.
+
+### After upgrading
+
+```bash
+openclaw plugins update openclaw-hybrid-memory@2026.6.252
+systemctl --user restart openclaw-gateway
+openclaw hybrid-mem verify
+```
+
+Validate maintenance impact:
+
+```bash
+openclaw hybrid-mem quality contradictions --project-state-lww --dry-run --verbose
+# After the next nightly distill, confirm distill→distill pair growth slows
+```

--- a/release-notes/release-notes-2026.6.253.md
+++ b/release-notes/release-notes-2026.6.253.md
@@ -1,0 +1,24 @@
+# Release notes — OpenClaw Hybrid Memory **2026.6.253**
+
+**Release date:** 2026-06-25  
+**Since:** [2026.6.252](CHANGELOG.md#2026252---2026-06-25)  
+**Full changelog:** [CHANGELOG.md](../CHANGELOG.md) — section **[2026.6.253]**
+
+## Highlights
+
+QA hardening follow-up for [#1945](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/1945) and [#1947](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/1947).
+
+### What changed
+
+- **Distill dedupe:** Restored `vectorDb.hasDuplicate` when `fuzzyDedupe` is off; redact before lexical pre-check; count `storeResult.skipped` in telemetry.
+- **Vector fallback:** Skip ineffective `hasDuplicate` when LanceDB schema is invalid.
+- **Entity safety:** Distillation vector dedupe requires compatible entity slugs (prefix), not key-only.
+- **LWW overload:** Flag asymmetric ref splits (2+1) while preserving 2+2 queue-drift supersede (#1945).
+
+### After upgrading
+
+```bash
+openclaw plugins update openclaw-hybrid-memory@2026.6.253
+systemctl --user restart openclaw-gateway
+openclaw hybrid-mem verify
+```


### PR DESCRIPTION
## Summary

Combined maintenance release (**2026.6.252**) fixing ambiguity backlog drainage on two paths:

- **#1945 — Project-state LWW entity-reuse heuristic:** Count distinct `#NNNN` refs per fact instead of across both facts in a pair, so legitimate `status` / `next` transitions no longer false-positive as `possible-entity-reuse`.
- **#1947 — Distill vector dedupe:** Wire LanceDB neighbour candidates into `storeWithResult`, restore `hasDuplicate` fallback when vector search degrades, pass structured fields into the lexical pre-check, and allow distillation project facts to vector-dedupe across entity slug drift when keys match (#1276 guard preserved for other sources).

Also includes QA hardening from code review: shared `vector-dedupe-helpers`, distill `dedupeDegraded` / `distillDedupeMode` telemetry, scoped candidate filtering, and expanded regression tests.

## Root causes

**#1945:** `isPossiblyOverloadedEntity` summed PR/issue refs across old + new fact text/value. Split-ref transitions exceeded the combined threshold even when each fact alone was fine.

**#1947:** Two gaps:
1. Distill called `vectorDb.hasDuplicate()` but never plumbed `vectorCandidates` into `applyDedupe`.
2. Keyed `category=project` facts hit a #1276 early return before the vector branch, ignoring candidates for the dominant distill→distill shape.

## Test plan

- [x] `npm test -- project-state-lww.test.ts distill-vector-dedupe.test.ts dedupe-policy.test.ts vector-dedupe-helpers.test.ts extract-directives-cli.test.ts` (56+ tests pass)
- [ ] `openclaw hybrid-mem quality contradictions --project-state-lww --dry-run --verbose` → non-zero `would supersede` for split-ref pairs
- [ ] After nightly distill: distill→distill pair growth drops from ~80–100/night; check logs for `distill DEGRADED` when LanceDB unavailable

Fixes #1945
Fixes #1947