### PR TITLE
fix: maintenance nightly exit codes + memory_store empty args (#1949, #1950)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ---
 
+## [2026.6.257] - 2026-06-25
+
+### Fixed
+
+- **Maintenance nightly exit codes (#1949):** Treat `extract-implicit` budget-cap partial runs (`maxWallClock`, session/signal/trajectory caps) as successful monitoring steps instead of failures; stop counting continuous-verification LLM downgrades to `UNCERTAIN` as errors and do not fail nightly when all facts receive uncertain verdicts; run orchestrator `audit-health` non-strict (warnings only) while still failing on report errors. Cron exit validator ignores legacy `all_uncertain` degraded machine-status lines.
+
+---
+
 ## [2026.6.256] - 2026-06-25
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
+<<<<<<< HEAD
 - **Maintenance nightly exit codes (#1949):** Treat `extract-implicit` budget-cap partial runs (`maxWallClock`, session/signal/trajectory caps) as successful monitoring steps instead of failures; stop counting continuous-verification LLM downgrades to `UNCERTAIN` as errors and do not fail nightly when all facts receive uncertain verdicts; run orchestrator `audit-health` non-strict (warnings only) while still failing on report errors. Cron exit validator ignores legacy `all_uncertain` degraded machine-status lines.
+=======
+- **memory_store empty args (#1950):** Guard missing or non-string `text` with `String(text ?? "").trim()` so streaming-parser `{}` args return a structured `invalid_text` error instead of throwing `Cannot read properties of undefined (reading 'trim')`.
+>>>>>>> 2b1d5c0ec (fix(memory_store): handle missing text from empty tool args (#1950))
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,11 +31,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
-<<<<<<< HEAD
 - **Maintenance nightly exit codes (#1949):** Treat `extract-implicit` budget-cap partial runs (`maxWallClock`, session/signal/trajectory caps) as successful monitoring steps instead of failures; stop counting continuous-verification LLM downgrades to `UNCERTAIN` as errors and do not fail nightly when all facts receive uncertain verdicts; run orchestrator `audit-health` non-strict (warnings only) while still failing on report errors. Cron exit validator ignores legacy `all_uncertain` degraded machine-status lines.
-=======
-- **memory_store empty args (#1950):** Guard missing or non-string `text` with `String(text ?? "").trim()` so streaming-parser `{}` args return a structured `invalid_text` error instead of throwing `Cannot read properties of undefined (reading 'trim')`.
->>>>>>> 2b1d5c0ec (fix(memory_store): handle missing text from empty tool args (#1950))
+- **memory_store empty args (#1950):** Require string `text` before validation so streaming-parser `{}` or malformed args return structured `invalid_text` instead of throwing on `undefined.trim()` or coercing objects to `[object Object]`.
+- **Maintenance guard (#1949 review):** Allow cron guard advancement when summary validation reports monitoring-only degraded semantics with no blocking issues.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ---
 
-## [2026.6.257] - 2026-06-25
+## [2026.6.258] - 2026-06-25
 
 ### Fixed
 

--- a/extensions/memory-hybrid/cli/commands/manage/dream-cycle-followup-steps.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/dream-cycle-followup-steps.ts
@@ -9,7 +9,9 @@ import { runCrystallizationProposalCycle } from "../../../services/crystallizati
 import { getEffectivenessReport, runClosedLoopAnalysis } from "../../../services/feedback-effectiveness.js";
 import {
   assessContinuousVerificationResult,
+  extractImplicitSemanticOutcome,
   formatContinuousVerificationAssessmentLine,
+  isGracefulExtractImplicitPartial,
 } from "./dream-cycle-followup.js";
 
 export interface DreamCycleFollowUpDeps {
@@ -66,8 +68,8 @@ export async function runExtractImplicitStep(deps: DreamCycleFollowUpDeps, verbo
     includeClosedLoop: false,
     verbose,
   });
-  const summary = `${res.signalsExtracted} signals (${res.positiveCount}+/${res.negativeCount}-) from ${res.sessionsProcessed}/${res.sessionsScanned} sessions semantic=${res.partial ? "partial" : "success"}`;
-  if (res.partial) {
+  const summary = `${res.signalsExtracted} signals (${res.positiveCount}+/${res.negativeCount}-) from ${res.sessionsProcessed}/${res.sessionsScanned} sessions semantic=${extractImplicitSemanticOutcome(res)}`;
+  if (res.partial && !isGracefulExtractImplicitPartial(res.partialReason)) {
     throw new Error(`extract-implicit partial failure (${res.partialReason ?? "capped"}): ${summary}`);
   }
   return summary;

--- a/extensions/memory-hybrid/cli/commands/manage/dream-cycle-followup.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/dream-cycle-followup.ts
@@ -20,6 +20,24 @@ export interface ContinuousVerificationAssessment {
   summary?: string;
 }
 
+/** Budget-cap partial runs that persist useful work and resume on the next nightly. */
+const GRACEFUL_EXTRACT_IMPLICIT_PARTIAL_REASONS = new Set([
+  "maxWallClock",
+  "maxSessions",
+  "maxSignals",
+  "maxTrajectories",
+]);
+
+export function isGracefulExtractImplicitPartial(partialReason?: string): boolean {
+  return partialReason != null && GRACEFUL_EXTRACT_IMPLICIT_PARTIAL_REASONS.has(partialReason);
+}
+
+export function extractImplicitSemanticOutcome(res: { partial?: boolean; partialReason?: string }): string {
+  if (!res.partial) return "success";
+  if (isGracefulExtractImplicitPartial(res.partialReason)) return "monitoring";
+  return "partial";
+}
+
 export function formatExtractImplicitFeedbackProgress(
   snapshot: ExtractImplicitFeedbackProgressSnapshot | undefined,
 ): string | undefined {
@@ -57,24 +75,17 @@ export function formatExtractImplicitFeedbackProgress(
 }
 
 export function assessContinuousVerificationResult(result: VerificationCycleResult): ContinuousVerificationAssessment {
-  if (result.errors > 0) {
+  const verdicts = result.confirmed + result.stale + result.uncertain;
+  if (result.errors > 0 && (result.checked === 0 || verdicts < result.checked)) {
     const summary =
       result.checked === 0
         ? `infrastructure error prevented verification (${result.errors} error(s))`
-        : `${result.errors}/${result.checked} verification check(s) errored`;
+        : `${result.errors}/${result.checked} verification check(s) failed without a verdict`;
     return {
       status: "degraded",
       reason: "errors_present",
       shouldFailPipeline: true,
       summary,
-    };
-  }
-  if (result.checked > 0 && result.confirmed === 0 && result.stale === 0) {
-    return {
-      status: "degraded",
-      reason: "all_uncertain",
-      shouldFailPipeline: true,
-      summary: `all ${result.checked} verification check(s) were uncertain`,
     };
   }
   return { status: "healthy", reason: "healthy", shouldFailPipeline: false };

--- a/extensions/memory-hybrid/cli/commands/manage/maintenance-step-runners.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/maintenance-step-runners.ts
@@ -19,7 +19,6 @@ import {
 import { syncLifecycleFromGitHub } from "../../../services/lifecycle/github-adapter.js";
 import { runAnalyzeMaintenanceLogs } from "./register-analyze-maintenance-logs.js";
 import { buildAuditHealthReport } from "./storage-stats-helpers.js";
-import { buildAuditHealthExitInfo } from "../../../services/audit-health-exit-info.js";
 import { recordStorageGrowthSample } from "./storage-stats-helpers.js";
 import { runPendingDigestAutopilotCron } from "../../../services/pending-digest-autopilot-cron.js";
 import { buildPendingReviewDigestReport } from "../../../services/pending-review-digest.js";
@@ -40,6 +39,7 @@ import {
   runExtractImplicitStep,
   runToolEffectivenessStep,
 } from "./dream-cycle-followup-steps.js";
+import { extractImplicitSemanticOutcome, isGracefulExtractImplicitPartial } from "./dream-cycle-followup.js";
 import { cleanupImplicitFeedbackDuplicates } from "../../cmd-feedback.js";
 import { resolveScanMaintenanceOverrides, type ScanMaintenanceOverrideInput } from "../../maintenance-overrides.js";
 import { nowIso } from "../../../utils/dates.js";
@@ -142,12 +142,13 @@ function formatExtractImplicitSummary(res: {
   sessionsProcessed: number;
   sessionsScanned: number;
   partial?: boolean;
+  partialReason?: string;
 }): string {
-  return `${res.signalsExtracted} signals (${res.positiveCount}+/${res.negativeCount}-) from ${res.sessionsProcessed}/${res.sessionsScanned} sessions semantic=${res.partial ? "partial" : "success"}`;
+  return `${res.signalsExtracted} signals (${res.positiveCount}+/${res.negativeCount}-) from ${res.sessionsProcessed}/${res.sessionsScanned} sessions semantic=${extractImplicitSemanticOutcome(res)}`;
 }
 
 function assertExtractImplicitNotPartial(res: { partial?: boolean; partialReason?: string }, summary: string): void {
-  if (res.partial) {
+  if (res.partial && !isGracefulExtractImplicitPartial(res.partialReason)) {
     throw new Error(`extract-implicit partial failure (${res.partialReason ?? "capped"}): ${summary}`);
   }
 }
@@ -671,19 +672,11 @@ export function buildCliMaintenanceRunners(
       b.cfg.entityExtraction?.stopWords ?? [],
       b.cfg.graph?.hubDegreeCap,
     );
-    const exitInfo = buildAuditHealthExitInfo({
-      strict: true,
-      warningCount: report.warningCount,
-      errorCount: report.errorCount,
-      ok: report.ok,
-      status: report.status,
-    });
-    if (exitInfo.exitCode !== 0) {
-      throw new Error(
-        exitInfo.strictFailureReason ?? `${exitInfo.errorCount} error(s), ${exitInfo.warningCount} warning(s)`,
-      );
+    if (report.errorCount > 0) {
+      throw new Error(`${report.errorCount} error(s) present`);
     }
-    return `warnings=${report.warningCount} errors=${report.errorCount}`;
+    const semantic = report.warningCount > 0 ? "monitoring" : "success";
+    return `warnings=${report.warningCount} errors=${report.errorCount} semantic=${semantic}`;
   });
 
   set("crystallization-rescan", async () => {

--- a/extensions/memory-hybrid/openclaw.plugin.json
+++ b/extensions/memory-hybrid/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "openclaw-hybrid-memory",
   "kind": "memory",
-  "version": "2026.6.256",
+  "version": "2026.6.257",
   "contracts": {
     "tools": [
       "active_task_checkpoint",

--- a/extensions/memory-hybrid/openclaw.plugin.json
+++ b/extensions/memory-hybrid/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "openclaw-hybrid-memory",
   "kind": "memory",
-  "version": "2026.6.257",
+  "version": "2026.6.258",
   "contracts": {
     "tools": [
       "active_task_checkpoint",

--- a/extensions/memory-hybrid/package.json
+++ b/extensions/memory-hybrid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-hybrid-memory",
-  "version": "2026.6.256",
+  "version": "2026.6.257",
   "type": "module",
   "description": "Give your OpenClaw agent lasting memory: structured facts, semantic search, auto-capture & recall, decay, optional credential vault. Part of Hybrid Memory v3.",
   "files": [

--- a/extensions/memory-hybrid/package.json
+++ b/extensions/memory-hybrid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-hybrid-memory",
-  "version": "2026.6.257",
+  "version": "2026.6.258",
   "type": "module",
   "description": "Give your OpenClaw agent lasting memory: structured facts, semantic search, auto-capture & recall, decay, optional credential vault. Part of Hybrid Memory v3.",
   "files": [

--- a/extensions/memory-hybrid/services/continuous-verifier.ts
+++ b/extensions/memory-hybrid/services/continuous-verifier.ts
@@ -249,7 +249,6 @@ export class ContinuousVerifier {
             operation: "verify-fact",
             metadata: { factId: fact.factId },
           });
-          result.errors++;
           recordVerificationError(result, `fact=${fact.factId.slice(0, 8)}…`, err);
           outcome = "UNCERTAIN";
         }

--- a/extensions/memory-hybrid/services/cron-exit-validator.ts
+++ b/extensions/memory-hybrid/services/cron-exit-validator.ts
@@ -251,8 +251,15 @@ function detectDegradedContinuousVerificationStatus(logContent: string): Degrade
     if (!marker) continue;
     const machineLine = marker[1].trim();
     const reasonMatch = machineLine.match(/\breason=([a-z_]+)/i);
+    const reason = reasonMatch?.[1]?.toLowerCase();
+    if (reason === "all_uncertain") continue;
+    if (reason === "errors_present") {
+      const errorsMatch = machineLine.match(/\berrors=(\d+)/i);
+      const errors = errorsMatch ? Number.parseInt(errorsMatch[1], 10) : 0;
+      if (!Number.isFinite(errors) || errors <= 0) continue;
+    }
     return {
-      reason: reasonMatch?.[1]?.toLowerCase(),
+      reason,
       machineLine,
     };
   }

--- a/extensions/memory-hybrid/services/cron-exit-validator.ts
+++ b/extensions/memory-hybrid/services/cron-exit-validator.ts
@@ -1809,11 +1809,11 @@ export function shouldUpdateMaintenanceGuard(
   if (reportableIssues.some(isGuardBlockingSemanticIssue)) return false;
   if (semanticStatus === "semantic_fail") return false;
   if (semanticStatus === "degraded") {
-    return (
-      reportableIssues.length > 0 &&
-      reportableIssues.every((issue) =>
-        (MONITORING_ONLY_FAILURE_CLASSES as readonly string[]).includes(issue.failureClass),
-      )
+    // Monitoring-only step semantics (budget caps, advisory audit warnings) can leave
+    // semanticStatus degraded without reportable issues when summary.json validation runs.
+    if (reportableIssues.length === 0) return true;
+    return reportableIssues.every((issue) =>
+      (MONITORING_ONLY_FAILURE_CLASSES as readonly string[]).includes(issue.failureClass),
     );
   }
   return true;

--- a/extensions/memory-hybrid/tests/continuous-verifier.test.ts
+++ b/extensions/memory-hybrid/tests/continuous-verifier.test.ts
@@ -20,7 +20,7 @@
  *     - CONFIRMED path: store updated (new version), confirmed counter incremented
  *     - STALE path: fact confidence set to 0.5, tag 'needs-verification' added
  *     - UNCERTAIN path: tag 'review-needed' added, confidence unchanged
- *     - counts errors without aborting the rest of the cycle
+ *     - LLM failures degrade to UNCERTAIN without incrementing errors
  *     - processes multiple facts in a single cycle
  *     - underlying fact not found — STALE/UNCERTAIN tags are no-ops (no crash)
  *   runVerificationCycle:
@@ -360,7 +360,7 @@ describe("ContinuousVerifier.runCycle — UNCERTAIN", () => {
 // ---------------------------------------------------------------------------
 
 describe("ContinuousVerifier.runCycle — error handling", () => {
-  it("counts errors but continues processing remaining facts", async () => {
+  it("continues processing remaining facts when an LLM call degrades to UNCERTAIN", async () => {
     let callCount = 0;
     const mockOpenAI = {
       chat: {
@@ -386,14 +386,15 @@ describe("ContinuousVerifier.runCycle — error handling", () => {
 
     const result = await verifier.runCycle();
     expect(result.checked).toBe(2);
-    expect(result.errors).toBe(1);
+    expect(result.errors).toBe(0);
+    expect(result.uncertain).toBe(1);
     expect(result.confirmed).toBe(1);
     expect(result.errorSummaries).toHaveLength(1);
     expect(result.errorSummaries[0]).toContain("fact=fact-err");
     expect(result.errorSummaries[0]).toContain("transient error");
   });
 
-  it("records compact summaries when every verification call errors", async () => {
+  it("records compact summaries when every verification call degrades to UNCERTAIN", async () => {
     const mockOpenAI = makeMockOpenAI(new Error("provider timeout while checking fact"));
     const verifier = new ContinuousVerifier(store, factsDb, mockOpenAI as never);
 
@@ -430,7 +431,7 @@ describe("ContinuousVerifier.runCycle — error handling", () => {
     expect(result.confirmed).toBe(0);
     expect(result.stale).toBe(0);
     expect(result.uncertain).toBe(2);
-    expect(result.errors).toBe(2);
+    expect(result.errors).toBe(0);
     expect(result.errorSummaries).toHaveLength(2);
     expect(result.errorSummaries[0]).toContain("provider timeout while checking fact");
     expect(result.errorSummaries[1]).toContain("provider timeout while checking fact");

--- a/extensions/memory-hybrid/tests/cron-exit-validator.test.ts
+++ b/extensions/memory-hybrid/tests/cron-exit-validator.test.ts
@@ -2246,6 +2246,52 @@ error: unknown command 'bar'
       expect(result.guardUpdated).toBe(false);
     });
 
+    it("updates guard for successful nightly summary with monitoring-only step semantics", () => {
+      const tmpDir = mkdtempSync(join(tmpdir(), "cron-summary-monitoring-"));
+      const summaryPath = join(tmpDir, "maintenance-nightly-run.summary.json");
+      const exitPath = join(tmpDir, "maintenance-nightly-run.exit.txt");
+      const logPath = join(tmpDir, "maintenance-nightly-run.log");
+      writeFileSync(
+        summaryPath,
+        JSON.stringify({
+          schemaVersion: 1,
+          runId: "orch-monitoring",
+          tierLabel: "nightly",
+          startedAt: "2026-06-05T02:00:00.000Z",
+          finishedAt: "2026-06-05T02:30:00.000Z",
+          durationMs: 1000,
+          exitCode: 0,
+          summaryLine: "ok with monitoring semantics",
+          steps: [
+            {
+              name: "extract-implicit",
+              status: "ok",
+              summary:
+                "128 signals (106+/22-) from 116/471 sessions semantic=monitoring",
+              durationMs: 1200000,
+              semanticOutcome: "monitoring",
+            },
+            {
+              name: "audit-health",
+              status: "ok",
+              summary: "warnings=7 errors=0 semantic=monitoring",
+              durationMs: 1200,
+              semanticOutcome: "monitoring",
+            },
+          ],
+          counts: { ok: 2, skipped: 0, deferred: 0, failed: 0, rateLimited: 0 },
+        }),
+      );
+      writeFileSync(exitPath, "2026-06-05T02:30:00Z maintenance-nightly exit=0\n");
+      writeFileSync(logPath, "");
+
+      const result = validateFromSummaryJson(summaryPath, exitPath, logPath, ["maintenance-nightly"], true);
+      expect(result.maintenanceStatus).toBe("success");
+      expect(result.semanticStatus).toBe("degraded");
+      expect(result.guardUpdated).toBe(true);
+      expect(result.failedSteps).toHaveLength(0);
+    });
+
     it("falls back to HM_EXIT validation for empty consolidated summary", () => {
       const tmpDir = mkdtempSync(join(tmpdir(), "cron-summary-empty-consolidated-"));
       const summaryPath = join(tmpDir, "maintenance-nightly-run.summary.json");

--- a/extensions/memory-hybrid/tests/cron-exit-validator.test.ts
+++ b/extensions/memory-hybrid/tests/cron-exit-validator.test.ts
@@ -478,10 +478,9 @@ error: unknown command 'bar'
       expect(result.error).toContain("continuous-verification (exit=2 errors_present)");
     });
 
-    it.each([
-      ["errors_present", 12],
-      ["all_uncertain", 0],
-    ])("fails dream-cycle validation when continuous verification reports degraded %s machine status", (reason, errors) => {
+    it.each([["errors_present", 12] as const])(
+      "fails dream-cycle validation when continuous verification reports degraded %s machine status",
+      (reason, errors) => {
       const tmpDir = mkdtempSync(join(tmpdir(), "cron-test-"));
       const exitPath = join(tmpDir, "test.exit.txt");
       const logPath = join(tmpDir, "test.log");
@@ -510,11 +509,11 @@ error: unknown command 'bar'
       expect(result.error).toContain(`continuous-verification (exit=2 ${reason})`);
     });
 
-    it("uses an ISO-compatible timestamp for synthetic degraded verification failures without a dream-cycle ledger step", () => {
+    it("does not fail dream-cycle validation when continuous verification only reports all-uncertain outcomes", () => {
       const tmpDir = mkdtempSync(join(tmpdir(), "cron-test-"));
       const exitPath = join(tmpDir, "test.exit.txt");
       const logPath = join(tmpDir, "test.log");
-      writeFileSync(exitPath, "");
+      writeFileSync(exitPath, "2024-05-08T03:00:00Z dream-cycle exit=0\n");
       writeFileSync(
         logPath,
         [
@@ -530,11 +529,35 @@ error: unknown command 'bar'
 
       const result = validateMaintenanceExecution(exitPath, logPath, ["dream-cycle"]);
 
+      expect(result.maintenanceStatus).not.toBe("failed");
+      expect(result.failedSteps.some((s) => s.step === "continuous-verification")).toBe(false);
+    });
+
+    it("uses an ISO-compatible timestamp for synthetic degraded verification failures without a dream-cycle ledger step", () => {
+      const tmpDir = mkdtempSync(join(tmpdir(), "cron-test-"));
+      const exitPath = join(tmpDir, "test.exit.txt");
+      const logPath = join(tmpDir, "test.log");
+      writeFileSync(exitPath, "");
+      writeFileSync(
+        logPath,
+        [
+          "Continuous verification complete:",
+          "  Checked: 12",
+          "  Confirmed: 0",
+          "  Stale: 0",
+          "  Uncertain: 12",
+          "  Errors: 12",
+          "  Machine status: status=degraded reason=errors_present checked=12 confirmed=0 stale=0 uncertain=12 errors=12",
+        ].join("\n"),
+      );
+
+      const result = validateMaintenanceExecution(exitPath, logPath, ["dream-cycle"]);
+
       expect(result.maintenanceStatus).toBe("failed");
       expect(result.failedSteps).toHaveLength(1);
       expect(result.failedSteps[0].timestamp).toBe("1970-01-01T00:00:00Z");
       expect(Number.isNaN(Date.parse(result.failedSteps[0].timestamp))).toBe(false);
-      expect(result.failedSteps[0].failureReason).toBe("all_uncertain");
+      expect(result.failedSteps[0].failureReason).toBe("errors_present");
     });
 
     it("fails dream-cycle validation when core stages report failures in the log", () => {
@@ -990,21 +1013,20 @@ error: unknown command 'bar'
       );
     });
 
-    it("detects continuous-verification degraded on exit=0 and blocks guard", () => {
+    it("does not treat all-uncertain continuous-verification as a nightly failure on exit=0", () => {
       const tmpDir = mkdtempSync(join(tmpdir(), "cron-test-"));
       const exitPath = join(tmpDir, "continuous-verification.exit.txt");
       const logPath = join(tmpDir, "continuous-verification.log");
       writeFileSync(exitPath, "2026-05-08T02:15:30Z continuous-verification exit=0\n");
       writeFileSync(
         logPath,
-        "continuous-verification checked=12 confirmed=0 stale=0 uncertain=12 errors=0 semantic=partial Machine status: status=degraded reason=all_uncertain checked=12 confirmed=0 stale=0 uncertain=12 errors=0\n",
+        "continuous-verification checked=12 confirmed=0 stale=0 uncertain=12 errors=0 semantic=success Machine status: status=healthy reason=healthy checked=12 confirmed=0 stale=0 uncertain=12 errors=0\n",
       );
 
       const result = validateMaintenanceExecution(exitPath, logPath, ["continuous-verification"]);
 
-      expect(result.maintenanceStatus).toBe("failed");
-      expect(result.guardUpdated).toBe(false);
-      expect(result.reportableIssues).toContainEqual(
+      expect(result.maintenanceStatus).not.toBe("failed");
+      expect(result.reportableIssues).not.toContainEqual(
         expect.objectContaining({
           stepName: "continuous-verification",
           failureClass: "continuous_verification_all_uncertain",

--- a/extensions/memory-hybrid/tests/dream-cycle-followup-logging.test.ts
+++ b/extensions/memory-hybrid/tests/dream-cycle-followup-logging.test.ts
@@ -4,8 +4,10 @@ import {
   assessContinuousVerificationResult,
   applyDreamCyclePipelineExitCode,
   dreamCycleFollowUpSkipReason,
+  extractImplicitSemanticOutcome,
   formatContinuousVerificationAssessmentLine,
   formatExtractImplicitFeedbackProgress,
+  isGracefulExtractImplicitPartial,
   recordDreamCycleFollowUpFailure,
   shouldSkipDreamCycleFollowUps,
   runVerboseFollowUp,
@@ -99,7 +101,13 @@ describe("dream-cycle follow-up heartbeat logging", () => {
     );
   });
 
-  it("treats all-uncertain verification results as degraded", () => {
+  it("maps graceful extract-implicit budget caps to monitoring semantics", () => {
+    expect(isGracefulExtractImplicitPartial("maxWallClock")).toBe(true);
+    expect(extractImplicitSemanticOutcome({ partial: true, partialReason: "maxWallClock" })).toBe("monitoring");
+    expect(extractImplicitSemanticOutcome({ partial: true, partialReason: "reinforcementError" })).toBe("partial");
+  });
+
+  it("treats all-uncertain verification results as healthy when the cycle completed", () => {
     const assessment = assessContinuousVerificationResult({
       checked: 12,
       confirmed: 0,
@@ -109,46 +117,73 @@ describe("dream-cycle follow-up heartbeat logging", () => {
       errorSummaries: [],
     });
 
-    expect(assessment.status).toBe("degraded");
-    expect(assessment.reason).toBe("all_uncertain");
-    expect(assessment.shouldFailPipeline).toBe(true);
-    expect(assessment.summary).toContain("all 12 verification check(s) were uncertain");
+    expect(assessment.status).toBe("healthy");
+    expect(assessment.reason).toBe("healthy");
+    expect(assessment.shouldFailPipeline).toBe(false);
   });
 
-  it("treats verification errors as degraded even when outcomes are uncertain", () => {
+  it("treats LLM-downgraded uncertain outcomes as healthy when every fact got a verdict", () => {
     const assessment = assessContinuousVerificationResult({
       checked: 5,
       confirmed: 0,
       stale: 0,
       uncertain: 5,
-      errors: 5,
+      errors: 0,
       errorSummaries: [
         "fact=abc12345…: provider timeout",
         "fact=def67890…: provider timeout",
-        "fact=ghi54321…: provider timeout",
-        "fact=jkl98765…: provider timeout",
-        "fact=mno24680…: provider timeout",
       ],
+    });
+
+    expect(assessment.status).toBe("healthy");
+    expect(assessment.reason).toBe("healthy");
+    expect(assessment.shouldFailPipeline).toBe(false);
+  });
+
+  it("treats infrastructure verification errors as degraded pipeline failures", () => {
+    const assessment = assessContinuousVerificationResult({
+      checked: 0,
+      confirmed: 0,
+      stale: 0,
+      uncertain: 0,
+      errors: 1,
+      errorSummaries: ["listDueForReverification: db locked"],
     });
 
     expect(assessment.status).toBe("degraded");
     expect(assessment.reason).toBe("errors_present");
     expect(assessment.shouldFailPipeline).toBe(true);
-    expect(assessment.summary).toContain("5/5 verification check(s) errored");
+    expect(assessment.summary).toContain("infrastructure error prevented verification");
   });
 
-  it("emits machine-readable degraded verification status details", () => {
-    const result = {
+  it("treats per-fact failures without verdicts as degraded pipeline failures", () => {
+    const assessment = assessContinuousVerificationResult({
       checked: 5,
+      confirmed: 1,
+      stale: 0,
+      uncertain: 3,
+      errors: 1,
+      errorSummaries: ["fact=abc12345…: unexpected store failure"],
+    });
+
+    expect(assessment.status).toBe("degraded");
+    expect(assessment.reason).toBe("errors_present");
+    expect(assessment.shouldFailPipeline).toBe(true);
+    expect(assessment.summary).toContain("failed without a verdict");
+  });
+
+  it("emits machine-readable verification status details for infrastructure failures", () => {
+    const result = {
+      checked: 0,
       confirmed: 0,
       stale: 0,
-      uncertain: 5,
-      errors: 5,
-      errorSummaries: ["fact=abc12345…: provider timeout"],
+      uncertain: 0,
+      errors: 1,
+      errorSummaries: ["listDueForReverification: db locked"],
     };
     const assessment = assessContinuousVerificationResult(result);
     expect(formatContinuousVerificationAssessmentLine(result, assessment)).toBe(
-      "status=degraded reason=errors_present checked=5 confirmed=0 stale=0 uncertain=5 errors=5",
+      "status=degraded reason=errors_present checked=0 confirmed=0 stale=0 uncertain=0 errors=1",
     );
   });
 

--- a/extensions/memory-hybrid/tests/maintenance-validator-coverage.test.ts
+++ b/extensions/memory-hybrid/tests/maintenance-validator-coverage.test.ts
@@ -141,8 +141,11 @@ describe("maintenance validator coverage registry", () => {
     ).toBe(true);
   });
 
-  it("shouldUpdateMaintenanceGuard blocks guard for degraded semantic status without monitoring issues", () => {
-    expect(shouldUpdateMaintenanceGuard("success", [], "degraded")).toBe(false);
+  it("shouldUpdateMaintenanceGuard allows guard update for monitoring-only degraded semantics without issues", () => {
+    expect(shouldUpdateMaintenanceGuard("success", [], "degraded")).toBe(true);
+  });
+
+  it("shouldUpdateMaintenanceGuard blocks guard for degraded semantic status with blocking issues", () => {
     expect(
       shouldUpdateMaintenanceGuard(
         "success",

--- a/extensions/memory-hybrid/tests/memory-store-early-validation.test.ts
+++ b/extensions/memory-hybrid/tests/memory-store-early-validation.test.ts
@@ -153,6 +153,25 @@ describe("memory_store early validation — invalid text", () => {
     expect(embeddings.embed).not.toHaveBeenCalled();
   });
 
+  it("returns invalid_text error for non-string text without persisting garbage", async () => {
+    const walWrite = vi.fn().mockResolvedValue("wal-id");
+    const embeddings = makeMockEmbeddings();
+    const { api } = setupTool(walWrite, embeddings);
+
+    const storeTool = api.getTool("memory_store");
+    const result = (await storeTool?.execute("call-object-text", {
+      text: { note: "not a string" },
+    })) as {
+      content: Array<{ text: string }>;
+      details: { error: string };
+    };
+
+    expect(result.details.error).toBe("invalid_text");
+    expect(walWrite).not.toHaveBeenCalled();
+    expect(embeddings.embed).not.toHaveBeenCalled();
+    expect(factsDb.getAll()).toHaveLength(0);
+  });
+
   it("returns invalid_text error for empty string without writing WAL", async () => {
     const walWrite = vi.fn().mockResolvedValue("wal-id");
     const embeddings = makeMockEmbeddings();

--- a/extensions/memory-hybrid/tests/memory-store-early-validation.test.ts
+++ b/extensions/memory-hybrid/tests/memory-store-early-validation.test.ts
@@ -136,6 +136,23 @@ function setupTool(walWriteMock: ReturnType<typeof vi.fn>, embeddings: ReturnTyp
 // ---------------------------------------------------------------------------
 
 describe("memory_store early validation — invalid text", () => {
+  it("returns invalid_text error for missing text without throwing (Issue #1950)", async () => {
+    const walWrite = vi.fn().mockResolvedValue("wal-id");
+    const embeddings = makeMockEmbeddings();
+    const { api } = setupTool(walWrite, embeddings);
+
+    const storeTool = api.getTool("memory_store");
+    const result = (await storeTool?.execute("call-missing-text", {})) as {
+      content: Array<{ text: string }>;
+      details: { error: string };
+    };
+
+    expect(result.details.error).toBe("invalid_text");
+    expect(result.content[0]?.text).toContain("text is required");
+    expect(walWrite).not.toHaveBeenCalled();
+    expect(embeddings.embed).not.toHaveBeenCalled();
+  });
+
   it("returns invalid_text error for empty string without writing WAL", async () => {
     const walWrite = vi.fn().mockResolvedValue("wal-id");
     const embeddings = makeMockEmbeddings();

--- a/extensions/memory-hybrid/tools/memory/register-store-tools.ts
+++ b/extensions/memory-hybrid/tools/memory/register-store-tools.ts
@@ -240,7 +240,7 @@ export function registerStoreTools(runtime: MemoryToolRuntime): void {
           const storeWal = resolveToolVaultWal(runtime, typeof vaultParam === "string" ? vaultParam : undefined);
 
           // --- Early input validation (must run before any side effects) ---
-          const trimmedText = String(text ?? "").trim();
+          const trimmedText = typeof text === "string" ? text.trim() : "";
           if (trimmedText.length === 0) {
             return {
               content: [

--- a/extensions/memory-hybrid/tools/memory/register-store-tools.ts
+++ b/extensions/memory-hybrid/tools/memory/register-store-tools.ts
@@ -240,14 +240,20 @@ export function registerStoreTools(runtime: MemoryToolRuntime): void {
           const storeWal = resolveToolVaultWal(runtime, typeof vaultParam === "string" ? vaultParam : undefined);
 
           // --- Early input validation (must run before any side effects) ---
-          if (text.trim().length === 0) {
+          const trimmedText = String(text ?? "").trim();
+          if (trimmedText.length === 0) {
             return {
-              content: [{ type: "text", text: "memory_store: text must not be empty or whitespace." }],
+              content: [
+                {
+                  type: "text",
+                  text: "memory_store: text is required and must be non-empty (received empty or non-string text)",
+                },
+              ],
               details: { error: "invalid_text" },
             };
           }
 
-          const textToStore = prepareMemoryTextForStorage(text, cfg.captureMaxChars);
+          const textToStore = prepareMemoryTextForStorage(trimmedText, cfg.captureMaxChars);
           if (!textToStore || !isSubstantiveMemoryText(textToStore)) {
             return {
               content: [


### PR DESCRIPTION
## Summary

Combined fix for two unrelated false-failure / crash paths:

### #1949 — Maintenance nightly misleading exit codes

- **extract-implicit:** Budget-cap partial runs (`maxWallClock`, session/signal/trajectory caps) succeed with `semantic=monitoring` instead of failing the pipeline.
- **continuous-verification:** LLM downgrades to `UNCERTAIN` no longer increment `errors`; all-uncertain completed cycles are healthy. Cron validator ignores legacy `all_uncertain` degraded machine-status lines.
- **audit-health:** Orchestrator step runs non-strict (warnings only); report errors still fail the step.
- **Guard advancement:** Monitoring-only degraded summary semantics no longer block cron guard updates when there are no reportable blocking issues (`360597ba1`).

### #1950 — memory_store crash on empty tool args

- Require string `text` before validation so `{}` or malformed streaming args return structured `invalid_text` instead of throwing on `undefined.trim()` or coercing objects to `[object Object]`.

Closes #1949. Closes #1950.

## Test plan

- [x] Targeted: `dream-cycle-followup-logging`, `continuous-verifier`, `cron-exit-validator`, `memory-store-early-validation`, `maintenance-validator-coverage`
- [x] Codex P1/P2 review feedback addressed in `360597ba1`
- [ ] Host: `maintenance nightly --verbose` exits 0 for prior false-failure scenario
- [ ] Host: agent `memory_store` with truncated args returns `invalid_text`, not TypeError