### PR TITLE
fix(memory_store): handle missing text from empty tool args (#1950)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ---
 
+## [2026.6.257] - 2026-06-25
+
+### Fixed
+
+- **memory_store empty args (#1950):** Guard missing or non-string `text` with `String(text ?? "").trim()` so streaming-parser `{}` args return a structured `invalid_text` error instead of throwing `Cannot read properties of undefined (reading 'trim')`.
+
+---
+
 ## [2026.6.256] - 2026-06-25
 
 ### Fixed

--- a/extensions/memory-hybrid/openclaw.plugin.json
+++ b/extensions/memory-hybrid/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "openclaw-hybrid-memory",
   "kind": "memory",
-  "version": "2026.6.256",
+  "version": "2026.6.257",
   "contracts": {
     "tools": [
       "active_task_checkpoint",

--- a/extensions/memory-hybrid/package.json
+++ b/extensions/memory-hybrid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-hybrid-memory",
-  "version": "2026.6.256",
+  "version": "2026.6.257",
   "type": "module",
   "description": "Give your OpenClaw agent lasting memory: structured facts, semantic search, auto-capture & recall, decay, optional credential vault. Part of Hybrid Memory v3.",
   "files": [

--- a/extensions/memory-hybrid/tests/memory-store-early-validation.test.ts
+++ b/extensions/memory-hybrid/tests/memory-store-early-validation.test.ts
@@ -136,6 +136,23 @@ function setupTool(walWriteMock: ReturnType<typeof vi.fn>, embeddings: ReturnTyp
 // ---------------------------------------------------------------------------
 
 describe("memory_store early validation — invalid text", () => {
+  it("returns invalid_text error for missing text without throwing (Issue #1950)", async () => {
+    const walWrite = vi.fn().mockResolvedValue("wal-id");
+    const embeddings = makeMockEmbeddings();
+    const { api } = setupTool(walWrite, embeddings);
+
+    const storeTool = api.getTool("memory_store");
+    const result = (await storeTool?.execute("call-missing-text", {})) as {
+      content: Array<{ text: string }>;
+      details: { error: string };
+    };
+
+    expect(result.details.error).toBe("invalid_text");
+    expect(result.content[0]?.text).toContain("text is required");
+    expect(walWrite).not.toHaveBeenCalled();
+    expect(embeddings.embed).not.toHaveBeenCalled();
+  });
+
   it("returns invalid_text error for empty string without writing WAL", async () => {
     const walWrite = vi.fn().mockResolvedValue("wal-id");
     const embeddings = makeMockEmbeddings();

--- a/extensions/memory-hybrid/tools/memory/register-store-tools.ts
+++ b/extensions/memory-hybrid/tools/memory/register-store-tools.ts
@@ -240,14 +240,20 @@ export function registerStoreTools(runtime: MemoryToolRuntime): void {
           const storeWal = resolveToolVaultWal(runtime, typeof vaultParam === "string" ? vaultParam : undefined);
 
           // --- Early input validation (must run before any side effects) ---
-          if (text.trim().length === 0) {
+          const trimmedText = String(text ?? "").trim();
+          if (trimmedText.length === 0) {
             return {
-              content: [{ type: "text", text: "memory_store: text must not be empty or whitespace." }],
+              content: [
+                {
+                  type: "text",
+                  text: "memory_store: text is required and must be non-empty (received empty or non-string text)",
+                },
+              ],
               details: { error: "invalid_text" },
             };
           }
 
-          const textToStore = prepareMemoryTextForStorage(text, cfg.captureMaxChars);
+          const textToStore = prepareMemoryTextForStorage(trimmedText, cfg.captureMaxChars);
           if (!textToStore || !isSubstantiveMemoryText(textToStore)) {
             return {
               content: [


### PR DESCRIPTION
## Summary

Fixes [#1950](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/1950): when the OpenClaw streaming JSON parser yields `{}` for `memory_store` (missing `text`), the plugin now returns a structured `invalid_text` tool result instead of throwing `Cannot read properties of undefined (reading 'trim')`.

- Uses `String(text ?? "").trim()` — same defensive pattern as `diary_write` / agent verb tools
- Clearer error message for missing/non-string text
- Regression test for `{}` args

Upstream improvements (streaming parser diagnostics, pre-dispatch schema validation) remain separate OpenClaw core work as described in the issue.

## Test plan

- [x] `npm test -- --run tests/memory-store-early-validation.test.ts` (15 passed)