### PR TITLE
fix(extract-implicit): cap trajectory LLM budget and run with bounded concurrency (#1953)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ---
 
+## [2026.6.259] - 2026-06-25
+
+### Fixed
+
+- **Extract-implicit trajectory LLM (#1953):** Bounded concurrency (4 workers), per-trajectory timeout (~30s), and wall-clock watchdog so one hung call cannot block the nightly run for hours; scan cursor advances on sessions processed, not visited.
+- **Maintenance run deadline (#1953 follow-up):** Orchestrator-wide deadline with cooperative abort signal; per-step timeouts capped by remaining run time across auto-classify, distill, passive-observer, entity-enrichment, consolidation, incident batch analysis, reinforcement/self-correction batch loops, and inter-step LLM cooldown.
+- **Auto-classify:** Nightly path uses `chatCompleteWithRetry` with maintenance timeouts; preserves `"[]"` fallback when the assistant message is stripped as an empty placeholder.
+- **Incident batch analysis:** Retries and batch splits stop when the orchestrator deadline is reached.
+
+---
+
 ## [2026.6.258] - 2026-06-25
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - **Auto-classify:** Nightly path uses `chatCompleteWithRetry` with maintenance timeouts; preserves `"[]"` fallback when the assistant message is stripped as an empty placeholder.
 - **Incident batch analysis:** Retries and batch splits stop when the orchestrator deadline is reached.
 
+### Changed
+
+- Bumped plugin, `openclaw.plugin.json`, and `openclaw-hybrid-memory-install` package versions to **2026.6.259**.
+
 ---
 
 ## [2026.6.258] - 2026-06-25

--- a/extensions/memory-hybrid/backends/facts-db/crud.ts
+++ b/extensions/memory-hybrid/backends/facts-db/crud.ts
@@ -32,7 +32,7 @@ function sleepSync(ms: number): void {
   Atomics.wait(SQLITE_BUSY_STORE_SLEEP, 0, 0, ms);
 }
 
-function runWithSqliteBusyRetry(db: DatabaseSync, run: () => void): void {
+export function runWithSqliteBusyRetry(db: DatabaseSync, run: () => void): void {
   for (let attempt = 0; attempt <= SQLITE_BUSY_STORE_MAX_RETRIES; attempt += 1) {
     try {
       run();

--- a/extensions/memory-hybrid/backends/facts-db/facts-db-layer3.ts
+++ b/extensions/memory-hybrid/backends/facts-db/facts-db-layer3.ts
@@ -3,6 +3,7 @@
  */
 
 import type { ExtractedMention } from "../../services/entity-enrichment.js";
+import { runWithSqliteBusyRetry } from "./crud.js";
 import type { Episode, EpisodeOutcome, MemoryEntry, ScopeFilter } from "../../types/memory.js";
 import {
   getAllEdges as getAllEdgesImpl,
@@ -537,19 +538,21 @@ export class FactsDB extends FactsDBLayer2 {
 
   /** Replace stored NER rows for a fact (typically after LLM extraction). */
   applyEntityEnrichment(factId: string, mentions: ExtractedMention[], detectedLang: string): void {
-    replaceFactEntityMentions(
-      this.liveDb,
-      factId,
-      mentions.map((m) => ({
-        label: m.label,
-        surfaceText: m.surfaceText,
-        normalizedSurface: m.normalizedSurface,
-        startOffset: m.startOffset,
-        endOffset: m.endOffset,
-        confidence: m.confidence,
-        detectedLang,
-        source: "llm",
-      })),
+    runWithSqliteBusyRetry(this.liveDb, () =>
+      replaceFactEntityMentions(
+        this.liveDb,
+        factId,
+        mentions.map((m) => ({
+          label: m.label,
+          surfaceText: m.surfaceText,
+          normalizedSurface: m.normalizedSurface,
+          startOffset: m.startOffset,
+          endOffset: m.endOffset,
+          confidence: m.confidence,
+          detectedLang,
+          source: "llm",
+        })),
+      ),
     );
   }
 

--- a/extensions/memory-hybrid/cli/cmd-distill.ts
+++ b/extensions/memory-hybrid/cli/cmd-distill.ts
@@ -55,6 +55,7 @@ import { formatDateUtc, formatTimestampUtcFromMs, nowIso } from "../utils/dates.
 import { getEnv } from "../utils/env-manager.js";
 import {
   capTimeoutByMaintenanceRunDeadline,
+  getMaintenanceRunAbortSignal,
   maintenanceRunDeadlineReached,
 } from "../utils/maintenance-run-deadline.js";
 import { redactMaintenancePrivateText } from "../utils/maintenance-privacy.js";
@@ -585,6 +586,7 @@ export async function runDistillForCli(
             capTimeoutByMaintenanceRunDeadline(
               resolveMaintenanceChatTimeoutMs(m, resolveDistillThinkingMode(cfg)),
             ),
+          signal: getMaintenanceRunAbortSignal(),
         });
         if (detail.finishReason?.toLowerCase() === "length") {
           logger.warn?.(

--- a/extensions/memory-hybrid/cli/cmd-distill.ts
+++ b/extensions/memory-hybrid/cli/cmd-distill.ts
@@ -53,6 +53,10 @@ import { cleanupEvictedVector } from "../services/vector-maintenance.js";
 import { BATCH_STORE_IMPORTANCE, DISTILL_DEDUP_THRESHOLD } from "../utils/constants.js";
 import { formatDateUtc, formatTimestampUtcFromMs, nowIso } from "../utils/dates.js";
 import { getEnv } from "../utils/env-manager.js";
+import {
+  capTimeoutByMaintenanceRunDeadline,
+  maintenanceRunDeadlineReached,
+} from "../utils/maintenance-run-deadline.js";
 import { redactMaintenancePrivateText } from "../utils/maintenance-privacy.js";
 import { resolveTierPreferenceWithSources } from "../utils/llm-selection.js";
 import { loadPrompt } from "../utils/prompt-loader.js";
@@ -516,6 +520,11 @@ export async function runDistillForCli(
     let batchFailures = 0;
 
     while (cursorBlock < blocks.length) {
+      if (maintenanceRunDeadlineReached()) {
+        sink.warn("memory-hybrid: distill: maintenance run deadline reached; stopping batch loop");
+        batchFailures++;
+        break;
+      }
       batchNum++;
       const limits = effectiveLimitsForModel(model);
       const batch = buildBatch(cursorBlock, limits.batchTokenLimit);
@@ -572,7 +581,10 @@ export async function runDistillForCli(
           label: `memory-hybrid: distill batch ${batchNum}`,
           feature: CostFeature.distillCli,
           thinkingMode: resolveDistillThinkingMode(cfg),
-          timeoutMsPerModel: (m) => resolveMaintenanceChatTimeoutMs(m, resolveDistillThinkingMode(cfg)),
+          timeoutMsPerModel: (m) =>
+            capTimeoutByMaintenanceRunDeadline(
+              resolveMaintenanceChatTimeoutMs(m, resolveDistillThinkingMode(cfg)),
+            ),
         });
         if (detail.finishReason?.toLowerCase() === "length") {
           logger.warn?.(

--- a/extensions/memory-hybrid/cli/cmd-extract-reinforcement.ts
+++ b/extensions/memory-hybrid/cli/cmd-extract-reinforcement.ts
@@ -43,6 +43,7 @@ import { CLI_STORE_IMPORTANCE } from "../utils/constants.js";
 import { getEnv } from "../utils/env-manager.js";
 import { getReinforcementSignalRegex } from "../utils/language-keywords.js";
 import { redactMaintenancePrivateText } from "../utils/maintenance-privacy.js";
+import { maintenanceRunDeadlineReached } from "../utils/maintenance-run-deadline.js";
 import { parseStructuredItemsAcceptingEmpty } from "../utils/llm-json-array.js";
 import { resolveTierPreferenceWithSources } from "../utils/llm-selection.js";
 import { resolveExtractSessionFilePaths } from "../services/extract-session-paths.js";
@@ -462,6 +463,12 @@ export async function runExtractReinforcementForCli(
         };
 
         for (let batchIndex = 0; batchIndex < batches.length; batchIndex++) {
+          if (maintenanceRunDeadlineReached()) {
+            logger.warn?.(
+              "memory-hybrid: extract-reinforcement stopped — maintenance run deadline reached",
+            );
+            break;
+          }
           if (completedBatchIndexes.has(batchIndex)) continue;
           const batch = batches[batchIndex];
           const globalIncidentOffset = globalIncidentOffsetForBatch(batches, batchIndex);
@@ -485,7 +492,7 @@ export async function runExtractReinforcementForCli(
                 completedBatchIndexes.add(batchIndex);
                 completedBatches = completedBatchIndexes.size;
                 persistBatchState();
-                if (batchDelayMs > 0 && batchIndex < batches.length - 1) {
+                if (batchDelayMs > 0 && batchIndex < batches.length - 1 && !maintenanceRunDeadlineReached()) {
                   await new Promise((resolve) => setTimeout(resolve, batchDelayMs));
                 }
                 continue;
@@ -513,7 +520,7 @@ export async function runExtractReinforcementForCli(
               completedBatchIndexes.add(batchIndex);
               completedBatches = completedBatchIndexes.size;
               persistBatchState();
-              if (batchDelayMs > 0 && batchIndex < batches.length - 1) {
+              if (batchDelayMs > 0 && batchIndex < batches.length - 1 && !maintenanceRunDeadlineReached()) {
                 await new Promise((resolve) => setTimeout(resolve, batchDelayMs));
               }
               continue;
@@ -554,7 +561,7 @@ export async function runExtractReinforcementForCli(
           completedBatches = completedBatchIndexes.size;
           persistBatchState();
 
-          if (batchDelayMs > 0 && batchIndex < batches.length - 1) {
+          if (batchDelayMs > 0 && batchIndex < batches.length - 1 && !maintenanceRunDeadlineReached()) {
             await new Promise((resolve) => setTimeout(resolve, batchDelayMs));
           }
         }

--- a/extensions/memory-hybrid/cli/cmd-feedback.ts
+++ b/extensions/memory-hybrid/cli/cmd-feedback.ts
@@ -48,6 +48,7 @@ import { runSelfCorrectionRunForCli } from "./cmd-selfcorrection.js";
 import { resolveExtractSessionFilePaths } from "../services/extract-session-paths.js";
 import type { HandlerContext } from "./handlers.js";
 import { resolveScanMaintenanceOverrides } from "./maintenance-overrides.js";
+import { getMaintenanceRunAbortSignal, maintenanceRunDeadlineReached } from "../utils/maintenance-run-deadline.js";
 
 const IMPLICIT_FEEDBACK_LESSON_TAGS = ["implicit-feedback", "trajectory", "feedback"];
 
@@ -832,6 +833,10 @@ export async function runExtractImplicitFeedbackForCli(
       markPartialProgress("maxWallClock");
       break;
     }
+    if (maintenanceRunDeadlineReached()) {
+      markPartialProgress("maxWallClock");
+      break;
+    }
     // BUG FIX #2: Check against sessionsVisited to ensure session cap includes skipped sessions
     if (maxSessionsPerRun > 0 && progress.sessionsVisited >= maxSessionsPerRun) {
       markPartialProgress("maxSessions");
@@ -1167,6 +1172,10 @@ export async function runExtractImplicitFeedbackForCli(
                   llmBudgetMs,
                 );
                 const disposeRunAbortLink = propagateAbortSignal(runWallClockAbort.signal, perCallAbort);
+                const maintenanceAbort = getMaintenanceRunAbortSignal();
+                const disposeMaintenanceAbortLink = maintenanceAbort
+                  ? propagateAbortSignal(maintenanceAbort, perCallAbort)
+                  : () => {};
                 const chatFn = async (opts: { model?: string; messages: Array<{ role: string; content: string }> }) => {
                   const userMessage = opts.messages.find((m) => m.role === "user");
                   if (!userMessage) throw new Error("No user message found");
@@ -1213,6 +1222,7 @@ export async function runExtractImplicitFeedbackForCli(
                 } finally {
                   clearTimeout(perCallTimeout);
                   disposeRunAbortLink();
+                  disposeMaintenanceAbortLink();
                 }
                 if (wallClockLimitReached()) {
                   stopTrajectoryLlm = true;

--- a/extensions/memory-hybrid/cli/cmd-feedback.ts
+++ b/extensions/memory-hybrid/cli/cmd-feedback.ts
@@ -19,7 +19,7 @@ import {
   isCompactVerbosity,
   resolveReflectionModelAndFallbacks,
 } from "../config.js";
-import { chatCompleteWithRetry } from "../services/chat.js";
+import { chatCompleteWithRetryDetailed } from "../services/chat.js";
 import { CostFeature } from "../services/cost-feature-labels.js";
 import { runCrossAgentLearning } from "../services/cross-agent-learning.js";
 import { capturePluginError } from "../services/error-reporter.js";
@@ -433,11 +433,42 @@ export function resolveTrajectoryLlmBudgetMs(remainingWallClockMs: number): numb
   return Math.min(TRAJECTORY_PER_CALL_BUDGET_MS, Math.max(1, Math.floor(remainingWallClockMs)));
 }
 
+/** Remaining milliseconds until an absolute deadline (0 when expired). */
+export function remainingDeadlineMs(deadlineMs: number, nowMs: number = Date.now()): number {
+  return Math.max(0, deadlineMs - nowMs);
+}
+
+/** Timeout for the next LLM attempt within a per-trajectory deadline (0 when expired). */
+export function trajectoryCallTimeoutMs(deadlineMs: number, nowMs: number = Date.now()): number {
+  const remaining = remainingDeadlineMs(deadlineMs, nowMs);
+  return remaining > 0 ? Math.max(1, remaining) : 0;
+}
+
+/** Propagate a source abort signal into a target controller (first abort wins). */
+export function propagateAbortSignal(source: AbortSignal, target: AbortController): void {
+  if (source.aborted) {
+    if (!target.signal.aborted) {
+      target.abort(source.reason ?? new Error("aborted"));
+    }
+    return;
+  }
+  source.addEventListener(
+    "abort",
+    () => {
+      if (!target.signal.aborted) {
+        target.abort(source.reason ?? new Error("aborted"));
+      }
+    },
+    { once: true },
+  );
+}
+
 /** Run async work over items with a bounded worker pool. */
 export async function runWithConcurrencyLimit<TItem, TResult>(
   items: readonly TItem[],
   concurrency: number,
   worker: (item: TItem, index: number) => Promise<TResult>,
+  opts?: { shouldStop?: () => boolean },
 ): Promise<TResult[]> {
   if (items.length === 0) return [];
   const results: TResult[] = new Array(items.length);
@@ -446,6 +477,7 @@ export async function runWithConcurrencyLimit<TItem, TResult>(
   await Promise.all(
     Array.from({ length: workerCount }, async () => {
       while (true) {
+        if (opts?.shouldStop?.()) return;
         const index = nextIndex++;
         if (index >= items.length) return;
         results[index] = await worker(items[index]!, index);
@@ -1106,67 +1138,95 @@ export async function runExtractImplicitFeedbackForCli(
           const nanoPref = getLLMModelPreference(getCronModelConfig(cfg), "nano");
           const model = nanoPref[0] ?? getDefaultCronModel(getCronModelConfig(cfg), "nano");
           const fallbackModels = nanoPref.length > 1 ? nanoPref.slice(1) : (cfg.distill?.fallbackModels ?? []);
+          const runWallClockAbort = new AbortController();
           let stopTrajectoryLlm = false;
-          await runWithConcurrencyLimit(trajectories, TRAJECTORY_LLM_CONCURRENCY, async (traj) => {
-            if (stopTrajectoryLlm) return;
+          const shouldStopTrajectoryLlm = (): boolean => stopTrajectoryLlm || runWallClockAbort.signal.aborted;
+          const wallClockWatchdog = setInterval(() => {
             if (wallClockLimitReached()) {
               stopTrajectoryLlm = true;
-              return;
+              runWallClockAbort.abort(new Error("implicit-feedback wall-clock budget exceeded"));
             }
-            const llmBudgetMs = resolveTrajectoryLlmBudgetMs(remainingWallClockMs());
-            if (llmBudgetMs === 0) {
-              stopTrajectoryLlm = true;
-              return;
-            }
-            const llmAbort = new AbortController();
-            const llmTimeout = setTimeout(
-              () => llmAbort.abort(new Error("implicit-feedback trajectory LLM budget exceeded")),
-              llmBudgetMs,
+          }, 250);
+          try {
+            await runWithConcurrencyLimit(
+              trajectories,
+              TRAJECTORY_LLM_CONCURRENCY,
+              async (traj) => {
+                if (shouldStopTrajectoryLlm()) return;
+                if (wallClockLimitReached()) {
+                  stopTrajectoryLlm = true;
+                  runWallClockAbort.abort(new Error("implicit-feedback wall-clock budget exceeded"));
+                  return;
+                }
+                const llmBudgetMs = resolveTrajectoryLlmBudgetMs(remainingWallClockMs());
+                if (llmBudgetMs === 0) {
+                  stopTrajectoryLlm = true;
+                  runWallClockAbort.abort(new Error("implicit-feedback wall-clock budget exceeded"));
+                  return;
+                }
+                const deadlineMs = Date.now() + llmBudgetMs;
+                const perCallAbort = new AbortController();
+                const perCallTimeout = setTimeout(
+                  () => perCallAbort.abort(new Error("implicit-feedback trajectory LLM budget exceeded")),
+                  llmBudgetMs,
+                );
+                propagateAbortSignal(runWallClockAbort.signal, perCallAbort);
+                const chatFn = async (opts: { model?: string; messages: Array<{ role: string; content: string }> }) => {
+                  const userMessage = opts.messages.find((m) => m.role === "user");
+                  if (!userMessage) throw new Error("No user message found");
+                  const timeoutMs = trajectoryCallTimeoutMs(deadlineMs);
+                  if (timeoutMs === 0 || perCallAbort.signal.aborted || runWallClockAbort.signal.aborted) {
+                    throw new Error("implicit-feedback trajectory LLM budget exceeded");
+                  }
+                  const detail = await chatCompleteWithRetryDetailed({
+                    model: opts.model ?? model,
+                    content: userMessage.content,
+                    temperature: 0.2,
+                    maxTokens: 4000,
+                    openai,
+                    fallbackModels,
+                    label: "memory-hybrid: trajectory-analyze",
+                    feature: CostFeature.trajectoryAnalyze,
+                    timeoutMs,
+                    timeoutMsPerModel: () => trajectoryCallTimeoutMs(deadlineMs),
+                    signal: perCallAbort.signal,
+                  });
+                  return detail.content;
+                };
+                try {
+                  const llmAnalysis = await analyzeTrajectoriesWithLLM(traj, prompt, chatFn);
+                  if (llmAnalysis) {
+                    traj.lessonsExtracted = [llmAnalysis.keyLesson, ...llmAnalysis.patterns];
+                    if (llmAnalysis.pivotTurn !== null) {
+                      traj.keyPivot = llmAnalysis.pivotTurn;
+                    }
+                    if (llmAnalysis.outcome) {
+                      traj.outcome = llmAnalysis.outcome;
+                    }
+                  }
+                } catch (err) {
+                  if (wallClockLimitReached() || runWallClockAbort.signal.aborted) {
+                    stopTrajectoryLlm = true;
+                    return;
+                  }
+                  capturePluginError(err instanceof Error ? err : new Error(String(err)), {
+                    operation: "runExtractImplicitFeedbackForCli:llm-trajectory-analysis",
+                    severity: "info",
+                    subsystem: "implicit-feedback",
+                  });
+                } finally {
+                  clearTimeout(perCallTimeout);
+                }
+                if (wallClockLimitReached()) {
+                  stopTrajectoryLlm = true;
+                  runWallClockAbort.abort(new Error("implicit-feedback wall-clock budget exceeded"));
+                }
+              },
+              { shouldStop: shouldStopTrajectoryLlm },
             );
-            const chatFn = async (opts: { model?: string; messages: Array<{ role: string; content: string }> }) => {
-              const userMessage = opts.messages.find((m) => m.role === "user");
-              if (!userMessage) throw new Error("No user message found");
-              return await chatCompleteWithRetry({
-                model: opts.model ?? model,
-                content: userMessage.content,
-                temperature: 0.2,
-                maxTokens: 4000,
-                openai,
-                fallbackModels,
-                label: "memory-hybrid: trajectory-analyze",
-                feature: CostFeature.trajectoryAnalyze,
-                timeoutMs: llmBudgetMs,
-                signal: llmAbort.signal,
-              });
-            };
-            try {
-              const llmAnalysis = await analyzeTrajectoriesWithLLM(traj, prompt, chatFn);
-              if (llmAnalysis) {
-                traj.lessonsExtracted = [llmAnalysis.keyLesson, ...llmAnalysis.patterns];
-                if (llmAnalysis.pivotTurn !== null) {
-                  traj.keyPivot = llmAnalysis.pivotTurn;
-                }
-                if (llmAnalysis.outcome) {
-                  traj.outcome = llmAnalysis.outcome;
-                }
-              }
-            } catch (err) {
-              if (wallClockLimitReached()) {
-                stopTrajectoryLlm = true;
-                return;
-              }
-              capturePluginError(err instanceof Error ? err : new Error(String(err)), {
-                operation: "runExtractImplicitFeedbackForCli:llm-trajectory-analysis",
-                severity: "info",
-                subsystem: "implicit-feedback",
-              });
-            } finally {
-              clearTimeout(llmTimeout);
-            }
-            if (wallClockLimitReached()) {
-              stopTrajectoryLlm = true;
-            }
-          });
+          } finally {
+            clearInterval(wallClockWatchdog);
+          }
         }
 
         for (const traj of trajectories) {

--- a/extensions/memory-hybrid/cli/cmd-feedback.ts
+++ b/extensions/memory-hybrid/cli/cmd-feedback.ts
@@ -33,7 +33,11 @@ import {
   generateMonthlyReport,
   ToolEffectivenessStore,
 } from "../services/tool-effectiveness.js";
-import { analyzeTrajectoriesWithLLM, buildTrajectories, serializeTrajectory } from "../services/trajectory-tracker.js";
+import {
+  analyzeTrajectoriesWithLLM,
+  buildTrajectories,
+  serializeTrajectory,
+} from "../services/trajectory-tracker.js";
 import { cleanupEvictedVector } from "../services/vector-maintenance.js";
 import { loadPrompt } from "../utils/prompt-loader.js";
 import { createTransaction } from "../utils/sqlite-transaction.js";
@@ -413,6 +417,43 @@ export function cleanupImplicitFeedbackDuplicates(
 // ---------------------------------------------------------------------------
 // extract-implicit-feedback
 // ---------------------------------------------------------------------------
+
+/** Minimum wall-clock remaining before scheduling another trajectory LLM call. */
+export const TRAJECTORY_LLM_MIN_BUDGET_MS = 1000;
+
+/** Per-trajectory LLM call wall-clock cap (Issue #1953). */
+export const TRAJECTORY_PER_CALL_BUDGET_MS = 30_000;
+
+/** Max concurrent trajectory LLM analyses per session (Issue #1953). */
+export const TRAJECTORY_LLM_CONCURRENCY = 4;
+
+/** Resolve per-trajectory LLM budget from remaining run wall-clock (Issue #1953). */
+export function resolveTrajectoryLlmBudgetMs(remainingWallClockMs: number): number {
+  if (remainingWallClockMs < TRAJECTORY_LLM_MIN_BUDGET_MS) return 0;
+  return Math.min(TRAJECTORY_PER_CALL_BUDGET_MS, Math.max(1, Math.floor(remainingWallClockMs)));
+}
+
+/** Run async work over items with a bounded worker pool. */
+export async function runWithConcurrencyLimit<TItem, TResult>(
+  items: readonly TItem[],
+  concurrency: number,
+  worker: (item: TItem, index: number) => Promise<TResult>,
+): Promise<TResult[]> {
+  if (items.length === 0) return [];
+  const results: TResult[] = new Array(items.length);
+  let nextIndex = 0;
+  const workerCount = Math.min(Math.max(1, concurrency), items.length);
+  await Promise.all(
+    Array.from({ length: workerCount }, async () => {
+      while (true) {
+        const index = nextIndex++;
+        if (index >= items.length) return;
+        results[index] = await worker(items[index]!, index);
+      }
+    }),
+  );
+  return results;
+}
 
 export type ExtractImplicitFeedbackStopReason =
   | "maxWallClock"
@@ -1060,80 +1101,80 @@ export async function runExtractImplicitFeedbackForCli(
            WHERE session_file = ? AND turns_json = ?
            LIMIT 1`,
         );
-        const TRAJECTORY_LLM_MIN_BUDGET_MS = 1000;
+        if (implicitCfg.trajectoryLLMAnalysis && trajectories.length > 0) {
+          const prompt = loadPrompt("trajectory-analyze");
+          const nanoPref = getLLMModelPreference(getCronModelConfig(cfg), "nano");
+          const model = nanoPref[0] ?? getDefaultCronModel(getCronModelConfig(cfg), "nano");
+          const fallbackModels = nanoPref.length > 1 ? nanoPref.slice(1) : (cfg.distill?.fallbackModels ?? []);
+          let stopTrajectoryLlm = false;
+          await runWithConcurrencyLimit(trajectories, TRAJECTORY_LLM_CONCURRENCY, async (traj) => {
+            if (stopTrajectoryLlm) return;
+            if (wallClockLimitReached()) {
+              stopTrajectoryLlm = true;
+              return;
+            }
+            const llmBudgetMs = resolveTrajectoryLlmBudgetMs(remainingWallClockMs());
+            if (llmBudgetMs === 0) {
+              stopTrajectoryLlm = true;
+              return;
+            }
+            const llmAbort = new AbortController();
+            const llmTimeout = setTimeout(
+              () => llmAbort.abort(new Error("implicit-feedback trajectory LLM budget exceeded")),
+              llmBudgetMs,
+            );
+            const chatFn = async (opts: { model?: string; messages: Array<{ role: string; content: string }> }) => {
+              const userMessage = opts.messages.find((m) => m.role === "user");
+              if (!userMessage) throw new Error("No user message found");
+              return await chatCompleteWithRetry({
+                model: opts.model ?? model,
+                content: userMessage.content,
+                temperature: 0.2,
+                maxTokens: 4000,
+                openai,
+                fallbackModels,
+                label: "memory-hybrid: trajectory-analyze",
+                feature: CostFeature.trajectoryAnalyze,
+                timeoutMs: llmBudgetMs,
+                signal: llmAbort.signal,
+              });
+            };
+            try {
+              const llmAnalysis = await analyzeTrajectoriesWithLLM(traj, prompt, chatFn);
+              if (llmAnalysis) {
+                traj.lessonsExtracted = [llmAnalysis.keyLesson, ...llmAnalysis.patterns];
+                if (llmAnalysis.pivotTurn !== null) {
+                  traj.keyPivot = llmAnalysis.pivotTurn;
+                }
+                if (llmAnalysis.outcome) {
+                  traj.outcome = llmAnalysis.outcome;
+                }
+              }
+            } catch (err) {
+              if (wallClockLimitReached()) {
+                stopTrajectoryLlm = true;
+                return;
+              }
+              capturePluginError(err instanceof Error ? err : new Error(String(err)), {
+                operation: "runExtractImplicitFeedbackForCli:llm-trajectory-analysis",
+                severity: "info",
+                subsystem: "implicit-feedback",
+              });
+            } finally {
+              clearTimeout(llmTimeout);
+            }
+            if (wallClockLimitReached()) {
+              stopTrajectoryLlm = true;
+            }
+          });
+        }
+
         for (const traj of trajectories) {
           try {
-            // Check wall clock limit before processing each trajectory (especially before LLM analysis)
+            // Check wall clock limit before persisting each trajectory
             if (wallClockLimitReached()) {
               markPartialProgress("maxWallClock", deferredIncludingCurrentSession());
               break;
-            }
-
-            // If LLM analysis is enabled, use it to enhance lessons
-            if (implicitCfg.trajectoryLLMAnalysis) {
-              try {
-                const prompt = loadPrompt("trajectory-analyze");
-                const nanoPref = getLLMModelPreference(getCronModelConfig(cfg), "nano");
-                const model = nanoPref[0] ?? getDefaultCronModel(getCronModelConfig(cfg), "nano");
-                const fallbackModels = nanoPref.length > 1 ? nanoPref.slice(1) : (cfg.distill?.fallbackModels ?? []);
-                const remainingMs = remainingWallClockMs();
-                if (remainingMs < TRAJECTORY_LLM_MIN_BUDGET_MS) {
-                  markPartialProgress("maxWallClock", deferredIncludingCurrentSession());
-                  break;
-                }
-                const llmBudgetMs = Math.max(1, Math.floor(remainingMs));
-                const llmAbort = new AbortController();
-                const llmTimeout = setTimeout(
-                  () => llmAbort.abort(new Error("implicit-feedback trajectory LLM budget exceeded")),
-                  llmBudgetMs,
-                );
-                const chatFn = async (opts: { model?: string; messages: Array<{ role: string; content: string }> }) => {
-                  const userMessage = opts.messages.find((m) => m.role === "user");
-                  if (!userMessage) throw new Error("No user message found");
-                  return await chatCompleteWithRetry({
-                    model: opts.model ?? model,
-                    content: userMessage.content,
-                    temperature: 0.2,
-                    maxTokens: 4000,
-                    openai,
-                    fallbackModels,
-                    label: "memory-hybrid: trajectory-analyze",
-                    feature: CostFeature.trajectoryAnalyze,
-                    timeoutMs: llmBudgetMs,
-                    signal: llmAbort.signal,
-                  });
-                };
-                let llmAnalysis: Awaited<ReturnType<typeof analyzeTrajectoriesWithLLM>> | null = null;
-                try {
-                  llmAnalysis = await analyzeTrajectoriesWithLLM(traj, prompt, chatFn);
-                } finally {
-                  clearTimeout(llmTimeout);
-                }
-                if (llmAbort.signal.aborted || wallClockLimitReached()) {
-                  markPartialProgress("maxWallClock", deferredIncludingCurrentSession());
-                  break;
-                }
-                if (llmAnalysis) {
-                  // Replace heuristic lessons with LLM-produced lesson and patterns
-                  traj.lessonsExtracted = [llmAnalysis.keyLesson, ...llmAnalysis.patterns];
-                  if (llmAnalysis.pivotTurn !== null) {
-                    traj.keyPivot = llmAnalysis.pivotTurn;
-                  }
-                  if (llmAnalysis.outcome) {
-                    traj.outcome = llmAnalysis.outcome;
-                  }
-                }
-              } catch (err) {
-                if (wallClockLimitReached()) {
-                  markPartialProgress("maxWallClock", deferredIncludingCurrentSession());
-                  break;
-                }
-                capturePluginError(err instanceof Error ? err : new Error(String(err)), {
-                  operation: "runExtractImplicitFeedbackForCli:llm-trajectory-analysis",
-                  severity: "info",
-                  subsystem: "implicit-feedback",
-                });
-              }
             }
 
             const row = serializeTrajectory(traj);

--- a/extensions/memory-hybrid/cli/cmd-feedback.ts
+++ b/extensions/memory-hybrid/cli/cmd-feedback.ts
@@ -1609,7 +1609,7 @@ export async function runExtractImplicitFeedbackForCli(
       const stat = statSync(lastProcessedFilePath);
       const lastSessionTs = stat.mtimeMs;
       const lastSessionFile = basename(lastProcessedFilePath);
-      factsDb.updateScanCursor(SCAN_TYPE, lastSessionTs, progress.sessionsVisited, lastSessionFile);
+      factsDb.updateScanCursor(SCAN_TYPE, lastSessionTs, progress.sessionsProcessed, lastSessionFile);
     }
   }
 

--- a/extensions/memory-hybrid/cli/cmd-feedback.ts
+++ b/extensions/memory-hybrid/cli/cmd-feedback.ts
@@ -444,23 +444,19 @@ export function trajectoryCallTimeoutMs(deadlineMs: number, nowMs: number = Date
   return remaining > 0 ? Math.max(1, remaining) : 0;
 }
 
-/** Propagate a source abort signal into a target controller (first abort wins). */
-export function propagateAbortSignal(source: AbortSignal, target: AbortController): void {
-  if (source.aborted) {
+/** Propagate a source abort signal into a target controller (first abort wins). Returns a disposer. */
+export function propagateAbortSignal(source: AbortSignal, target: AbortController): () => void {
+  const onAbort = () => {
     if (!target.signal.aborted) {
       target.abort(source.reason ?? new Error("aborted"));
     }
-    return;
+  };
+  if (source.aborted) {
+    onAbort();
+    return () => {};
   }
-  source.addEventListener(
-    "abort",
-    () => {
-      if (!target.signal.aborted) {
-        target.abort(source.reason ?? new Error("aborted"));
-      }
-    },
-    { once: true },
-  );
+  source.addEventListener("abort", onAbort, { once: true });
+  return () => source.removeEventListener("abort", onAbort);
 }
 
 /** Run async work over items with a bounded worker pool. */
@@ -1160,8 +1156,9 @@ export async function runExtractImplicitFeedbackForCli(
                 }
                 const llmBudgetMs = resolveTrajectoryLlmBudgetMs(remainingWallClockMs());
                 if (llmBudgetMs === 0) {
+                  // Stop scheduling new calls, but do not abort in-flight workers that already
+                  // claimed budget — remaining wall-clock may be <1s while calls finish.
                   stopTrajectoryLlm = true;
-                  runWallClockAbort.abort(new Error("implicit-feedback wall-clock budget exceeded"));
                   return;
                 }
                 const deadlineMs = Date.now() + llmBudgetMs;
@@ -1170,7 +1167,7 @@ export async function runExtractImplicitFeedbackForCli(
                   () => perCallAbort.abort(new Error("implicit-feedback trajectory LLM budget exceeded")),
                   llmBudgetMs,
                 );
-                propagateAbortSignal(runWallClockAbort.signal, perCallAbort);
+                const disposeRunAbortLink = propagateAbortSignal(runWallClockAbort.signal, perCallAbort);
                 const chatFn = async (opts: { model?: string; messages: Array<{ role: string; content: string }> }) => {
                   const userMessage = opts.messages.find((m) => m.role === "user");
                   if (!userMessage) throw new Error("No user message found");
@@ -1216,6 +1213,7 @@ export async function runExtractImplicitFeedbackForCli(
                   });
                 } finally {
                   clearTimeout(perCallTimeout);
+                  disposeRunAbortLink();
                 }
                 if (wallClockLimitReached()) {
                   stopTrajectoryLlm = true;

--- a/extensions/memory-hybrid/cli/cmd-feedback.ts
+++ b/extensions/memory-hybrid/cli/cmd-feedback.ts
@@ -861,7 +861,6 @@ export async function runExtractImplicitFeedbackForCli(
         subsystem: "implicit-feedback",
       });
       emitProgress();
-      lastProcessedFilePath = filePath;
       continue;
     }
 
@@ -1541,7 +1540,12 @@ export async function runExtractImplicitFeedbackForCli(
   progress.stage = "done";
   emitProgress();
 
-  if (!opts.dryRun && implicitCfg.triggerSelfCorrectionRun && bridgeIncidents.length > 0) {
+  if (
+    !opts.dryRun &&
+    implicitCfg.triggerSelfCorrectionRun &&
+    bridgeIncidents.length > 0 &&
+    !wallClockLimitReached()
+  ) {
     if (implicitCfg.llmSignalAnalysis !== false) {
       const { defaultModel, fallbackModels } = resolveReflectionModelAndFallbacks(cfg, "maintenance");
       try {
@@ -1569,7 +1573,12 @@ export async function runExtractImplicitFeedbackForCli(
     }
   }
 
-  if (!opts.dryRun && implicitCfg.triggerSelfCorrectionRun && bridgeIncidents.length > 0) {
+  if (
+    !opts.dryRun &&
+    implicitCfg.triggerSelfCorrectionRun &&
+    bridgeIncidents.length > 0 &&
+    !wallClockLimitReached()
+  ) {
     const cap = implicitCfg.selfCorrectionBridgeMaxIncidents ?? 5;
     const incidents = bridgeIncidents.slice(0, cap);
     const workspace = getEnv("OPENCLAW_WORKSPACE") ?? join(homedir(), ".openclaw", "workspace");
@@ -1588,7 +1597,7 @@ export async function runExtractImplicitFeedbackForCli(
   }
 
   // Update scan cursor with the last fully processed session
-  if (!opts.dryRun && lastProcessedFilePath && progress.sessionsProcessed > 0) {
+  if (!opts.dryRun && lastProcessedFilePath && progress.sessionsProcessed > 0 && progress.sessionsReadErrors === 0) {
     const shouldAdvanceCursor =
       !partial ||
       partialReason === "maxSessions" ||

--- a/extensions/memory-hybrid/cli/cmd-selfcorrection.ts
+++ b/extensions/memory-hybrid/cli/cmd-selfcorrection.ts
@@ -64,6 +64,7 @@ import {
 import { MaintenanceJobRun } from "../services/maintenance-job-run/job-run.js";
 import { selfCorrectionStatusToJobRunOutcome } from "../services/maintenance-job-run/semantic-outcome.js";
 import { formatDateUtc, nowIso } from "../utils/dates.js";
+import { maintenanceRunDeadlineReached } from "../utils/maintenance-run-deadline.js";
 import { CLI_STORE_IMPORTANCE } from "../utils/constants.js";
 import { getCorrectionSignalRegex } from "../utils/language-keywords.js";
 import { parseSelfCorrectionLLMResponse } from "../services/self-correction-llm-parser.js";
@@ -244,6 +245,7 @@ function chunkSelfCorrectionIncidents<T>(items: T[], batchSize: number): T[][] {
 }
 
 async function sleepSelfCorrectionBackoff(ms: number): Promise<void> {
+  if (maintenanceRunDeadlineReached()) return;
   await new Promise((resolve) => setTimeout(resolve, ms));
 }
 
@@ -1130,6 +1132,12 @@ export async function runSelfCorrectionRunForCli(
       );
 
       for (let batchIndex = 0; batchIndex < batches.length; batchIndex++) {
+        if (maintenanceRunDeadlineReached()) {
+          logger.warn?.(
+            `memory-hybrid: ${SCAN_TYPE} stopped — maintenance run deadline reached`,
+          );
+          break;
+        }
         if (completedBatchIndexes.has(batchIndex)) continue;
         const batch = batches[batchIndex];
         const globalIncidentOffset = globalIncidentOffsetForBatch(batches, batchIndex);
@@ -1138,9 +1146,20 @@ export async function runSelfCorrectionRunForCli(
           `memory-hybrid: ${SCAN_TYPE} batch ${batchIndex + 1}/${batches.length} start incidents=${batch.length}`,
         );
         await processBatchResult(batchIndex, batch, globalIncidentOffset);
-        if (batchDelayMs > 0 && batchIndex < batches.length - 1) {
+        if (batchDelayMs > 0 && batchIndex < batches.length - 1 && !maintenanceRunDeadlineReached()) {
           await sleepSelfCorrectionBackoff(batchDelayMs);
         }
+      }
+
+      if (
+        maintenanceRunDeadlineReached() &&
+        completedBatchIndexes.size > 0 &&
+        completedBatchIndexes.size < batches.length
+      ) {
+        persistBatchState();
+        logger.warn?.(
+          `memory-hybrid: ${SCAN_TYPE} partial run — maintenance deadline (batches ${completedBatchIndexes.size}/${batches.length})`,
+        );
       }
 
       if (opts.verbose && analysed.length > 0) {

--- a/extensions/memory-hybrid/cli/cmd-selfcorrection.ts
+++ b/extensions/memory-hybrid/cli/cmd-selfcorrection.ts
@@ -683,6 +683,7 @@ export async function runSelfCorrectionRunForCli(
     const today = formatDateUtc(Math.floor(Date.now() / 1000));
     const reportPath = join(reportDir, `self-correction-${today}.md`);
     let incidents: CorrectionIncident[];
+    let extractSessionsScanned = 0;
     if (opts.incidents !== undefined) {
       incidents = opts.incidents;
     } else if (opts.extractPath) {
@@ -719,6 +720,7 @@ export async function runSelfCorrectionRunForCli(
         filePaths: scFilePaths,
         verbose: opts.verbose,
       });
+      extractSessionsScanned = extractResult.sessionsScanned;
       incidents = extractResult.incidents;
       const scCfgExtract = cfg.selfCorrection ?? DEFAULT_SELF_CORRECTION;
       if (scCfgExtract.llmExtract !== false && incidents.length >= 0) {
@@ -1301,7 +1303,13 @@ export async function runSelfCorrectionRunForCli(
     if (!opts.dryRun && !opts.incidents && !opts.extractPath && allBatchesCompleted) {
       const sessionPaths = [...new Set(incidents.map((i) => i.sessionFile).filter(Boolean))];
       const lastSessionTs = sessionPaths.length > 0 ? (getMaxMtime(sessionPaths) ?? Date.now()) : Date.now();
-      factsDb.updateScanCursor(SCAN_TYPE, lastSessionTs, incidents.length);
+      const sessionsProcessedThisRun =
+        extractSessionsScanned > 0
+          ? extractSessionsScanned
+          : sessionPaths.length > 0
+            ? sessionPaths.length
+            : 1;
+      factsDb.updateScanCursor(SCAN_TYPE, lastSessionTs, sessionsProcessedThisRun);
     }
 
     if (jobRun) {

--- a/extensions/memory-hybrid/lifecycle/stage-injection.ts
+++ b/extensions/memory-hybrid/lifecycle/stage-injection.ts
@@ -9,7 +9,6 @@ import type { ClawdbotPluginApi } from "openclaw/plugin-sdk/core";
 import { getCronModelConfig, getDefaultCronModel } from "../config/index.js";
 import "../config.js";
 import { capturePluginError } from "../services/error-reporter.js";
-import { chatCompletionTokenParams } from "../services/model-capabilities.js";
 import { trimBlockToBudget } from "../services/context-block-trim.js";
 import { consumePrependBudget } from "../services/prepend-budget.js";
 import { shouldPinFactForInjection } from "../services/pinned-recall-policy.js";
@@ -28,7 +27,6 @@ import { createRecallSpan, createRecallTimingLogger } from "../services/recall-t
 import { resolveRecallInjectionText, resolveFactsDbForEntry } from "../services/fragment-recall.js";
 import { sanitizePromptInjection } from "../services/skill-prompt-injection.js";
 import { extractLastUserMessageText } from "../utils/extract-last-user-message.js";
-import { extractAssistantMessageText } from "../utils/llm-message.js";
 import {
   estimateTokens,
   estimateTokensForDisplay,
@@ -579,29 +577,20 @@ async function runInjection(
       })
       .join("\n");
     try {
-      const { withLLMRetry } = await import("../services/chat.js");
+      const { chatCompleteWithRetry } = await import("../services/chat.js");
       const injectionSummarizeModel = summarizeModel ?? getDefaultCronModel(getCronModelConfig(ctx.cfg), "nano");
-      const resp = await withLLMRetry(
-        () => {
-          if (options.abortSignal?.aborted) {
-            throw Object.assign(new Error("injection stage aborted"), { name: "AbortError" });
-          }
-          return ctx.openai.chat.completions.create({
-            model: injectionSummarizeModel,
-            messages: [
-              {
-                role: "user",
-                content: `Summarize these memories into 2-3 short sentences. Preserve key facts.\n\n${fullBullets.slice(0, 4000)}`,
-              },
-            ],
-            temperature: 0,
-            ...chatCompletionTokenParams(injectionSummarizeModel, 200),
-          });
-        },
-        { maxRetries: 2 },
-      );
-      const summary = extractAssistantMessageText(resp.choices[0]?.message).text;
-      if (summary) {
+      const summary = await chatCompleteWithRetry({
+        model: injectionSummarizeModel,
+        content: `Summarize these memories into 2-3 short sentences. Preserve key facts.\n\n${fullBullets.slice(0, 4000)}`,
+        temperature: 0,
+        maxTokens: 200,
+        openai: ctx.openai,
+        label: "memory-hybrid: injection-summarize",
+        feature: "auto-recall",
+        timeoutMs: INJECTION_STAGE_TIMEOUT_MS,
+        signal: options.abortSignal,
+      });
+      if (summary.trim()) {
         let sanitizedSummary = sanitizePromptInjection(summary);
         let summaryTokens = estimateTokens(header + sanitizedSummary + footer);
         if (summaryTokens > memoryTokenBudget) {

--- a/extensions/memory-hybrid/openclaw.plugin.json
+++ b/extensions/memory-hybrid/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "openclaw-hybrid-memory",
   "kind": "memory",
-  "version": "2026.6.258",
+  "version": "2026.6.259",
   "contracts": {
     "tools": [
       "active_task_checkpoint",

--- a/extensions/memory-hybrid/package.json
+++ b/extensions/memory-hybrid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-hybrid-memory",
-  "version": "2026.6.258",
+  "version": "2026.6.259",
   "type": "module",
   "description": "Give your OpenClaw agent lasting memory: structured facts, semantic search, auto-capture & recall, decay, optional credential vault. Part of Hybrid Memory v3.",
   "files": [

--- a/extensions/memory-hybrid/services/adaptive-maintenance-llm.ts
+++ b/extensions/memory-hybrid/services/adaptive-maintenance-llm.ts
@@ -25,6 +25,10 @@ import {
 } from "./chat.js";
 import type { CostFeatureId } from "./cost-feature-labels.js";
 import { capturePluginError } from "./error-reporter.js";
+import {
+  capTimeoutByMaintenanceRunDeadline,
+  getMaintenanceRunAbortSignal,
+} from "../utils/maintenance-run-deadline.js";
 
 export type MaintenanceLlmLogger = {
   info?: (msg: string) => void;
@@ -141,7 +145,9 @@ async function callMaintenanceDetailed(
     feature: opts.feature,
     responseFormat: opts.responseFormat,
     onRetry: opts.onRetry,
-    timeoutMsPerModel: (m) => resolveMaintenanceChatTimeoutMs(m, thinkingMode),
+    timeoutMsPerModel: (m) =>
+      capTimeoutByMaintenanceRunDeadline(resolveMaintenanceChatTimeoutMs(m, thinkingMode)),
+    signal: getMaintenanceRunAbortSignal(),
     ...(thinkingMode != null ? { thinkingMode } : {}),
   });
 }

--- a/extensions/memory-hybrid/services/auto-classifier.ts
+++ b/extensions/memory-hybrid/services/auto-classifier.ts
@@ -12,7 +12,7 @@ import type { FactsDB } from "../backends/facts-db.js";
 import { getMemoryCategories, isValidCategory } from "../config.js";
 import { tryParseFirstJsonArray } from "../utils/llm-json-array.js";
 import { fillPrompt, loadPrompt } from "../utils/prompt-loader.js";
-import { capTimeoutByMaintenanceRunDeadline, maintenanceRunDeadlineReached } from "../utils/maintenance-run-deadline.js";
+import { capTimeoutByMaintenanceRunDeadline, getMaintenanceRunAbortSignal, maintenanceRunDeadlineReached } from "../utils/maintenance-run-deadline.js";
 import {
   chatCompleteWithRetry,
   is404Like,
@@ -160,6 +160,7 @@ async function discoverCategoriesFromOther(
         label: "memory-hybrid: category-discovery",
         feature: "auto-classify",
         timeoutMs,
+        signal: getMaintenanceRunAbortSignal(),
       });
       // chatComplete strips literal "[]" as a placeholder; empty array is valid discovery output.
       const content = raw.trim().length > 0 ? raw : "[]";
@@ -277,6 +278,7 @@ Respond with ONLY a JSON array of category strings, one per fact, in order. Exam
       label: "memory-hybrid: classify-batch",
       feature: "auto-classify",
       timeoutMs,
+      signal: getMaintenanceRunAbortSignal(),
     });
     // chatComplete strips literal "[]" as a placeholder; empty array is valid classify output.
     const content = raw.trim().length > 0 ? raw : "[]";

--- a/extensions/memory-hybrid/services/auto-classifier.ts
+++ b/extensions/memory-hybrid/services/auto-classifier.ts
@@ -11,11 +11,21 @@ import type OpenAI from "openai";
 import type { FactsDB } from "../backends/facts-db.js";
 import { getMemoryCategories, isValidCategory } from "../config.js";
 import { tryParseFirstJsonArray } from "../utils/llm-json-array.js";
-import { extractAssistantMessageText } from "../utils/llm-message.js";
 import { fillPrompt, loadPrompt } from "../utils/prompt-loader.js";
-import { is404Like, is500Like, isConnectionErrorLike, isOllamaOOM } from "./chat.js";
+import { capTimeoutByMaintenanceRunDeadline, maintenanceRunDeadlineReached } from "../utils/maintenance-run-deadline.js";
+import {
+  chatCompleteWithRetry,
+  is404Like,
+  is500Like,
+  isConnectionErrorLike,
+  isOllamaOOM,
+  resolveMaintenanceChatTimeoutMs,
+} from "./chat.js";
 import { capturePluginError } from "./error-reporter.js";
-import { chatCompletionTokenParams } from "./model-capabilities.js";
+
+function resolveAutoClassifyLlmTimeoutMs(model: string): number {
+  return capTimeoutByMaintenanceRunDeadline(resolveMaintenanceChatTimeoutMs(model));
+}
 
 /** Minimum "other" facts before category discovery kicks in. */
 const MIN_OTHER_FOR_DISCOVERY = 15;
@@ -126,23 +136,33 @@ async function discoverCategoriesFromOther(
   let anyBatchSucceeded = false;
 
   for (let i = 0; i < others.length; i += DISCOVERY_BATCH_SIZE) {
+    if (maintenanceRunDeadlineReached()) {
+      logger.info("memory-hybrid: category discovery stopped — maintenance run deadline reached");
+      break;
+    }
     const batch = others.slice(i, i + DISCOVERY_BATCH_SIZE);
     const factLines = batch.map((f, idx) => `${idx + 1}. ${f.text.slice(0, 280)}`).join("\n");
     const prompt = fillPrompt(loadPrompt("category-discovery"), { facts: factLines });
 
+    const timeoutMs = resolveAutoClassifyLlmTimeoutMs(config.model);
+    if (timeoutMs <= 0) {
+      logger.info("memory-hybrid: category discovery stopped — no remaining LLM budget");
+      break;
+    }
+
     try {
-      const { withLLMRetry } = await import("./chat.js");
-      const resp = await withLLMRetry(
-        () =>
-          openai.chat.completions.create({
-            model: config.model,
-            messages: [{ role: "user", content: prompt }],
-            temperature: 0,
-            ...chatCompletionTokenParams(config.model, batch.length * 24),
-          }),
-        { maxRetries: 2 },
-      );
-      const content = extractAssistantMessageText(resp.choices?.[0]?.message).text || "[]";
+      const raw = await chatCompleteWithRetry({
+        model: config.model,
+        content: prompt,
+        temperature: 0,
+        maxTokens: batch.length * 24,
+        openai,
+        label: "memory-hybrid: category-discovery",
+        feature: "auto-classify",
+        timeoutMs,
+      });
+      // chatComplete strips literal "[]" as a placeholder; empty array is valid discovery output.
+      const content = raw.trim().length > 0 ? raw : "[]";
       const labels = tryParseFirstJsonArray(content);
       if (!labels) continue;
       anyBatchSucceeded = true;
@@ -242,20 +262,24 @@ ${factLines}
 
 Respond with ONLY a JSON array of category strings, one per fact, in order. Example: ["fact","entity","preference"]`;
 
-  try {
-    const { withLLMRetry } = await import("./chat.js");
-    const resp = await withLLMRetry(
-      () =>
-        openai.chat.completions.create({
-          model,
-          messages: [{ role: "user", content: prompt }],
-          temperature: 0,
-          ...chatCompletionTokenParams(model, facts.length * 20),
-        }),
-      { maxRetries: 2 },
-    );
+  const timeoutMs = resolveAutoClassifyLlmTimeoutMs(model);
+  if (timeoutMs <= 0) {
+    return { results: new Map(), suggestions: new Map(), success: false };
+  }
 
-    const content = extractAssistantMessageText(resp.choices?.[0]?.message).text || "[]";
+  try {
+    const raw = await chatCompleteWithRetry({
+      model,
+      content: prompt,
+      temperature: 0,
+      maxTokens: facts.length * 20,
+      openai,
+      label: "memory-hybrid: classify-batch",
+      feature: "auto-classify",
+      timeoutMs,
+    });
+    // chatComplete strips literal "[]" as a placeholder; empty array is valid classify output.
+    const content = raw.trim().length > 0 ? raw : "[]";
     const parsed = tryParseFirstJsonArray(content);
     if (!parsed) return { results: new Map(), suggestions: new Map(), success: false };
 
@@ -377,6 +401,10 @@ async function runClassifyForCli(
   let batchFailures = 0;
   let batchIndex = 0;
   for (let i = 0; i < others.length; i += config.batchSize) {
+    if (maintenanceRunDeadlineReached()) {
+      logger.info("memory-hybrid: classify stopped — maintenance run deadline reached");
+      break;
+    }
     reporter?.update(batchIndex + 1);
     const batch = others.slice(i, i + config.batchSize).map((e) => ({ id: e.id, text: e.text }));
     const { results, suggestions, success } = await classifyBatch(openai, classifyModel, batch, categories);
@@ -461,6 +489,10 @@ async function runAutoClassify(
   let batchFailures = 0;
 
   for (let i = 0; i < others.length; i += config.batchSize) {
+    if (maintenanceRunDeadlineReached()) {
+      logger.info("memory-hybrid: auto-classify stopped — maintenance run deadline reached");
+      break;
+    }
     const batch = others.slice(i, i + config.batchSize).map((e) => ({
       id: e.id,
       text: e.text,

--- a/extensions/memory-hybrid/services/classification.ts
+++ b/extensions/memory-hybrid/services/classification.ts
@@ -10,7 +10,7 @@ import { extractBalancedArraySlice, stripThinkingWrapperBlocks } from "../utils/
 import { fillPrompt, loadPrompt } from "../utils/prompt-loader.js";
 import { capturePluginError } from "./error-reporter.js";
 import { isMiniMaxModel } from "./model-capabilities.js";
-import { capTimeoutByMaintenanceRunDeadline } from "../utils/maintenance-run-deadline.js";
+import { capTimeoutByMaintenanceRunDeadline, getMaintenanceRunAbortSignal } from "../utils/maintenance-run-deadline.js";
 
 export type MemoryClassification = {
   action: "ADD" | "UPDATE" | "DELETE" | "NOOP";
@@ -130,6 +130,7 @@ export async function classifyMemoryOperation(
       label: "memory-hybrid: classify-memory-operation",
       feature: "auto-classify",
       timeoutMs: capTimeoutByMaintenanceRunDeadline(resolveMaintenanceChatTimeoutMs(model)),
+      signal: getMaintenanceRunAbortSignal(),
       ...(isMiniMaxModel(model) ? { thinkingMode: "disabled" as const } : {}),
     });
     return parseClassificationResponse(content, existingFacts);
@@ -382,6 +383,7 @@ For UPDATE or DELETE, targetId must be one of the existing fact ids listed under
       label: "memory-hybrid: classify-memory-operations-batch",
       feature: "auto-classify",
       timeoutMs: capTimeoutByMaintenanceRunDeadline(resolveMaintenanceChatTimeoutMs(model)),
+      signal: getMaintenanceRunAbortSignal(),
       ...(isMiniMaxModel(model) ? { thinkingMode: "disabled" as const } : {}),
     });
     const parsed = parseBatchClassifyResponseContent(raw);

--- a/extensions/memory-hybrid/services/classification.ts
+++ b/extensions/memory-hybrid/services/classification.ts
@@ -7,33 +7,10 @@
 import type OpenAI from "openai";
 import type { MemoryEntry } from "../types/memory.js";
 import { extractBalancedArraySlice, stripThinkingWrapperBlocks } from "../utils/llm-json-array.js";
-import { extractAssistantMessageText } from "../utils/llm-message.js";
 import { fillPrompt, loadPrompt } from "../utils/prompt-loader.js";
 import { capturePluginError } from "./error-reporter.js";
-import { isMiniMaxModel, requiresMaxCompletionTokens, shouldOmitSamplingParams } from "./model-capabilities.js";
-
-/** Chat body for classify completions — mirrors `chatComplete` in `chat.ts` (#1008). */
-function buildClassifyChatBody(
-  model: string,
-  userContent: string,
-  maxOutputTokens: number,
-): OpenAI.ChatCompletionCreateParamsNonStreaming {
-  const useMaxCompletionTokens = requiresMaxCompletionTokens(model);
-  const body: OpenAI.ChatCompletionCreateParamsNonStreaming & {
-    thinking?: { type: "disabled" | "adaptive" };
-  } = {
-    model,
-    messages: [{ role: "user", content: userContent }],
-    ...(useMaxCompletionTokens ? { max_completion_tokens: maxOutputTokens } : { max_tokens: maxOutputTokens }),
-  };
-  if (!shouldOmitSamplingParams(model)) {
-    body.temperature = 0;
-  }
-  if (isMiniMaxModel(model)) {
-    body.thinking = { type: "disabled" };
-  }
-  return body;
-}
+import { isMiniMaxModel } from "./model-capabilities.js";
+import { capTimeoutByMaintenanceRunDeadline } from "../utils/maintenance-run-deadline.js";
 
 export type MemoryClassification = {
   action: "ADD" | "UPDATE" | "DELETE" | "NOOP";
@@ -143,17 +120,18 @@ export async function classifyMemoryOperation(
   const { prompt } = buildClassifyPromptParts(candidateText, candidateEntity, candidateKey, existingFacts);
 
   try {
-    const { withLLMRetry } = await import("./chat.js");
-    const resp = (await withLLMRetry(
-      () =>
-        openai.chat.completions.create(
-          buildClassifyChatBody(model, prompt, 100) as unknown as Parameters<
-            OpenAI["chat"]["completions"]["create"]
-          >[0],
-        ),
-      { maxRetries: 2 },
-    )) as OpenAI.Chat.ChatCompletion;
-    const content = extractAssistantMessageText(resp.choices?.[0]?.message).text;
+    const { chatCompleteWithRetry, resolveMaintenanceChatTimeoutMs } = await import("./chat.js");
+    const content = await chatCompleteWithRetry({
+      model,
+      content: prompt,
+      temperature: 0,
+      maxTokens: 100,
+      openai,
+      label: "memory-hybrid: classify-memory-operation",
+      feature: "auto-classify",
+      timeoutMs: capTimeoutByMaintenanceRunDeadline(resolveMaintenanceChatTimeoutMs(model)),
+      ...(isMiniMaxModel(model) ? { thinkingMode: "disabled" as const } : {}),
+    });
     return parseClassificationResponse(content, existingFacts);
   } catch (err) {
     capturePluginError(err instanceof Error ? err : new Error(String(err)), {
@@ -393,18 +371,19 @@ For UPDATE or DELETE, targetId must be one of the existing fact ids listed under
   };
 
   try {
-    const { withLLMRetry } = await import("./chat.js");
+    const { chatCompleteWithRetry, resolveMaintenanceChatTimeoutMs } = await import("./chat.js");
     const batchMaxOut = Math.min(800, 80 * items.length);
-    const resp = (await withLLMRetry(
-      () =>
-        openai.chat.completions.create(
-          buildClassifyChatBody(model, fullPrompt, batchMaxOut) as unknown as Parameters<
-            OpenAI["chat"]["completions"]["create"]
-          >[0],
-        ),
-      { maxRetries: 2 },
-    )) as OpenAI.Chat.ChatCompletion;
-    const raw = extractAssistantMessageText(resp.choices?.[0]?.message).text;
+    const raw = await chatCompleteWithRetry({
+      model,
+      content: fullPrompt,
+      temperature: 0,
+      maxTokens: batchMaxOut,
+      openai,
+      label: "memory-hybrid: classify-memory-operations-batch",
+      feature: "auto-classify",
+      timeoutMs: capTimeoutByMaintenanceRunDeadline(resolveMaintenanceChatTimeoutMs(model)),
+      ...(isMiniMaxModel(model) ? { thinkingMode: "disabled" as const } : {}),
+    });
     const parsed = parseBatchClassifyResponseContent(raw);
     if (!Array.isArray(parsed) || parsed.length !== items.length) {
       logger.warn(

--- a/extensions/memory-hybrid/services/classification.ts
+++ b/extensions/memory-hybrid/services/classification.ts
@@ -10,7 +10,7 @@ import { extractBalancedArraySlice, stripThinkingWrapperBlocks } from "../utils/
 import { fillPrompt, loadPrompt } from "../utils/prompt-loader.js";
 import { capturePluginError } from "./error-reporter.js";
 import { isMiniMaxModel } from "./model-capabilities.js";
-import { capTimeoutByMaintenanceRunDeadline, getMaintenanceRunAbortSignal } from "../utils/maintenance-run-deadline.js";
+import { capTimeoutByMaintenanceRunDeadline, getMaintenanceRunAbortSignal, maintenanceRunDeadlineReached } from "../utils/maintenance-run-deadline.js";
 
 export type MemoryClassification = {
   action: "ADD" | "UPDATE" | "DELETE" | "NOOP";
@@ -356,6 +356,13 @@ For UPDATE or DELETE, targetId must be one of the existing fact ids listed under
   const runSequential = async (): Promise<MemoryClassification[]> => {
     const out: MemoryClassification[] = [];
     for (const it of items) {
+      if (maintenanceRunDeadlineReached()) {
+        logger.warn(
+          "memory-hybrid: batch classify sequential fallback stopped — maintenance run deadline reached",
+        );
+        out.push({ action: "ADD", reason: "maintenance run deadline reached; defaulting to ADD" });
+        continue;
+      }
       out.push(
         await classifyMemoryOperation(
           it.candidateText,

--- a/extensions/memory-hybrid/services/consolidation.ts
+++ b/extensions/memory-hybrid/services/consolidation.ts
@@ -19,9 +19,7 @@ import { withCostFeature } from "./cost-context.js";
 import type { EmbeddingProvider } from "./embeddings.js";
 import { shouldSuppressEmbeddingError } from "./embeddings.js";
 import { capturePluginError } from "./error-reporter.js";
-import { chatCompletionTokenParams } from "./model-capabilities.js";
 import { isMiniMaxModel } from "./chat.js";
-import { extractAssistantMessageText } from "../utils/llm-message.js";
 import type { ProvenanceService } from "./provenance.js";
 import { dotProductSimilarity, loadReflectionDedupeCorpusVectors } from "./reflection.js";
 import { deleteVectorsForFactIds, cleanupEvictedVector } from "./vector-maintenance.js";
@@ -204,23 +202,20 @@ export async function runConsolidate(
     const prompt = fillPrompt(loadPrompt("consolidate"), { facts_list: factsList });
     let mergedText: string;
     try {
-      const { withLLMRetry } = await import("./chat.js");
-      // Uses withCostFeature context-wrapper (rather than a feature: param) because
-      // openai.chat.completions.create is called directly here, not via chatCompleteWithRetry.
-      const resp = await withCostFeature("consolidation", () =>
-        withLLMRetry(
-          () =>
-            openai.chat.completions.create({
-              model: opts.model,
-              messages: [{ role: "user", content: prompt }],
-              temperature: 0,
-              ...chatCompletionTokenParams(opts.model, 300),
-              ...(opts.thinkingMode && isMiniMaxModel(opts.model) ? { thinking: { type: opts.thinkingMode } } : {}),
-            }),
-          { maxRetries: 2 },
-        ),
+      const { chatCompleteWithRetryDetailed, resolveMaintenanceChatTimeoutMs } = await import("./chat.js");
+      const detail = await withCostFeature("consolidation", () =>
+        chatCompleteWithRetryDetailed({
+          model: opts.model,
+          content: prompt,
+          temperature: 0,
+          maxTokens: 300,
+          openai: opts.openai,
+          label: "memory-hybrid: consolidate",
+          timeoutMs: resolveMaintenanceChatTimeoutMs(opts.model, opts.thinkingMode),
+          ...(opts.thinkingMode && isMiniMaxModel(opts.model) ? { thinkingMode: opts.thinkingMode } : {}),
+        }),
       );
-      mergedText = extractAssistantMessageText(resp.choices[0]?.message).text.slice(0, CONSOLIDATION_MERGE_MAX_CHARS);
+      mergedText = detail.content.slice(0, CONSOLIDATION_MERGE_MAX_CHARS);
     } catch (err) {
       logger.warn(`memory-hybrid: consolidate LLM failed for cluster: ${err}`);
       capturePluginError(err instanceof Error ? err : new Error(String(err)), {

--- a/extensions/memory-hybrid/services/consolidation.ts
+++ b/extensions/memory-hybrid/services/consolidation.ts
@@ -20,6 +20,11 @@ import type { EmbeddingProvider } from "./embeddings.js";
 import { shouldSuppressEmbeddingError } from "./embeddings.js";
 import { capturePluginError } from "./error-reporter.js";
 import { isMiniMaxModel } from "./chat.js";
+import {
+  capTimeoutByMaintenanceRunDeadline,
+  getMaintenanceRunAbortSignal,
+  maintenanceRunDeadlineReached,
+} from "../utils/maintenance-run-deadline.js";
 import type { ProvenanceService } from "./provenance.js";
 import { dotProductSimilarity, loadReflectionDedupeCorpusVectors } from "./reflection.js";
 import { deleteVectorsForFactIds, cleanupEvictedVector } from "./vector-maintenance.js";
@@ -197,6 +202,10 @@ export async function runConsolidate(
   let storeDedupeVectorFallbackSuppressed = 0;
   const consolidationRunId = provenanceService ? randomUUID() : null;
   for (const clusterIds of clusters) {
+    if (maintenanceRunDeadlineReached()) {
+      logger.warn("memory-hybrid: consolidate stopped — maintenance run deadline reached");
+      break;
+    }
     const texts = clusterIds.map((id) => idToFact.get(id)?.text);
     const factsList = texts.map((t, i) => `${i + 1}. ${t}`).join("\n");
     const prompt = fillPrompt(loadPrompt("consolidate"), { facts_list: factsList });
@@ -211,7 +220,8 @@ export async function runConsolidate(
           maxTokens: 300,
           openai: opts.openai,
           label: "memory-hybrid: consolidate",
-          timeoutMs: resolveMaintenanceChatTimeoutMs(opts.model, opts.thinkingMode),
+          timeoutMs: capTimeoutByMaintenanceRunDeadline(resolveMaintenanceChatTimeoutMs(opts.model, opts.thinkingMode)),
+          signal: getMaintenanceRunAbortSignal(),
           ...(opts.thinkingMode && isMiniMaxModel(opts.model) ? { thinkingMode: opts.thinkingMode } : {}),
         }),
       );

--- a/extensions/memory-hybrid/services/contradiction-adjudicator.ts
+++ b/extensions/memory-hybrid/services/contradiction-adjudicator.ts
@@ -1,7 +1,11 @@
 import type OpenAI from "openai";
 import type { ContradictionReviewItem, LlmContradictionDecision } from "../backends/facts-db/contradictions.js";
 import { tryParseFirstJsonObject } from "../utils/llm-json-array.js";
-import { extractAssistantMessageText } from "../utils/llm-message.js";
+import {
+  capTimeoutByMaintenanceRunDeadline,
+  getMaintenanceRunAbortSignal,
+} from "../utils/maintenance-run-deadline.js";
+import { chatCompleteWithRetry, resolveMaintenanceChatTimeoutMs } from "./chat.js";
 
 export function parseContradictionAdjudicationResponse(content: string): LlmContradictionDecision | null {
   const parsed = tryParseFirstJsonObject(content) as Partial<LlmContradictionDecision> | null;
@@ -30,33 +34,32 @@ export function parseContradictionAdjudicationResponse(content: string): LlmCont
   }
 }
 
+const ADJUDICATION_SYSTEM_PROMPT =
+  "You adjudicate memory contradictions. Return JSON only with decision, confidence, reason, and optional mergedFactText. " +
+  "Use manual_review unless one side is clearly the safer current fact. Never invent facts.";
+
 export async function adjudicateContradictionWithLlm(
   openai: OpenAI,
   model: string,
   item: ContradictionReviewItem,
 ): Promise<LlmContradictionDecision> {
-  const response = await openai.chat.completions.create({
-    model,
-    temperature: 0,
-    response_format: { type: "json_object" },
-    messages: [
-      {
-        role: "system",
-        content:
-          "You adjudicate memory contradictions. Return JSON only with decision, confidence, reason, and optional mergedFactText. " +
-          "Use manual_review unless one side is clearly the safer current fact. Never invent facts.",
-      },
-      {
-        role: "user",
-        content: JSON.stringify({
-          task: "Adjudicate contradiction",
-          contradiction: item,
-          allowedDecisions: ["keep_new", "keep_old", "merge", "manual_review"],
-        }),
-      },
-    ],
+  const userPayload = JSON.stringify({
+    task: "Adjudicate contradiction",
+    contradiction: item,
+    allowedDecisions: ["keep_new", "keep_old", "merge", "manual_review"],
   });
-  const content = extractAssistantMessageText(response.choices[0]?.message).text;
+  const content = await chatCompleteWithRetry({
+    model,
+    content: `${ADJUDICATION_SYSTEM_PROMPT}\n\n${userPayload}`,
+    temperature: 0,
+    maxTokens: 500,
+    openai,
+    label: "memory-hybrid: adjudicate-contradiction",
+    feature: "contradiction-adjudication",
+    responseFormat: { type: "json_object" },
+    timeoutMs: capTimeoutByMaintenanceRunDeadline(resolveMaintenanceChatTimeoutMs(model)),
+    signal: getMaintenanceRunAbortSignal(),
+  });
   const parsed = parseContradictionAdjudicationResponse(content);
   if (!parsed) {
     throw new Error("LLM returned malformed contradiction adjudication JSON.");

--- a/extensions/memory-hybrid/services/cross-agent-learning.ts
+++ b/extensions/memory-hybrid/services/cross-agent-learning.ts
@@ -18,7 +18,12 @@ import type { CrossAgentLearningConfig } from "../config/types/features.js";
 import type { MemoryEntry } from "../types/memory.js";
 import { fillPrompt, loadPrompt as loadPromptSync } from "../utils/prompt-loader.js";
 import { parseTags, serializeTags } from "../utils/tags.js";
-import { chatCompleteWithRetry } from "./chat.js";
+import {
+  capTimeoutByMaintenanceRunDeadline,
+  getMaintenanceRunAbortSignal,
+  maintenanceRunDeadlineReached,
+} from "../utils/maintenance-run-deadline.js";
+import { chatCompleteWithRetry, resolveMaintenanceChatTimeoutMs } from "./chat.js";
 import { CostFeature } from "./cost-feature-labels.js";
 import { capturePluginError } from "./error-reporter.js";
 
@@ -210,7 +215,10 @@ async function callLLMForGeneralisation(
     fallbackModels,
     content: prompt,
     maxTokens: 2000,
-    timeoutMs: 40000,
+    timeoutMs: capTimeoutByMaintenanceRunDeadline(
+      Math.min(40_000, resolveMaintenanceChatTimeoutMs(model)),
+    ),
+    signal: getMaintenanceRunAbortSignal(),
     feature: CostFeature.crossAgentLearning,
   });
 
@@ -303,6 +311,10 @@ export async function runCrossAgentLearning(
 
     let batchIndex = 0;
     for (const batch of batches) {
+      if (maintenanceRunDeadlineReached()) {
+        logger.warn?.("cross-agent-learning: maintenance run deadline reached; stopping batches");
+        break;
+      }
       batchIndex++;
       if (runOpts?.verbose) {
         logger.info?.(

--- a/extensions/memory-hybrid/services/entity-enrichment-cli.ts
+++ b/extensions/memory-hybrid/services/entity-enrichment-cli.ts
@@ -19,6 +19,8 @@ import {
   sanitizeProviderPressureBudget,
   sanitizeTimeBudgetSec,
 } from "./entity-enrichment-adaptive.js";
+import { capturePluginError } from "./error-reporter.js";
+import { resolveMaintenanceStepDeadlineMs } from "../utils/maintenance-run-deadline.js";
 
 function sanitizeEnrichmentLimit(n: number): number {
   const x = Math.floor(Number(n));
@@ -298,7 +300,7 @@ export async function runEntityEnrichmentForCli(
   const timeBudgetSec = sanitizeTimeBudgetSec(opts.timeBudgetSec ?? opts.targetDurationSec);
   const providerPressureBudget = sanitizeProviderPressureBudget(opts.providerPressureBudget);
   const startedAtMs = Date.now();
-  const deadlineMs = timeBudgetSec != null ? startedAtMs + timeBudgetSec * 1000 : undefined;
+  const deadlineMs = resolveMaintenanceStepDeadlineMs(startedAtMs, timeBudgetSec ?? undefined);
   const isPastDeadline = (): boolean => deadlineMs != null && Date.now() >= deadlineMs;
 
   let effectiveBatchSize = sanitizeBatchSize(opts.batchSize ?? 20);
@@ -442,7 +444,17 @@ export async function runEntityEnrichmentForCli(
           if (extraction.pressureSignals.timeoutFailure) factTimeout = 1;
           stats.llmFailuresDelta++;
         } else {
-          factsDb.applyEntityEnrichment(id, extraction.mentions, extraction.detectedLang);
+          try {
+            factsDb.applyEntityEnrichment(id, extraction.mentions, extraction.detectedLang);
+          } catch (err) {
+            capturePluginError(err instanceof Error ? err : new Error(String(err)), {
+              operation: "entity-enrichment:apply",
+              severity: "info",
+              subsystem: "entity-enrichment",
+            });
+            stats.batchFailures++;
+            stats.llmFailuresDelta++;
+          }
         }
 
         stats.mentionsDelta = extraction.quality.mentions;
@@ -450,7 +462,7 @@ export async function runEntityEnrichmentForCli(
         stats.rejectedDelta = extraction.quality.rejected;
         stats.duplicatesDelta = extraction.quality.duplicates;
         stats.rejectReasonsDelta = { ...extraction.quality.rejectReasons };
-        if (extraction.mentions.length > 0) {
+        if (extraction.mentions.length > 0 && stats.batchFailures === 0) {
           stats.factsEnrichedDelta = 1;
         }
         if (verbose && (extraction.mentions.length > 0 || extraction.rejectedMentions.length > 0)) {
@@ -471,6 +483,19 @@ export async function runEntityEnrichmentForCli(
           rateLimitCount: factRateLimit,
           transientFailureCount: factTransient,
           timeoutFailureCount: factTimeout,
+        };
+      } catch (err) {
+        capturePluginError(err instanceof Error ? err : new Error(String(err)), {
+          operation: "entity-enrichment:process-fact",
+          severity: "info",
+          subsystem: "entity-enrichment",
+        });
+        return {
+          processed: 1,
+          stats: { ...emptyBatchStats(), batchFailures: 1, llmFailuresDelta: 1 },
+          rateLimitCount: 0,
+          transientFailureCount: 0,
+          timeoutFailureCount: 0,
         };
       } finally {
         mergeCounters.pendingLlmCalls.value--;

--- a/extensions/memory-hybrid/services/entity-enrichment.ts
+++ b/extensions/memory-hybrid/services/entity-enrichment.ts
@@ -16,19 +16,17 @@ import {
 } from "../utils/entity-mention-quality.js";
 import { isEntityStopWord as isConfiguredEntityStopWord } from "../utils/entity-stopwords.js";
 import { stripThinkingWrapperBlocks, parseFirstJsonObjectValue } from "../utils/llm-json-array.js";
-import { extractAssistantMessageText } from "../utils/llm-message.js";
 import {
+  chatCompleteWithRetry,
   is403QuotaOrRateLimitLike,
   is429OrWrapped,
   is500OrWrapped,
   isConnectionErrorLike,
   parseRetryAfterMs,
-  withLLMRetry,
+  resolveMaintenanceChatTimeoutMs,
 } from "./chat.js";
-import { withCostFeature } from "./cost-context.js";
 import { errorIndicatesLlmTimeout } from "./entity-enrichment-adaptive.js";
 import { capturePluginError } from "./error-reporter.js";
-import { chatCompletionTokenParams } from "./model-capabilities.js";
 
 const MIN_CHARS = 24;
 const MAX_CHARS = 8000;
@@ -158,19 +156,16 @@ INPUT:
 ${body}`;
 
   try {
-    const resp = await withCostFeature("entity-enrichment", () =>
-      withLLMRetry(
-        () =>
-          openai.chat.completions.create({
-            model,
-            messages: [{ role: "user", content: prompt }],
-            temperature: 0,
-            ...chatCompletionTokenParams(model, 1200),
-          }),
-        { maxRetries: 2 },
-      ),
-    );
-    const content = extractAssistantMessageText(resp.choices[0]?.message).text;
+    const content = await chatCompleteWithRetry({
+      model,
+      content: prompt,
+      temperature: 0,
+      maxTokens: 1200,
+      openai,
+      label: "memory-hybrid: entity-enrichment",
+      feature: "entity-enrichment",
+      timeoutMs: resolveMaintenanceChatTimeoutMs(model),
+    });
     const raw = parseMentionJson(content);
     const mentions: ExtractedMention[] = [];
     const rejectedMentions: EntityMentionRejection[] = [];

--- a/extensions/memory-hybrid/services/entity-enrichment.ts
+++ b/extensions/memory-hybrid/services/entity-enrichment.ts
@@ -17,6 +17,10 @@ import {
 import { isEntityStopWord as isConfiguredEntityStopWord } from "../utils/entity-stopwords.js";
 import { stripThinkingWrapperBlocks, parseFirstJsonObjectValue } from "../utils/llm-json-array.js";
 import {
+  capTimeoutByMaintenanceRunDeadline,
+  getMaintenanceRunAbortSignal,
+} from "../utils/maintenance-run-deadline.js";
+import {
   chatCompleteWithRetry,
   is403QuotaOrRateLimitLike,
   is429OrWrapped,
@@ -164,7 +168,8 @@ ${body}`;
       openai,
       label: "memory-hybrid: entity-enrichment",
       feature: "entity-enrichment",
-      timeoutMs: resolveMaintenanceChatTimeoutMs(model),
+      timeoutMs: capTimeoutByMaintenanceRunDeadline(resolveMaintenanceChatTimeoutMs(model)),
+      signal: getMaintenanceRunAbortSignal(),
     });
     const raw = parseMentionJson(content);
     const mentions: ExtractedMention[] = [];

--- a/extensions/memory-hybrid/services/goal-stewardship-llm-triage.ts
+++ b/extensions/memory-hybrid/services/goal-stewardship-llm-triage.ts
@@ -6,7 +6,11 @@ import type OpenAI from "openai";
 import type { HybridMemoryConfig } from "../config.js";
 import { getCronModelConfig, getLLMModelPreference } from "../config.js";
 import { tryParseFirstJsonObject } from "../utils/llm-json-array.js";
-import { extractAssistantMessageText } from "../utils/llm-message.js";
+import {
+  capTimeoutByMaintenanceRunDeadline,
+  getMaintenanceRunAbortSignal,
+} from "../utils/maintenance-run-deadline.js";
+import { chatCompleteWithRetry, resolveMaintenanceChatTimeoutMs } from "./chat.js";
 import { capturePluginError } from "./error-reporter.js";
 
 export async function llmTriageNeedsHeavy(
@@ -19,21 +23,20 @@ export async function llmTriageNeedsHeavy(
     const models = getLLMModelPreference(getCronModelConfig(cfg), "nano");
     const model = models[0];
     if (!model) return null;
-    const res = await openai.chat.completions.create({
+    const raw = await chatCompleteWithRetry({
       model,
-      messages: [
-        {
-          role: "user",
-          content: `Reply with ONLY valid JSON: {"needsHeavy":true or false}. needsHeavy means substantive reasoning or multi-step dispatch is likely needed (not a trivial heartbeat).
+      content: `Reply with ONLY valid JSON: {"needsHeavy":true or false}. needsHeavy means substantive reasoning or multi-step dispatch is likely needed (not a trivial heartbeat).
 Goals summary (truncated):
 ${goalSummaries.slice(0, 6000)}`,
-        },
-      ],
-      max_tokens: 60,
+      maxTokens: 60,
       temperature: 0,
+      openai,
+      label: "goal-stewardship: llm-triage",
+      feature: "goal-stewardship",
+      timeoutMs: capTimeoutByMaintenanceRunDeadline(resolveMaintenanceChatTimeoutMs(model)),
+      signal: getMaintenanceRunAbortSignal(),
     });
-    const text = extractAssistantMessageText(res.choices[0]?.message).text;
-    const cleaned = text.replace(/^```(?:json)?\s*/i, "").replace(/\s*```$/i, "");
+    const cleaned = raw.replace(/^```(?:json)?\s*/i, "").replace(/\s*```$/i, "");
     const j = tryParseFirstJsonObject(cleaned) as { needsHeavy?: boolean } | null;
     if (!j) return null;
     return j.needsHeavy === true;

--- a/extensions/memory-hybrid/services/identity-reflection.ts
+++ b/extensions/memory-hybrid/services/identity-reflection.ts
@@ -4,7 +4,12 @@ import type { FactsDB } from "../backends/facts-db.js";
 import type { IdentityReflectionStore } from "../backends/identity-reflection-store.js";
 import type { ScopeFilter } from "../types/memory.js";
 import { fillPrompt, loadPrompt } from "../utils/prompt-loader.js";
-import { LLMRetryError, chatCompleteWithRetry } from "./chat.js";
+import {
+  capTimeoutByMaintenanceRunDeadline,
+  getMaintenanceRunAbortSignal,
+  maintenanceRunDeadlineReached,
+} from "../utils/maintenance-run-deadline.js";
+import { LLMRetryError, chatCompleteWithRetry, resolveMaintenanceChatTimeoutMs } from "./chat.js";
 import { CostFeature } from "./cost-feature-labels.js";
 import { capturePluginError } from "./error-reporter.js";
 
@@ -111,6 +116,15 @@ export async function runIdentityReflection(
   if (!config.enabled) {
     return { insightsExtracted: 0, insightsStored: 0, questionsAsked: 0 };
   }
+  if (maintenanceRunDeadlineReached()) {
+    logger.info("memory-hybrid: reflect-identity — maintenance run deadline reached; skipping");
+    return {
+      insightsExtracted: 0,
+      insightsStored: 0,
+      questionsAsked: config.questions.length,
+      semanticOutcome: "deferred",
+    };
+  }
 
   const windowDays = Math.min(90, Math.max(1, Math.floor(opts.window ?? config.defaultWindow)));
   const nowSec = Math.floor(Date.now() / 1000);
@@ -167,6 +181,8 @@ export async function runIdentityReflection(
       fallbackModels: opts.fallbackModels ?? [],
       label: "memory-hybrid: reflect-identity",
       feature: CostFeature.identityReflection,
+      timeoutMs: capTimeoutByMaintenanceRunDeadline(resolveMaintenanceChatTimeoutMs(opts.model)),
+      signal: getMaintenanceRunAbortSignal(),
     });
   } catch (err) {
     logger.warn(`memory-hybrid: reflect-identity LLM failed: ${err}`);

--- a/extensions/memory-hybrid/services/incident-batch-analyze-core.ts
+++ b/extensions/memory-hybrid/services/incident-batch-analyze-core.ts
@@ -4,6 +4,10 @@ import { chatCompleteWithAdaptiveMaintenanceRetry } from "./adaptive-maintenance
 import { maintenanceMaxOutputTokens, type MiniMaxThinkingMode } from "./chat.js";
 import { checkBatchRemediationCoverage, mergeSplitBatchItemsWithOffset } from "./batch-incident-analysis.js";
 import type { CostFeature } from "./cost-feature-labels.js";
+import {
+  getMaintenanceRunAbortSignal,
+  maintenanceRunDeadlineReached,
+} from "../utils/maintenance-run-deadline.js";
 import { estimateTokens } from "../utils/text.js";
 
 export type IncidentBatchAnalyzeDiagnostics = {
@@ -61,6 +65,10 @@ async function sleepMs(ms: number): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+function maintenanceDeadlineBlocked(): boolean {
+  return maintenanceRunDeadlineReached() || getMaintenanceRunAbortSignal()?.aborted === true;
+}
+
 async function callBatchAnalyzeLlm<TIncident>(
   deps: IncidentBatchAnalyzeDeps<unknown, TIncident>,
   batch: TIncident[],
@@ -70,6 +78,11 @@ async function callBatchAnalyzeLlm<TIncident>(
 ): Promise<IncidentBatchLlmResult> {
   let lastError: unknown;
   for (let attempt = 1; attempt <= 4; attempt++) {
+    if (maintenanceDeadlineBlocked()) {
+      const blockedError =
+        lastError instanceof Error ? lastError : new Error("maintenance run deadline reached");
+      throw blockedError;
+    }
     try {
       if (deps.llmCall) {
         return await deps.llmCall(batch, batchLabel, maxTokensOverride);
@@ -110,6 +123,9 @@ async function callBatchAnalyzeLlm<TIncident>(
     } catch (err) {
       lastError = err;
       if (!isTransientBatchLlmError(err) || attempt >= 4) throw err;
+      if (maintenanceDeadlineBlocked()) {
+        throw err instanceof Error ? err : new Error(String(err));
+      }
       const delay = 5000 * 2 ** (attempt - 1);
       diagnostics.retries++;
       deps.onTransientRetry?.({
@@ -203,6 +219,18 @@ export async function analyzeIncidentBatchWithSplit<TItem, TIncident>(
   },
   batch: TIncident[],
 ): Promise<IncidentBatchAnalyzeResult<TItem>> {
+  if (maintenanceRunDeadlineReached()) {
+    return {
+      items: null,
+      diagnostics: {
+        fallbacks: 0,
+        parseFailures: 0,
+        batchSplits: 0,
+        truncations: 0,
+        retries: 0,
+      },
+    };
+  }
   const diagnostics: IncidentBatchAnalyzeDiagnostics = {
     fallbacks: 0,
     parseFailures: 0,
@@ -234,6 +262,7 @@ export async function analyzeIncidentBatchWithSplit<TItem, TIncident>(
 
   if (
     allowBudgetBump &&
+    !maintenanceRunDeadlineReached() &&
     isTruncated &&
     batch.length > 0 &&
     items !== null &&
@@ -270,6 +299,9 @@ export async function analyzeIncidentBatchWithSplit<TItem, TIncident>(
       (effectiveParsedCount > 0 && effectiveParsedCount < batch.length));
 
   if (needsSplit) {
+    if (maintenanceRunDeadlineReached()) {
+      return { items: null, finishReason, rawContent: content, diagnostics };
+    }
     diagnostics.batchSplits++;
     deps.logger.warn?.(
       `memory-hybrid: incident-batch ${batchLabel}: auto-split expected=${batch.length} parsed=${effectiveParsedCount} finish=${finishReason ?? "stop"}`,

--- a/extensions/memory-hybrid/services/language-keywords-build.ts
+++ b/extensions/memory-hybrid/services/language-keywords-build.ts
@@ -19,15 +19,27 @@ import {
   type LanguageKeywordsFile,
 } from "../utils/language-keywords.js";
 import { parseFirstJsonObjectValue, tryParseFirstJsonArray } from "../utils/llm-json-array.js";
-import { extractAssistantMessageText } from "../utils/llm-message.js";
 import { capturePluginError } from "./error-reporter.js";
 import { nowIso } from "../utils/dates.js";
+import {
+  capTimeoutByMaintenanceRunDeadline,
+  getMaintenanceRunAbortSignal,
+  maintenanceRunDeadlineReached,
+} from "../utils/maintenance-run-deadline.js";
 import { EXTRACTION_INTENTS, KEYWORD_GROUP_INTENTS, STRUCTURAL_TRIGGER_INTENTS } from "./intent-template.js";
-import { chatCompletionTokenParams } from "./model-capabilities.js";
+import { chatCompleteWithRetry, resolveMaintenanceChatTimeoutMs } from "./chat.js";
 
 const LANG_FILE_NAME = ".language-keywords.json";
 const MAX_SAMPLES = 50;
 const CHARS_PER_SAMPLE = 400;
+
+function resolveLangKeywordsLlmOpts(model: string, maxTokens: number) {
+  return {
+    maxTokens,
+    timeoutMs: capTimeoutByMaintenanceRunDeadline(resolveMaintenanceChatTimeoutMs(model)),
+    signal: getMaintenanceRunAbortSignal(),
+  };
+}
 
 const KEYWORD_GROUPS = Object.keys(ENGLISH_KEYWORDS) as KeywordGroup[];
 
@@ -77,19 +89,20 @@ Do not include any other text. If you see only one or two languages, return 1 or
 
 Samples:
 ${block}`;
+  if (maintenanceRunDeadlineReached()) return [];
+  const llmOpts = resolveLangKeywordsLlmOpts(model, 100);
+  if (llmOpts.timeoutMs <= 0) return [];
   try {
-    const { withLLMRetry } = await import("./chat.js");
-    const resp = await withLLMRetry(
-      () =>
-        openai.chat.completions.create({
-          model,
-          messages: [{ role: "user", content: prompt }],
-          temperature: 0,
-          ...chatCompletionTokenParams(model, 100),
-        }),
-      { maxRetries: 2 },
-    );
-    const content = extractAssistantMessageText(resp.choices[0]?.message).text;
+    const raw = await chatCompleteWithRetry({
+      model,
+      content: prompt,
+      temperature: 0,
+      openai,
+      label: "memory-hybrid: detect-top-languages",
+      feature: "language-keywords",
+      ...llmOpts,
+    });
+    const content = raw.trim().length > 0 ? raw : "[]";
     const arr = tryParseFirstJsonArray(content);
     if (!arr) return [];
     if (!Array.isArray(arr)) return [];
@@ -249,19 +262,25 @@ async function generateIntentBasedLanguages(
 
   const prompt = buildIntentPrompt(toTranslate, englishPayload);
 
+  if (maintenanceRunDeadlineReached()) {
+    return { translations: {}, triggerStructures: {}, extraction: {} };
+  }
+  const llmOpts = resolveLangKeywordsLlmOpts(model, 6000);
+  if (llmOpts.timeoutMs <= 0) {
+    return { translations: {}, triggerStructures: {}, extraction: {} };
+  }
+
   try {
-    const { withLLMRetry } = await import("./chat.js");
-    const resp = await withLLMRetry(
-      () =>
-        openai.chat.completions.create({
-          model,
-          messages: [{ role: "user", content: prompt }],
-          temperature: 0.2,
-          ...chatCompletionTokenParams(model, 6000),
-        }),
-      { maxRetries: 2 },
-    );
-    const content = extractAssistantMessageText(resp.choices[0]?.message).text;
+    const raw = await chatCompleteWithRetry({
+      model,
+      content: prompt,
+      temperature: 0.2,
+      openai,
+      label: "memory-hybrid: generate-intent-languages",
+      feature: "language-keywords",
+      ...llmOpts,
+    });
+    const content = raw.trim();
     const parsed = parseFirstJsonObjectValue(content) as Record<
       string,
       Record<string, unknown> & { triggerStructures?: string[]; extraction?: unknown }
@@ -335,19 +354,21 @@ Reply with ONLY valid JSON in this exact shape (no markdown, no explanation):
 Each key must be one of: ${KEYWORD_GROUPS.join(", ")}.
 Each value must be an array of translated strings in the same order as the English list. Translate correctionSignals as natural phrases users say when correcting an AI (e.g. "that was wrong", "try again", "you misunderstood") in the target language.`;
 
+  if (maintenanceRunDeadlineReached()) return {};
+  const llmOpts = resolveLangKeywordsLlmOpts(model, 4000);
+  if (llmOpts.timeoutMs <= 0) return {};
+
   try {
-    const { withLLMRetry } = await import("./chat.js");
-    const resp = await withLLMRetry(
-      () =>
-        openai.chat.completions.create({
-          model,
-          messages: [{ role: "user", content: prompt }],
-          temperature: 0.2,
-          ...chatCompletionTokenParams(model, 4000),
-        }),
-      { maxRetries: 2 },
-    );
-    const content = extractAssistantMessageText(resp.choices[0]?.message).text;
+    const raw = await chatCompleteWithRetry({
+      model,
+      content: prompt,
+      temperature: 0.2,
+      openai,
+      label: "memory-hybrid: translate-keywords",
+      feature: "language-keywords",
+      ...llmOpts,
+    });
+    const content = raw.trim();
     const parsed = parseFirstJsonObjectValue(content) as Record<string, Record<string, string[]>> | null;
     if (!parsed) return {};
     const result: Record<string, Record<KeywordGroup, string[]>> = {};
@@ -381,8 +402,14 @@ export async function runBuildLanguageKeywords(
   sqliteDir: string,
   opts: { model: string; dryRun?: boolean },
 ): Promise<BuildLanguageKeywordsResult> {
+  if (maintenanceRunDeadlineReached()) {
+    return { ok: false, error: "maintenance run deadline reached" };
+  }
   const samples = collectSamplesFromFacts(facts);
   const topLanguages = await detectTopLanguages(samples, openai, opts.model);
+  if (maintenanceRunDeadlineReached()) {
+    return { ok: false, error: "maintenance run deadline reached" };
+  }
   const toTranslate = topLanguages.filter((c) => c !== "en");
   if (toTranslate.length === 0 && samples.length > 0) {
     return { ok: true, path: join(sqliteDir, LANG_FILE_NAME), topLanguages: ["en"], languagesAdded: 0 };
@@ -408,6 +435,10 @@ export async function runBuildLanguageKeywords(
     }
   } catch {
     // File missing or malformed — proceed with full build
+  }
+
+  if (maintenanceRunDeadlineReached()) {
+    return { ok: false, error: "maintenance run deadline reached" };
   }
 
   const { translations, triggerStructures, extraction } = await generateIntentBasedLanguages(

--- a/extensions/memory-hybrid/services/maintenance-orchestrator.ts
+++ b/extensions/memory-hybrid/services/maintenance-orchestrator.ts
@@ -6,6 +6,10 @@
 import type { HybridMemoryConfig } from "../config.js";
 import type { DatabaseSync } from "node:sqlite";
 import { nowIso } from "../utils/dates.js";
+import {
+  clearMaintenanceRunDeadline,
+  setMaintenanceRunDeadlineMs,
+} from "../utils/maintenance-run-deadline.js";
 import { is429OrWrapped } from "./chat.js";
 import { generateOrchestratorRunId } from "./maintenance-job-run/orchestrator-summary.js";
 import { recordMaintenanceStepRun } from "./maintenance-audit-journal.js";
@@ -466,6 +470,7 @@ export async function runMaintenanceOrchestrator(
   const maxRuntimeMs =
     options.maxRuntimeMs ??
     (orchestratorCfg?.maxRuntimeMinutes ? orchestratorCfg.maxRuntimeMinutes * 60_000 : undefined);
+  const runDeadlineMs = maxRuntimeMs != null ? startedAtMs + maxRuntimeMs : undefined;
 
   let steps = MAINTENANCE_STEPS.filter((s) => options.tiers.includes(s.tier));
   if (options.include?.length) {
@@ -497,6 +502,8 @@ export async function runMaintenanceOrchestrator(
     }
   };
 
+  setMaintenanceRunDeadlineMs(runDeadlineMs);
+  try {
   for (const step of steps) {
     if (maxRuntimeMs !== undefined && Date.now() - startedAtMs >= maxRuntimeMs) {
       pushStepResult({
@@ -677,6 +684,9 @@ export async function runMaintenanceOrchestrator(
     finishedAt,
     durationMs: Date.now() - startedAtMs,
   };
+  } finally {
+    clearMaintenanceRunDeadline();
+  }
 }
 
 export { toOrchestratorRunSummary, generateOrchestratorRunId } from "./maintenance-job-run/orchestrator-summary.js";

--- a/extensions/memory-hybrid/services/maintenance-orchestrator.ts
+++ b/extensions/memory-hybrid/services/maintenance-orchestrator.ts
@@ -8,6 +8,8 @@ import type { DatabaseSync } from "node:sqlite";
 import { nowIso } from "../utils/dates.js";
 import {
   clearMaintenanceRunDeadline,
+  maintenanceRunDeadlineReached,
+  remainingMaintenanceRunMs,
   setMaintenanceRunDeadlineMs,
 } from "../utils/maintenance-run-deadline.js";
 import { is429OrWrapped } from "./chat.js";
@@ -592,8 +594,14 @@ export async function runMaintenanceOrchestrator(
       continue;
     }
 
-    if (lastWasLlmStep && isLlmProviderStep(step.llmTier) && llmCooldownMs > 0) {
-      await sleep(llmCooldownMs);
+    if (lastWasLlmStep && isLlmProviderStep(step.llmTier) && llmCooldownMs > 0 && !maintenanceRunDeadlineReached()) {
+      const remaining = remainingMaintenanceRunMs();
+      const cooldownMs = Number.isFinite(remaining)
+        ? Math.min(llmCooldownMs, Math.max(0, Math.floor(remaining)))
+        : llmCooldownMs;
+      if (cooldownMs > 0) {
+        await sleep(cooldownMs);
+      }
     }
 
     const stepStarted = Date.now();

--- a/extensions/memory-hybrid/services/memory-index.ts
+++ b/extensions/memory-hybrid/services/memory-index.ts
@@ -8,12 +8,18 @@ import { resolveOpenClawWorkspaceRoot } from "../utils/openclaw-workspace.js";
 import { formatDateUtc, nowIso } from "../utils/dates.js";
 import { fillPrompt, loadPrompt } from "../utils/prompt-loader.js";
 import {
+  capTimeoutByMaintenanceRunDeadline,
+  getMaintenanceRunAbortSignal,
+  maintenanceRunDeadlineReached,
+} from "../utils/maintenance-run-deadline.js";
+import {
   LLMRetryError,
   chatCompleteWithRetry,
   is404Like,
   is500Like,
   isConnectionErrorLike,
   isOllamaOOM,
+  resolveMaintenanceChatTimeoutMs,
 } from "./chat.js";
 import { CostFeature } from "./cost-feature-labels.js";
 import { capturePluginError } from "./error-reporter.js";
@@ -272,6 +278,8 @@ async function synthesizeMemoryIndex(
       fallbackModels: options.fallbackModels ?? [],
       label: "memory-hybrid: memory-index",
       feature: CostFeature.memoryIndex,
+      timeoutMs: capTimeoutByMaintenanceRunDeadline(resolveMaintenanceChatTimeoutMs(options.model)),
+      signal: getMaintenanceRunAbortSignal(),
     });
     return sanitizeIndexMarkdown(response);
   } catch (err) {
@@ -353,6 +361,14 @@ export async function writeMemoryIndex(
     if (existingContent) {
       return { path: outputPath, content: existingContent, usedFallback: false };
     }
+  }
+
+  if (maintenanceRunDeadlineReached()) {
+    logger.warn("memory-hybrid: memory-index — maintenance run deadline reached; using deterministic fallback");
+    const content = renderMemoryIndexMarkdown(snapshot);
+    await mkdir(dirname(outputPath), { recursive: true });
+    await writeFile(outputPath, content, "utf-8");
+    return { path: outputPath, content, usedFallback: true };
   }
 
   const llmMarkdown = await synthesizeMemoryIndex(snapshot, openai, options, logger);

--- a/extensions/memory-hybrid/services/passive-observer.ts
+++ b/extensions/memory-hybrid/services/passive-observer.ts
@@ -24,11 +24,15 @@ import type { MemoryCategory, ReinforcementConfig } from "../config.js";
 import { fillPrompt, loadPrompt } from "../utils/prompt-loader.js";
 import { chunkTextByChars } from "../utils/text.js";
 import { nowIso } from "../utils/dates.js";
-import { LLMRetryError, chatCompleteWithRetry } from "./chat.js";
+import { LLMRetryError, chatCompleteWithRetry, resolveMaintenanceChatTimeoutMs } from "./chat.js";
 import { CostFeature } from "./cost-feature-labels.js";
 import type { EmbeddingProvider } from "./embeddings.js";
 import { shouldSuppressEmbeddingError } from "./embeddings.js";
 import { capturePluginError } from "./error-reporter.js";
+import {
+  capTimeoutByMaintenanceRunDeadline,
+  maintenanceRunDeadlineReached,
+} from "../utils/maintenance-run-deadline.js";
 import {
   isSubstantiveMemoryText,
   prepareMemoryMetadataForStorage,
@@ -487,6 +491,10 @@ export async function runPassiveObserver(
   // Phase 3: process each session that has new content.
   // ---------------------------------------------------------------------------
   for (const { filePath, sessionId, fileBytelen, cursor } of sessions) {
+    if (maintenanceRunDeadlineReached()) {
+      logger.warn("memory-hybrid: passive-observer — maintenance run deadline reached; stopping session scan");
+      break;
+    }
     if (cursor >= fileBytelen) continue; // Nothing new
 
     let rawBuf: Buffer;
@@ -557,7 +565,17 @@ export async function runPassiveObserver(
     let chunksAttempted = 0;
     let chunksSucceeded = 0;
 
+    let deadlineStopped = false;
+
     for (const chunk of chunks) {
+      if (maintenanceRunDeadlineReached()) {
+        logger.warn(
+          `memory-hybrid: passive-observer — maintenance run deadline reached; deferring session ${sessionId}`,
+        );
+        deadlineStopped = true;
+        result.errors++;
+        break;
+      }
       if (!chunk.trim()) continue;
       chunksAttempted++;
       result.chunksProcessed++;
@@ -578,6 +596,7 @@ export async function runPassiveObserver(
           fallbackModels: opts.fallbackModels ?? [],
           label: "memory-hybrid: passive-observer",
           feature: CostFeature.passiveObserver,
+          timeoutMs: capTimeoutByMaintenanceRunDeadline(resolveMaintenanceChatTimeoutMs(opts.model)),
         });
       } catch (err) {
         logger.warn(`memory-hybrid: passive-observer — LLM failed for session ${sessionId}: ${err}`);
@@ -843,6 +862,10 @@ export async function runPassiveObserver(
           result.factsStored++;
         }
       }
+    }
+
+    if (deadlineStopped) {
+      break;
     }
 
     // Advance cursor only when every attempted chunk in this segment succeeded (or there were none).

--- a/extensions/memory-hybrid/services/passive-observer.ts
+++ b/extensions/memory-hybrid/services/passive-observer.ts
@@ -31,6 +31,7 @@ import { shouldSuppressEmbeddingError } from "./embeddings.js";
 import { capturePluginError } from "./error-reporter.js";
 import {
   capTimeoutByMaintenanceRunDeadline,
+  getMaintenanceRunAbortSignal,
   maintenanceRunDeadlineReached,
 } from "../utils/maintenance-run-deadline.js";
 import {
@@ -597,6 +598,7 @@ export async function runPassiveObserver(
           label: "memory-hybrid: passive-observer",
           feature: CostFeature.passiveObserver,
           timeoutMs: capTimeoutByMaintenanceRunDeadline(resolveMaintenanceChatTimeoutMs(opts.model)),
+          signal: getMaintenanceRunAbortSignal(),
         });
       } catch (err) {
         logger.warn(`memory-hybrid: passive-observer — LLM failed for session ${sessionId}: ${err}`);

--- a/extensions/memory-hybrid/tests/implicit-feedback-routing.test.ts
+++ b/extensions/memory-hybrid/tests/implicit-feedback-routing.test.ts
@@ -1232,6 +1232,7 @@ describe("implicit feedback routing — cleanup progress reporting", () => {
       expect(result.sessionsDeferred).toBe(1);
       expect(result.backlogSessionsEstimate).toBe(1);
       expect(db.getScanCursor("extract-implicit-feedback")?.lastSessionFile).toBe("2026-01-01-a.jsonl");
+      expect(db.getScanCursor("extract-implicit-feedback")?.sessionsProcessed).toBe(1);
     });
 
     it("processes one oversized session instead of stalling on per-run caps", async () => {

--- a/extensions/memory-hybrid/tests/implicit-feedback-routing.test.ts
+++ b/extensions/memory-hybrid/tests/implicit-feedback-routing.test.ts
@@ -1757,9 +1757,19 @@ describe("trajectory LLM budget (#1953)", () => {
   it("propagateAbortSignal aborts target when source aborts", () => {
     const source = new AbortController();
     const target = new AbortController();
-    propagateAbortSignal(source.signal, target);
+    const dispose = propagateAbortSignal(source.signal, target);
     source.abort(new Error("wall clock"));
     expect(target.signal.aborted).toBe(true);
+    dispose();
+  });
+
+  it("propagateAbortSignal disposer removes listener before source aborts", () => {
+    const source = new AbortController();
+    const target = new AbortController();
+    const dispose = propagateAbortSignal(source.signal, target);
+    dispose();
+    source.abort(new Error("wall clock"));
+    expect(target.signal.aborted).toBe(false);
   });
 });
 

--- a/extensions/memory-hybrid/tests/implicit-feedback-routing.test.ts
+++ b/extensions/memory-hybrid/tests/implicit-feedback-routing.test.ts
@@ -8,7 +8,7 @@
  *   - CLI command 'extract-implicit' is registered in ManageContext
  */
 
-import { mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -1113,6 +1113,33 @@ describe("implicit feedback routing — cleanup progress reporting", () => {
         });
       } finally {
         vi.useRealTimers();
+      }
+    });
+
+    it("does not advance scan cursor when a session read fails but a later session succeeds", async () => {
+      const db = makeDb(capsTmpDir);
+      writePositiveSession(capsSessionsDir, "2026-01-01-a.jsonl");
+      writePositiveSession(capsSessionsDir, "2026-01-01-b.jsonl");
+      const olderMtime = new Date("2026-01-01T00:00:00.000Z");
+      const newerMtime = new Date("2026-01-02T00:00:00.000Z");
+      const unreadablePath = join(capsSessionsDir, "2026-01-01-a.jsonl");
+      utimesSync(unreadablePath, olderMtime, olderMtime);
+      utimesSync(join(capsSessionsDir, "2026-01-01-b.jsonl"), newerMtime, newerMtime);
+      chmodSync(unreadablePath, 0o000);
+
+      try {
+        const ctx = makeCtx(db, capsSessionsDir, { feedToSelfCorrection: false });
+        const result = await runExtractImplicitFeedbackForCli(ctx, {
+          days: 365,
+          dryRun: false,
+          includeTrajectories: false,
+          includeClosedLoop: false,
+        });
+        expect(result.sessionsSkipped).toBe(1);
+        expect(result.sessionsProcessed).toBe(1);
+        expect(db.getScanCursor("extract-implicit-feedback")).toBeNull();
+      } finally {
+        chmodSync(unreadablePath, 0o644);
       }
     });
 

--- a/extensions/memory-hybrid/tests/implicit-feedback-routing.test.ts
+++ b/extensions/memory-hybrid/tests/implicit-feedback-routing.test.ts
@@ -12,7 +12,14 @@ import { mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from "node:
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { implicitFeedbackCollapseStatus, isSemanticNoOpImplicitFeedbackCollapseStatus } from "../cli/cmd-feedback.js";
+import {
+  implicitFeedbackCollapseStatus,
+  isSemanticNoOpImplicitFeedbackCollapseStatus,
+  resolveTrajectoryLlmBudgetMs,
+  runWithConcurrencyLimit,
+  TRAJECTORY_LLM_MIN_BUDGET_MS,
+  TRAJECTORY_PER_CALL_BUDGET_MS,
+} from "../cli/cmd-feedback.js";
 import {
   cleanupImplicitFeedbackDuplicates,
   type HandlerContext,
@@ -1691,6 +1698,33 @@ describe("implicit feedback routing — self-correction bridge", () => {
     });
     expect(spy).not.toHaveBeenCalled();
     spy.mockRestore();
+  });
+});
+
+describe("trajectory LLM budget (#1953)", () => {
+  it("resolveTrajectoryLlmBudgetMs returns 0 when remaining wall-clock is below minimum", () => {
+    expect(resolveTrajectoryLlmBudgetMs(TRAJECTORY_LLM_MIN_BUDGET_MS - 1)).toBe(0);
+    expect(resolveTrajectoryLlmBudgetMs(0)).toBe(0);
+  });
+
+  it("resolveTrajectoryLlmBudgetMs caps per-trajectory budget at TRAJECTORY_PER_CALL_BUDGET_MS", () => {
+    expect(resolveTrajectoryLlmBudgetMs(120_000)).toBe(TRAJECTORY_PER_CALL_BUDGET_MS);
+    expect(resolveTrajectoryLlmBudgetMs(TRAJECTORY_PER_CALL_BUDGET_MS)).toBe(TRAJECTORY_PER_CALL_BUDGET_MS);
+    expect(resolveTrajectoryLlmBudgetMs(5_000)).toBe(5_000);
+  });
+
+  it("runWithConcurrencyLimit bounds in-flight workers", async () => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const items = Array.from({ length: 12 }, (_, i) => i);
+    await runWithConcurrencyLimit(items, 4, async () => {
+      inFlight++;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      inFlight--;
+    });
+    expect(maxInFlight).toBeLessThanOrEqual(4);
+    expect(maxInFlight).toBeGreaterThan(1);
   });
 });
 

--- a/extensions/memory-hybrid/tests/implicit-feedback-routing.test.ts
+++ b/extensions/memory-hybrid/tests/implicit-feedback-routing.test.ts
@@ -15,8 +15,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   implicitFeedbackCollapseStatus,
   isSemanticNoOpImplicitFeedbackCollapseStatus,
+  propagateAbortSignal,
+  remainingDeadlineMs,
   resolveTrajectoryLlmBudgetMs,
   runWithConcurrencyLimit,
+  trajectoryCallTimeoutMs,
   TRAJECTORY_LLM_MIN_BUDGET_MS,
   TRAJECTORY_PER_CALL_BUDGET_MS,
 } from "../cli/cmd-feedback.js";
@@ -1725,6 +1728,38 @@ describe("trajectory LLM budget (#1953)", () => {
     });
     expect(maxInFlight).toBeLessThanOrEqual(4);
     expect(maxInFlight).toBeGreaterThan(1);
+  });
+
+  it("runWithConcurrencyLimit honors shouldStop before claiming new work", async () => {
+    const processed: number[] = [];
+    let stopAfter = 2;
+    await runWithConcurrencyLimit(
+      [0, 1, 2, 3, 4],
+      2,
+      async (item) => {
+        processed.push(item);
+        if (processed.length >= stopAfter) stopAfter = 0;
+        await new Promise((resolve) => setTimeout(resolve, 5));
+      },
+      { shouldStop: () => stopAfter === 0 },
+    );
+    expect(processed.length).toBeLessThanOrEqual(3);
+    expect(processed.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("trajectoryCallTimeoutMs shrinks as deadline approaches", () => {
+    const deadline = 10_000;
+    expect(trajectoryCallTimeoutMs(deadline, 9_000)).toBe(1_000);
+    expect(trajectoryCallTimeoutMs(deadline, 10_000)).toBe(0);
+    expect(remainingDeadlineMs(deadline, 9_500)).toBe(500);
+  });
+
+  it("propagateAbortSignal aborts target when source aborts", () => {
+    const source = new AbortController();
+    const target = new AbortController();
+    propagateAbortSignal(source.signal, target);
+    source.abort(new Error("wall clock"));
+    expect(target.signal.aborted).toBe(true);
   });
 });
 

--- a/extensions/memory-hybrid/tests/incident-batch-analyze-core.test.ts
+++ b/extensions/memory-hybrid/tests/incident-batch-analyze-core.test.ts
@@ -5,6 +5,10 @@ import {
   inferFinishReasonFromLlmContent,
 } from "../services/incident-batch-analyze-core.js";
 import { maintenanceMaxOutputTokens } from "../services/chat.js";
+import {
+  clearMaintenanceRunDeadline,
+  setMaintenanceRunDeadlineMs,
+} from "../utils/maintenance-run-deadline.js";
 
 const SAMPLE_ITEM = { remediationType: "TOOLS_RULE", category: "X", severity: "LOW" };
 
@@ -30,7 +34,53 @@ const baseDeps = {
 
 describe("analyzeIncidentBatchWithSplit", () => {
   afterEach(() => {
+    clearMaintenanceRunDeadline();
     vi.restoreAllMocks();
+  });
+
+  it("returns null items when maintenance run deadline is already reached", async () => {
+    setMaintenanceRunDeadlineMs(Date.now() - 1);
+    const llmCall = vi.fn(async () => ({
+      content: JSON.stringify([SAMPLE_ITEM]),
+      fallbacks: 0,
+      finishReason: "stop" as const,
+    }));
+    const result = await analyzeIncidentBatchWithSplit(
+      {
+        ...baseDeps,
+        maxTokens: 8000,
+        llmCall,
+      },
+      [{ id: 1 }],
+    );
+    expect(result.items).toBeNull();
+    expect(llmCall).not.toHaveBeenCalled();
+  });
+
+  it("does not retry transient LLM errors after maintenance run deadline", async () => {
+    vi.useFakeTimers();
+    try {
+      setMaintenanceRunDeadlineMs(Date.now() + 100);
+      let calls = 0;
+      const resultPromise = analyzeIncidentBatchWithSplit(
+        {
+          ...baseDeps,
+          maxTokens: 8000,
+          llmCall: async () => {
+            calls++;
+            throw new Error("LLM request timeout after 120s");
+          },
+        },
+        [{ id: 1 }],
+      );
+      const rejection = expect(resultPromise).rejects.toThrow(/timeout|deadline/i);
+      await vi.advanceTimersByTimeAsync(6000);
+      await rejection;
+      expect(calls).toBe(1);
+    } finally {
+      vi.useRealTimers();
+      clearMaintenanceRunDeadline();
+    }
   });
 
   it("retries transient LLM errors and records diagnostics.retries", async () => {

--- a/extensions/memory-hybrid/tests/maintenance-run-deadline.test.ts
+++ b/extensions/memory-hybrid/tests/maintenance-run-deadline.test.ts
@@ -1,7 +1,8 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   capTimeoutByMaintenanceRunDeadline,
   clearMaintenanceRunDeadline,
+  getMaintenanceRunAbortSignal,
   getMaintenanceRunDeadlineMs,
   maintenanceRunDeadlineReached,
   remainingMaintenanceRunMs,
@@ -34,5 +35,21 @@ describe("maintenance-run-deadline", () => {
     setMaintenanceRunDeadlineMs(10_000);
     expect(capTimeoutByMaintenanceRunDeadline(45_000, 9_000)).toBe(1_000);
     expect(capTimeoutByMaintenanceRunDeadline(45_000, 10_000)).toBe(0);
+  });
+
+  it("getMaintenanceRunAbortSignal aborts when run deadline elapses", () => {
+    vi.useFakeTimers();
+    try {
+      setMaintenanceRunDeadlineMs(Date.now() + 5_000);
+      const signal = getMaintenanceRunAbortSignal();
+      expect(signal).toBeDefined();
+      expect(signal?.aborted).toBe(false);
+      vi.advanceTimersByTime(5_001);
+      expect(signal?.aborted).toBe(true);
+      expect(maintenanceRunDeadlineReached()).toBe(true);
+    } finally {
+      vi.useRealTimers();
+      clearMaintenanceRunDeadline();
+    }
   });
 });

--- a/extensions/memory-hybrid/tests/maintenance-run-deadline.test.ts
+++ b/extensions/memory-hybrid/tests/maintenance-run-deadline.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  capTimeoutByMaintenanceRunDeadline,
+  clearMaintenanceRunDeadline,
+  getMaintenanceRunDeadlineMs,
+  maintenanceRunDeadlineReached,
+  remainingMaintenanceRunMs,
+  resolveMaintenanceStepDeadlineMs,
+  setMaintenanceRunDeadlineMs,
+} from "../utils/maintenance-run-deadline.js";
+
+describe("maintenance-run-deadline", () => {
+  afterEach(() => {
+    clearMaintenanceRunDeadline();
+  });
+
+  it("tracks orchestrator deadline via env", () => {
+    setMaintenanceRunDeadlineMs(10_000);
+    expect(getMaintenanceRunDeadlineMs()).toBe(10_000);
+    expect(maintenanceRunDeadlineReached(9_999)).toBe(false);
+    expect(maintenanceRunDeadlineReached(10_000)).toBe(true);
+    expect(remainingMaintenanceRunMs(9_000)).toBe(1_000);
+  });
+
+  it("resolveMaintenanceStepDeadlineMs picks earliest deadline", () => {
+    setMaintenanceRunDeadlineMs(50_000);
+    expect(resolveMaintenanceStepDeadlineMs(40_000, 30)).toBe(50_000);
+    expect(resolveMaintenanceStepDeadlineMs(40_000, 120)).toBe(50_000);
+    clearMaintenanceRunDeadline();
+    expect(resolveMaintenanceStepDeadlineMs(40_000, 30)).toBe(70_000);
+  });
+
+  it("capTimeoutByMaintenanceRunDeadline shrinks per-call timeout near run end", () => {
+    setMaintenanceRunDeadlineMs(10_000);
+    expect(capTimeoutByMaintenanceRunDeadline(45_000, 9_000)).toBe(1_000);
+    expect(capTimeoutByMaintenanceRunDeadline(45_000, 10_000)).toBe(0);
+  });
+});

--- a/extensions/memory-hybrid/tools/document-tools.ts
+++ b/extensions/memory-hybrid/tools/document-tools.ts
@@ -25,6 +25,7 @@ import {
 import { chunkMarkdown } from "../services/document-chunker.js";
 import type { EmbeddingProvider } from "../services/embeddings.js";
 import { capturePluginError } from "../services/error-reporter.js";
+import { resolveMaintenanceChatTimeoutMs } from "../services/chat.js";
 import { chatCompletionTokenParams } from "../services/model-capabilities.js";
 import type { ProvenanceService } from "../services/provenance.js";
 import type { PythonBridge } from "../services/python-bridge.js";
@@ -227,23 +228,32 @@ async function describeImageWithVision(opts: {
     "Describe this image for memory storage. Focus on concrete, factual details: " +
     "objects, people, text, labels, charts, and context. Keep it concise but complete.";
 
+  const visionTimeoutMs = Math.min(120_000, resolveMaintenanceChatTimeoutMs(primaryModel) * 2);
+
   let lastError: Error | undefined;
   for (const model of modelsToTry) {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => {
+      controller.abort(new Error(`Vision LLM request timeout after ${visionTimeoutMs}ms (model: ${model})`));
+    }, visionTimeoutMs);
     try {
-      const resp = await openai.chat.completions.create({
-        model,
-        messages: [
-          {
-            role: "user",
-            content: [
-              { type: "text", text: prompt },
-              { type: "image_url", image_url: { url: imageUrl } },
-            ],
-          },
-        ],
-        temperature: 0.2,
-        ...chatCompletionTokenParams(model, 800),
-      });
+      const resp = await openai.chat.completions.create(
+        {
+          model,
+          messages: [
+            {
+              role: "user",
+              content: [
+                { type: "text", text: prompt },
+                { type: "image_url", image_url: { url: imageUrl } },
+              ],
+            },
+          ],
+          temperature: 0.2,
+          ...chatCompletionTokenParams(model, 800),
+        },
+        { signal: controller.signal },
+      );
       const text = extractAssistantMessageText(resp.choices[0]?.message).text;
       if (!text) {
         throw new Error(`Vision model ${model} returned empty response.`);
@@ -251,6 +261,8 @@ async function describeImageWithVision(opts: {
       return { text, model };
     } catch (err) {
       lastError = err instanceof Error ? err : new Error(String(err));
+    } finally {
+      clearTimeout(timeoutId);
     }
   }
 

--- a/extensions/memory-hybrid/utils/maintenance-run-deadline.ts
+++ b/extensions/memory-hybrid/utils/maintenance-run-deadline.ts
@@ -5,16 +5,47 @@
 
 const MAINTENANCE_RUN_DEADLINE_ENV = "HM_MAINTENANCE_RUN_DEADLINE_MS";
 
+let deadlineAbortTimer: ReturnType<typeof setTimeout> | null = null;
+let deadlineAbortController: AbortController | null = null;
+
+function clearDeadlineAbortResources(): void {
+  if (deadlineAbortTimer != null) {
+    clearTimeout(deadlineAbortTimer);
+    deadlineAbortTimer = null;
+  }
+  deadlineAbortController = null;
+}
+
+/** AbortSignal that fires when the orchestrator run deadline is reached (aborts in-flight LLM calls). */
+export function getMaintenanceRunAbortSignal(): AbortSignal | undefined {
+  return deadlineAbortController?.signal;
+}
+
 export function setMaintenanceRunDeadlineMs(deadlineMs: number | undefined): void {
+  clearDeadlineAbortResources();
   if (deadlineMs == null || !Number.isFinite(deadlineMs)) {
     delete process.env[MAINTENANCE_RUN_DEADLINE_ENV];
     return;
   }
-  process.env[MAINTENANCE_RUN_DEADLINE_ENV] = String(Math.floor(deadlineMs));
+  const floored = Math.floor(deadlineMs);
+  process.env[MAINTENANCE_RUN_DEADLINE_ENV] = String(floored);
+  deadlineAbortController = new AbortController();
+  const remainingMs = Math.max(0, floored - Date.now());
+  if (remainingMs <= 0) {
+    deadlineAbortController.abort(new Error("maintenance run deadline reached"));
+    return;
+  }
+  deadlineAbortTimer = setTimeout(() => {
+    deadlineAbortController?.abort(new Error("maintenance run deadline reached"));
+  }, remainingMs);
+  if (typeof deadlineAbortTimer.unref === "function") {
+    deadlineAbortTimer.unref();
+  }
 }
 
 export function clearMaintenanceRunDeadline(): void {
   delete process.env[MAINTENANCE_RUN_DEADLINE_ENV];
+  clearDeadlineAbortResources();
 }
 
 export function getMaintenanceRunDeadlineMs(): number | undefined {

--- a/extensions/memory-hybrid/utils/maintenance-run-deadline.ts
+++ b/extensions/memory-hybrid/utils/maintenance-run-deadline.ts
@@ -1,0 +1,58 @@
+/**
+ * Orchestrator-wide maintenance run deadline (Issue #1953 follow-up).
+ * Set once per orchestrator run; long-running steps consult it to stop before overrunning maxRuntimeMinutes.
+ */
+
+const MAINTENANCE_RUN_DEADLINE_ENV = "HM_MAINTENANCE_RUN_DEADLINE_MS";
+
+export function setMaintenanceRunDeadlineMs(deadlineMs: number | undefined): void {
+  if (deadlineMs == null || !Number.isFinite(deadlineMs)) {
+    delete process.env[MAINTENANCE_RUN_DEADLINE_ENV];
+    return;
+  }
+  process.env[MAINTENANCE_RUN_DEADLINE_ENV] = String(Math.floor(deadlineMs));
+}
+
+export function clearMaintenanceRunDeadline(): void {
+  delete process.env[MAINTENANCE_RUN_DEADLINE_ENV];
+}
+
+export function getMaintenanceRunDeadlineMs(): number | undefined {
+  const raw = process.env[MAINTENANCE_RUN_DEADLINE_ENV]?.trim();
+  if (!raw) return undefined;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+export function maintenanceRunDeadlineReached(nowMs: number = Date.now()): boolean {
+  const deadline = getMaintenanceRunDeadlineMs();
+  return deadline != null && nowMs >= deadline;
+}
+
+export function remainingMaintenanceRunMs(nowMs: number = Date.now()): number {
+  const deadline = getMaintenanceRunDeadlineMs();
+  if (deadline == null) return Number.POSITIVE_INFINITY;
+  return Math.max(0, deadline - nowMs);
+}
+
+/** Cap a per-call timeout by the orchestrator run deadline when one is active. */
+export function capTimeoutByMaintenanceRunDeadline(timeoutMs: number, nowMs: number = Date.now()): number {
+  const remaining = remainingMaintenanceRunMs(nowMs);
+  if (!Number.isFinite(remaining)) return timeoutMs;
+  if (remaining <= 0) return 0;
+  return Math.min(timeoutMs, Math.max(1, Math.floor(remaining)));
+}
+
+/** Earliest deadline from an explicit step budget and the orchestrator run deadline. */
+export function resolveMaintenanceStepDeadlineMs(
+  startedAtMs: number,
+  stepBudgetSec: number | undefined,
+): number | undefined {
+  const stepDeadline =
+    stepBudgetSec != null && stepBudgetSec > 0 ? startedAtMs + stepBudgetSec * 1000 : undefined;
+  const runDeadline = getMaintenanceRunDeadlineMs();
+  if (stepDeadline == null && runDeadline == null) return undefined;
+  if (stepDeadline == null) return runDeadline;
+  if (runDeadline == null) return stepDeadline;
+  return Math.min(stepDeadline, runDeadline);
+}

--- a/packages/openclaw-hybrid-memory-install/package.json
+++ b/packages/openclaw-hybrid-memory-install/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-hybrid-memory-install",
-  "version": "2026.6.254",
+  "version": "2026.6.259",
   "description": "Standalone installer for openclaw-hybrid-memory. Use when OpenClaw config validation fails.",
   "bin": {
     "openclaw-hybrid-memory-install": "./install.js"


### PR DESCRIPTION
## Summary
- Cap each trajectory LLM call at 30s instead of allocating the entire remaining nightly wall-clock budget to a single call
- Run trajectory LLM analysis with bounded concurrency (4 workers) before sequential SQLite persistence
- Treat per-trajectory LLM timeouts as heuristic fallback instead of aborting the whole extract-implicit run

Fixes #1953

## Problem
Nightly `extract-implicit` runs were processing only ~15–30% of pending sessions before hitting `maxWallClock`, and a single hung provider call could freeze the loop at 0% CPU for hours because the first trajectory received the full remaining budget.

## Test plan
- [x] `npm test -- --run tests/implicit-feedback-routing.test.ts` (45 passed, including new budget/concurrency tests)
- [x] `npm run build`
- [ ] Verify next nightly extract-implicit run drains more of the backlog within the 20-minute wall-clock budget
- [ ] Confirm a slow/hung trajectory falls back to heuristic lessons without stalling the entire run