### PR TITLE
fix: maintenance observability, cron delivery, and provider fallbacks (#1955–#1963)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
+- **memory_procedure_feedback procedure_not_found (#1965):** Unknown `procedureId` now returns `isError: true` with actionable text and stable `details.hint`; prevents agent tool retry loops.
 - **Credentials vault type=url:** Reject invalid credential types at store time; auto-migrate legacy `type=url` rows (merge URL into sibling bearer/token entry or convert to `type=other` with `url` field). Clarify in tools/docs that endpoint URLs use the `url` parameter, not `type`.
+
+### Added
+
+- **Procedural memory first-run capture (#1967):** `memory_procedure_feedback` accepts optional `registerIfMissing` with `taskPattern` + `steps[]` to register a draft procedure and record feedback in one call.
+- **Procedures workflow docs (#1966):** Tool schema and bundled `hybrid-memory` SKILL document recall → feedback vs first-run paths and anti-patterns.
 
 ---
 

--- a/extensions/memory-hybrid/cli/cmd-distill.ts
+++ b/extensions/memory-hybrid/cli/cmd-distill.ts
@@ -445,6 +445,7 @@ export async function runDistillForCli(
     let batchNum = 0;
     let cursorBlock = 0;
     let shrinkBudget = 8;
+    let truncatedBatches = 0;
     let nonAdaptiveBatchFactor = 1;
     let nonAdaptiveOutFactor = 1;
     const minBatchForModel = Math.max(2048, promptTokens + 256);
@@ -465,6 +466,7 @@ export async function runDistillForCli(
         catalogBatchTokenLimit,
         catalogMaxOutputTokens,
         minBatchTokenLimit: minBatchForModel,
+        minMaxOutputTokens: Math.max(2048, Math.floor(catalogMaxOutputTokens * 0.25)),
       });
     };
 
@@ -589,6 +591,7 @@ export async function runDistillForCli(
           signal: getMaintenanceRunAbortSignal(),
         });
         if (detail.finishReason?.toLowerCase() === "length") {
+          truncatedBatches++;
           logger.warn?.(
             `memory-hybrid: distill batch ${batchNum} output truncated (finish=length); extracted facts may be incomplete`,
           );
@@ -597,6 +600,14 @@ export async function runDistillForCli(
             shrinkForRetry("other", detail.modelUsed ?? model);
             logger.warn?.(
               `memory-hybrid: distill batch ${batchNum} truncated — shrinking and retrying (budget left=${shrinkBudget})`,
+            );
+            continue;
+          }
+          if (!opts.dryRun) {
+            nonAdaptiveBatchFactor *= 0.6;
+            nonAdaptiveOutFactor = Math.max(nonAdaptiveOutFactor, 0.5);
+            logger.warn?.(
+              `memory-hybrid: distill batch ${batchNum} truncated — splitting batch after shrink budget exhausted`,
             );
             continue;
           }
@@ -706,6 +717,11 @@ export async function runDistillForCli(
       }
     }
     progress.done();
+    if (truncatedBatches > 0) {
+      sink.warn(
+        `memory-hybrid: distill truncatedBatches=${truncatedBatches} — some batches hit finish=length; consider resetting .adaptive-llm-limits.json or using --force with smaller --days`,
+      );
+    }
     const semanticEmpty = filesToProcess.length > 0 && allFacts.length === 0;
     if (semanticEmpty) {
       sink.warn(

--- a/extensions/memory-hybrid/cli/cmd-distill.ts
+++ b/extensions/memory-hybrid/cli/cmd-distill.ts
@@ -521,6 +521,8 @@ export async function runDistillForCli(
     };
 
     let batchFailures = 0;
+    let lengthRetriesAtCursor = 0;
+    const maxLengthRetriesPerCursor = 8;
 
     while (cursorBlock < blocks.length) {
       if (maintenanceRunDeadlineReached()) {
@@ -603,13 +605,22 @@ export async function runDistillForCli(
             );
             continue;
           }
-          if (!opts.dryRun) {
-            nonAdaptiveBatchFactor *= 0.6;
-            nonAdaptiveOutFactor = Math.max(nonAdaptiveOutFactor, 0.5);
+          if (!opts.dryRun && lengthRetriesAtCursor < maxLengthRetriesPerCursor) {
+            lengthRetriesAtCursor++;
+            shrinkForRetry("other", detail.modelUsed ?? model);
+            if (!adaptiveEnabled) {
+              nonAdaptiveBatchFactor *= 0.6;
+              nonAdaptiveOutFactor = Math.max(nonAdaptiveOutFactor, 0.5);
+            }
             logger.warn?.(
-              `memory-hybrid: distill batch ${batchNum} truncated — splitting batch after shrink budget exhausted`,
+              `memory-hybrid: distill batch ${batchNum} truncated — splitting batch (retry ${lengthRetriesAtCursor}/${maxLengthRetriesPerCursor} at cursor=${cursorBlock})`,
             );
             continue;
+          }
+          if (!opts.dryRun) {
+            logger.warn?.(
+              `memory-hybrid: distill batch ${batchNum} truncated — accepting partial output after ${lengthRetriesAtCursor} split retries`,
+            );
           }
         }
         if (detail.modelUsed !== model) {
@@ -667,6 +678,7 @@ export async function runDistillForCli(
         }
         cursorBlock += batch.count;
         processedBlocks += batch.count;
+        lengthRetriesAtCursor = 0;
         progress.update(processedBlocks);
       } catch (err) {
         const e = err instanceof Error ? err : new Error(String(err));

--- a/extensions/memory-hybrid/cli/cmd-distill.ts
+++ b/extensions/memory-hybrid/cli/cmd-distill.ts
@@ -623,6 +623,10 @@ export async function runDistillForCli(
             );
           }
         }
+        const acceptingTruncatedPartial =
+          detail.finishReason?.toLowerCase() === "length" &&
+          !opts.dryRun &&
+          lengthRetriesAtCursor >= maxLengthRetriesPerCursor;
         if (detail.modelUsed !== model) {
           const src = fallbackSources.get(detail.modelUsed) ?? "fallback";
           logger.info?.(
@@ -676,8 +680,15 @@ export async function runDistillForCli(
             capturePluginError(err as Error, { subsystem: "cli", operation: "runDistillForCli:parse-json" });
           }
         }
-        cursorBlock += batch.count;
-        processedBlocks += batch.count;
+        let advanceBlocks = batch.count;
+        if (acceptingTruncatedPartial && batch.count > 1) {
+          advanceBlocks = Math.max(1, Math.floor(batch.count / 2));
+          logger.warn?.(
+            `memory-hybrid: distill batch ${batchNum} force-split — advancing ${advanceBlocks}/${batch.count} blocks at cursor=${cursorBlock}`,
+          );
+        }
+        cursorBlock += advanceBlocks;
+        processedBlocks += advanceBlocks;
         lengthRetriesAtCursor = 0;
         progress.update(processedBlocks);
       } catch (err) {

--- a/extensions/memory-hybrid/cli/cmd-distill.ts
+++ b/extensions/memory-hybrid/cli/cmd-distill.ts
@@ -592,7 +592,8 @@ export async function runDistillForCli(
             ),
           signal: getMaintenanceRunAbortSignal(),
         });
-        if (detail.finishReason?.toLowerCase() === "length") {
+        const outputTruncated = detail.finishReason?.toLowerCase() === "length";
+        if (outputTruncated) {
           truncatedBatches++;
           logger.warn?.(
             `memory-hybrid: distill batch ${batchNum} output truncated (finish=length); extracted facts may be incomplete`,
@@ -624,16 +625,14 @@ export async function runDistillForCli(
           }
         }
         const acceptingTruncatedPartial =
-          detail.finishReason?.toLowerCase() === "length" &&
-          !opts.dryRun &&
-          lengthRetriesAtCursor >= maxLengthRetriesPerCursor;
+          outputTruncated && !opts.dryRun && lengthRetriesAtCursor >= maxLengthRetriesPerCursor;
         if (detail.modelUsed !== model) {
           const src = fallbackSources.get(detail.modelUsed) ?? "fallback";
           logger.info?.(
             `memory-hybrid: distill batch ${batchNum} succeeded with fallback model ${detail.modelUsed} (source=${src})`,
           );
         }
-        if (adaptiveEnabled && !opts.dryRun && adaptiveStatePath) {
+        if (adaptiveEnabled && !opts.dryRun && !outputTruncated && adaptiveStatePath) {
           const usedLimits = effectiveLimitsForModel(detail.modelUsed);
           recordAdaptiveSuccess({
             state: adaptiveState,
@@ -1026,7 +1025,7 @@ export async function runDistillForCli(
       dedupSkipped: skipped,
       dryRun: false,
       semanticEmpty,
-      partialFailure: batchFailures > 0,
+      partialFailure: batchFailures > 0 || truncatedBatches > 0,
       batchFailures,
       dedupeDegraded,
       distillDedupeMode,

--- a/extensions/memory-hybrid/cli/commands/manage/dream-cycle-followup.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/dream-cycle-followup.ts
@@ -88,6 +88,20 @@ export function assessContinuousVerificationResult(result: VerificationCycleResu
       summary,
     };
   }
+  if (
+    result.checked > 0 &&
+    result.errors === 0 &&
+    result.confirmed === 0 &&
+    result.stale === 0 &&
+    result.uncertain === result.checked
+  ) {
+    return {
+      status: "degraded",
+      reason: "all_uncertain",
+      shouldFailPipeline: false,
+      summary: `all ${result.checked} fact(s) returned UNCERTAIN — check verificationModel and provider availability`,
+    };
+  }
   return { status: "healthy", reason: "healthy", shouldFailPipeline: false };
 }
 

--- a/extensions/memory-hybrid/cli/commands/manage/maintenance-step-runners.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/maintenance-step-runners.ts
@@ -143,8 +143,20 @@ function formatExtractImplicitSummary(res: {
   sessionsScanned: number;
   partial?: boolean;
   partialReason?: string;
+  sessionsDeferred?: number;
 }): string {
-  return `${res.signalsExtracted} signals (${res.positiveCount}+/${res.negativeCount}-) from ${res.sessionsProcessed}/${res.sessionsScanned} sessions semantic=${extractImplicitSemanticOutcome(res)}`;
+  const base = `${res.signalsExtracted} signals (${res.positiveCount}+/${res.negativeCount}-) from ${res.sessionsProcessed}/${res.sessionsScanned} sessions semantic=${extractImplicitSemanticOutcome(res)}`;
+  if (
+    res.partial &&
+    isGracefulExtractImplicitPartial(res.partialReason) &&
+    res.sessionsProcessed > 0 &&
+    res.sessionsScanned > res.sessionsProcessed
+  ) {
+    const remaining = res.sessionsDeferred ?? res.sessionsScanned - res.sessionsProcessed;
+    const estimatedRunsToComplete = Math.ceil(remaining / res.sessionsProcessed);
+    return `${base} sessionsRemaining=${remaining} estimatedRunsToComplete=${estimatedRunsToComplete} partialReason=${res.partialReason ?? "capped"}`;
+  }
+  return base;
 }
 
 function assertExtractImplicitNotPartial(res: { partial?: boolean; partialReason?: string }, summary: string): void {

--- a/extensions/memory-hybrid/cli/commands/manage/register-storage-graph-audit.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/register-storage-graph-audit.ts
@@ -118,7 +118,7 @@ export function registerManageStorageGraphAudit(mem: Chainable, b: ManageBinding
     );
 
   const runAuditHealth = async (
-    opts?: { json?: boolean; format?: string; strict?: boolean; timeoutMs?: string; output?: string },
+    opts?: { json?: boolean; format?: string; strict?: boolean; strictErrors?: boolean; timeoutMs?: string; output?: string },
     cmd?: CommanderOptsParent,
   ) => {
     const parsedTimeoutMs = Number.parseInt(String(opts?.timeoutMs ?? "30000"), 10);
@@ -248,9 +248,11 @@ export function registerManageStorageGraphAudit(mem: Chainable, b: ManageBinding
           lastReembedProgress,
         },
       );
-      const strict = opts?.strict === true;
+      const strict = opts?.strict === true || opts?.strictErrors === true;
+      const strictErrorsOnly = opts?.strictErrors === true && opts?.strict !== true;
       const exitInfo = buildAuditHealthExitInfo({
         strict,
+        strictErrorsOnly,
         warningCount: report.warningCount,
         errorCount: report.errorCount,
         ok: report.ok,
@@ -296,7 +298,7 @@ export function registerManageStorageGraphAudit(mem: Chainable, b: ManageBinding
       });
       if (wantsJson || outputPath) {
         try {
-          const strict = opts?.strict === true;
+          const strict = opts?.strict === true || opts?.strictErrors === true;
           emitJsonArtifact(
             buildAuditFailureArtifact(err, Date.now() - startedAtMs, strict, preReportErrors, preReportWarnings),
           );
@@ -325,6 +327,10 @@ export function registerManageStorageGraphAudit(mem: Chainable, b: ManageBinding
       "Exit 2 when warnings/errors or partial/failed status are present. JSON includes exitCode/exitReason/strictFailureReason.",
     )
     .option(
+      "--strict-errors",
+      "Exit 2 only on errors or degraded status — warnings are informational (#1955). JSON includes exitCode/exitReason/strictFailureReason.",
+    )
+    .option(
       "--output <path>",
       "Write JSON artifact atomically to this path (tmp+rename) instead of stdout. Always written even on strict failure (#1823).",
     )
@@ -340,6 +346,10 @@ export function registerManageStorageGraphAudit(mem: Chainable, b: ManageBinding
     .option(
       "--strict",
       "Exit 2 when warnings/errors or partial/failed status are present. JSON includes exitCode/exitReason/strictFailureReason.",
+    )
+    .option(
+      "--strict-errors",
+      "Exit 2 only on errors or degraded status — warnings are informational (#1955). JSON includes exitCode/exitReason/strictFailureReason.",
     )
     .option(
       "--output <path>",

--- a/extensions/memory-hybrid/cli/install/cron-jobs.ts
+++ b/extensions/memory-hybrid/cli/install/cron-jobs.ts
@@ -170,7 +170,7 @@ const CONSOLIDATED_CRON_JOBS: Array<
     channel: "system",
     message: buildHybridMemCronTaskMessage("maintenance-nightly", {
       preamble:
-        "Unified hybrid-memory maintenance. The orchestrator runs due nightly/weekly/monthly steps with staggered per-step guards. Report summary counts.",
+        "Unified hybrid-memory maintenance. The orchestrator runs due nightly/weekly/monthly steps with staggered per-step guards. Report summary counts. Use exec/bash only — never deferred tool_call.",
       steps: [{ name: "maintenance-nightly", cmd: "openclaw hybrid-mem maintenance nightly --verbose" }],
     }),
     isolated: true,
@@ -216,9 +216,12 @@ function ensureHybridMemCronMessageHasEnvSanitizer(message: string): string | nu
   return next === message ? null : next;
 }
 
-/** Agent-turn reminder for operator workshop/pending review backlog (#1921). */
-export const WORKSHOP_APPROVAL_REMINDER_MESSAGE =
-  "Workshop approval reminder. Run: openclaw hybrid-mem digest pending --since 7d. If pending items are listed, summarize for the operator with approve/review instructions. If the command fails (unknown subcommand or non-zero exit), report the error — do not treat it as empty. If throttled or empty, reply briefly.";
+/** Agent-turn reminder for operator workshop/pending review backlog (#1921, #1962). */
+export const WORKSHOP_APPROVAL_REMINDER_MESSAGE = buildHybridMemCronTaskMessage("workshop-approval-reminder", {
+  preamble:
+    "Workshop approval reminder. Run digest pending, then summarize pending approve/review actions for cron delivery. Do NOT use the message tool — cron announce delivery sends your final reply to the operator.",
+  steps: [{ name: "digest-pending", cmd: "openclaw hybrid-mem digest pending --since 7d --format md" }],
+});
 
 // buildGuardPrefix is imported from services/cron-guard.ts (issue #305).
 
@@ -406,7 +409,7 @@ const MAINTENANCE_CRON_JOBS: Array<
     message: buildHybridMemCronTaskMessage("weekly-audit-health", {
       preamble:
         "Weekly operator health audit. Run in strict mode, summarize warnings/remediation, and alert the user if the command exits non-zero.",
-      steps: [{ name: "audit-health", cmd: "openclaw hybrid-mem audit health --strict --json" }],
+      steps: [{ name: "audit-health", cmd: "openclaw hybrid-mem audit health --strict-errors --json" }],
     }),
     isolated: true,
     modelTier: "nano",

--- a/extensions/memory-hybrid/config/index.ts
+++ b/extensions/memory-hybrid/config/index.ts
@@ -302,11 +302,18 @@ export function resolveVerificationModel(pluginConfig: CronModelConfig | undefin
   if (enabled) return enabled;
   const legacyDefault = filterModelsByDisabled([OPENAI_DEFAULT_CRON_MODEL], disabledSet)[0];
   if (legacyDefault) return legacyDefault;
-  const heavyFallback = filterModelsByDisabled(
-    [OPENAI_HEAVY_CRON_MODEL],
+  const heavyFallback = filterModelsByDisabled([OPENAI_HEAVY_CRON_MODEL], disabledSet)[0];
+  if (heavyFallback) return heavyFallback;
+  // All tier preferences were disabled — scan unfiltered lists once more before a bare default.
+  const unfilteredCandidates = filterModelsByDisabled(
+    [
+      ...getLLMModelPreferenceUnfiltered(pluginConfig, "nano"),
+      ...getLLMModelPreferenceUnfiltered(pluginConfig, "maintenance"),
+      ...getLLMModelPreferenceUnfiltered(pluginConfig, "default"),
+    ],
     disabledSet,
-  )[0];
-  return heavyFallback ?? OPENAI_DEFAULT_CRON_MODEL;
+  );
+  return unfilteredCandidates.find((m) => m.trim().length > 0) ?? OPENAI_DEFAULT_CRON_MODEL;
 }
 
 /** Build minimal config for getDefaultCronModel from full HybridMemoryConfig (used by cron jobs and self-correction spawn). */

--- a/extensions/memory-hybrid/config/index.ts
+++ b/extensions/memory-hybrid/config/index.ts
@@ -282,6 +282,22 @@ export function getDefaultCronModel(pluginConfig: CronModelConfig | undefined, t
   return preferred[0] ?? (tier === "heavy" ? OPENAI_HEAVY_CRON_MODEL : OPENAI_DEFAULT_CRON_MODEL);
 }
 
+/**
+ * Resolve continuous-verification model from config, skipping disabled providers (#1956).
+ * Falls back through nano → maintenance → default tiers before the legacy OpenAI default.
+ */
+export function resolveVerificationModel(pluginConfig: CronModelConfig | undefined, explicit?: string): string {
+  const trimmed = explicit?.trim();
+  if (trimmed) return trimmed;
+  const candidates = [
+    ...getLLMModelPreference(pluginConfig, "nano"),
+    ...getLLMModelPreference(pluginConfig, "maintenance"),
+    ...getLLMModelPreference(pluginConfig, "default"),
+  ];
+  const enabled = candidates.find((m) => m.trim().length > 0);
+  return enabled ?? OPENAI_DEFAULT_CRON_MODEL;
+}
+
 /** Build minimal config for getDefaultCronModel from full HybridMemoryConfig (used by cron jobs and self-correction spawn). */
 export function getCronModelConfig(cfg: HybridMemoryConfig): CronModelConfig {
   return {

--- a/extensions/memory-hybrid/config/index.ts
+++ b/extensions/memory-hybrid/config/index.ts
@@ -287,15 +287,26 @@ export function getDefaultCronModel(pluginConfig: CronModelConfig | undefined, t
  * Falls back through nano → maintenance → default tiers before the legacy OpenAI default.
  */
 export function resolveVerificationModel(pluginConfig: CronModelConfig | undefined, explicit?: string): string {
+  const disabledSet = getDisabledProviderSet(pluginConfig);
   const trimmed = explicit?.trim();
-  if (trimmed) return trimmed;
+  if (trimmed) {
+    const allowed = filterModelsByDisabled([trimmed], disabledSet);
+    if (allowed.length > 0) return allowed[0];
+  }
   const candidates = [
     ...getLLMModelPreference(pluginConfig, "nano"),
     ...getLLMModelPreference(pluginConfig, "maintenance"),
     ...getLLMModelPreference(pluginConfig, "default"),
   ];
   const enabled = candidates.find((m) => m.trim().length > 0);
-  return enabled ?? OPENAI_DEFAULT_CRON_MODEL;
+  if (enabled) return enabled;
+  const legacyDefault = filterModelsByDisabled([OPENAI_DEFAULT_CRON_MODEL], disabledSet)[0];
+  if (legacyDefault) return legacyDefault;
+  const heavyFallback = filterModelsByDisabled(
+    [OPENAI_HEAVY_CRON_MODEL],
+    disabledSet,
+  )[0];
+  return heavyFallback ?? OPENAI_DEFAULT_CRON_MODEL;
 }
 
 /** Build minimal config for getDefaultCronModel from full HybridMemoryConfig (used by cron jobs and self-correction spawn). */

--- a/extensions/memory-hybrid/services/audit-health-exit-info.ts
+++ b/extensions/memory-hybrid/services/audit-health-exit-info.ts
@@ -54,7 +54,7 @@ export function buildAuditHealthExitInfo(input: {
   const looksDegraded = input.ok === false || (input.status != null && input.status !== "ok");
   const strictFailed = strict
     ? strictErrorsOnly
-      ? input.errorCount > 0 || input.status === "failed"
+      ? errorCount > 0 || input.status === "failed"
       : errorCount > 0 || warningCount > 0 || looksDegraded
     : false;
 

--- a/extensions/memory-hybrid/services/audit-health-exit-info.ts
+++ b/extensions/memory-hybrid/services/audit-health-exit-info.ts
@@ -38,6 +38,8 @@ export type AuditHealthExitInfo = {
 
 export function buildAuditHealthExitInfo(input: {
   strict: boolean;
+  /** When true with --strict, exit only on errors/degraded status — warnings are informational (#1955). */
+  strictErrorsOnly?: boolean;
   warningCount: number;
   errorCount: number;
   ok?: boolean;
@@ -46,9 +48,12 @@ export function buildAuditHealthExitInfo(input: {
   const warningCount = Math.max(0, input.warningCount || 0);
   const errorCount = Math.max(0, input.errorCount || 0);
   const strict = input.strict === true;
+  const strictErrorsOnly = input.strictErrorsOnly === true;
 
   const looksDegraded = input.ok === false || (input.status != null && input.status !== "ok");
-  const strictFailed = strict && (warningCount > 0 || errorCount > 0 || looksDegraded);
+  const strictFailed =
+    strict &&
+    (errorCount > 0 || looksDegraded || (!strictErrorsOnly && warningCount > 0));
 
   if (strictFailed) {
     const strictFailureReason = (() => {

--- a/extensions/memory-hybrid/services/audit-health-exit-info.ts
+++ b/extensions/memory-hybrid/services/audit-health-exit-info.ts
@@ -49,20 +49,24 @@ export function buildAuditHealthExitInfo(input: {
   const errorCount = Math.max(0, input.errorCount || 0);
   const strict = input.strict === true;
   const strictErrorsOnly = input.strictErrorsOnly === true;
+  const strictFlagLabel = strictErrorsOnly ? "--strict-errors" : "--strict";
 
   const looksDegraded = input.ok === false || (input.status != null && input.status !== "ok");
-  const strictFailed =
-    strict &&
-    (errorCount > 0 || looksDegraded || (!strictErrorsOnly && warningCount > 0));
+  const strictFailed = strict
+    ? strictErrorsOnly
+      ? input.errorCount > 0 || input.status === "failed"
+      : errorCount > 0 || warningCount > 0 || looksDegraded
+    : false;
 
   if (strictFailed) {
     const strictFailureReason = (() => {
       if (errorCount > 0 && warningCount > 0) {
-        return `${errorCount} error(s) and ${warningCount} warning(s) present and --strict was set`;
+        return `${errorCount} error(s) and ${warningCount} warning(s) present and ${strictFlagLabel} was set`;
       }
-      if (errorCount > 0) return `${errorCount} error(s) present and --strict was set`;
-      if (warningCount > 0) return `${warningCount} warning(s) present and --strict was set`;
-      return "--strict was set and the report was not ok";
+      if (errorCount > 0) return `${errorCount} error(s) present and ${strictFlagLabel} was set`;
+      if (warningCount > 0) return `${warningCount} warning(s) present and ${strictFlagLabel} was set`;
+      if (input.status === "failed") return `${strictFlagLabel} was set and the report status was failed`;
+      return `${strictFlagLabel} was set and the report was not ok`;
     })();
     return {
       exitCode: 2,

--- a/extensions/memory-hybrid/services/contradiction-progress-summary.ts
+++ b/extensions/memory-hybrid/services/contradiction-progress-summary.ts
@@ -131,7 +131,29 @@ export function formatContradictionProgressSummaryLine(
   metrics: ContradictionProgressMetrics,
   evaluation: ContradictionProgressEvaluation,
 ): string {
-  return `resolve-contradictions summary mode=${mode} auto_resolved=${metrics.autoResolved} ambiguous=${metrics.ambiguous} no_progress=${evaluation.noProgress ? 1 : 0} degraded=${evaluation.degraded ? 1 : 0} threshold_enabled=${evaluation.degradedThresholdEnabled ? 1 : 0} threshold=${evaluation.degradedAmbiguousThreshold} consecutive=${evaluation.consecutiveNoProgressRuns} consecutive_threshold=${evaluation.degradedConsecutiveThreshold}`;
+  const parts = [
+    `resolve-contradictions summary mode=${mode}`,
+    `auto_resolved=${metrics.autoResolved}`,
+    `ambiguous=${metrics.ambiguous}`,
+    `no_progress=${evaluation.noProgress ? 1 : 0}`,
+    `degraded=${evaluation.degraded ? 1 : 0}`,
+    `threshold_enabled=${evaluation.degradedThresholdEnabled ? 1 : 0}`,
+    `threshold=${evaluation.degradedAmbiguousThreshold}`,
+    `consecutive=${evaluation.consecutiveNoProgressRuns}`,
+    `consecutive_threshold=${evaluation.degradedConsecutiveThreshold}`,
+  ];
+  if (
+    evaluation.noProgress &&
+    evaluation.degradedThresholdEnabled &&
+    metrics.ambiguous >= evaluation.degradedAmbiguousThreshold
+  ) {
+    parts.push("backlog_alert=1");
+    parts.push("triage_cmd=openclaw hybrid-mem resolve-contradictions --details --limit 20");
+    if (evaluation.consecutiveNoProgressRuns >= evaluation.degradedConsecutiveThreshold) {
+      parts.push("operator_action=manual_triage_required");
+    }
+  }
+  return parts.join(" ");
 }
 
 export function buildContradictionProgressJsonSummary(

--- a/extensions/memory-hybrid/services/cron-job-bash-harness.ts
+++ b/extensions/memory-hybrid/services/cron-job-bash-harness.ts
@@ -259,6 +259,7 @@ export function buildHybridMemCronTaskMessage(
   const orchestration = [
     "EXECUTION (durable logs + per-step exits)",
     "Run the bash below in ONE foreground shell session and wait until it exits. Do not background this work and end the turn while commands are still running.",
+    "TOOLING: Use the exec tool with a full shell command string (e.g. bash with the script body). Do NOT use deferred tool surfaces (tool_call, tool_describe, tool_search) — they strip exec arguments in isolated cron sessions (#1961).",
     "- HM_LOG: full stdout/stderr for the run. HM_EXIT: one line per hm_step with UTC timestamp and exit= (first command in the pipeline).",
     "",
     "```bash",

--- a/extensions/memory-hybrid/services/deprecated-cron-commands.ts
+++ b/extensions/memory-hybrid/services/deprecated-cron-commands.ts
@@ -23,6 +23,15 @@ export const DEPRECATED_HYBRID_MEM_CRON_TOKENS: readonly DeprecatedCronToken[] =
     replacement: `enrich-entities --limit "\${HYBRID_MEM_CLI_JOB_ENRICH_LIMIT:-25}" --verbose`,
     note: "Old monthly-consolidation entity enrichment cap was too large for live throughput; use the safe configurable cap.",
   },
+  {
+    token: "audit health --strict --json",
+    replacement: "audit health --strict-errors --json",
+    note: "Weekly audit-health cron should use --strict-errors so sustained store-backlog warnings do not hard-fail (#1955).",
+  },
+  {
+    token: "Workshop approval reminder. Run:",
+    note: "Free-form workshop reminder predates bash harness digest step (#1962).",
+  },
 ];
 
 function escapeRegExpLiteral(token: string): string {

--- a/extensions/memory-hybrid/services/procedure-feedback-tool.ts
+++ b/extensions/memory-hybrid/services/procedure-feedback-tool.ts
@@ -1,0 +1,159 @@
+/**
+ * Agent tool helpers for memory_procedure_feedback (#1965–#1967).
+ */
+import type { FactsDB } from "../backends/facts-db.js";
+import type { ProcedureEntry, ProcedureStep } from "../types/memory.js";
+import { minimalRecipe } from "./procedure-extractor.js";
+
+export type ProcedureFeedbackToolParams = {
+  procedureId: string;
+  success: boolean;
+  context?: string;
+  failedAtStep?: number;
+  duration?: number;
+  tags?: string[];
+  registerIfMissing?: boolean;
+  taskPattern?: string;
+  steps?: ProcedureStep[];
+  procedureType?: "positive" | "negative";
+};
+
+export type ProcedureFeedbackToolResult = {
+  content: Array<{ type: "text"; text: string }>;
+  details: Record<string, unknown>;
+  isError?: boolean;
+};
+
+const NOT_FOUND_HINT = "use_memory_record_episode_or_recall_first";
+
+export function buildProcedureNotFoundToolResult(procedureId: string): ProcedureFeedbackToolResult {
+  const text = [
+    `Procedure not found: \`${procedureId}\`.`,
+    "This tool records feedback for an **existing** procedure (from `memory_recall_procedures` or nightly `extract-procedures`).",
+    "It does not create procedures unless `registerIfMissing: true` with `taskPattern` and `steps`.",
+    "For a first-run outcome without a stored procedure, use `memory_record_episode` or `memory_store`; do not retry this tool with the same id.",
+  ].join(" ");
+  return {
+    content: [{ type: "text", text }],
+    isError: true,
+    details: {
+      success: false,
+      error: "procedure_not_found",
+      procedureId,
+      hint: NOT_FOUND_HINT,
+    },
+  };
+}
+
+function buildRegisterValidationError(message: string): ProcedureFeedbackToolResult {
+  return {
+    content: [{ type: "text", text: message }],
+    isError: true,
+    details: {
+      success: false,
+      error: "register_validation_failed",
+      hint: NOT_FOUND_HINT,
+    },
+  };
+}
+
+function buildProcedureFeedbackSuccessResult(
+  result: ProcedureEntry,
+  success: boolean,
+  context?: string,
+  created?: boolean,
+): ProcedureFeedbackToolResult {
+  const lines: string[] = [];
+  if (created) {
+    lines.push(`📝 Procedure registered as draft: \`${result.id}\``);
+  }
+  if (success) {
+    lines.push(
+      `✅ Procedure validated (now ${result.successCount} successes, confidence: ${(result.confidence ?? 0).toFixed(2)})`,
+    );
+  } else {
+    lines.push(
+      `❌ Procedure failure recorded (now ${result.failureCount} failures, version ${result.version ?? 1}, confidence: ${(result.confidence ?? 0).toFixed(2)})`,
+    );
+    if (context) lines.push(`  Context: ${context}`);
+    if (result.avoidanceNotes && result.avoidanceNotes.length > 0) {
+      lines.push(`  Avoidance notes: ${result.avoidanceNotes.join("; ")}`);
+    }
+  }
+
+  return {
+    content: [{ type: "text", text: lines.join("\n") }],
+    details: {
+      success: true,
+      procedureId: result.id,
+      version: result.version,
+      outcome: success ? "success" : "failure",
+      successCount: result.successCount,
+      failureCount: result.failureCount,
+      successRate: result.successRate,
+      ...(created ? { created: true } : {}),
+    },
+  };
+}
+
+function bootstrapProcedureIfMissing(
+  factsDb: FactsDB,
+  params: ProcedureFeedbackToolParams,
+): { ok: true; created: boolean } | { ok: false; result: ProcedureFeedbackToolResult } {
+  if (factsDb.getProcedureById(params.procedureId)) {
+    return { ok: true, created: false };
+  }
+  if (!params.registerIfMissing) {
+    return { ok: false, result: buildProcedureNotFoundToolResult(params.procedureId) };
+  }
+
+  const taskPattern = params.taskPattern?.trim() ?? "";
+  const steps = params.steps?.filter((s) => typeof s?.tool === "string" && s.tool.trim().length > 0) ?? [];
+  if (!taskPattern || steps.length === 0) {
+    return {
+      ok: false,
+      result: buildRegisterValidationError(
+        "registerIfMissing requires `taskPattern` and at least one `steps[]` entry with a `tool` name when the procedure id does not exist.",
+      ),
+    };
+  }
+
+  const recipeJson = JSON.stringify(minimalRecipe(steps));
+  const procedureType = params.procedureType ?? (params.success ? "positive" : "negative");
+  factsDb.upsertProcedure({
+    id: params.procedureId,
+    taskPattern,
+    recipeJson,
+    procedureType,
+    successCount: 0,
+    failureCount: 0,
+    lastValidated: null,
+    lastFailed: null,
+    confidence: 0.5,
+  });
+  return { ok: true, created: true };
+}
+
+/** Core handler for memory_procedure_feedback — testable without plugin API wiring. */
+export function executeProcedureFeedbackTool(
+  factsDb: FactsDB,
+  params: ProcedureFeedbackToolParams,
+): ProcedureFeedbackToolResult {
+  const bootstrap = bootstrapProcedureIfMissing(factsDb, params);
+  if (!bootstrap.ok) return bootstrap.result;
+
+  const result = factsDb.procedureFeedback({
+    procedureId: params.procedureId,
+    success: params.success,
+    context: params.context,
+    failedAtStep: params.failedAtStep,
+    duration: params.duration,
+    tags: params.tags,
+  });
+
+  if (!result) {
+    return buildProcedureNotFoundToolResult(params.procedureId);
+  }
+
+  return buildProcedureFeedbackSuccessResult(result, params.success, params.context, bootstrap.created);
+}

--- a/extensions/memory-hybrid/setup/cli-context/cli-services.ts
+++ b/extensions/memory-hybrid/setup/cli-context/cli-services.ts
@@ -10,6 +10,7 @@ import {
   getMemoryCategories,
   resolveReflectionModelAndFallbacks,
   resolveReflectionThinkingMode,
+  resolveVerificationModel,
 } from "../../config.js";
 import { runClassifyForCli } from "../../services/auto-classifier.js";
 import { runConsolidate } from "../../services/consolidation.js";
@@ -533,7 +534,7 @@ export function buildCliContextServices(
       const verbose = !!opts?.verbose;
       return runVerificationCycle(verificationStore, factsDb, openai, {
         cycleDays: cfg.verification.cycleDays,
-        verificationModel: cfg.verification.verificationModel,
+        verificationModel: resolveVerificationModel(getCronModelConfig(cfg), cfg.verification.verificationModel),
         ...(verbose
           ? {
               onProgress: (message: string) => {

--- a/extensions/memory-hybrid/setup/plugin-service.ts
+++ b/extensions/memory-hybrid/setup/plugin-service.ts
@@ -638,9 +638,20 @@ export function createPluginService(ctx: PluginServiceContext) {
       // Unified maintenance tick (cycle tier) — replaces scattered prune/classify/language/observer timers
       let maintenanceTickInFlight = false;
       const runMaintenanceCycleTick = async (label: string) => {
-        if (maintenanceTickInFlight || shuttingDown) return;
-        if (typeof factsDb.isOpen === "function" && !factsDb.isOpen()) return;
+        if (maintenanceTickInFlight) {
+          api.logger.debug?.(`memory-hybrid: maintenance tick (${label}) skipped: in_flight`);
+          return;
+        }
+        if (shuttingDown) {
+          api.logger.debug?.(`memory-hybrid: maintenance tick (${label}) skipped: shutting_down`);
+          return;
+        }
+        if (typeof factsDb.isOpen === "function" && !factsDb.isOpen()) {
+          api.logger.debug?.(`memory-hybrid: maintenance tick (${label}) skipped: db_closed`);
+          return;
+        }
         maintenanceTickInFlight = true;
+        const tickStartedMs = Date.now();
         try {
           const runCompaction = async () =>
             factsDb.retier(
@@ -779,9 +790,16 @@ export function createPluginService(ctx: PluginServiceContext) {
               verbose: false,
             },
           );
+          const durationMs = Date.now() - tickStartedMs;
+          const summaryTrunc =
+            result.summaryLine.length > 240 ? `${result.summaryLine.slice(0, 237)}...` : result.summaryLine;
           if (result.exitCode !== 0) {
             api.logger.warn?.(
-              `memory-hybrid: maintenance tick (${label}) exit=${result.exitCode}: ${result.summaryLine}`,
+              `memory-hybrid: maintenance tick (${label}) exit=${result.exitCode} durationMs=${durationMs}: ${summaryTrunc}`,
+            );
+          } else {
+            api.logger.info?.(
+              `memory-hybrid: maintenance tick (${label}) ok durationMs=${durationMs} stepsRun=${result.steps.length}: ${summaryTrunc}`,
             );
           }
         } catch (err) {

--- a/extensions/memory-hybrid/skills/hybrid-memory/SKILL.md
+++ b/extensions/memory-hybrid/skills/hybrid-memory/SKILL.md
@@ -154,6 +154,21 @@ All tools use **underscore** names. Below is a compact index — not every deplo
 | **Issues & proposals** | `memory_issue_*`, `persona_propose`, `persona_proposals_list`, `memory_propose_tool`, `memory_tool_proposals`, `memory_tool_approve`, `memory_tool_reject` |
 | **Workflows & capture** | `memory_workflows`, `apitap_capture`, `apitap_list`, `apitap_peek`, `apitap_to_skill`, `memory_session_observability` |
 
+### Procedures workflow
+
+1. **Recall** — call `memory_recall_procedures` before repeating a known task pattern; use the returned **`id`** for feedback.
+2. **Execute** the steps from the recalled recipe.
+3. **Feedback** — call `memory_procedure_feedback` with that exact `id`, `success`, and optional `context`.
+4. **First run / no procedure yet** — either:
+   - `memory_record_episode` (+ `memory_store` for durable facts); maintenance `extract-procedures` promotes patterns asynchronously, **or**
+   - `memory_procedure_feedback` with `registerIfMissing: true`, plus `taskPattern` and `steps[]` (creates a **draft** procedure, then records feedback).
+
+**Anti-patterns**
+
+- Do **not** invent slug ids and retry `memory_procedure_feedback` after `procedure_not_found` — that error is **`isError: true`**; stop after one failure unless using `registerIfMissing`.
+- Do **not** use `memory_procedure_feedback` to create procedures without `registerIfMissing` — it updates existing rows only.
+- `memory_store` writes **facts**, not procedure rows.
+
 When vault is **off**, credential-like content is blocked from ordinary `memory_store`. When vault is **on**, use `credential_get` — recall returns pointers, not secrets.
 
 ## Credentials vault (when `credentials.enabled: true`)

--- a/extensions/memory-hybrid/tests/audit-health-failed-artifact.test.ts
+++ b/extensions/memory-hybrid/tests/audit-health-failed-artifact.test.ts
@@ -124,12 +124,25 @@ describe("buildAuditHealthExitInfo strict mode (#1823)", () => {
       strictErrorsOnly: true,
       warningCount: 7,
       errorCount: 0,
-      ok: true,
-      status: "ok",
+      ok: false,
+      status: "partial",
     });
     expect(info.exitCode).toBe(0);
     expect(info.exitReason).toBe("warnings");
     expect(info.strictFailureReason).toBeUndefined();
+  });
+
+  it("returns exitCode 2 when strict-errors and report status is failed (#1955)", () => {
+    const info = buildAuditHealthExitInfo({
+      strict: true,
+      strictErrorsOnly: true,
+      warningCount: 0,
+      errorCount: 0,
+      ok: false,
+      status: "failed",
+    });
+    expect(info.exitCode).toBe(2);
+    expect(info.exitReason).toBe("strict_failed");
   });
 
   it("returns exitCode 2 when strict-errors and errors present (#1955)", () => {
@@ -188,6 +201,40 @@ describe("strict audit failure artifact integration (#1823)", () => {
     expect(parsed.warningCount).toBeGreaterThanOrEqual(1);
     expect(Array.isArray(parsed.warnings)).toBe(true);
     expect(Array.isArray(parsed.errors)).toBe(true);
+
+    db.close();
+  });
+
+  it("strict-errors exits 0 on warning-only report shape from buildAuditHealthReport (#1955)", () => {
+    const db = new FactsDB(":memory:");
+    db.store({
+      text: "Unconfigured category test fact",
+      category: "off-roster-unconfigured",
+      importance: 0.5,
+      entity: null,
+      key: null,
+      value: null,
+      source: "test",
+    });
+
+    const report = buildAuditHealthReport(db as never, () => ["technical"], [], 500);
+    expect(report.ok).toBe(false);
+    expect(report.status).toBe("partial");
+    expect(report.errorCount).toBe(0);
+    expect(report.warningCount).toBeGreaterThanOrEqual(1);
+
+    const exitInfo = buildAuditHealthExitInfo({
+      strict: true,
+      strictErrorsOnly: true,
+      warningCount: report.warningCount,
+      errorCount: report.errorCount,
+      ok: report.ok,
+      status: report.status,
+    });
+
+    expect(exitInfo.exitCode).toBe(0);
+    expect(exitInfo.exitReason).toBe("warnings");
+    expect(exitInfo.strictFailureReason).toBeUndefined();
 
     db.close();
   });

--- a/extensions/memory-hybrid/tests/audit-health-failed-artifact.test.ts
+++ b/extensions/memory-hybrid/tests/audit-health-failed-artifact.test.ts
@@ -117,6 +117,31 @@ describe("buildAuditHealthExitInfo strict mode (#1823)", () => {
     expect(info.exitCode).toBe(0);
     expect(info.exitReason).toBe("ok");
   });
+
+  it("returns exitCode 0 when strict-errors and only warnings present (#1955)", () => {
+    const info = buildAuditHealthExitInfo({
+      strict: true,
+      strictErrorsOnly: true,
+      warningCount: 7,
+      errorCount: 0,
+      ok: true,
+      status: "ok",
+    });
+    expect(info.exitCode).toBe(0);
+    expect(info.exitReason).toBe("warnings");
+    expect(info.strictFailureReason).toBeUndefined();
+  });
+
+  it("returns exitCode 2 when strict-errors and errors present (#1955)", () => {
+    const info = buildAuditHealthExitInfo({
+      strict: true,
+      strictErrorsOnly: true,
+      warningCount: 3,
+      errorCount: 1,
+    });
+    expect(info.exitCode).toBe(2);
+    expect(info.exitReason).toBe("strict_errors");
+  });
 });
 
 // ─── Integration: strict failure produces a parseable artifact ───────────────

--- a/extensions/memory-hybrid/tests/config.test.ts
+++ b/extensions/memory-hybrid/tests/config.test.ts
@@ -1357,7 +1357,7 @@ describe("hybridConfigSchema.parse", () => {
     });
     const cronCfg = getCronModelConfig(cfg);
     expect(resolveVerificationModel(cronCfg)).toBe("minimax/MiniMax-M2.7-highspeed");
-    expect(resolveVerificationModel(cronCfg, "openai/gpt-4.1-nano")).toBe("openai/gpt-4.1-nano");
+    expect(resolveVerificationModel(cronCfg, "openai/gpt-4.1-nano")).toBe("minimax/MiniMax-M2.7-highspeed");
   });
 
   it("getLLMModelPreference when llm is undefined uses legacy single model (OpenClaw provider/model IDs)", () => {

--- a/extensions/memory-hybrid/tests/config.test.ts
+++ b/extensions/memory-hybrid/tests/config.test.ts
@@ -13,6 +13,7 @@ import {
   getProvidersWithKeys,
   hybridConfigSchema,
   isValidCategory,
+  resolveVerificationModel,
   resolveReflectionModelAndFallbacks,
   setMemoryCategories,
   vectorDimsForModel,
@@ -1341,6 +1342,22 @@ describe("hybridConfigSchema.parse", () => {
     expect(getLLMModelPreference(cronCfg, "heavy")).toEqual([]);
     expect(getProvidersWithKeys(cronCfg)).toEqual(expect.arrayContaining(["google", "openai"]));
     expect(getProvidersWithKeys(cronCfg)).not.toContain("anthropic");
+  });
+
+  it("resolveVerificationModel skips disabled providers (#1956)", () => {
+    const cfg = hybridConfigSchema.parse({
+      ...validBase,
+      llm: {
+        nano: ["openai/gpt-4.1-nano"],
+        maintenance: ["minimax/MiniMax-M2.7-highspeed"],
+        default: ["openai/gpt-4.1-mini"],
+        disabledProviders: ["openai"],
+      },
+      embedding: { provider: "openai", apiKey: "openai-key-10ch", model: "text-embedding-3-small" },
+    });
+    const cronCfg = getCronModelConfig(cfg);
+    expect(resolveVerificationModel(cronCfg)).toBe("minimax/MiniMax-M2.7-highspeed");
+    expect(resolveVerificationModel(cronCfg, "openai/gpt-4.1-nano")).toBe("openai/gpt-4.1-nano");
   });
 
   it("getLLMModelPreference when llm is undefined uses legacy single model (OpenClaw provider/model IDs)", () => {

--- a/extensions/memory-hybrid/tests/config.test.ts
+++ b/extensions/memory-hybrid/tests/config.test.ts
@@ -1360,6 +1360,22 @@ describe("hybridConfigSchema.parse", () => {
     expect(resolveVerificationModel(cronCfg, "openai/gpt-4.1-nano")).toBe("minimax/MiniMax-M2.7-highspeed");
   });
 
+  it("resolveVerificationModel falls back through unfiltered tiers when filtered lists are empty (#1956)", () => {
+    const cfg = hybridConfigSchema.parse({
+      ...validBase,
+      llm: {
+        nano: ["openai/gpt-4.1-nano"],
+        maintenance: ["minimax/MiniMax-M2.7-highspeed"],
+        default: ["openai/gpt-4.1-mini"],
+        disabledProviders: ["openai"],
+      },
+      embedding: { provider: "openai", apiKey: "openai-key-10ch", model: "text-embedding-3-small" },
+    });
+    const cronCfg = getCronModelConfig(cfg);
+    // Explicit disabled model should fall through to maintenance tier.
+    expect(resolveVerificationModel(cronCfg, "openai/gpt-4.1-mini")).toBe("minimax/MiniMax-M2.7-highspeed");
+  });
+
   it("getLLMModelPreference when llm is undefined uses legacy single model (OpenClaw provider/model IDs)", () => {
     const cronCfg = undefined;
     const defaultList = getLLMModelPreference(cronCfg, "default");

--- a/extensions/memory-hybrid/tests/cron-session-key-normalization.test.ts
+++ b/extensions/memory-hybrid/tests/cron-session-key-normalization.test.ts
@@ -46,7 +46,7 @@ describe("ensureMaintenanceCronJobs sessionKey normalization (#977)", () => {
     const target = jobs.find((j) => j.pluginJobId === "hybrid-mem:weekly-audit-health");
     expect(target).toBeTruthy();
     expect(target?.name).toBe("weekly-audit-health");
-    expect(JSON.stringify(target)).toContain("openclaw hybrid-mem audit health --strict --json");
+    expect(JSON.stringify(target)).toContain("openclaw hybrid-mem audit health --strict-errors --json");
   });
 
   it("publishes the weekly pending digest maintenance job", () => {

--- a/extensions/memory-hybrid/tests/deprecated-cron-commands.test.ts
+++ b/extensions/memory-hybrid/tests/deprecated-cron-commands.test.ts
@@ -36,6 +36,60 @@ describe("deprecated-cron-commands", () => {
     expect(hits).toContain("Workshop approval reminder. Run:");
   });
 
+  it("verify --fix path normalizes stale audit health --strict cron messages (#1955)", () => {
+    const openclawDir = mkdtempSync(join(tmpdir(), "hm-test-openclaw-"));
+    try {
+      mkdirSync(join(openclawDir, "cron"), { recursive: true });
+      writeFileSync(join(openclawDir, "openclaw.json"), "{}", "utf-8");
+
+      const jobsPath = join(openclawDir, "cron", "jobs.json");
+      writeFileSync(
+        jobsPath,
+        JSON.stringify(
+          {
+            jobs: [
+              {
+                pluginJobId: "hybrid-mem:weekly-audit-health",
+                id: "hybrid-mem:weekly-audit-health",
+                name: "weekly-audit-health",
+                schedule: { kind: "cron", expr: "0 5 * * 0" },
+                enabled: true,
+                sessionTarget: "isolated",
+                payload: {
+                  kind: "agentTurn",
+                  message:
+                    'EXECUTION\n```bash\nhm_step "audit-health" openclaw hybrid-mem audit health --strict --json\n```',
+                },
+              },
+            ],
+          },
+          null,
+          2,
+        ),
+        "utf-8",
+      );
+
+      const result = ensureMaintenanceCronJobs(openclawDir, undefined, {
+        normalizeExisting: true,
+        reEnableDisabled: false,
+        consolidatedCronJobs: false,
+      });
+      expect(result.normalized).toContain("weekly-audit-health");
+
+      const next = JSON.parse(readFileSync(jobsPath, "utf-8")) as { jobs: Array<Record<string, unknown>> };
+      const job = next.jobs.find((j) => j.pluginJobId === "hybrid-mem:weekly-audit-health") as
+        | Record<string, unknown>
+        | undefined;
+      expect(job).toBeTruthy();
+      const payload = job?.payload as { message?: unknown } | undefined;
+      const msg = String(payload?.message ?? job?.message ?? "");
+      expect(msg).toContain("openclaw hybrid-mem audit health --strict-errors --json");
+      expect(msg).not.toContain("audit health --strict --json");
+    } finally {
+      rmSync(openclawDir, { recursive: true, force: true });
+    }
+  });
+
   it("verify --fix path normalizes stale workshop remind-pending messages", () => {
     const openclawDir = mkdtempSync(join(tmpdir(), "hm-test-openclaw-"));
     try {

--- a/extensions/memory-hybrid/tests/deprecated-cron-commands.test.ts
+++ b/extensions/memory-hybrid/tests/deprecated-cron-commands.test.ts
@@ -24,6 +24,18 @@ describe("deprecated-cron-commands", () => {
     expect(hits).toContain("workshop remind-pending");
   });
 
+  it("detects legacy audit health --strict cron step (#1955)", () => {
+    const msg = "hm_step audit-health openclaw hybrid-mem audit health --strict --json";
+    const hits = findDeprecatedHybridMemCronTokens(msg).map((h) => h.token);
+    expect(hits).toContain("audit health --strict --json");
+  });
+
+  it("detects free-form workshop reminder without bash harness (#1962)", () => {
+    const msg = "Workshop approval reminder. Run: openclaw hybrid-mem digest pending --since 7d";
+    const hits = findDeprecatedHybridMemCronTokens(msg).map((h) => h.token);
+    expect(hits).toContain("Workshop approval reminder. Run:");
+  });
+
   it("verify --fix path normalizes stale workshop remind-pending messages", () => {
     const openclawDir = mkdtempSync(join(tmpdir(), "hm-test-openclaw-"));
     try {

--- a/extensions/memory-hybrid/tests/dream-cycle-followup-logging.test.ts
+++ b/extensions/memory-hybrid/tests/dream-cycle-followup-logging.test.ts
@@ -107,7 +107,7 @@ describe("dream-cycle follow-up heartbeat logging", () => {
     expect(extractImplicitSemanticOutcome({ partial: true, partialReason: "reinforcementError" })).toBe("partial");
   });
 
-  it("treats all-uncertain verification results as healthy when the cycle completed", () => {
+  it("treats all-uncertain verification results as monitoring when errors=0", () => {
     const assessment = assessContinuousVerificationResult({
       checked: 12,
       confirmed: 0,
@@ -117,12 +117,12 @@ describe("dream-cycle follow-up heartbeat logging", () => {
       errorSummaries: [],
     });
 
-    expect(assessment.status).toBe("healthy");
-    expect(assessment.reason).toBe("healthy");
+    expect(assessment.status).toBe("degraded");
+    expect(assessment.reason).toBe("all_uncertain");
     expect(assessment.shouldFailPipeline).toBe(false);
   });
 
-  it("treats LLM-downgraded uncertain outcomes as healthy when every fact got a verdict", () => {
+  it("treats LLM-downgraded uncertain outcomes as monitoring when every fact got a verdict", () => {
     const assessment = assessContinuousVerificationResult({
       checked: 5,
       confirmed: 0,
@@ -135,8 +135,8 @@ describe("dream-cycle follow-up heartbeat logging", () => {
       ],
     });
 
-    expect(assessment.status).toBe("healthy");
-    expect(assessment.reason).toBe("healthy");
+    expect(assessment.status).toBe("degraded");
+    expect(assessment.reason).toBe("all_uncertain");
     expect(assessment.shouldFailPipeline).toBe(false);
   });
 

--- a/extensions/memory-hybrid/tests/maintenance-writefile-sync-imports.test.ts
+++ b/extensions/memory-hybrid/tests/maintenance-writefile-sync-imports.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Regression guard for #1963: maintenance paths must import writeFileSync from node:fs
+ * so esbuild bundles do not emit bare ReferenceError at runtime.
+ */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const ROOT = join(import.meta.dirname, "..");
+
+const MAINTENANCE_FS_WRITE_PATHS = [
+  "services/cron-guard.ts",
+  "services/maintenance-timestamp.ts",
+  "cli/cmd-distill.ts",
+  "cli/commands/manage/maintenance-step-runners.ts",
+  "utils/atomic-write.ts",
+];
+
+describe("maintenance writeFileSync imports (#1963)", () => {
+  for (const rel of MAINTENANCE_FS_WRITE_PATHS) {
+    it(`${rel} imports writeFileSync from node:fs when used`, () => {
+      const content = readFileSync(join(ROOT, rel), "utf-8");
+      if (!content.includes("writeFileSync")) return;
+      expect(content).toMatch(/from\s+["']node:fs["']/);
+      expect(content).toMatch(/\bwriteFileSync\b/);
+    });
+  }
+
+  it("maintenance modules load without ReferenceError", async () => {
+    await import("../services/cron-guard.ts");
+    await import("../services/maintenance-timestamp.ts");
+    await import("../utils/atomic-write.ts");
+    await import("../cli/commands/manage/maintenance-step-runners.ts");
+  });
+});

--- a/extensions/memory-hybrid/tests/procedure-feedback-tool.test.ts
+++ b/extensions/memory-hybrid/tests/procedure-feedback-tool.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Tests for memory_procedure_feedback tool contract (#1965–#1967).
+ */
+import { afterEach, describe, expect, it } from "vitest";
+
+import { FactsDB } from "../backends/facts-db.js";
+import {
+  buildProcedureNotFoundToolResult,
+  executeProcedureFeedbackTool,
+} from "../services/procedure-feedback-tool.js";
+
+describe("procedure-feedback-tool (#1965–#1967)", () => {
+  let db: FactsDB;
+
+  afterEach(() => {
+    db?.close();
+  });
+
+  it("buildProcedureNotFoundToolResult sets isError true with actionable details (#1965)", () => {
+    const result = buildProcedureNotFoundToolResult("armor01-foundation-greenfield-rebuild-v1");
+    expect(result.isError).toBe(true);
+    expect(result.details).toMatchObject({
+      success: false,
+      error: "procedure_not_found",
+      procedureId: "armor01-foundation-greenfield-rebuild-v1",
+      hint: "use_memory_record_episode_or_recall_first",
+    });
+    expect(result.content[0]?.text).toContain("memory_record_episode");
+    expect(result.content[0]?.text).toContain("does not create procedures");
+  });
+
+  it("executeProcedureFeedbackTool returns isError for unknown procedure without registerIfMissing (#1965)", () => {
+    db = new FactsDB(":memory:");
+    const result = executeProcedureFeedbackTool(db, {
+      procedureId: "nonexistent-slug",
+      success: true,
+      context: "test",
+    });
+    expect(result.isError).toBe(true);
+    expect(result.details.error).toBe("procedure_not_found");
+  });
+
+  it("executeProcedureFeedbackTool succeeds on existing procedure (#1965 regression)", () => {
+    db = new FactsDB(":memory:");
+    const proc = db.upsertProcedure({
+      taskPattern: "Deploy service",
+      recipeJson: JSON.stringify([{ tool: "exec", summary: "deploy" }]),
+      procedureType: "positive",
+    });
+    const result = executeProcedureFeedbackTool(db, {
+      procedureId: proc.id,
+      success: true,
+      context: "Clean deploy",
+    });
+    expect(result.isError).not.toBe(true);
+    expect(result.details).toMatchObject({
+      success: true,
+      procedureId: proc.id,
+      outcome: "success",
+    });
+  });
+
+  it("registerIfMissing creates draft procedure and records feedback (#1967)", () => {
+    db = new FactsDB(":memory:");
+    const slug = "armor01-foundation-greenfield-rebuild-v1";
+    const result = executeProcedureFeedbackTool(db, {
+      procedureId: slug,
+      success: true,
+      registerIfMissing: true,
+      taskPattern: "Greenfield ARM rebuild foundation",
+      steps: [{ tool: "exec", summary: "Run foundation script" }],
+      context: "First successful run",
+    });
+    expect(result.isError).not.toBe(true);
+    expect(result.details.created).toBe(true);
+    expect(result.details.procedureId).toBe(slug);
+    const stored = db.getProcedureById(slug);
+    expect(stored?.taskPattern).toBe("Greenfield ARM rebuild foundation");
+    expect(stored?.skillState).toBe("draft");
+  });
+
+  it("registerIfMissing is idempotent when procedure already exists (#1967)", () => {
+    db = new FactsDB(":memory:");
+    const proc = db.upsertProcedure({
+      id: "existing-proc-id",
+      taskPattern: "Existing workflow",
+      recipeJson: "[]",
+      procedureType: "positive",
+    });
+    const result = executeProcedureFeedbackTool(db, {
+      procedureId: proc.id,
+      success: true,
+      registerIfMissing: true,
+      taskPattern: "Should be ignored",
+      steps: [{ tool: "exec" }],
+    });
+    expect(result.isError).not.toBe(true);
+    expect(result.details.created).toBeUndefined();
+    expect(db.getProcedureById(proc.id)?.taskPattern).toBe("Existing workflow");
+  });
+
+  it("registerIfMissing without taskPattern/steps returns validation error (#1967)", () => {
+    db = new FactsDB(":memory:");
+    const result = executeProcedureFeedbackTool(db, {
+      procedureId: "new-slug",
+      success: true,
+      registerIfMissing: true,
+    });
+    expect(result.isError).toBe(true);
+    expect(result.details.error).toBe("register_validation_failed");
+  });
+});

--- a/extensions/memory-hybrid/tools/memory/register-recall-tools.ts
+++ b/extensions/memory-hybrid/tools/memory/register-recall-tools.ts
@@ -28,6 +28,7 @@ import {
   resolveWorkerLeasesConfig,
 } from "../../services/worker-lease.js";
 import { emitFeatureTelemetry } from "../../services/feature-telemetry.js";
+import { executeProcedureFeedbackTool } from "../../services/procedure-feedback-tool.js";
 import { inferEntityFilterFromQuery, inferRetrievalModeFromQuery } from "../../services/retrieval-mode-selector.js";
 import {
   getFactIdsForEntitySurfaces,
@@ -1550,15 +1551,18 @@ export function registerRecallTools(runtime: MemoryToolRuntime): void {
       { name: "memory_recall_procedures" },
     );
 
-    // Procedure feedback loop (#782)
+    // Procedure feedback loop (#782, #1965–#1967)
     api.registerTool(
       {
         name: "memory_procedure_feedback",
         label: "Procedure Feedback",
         description:
-          "Record the outcome of using a procedure — success or failure. On failure, bumps the procedure version, logs the failure context, and creates an episode record. On success, records the validation. Use this whenever a procedure from memory_recall_procedures is attempted.",
+          "Record success/failure for a procedure that already exists in procedural memory. Prerequisite: call memory_recall_procedures first and use the returned id. Do not invent slug ids. For first-time run capture without a stored procedure, set registerIfMissing with taskPattern and steps, or use memory_record_episode (+ memory_store for facts). Procedures are also extracted asynchronously by maintenance extract-procedures.",
         parameters: Type.Object({
-          procedureId: Type.String({ description: "ID of the procedure that was used" }),
+          procedureId: Type.String({
+            description:
+              "Exact id from memory_recall_procedures or the procedures DB — not an invented slug unless registerIfMissing is true.",
+          }),
           success: Type.Boolean({ description: "true if the procedure succeeded, false if it failed" }),
           context: Type.Optional(
             Type.String({
@@ -1580,61 +1584,71 @@ export function registerRecallTools(runtime: MemoryToolRuntime): void {
               description: "Optional tags to associate with the episode (e.g. 'production', 'doris').",
             }),
           ),
+          registerIfMissing: Type.Optional(
+            Type.Boolean({
+              description:
+                "When true and procedureId is not found: register a draft procedure from taskPattern + steps, then record feedback. Use for first successful greenfield runs.",
+            }),
+          ),
+          taskPattern: Type.Optional(
+            Type.String({
+              description: "Required with registerIfMissing: short label for the workflow (max ~300 chars).",
+            }),
+          ),
+          steps: Type.Optional(
+            Type.Array(
+              Type.Object({
+                tool: Type.String({ description: "Tool or action name for this step" }),
+                summary: Type.Optional(Type.String()),
+                args: Type.Optional(Type.Record(Type.String(), Type.Unknown())),
+              }),
+              { description: "Required with registerIfMissing: ordered steps for the procedure recipe." },
+            ),
+          ),
+          procedureType: Type.Optional(
+            Type.Union([Type.Literal("positive"), Type.Literal("negative")], {
+              description: "Procedure type when registerIfMissing creates a new row (default: derived from success).",
+            }),
+          ),
         }),
         async execute(_toolCallId: string, params: Record<string, unknown>) {
           try {
-            const { procedureId, success, context, failedAtStep, duration, tags } = params as {
-              procedureId: string;
-              success: boolean;
-              context?: string;
-              failedAtStep?: number;
-              duration?: number;
-              tags?: string[];
-            };
-
-            const result = factsDb.procedureFeedback({
+            const {
               procedureId,
               success,
               context,
               failedAtStep,
               duration,
               tags,
-            });
-
-            if (!result) {
-              return {
-                content: [{ type: "text" as const, text: `Procedure not found: ${procedureId}` }],
-                details: { success: false, error: "procedure_not_found" },
-              };
-            }
-
-            const lines: string[] = [];
-            if (success) {
-              lines.push(
-                `✅ Procedure validated (now ${result.successCount} successes, confidence: ${(result.confidence ?? 0).toFixed(2)})`,
-              );
-            } else {
-              lines.push(
-                `❌ Procedure failure recorded (now ${result.failureCount} failures, version ${result.version ?? 1}, confidence: ${(result.confidence ?? 0).toFixed(2)})`,
-              );
-              if (context) lines.push(`  Context: ${context}`);
-              if (result.avoidanceNotes && result.avoidanceNotes.length > 0) {
-                lines.push(`  Avoidance notes: ${result.avoidanceNotes.join("; ")}`);
-              }
-            }
-
-            return {
-              content: [{ type: "text" as const, text: lines.join("\n") }],
-              details: {
-                success: true,
-                procedureId: result.id,
-                version: result.version,
-                outcome: success ? "success" : "failure",
-                successCount: result.successCount,
-                failureCount: result.failureCount,
-                successRate: result.successRate,
-              },
+              registerIfMissing,
+              taskPattern,
+              steps,
+              procedureType,
+            } = params as {
+              procedureId: string;
+              success: boolean;
+              context?: string;
+              failedAtStep?: number;
+              duration?: number;
+              tags?: string[];
+              registerIfMissing?: boolean;
+              taskPattern?: string;
+              steps?: Array<{ tool: string; summary?: string; args?: Record<string, unknown> }>;
+              procedureType?: "positive" | "negative";
             };
+
+            return executeProcedureFeedbackTool(factsDb, {
+              procedureId,
+              success,
+              context,
+              failedAtStep,
+              duration,
+              tags,
+              registerIfMissing,
+              taskPattern,
+              steps,
+              procedureType,
+            });
           } catch (err) {
             capturePluginError(err instanceof Error ? err : new Error(String(err)), {
               subsystem: "memory",


### PR DESCRIPTION
## Summary
- **#1955**: Add `audit health --strict-errors` so weekly cron fails only on errors/degraded status, not sustained store-backlog warnings; weekly cron job uses the new flag.
- **#1956**: Resolve continuous-verification model from enabled providers via `resolveVerificationModel()`; classify all-UNCERTAIN cycles as monitoring (`all_uncertain`) instead of silent success.
- **#1957**: Orchestrator extract-implicit summary includes `sessionsRemaining` and `estimatedRunsToComplete` on graceful `maxWallClock` partials.
- **#1958**: Contradiction auto summary emits `backlog_alert` and triage command when ambiguous backlog exceeds threshold with no auto-progress.
- **#1959**: Distill enforces output-token floor, splits batches after shrink budget exhaustion on `finish=length`, and logs `truncatedBatches` count.
- **#1960**: Unified maintenance cycle tick logs success (info) and skip reasons (debug) with duration and step count.
- **#1961**: Cron bash harness forbids deferred `tool_call` tooling; maintenance-nightly preamble reinforces exec/bash-only execution.
- **#1962**: Workshop approval reminder uses bash harness + digest step; forbids manual `message` tool (cron announce delivers final reply).
- **#1963**: Regression test ensures maintenance modules import `writeFileSync` from `node:fs` and load without ReferenceError.
- **#1965**: `memory_procedure_feedback` returns `isError: true` for `procedure_not_found` with actionable text and stable `details.hint`.
- **#1966**: Tool schema + bundled `hybrid-memory` SKILL document feedback-only contract, recall → feedback workflow, and anti-patterns.
- **#1967**: Optional `registerIfMissing` + `taskPattern` + `steps[]` on `memory_procedure_feedback` for first-run greenfield capture (draft procedure + feedback in one call).

Closes #1955
Closes #1956
Closes #1957
Closes #1958
Closes #1959
Closes #1960
Closes #1961
Closes #1962
Closes #1963
Closes #1965
Closes #1966
Closes #1967

## Test plan
- [x] `npm test -- --run maintenance-writefile-sync-imports.test.ts audit-health-failed-artifact.test.ts dream-cycle-followup-logging.test.ts config.test.ts cron-session-key-normalization.test.ts deprecated-cron-commands.test.ts procedure-feedback-tool.test.ts`
- [ ] After deploy: grep gateway logs for `maintenance tick` success lines after 65+ minutes
- [ ] Verify `openclaw hybrid-mem audit health --strict-errors --json` exits 0 with warnings-only backlog
- [ ] Confirm workshop-approval-reminder cron message contains bash harness and no message-tool instructions
- [ ] Agent smoke: `memory_procedure_feedback` with unknown id → `isError: true`; with `registerIfMissing` + steps → draft created