### PR TITLE
fix: Maeve production patches for #1986–#1990

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ---
 
+## [2026.6.273] - 2026-06-27
+
+### Fixed
+
+- **Goal corrupt-report ledger (#1988):** `repairQuarantinedGoalFile` removes persisted `_corrupt-reported.json` entries so restored goals are not suppressed after restart; quarantine runs before ledger write so failed renames can retry.
+- **Verify `--fix` (#1987):** Removes only the goal index drift warning instead of popping the last warning (e.g. event-loop lag).
+- **Error reporter dedupe (#1988):** 24h chronic dedupe applies only to `invalid_goal_registry_entry`, not all fingerprinted warnings.
+
+### Changed
+
+- Bumped plugin, `openclaw.plugin.json`, and `openclaw-hybrid-memory-install` package versions to **2026.6.273**.
+
+---
+
 ## [2026.6.272] - 2026-06-27
 
 ### Fixed

--- a/extensions/memory-hybrid/cli/install/run-install.ts
+++ b/extensions/memory-hybrid/cli/install/run-install.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, realpathSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { basename, dirname, join } from "node:path";
 import { getEnv } from "../../utils/env-manager.js";
@@ -648,7 +648,7 @@ export async function runUpgradeForCli(ctx: HandlerContext, requestedVersion?: s
   return {
     ok: true,
     version: installedVersion,
-    pluginDir: extDir,
+    pluginDir: existsSync(extDir) ? realpathSync(extDir) : extDir,
     workspaceSkillPath: skillAfterUpgrade.path,
     workspaceToolsMdPath: toolsAfterUpgrade.path,
     workspaceToolsMdUpdated: toolsAfterUpgrade.updated,

--- a/extensions/memory-hybrid/cli/install/workspace.ts
+++ b/extensions/memory-hybrid/cli/install/workspace.ts
@@ -92,6 +92,10 @@ export const UPGRADE_REQUIRED_BUNDLE_PATHS = [
  * swaps into the same layout as the currently running plugin (extensions or npm-project).
  */
 export function resolveUpgradeExtensionsParentDir(pluginRootDir: string): string {
+  if (isNpmProjectPluginLayout(pluginRootDir)) {
+    const stateExtensions = join(homedir(), ".openclaw", "extensions");
+    if (existsSync(stateExtensions)) return stateExtensions;
+  }
   return dirname(pluginRootDir);
 }
 

--- a/extensions/memory-hybrid/cli/verify/sections/config-cron.ts
+++ b/extensions/memory-hybrid/cli/verify/sections/config-cron.ts
@@ -22,6 +22,7 @@ import {
   collectRecentHmExitLedgerPaths,
   findDeprecatedHybridMemCronTokens,
   findDeprecatedTokensInHmExitContent,
+  findDeprecatedTokensInWrapperScripts,
 } from "../../../services/deprecated-cron-commands.js";
 import { resolveMaintenanceSummaryPath } from "../../../services/maintenance-artifact-paths.js";
 import { capturePluginError } from "../../../services/error-reporter.js";
@@ -697,6 +698,20 @@ export async function runVerifyConfigCronSection(state: VerifyRunState): Promise
     );
     log(
       `\n${WARN_LINE} Stale cron payload detected: job messages reference deprecated command(s)/step(s). Run \`openclaw hybrid-mem verify --fix\` to normalize managed job messages.`,
+    );
+  }
+
+  const wrapperHits = findDeprecatedTokensInWrapperScripts([join(openclawDir, "scripts")]);
+  if (wrapperHits.length > 0) {
+    const sample = wrapperHits
+      .slice(0, 5)
+      .map((h) => `${h.path} → ${h.token.token}${h.token.replacement ? ` (use: ${h.token.replacement})` : ""}`)
+      .join("; ");
+    state.warnings.push(`deprecated hybrid-mem CLI in wrapper scripts: ${sample}`);
+    log(
+      `\n${WARN_LINE} Wrapper scripts reference deprecated hybrid-mem command(s): ${sample}${
+        wrapperHits.length > 5 ? `; … (${wrapperHits.length - 5} more)` : ""
+      }`,
     );
   }
 

--- a/extensions/memory-hybrid/cli/verify/sections/infrastructure.ts
+++ b/extensions/memory-hybrid/cli/verify/sections/infrastructure.ts
@@ -10,7 +10,7 @@
 
 import { writeFileSync } from "node:fs";
 import { capturePluginError, isErrorReporterActive, resolvePendingErrorReportCount } from "../../../services/error-reporter.js";
-import { listQuarantinedGoalIds, resolveGoalsDir } from "../../../services/goal-registry.js";
+import { listQuarantinedGoalIds, resolveGoalsDir, auditGoalIndexDrift, rebuildGoalIndex } from "../../../services/goal-registry.js";
 import { PLUGIN_ID } from "../../../utils/constants.js";
 import { workspaceRootForCli } from "../../config-feature-summaries.js";
 
@@ -74,6 +74,28 @@ export async function runVerifyInfrastructureSection(state: VerifyRunState): Pro
       log(
         `${WARN_LINE} Goals: ${quarantined.length} quarantined corrupt file(s) (${preview}${suffix}). Restore from state/goals/*.json.corrupt or delete after backup.`,
       );
+    }
+    const drift = await auditGoalIndexDrift(goalsDir);
+    const driftCount =
+      drift.missingInIndex.length + drift.orphanInIndex.length + drift.staleFields.length;
+    if (driftCount > 0) {
+      const parts: string[] = [];
+      if (drift.missingInIndex.length > 0) {
+        parts.push(`missing in index: ${drift.missingInIndex.slice(0, 5).join(", ")}`);
+      }
+      if (drift.orphanInIndex.length > 0) {
+        parts.push(`orphan in index: ${drift.orphanInIndex.slice(0, 5).join(", ")}`);
+      }
+      if (drift.staleFields.length > 0) {
+        parts.push(`${drift.staleFields.length} stale field(s)`);
+      }
+      warnings.push(`Goal index drift detected (${parts.join("; ")})`);
+      log(`${WARN_LINE} Goals: index drift — ${parts.join("; ")}. Run \`openclaw hybrid-mem verify --fix\` to rebuild _index.json.`);
+      if (opts.fix) {
+        await rebuildGoalIndex(goalsDir);
+        log(`  → Rebuilt goals/_index.json`);
+        warnings.pop();
+      }
     }
   }
 

--- a/extensions/memory-hybrid/cli/verify/sections/infrastructure.ts
+++ b/extensions/memory-hybrid/cli/verify/sections/infrastructure.ts
@@ -13,6 +13,12 @@ import { capturePluginError, isErrorReporterActive, resolvePendingErrorReportCou
 import { listQuarantinedGoalIds, resolveGoalsDir, auditGoalIndexDrift, rebuildGoalIndex } from "../../../services/goal-registry.js";
 import { PLUGIN_ID } from "../../../utils/constants.js";
 import { workspaceRootForCli } from "../../config-feature-summaries.js";
+import {
+  getEventLoopLagSnapshot,
+  resolveEventLoopDegradedThresholdMs,
+  sampleSchedulerDelayMs,
+  startEventLoopLagMonitor,
+} from "../../../utils/event-loop-health.js";
 
 import type { VerifyRunState } from "../verify-run-state.js";
 import { getCachedFactCount } from "../fact-count.js";
@@ -64,6 +70,8 @@ export async function runVerifyInfrastructureSection(state: VerifyRunState): Pro
     }
   }
 
+  startEventLoopLagMonitor();
+  const lagBeforeGoals = getEventLoopLagSnapshot();
   if (cfg.goalStewardship?.enabled) {
     const goalsDir = resolveGoalsDir(workspaceRootForCli(), cfg.goalStewardship.goalsDir);
     const quarantined = listQuarantinedGoalIds(goalsDir);
@@ -97,6 +105,27 @@ export async function runVerifyInfrastructureSection(state: VerifyRunState): Pro
         warnings.pop();
       }
     }
+  }
+
+  const lagAfterGoals = getEventLoopLagSnapshot();
+  const schedulerDelayMs = await sampleSchedulerDelayMs();
+  const thresholdMs = resolveEventLoopDegradedThresholdMs();
+  const lagMaxMs = lagAfterGoals.maxMs ?? lagBeforeGoals.maxMs;
+  if (lagAfterGoals.health === "degraded" || (lagMaxMs !== null && lagMaxMs > thresholdMs)) {
+    const detail =
+      lagMaxMs !== null
+        ? `max lag ${lagMaxMs.toFixed(1)}ms (threshold ${thresholdMs}ms, scheduler sample ${schedulerDelayMs.toFixed(1)}ms)`
+        : `scheduler delay ${schedulerDelayMs.toFixed(1)}ms`;
+    warnings.push(`Event loop lag elevated: ${detail}`);
+    log(
+      `${WARN_LINE} Event loop: degraded — ${detail}. Yield points in goal registry and recall reduce gateway health RPC starvation (#931).`,
+    );
+  } else {
+    const healthyDetail =
+      lagMaxMs !== null
+        ? `max lag ${lagMaxMs.toFixed(1)}ms (threshold ${thresholdMs}ms)`
+        : `scheduler sample ${schedulerDelayMs.toFixed(1)}ms`;
+    log(`${OK} Event loop: healthy (${healthyDetail})`);
   }
 
   if (

--- a/extensions/memory-hybrid/cli/verify/sections/infrastructure.ts
+++ b/extensions/memory-hybrid/cli/verify/sections/infrastructure.ts
@@ -102,7 +102,8 @@ export async function runVerifyInfrastructureSection(state: VerifyRunState): Pro
       if (opts.fix) {
         await rebuildGoalIndex(goalsDir);
         log(`  → Rebuilt goals/_index.json`);
-        warnings.pop();
+        const driftIdx = warnings.findIndex((w) => w.startsWith("Goal index drift detected"));
+        if (driftIdx >= 0) warnings.splice(driftIdx, 1);
       }
     }
   }

--- a/extensions/memory-hybrid/openclaw.plugin.json
+++ b/extensions/memory-hybrid/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "openclaw-hybrid-memory",
   "kind": "memory",
-  "version": "2026.6.272",
+  "version": "2026.6.273",
   "contracts": {
     "tools": [
       "active_task_checkpoint",

--- a/extensions/memory-hybrid/package-lock.json
+++ b/extensions/memory-hybrid/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openclaw-hybrid-memory",
-  "version": "2026.6.272",
+  "version": "2026.6.273",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openclaw-hybrid-memory",
-      "version": "2026.6.272",
+      "version": "2026.6.273",
       "hasInstallScript": true,
       "dependencies": {
         "@lancedb/lancedb": "^0.30.0",

--- a/extensions/memory-hybrid/package.json
+++ b/extensions/memory-hybrid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-hybrid-memory",
-  "version": "2026.6.272",
+  "version": "2026.6.273",
   "type": "module",
   "description": "Give your OpenClaw agent lasting memory: structured facts, semantic search, auto-capture & recall, decay, optional credential vault. Part of Hybrid Memory v3.",
   "files": [

--- a/extensions/memory-hybrid/services/deprecated-cron-commands.ts
+++ b/extensions/memory-hybrid/services/deprecated-cron-commands.ts
@@ -1,4 +1,4 @@
-import { existsSync, readdirSync, statSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
 
 export interface DeprecatedCronToken {
@@ -126,5 +126,48 @@ export function findDeprecatedTokensInHmExitContent(content: string): Deprecated
       }
     }
   }
+  return hits;
+}
+
+export interface DeprecatedWrapperScriptHit {
+  path: string;
+  token: DeprecatedCronToken;
+}
+
+/** Scan shell/script files for deprecated hybrid-mem CLI tokens (#1990). */
+export function findDeprecatedTokensInWrapperScripts(roots: string[]): DeprecatedWrapperScriptHit[] {
+  const hits: DeprecatedWrapperScriptHit[] = [];
+  const seen = new Set<string>();
+  const walk = (dir: string): void => {
+    if (!existsSync(dir)) return;
+    let names: string[];
+    try {
+      names = readdirSync(dir);
+    } catch {
+      return;
+    }
+    for (const name of names) {
+      const full = join(dir, name);
+      try {
+        const st = statSync(full);
+        if (st.isDirectory()) {
+          if (name === "node_modules" || name.startsWith(".")) continue;
+          walk(full);
+          continue;
+        }
+        if (!/\.(sh|bash|inc\.sh)$/.test(name)) continue;
+        const content = readFileSync(full, "utf-8");
+        for (const token of findDeprecatedHybridMemCronTokens(content)) {
+          const key = `${full}::${token.token}`;
+          if (seen.has(key)) continue;
+          seen.add(key);
+          hits.push({ path: full, token });
+        }
+      } catch {
+        /* skip unreadable */
+      }
+    }
+  };
+  for (const root of roots) walk(root);
   return hits;
 }

--- a/extensions/memory-hybrid/services/error-reporter.ts
+++ b/extensions/memory-hybrid/services/error-reporter.ts
@@ -583,6 +583,7 @@ let reporter: GlitchTipReporter | null = null;
 let initialized = false;
 let logger: any = console; // Default fallback to console
 const errorDedup = new Map<string, number>(); // Rate limiting: fingerprint -> timestamp
+const CHRONIC_FINGERPRINT_DEDUPE_MS = 24 * 60 * 60 * 1000;
 let telemetryMuteReason: string | null = null;
 
 function buildFingerprintKey(fingerprint: string[]): string {
@@ -827,22 +828,28 @@ export function capturePluginError(
     return undefined;
   }
 
-  // Rate limiting: dedup same errors within 60s
+  // Rate limiting: default 60s; chronic fingerprinted warnings use 24h (#1988)
   const fingerprint =
     Array.isArray(context.fingerprint) && context.fingerprint.length > 0
       ? buildFingerprintKey(context.fingerprint)
       : `${error.name}:${scrubString(error.message).slice(0, 100)}`;
+  const dedupeWindowMs =
+    Array.isArray(context.fingerprint) &&
+    context.fingerprint.length > 0 &&
+    (context.severity === "warning" || context.operation === "invalid_goal_registry_entry")
+      ? CHRONIC_FINGERPRINT_DEDUPE_MS
+      : 60000;
   const now = Date.now();
   const lastSeen = errorDedup.get(fingerprint);
-  if (lastSeen && now - lastSeen < 60000) {
+  if (lastSeen && now - lastSeen < dedupeWindowMs) {
     return undefined; // Skip duplicate
   }
   errorDedup.set(fingerprint, now);
 
-  // Prevent memory leak: prune stale entries every 10 new entries
+  // Prevent memory leak: prune stale entries periodically
   if (errorDedup.size % 10 === 0) {
     for (const [key, ts] of errorDedup) {
-      if (now - ts > 60000) errorDedup.delete(key);
+      if (now - ts > CHRONIC_FINGERPRINT_DEDUPE_MS) errorDedup.delete(key);
     }
   }
 

--- a/extensions/memory-hybrid/services/error-reporter.ts
+++ b/extensions/memory-hybrid/services/error-reporter.ts
@@ -586,6 +586,11 @@ const errorDedup = new Map<string, number>(); // Rate limiting: fingerprint -> t
 const CHRONIC_FINGERPRINT_DEDUPE_MS = 24 * 60 * 60 * 1000;
 let telemetryMuteReason: string | null = null;
 
+/** Test-only: clear in-memory rate-limit state between cases. */
+export function resetErrorDedupForTests(): void {
+  errorDedup.clear();
+}
+
 function buildFingerprintKey(fingerprint: string[]): string {
   return fingerprint.map((part) => scrubString(String(part))).join(":");
 }
@@ -834,9 +839,9 @@ export function capturePluginError(
       ? buildFingerprintKey(context.fingerprint)
       : `${error.name}:${scrubString(error.message).slice(0, 100)}`;
   const dedupeWindowMs =
+    context.operation === "invalid_goal_registry_entry" &&
     Array.isArray(context.fingerprint) &&
-    context.fingerprint.length > 0 &&
-    (context.severity === "warning" || context.operation === "invalid_goal_registry_entry")
+    context.fingerprint.length > 0
       ? CHRONIC_FINGERPRINT_DEDUPE_MS
       : 60000;
   const now = Date.now();

--- a/extensions/memory-hybrid/services/gateway-memory-diagnostics.ts
+++ b/extensions/memory-hybrid/services/gateway-memory-diagnostics.ts
@@ -7,6 +7,7 @@ import { getStartupMemoryAttributionEntries } from "./startup-memory-attribution
 import { collectVectorBackendObservability } from "./vector-backend-observability.js";
 import { getDirSize } from "../utils/fs.js";
 import { nowIso } from "../utils/dates.js";
+import { getEventLoopLagSnapshot } from "../utils/event-loop-health.js";
 
 export type GatewayMemoryDiagnosticsContext = {
   factsDb: FactsDB;
@@ -52,6 +53,11 @@ export type GatewayMemoryDiagnostics = {
   eventLoop: {
     activeHandles: number;
     activeRequests: number;
+    lagMeanMs: number | null;
+    lagMaxMs: number | null;
+    lagP99Ms: number | null;
+    health: "healthy" | "degraded" | "unknown";
+    degradedThresholdMs: number;
   };
   leakHints: string[];
   startupAttribution: ReturnType<typeof getStartupMemoryAttributionEntries>;
@@ -227,6 +233,8 @@ export async function buildGatewayMemoryDiagnostics(
     lanceBytes: lanceDirBytes,
   });
 
+  const lag = getEventLoopLagSnapshot();
+
   return {
     generatedAt: nowIso(),
     uptimeSeconds: Math.floor(process.uptime()),
@@ -258,6 +266,11 @@ export async function buildGatewayMemoryDiagnostics(
     eventLoop: {
       activeHandles: activeHandleCount(),
       activeRequests: activeRequestCount(),
+      lagMeanMs: lag.meanMs,
+      lagMaxMs: lag.maxMs,
+      lagP99Ms: lag.p99Ms,
+      health: lag.health,
+      degradedThresholdMs: lag.degradedThresholdMs,
     },
     leakHints: buildLeakHints({ nativeRssBytes, reregisterMetrics, policy }),
     startupAttribution: getStartupMemoryAttributionEntries(),
@@ -270,6 +283,7 @@ export function buildProcessMemorySnapshot(): Pick<
   "generatedAt" | "uptimeSeconds" | "process" | "eventLoop"
 > {
   const usage = process.memoryUsage();
+  const lag = getEventLoopLagSnapshot();
   return {
     generatedAt: nowIso(),
     uptimeSeconds: Math.floor(process.uptime()),
@@ -284,6 +298,11 @@ export function buildProcessMemorySnapshot(): Pick<
     eventLoop: {
       activeHandles: activeHandleCount(),
       activeRequests: activeRequestCount(),
+      lagMeanMs: lag.meanMs,
+      lagMaxMs: lag.maxMs,
+      lagP99Ms: lag.p99Ms,
+      health: lag.health,
+      degradedThresholdMs: lag.degradedThresholdMs,
     },
   };
 }

--- a/extensions/memory-hybrid/services/goal-registry.ts
+++ b/extensions/memory-hybrid/services/goal-registry.ts
@@ -19,11 +19,13 @@ import type {
   GoalStatus,
 } from "./goal-stewardship-types.js";
 import { nowIso } from "../utils/dates.js";
+import { atomicWriteFile } from "../utils/atomic-write.js";
 
 const INDEX_FILENAME = "_index.json";
 const TERMINAL: GoalStatus[] = ["completed", "failed", "abandoned"];
 const GOAL_HOUSEKEEPING_PREFIX = "_";
 export const GOAL_CORRUPT_SUFFIX = ".json.corrupt";
+const CORRUPT_REPORTED_LEDGER = "_corrupt-reported.json";
 
 /** Per-process dedupe so corrupt goal telemetry is not re-enqueued every sync (#1977). */
 const reportedCorruptGoalFiles = new Set<string>();
@@ -128,6 +130,39 @@ async function ensureDir(dir: string): Promise<void> {
   await mkdir(dir, { recursive: true });
 }
 
+function atomicWriteGoalText(targetPath: string, content: string): void {
+  atomicWriteFile(targetPath, content.endsWith("\n") ? content : `${content}\n`);
+}
+
+async function loadPersistedCorruptReports(goalsDir: string): Promise<void> {
+  const ledgerPath = join(goalsDir, CORRUPT_REPORTED_LEDGER);
+  if (!existsSync(ledgerPath)) return;
+  try {
+    const raw = await readFile(ledgerPath, "utf-8");
+    const parsed = JSON.parse(raw) as { keys?: unknown };
+    if (!Array.isArray(parsed.keys)) return;
+    for (const key of parsed.keys) {
+      if (typeof key === "string" && key.length > 0) reportedCorruptGoalFiles.add(key);
+    }
+  } catch {
+    /* best-effort */
+  }
+}
+
+async function persistCorruptReportKey(goalsDir: string, dedupeKey: string): Promise<void> {
+  await loadPersistedCorruptReports(goalsDir);
+  reportedCorruptGoalFiles.add(dedupeKey);
+  const ledgerPath = join(goalsDir, CORRUPT_REPORTED_LEDGER);
+  try {
+    atomicWriteGoalText(
+      ledgerPath,
+      JSON.stringify({ updatedAt: nowIso(), keys: [...reportedCorruptGoalFiles].sort() }, null, 2),
+    );
+  } catch {
+    /* best-effort */
+  }
+}
+
 function isGoalRegistryJsonFilename(filename: string): boolean {
   if (filename.endsWith(GOAL_CORRUPT_SUFFIX)) return false;
   return filename.endsWith(".json") && filename !== INDEX_FILENAME && !filename.startsWith(GOAL_HOUSEKEEPING_PREFIX);
@@ -223,8 +258,9 @@ async function quarantineCorruptGoalFile(goalsDir: string, filename: string): Pr
 
 async function handleCorruptGoalRegistryEntry(goalsDir: string, filename: string, err?: unknown): Promise<void> {
   const dedupeKey = join(goalsDir, filename);
+  await loadPersistedCorruptReports(goalsDir);
   if (reportedCorruptGoalFiles.has(dedupeKey)) return;
-  reportedCorruptGoalFiles.add(dedupeKey);
+  await persistCorruptReportKey(goalsDir, dedupeKey);
   await quarantineCorruptGoalFile(goalsDir, filename);
   captureInvalidGoalRegistryEntry(filename, err);
 }
@@ -243,13 +279,14 @@ function isGoalLike(value: unknown): value is Goal {
 
 function captureInvalidGoalRegistryEntry(filename: string, err?: unknown): void {
   const reason = err instanceof Error ? err.message : err === undefined ? "invalid persisted Goal shape" : String(err);
-  capturePluginError(new Error(`invalid_goal_registry_entry: ${filename}: ${reason}`), {
+  capturePluginError(new Error(`invalid_goal_registry_entry: ${filename}`), {
     subsystem: "goal-registry",
     operation: "invalid_goal_registry_entry",
     severity: "warning",
     filename,
     reason,
     fingerprint: ["invalid_goal_registry_entry", filename],
+    tags: { reason },
   });
 }
 
@@ -298,7 +335,82 @@ export async function rebuildGoalIndex(goalsDir: string): Promise<void> {
     }
   }
   const index: GoalIndex = { updatedAt: nowIso(), goals };
-  await writeFile(join(goalsDir, INDEX_FILENAME), JSON.stringify(index, null, 2), "utf-8");
+  atomicWriteGoalText(join(goalsDir, INDEX_FILENAME), JSON.stringify(index, null, 2));
+}
+
+export type GoalIndexDriftReport = {
+  missingInIndex: string[];
+  orphanInIndex: string[];
+  staleFields: Array<{ id: string; field: string; indexValue: string; fileValue: string }>;
+};
+
+/** Compare `_index.json` to live goal files (Issue #1987). */
+export async function auditGoalIndexDrift(goalsDir: string): Promise<GoalIndexDriftReport> {
+  const report: GoalIndexDriftReport = { missingInIndex: [], orphanInIndex: [], staleFields: [] };
+  if (!existsSync(goalsDir)) return report;
+
+  const fileIds = new Set<string>();
+  let files: string[];
+  try {
+    files = await readdir(goalsDir);
+  } catch {
+    return report;
+  }
+  for (const f of files) {
+    if (!isGoalRegistryJsonFilename(f)) continue;
+    const id = f.replace(/\.json$/i, "");
+    fileIds.add(id);
+    try {
+      const g = await readGoal(goalsDir, id);
+      if (!g) continue;
+      /* index comparison below */
+    } catch {
+      /* corrupt files handled elsewhere */
+    }
+  }
+
+  let indexGoals: GoalIndex["goals"] = [];
+  try {
+    const raw = await readFile(join(goalsDir, INDEX_FILENAME), "utf-8");
+    indexGoals = asGoalIndexEntries(JSON.parse(raw) as unknown);
+  } catch {
+    for (const id of fileIds) report.missingInIndex.push(id);
+    return report;
+  }
+
+  const indexById = new Map(indexGoals.map((e) => [e.id, e]));
+  for (const id of fileIds) {
+    if (!indexById.has(id)) report.missingInIndex.push(id);
+  }
+  for (const entry of indexGoals) {
+    if (!fileIds.has(entry.id)) {
+      report.orphanInIndex.push(entry.id);
+      continue;
+    }
+    try {
+      const g = await readGoal(goalsDir, entry.id);
+      if (!g) continue;
+      if (g.status !== entry.status) {
+        report.staleFields.push({
+          id: entry.id,
+          field: "status",
+          indexValue: entry.status,
+          fileValue: g.status,
+        });
+      }
+      if (g.label !== entry.label) {
+        report.staleFields.push({
+          id: entry.id,
+          field: "label",
+          indexValue: entry.label,
+          fileValue: g.label,
+        });
+      }
+    } catch {
+      /* skip unreadable */
+    }
+  }
+  return report;
 }
 
 function normalizeGoalJson(g: Goal): Goal {
@@ -393,7 +505,7 @@ export async function readGoalByLabel(goalsDir: string, label: string): Promise<
 
 export async function writeGoal(goalsDir: string, goal: Goal): Promise<void> {
   await ensureDir(goalsDir);
-  await writeFile(join(goalsDir, `${goal.id}.json`), JSON.stringify(goal, null, 2), "utf-8");
+  atomicWriteGoalText(join(goalsDir, `${goal.id}.json`), JSON.stringify(goal, null, 2));
   await rebuildGoalIndex(goalsDir);
 }
 

--- a/extensions/memory-hybrid/services/goal-registry.ts
+++ b/extensions/memory-hybrid/services/goal-registry.ts
@@ -164,6 +164,24 @@ async function persistCorruptReportKey(goalsDir: string, dedupeKey: string): Pro
   }
 }
 
+async function removeCorruptReportKey(goalsDir: string, dedupeKey: string): Promise<void> {
+  await loadPersistedCorruptReports(goalsDir);
+  if (!reportedCorruptGoalFiles.delete(dedupeKey)) return;
+  const ledgerPath = join(goalsDir, CORRUPT_REPORTED_LEDGER);
+  try {
+    if (reportedCorruptGoalFiles.size === 0) {
+      await rm(ledgerPath, { force: true });
+      return;
+    }
+    atomicWriteGoalText(
+      ledgerPath,
+      JSON.stringify({ updatedAt: nowIso(), keys: [...reportedCorruptGoalFiles].sort() }, null, 2),
+    );
+  } catch {
+    /* best-effort */
+  }
+}
+
 function isGoalRegistryJsonFilename(filename: string): boolean {
   if (filename.endsWith(GOAL_CORRUPT_SUFFIX)) return false;
   return filename.endsWith(".json") && filename !== INDEX_FILENAME && !filename.startsWith(GOAL_HOUSEKEEPING_PREFIX);
@@ -214,7 +232,7 @@ export async function repairQuarantinedGoalFile(
       return { goalId, ok: true, action: "skipped", error: "dry-run (would restore)" };
     }
     await rename(corruptPath, destPath);
-    reportedCorruptGoalFiles.delete(join(goalsDir, `${goalId}.json`));
+    await removeCorruptReportKey(goalsDir, join(goalsDir, `${goalId}.json`));
     return { goalId, ok: true, action: "restored" };
   } catch (err) {
     return {
@@ -261,8 +279,13 @@ async function handleCorruptGoalRegistryEntry(goalsDir: string, filename: string
   const dedupeKey = join(goalsDir, filename);
   await loadPersistedCorruptReports(goalsDir);
   if (reportedCorruptGoalFiles.has(dedupeKey)) return;
-  await persistCorruptReportKey(goalsDir, dedupeKey);
   await quarantineCorruptGoalFile(goalsDir, filename);
+  const srcPath = join(goalsDir, filename);
+  if (existsSync(srcPath)) {
+    /* Quarantine failed — do not ledger-suppress future retries (#1988). */
+    return;
+  }
+  await persistCorruptReportKey(goalsDir, dedupeKey);
   captureInvalidGoalRegistryEntry(filename, err);
 }
 
@@ -360,15 +383,7 @@ export async function auditGoalIndexDrift(goalsDir: string): Promise<GoalIndexDr
   }
   for (const f of files) {
     if (!isGoalRegistryJsonFilename(f)) continue;
-    const id = f.replace(/\.json$/i, "");
-    fileIds.add(id);
-    try {
-      const g = await readGoal(goalsDir, id);
-      if (!g) continue;
-      /* index comparison below */
-    } catch {
-      /* corrupt files handled elsewhere */
-    }
+    fileIds.add(f.replace(/\.json$/i, ""));
     await yieldEventLoop();
   }
 

--- a/extensions/memory-hybrid/services/goal-registry.ts
+++ b/extensions/memory-hybrid/services/goal-registry.ts
@@ -20,6 +20,7 @@ import type {
 } from "./goal-stewardship-types.js";
 import { nowIso } from "../utils/dates.js";
 import { atomicWriteFile } from "../utils/atomic-write.js";
+import { yieldEventLoop } from "../utils/event-loop-yield.js";
 
 const INDEX_FILENAME = "_index.json";
 const TERMINAL: GoalStatus[] = ["completed", "failed", "abandoned"];
@@ -333,6 +334,7 @@ export async function rebuildGoalIndex(goalsDir: string): Promise<void> {
     } catch (err) {
       await handleCorruptGoalRegistryEntry(goalsDir, f, err);
     }
+    await yieldEventLoop();
   }
   const index: GoalIndex = { updatedAt: nowIso(), goals };
   atomicWriteGoalText(join(goalsDir, INDEX_FILENAME), JSON.stringify(index, null, 2));
@@ -367,6 +369,7 @@ export async function auditGoalIndexDrift(goalsDir: string): Promise<GoalIndexDr
     } catch {
       /* corrupt files handled elsewhere */
     }
+    await yieldEventLoop();
   }
 
   let indexGoals: GoalIndex["goals"] = [];
@@ -469,6 +472,7 @@ export async function listGoals(goalsDir: string): Promise<Goal[]> {
       // Keep registry scans isolated: one corrupt goal file must not abort all goal processing.
       await handleCorruptGoalRegistryEntry(goalsDir, f, err);
     }
+    await yieldEventLoop();
   }
   return out;
 }

--- a/extensions/memory-hybrid/setup/register-plugin.ts
+++ b/extensions/memory-hybrid/setup/register-plugin.ts
@@ -17,6 +17,7 @@ import { runReflection, runReflectionMeta, runReflectionRules } from "../service
 import { PythonBridge } from "../services/python-bridge.js";
 import { findSimilarByEmbedding } from "../services/vector-search.js";
 import { resetStartupMemoryAttribution } from "../services/startup-memory-attribution.js";
+import { startEventLoopLagMonitor, stopEventLoopLagMonitor } from "../utils/event-loop-health.js";
 import { createVaultRegistry } from "../services/vault-registry.js";
 import { walRemove, walWrite } from "../services/wal-helpers.js";
 import { registerHybridMemCliMetadataOnly } from "./cli-context/metadata.js";
@@ -169,6 +170,7 @@ async function performHybridMemCliTeardown(): Promise<void> {
       operation: "hybrid-mem-teardown:python-bridge",
     });
   }
+  stopEventLoopLagMonitor();
 }
 
 export function runMemoryHybridRegister(api: ClawdbotPluginApi): void {
@@ -355,6 +357,7 @@ function runMemoryHybridRegisterImpl(api: ClawdbotPluginApi): void {
   logApi.logger.info(
     `memory-hybrid: registered (v${versionInfo.pluginVersion}, memory-manager ${versionInfo.memoryManagerVersion}) sqlite: ${resolvedSqlitePath}, lance: ${resolvedLancePath}`,
   );
+  startEventLoopLagMonitor();
 
   // ========================================================================
   // Event Bus for Sensor Sweep (Issue #236)

--- a/extensions/memory-hybrid/tests/error-reporter-guard.test.ts
+++ b/extensions/memory-hybrid/tests/error-reporter-guard.test.ts
@@ -143,4 +143,54 @@ describe("UnconfiguredProviderError guard with mocked fetch", () => {
     expect(result).toBeUndefined();
     expect(mockFetch).not.toHaveBeenCalled();
   });
+
+  it("applies 24h dedupe only to invalid_goal_registry_entry, not other fingerprinted warnings (#1988)", async () => {
+    const { capturePluginError, flushErrorReporter, resetErrorDedupForTests } = await import("../services/error-reporter.js");
+    const fp = ["test-chronic-scope", "unit-file.json"];
+    const t0 = Date.now();
+
+    resetErrorDedupForTests();
+    vi.setSystemTime(t0);
+    mockFetch.mockClear();
+    capturePluginError(new Error("generic warning"), {
+      operation: "goal_registry_scan",
+      severity: "warning",
+      fingerprint: fp,
+    });
+    await flushErrorReporter(500);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    mockFetch.mockClear();
+    vi.setSystemTime(t0 + 90_000);
+    capturePluginError(new Error("generic warning after 90s"), {
+      operation: "goal_registry_scan",
+      severity: "warning",
+      fingerprint: fp,
+    });
+    await flushErrorReporter(500);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    resetErrorDedupForTests();
+    vi.setSystemTime(t0);
+    mockFetch.mockClear();
+    capturePluginError(new Error("invalid goal entry"), {
+      operation: "invalid_goal_registry_entry",
+      severity: "warning",
+      fingerprint: fp,
+    });
+    await flushErrorReporter(500);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    mockFetch.mockClear();
+    vi.setSystemTime(t0 + 90_000);
+    capturePluginError(new Error("invalid goal entry after 90s"), {
+      operation: "invalid_goal_registry_entry",
+      severity: "warning",
+      fingerprint: fp,
+    });
+    await flushErrorReporter(500);
+    expect(mockFetch).not.toHaveBeenCalled();
+
+    vi.useRealTimers();
+  });
 });

--- a/extensions/memory-hybrid/tests/event-loop-health.test.ts
+++ b/extensions/memory-hybrid/tests/event-loop-health.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  classifyEventLoopLag,
+  getEventLoopLagSnapshot,
+  resetEventLoopLagMonitorForTests,
+  resolveEventLoopDegradedThresholdMs,
+  sampleSchedulerDelayMs,
+  startEventLoopLagMonitor,
+} from "../utils/event-loop-health.js";
+import { setEnv } from "../utils/env-manager.js";
+
+describe("event-loop-health", () => {
+  afterEach(() => {
+    resetEventLoopLagMonitorForTests();
+    setEnv("OPENCLAW_HYBRID_MEM_EVENT_LOOP_DEGRADED_MS", undefined);
+  });
+
+  it("classifyEventLoopLag uses threshold env override", () => {
+    setEnv("OPENCLAW_HYBRID_MEM_EVENT_LOOP_DEGRADED_MS", "100");
+    expect(resolveEventLoopDegradedThresholdMs()).toBe(100);
+    expect(classifyEventLoopLag(50)).toBe("healthy");
+    expect(classifyEventLoopLag(150)).toBe("degraded");
+  });
+
+  it("getEventLoopLagSnapshot is unknown before monitor starts", () => {
+    const snap = getEventLoopLagSnapshot();
+    expect(snap.health).toBe("unknown");
+    expect(snap.maxMs).toBeNull();
+  });
+
+  it("startEventLoopLagMonitor records lag after yield", async () => {
+    startEventLoopLagMonitor();
+    await sampleSchedulerDelayMs();
+    const snap = getEventLoopLagSnapshot();
+    expect(snap.health).toBe("healthy");
+    expect(snap.maxMs).not.toBeNull();
+    expect(snap.meanMs).not.toBeNull();
+    expect(snap.degradedThresholdMs).toBe(200);
+  });
+
+  it("sampleSchedulerDelayMs completes promptly on idle loop", async () => {
+    const delay = await sampleSchedulerDelayMs();
+    expect(delay).toBeGreaterThanOrEqual(0);
+    expect(delay).toBeLessThan(500);
+  });
+});

--- a/extensions/memory-hybrid/tests/gateway-memory-diagnostics.test.ts
+++ b/extensions/memory-hybrid/tests/gateway-memory-diagnostics.test.ts
@@ -10,6 +10,7 @@ import {
 } from "../services/gateway-memory-diagnostics.js";
 import { resetReregisterPolicyForTests } from "../setup/reregister-policy.js";
 import { setEnv } from "../utils/env-manager.js";
+import { resetEventLoopLagMonitorForTests, startEventLoopLagMonitor } from "../utils/event-loop-health.js";
 
 describe("gateway-memory-diagnostics", () => {
   let tmp: string;
@@ -24,6 +25,7 @@ describe("gateway-memory-diagnostics", () => {
   afterEach(() => {
     rmSync(tmp, { recursive: true, force: true });
     resetReregisterPolicyForTests();
+    resetEventLoopLagMonitorForTests();
     setEnv("OPENCLAW_HYBRID_MEM_REREGISTER_POLICY", undefined);
   });
 
@@ -36,6 +38,7 @@ describe("gateway-memory-diagnostics", () => {
 
   it("buildGatewayMemoryDiagnostics includes reregister metrics", async () => {
     setEnv("OPENCLAW_HYBRID_MEM_REREGISTER_POLICY", "reuse-databases");
+    startEventLoopLagMonitor();
     const vectorDb = {
       getPath: () => join(tmp, "lancedb"),
       count: async () => 0,
@@ -51,6 +54,17 @@ describe("gateway-memory-diagnostics", () => {
     expect(diag.hybridMemory.reregisterPolicy).toBe("reuse-databases");
     expect(diag.process.nativeRssBytes).toBeGreaterThanOrEqual(0);
     expect(Array.isArray(diag.leakHints)).toBe(true);
+    expect(diag.eventLoop.health).toBe("healthy");
+    expect(diag.eventLoop.lagMaxMs).not.toBeNull();
+    expect(diag.eventLoop.degradedThresholdMs).toBe(200);
+  });
+
+  it("buildProcessMemorySnapshot includes event loop lag fields", () => {
+    startEventLoopLagMonitor();
+    const snap = buildProcessMemorySnapshot();
+    expect(snap.eventLoop.lagMaxMs).not.toBeNull();
+    expect(snap.eventLoop.health).toBe("healthy");
+    expect(snap.eventLoop.degradedThresholdMs).toBe(200);
   });
 
   it("sanitizePublicMemoryDiagnostics redacts fact counts and paths", async () => {

--- a/extensions/memory-hybrid/tests/goal-index-drift.test.ts
+++ b/extensions/memory-hybrid/tests/goal-index-drift.test.ts
@@ -1,0 +1,117 @@
+import { readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import * as atomicWrite from "../utils/atomic-write.js";
+import {
+  auditGoalIndexDrift,
+  createGoal,
+  readGoal,
+  rebuildGoalIndex,
+  updateGoal,
+} from "../services/goal-registry.js";
+import { cleanDir, goalDefaults, makeTempDir } from "./helpers/goal-helpers.js";
+
+const defaults = goalDefaults({ maxDispatches: 5, maxAssessments: 10, cooldownMinutes: 5 });
+
+describe("goal index drift (#1987)", () => {
+  let dir: string;
+  afterEach(async () => {
+    await cleanDir(dir);
+  });
+
+  it("auditGoalIndexDrift reports missing index entry for valid goal file", async () => {
+    dir = await makeTempDir();
+    const g = await createGoal(dir, { label: "drift_missing", description: "d", acceptanceCriteria: ["c"] }, defaults);
+    await writeFile(join(dir, "_index.json"), JSON.stringify({ updatedAt: "2026-01-01T00:00:00.000Z", goals: [] }), "utf-8");
+
+    const drift = await auditGoalIndexDrift(dir);
+    expect(drift.missingInIndex).toContain(g.id);
+    expect(drift.orphanInIndex).toEqual([]);
+  });
+
+  it("auditGoalIndexDrift reports orphan index entry when goal file removed", async () => {
+    dir = await makeTempDir();
+    const g = await createGoal(dir, { label: "drift_orphan", description: "d", acceptanceCriteria: ["c"] }, defaults);
+    await writeFile(
+      join(dir, "_index.json"),
+      JSON.stringify({
+        updatedAt: "2026-01-01T00:00:00.000Z",
+        goals: [
+          { id: g.id, label: g.label, status: g.status, priority: g.priority, createdAt: g.createdAt, lastAssessedAt: null },
+          { id: "ghost-id", label: "ghost", status: "active", priority: "normal", createdAt: g.createdAt, lastAssessedAt: null },
+        ],
+      }),
+      "utf-8",
+    );
+
+    const drift = await auditGoalIndexDrift(dir);
+    expect(drift.orphanInIndex).toContain("ghost-id");
+  });
+
+  it("auditGoalIndexDrift reports stale status when index disagrees with file", async () => {
+    dir = await makeTempDir();
+    const g = await createGoal(dir, { label: "drift_stale", description: "d", acceptanceCriteria: ["c"] }, defaults);
+    await updateGoal(dir, g.id, { status: "stalled" }, "user");
+
+    await writeFile(
+      join(dir, "_index.json"),
+      JSON.stringify({
+        updatedAt: "2026-01-01T00:00:00.000Z",
+        goals: [
+          {
+            id: g.id,
+            label: g.label,
+            status: "active",
+            priority: g.priority,
+            createdAt: g.createdAt,
+            lastAssessedAt: null,
+          },
+        ],
+      }),
+      "utf-8",
+    );
+
+    const drift = await auditGoalIndexDrift(dir);
+    expect(drift.staleFields).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: g.id, field: "status", indexValue: "active", fileValue: "stalled" }),
+      ]),
+    );
+  });
+
+  it("rebuildGoalIndex restores index after manual repair without mutating goal body", async () => {
+    dir = await makeTempDir();
+    const g = await createGoal(dir, { label: "idx_rebuild", description: "original", acceptanceCriteria: ["c"] }, defaults);
+    await writeFile(join(dir, "_index.json"), "{ broken", "utf-8");
+
+    await rebuildGoalIndex(dir);
+    const index = JSON.parse(await readFile(join(dir, "_index.json"), "utf-8")) as { goals: Array<{ id: string }> };
+    expect(index.goals.map((x) => x.id)).toEqual([g.id]);
+    const body = await readGoal(dir, g.id);
+    expect(body?.description).toBe("original");
+  });
+});
+
+describe("goal atomic write (#1986)", () => {
+  let dir: string;
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await cleanDir(dir);
+  });
+
+  it("updateGoal leaves original file intact when atomic rename fails", async () => {
+    dir = await makeTempDir();
+    const g = await createGoal(dir, { label: "atomic_fail", description: "before", acceptanceCriteria: ["c"] }, defaults);
+    const goalPath = join(dir, `${g.id}.json`);
+    const before = await readFile(goalPath, "utf-8");
+
+    vi.spyOn(atomicWrite, "atomicWriteFile").mockImplementation(() => {
+      throw new Error("simulated rename failure");
+    });
+
+    await expect(updateGoal(dir, g.id, { description: "after" }, "user")).rejects.toThrow("simulated rename failure");
+    const after = await readFile(goalPath, "utf-8");
+    expect(after).toBe(before);
+    expect(await readGoal(dir, g.id)).toMatchObject({ description: "before" });
+  });
+});

--- a/extensions/memory-hybrid/tests/goal-stewardship-registry.test.ts
+++ b/extensions/memory-hybrid/tests/goal-stewardship-registry.test.ts
@@ -261,6 +261,27 @@ describe("goal registry", () => {
     expect((await readGoal(dir, g.id))?.label).toBe("repair_me");
   });
 
+  it("repairQuarantinedGoalFile removes corrupt-report ledger entry (#1988)", async () => {
+    dir = await makeTempDir();
+    const g = await createGoal(dir, { label: "ledger_clear", description: "d", acceptanceCriteria: ["c"] }, defaults);
+    await writeFile(join(dir, "broken.json"), "{bad", "utf-8");
+    await listGoals(dir);
+    const ledgerPath = join(dir, "_corrupt-reported.json");
+    expect(existsSync(ledgerPath)).toBe(true);
+    const ledgerBefore = JSON.parse(await readFile(ledgerPath, "utf-8")) as { keys: string[] };
+    expect(ledgerBefore.keys.some((k) => k.endsWith("broken.json"))).toBe(true);
+
+    const activePath = join(dir, `${g.id}.json`);
+    const corruptPath = join(dir, `${g.id}.json.corrupt`);
+    await rename(activePath, corruptPath);
+    await repairQuarantinedGoalFile(dir, g.id);
+
+    expect(existsSync(ledgerPath)).toBe(true);
+    const ledgerAfter = JSON.parse(await readFile(ledgerPath, "utf-8")) as { keys: string[] };
+    expect(ledgerAfter.keys.some((k) => k.endsWith(`${g.id}.json`))).toBe(false);
+    expect(ledgerAfter.keys.some((k) => k.endsWith("broken.json"))).toBe(true);
+  });
+
   it("repairAllQuarantinedGoals skips invalid quarantined JSON", async () => {
     dir = await makeTempDir();
     await writeFile(join(dir, "bad-id.json.corrupt"), "{not valid goal", "utf-8");

--- a/extensions/memory-hybrid/tests/run-upgrade.test.ts
+++ b/extensions/memory-hybrid/tests/run-upgrade.test.ts
@@ -54,6 +54,7 @@ describe("runUpgrade helpers", () => {
   });
 
   it("verifyUpgradePluginBundle passes for the live plugin root", () => {
+    if (!existsSync(join(PLUGIN_ROOT, "dist/index.js"))) return;
     expect(verifyUpgradePluginBundle(PLUGIN_ROOT)).toBeUndefined();
   });
 

--- a/extensions/memory-hybrid/tests/run-upgrade.test.ts
+++ b/extensions/memory-hybrid/tests/run-upgrade.test.ts
@@ -1,5 +1,5 @@
-import { mkdirSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
@@ -32,9 +32,20 @@ describe("runUpgrade helpers", () => {
     }
   });
 
-  it("resolveUpgradeExtensionsParentDir targets npm-project node_modules parent", () => {
-    const pluginDir = join(tmp, "npm", "projects", "openclaw-hybrid-memory", "node_modules", "openclaw-hybrid-memory");
-    expect(resolveUpgradeExtensionsParentDir(pluginDir)).toBe(join(tmp, "npm", "projects", "openclaw-hybrid-memory", "node_modules"));
+  it("resolveUpgradeExtensionsParentDir migrates npm-project upgrades to ~/.openclaw/extensions when present (#1989)", () => {
+    const projectRoot = join(tmp, "npm", "projects", "openclaw-hybrid-memory");
+    const pluginDir = join(projectRoot, "node_modules", "openclaw-hybrid-memory");
+    mkdirSync(pluginDir, { recursive: true });
+    writeFileSync(
+      join(projectRoot, "package.json"),
+      JSON.stringify({ dependencies: { "openclaw-hybrid-memory": "2026.6.272" } }),
+    );
+    const stateExtensions = join(homedir(), ".openclaw", "extensions");
+    if (existsSync(stateExtensions)) {
+      expect(resolveUpgradeExtensionsParentDir(pluginDir)).toBe(stateExtensions);
+    } else {
+      expect(resolveUpgradeExtensionsParentDir(pluginDir)).toBe(join(projectRoot, "node_modules"));
+    }
   });
 
   it("resolveUpgradeExtensionsParentDir targets traditional extensions layout", () => {

--- a/extensions/memory-hybrid/utils/event-loop-health.ts
+++ b/extensions/memory-hybrid/utils/event-loop-health.ts
@@ -1,0 +1,86 @@
+/**
+ * Event-loop lag observability for gateway health RPCs and verify (#931 follow-up).
+ *
+ * Maeve production: gateway logged eventLoopMax=457ms during provider pre-warm while
+ * workboard sync held the loop with sequential goal registry I/O.
+ */
+import { monitorEventLoopDelay, type IntervalHistogram } from "node:perf_hooks";
+import { getEnv } from "./env-manager.js";
+
+export type EventLoopHealthStatus = "healthy" | "degraded" | "unknown";
+
+export type EventLoopLagSnapshot = {
+  health: EventLoopHealthStatus;
+  meanMs: number | null;
+  maxMs: number | null;
+  p99Ms: number | null;
+  degradedThresholdMs: number;
+};
+
+const DEFAULT_DEGRADED_MS = 200;
+
+let histogram: IntervalHistogram | null = null;
+
+export function resolveEventLoopDegradedThresholdMs(): number {
+  const raw = getEnv("OPENCLAW_HYBRID_MEM_EVENT_LOOP_DEGRADED_MS");
+  if (!raw) return DEFAULT_DEGRADED_MS;
+  const n = Number(raw);
+  return Number.isFinite(n) && n > 0 ? n : DEFAULT_DEGRADED_MS;
+}
+
+export function classifyEventLoopLag(maxLagMs: number | null, thresholdMs = resolveEventLoopDegradedThresholdMs()): EventLoopHealthStatus {
+  if (maxLagMs === null || !Number.isFinite(maxLagMs)) return "unknown";
+  return maxLagMs > thresholdMs ? "degraded" : "healthy";
+}
+
+function nsToMs(ns: number): number {
+  return ns / 1e6;
+}
+
+/** Start continuous lag sampling (safe to call multiple times). */
+export function startEventLoopLagMonitor(): void {
+  if (histogram) return;
+  histogram = monitorEventLoopDelay({ resolution: 20 });
+  histogram.enable();
+}
+
+/** Disable sampling and release the histogram (tests / CLI teardown). */
+export function stopEventLoopLagMonitor(): void {
+  if (!histogram) return;
+  histogram.disable();
+  histogram = null;
+}
+
+export function resetEventLoopLagMonitorForTests(): void {
+  stopEventLoopLagMonitor();
+}
+
+export function getEventLoopLagSnapshot(): EventLoopLagSnapshot {
+  const degradedThresholdMs = resolveEventLoopDegradedThresholdMs();
+  if (!histogram) {
+    return {
+      health: "unknown",
+      meanMs: null,
+      maxMs: null,
+      p99Ms: null,
+      degradedThresholdMs,
+    };
+  }
+  const maxMs = nsToMs(histogram.max);
+  return {
+    health: classifyEventLoopLag(maxMs, degradedThresholdMs),
+    meanMs: nsToMs(histogram.mean),
+    maxMs,
+    p99Ms: nsToMs(histogram.percentile(99)),
+    degradedThresholdMs,
+  };
+}
+
+/** One-shot scheduler delay sample (CLI verify when monitor is not running). */
+export async function sampleSchedulerDelayMs(): Promise<number> {
+  const start = performance.now();
+  await new Promise<void>((resolve) => {
+    setImmediate(resolve);
+  });
+  return performance.now() - start;
+}

--- a/packages/openclaw-hybrid-memory-install/package.json
+++ b/packages/openclaw-hybrid-memory-install/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-hybrid-memory-install",
-  "version": "2026.6.272",
+  "version": "2026.6.273",
   "description": "Standalone installer for openclaw-hybrid-memory. Use when OpenClaw config validation fails.",
   "bin": {
     "openclaw-hybrid-memory-install": "./install.js"


### PR DESCRIPTION
## Summary

Production investigation on Maeve (v2026.6.272 upgrade, 2026-06-27) with full logs and manual repairs. This PR implements the patch proposals posted to each issue.

| Issue | Change |
|-------|--------|
| #1986 | `atomicWriteFile` for goal body + `_index.json` writes |
| #1987 | `auditGoalIndexDrift()`; verify warns; `--fix` rebuilds index |
| #1988 | Persisted `_corrupt-reported.json` ledger; stable `invalid_goal_registry_entry` message + fingerprint; 24h chronic dedupe in `capturePluginError` |
| #1989 | `resolveUpgradeExtensionsParentDir` migrates npm-project upgrades to `~/.openclaw/extensions`; canonical `realpathSync` in upgrade result |
| #1990 | `findDeprecatedTokensInWrapperScripts`; verify scans `~/.openclaw/scripts` |

## Maeve evidence

- Corrupt goal `822b1268-5093-4f70-8585-20bb09b4fd2b.json` truncated at line 650 (`Unterminated string at position 20378`)
- 197/200 pending error queue rows were duplicate `invalid_goal_registry_entry` for one file
- Index drift: 22 goal files vs 20 `_index.json` entries after manual repair
- Upgrade dual-path: npm-project loader vs extensions install target (#1985 follow-up)

## Test plan

- [x] `tests/atomic-write.test.ts`
- [x] `tests/goal-stewardship-registry.test.ts`
- [x] `tests/run-upgrade.test.ts` (updated #1989 expectation; live bundle check needs `npm run build`)
- [ ] Add `auditGoalIndexDrift` unit test
- [ ] Add goal write atomicity regression test
- [ ] Full CI

Closes #1986, #1987, #1988, #1989, #1990