### PR TITLE
fix: graph config schema drift (#1997) — 2026.6.276

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ---
 
+## [2026.6.276] - 2026-06-27
+
+### Fixed
+
+- **Graph config schema (#1997):** Add missing `coOccurrenceWeight`, `autoSupersede`, and `hubScorePenalty` to `openclaw.plugin.json` graph schema so Maeve-style configs pass gateway validation (`additionalProperties: false`).
+
+### Added
+
+- **Schema parity gate:** `plugin-graph-schema-parity.test.ts` + `GRAPH_CONFIG_INPUT_KEYS` assert parser-accepted graph keys exist in the plugin manifest; wired into `verify:gate` so schema drift is caught before release.
+
+---
+
 ## [2026.6.275] - 2026-06-27
 
 ### Fixed

--- a/extensions/memory-hybrid/config/graph-config-schema-keys.ts
+++ b/extensions/memory-hybrid/config/graph-config-schema-keys.ts
@@ -1,0 +1,22 @@
+/**
+ * Keys accepted under `graph` in openclaw config (read by `parseGraphConfig`).
+ * Must stay in sync with `openclaw.plugin.json` → configSchema.properties.graph.properties
+ * when graph.additionalProperties is false (gateway validation rejects unknown keys).
+ */
+export const GRAPH_CONFIG_INPUT_KEYS = [
+  "enabled",
+  "autoLink",
+  "autoLinkMinScore",
+  "autoLinkStrength",
+  "autoLinkSimilarityThreshold",
+  "autoLinkLimit",
+  "maxTraversalDepth",
+  "useInRecall",
+  "coOccurrenceWeight",
+  "autoSupersede",
+  "strengthenOnRecall",
+  "hubDegreeCap",
+  "hubScorePenalty",
+] as const;
+
+export type GraphConfigInputKey = (typeof GRAPH_CONFIG_INPUT_KEYS)[number];

--- a/extensions/memory-hybrid/openclaw.plugin.json
+++ b/extensions/memory-hybrid/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "openclaw-hybrid-memory",
   "kind": "memory",
-  "version": "2026.6.275",
+  "version": "2026.6.276",
   "contracts": {
     "tools": [
       "active_task_checkpoint",
@@ -512,6 +512,14 @@
     "graph.useInRecall": {
       "label": "Use in recall",
       "help": "Enable graph traversal in memory_recall (default true)"
+    },
+    "graph.coOccurrenceWeight": {
+      "label": "Co-occurrence weight",
+      "help": "Strength (0–1) for RELATED_TO links created from shared session or entity context (default 0.3)"
+    },
+    "graph.autoSupersede": {
+      "label": "Auto-supersede contradictions",
+      "help": "When true, mark older facts superseded when entity auto-link detects a contradiction (default true)"
     },
     "graph.strengthenOnRecall": {
       "label": "Strengthen on recall",
@@ -1635,6 +1643,16 @@
             "type": "boolean",
             "description": "Enable graph traversal in memory_recall (default: true)"
           },
+          "coOccurrenceWeight": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 1,
+            "description": "Weight for co-occurrence RELATED_TO links when facts share session or entity context (default: 0.3)"
+          },
+          "autoSupersede": {
+            "type": "boolean",
+            "description": "When true, auto-mark superseded facts on contradictory entity auto-link (default: true)"
+          },
           "strengthenOnRecall": {
             "type": "boolean",
             "description": "Strengthen RELATED_TO links when facts are recalled together (default: false)"
@@ -1643,6 +1661,12 @@
             "type": ["number", "null"],
             "minimum": 1,
             "description": "Hub guard: skip nodes above this total link degree and cap per-hop traversable fanout (default: 500; null disables)"
+          },
+          "hubScorePenalty": {
+            "type": ["number", "null"],
+            "minimum": 0,
+            "maximum": 1,
+            "description": "Optional hub attenuation (#1192): when set in (0,1), hub nodes' descendants get score multiplied by (1 - penalty) per hop; null uses skip mode"
           }
         },
         "description": "Graph-based spreading activation: typed relationships for zero-LLM recall"

--- a/extensions/memory-hybrid/package-lock.json
+++ b/extensions/memory-hybrid/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openclaw-hybrid-memory",
-  "version": "2026.6.275",
+  "version": "2026.6.276",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openclaw-hybrid-memory",
-      "version": "2026.6.275",
+      "version": "2026.6.276",
       "hasInstallScript": true,
       "dependencies": {
         "@lancedb/lancedb": "^0.30.0",

--- a/extensions/memory-hybrid/package.json
+++ b/extensions/memory-hybrid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-hybrid-memory",
-  "version": "2026.6.275",
+  "version": "2026.6.276",
   "type": "module",
   "description": "Give your OpenClaw agent lasting memory: structured facts, semantic search, auto-capture & recall, decay, optional credential vault. Part of Hybrid Memory v3.",
   "files": [
@@ -97,7 +97,8 @@
     "lint:arch": "bash scripts/lint-arch.sh",
     "typecheck:gate": "node ../../scripts/run-with-supported-node.mjs tsc --noEmit -p tsconfig.gate.json",
     "test:maintenance-gate": "node ../../scripts/run-with-supported-node.mjs vitest run --maxWorkers 1 tests/cron-guard.test.ts tests/maintenance-orchestrator.integration.test.ts tests/maintenance-step-guard-intervals.test.ts",
-    "verify:gate": "npm run typecheck:gate && npm run test:maintenance-gate",
+    "test:schema-gate": "node ../../scripts/run-with-supported-node.mjs vitest run tests/plugin-graph-schema-parity.test.ts tests/agent-tool-contracts.test.ts",
+    "verify:gate": "npm run typecheck:gate && npm run test:maintenance-gate && npm run test:schema-gate",
     "postinstall": "node scripts/postinstall-rebuild.cjs",
     "prepack": "npm run build && node scripts/manage-shrinkwrap.cjs create",
     "postpack": "node scripts/manage-shrinkwrap.cjs clean",

--- a/extensions/memory-hybrid/tests/plugin-graph-schema-parity.test.ts
+++ b/extensions/memory-hybrid/tests/plugin-graph-schema-parity.test.ts
@@ -1,0 +1,78 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { GRAPH_CONFIG_INPUT_KEYS } from "../config/graph-config-schema-keys.js";
+
+const hybridRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+const manifestPath = join(hybridRoot, "openclaw.plugin.json");
+
+type PluginManifest = {
+  configSchema?: {
+    properties?: {
+      graph?: {
+        additionalProperties?: boolean;
+        properties?: Record<string, unknown>;
+      };
+    };
+  };
+  uiHints?: Record<string, unknown>;
+};
+
+function loadManifest(): PluginManifest {
+  return JSON.parse(readFileSync(manifestPath, "utf8")) as PluginManifest;
+}
+
+/** Maeve-style graph block that previously crashed gateway config validation (#1997). */
+const MAEVE_GRAPH_SAMPLE = {
+  enabled: true,
+  autoLink: true,
+  autoLinkStrength: 0.7,
+  autoLinkSimilarityThreshold: 0.7,
+  autoLinkLimit: 3,
+  maxTraversalDepth: 2,
+  useInRecall: true,
+  coOccurrenceWeight: 0.3,
+  autoSupersede: true,
+  strengthenOnRecall: false,
+  hubDegreeCap: 500,
+  hubScorePenalty: null,
+} as const;
+
+describe("plugin graph config schema parity", () => {
+  it("openclaw.plugin.json graph.properties includes every parseGraphConfig input key", () => {
+    const manifest = loadManifest();
+    const graphSchema = manifest.configSchema?.properties?.graph;
+    expect(graphSchema?.additionalProperties).toBe(false);
+
+    const schemaKeys = new Set(Object.keys(graphSchema?.properties ?? {}));
+    const missing = GRAPH_CONFIG_INPUT_KEYS.filter((key) => !schemaKeys.has(key));
+    expect(missing, `add to openclaw.plugin.json graph.properties: ${missing.join(", ")}`).toEqual(
+      [],
+    );
+  });
+
+  it("Maeve-style graph config keys are all declared (no additionalProperties rejection)", () => {
+    const manifest = loadManifest();
+    const schemaKeys = new Set(
+      Object.keys(manifest.configSchema?.properties?.graph?.properties ?? {}),
+    );
+    const unknown = Object.keys(MAEVE_GRAPH_SAMPLE).filter((key) => !schemaKeys.has(key));
+    expect(unknown, `unknown graph keys would fail gateway validation: ${unknown.join(", ")}`).toEqual(
+      [],
+    );
+  });
+
+  it("uiHints cover graph config keys shown in settings UI", () => {
+    const manifest = loadManifest();
+    const uiHints = manifest.uiHints ?? {};
+    const labelKeys = [
+      "graph.coOccurrenceWeight",
+      "graph.autoSupersede",
+      "graph.hubScorePenalty",
+    ] as const;
+    for (const key of labelKeys) {
+      expect(uiHints[key], `missing uiHints.${key}`).toBeDefined();
+    }
+  });
+});

--- a/packages/openclaw-hybrid-memory-install/package.json
+++ b/packages/openclaw-hybrid-memory-install/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-hybrid-memory-install",
-  "version": "2026.6.275",
+  "version": "2026.6.276",
   "description": "Standalone installer for openclaw-hybrid-memory. Use when OpenClaw config validation fails.",
   "bin": {
     "openclaw-hybrid-memory-install": "./install.js"


### PR DESCRIPTION
## Summary

- Add missing `coOccurrenceWeight`, `autoSupersede`, and `hubScorePenalty` to `openclaw.plugin.json` `graph.properties` so Maeve-style configs pass gateway validation (`additionalProperties: false`).
- Add `GRAPH_CONFIG_INPUT_KEYS` + `plugin-graph-schema-parity.test.ts` to assert parser-accepted graph keys exist in the manifest.
- Wire schema parity into `verify:gate` (maintenance CI) so schema drift is caught before release.
- UI hints for `graph.coOccurrenceWeight` and `graph.autoSupersede`.
- Version **2026.6.276**.

## Closes

- Closes #1997 — graph JSON schema missing `coOccurrenceWeight`, `autoSupersede`, `hubScorePenalty` (gateway crash on upgrade)
- Closes #1993 — rename `graph.autoLinkMinScore` to `autoLinkStrength` + `autoLinkSimilarityThreshold` (shipped in #1992; verified on this branch)
- Closes #1994 — gate graph auto-linking on embedding similarity and canonicalize RELATED_TO edges (shipped in #1992; verified on this branch)
- Closes #1995 — GraphRAG recall presets, `defaultExpand`, `retrieval.strategies` graph, operator warnings (shipped in #1992; verified on this branch)

## Test plan

- [x] `npm run test:schema-gate`
- [x] `npm run verify:gate`