### PR TITLE
Fix #1999 goal index drift false positives and #2000 upgrade schema-drift bootstrap

### DIFF
--- a/extensions/memory-hybrid/cli/install/run-install.ts
+++ b/extensions/memory-hybrid/cli/install/run-install.ts
@@ -42,6 +42,10 @@ import {
   rollbackNpmProjectPinAfterUpgradeFailure,
   type NpmProjectPinBackup,
 } from "./workspace.js";
+import {
+  formatManualUpgradeFallback,
+  preflightUpgradePluginConfig,
+} from "./upgrade-config-preflight.js";
 
 export function runInstallForCli(opts: { dryRun: boolean }): InstallCliResult {
   const openclawDir = join(homedir(), ".openclaw");
@@ -514,8 +518,23 @@ export async function runUpgradeForCli(ctx: HandlerContext, requestedVersion?: s
   if (!existsSync(manifestPath) || !existsSync(pkgPath)) {
     return {
       ok: false,
-      error: `Refusing to upgrade: plugin directory does not look valid: ${preUpgradePluginDir}`,
+      error: `Refusing to upgrade: plugin directory does not look valid: ${preUpgradePluginDir}. ${formatManualUpgradeFallback(version)}`,
     };
+  }
+
+  const preflight = preflightUpgradePluginConfig({
+    installedPluginDir: preUpgradePluginDir,
+    targetVersion: version,
+  });
+  if (preflight.message) {
+    if (preflight.canProceedWithUpgrade) {
+      logger?.warn?.(`memory-hybrid: upgrade preflight — ${preflight.message}`);
+    } else {
+      return {
+        ok: false,
+        error: `${preflight.message} ${formatManualUpgradeFallback(version)}`,
+      };
+    }
   }
 
   const backupDir = join(dirname(preUpgradePluginDir), `${basename(preUpgradePluginDir)}.bak-${Date.now()}`);

--- a/extensions/memory-hybrid/cli/install/upgrade-config-preflight.ts
+++ b/extensions/memory-hybrid/cli/install/upgrade-config-preflight.ts
@@ -1,0 +1,202 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+
+import { PLUGIN_ID } from "../../utils/constants.js";
+import { npxExecutable } from "./workspace.js";
+
+export const MANUAL_UPGRADE_DOC_URL =
+  "https://github.com/markus-lassfolk/openclaw-hybrid-memory/blob/main/docs/UPGRADE-PLUGIN.md#manual-upgrade-copy-from-repo";
+
+export type PluginConfigSchemaValidation = {
+  ok: boolean;
+  errors: string[];
+};
+
+type JsonSchemaNode = {
+  type?: string | string[];
+  properties?: Record<string, JsonSchemaNode>;
+  additionalProperties?: boolean | JsonSchemaNode;
+  items?: JsonSchemaNode;
+};
+
+function schemaAllowsAdditionalProperties(schema: JsonSchemaNode | undefined): boolean {
+  if (!schema) return true;
+  return schema.additionalProperties !== false;
+}
+
+/** Lightweight JSON-schema check for unknown keys (matches OpenClaw gateway rejection). */
+export function validatePluginConfigAgainstSchema(
+  config: unknown,
+  rootSchema: JsonSchemaNode | undefined,
+  pathPrefix = "",
+): PluginConfigSchemaValidation {
+  const errors: string[] = [];
+  if (config === null || config === undefined) {
+    return { ok: true, errors };
+  }
+  if (!rootSchema) return { ok: true, errors };
+
+  const types = Array.isArray(rootSchema.type) ? rootSchema.type : rootSchema.type ? [rootSchema.type] : [];
+  const isObject = types.length === 0 || types.includes("object");
+  if (isObject && typeof config === "object" && !Array.isArray(config)) {
+    const record = config as Record<string, unknown>;
+    const props = rootSchema.properties ?? {};
+    const allowExtra = schemaAllowsAdditionalProperties(rootSchema);
+    for (const key of Object.keys(record)) {
+      const childPath = pathPrefix ? `${pathPrefix}.${key}` : key;
+      if (!(key in props)) {
+        if (!allowExtra) {
+          errors.push(`${pathPrefix || "config"}: must not have additional properties: "${key}"`);
+        }
+        continue;
+      }
+      const nested = validatePluginConfigAgainstSchema(record[key], props[key], childPath);
+      errors.push(...nested.errors);
+    }
+    return { ok: errors.length === 0, errors };
+  }
+
+  if (rootSchema.items && Array.isArray(config)) {
+    for (let i = 0; i < config.length; i++) {
+      const nested = validatePluginConfigAgainstSchema(config[i], rootSchema.items, `${pathPrefix}[${i}]`);
+      errors.push(...nested.errors);
+    }
+  }
+  return { ok: errors.length === 0, errors };
+}
+
+export function loadPluginManifestSchema(manifestPath: string): JsonSchemaNode | undefined {
+  try {
+    const manifest = JSON.parse(readFileSync(manifestPath, "utf-8")) as { configSchema?: JsonSchemaNode };
+    return manifest.configSchema;
+  } catch {
+    return undefined;
+  }
+}
+
+export function readHybridMemPluginConfigFromOpenclawJson(
+  openclawJsonPath = join(homedir(), ".openclaw", "openclaw.json"),
+): unknown {
+  if (!existsSync(openclawJsonPath)) return undefined;
+  try {
+    const root = JSON.parse(readFileSync(openclawJsonPath, "utf-8")) as {
+      plugins?: { entries?: Record<string, { config?: unknown }> };
+    };
+    return root.plugins?.entries?.[PLUGIN_ID]?.config;
+  } catch {
+    return undefined;
+  }
+}
+
+export type UpgradeConfigPreflightResult = {
+  currentValid: boolean;
+  targetValid: boolean;
+  currentErrors: string[];
+  targetErrors: string[];
+  canProceedWithUpgrade: boolean;
+  message?: string;
+};
+
+function extractManifestFromNpmPack(version: string): { manifestPath: string; cleanup: () => void } | undefined {
+  const tmpDir = mkdtempSync(join(tmpdir(), "mh-upgrade-preflight-"));
+  const pack = spawnSync("npm", ["pack", `${PLUGIN_ID}@${version}`], {
+    cwd: tmpDir,
+    encoding: "utf-8",
+    shell: false,
+  });
+  if (pack.status !== 0) return undefined;
+  const tgz = readdirSync(tmpDir).find((f) => f.endsWith(".tgz"));
+  if (!tgz) return undefined;
+  const extractDir = join(tmpDir, "extract");
+  mkdirSync(extractDir, { recursive: true });
+  const tar = spawnSync("tar", ["-xzf", join(tmpDir, tgz), "-C", extractDir, "--strip-components=1"], {
+    shell: false,
+  });
+  if (tar.status !== 0) {
+    rmSync(tmpDir, { recursive: true, force: true });
+    return undefined;
+  }
+  const manifestPath = join(extractDir, "openclaw.plugin.json");
+  if (!existsSync(manifestPath)) {
+    rmSync(tmpDir, { recursive: true, force: true });
+    return undefined;
+  }
+  return {
+    manifestPath,
+    cleanup: () => {
+      try {
+        rmSync(tmpDir, { recursive: true, force: true });
+      } catch {
+        /* best-effort */
+      }
+    },
+  };
+}
+
+/** Compare installed vs target plugin schema against live openclaw.json plugin config (#2000). */
+export function preflightUpgradePluginConfig(opts: {
+  installedPluginDir: string;
+  targetVersion: string;
+  pluginConfig?: unknown;
+}): UpgradeConfigPreflightResult {
+  const pluginConfig = opts.pluginConfig ?? readHybridMemPluginConfigFromOpenclawJson();
+  const currentSchema = loadPluginManifestSchema(join(opts.installedPluginDir, "openclaw.plugin.json"));
+  const current = validatePluginConfigAgainstSchema(pluginConfig, currentSchema);
+
+  const packed = extractManifestFromNpmPack(opts.targetVersion);
+  if (!packed) {
+    return {
+      currentValid: current.ok,
+      targetValid: false,
+      currentErrors: current.errors,
+      targetErrors: ["Could not fetch target plugin manifest for preflight"],
+      canProceedWithUpgrade: current.ok,
+      message: current.ok
+        ? undefined
+        : `Config fails current plugin schema. Could not verify target schema; use manual upgrade: npx -y openclaw-hybrid-memory-install ${opts.targetVersion}. See ${MANUAL_UPGRADE_DOC_URL}`,
+    };
+  }
+  try {
+    const targetSchema = loadPluginManifestSchema(packed.manifestPath);
+    const target = validatePluginConfigAgainstSchema(pluginConfig, targetSchema);
+    const canProceed = current.ok || target.ok;
+    let message: string | undefined;
+    if (!current.ok && target.ok) {
+      message = `Config rejected by installed plugin schema but accepted by ${opts.targetVersion}; proceeding with upgrade.`;
+    } else if (!current.ok && !target.ok) {
+      message = `Config fails both installed and target (${opts.targetVersion}) plugin schemas. Manual upgrade may still be required after fixing config. See ${MANUAL_UPGRADE_DOC_URL}`;
+    }
+    return {
+      currentValid: current.ok,
+      targetValid: target.ok,
+      currentErrors: current.errors,
+      targetErrors: target.errors,
+      canProceedWithUpgrade: canProceed,
+      message,
+    };
+  } finally {
+    packed.cleanup();
+  }
+}
+
+export function formatManualUpgradeFallback(version: string): string {
+  return `When openclaw hybrid-mem is unavailable (invalid plugin config), run: npx -y openclaw-hybrid-memory-install ${version}. See ${MANUAL_UPGRADE_DOC_URL}`;
+}
+
+export function runStandaloneUpgradeInstall(version: string, extensionsParentDir: string): { ok: boolean; error?: string } {
+  const r = spawnSync(npxExecutable(), ["-y", "openclaw-hybrid-memory-install", version], {
+    stdio: "inherit",
+    cwd: homedir(),
+    shell: false,
+    env: { ...process.env, OPENCLAW_EXTENSIONS_DIR: extensionsParentDir },
+  });
+  if (r.status !== 0) {
+    return {
+      ok: false,
+      error: `Standalone install failed (exit ${r.status ?? "unknown"}). ${formatManualUpgradeFallback(version)}`,
+    };
+  }
+  return { ok: true };
+}

--- a/extensions/memory-hybrid/index-upgrade-cli.ts
+++ b/extensions/memory-hybrid/index-upgrade-cli.ts
@@ -1,0 +1,11 @@
+/** Upgrade subcommand that skips full plugin bootstrap (issue #2000). */
+export function isHybridMemUpgradeOnlyInvocation(argv: string[]): boolean {
+  const hybridIdx = argv.indexOf("hybrid-mem");
+  if (hybridIdx === -1) return false;
+  for (let i = hybridIdx + 1; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--") break;
+    if (a === "upgrade") return true;
+  }
+  return false;
+}

--- a/extensions/memory-hybrid/index.ts
+++ b/extensions/memory-hybrid/index.ts
@@ -8,6 +8,7 @@ import { isHybridMemHelpInvocation } from "./index-help.js";
 
 export { isHybridMemHelpInvocation };
 export { isHybridMemCredentialsOnlyInvocation } from "./index-credentials-cli.js";
+export { isHybridMemUpgradeOnlyInvocation } from "./index-upgrade-cli.js";
 export {
   isHybridMemJsonInvocation,
   isHybridMemCredentialsValueOnlyInvocation,

--- a/extensions/memory-hybrid/package.json
+++ b/extensions/memory-hybrid/package.json
@@ -8,6 +8,7 @@
     "index.ts",
     "index-help.ts",
     "index-credentials-cli.ts",
+    "index-upgrade-cli.ts",
     "index-testing-exports.ts",
     "api",
     "config.ts",

--- a/extensions/memory-hybrid/services/goal-registry.ts
+++ b/extensions/memory-hybrid/services/goal-registry.ts
@@ -301,6 +301,69 @@ function isGoalLike(value: unknown): value is Goal {
   );
 }
 
+function normalizeGoalJson(g: Goal): Goal {
+  return {
+    ...g,
+    linkedTasks: Array.isArray(g.linkedTasks) ? g.linkedTasks : [],
+    currentBlockers: Array.isArray(g.currentBlockers)
+      ? g.currentBlockers
+          .filter((b): b is string => typeof b === "string")
+          .map((b) => b.trim())
+          .filter(Boolean)
+      : [],
+    assessmentCount: typeof g.assessmentCount === "number" && Number.isFinite(g.assessmentCount) ? g.assessmentCount : 0,
+    dispatchCount: typeof g.dispatchCount === "number" && Number.isFinite(g.dispatchCount) ? g.dispatchCount : 0,
+    maxAssessments:
+      typeof g.maxAssessments === "number" && Number.isFinite(g.maxAssessments) ? g.maxAssessments : 10,
+    maxDispatches: typeof g.maxDispatches === "number" && Number.isFinite(g.maxDispatches) ? g.maxDispatches : 5,
+    lastOutcome: typeof g.lastOutcome === "string" ? g.lastOutcome : null,
+    lastAssessedAt: typeof g.lastAssessedAt === "string" ? g.lastAssessedAt : null,
+    lastDispatchedAt: typeof g.lastDispatchedAt === "string" ? g.lastDispatchedAt : null,
+    lastBlockerFingerprint: g.lastBlockerFingerprint ?? null,
+    sameBlockerStreak: g.sameBlockerStreak ?? 0,
+    circuitBreakerLastProgressAssessmentCount: g.circuitBreakerLastProgressAssessmentCount ?? 0,
+    humanEscalationSummary: g.humanEscalationSummary ?? null,
+    escalationKind: g.escalationKind ?? null,
+    lastMechanicalCheck: g.lastMechanicalCheck ?? null,
+  };
+}
+
+async function readGoalJsonFile(goalsDir: string, filename: string): Promise<Goal | null> {
+  try {
+    const raw = await readFile(join(goalsDir, filename), "utf-8");
+    const parsed = JSON.parse(raw) as unknown;
+    if (!isGoalLike(parsed)) {
+      throw new Error(`Goal file has invalid schema (${join(goalsDir, filename)})`);
+    }
+    return normalizeGoalJson(parsed);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw err;
+  }
+}
+
+/** Resolve a goal file path when canonical `${id}.json` is missing (legacy label-based filenames, #1999). */
+async function findGoalFilenameById(goalsDir: string, id: string): Promise<string | null> {
+  let files: string[];
+  try {
+    files = await readdir(goalsDir);
+  } catch {
+    return null;
+  }
+  for (const f of files) {
+    if (!isGoalRegistryJsonFilename(f)) continue;
+    try {
+      const raw = await readFile(join(goalsDir, f), "utf-8");
+      const parsed = JSON.parse(raw) as unknown;
+      if (isGoalLike(parsed) && parsed.id === id) return f;
+    } catch {
+      /* skip unreadable */
+    }
+    await yieldEventLoop();
+  }
+  return null;
+}
+
 function captureInvalidGoalRegistryEntry(filename: string, err?: unknown): void {
   const reason = err instanceof Error ? err.message : err === undefined ? "invalid persisted Goal shape" : String(err);
   capturePluginError(new Error(`invalid_goal_registry_entry: ${filename}`), {
@@ -383,7 +446,12 @@ export async function auditGoalIndexDrift(goalsDir: string): Promise<GoalIndexDr
   }
   for (const f of files) {
     if (!isGoalRegistryJsonFilename(f)) continue;
-    fileIds.add(f.replace(/\.json$/i, ""));
+    try {
+      const g = await readGoalJsonFile(goalsDir, f);
+      if (g) fileIds.add(g.id);
+    } catch {
+      /* skip unreadable; drift audit treats corrupt files as missing from index */
+    }
     await yieldEventLoop();
   }
 
@@ -431,46 +499,23 @@ export async function auditGoalIndexDrift(goalsDir: string): Promise<GoalIndexDr
   return report;
 }
 
-function normalizeGoalJson(g: Goal): Goal {
-  return {
-    ...g,
-    linkedTasks: Array.isArray(g.linkedTasks) ? g.linkedTasks : [],
-    currentBlockers: Array.isArray(g.currentBlockers)
-      ? g.currentBlockers
-          .filter((b): b is string => typeof b === "string")
-          .map((b) => b.trim())
-          .filter(Boolean)
-      : [],
-    assessmentCount: typeof g.assessmentCount === "number" && Number.isFinite(g.assessmentCount) ? g.assessmentCount : 0,
-    dispatchCount: typeof g.dispatchCount === "number" && Number.isFinite(g.dispatchCount) ? g.dispatchCount : 0,
-    maxAssessments:
-      typeof g.maxAssessments === "number" && Number.isFinite(g.maxAssessments) ? g.maxAssessments : 10,
-    maxDispatches: typeof g.maxDispatches === "number" && Number.isFinite(g.maxDispatches) ? g.maxDispatches : 5,
-    lastOutcome: typeof g.lastOutcome === "string" ? g.lastOutcome : null,
-    lastAssessedAt: typeof g.lastAssessedAt === "string" ? g.lastAssessedAt : null,
-    lastDispatchedAt: typeof g.lastDispatchedAt === "string" ? g.lastDispatchedAt : null,
-    lastBlockerFingerprint: g.lastBlockerFingerprint ?? null,
-    sameBlockerStreak: g.sameBlockerStreak ?? 0,
-    circuitBreakerLastProgressAssessmentCount: g.circuitBreakerLastProgressAssessmentCount ?? 0,
-    humanEscalationSummary: g.humanEscalationSummary ?? null,
-    escalationKind: g.escalationKind ?? null,
-    lastMechanicalCheck: g.lastMechanicalCheck ?? null,
-  };
-}
-
 export async function readGoal(goalsDir: string, id: string): Promise<Goal | null> {
-  const path = join(goalsDir, `${id}.json`);
-  if (!existsSync(path)) return null;
-  try {
-    const raw = await readFile(path, "utf-8");
-    const parsed = JSON.parse(raw) as unknown;
-    if (!isGoalLike(parsed)) {
-      throw new Error(`Goal file has invalid schema (${path})`);
+  const canonicalPath = join(goalsDir, `${id}.json`);
+  if (existsSync(canonicalPath)) {
+    try {
+      return await readGoalJsonFile(goalsDir, `${id}.json`);
+    } catch (err) {
+      throw new Error(`Goal file is corrupt or unreadable (${canonicalPath}): ${String(err)}`);
     }
-    return normalizeGoalJson(parsed);
+  }
+  const legacyFilename = await findGoalFilenameById(goalsDir, id);
+  if (!legacyFilename) return null;
+  try {
+    return await readGoalJsonFile(goalsDir, legacyFilename);
   } catch (err) {
-    if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
-    throw new Error(`Goal file is corrupt or unreadable (${path}): ${String(err)}`);
+    throw new Error(
+      `Goal file is corrupt or unreadable (${join(goalsDir, legacyFilename)}): ${String(err)}`,
+    );
   }
 }
 
@@ -481,7 +526,7 @@ export async function listGoals(goalsDir: string): Promise<Goal[]> {
   for (const f of files) {
     if (!isGoalRegistryJsonFilename(f)) continue;
     try {
-      const g = await readGoal(goalsDir, f.replace(/\.json$/, ""));
+      const g = await readGoalJsonFile(goalsDir, f);
       if (g) out.push(g);
     } catch (err) {
       // Keep registry scans isolated: one corrupt goal file must not abort all goal processing.

--- a/extensions/memory-hybrid/setup/cli-context/register-upgrade-only.ts
+++ b/extensions/memory-hybrid/setup/cli-context/register-upgrade-only.ts
@@ -1,0 +1,97 @@
+import type { Command } from "commander";
+import type { ClawdbotPluginApi } from "openclaw/plugin-sdk/core";
+
+import { runUpgradeForCli } from "../../cli/install/run-install.js";
+import type { HandlerContext } from "../../cli/handlers.js";
+import { hybridConfigSchema } from "../../config.js";
+import { HYBRID_MEM_CLI_ROOT_DESCRIPTOR } from "./help-text.js";
+import { attachHybridMemCliFatalExit } from "../../cli/hybrid-mem-commander-utils.js";
+import { withExit } from "../../cli/shared.js";
+import { resetPluginLogger, restoreDefaultLogger } from "../../utils/logger.js";
+
+/**
+ * Upgrade-only CLI wiring (issue #2000).
+ *
+ * Skips DB bootstrap and config secrets resolution so `openclaw hybrid-mem upgrade` can run
+ * when full registration would fail on config parse — but only when OpenClaw already loaded the plugin.
+ */
+export function registerHybridMemCliUpgradeOnlyWithApi(api: ClawdbotPluginApi): void {
+  resetPluginLogger();
+  let cfg: HandlerContext["cfg"];
+  try {
+    cfg = hybridConfigSchema.parse({
+      embedding: {
+        provider: "openai",
+        apiKey: "sk-upgrade-key-that-is-long-enough-to-pass",
+        model: "text-embedding-3-small",
+      },
+    });
+  } catch {
+    cfg = hybridConfigSchema.parse({
+      embedding: {
+        provider: "ollama",
+        model: "nomic-embed-text",
+      },
+    });
+  } finally {
+    restoreDefaultLogger();
+  }
+
+  const handlerCtx: HandlerContext = {
+    cfg,
+    logger: api.logger,
+    api,
+    factsDb: null as unknown as HandlerContext["factsDb"],
+    vectorDb: null as unknown as HandlerContext["vectorDb"],
+    embeddings: null as unknown as HandlerContext["embeddings"],
+    openai: null as unknown as HandlerContext["openai"],
+    credentialsDb: null,
+    aliasDb: null,
+    wal: null,
+    proposalsDb: null,
+    identityReflectionStore: null,
+    personaStateStore: null,
+    crystallizationStore: null,
+    toolProposalStore: null,
+    eventLog: null,
+    verificationStore: null,
+    provenanceService: null,
+    resolvedSqlitePath: api.resolvePath(cfg.sqlitePath),
+    resolvedLancePath: api.resolvePath(cfg.lanceDbPath),
+    pluginId: "openclaw-hybrid-memory",
+    detectCategory: (() => "fact") as HandlerContext["detectCategory"],
+    costTracker: null,
+    eventBus: null,
+    auditStore: null,
+    agentHealthStore: null,
+    changeFeed: null,
+  };
+
+  api.registerCli(
+    ({ program }: { program: Command }) => {
+      const mem = program.command("hybrid-mem").description(HYBRID_MEM_CLI_ROOT_DESCRIPTOR.description);
+      attachHybridMemCliFatalExit(mem);
+      mem
+        .command("upgrade [version]")
+        .description("Upgrade hybrid-mem to a specific version (or latest). Downloads and installs plugin from npm.")
+        .action(
+          withExit(async (version?: string) => {
+            const res = await runUpgradeForCli(handlerCtx, version);
+            if (res.ok) {
+              console.log(`Upgraded to version ${res.version}. Plugin installed at: ${res.pluginDir}`);
+              if (res.workspaceSkillPath) {
+                console.log(`Workspace skill: ${res.workspaceSkillPath}`);
+              }
+              if (res.workspaceToolsMdPath) {
+                console.log(`TOOLS.md: ${res.workspaceToolsMdPath}`);
+              }
+            } else {
+              console.error(`Error upgrading: ${res.error}`);
+              process.exitCode = 1;
+            }
+          }),
+        );
+    },
+    { descriptors: [HYBRID_MEM_CLI_ROOT_DESCRIPTOR] },
+  );
+}

--- a/extensions/memory-hybrid/setup/register-plugin.ts
+++ b/extensions/memory-hybrid/setup/register-plugin.ts
@@ -24,6 +24,7 @@ import { walRemove, walWrite } from "../services/wal-helpers.js";
 import { registerHybridMemCliMetadataOnly } from "./cli-context/metadata.js";
 import { registerHybridMemCliHelpOnlyWithApi } from "./cli-context/register-help.js";
 import { registerHybridMemCliCredentialsOnlyWithApi } from "./cli-context/register-credentials-only.js";
+import { registerHybridMemCliUpgradeOnlyWithApi } from "./cli-context/register-upgrade-only.js";
 import { registerHybridMemCliWithApi } from "./cli-context/register-full.js";
 import { parseHybridMemPluginConfig } from "./parse-plugin-config.js";
 import "./cli-context.js";
@@ -57,6 +58,7 @@ import { registerTools } from "./register-tools.js";
 import { PLUGIN_ID } from "../utils/constants.js";
 import { isHybridMemHelpInvocation } from "../index-help.js";
 import { isHybridMemCredentialsOnlyInvocation } from "../index-credentials-cli.js";
+import { isHybridMemUpgradeOnlyInvocation } from "../index-upgrade-cli.js";
 import { wrapApiLoggerStderrForJsonCli, restoreStdoutAfterJsonCli } from "../utils/hybrid-mem-json-cli.js";
 import {
   getCategoryDecisionRegex,
@@ -193,6 +195,12 @@ export function runMemoryHybridRegister(api: ClawdbotPluginApi): void {
   // Examples: `openclaw hybrid-mem --help`, `openclaw hybrid-mem verify --help`.
   if (isHybridMemHelpInvocation(process.argv)) {
     registerHybridMemCliHelpOnlyWithApi(api);
+    return;
+  }
+
+  // Upgrade-only path skips DB bootstrap and live config parse (issue #2000).
+  if (isHybridMemUpgradeOnlyInvocation(process.argv)) {
+    registerHybridMemCliUpgradeOnlyWithApi(api);
     return;
   }
 

--- a/extensions/memory-hybrid/tests/goal-index-drift.test.ts
+++ b/extensions/memory-hybrid/tests/goal-index-drift.test.ts
@@ -6,6 +6,7 @@ import {
   auditGoalIndexDrift,
   createGoal,
   readGoal,
+  readGoalByLabel,
   rebuildGoalIndex,
   updateGoal,
 } from "../services/goal-registry.js";
@@ -89,6 +90,61 @@ describe("goal index drift (#1987)", () => {
     expect(index.goals.map((x) => x.id)).toEqual([g.id]);
     const body = await readGoal(dir, g.id);
     expect(body?.description).toBe("original");
+  });
+
+  it("auditGoalIndexDrift does not false-positive when filename stem differs from goal.id (#1999)", async () => {
+    dir = await makeTempDir();
+    const goalId = "smart-pool-qa-code-review-0001";
+    const label = "smart-pool-qa-code-review";
+    await writeFile(
+      join(dir, `${label}.json`),
+      JSON.stringify({
+        id: goalId,
+        label,
+        description: "d",
+        acceptanceCriteria: ["c"],
+        status: "active",
+        priority: "normal",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        lastAssessedAt: null,
+        lastDispatchedAt: null,
+        assessmentCount: 0,
+        dispatchCount: 0,
+        currentBlockers: [],
+        lastOutcome: null,
+        maxDispatches: 5,
+        maxAssessments: 10,
+        cooldownMinutes: 5,
+        escalateAfterFailures: 3,
+        consecutiveFailures: 0,
+        linkedTasks: [],
+        history: [],
+      }),
+      "utf-8",
+    );
+    await writeFile(
+      join(dir, "_index.json"),
+      JSON.stringify({
+        updatedAt: "2026-01-01T00:00:00.000Z",
+        goals: [
+          {
+            id: goalId,
+            label,
+            status: "active",
+            priority: "normal",
+            createdAt: "2026-01-01T00:00:00.000Z",
+            lastAssessedAt: null,
+          },
+        ],
+      }),
+      "utf-8",
+    );
+
+    const drift = await auditGoalIndexDrift(dir);
+    expect(drift.missingInIndex).toEqual([]);
+    expect(drift.orphanInIndex).toEqual([]);
+    expect(drift.staleFields).toEqual([]);
+    expect(await readGoal(dir, goalId)).toMatchObject({ label });
   });
 });
 

--- a/extensions/memory-hybrid/tests/goal-stewardship-registry.test.ts
+++ b/extensions/memory-hybrid/tests/goal-stewardship-registry.test.ts
@@ -66,6 +66,42 @@ describe("goal registry", () => {
     expect(await readGoal(dir, "nonexistent")).toBeNull();
   });
 
+  it("readGoal and readGoalByLabel resolve legacy label-based filenames (#1999)", async () => {
+    dir = await makeTempDir();
+    const goalId = "legacy-label-0001";
+    const label = "legacy-label";
+    await writeFile(
+      join(dir, `${label}.json`),
+      JSON.stringify({
+        id: goalId,
+        label,
+        description: "legacy layout",
+        acceptanceCriteria: ["a"],
+        status: "active",
+        priority: "normal",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        lastAssessedAt: null,
+        lastDispatchedAt: null,
+        assessmentCount: 0,
+        dispatchCount: 0,
+        currentBlockers: [],
+        lastOutcome: null,
+        maxDispatches: 5,
+        maxAssessments: 10,
+        cooldownMinutes: 5,
+        escalateAfterFailures: 3,
+        consecutiveFailures: 0,
+        linkedTasks: [],
+        history: [],
+      }),
+      "utf-8",
+    );
+    const byId = await readGoal(dir, goalId);
+    expect(byId?.description).toBe("legacy layout");
+    const byLabel = await readGoalByLabel(dir, label);
+    expect(byLabel?.id).toBe(goalId);
+  });
+
   it("readGoal normalizes legacy JSON without circuit-breaker fields", async () => {
     dir = await makeTempDir();
     const raw = {

--- a/extensions/memory-hybrid/tests/upgrade-cli-fast-path.test.ts
+++ b/extensions/memory-hybrid/tests/upgrade-cli-fast-path.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+
+import { isHybridMemUpgradeOnlyInvocation } from "../index-upgrade-cli.js";
+
+describe("isHybridMemUpgradeOnlyInvocation (#2000)", () => {
+  it("detects hybrid-mem upgrade invocations", () => {
+    expect(isHybridMemUpgradeOnlyInvocation(["node", "openclaw", "hybrid-mem", "upgrade"])).toBe(true);
+    expect(isHybridMemUpgradeOnlyInvocation(["node", "openclaw", "hybrid-mem", "upgrade", "2026.6.276"])).toBe(true);
+  });
+
+  it("does not match other hybrid-mem commands", () => {
+    expect(isHybridMemUpgradeOnlyInvocation(["node", "openclaw", "hybrid-mem", "verify"])).toBe(false);
+    expect(isHybridMemUpgradeOnlyInvocation(["node", "openclaw", "hybrid-mem", "--help"])).toBe(false);
+    expect(isHybridMemUpgradeOnlyInvocation(["node", "openclaw", "hybrid-mem", "upgrade", "--", "other"])).toBe(true);
+  });
+});

--- a/extensions/memory-hybrid/tests/upgrade-config-preflight.test.ts
+++ b/extensions/memory-hybrid/tests/upgrade-config-preflight.test.ts
@@ -1,0 +1,70 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+import {
+  loadPluginManifestSchema,
+  validatePluginConfigAgainstSchema,
+} from "../cli/install/upgrade-config-preflight.js";
+
+const hybridRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+const manifestPath = join(hybridRoot, "openclaw.plugin.json");
+
+/** Maeve-style graph block rejected by older schemas (#1997 / #2000). */
+const MAEVE_GRAPH_CONFIG = {
+  embedding: {
+    provider: "openai",
+    apiKey: "sk-test-key-that-is-long-enough-for-validation",
+    model: "text-embedding-3-small",
+  },
+  graph: {
+    enabled: true,
+    autoLink: true,
+    autoLinkStrength: 0.7,
+    coOccurrenceWeight: 0.3,
+    autoSupersede: true,
+    hubScorePenalty: null,
+  },
+};
+
+describe("upgrade config preflight (#2000)", () => {
+  it("validatePluginConfigAgainstSchema accepts Maeve graph keys on current manifest", () => {
+    const schema = loadPluginManifestSchema(manifestPath);
+    const result = validatePluginConfigAgainstSchema(MAEVE_GRAPH_CONFIG, schema);
+    expect(result.ok).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+
+  it("validatePluginConfigAgainstSchema rejects unknown graph keys when schema disallows extras", () => {
+    const schema = loadPluginManifestSchema(manifestPath);
+    const graphSchema = schema?.properties?.graph;
+    expect(graphSchema).toBeDefined();
+    const legacyGraphSchema = {
+      ...graphSchema,
+      properties: Object.fromEntries(
+        Object.entries(graphSchema?.properties ?? {}).filter(([key]) => key !== "coOccurrenceWeight"),
+      ),
+    };
+    const legacySchema = {
+      ...schema,
+      properties: {
+        ...schema?.properties,
+        graph: legacyGraphSchema,
+      },
+    };
+    const result = validatePluginConfigAgainstSchema(MAEVE_GRAPH_CONFIG, legacySchema);
+    expect(result.ok).toBe(false);
+    expect(result.errors.some((e) => e.includes("coOccurrenceWeight"))).toBe(true);
+  });
+
+  it("current openclaw.plugin.json includes graph keys from Maeve production config", () => {
+    const manifest = JSON.parse(readFileSync(manifestPath, "utf8")) as {
+      configSchema?: { properties?: { graph?: { properties?: Record<string, unknown> } } };
+    };
+    const graphKeys = Object.keys(manifest.configSchema?.properties?.graph?.properties ?? {});
+    for (const key of ["coOccurrenceWeight", "autoSupersede", "hubScorePenalty", "autoLinkStrength"]) {
+      expect(graphKeys, `missing graph.${key} in openclaw.plugin.json`).toContain(key);
+    }
+  });
+});

--- a/packages/openclaw-hybrid-memory-install/install.js
+++ b/packages/openclaw-hybrid-memory-install/install.js
@@ -102,6 +102,12 @@ const stagingDir = path.join(
 
 try {
 	console.log(`Installing openclaw-hybrid-memory@${version} to ${pluginDir}\n`);
+	console.log(
+		"Note: this bypasses OpenClaw config validation when hybrid-mem upgrade is unavailable (schema drift).",
+	);
+	console.log(
+		`Docs: https://github.com/markus-lassfolk/openclaw-hybrid-memory/blob/main/docs/UPGRADE-PLUGIN.md\n`,
+	);
 
 	if (fs.existsSync(stagingDir)) {
 		fs.rmSync(stagingDir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- **#1999**: `auditGoalIndexDrift` now indexes goals by parsed `goal.id` instead of filename stem, eliminating false drift when legacy files use label-based names (e.g. `smart-pool-qa-code-review.json` with `id: smart-pool-qa-code-review-0001`). `readGoal` scans goal files by `id` when `${id}.json` is missing; `readGoalByLabel` and stewardship lookups work again.
- **#2000**: Adds an upgrade-only CLI fast path (`hybrid-mem upgrade`) that skips DB bootstrap, config schema preflight comparing installed vs target npm manifest, and clearer manual fallback via `npx -y openclaw-hybrid-memory-install` with doc links when OpenClaw blocks plugin load due to schema drift.

## Test plan
- [x] `npm test -- tests/goal-index-drift.test.ts tests/goal-stewardship-registry.test.ts`
- [x] `npm test -- tests/upgrade-cli-fast-path.test.ts tests/upgrade-config-preflight.test.ts`
- [x] `npm test -- tests/run-upgrade.test.ts tests/cli-help-hang.test.ts`
- [ ] Verify on Maeve-like layout: goal file named by label with distinct `id` — `verify --fix` clears drift warning
- [ ] When old schema rejects new graph keys: `openclaw hybrid-mem upgrade` preflight warns and proceeds, or standalone installer succeeds

Fixes #1999
Fixes #2000