### PR TITLE
feat: add durable-rule router for persona proposals (#2002)

### DIFF
--- a/extensions/memory-hybrid/cli/proposals.ts
+++ b/extensions/memory-hybrid/cli/proposals.ts
@@ -18,6 +18,7 @@ import {
   type PersonaProposalAssessment,
   classifyAuthorityBucket,
   findCrossFileContentMatch,
+  createDisabledRoutingPassthroughAssessment,
   resolvePersonaRuleRoutingConfig,
   routePersonaProposal,
   shouldBlockProposalCreation,
@@ -385,7 +386,11 @@ export async function assessPersonaProposalRouting(
 ): Promise<PersonaProposalAssessment> {
   const routing = resolvePersonaRuleRoutingConfig({ personaRuleRouting: input.personaRuleRouting });
   if (!routing.enabled) {
-    return assessPersonaProposalRoutingSync(input);
+    return createDisabledRoutingPassthroughAssessment({
+      targetFile: input.targetFile,
+      confidence: input.confidence,
+      suggestedChange: input.suggestedChange,
+    });
   }
   return routePersonaProposal({
     targetFile: input.targetFile,

--- a/extensions/memory-hybrid/cli/proposals.ts
+++ b/extensions/memory-hybrid/cli/proposals.ts
@@ -8,11 +8,21 @@ import { createHash } from "node:crypto";
 import { mkdir, writeFile } from "node:fs/promises";
 import { homedir, tmpdir } from "node:os";
 import { dirname, join, relative } from "node:path";
+import type { FactsDB } from "../backends/facts-db.js";
 import type { ProposalEntry, ProposalsDB } from "../backends/proposals-db.js";
 import type { IdentityFileType, HybridMemoryConfig } from "../config.js";
 import { capturePluginError } from "../services/error-reporter.js";
 import { emitPersonaApplied, supersedeActiveProposedEvent } from "../services/change-feed-emit.js";
 import type { ChangeFeed } from "../services/change-feed.js";
+import {
+  type PersonaProposalAssessment,
+  classifyAuthorityBucket,
+  findCrossFileContentMatch,
+  resolvePersonaRuleRoutingConfig,
+  routePersonaProposal,
+  shouldBlockProposalCreation,
+} from "../services/persona-rule-router.js";
+import type { EmbeddingProvider } from "../services/embeddings/types.js";
 import { writeProposalRollback, deleteProposalRollback } from "../services/proposal-rollback.js";
 import {
   enforceMaxPendingCap,
@@ -195,6 +205,8 @@ export function getProposalExpiryError(
 /** Snapshot + validation helpers for pipeline-created proposals (self-correction, reinforcement, generate-proposals). */
 export function resolvePipelineProposalTarget(input: {
   targetFile: string;
+  title?: string;
+  observation?: string;
   suggestedChange: string;
   allowedFiles: readonly string[];
   workspaceRoot: string;
@@ -203,9 +215,15 @@ export function resolvePipelineProposalTarget(input: {
   minConfidence?: number;
   nowSec?: number;
   proposalsDb?: ProposalsDB;
+  factsDb?: FactsDB | null;
+  embeddings?: EmbeddingProvider | null;
+  personaRuleRouting?: HybridMemoryConfig["personaProposals"]["personaRuleRouting"];
+  evidenceSessions?: string[];
   /** When set, block pipeline proposal creation when the unified workshop queue is full. */
   workshopStores?: UnifiedProposalStores;
   maxPending?: number;
+  /** Populated when routing assessment runs (for callers/logging). */
+  routingAssessment?: PersonaProposalAssessment;
 }): {
   targetFile: string;
   confidence: number;
@@ -217,6 +235,22 @@ export function resolvePipelineProposalTarget(input: {
   if (!targetFile || !input.allowedFiles.includes(targetFile as IdentityFileType)) return null;
   const contentCheck = validateProposalContent(input.suggestedChange);
   if (!contentCheck.ok) return null;
+  const routing = resolvePersonaRuleRoutingConfig({ personaRuleRouting: input.personaRuleRouting });
+  if (routing.enabled) {
+    const syncAssessment = assessPersonaProposalRoutingSync({
+      targetFile,
+      title: input.title ?? "Pipeline proposal",
+      observation: input.observation ?? "",
+      suggestedChange: input.suggestedChange,
+      confidence: input.confidence,
+      evidenceSessions: input.evidenceSessions ?? [],
+      workspaceRoot: input.workspaceRoot,
+      allowedFiles: input.allowedFiles,
+      personaRuleRouting: input.personaRuleRouting,
+    });
+    input.routingAssessment = syncAssessment;
+    if (shouldBlockProposalCreation(syncAssessment, routing.routingMode)) return null;
+  }
   if (input.proposalsDb) {
     const duplicate = input.proposalsDb.findPendingOrAppliedDuplicate(targetFile, input.suggestedChange);
     if (duplicate) return null;
@@ -239,6 +273,152 @@ export function resolvePipelineProposalTarget(input: {
     targetHash: snapshot?.hash ?? null,
     expiresAt: input.proposalTTLDays > 0 ? nowSec + input.proposalTTLDays * 24 * 3600 : null,
   };
+}
+
+export type AssessPersonaProposalRoutingInput = {
+  targetFile: string;
+  title: string;
+  observation: string;
+  suggestedChange: string;
+  confidence: number;
+  evidenceSessions: string[];
+  workspaceRoot: string;
+  allowedFiles: readonly string[];
+  factsDb?: FactsDB | null;
+  embeddings?: EmbeddingProvider | null;
+  personaRuleRouting?: HybridMemoryConfig["personaProposals"]["personaRuleRouting"];
+  adjudicateContradiction?: RoutePersonaProposalInput["adjudicateContradiction"];
+};
+
+type RoutePersonaProposalInput = Parameters<typeof routePersonaProposal>[0];
+
+/** Sync keyword routing + cross-file content checks (no embeddings). */
+export function assessPersonaProposalRoutingSync(
+  input: Omit<AssessPersonaProposalRoutingInput, "factsDb" | "embeddings" | "adjudicateContradiction">,
+): PersonaProposalAssessment {
+  const routing = resolvePersonaRuleRoutingConfig({ personaRuleRouting: input.personaRuleRouting });
+  const crossFileMatch = findCrossFileContentMatch({
+    suggestedChange: input.suggestedChange,
+    workspaceRoot: input.workspaceRoot,
+    excludeFile: input.targetFile,
+  });
+  const body = `${input.title}\n${input.observation}\n${input.suggestedChange}`;
+  const classification = classifyAuthorityBucket(body);
+  const supportScore = computeSupportScoreForRouting(input);
+  const mutationRisk = computeMutationRiskForRouting(input.targetFile, input.suggestedChange);
+
+  let blockReason: PersonaProposalAssessment["blockReason"];
+  let blockCandidate: PersonaProposalAssessment["blockCandidate"];
+  const evidence: PersonaProposalAssessment["evidence"] = [];
+  if (crossFileMatch) {
+    blockReason = "already-in-file";
+    blockCandidate = {
+      source: "file-section",
+      location: crossFileMatch.file,
+      snippet: crossFileMatch.snippet,
+      similarity: 1,
+    };
+    evidence.push({
+      type: "file-section",
+      location: crossFileMatch.file,
+      snippet: crossFileMatch.snippet,
+      summary: `Content already present in ${crossFileMatch.file}.`,
+    });
+  }
+
+  const recommendedTargetFile = classification.bucket;
+  const routingDisagrees =
+    recommendedTargetFile !== "skill_workshop" &&
+    recommendedTargetFile !== "memory_fact" &&
+    recommendedTargetFile !== input.targetFile;
+
+  let routingSuggestion: PersonaProposalAssessment["routingSuggestion"];
+  const routingConfident = classification.routingScore >= 0.7;
+  if (routingDisagrees && routingConfident) {
+    routingSuggestion = {
+      recommendedTargetFile: String(recommendedTargetFile),
+      rationale: classification.rationale,
+      callerTargetFile: input.targetFile,
+    };
+  } else if (routingDisagrees) {
+    routingSuggestion = {
+      recommendedTargetFile: String(recommendedTargetFile),
+      rationale: `${classification.rationale} (low routing confidence ${classification.routingScore.toFixed(2)}; advisory only)`,
+      callerTargetFile: input.targetFile,
+    };
+  }
+
+  let overallDisposition: PersonaProposalAssessment["overallDisposition"] = blockReason ? "reject" : "propose";
+  if (routingDisagrees && routingConfident && !blockReason) overallDisposition = "retarget";
+  if (supportScore < 0.55) {
+    overallDisposition = "reject";
+    blockReason = blockReason ?? "low-support";
+  }
+  if (routing.routingMode === "enforce" && routingDisagrees && routingConfident && !blockReason) {
+    blockReason = "enforce-routing";
+  }
+
+  return {
+    supportScore,
+    routingScore: classification.routingScore,
+    dedupScore: crossFileMatch ? 1 : 0,
+    contradictionRisk: 0,
+    mutationRisk,
+    llmConfidenceHint: input.confidence,
+    overallDisposition,
+    recommendedTargetFile,
+    routingRationale: classification.rationale,
+    routingSuggestion,
+    dedupCandidates: [],
+    contradictionCandidates: [],
+    evidence,
+    humanReviewRequired: Boolean((routingDisagrees && routingConfident) || blockReason),
+    applyAllowed: !blockReason,
+    contradiction: false,
+    blockReason,
+    blockCandidate,
+  };
+}
+
+export async function assessPersonaProposalRouting(
+  input: AssessPersonaProposalRoutingInput,
+): Promise<PersonaProposalAssessment> {
+  const routing = resolvePersonaRuleRoutingConfig({ personaRuleRouting: input.personaRuleRouting });
+  if (!routing.enabled) {
+    return assessPersonaProposalRoutingSync(input);
+  }
+  return routePersonaProposal({
+    targetFile: input.targetFile,
+    title: input.title,
+    observation: input.observation,
+    suggestedChange: input.suggestedChange,
+    confidence: input.confidence,
+    evidenceSessions: input.evidenceSessions,
+    workspaceRoot: input.workspaceRoot,
+    allowedFiles: input.allowedFiles,
+    routing,
+    factsDb: input.factsDb,
+    embedText: input.embeddings ? (text) => input.embeddings!.embed(text) : undefined,
+    adjudicateContradiction: input.adjudicateContradiction,
+  });
+}
+
+function computeSupportScoreForRouting(input: {
+  confidence: number;
+  evidenceSessions: string[];
+  observation: string;
+}): number {
+  const evidenceBoost = Math.min(0.25, Math.max(0, input.evidenceSessions.length - 1) * 0.05);
+  const base = Math.max(0, Math.min(1, input.confidence));
+  return Math.min(1, base * 0.85 + evidenceBoost + (input.observation.trim().length > 40 ? 0.05 : 0));
+}
+
+function computeMutationRiskForRouting(targetFile: string, suggestedChange: string): number {
+  if (targetFile === "SOUL.md" || targetFile === "IDENTITY.md") return 0.85;
+  if (targetFile === "USER.md") return 0.7;
+  if (/^\s*replace\b/i.test(suggestedChange)) return 0.8;
+  if (targetFile === "AGENTS.md" || targetFile === "TOOLS.md") return 0.45;
+  return 0.55;
 }
 
 function buildAppendBlock(proposalId: string, observation: string, suggestedChange: string, timestamp: string): string {

--- a/extensions/memory-hybrid/config/parsers/features.ts
+++ b/extensions/memory-hybrid/config/parsers/features.ts
@@ -453,7 +453,38 @@ export function parsePersonaProposalsConfig(cfg: Record<string, unknown>): Perso
       typeof proposalsRaw?.workshopMaxPending === "number" && proposalsRaw.workshopMaxPending >= 0
         ? Math.floor(proposalsRaw.workshopMaxPending)
         : undefined,
+    personaRuleRouting: parsePersonaRuleRoutingConfig(proposalsRaw),
   };
+}
+
+function parsePersonaRuleRoutingConfig(
+  proposalsRaw: Record<string, unknown> | undefined,
+): PersonaProposalsConfig["personaRuleRouting"] {
+  const raw = proposalsRaw?.personaRuleRouting as Record<string, unknown> | undefined;
+  if (!raw) return undefined;
+  const semanticRaw = raw.semanticDedup as Record<string, unknown> | undefined;
+  const out: NonNullable<PersonaProposalsConfig["personaRuleRouting"]> = {};
+  if (raw.enabled === false) out.enabled = false;
+  if (raw.enabled === true) out.enabled = true;
+  if (raw.routingMode === "advisory" || raw.routingMode === "enforce") out.routingMode = raw.routingMode;
+  if (semanticRaw?.enabled === true) out.semanticDedup = { enabled: true };
+  if (semanticRaw?.enabled === false) out.semanticDedup = { enabled: false };
+  if (typeof raw.dedupeThreshold === "number" && raw.dedupeThreshold > 0 && raw.dedupeThreshold <= 1) {
+    out.dedupeThreshold = raw.dedupeThreshold;
+  }
+  if (typeof raw.nearDedupeThreshold === "number" && raw.nearDedupeThreshold > 0 && raw.nearDedupeThreshold <= 1) {
+    out.nearDedupeThreshold = raw.nearDedupeThreshold;
+  }
+  if (typeof raw.contradictionThreshold === "number" && raw.contradictionThreshold > 0 && raw.contradictionThreshold <= 1) {
+    out.contradictionThreshold = raw.contradictionThreshold;
+  }
+  if (typeof raw.routingCacheTtlSeconds === "number" && raw.routingCacheTtlSeconds >= 0) {
+    out.routingCacheTtlSeconds = Math.floor(raw.routingCacheTtlSeconds);
+  }
+  if (typeof raw.topK === "number" && raw.topK > 0) {
+    out.topK = Math.floor(raw.topK);
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
 }
 
 export function parseWorkshopConfig(cfg: Record<string, unknown>): WorkshopConfig | undefined {

--- a/extensions/memory-hybrid/config/types/agents.ts
+++ b/extensions/memory-hybrid/config/types/agents.ts
@@ -22,6 +22,25 @@ export type MultiAgentConfig = {
   trustToolScopeParams?: boolean;
 };
 
+/** Durable-rule routing / dedup / contradiction gates for persona proposals (#2002). */
+export type PersonaRuleRoutingConfig = {
+  enabled: boolean;
+  routingMode: "advisory" | "enforce";
+  semanticDedup: { enabled: boolean };
+  dedupeThreshold: number;
+  nearDedupeThreshold: number;
+  contradictionThreshold: number;
+  routingCacheTtlSeconds: number;
+  topK: number;
+};
+
+export type PersonaProposalMetricsSnapshot = {
+  routingSuggestions: number;
+  dedupHits: number;
+  contradictionHits: number;
+  contradictionDegraded: number;
+};
+
 /** Opt-in persona proposals: agent self-evolution with human approval gate */
 export type PersonaProposalsConfig = {
   enabled: boolean;
@@ -52,6 +71,10 @@ export type PersonaProposalsConfig = {
   separateSelfCorrectionQuota: boolean;
   /** Unified workshop queue cap across persona, crystallization, tool, and procedure-skill backlogs (default: 50). */
   workshopMaxPending?: number;
+  /** Destination classifier + semantic dedup + contradiction detection (#2002). */
+  personaRuleRouting?: Partial<PersonaRuleRoutingConfig>;
+  /** Runtime counters surfaced in workshop digest (populated by persona-rule-router). */
+  metrics?: PersonaProposalMetricsSnapshot;
 };
 
 /** Unified memory workshop (proposal review queue). */

--- a/extensions/memory-hybrid/services/pending-review-digest.ts
+++ b/extensions/memory-hybrid/services/pending-review-digest.ts
@@ -9,6 +9,7 @@ import type { HybridMemoryConfig } from "../config.js";
 import { pluginLogger } from "../utils/logger.js";
 import { formatTimestampUtc } from "../utils/dates.js";
 import { summarizeSkillProposalValidation } from "./generated-skill-validation.js";
+import { personaRuleRoutingMetrics } from "./persona-rule-router.js";
 
 type FactsDbForPendingDigest = {
   proceduresCount(): number;
@@ -79,6 +80,13 @@ export type PendingReviewDigestReport = {
        */
       evidence: { topFactIds: string[]; facts: number };
     }>;
+    /** #2002: durable-rule router counters since process start. */
+    metrics?: {
+      routingSuggestions: number;
+      dedupHits: number;
+      contradictionHits: number;
+      contradictionDegraded: number;
+    };
   };
   toolProposals: {
     proposed: number;
@@ -315,6 +323,7 @@ export function buildPendingReviewDigestReport(opts: {
         deferCommand: "openclaw hybrid-mem proposals list --status pending",
         evidence: evidenceForProposal(p.evidenceSessions ?? []),
       })),
+      metrics: { ...personaRuleRoutingMetrics },
     },
     toolProposals: {
       proposed: toolProposed.length,

--- a/extensions/memory-hybrid/services/persona-proposal-triage.ts
+++ b/extensions/memory-hybrid/services/persona-proposal-triage.ts
@@ -13,6 +13,7 @@ import { homedir } from "node:os";
 import { isAbsolute, join, relative, resolve } from "node:path";
 import type { ProposalEntry, ProposalsDB } from "../backends/proposals-db.js";
 import { buildAppliedContent, buildUnifiedDiff, parseSuggestedChange, assessPersonaProposalRoutingSync } from "../cli/proposals.js";
+import { resolvePersonaRuleRoutingConfig } from "./persona-rule-router.js";
 import type { HybridMemoryConfig } from "../config.js";
 import {
   emitPersonaApplied,
@@ -624,50 +625,56 @@ function analyzePersonaProposal(
       1,
     );
   }
-  const routingAssessment = assessPersonaProposalRoutingSync({
-    targetFile: p.targetFile,
-    title: p.title,
-    observation: p.observation,
-    suggestedChange: p.suggestedChange,
-    confidence: p.confidence,
-    evidenceSessions: p.evidenceSessions ?? [],
-    workspaceRoot: item.workspace,
-    allowedFiles: cfg.personaProposals.allowedFiles,
-    personaRuleRouting: cfg.personaProposals.personaRuleRouting,
-  });
-  if (routingAssessment.blockReason === "already-in-file" && routingAssessment.blockCandidate) {
-    return rejectOrDefer(
-      policy,
-      "low",
-      "already-in-file",
-      `Proposed text already present in ${routingAssessment.blockCandidate.location}.`,
-      [...evidence, ...routingAssessment.evidence],
-      1,
-    );
-  }
-  if (routingAssessment.contradiction || routingAssessment.contradictionCandidates.length > 0) {
-    return {
-      risk: "medium",
-      action: "deferred",
-      reasonCode: "policy-requires-human",
-      actionClass: "observe",
-      capabilityClass: "read-only",
+  const routingCfg = resolvePersonaRuleRoutingConfig({ personaRuleRouting: cfg.personaProposals.personaRuleRouting });
+  let routingHumanReviewRequired = false;
+  if (routingCfg.enabled) {
+    const routingAssessment = assessPersonaProposalRoutingSync({
+      targetFile: p.targetFile,
+      title: p.title,
+      observation: p.observation,
+      suggestedChange: p.suggestedChange,
       confidence: p.confidence,
-      humanReviewRequired: true,
-      diffSummary: summarizeDiff(p, item),
-      evidence: [...evidence, ...routingAssessment.evidence],
-      applyAllowed: false,
-    };
-  }
-  if (routingAssessment.routingSuggestion && routingAssessment.routingScore >= 0.7) {
-    evidence.push({
-      type: "rule",
-      id: routingAssessment.routingSuggestion.recommendedTargetFile,
-      summary: `Routing suggestion: ${routingAssessment.routingSuggestion.recommendedTargetFile} — ${routingAssessment.routingSuggestion.rationale}`,
+      evidenceSessions: p.evidenceSessions ?? [],
+      workspaceRoot: item.workspace,
+      allowedFiles: cfg.personaProposals.allowedFiles,
+      personaRuleRouting: cfg.personaProposals.personaRuleRouting,
     });
-  }
-  for (const entry of routingAssessment.evidence) {
-    evidence.push({ type: entry.type, id: entry.id, summary: entry.summary });
+    if (routingAssessment.blockReason === "already-in-file" && routingAssessment.blockCandidate) {
+      return rejectOrDefer(
+        policy,
+        "low",
+        "already-in-file",
+        `Proposed text already present in ${routingAssessment.blockCandidate.location}.`,
+        [...evidence, ...routingAssessment.evidence],
+        1,
+      );
+    }
+    if (routingAssessment.contradiction || routingAssessment.contradictionCandidates.length > 0) {
+      return {
+        risk: "medium",
+        action: "deferred",
+        reasonCode: "policy-requires-human",
+        actionClass: "observe",
+        capabilityClass: "read-only",
+        confidence: p.confidence,
+        humanReviewRequired: true,
+        diffSummary: summarizeDiff(p, item),
+        evidence: [...evidence, ...routingAssessment.evidence],
+        applyAllowed: false,
+      };
+    }
+    if (routingAssessment.routingSuggestion && routingAssessment.routingScore >= 0.7) {
+      evidence.push({
+        type: "rule",
+        id: routingAssessment.routingSuggestion.recommendedTargetFile,
+        summary: `Routing suggestion: ${routingAssessment.routingSuggestion.recommendedTargetFile} — ${routingAssessment.routingSuggestion.rationale}`,
+      });
+    }
+    for (const entry of routingAssessment.evidence) {
+      evidence.push({ type: entry.type, id: entry.id, summary: entry.summary });
+    }
+    routingHumanReviewRequired =
+      routingAssessment.humanReviewRequired && routingAssessment.routingScore >= 0.7;
   }
   if (isStaleTarget(item)) {
     return rejectOrDefer(
@@ -690,7 +697,7 @@ function analyzePersonaProposal(
   }
   if (!hasEvidence(p)) return defer("low", "missing-evidence", diffSummary, evidence, p.confidence);
   if (policy !== "apply-safe") return defer("low", "policy-requires-human", diffSummary, evidence, p.confidence);
-  if (routingAssessment.humanReviewRequired && routingAssessment.routingScore >= 0.7) {
+  if (routingHumanReviewRequired) {
     return defer("low", "policy-requires-human", diffSummary, evidence, p.confidence);
   }
   if (!hasReliableTargetSnapshot(p)) {

--- a/extensions/memory-hybrid/services/persona-proposal-triage.ts
+++ b/extensions/memory-hybrid/services/persona-proposal-triage.ts
@@ -12,7 +12,7 @@ import { existsSync, lstatSync, readFileSync, realpathSync, renameSync, rmSync, 
 import { homedir } from "node:os";
 import { isAbsolute, join, relative, resolve } from "node:path";
 import type { ProposalEntry, ProposalsDB } from "../backends/proposals-db.js";
-import { buildAppliedContent, buildUnifiedDiff, parseSuggestedChange } from "../cli/proposals.js";
+import { buildAppliedContent, buildUnifiedDiff, parseSuggestedChange, assessPersonaProposalRoutingSync } from "../cli/proposals.js";
 import type { HybridMemoryConfig } from "../config.js";
 import {
   emitPersonaApplied,
@@ -371,7 +371,7 @@ export function decidePersonaProposal(
   },
 ): PendingDecision {
   const all = input.allProposals ?? input.proposalsDb.list();
-  const analysis = analyzePersonaProposal(item, context.policy as PersonaProposalTriagePolicy, all);
+  const analysis = analyzePersonaProposal(item, context.policy as PersonaProposalTriagePolicy, all, input.cfg);
   const reportOnly = context.policy === "report-only";
   const readOnlyCapability = context.mode === "dry-run" ? "dry-run" : "read-only";
   const action = reportOnly ? "reported" : analysis.action;
@@ -545,6 +545,7 @@ function analyzePersonaProposal(
   item: PersonaProposalPendingItem,
   policy: PersonaProposalTriagePolicy,
   allProposals: ProposalEntry[],
+  cfg: Pick<HybridMemoryConfig, "personaProposals">,
 ): Analysis {
   const p = item.proposal;
   const text = `${p.title}\n${p.observation}\n${p.suggestedChange}`;
@@ -623,6 +624,51 @@ function analyzePersonaProposal(
       1,
     );
   }
+  const routingAssessment = assessPersonaProposalRoutingSync({
+    targetFile: p.targetFile,
+    title: p.title,
+    observation: p.observation,
+    suggestedChange: p.suggestedChange,
+    confidence: p.confidence,
+    evidenceSessions: p.evidenceSessions ?? [],
+    workspaceRoot: item.workspace,
+    allowedFiles: cfg.personaProposals.allowedFiles,
+    personaRuleRouting: cfg.personaProposals.personaRuleRouting,
+  });
+  if (routingAssessment.blockReason === "already-in-file" && routingAssessment.blockCandidate) {
+    return rejectOrDefer(
+      policy,
+      "low",
+      "already-in-file",
+      `Proposed text already present in ${routingAssessment.blockCandidate.location}.`,
+      [...evidence, ...routingAssessment.evidence],
+      1,
+    );
+  }
+  if (routingAssessment.contradiction || routingAssessment.contradictionCandidates.length > 0) {
+    return {
+      risk: "medium",
+      action: "deferred",
+      reasonCode: "policy-requires-human",
+      actionClass: "observe",
+      capabilityClass: "read-only",
+      confidence: p.confidence,
+      humanReviewRequired: true,
+      diffSummary: summarizeDiff(p, item),
+      evidence: [...evidence, ...routingAssessment.evidence],
+      applyAllowed: false,
+    };
+  }
+  if (routingAssessment.routingSuggestion && routingAssessment.routingScore >= 0.7) {
+    evidence.push({
+      type: "rule",
+      id: routingAssessment.routingSuggestion.recommendedTargetFile,
+      summary: `Routing suggestion: ${routingAssessment.routingSuggestion.recommendedTargetFile} — ${routingAssessment.routingSuggestion.rationale}`,
+    });
+  }
+  for (const entry of routingAssessment.evidence) {
+    evidence.push({ type: entry.type, id: entry.id, summary: entry.summary });
+  }
   if (isStaleTarget(item)) {
     return rejectOrDefer(
       policy,
@@ -644,6 +690,9 @@ function analyzePersonaProposal(
   }
   if (!hasEvidence(p)) return defer("low", "missing-evidence", diffSummary, evidence, p.confidence);
   if (policy !== "apply-safe") return defer("low", "policy-requires-human", diffSummary, evidence, p.confidence);
+  if (routingAssessment.humanReviewRequired && routingAssessment.routingScore >= 0.7) {
+    return defer("low", "policy-requires-human", diffSummary, evidence, p.confidence);
+  }
   if (!hasReliableTargetSnapshot(p)) {
     return defer(
       "low",

--- a/extensions/memory-hybrid/services/persona-rule-router.ts
+++ b/extensions/memory-hybrid/services/persona-rule-router.ts
@@ -422,12 +422,7 @@ export async function routePersonaProposal(input: RoutePersonaProposalInput): Pr
     recommendedTargetFile !== "memory_fact" &&
     !input.allowedFiles.includes(recommendedTargetFile)
   ) {
-    const fallback = input.allowedFiles.includes("USER.md") ? "USER.md" : input.allowedFiles[0];
-    if (fallback) {
-      recommendedTargetFile = fallback as AuthorityTarget;
-      routingScore *= 0.8;
-      routingRationale += ` Recommended file not in allowedFiles; softened to ${fallback}.`;
-    }
+    routingRationale += ` Note: ${recommendedTargetFile} is not in personaProposals.allowedFiles; retarget suggestion remains advisory.`;
   }
 
   const evidence: RuleRoutingEvidence[] = [];
@@ -702,6 +697,31 @@ export function resolvePersonaRuleRoutingConfig(
   cfg: { personaRuleRouting?: PersonaRuleRoutingConfig },
 ): PersonaRuleRoutingConfig {
   return { ...DEFAULT_PERSONA_RULE_ROUTING, ...cfg.personaRuleRouting };
+}
+
+/** No-op assessment when persona rule routing is disabled. */
+export function createDisabledRoutingPassthroughAssessment(input: {
+  targetFile: string;
+  confidence: number;
+  suggestedChange: string;
+}): PersonaProposalAssessment {
+  return {
+    supportScore: input.confidence,
+    routingScore: 0,
+    dedupScore: 0,
+    contradictionRisk: 0,
+    mutationRisk: computeMutationRisk(input.targetFile, input.suggestedChange),
+    llmConfidenceHint: input.confidence,
+    overallDisposition: "propose",
+    recommendedTargetFile: input.targetFile as AuthorityTarget,
+    routingRationale: "Persona rule routing disabled.",
+    dedupCandidates: [],
+    contradictionCandidates: [],
+    evidence: [],
+    humanReviewRequired: false,
+    applyAllowed: true,
+    contradiction: false,
+  };
 }
 
 export function shouldBlockProposalCreation(

--- a/extensions/memory-hybrid/services/persona-rule-router.ts
+++ b/extensions/memory-hybrid/services/persona-rule-router.ts
@@ -1,0 +1,715 @@
+/**
+ * Durable-rule destination classifier for persona proposals (#2002).
+ *
+ * Multi-gate assessment: authority-bucket routing, cross-surface semantic dedup,
+ * and contradiction detection against reflection rules and authority files.
+ */
+
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import type { FactsDB } from "../backends/facts-db.js";
+import type { MemoryEntry } from "../types/memory.js";
+import { normalizeProposalText } from "../cli/proposals.js";
+import type { PersonaRuleRoutingConfig } from "../config/types/agents.js";
+import { cosineSimilarity } from "./ambient-retrieval.js";
+
+export type AuthorityTarget =
+  | "SOUL.md"
+  | "IDENTITY.md"
+  | "USER.md"
+  | "AGENTS.md"
+  | "TOOLS.md"
+  | "skill_workshop"
+  | "memory_fact";
+
+export type PersonaProposalDisposition = "propose" | "retarget" | "merge" | "manual-review" | "reject";
+
+export type RuleRoutingEvidence = {
+  type: "rule" | "file-section" | "skill" | "memory-fact" | "contradiction-degraded";
+  id?: string;
+  summary: string;
+  similarity?: number;
+  location?: string;
+  snippet?: string;
+};
+
+export type DedupCandidate = RuleRoutingEvidence & {
+  source: "memory-fact" | "file-section" | "skill";
+  mergeWith?: boolean;
+};
+
+export type ContradictionCandidate = RuleRoutingEvidence & {
+  existingRuleId?: string;
+  existingLocation?: string;
+  decision?: "manual_review" | "merge" | "supersedes";
+  mergedRuleText?: string | null;
+};
+
+export type PersonaProposalAssessment = {
+  supportScore: number;
+  routingScore: number;
+  dedupScore: number;
+  contradictionRisk: number;
+  mutationRisk: number;
+  llmConfidenceHint?: number;
+  overallDisposition: PersonaProposalDisposition;
+  recommendedTargetFile: AuthorityTarget;
+  routingRationale: string;
+  routingSuggestion?: {
+    recommendedTargetFile: string;
+    rationale: string;
+    callerTargetFile: string;
+  };
+  dedupCandidates: DedupCandidate[];
+  contradictionCandidates: ContradictionCandidate[];
+  evidence: RuleRoutingEvidence[];
+  humanReviewRequired: boolean;
+  applyAllowed: boolean;
+  contradiction: boolean;
+  /** Hard block reason for proposal creation (duplicate-rule, enforce-routing, etc.). */
+  blockReason?: "duplicate-rule" | "near-duplicate-rule" | "already-in-file" | "enforce-routing" | "low-support";
+  blockCandidate?: {
+    source: string;
+    location: string;
+    snippet: string;
+    similarity?: number;
+  };
+};
+
+export type RuleContradictionAdjudication = {
+  decision: "manual_review" | "merge" | "supersedes";
+  reason: string;
+  mergedRuleText?: string | null;
+};
+
+export type RoutePersonaProposalInput = {
+  targetFile: string;
+  title: string;
+  observation: string;
+  suggestedChange: string;
+  confidence: number;
+  evidenceSessions: string[];
+  workspaceRoot: string;
+  allowedFiles: readonly string[];
+  routing: PersonaRuleRoutingConfig;
+  factsDb?: FactsDB | null;
+  embedText?: (text: string) => Promise<number[]>;
+  adjudicateContradiction?: (
+    proposed: string,
+    existing: string,
+  ) => Promise<RuleContradictionAdjudication | null>;
+};
+
+export const DEFAULT_PERSONA_RULE_ROUTING: PersonaRuleRoutingConfig = {
+  enabled: true,
+  routingMode: "advisory",
+  semanticDedup: { enabled: true },
+  dedupeThreshold: 0.92,
+  nearDedupeThreshold: 0.75,
+  contradictionThreshold: 0.6,
+  routingCacheTtlSeconds: 3600,
+  topK: 8,
+};
+
+export const AUTHORITY_FILE_TARGETS = ["AGENTS.md", "TOOLS.md", "SOUL.md", "USER.md", "IDENTITY.md"] as const;
+
+const BUCKET_PRIORITY: AuthorityTarget[] = [
+  "skill_workshop",
+  "AGENTS.md",
+  "TOOLS.md",
+  "SOUL.md",
+  "USER.md",
+  "IDENTITY.md",
+  "memory_fact",
+];
+
+const BUCKET_PATTERNS: Record<Exclude<AuthorityTarget, "memory_fact">, RegExp[]> = {
+  "AGENTS.md": [
+    /\b(github|issue|pr|pull request|commit|ci|cron|dispatch|gate|council|workflow|omnibus|triage|stewardship)\b/i,
+  ],
+  "TOOLS.md": [/\b(host|hostname|port|wrapper|alias|local path|\/usr\/|\/mnt\/)\b/i],
+  "SOUL.md": [/\b(values|principles|ethos|character|integrity|honesty|helpful)\b/i],
+  "USER.md": [/\b(user preference|profile|personal fact|communication style|timezone|locale)\b/i],
+  "IDENTITY.md": [/\b(name|persona|identity|voice|tone|role|agent name)\b/i],
+  skill_workshop: [
+    /\b(reusable|playbook|recurring workflow|step \d|^\d+\.|procedure)\b/im,
+    /\b(first,|second,|third,|then .+ then .+ then)\b/i,
+  ],
+};
+
+const OPERATIONAL_FAMILY = new Set<string>(["AGENTS.md", "TOOLS.md"]);
+const IDENTITY_FAMILY = new Set<string>(["SOUL.md", "IDENTITY.md"]);
+
+const embeddingCache = new Map<string, { vector: number[]; expiresAt: number }>();
+
+export const personaRuleRoutingMetrics = {
+  routingSuggestions: 0,
+  dedupHits: 0,
+  contradictionHits: 0,
+  contradictionDegraded: 0,
+};
+
+export function resetPersonaRuleRoutingMetrics(): void {
+  personaRuleRoutingMetrics.routingSuggestions = 0;
+  personaRuleRoutingMetrics.dedupHits = 0;
+  personaRuleRoutingMetrics.contradictionHits = 0;
+  personaRuleRoutingMetrics.contradictionDegraded = 0;
+}
+
+function bucketPriorityIndex(bucket: AuthorityTarget): number {
+  const idx = BUCKET_PRIORITY.indexOf(bucket);
+  return idx >= 0 ? idx : BUCKET_PRIORITY.length;
+}
+
+function proposalBody(input: Pick<RoutePersonaProposalInput, "title" | "observation" | "suggestedChange">): string {
+  return `${input.title}\n${input.observation}\n${input.suggestedChange}`;
+}
+
+function scoreBucket(text: string, bucket: Exclude<AuthorityTarget, "memory_fact">): number {
+  const patterns = BUCKET_PATTERNS[bucket];
+  let hits = 0;
+  for (const re of patterns) {
+    if (re.test(text)) hits += 1;
+  }
+  if (hits === 0) return 0;
+  return Math.min(1, 0.55 + hits * 0.15);
+}
+
+export function classifyAuthorityBucket(text: string): {
+  bucket: AuthorityTarget;
+  routingScore: number;
+  rationale: string;
+} {
+  const normalized = text.toLowerCase();
+  if (/\b(remember|store|recall|on next turn)\b/i.test(normalized) && normalized.split(/\s+/).length <= 24) {
+    return {
+      bucket: "memory_fact",
+      routingScore: 0.65,
+      rationale: "Declarative recall instruction suited to a memory fact, not a persona file.",
+    };
+  }
+
+  let best: { bucket: AuthorityTarget; routingScore: number; rationale: string } | null = null;
+  for (const bucket of BUCKET_PRIORITY) {
+    if (bucket === "memory_fact") continue;
+    const score = scoreBucket(text, bucket);
+    if (score <= 0) continue;
+    const candidate = {
+      bucket,
+      routingScore: score,
+      rationale: bucketRationale(bucket),
+    };
+    if (!best || bucketPriorityIndex(candidate.bucket) < bucketPriorityIndex(best.bucket)) {
+      best = candidate;
+    } else if (
+      best &&
+      bucketPriorityIndex(candidate.bucket) === bucketPriorityIndex(best.bucket) &&
+      candidate.routingScore > best.routingScore
+    ) {
+      best = candidate;
+    }
+  }
+
+  if (best) return best;
+  return {
+    bucket: "USER.md",
+    routingScore: 0.5,
+    rationale: "No strong operational or identity signals; defaulting to user-context guidance.",
+  };
+}
+
+function bucketRationale(bucket: AuthorityTarget): string {
+  switch (bucket) {
+    case "AGENTS.md":
+      return "Operational workflow rule (GitHub/issue/PR/CI/dispatch/gate semantics).";
+    case "TOOLS.md":
+      return "Local environment or tool invocation specifics.";
+    case "SOUL.md":
+      return "Values or principles guidance.";
+    case "USER.md":
+      return "User-specific preference or profile guidance.";
+    case "IDENTITY.md":
+      return "Agent identity, voice, or role guidance.";
+    case "skill_workshop":
+      return "Multi-step recurring procedure better promoted as a named skill.";
+    case "memory_fact":
+      return "Machine-readable recall instruction.";
+    default:
+      return "Authority file routing.";
+  }
+}
+
+function computeSupportScore(input: RoutePersonaProposalInput): number {
+  const evidenceBoost = Math.min(0.25, Math.max(0, input.evidenceSessions.length - 1) * 0.05);
+  const base = Math.max(0, Math.min(1, input.confidence));
+  return Math.min(1, base * 0.85 + evidenceBoost + (input.observation.trim().length > 40 ? 0.05 : 0));
+}
+
+function computeMutationRisk(targetFile: string, suggestedChange: string): number {
+  if (targetFile === "SOUL.md" || targetFile === "IDENTITY.md") return 0.85;
+  if (targetFile === "USER.md") return 0.7;
+  if (/^\s*replace\b/i.test(suggestedChange)) return 0.8;
+  if (targetFile === "AGENTS.md" || targetFile === "TOOLS.md") return 0.45;
+  return 0.55;
+}
+
+function sameBucketFamily(a: string, b: string): boolean {
+  if (a === b) return true;
+  if (OPERATIONAL_FAMILY.has(a) && OPERATIONAL_FAMILY.has(b)) return true;
+  if (IDENTITY_FAMILY.has(a) && IDENTITY_FAMILY.has(b)) return true;
+  return false;
+}
+
+function hashCacheKey(text: string): string {
+  return createHash("sha256").update(normalizeProposalText(text)).digest("hex");
+}
+
+async function cachedEmbed(
+  text: string,
+  embedText: ((text: string) => Promise<number[]>) | undefined,
+  ttlSeconds: number,
+): Promise<number[] | null> {
+  if (!embedText) return null;
+  const key = hashCacheKey(text);
+  const now = Date.now();
+  const cached = embeddingCache.get(key);
+  if (cached && cached.expiresAt > now) return cached.vector;
+  try {
+    const vector = await embedText(text);
+    embeddingCache.set(key, { vector, expiresAt: now + ttlSeconds * 1000 });
+    return vector;
+  } catch {
+    return null;
+  }
+}
+
+function readAuthorityFileSections(workspaceRoot: string, files: readonly string[]): Array<{
+  file: string;
+  text: string;
+}> {
+  const out: Array<{ file: string; text: string }> = [];
+  for (const file of files) {
+    const path = join(workspaceRoot, file);
+    if (!existsSync(path)) continue;
+    try {
+      out.push({ file, text: readFileSync(path, "utf-8") });
+    } catch {
+      // skip unreadable
+    }
+  }
+  return out;
+}
+
+function splitSubstantiveSections(text: string): string[] {
+  return text
+    .split(/\n{2,}|(?=^#{1,3} )/m)
+    .map((s) => s.trim())
+    .filter((s) => s.length >= 30);
+}
+
+export function findCrossFileContentMatch(input: {
+  suggestedChange: string;
+  workspaceRoot: string;
+  excludeFile?: string;
+  authorityFiles?: readonly string[];
+}): { file: string; snippet: string } | null {
+  const files = input.authorityFiles ?? AUTHORITY_FILE_TARGETS;
+  const normalizedChange = normalizeProposalText(input.suggestedChange);
+  if (normalizedChange.length < 20) return null;
+
+  for (const { file, text } of readAuthorityFileSections(input.workspaceRoot, files)) {
+    if (input.excludeFile && file === input.excludeFile) continue;
+    const normalizedFile = normalizeProposalText(text);
+    if (normalizedFile.includes(normalizedChange)) {
+      return { file, snippet: input.suggestedChange.slice(0, 160) };
+    }
+    for (const section of splitSubstantiveSections(text)) {
+      if (normalizeProposalText(section) === normalizedChange) {
+        return { file, snippet: section.slice(0, 160) };
+      }
+    }
+  }
+  return null;
+}
+
+function listRuleFacts(factsDb: FactsDB | null | undefined, limit: number): MemoryEntry[] {
+  if (!factsDb) return [];
+  try {
+    return factsDb.listFactsByCategory("rule", limit);
+  } catch {
+    return [];
+  }
+}
+
+async function collectSemanticCandidates(input: {
+  queryText: string;
+  workspaceRoot: string;
+  factsDb?: FactsDB | null;
+  embedText?: (text: string) => Promise<number[]>;
+  topK: number;
+  cacheTtlSeconds: number;
+}): Promise<Array<{ source: DedupCandidate["source"]; location: string; id?: string; text: string; similarity: number }>> {
+  const queryVector = await cachedEmbed(input.queryText, input.embedText, input.cacheTtlSeconds);
+  if (!queryVector) return [];
+
+  const candidates: Array<{
+    source: DedupCandidate["source"];
+    location: string;
+    id?: string;
+    text: string;
+    similarity: number;
+  }> = [];
+
+  for (const fact of listRuleFacts(input.factsDb, 200)) {
+    const tags = fact.tags ?? [];
+    const factVector = await cachedEmbed(fact.text, input.embedText, input.cacheTtlSeconds);
+    if (!factVector) continue;
+    const similarity = cosineSimilarity(queryVector, factVector);
+    candidates.push({
+      source: "memory-fact",
+      location: `fact:${fact.id}`,
+      id: fact.id,
+      text: fact.text,
+      similarity,
+    });
+    void tags;
+  }
+
+  for (const { file, text } of readAuthorityFileSections(input.workspaceRoot, AUTHORITY_FILE_TARGETS)) {
+    for (const section of splitSubstantiveSections(text)) {
+      const sectionVector = await cachedEmbed(section, input.embedText, input.cacheTtlSeconds);
+      if (!sectionVector) continue;
+      const similarity = cosineSimilarity(queryVector, sectionVector);
+      candidates.push({
+        source: "file-section",
+        location: file,
+        text: section,
+        similarity,
+      });
+    }
+  }
+
+  candidates.sort((a, b) => b.similarity - a.similarity);
+  return candidates.slice(0, input.topK);
+}
+
+function looksContradictory(a: string, b: string): boolean {
+  const na = normalizeProposalText(a);
+  const nb = normalizeProposalText(b);
+  const neverNever = /\bnever\b/i.test(na) && /\bnever\b/i.test(nb);
+  const alwaysNever =
+    (/\balways\b/i.test(na) && /\bnever\b/i.test(nb)) || (/\bnever\b/i.test(na) && /\balways\b/i.test(nb));
+  const preferVsDefault =
+    (/\bprefer\b/i.test(na) && /\bdefault\b/i.test(nb)) || (/\bdefault\b/i.test(na) && /\bprefer\b/i.test(nb));
+  return neverNever || alwaysNever || preferVsDefault;
+}
+
+export async function routePersonaProposal(input: RoutePersonaProposalInput): Promise<PersonaProposalAssessment> {
+  const routing = input.routing.enabled ? input.routing : { ...DEFAULT_PERSONA_RULE_ROUTING, enabled: false };
+  const body = proposalBody(input);
+  const llmConfidenceHint = input.confidence;
+  const supportScore = computeSupportScore(input);
+  const mutationRisk = computeMutationRisk(input.targetFile, input.suggestedChange);
+
+  const classification = classifyAuthorityBucket(body);
+  let recommendedTargetFile = classification.bucket;
+  let routingScore = classification.routingScore;
+  let routingRationale = classification.rationale;
+
+  if (
+    recommendedTargetFile !== "skill_workshop" &&
+    recommendedTargetFile !== "memory_fact" &&
+    !input.allowedFiles.includes(recommendedTargetFile)
+  ) {
+    const fallback = input.allowedFiles.includes("USER.md") ? "USER.md" : input.allowedFiles[0];
+    if (fallback) {
+      recommendedTargetFile = fallback as AuthorityTarget;
+      routingScore *= 0.8;
+      routingRationale += ` Recommended file not in allowedFiles; softened to ${fallback}.`;
+    }
+  }
+
+  const evidence: RuleRoutingEvidence[] = [];
+  const dedupCandidates: DedupCandidate[] = [];
+  const contradictionCandidates: ContradictionCandidate[] = [];
+  let dedupScore = 0;
+  let contradictionRisk = 0;
+  let humanReviewRequired = false;
+  let applyAllowed = true;
+  let contradiction = false;
+  let overallDisposition: PersonaProposalDisposition = "propose";
+  let blockReason: PersonaProposalAssessment["blockReason"];
+  let blockCandidate: PersonaProposalAssessment["blockCandidate"];
+
+  const crossFileMatch = findCrossFileContentMatch({
+    suggestedChange: input.suggestedChange,
+    workspaceRoot: input.workspaceRoot,
+    excludeFile: input.targetFile,
+  });
+  if (crossFileMatch) {
+    dedupScore = 1;
+    personaRuleRoutingMetrics.dedupHits += 1;
+    const candidate: DedupCandidate = {
+      type: "file-section",
+      source: "file-section",
+      location: crossFileMatch.file,
+      snippet: crossFileMatch.snippet,
+      similarity: 1,
+      summary: `Content already present in ${crossFileMatch.file}.`,
+    };
+    dedupCandidates.push(candidate);
+    evidence.push(candidate);
+    blockReason = "already-in-file";
+    blockCandidate = {
+      source: "file-section",
+      location: crossFileMatch.file,
+      snippet: crossFileMatch.snippet,
+      similarity: 1,
+    };
+    overallDisposition = "reject";
+  }
+
+  if (routing.enabled && routing.semanticDedup.enabled && input.embedText) {
+    const semantic = await collectSemanticCandidates({
+      queryText: `${input.title}\n${input.suggestedChange}`,
+      workspaceRoot: input.workspaceRoot,
+      factsDb: input.factsDb,
+      embedText: input.embedText,
+      topK: routing.topK,
+      cacheTtlSeconds: routing.routingCacheTtlSeconds,
+    });
+    for (const hit of semantic) {
+      if (hit.similarity > dedupScore) dedupScore = hit.similarity;
+      if (hit.similarity >= routing.dedupeThreshold) {
+        personaRuleRoutingMetrics.dedupHits += 1;
+        const candidate: DedupCandidate = {
+          type: hit.source === "memory-fact" ? "memory-fact" : "file-section",
+          source: hit.source,
+          id: hit.id,
+          location: hit.location,
+          snippet: hit.text.slice(0, 160),
+          similarity: hit.similarity,
+          summary: `Semantic duplicate (${hit.similarity.toFixed(2)}) in ${hit.location}.`,
+        };
+        dedupCandidates.push(candidate);
+        evidence.push(candidate);
+        blockReason = "duplicate-rule";
+        blockCandidate = {
+          source: hit.source,
+          location: hit.location,
+          snippet: hit.text.slice(0, 160),
+          similarity: hit.similarity,
+        };
+        overallDisposition = "merge";
+      } else if (hit.similarity >= routing.nearDedupeThreshold) {
+        const candidate: DedupCandidate = {
+          type: hit.source === "memory-fact" ? "memory-fact" : "file-section",
+          source: hit.source,
+          id: hit.id,
+          location: hit.location,
+          snippet: hit.text.slice(0, 160),
+          similarity: hit.similarity,
+          mergeWith: true,
+          summary: `Near-duplicate (${hit.similarity.toFixed(2)}) in ${hit.location}.`,
+        };
+        dedupCandidates.push(candidate);
+        evidence.push(candidate);
+        if (overallDisposition === "propose") overallDisposition = "merge";
+        if (!blockReason) blockReason = "near-duplicate-rule";
+      }
+
+      const inSameFamily =
+        hit.source === "file-section" &&
+        sameBucketFamily(input.targetFile, hit.location) &&
+        hit.similarity >= routing.nearDedupeThreshold;
+      const inRecommendedFamily =
+        recommendedTargetFile !== "skill_workshop" &&
+        recommendedTargetFile !== "memory_fact" &&
+        hit.source === "file-section" &&
+        sameBucketFamily(recommendedTargetFile, hit.location) &&
+        hit.similarity >= routing.nearDedupeThreshold;
+      if (inSameFamily || inRecommendedFamily) {
+        evidence.push({
+          type: "file-section",
+          location: hit.location,
+          similarity: hit.similarity,
+          snippet: hit.text.slice(0, 160),
+          summary: `Same-bucket semantic overlap with ${hit.location}.`,
+        });
+      }
+    }
+  }
+
+  if (routing.enabled && input.embedText) {
+    const queryVector = await cachedEmbed(`${input.title}\n${input.suggestedChange}`, input.embedText, routing.routingCacheTtlSeconds);
+    if (queryVector) {
+      for (const fact of listRuleFacts(input.factsDb, 100)) {
+        const factVector = await cachedEmbed(fact.text, input.embedText, routing.routingCacheTtlSeconds);
+        if (!factVector) continue;
+        const similarity = cosineSimilarity(queryVector, factVector);
+        if (similarity < routing.contradictionThreshold || similarity >= routing.dedupeThreshold) continue;
+        if (!looksContradictory(input.suggestedChange, fact.text)) continue;
+
+        let adjudication: RuleContradictionAdjudication | null = null;
+        if (input.adjudicateContradiction) {
+          try {
+            adjudication = await input.adjudicateContradiction(input.suggestedChange, fact.text);
+          } catch {
+            personaRuleRoutingMetrics.contradictionDegraded += 1;
+            evidence.push({
+              type: "contradiction-degraded",
+              summary: "Contradiction adjudication failed; manual review required.",
+            });
+            humanReviewRequired = true;
+            applyAllowed = false;
+            contradictionRisk = Math.max(contradictionRisk, 0.75);
+            continue;
+          }
+          if (!adjudication) {
+            personaRuleRoutingMetrics.contradictionDegraded += 1;
+            evidence.push({
+              type: "contradiction-degraded",
+              summary: "Contradiction adjudication returned malformed JSON; manual review required.",
+            });
+            humanReviewRequired = true;
+            applyAllowed = false;
+            contradictionRisk = Math.max(contradictionRisk, 0.75);
+            continue;
+          }
+        } else {
+          adjudication = { decision: "manual_review", reason: "embedding-only contradiction signal" };
+        }
+
+        personaRuleRoutingMetrics.contradictionHits += 1;
+        contradiction = true;
+        contradictionRisk = Math.max(contradictionRisk, similarity);
+        humanReviewRequired = true;
+        applyAllowed = false;
+        if (overallDisposition === "propose") overallDisposition = "manual-review";
+
+        const candidate: ContradictionCandidate = {
+          type: "memory-fact",
+          id: fact.id,
+          existingRuleId: fact.id,
+          existingLocation: `fact:${fact.id}`,
+          similarity,
+          snippet: fact.text.slice(0, 160),
+          summary: `Potential contradiction with rule fact ${fact.id}.`,
+          decision: adjudication.decision,
+          mergedRuleText: adjudication.mergedRuleText ?? null,
+        };
+        contradictionCandidates.push(candidate);
+        evidence.push({
+          type: "memory-fact",
+          id: fact.id,
+          similarity,
+          snippet: fact.text.slice(0, 160),
+          summary: adjudication.reason || candidate.summary,
+        });
+      }
+    }
+  }
+
+  const recommendedFile =
+    recommendedTargetFile === "skill_workshop" || recommendedTargetFile === "memory_fact"
+      ? recommendedTargetFile
+      : recommendedTargetFile;
+  const callerTarget = input.targetFile;
+  const routingDisagrees =
+    recommendedFile !== "skill_workshop" &&
+    recommendedFile !== "memory_fact" &&
+    recommendedFile !== callerTarget;
+
+  let routingSuggestion: PersonaProposalAssessment["routingSuggestion"];
+  const routingConfident = routingScore >= 0.7;
+  if (routingDisagrees && routingConfident) {
+    personaRuleRoutingMetrics.routingSuggestions += 1;
+    routingSuggestion = {
+      recommendedTargetFile: String(recommendedFile),
+      rationale: routingRationale,
+      callerTargetFile: callerTarget,
+    };
+    if (overallDisposition === "propose") overallDisposition = "retarget";
+    humanReviewRequired = true;
+  } else if (routingDisagrees) {
+    routingSuggestion = {
+      recommendedTargetFile: String(recommendedFile),
+      rationale: `${routingRationale} (low routing confidence ${routingScore.toFixed(2)}; advisory only)`,
+      callerTargetFile: callerTarget,
+    };
+  }
+
+  if (recommendedTargetFile === "skill_workshop" && callerTarget !== "skill_workshop") {
+    humanReviewRequired = true;
+    routingSuggestion = {
+      recommendedTargetFile: "skill_workshop",
+      rationale: routingRationale,
+      callerTargetFile: callerTarget,
+    };
+    if (overallDisposition === "propose") overallDisposition = "retarget";
+  }
+
+  if (supportScore < 0.55) {
+    overallDisposition = "reject";
+    blockReason = blockReason ?? "low-support";
+  } else if (supportScore < 0.75 && overallDisposition === "propose") {
+    overallDisposition = "manual-review";
+    humanReviewRequired = true;
+  }
+
+  if (routing.routingMode === "enforce") {
+    if (routingDisagrees && routingConfident && blockReason !== "duplicate-rule" && blockReason !== "already-in-file") {
+      blockReason = blockReason ?? "enforce-routing";
+      overallDisposition = "retarget";
+    }
+    if (contradiction) {
+      overallDisposition = "manual-review";
+    }
+  }
+
+  if (blockReason === "duplicate-rule" || blockReason === "already-in-file") {
+    applyAllowed = false;
+    humanReviewRequired = true;
+  }
+  if (contradiction) {
+    applyAllowed = false;
+  }
+
+  return {
+    supportScore,
+    routingScore,
+    dedupScore,
+    contradictionRisk,
+    mutationRisk,
+    llmConfidenceHint,
+    overallDisposition,
+    recommendedTargetFile,
+    routingRationale,
+    routingSuggestion,
+    dedupCandidates,
+    contradictionCandidates,
+    evidence,
+    humanReviewRequired,
+    applyAllowed,
+    contradiction,
+    blockReason,
+    blockCandidate,
+  };
+}
+
+export function resolvePersonaRuleRoutingConfig(
+  cfg: { personaRuleRouting?: PersonaRuleRoutingConfig },
+): PersonaRuleRoutingConfig {
+  return { ...DEFAULT_PERSONA_RULE_ROUTING, ...cfg.personaRuleRouting };
+}
+
+export function shouldBlockProposalCreation(
+  assessment: PersonaProposalAssessment,
+  routingMode: PersonaRuleRoutingConfig["routingMode"],
+): boolean {
+  if (assessment.blockReason === "duplicate-rule" || assessment.blockReason === "already-in-file") return true;
+  if (assessment.blockReason === "low-support") return true;
+  if (routingMode === "enforce" && assessment.blockReason === "enforce-routing") return true;
+  return false;
+}

--- a/extensions/memory-hybrid/setup/tool-installers.ts
+++ b/extensions/memory-hybrid/setup/tool-installers.ts
@@ -1,5 +1,5 @@
 import { homedir } from "node:os";
-import { join as pathJoin } from "node:path";
+import { dirname, join as pathJoin } from "node:path";
 import type { ClawdbotPluginApi } from "openclaw/plugin-sdk/core";
 import type { MemoryPluginAPI } from "../api/memory-plugin-api.js";
 import type { BootstrapPhaseConfig } from "../config.js";
@@ -220,6 +220,7 @@ function selectPersonaToolsContext({
   factsDb,
   crystallizationStore,
   toolProposalStore,
+  embeddings,
   timers,
 }: ToolsContext): PersonaInstallerContext {
   return {
@@ -230,17 +231,37 @@ function selectPersonaToolsContext({
     factsDb,
     crystallizationStore,
     toolProposalStore,
+    embeddings,
     timers,
   };
 }
 
 function installPersonaTools(ctx: PersonaInstallerContext, api: ClawdbotPluginApi): void {
-  const { proposalsDb, cfg, resolvedSqlitePath, changeFeed, factsDb, crystallizationStore, toolProposalStore, timers } =
-    ctx;
+  const {
+    proposalsDb,
+    cfg,
+    resolvedSqlitePath,
+    changeFeed,
+    factsDb,
+    crystallizationStore,
+    toolProposalStore,
+    embeddings,
+    timers,
+  } = ctx;
   if (!(cfg.personaProposals.enabled && proposalsDb)) return;
 
   registerPersonaTools(
-    { proposalsDb, cfg, resolvedSqlitePath, changeFeed, factsDb, crystallizationStore, toolProposalStore },
+    {
+      proposalsDb,
+      cfg,
+      resolvedSqlitePath,
+      changeFeed,
+      factsDb,
+      crystallizationStore,
+      toolProposalStore,
+      embeddings,
+      workspaceRoot: dirname(api.resolvePath(".")),
+    },
     api,
   );
   timers.proposalsPruneTimer.value = null; // proposals-prune handled by maintenance orchestrator cycle tick

--- a/extensions/memory-hybrid/setup/tool-installers.ts
+++ b/extensions/memory-hybrid/setup/tool-installers.ts
@@ -1,5 +1,5 @@
 import { homedir } from "node:os";
-import { dirname, join as pathJoin } from "node:path";
+import { join as pathJoin } from "node:path";
 import type { ClawdbotPluginApi } from "openclaw/plugin-sdk/core";
 import type { MemoryPluginAPI } from "../api/memory-plugin-api.js";
 import type { BootstrapPhaseConfig } from "../config.js";
@@ -260,7 +260,7 @@ function installPersonaTools(ctx: PersonaInstallerContext, api: ClawdbotPluginAp
       crystallizationStore,
       toolProposalStore,
       embeddings,
-      workspaceRoot: dirname(api.resolvePath(".")),
+      workspaceRoot: api.resolvePath("."),
     },
     api,
   );

--- a/extensions/memory-hybrid/tests/persona-rule-router.test.ts
+++ b/extensions/memory-hybrid/tests/persona-rule-router.test.ts
@@ -1,0 +1,301 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { FactsDB } from "../backends/facts-db.js";
+import { assessPersonaProposalRoutingSync } from "../cli/proposals.js";
+import {
+  classifyAuthorityBucket,
+  findCrossFileContentMatch,
+  personaRuleRoutingMetrics,
+  resetPersonaRuleRoutingMetrics,
+  routePersonaProposal,
+  shouldBlockProposalCreation,
+} from "../services/persona-rule-router.js";
+import { DEFAULT_PERSONA_RULE_ROUTING } from "../services/persona-rule-router.js";
+
+const LIVE_GITHUB_RULE =
+  "File one focused GitHub issue per distinct problem with cloud-readable evidence; avoid omnibus tickets.";
+
+const REGRESSION_PROPOSAL = {
+  id: "de5ac67f-2bd0-4c56-b589-fe74f2aac639",
+  targetFile: "SOUL.md",
+  title: "GitHub issue discipline",
+  observation: "Repeated omnibus tickets slow triage.",
+  suggestedChange: LIVE_GITHUB_RULE,
+  confidence: 0.75,
+};
+
+let tmpDir: string;
+let factsDb: FactsDB;
+
+beforeEach(() => {
+  resetPersonaRuleRoutingMetrics();
+  tmpDir = mkdtempSync(join(tmpdir(), "persona-rule-router-"));
+  writeFileSync(join(tmpDir, "SOUL.md"), "# SOUL\nValues and tone.\n", "utf-8");
+  writeFileSync(
+    join(tmpDir, "AGENTS.md"),
+    "# AGENTS\n## Issue Stewardship Phase Gate\nPrefer focused issues.\n",
+    "utf-8",
+  );
+  writeFileSync(join(tmpDir, "USER.md"), "# USER\nPreferences.\n", "utf-8");
+  factsDb = new FactsDB(join(tmpDir, "facts.db"));
+});
+
+afterEach(() => {
+  factsDb.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function unit(vec: number[]): number[] {
+  const mag = Math.sqrt(vec.reduce((s, v) => s + v * v, 0));
+  return mag === 0 ? vec : vec.map((v) => v / mag);
+}
+
+function makeEmbedder(vectors: Record<string, number[]>): (text: string) => Promise<number[]> {
+  return async (text: string) => {
+    const normalized = text.toLowerCase().replace(/\s+/g, " ").trim();
+    for (const [needle, vector] of Object.entries(vectors)) {
+      if (normalized.includes(needle.toLowerCase())) return unit(vector);
+    }
+    return unit([0, 0, 1]);
+  };
+}
+
+describe("routePersonaProposal", () => {
+  it("routes GitHub issue workflow rules to AGENTS.md instead of SOUL.md", async () => {
+    const assessment = await routePersonaProposal({
+      targetFile: "SOUL.md",
+      title: REGRESSION_PROPOSAL.title,
+      observation: REGRESSION_PROPOSAL.observation,
+      suggestedChange: REGRESSION_PROPOSAL.suggestedChange,
+      confidence: REGRESSION_PROPOSAL.confidence,
+      evidenceSessions: ["session-1"],
+      workspaceRoot: tmpDir,
+      allowedFiles: ["SOUL.md", "IDENTITY.md", "USER.md", "AGENTS.md"],
+      routing: DEFAULT_PERSONA_RULE_ROUTING,
+    });
+
+    expect(assessment.recommendedTargetFile).toBe("AGENTS.md");
+    expect(assessment.routingRationale).toMatch(/operational|GitHub|issue|workflow/i);
+    expect(assessment.routingSuggestion?.recommendedTargetFile).toBe("AGENTS.md");
+    expect(assessment.routingSuggestion?.callerTargetFile).toBe("SOUL.md");
+  });
+
+  it("rejects semantic duplicate rule facts at or above dedupe threshold", async () => {
+    const duplicateText = "Always file one focused GitHub issue per distinct problem.";
+    factsDb.store({
+      text: duplicateText,
+      category: "rule",
+      entity: "workflow",
+      key: "github-issues",
+      source: "reflection",
+      importance: 0.8,
+      value: null,
+      tags: ["reflection", "rule"],
+    });
+
+    const embedText = makeEmbedder({
+      "focused github issue": [1, 0, 0],
+      "file one focused github issue per distinct problem": [1, 0, 0],
+    });
+
+    const assessment = await routePersonaProposal({
+      targetFile: "SOUL.md",
+      title: "Focused issues",
+      observation: "Observed pattern",
+      suggestedChange: "Append: File one focused GitHub issue per distinct problem with evidence.",
+      confidence: 0.9,
+      evidenceSessions: ["s1", "s2"],
+      workspaceRoot: tmpDir,
+      allowedFiles: ["SOUL.md", "AGENTS.md"],
+      routing: DEFAULT_PERSONA_RULE_ROUTING,
+      factsDb,
+      embedText,
+    });
+
+    expect(assessment.blockReason).toBe("duplicate-rule");
+    expect(assessment.blockCandidate?.source).toBe("memory-fact");
+    expect(shouldBlockProposalCreation(assessment, "advisory")).toBe(true);
+    expect(personaRuleRoutingMetrics.dedupHits).toBeGreaterThan(0);
+  });
+
+  it("flags cross-file already-in-file matches against AGENTS.md when targeting USER.md", () => {
+    const paragraph = "Dispatch all GitHub issue workflow through the Issue Stewardship Phase Gate.";
+    writeFileSync(join(tmpDir, "AGENTS.md"), `# AGENTS\n${paragraph}\n`, "utf-8");
+
+    const sync = assessPersonaProposalRoutingSync({
+      targetFile: "USER.md",
+      title: "Issue workflow",
+      observation: "Observed",
+      suggestedChange: paragraph,
+      confidence: 0.9,
+      evidenceSessions: ["s1"],
+      workspaceRoot: tmpDir,
+      allowedFiles: ["USER.md", "AGENTS.md"],
+    });
+
+    expect(sync.blockReason).toBe("already-in-file");
+    expect(sync.blockCandidate?.location).toBe("AGENTS.md");
+    expect(shouldBlockProposalCreation(sync, "advisory")).toBe(true);
+  });
+
+  it("marks contradictory rules with applyAllowed false and evidence excerpts", async () => {
+    factsDb.store({
+      text: "Always bundle related issues to reduce triage overhead.",
+      category: "rule",
+      entity: "workflow",
+      key: "bundle-issues",
+      source: "reflection",
+      importance: 0.8,
+      value: null,
+      tags: ["reflection", "rule"],
+    });
+
+    const embedText = makeEmbedder({
+      "never create omnibus": [1, 0, 0],
+      "always bundle related issues": [0.7, 0.714, 0],
+    });
+
+    const assessment = await routePersonaProposal({
+      targetFile: "AGENTS.md",
+      title: "Issue bundling",
+      observation: "Conflict spotted",
+      suggestedChange: "Never create omnibus issues; always file one focused ticket.",
+      confidence: 0.85,
+      evidenceSessions: ["s1"],
+      workspaceRoot: tmpDir,
+      allowedFiles: ["AGENTS.md"],
+      routing: DEFAULT_PERSONA_RULE_ROUTING,
+      factsDb,
+      embedText,
+      adjudicateContradiction: async () => ({
+        decision: "manual_review",
+        reason: "Opposing issue bundling guidance",
+      }),
+    });
+
+    expect(assessment.contradiction).toBe(true);
+    expect(assessment.applyAllowed).toBe(false);
+    expect(assessment.contradictionCandidates.length).toBeGreaterThan(0);
+    expect(assessment.evidence.some((e) => e.type === "memory-fact")).toBe(true);
+    expect(personaRuleRoutingMetrics.contradictionHits).toBeGreaterThan(0);
+  });
+
+  it("degrades to manual review when contradiction adjudication fails", async () => {
+    factsDb.store({
+      text: "Always bundle related issues to reduce triage overhead.",
+      category: "rule",
+      entity: "workflow",
+      key: "bundle-issues",
+      source: "reflection",
+      importance: 0.8,
+      value: null,
+    });
+
+    const embedText = makeEmbedder({
+      "never create omnibus": [1, 0, 0],
+      "always bundle related issues": [0.7, 0.714, 0],
+    });
+
+    const assessment = await routePersonaProposal({
+      targetFile: "AGENTS.md",
+      title: "Issue bundling",
+      observation: "Conflict spotted",
+      suggestedChange: "Never create omnibus issues.",
+      confidence: 0.85,
+      evidenceSessions: ["s1"],
+      workspaceRoot: tmpDir,
+      allowedFiles: ["AGENTS.md"],
+      routing: DEFAULT_PERSONA_RULE_ROUTING,
+      factsDb,
+      embedText,
+      adjudicateContradiction: async () => {
+        throw new Error("timeout");
+      },
+    });
+
+    expect(assessment.humanReviewRequired).toBe(true);
+    expect(assessment.applyAllowed).toBe(false);
+    expect(assessment.evidence.some((e) => e.type === "contradiction-degraded")).toBe(true);
+    expect(personaRuleRoutingMetrics.contradictionDegraded).toBeGreaterThan(0);
+  });
+
+  it("routes recurring multi-step procedures to skill_workshop", async () => {
+    const assessment = await routePersonaProposal({
+      targetFile: "AGENTS.md",
+      title: "Weekly release playbook",
+      observation: "Repeats every sprint",
+      suggestedChange:
+        "Reusable workflow procedure:\n1. Run tests\n2. Tag release\n3. Publish notes\n4. Notify channel",
+      confidence: 0.9,
+      evidenceSessions: ["s1", "s2", "s3"],
+      workspaceRoot: tmpDir,
+      allowedFiles: ["AGENTS.md"],
+      routing: DEFAULT_PERSONA_RULE_ROUTING,
+    });
+
+    expect(assessment.recommendedTargetFile).toBe("skill_workshop");
+    expect(assessment.humanReviewRequired).toBe(true);
+    expect(assessment.routingSuggestion?.recommendedTargetFile).toBe("skill_workshop");
+  });
+
+  it("regression fixture de5ac67f surfaces routing suggestion and cross-file awareness", async () => {
+    writeFileSync(
+      join(tmpDir, "AGENTS.md"),
+      `# AGENTS\n${LIVE_GITHUB_RULE}\n`,
+      "utf-8",
+    );
+
+    const assessment = await routePersonaProposal({
+      targetFile: REGRESSION_PROPOSAL.targetFile,
+      title: REGRESSION_PROPOSAL.title,
+      observation: REGRESSION_PROPOSAL.observation,
+      suggestedChange: REGRESSION_PROPOSAL.suggestedChange,
+      confidence: REGRESSION_PROPOSAL.confidence,
+      evidenceSessions: ["session-a"],
+      workspaceRoot: tmpDir,
+      allowedFiles: ["SOUL.md", "USER.md", "AGENTS.md"],
+      routing: DEFAULT_PERSONA_RULE_ROUTING,
+    });
+
+    expect(assessment.routingSuggestion?.recommendedTargetFile).toBe("AGENTS.md");
+    expect(assessment.blockReason === "already-in-file" || assessment.dedupScore >= 1).toBe(true);
+    expect(assessment.overallDisposition).not.toBe("propose");
+  });
+
+  it("increments routing suggestion telemetry counters", async () => {
+    await routePersonaProposal({
+      targetFile: "SOUL.md",
+      title: REGRESSION_PROPOSAL.title,
+      observation: REGRESSION_PROPOSAL.observation,
+      suggestedChange: REGRESSION_PROPOSAL.suggestedChange,
+      confidence: 0.8,
+      evidenceSessions: ["s1"],
+      workspaceRoot: tmpDir,
+      allowedFiles: ["SOUL.md", "AGENTS.md"],
+      routing: DEFAULT_PERSONA_RULE_ROUTING,
+    });
+    expect(personaRuleRoutingMetrics.routingSuggestions).toBeGreaterThan(0);
+  });
+});
+
+describe("classifyAuthorityBucket", () => {
+  it("classifies operational GitHub language into AGENTS.md bucket", () => {
+    const result = classifyAuthorityBucket(LIVE_GITHUB_RULE);
+    expect(result.bucket).toBe("AGENTS.md");
+  });
+});
+
+describe("findCrossFileContentMatch", () => {
+  it("finds exact paragraph matches in other authority files", () => {
+    const snippet = "Only file focused GitHub issues with cloud-readable evidence.";
+    writeFileSync(join(tmpDir, "AGENTS.md"), `# AGENTS\n${snippet}\n`, "utf-8");
+    const match = findCrossFileContentMatch({
+      suggestedChange: snippet,
+      workspaceRoot: tmpDir,
+      excludeFile: "USER.md",
+    });
+    expect(match?.file).toBe("AGENTS.md");
+  });
+});

--- a/extensions/memory-hybrid/tests/persona-rule-router.test.ts
+++ b/extensions/memory-hybrid/tests/persona-rule-router.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { FactsDB } from "../backends/facts-db.js";
-import { assessPersonaProposalRoutingSync } from "../cli/proposals.js";
+import { assessPersonaProposalRouting, assessPersonaProposalRoutingSync } from "../cli/proposals.js";
 import {
   classifyAuthorityBucket,
   findCrossFileContentMatch,
@@ -80,6 +80,24 @@ describe("routePersonaProposal", () => {
     expect(assessment.routingRationale).toMatch(/operational|GitHub|issue|workflow/i);
     expect(assessment.routingSuggestion?.recommendedTargetFile).toBe("AGENTS.md");
     expect(assessment.routingSuggestion?.callerTargetFile).toBe("SOUL.md");
+  });
+
+  it("preserves AGENTS.md routing suggestion when AGENTS.md is not in allowedFiles", async () => {
+    const assessment = await routePersonaProposal({
+      targetFile: "SOUL.md",
+      title: REGRESSION_PROPOSAL.title,
+      observation: REGRESSION_PROPOSAL.observation,
+      suggestedChange: REGRESSION_PROPOSAL.suggestedChange,
+      confidence: REGRESSION_PROPOSAL.confidence,
+      evidenceSessions: ["session-1"],
+      workspaceRoot: tmpDir,
+      allowedFiles: ["SOUL.md", "IDENTITY.md", "USER.md"],
+      routing: DEFAULT_PERSONA_RULE_ROUTING,
+    });
+
+    expect(assessment.recommendedTargetFile).toBe("AGENTS.md");
+    expect(assessment.routingSuggestion?.recommendedTargetFile).toBe("AGENTS.md");
+    expect(assessment.routingRationale).toMatch(/allowedFiles/i);
   });
 
   it("rejects semantic duplicate rule facts at or above dedupe threshold", async () => {
@@ -277,6 +295,23 @@ describe("routePersonaProposal", () => {
       routing: DEFAULT_PERSONA_RULE_ROUTING,
     });
     expect(personaRuleRoutingMetrics.routingSuggestions).toBeGreaterThan(0);
+  });
+
+  it("does not block proposal creation when routing is disabled", async () => {
+    writeFileSync(join(tmpDir, "AGENTS.md"), `# AGENTS\n${LIVE_GITHUB_RULE}\n`, "utf-8");
+    const assessment = await assessPersonaProposalRouting({
+      targetFile: "USER.md",
+      title: "Dup",
+      observation: "Observed",
+      suggestedChange: LIVE_GITHUB_RULE,
+      confidence: 0.9,
+      evidenceSessions: ["s1"],
+      workspaceRoot: tmpDir,
+      allowedFiles: ["USER.md"],
+      personaRuleRouting: { enabled: false },
+    });
+    expect(assessment.blockReason).toBeUndefined();
+    expect(shouldBlockProposalCreation(assessment, "advisory")).toBe(false);
   });
 });
 

--- a/extensions/memory-hybrid/tools/persona-tools.ts
+++ b/extensions/memory-hybrid/tools/persona-tools.ts
@@ -306,7 +306,7 @@ export function registerPersonaTools(ctx: PluginContext, api: ClawdbotPluginApi)
           };
         }
 
-        const wsRoot = workspaceRoot ?? dirname(api.resolvePath("."));
+        const wsRoot = workspaceRoot ?? api.resolvePath(".");
         const routingAssessment = await assessPersonaProposalRouting({
           targetFile,
           title,

--- a/extensions/memory-hybrid/tools/persona-tools.ts
+++ b/extensions/memory-hybrid/tools/persona-tools.ts
@@ -13,6 +13,7 @@ import type { ProposalsDB } from "../backends/proposals-db.js";
 import type { ToolProposalStore } from "../backends/tool-proposal-store.js";
 import {
   applyApprovedProposal,
+  assessPersonaProposalRouting,
   capProposalConfidence,
   findDuplicateProposal,
   validateProposalContent,
@@ -21,6 +22,8 @@ import { type HybridMemoryConfig, PROPOSAL_STATUSES, isCompactVerbosity } from "
 import { capturePluginError } from "../services/error-reporter.js";
 import { emitPersonaApplied, emitPersonaProposed } from "../services/change-feed-emit.js";
 import type { ChangeFeed } from "../services/change-feed.js";
+import type { EmbeddingProvider } from "../services/embeddings/types.js";
+import { shouldBlockProposalCreation } from "../services/persona-rule-router.js";
 import { enforceMaxPendingCap, resolveWorkshopMaxPending } from "../services/unified-proposals.js";
 import { resolveWorkshopAppliedSessionKey, resolveWorkshopProposedSessionKey } from "../services/workshop-config.js";
 import { SECONDS_PER_DAY } from "../utils/constants.js";
@@ -36,6 +39,8 @@ export interface PluginContext {
   factsDb?: FactsDB;
   crystallizationStore?: CrystallizationStore | null;
   toolProposalStore?: ToolProposalStore | null;
+  embeddings?: EmbeddingProvider | null;
+  workspaceRoot?: string;
 }
 
 /**
@@ -43,7 +48,17 @@ export interface PluginContext {
  * Only registers if cfg.personaProposals.enabled && proposalsDb is available
  */
 export function registerPersonaTools(ctx: PluginContext, api: ClawdbotPluginApi) {
-  const { proposalsDb, cfg, resolvedSqlitePath, changeFeed, factsDb, crystallizationStore, toolProposalStore } = ctx;
+  const {
+    proposalsDb,
+    cfg,
+    resolvedSqlitePath,
+    changeFeed,
+    factsDb,
+    crystallizationStore,
+    toolProposalStore,
+    embeddings,
+    workspaceRoot,
+  } = ctx;
 
   // Only register if persona proposals are enabled and database is available
   if (!cfg.personaProposals.enabled || !proposalsDb) {
@@ -291,6 +306,42 @@ export function registerPersonaTools(ctx: PluginContext, api: ClawdbotPluginApi)
           };
         }
 
+        const wsRoot = workspaceRoot ?? dirname(api.resolvePath("."));
+        const routingAssessment = await assessPersonaProposalRouting({
+          targetFile,
+          title,
+          observation,
+          suggestedChange,
+          confidence: cappedConfidence,
+          evidenceSessions,
+          workspaceRoot: wsRoot,
+          allowedFiles: cfg.personaProposals.allowedFiles,
+          factsDb,
+          embeddings,
+          personaRuleRouting: cfg.personaProposals.personaRuleRouting,
+        });
+        const routingMode = cfg.personaProposals.personaRuleRouting?.routingMode ?? "advisory";
+        if (shouldBlockProposalCreation(routingAssessment, routingMode)) {
+          const block = routingAssessment.blockReason ?? "blocked";
+          const candidate = routingAssessment.blockCandidate;
+          return {
+            content: [
+              {
+                type: "text",
+                text: candidate
+                  ? `Proposal blocked (${block}): similar content exists in ${candidate.location}.`
+                  : `Proposal blocked (${block}).`,
+              },
+            ],
+            details: {
+              error: block,
+              candidate,
+              routingSuggestion: routingAssessment.routingSuggestion,
+              assessment: routingAssessment,
+            },
+          };
+        }
+
         // Calculate expiry
         const expiresAt =
           cfg.personaProposals.proposalTTLDays > 0
@@ -465,10 +516,19 @@ export function registerPersonaTools(ctx: PluginContext, api: ClawdbotPluginApi)
           content: [
             {
               type: "text",
-              text: `Proposal created: ${proposal.id}\nTitle: ${title}\nTarget: ${targetFile}\nStatus: pending\n\nAwaiting human review. Use persona_proposals_list to view all pending proposals.`,
+              text: routingAssessment.routingSuggestion
+                ? `Proposal created: ${proposal.id}\nTitle: ${title}\nTarget: ${targetFile}\nSuggested target: ${routingAssessment.routingSuggestion.recommendedTargetFile} (${routingAssessment.routingSuggestion.rationale})\nStatus: pending`
+                : `Proposal created: ${proposal.id}\nTitle: ${title}\nTarget: ${targetFile}\nStatus: pending\n\nAwaiting human review. Use persona_proposals_list to view all pending proposals.`,
             },
           ],
-          details: { proposalId: proposal.id, status: "pending", expiresAt: proposal.expiresAt },
+          details: {
+            proposalId: proposal.id,
+            status: "pending",
+            expiresAt: proposal.expiresAt,
+            routingSuggestion: routingAssessment.routingSuggestion,
+            humanReviewRequired: routingAssessment.humanReviewRequired,
+            assessment: routingAssessment,
+          },
         };
       },
     },


### PR DESCRIPTION
## Summary
- Introduces `persona-rule-router.ts`: multi-gate assessment with authority-bucket routing, cross-file/semantic dedup, and contradiction detection against reflection `category:"rule"` facts.
- Wires the router into `persona_propose`, pipeline proposal validation (`resolvePipelineProposalTarget`), and persona triage (cross-file + routing evidence).
- Adds `personaProposals.personaRuleRouting` config (default advisory mode) and exposes routing metrics in the workshop digest.

Fixes the failure mode from #2002 where an operational GitHub issue rule was proposed against `SOUL.md` instead of `AGENTS.md`.

## Test plan
- [x] `npm test -- --run tests/persona-rule-router.test.ts` (10 tests: routing, dedup, contradiction, skill_workshop, regression fixture `de5ac67f…`, telemetry)
- [x] `npm test -- --run tests/persona-proposal-triage.test.ts` (no regressions)
- [x] `npm test -- --run tests/proposals.test.ts tests/pending-review-digest.test.ts`

## Acceptance criteria mapping
| Criterion | Status |
|---|---|
| GitHub issue rule → `AGENTS.md` routing suggestion when target is `SOUL.md` | ✅ |
| Semantic duplicate rule fact → `duplicate-rule` block | ✅ |
| Cross-file content in `AGENTS.md` → `already-in-file` when targeting `USER.md` | ✅ |
| Contradiction with memory fact → `applyAllowed: false` + evidence | ✅ |
| LLM adjudicator failure → `contradiction-degraded` + manual review | ✅ |
| Multi-step procedure → `skill_workshop` routing suggestion | ✅ |
| Regression fixture `de5ac67f-…` surfaces routing + cross-file signal | ✅ |
| Telemetry counters in workshop digest | ✅ |

Closes #2002