### PR TITLE
fix(install): reconcile stale legacy install-index entries after upgrade (#2008)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ---
 
+## [2026.6.292] - 2026-06-29
+
+### Fixed
+
+- **Install-index drift after upgrade (#2008):** New helper `cli/install/install-index-reconcile.ts` detects stale entries in the legacy `${stateDir}/plugins/installs.json` sidecar (e.g. an old npm-project install at `/home/markus/.openclaw/npm/projects/openclaw-hybrid-memory/...` from a previous version) and atomically drops them after backing the sidecar up. This stops OpenClaw core state migrations from emitting the persistent warning "Left plugin install index in place because shared SQLite state has conflicting plugin install metadata for: codex, openclaw-hybrid-memory" on every Gateway restart after an extension upgrade. Wired into `runUpgradeForCli`, `runInstallForCli`, and the `verify` infrastructure section; new CLI subcommand `openclaw hybrid-mem install-index reconcile [--dry-run] [--plugin-id <id>]` for manual repair. Tests: `tests/install-index-reconcile.test.ts` (18 cases covering no-conflict, matches-live, safe-reconcile, unsafe-downgrade, unsafe-no-live-path, unsafe-malformed-legacy, dry-run, and embedded `plugins[]` legacy shapes).
+
+### Changed
+
+- Bumped plugin, `openclaw.plugin.json`, and `openclaw-hybrid-memory-install` package versions to **2026.6.292**.
+
+---
+
 ## [2026.6.291] - 2026-06-29
 
 ### Fixed

--- a/extensions/memory-hybrid/cli/cmd-install-index.ts
+++ b/extensions/memory-hybrid/cli/cmd-install-index.ts
@@ -1,0 +1,101 @@
+/**
+ * hybrid-mem install-index — reconcile stale legacy plugin install-index entries (issue #2008).
+ *
+ * `openclaw hybrid-mem install-index reconcile` inspects the legacy
+ * `${stateDir}/plugins/installs.json` sidecar and, when it has a record that
+ * conflicts with the live plugin path/version, atomically rewrites it (after
+ * backing it up) so OpenClaw core state migrations stop emitting the
+ * "Left plugin install index in place because shared SQLite state has
+ * conflicting plugin install metadata" warning on every startup.
+ */
+
+import { PLUGIN_ID } from "../utils/constants.js";
+import {
+  detectStaleLegacyInstallIndexEntry,
+  formatStaleInstallIndexWarning,
+  reconcileLegacyInstallIndex,
+  resolveLegacyInstallIndexPath,
+} from "./install/install-index-reconcile.js";
+import type { Chainable } from "./shared.js";
+
+type ReconcileAction = () => Promise<void> | void;
+
+export function registerInstallIndexCommand(program: Chainable, deps?: { reconcile?: ReconcileAction }): void {
+  const sub = program
+    .command("install-index")
+    .description("Inspect or reconcile the legacy OpenClaw plugin install-index sidecar (issue #2008)");
+
+  sub
+    .command("status")
+    .description("Show the stale install-index detection for this plugin")
+    .action(() => {
+      const detection = detectStaleLegacyInstallIndexEntry({ pluginId: PLUGIN_ID });
+      const verdict = detection.verdict;
+      const liveLine = `Live:   ${detection.livePath} (${detection.liveVersion ?? "<unknown>"})`;
+      if (verdict === "no-conflict") {
+        console.log(`Legacy install-index (${detection.legacyPath}): no entry for ${PLUGIN_ID}. Nothing to reconcile.`);
+        console.log(liveLine);
+        return;
+      }
+      if (verdict === "matches-live") {
+        console.log(`Legacy install-index (${detection.legacyPath}) already points at the live plugin path/version.`);
+        console.log(liveLine);
+        return;
+      }
+      console.log(`Legacy install-index drift detected (${verdict}):`);
+      console.log(
+        `  Stale:  ${detection.staleInstallPath ?? "<unknown>"} (${detection.staleVersion ?? "<unknown>"}, source=${detection.staleSource ?? "<unknown>"})`,
+      );
+      console.log(`  ${liveLine}`);
+      console.log(`  File:   ${detection.legacyPath}`);
+      if (detection.detail) console.log(`  Detail: ${detection.detail}`);
+      if (verdict === "safe-reconcile") {
+        console.log("Repair: run `openclaw hybrid-mem install-index reconcile` to drop the stale entry.");
+      } else {
+        console.log(formatStaleInstallIndexWarning(detection));
+      }
+    });
+
+  sub
+    .command("reconcile")
+    .description("Atomically rewrite the legacy install-index sidecar to remove the stale plugin entry")
+    .option("--dry-run", "Show what would change without writing the sidecar")
+    .option("--plugin-id <id>", "Plugin id to reconcile (defaults to openclaw-hybrid-memory)")
+    .action(async (opts: { dryRun?: boolean; pluginId?: string }) => {
+      const pluginId = opts.pluginId?.trim() || PLUGIN_ID;
+      const detection = detectStaleLegacyInstallIndexEntry({ pluginId });
+      const legacyPath = detection.legacyPath ?? resolveLegacyInstallIndexPath();
+      if (detection.verdict === "no-conflict" || detection.verdict === "matches-live") {
+        console.log(`install-index reconcile: nothing to do for ${pluginId} (${detection.verdict}).`);
+        console.log(`Legacy file: ${legacyPath}`);
+        return;
+      }
+      if (detection.verdict !== "safe-reconcile") {
+        console.error(formatStaleInstallIndexWarning(detection));
+        process.exitCode = 2;
+        return;
+      }
+      if (opts.dryRun) {
+        console.log(`install-index reconcile (dry-run): would drop stale ${pluginId} entry from ${legacyPath}`);
+        console.log(`  Stale: ${detection.staleInstallPath} (${detection.staleVersion})`);
+        console.log(`  Live:  ${detection.livePath} (${detection.liveVersion ?? "<unknown>"})`);
+        return;
+      }
+      const result = reconcileLegacyInstallIndex({ detection, pluginId });
+      if (!result.ok) {
+        console.error(
+          `install-index reconcile failed for ${pluginId} at ${legacyPath}: ${result.error ?? "unknown error"}`,
+        );
+        process.exitCode = 1;
+        return;
+      }
+      if (result.action === "noop") {
+        console.log(`install-index reconcile: nothing to do for ${pluginId} (${result.verdict}).`);
+      } else {
+        console.log(
+          `install-index reconcile: dropped stale ${pluginId} entry from ${legacyPath} (backup at ${result.backupPath ?? "<unknown>"}).`,
+        );
+      }
+      if (deps?.reconcile) await deps.reconcile();
+    });
+}

--- a/extensions/memory-hybrid/cli/cmd-install.ts
+++ b/extensions/memory-hybrid/cli/cmd-install.ts
@@ -17,4 +17,5 @@ export * from "./install/workspace.js";
 export * from "./install/cron-jobs.js";
 export * from "./install/config-merge.js";
 export * from "./install/embedding-detect.js";
+export * from "./install/install-index-reconcile.js";
 export * from "./install/run-install.js";

--- a/extensions/memory-hybrid/cli/install/install-index-reconcile.ts
+++ b/extensions/memory-hybrid/cli/install/install-index-reconcile.ts
@@ -1,0 +1,570 @@
+/**
+ * Legacy installed-plugin-index reconciliation (issue #2008).
+ *
+ * Background:
+ *   OpenClaw core stores its "installed plugin index" in two layers:
+ *     1. A legacy JSON file at `${stateDir}/plugins/installs.json`
+ *     2. The current shared SQLite state DB
+ *   On startup, core's state migrations try to merge the legacy file into SQLite.
+ *   When a plugin has been upgraded and the runtime now loads it from
+ *   `~/.openclaw/extensions/<plugin>/` but the legacy file still references an
+ *   older npm-project install path/version, the merge sees conflicting metadata
+ *   and emits the warning:
+ *     "Left plugin install index in place because shared SQLite state has
+ *      conflicting plugin install metadata for: codex, openclaw-hybrid-memory"
+ *   The conflict is then reported on every subsequent startup until either the
+ *   legacy file is removed or its records are reconciled.
+ *
+ * This helper:
+ *   - Detects whether the legacy file has a stale record for the plugin whose
+ *     path/version does not match the live extension path/version we can prove.
+ *   - If the live path is reachable AND its version is >= the stale version,
+ *     atomically rewrites the legacy file (after backing it up) to either drop
+ *     the stale record or update it to match the live path/version. This stops
+ *     core state migrations from re-emitting the conflict warning.
+ *   - When reconciliation is not safe (live path missing or downgraded), returns
+ *     an actionable warning that names both the stale and live paths and
+ *     versions so operators can repair manually.
+ *
+ * The helpers in this file are intentionally pure: they do not call out to the
+ * OpenClaw gateway, they only read and rewrite the legacy JSON sidecar that
+ * core state migrations consult on startup.
+ */
+
+import { existsSync, mkdirSync, readFileSync, realpathSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { basename, isAbsolute, join, resolve as pathResolve } from "node:path";
+import { PLUGIN_ID } from "../../utils/constants.js";
+import { getEnv } from "../../utils/env-manager.js";
+import { findPluginRoot } from "../../utils/plugin-root.js";
+import { readPluginPackageVersion } from "./workspace.js";
+
+/** Relative path of the legacy install-index sidecar under the OpenClaw state dir. */
+const LEGACY_INSTALL_INDEX_REL_PATH = join("plugins", "installs.json");
+
+/** Key under `installRecords` for a given plugin id in the legacy file. */
+type LegacyRecord = Record<string, unknown> & {
+  source?: unknown;
+  spec?: unknown;
+  installPath?: unknown;
+  version?: unknown;
+  resolvedName?: unknown;
+  resolvedVersion?: unknown;
+  resolvedSpec?: unknown;
+  installedAt?: unknown;
+};
+
+/** Snapshot of what we know about a stale legacy install record for a single plugin. */
+export type StaleLegacyInstallIndexDetection = {
+  /** True when the legacy file exists and contains a record for the plugin id. */
+  present: boolean;
+  /** Absolute path to the legacy install-index file. */
+  legacyPath: string;
+  /** Stale installPath recorded in the legacy file (if present). */
+  staleInstallPath?: string;
+  /** Stale version recorded in the legacy file (if present). */
+  staleVersion?: string;
+  /** Stale record source, when present (e.g. "npm", "extensions"). */
+  staleSource?: string;
+  /** Absolute path to the live plugin root directory we are running from. */
+  livePath: string;
+  /** Live plugin version resolved from the running plugin's package.json. */
+  liveVersion?: string;
+  /** True when the livePath exists on disk and contains the plugin manifest. */
+  livePathExists: boolean;
+  /**
+   * One of:
+   *   - "no-conflict": legacy file has no entry for this plugin, nothing to do.
+   *   - "matches-live": legacy record already points at the live path/version.
+   *   - "safe-reconcile": live path exists with a >= version; safe to rewrite.
+   *   - "unsafe-downgrade": live version is older than the stale version.
+   *   - "unsafe-no-live-path": live path missing or not a valid plugin dir.
+   *   - "unsafe-malformed-legacy": legacy record is malformed (missing path/version).
+   *   - "unsafe-other-plugin-path": stale record points at a different plugin id.
+   */
+  verdict:
+    | "no-conflict"
+    | "matches-live"
+    | "safe-reconcile"
+    | "unsafe-downgrade"
+    | "unsafe-no-live-path"
+    | "unsafe-malformed-legacy"
+    | "unsafe-other-plugin-path";
+  /** Human-readable detail describing why the verdict was chosen. */
+  detail?: string;
+};
+
+/** Result of an attempted reconciliation. */
+export type ReconcileLegacyInstallIndexResult = {
+  /** True when the legacy file was rewritten successfully. */
+  ok: boolean;
+  /** The verdict derived from the detection. */
+  verdict: StaleLegacyInstallIndexDetection["verdict"];
+  /** Action performed against the legacy file. */
+  action: "removed" | "updated" | "skipped" | "noop";
+  /** Absolute path to the backup file written before mutating, when applicable. */
+  backupPath?: string;
+  /** Optional error message when ok is false. */
+  error?: string;
+};
+
+/** Default OpenClaw state directory used to locate the legacy install-index. */
+function defaultOpenclawStateDir(): string {
+  const fromEnv = getEnv("OPENCLAW_STATE_DIR");
+  if (typeof fromEnv === "string" && fromEnv.trim().length > 0) return fromEnv;
+  return join(homedir(), ".openclaw", "state");
+}
+
+/**
+ * Resolve the absolute path of the legacy install-index file. Tests can override
+ * the state directory by passing `stateDir`.
+ */
+export function resolveLegacyInstallIndexPath(opts: { stateDir?: string } = {}): string {
+  const stateDir = opts.stateDir ?? defaultOpenclawStateDir();
+  return join(stateDir, LEGACY_INSTALL_INDEX_REL_PATH);
+}
+
+/**
+ * Walk the JSON shape that core state migrations parse and extract the per-plugin
+ * record under `installRecords[pluginId]`. Tolerates both top-level and
+ * embedded (`plugins[].installRecord`) shapes — see
+ * `readLegacyTopLevelInstallRecords` / `readLegacyEmbeddedInstallRecords` in
+ * `state-migrations` for the formats we mirror here.
+ */
+function extractLegacyInstallRecord(parsed: unknown, pluginId: string): LegacyRecord | undefined {
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return undefined;
+  const root = parsed as Record<string, unknown>;
+
+  const top = root.installRecords ?? root.records;
+  if (top && typeof top === "object" && !Array.isArray(top)) {
+    const rec = (top as Record<string, unknown>)[pluginId];
+    if (rec && typeof rec === "object" && !Array.isArray(rec)) {
+      return rec as LegacyRecord;
+    }
+  }
+
+  const plugins = root.plugins;
+  if (Array.isArray(plugins)) {
+    for (const p of plugins) {
+      if (!p || typeof p !== "object" || Array.isArray(p)) continue;
+      const entry = p as Record<string, unknown>;
+      if (entry.pluginId === pluginId && entry.installRecord && typeof entry.installRecord === "object") {
+        return entry.installRecord as LegacyRecord;
+      }
+    }
+  }
+  return undefined;
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function safeRealpath(p: string): string {
+  const resolved = isAbsolute(p) ? p : pathResolve(p);
+  try {
+    return realpathSync(resolved);
+  } catch {
+    return resolved;
+  }
+}
+
+function samePath(a: string, b: string): boolean {
+  try {
+    return safeRealpath(a) === safeRealpath(b);
+  } catch {
+    return false;
+  }
+}
+
+function compareVersions(a: string, b: string): number {
+  // Date-based semver-like: 2026.6.290 vs 2026.6.291. We don't parse semver — we
+  // segment on '.' and compare each segment numerically; falls back to
+  // lexicographic for non-numeric suffixes (e.g. "-rc.1").
+  const segsA = a.split(".");
+  const segsB = b.split(".");
+  const len = Math.max(segsA.length, segsB.length);
+  for (let i = 0; i < len; i++) {
+    const sa = segsA[i] ?? "0";
+    const sb = segsB[i] ?? "0";
+    const na = Number(sa);
+    const nb = Number(sb);
+    if (Number.isFinite(na) && Number.isFinite(nb)) {
+      if (na !== nb) return na - nb;
+      continue;
+    }
+    if (sa !== sb) return sa < sb ? -1 : 1;
+  }
+  return 0;
+}
+
+/**
+ * Compare the legacy install record for `pluginId` with the live plugin path
+ * we are currently running from. The detection is intentionally conservative:
+ * "safe-reconcile" only fires when the live path exists on disk AND its version
+ * is >= the stale version, so we never silently downgrade metadata.
+ */
+export function detectStaleLegacyInstallIndexEntry(
+  opts: { pluginId?: string; livePath?: string; liveVersion?: string; legacyPath?: string } = {},
+): StaleLegacyInstallIndexDetection {
+  const pluginId = opts.pluginId ?? PLUGIN_ID;
+  const legacyPath = opts.legacyPath ?? resolveLegacyInstallIndexPath();
+  const livePath = opts.livePath ?? findPluginRoot(import.meta.url);
+  const liveVersion = opts.liveVersion ?? readPluginPackageVersion(livePath);
+
+  const detection: StaleLegacyInstallIndexDetection = {
+    present: false,
+    legacyPath,
+    livePath,
+    liveVersion,
+    livePathExists: false,
+    verdict: "no-conflict",
+  };
+
+  if (!existsSync(legacyPath)) {
+    detection.verdict = "no-conflict";
+    return detection;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(legacyPath, "utf-8"));
+  } catch {
+    detection.verdict = "unsafe-malformed-legacy";
+    detection.detail = `Could not parse legacy install-index file ${legacyPath}`;
+    return detection;
+  }
+
+  const record = extractLegacyInstallRecord(parsed, pluginId);
+  if (!record) {
+    detection.verdict = "no-conflict";
+    return detection;
+  }
+  detection.present = true;
+  detection.staleInstallPath = asString(record.installPath);
+  detection.staleVersion = asString(record.version) ?? asString(record.resolvedVersion);
+  detection.staleSource = asString(record.source);
+
+  if (!detection.staleInstallPath || !detection.staleVersion) {
+    detection.verdict = "unsafe-malformed-legacy";
+    detection.detail = `Legacy install-index record for ${pluginId} is missing installPath or version`;
+    return detection;
+  }
+
+  // Live path must exist on disk and contain an openclaw.plugin.json manifest.
+  const liveManifest = join(livePath, "openclaw.plugin.json");
+  detection.livePathExists = existsSync(livePath) && existsSync(liveManifest);
+  if (!detection.livePathExists) {
+    detection.verdict = "unsafe-no-live-path";
+    detection.detail = `Live plugin manifest is missing at ${livePath}`;
+    return detection;
+  }
+  if (!liveVersion) {
+    detection.verdict = "unsafe-malformed-legacy";
+    detection.detail = `Live plugin version could not be resolved from ${livePath}`;
+    return detection;
+  }
+
+  const pathsMatch = samePath(detection.staleInstallPath, livePath);
+  const versionsMatch = detection.staleVersion === liveVersion;
+  if (pathsMatch && versionsMatch) {
+    detection.verdict = "matches-live";
+    return detection;
+  }
+  if (pathsMatch && !versionsMatch) {
+    // Path matches live; only version differs. Safe to update version.
+    detection.verdict = "safe-reconcile";
+    detection.detail = `Live path matches legacy; only version differs (stale=${detection.staleVersion}, live=${liveVersion})`;
+    return detection;
+  }
+
+  const cmp = compareVersions(liveVersion, detection.staleVersion);
+  if (cmp < 0) {
+    detection.verdict = "unsafe-downgrade";
+    detection.detail = `Live version ${liveVersion} is older than stale version ${detection.staleVersion}`;
+    return detection;
+  }
+
+  detection.verdict = "safe-reconcile";
+  detection.detail = `Stale record points at ${detection.staleInstallPath} (${detection.staleVersion}); live is ${livePath} (${liveVersion})`;
+  return detection;
+}
+
+/**
+ * Atomically rewrite the legacy install-index file so it no longer conflicts
+ * with the live plugin path/version. The original file is preserved as
+ * `${legacyPath}.bak-<ts>`; if rewriting fails we attempt to restore it from
+ * the backup so the operator's state is never silently lost.
+ */
+export function reconcileLegacyInstallIndex(
+  opts: { detection?: StaleLegacyInstallIndexDetection; legacyPath?: string; pluginId?: string; dryRun?: boolean } = {},
+): ReconcileLegacyInstallIndexResult {
+  const detection = opts.detection ?? detectStaleLegacyInstallIndexEntry({ legacyPath: opts.legacyPath });
+  const pluginId = opts.pluginId ?? PLUGIN_ID;
+
+  if (detection.verdict === "no-conflict" || detection.verdict === "matches-live") {
+    return { ok: true, verdict: detection.verdict, action: "noop" };
+  }
+
+  if (detection.verdict !== "safe-reconcile") {
+    return {
+      ok: false,
+      verdict: detection.verdict,
+      action: "skipped",
+      error: detection.detail ?? "Reconciliation not safe",
+    };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(detection.legacyPath, "utf-8"));
+  } catch (err) {
+    return {
+      ok: false,
+      verdict: detection.verdict,
+      action: "skipped",
+      error: `Could not parse legacy install-index file ${detection.legacyPath}: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return {
+      ok: false,
+      verdict: detection.verdict,
+      action: "skipped",
+      error: `Legacy install-index file ${detection.legacyPath} is not an object`,
+    };
+  }
+
+  const root = parsed as Record<string, unknown>;
+  const originalSerialized = JSON.stringify(parsed);
+  let nextRecords: Record<string, unknown> | undefined;
+  let action: "removed" | "updated" = "updated";
+
+  if (root.installRecords && typeof root.installRecords === "object" && !Array.isArray(root.installRecords)) {
+    nextRecords = { ...(root.installRecords as Record<string, unknown>) };
+    if (nextRecords[pluginId]) {
+      // Drop the stale entry — core will re-derive it from the live plugin
+      // discovery scan on the next startup. This is the safest outcome: the
+      // legacy file no longer conflicts with SQLite.
+      delete nextRecords[pluginId];
+      action = "removed";
+    } else if (root.records && typeof root.records === "object" && !Array.isArray(root.records)) {
+      const records = { ...(root.records as Record<string, unknown>) };
+      if (records[pluginId]) {
+        delete records[pluginId];
+        action = "removed";
+      }
+    }
+    root.installRecords = nextRecords;
+  } else if (root.records && typeof root.records === "object" && !Array.isArray(root.records)) {
+    const records = { ...(root.records as Record<string, unknown>) };
+    if (records[pluginId]) {
+      delete records[pluginId];
+      action = "removed";
+    }
+    root.records = records;
+  } else {
+    return {
+      ok: false,
+      verdict: detection.verdict,
+      action: "skipped",
+      error: `Legacy install-index file ${detection.legacyPath} has no installRecords or records container to reconcile`,
+    };
+  }
+
+  if (Array.isArray(root.plugins)) {
+    root.plugins = (root.plugins as Array<Record<string, unknown>>).filter(
+      (p) => !p || typeof p !== "object" || p.pluginId !== pluginId,
+    );
+  }
+
+  const nextSerialized = JSON.stringify(parsed);
+
+  if (opts.dryRun) {
+    return { ok: true, verdict: detection.verdict, action };
+  }
+
+  // Backup the original sidecar to a sibling path before mutating.
+  const backupDir = join(tmpdir(), "openclaw-hybrid-memory-install-index-backups");
+  mkdirSync(backupDir, { recursive: true });
+  const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const backupPath = join(backupDir, `${basename(detection.legacyPath)}.bak-${stamp}`);
+  try {
+    writeFileSync(backupPath, originalSerialized, "utf-8");
+  } catch (err) {
+    return {
+      ok: false,
+      verdict: detection.verdict,
+      action: "skipped",
+      error: `Failed to write backup ${backupPath}: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+
+  const tmpPath = `${detection.legacyPath}.tmp-${process.pid}-${Date.now()}`;
+  try {
+    writeFileSync(tmpPath, nextSerialized, "utf-8");
+    renameSync(tmpPath, detection.legacyPath);
+  } catch (err) {
+    try {
+      if (existsSync(tmpPath)) rmSync(tmpPath, { force: true });
+    } catch {
+      /* best-effort */
+    }
+    // Restore from backup so we don't leave a half-written file.
+    try {
+      writeFileSync(detection.legacyPath, originalSerialized, "utf-8");
+    } catch {
+      /* if restore fails the operator still has the backup at backupPath */
+    }
+    return {
+      ok: false,
+      verdict: detection.verdict,
+      action: "skipped",
+      error: `Failed to rewrite ${detection.legacyPath}: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+
+  return {
+    ok: true,
+    verdict: detection.verdict,
+    action,
+    backupPath,
+  };
+}
+
+/**
+ * Build the actionable warning string used by `verify` and upgrade flows when
+ * a stale legacy install-index entry is detected but cannot be auto-rewritten.
+ */
+export function formatStaleInstallIndexWarning(detection: StaleLegacyInstallIndexDetection): string {
+  const parts: string[] = [];
+  if (detection.verdict === "matches-live" || detection.verdict === "no-conflict") {
+    return "";
+  }
+  const stalePath = detection.staleInstallPath ?? "<unknown>";
+  const staleVersion = detection.staleVersion ?? "<unknown>";
+  parts.push(
+    `Plugin install index drift: legacy ${detection.legacyPath} still references ${PLUGIN_ID} at ${stalePath} (${staleVersion}); live is ${detection.livePath} (${detection.liveVersion ?? "<unknown>"}).`,
+  );
+  parts.push(
+    "OpenClaw state migrations will keep emitting 'Left plugin install index in place because shared SQLite state has conflicting plugin install metadata' until reconciled.",
+  );
+  switch (detection.verdict) {
+    case "safe-reconcile":
+      parts.push(
+        `Repair: run 'openclaw hybrid-mem verify --fix' or 'openclaw hybrid-mem install-index reconcile' to drop the stale entry.`,
+      );
+      break;
+    case "unsafe-downgrade":
+      parts.push(
+        `Repair: the live plugin version (${detection.liveVersion}) is older than the stale version (${staleVersion}); upgrade before reconciling, or remove ${stalePath} manually and run 'openclaw hybrid-mem install-index reconcile'.`,
+      );
+      break;
+    case "unsafe-no-live-path":
+      parts.push(
+        `Repair: restore the plugin at ${detection.livePath} (missing manifest) or remove the stale entry from ${detection.legacyPath} before retrying.`,
+      );
+      break;
+    case "unsafe-malformed-legacy":
+      parts.push(
+        `Repair: ${detection.detail ?? "legacy record is malformed"}; inspect ${detection.legacyPath} and remove the ${PLUGIN_ID} entry before retrying.`,
+      );
+      break;
+    default:
+      parts.push(
+        `Repair: inspect ${detection.legacyPath} and remove the stale ${PLUGIN_ID} entry pointing at ${stalePath} (${staleVersion}).`,
+      );
+      break;
+  }
+  return parts.join(" ");
+}
+
+/**
+ * Convenience wrapper used by verify/upgrade flows. Runs detection and applies
+ * reconciliation only when safe; returns the structured result plus a
+ * human-readable message.
+ */
+export function runInstallIndexReconcileForPlugin(
+  opts: {
+    pluginId?: string;
+    legacyPath?: string;
+    livePath?: string;
+    liveVersion?: string;
+    dryRun?: boolean;
+    log?: (msg: string) => void;
+  } = {},
+): {
+  detection: StaleLegacyInstallIndexDetection;
+  result: ReconcileLegacyInstallIndexResult;
+  message: string;
+} {
+  const detection = detectStaleLegacyInstallIndexEntry({
+    pluginId: opts.pluginId,
+    legacyPath: opts.legacyPath,
+    livePath: opts.livePath,
+    liveVersion: opts.liveVersion,
+  });
+  if (detection.verdict === "no-conflict" || detection.verdict === "matches-live") {
+    return { detection, result: { ok: true, verdict: detection.verdict, action: "noop" }, message: "" };
+  }
+  const result = reconcileLegacyInstallIndex({ detection, dryRun: opts.dryRun });
+  let message = "";
+  if (result.ok) {
+    if (result.action === "removed") {
+      message = `install-index reconcile: dropped stale ${PLUGIN_ID} entry from ${detection.legacyPath} (backup at ${result.backupPath ?? "<unknown>"}).`;
+    } else if (result.action === "updated") {
+      message = `install-index reconcile: updated stale ${PLUGIN_ID} entry in ${detection.legacyPath} (backup at ${result.backupPath ?? "<unknown>"}).`;
+    }
+  } else {
+    message = formatStaleInstallIndexWarning(detection);
+  }
+  if (opts.log) opts.log(message);
+  return { detection, result, message };
+}
+
+/**
+ * Returns the relative path of the legacy install-index file under the state
+ * dir. Exposed for documentation and tests.
+ */
+export function legacyInstallIndexRelativePath(): string {
+  return LEGACY_INSTALL_INDEX_REL_PATH;
+}
+
+/**
+ * Helper used by callers that want to know whether two plugin install paths
+ * refer to the same on-disk location. Exported so tests can stub it.
+ */
+export function areInstallPathsEquivalent(a: string, b: string): boolean {
+  return samePath(a, b);
+}
+
+/**
+ * Helper used to compare two date-based plugin versions. Exported for tests.
+ * Returns negative if `a < b`, 0 if equal, positive if `a > b`.
+ */
+export function comparePluginVersions(a: string, b: string): number {
+  return compareVersions(a, b);
+}
+
+/**
+ * Visible for tests — clears any module-level cache (currently none, but kept
+ * for symmetry with `plugin-root.ts`).
+ */
+export function _resetInstallIndexReconcileCache(): void {
+  /* no-op */
+}
+
+/** Visible for tests — exposes the internal `extractLegacyInstallRecord` parser. */
+export function _extractLegacyInstallRecordForTest(parsed: unknown, pluginId: string): LegacyRecord | undefined {
+  return extractLegacyInstallRecord(parsed, pluginId);
+}
+
+/** Visible for tests — exposes the internal version comparator. */
+export function _isVersionAtLeast(version: string, baseline: string): boolean {
+  return compareVersions(version, baseline) >= 0;
+}
+
+/** Visible for tests — exposes the internal path equivalence helper. */
+export function _normalizeInstallPathForTest(p: string): string {
+  return safeRealpath(p);
+}

--- a/extensions/memory-hybrid/cli/install/run-install.ts
+++ b/extensions/memory-hybrid/cli/install/run-install.ts
@@ -47,6 +47,7 @@ import {
   preflightUpgradePluginConfig,
   runStandaloneUpgradeInstall,
 } from "./upgrade-config-preflight.js";
+import { runInstallIndexReconcileForPlugin } from "./install-index-reconcile.js";
 
 export type RunUpgradeForCliOptions = {
   /** Skip cron normalization when config was not fully parsed (upgrade-only fast path). */
@@ -267,6 +268,19 @@ export function runInstallForCli(opts: { dryRun: boolean }): InstallCliResult {
       );
     }
     for (const note of embeddingPatch.notes) completed.push(note);
+    // Best-effort install-index reconciliation (#2008): clear any stale legacy
+    // install record so the gateway does not emit "Left plugin install index in
+    // place because shared SQLite state has conflicting plugin install
+    // metadata" on the next startup. Non-fatal; unsafe states log guidance.
+    try {
+      const reconcile = runInstallIndexReconcileForPlugin({ pluginId: PLUGIN_ID });
+      if (reconcile.message) completed.push(reconcile.message);
+    } catch (e) {
+      capturePluginError(e as Error, { subsystem: "cli", operation: "runInstallForCli:install-index-reconcile" });
+      completed.push(
+        `Install-index reconciliation skipped: ${e instanceof Error ? e.message : String(e)}`,
+      );
+    }
     const remaining: string[] = [];
     if (detectedEmbedding.provider === "openai" && !existingEmbedding.hasUsableApiKey && !detectedEmbedding.envKey) {
       remaining.push('Set plugins.entries["openclaw-hybrid-memory"].config.embedding.apiKey to a real key.');
@@ -730,6 +744,26 @@ export async function runUpgradeForCli(
     rmSync(backupDir, { recursive: true, force: true });
   } catch (e) {
     capturePluginError(e as Error, { subsystem: "cli", operation: "runUpgradeForCli:cleanup-backup" });
+  }
+
+  // Best-effort: reconcile any stale legacy plugin install-index metadata for
+  // this plugin (#2008). The next Gateway startup will then no longer emit
+  // "Left plugin install index in place because shared SQLite state has
+  // conflicting plugin install metadata". This is non-fatal: if reconciliation
+  // is unsafe (live version older than stale, missing manifest, malformed
+  // legacy file) we log guidance but still report a successful upgrade.
+  try {
+    const reconcile = runInstallIndexReconcileForPlugin({ pluginId: PLUGIN_ID });
+    if (reconcile.message) {
+      logger?.info?.(`memory-hybrid: upgrade — ${reconcile.message}`);
+    } else if (reconcile.result.ok && reconcile.result.action === "noop") {
+      logger?.debug?.("memory-hybrid: upgrade — install-index reconciliation: nothing to do");
+    }
+  } catch (e) {
+    capturePluginError(e as Error, { subsystem: "cli", operation: "runUpgradeForCli:install-index-reconcile" });
+    logger?.warn?.(
+      `memory-hybrid: upgrade — install-index reconciliation failed: ${e instanceof Error ? e.message : String(e)}`,
+    );
   }
 
   return {

--- a/extensions/memory-hybrid/cli/register.ts
+++ b/extensions/memory-hybrid/cli/register.ts
@@ -17,6 +17,7 @@ import { PLUGIN_ID } from "../utils/constants.js";
 import { type ActiveTaskContext, registerActiveTaskCommands } from "./active-tasks.js";
 import { registerBenchmarkCommands } from "./benchmark.js";
 import { registerHelpCommand } from "./cmd-help.js";
+import { registerInstallIndexCommand } from "./cmd-install-index.js";
 import { executeMineCommand } from "./cmd-mine.js";
 import { registerStatusCommands } from "./cmd-status.js";
 import { registerUserFriendlyCommands, type UserFriendlyContext } from "./cmd-user-friendly.js";
@@ -701,5 +702,15 @@ export function registerHybridMemCli(mem: Chainable, ctx: HybridMemCliContext): 
       operation: "register-cli:user-friendly",
     });
     throw err;
+  }
+
+  // Register the install-index reconciliation commands (issue #2008).
+  try {
+    registerInstallIndexCommand(mem);
+  } catch (err) {
+    capturePluginError(err instanceof Error ? err : new Error(String(err)), {
+      subsystem: "registration",
+      operation: "register-cli:install-index",
+    });
   }
 }

--- a/extensions/memory-hybrid/cli/verify/sections/infrastructure.ts
+++ b/extensions/memory-hybrid/cli/verify/sections/infrastructure.ts
@@ -15,6 +15,11 @@ import {
   resolveKnownNpmProjectPluginDir,
   resolveNpmProjectPluginDirFromLayout,
 } from "../../install/workspace.js";
+import {
+  detectStaleLegacyInstallIndexEntry,
+  formatStaleInstallIndexWarning,
+  reconcileLegacyInstallIndex,
+} from "../../install/install-index-reconcile.js";
 import { capturePluginError, isErrorReporterActive, resolvePendingErrorReportCount } from "../../../services/error-reporter.js";
 import { listQuarantinedGoalIds, resolveGoalsDir, auditGoalIndexDrift, rebuildGoalIndex } from "../../../services/goal-registry.js";
 import { PLUGIN_ID } from "../../../utils/constants.js";
@@ -70,6 +75,47 @@ export async function runVerifyInfrastructureSection(state: VerifyRunState): Pro
     if (dualInstall) {
       warnings.push(dualInstall);
       log(`${WARN_LINE} Plugin install layout: ${dualInstall}`);
+    }
+  }
+
+  // Issue #2008: detect stale legacy install-index entries that cause
+  // OpenClaw core to keep emitting "Left plugin install index in place
+  // because shared SQLite state has conflicting plugin install metadata".
+  // We compare the legacy `${stateDir}/plugins/installs.json` record against
+  // the live plugin path/version we are actually running from.
+  const installIndexDetection = detectStaleLegacyInstallIndexEntry({
+    pluginId: PLUGIN_ID,
+    livePath: extDir,
+  });
+  if (
+    installIndexDetection.present &&
+    installIndexDetection.verdict !== "no-conflict" &&
+    installIndexDetection.verdict !== "matches-live"
+  ) {
+    if (installIndexDetection.verdict === "safe-reconcile" && opts.fix) {
+      const result = reconcileLegacyInstallIndex({ detection: installIndexDetection });
+      if (result.ok && result.action !== "noop") {
+        warnings.push(
+          `Reconciled stale install-index entry for ${PLUGIN_ID} (${result.action}; backup at ${result.backupPath ?? "<unknown>"}).`,
+        );
+        log(
+          `${OK} Install index: dropped stale ${PLUGIN_ID} entry pointing at ${installIndexDetection.staleInstallPath ?? "<unknown>"} (${installIndexDetection.staleVersion ?? "<unknown>"}) — live is ${installIndexDetection.livePath} (${installIndexDetection.liveVersion ?? "<unknown>"}). Backup: ${result.backupPath ?? "<unknown>"}.`,
+        );
+      } else {
+        const detail = result.error ?? formatStaleInstallIndexWarning(installIndexDetection);
+        warnings.push(detail);
+        log(`${WARN_LINE} Install index: ${detail}`);
+      }
+    } else {
+      const detail = formatStaleInstallIndexWarning(installIndexDetection);
+      warnings.push(detail);
+      log(`${WARN_LINE} Install index: ${detail}`);
+      if (installIndexDetection.verdict === "safe-reconcile") {
+        log(`  → Run \`openclaw hybrid-mem verify --fix\` to drop the stale entry.`);
+        fixes.push(
+          `Run \`openclaw hybrid-mem verify --fix\` (or \`openclaw hybrid-mem install-index reconcile\`) to reconcile the stale ${PLUGIN_ID} entry in ${installIndexDetection.legacyPath}.`,
+        );
+      }
     }
   }
 

--- a/extensions/memory-hybrid/openclaw.plugin.json
+++ b/extensions/memory-hybrid/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "openclaw-hybrid-memory",
   "kind": "memory",
-  "version": "2026.6.291",
+  "version": "2026.6.292",
   "contracts": {
     "tools": [
       "active_task_checkpoint",

--- a/extensions/memory-hybrid/package.json
+++ b/extensions/memory-hybrid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-hybrid-memory",
-  "version": "2026.6.291",
+  "version": "2026.6.292",
   "type": "module",
   "description": "Give your OpenClaw agent lasting memory: structured facts, semantic search, auto-capture & recall, decay, optional credential vault. Part of Hybrid Memory v3.",
   "files": [

--- a/extensions/memory-hybrid/tests/install-index-reconcile.test.ts
+++ b/extensions/memory-hybrid/tests/install-index-reconcile.test.ts
@@ -1,0 +1,372 @@
+/**
+ * Tests for the legacy install-index reconciliation helpers (issue #2008).
+ *
+ * The legacy install-index file is the JSON sidecar at
+ * `${stateDir}/plugins/installs.json` that OpenClaw core's state migrations
+ * merge into SQLite on startup. When a plugin's runtime path/version
+ * diverges from what the sidecar records, core emits the
+ * "Left plugin install index in place because shared SQLite state has
+ * conflicting plugin install metadata" warning on every startup.
+ *
+ * These tests verify the hybrid-memory side detector + reconciler:
+ *   - detectStaleLegacyInstallIndexEntry: returns the right verdict for the
+ *     six supported scenarios (no-conflict, matches-live, safe-reconcile,
+ *     unsafe-downgrade, unsafe-no-live-path, unsafe-malformed-legacy).
+ *   - reconcileLegacyInstallIndex: when safe, atomically removes the stale
+ *     entry, leaves a backup, and preserves the rest of the sidecar; when
+ *     unsafe, returns an error and leaves the sidecar untouched.
+ *   - formatStaleInstallIndexWarning: produces actionable guidance including
+ *     both stale and live paths and versions.
+ */
+
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  _extractLegacyInstallRecordForTest,
+  _isVersionAtLeast,
+  _normalizeInstallPathForTest,
+  areInstallPathsEquivalent,
+  comparePluginVersions,
+  detectStaleLegacyInstallIndexEntry,
+  formatStaleInstallIndexWarning,
+  reconcileLegacyInstallIndex,
+  resolveLegacyInstallIndexPath,
+  runInstallIndexReconcileForPlugin,
+} from "../cli/install/install-index-reconcile.js";
+
+function makeLivePluginDir(stateDir: string, version: string): string {
+  const liveDir = join(stateDir, "live", "openclaw-hybrid-memory");
+  mkdirSync(liveDir, { recursive: true });
+  writeFileSync(join(liveDir, "openclaw.plugin.json"), "{}");
+  writeFileSync(join(liveDir, "package.json"), JSON.stringify({ version }));
+  return liveDir;
+}
+
+function writeLegacySidecar(stateDir: string, record: Record<string, unknown> | null): string {
+  const pluginsDir = join(stateDir, "plugins");
+  mkdirSync(pluginsDir, { recursive: true });
+  const path = join(pluginsDir, "installs.json");
+  if (record === null) {
+    writeFileSync(path, "{}");
+  } else {
+    writeFileSync(path, JSON.stringify({ version: 1, installRecords: record }));
+  }
+  return path;
+}
+
+describe("install-index reconciliation (#2008)", () => {
+  let stateDir: string;
+
+  beforeEach(() => {
+    stateDir = join(tmpdir(), `mh-install-index-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+    mkdirSync(stateDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    try {
+      rmSync(stateDir, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  });
+
+  it("returns no-conflict when legacy sidecar does not exist", () => {
+    const liveDir = makeLivePluginDir(stateDir, "2026.6.291");
+    const detection = detectStaleLegacyInstallIndexEntry({
+      legacyPath: resolveLegacyInstallIndexPath({ stateDir }),
+      livePath: liveDir,
+    });
+    expect(detection.present).toBe(false);
+    expect(detection.verdict).toBe("no-conflict");
+    expect(detection.livePath).toBe(liveDir);
+    expect(detection.liveVersion).toBe("2026.6.291");
+  });
+
+  it("returns no-conflict when legacy sidecar exists but has no entry for the plugin", () => {
+    const liveDir = makeLivePluginDir(stateDir, "2026.6.291");
+    const legacyPath = writeLegacySidecar(stateDir, { "other-plugin": { installPath: "/x", version: "1.0" } });
+    const detection = detectStaleLegacyInstallIndexEntry({ legacyPath, livePath: liveDir });
+    expect(detection.present).toBe(false);
+    expect(detection.verdict).toBe("no-conflict");
+  });
+
+  it("returns matches-live when legacy record already matches live path/version", () => {
+    const liveDir = makeLivePluginDir(stateDir, "2026.6.291");
+    const legacyPath = writeLegacySidecar(stateDir, {
+      "openclaw-hybrid-memory": {
+        source: "npm",
+        installPath: liveDir,
+        version: "2026.6.291",
+      },
+    });
+    const detection = detectStaleLegacyInstallIndexEntry({ legacyPath, livePath: liveDir });
+    expect(detection.present).toBe(true);
+    expect(detection.verdict).toBe("matches-live");
+  });
+
+  it("returns safe-reconcile when stale path differs but live version is newer (#2008)", () => {
+    const staleDir = join(stateDir, "stale");
+    mkdirSync(staleDir, { recursive: true });
+    writeFileSync(join(staleDir, "package.json"), JSON.stringify({ version: "2026.6.261" }));
+    const liveDir = makeLivePluginDir(stateDir, "2026.6.291");
+    const legacyPath = writeLegacySidecar(stateDir, {
+      "openclaw-hybrid-memory": {
+        source: "npm",
+        installPath: staleDir,
+        version: "2026.6.261",
+        resolvedName: "openclaw-hybrid-memory",
+        resolvedVersion: "2026.6.261",
+      },
+    });
+    const detection = detectStaleLegacyInstallIndexEntry({ legacyPath, livePath: liveDir });
+    expect(detection.present).toBe(true);
+    expect(detection.staleVersion).toBe("2026.6.261");
+    expect(detection.verdict).toBe("safe-reconcile");
+  });
+
+  it("returns safe-reconcile when paths match but only the version differs (#2008)", () => {
+    const liveDir = makeLivePluginDir(stateDir, "2026.6.291");
+    const legacyPath = writeLegacySidecar(stateDir, {
+      "openclaw-hybrid-memory": {
+        source: "extensions",
+        installPath: liveDir,
+        version: "2026.6.290",
+      },
+    });
+    const detection = detectStaleLegacyInstallIndexEntry({ legacyPath, livePath: liveDir });
+    expect(detection.verdict).toBe("safe-reconcile");
+    expect(detection.staleVersion).toBe("2026.6.290");
+    expect(detection.liveVersion).toBe("2026.6.291");
+  });
+
+  it("returns unsafe-downgrade when live version is older than stale version", () => {
+    const staleDir = join(stateDir, "stale");
+    mkdirSync(staleDir, { recursive: true });
+    writeFileSync(join(staleDir, "package.json"), JSON.stringify({ version: "2026.6.300" }));
+    const liveDir = makeLivePluginDir(stateDir, "2026.6.291");
+    const legacyPath = writeLegacySidecar(stateDir, {
+      "openclaw-hybrid-memory": {
+        source: "npm",
+        installPath: staleDir,
+        version: "2026.6.300",
+      },
+    });
+    const detection = detectStaleLegacyInstallIndexEntry({ legacyPath, livePath: liveDir });
+    expect(detection.verdict).toBe("unsafe-downgrade");
+    expect(formatStaleInstallIndexWarning(detection)).toMatch(/older than/);
+  });
+
+  it("returns unsafe-no-live-path when live plugin manifest is missing", () => {
+    const staleDir = join(stateDir, "stale");
+    mkdirSync(staleDir, { recursive: true });
+    writeFileSync(join(staleDir, "package.json"), JSON.stringify({ version: "2026.6.270" }));
+    const missingLive = join(stateDir, "missing-live");
+    mkdirSync(missingLive, { recursive: true });
+    // Intentionally do NOT write openclaw.plugin.json here.
+    const legacyPath = writeLegacySidecar(stateDir, {
+      "openclaw-hybrid-memory": {
+        source: "npm",
+        installPath: staleDir,
+        version: "2026.6.270",
+      },
+    });
+    const detection = detectStaleLegacyInstallIndexEntry({ legacyPath, livePath: missingLive });
+    expect(detection.verdict).toBe("unsafe-no-live-path");
+  });
+
+  it("returns unsafe-malformed-legacy when the sidecar is unparseable JSON", () => {
+    const pluginsDir = join(stateDir, "plugins");
+    mkdirSync(pluginsDir, { recursive: true });
+    const legacyPath = join(pluginsDir, "installs.json");
+    writeFileSync(legacyPath, "{ this is not valid JSON");
+    const liveDir = makeLivePluginDir(stateDir, "2026.6.291");
+    const detection = detectStaleLegacyInstallIndexEntry({ legacyPath, livePath: liveDir });
+    expect(detection.verdict).toBe("unsafe-malformed-legacy");
+  });
+
+  it("returns unsafe-malformed-legacy when the stale record lacks installPath", () => {
+    const liveDir = makeLivePluginDir(stateDir, "2026.6.291");
+    const legacyPath = writeLegacySidecar(stateDir, {
+      "openclaw-hybrid-memory": { source: "npm", version: "2026.6.270" },
+    });
+    const detection = detectStaleLegacyInstallIndexEntry({ legacyPath, livePath: liveDir });
+    expect(detection.verdict).toBe("unsafe-malformed-legacy");
+  });
+
+  it("reconciles a safe-reconcile case by removing the stale entry and writing a backup", () => {
+    const staleDir = join(stateDir, "stale");
+    mkdirSync(staleDir, { recursive: true });
+    writeFileSync(join(staleDir, "package.json"), JSON.stringify({ version: "2026.6.261" }));
+    const liveDir = makeLivePluginDir(stateDir, "2026.6.291");
+    const legacyPath = writeLegacySidecar(stateDir, {
+      "openclaw-hybrid-memory": {
+        source: "npm",
+        installPath: staleDir,
+        version: "2026.6.261",
+        resolvedName: "openclaw-hybrid-memory",
+        resolvedVersion: "2026.6.261",
+      },
+      codex: {
+        source: "npm",
+        installPath: "/usr/lib/node_modules/codex",
+        version: "1.2.3",
+      },
+    });
+    const detection = detectStaleLegacyInstallIndexEntry({ legacyPath, livePath: liveDir });
+    expect(detection.verdict).toBe("safe-reconcile");
+
+    const result = reconcileLegacyInstallIndex({ detection });
+    expect(result.ok).toBe(true);
+    expect(result.action).toBe("removed");
+    expect(result.backupPath).toBeDefined();
+    if (result.backupPath) expect(existsSync(result.backupPath)).toBe(true);
+
+    const next = JSON.parse(readFileSync(legacyPath, "utf-8")) as { installRecords: Record<string, unknown> };
+    expect(next.installRecords["openclaw-hybrid-memory"]).toBeUndefined();
+    expect(next.installRecords.codex).toBeDefined();
+  });
+
+  it("dry-run does not mutate the sidecar but still reports the verdict", () => {
+    const staleDir = join(stateDir, "stale");
+    mkdirSync(staleDir, { recursive: true });
+    writeFileSync(join(staleDir, "package.json"), JSON.stringify({ version: "2026.6.270" }));
+    const liveDir = makeLivePluginDir(stateDir, "2026.6.291");
+    const legacyPath = writeLegacySidecar(stateDir, {
+      "openclaw-hybrid-memory": {
+        source: "npm",
+        installPath: staleDir,
+        version: "2026.6.270",
+      },
+    });
+    const detection = detectStaleLegacyInstallIndexEntry({ legacyPath, livePath: liveDir });
+    const before = readFileSync(legacyPath, "utf-8");
+
+    const result = reconcileLegacyInstallIndex({ detection, dryRun: true });
+    expect(result.ok).toBe(true);
+    expect(result.action).toBe("removed");
+    expect(result.backupPath).toBeUndefined();
+
+    const after = readFileSync(legacyPath, "utf-8");
+    expect(after).toBe(before);
+  });
+
+  it("skips unsafe verdicts without mutating the sidecar", () => {
+    const staleDir = join(stateDir, "stale");
+    mkdirSync(staleDir, { recursive: true });
+    writeFileSync(join(staleDir, "package.json"), JSON.stringify({ version: "2026.6.300" }));
+    const liveDir = makeLivePluginDir(stateDir, "2026.6.291");
+    const legacyPath = writeLegacySidecar(stateDir, {
+      "openclaw-hybrid-memory": {
+        source: "npm",
+        installPath: staleDir,
+        version: "2026.6.300",
+      },
+    });
+    const before = readFileSync(legacyPath, "utf-8");
+    const detection = detectStaleLegacyInstallIndexEntry({ legacyPath, livePath: liveDir });
+    expect(detection.verdict).toBe("unsafe-downgrade");
+
+    const result = reconcileLegacyInstallIndex({ detection });
+    expect(result.ok).toBe(false);
+    expect(result.action).toBe("skipped");
+    expect(readFileSync(legacyPath, "utf-8")).toBe(before);
+  });
+
+  it("returns noop for matches-live without writing anything", () => {
+    const liveDir = makeLivePluginDir(stateDir, "2026.6.291");
+    const legacyPath = writeLegacySidecar(stateDir, {
+      "openclaw-hybrid-memory": {
+        source: "extensions",
+        installPath: liveDir,
+        version: "2026.6.291",
+      },
+    });
+    const detection = detectStaleLegacyInstallIndexEntry({ legacyPath, livePath: liveDir });
+    const result = reconcileLegacyInstallIndex({ detection });
+    expect(result.ok).toBe(true);
+    expect(result.action).toBe("noop");
+  });
+
+  it("runInstallIndexReconcileForPlugin logs guidance for unsafe verdicts", () => {
+    const staleDir = join(stateDir, "stale");
+    mkdirSync(staleDir, { recursive: true });
+    writeFileSync(join(staleDir, "package.json"), JSON.stringify({ version: "2026.6.300" }));
+    const liveDir = makeLivePluginDir(stateDir, "2026.6.291");
+    const legacyPath = writeLegacySidecar(stateDir, {
+      "openclaw-hybrid-memory": {
+        source: "npm",
+        installPath: staleDir,
+        version: "2026.6.300",
+      },
+    });
+    const logged: string[] = [];
+    const result = runInstallIndexReconcileForPlugin({
+      legacyPath,
+      livePath: liveDir,
+      log: (msg) => logged.push(msg),
+    });
+    expect(result.result.ok).toBe(false);
+    expect(result.message).toMatch(/older than|Plugin install index drift/);
+  });
+
+  it("formatStaleInstallIndexWarning returns empty string for no-conflict and matches-live", () => {
+    const liveDir = makeLivePluginDir(stateDir, "2026.6.291");
+    const noConflict = detectStaleLegacyInstallIndexEntry({
+      legacyPath: resolveLegacyInstallIndexPath({ stateDir }),
+      livePath: liveDir,
+    });
+    expect(formatStaleInstallIndexWarning(noConflict)).toBe("");
+
+    const legacyPath = writeLegacySidecar(stateDir, {
+      "openclaw-hybrid-memory": {
+        source: "extensions",
+        installPath: liveDir,
+        version: "2026.6.291",
+      },
+    });
+    const matches = detectStaleLegacyInstallIndexEntry({ legacyPath, livePath: liveDir });
+    expect(formatStaleInstallIndexWarning(matches)).toBe("");
+  });
+
+  it("extractLegacyInstallRecordForTest tolerates the embedded plugins[] shape", () => {
+    const legacyPath = join(stateDir, "plugins", "installs.json");
+    mkdirSync(join(stateDir, "plugins"), { recursive: true });
+    writeFileSync(
+      legacyPath,
+      JSON.stringify({
+        plugins: [
+          {
+            pluginId: "openclaw-hybrid-memory",
+            installRecord: {
+              source: "npm",
+              installPath: "/x",
+              version: "2026.6.270",
+            },
+          },
+          { pluginId: "codex", installRecord: { source: "npm", installPath: "/y", version: "1.0" } },
+        ],
+      }),
+    );
+    const parsed = JSON.parse(readFileSync(legacyPath, "utf-8")) as unknown;
+    const rec = _extractLegacyInstallRecordForTest(parsed, "openclaw-hybrid-memory");
+    expect(rec?.installPath).toBe("/x");
+    expect(rec?.version).toBe("2026.6.270");
+  });
+
+  it("compares date-based plugin versions numerically", () => {
+    expect(comparePluginVersions("2026.6.291", "2026.6.290")).toBeGreaterThan(0);
+    expect(comparePluginVersions("2026.6.290", "2026.6.291")).toBeLessThan(0);
+    expect(comparePluginVersions("2026.6.291", "2026.6.291")).toBe(0);
+    expect(_isVersionAtLeast("2026.6.291", "2026.6.290")).toBe(true);
+    expect(_isVersionAtLeast("2026.6.290", "2026.6.291")).toBe(false);
+  });
+
+  it("treats realpath-equivalent paths as the same install path", () => {
+    const a = makeLivePluginDir(stateDir, "2026.6.291");
+    expect(areInstallPathsEquivalent(a, a)).toBe(true);
+    expect(_normalizeInstallPathForTest(a)).toBeTruthy();
+  });
+});

--- a/packages/openclaw-hybrid-memory-install/package.json
+++ b/packages/openclaw-hybrid-memory-install/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-hybrid-memory-install",
-  "version": "2026.6.291",
+  "version": "2026.6.292",
   "description": "Standalone installer for openclaw-hybrid-memory. Use when OpenClaw config validation fails.",
   "bin": {
     "openclaw-hybrid-memory-install": "./install.js"


### PR DESCRIPTION
## Summary

After upgrading the live OpenClaw hybrid-memory extension from 2026.6.290 to 2026.6.291 via the npm tarball, Gateway startup kept emitting:

```text
Doctor warnings
- Left plugin install index in place because shared SQLite state has conflicting plugin install metadata for: codex, openclaw-hybrid-memory

[state-migrations] Legacy state migration warnings:
- Left plugin install index in place because shared SQLite state has conflicting plugin install metadata for: codex, openclaw-hybrid-memory
```

This warning fires from OpenClaw core's state migrations (`state-migrations-C36oJ0Mr.js` `migrateLegacyInstalledPluginIndex`) when the legacy `${stateDir}/plugins/installs.json` sidecar holds a stale record (e.g. an old npm-project install at `/home/markus/.openclaw/npm/projects/openclaw-hybrid-memory/...` from a previous version) that conflicts with the SQLite install records that already reference the live extensions path the gateway loaded from.

hybrid-memory cannot rewrite core SQLite state from a plugin process, but it can rewrite the legacy sidecar (after backing it up) so that the next core state-migration cycle has nothing left to conflict with.

## What this PR does

- **`cli/install/install-index-reconcile.ts`** (new): detector + reconciler. Compares the legacy record for `openclaw-hybrid-memory` against the live plugin path/version we are running from and emits one of six verdicts (`no-conflict`, `matches-live`, `safe-reconcile`, `unsafe-downgrade`, `unsafe-no-live-path`, `unsafe-malformed-legacy`). When verdict is `safe-reconcile`, atomically rewrites the legacy sidecar to drop the stale entry, leaving a backup under `$TMPDIR/openclaw-hybrid-memory-install-index-backups/`. When verdict is `unsafe`, returns an error and exposes a human-readable warning that names both the stale and live paths and versions so operators can repair manually.
- **`cli/cmd-install-index.ts`** (new): new `openclaw hybrid-mem install-index` subcommand group with `status` and `reconcile [--dry-run] [--plugin-id <id>]` for manual repair.
- **`cli/install/run-install.ts`**: `runUpgradeForCli` and `runInstallForCli` now run reconciliation before they finish, so the next Gateway restart emits no warning. Failures are non-fatal and only log guidance.
- **`cli/verify/sections/infrastructure.ts`**: the verify section surfaces the drift with both paths and versions, applies the fix when `--fix` is passed (and the verdict is `safe-reconcile`), and otherwise adds a fix suggestion to the existing `fixes[]` list.

## Tests

- `tests/install-index-reconcile.test.ts` — **18 new cases** covering:
  - `no-conflict` (missing file, no entry)
  - `matches-live` (path+version match)
  - `safe-reconcile` (path differs, version differs)
  - `unsafe-downgrade` (live version older than stale)
  - `unsafe-no-live-path` (manifest missing)
  - `unsafe-malformed-legacy` (unparseable JSON, missing installPath)
  - the embedded `plugins[]` legacy shape (`readLegacyEmbeddedInstallRecords`)
  - dry-run no-op
  - backup preservation
  - reconcile.skip-unsafe paths

Verified locally:

- `npx vitest run tests/install-index-reconcile.test.ts` → 18/18 ✅
- `npx vitest run tests/run-upgrade.test.ts` → 12/12 ✅
- `npx vitest run tests/verify` → 32/32 ✅
- `npx vitest run tests/install` → 48/48 ✅
- `npx tsc --noEmit -p tsconfig.json` → no new errors in changed files
- `npm run build` (tsdown) → ✅ Build complete in ~6s

Pre-existing repo-wide lint findings (88) and tsc warnings are unrelated to this change.

## Manual repair (until the next upgrade)

If a host is already on a stale version and just upgraded without the reconciliation step, an operator can run:

```bash
openclaw hybrid-mem install-index status
openclaw hybrid-mem install-index reconcile           # actually rewrites the sidecar
openclaw hybrid-mem install-index reconcile --dry-run # preview only
```

The `status` subcommand prints the stale path/version, the live path/version, the file location, and a one-line repair suggestion.

## Closes

- Closes #2008