### PR TITLE
fix: ContextEngine registration and add hybrid-mem --version (#2012)

### DIFF
--- a/extensions/memory-hybrid/cli/cmd-version.ts
+++ b/extensions/memory-hybrid/cli/cmd-version.ts
@@ -1,0 +1,172 @@
+/**
+ * hybrid-mem version reporting — shared by `hybrid-mem version` and root `--version` (issue #2012).
+ */
+
+export const HYBRID_MEM_PACKAGE_NAME = "openclaw-hybrid-memory";
+export const HYBRID_MEM_UPGRADE_COMMAND = "openclaw hybrid-mem upgrade";
+
+const GITHUB_LATEST_URL = "https://api.github.com/repos/markus-lassfolk/openclaw-hybrid-memory/releases/latest";
+const NPM_LATEST_URL = "https://registry.npmjs.org/openclaw-hybrid-memory/latest";
+const DEFAULT_FETCH_TIMEOUT_MS = 3000;
+
+export type VersionReport = {
+  name: string;
+  installed: string;
+  github: string | null;
+  npm: string | null;
+  updateAvailable: boolean;
+};
+
+export function comparePluginVersions(a: string, b: string): number {
+  const parseNum = (s: string): number => {
+    const n = Number.parseInt(s, 10);
+    return Number.isNaN(n) ? 0 : n;
+  };
+  const pa = a
+    .replace(/[-+].*/, "")
+    .split(".")
+    .map(parseNum);
+  const pb = b
+    .replace(/[-+].*/, "")
+    .split(".")
+    .map(parseNum);
+  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+    const va = pa[i] ?? 0;
+    const vb = pb[i] ?? 0;
+    if (va !== vb) return va < vb ? -1 : 1;
+  }
+  return 0;
+}
+
+export async function fetchWithTimeout(url: string, timeoutMs: number): Promise<Response> {
+  const c = new AbortController();
+  const t = setTimeout(() => c.abort(), timeoutMs);
+  try {
+    const res = await fetch(url, { signal: c.signal });
+    clearTimeout(t);
+    return res;
+  } catch (err) {
+    clearTimeout(t);
+    if (err instanceof Error && err.name === "AbortError") throw new Error("Request timed out");
+    throw err;
+  }
+}
+
+export async function fetchLatestPluginVersions(
+  timeoutMs = DEFAULT_FETCH_TIMEOUT_MS,
+): Promise<{ github: string | null; npm: string | null }> {
+  let github: string | null = null;
+  let npm: string | null = null;
+
+  try {
+    const ghRes = await fetchWithTimeout(GITHUB_LATEST_URL, timeoutMs);
+    if (ghRes.ok) {
+      const data = (await ghRes.json()) as { tag_name?: string };
+      const tag = data.tag_name;
+      github = typeof tag === "string" ? tag.replace(/^v/, "") : null;
+    }
+  } catch {
+    github = null;
+  }
+
+  try {
+    const npmRes = await fetchWithTimeout(NPM_LATEST_URL, timeoutMs);
+    if (npmRes.ok) {
+      const data = (await npmRes.json()) as { version?: string };
+      npm = typeof data.version === "string" ? data.version : null;
+    }
+  } catch {
+    npm = null;
+  }
+
+  return { github, npm };
+}
+
+export function buildVersionReport(
+  installed: string,
+  github: string | null,
+  npm: string | null,
+): VersionReport {
+  return {
+    name: HYBRID_MEM_PACKAGE_NAME,
+    installed,
+    github,
+    npm,
+    updateAvailable:
+      (github != null && comparePluginVersions(installed, github) < 0) ||
+      (npm != null && comparePluginVersions(installed, npm) < 0),
+  };
+}
+
+function updateHint(installed: string, latest: string | null): string {
+  if (latest == null) return "";
+  return comparePluginVersions(installed, latest) < 0 ? " ⬆ update available" : " (up to date)";
+}
+
+function versionJsonPayload(report: VersionReport): Record<string, unknown> {
+  return {
+    name: report.name,
+    installed: report.installed,
+    github: report.github ?? "unavailable",
+    npm: report.npm ?? "unavailable",
+    updateAvailable: report.updateAvailable,
+  };
+}
+
+/** Concise output for root `--version` (issue #2012). */
+export function printVersionFlag(report: VersionReport, opts?: { json?: boolean }): void {
+  if (opts?.json) {
+    console.log(JSON.stringify(versionJsonPayload(report), null, 2));
+    return;
+  }
+
+  console.log(`${report.name} ${report.installed}`);
+
+  const npmUpdate =
+    report.npm != null && comparePluginVersions(report.installed, report.npm) < 0 ? report.npm : null;
+  const githubUpdate =
+    report.github != null && comparePluginVersions(report.installed, report.github) < 0 ? report.github : null;
+
+  if (npmUpdate != null) {
+    console.log(`Update available: npm ${npmUpdate} (run: ${HYBRID_MEM_UPGRADE_COMMAND})`);
+  } else if (githubUpdate != null) {
+    console.log(`Update available: GitHub ${githubUpdate} (run: ${HYBRID_MEM_UPGRADE_COMMAND})`);
+  }
+}
+
+/** Detailed output for `hybrid-mem version` subcommand. */
+export function printVersionSubcommand(report: VersionReport, opts?: { json?: boolean }): void {
+  if (opts?.json) {
+    console.log(JSON.stringify(versionJsonPayload(report), null, 2));
+    return;
+  }
+
+  const { installed, github, npm } = report;
+  console.log(HYBRID_MEM_PACKAGE_NAME);
+  console.log(`  Installed:  ${installed}`);
+  console.log(
+    `  GitHub:     ${github ?? "unavailable"}${
+      github != null && comparePluginVersions(installed, github) > 0
+        ? " (installed is newer)"
+        : updateHint(installed, github)
+    }`,
+  );
+  console.log(
+    `  npm:        ${npm ?? "unavailable"}${
+      npm != null && comparePluginVersions(installed, npm) > 0 ? " (installed is newer)" : updateHint(installed, npm)
+    }`,
+  );
+}
+
+export async function runHybridMemVersion(
+  installed: string,
+  opts?: { json?: boolean; format?: "flag" | "subcommand"; timeoutMs?: number },
+): Promise<void> {
+  const { github, npm } = await fetchLatestPluginVersions(opts?.timeoutMs);
+  const report = buildVersionReport(installed, github, npm);
+  if (opts?.format === "flag") {
+    printVersionFlag(report, { json: opts.json });
+  } else {
+    printVersionSubcommand(report, { json: opts.json });
+  }
+}

--- a/extensions/memory-hybrid/cli/cmd-version.ts
+++ b/extensions/memory-hybrid/cli/cmd-version.ts
@@ -167,6 +167,6 @@ export async function runHybridMemVersion(
   if (opts?.format === "flag") {
     printVersionFlag(report, { json: opts.json });
   } else {
-    printVersionSubcommand(report, { json: opts.json });
+    printVersionSubcommand(report, { json: opts?.json });
   }
 }

--- a/extensions/memory-hybrid/cli/commands/manage/register-procedure-lifecycle.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/register-procedure-lifecycle.ts
@@ -19,6 +19,7 @@ import {
 import { generateAutoSkillForProcedure } from "../../../services/procedure-skill-generator.js";
 import { resolveWorkspacePath } from "../../../utils/path.js";
 import { formatTimestampUtc, nowIso } from "../../../utils/dates.js";
+import { runHybridMemVersion } from "../../cmd-version.js";
 import { type Chainable, withExit } from "../../shared.js";
 import type { ManageBindings } from "./bindings.js";
 
@@ -348,104 +349,7 @@ export function registerManageProcedureAndLifecycle(mem: Chainable, b: ManageBin
     .option("--json", "Machine-readable JSON output")
     .action(
       withExit(async (opts?: { json?: boolean }) => {
-        const installed = ctx.versionInfo.pluginVersion;
-        const timeoutMs = 3000;
-        const fetchWithTimeout = async (url: string): Promise<Response> => {
-          const c = new AbortController();
-          const t = setTimeout(() => c.abort(), timeoutMs);
-          try {
-            const res = await fetch(url, { signal: c.signal });
-            clearTimeout(t);
-            return res;
-          } catch (err) {
-            clearTimeout(t);
-            if (err instanceof Error && err.name === "AbortError") throw new Error("Request timed out");
-            throw err;
-          }
-        };
-
-        let githubVersion: string | null = null;
-        let npmVersion: string | null = null;
-        try {
-          const ghRes = await fetchWithTimeout(
-            "https://api.github.com/repos/markus-lassfolk/openclaw-hybrid-memory/releases/latest",
-          );
-          if (ghRes.ok) {
-            const data = (await ghRes.json()) as { tag_name?: string };
-            const tag = data.tag_name;
-            githubVersion = typeof tag === "string" ? tag.replace(/^v/, "") : null;
-          }
-        } catch {
-          githubVersion = null;
-        }
-        try {
-          const npmRes = await fetchWithTimeout("https://registry.npmjs.org/openclaw-hybrid-memory/latest");
-          if (npmRes.ok) {
-            const data = (await npmRes.json()) as { version?: string };
-            npmVersion = typeof data.version === "string" ? data.version : null;
-          }
-        } catch {
-          npmVersion = null;
-        }
-
-        const compare = (a: string, b: string): number => {
-          const parseNum = (s: string): number => {
-            const n = Number.parseInt(s, 10);
-            return Number.isNaN(n) ? 0 : n;
-          };
-          const pa = a
-            .replace(/[-+].*/, "")
-            .split(".")
-            .map(parseNum);
-          const pb = b
-            .replace(/[-+].*/, "")
-            .split(".")
-            .map(parseNum);
-          for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
-            const va = pa[i] ?? 0;
-            const vb = pb[i] ?? 0;
-            if (va !== vb) return va < vb ? -1 : 1;
-          }
-          return 0;
-        };
-        const updateHint = (latest: string | null) => {
-          if (latest == null) return "";
-          return compare(installed, latest) < 0 ? " ⬆ update available" : " (up to date)";
-        };
-
-        if (opts?.json) {
-          console.log(
-            JSON.stringify(
-              {
-                name: "openclaw-hybrid-memory",
-                installed,
-                github: githubVersion ?? "unavailable",
-                npm: npmVersion ?? "unavailable",
-                updateAvailable:
-                  (githubVersion != null && compare(installed, githubVersion) < 0) ||
-                  (npmVersion != null && compare(installed, npmVersion) < 0),
-              },
-              null,
-              2,
-            ),
-          );
-          return;
-        }
-
-        console.log("openclaw-hybrid-memory");
-        console.log(`  Installed:  ${installed}`);
-        console.log(
-          `  GitHub:     ${githubVersion ?? "unavailable"}${
-            githubVersion != null && compare(installed, githubVersion) > 0
-              ? " (installed is newer)"
-              : updateHint(githubVersion)
-          }`,
-        );
-        console.log(
-          `  npm:        ${npmVersion ?? "unavailable"}${
-            npmVersion != null && compare(installed, npmVersion) > 0 ? " (installed is newer)" : updateHint(npmVersion)
-          }`,
-        );
+        await runHybridMemVersion(ctx.versionInfo.pluginVersion, { json: opts?.json, format: "subcommand" });
       }),
     );
 

--- a/extensions/memory-hybrid/cli/register-hybrid-mem-version-flag.ts
+++ b/extensions/memory-hybrid/cli/register-hybrid-mem-version-flag.ts
@@ -1,0 +1,23 @@
+/**
+ * Root `--version` / `--json` wiring for hybrid-mem (issue #2012).
+ */
+
+import type { Command } from "commander";
+import { runHybridMemVersion } from "./cmd-version.js";
+import { versionInfo } from "../versionInfo.js";
+
+const VERSION_FLAG_DESC = "Show installed plugin version and check for updates";
+const VERSION_JSON_DESC = "Machine-readable JSON output (use with --version)";
+
+/** Register root `--version` handling on the hybrid-mem Commander node. */
+export function registerHybridMemVersionFlag(mem: Command): void {
+  mem.option("--version", VERSION_FLAG_DESC);
+  mem.option("--json", VERSION_JSON_DESC);
+
+  mem.action(async () => {
+    const opts = mem.opts() as { version?: boolean; json?: boolean };
+    if (!opts.version) return;
+    await runHybridMemVersion(versionInfo.pluginVersion, { json: opts.json, format: "flag" });
+    process.exit(0);
+  });
+}

--- a/extensions/memory-hybrid/index-version-cli.ts
+++ b/extensions/memory-hybrid/index-version-cli.ts
@@ -1,0 +1,28 @@
+/**
+ * Root `--version` fast path for `hybrid-mem` (issue #2012).
+ *
+ * Matches only when `--version` is a leading flag directly after `hybrid-mem`, before any
+ * subcommand token. This keeps `--version` out of the full Commander tree entirely, so it can
+ * never shadow an identically-named option on a subcommand (e.g. `upgrade --json`, `list --json`)
+ * the way a root-registered `--version`/`--json` option would (PR #2013 review). When a subcommand
+ * is selected first (e.g. `hybrid-mem upgrade --version`), this returns false and the flag is left
+ * for that subcommand's own parser to accept or reject.
+ */
+export function isHybridMemVersionOnlyInvocation(argv: string[]): boolean {
+  const hybridIdx = argv.indexOf("hybrid-mem");
+  if (hybridIdx === -1) return false;
+
+  let sawVersion = false;
+  for (let i = hybridIdx + 1; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--") break;
+    if (a === "--version") {
+      sawVersion = true;
+      continue;
+    }
+    if (a.startsWith("-")) continue;
+    // First non-flag token is a subcommand/positional — stop scanning.
+    break;
+  }
+  return sawVersion;
+}

--- a/extensions/memory-hybrid/index.ts
+++ b/extensions/memory-hybrid/index.ts
@@ -9,6 +9,7 @@ import { isHybridMemHelpInvocation } from "./index-help.js";
 export { isHybridMemHelpInvocation };
 export { isHybridMemCredentialsOnlyInvocation } from "./index-credentials-cli.js";
 export { isHybridMemUpgradeOnlyInvocation } from "./index-upgrade-cli.js";
+export { isHybridMemVersionOnlyInvocation } from "./index-version-cli.js";
 export {
   isHybridMemJsonInvocation,
   isHybridMemCredentialsValueOnlyInvocation,

--- a/extensions/memory-hybrid/services/context-engine.ts
+++ b/extensions/memory-hybrid/services/context-engine.ts
@@ -11,8 +11,8 @@
  *  - assemble: pass-through (autoRecall handles injection via before_agent_start)
  *  - ingest: no-op (SessionManager owns persistence)
  *
- * Feature detection: if registerContextEngine is absent the module exports a
- * no-op so callers do not need to guard on their side.
+ * Feature detection: prefers `api.registerContextEngine`, then `openclaw/plugin-sdk`.
+ * Registration is a no-op when neither is available.
  */
 
 import { access, readFile } from "node:fs/promises";
@@ -226,6 +226,8 @@ interface MinimalContextEngine {
 // Engine implementation
 // ---------------------------------------------------------------------------
 
+export type ContextEngineRegistrar = (id: string, factory: () => MinimalContextEngine) => void;
+
 export interface ContextEngineOptions {
   factsDb: FactsDB;
   vectorDb: VectorDB;
@@ -235,6 +237,8 @@ export interface ContextEngineOptions {
   logger: { info?: (m: string) => void; warn?: (m: string) => void; debug?: (m: string) => void };
   pluginVersion?: string;
   injectedFactIdsBySession?: InjectedFactIdsBySession;
+  /** Prefer `api.registerContextEngine` from the plugin host (OpenClaw ≥ 2026.6). */
+  registerContextEngine?: ContextEngineRegistrar;
 }
 
 // ---------------------------------------------------------------------------
@@ -663,30 +667,39 @@ export class HybridMemoryContextEngine implements MinimalContextEngine {
 
 let loggedMissingRegisterContextEngine = false;
 
+async function resolveRegisterContextEngine(
+  explicit?: ContextEngineRegistrar,
+): Promise<ContextEngineRegistrar | null> {
+  if (typeof explicit === "function") return explicit;
+
+  try {
+    // Host API lives on openclaw/plugin-sdk (not plugin-sdk/core).
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const sdk: any = await import("openclaw/plugin-sdk").catch(() => null);
+    if (sdk && typeof sdk.registerContextEngine === "function") {
+      return sdk.registerContextEngine as ContextEngineRegistrar;
+    }
+  } catch {
+    /* feature-detected fallback */
+  }
+
+  return null;
+}
+
 /**
  * Attempt to register HybridMemoryContextEngine with the OpenClaw plugin SDK.
  *
  * Safe to call even when:
- *  - The registerContextEngine export doesn't exist (older OpenClaw versions)
- *  - The import fails (ESM resolution error in older runtime)
+ *  - `api.registerContextEngine` is absent (older OpenClaw versions)
+ *  - The SDK import fails (ESM resolution error in older runtime)
  *
  * Returns true if registration succeeded, false otherwise.
  */
 export async function registerHybridContextEngine(opts: ContextEngineOptions): Promise<boolean> {
   try {
-    // Dynamic import for feature detection — avoids hard dependency on the API.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const sdk: any = await import("openclaw/plugin-sdk/core").catch(() => null);
-    if (!sdk) {
-      opts.logger.debug?.("memory-hybrid: openclaw/plugin-sdk not available; skipping ContextEngine registration");
-      return false;
-    }
+    const registerContextEngine = await resolveRegisterContextEngine(opts.registerContextEngine);
 
-    const { registerContextEngine } = sdk as {
-      registerContextEngine?: (id: string, factory: () => MinimalContextEngine) => void;
-    };
-
-    if (typeof registerContextEngine !== "function") {
+    if (registerContextEngine == null) {
       if (!loggedMissingRegisterContextEngine) {
         loggedMissingRegisterContextEngine = true;
         opts.logger.debug?.(

--- a/extensions/memory-hybrid/setup/cli-context/help-text.ts
+++ b/extensions/memory-hybrid/setup/cli-context/help-text.ts
@@ -60,6 +60,8 @@ Commands by category:
     scope list|stats|prune|promote
 
   Plugin lifecycle
+    --version            Show installed version (update notice when npm/GitHub are newer)
+    version              Detailed version info (GitHub, npm, --json)
     upgrade [version]    Upgrade to version or latest
     uninstall            Remove plugin (--clean-all, --leave-config)
     backup               Create a point-in-time snapshot (SQLite + LanceDB)

--- a/extensions/memory-hybrid/setup/cli-context/register-cli-with-help.ts
+++ b/extensions/memory-hybrid/setup/cli-context/register-cli-with-help.ts
@@ -1,6 +1,5 @@
 import type { Command } from "commander";
 import { attachHybridMemCliFatalExit, ensureVerboseFlagOnHybridMemTree } from "../../cli/hybrid-mem-commander-utils.js";
-import { registerHybridMemVersionFlag } from "../../cli/register-hybrid-mem-version-flag.js";
 import { type HybridMemCliContext, registerHybridMemCli } from "../../cli/register.js";
 import { capturePluginError } from "../../services/error-reporter.js";
 import { HYBRID_MEM_HELP_ACTIVE_TASKS, HYBRID_MEM_HELP_GROUPED } from "./help-text.js";
@@ -18,7 +17,11 @@ export function registerCliWithHelp(
     "Verbose output for subcommands that support it (same effect as per-command --verbose where available)",
     false,
   );
-  registerHybridMemVersionFlag(mem);
+  // `--version` is intentionally NOT registered here — it is handled by a dedicated fast path
+  // (registerHybridMemCliVersionOnlyWithApi, issue #2012) so it can never shadow an
+  // identically-named option on a subcommand (e.g. `upgrade --json`, `list --json`); see PR #2013
+  // review. A stray `hybrid-mem --version` that somehow reaches this tree correctly falls back to
+  // Commander's "unknown option" error instead of silently doing nothing.
   const onComplete = options?.onHybridMemCliComplete;
   // Before subcommands are registered — children inherit this exit handler (Issue #1224).
   attachHybridMemCliFatalExit(mem, onComplete);

--- a/extensions/memory-hybrid/setup/cli-context/register-cli-with-help.ts
+++ b/extensions/memory-hybrid/setup/cli-context/register-cli-with-help.ts
@@ -1,5 +1,6 @@
 import type { Command } from "commander";
 import { attachHybridMemCliFatalExit, ensureVerboseFlagOnHybridMemTree } from "../../cli/hybrid-mem-commander-utils.js";
+import { registerHybridMemVersionFlag } from "../../cli/register-hybrid-mem-version-flag.js";
 import { type HybridMemCliContext, registerHybridMemCli } from "../../cli/register.js";
 import { capturePluginError } from "../../services/error-reporter.js";
 import { HYBRID_MEM_HELP_ACTIVE_TASKS, HYBRID_MEM_HELP_GROUPED } from "./help-text.js";
@@ -17,6 +18,7 @@ export function registerCliWithHelp(
     "Verbose output for subcommands that support it (same effect as per-command --verbose where available)",
     false,
   );
+  registerHybridMemVersionFlag(mem);
   const onComplete = options?.onHybridMemCliComplete;
   // Before subcommands are registered — children inherit this exit handler (Issue #1224).
   attachHybridMemCliFatalExit(mem, onComplete);

--- a/extensions/memory-hybrid/setup/cli-context/register-upgrade-only.ts
+++ b/extensions/memory-hybrid/setup/cli-context/register-upgrade-only.ts
@@ -6,6 +6,7 @@ import type { HandlerContext } from "../../cli/handlers.js";
 import { hybridConfigSchema } from "../../config.js";
 import { HYBRID_MEM_CLI_ROOT_DESCRIPTOR } from "./help-text.js";
 import { attachHybridMemCliFatalExit } from "../../cli/hybrid-mem-commander-utils.js";
+import { registerHybridMemVersionFlag } from "../../cli/register-hybrid-mem-version-flag.js";
 import { withExit } from "../../cli/shared.js";
 import { resetPluginLogger, restoreDefaultLogger } from "../../utils/logger.js";
 
@@ -71,6 +72,7 @@ export function registerHybridMemCliUpgradeOnlyWithApi(api: ClawdbotPluginApi): 
     ({ program }: { program: Command }) => {
       const mem = program.command("hybrid-mem").description(HYBRID_MEM_CLI_ROOT_DESCRIPTOR.description);
       attachHybridMemCliFatalExit(mem);
+      registerHybridMemVersionFlag(mem);
       mem
         .command("upgrade [version]")
         .description("Upgrade hybrid-mem to a specific version (or latest). Downloads and installs plugin from npm.")

--- a/extensions/memory-hybrid/setup/cli-context/register-upgrade-only.ts
+++ b/extensions/memory-hybrid/setup/cli-context/register-upgrade-only.ts
@@ -6,7 +6,6 @@ import type { HandlerContext } from "../../cli/handlers.js";
 import { hybridConfigSchema } from "../../config.js";
 import { HYBRID_MEM_CLI_ROOT_DESCRIPTOR } from "./help-text.js";
 import { attachHybridMemCliFatalExit } from "../../cli/hybrid-mem-commander-utils.js";
-import { registerHybridMemVersionFlag } from "../../cli/register-hybrid-mem-version-flag.js";
 import { withExit } from "../../cli/shared.js";
 import { resetPluginLogger, restoreDefaultLogger } from "../../utils/logger.js";
 
@@ -72,7 +71,9 @@ export function registerHybridMemCliUpgradeOnlyWithApi(api: ClawdbotPluginApi): 
     ({ program }: { program: Command }) => {
       const mem = program.command("hybrid-mem").description(HYBRID_MEM_CLI_ROOT_DESCRIPTOR.description);
       attachHybridMemCliFatalExit(mem);
-      registerHybridMemVersionFlag(mem);
+      // `--version` is handled by a dedicated fast path (registerHybridMemCliVersionOnlyWithApi,
+      // issue #2012), not registered here — a root `--version`/`--json` option previously shadowed
+      // this "upgrade" subcommand's own flags (PR #2013 review).
       mem
         .command("upgrade [version]")
         .description("Upgrade hybrid-mem to a specific version (or latest). Downloads and installs plugin from npm.")

--- a/extensions/memory-hybrid/setup/cli-context/register-version-only.ts
+++ b/extensions/memory-hybrid/setup/cli-context/register-version-only.ts
@@ -1,0 +1,25 @@
+import type { Command } from "commander";
+import type { ClawdbotPluginApi } from "openclaw/plugin-sdk/core";
+import { attachHybridMemCliFatalExit } from "../../cli/hybrid-mem-commander-utils.js";
+import { registerHybridMemVersionFlag } from "../../cli/register-hybrid-mem-version-flag.js";
+import { HYBRID_MEM_CLI_ROOT_DESCRIPTOR } from "./help-text.js";
+
+/**
+ * Version-only CLI wiring for `openclaw hybrid-mem --version` (issue #2012).
+ *
+ * Registers a `hybrid-mem` command with only the `--version`/`--json` flags and no
+ * subcommands, so there is no full command tree for those flags to collide with (PR #2013
+ * review — a root-level `--version`/`--json` option previously shadowed the identically-named
+ * option on subcommands like `upgrade`/`list`). It also skips config parsing and DB bootstrap
+ * entirely, so `--version` stays fast and works even when the plugin config is incomplete.
+ */
+export function registerHybridMemCliVersionOnlyWithApi(api: ClawdbotPluginApi): void {
+  api.registerCli(
+    ({ program }: { program: Command }) => {
+      const mem = program.command("hybrid-mem").description(HYBRID_MEM_CLI_ROOT_DESCRIPTOR.description);
+      attachHybridMemCliFatalExit(mem);
+      registerHybridMemVersionFlag(mem);
+    },
+    { descriptors: [HYBRID_MEM_CLI_ROOT_DESCRIPTOR] },
+  );
+}

--- a/extensions/memory-hybrid/setup/register-context-engine.ts
+++ b/extensions/memory-hybrid/setup/register-context-engine.ts
@@ -1,4 +1,5 @@
 import type { PluginRuntime } from "../api/plugin-runtime.js";
+import type { ContextEngineRegistrar } from "../services/context-engine.js";
 import { capturePluginError } from "../services/error-reporter.js";
 
 type ContextEngineRegistrationRuntime = Pick<
@@ -25,9 +26,10 @@ export function registerContextEngineBestEffort(args: {
   runtime: ContextEngineRegistrationRuntime;
   logger: { warn?: (message: string) => void };
   pluginVersion: string;
+  registerContextEngine?: ContextEngineRegistrar;
   loadContextEngine?: ContextEngineLoader;
 }): void {
-  const { runtime, logger, pluginVersion } = args;
+  const { runtime, logger, pluginVersion, registerContextEngine } = args;
   const loadContextEngine = args.loadContextEngine ?? (() => import("../services/context-engine.js"));
 
   void loadContextEngine()
@@ -41,6 +43,7 @@ export function registerContextEngineBestEffort(args: {
         injectedFactIdsBySession: runtime.injectedFactIdsBySession,
         logger,
         pluginVersion,
+        registerContextEngine,
       }),
     )
     .catch((err: unknown) => {

--- a/extensions/memory-hybrid/setup/register-context-engine.ts
+++ b/extensions/memory-hybrid/setup/register-context-engine.ts
@@ -7,7 +7,10 @@ type ContextEngineRegistrationRuntime = Pick<
   "factsDb" | "vectorDb" | "wal" | "embeddings" | "cfg" | "injectedFactIdsBySession"
 >;
 
-type ContextEngineRegistrar = (opts: {
+// Shape of the `registerHybridContextEngine` function loaded from services/context-engine.js — not
+// to be confused with `ContextEngineRegistrar` (imported above), which is the `api.registerContextEngine`
+// id/factory callback passed *through* this function's `registerContextEngine` option.
+type RegisterHybridContextEngineFn = (opts: {
   factsDb: ContextEngineRegistrationRuntime["factsDb"];
   vectorDb: ContextEngineRegistrationRuntime["vectorDb"];
   wal: ContextEngineRegistrationRuntime["wal"];
@@ -16,10 +19,11 @@ type ContextEngineRegistrar = (opts: {
   injectedFactIdsBySession: ContextEngineRegistrationRuntime["injectedFactIdsBySession"];
   logger: { warn?: (message: string) => void };
   pluginVersion: string;
+  registerContextEngine?: ContextEngineRegistrar;
 }) => unknown;
 
 type ContextEngineLoader = () => Promise<{
-  registerHybridContextEngine: ContextEngineRegistrar;
+  registerHybridContextEngine: RegisterHybridContextEngineFn;
 }>;
 
 export function registerContextEngineBestEffort(args: {

--- a/extensions/memory-hybrid/setup/register-plugin.ts
+++ b/extensions/memory-hybrid/setup/register-plugin.ts
@@ -688,6 +688,10 @@ function runMemoryHybridRegisterImpl(api: ClawdbotPluginApi): void {
     runtime,
     logger: logApi.logger,
     pluginVersion: versionInfo.pluginVersion,
+    registerContextEngine:
+      typeof api.registerContextEngine === "function"
+        ? api.registerContextEngine.bind(api)
+        : undefined,
   });
 
   // Lifecycle Hooks (issueStore may be null; issue-related behavior is gated inside hooks)

--- a/extensions/memory-hybrid/setup/register-plugin.ts
+++ b/extensions/memory-hybrid/setup/register-plugin.ts
@@ -25,6 +25,7 @@ import { registerHybridMemCliMetadataOnly } from "./cli-context/metadata.js";
 import { registerHybridMemCliHelpOnlyWithApi } from "./cli-context/register-help.js";
 import { registerHybridMemCliCredentialsOnlyWithApi } from "./cli-context/register-credentials-only.js";
 import { registerHybridMemCliUpgradeOnlyWithApi } from "./cli-context/register-upgrade-only.js";
+import { registerHybridMemCliVersionOnlyWithApi } from "./cli-context/register-version-only.js";
 import { registerHybridMemCliWithApi } from "./cli-context/register-full.js";
 import { parseHybridMemPluginConfig } from "./parse-plugin-config.js";
 import "./cli-context.js";
@@ -59,6 +60,7 @@ import { PLUGIN_ID } from "../utils/constants.js";
 import { isHybridMemHelpInvocation } from "../index-help.js";
 import { isHybridMemCredentialsOnlyInvocation } from "../index-credentials-cli.js";
 import { isHybridMemUpgradeOnlyInvocation } from "../index-upgrade-cli.js";
+import { isHybridMemVersionOnlyInvocation } from "../index-version-cli.js";
 import { wrapApiLoggerStderrForJsonCli, restoreStdoutAfterJsonCli } from "../utils/hybrid-mem-json-cli.js";
 import {
   getCategoryDecisionRegex,
@@ -195,6 +197,15 @@ export function runMemoryHybridRegister(api: ClawdbotPluginApi): void {
   // Examples: `openclaw hybrid-mem --help`, `openclaw hybrid-mem verify --help`.
   if (isHybridMemHelpInvocation(process.argv)) {
     registerHybridMemCliHelpOnlyWithApi(api);
+    return;
+  }
+
+  // `--version` should be fast, deterministic, and side-effect-free (issue #2012): no DB
+  // bootstrap, no live config parse. Checked before the other fast paths since it is the
+  // lightest — it registers no subcommands at all (see PR #2013 review on why `--version`/
+  // `--json` cannot be root-level Commander options in the full command tree).
+  if (isHybridMemVersionOnlyInvocation(process.argv)) {
+    registerHybridMemCliVersionOnlyWithApi(api);
     return;
   }
 

--- a/extensions/memory-hybrid/tests/hybrid-mem-root-flags-no-shadow.test.ts
+++ b/extensions/memory-hybrid/tests/hybrid-mem-root-flags-no-shadow.test.ts
@@ -1,0 +1,71 @@
+import { Command } from "commander";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { runUpgradeForCli } from "../cli/install/run-install.js";
+import { registerHybridMemCliUpgradeOnlyWithApi } from "../setup/cli-context/register-upgrade-only.js";
+
+vi.mock("../cli/install/run-install.js", () => ({
+  runUpgradeForCli: vi.fn(async () => ({ ok: true, version: "2026.6.999", pluginDir: "/tmp/plugin" })),
+}));
+
+/**
+ * Regression coverage for PR #2013 review: a root-level `--version`/`--json` Commander option
+ * previously shadowed an identically-named option on subcommands like `upgrade`, so
+ * `hybrid-mem upgrade --json` silently ran `upgrade` while swallowing `--json` with no effect,
+ * instead of surfacing the unknown-option error a user relying on `--json` output would expect.
+ *
+ * `registerHybridMemCliUpgradeOnlyWithApi` no longer registers `--version`/`--json` at the root,
+ * so these flags now correctly fall through to Commander's normal unknown-option handling on the
+ * `upgrade` subcommand instead of being silently consumed by the parent.
+ */
+function makeApi() {
+  return {
+    logger: { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() },
+    resolvePath: (p: string) => p,
+    registerCli: vi.fn(),
+  };
+}
+
+function buildUpgradeOnlyProgram(): Command {
+  const api = makeApi();
+  registerHybridMemCliUpgradeOnlyWithApi(api as never);
+  const registerCliCallback = api.registerCli.mock.calls[0]?.[0] as (args: { program: Command }) => void;
+  const program = new Command();
+  program.exitOverride();
+  registerCliCallback({ program });
+  return program;
+}
+
+describe("hybrid-mem upgrade-only fast path does not shadow subcommand flags", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.restoreAllMocks();
+  });
+
+  it("rejects `upgrade --version` instead of silently running upgrade", async () => {
+    // attachHybridMemCliFatalExit schedules a real process.exit() alongside the rethrown error.
+    const exit = vi.spyOn(process, "exit").mockImplementation((() => undefined) as never);
+    const program = buildUpgradeOnlyProgram();
+    await expect(program.parseAsync(["hybrid-mem", "upgrade", "--version"], { from: "user" })).rejects.toThrow(
+      /unknown option/,
+    );
+    expect(runUpgradeForCli).not.toHaveBeenCalled();
+    exit.mockRestore();
+  });
+
+  it("rejects `upgrade --json` instead of silently swallowing it", async () => {
+    const exit = vi.spyOn(process, "exit").mockImplementation((() => undefined) as never);
+    const program = buildUpgradeOnlyProgram();
+    await expect(program.parseAsync(["hybrid-mem", "upgrade", "--json"], { from: "user" })).rejects.toThrow(
+      /unknown option/,
+    );
+    expect(runUpgradeForCli).not.toHaveBeenCalled();
+    exit.mockRestore();
+  });
+
+  it("still runs a normal `upgrade [version]` invocation", async () => {
+    const program = buildUpgradeOnlyProgram();
+    await program.parseAsync(["hybrid-mem", "upgrade", "2026.6.999"], { from: "user" });
+    expect(runUpgradeForCli).toHaveBeenCalledWith(expect.anything(), "2026.6.999", { skipPostUpgradeCron: true });
+  });
+});

--- a/extensions/memory-hybrid/tests/hybrid-mem-version-flag.test.ts
+++ b/extensions/memory-hybrid/tests/hybrid-mem-version-flag.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Issue #2012 — root `--version` flag and shared version helpers.
+ */
+
+import { Command } from "commander";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  buildVersionReport,
+  comparePluginVersions,
+  printVersionFlag,
+  printVersionSubcommand,
+  runHybridMemVersion,
+} from "../cli/cmd-version.js";
+import { registerHybridMemVersionFlag } from "../cli/register-hybrid-mem-version-flag.js";
+import { versionInfo } from "../versionInfo.js";
+
+describe("comparePluginVersions", () => {
+  it("compares semver-like release numbers", () => {
+    expect(comparePluginVersions("2026.2.220", "2026.2.222")).toBe(-1);
+    expect(comparePluginVersions("2026.2.222", "2026.2.220")).toBe(1);
+    expect(comparePluginVersions("2026.2.222", "2026.2.222")).toBe(0);
+  });
+});
+
+describe("buildVersionReport", () => {
+  it("marks updateAvailable when npm is newer", () => {
+    const report = buildVersionReport("2026.6.292", "2026.6.292", "2026.6.300");
+    expect(report.updateAvailable).toBe(true);
+  });
+
+  it("marks updateAvailable false when installed is current", () => {
+    const report = buildVersionReport("2026.6.292", "2026.6.292", "2026.6.292");
+    expect(report.updateAvailable).toBe(false);
+  });
+});
+
+describe("printVersionFlag", () => {
+  it("prints concise installed line", () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    printVersionFlag(buildVersionReport("2026.6.292", null, null));
+    expect(log).toHaveBeenCalledWith("openclaw-hybrid-memory 2026.6.292");
+    log.mockRestore();
+  });
+
+  it("prints npm update notice when npm is newer", () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    printVersionFlag(buildVersionReport("2026.6.292", "2026.6.292", "2026.6.300"));
+    expect(log).toHaveBeenNthCalledWith(1, "openclaw-hybrid-memory 2026.6.292");
+    expect(log).toHaveBeenNthCalledWith(
+      2,
+      "Update available: npm 2026.6.300 (run: openclaw hybrid-mem upgrade)",
+    );
+    log.mockRestore();
+  });
+
+  it("prints GitHub update notice when only GitHub is newer", () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    printVersionFlag(buildVersionReport("2026.6.292", "2026.6.300", "2026.6.292"));
+    expect(log).toHaveBeenNthCalledWith(
+      2,
+      "Update available: GitHub 2026.6.300 (run: openclaw hybrid-mem upgrade)",
+    );
+    log.mockRestore();
+  });
+
+  it("emits JSON payload with --json", () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    printVersionFlag(buildVersionReport("2026.6.292", null, "2026.6.300"), { json: true });
+    const payload = JSON.parse(String(log.mock.calls[0]?.[0]));
+    expect(payload).toMatchObject({
+      name: "openclaw-hybrid-memory",
+      installed: "2026.6.292",
+      npm: "2026.6.300",
+      updateAvailable: true,
+    });
+    log.mockRestore();
+  });
+});
+
+describe("printVersionSubcommand", () => {
+  it("keeps detailed multi-line output", () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    printVersionSubcommand(buildVersionReport("2026.6.292", "2026.6.292", "2026.6.300"));
+    expect(log.mock.calls[0]?.[0]).toBe("openclaw-hybrid-memory");
+    expect(log.mock.calls[1]?.[0]).toBe("  Installed:  2026.6.292");
+    expect(String(log.mock.calls[3]?.[0])).toContain("npm:        2026.6.300");
+    expect(String(log.mock.calls[3]?.[0])).toContain("update available");
+    log.mockRestore();
+  });
+});
+
+describe("runHybridMemVersion", () => {
+  beforeEach(() => {
+    global.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("exits gracefully when registry lookups fail", async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("offline"));
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    await runHybridMemVersion("2026.6.292", { format: "flag" });
+    expect(log).toHaveBeenCalledWith("openclaw-hybrid-memory 2026.6.292");
+    expect(log).toHaveBeenCalledTimes(1);
+    log.mockRestore();
+  });
+});
+
+describe("registerHybridMemVersionFlag (#2012)", () => {
+  it("prints version and exits when --version is passed without a subcommand", async () => {
+    const exit = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`exit:${code ?? 0}`);
+    }) as typeof process.exit);
+
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ version: "2099.1.1" }),
+    });
+
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const program = new Command();
+    program.exitOverride((err) => {
+      throw err;
+    });
+    const mem = program.command("hybrid-mem").description("test");
+    registerHybridMemVersionFlag(mem);
+    mem.command("upgrade").action(() => {});
+
+    await expect(program.parseAsync(["hybrid-mem", "--version"], { from: "user" })).rejects.toThrow("exit:0");
+
+    expect(log).toHaveBeenCalledWith(`openclaw-hybrid-memory ${versionInfo.pluginVersion}`);
+    expect(log.mock.calls.some((call) => String(call[0]).startsWith("Update available:"))).toBe(true);
+
+    exit.mockRestore();
+    log.mockRestore();
+    vi.restoreAllMocks();
+  });
+
+  it("supports --version --json", async () => {
+    const exit = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`exit:${code ?? 0}`);
+    }) as typeof process.exit);
+
+    global.fetch = vi.fn().mockRejectedValue(new Error("offline"));
+
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const program = new Command();
+    program.exitOverride((err) => {
+      throw err;
+    });
+    const mem = program.command("hybrid-mem");
+    registerHybridMemVersionFlag(mem);
+
+    await expect(program.parseAsync(["hybrid-mem", "--version", "--json"], { from: "user" })).rejects.toThrow(
+      "exit:0",
+    );
+
+    const payload = JSON.parse(String(log.mock.calls[0]?.[0]));
+    expect(payload.installed).toBe(versionInfo.pluginVersion);
+    expect(payload).toHaveProperty("updateAvailable");
+
+    exit.mockRestore();
+    log.mockRestore();
+    vi.restoreAllMocks();
+  });
+});

--- a/extensions/memory-hybrid/tests/hybrid-mem-version-only-fast-path.test.ts
+++ b/extensions/memory-hybrid/tests/hybrid-mem-version-only-fast-path.test.ts
@@ -1,0 +1,102 @@
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { hybridConfigSchema } from "../config.js";
+import memoryHybridPlugin, { isHybridMemVersionOnlyInvocation } from "../index.js";
+import { resetPluginRegistrationStateForTests } from "../setup/register-plugin.js";
+
+function makeMockApi() {
+  return {
+    registerCli: vi.fn(),
+    registerTool: vi.fn(),
+    registerService: vi.fn(),
+    registerLifecycleHook: vi.fn(),
+    registerHttpRoute: vi.fn(),
+    on: vi.fn(),
+    logger: { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() },
+    context: { sessionId: "test-session", agentId: "test-agent" },
+    config: {},
+  };
+}
+
+describe("isHybridMemVersionOnlyInvocation (#2012)", () => {
+  it("matches --version as a leading flag before any subcommand", () => {
+    expect(isHybridMemVersionOnlyInvocation(["node", "openclaw", "hybrid-mem", "--version"])).toBe(true);
+    expect(isHybridMemVersionOnlyInvocation(["node", "openclaw", "hybrid-mem", "--version", "--json"])).toBe(true);
+    expect(isHybridMemVersionOnlyInvocation(["node", "openclaw", "hybrid-mem", "--json", "--version"])).toBe(true);
+  });
+
+  it("does not match when a subcommand is selected first (PR #2013 review)", () => {
+    // `--version` after a subcommand name must not be silently swallowed by a root option —
+    // it is left for that subcommand's own parser to accept or reject.
+    expect(isHybridMemVersionOnlyInvocation(["node", "openclaw", "hybrid-mem", "upgrade", "--version"])).toBe(false);
+    expect(isHybridMemVersionOnlyInvocation(["node", "openclaw", "hybrid-mem", "list", "--json"])).toBe(false);
+  });
+
+  it("does not match other hybrid-mem commands", () => {
+    expect(isHybridMemVersionOnlyInvocation(["node", "openclaw", "hybrid-mem", "verify"])).toBe(false);
+    expect(isHybridMemVersionOnlyInvocation(["node", "openclaw", "hybrid-mem"])).toBe(false);
+  });
+
+  it("stops at -- separator", () => {
+    expect(isHybridMemVersionOnlyInvocation(["node", "openclaw", "hybrid-mem", "--", "--version"])).toBe(false);
+  });
+});
+
+describe("hybrid-mem --version invocations", () => {
+  let tmpDir: string;
+  let oldArgv: string[];
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "hybrid-mem-version-only-"));
+    oldArgv = process.argv;
+  });
+
+  afterEach(() => {
+    process.argv = oldArgv;
+    rmSync(tmpDir, { recursive: true, force: true });
+    resetPluginRegistrationStateForTests();
+  });
+
+  it("openclaw hybrid-mem --version registers CLI only (no DB bootstrap, no tools/services)", () => {
+    process.argv = ["node", "openclaw", "hybrid-mem", "--version"];
+    const api = makeMockApi();
+    const sqlitePath = join(tmpDir, "facts.db");
+    const lanceDbPath = join(tmpDir, "lancedb");
+    const pluginConfig = hybridConfigSchema.parse({
+      sqlitePath,
+      lanceDbPath,
+      embedding: { apiKey: "sk-test-key-that-is-long-enough-to-pass", model: "text-embedding-3-small" },
+    });
+    const mockApi = {
+      ...api,
+      pluginConfig,
+      registrationMode: "full" as const,
+      resolvePath: (p: string) => (p.startsWith("/") || /^[A-Z]:/.test(p) ? p : join(tmpDir, p)),
+    };
+
+    expect(memoryHybridPlugin.register(mockApi as never)).toBeUndefined();
+    expect(existsSync(sqlitePath)).toBe(false);
+    expect(api.registerCli).toHaveBeenCalled();
+    expect(api.registerTool).not.toHaveBeenCalled();
+    expect(api.registerService).not.toHaveBeenCalled();
+  });
+
+  it("openclaw hybrid-mem --version works even with an invalid embedding config (no bootstrap)", () => {
+    process.argv = ["node", "openclaw", "hybrid-mem", "--version"];
+    const api = makeMockApi();
+    const mockApi = {
+      ...api,
+      // Deliberately invalid/incomplete plugin config — the version-only fast path must not
+      // need a valid config at all (issue #2012 acceptance criteria).
+      pluginConfig: {},
+      registrationMode: "full" as const,
+      resolvePath: (p: string) => (p.startsWith("/") || /^[A-Z]:/.test(p) ? p : join(tmpDir, p)),
+    };
+
+    expect(() => memoryHybridPlugin.register(mockApi as never)).not.toThrow();
+    expect(api.registerCli).toHaveBeenCalled();
+  });
+});

--- a/extensions/memory-hybrid/tests/register-context-engine.test.ts
+++ b/extensions/memory-hybrid/tests/register-context-engine.test.ts
@@ -34,11 +34,13 @@ describe("registerContextEngineBestEffort", () => {
     const logger = { warn: vi.fn() };
     const runtime = makeRuntime();
     const registerHybridContextEngine = vi.fn();
+    const registerContextEngine = vi.fn();
 
     registerContextEngineBestEffort({
       runtime,
       logger,
       pluginVersion: "2026.5.0",
+      registerContextEngine,
       loadContextEngine: async () => ({ registerHybridContextEngine }),
     });
 
@@ -53,6 +55,7 @@ describe("registerContextEngineBestEffort", () => {
       injectedFactIdsBySession: runtime.injectedFactIdsBySession,
       logger,
       pluginVersion: "2026.5.0",
+      registerContextEngine,
     });
     expect(capturePluginErrorMock).not.toHaveBeenCalled();
     expect(logger.warn).not.toHaveBeenCalled();

--- a/extensions/memory-hybrid/tests/register-hybrid-context-engine.test.ts
+++ b/extensions/memory-hybrid/tests/register-hybrid-context-engine.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { registerHybridContextEngine } from "../services/context-engine.js";
+
+describe("registerHybridContextEngine", () => {
+  const baseOpts = {
+    factsDb: {} as never,
+    vectorDb: {} as never,
+    wal: null,
+    embeddings: {} as never,
+    cfg: {} as never,
+    logger: { info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+  };
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it("registers via api.registerContextEngine when provided", async () => {
+    const registerContextEngine = vi.fn();
+    const ok = await registerHybridContextEngine({
+      ...baseOpts,
+      registerContextEngine,
+    });
+
+    expect(ok).toBe(true);
+    expect(registerContextEngine).toHaveBeenCalledWith("hybrid-memory", expect.any(Function));
+    expect(baseOpts.logger.info).toHaveBeenCalledWith("memory-hybrid: ContextEngine registered (id=hybrid-memory)");
+  });
+
+  it("returns false when no registrar is available", async () => {
+    vi.doMock("openclaw/plugin-sdk", () => ({}));
+
+    const ok = await registerHybridContextEngine({ ...baseOpts });
+
+    expect(ok).toBe(false);
+    expect(baseOpts.logger.debug).toHaveBeenCalledWith(
+      "memory-hybrid: registerContextEngine not found in SDK; skipping ContextEngine registration",
+    );
+  });
+
+  it("falls back to openclaw/plugin-sdk when api hook is absent", async () => {
+    const registerContextEngine = vi.fn();
+    vi.doMock("openclaw/plugin-sdk", () => ({ registerContextEngine }));
+
+    const { registerHybridContextEngine: registerFresh } = await import("../services/context-engine.js");
+    const ok = await registerFresh({ ...baseOpts });
+
+    expect(ok).toBe(true);
+    expect(registerContextEngine).toHaveBeenCalledWith("hybrid-memory", expect.any(Function));
+  });
+});

--- a/extensions/memory-hybrid/types/openclaw-plugin-sdk.d.ts
+++ b/extensions/memory-hybrid/types/openclaw-plugin-sdk.d.ts
@@ -7,8 +7,13 @@ declare module "openclaw/plugin-sdk/core" {
 
   // ClawdbotPluginApi is the local plugin API type — a named alias for the SDK's OpenClawPluginApi.
   // This preserves the plugin's existing type name while using the scoped subpath import.
-  export type ClawdbotPluginApi = _OpenClawPluginApi;
+  export type ClawdbotPluginApi = _OpenClawPluginApi & {
+    /** OpenClaw ≥ 2026.6 — register a ContextEngine factory (preferred over SDK module import). */
+    registerContextEngine?: (id: string, factory: () => unknown) => void;
+  };
+}
 
-  /** Optional SDK hook (OpenClaw ≥2026.5); feature-detected at runtime in `registerHybridContextEngine`. */
+declare module "openclaw/plugin-sdk" {
+  /** Fallback for older hosts that export registerContextEngine from the SDK entry. */
   export function registerContextEngine(id: string, factory: () => unknown): void;
 }


### PR DESCRIPTION
## Summary

- **ContextEngine registration**: Pass `api.registerContextEngine` during plugin registration, with fallback to `openclaw/plugin-sdk`. The previous lookup on `openclaw/plugin-sdk/core` silently skipped registration on OpenClaw 2026.6+, disabling compaction WAL flush and subagent memory handoff.
- **`hybrid-mem --version` (#2012)**: Add standard root `--version` (and `--version --json`) with concise installed-version output and npm/GitHub update notices. Refactors shared logic from the `version` subcommand; wired into full CLI and upgrade-only CLI paths.
- **Fix (review follow-up)**: `--version`/`--json` are no longer registered as options on the shared `hybrid-mem` root Commander command. A root-level option there was found to always win Commander's parse over an identically-named option on a subcommand (regardless of `enablePositionalOptions`), which silently swallowed `--json` on every subcommand that defines its own (83 occurrences) and on `upgrade`'s own parsing — e.g. `hybrid-mem upgrade --json` ran upgrade with no visible effect. `--version` is now handled by a dedicated argv fast path (`isHybridMemVersionOnlyInvocation` / `registerHybridMemCliVersionOnlyWithApi`) that only matches a leading `--version` before any subcommand, mirroring the existing help/upgrade/credentials fast paths — and, as a side benefit, this also skips config parsing and DB bootstrap entirely for `--version`, addressing the other review comment about it needing to stay fast and side-effect-free.
- Also fixes two latent type errors: `opts?.json` narrowing in `cmd-version.ts`, and a local/imported `ContextEngineRegistrar` name collision in `register-context-engine.ts`.

Closes #2012

## Test plan

- [x] `npm test -- --run tests/register-hybrid-context-engine.test.ts tests/register-context-engine.test.ts`
- [x] `npm test -- --run tests/hybrid-mem-version-flag.test.ts`
- [x] `npm test -- --run tests/hybrid-mem-version-only-fast-path.test.ts tests/hybrid-mem-root-flags-no-shadow.test.ts` (new fast-path + shadowing regression coverage)
- [x] `npx tsc --noEmit` (no new errors vs. base; two pre-existing errors in this branch's own new code fixed)
- [ ] After deploy: gateway log shows `memory-hybrid: ContextEngine registered (id=hybrid-memory)`
- [ ] `openclaw hybrid-mem --version` prints installed version and exits 0
- [ ] Optional: set `plugins.slots.contextEngine` to `hybrid-memory` in `openclaw.json` to activate ContextEngine lifecycle hooks