### PR TITLE
fix(release): include index-version-cli.ts in npm files allowlist

### DIFF
--- a/extensions/memory-hybrid/package.json
+++ b/extensions/memory-hybrid/package.json
@@ -9,6 +9,7 @@
     "index-help.ts",
     "index-credentials-cli.ts",
     "index-upgrade-cli.ts",
+    "index-version-cli.ts",
     "index-testing-exports.ts",
     "api",
     "config.ts",


### PR DESCRIPTION
## Summary

The `v2026.7.30` release ([workflow run](https://github.com/markus-lassfolk/openclaw-hybrid-memory/actions/runs/28652544179)) failed at the **Publish to NPM** job's `npm run verify:publish` step:

```
FAIL: package.json "files" does not cover imports from index.ts: [ 'index-version-cli' ]
```

`index.ts` re-exports `isHybridMemVersionOnlyInvocation` from `./index-version-cli.js` (added with the `hybrid-mem --version` fast-path in #2013), but `index-version-cli.ts` was never added to `package.json` `files`. `verify-publish.cjs` requires every top-level `index.ts` import to have a matching `files` entry, so the check fails and the published npm tarball would omit the module. This is a latent packaging bug from #2013 — surfaced now because this is the first release since then (regular CI does not run `verify:publish`; only `build:check` / the release workflow do).

Fix: add `index-version-cli.ts` alongside the sibling `index-*.ts` entries in `files`. `npm run verify:publish` now passes locally (`verify-publish: all checks passed`), which unblocks the `2026.7.30` npm publish.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor / internal improvement (no behavior change)
- [ ] Documentation update
- [x] CI / tooling change

## Quality Checklist

- [x] `cd extensions/memory-hybrid && npx tsc --noEmit` passes with no errors
- [x] `cd extensions/memory-hybrid && npm run lint` passes with no warnings
- [x] `cd extensions/memory-hybrid && npm test` passes (targeted suites green)
- [x] `npm run verify:publish` passes (the gate that was failing)
- [x] No secrets, credentials, or API keys committed
- [x] No `console.log` debug statements left in production code

## Documentation Impact (REQUIRED)

- [x] No code behavior changes — packaging metadata only (`package.json` `files`)
- [x] No `docs/` / `README.md` impact
- [x] Cross-referenced: `index-version-cli.ts` is the only uncovered import; `verify-publish.cjs` confirms all others are covered

## Testing

- [x] Ran `npm run build` + `npm run verify:publish` locally — all checks pass
- [ ] Unit tests added / updated (n/a — packaging-only metadata change)

## Notes for Reviewer

Keeps the version at `2026.7.30`. After this merges, the plan is to move the `v2026.7.30` tag to the fixed commit and re-run the release workflow so the npm publish (which never happened for `2026.7.30`) completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XvCckyPvQmyk47H36ifz9D

---
_Generated by [Claude Code](https://claude.ai/code/session_01XvCckyPvQmyk47H36ifz9D)_