### PR TITLE
chore(release): bump hybrid memory to 2026.7.31

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ---
 
-## [2026.7.30] - 2026-07-03
+## [2026.7.31] - 2026-07-03
 
 ### Added
 
@@ -35,10 +35,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - `contacts merge` now repoints `facts.entity_contact_id` (not just NER mentions) before deleting the merged-away contact, so no fact is left pointing at a deleted contact row.
 - Contact-import roster stores are idempotent on re-run (deduped stores no longer create duplicate facts or `PART_OF` links).
+- **Packaging:** `index-version-cli.ts` (the `hybrid-mem --version` fast-path added in #2013) was missing from `package.json` `files`, failing `verify:publish` and blocking the npm publish for this release (originally tagged 2026.7.30; re-cut as 2026.7.31 after the fix).
 
 ### Changed
 
-- Bumped plugin, `openclaw.plugin.json`, and `openclaw-hybrid-memory-install` package versions to **2026.7.30**.
+- Bumped plugin, `openclaw.plugin.json`, and `openclaw-hybrid-memory-install` package versions to **2026.7.31**.
 
 ---
 

--- a/extensions/memory-hybrid/openclaw.plugin.json
+++ b/extensions/memory-hybrid/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "openclaw-hybrid-memory",
   "kind": "memory",
-  "version": "2026.7.30",
+  "version": "2026.7.31",
   "contracts": {
     "tools": [
       "active_task_checkpoint",

--- a/extensions/memory-hybrid/package-lock.json
+++ b/extensions/memory-hybrid/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openclaw-hybrid-memory",
-  "version": "2026.7.30",
+  "version": "2026.7.31",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openclaw-hybrid-memory",
-      "version": "2026.7.30",
+      "version": "2026.7.31",
       "hasInstallScript": true,
       "dependencies": {
         "@lancedb/lancedb": "^0.30.0",

--- a/extensions/memory-hybrid/package.json
+++ b/extensions/memory-hybrid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-hybrid-memory",
-  "version": "2026.7.30",
+  "version": "2026.7.31",
   "type": "module",
   "description": "Give your OpenClaw agent lasting memory: structured facts, semantic search, auto-capture & recall, decay, optional credential vault. Part of Hybrid Memory v3.",
   "files": [

--- a/packages/openclaw-hybrid-memory-install/package.json
+++ b/packages/openclaw-hybrid-memory-install/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-hybrid-memory-install",
-  "version": "2026.7.30",
+  "version": "2026.7.31",
   "description": "Standalone installer for openclaw-hybrid-memory. Use when OpenClaw config validation fails.",
   "bin": {
     "openclaw-hybrid-memory-install": "./install.js"


### PR DESCRIPTION
## Summary

The `v2026.7.30` release tag/GitHub Release exist, but the npm publish for that version never completed — it failed on the `index-version-cli.ts` `files`-allowlist bug (fixed in #2019, already on `main`). Rather than force-rewrite the existing `v2026.7.30` tag (git tag mutation isn't available in this environment), this cuts a fresh same-day revision: **2026.7.31**, which already carries the #2019 fix.

Closes the loop from #2018 / #2019 so `main` CI green → tag → GitHub Release → npm publish can complete end-to-end for a version that was never actually published.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor / internal improvement (no behavior change)
- [ ] Documentation update
- [x] CI / tooling change

## Quality Checklist

- [x] `cd extensions/memory-hybrid && npx tsc --noEmit` passes with no errors
- [x] `cd extensions/memory-hybrid && npm run lint` passes with no warnings
- [x] `cd extensions/memory-hybrid && npm test` passes (targeted suites green)
- [x] `npm run build && npm run verify:publish` passes locally — all checks pass
- [x] No secrets, credentials, or API keys committed
- [x] No `console.log` debug statements left in production code

## Documentation Impact (REQUIRED)

- [x] `CHANGELOG.md` updated: renamed the `2026.7.30` entry to `2026.7.31`, added a note on the packaging fix
- [x] No `docs/` / `README.md` impact (version-only change)

## Testing

- [x] `npm run build && npm run verify:publish` — all checks pass locally
- [x] `tests/hybrid-mem-version-flag.test.ts`, `tests/plugin-root.test.ts` — 19/19 pass

## Notes for Reviewer

Once this merges and main CI is green, the existing `tag-release-after-ci.yml` automation should push `v2026.7.31` and dispatch the release workflow (GitHub Release + `npm publish --provenance` for both `openclaw-hybrid-memory` and `openclaw-hybrid-memory-install`). The `v2026.7.30` tag/Release will be left in place as a historical marker (npm was never published for it) — happy to delete them if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XvCckyPvQmyk47H36ifz9D

---
_Generated by [Claude Code](https://claude.ai/code/session_01XvCckyPvQmyk47H36ifz9D)_