### PR TITLE
fix: route operational persona proposals to AGENTS.md/TOOLS.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ---
 
+## [2026.7.32] - 2026-07-03
+
+### Fixed
+
+- **Persona proposal routing bias:** the durable-rule router already classified operational guidance to `AGENTS.md`/`TOOLS.md`, but `resolvePipelineProposalTarget()` only recorded the suggestion as advisory, so every pipeline-generated rule (dream-cycle, self-correction, reinforcement) still landed in `SOUL.md` via `inferTargetFile()`'s default. Confident routing suggestions now **retarget** the proposal onto the recommended operational file when it is allowlisted. Retargeting is intentionally limited to `AGENTS.md`/`TOOLS.md` (the destinations upstream target inference cannot produce); routing among the identity files stays advisory so it never overrides a deliberate `USER.md`/`IDENTITY.md` choice.
+
+### Changed
+
+- **`personaProposals.allowedFiles`** now accepts and defaults to the operational authority files as well: `["SOUL.md", "IDENTITY.md", "USER.md", "AGENTS.md", "TOOLS.md"]`. Human approval is still required before any file is written (`autoApply` stays off by default); narrow the list to keep proposals away from operational files.
+
+---
+
 ## [2026.7.31] - 2026-07-03
 
 ### Added

--- a/docs/PERSONA-PROPOSALS.md
+++ b/docs/PERSONA-PROPOSALS.md
@@ -6,7 +6,9 @@ nav_order: 12
 ---
 # Persona Proposals
 
-**Agent self-evolution with human approval** — the agent can propose changes to identity files (SOUL.md, IDENTITY.md, USER.md) based on observed patterns. By default a human reviews and approves or rejects via CLI; optionally you can enable **automatic handling** so proposals are applied without human review.
+**Agent self-evolution with human approval** — the agent can propose changes to its authority files (identity files SOUL.md / IDENTITY.md / USER.md, and the operational files AGENTS.md / TOOLS.md) based on observed patterns. By default a human reviews and approves or rejects via CLI; optionally you can enable **automatic handling** so proposals are applied without human review.
+
+Pipeline-generated proposals (dream-cycle reflection, self-correction, reinforcement) are routed by the durable-rule classifier: operational guidance the classifier confidently attributes to **AGENTS.md** (GitHub/PR/CI/workflow rules) or **TOOLS.md** (wrapper/host/local-path rules) is retargeted there instead of defaulting to SOUL.md, provided the file is in `allowedFiles`. Routing between the identity files stays advisory and never overrides a deliberate target.
 
 ---
 
@@ -52,7 +54,7 @@ Proposes a change to one of the allowed identity files.
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `targetFile` | enum | One of `SOUL.md`, `IDENTITY.md`, `USER.md` (or subset if you restrict `allowedFiles`). |
+| `targetFile` | enum | One of `SOUL.md`, `IDENTITY.md`, `USER.md`, `AGENTS.md`, `TOOLS.md` (or subset if you restrict `allowedFiles`). |
 | `title` | string | Short title (e.g. "Add tone-matching guidance"). |
 | `observation` | string | What the agent observed that motivates the change. |
 | `suggestedChange` | string | The exact text to add/change in the file. |
@@ -134,7 +136,7 @@ If the target file is missing or write fails, an error is printed and the propos
 |--------|---------|-------------|
 | `enabled` | `false` | Turn persona proposals on. |
 | `autoApply` | `false` | When `true`, proposals that pass validation are approved and applied automatically (no human review). **Use with care:** the agent can modify identity files. |
-| `allowedFiles` | `["SOUL.md", "IDENTITY.md", "USER.md"]` | Only these identity files can be modified by proposals. |
+| `allowedFiles` | `["SOUL.md", "IDENTITY.md", "USER.md", "AGENTS.md", "TOOLS.md"]` | Only these authority files can be modified by proposals. Narrow the list (e.g. drop `AGENTS.md`/`TOOLS.md`) to keep proposals away from operational files. |
 | `maxProposalsPerWeek` | `5` | Rate limit: max new proposals in a rolling 7-day window. |
 | `minConfidence` | `0.7` | Minimum confidence (0–1) for the agent to submit a proposal. |
 | `proposalTTLDays` | `30` | Days until a **pending** proposal expires; expired ones are pruned. Use `0` for no expiry. |

--- a/extensions/memory-hybrid/cli/proposals.ts
+++ b/extensions/memory-hybrid/cli/proposals.ts
@@ -203,6 +203,17 @@ export function getProposalExpiryError(
   return `Proposal ${proposal.id} expired and cannot be approved or applied`;
 }
 
+/**
+ * Operational authority files the router may retarget a pipeline proposal onto. These are the
+ * proposal targets that the identity-oriented upstream inference cannot produce, so routing a rule
+ * here only ever adds a destination rather than overriding a deliberate identity-file choice.
+ */
+const OPERATIONAL_RETARGET_FILES: ReadonlySet<string> = new Set(["AGENTS.md", "TOOLS.md"]);
+
+function isOperationalRetargetFile(file: string): boolean {
+  return OPERATIONAL_RETARGET_FILES.has(file);
+}
+
 /** Snapshot + validation helpers for pipeline-created proposals (self-correction, reinforcement, generate-proposals). */
 export function resolvePipelineProposalTarget(input: {
   targetFile: string;
@@ -232,7 +243,7 @@ export function resolvePipelineProposalTarget(input: {
   targetHash: string | null;
   expiresAt: number | null;
 } | null {
-  const targetFile = input.targetFile.trim();
+  let targetFile = input.targetFile.trim();
   if (!targetFile || !input.allowedFiles.includes(targetFile as IdentityFileType)) return null;
   const contentCheck = validateProposalContent(input.suggestedChange);
   if (!contentCheck.ok) return null;
@@ -250,7 +261,28 @@ export function resolvePipelineProposalTarget(input: {
       personaRuleRouting: input.personaRuleRouting,
     });
     input.routingAssessment = syncAssessment;
-    if (shouldBlockProposalCreation(syncAssessment, routing.routingMode)) return null;
+    // Honor a confident routing suggestion by retargeting the proposal onto an operational
+    // authority file (AGENTS.md/TOOLS.md) when that file is allowlisted. These are exactly the
+    // destinations the upstream target inference (inferTargetFile / an explicit caller target)
+    // can never produce, so operational guidance used to pile into SOUL.md even when the router
+    // classified it as AGENTS.md/TOOLS.md. We deliberately do NOT retarget among the identity
+    // files (SOUL/IDENTITY/USER): the keyword classifier is only advisory there and must not
+    // override a deliberate caller choice (e.g. a USER.md working-style rule that trips the
+    // SOUL "values" keyword). All dedup/snapshot/confidence checks below use the final target.
+    const suggestion = syncAssessment.routingSuggestion;
+    const canRetarget =
+      syncAssessment.overallDisposition === "retarget" &&
+      suggestion != null &&
+      isOperationalRetargetFile(suggestion.recommendedTargetFile) &&
+      suggestion.recommendedTargetFile !== targetFile &&
+      input.allowedFiles.includes(suggestion.recommendedTargetFile as IdentityFileType);
+    if (canRetarget) {
+      // In enforce mode this also resolves the "enforce-routing" block: we route to the correct
+      // allowlisted file instead of dropping the proposal.
+      targetFile = suggestion!.recommendedTargetFile;
+    } else if (shouldBlockProposalCreation(syncAssessment, routing.routingMode)) {
+      return null;
+    }
   }
   if (input.proposalsDb) {
     const duplicate = input.proposalsDb.findPendingOrAppliedDuplicate(targetFile, input.suggestedChange);

--- a/extensions/memory-hybrid/config/parsers/features.ts
+++ b/extensions/memory-hybrid/config/parsers/features.ts
@@ -11,7 +11,7 @@ import {
   DEFAULT_WORKBOARD_CONFIG,
   DEFAULT_WORKBOARD_COLUMNS,
 } from "../types/workboard.js";
-import { IDENTITY_FILE_TYPES, type IdentityFileType } from "../types/agents.js";
+import { PERSONA_PROPOSAL_TARGET_FILES, type PersonaProposalTargetFile } from "../types/agents.js";
 import type {
   AliasesConfig,
   AmbientConfig,
@@ -65,8 +65,7 @@ export function parseEntityExtractionConfig(cfg: Record<string, unknown>): Entit
 
 export function parseContactsConfig(cfg: Record<string, unknown>): ContactsConfig {
   const raw = cfg.contacts as Record<string, unknown> | undefined;
-  const importPath =
-    typeof raw?.importPath === "string" && raw.importPath.trim() ? raw.importPath.trim() : null;
+  const importPath = typeof raw?.importPath === "string" && raw.importPath.trim() ? raw.importPath.trim() : null;
   return {
     profileEnrichment: raw?.profileEnrichment !== false,
     requireSurname: raw?.requireSurname === true,
@@ -82,10 +81,7 @@ export function parseGraphConfig(cfg: Record<string, unknown>): GraphConfig {
   const graphRaw = cfg.graph as Record<string, unknown> | undefined;
   const legacyMinScore = graphRaw?.autoLinkMinScore;
   const autoLinkStrength = parseUnitInterval(graphRaw?.autoLinkStrength ?? legacyMinScore, 0.7);
-  const autoLinkSimilarityThreshold = parseUnitInterval(
-    graphRaw?.autoLinkSimilarityThreshold ?? legacyMinScore,
-    0.7,
-  );
+  const autoLinkSimilarityThreshold = parseUnitInterval(graphRaw?.autoLinkSimilarityThreshold ?? legacyMinScore, 0.7);
   if (
     legacyMinScore !== undefined &&
     graphRaw?.autoLinkStrength === undefined &&
@@ -433,13 +429,13 @@ export function parsePersonaProposalsConfig(cfg: Record<string, unknown>): Perso
     autoApply: proposalsRaw?.autoApply === true,
     allowedFiles: (() => {
       if (!Array.isArray(proposalsRaw?.allowedFiles)) {
-        return [...IDENTITY_FILE_TYPES];
+        return [...PERSONA_PROPOSAL_TARGET_FILES];
       }
       const filtered = (proposalsRaw.allowedFiles as string[]).filter((f) =>
-        IDENTITY_FILE_TYPES.includes(f as IdentityFileType),
-      ) as IdentityFileType[];
+        PERSONA_PROPOSAL_TARGET_FILES.includes(f as PersonaProposalTargetFile),
+      ) as PersonaProposalTargetFile[];
       // Fallback to defaults if filter produces empty array
-      return filtered.length > 0 ? filtered : [...IDENTITY_FILE_TYPES];
+      return filtered.length > 0 ? filtered : [...PERSONA_PROPOSAL_TARGET_FILES];
     })(),
     maxProposalsPerWeek:
       typeof proposalsRaw?.maxProposalsPerWeek === "number" && proposalsRaw.maxProposalsPerWeek > 0
@@ -487,7 +483,11 @@ function parsePersonaRuleRoutingConfig(
   if (typeof raw.nearDedupeThreshold === "number" && raw.nearDedupeThreshold > 0 && raw.nearDedupeThreshold <= 1) {
     out.nearDedupeThreshold = raw.nearDedupeThreshold;
   }
-  if (typeof raw.contradictionThreshold === "number" && raw.contradictionThreshold > 0 && raw.contradictionThreshold <= 1) {
+  if (
+    typeof raw.contradictionThreshold === "number" &&
+    raw.contradictionThreshold > 0 &&
+    raw.contradictionThreshold <= 1
+  ) {
     out.contradictionThreshold = raw.contradictionThreshold;
   }
   if (typeof raw.routingCacheTtlSeconds === "number" && raw.routingCacheTtlSeconds >= 0) {

--- a/extensions/memory-hybrid/config/types/agents.ts
+++ b/extensions/memory-hybrid/config/types/agents.ts
@@ -6,6 +6,14 @@ export type ProposalStatus = (typeof PROPOSAL_STATUSES)[number];
 export const IDENTITY_FILE_TYPES = ["SOUL.md", "IDENTITY.md", "USER.md"] as const;
 export type IdentityFileType = (typeof IDENTITY_FILE_TYPES)[number];
 
+/**
+ * Files a persona proposal may target. Extends the identity files with the two operational
+ * authority files (AGENTS.md, TOOLS.md) so the durable-rule router can retarget operational
+ * guidance to the file it belongs in instead of forcing everything into SOUL.md (#2002 follow-up).
+ */
+export const PERSONA_PROPOSAL_TARGET_FILES = [...IDENTITY_FILE_TYPES, "AGENTS.md", "TOOLS.md"] as const;
+export type PersonaProposalTargetFile = (typeof PERSONA_PROPOSAL_TARGET_FILES)[number];
+
 /** Multi-agent memory scoping configuration (dynamic agent detection) */
 export type MultiAgentConfig = {
   /** Agent ID of the orchestrator (main agent). Default: "main". This agent sees all scopes. */
@@ -46,8 +54,13 @@ export type PersonaProposalsConfig = {
   enabled: boolean;
   /** When true, approved proposals are applied automatically without human review (default: false). */
   autoApply: boolean;
-  /** Identity files that can be modified via proposals (default: ["SOUL.md", "IDENTITY.md", "USER.md"]) */
-  allowedFiles: IdentityFileType[];
+  /**
+   * Files that can be modified via proposals
+   * (default: ["SOUL.md", "IDENTITY.md", "USER.md", "AGENTS.md", "TOOLS.md"]). Operational
+   * authority files (AGENTS.md, TOOLS.md) are targets so the router can route operational rules
+   * to them; identity files (SOUL/IDENTITY/USER) remain the default for behavioural guidance.
+   */
+  allowedFiles: PersonaProposalTargetFile[];
   /** Max proposals per week to prevent spam (default: 5) */
   maxProposalsPerWeek: number;
   /** Min confidence score 0-1 for proposals (default: 0.7) */

--- a/extensions/memory-hybrid/openclaw.plugin.json
+++ b/extensions/memory-hybrid/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "openclaw-hybrid-memory",
   "kind": "memory",
-  "version": "2026.7.31",
+  "version": "2026.7.32",
   "contracts": {
     "tools": [
       "active_task_checkpoint",

--- a/extensions/memory-hybrid/package-lock.json
+++ b/extensions/memory-hybrid/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openclaw-hybrid-memory",
-  "version": "2026.7.31",
+  "version": "2026.7.32",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openclaw-hybrid-memory",
-      "version": "2026.7.31",
+      "version": "2026.7.32",
       "hasInstallScript": true,
       "dependencies": {
         "@lancedb/lancedb": "^0.30.0",

--- a/extensions/memory-hybrid/package.json
+++ b/extensions/memory-hybrid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-hybrid-memory",
-  "version": "2026.7.31",
+  "version": "2026.7.32",
   "type": "module",
   "description": "Give your OpenClaw agent lasting memory: structured facts, semantic search, auto-capture & recall, decay, optional credential vault. Part of Hybrid Memory v3.",
   "files": [

--- a/extensions/memory-hybrid/tests/dream-cycle-proposal-bridge.test.ts
+++ b/extensions/memory-hybrid/tests/dream-cycle-proposal-bridge.test.ts
@@ -75,6 +75,92 @@ describe("dream-cycle proposal bridge", () => {
     }
   });
 
+  it("retargets operational rules to AGENTS.md/TOOLS.md instead of defaulting to SOUL.md", () => {
+    // Regression for the routing-bias bug: the router classifies these rules as AGENTS.md /
+    // TOOLS.md, but the pipeline used to file every dream-cycle rule under SOUL.md (via
+    // inferTargetFile's default) because the confident routing suggestion was only advisory.
+    writeFileSync(join(tmpDir, "AGENTS.md"), "# AGENTS\nOperational workflow.\n", "utf-8");
+    writeFileSync(join(tmpDir, "TOOLS.md"), "# TOOLS\nTool invocation notes.\n", "utf-8");
+    const opsCfg = {
+      ...cfg,
+      personaProposals: {
+        ...cfg.personaProposals,
+        allowedFiles: ["SOUL.md", "IDENTITY.md", "USER.md", "AGENTS.md", "TOOLS.md"],
+      },
+    } as HybridMemoryConfig;
+
+    const githubRule = factsDb.store({
+      text: "Always verify GitHub PR headRefOid and CI status before claiming a PR is merge-ready.",
+      category: "rule",
+      importance: 0.8,
+      entity: null,
+      key: null,
+      value: null,
+      source: "dream-cycle-test",
+    });
+    const wrapperRule = factsDb.store({
+      text: "Use the proxmox.sh wrapper at /usr/local/bin to invoke the host tooling.",
+      category: "rule",
+      importance: 0.8,
+      entity: null,
+      key: null,
+      value: null,
+      source: "dream-cycle-test",
+    });
+
+    const result = runDreamCycleProposalBridge({
+      cfg: opsCfg,
+      factsDb,
+      proposalsDb,
+      patternsStored: 0,
+      rulesGenerated: 2,
+      newRuleFactIds: [githubRule.id, wrapperRule.id],
+      logger: { info: () => {}, warn: () => {} },
+      workspaceRoot: tmpDir,
+    });
+
+    expect(result.personaProposalsCreated).toBe(2);
+    const created = proposalsDb.list({ status: "pending" });
+    const byChange = new Map(created.map((p) => [p.suggestedChange, p.targetFile]));
+    expect(byChange.get("Always verify GitHub PR headRefOid and CI status before claiming a PR is merge-ready.")).toBe(
+      "AGENTS.md",
+    );
+    expect(byChange.get("Use the proxmox.sh wrapper at /usr/local/bin to invoke the host tooling.")).toBe("TOOLS.md");
+    // None of the operational rules should have leaked into SOUL.md.
+    expect(created.some((p) => p.targetFile === "SOUL.md")).toBe(false);
+  });
+
+  it("keeps operational rules on the caller target when AGENTS.md/TOOLS.md are not allowlisted", () => {
+    // With the default (identity-only) allowlist and no operational files present, a confident
+    // AGENTS.md suggestion cannot be honored, so the proposal is still created (not dropped)
+    // against the caller's allowlisted target rather than silently discarded.
+    const githubRule = factsDb.store({
+      text: "Always verify GitHub PR headRefOid and CI status before claiming a PR is merge-ready.",
+      category: "rule",
+      importance: 0.8,
+      entity: null,
+      key: null,
+      value: null,
+      source: "dream-cycle-test",
+    });
+
+    const result = runDreamCycleProposalBridge({
+      cfg, // allowedFiles: ["SOUL.md", "IDENTITY.md", "USER.md"]
+      factsDb,
+      proposalsDb,
+      patternsStored: 0,
+      rulesGenerated: 1,
+      newRuleFactIds: [githubRule.id],
+      logger: { info: () => {}, warn: () => {} },
+      workspaceRoot: tmpDir,
+    });
+
+    expect(result.personaProposalsCreated).toBe(1);
+    const created = proposalsDb.list({ status: "pending" });
+    expect(created).toHaveLength(1);
+    expect(cfg.personaProposals.allowedFiles).toContain(created[0].targetFile);
+  });
+
   it("does not re-propose existing rules when newRuleFactIds is omitted", () => {
     const result = runDreamCycleProposalBridge({
       cfg,

--- a/extensions/memory-hybrid/tests/proposals.test.ts
+++ b/extensions/memory-hybrid/tests/proposals.test.ts
@@ -244,11 +244,9 @@ describe("applyApprovedProposal (non-git workspace — issue #90)", () => {
     proposalsDb.updateStatus(proposal.id, "approved");
 
     const changeFeedEmit = await import("../services/change-feed-emit.js");
-    const emitSpy = vi
-      .spyOn(changeFeedEmit, "emitPersonaApplied")
-      .mockImplementation(() => {
-        throw new Error("simulated late failure after write");
-      });
+    const emitSpy = vi.spyOn(changeFeedEmit, "emitPersonaApplied").mockImplementation(() => {
+      throw new Error("simulated late failure after write");
+    });
     try {
       const ctx = {
         proposalsDb,
@@ -623,5 +621,101 @@ describe("ProposalsDB.countRecentProposals separateSelfCorrectionQuota", () => {
     });
     expect(proposalsDb.countRecentProposals(7)).toBe(2);
     expect(proposalsDb.countRecentProposals(7, { excludeSelfCorrection: true })).toBe(1);
+  });
+});
+
+describe("resolvePipelineProposalTarget routing retarget", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "pipeline-retarget-"));
+    writeFileSync(join(tmpDir, "SOUL.md"), "# SOUL\nValues and tone.\n", "utf-8");
+    writeFileSync(join(tmpDir, "AGENTS.md"), "# AGENTS\nOperational workflow.\n", "utf-8");
+    writeFileSync(join(tmpDir, "TOOLS.md"), "# TOOLS\nTool invocation notes.\n", "utf-8");
+    writeFileSync(join(tmpDir, "USER.md"), "# USER\nPreferences.\n", "utf-8");
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  const ALL_FILES = ["SOUL.md", "IDENTITY.md", "USER.md", "AGENTS.md", "TOOLS.md"] as const;
+
+  it("retargets a confident AGENTS.md classification away from the caller's SOUL.md", () => {
+    const resolved = resolvePipelineProposalTarget({
+      targetFile: "SOUL.md",
+      suggestedChange: "Always verify GitHub PR headRefOid and CI status before claiming a PR is merge-ready.",
+      allowedFiles: [...ALL_FILES],
+      workspaceRoot: tmpDir,
+      confidence: 0.75,
+      proposalTTLDays: 30,
+    });
+    expect(resolved?.targetFile).toBe("AGENTS.md");
+  });
+
+  it("retargets a wrapper/local-path rule to TOOLS.md", () => {
+    const resolved = resolvePipelineProposalTarget({
+      targetFile: "SOUL.md",
+      suggestedChange: "Use the proxmox.sh wrapper at /usr/local/bin to invoke the host tooling.",
+      allowedFiles: [...ALL_FILES],
+      workspaceRoot: tmpDir,
+      confidence: 0.75,
+      proposalTTLDays: 30,
+    });
+    expect(resolved?.targetFile).toBe("TOOLS.md");
+  });
+
+  it("leaves the caller target unchanged when the recommended file is not allowlisted", () => {
+    const resolved = resolvePipelineProposalTarget({
+      targetFile: "SOUL.md",
+      suggestedChange: "Always verify GitHub PR headRefOid and CI status before claiming a PR is merge-ready.",
+      allowedFiles: ["SOUL.md", "IDENTITY.md", "USER.md"], // AGENTS.md intentionally absent
+      workspaceRoot: tmpDir,
+      confidence: 0.75,
+      proposalTTLDays: 30,
+    });
+    expect(resolved?.targetFile).toBe("SOUL.md");
+  });
+
+  it("does not override a deliberate identity-file target for an advisory identity-family suggestion", () => {
+    // A working-style preference deliberately filed under USER.md trips the SOUL "values"
+    // keyword, so the classifier advises SOUL.md. Identity-family suggestions are advisory only
+    // and must not override the deliberate USER.md choice (regression: reinforcement pipeline).
+    const resolved = resolvePipelineProposalTarget({
+      targetFile: "USER.md",
+      suggestedChange: "Add to Working Style: Values thorough inline code reviews with resolvable threads.",
+      allowedFiles: [...ALL_FILES],
+      workspaceRoot: tmpDir,
+      confidence: 0.75,
+      proposalTTLDays: 30,
+    });
+    expect(resolved?.targetFile).toBe("USER.md");
+  });
+
+  it("does not retarget identity/values guidance that already belongs in SOUL.md", () => {
+    const resolved = resolvePipelineProposalTarget({
+      targetFile: "SOUL.md",
+      suggestedChange: "Uphold honesty and integrity; act with a helpful, principled character.",
+      allowedFiles: [...ALL_FILES],
+      workspaceRoot: tmpDir,
+      confidence: 0.75,
+      proposalTTLDays: 30,
+    });
+    expect(resolved?.targetFile).toBe("SOUL.md");
+  });
+
+  it("surfaces the routing assessment for callers/logging", () => {
+    const input = {
+      targetFile: "SOUL.md",
+      suggestedChange: "Always verify GitHub PR headRefOid and CI status before claiming a PR is merge-ready.",
+      allowedFiles: [...ALL_FILES],
+      workspaceRoot: tmpDir,
+      confidence: 0.75,
+      proposalTTLDays: 30,
+    } as Parameters<typeof resolvePipelineProposalTarget>[0];
+    const resolved = resolvePipelineProposalTarget(input);
+    expect(resolved?.targetFile).toBe("AGENTS.md");
+    expect(input.routingAssessment?.routingSuggestion?.recommendedTargetFile).toBe("AGENTS.md");
+    expect(input.routingAssessment?.overallDisposition).toBe("retarget");
   });
 });

--- a/packages/openclaw-hybrid-memory-install/package.json
+++ b/packages/openclaw-hybrid-memory-install/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-hybrid-memory-install",
-  "version": "2026.7.31",
+  "version": "2026.7.32",
   "description": "Standalone installer for openclaw-hybrid-memory. Use when OpenClaw config validation fails.",
   "bin": {
     "openclaw-hybrid-memory-install": "./install.js"


### PR DESCRIPTION
## Summary

The durable-rule router (`persona-rule-router.ts`) already classifies operational guidance correctly — GitHub/PR/CI/workflow rules → `AGENTS.md`, wrapper/host/local-path rules → `TOOLS.md` — but the generator never honored it. `resolvePipelineProposalTarget()` ran the routing assessment yet only stored the suggestion as **advisory**, so every pipeline-generated rule (dream-cycle, self-correction, reinforcement) still landed in `SOUL.md` via `inferTargetFile()`'s default. That is the root cause behind operational rules piling up in the values file (the "23/23 SOUL.md suggestions" symptom).

Reproduced end-to-end before fixing: with `AGENTS.md`/`TOOLS.md` allowlisted, `resolvePipelineProposalTarget()` returned `SOUL.md` for both an "Always verify GitHub PR headRefOid and CI status…" rule (classifier: AGENTS.md, disposition: retarget) and a "Use the proxmox.sh wrapper…" rule (classifier: TOOLS.md, disposition: retarget).

**What changed**

- **Retarget on confident routing suggestions.** When the router confidently classifies a pipeline proposal as an operational file and that file is allowlisted, the proposal is now retargeted there instead of only annotated. This single change covers all three generators (dream-cycle bridge, self-correction, reinforcement) since they all route through `resolvePipelineProposalTarget()`.
- **Scoped deliberately to `AGENTS.md`/`TOOLS.md`.** These are the destinations the upstream target inference can never produce. Routing among the identity files (`SOUL`/`IDENTITY`/`USER`) stays advisory so the keyword classifier never overrides a deliberate caller choice — e.g. a `USER.md` working-style rule that trips the broad SOUL "values" keyword must remain on `USER.md`.
- **`AGENTS.md`/`TOOLS.md` are now valid proposal targets** (new `PERSONA_PROPOSAL_TARGET_FILES` type) and are included in the default `personaProposals.allowedFiles`. Human approval is still required before any file is written (`autoApply` stays off by default); narrow `allowedFiles` to keep proposals off operational files. The triage/safety layer already treated these as sensitive targets requiring review.

Closes: internal memory issue `ff93a312-5e47-4c67-8a8a-35e181c015d7` (no GitHub issue).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor / internal improvement (no behavior change)
- [ ] Documentation update
- [ ] CI / tooling change

## Quality Checklist

- [x] `cd extensions/memory-hybrid && npx tsc --noEmit` passes with no errors
- [x] `cd extensions/memory-hybrid && npm run lint` passes (only pre-existing warnings in unrelated `parseWorkboardConfig`; none introduced by this change)
- [x] `cd extensions/memory-hybrid && npm test` passes (the only two red tests fail identically on `main` — read-only-dir permission tests that don't hold when the suite runs as root; unrelated to this change)
- [x] No secrets, credentials, or API keys committed
- [x] No `console.log` debug statements left in production code

## Documentation Impact (REQUIRED)

- [x] Inline code comments (JSDoc) updated for modified functions and types
- [x] `docs/` or `README.md` updated to reflect architectural or usage changes (`docs/PERSONA-PROPOSALS.md`: overview, `targetFile` enum, `allowedFiles` default)
- [x] Cross-referenced functions/services checked for outdated documentation

## Testing

- [x] Unit tests added / updated
  - `dream-cycle-proposal-bridge.test.ts`: operational GitHub rule → `AGENTS.md`, wrapper/local-path rule → `TOOLS.md` (not `SOUL.md`); and a non-allowlisted case that keeps the caller target rather than dropping the proposal.
  - `proposals.test.ts`: `resolvePipelineProposalTarget` retarget to `AGENTS.md`/`TOOLS.md`, advisory-not-allowlisted fallback, values guidance staying on `SOUL.md`, and a deliberate `USER.md` target not being overridden by an advisory SOUL suggestion.
- [ ] Integration tests added / updated
- [ ] Manually verified against a running OpenClaw instance (verified via dry-run reproduction against the pipeline function instead)

## Notes for Reviewer

- Retargeting keys off `assessment.overallDisposition === "retarget"` plus an allowlist membership check, and is gated to `AGENTS.md`/`TOOLS.md` only. In `enforce` routing mode this also resolves the `enforce-routing` block by routing to the correct allowlisted file instead of dropping the proposal.
- The default-allowlist expansion is opt-out (narrow `allowedFiles` to exclude operational files); no file is ever written without human approval while `autoApply` is off.
- Version bumped to `2026.7.32`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011pqbBipSUCpvbhCsm7scJj

---
_Generated by [Claude Code](https://claude.ai/code/session_011pqbBipSUCpvbhCsm7scJj)_