### PR TITLE
fix: resolve open maintenance issues #2024–#2029

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ---
 
+## [2026.7.50] - 2026-07-05
+
+### Fixed
+
+- **distill partial failure now surfaces the concrete cause (#2024):** the batch loop captured only `partialFailure`, so the ledger showed `distill partial failure (… semantic=partial)` with no root cause. The first concrete batch-failure reason (error kind + model + message, or maintenance-deadline / context-overflow) is now captured, persisted into the job-run `semanticReason`, and folded into the step-runner throw. `buildJobRunId` fingerprints are sanitized so run ids can no longer be malformed like `job-distill-::14:fal` (cap kept at 8 chars so hash-fingerprinted checkpoint dirs stay stable across upgrade).
+- **`analyze-maintenance-logs` false-positive missing-exit-ledger (#2025):** aggregate `<job>.cron.log` files have no sibling `.exit.txt`; each run records an `HM_RUN_SUMMARY` referencing its own per-run ledger. The analyzer now validates each in-window run's `exit=` path, suppressing the anomaly when the ledger exists and flagging a genuinely-missing one pegged to its exact run id/timestamp.
+- **`maintenance full --verbose` CPU-active but log-silent (#2026):** each orchestrator step now emits `start` / `still running after Ns` / `complete` heartbeat lines; the analyzer's progress regexes were broadened to recognize the generic `maintenance-orchestrator:` marker so a live CPU/LLM-bound step is classified as running rather than stale/hung.
+- **store dedupe vectorThreshold plumbed on the live path (#2027):** the `memory_store` write path now resolves source/scope-filtered vector neighbour candidates from the already-computed embedding and passes them into write-time dedupe, so the configured `vectorThreshold` actually runs instead of silently degrading to lexical-only. Write-time vector dedupe is skipped when an explicit `supersedes` is provided so a near-identical correction cannot be swallowed as a dedupe no-op.
+
+### Added
+
+- **`maintenance step <name>` (#2028):** run exactly one named maintenance step in isolation (bypasses that step's cadence guard; inherits `--verbose`/`--json`). Unknown names exit non-zero and print the valid step list. Named `step` to avoid colliding with the `maintenance run` JobRun-inspection group and the `steps` list command.
+- **Verbose distill progress/heartbeat (#2029):** distill emits a start marker, a periodic block-count heartbeat, and a final status/counter summary in verbose runs so a long LLM-bound batch is distinguishable from a hung one. Only counts/status are logged — never raw fact text.
+
+### Changed
+
+- Bumped plugin, `openclaw.plugin.json`, and `openclaw-hybrid-memory-install` package versions to **2026.7.50**.
+
+---
+
 ## [2026.7.33] - 2026-07-03
 
 ### Fixed

--- a/extensions/memory-hybrid/cli/cmd-distill.ts
+++ b/extensions/memory-hybrid/cli/cmd-distill.ts
@@ -521,6 +521,9 @@ export async function runDistillForCli(
     };
 
     let batchFailures = 0;
+    // Preserve the first concrete batch failure cause so maintenance surfaces the real reason
+    // (model/error kind/message) instead of only `semantic=partial` (#2024).
+    let batchFailureReason: string | undefined;
     let lengthRetriesAtCursor = 0;
     const maxLengthRetriesPerCursor = 8;
 
@@ -528,6 +531,7 @@ export async function runDistillForCli(
       if (maintenanceRunDeadlineReached()) {
         sink.warn("memory-hybrid: distill: maintenance run deadline reached; stopping batch loop");
         batchFailures++;
+        batchFailureReason ??= `batch ${batchNum + 1} aborted: maintenance run deadline reached before completion`;
         break;
       }
       batchNum++;
@@ -567,6 +571,7 @@ export async function runDistillForCli(
             `memory-hybrid: distill batch ${batchNum} input (~${inputTokens} tokens) exceeds primary limit (${primaryInputLimit}) with no compatible fallbacks`,
           );
           batchFailures++;
+          batchFailureReason ??= `batch ${batchNum} input (~${inputTokens} tokens) exceeds primary model ${model} limit (${primaryInputLimit}) and all fallbacks were context-incompatible${skippedFallbacks.length > 0 ? ` (skipped: ${skippedFallbacks.join(", ")})` : ""}`;
           break;
         }
         callModel = callFallbacks[0];
@@ -731,6 +736,7 @@ export async function runDistillForCli(
         sink.warn(`memory-hybrid: distill batch ${batchNum} failed: ${e}`);
         capturePluginError(e, { subsystem: "cli", operation: "runDistillForCli:llm-batch" });
         batchFailures++;
+        batchFailureReason ??= `batch ${batchNum} ${kind} error on model ${failureModel}: ${e.message}`;
         if (!adaptiveEnabled) {
           nonAdaptiveBatchFactor = 1;
           nonAdaptiveOutFactor = 1;
@@ -1018,18 +1024,28 @@ export async function runDistillForCli(
         `memory-hybrid: distill DEGRADED — vector neighbour search unavailable${usedHasDuplicateFallback ? "; used hasDuplicate fallback where applicable" : ""}`,
       );
     }
-    return withDistillJobRun({
-      sessionsScanned: filesToProcess.length,
-      factsExtracted: allFacts.length,
-      stored,
-      dedupSkipped: skipped,
-      dryRun: false,
-      semanticEmpty,
-      partialFailure: batchFailures > 0 || truncatedBatches > 0,
-      batchFailures,
-      dedupeDegraded,
-      distillDedupeMode,
-    });
+    const partialFailure = batchFailures > 0 || truncatedBatches > 0;
+    const resolvedFailureReason =
+      batchFailureReason ??
+      (truncatedBatches > 0
+        ? `${truncatedBatches} batch(es) hit finish=length (output truncated); consider resetting adaptive limits or smaller --days`
+        : undefined);
+    return withDistillJobRun(
+      {
+        sessionsScanned: filesToProcess.length,
+        factsExtracted: allFacts.length,
+        stored,
+        dedupSkipped: skipped,
+        dryRun: false,
+        semanticEmpty,
+        partialFailure,
+        batchFailures,
+        batchFailureReason: resolvedFailureReason,
+        dedupeDegraded,
+        distillDedupeMode,
+      },
+      partialFailure ? { reason: resolvedFailureReason } : undefined,
+    );
   } finally {
     if (shouldAcquireLock && !opts.dryRun) clearScanLock(SCAN_TYPE);
   }

--- a/extensions/memory-hybrid/cli/cmd-distill.ts
+++ b/extensions/memory-hybrid/cli/cmd-distill.ts
@@ -80,6 +80,7 @@ import {
   classifyStoreDedupeMode,
   resolveDistillVectorCandidates,
 } from "./vector-dedupe-helpers.js";
+import { startDistillProgress } from "./distill-progress.js";
 
 // Constants used only by distill functions
 const FULL_DISTILL_MAX_DAYS = 90;
@@ -527,6 +528,16 @@ export async function runDistillForCli(
     let lengthRetriesAtCursor = 0;
     const maxLengthRetriesPerCursor = 8;
 
+    // Operator progress/heartbeat (#2029): emit a start marker + periodic block-count heartbeat so a
+    // long LLM-bound batch is distinguishable from a hung run. Only counts/status are logged.
+    const distillProgress = startDistillProgress({
+      verbose: !!opts.verbose,
+      logger,
+      sessions: filesToProcess.length,
+      totalBlocks: blocks.length,
+      getState: () => ({ batch: batchNum, processedBlocks }),
+    });
+
     while (cursorBlock < blocks.length) {
       if (maintenanceRunDeadlineReached()) {
         sink.warn("memory-hybrid: distill: maintenance run deadline reached; stopping batch loop");
@@ -744,6 +755,13 @@ export async function runDistillForCli(
         break;
       }
     }
+    distillProgress.done({
+      status: batchFailures > 0 || truncatedBatches > 0 ? "partial" : allFacts.length === 0 ? "empty" : "ok",
+      extracted: allFacts.length,
+      processedBlocks,
+      batchFailures,
+      truncatedBatches,
+    });
     progress.done();
     if (truncatedBatches > 0) {
       sink.warn(

--- a/extensions/memory-hybrid/cli/commands/manage/maintenance-step-runners.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/maintenance-step-runners.ts
@@ -410,7 +410,10 @@ export function buildCliMaintenanceRunners(
     const r = await b.runDistill({ dryRun: false, verbose, days: maxCatchUpDays, ...scanFlags }, sink);
     const summary = `stored=${r.stored} sessions=${r.sessionsScanned} jobRunId=${r.jobRunId ?? "-"} semantic=${r.semanticOutcome ?? "unknown"}`;
     if (r.partialFailure) {
-      throw new Error(`distill partial failure (${summary})`);
+      // Surface the concrete batch cause (model/error kind/message) in the ledger instead of only
+      // `semantic=partial`, so health state points at the real distill failure (#2024).
+      const cause = r.batchFailureReason ? ` cause=${r.batchFailureReason}` : "";
+      throw new Error(`distill partial failure (${summary}${cause})`);
     }
     assertSemanticOutcomeDoesNotBlockStep("distill", r.semanticOutcome, summary);
     return summary;

--- a/extensions/memory-hybrid/cli/commands/manage/register-maintenance-orchestrator.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/register-maintenance-orchestrator.ts
@@ -156,6 +156,38 @@ export function registerMaintenanceOrchestratorCommands(maintenance: Chainable, 
       ),
   );
 
+  // `maintenance step <name>` runs exactly one named step in isolation (#2028). Named `step` (singular)
+  // to avoid colliding with the `maintenance run` JobRun-inspection group and the `steps` list command.
+  commonOptions(
+    maintenance
+      .command("step <step>")
+      .description(
+        "Run exactly one named maintenance step in isolation (bypasses that step's cadence guard). Use `maintenance steps` to list valid names.",
+      )
+      .action(
+        withExit(async (step: string, opts, cmd?: CommanderOptsParent) => {
+          const stepName = step?.trim();
+          const validNames = listMaintenanceSteps().map((s) => s.name);
+          if (!stepName || !validNames.includes(stepName)) {
+            console.error(`Unknown maintenance step: ${stepName || "(none)"}`);
+            console.error(`Valid steps (${validNames.length}):`);
+            for (const name of validNames) console.error(`  ${name}`);
+            process.exitCode = 1;
+            return;
+          }
+          // Force so the targeted step actually runs even if its cadence guard has not expired (this
+          // command is an explicit "run this step now" diagnostic). include=[step] across both tiers
+          // means the orchestrator executes ONLY that step and no unrelated stages (#2028).
+          await runTier(["cycle", "nightly"], {
+            ...opts,
+            include: stepName,
+            force: true,
+            verbose: !!opts?.verbose || readHybridMemVerbose(cmd),
+          });
+        }),
+      ),
+  );
+
   maintenance
     .command("steps")
     .description("List registered maintenance steps with tier, guard interval, and cadence")

--- a/extensions/memory-hybrid/cli/context.ts
+++ b/extensions/memory-hybrid/cli/context.ts
@@ -163,6 +163,7 @@ export type ManageContext = {
     dryRun?: boolean;
     skipped?: boolean;
     partialFailure?: boolean;
+    batchFailureReason?: string;
     jobRunId?: string;
     semanticOutcome?: string;
   }>;

--- a/extensions/memory-hybrid/cli/distill-progress.ts
+++ b/extensions/memory-hybrid/cli/distill-progress.ts
@@ -1,0 +1,83 @@
+/**
+ * Operator progress/heartbeat for verbose distill runs (#2029).
+ *
+ * A distill batch can block for minutes inside a single LLM call, during which the block-percentage
+ * progress reporter (which only fires when a batch advances) stays silent — making a live run look
+ * hung. This emits a clear start marker, a periodic heartbeat with block counts + elapsed time, and a
+ * final summary line. Only ids/counts/status are logged — never raw fact text — so no sensitive memory
+ * content leaks into operator logs.
+ */
+
+/** Verbose distill heartbeat cadence so long LLM-bound batches don't look hung (#2029). */
+export const DISTILL_HEARTBEAT_INTERVAL_MS = 30_000;
+
+export interface DistillProgressState {
+  /** 1-based index of the batch currently being processed. */
+  batch: number;
+  /** Blocks fully processed so far. */
+  processedBlocks: number;
+}
+
+export interface DistillDoneSummary {
+  /** Terminal status: "ok" | "empty" | "partial". */
+  status: string;
+  extracted: number;
+  processedBlocks: number;
+  batchFailures: number;
+  truncatedBatches: number;
+}
+
+export interface DistillProgressReporter {
+  /** Emit the final summary line and stop the heartbeat. Idempotent. */
+  done: (summary: DistillDoneSummary) => void;
+  /** Stop the heartbeat without emitting a summary (e.g. an early return path). Idempotent. */
+  stop: () => void;
+}
+
+/**
+ * Start emitting distill progress markers. A no-op reporter is returned when `verbose` is false or no
+ * logger is available, so callers can unconditionally call `done()`/`stop()`.
+ */
+export function startDistillProgress(opts: {
+  verbose: boolean;
+  logger?: { info?: (msg: string) => void };
+  sessions: number;
+  totalBlocks: number;
+  /** Read the live batch/processed counters at heartbeat time. */
+  getState: () => DistillProgressState;
+  /** Override the heartbeat cadence (tests). */
+  intervalMs?: number;
+}): DistillProgressReporter {
+  const info = opts.logger?.info;
+  if (!opts.verbose || typeof info !== "function") {
+    return { done: () => {}, stop: () => {} };
+  }
+  const log = (msg: string) => info.call(opts.logger, msg);
+  const startedMs = Date.now();
+  log(`memory-hybrid: distill start — sessions=${opts.sessions} blocks=${opts.totalBlocks}`);
+  const heartbeat = setInterval(() => {
+    const { batch, processedBlocks } = opts.getState();
+    const elapsedSec = Math.floor((Date.now() - startedMs) / 1000);
+    log(
+      `memory-hybrid: distill — still running: batch ${batch} processed ${processedBlocks}/${opts.totalBlocks} blocks (elapsed ${elapsedSec}s)`,
+    );
+  }, opts.intervalMs ?? DISTILL_HEARTBEAT_INTERVAL_MS);
+  heartbeat.unref?.();
+
+  let stopped = false;
+  const stop = () => {
+    if (stopped) return;
+    stopped = true;
+    clearInterval(heartbeat);
+  };
+  return {
+    stop,
+    done: (summary) => {
+      stop();
+      const durationSec = Math.floor((Date.now() - startedMs) / 1000);
+      log(
+        `memory-hybrid: distill done — status=${summary.status} extracted=${summary.extracted} blocks=${summary.processedBlocks}/${opts.totalBlocks} batchFailures=${summary.batchFailures} truncatedBatches=${summary.truncatedBatches} duration=${durationSec}s`,
+      );
+    },
+  };
+}

--- a/extensions/memory-hybrid/cli/types.ts
+++ b/extensions/memory-hybrid/cli/types.ts
@@ -233,6 +233,11 @@ export type DistillCliResult = {
   semanticEmpty?: boolean;
   partialFailure?: boolean;
   batchFailures?: number;
+  /**
+   * Concrete underlying cause of a batch failure (model/error kind/message), preserved so
+   * maintenance ledger/health state surfaces the real reason instead of only `semantic=partial` (#2024).
+   */
+  batchFailureReason?: string;
   jobRunId?: string;
   semanticOutcome?: string;
   dedupeDegraded?: boolean;

--- a/extensions/memory-hybrid/cli/vector-dedupe-helpers.ts
+++ b/extensions/memory-hybrid/cli/vector-dedupe-helpers.ts
@@ -82,6 +82,91 @@ export function filterDistillVectorCandidates(
     .slice(0, VECTOR_CANDIDATE_LIMIT);
 }
 
+/**
+ * Filter LanceDB neighbours to live facts of a given source/scope for write-time dedupe (#2027).
+ *
+ * `applyDedupe`'s vector path (non-project facts) trusts that candidates are already scope/source
+ * matched — it only compares cosine score against the threshold. So candidates fed to the store path
+ * MUST be pre-filtered here to the same source + scope + scopeTarget as the incoming fact, otherwise a
+ * high-similarity fact from a different source/scope could be wrongly treated as a duplicate.
+ */
+export function filterWriteVectorCandidates(
+  neighbors: VectorNeighbor[],
+  factsDb: { getById: (id: string) => VectorCandidateFact | null },
+  opts: {
+    source: string;
+    embeddingModelName: string | null;
+    candidateScope?: string;
+    candidateScopeTarget?: string | null;
+  },
+): VectorCandidate[] {
+  const scope = opts.candidateScope ?? "global";
+  const scopeTarget = opts.candidateScopeTarget ?? null;
+  return mapValidVectorCandidates(neighbors)
+    .filter((candidate) => {
+      const live = factsDb.getById(candidate.id);
+      return (
+        live != null &&
+        isLiveFact(live) &&
+        (live.source ?? null) === opts.source &&
+        (live.scope ?? "global") === scope &&
+        (live.scope === "global" ? null : (live.scopeTarget ?? null)) === scopeTarget &&
+        (opts.embeddingModelName == null ||
+          live.embeddingModel == null ||
+          live.embeddingModel === opts.embeddingModelName)
+      );
+    })
+    .slice(0, VECTOR_CANDIDATE_LIMIT);
+}
+
+/**
+ * Pre-compute vector neighbour candidates for a generic write-time store, source/scope filtered (#2027).
+ *
+ * Mirrors {@link resolveDistillVectorCandidates} but for arbitrary sources (e.g. the live `memory_store`
+ * path). Returns `undefined` candidates (and `vectorSearchDegraded=true`) when the vector search fails,
+ * so the caller falls back to lexical-only dedupe rather than throwing.
+ */
+export async function resolveWriteVectorCandidates(input: {
+  fuzzyDedupe: boolean;
+  vector: number[];
+  vectorDb: { search: (vector: number[], limit: number, minScore: number) => Promise<VectorNeighbor[]> };
+  factsDb: { getById: (id: string) => VectorCandidateFact | null };
+  source: string;
+  embeddingModelName: string | null;
+  candidateScope?: string;
+  candidateScopeTarget?: string | null;
+}): Promise<{ vectorCandidates?: VectorCandidate[]; vectorSearchDegraded: boolean }> {
+  if (!input.fuzzyDedupe || !Array.isArray(input.vector) || input.vector.length === 0) {
+    return { vectorSearchDegraded: false };
+  }
+  try {
+    const neighbors = await input.vectorDb.search(
+      input.vector,
+      VECTOR_CANDIDATE_OVERFETCH_LIMIT,
+      VECTOR_CANDIDATE_MIN_SCORE,
+    );
+    if (getVectorSearchFailReason(input.vectorDb)) {
+      return { vectorSearchDegraded: true };
+    }
+    return {
+      vectorCandidates: filterWriteVectorCandidates(neighbors, input.factsDb, {
+        source: input.source,
+        embeddingModelName: input.embeddingModelName,
+        candidateScope: input.candidateScope,
+        candidateScopeTarget: input.candidateScopeTarget,
+      }),
+      vectorSearchDegraded: false,
+    };
+  } catch (err) {
+    capturePluginError(err as Error, {
+      subsystem: "cli",
+      operation: "resolveWriteVectorCandidates:search",
+      severity: "info",
+    });
+    return { vectorSearchDegraded: true };
+  }
+}
+
 export type ResolveDistillVectorCandidatesResult = {
   vectorCandidates?: VectorCandidate[];
   vectorSearchDegraded: boolean;

--- a/extensions/memory-hybrid/openclaw.plugin.json
+++ b/extensions/memory-hybrid/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "openclaw-hybrid-memory",
   "kind": "memory",
-  "version": "2026.7.33",
+  "version": "2026.7.50",
   "contracts": {
     "tools": [
       "active_task_checkpoint",

--- a/extensions/memory-hybrid/package-lock.json
+++ b/extensions/memory-hybrid/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openclaw-hybrid-memory",
-  "version": "2026.7.33",
+  "version": "2026.7.50",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openclaw-hybrid-memory",
-      "version": "2026.7.33",
+      "version": "2026.7.50",
       "hasInstallScript": true,
       "dependencies": {
         "@lancedb/lancedb": "^0.30.0",

--- a/extensions/memory-hybrid/package.json
+++ b/extensions/memory-hybrid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-hybrid-memory",
-  "version": "2026.7.33",
+  "version": "2026.7.50",
   "type": "module",
   "description": "Give your OpenClaw agent lasting memory: structured facts, semantic search, auto-capture & recall, decay, optional credential vault. Part of Hybrid Memory v3.",
   "files": [

--- a/extensions/memory-hybrid/services/maintenance-job-run/artifact-paths.ts
+++ b/extensions/memory-hybrid/services/maintenance-job-run/artifact-paths.ts
@@ -27,7 +27,15 @@ export function resolveOrchestratorJobFromEnv(): string | undefined {
 
 export function buildJobRunId(command: string, fingerprint: string): string {
   const safeCmd = command.replace(/[^a-z0-9-]+/gi, "-").replace(/^-+|-+$/g, "");
-  const fp = fingerprint.slice(0, 8);
+  // Sanitize the fingerprint the same way as the command before truncating so raw separators
+  // (colons, dots) and mid-token boolean truncation cannot produce misleading ids like
+  // `job-distill-::14:fal` (#2024). Collapse non-alphanumeric runs to single dashes, then cap.
+  const fp =
+    fingerprint
+      .replace(/[^a-z0-9]+/gi, "-")
+      .replace(/^-+/g, "")
+      .slice(0, 16)
+      .replace(/-+$/g, "") || "0";
   return `job-${safeCmd}-${fp}`;
 }
 

--- a/extensions/memory-hybrid/services/maintenance-job-run/artifact-paths.ts
+++ b/extensions/memory-hybrid/services/maintenance-job-run/artifact-paths.ts
@@ -30,11 +30,14 @@ export function buildJobRunId(command: string, fingerprint: string): string {
   // Sanitize the fingerprint the same way as the command before truncating so raw separators
   // (colons, dots) and mid-token boolean truncation cannot produce misleading ids like
   // `job-distill-::14:fal` (#2024). Collapse non-alphanumeric runs to single dashes, then cap.
+  // Keep the 8-char cap: purely-alphanumeric fingerprints (e.g. hex hashes used by batch/
+  // self-correction job-runs) are unchanged by the sanitize, so their checkpoint/artifact dir
+  // names stay stable across upgrade — only the malformed separator/boolean cases change.
   const fp =
     fingerprint
       .replace(/[^a-z0-9]+/gi, "-")
       .replace(/^-+/g, "")
-      .slice(0, 16)
+      .slice(0, 8)
       .replace(/-+$/g, "") || "0";
   return `job-${safeCmd}-${fp}`;
 }

--- a/extensions/memory-hybrid/services/maintenance-job-run/light-job-run-bridge.ts
+++ b/extensions/memory-hybrid/services/maintenance-job-run/light-job-run-bridge.ts
@@ -10,6 +10,8 @@ export type LightJobRunParams = {
   partialFailure?: boolean;
   inputsProcessed?: number;
   outputsProduced?: number;
+  /** Concrete failure cause persisted into the job-run summary's semanticReason (#2024). */
+  reason?: string;
 };
 
 export function resolveLightJobRunOutcome(params: LightJobRunParams): JobRunSemanticOutcome {
@@ -42,6 +44,6 @@ export function finishLightJobRun(
     semanticOutcome === "skipped" ||
     semanticOutcome === "success_with_review";
   jobRun.endPhase("run", phaseOk ? "completed" : "failed");
-  const jobRunId = finishBatchJobRun(jobRun, semanticOutcome, { clearCheckpoint: true });
+  const jobRunId = finishBatchJobRun(jobRun, semanticOutcome, { clearCheckpoint: true, reason: params.reason });
   return { jobRunId, semanticOutcome };
 }

--- a/extensions/memory-hybrid/services/maintenance-log-analyzer.ts
+++ b/extensions/memory-hybrid/services/maintenance-log-analyzer.ts
@@ -325,10 +325,13 @@ function extractJobFromPath(path: string, suffix: string): string {
   return extractJobName(file);
 }
 
+// The `maintenance-orchestrator: <step> — start|still running after Ns|complete` alternative matches
+// the generic per-step heartbeat the orchestrator emits for every step (#2026), so a live CPU/LLM-bound
+// step is recognized as progressing rather than mislabeled as a stale/hung empty-exit run.
 const DREAM_CYCLE_PROGRESS_MARKER_RE =
-  /(?:\[dream-cycle\].*(?:start|still running after|complete)|memory-hybrid:\s*(?:dream-cycle|reflect-meta(?:-collapse)?|build-languages|backfill-decay|reembed-vectorless|enrich-entities)\s*[—-].*(?:start|still running after|complete|episodic consolidation progress)|Dream cycle complete:|Extract-implicit:|Closed-loop analysis:|Cross-agent learning:|Tool effectiveness:|Cost log:)/im;
+  /(?:\[dream-cycle\].*(?:start|still running after|complete)|memory-hybrid:\s*(?:dream-cycle|reflect-meta(?:-collapse)?|build-languages|backfill-decay|reembed-vectorless|enrich-entities)\s*[—-].*(?:start|still running after|complete|episodic consolidation progress)|maintenance-orchestrator:\s*\S+\s*[—-]\s*(?:start|still running after \d+s|complete)|Dream cycle complete:|Extract-implicit:|Closed-loop analysis:|Cross-agent learning:|Tool effectiveness:|Cost log:)/im;
 const DREAM_CYCLE_STILL_RUNNING_RE =
-  /(?:\[dream-cycle\].*still running after \d+s|memory-hybrid:\s*(?:dream-cycle|reflect-meta(?:-collapse)?|build-languages|backfill-decay|reembed-vectorless|enrich-entities)\s*[—-].*still running after \d+s)/im;
+  /(?:\[dream-cycle\].*still running after \d+s|memory-hybrid:\s*(?:dream-cycle|reflect-meta(?:-collapse)?|build-languages|backfill-decay|reembed-vectorless|enrich-entities)\s*[—-].*still running after \d+s|maintenance-orchestrator:\s*\S+\s*[—-]\s*still running after \d+s)/im;
 
 function logHasDreamCycleProgress(logContent: string): boolean {
   if (!logContent) return false;
@@ -391,6 +394,81 @@ function buildOrchestrationSyntheticStep(params: {
     logContent,
     line: `${line}; ${markerBits.join("; ")}`,
   };
+}
+
+/**
+ * A single run recorded in an aggregate `<job>.cron.log` via an `HM_RUN_SUMMARY` line (#2025).
+ * Aggregate cron logs accumulate one summary line per run, each referencing that run's own
+ * per-run `.exit.txt` ledger — the aggregate file itself has no sibling `.exit.txt`.
+ */
+interface CronAggregateRun {
+  runId: string;
+  status: string;
+  job: string | null;
+  exitPath: string | null;
+  occurredAtMs: number;
+}
+
+/** Parse the `YYYYMMDDTHHMMSSZ` prefix of an HM run id into epoch ms (0 if unparseable). */
+function parseRunIdTimestampMs(runId: string): number {
+  const m = runId.match(/^(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})Z/);
+  if (!m) return 0;
+  const ms = Date.UTC(Number(m[1]), Number(m[2]) - 1, Number(m[3]), Number(m[4]), Number(m[5]), Number(m[6]));
+  return Number.isFinite(ms) ? ms : 0;
+}
+
+/** Extract `HM_RUN_SUMMARY` run entries from an aggregate cron log (#2025). */
+export function parseCronAggregateRuns(logContent: string): CronAggregateRun[] {
+  if (!logContent || !logContent.includes("HM_RUN_SUMMARY")) return [];
+  const runs: CronAggregateRun[] = [];
+  for (const line of logContent.split("\n")) {
+    if (!line.includes("HM_RUN_SUMMARY")) continue;
+    const get = (k: string): string | null => {
+      const m = line.match(new RegExp(`\\b${k}=(\\S+)`));
+      return m ? m[1] : null;
+    };
+    const runId = get("run_id");
+    if (!runId) continue;
+    runs.push({
+      runId,
+      status: (get("status") ?? "").toUpperCase(),
+      job: get("job"),
+      exitPath: get("exit"),
+      occurredAtMs: parseRunIdTimestampMs(runId),
+    });
+  }
+  return runs;
+}
+
+/**
+ * For an aggregate `<job>.cron.log`, validate each in-window run's referenced `.exit.txt` ledger (#2025).
+ * Returns `null` when the aggregate is healthy (every in-window run has a resolvable exit ledger, or no
+ * run references a missing one) so the caller suppresses the spurious missing-exit-ledger anomaly.
+ * Otherwise returns the most-recent run whose referenced ledger is genuinely missing, so the finding is
+ * pegged to that exact run id/timestamp rather than the aggregate file's current mtime.
+ */
+function findCronAggregateMissingLedgerRun(
+  logPath: string,
+  logContent: string,
+  cutoff: number,
+): CronAggregateRun | null {
+  const runs = parseCronAggregateRuns(logContent);
+  if (runs.length === 0) return null;
+  const resolveExit = (run: CronAggregateRun): string | null => {
+    if (!run.exitPath) return null;
+    if (existsSync(run.exitPath)) return run.exitPath;
+    // Tolerate relocated/copied log bundles: check for the same basename next to the aggregate log.
+    const local = join(dirname(logPath), basename(run.exitPath));
+    return existsSync(local) ? local : null;
+  };
+  const missing = runs
+    .filter((r) => r.occurredAtMs >= cutoff)
+    // Only runs that reference an exit ledger which does NOT exist are genuine anomalies. Runs whose
+    // referenced ledger exists are already analyzed via the per-run .exit.txt files; runs without any
+    // exit= reference are left to other detectors rather than flagged from the aggregate.
+    .filter((r) => r.exitPath != null && resolveExit(r) === null);
+  if (missing.length === 0) return null;
+  return missing.sort((a, b) => a.occurredAtMs - b.occurredAtMs).at(-1) ?? null;
 }
 
 export function collectMaintenanceSteps(
@@ -534,6 +612,27 @@ export function collectMaintenanceSteps(
     if (seenExit.has(exitPath) || existsSync(exitPath)) continue;
     const logContent = safeRead(logPath);
     const job = extractJobFromPath(logPath, ".log");
+    // Aggregate `<job>.cron.log` files never have a sibling `<job>.cron.exit.txt`; instead each run
+    // records an HM_RUN_SUMMARY line pointing at its own per-run `.exit.txt` ledger. Validate those
+    // per-run ledgers rather than blindly flagging the aggregate as missing-exit-ledger (#2025).
+    if (basename(logPath).endsWith(".cron.log") && logContent.includes("HM_RUN_SUMMARY")) {
+      const missingRun = findCronAggregateMissingLedgerRun(logPath, logContent, cutoff);
+      if (!missingRun) continue; // Every in-window run has a valid exit ledger — healthy, no anomaly.
+      const syntheticStep = buildOrchestrationSyntheticStep({
+        job: missingRun.job ?? job,
+        exitPath: missingRun.exitPath ?? exitPath,
+        logPath,
+        logContent,
+        nowMs,
+        staleThresholdMs,
+        // Peg the finding to the specific run's timestamp/id, not the aggregate file's current mtime.
+        latestActivityMs: missingRun.occurredAtMs || logMtime,
+        kind: "missing-exit-ledger",
+      });
+      syntheticStep.line += `; run_id=${missingRun.runId}`;
+      steps.push(syntheticStep);
+      continue;
+    }
     steps.push(
       buildOrchestrationSyntheticStep({
         job,

--- a/extensions/memory-hybrid/services/maintenance-orchestrator.ts
+++ b/extensions/memory-hybrid/services/maintenance-orchestrator.ts
@@ -466,6 +466,46 @@ function stepSemanticBlocksGuard(semantic?: string): boolean {
   return semanticOutcomeBlocksOrchestratorGuard(semantic);
 }
 
+/** Heartbeat cadence for per-step progress lines during long CPU/LLM-bound steps (#2026). */
+const ORCHESTRATOR_STEP_HEARTBEAT_MS = 60_000;
+
+/**
+ * Run a maintenance step while emitting per-step start/heartbeat/finish lines (#2026).
+ *
+ * Long CPU- or LLM-bound steps (e.g. distill, dream-cycle, self-correction) previously ran
+ * log-silent for minutes, making a live run indistinguishable from a hung one to operators and
+ * the stale-run detector. This wrapper emits:
+ *   - `maintenance-orchestrator: <step> — start`
+ *   - `maintenance-orchestrator: <step> — still running after <N>s` every ORCHESTRATOR_STEP_HEARTBEAT_MS
+ *   - `maintenance-orchestrator: <step> — complete in <N>s`
+ *
+ * The lines advance the wrapper-log mtime (resetting the analyzer's staleness signal) and match the
+ * analyzer's progress/still-running regexes, so a live step is classified as running rather than stale.
+ */
+async function runStepWithHeartbeat<T>(
+  stepName: string,
+  emit: boolean,
+  logger: MaintenanceOrchestratorContext["logger"],
+  fn: () => Promise<T>,
+): Promise<T> {
+  if (!emit || !logger?.info) return fn();
+  const started = Date.now();
+  logger.info(`maintenance-orchestrator: ${stepName} — start`);
+  const heartbeat = setInterval(() => {
+    const elapsedSec = Math.floor((Date.now() - started) / 1000);
+    logger.info?.(`maintenance-orchestrator: ${stepName} — still running after ${elapsedSec}s`);
+  }, ORCHESTRATOR_STEP_HEARTBEAT_MS);
+  heartbeat.unref?.();
+  try {
+    const result = await fn();
+    const elapsedSec = Math.floor((Date.now() - started) / 1000);
+    logger.info?.(`maintenance-orchestrator: ${stepName} — complete in ${elapsedSec}s`);
+    return result;
+  } finally {
+    clearInterval(heartbeat);
+  }
+}
+
 export async function runMaintenanceOrchestrator(
   ctx: MaintenanceOrchestratorContext,
   options: OrchestratorRunOptions,
@@ -651,7 +691,7 @@ export async function runMaintenanceOrchestrator(
 
     const stepStarted = Date.now();
     try {
-      const summary = await runner();
+      const summary = await runStepWithHeartbeat(step.name, options.verbose !== false, logger, () => runner());
       const meta = parseStepRunnerMetadata(summary);
       if (step.name === "reflect-rules" && reflectRulesStepSummaryIndicatesFailure(summary)) {
         logger?.warn?.(`maintenance-orchestrator: ${step.name} semantic failure (summary diagnostics): ${summary}`);

--- a/extensions/memory-hybrid/tests/distill-progress.test.ts
+++ b/extensions/memory-hybrid/tests/distill-progress.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { startDistillProgress } from "../cli/distill-progress.js";
+
+describe("distill progress heartbeat (#2029)", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("emits start, periodic heartbeat, and done markers in verbose mode", () => {
+    vi.useFakeTimers();
+    const lines: string[] = [];
+    const logger = { info: (m: string) => lines.push(m) };
+    let state = { batch: 1, processedBlocks: 0 };
+
+    const reporter = startDistillProgress({
+      verbose: true,
+      logger,
+      sessions: 358,
+      totalBlocks: 12,
+      getState: () => state,
+      intervalMs: 30_000,
+    });
+
+    // Start marker fires immediately with counts (no fact text).
+    expect(lines[0]).toBe("memory-hybrid: distill start — sessions=358 blocks=12");
+
+    // Advance into a long batch → at least one heartbeat with current block counts + elapsed.
+    state = { batch: 1, processedBlocks: 3 };
+    vi.advanceTimersByTime(30_000);
+    expect(lines.some((l) => /distill — still running: batch 1 processed 3\/12 blocks \(elapsed 30s\)/.test(l))).toBe(
+      true,
+    );
+
+    reporter.done({ status: "partial", extracted: 0, processedBlocks: 3, batchFailures: 1, truncatedBatches: 0 });
+    const doneLine = lines.at(-1) ?? "";
+    expect(doneLine).toContain("distill done — status=partial");
+    expect(doneLine).toContain("extracted=0");
+    expect(doneLine).toContain("blocks=3/12");
+    expect(doneLine).toContain("batchFailures=1");
+  });
+
+  it("stops the heartbeat after done so no further lines are emitted", () => {
+    vi.useFakeTimers();
+    const lines: string[] = [];
+    const reporter = startDistillProgress({
+      verbose: true,
+      logger: { info: (m: string) => lines.push(m) },
+      sessions: 1,
+      totalBlocks: 1,
+      getState: () => ({ batch: 1, processedBlocks: 1 }),
+      intervalMs: 30_000,
+    });
+    reporter.done({ status: "ok", extracted: 5, processedBlocks: 1, batchFailures: 0, truncatedBatches: 0 });
+    const countAfterDone = lines.length;
+    vi.advanceTimersByTime(120_000);
+    expect(lines.length).toBe(countAfterDone); // interval cleared — no stray heartbeats
+  });
+
+  it("is a no-op when not verbose (no progress lines, safe done/stop)", () => {
+    const lines: string[] = [];
+    const reporter = startDistillProgress({
+      verbose: false,
+      logger: { info: (m: string) => lines.push(m) },
+      sessions: 10,
+      totalBlocks: 5,
+      getState: () => ({ batch: 1, processedBlocks: 0 }),
+    });
+    reporter.done({ status: "ok", extracted: 1, processedBlocks: 5, batchFailures: 0, truncatedBatches: 0 });
+    reporter.stop();
+    expect(lines).toEqual([]);
+  });
+
+  it("never logs raw fact text — only counts and status", () => {
+    vi.useFakeTimers();
+    const lines: string[] = [];
+    const reporter = startDistillProgress({
+      verbose: true,
+      logger: { info: (m: string) => lines.push(m) },
+      sessions: 2,
+      totalBlocks: 4,
+      getState: () => ({ batch: 2, processedBlocks: 2 }),
+      intervalMs: 10_000,
+    });
+    vi.advanceTimersByTime(10_000);
+    reporter.done({ status: "ok", extracted: 3, processedBlocks: 4, batchFailures: 0, truncatedBatches: 0 });
+    // Every emitted line is a structured marker; none carries free-form memory content.
+    for (const line of lines) {
+      expect(line.startsWith("memory-hybrid: distill")).toBe(true);
+    }
+  });
+});

--- a/extensions/memory-hybrid/tests/maintenance-artifact-paths.test.ts
+++ b/extensions/memory-hybrid/tests/maintenance-artifact-paths.test.ts
@@ -7,6 +7,21 @@ import {
   resolveMaintenanceExitPathForSummary,
   resolveMaintenanceSummaryPath,
 } from "../services/maintenance-artifact-paths.js";
+import { buildJobRunId } from "../services/maintenance-job-run/artifact-paths.js";
+
+describe("buildJobRunId", () => {
+  it("sanitizes raw separators in the fingerprint instead of producing malformed ids (#2024)", () => {
+    // Regression: `::14:false` previously sliced to `::14:fal`, producing `job-distill-::14:fal`.
+    const id = buildJobRunId("distill", "::14:false");
+    expect(id).toBe("job-distill-14-false");
+    expect(id).not.toContain(":");
+  });
+
+  it("keeps ids stable and safe for typical fingerprints", () => {
+    expect(buildJobRunId("distill", "true:2026-01-01:3:false")).toBe("job-distill-true-2026-01-01");
+    expect(buildJobRunId("self correction", "::::")).toBe("job-self-correction-0");
+  });
+});
 
 describe("resolveMaintenanceSummaryPath", () => {
   it("finds summary in YYYYMMDD day subdir", () => {

--- a/extensions/memory-hybrid/tests/maintenance-artifact-paths.test.ts
+++ b/extensions/memory-hybrid/tests/maintenance-artifact-paths.test.ts
@@ -18,8 +18,14 @@ describe("buildJobRunId", () => {
   });
 
   it("keeps ids stable and safe for typical fingerprints", () => {
-    expect(buildJobRunId("distill", "true:2026-01-01:3:false")).toBe("job-distill-true-2026-01-01");
+    expect(buildJobRunId("distill", "true:2026-01-01:3:false")).toBe("job-distill-true-202");
     expect(buildJobRunId("self correction", "::::")).toBe("job-self-correction-0");
+  });
+
+  it("leaves purely-alphanumeric (hex hash) fingerprints byte-identical to the legacy 8-char slice", () => {
+    // Hash-fingerprinted job-runs (self-correction / batch) must keep stable checkpoint dir names
+    // across upgrade — sanitize is a no-op for hex, and the cap stays at 8 chars (#2024 review).
+    expect(buildJobRunId("self-correction", "a1b2c3d4e5f6a7b8")).toBe("job-self-correction-a1b2c3d4");
   });
 });
 

--- a/extensions/memory-hybrid/tests/maintenance-log-analyzer.test.ts
+++ b/extensions/memory-hybrid/tests/maintenance-log-analyzer.test.ts
@@ -31,6 +31,7 @@ import {
   isCanonicalMaintenanceLog,
   isUnderAuxiliaryDir,
   maintenanceRules,
+  parseCronAggregateRuns,
   persistMaintenanceFindings,
   pluginVersionGte,
   reportGlitchTipFindings,
@@ -658,6 +659,62 @@ describe("maintenance log analyzer", () => {
     expect(steps).toHaveLength(1);
     expect(steps[0].step).toBe("orchestration-missing-exit-ledger");
     expect(steps[0].job).toBe("nightly-memory-sweep");
+  });
+
+  it("does not flag aggregate .cron.log runs whose HM_RUN_SUMMARY exit ledger exists (#2025)", () => {
+    const root = tmpRoot();
+    const runExit = join(root, "hybrid-mem-backup-20260705T040001Z-30251.exit.txt");
+    writeFileSync(runExit, "2026-07-05T04:00:35Z backup exit=0\n");
+    const logPath = join(root, "hybrid-mem-backup.cron.log");
+    writeFileSync(
+      logPath,
+      [
+        "HM_RUN_SUMMARY status=SUCCESS job=hybrid-mem-backup run_id=20260705T040001Z-30251 duration_s=37 step_exit=0 validation_exit=0 guard_updated=yes " +
+          `log=${logPath} exit=${runExit}`,
+        "SUCCESS: hybrid-mem-backup",
+        `HM_EXIT=${runExit}`,
+        "2026-07-05T04:00:35Z backup exit=0",
+      ].join("\n"),
+    );
+
+    const nowMs = Date.UTC(2026, 6, 5, 5, 0, 0);
+    const steps = collectMaintenanceSteps(root, "24h", nowMs, { staleThresholdMs: 45 * 60 * 1000 });
+    // The aggregate .cron.log must not be reported as missing-exit-ledger — its run has a real ledger.
+    expect(steps.some((s) => s.step === "orchestration-missing-exit-ledger")).toBe(false);
+    const findings = analyzeMaintenanceSteps(steps);
+    expect(findings.some((f) => f.ruleId === "orchestration-missing-exit-ledger")).toBe(false);
+  });
+
+  it("flags the specific aggregate run whose exit ledger is missing, pegged to its run id (#2025)", () => {
+    const root = tmpRoot();
+    // Referenced per-run exit ledger deliberately NOT created → genuinely missing.
+    const missingExit = join(root, "hybrid-mem-backup-20260705T040001Z-30251.exit.txt");
+    const logPath = join(root, "hybrid-mem-backup.cron.log");
+    writeFileSync(
+      logPath,
+      "HM_RUN_SUMMARY status=SUCCESS job=hybrid-mem-backup run_id=20260705T040001Z-30251 duration_s=37 step_exit=0 validation_exit=0 guard_updated=yes " +
+        `log=${logPath} exit=${missingExit}\n`,
+    );
+
+    const nowMs = Date.UTC(2026, 6, 5, 5, 0, 0);
+    const steps = collectMaintenanceSteps(root, "24h", nowMs, { staleThresholdMs: 45 * 60 * 1000 });
+    const missing = steps.find((s) => s.step === "orchestration-missing-exit-ledger");
+    expect(missing).toBeDefined();
+    expect(missing?.job).toBe("hybrid-mem-backup");
+    expect(missing?.line).toContain("run_id=20260705T040001Z-30251");
+    // Occurred-at is pegged to the run id timestamp (04:00:01Z), not nowMs (05:00Z).
+    expect(missing?.occurredAt).toBe(Math.floor(Date.UTC(2026, 6, 5, 4, 0, 1) / 1000));
+  });
+
+  it("parseCronAggregateRuns extracts run id, status and exit path (#2025)", () => {
+    const runs = parseCronAggregateRuns(
+      "HM_RUN_SUMMARY status=SUCCESS job=hybrid-mem-backup run_id=20260705T040001Z-30251 step_exit=0 validation_exit=0 guard_updated=yes log=/l/x.log exit=/l/x.exit.txt\nunrelated line\n",
+    );
+    expect(runs).toHaveLength(1);
+    expect(runs[0].runId).toBe("20260705T040001Z-30251");
+    expect(runs[0].status).toBe("SUCCESS");
+    expect(runs[0].job).toBe("hybrid-mem-backup");
+    expect(runs[0].exitPath).toBe("/l/x.exit.txt");
   });
 
   it("ignores stale manual exit rows even when the files were touched recently", () => {

--- a/extensions/memory-hybrid/tests/maintenance-orchestrator.test.ts
+++ b/extensions/memory-hybrid/tests/maintenance-orchestrator.test.ts
@@ -160,6 +160,39 @@ describe("maintenance-orchestrator", () => {
     expect(summary.counts.ok).toBe(1);
   });
 
+  it("emits per-step start/complete heartbeat lines when verbose (#2026)", async () => {
+    openclawDir = mkdtempSync(join(tmpdir(), "hm-orch-"));
+    const infoLines: string[] = [];
+    const runners = new Map<string, () => Promise<string>>([["prune", async () => "pruned=1"]]);
+    await runMaintenanceOrchestrator(
+      {
+        cfg: minimalCfg(),
+        runners,
+        openclawDir,
+        logger: { info: (m: string) => infoLines.push(m), warn: () => {} },
+      },
+      { tiers: ["cycle"], force: true, verbose: true, include: ["prune"] },
+    );
+    expect(infoLines).toContain("maintenance-orchestrator: prune — start");
+    expect(infoLines.some((l) => /^maintenance-orchestrator: prune — complete in \d+s$/.test(l))).toBe(true);
+  });
+
+  it("does not emit per-step heartbeat lines when verbose is false (#2026)", async () => {
+    openclawDir = mkdtempSync(join(tmpdir(), "hm-orch-"));
+    const infoLines: string[] = [];
+    const runners = new Map<string, () => Promise<string>>([["prune", async () => "pruned=1"]]);
+    await runMaintenanceOrchestrator(
+      {
+        cfg: minimalCfg(),
+        runners,
+        openclawDir,
+        logger: { info: (m: string) => infoLines.push(m), warn: () => {} },
+      },
+      { tiers: ["cycle"], force: true, verbose: false, include: ["prune"] },
+    );
+    expect(infoLines.some((l) => l.includes("prune — start"))).toBe(false);
+  });
+
   it("writes step guard on success", async () => {
     openclawDir = mkdtempSync(join(tmpdir(), "hm-orch-"));
     const runners = new Map<string, () => Promise<string>>([["prune", async () => "done"]]);

--- a/extensions/memory-hybrid/tests/maintenance-orchestrator.test.ts
+++ b/extensions/memory-hybrid/tests/maintenance-orchestrator.test.ts
@@ -193,6 +193,24 @@ describe("maintenance-orchestrator", () => {
     expect(infoLines.some((l) => l.includes("prune — start"))).toBe(false);
   });
 
+  it("runs exactly one included step across both tiers and no unrelated steps (#2028 `maintenance run <step>`)", async () => {
+    openclawDir = mkdtempSync(join(tmpdir(), "hm-orch-"));
+    const called: string[] = [];
+    const runners = new Map<string, () => Promise<string>>([
+      ["prune", async () => (called.push("prune"), "pruned=1")],
+      ["compact", async () => (called.push("compact"), "ok")],
+      ["distill", async () => (called.push("distill"), "ok")],
+    ]);
+    // This mirrors what the `maintenance run prune` CLI delegates to: both tiers, include=[step], force.
+    const result = await runMaintenanceOrchestrator(
+      { cfg: minimalCfg(), runners, openclawDir },
+      { tiers: ["cycle", "nightly"], force: true, verbose: false, include: ["prune"] },
+    );
+    expect(called).toEqual(["prune"]);
+    expect(result.steps.map((s) => s.name)).toEqual(["prune"]);
+    expect(result.steps[0].status).toBe("ok");
+  });
+
   it("writes step guard on success", async () => {
     openclawDir = mkdtempSync(join(tmpdir(), "hm-orch-"));
     const runners = new Map<string, () => Promise<string>>([["prune", async () => "done"]]);

--- a/extensions/memory-hybrid/tests/register-maintenance-orchestrator-steps.test.ts
+++ b/extensions/memory-hybrid/tests/register-maintenance-orchestrator-steps.test.ts
@@ -30,3 +30,42 @@ describe("maintenance steps CLI step count", () => {
     expect(lines[0]).toBe(`Maintenance steps (${actualCount} registered):`);
   });
 });
+
+describe("maintenance step <step> CLI (#2028)", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    process.exitCode = 0;
+  });
+
+  it("rejects an unknown step name with a non-zero exit and lists the valid step names", async () => {
+    const mem = new Command("hybrid-mem");
+    mem.exitOverride();
+    const maintenance = mem.command("maintenance");
+    registerMaintenanceOrchestratorCommands(maintenance, { cfg: {} } as unknown as ManageBindings);
+
+    const errLines: string[] = [];
+    vi.spyOn(console, "error").mockImplementation((...args: unknown[]) => {
+      errLines.push(args.map((a) => String(a)).join(" "));
+    });
+
+    await mem.parseAsync(["maintenance", "step", "does-not-exist"], { from: "user" });
+
+    expect(process.exitCode).toBe(1);
+    expect(errLines[0]).toContain("Unknown maintenance step: does-not-exist");
+    // Lists valid step names so an operator can correct the invocation.
+    const validNames = listMaintenanceSteps().map((s) => s.name);
+    expect(errLines.some((l) => l.includes(`Valid steps (${validNames.length})`))).toBe(true);
+    expect(errLines.some((l) => l.trim() === validNames[0])).toBe(true);
+  });
+
+  it("registers a `step <step>` command that takes a required step argument", () => {
+    const mem = new Command("hybrid-mem");
+    mem.exitOverride();
+    const maintenance = mem.command("maintenance");
+    registerMaintenanceOrchestratorCommands(maintenance, { cfg: {} } as unknown as ManageBindings);
+    const stepCmd = maintenance.commands.find((c) => c.name() === "step");
+    expect(stepCmd).toBeDefined();
+    // The required positional makes `maintenance step` (no name) fail argument parsing.
+    expect(stepCmd?.usage()).toContain("<step>");
+  });
+});

--- a/extensions/memory-hybrid/tests/vector-dedupe-helpers.test.ts
+++ b/extensions/memory-hybrid/tests/vector-dedupe-helpers.test.ts
@@ -6,7 +6,9 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   classifyStoreDedupeMode,
   filterDistillVectorCandidates,
+  filterWriteVectorCandidates,
   resolveDistillVectorCandidates,
+  resolveWriteVectorCandidates,
 } from "../cli/vector-dedupe-helpers.js";
 import { DISTILL_DEDUP_THRESHOLD } from "../utils/constants.js";
 import { _testing } from "../index.js";
@@ -144,6 +146,102 @@ describe("vector-dedupe-helpers", () => {
 
     expect(filtered).toEqual([{ id: scoped.id, score: 0.92 }]);
     expect(filterDistillVectorCandidates([{ entry: { id: scoped.id }, score: 0.92 }], db, null)).toEqual([]);
+  });
+
+  it("filterWriteVectorCandidates keeps only same-source, in-scope live facts (#2027)", () => {
+    dir = mkdtempSync(join(tmpdir(), "write-vector-dedupe-"));
+    db = new FactsDB(join(dir, "facts.db"));
+    const convo = db.store({
+      text: "User likes tea",
+      importance: 0.6,
+      source: "conversation",
+      category: "other",
+      entity: null,
+      key: null,
+      value: null,
+    });
+    const distilled = db.store({
+      text: "Distilled fact",
+      importance: 0.6,
+      source: "distillation",
+      category: "other",
+      entity: null,
+      key: null,
+      value: null,
+    });
+
+    const filtered = filterWriteVectorCandidates(
+      [
+        { entry: { id: convo.id }, score: 0.97 },
+        { entry: { id: distilled.id }, score: 0.99 },
+      ],
+      db,
+      { source: "conversation", embeddingModelName: null },
+    );
+    // Only the conversation-source neighbour survives; the distillation one is filtered out.
+    expect(filtered).toEqual([{ id: convo.id, score: 0.97 }]);
+  });
+
+  it("resolveWriteVectorCandidates returns source-filtered candidates for the live store path (#2027)", async () => {
+    dir = mkdtempSync(join(tmpdir(), "resolve-write-vector-dedupe-"));
+    db = new FactsDB(join(dir, "facts.db"));
+    const convo = db.store({
+      text: "User likes tea",
+      importance: 0.6,
+      source: "conversation",
+      category: "other",
+      entity: null,
+      key: null,
+      value: null,
+    });
+    const vectorDb = {
+      search: vi.fn().mockResolvedValue([{ entry: { id: convo.id }, score: 0.96 }]),
+      getLastSearchFailReason: vi.fn().mockReturnValue(null),
+    };
+
+    const result = await resolveWriteVectorCandidates({
+      fuzzyDedupe: true,
+      vector: [0.1, 0.2],
+      vectorDb,
+      factsDb: db,
+      source: "conversation",
+      embeddingModelName: null,
+    });
+
+    expect(vectorDb.search).toHaveBeenCalledOnce();
+    expect(result.vectorSearchDegraded).toBe(false);
+    expect(result.vectorCandidates).toEqual([{ id: convo.id, score: 0.96 }]);
+  });
+
+  it("resolveWriteVectorCandidates degrades gracefully when vector search throws (#2027)", async () => {
+    const vectorDb = {
+      search: vi.fn().mockRejectedValue(new Error("lance down")),
+      getLastSearchFailReason: vi.fn().mockReturnValue(null),
+    };
+    const result = await resolveWriteVectorCandidates({
+      fuzzyDedupe: true,
+      vector: [0.1],
+      vectorDb,
+      factsDb: { getById: () => null },
+      source: "conversation",
+      embeddingModelName: null,
+    });
+    expect(result.vectorSearchDegraded).toBe(true);
+    expect(result.vectorCandidates).toBeUndefined();
+  });
+
+  it("resolveWriteVectorCandidates skips vector work when fuzzyDedupe is disabled (#2027)", async () => {
+    const vectorDb = { search: vi.fn(), getLastSearchFailReason: vi.fn() };
+    const result = await resolveWriteVectorCandidates({
+      fuzzyDedupe: false,
+      vector: [0.1],
+      vectorDb,
+      factsDb: { getById: () => null },
+      source: "conversation",
+      embeddingModelName: null,
+    });
+    expect(vectorDb.search).not.toHaveBeenCalled();
+    expect(result.vectorCandidates).toBeUndefined();
   });
 
   it("classifyStoreDedupeMode distinguishes vector and degraded lexical paths", () => {

--- a/extensions/memory-hybrid/tools/memory/register-store-tools.ts
+++ b/extensions/memory-hybrid/tools/memory/register-store-tools.ts
@@ -56,6 +56,7 @@ import {
 import { extractTags } from "../../utils/tags.js";
 import type { MemoryToolRuntime } from "./runtime.js";
 import { resolveToolVaultBackends, resolveToolVaultWal } from "./vault-resolve.js";
+import { resolveWriteVectorCandidates } from "../../cli/vector-dedupe-helpers.js";
 
 export function registerStoreTools(runtime: MemoryToolRuntime): void {
   const {
@@ -1044,27 +1045,47 @@ export function registerStoreTools(runtime: MemoryToolRuntime): void {
 
           const nowSec = Math.floor(Date.now() / 1000);
           const storeSessionId = api.context?.sessionId ?? null;
-          const storeResult = storeFactsDb.storeWithResult({
-            text: textToStore,
-            why: whyStored,
-            category: category as MemoryCategory,
-            importance,
-            entity: entity ?? null,
-            key: key ?? null,
-            value: value ?? null,
-            source: "conversation",
-            decayClass: paramDecayClass,
-            summary,
-            tags,
-            scope,
-            scopeTarget,
-            sourceSessions: storeSessionId ?? undefined,
-            provenanceSession: provenanceSessionId,
-            extractionMethod: "active",
-            extractionConfidence: importance,
-            decayFreezeUntil: decayFreezeUntil ?? undefined,
-            ...(supersedes?.trim() ? { validFrom: nowSec, supersedesId: supersedes.trim() } : {}),
-          });
+          // Plumb vector neighbour candidates into write-time dedupe so the configured vectorThreshold
+          // actually runs on the live store path instead of silently degrading to lexical-only (#2027).
+          // Reuses the already-computed embedding; candidates are source/scope filtered.
+          let storeVectorCandidates: ReadonlyArray<{ id: string; score: number }> | undefined;
+          if (cfg.store.fuzzyDedupe && vector) {
+            const resolvedCandidates = await resolveWriteVectorCandidates({
+              fuzzyDedupe: true,
+              vector,
+              vectorDb: storeVectorDb,
+              factsDb: storeFactsDb,
+              source: "conversation",
+              embeddingModelName: typeof embeddings.modelName === "string" ? embeddings.modelName : null,
+              candidateScope: scope,
+              candidateScopeTarget: scopeTarget,
+            });
+            storeVectorCandidates = resolvedCandidates.vectorCandidates;
+          }
+          const storeResult = storeFactsDb.storeWithResult(
+            {
+              text: textToStore,
+              why: whyStored,
+              category: category as MemoryCategory,
+              importance,
+              entity: entity ?? null,
+              key: key ?? null,
+              value: value ?? null,
+              source: "conversation",
+              decayClass: paramDecayClass,
+              summary,
+              tags,
+              scope,
+              scopeTarget,
+              sourceSessions: storeSessionId ?? undefined,
+              provenanceSession: provenanceSessionId,
+              extractionMethod: "active",
+              extractionConfidence: importance,
+              decayFreezeUntil: decayFreezeUntil ?? undefined,
+              ...(supersedes?.trim() ? { validFrom: nowSec, supersedesId: supersedes.trim() } : {}),
+            },
+            { vectorCandidates: storeVectorCandidates, warnContext: "memory-store" },
+          );
           const entry = storeResult.entry;
           if (!storeResult.skipped && storeResult.newlyStored === false && !storeResult.embeddingStale) {
             if (walEntryId) await removeStoreWal(storeWal, walEntryId);

--- a/extensions/memory-hybrid/tools/memory/register-store-tools.ts
+++ b/extensions/memory-hybrid/tools/memory/register-store-tools.ts
@@ -1048,8 +1048,14 @@ export function registerStoreTools(runtime: MemoryToolRuntime): void {
           // Plumb vector neighbour candidates into write-time dedupe so the configured vectorThreshold
           // actually runs on the live store path instead of silently degrading to lexical-only (#2027).
           // Reuses the already-computed embedding; candidates are source/scope filtered.
+          //
+          // Skip when the caller passed an explicit `supersedes`: the intent is to replace a specific
+          // fact with this (usually near-identical) corrected text. Semantic vector dedupe would match
+          // the supersede target itself (cosine ≥ threshold), return skip, and drop the supersession —
+          // silently losing the update. An explicit supersede must always store, so we do not widen
+          // write-time fuzzy dedupe on that path (matches pre-#2027 behaviour for supersede writes).
           let storeVectorCandidates: ReadonlyArray<{ id: string; score: number }> | undefined;
-          if (cfg.store.fuzzyDedupe && vector) {
+          if (cfg.store.fuzzyDedupe && vector && !supersedes?.trim()) {
             const resolvedCandidates = await resolveWriteVectorCandidates({
               fuzzyDedupe: true,
               vector,

--- a/packages/openclaw-hybrid-memory-install/package.json
+++ b/packages/openclaw-hybrid-memory-install/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-hybrid-memory-install",
-  "version": "2026.7.33",
+  "version": "2026.7.50",
   "description": "Standalone installer for openclaw-hybrid-memory. Use when OpenClaw config validation fails.",
   "bin": {
     "openclaw-hybrid-memory-install": "./install.js"


### PR DESCRIPTION
## Summary

Combined root-cause fixes for the six open maintenance-pipeline issues, each paired with a code-review pass of the surrounding feature. An adversarial review of the diff surfaced one regression and one hardening item, both now fixed in-branch.

Closes #2024
Closes #2025
Closes #2026
Closes #2027
Closes #2028
Closes #2029

### #2024 — distill partial failure exposed no root cause
The distill batch loop swallowed the underlying LLM/API/context error and only propagated `partialFailure`.
- Capture the first concrete batch-failure reason (error kind + model + message, or maintenance-deadline / context-overflow) in `runDistillForCli`, propagated via `DistillCliResult.batchFailureReason`, persisted into the job-run `semanticReason`, and folded into the distill step-runner throw so health/ledger state points at the real failure.
- Sanitize `buildJobRunId` fingerprints so run ids can no longer be malformed like `job-distill-::14:fal`. Cap stays at 8 chars so purely-alphanumeric hash fingerprints remain byte-identical across upgrade (preserves batch/self-correction checkpoint dirs).

### #2025 — `analyze-maintenance-logs` false-positive `orchestration-missing-exit-ledger`
Aggregate `<job>.cron.log` files never have a sibling `.exit.txt`; each run records an `HM_RUN_SUMMARY` line pointing at its own per-run ledger.
- Parse those summaries (`parseCronAggregateRuns`) and validate each in-window run's `exit=` path. Suppress the anomaly when the ledger exists; when genuinely missing, flag the specific run pegged to its run id/timestamp.

### #2026 — `maintenance full --verbose` ran CPU-active but log-silent
- Wrap each orchestrator step in a heartbeat emitting `start` / `still running after Ns` / `complete`. These advance the wrapper-log mtime and match the analyzer's progress regexes (broadened for the generic `maintenance-orchestrator:` marker), so a live CPU/LLM-bound step is classified as running instead of stale/hung.

### #2027 — store dedupe `vectorThreshold` set but candidates never plumbed
- Add source/scope-filtered write-time candidate resolvers (`filterWriteVectorCandidates` / `resolveWriteVectorCandidates`) and wire them into the live `memory_store` path using the already-computed embedding, so the configured `vectorThreshold` actually runs at write time instead of silently degrading to lexical-only.
- **Review fix:** skip write-time vector dedupe when an explicit `supersedes` is provided, so a near-identical correction can no longer be swallowed as a dedupe no-op that drops the supersession.

### #2028 — targeted single-step execution
- Add `openclaw hybrid-mem maintenance step <name>` which runs exactly one named maintenance step in isolation (`include=[step]` across both tiers, force so the cadence guard doesn't skip it). Named `step` to avoid colliding with the existing `maintenance run` JobRun-inspection group and the `steps` list command.
- Unknown step names exit non-zero and print the valid step list; `--verbose` and `--json` inherit the shared orchestrator options.

### #2029 — distill progress/heartbeat
- Add a testable `startDistillProgress` reporter that emits a start marker, a periodic block-count heartbeat (30s), and a final status/counter summary during verbose distill runs, so a long LLM-bound batch is distinguishable from a hung one. Only counts/status are logged — never raw fact text. Concrete partial-failure cause is surfaced via #2024's `batchFailureReason`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality) — `maintenance step <name>`, distill progress
- [ ] Breaking change
- [ ] Refactor / internal improvement (no behavior change)
- [ ] Documentation update
- [ ] CI / tooling change

## Quality Checklist

- [x] `cd extensions/memory-hybrid && npx tsc --noEmit` passes with no errors
- [ ] `cd extensions/memory-hybrid && npm run lint` — only pre-existing unused-destructure warnings remain; none introduced by this change
- [x] `cd extensions/memory-hybrid && npm test` — 8603 passing; the 3 failing suites (`crystallization-proposer`, `implicit-feedback-routing`, `memory-recall-timeline`) fail identically on the base branch and are unrelated
- [x] No secrets, credentials, or API keys committed
- [x] No `console.log` debug statements left in production code

## Documentation Impact (REQUIRED)

- [x] Inline code comments (JSDoc) updated for modified functions and types
- [ ] `docs/` / `README.md` — no user-facing doc surface changed; new command self-documents via `--help` and points to `maintenance steps`
- [x] Cross-referenced functions/services checked for outdated documentation

## Testing

- [x] Unit tests added / updated (distill progress reporter, `maintenance step` valid/invalid, aggregate cron-log analysis, write-vector-dedupe, buildJobRunId)
- [x] Integration tests added / updated (orchestrator heartbeat, single-step orchestrator isolation)
- [ ] Manually verified against a running OpenClaw instance

## Notes for Reviewer

- Adversarial review findings that were applied: (1) explicit `supersedes` no longer swallowed by the new vector dedupe (#2027); (2) `buildJobRunId` kept at an 8-char cap so hash-fingerprinted checkpoints stay stable across upgrade (#2024).
- `maintenance step` is a thin wrapper over the orchestrator's existing `include` filter (already unit-tested); the CLI test covers invalid-step handling and a dedicated orchestrator test covers single-step isolation.
- Pre-existing base-branch test failures were confirmed by stashing this branch's changes and re-running the three suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LXcm71MaXfnKQjevZNvvmC