### PR TITLE
fix: resolve maintenance orchestrator issues #2031-#2033, bump to 2026.7.51

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ---
 
+## [2026.7.51] - 2026-07-05
+
+### Fixed
+
+- **`maintenance step <name> --force` no longer exits 0 when the selected step didn't run (#2031):** a targeted step blocked by a lock, feature gate, or dependency reported `skipped_guard`/`skipped_gate`/`skipped_dep` while still exiting 0, so a verification harness could believe a step had been tested when the orchestrator only skipped it. `maintenance step <name>` now exits non-zero when the selected step didn't execute (pass `--allow-skip` to treat this as a non-strict status check), and the lock-skip summary now includes the lock owner's pid, hostname, hold duration, staleness, and lock path so an operator can tell a real concurrent run from an abandoned lock.
+- **`passive-observer --force` had no bounded runtime or mid-run progress (#2032):** a first-run backlog across many agents' sessions could keep a targeted `maintenance step passive-observer --force --verbose` run going for 12+ minutes with only generic `still running after Ns` heartbeats. `maintenance step <name>` now defaults `--max-runtime-min` to 15 (overridable) for these isolated diagnostic runs, passive-observer logs per-session phase/counter progress (`session N/M ... chunksProcessed=... factsStored=...`), and a run truncated by the maintenance-run deadline is now counted as an error instead of returning a silent "ok" that hides unprocessed sessions.
+- **`maintenance status` no longer claims "All maintenance jobs healthy" while log analysis is failing (#2033):** cron-cadence freshness and `analyze-maintenance-logs`'s strict findings were reported independently, so an operator could see a green `status` and miss a recent strict failure from the same window. `status` now folds in a 24h log-health check (via the same analyzer `analyze-maintenance-logs` already uses) and no longer prints the unconditional healthy line when strict findings exist; the text and `--json` output both distinguish scheduler freshness from log/semantic health. `status` also now lists any active/stale maintenance step locks, since those are exactly what would make a subsequent `maintenance step --force` report `skipped_guard`.
+
+### Changed
+
+- Bumped plugin, `openclaw.plugin.json`, and `openclaw-hybrid-memory-install` package versions to **2026.7.51**.
+
+---
+
 ## [2026.7.50] - 2026-07-05
 
 ### Fixed

--- a/extensions/memory-hybrid/cli/commands/manage/register-maintenance-health.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/register-maintenance-health.ts
@@ -1,18 +1,27 @@
 /**
  * Maintenance inventory, status, and cron-health subcommands (Issue #281).
  */
+import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
 import type { HybridMemoryConfig } from "../../../config.js";
+import { formatStepLockDetail, listActiveStepLocks } from "../../../services/cron-guard.js";
 import {
   collectMaintenanceInventory,
   renderMaintenanceInventoryMarkdown,
   renderMaintenanceInventoryText,
 } from "../../../services/maintenance-inventory.js";
+import {
+  collectMaintenanceSteps,
+  summarizeMaintenanceLogAnalysis,
+} from "../../../services/maintenance-log-analyzer.js";
+import { describeCronStoreLocation, readOpenClawCronStore } from "../../../services/openclaw-cron-store.js";
 import { formatTimestampUtcFromMs } from "../../../utils/dates.js";
-import { readOpenClawCronStore, describeCronStoreLocation } from "../../../services/openclaw-cron-store.js";
 import { type Chainable, relativeTime, withExit } from "../../shared.js";
+
+/** Lookback window for the log-health check folded into `maintenance status` (#2033). */
+const STATUS_LOG_HEALTH_SINCE = "24h";
 
 export function registerMaintenanceHealthCommands(maintenance: Chainable, cfg: HybridMemoryConfig): void {
   maintenance
@@ -48,8 +57,9 @@ export function registerMaintenanceHealthCommands(maintenance: Chainable, cfg: H
     .command("status")
     .description("Show maintenance cron job health: nightly cycle, weekly backup, and any reliability issues.")
     .option("--json", "Output as JSON")
+    .option("-v, --verbose", "Also show per-finding log-health detail and active/stale maintenance locks")
     .action(
-      withExit(async (opts?: { json?: boolean }) => {
+      withExit(async (opts?: { json?: boolean; verbose?: boolean }) => {
         const openclawDir = join(homedir(), ".openclaw");
         const staleThresholdMs = (cfg.maintenance?.cronReliability?.staleThresholdHours ?? 28) * 60 * 60 * 1000;
         const nightlyCronExpr = cfg.maintenance?.cronReliability?.nightlyCron ?? "0 3 * * *";
@@ -168,7 +178,29 @@ export function registerMaintenanceHealthCommands(maintenance: Chainable, cfg: H
 
         const issues = results.filter((r) => r.issue);
 
-        if (issues.length > 0) {
+        // Log health (#2033): scheduler cadence looking healthy must not imply the maintenance
+        // logs are clean — analyze-maintenance-logs can report strict findings for the same window
+        // even when cron cadence looks fine, and an operator who stops at `status` would miss it.
+        const logRoot = join(openclawDir, "logs", "cron-hybrid-mem");
+        let logHealth: { summary: string; strictFailed: boolean; findingsCount: number } | null = null;
+        if (existsSync(logRoot)) {
+          try {
+            const steps = collectMaintenanceSteps(logRoot, STATUS_LOG_HEALTH_SINCE);
+            logHealth = summarizeMaintenanceLogAnalysis(steps);
+          } catch {
+            // Best-effort — a log-analysis failure must not break the cron-freshness check below.
+            logHealth = null;
+          }
+        }
+
+        // Active/stale step locks (#2031): surfaces what `maintenance step <name> --force` would
+        // report as "locked by a concurrent maintenance run" instead of only discovering it there.
+        const locks = listActiveStepLocks(openclawDir);
+
+        const schedulerHealthy = issues.length === 0;
+        const logHealthy = !logHealth?.strictFailed;
+
+        if (issues.length > 0 || logHealth?.strictFailed) {
           process.exitCode = 1;
         }
 
@@ -176,9 +208,11 @@ export function registerMaintenanceHealthCommands(maintenance: Chainable, cfg: H
           console.log(
             JSON.stringify(
               {
-                ok: issues.length === 0,
+                ok: schedulerHealthy && logHealthy,
                 jobs: results,
                 issueCount: issues.length,
+                logHealth: logHealth ? { ...logHealth, since: STATUS_LOG_HEALTH_SINCE } : null,
+                locks,
               },
               null,
               2,
@@ -209,13 +243,37 @@ export function registerMaintenanceHealthCommands(maintenance: Chainable, cfg: H
         }
 
         console.log("");
-        if (issues.length === 0) {
-          console.log("✅ All maintenance jobs healthy.");
+        if (schedulerHealthy) {
+          console.log("✅ Scheduler freshness: all maintenance jobs healthy (cron cadence only).");
         } else {
-          console.log(`⚠️  ${issues.length} issue(s) detected. Run \`hybrid-mem verify --fix\` to repair.`);
+          console.log(`⚠️  ${issues.length} scheduler issue(s) detected. Run \`hybrid-mem verify --fix\` to repair.`);
           if (issues.some((r) => r.isMissing)) {
             console.log("   Missing jobs can be registered with: hybrid-mem install");
           }
+        }
+
+        if (logHealth?.strictFailed) {
+          console.log(
+            `⚠️  Log health: analyze-maintenance-logs reports strict findings in the last ${STATUS_LOG_HEALTH_SINCE} ` +
+              `(${logHealth.summary}). Run \`hybrid-mem maintenance step analyze-maintenance-logs --force --verbose\` for detail.`,
+          );
+        } else if (opts?.verbose) {
+          console.log(
+            logHealth
+              ? `✅ Log health: no strict findings in the last ${STATUS_LOG_HEALTH_SINCE} (${logHealth.summary}).`
+              : `ℹ️  Log health: unchecked (no logs found under ${logRoot}).`,
+          );
+        }
+
+        if (locks.length > 0) {
+          console.log("");
+          console.log(`🔒 Active/stale maintenance step locks (${locks.length}):`);
+          for (const lock of locks) {
+            console.log(`   step--${lock.stepName}  ${formatStepLockDetail(lock)}`);
+          }
+          console.log(
+            "   A lock here will make `maintenance step <name> --force` report skipped_guard until it clears.",
+          );
         }
       }),
     );

--- a/extensions/memory-hybrid/cli/commands/manage/register-maintenance-orchestrator.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/register-maintenance-orchestrator.ts
@@ -5,7 +5,7 @@
 import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
-import { atomicWriteFile } from "../../../utils/atomic-write.js";
+import { readStepGuardTimestampMs, stepGuardEligible } from "../../../services/cron-guard.js";
 import {
   effectiveCadenceLabel,
   formatMaintenanceSummary,
@@ -14,7 +14,7 @@ import {
   runMaintenanceOrchestrator,
   toOrchestratorRunSummary,
 } from "../../../services/maintenance-orchestrator.js";
-import { readStepGuardTimestampMs, stepGuardEligible } from "../../../services/cron-guard.js";
+import { atomicWriteFile } from "../../../utils/atomic-write.js";
 import { formatTimestampUtcFromMs } from "../../../utils/dates.js";
 import { type CommanderOptsParent, readHybridMemVerbose } from "../../global-verbose.js";
 import { type Chainable, withExit } from "../../shared.js";
@@ -44,6 +44,7 @@ export function registerMaintenanceOrchestratorCommands(maintenance: Chainable, 
       maxRuntimeMin?: string;
       json?: boolean;
       summaryOut?: string;
+      allowSkip?: boolean;
     },
   ) => {
     const verbose = !!opts?.verbose;
@@ -109,6 +110,28 @@ export function registerMaintenanceOrchestratorCommands(maintenance: Chainable, 
       for (const line of lines) console.log(line);
     }
     if (result.exitCode !== 0) process.exitCode = result.exitCode;
+
+    // An explicit, forced --include run (whether via the dedicated `step <name>` command or
+    // `cycle`/`nightly`/`full --include x,y --force`) is a targeted "run this now and verify it"
+    // diagnostic — computeExitCode() treats "skipped" as benign because it's normal cadence-guard
+    // behavior in an ordinary full/nightly run, so it doesn't cover "the step(s) I explicitly asked
+    // for didn't execute" (#2031). Scoped to include+force so ordinary unforced --include automation
+    // (which can legitimately skip by cadence) keeps its existing exit-0-on-skip behavior.
+    const includeNames = parseStepList(opts?.include);
+    if ((opts?.force || opts?.full) && includeNames?.length && !opts?.allowSkip) {
+      const selected = result.steps.filter((s) => includeNames.includes(s.name));
+      const didNotRun = selected.length > 0 && selected.every((s) => s.status.startsWith("skipped"));
+      if (didNotRun) {
+        console.error(
+          `maintenance ${result.tierLabel}: selected step(s) did not run ` +
+            `(${selected.map((s) => `${s.name}: ${s.status} — ${s.summary}`).join("; ")}). ` +
+            "Pass --allow-skip to treat this as a non-strict status check.",
+        );
+        if (!process.exitCode) process.exitCode = 3;
+      }
+    }
+
+    return result;
   };
 
   const commonOptions = (cmd: Chainable) =>
@@ -121,7 +144,11 @@ export function registerMaintenanceOrchestratorCommands(maintenance: Chainable, 
       .option("--exclude <steps>", "Comma-separated step names to skip")
       .option("--max-runtime-min <n>", "Optional time budget in minutes")
       .option("--json", "Emit orchestrator run summary as JSON")
-      .option("--summary-out <path>", "Write orchestrator run summary JSON to path");
+      .option("--summary-out <path>", "Write orchestrator run summary JSON to path")
+      .option(
+        "--allow-skip",
+        "With --include --force: exit 0 even if the selected step(s) didn't execute (locked/gated/guarded)",
+      );
 
   commonOptions(
     maintenance
@@ -158,34 +185,42 @@ export function registerMaintenanceOrchestratorCommands(maintenance: Chainable, 
 
   // `maintenance step <name>` runs exactly one named step in isolation (#2028). Named `step` (singular)
   // to avoid colliding with the `maintenance run` JobRun-inspection group and the `steps` list command.
+  //
+  // Bounded by default (#2032): this command is meant for isolated diagnostic/verification runs, so
+  // unlike cycle/nightly/full it caps runtime unless the operator overrides --max-runtime-min. Long
+  // CPU/LLM-bound steps (e.g. passive-observer scanning a large first-run backlog) already consult the
+  // orchestrator-wide deadline between sessions/chunks, so this cap actually bounds wall-clock time.
+  const DEFAULT_STEP_MAX_RUNTIME_MIN = "15";
+
   commonOptions(
     maintenance
       .command("step <step>")
       .description(
         "Run exactly one named maintenance step in isolation (bypasses that step's cadence guard). Use `maintenance steps` to list valid names.",
-      )
-      .action(
-        withExit(async (step: string, opts, cmd?: CommanderOptsParent) => {
-          const stepName = step?.trim();
-          const validNames = listMaintenanceSteps().map((s) => s.name);
-          if (!stepName || !validNames.includes(stepName)) {
-            console.error(`Unknown maintenance step: ${stepName || "(none)"}`);
-            console.error(`Valid steps (${validNames.length}):`);
-            for (const name of validNames) console.error(`  ${name}`);
-            process.exitCode = 1;
-            return;
-          }
-          // Force so the targeted step actually runs even if its cadence guard has not expired (this
-          // command is an explicit "run this step now" diagnostic). include=[step] across both tiers
-          // means the orchestrator executes ONLY that step and no unrelated stages (#2028).
-          await runTier(["cycle", "nightly"], {
-            ...opts,
-            include: stepName,
-            force: true,
-            verbose: !!opts?.verbose || readHybridMemVerbose(cmd),
-          });
-        }),
       ),
+  ).action(
+    withExit(async (step: string, opts, cmd?: CommanderOptsParent) => {
+      const stepName = step?.trim();
+      const validNames = listMaintenanceSteps().map((s) => s.name);
+      if (!stepName || !validNames.includes(stepName)) {
+        console.error(`Unknown maintenance step: ${stepName || "(none)"}`);
+        console.error(`Valid steps (${validNames.length}):`);
+        for (const name of validNames) console.error(`  ${name}`);
+        process.exitCode = 1;
+        return;
+      }
+      // Force so the targeted step actually runs even if its cadence guard has not expired (this
+      // command is an explicit "run this step now" diagnostic). include=[step] across both tiers
+      // means the orchestrator executes ONLY that step and no unrelated stages (#2028). runTier()
+      // itself checks whether this forced, explicitly-included step actually executed (#2031).
+      await runTier(["cycle", "nightly"], {
+        ...opts,
+        include: stepName,
+        force: true,
+        maxRuntimeMin: opts?.maxRuntimeMin ?? DEFAULT_STEP_MAX_RUNTIME_MIN,
+        verbose: !!opts?.verbose || readHybridMemVerbose(cmd),
+      });
+    }),
   );
 
   maintenance

--- a/extensions/memory-hybrid/openclaw.plugin.json
+++ b/extensions/memory-hybrid/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "openclaw-hybrid-memory",
   "kind": "memory",
-  "version": "2026.7.50",
+  "version": "2026.7.51",
   "contracts": {
     "tools": [
       "active_task_checkpoint",

--- a/extensions/memory-hybrid/package-lock.json
+++ b/extensions/memory-hybrid/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openclaw-hybrid-memory",
-  "version": "2026.7.50",
+  "version": "2026.7.51",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openclaw-hybrid-memory",
-      "version": "2026.7.50",
+      "version": "2026.7.51",
       "hasInstallScript": true,
       "dependencies": {
         "@lancedb/lancedb": "^0.30.0",

--- a/extensions/memory-hybrid/package.json
+++ b/extensions/memory-hybrid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-hybrid-memory",
-  "version": "2026.7.50",
+  "version": "2026.7.51",
   "type": "module",
   "description": "Give your OpenClaw agent lasting memory: structured facts, semantic search, auto-capture & recall, decay, optional credential vault. Part of Hybrid Memory v3.",
   "files": [

--- a/extensions/memory-hybrid/services/cron-guard.ts
+++ b/extensions/memory-hybrid/services/cron-guard.ts
@@ -19,8 +19,8 @@
  *   runner processes the queue on startup.
  */
 
-import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
-import { homedir } from "node:os";
+import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { homedir, hostname as osHostname } from "node:os";
 import { join } from "node:path";
 
 import { readOpenClawCronStore, writeOpenClawCronStore } from "./openclaw-cron-store.js";
@@ -64,6 +64,42 @@ function getStepLockFilePath(stepName: string, openclawDir?: string): string {
 /** Lock files older than this are treated as abandoned by a crashed process, not a live run. */
 export const STEP_LOCK_STALE_MS = 30 * 60 * 1000;
 
+interface StepLockPayload {
+  lockedAtMs: number;
+  pid?: number;
+  hostname?: string;
+}
+
+/** Owner metadata for a lock file this process is about to (re)write (#2031). */
+function serializeLockPayload(nowMs: number): string {
+  return JSON.stringify({ lockedAtMs: nowMs, pid: process.pid, hostname: osHostname() } satisfies StepLockPayload);
+}
+
+/**
+ * Parse a lock file's contents. Accepts the current JSON payload as well as the legacy bare
+ * epoch-ms number written by pre-#2031 versions, so an in-place upgrade with a live lock file
+ * from the old format doesn't get misread as corrupt.
+ */
+function parseLockPayload(raw: string): StepLockPayload | null {
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  if (/^\d+$/.test(trimmed)) {
+    const lockedAtMs = Number(trimmed);
+    return Number.isFinite(lockedAtMs) ? { lockedAtMs } : null;
+  }
+  try {
+    const parsed = JSON.parse(trimmed) as Partial<StepLockPayload>;
+    if (typeof parsed.lockedAtMs !== "number" || !Number.isFinite(parsed.lockedAtMs)) return null;
+    return {
+      lockedAtMs: parsed.lockedAtMs,
+      pid: typeof parsed.pid === "number" ? parsed.pid : undefined,
+      hostname: typeof parsed.hostname === "string" ? parsed.hostname : undefined,
+    };
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Acquire a real cross-process/cross-invocation lock for a maintenance step, so two orchestrator
  * runs starting near-simultaneously (a manual CLI run overlapping the gateway's own tick, or a
@@ -80,15 +116,15 @@ export function acquireStepLock(stepName: string, openclawDir?: string, nowMs = 
   mkdirSync(guardDir, { recursive: true });
   const lockPath = getStepLockFilePath(stepName, openclawDir);
   try {
-    writeFileSync(lockPath, String(nowMs), { encoding: "utf-8", flag: "wx" });
+    writeFileSync(lockPath, serializeLockPayload(nowMs), { encoding: "utf-8", flag: "wx" });
     return true;
   } catch {
     // Lock file already exists — check whether it's stale (abandoned by a crashed process).
     try {
-      const raw = readFileSync(lockPath, "utf-8").trim();
-      const lockedAtMs = Number(raw);
-      if (!Number.isFinite(lockedAtMs) || nowMs - lockedAtMs <= STEP_LOCK_STALE_MS) {
-        return false; // held by a live (or recent) run
+      const raw = readFileSync(lockPath, "utf-8");
+      const payload = parseLockPayload(raw);
+      if (!payload || nowMs - payload.lockedAtMs <= STEP_LOCK_STALE_MS) {
+        return false; // held by a live (or recent) run, or unreadable — fail closed
       }
     } catch {
       return false; // couldn't read the lock file — fail closed, don't run concurrently
@@ -97,7 +133,7 @@ export function acquireStepLock(stepName: string, openclawDir?: string, nowMs = 
     // failed `wx` above and this write), but the window is a single fs call and the consequence
     // of losing that race is a harmless re-run of an idempotent step, not corruption.
     try {
-      writeFileSync(lockPath, String(nowMs), "utf-8");
+      writeFileSync(lockPath, serializeLockPayload(nowMs), "utf-8");
       return true;
     } catch {
       return false;
@@ -111,6 +147,71 @@ export function releaseStepLock(stepName: string, openclawDir?: string): void {
   } catch {
     /* non-fatal — worst case a stale lock sits until STEP_LOCK_STALE_MS passes */
   }
+}
+
+export interface StepLockInfo {
+  stepName: string;
+  lockPath: string;
+  lockedAtMs: number;
+  ageMs: number;
+  pid?: number;
+  hostname?: string;
+  stale: boolean;
+}
+
+/** Read a single step's lock metadata, if a lock file is currently present (#2031). */
+export function readStepLockInfo(stepName: string, openclawDir?: string, nowMs = Date.now()): StepLockInfo | null {
+  const lockPath = getStepLockFilePath(stepName, openclawDir);
+  if (!existsSync(lockPath)) return null;
+  try {
+    const payload = parseLockPayload(readFileSync(lockPath, "utf-8"));
+    if (!payload) return null;
+    const ageMs = Math.max(0, nowMs - payload.lockedAtMs);
+    return {
+      stepName,
+      lockPath,
+      lockedAtMs: payload.lockedAtMs,
+      ageMs,
+      pid: payload.pid,
+      hostname: payload.hostname,
+      stale: ageMs > STEP_LOCK_STALE_MS,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * List every step lock file currently present under the guard dir, live or stale (#2031/#2033).
+ * Used by `maintenance status --verbose` to surface a lock that would block `maintenance step --force`
+ * instead of leaving operators to discover it only when a targeted run reports `skipped_guard`.
+ */
+export function listActiveStepLocks(openclawDir?: string, nowMs = Date.now()): StepLockInfo[] {
+  const guardDir = getGuardDir(openclawDir);
+  if (!existsSync(guardDir)) return [];
+  let entries: string[];
+  try {
+    entries = readdirSync(guardDir);
+  } catch {
+    return [];
+  }
+  const locks: StepLockInfo[] = [];
+  for (const f of entries) {
+    if (!f.startsWith("step--") || !f.endsWith(".lock")) continue;
+    const stepName = f.slice("step--".length, -".lock".length);
+    const info = readStepLockInfo(stepName, openclawDir, nowMs);
+    if (info) locks.push(info);
+  }
+  return locks;
+}
+
+/**
+ * Single canonical rendering of lock owner metadata, shared by the orchestrator's `skipped_guard`
+ * summary and `maintenance status`'s lock listing so the two surfaces can't drift out of sync (#2031).
+ */
+export function formatStepLockDetail(info: StepLockInfo | null): string {
+  if (!info) return "lock metadata unavailable";
+  return `pid=${info.pid ?? "unknown"} host=${info.hostname ?? "unknown"} held=${Math.round(info.ageMs / 1000)}s stale=${info.stale} lock=${info.lockPath}`;
 }
 
 export function stepGuardEligible(

--- a/extensions/memory-hybrid/services/maintenance-orchestrator.ts
+++ b/extensions/memory-hybrid/services/maintenance-orchestrator.ts
@@ -3,8 +3,8 @@
  * Cycle tier: gateway-native tick. Nightly tier: consolidated cron + CLI.
  */
 
-import type { HybridMemoryConfig } from "../config.js";
 import type { DatabaseSync } from "node:sqlite";
+import type { HybridMemoryConfig } from "../config.js";
 import { nowIso } from "../utils/dates.js";
 import {
   clearMaintenanceRunDeadline,
@@ -13,21 +13,23 @@ import {
   setMaintenanceRunDeadlineMs,
 } from "../utils/maintenance-run-deadline.js";
 import { is429OrWrapped } from "./chat.js";
-import { generateOrchestratorRunId } from "./maintenance-job-run/orchestrator-summary.js";
+import {
+  acquireStepLock,
+  formatStepLockDetail,
+  readStepGuardTimestampMs,
+  readStepLockInfo,
+  releaseStepLock,
+  stepGuardEligible,
+  writeStepGuardTimestampMs,
+} from "./cron-guard.js";
 import { recordMaintenanceStepRun } from "./maintenance-audit-journal.js";
+import { generateOrchestratorRunId } from "./maintenance-job-run/orchestrator-summary.js";
 import {
   parseSemanticTokenFromSummary,
   reflectRulesStepSummaryIndicatesFailure,
   semanticOutcomeBlocksOrchestratorGuard,
 } from "./maintenance-job-run/semantic-outcome.js";
 import type { JobRunSemanticOutcome } from "./maintenance-job-run/types.js";
-import {
-  acquireStepLock,
-  readStepGuardTimestampMs,
-  releaseStepLock,
-  stepGuardEligible,
-  writeStepGuardTimestampMs,
-} from "./cron-guard.js";
 
 export type StepTier = "cycle" | "nightly";
 export type StepLlmTier = "none" | "nano" | "maintenance" | "default" | "heavy" | "embed" | "local";
@@ -559,111 +561,52 @@ export async function runMaintenanceOrchestrator(
 
   setMaintenanceRunDeadlineMs(runDeadlineMs);
   try {
-  for (const step of steps) {
-    if (maxRuntimeMs !== undefined && Date.now() - startedAtMs >= maxRuntimeMs) {
-      pushStepResult({
-        name: step.name,
-        status: "deferred",
-        summary: "time budget exceeded",
-        durationMs: 0,
-      });
-      continue;
-    }
-
-    if (step.featureGate && !step.featureGate(cfg)) {
-      pushStepResult({
-        name: step.name,
-        status: "skipped_gate",
-        summary: "feature disabled",
-        durationMs: 0,
-      });
-      continue;
-    }
-
-    if (step.oneTimeMarkerPath && ctx.oneTimeMarkerExists?.(step.oneTimeMarkerPath)) {
-      pushStepResult({
-        name: step.name,
-        status: "skipped_guard",
-        summary: "one-time marker exists",
-        durationMs: 0,
-      });
-      continue;
-    }
-
-    if (!dependenciesMet(step, completedThisRun, openclawDir)) {
-      pushStepResult({
-        name: step.name,
-        status: "skipped_dep",
-        summary: `waiting for ${step.dependsOn?.join(", ")} in this run`,
-        durationMs: 0,
-      });
-      continue;
-    }
-
-    const guardMs = resolveStepGuardIntervalMs(step, cfg);
-    if (!options.force && guardMs > 0) {
-      const guard = stepGuardEligible(step.name, guardMs, openclawDir);
-      if (!guard.eligible) {
-        const agoH = guard.lastRunMs ? Math.round((Date.now() - guard.lastRunMs) / HOUR_MS) : 0;
+    for (const step of steps) {
+      if (maxRuntimeMs !== undefined && Date.now() - startedAtMs >= maxRuntimeMs) {
         pushStepResult({
           name: step.name,
-          status: "skipped_guard",
-          summary: `guard (ran ${agoH}h ago)`,
+          status: "deferred",
+          summary: "time budget exceeded",
           durationMs: 0,
         });
         continue;
       }
-    }
 
-    const runner = runners.get(step.name);
-    if (!runner) {
-      pushStepResult({
-        name: step.name,
-        status: "skipped_missing_runner",
-        summary: "no runner registered",
-        durationMs: 0,
-      });
-      continue;
-    }
-
-    if (deferRemainingLlm && isLlmProviderStep(step.llmTier)) {
-      pushStepResult({
-        name: step.name,
-        status: "deferred",
-        summary: "rate-limit circuit breaker",
-        durationMs: 0,
-      });
-      continue;
-    }
-
-    if (options.dryRun) {
-      pushStepResult({
-        name: step.name,
-        status: "ok",
-        summary: "dry-run (would execute)",
-        durationMs: 0,
-      });
-      completedThisRun.add(step.name);
-      continue;
-    }
-
-    if (lastWasLlmStep && isLlmProviderStep(step.llmTier) && llmCooldownMs > 0 && !maintenanceRunDeadlineReached()) {
-      const remaining = remainingMaintenanceRunMs();
-      const cooldownMs = Number.isFinite(remaining)
-        ? Math.min(llmCooldownMs, Math.max(0, Math.floor(remaining)))
-        : llmCooldownMs;
-      if (cooldownMs > 0) {
-        await sleep(cooldownMs);
+      if (step.featureGate && !step.featureGate(cfg)) {
+        pushStepResult({
+          name: step.name,
+          status: "skipped_gate",
+          summary: "feature disabled",
+          durationMs: 0,
+        });
+        continue;
       }
-      // Re-check eligibility after the cooldown sleep: another process (a manual CLI run, or a
-      // double-fired cron trigger) could have run and completed this step entirely inside the
-      // sleep window. acquireStepLock below only prevents *concurrent* execution — it does
-      // nothing to stop this process from re-running a step that already finished sequentially
-      // just before it woke up, since the lock is free again by the time it wakes.
+
+      if (step.oneTimeMarkerPath && ctx.oneTimeMarkerExists?.(step.oneTimeMarkerPath)) {
+        pushStepResult({
+          name: step.name,
+          status: "skipped_guard",
+          summary: "one-time marker exists",
+          durationMs: 0,
+        });
+        continue;
+      }
+
+      if (!dependenciesMet(step, completedThisRun, openclawDir)) {
+        pushStepResult({
+          name: step.name,
+          status: "skipped_dep",
+          summary: `waiting for ${step.dependsOn?.join(", ")} in this run`,
+          durationMs: 0,
+        });
+        continue;
+      }
+
+      const guardMs = resolveStepGuardIntervalMs(step, cfg);
       if (!options.force && guardMs > 0) {
-        const recheck = stepGuardEligible(step.name, guardMs, openclawDir);
-        if (!recheck.eligible) {
-          const agoH = recheck.lastRunMs ? Math.round((Date.now() - recheck.lastRunMs) / HOUR_MS) : 0;
+        const guard = stepGuardEligible(step.name, guardMs, openclawDir);
+        if (!guard.eligible) {
+          const agoH = guard.lastRunMs ? Math.round((Date.now() - guard.lastRunMs) / HOUR_MS) : 0;
           pushStepResult({
             name: step.name,
             status: "skipped_guard",
@@ -673,118 +616,182 @@ export async function runMaintenanceOrchestrator(
           continue;
         }
       }
-    }
 
-    // Real cross-process mutex on top of stepGuardEligible's cadence-only check above — prevents
-    // two orchestrator invocations that start near-simultaneously (a manual CLI run overlapping
-    // the gateway's own tick, or a double-fired cron trigger) from executing the same step
-    // concurrently (duplicate LLM calls, duplicate decay/prune passes).
-    if (!acquireStepLock(step.name, openclawDir)) {
-      pushStepResult({
-        name: step.name,
-        status: "skipped_guard",
-        summary: "locked by a concurrent maintenance run",
-        durationMs: 0,
-      });
-      continue;
-    }
-
-    const stepStarted = Date.now();
-    try {
-      const summary = await runStepWithHeartbeat(step.name, options.verbose !== false, logger, () => runner());
-      const meta = parseStepRunnerMetadata(summary);
-      if (step.name === "reflect-rules" && reflectRulesStepSummaryIndicatesFailure(summary)) {
-        logger?.warn?.(`maintenance-orchestrator: ${step.name} semantic failure (summary diagnostics): ${summary}`);
+      const runner = runners.get(step.name);
+      if (!runner) {
         pushStepResult({
           name: step.name,
-          status: "failed",
-          summary,
-          durationMs: Date.now() - stepStarted,
-          ...meta,
-          semanticOutcome: meta.semanticOutcome ?? "failed",
+          status: "skipped_missing_runner",
+          summary: "no runner registered",
+          durationMs: 0,
         });
-        lastWasLlmStep = isLlmProviderStep(step.llmTier);
         continue;
       }
-      if (stepSemanticBlocksGuard(meta.semanticOutcome)) {
-        logger?.warn?.(`maintenance-orchestrator: ${step.name} semantic failure (${meta.semanticOutcome}): ${summary}`);
+
+      if (deferRemainingLlm && isLlmProviderStep(step.llmTier)) {
         pushStepResult({
           name: step.name,
-          status: "failed",
-          summary,
-          durationMs: Date.now() - stepStarted,
-          ...meta,
+          status: "deferred",
+          summary: "rate-limit circuit breaker",
+          durationMs: 0,
         });
-        lastWasLlmStep = isLlmProviderStep(step.llmTier);
         continue;
       }
-      if (!options.dryRun && guardMs >= 0) {
-        writeStepGuardTimestampMs(step.name, Date.now(), openclawDir);
+
+      if (options.dryRun) {
+        pushStepResult({
+          name: step.name,
+          status: "ok",
+          summary: "dry-run (would execute)",
+          durationMs: 0,
+        });
+        completedThisRun.add(step.name);
+        continue;
       }
-      pushStepResult({
-        name: step.name,
-        status: "ok",
-        summary,
-        durationMs: Date.now() - stepStarted,
-        ...meta,
-      });
-      completedThisRun.add(step.name);
-      consecutiveRateLimitErrors = 0;
-      lastWasLlmStep = isLlmProviderStep(step.llmTier);
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      if (isRateLimitError(err)) {
-        consecutiveRateLimitErrors++;
-        if (consecutiveRateLimitErrors >= rateLimitMaxRetries) {
-          deferRemainingLlm = true;
+
+      if (lastWasLlmStep && isLlmProviderStep(step.llmTier) && llmCooldownMs > 0 && !maintenanceRunDeadlineReached()) {
+        const remaining = remainingMaintenanceRunMs();
+        const cooldownMs = Number.isFinite(remaining)
+          ? Math.min(llmCooldownMs, Math.max(0, Math.floor(remaining)))
+          : llmCooldownMs;
+        if (cooldownMs > 0) {
+          await sleep(cooldownMs);
         }
-        logger?.warn?.(`maintenance-orchestrator: ${step.name} rate-limited: ${message}`);
+        // Re-check eligibility after the cooldown sleep: another process (a manual CLI run, or a
+        // double-fired cron trigger) could have run and completed this step entirely inside the
+        // sleep window. acquireStepLock below only prevents *concurrent* execution — it does
+        // nothing to stop this process from re-running a step that already finished sequentially
+        // just before it woke up, since the lock is free again by the time it wakes.
+        if (!options.force && guardMs > 0) {
+          const recheck = stepGuardEligible(step.name, guardMs, openclawDir);
+          if (!recheck.eligible) {
+            const agoH = recheck.lastRunMs ? Math.round((Date.now() - recheck.lastRunMs) / HOUR_MS) : 0;
+            pushStepResult({
+              name: step.name,
+              status: "skipped_guard",
+              summary: `guard (ran ${agoH}h ago)`,
+              durationMs: 0,
+            });
+            continue;
+          }
+        }
+      }
+
+      // Real cross-process mutex on top of stepGuardEligible's cadence-only check above — prevents
+      // two orchestrator invocations that start near-simultaneously (a manual CLI run overlapping
+      // the gateway's own tick, or a double-fired cron trigger) from executing the same step
+      // concurrently (duplicate LLM calls, duplicate decay/prune passes).
+      if (!acquireStepLock(step.name, openclawDir)) {
+        // Surface enough lock metadata (owner pid/host, hold duration, lock path) for an operator to
+        // verify whether this is a real concurrent run or an abandoned lock (#2031).
+        const lockDetail = formatStepLockDetail(readStepLockInfo(step.name, openclawDir));
         pushStepResult({
           name: step.name,
-          status: "rate_limited",
-          summary: message,
-          durationMs: Date.now() - stepStarted,
+          status: "skipped_guard",
+          summary: `locked by a concurrent maintenance run (${lockDetail})`,
+          durationMs: 0,
         });
-      } else {
-        logger?.warn?.(`maintenance-orchestrator: ${step.name} failed: ${message}`);
-        const meta = parseStepRunnerMetadata(message);
+        continue;
+      }
+
+      const stepStarted = Date.now();
+      try {
+        const summary = await runStepWithHeartbeat(step.name, options.verbose !== false, logger, () => runner());
+        const meta = parseStepRunnerMetadata(summary);
+        if (step.name === "reflect-rules" && reflectRulesStepSummaryIndicatesFailure(summary)) {
+          logger?.warn?.(`maintenance-orchestrator: ${step.name} semantic failure (summary diagnostics): ${summary}`);
+          pushStepResult({
+            name: step.name,
+            status: "failed",
+            summary,
+            durationMs: Date.now() - stepStarted,
+            ...meta,
+            semanticOutcome: meta.semanticOutcome ?? "failed",
+          });
+          lastWasLlmStep = isLlmProviderStep(step.llmTier);
+          continue;
+        }
+        if (stepSemanticBlocksGuard(meta.semanticOutcome)) {
+          logger?.warn?.(
+            `maintenance-orchestrator: ${step.name} semantic failure (${meta.semanticOutcome}): ${summary}`,
+          );
+          pushStepResult({
+            name: step.name,
+            status: "failed",
+            summary,
+            durationMs: Date.now() - stepStarted,
+            ...meta,
+          });
+          lastWasLlmStep = isLlmProviderStep(step.llmTier);
+          continue;
+        }
+        if (!options.dryRun && guardMs >= 0) {
+          writeStepGuardTimestampMs(step.name, Date.now(), openclawDir);
+        }
         pushStepResult({
           name: step.name,
-          status: "failed",
-          summary: message,
+          status: "ok",
+          summary,
           durationMs: Date.now() - stepStarted,
           ...meta,
         });
+        completedThisRun.add(step.name);
+        consecutiveRateLimitErrors = 0;
+        lastWasLlmStep = isLlmProviderStep(step.llmTier);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        if (isRateLimitError(err)) {
+          consecutiveRateLimitErrors++;
+          if (consecutiveRateLimitErrors >= rateLimitMaxRetries) {
+            deferRemainingLlm = true;
+          }
+          logger?.warn?.(`maintenance-orchestrator: ${step.name} rate-limited: ${message}`);
+          pushStepResult({
+            name: step.name,
+            status: "rate_limited",
+            summary: message,
+            durationMs: Date.now() - stepStarted,
+          });
+        } else {
+          logger?.warn?.(`maintenance-orchestrator: ${step.name} failed: ${message}`);
+          const meta = parseStepRunnerMetadata(message);
+          pushStepResult({
+            name: step.name,
+            status: "failed",
+            summary: message,
+            durationMs: Date.now() - stepStarted,
+            ...meta,
+          });
+        }
+        lastWasLlmStep = isLlmProviderStep(step.llmTier);
+      } finally {
+        releaseStepLock(step.name, openclawDir);
       }
-      lastWasLlmStep = isLlmProviderStep(step.llmTier);
-    } finally {
-      releaseStepLock(step.name, openclawDir);
     }
-  }
 
-  const { summaryLine, lines } = formatMaintenanceSummary(tierLabel, results);
-  if (options.verbose !== false) {
-    logger?.info?.(summaryLine);
-    for (const line of lines) logger?.info?.(line);
-  }
+    const { summaryLine, lines } = formatMaintenanceSummary(tierLabel, results);
+    if (options.verbose !== false) {
+      logger?.info?.(summaryLine);
+      for (const line of lines) logger?.info?.(line);
+    }
 
-  const finishedAt = nowIso();
-  return {
-    tierLabel,
-    steps: results,
-    exitCode: computeExitCode(results),
-    summaryLine,
-    runId,
-    startedAt: startedAtIso,
-    finishedAt,
-    durationMs: Date.now() - startedAtMs,
-  };
+    const finishedAt = nowIso();
+    return {
+      tierLabel,
+      steps: results,
+      exitCode: computeExitCode(results),
+      summaryLine,
+      runId,
+      startedAt: startedAtIso,
+      finishedAt,
+      durationMs: Date.now() - startedAtMs,
+    };
   } finally {
     clearMaintenanceRunDeadline();
   }
 }
 
-export { toOrchestratorRunSummary, generateOrchestratorRunId } from "./maintenance-job-run/orchestrator-summary.js";
+export { generateOrchestratorRunId, toOrchestratorRunSummary } from "./maintenance-job-run/orchestrator-summary.js";
 
 export async function runMaintenanceTiers(
   ctx: MaintenanceOrchestratorContext,

--- a/extensions/memory-hybrid/services/passive-observer.ts
+++ b/extensions/memory-hybrid/services/passive-observer.ts
@@ -21,28 +21,28 @@ import { categoryToEventType } from "../backends/event-log.js";
 import type { FactsDB } from "../backends/facts-db.js";
 import type { VectorDB } from "../backends/vector-db.js";
 import type { MemoryCategory, ReinforcementConfig } from "../config.js";
-import { fillPrompt, loadPrompt } from "../utils/prompt-loader.js";
-import { chunkTextByChars } from "../utils/text.js";
 import { nowIso } from "../utils/dates.js";
-import { LLMRetryError, chatCompleteWithRetry, resolveMaintenanceChatTimeoutMs } from "./chat.js";
-import { CostFeature } from "./cost-feature-labels.js";
-import type { EmbeddingProvider } from "./embeddings.js";
-import { shouldSuppressEmbeddingError } from "./embeddings.js";
-import { capturePluginError } from "./error-reporter.js";
 import {
   capTimeoutByMaintenanceRunDeadline,
   getMaintenanceRunAbortSignal,
   maintenanceRunDeadlineReached,
 } from "../utils/maintenance-run-deadline.js";
+import { fillPrompt, loadPrompt } from "../utils/prompt-loader.js";
+import { chunkTextByChars } from "../utils/text.js";
+import { runCaptureStoreWithDedupWindow } from "./capture-dedup.js";
+import { chatCompleteWithRetry, LLMRetryError, resolveMaintenanceChatTimeoutMs } from "./chat.js";
+import { CostFeature } from "./cost-feature-labels.js";
+import type { EmbeddingProvider } from "./embeddings.js";
+import { shouldSuppressEmbeddingError } from "./embeddings.js";
+import { capturePluginError } from "./error-reporter.js";
+import type { ProvenanceService } from "./provenance.js";
 import {
   isSubstantiveMemoryText,
   prepareMemoryMetadataForStorage,
   prepareMemoryTextForStorage,
 } from "./recalled-context-assembler.js";
-import type { ProvenanceService } from "./provenance.js";
-import { cleanupEvictedVector } from "./vector-maintenance.js";
-import { runCaptureStoreWithDedupWindow } from "./capture-dedup.js";
 import { dotProductSimilarity, normalizeVector } from "./reflection.js";
+import { cleanupEvictedVector } from "./vector-maintenance.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -491,12 +491,24 @@ export async function runPassiveObserver(
   // ---------------------------------------------------------------------------
   // Phase 3: process each session that has new content.
   // ---------------------------------------------------------------------------
-  for (const { filePath, sessionId, fileBytelen, cursor } of sessions) {
+  for (const [sessionIdx, { filePath, sessionId, fileBytelen, cursor }] of sessions.entries()) {
     if (maintenanceRunDeadlineReached()) {
-      logger.warn("memory-hybrid: passive-observer — maintenance run deadline reached; stopping session scan");
+      // Deadline stops mid-run are counted as an error so the caller's summary (and
+      // assertPassiveObserverSummaryDoesNotBlock) surface a truncated run as a failure
+      // instead of a silent "ok" that hides unprocessed sessions (#2032).
+      result.errors++;
+      logger.warn(
+        "memory-hybrid: passive-observer — maintenance run deadline reached; stopping session scan " +
+          `(processed ${sessionIdx}/${sessions.length} sessions, sessionsScanned=${result.sessionsScanned}, ` +
+          `chunksProcessed=${result.chunksProcessed}, factsStored=${result.factsStored})`,
+      );
       break;
     }
     if (cursor >= fileBytelen) continue; // Nothing new
+    logger.info(
+      `memory-hybrid: passive-observer — progress: session ${sessionIdx + 1}/${sessions.length} (${sessionId}) ` +
+        `chunksProcessed=${result.chunksProcessed} factsExtracted=${result.factsExtracted} factsStored=${result.factsStored}`,
+    );
 
     let rawBuf: Buffer;
     let segmentEnd = fileBytelen;
@@ -771,28 +783,24 @@ export async function runPassiveObserver(
           scopeTarget: dedupScopeTarget,
         };
 
-        const txResult = runCaptureStoreWithDedupWindow(
-          factsDb,
-          dedupWindow,
-          dedupInput,
-          () =>
-            factsDb.storeWithResult({
-              text: storedText,
-              category: storedCategory,
-              importance: identity ? Math.max(fact.importance, 0.9) : fact.importance,
-              confidence: 0.6,
-              entity: null,
-              key: null,
-              value: null,
-              source: "passive-observer",
-              decayClass: identity ? "permanent" : "session",
-              scope: identity ? "global" : "session",
-              scopeTarget: identity ? undefined : sessionId,
-              tags: ["passive-observer"],
-              provenanceSession: sessionId,
-              extractionMethod: "passive",
-              extractionConfidence: fact.importance,
-            }),
+        const txResult = runCaptureStoreWithDedupWindow(factsDb, dedupWindow, dedupInput, () =>
+          factsDb.storeWithResult({
+            text: storedText,
+            category: storedCategory,
+            importance: identity ? Math.max(fact.importance, 0.9) : fact.importance,
+            confidence: 0.6,
+            entity: null,
+            key: null,
+            value: null,
+            source: "passive-observer",
+            decayClass: identity ? "permanent" : "session",
+            scope: identity ? "global" : "session",
+            scopeTarget: identity ? undefined : sessionId,
+            tags: ["passive-observer"],
+            provenanceSession: sessionId,
+            extractionMethod: "passive",
+            extractionConfidence: fact.importance,
+          }),
         );
         if (txResult.skipped) {
           continue;

--- a/extensions/memory-hybrid/tests/cron-guard.test.ts
+++ b/extensions/memory-hybrid/tests/cron-guard.test.ts
@@ -1,10 +1,15 @@
-import { mkdtempSync, rmSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { hostname, tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
+  acquireStepLock,
   getStepGuardFilePath,
+  listActiveStepLocks,
   readStepGuardTimestampMs,
+  readStepLockInfo,
+  releaseStepLock,
+  STEP_LOCK_STALE_MS,
   stepGuardEligible,
   writeStepGuardTimestampMs,
 } from "../services/cron-guard.js";
@@ -52,5 +57,71 @@ describe("cron-guard step helpers (#1934)", () => {
     openclawDir = mkdtempSync(join(tmpdir(), "hm-guard-"));
     writeStepGuardTimestampMs("test-step", Date.now(), openclawDir);
     expect(stepGuardEligible("test-step", 0, openclawDir).eligible).toBe(true);
+  });
+});
+
+describe("cron-guard step lock owner metadata (#2031)", () => {
+  let openclawDir: string;
+
+  afterEach(() => {
+    if (openclawDir) rmSync(openclawDir, { recursive: true, force: true });
+  });
+
+  it("acquireStepLock records pid/hostname, readable via readStepLockInfo", () => {
+    openclawDir = mkdtempSync(join(tmpdir(), "hm-guard-"));
+    const now = Date.now();
+    expect(acquireStepLock("distill", openclawDir, now)).toBe(true);
+
+    const info = readStepLockInfo("distill", openclawDir, now + 5_000);
+    expect(info).not.toBeNull();
+    expect(info?.pid).toBe(process.pid);
+    expect(info?.hostname).toBe(hostname());
+    expect(info?.lockedAtMs).toBe(now);
+    expect(info?.ageMs).toBe(5_000);
+    expect(info?.stale).toBe(false);
+  });
+
+  it("readStepLockInfo returns null when no lock file exists", () => {
+    openclawDir = mkdtempSync(join(tmpdir(), "hm-guard-"));
+    expect(readStepLockInfo("distill", openclawDir)).toBeNull();
+  });
+
+  it("readStepLockInfo tolerates the legacy bare-epoch-ms lock format from pre-#2031 versions", () => {
+    openclawDir = mkdtempSync(join(tmpdir(), "hm-guard-"));
+    const now = Date.now();
+    // Pre-upgrade code wrote just the epoch-ms number, no JSON envelope.
+    expect(acquireStepLock("distill", openclawDir, now)).toBe(true);
+    writeFileSync(join(openclawDir, "cron", "guard", "step--distill.lock"), String(now), "utf-8");
+
+    const info = readStepLockInfo("distill", openclawDir, now + 1_000);
+    expect(info?.lockedAtMs).toBe(now);
+    expect(info?.pid).toBeUndefined();
+    expect(info?.hostname).toBeUndefined();
+  });
+
+  it("readStepLockInfo marks a lock older than STEP_LOCK_STALE_MS as stale", () => {
+    openclawDir = mkdtempSync(join(tmpdir(), "hm-guard-"));
+    const lockedAt = Date.now() - STEP_LOCK_STALE_MS - 1_000;
+    expect(acquireStepLock("distill", openclawDir, lockedAt)).toBe(true);
+
+    const info = readStepLockInfo("distill", openclawDir);
+    expect(info?.stale).toBe(true);
+  });
+
+  it("listActiveStepLocks lists every held step--*.lock file", () => {
+    openclawDir = mkdtempSync(join(tmpdir(), "hm-guard-"));
+    expect(acquireStepLock("distill", openclawDir)).toBe(true);
+    expect(acquireStepLock("passive-observer", openclawDir)).toBe(true);
+
+    const locks = listActiveStepLocks(openclawDir);
+    expect(locks.map((l) => l.stepName).sort()).toEqual(["distill", "passive-observer"]);
+
+    releaseStepLock("distill", openclawDir);
+    expect(listActiveStepLocks(openclawDir).map((l) => l.stepName)).toEqual(["passive-observer"]);
+  });
+
+  it("listActiveStepLocks returns an empty array when the guard dir doesn't exist", () => {
+    openclawDir = join(tmpdir(), `hm-guard-nonexistent-${Date.now()}`);
+    expect(listActiveStepLocks(openclawDir)).toEqual([]);
   });
 });

--- a/extensions/memory-hybrid/tests/maintenance-orchestrator.test.ts
+++ b/extensions/memory-hybrid/tests/maintenance-orchestrator.test.ts
@@ -1,5 +1,5 @@
 import { mkdtempSync, rmSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { hostname, tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
@@ -7,7 +7,7 @@ import {
   runMaintenanceOrchestrator,
   toOrchestratorRunSummary,
 } from "../services/maintenance-orchestrator.js";
-import { readStepGuardTimestampMs, writeStepGuardTimestampMs } from "../services/cron-guard.js";
+import { acquireStepLock, readStepGuardTimestampMs, writeStepGuardTimestampMs } from "../services/cron-guard.js";
 import type { HybridMemoryConfig } from "../config.js";
 
 function minimalCfg(): HybridMemoryConfig {
@@ -38,6 +38,24 @@ describe("maintenance-orchestrator", () => {
     const prune = result.steps.find((s) => s.name === "prune");
     expect(prune?.status).toBe("skipped_guard");
     expect(result.exitCode).toBe(0);
+  });
+
+  it("surfaces lock owner metadata (pid/host/held) in the skipped_guard summary when a step is locked (#2031)", async () => {
+    openclawDir = mkdtempSync(join(tmpdir(), "hm-orch-"));
+    expect(acquireStepLock("prune", openclawDir)).toBe(true);
+    const runners = new Map<string, () => Promise<string>>([["prune", async () => "ok"]]);
+
+    const result = await runMaintenanceOrchestrator(
+      { cfg: minimalCfg(), runners, openclawDir },
+      { tiers: ["cycle"], verbose: false, include: ["prune"], force: true },
+    );
+
+    const prune = result.steps.find((s) => s.name === "prune");
+    expect(prune?.status).toBe("skipped_guard");
+    expect(prune?.summary).toContain("locked by a concurrent maintenance run");
+    expect(prune?.summary).toMatch(/pid=\d+/);
+    expect(prune?.summary).toContain(`host=${hostname()}`);
+    expect(prune?.summary).toMatch(/held=\d+s/);
   });
 
   it("re-checks the step guard after the inter-LLM-step cooldown sleep, skipping a step a concurrent run just completed", async () => {

--- a/extensions/memory-hybrid/tests/passive-observer.test.ts
+++ b/extensions/memory-hybrid/tests/passive-observer.test.ts
@@ -24,6 +24,7 @@ import {
   runPassiveObserver,
   saveCursors,
 } from "../services/passive-observer.js";
+import { clearMaintenanceRunDeadline, setMaintenanceRunDeadlineMs } from "../utils/maintenance-run-deadline.js";
 
 /** Mock factsDb.storeWithResult wired to an optional store spy (passive-observer uses storeWithResult). */
 function mockFactsDbStore(overrides: Record<string, unknown> = {}) {
@@ -435,6 +436,37 @@ describe("runPassiveObserver", () => {
 
     expect(result.sessionsScanned).toBe(1);
     expect(result.chunksProcessed).toBe(0);
+  });
+
+  it("counts a run truncated by the maintenance run deadline as errored, not silently ok (#2032)", async () => {
+    writeFileSync(
+      join(sessionsDir, "session-1.jsonl"),
+      `${JSON.stringify({ message: { role: "user", content: "Hello, this session has new content." } })}\n`,
+    );
+
+    setMaintenanceRunDeadlineMs(Date.now() - 1);
+    try {
+      const cfg = makeConfig({ sessionsDir });
+      const logger = makeLogger();
+      const result = await runPassiveObserver(
+        makeFactsDb() as never,
+        makeVectorDb() as never,
+        makeEmbeddings() as never,
+        makeOpenAI(),
+        cfg,
+        ["fact"],
+        { model: "test-model", dbDir: tmpDir },
+        logger,
+      );
+
+      // A deadline-truncated run must be visible as an error, not returned as a clean "ok" that
+      // silently hides unprocessed sessions from the caller's summary/assertions.
+      expect(result.errors).toBeGreaterThan(0);
+      expect(result.chunksProcessed).toBe(0);
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("maintenance run deadline reached"));
+    } finally {
+      clearMaintenanceRunDeadline();
+    }
   });
 
   it("respects minImportance threshold — skips low-importance facts", async () => {

--- a/extensions/memory-hybrid/tests/register-maintenance-health-cli.test.ts
+++ b/extensions/memory-hybrid/tests/register-maintenance-health-cli.test.ts
@@ -111,3 +111,158 @@ describe("maintenance status / cron-health exit codes", () => {
     expect(process.exitCode ?? 0).toBe(0);
   });
 });
+
+describe("maintenance status folds in analyze-maintenance-logs strict findings (#2033)", () => {
+  let homeDir: string;
+
+  beforeEach(() => {
+    homeDir = mkdtempSync(join(tmpdir(), "hm-maint-health-"));
+    mkdirSync(join(homeDir, ".openclaw", "cron"), { recursive: true });
+    vi.stubEnv("HOME", homeDir);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+    process.exitCode = undefined;
+    rmSync(homeDir, { recursive: true, force: true });
+  });
+
+  function makeProgram(cfg: Partial<HybridMemoryConfig> = {}): Command {
+    const mem = new Command("hybrid-mem");
+    mem.exitOverride();
+    const maintenance = mem.command("maintenance");
+    registerMaintenanceHealthCommands(maintenance, cfg as HybridMemoryConfig);
+    return mem;
+  }
+
+  function writeHealthyNightlyJob() {
+    writeFileSync(
+      join(homeDir, ".openclaw", "cron", "jobs.json"),
+      JSON.stringify({
+        jobs: [
+          {
+            pluginJobId: "hybrid-mem:maintenance-nightly",
+            name: "maintenance-nightly",
+            enabled: true,
+            state: { lastRunAtMs: Date.now(), lastStatus: "success" },
+          },
+        ],
+      }),
+      "utf-8",
+    );
+  }
+
+  function writeStrictFailingMaintenanceLog() {
+    const logRoot = join(homeDir, ".openclaw", "logs", "cron-hybrid-mem");
+    mkdirSync(logRoot, { recursive: true });
+    const exitPath = join(logRoot, "maintenance-nightly-20260705T020000Z-123.exit.txt");
+    const logPath = exitPath.replace(/\.exit\.txt$/, ".log");
+    writeFileSync(exitPath, `${new Date().toISOString()} distill exit=1\n`);
+    writeFileSync(logPath, "openclaw-hybrid-memory 2026.7.51\nTypeError: Cannot read properties of undefined\n");
+  }
+
+  it("does not print the unconditional healthy line and exits non-zero when logs have strict findings", async () => {
+    writeHealthyNightlyJob();
+    writeStrictFailingMaintenanceLog();
+
+    const lines: string[] = [];
+    vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+      lines.push(args.map((a) => String(a)).join(" "));
+    });
+    const mem = makeProgram();
+
+    await mem.parseAsync(["maintenance", "status"], { from: "user" });
+
+    expect(process.exitCode).toBe(1);
+    // Scheduler cadence is still reported as healthy (distinct from log/semantic health)...
+    expect(lines.some((l) => l.includes("Scheduler freshness"))).toBe(true);
+    // ...but the unconditional "healthy" claim from before #2033 must be gone...
+    expect(lines).not.toContain("✅ All maintenance jobs healthy.");
+    // ...and the strict log-health failure must be surfaced.
+    expect(lines.some((l) => l.includes("Log health") && l.includes("strict findings"))).toBe(true);
+  });
+
+  it("reports ok:false and logHealth.strictFailed in --json mode", async () => {
+    writeHealthyNightlyJob();
+    writeStrictFailingMaintenanceLog();
+
+    let jsonOut = "";
+    vi.spyOn(console, "log").mockImplementation((arg: unknown) => {
+      jsonOut = String(arg);
+    });
+    const mem = makeProgram();
+
+    await mem.parseAsync(["maintenance", "status", "--json"], { from: "user" });
+
+    const parsed = JSON.parse(jsonOut);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.logHealth.strictFailed).toBe(true);
+    expect(parsed.logHealth.findingsCount).toBeGreaterThan(0);
+  });
+
+  it("stays healthy and quiet about log health when no maintenance logs exist yet", async () => {
+    writeHealthyNightlyJob();
+
+    const lines: string[] = [];
+    vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+      lines.push(args.map((a) => String(a)).join(" "));
+    });
+    const mem = makeProgram();
+
+    await mem.parseAsync(["maintenance", "status"], { from: "user" });
+
+    expect(process.exitCode ?? 0).toBe(0);
+    expect(lines.some((l) => l.includes("Log health"))).toBe(false);
+  });
+});
+
+describe("maintenance status surfaces active/stale maintenance step locks (#2031)", () => {
+  let homeDir: string;
+
+  beforeEach(() => {
+    homeDir = mkdtempSync(join(tmpdir(), "hm-maint-health-"));
+    mkdirSync(join(homeDir, ".openclaw", "cron"), { recursive: true });
+    vi.stubEnv("HOME", homeDir);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+    process.exitCode = undefined;
+    rmSync(homeDir, { recursive: true, force: true });
+  });
+
+  it("lists a held step lock so operators can see what `maintenance step --force` would report as locked", async () => {
+    writeFileSync(
+      join(homeDir, ".openclaw", "cron", "jobs.json"),
+      JSON.stringify({
+        jobs: [
+          {
+            pluginJobId: "hybrid-mem:maintenance-nightly",
+            name: "maintenance-nightly",
+            enabled: true,
+            state: { lastRunAtMs: Date.now(), lastStatus: "success" },
+          },
+        ],
+      }),
+      "utf-8",
+    );
+    const { acquireStepLock } = await import("../services/cron-guard.js");
+    acquireStepLock("distill", join(homeDir, ".openclaw"));
+
+    const lines: string[] = [];
+    vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+      lines.push(args.map((a) => String(a)).join(" "));
+    });
+    const mem = new Command("hybrid-mem");
+    mem.exitOverride();
+    const maintenance = mem.command("maintenance");
+    registerMaintenanceHealthCommands(maintenance, {} as HybridMemoryConfig);
+
+    await mem.parseAsync(["maintenance", "status"], { from: "user" });
+
+    expect(lines.some((l) => l.includes("Active/stale maintenance step locks"))).toBe(true);
+    expect(lines.some((l) => l.includes("step--distill"))).toBe(true);
+  });
+});

--- a/extensions/memory-hybrid/tests/register-maintenance-orchestrator-steps.test.ts
+++ b/extensions/memory-hybrid/tests/register-maintenance-orchestrator-steps.test.ts
@@ -4,9 +4,57 @@
  */
 import { Command } from "commander";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ManageBindings } from "../cli/commands/manage/bindings.js";
 import { registerMaintenanceOrchestratorCommands } from "../cli/commands/manage/register-maintenance-orchestrator.js";
 import { listMaintenanceSteps } from "../services/maintenance-orchestrator.js";
-import type { ManageBindings } from "../cli/commands/manage/bindings.js";
+
+const { runMaintenanceOrchestratorMock } = vi.hoisted(() => ({
+  runMaintenanceOrchestratorMock: vi.fn(),
+}));
+
+vi.mock("../services/maintenance-orchestrator.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../services/maintenance-orchestrator.js")>();
+  return {
+    ...actual,
+    runMaintenanceOrchestrator: runMaintenanceOrchestratorMock,
+  };
+});
+
+// The real runner map requires a fully-wired ManageBindings (factsDb, vectorDb, runCompaction, ...);
+// since runMaintenanceOrchestrator itself is mocked above, the runners it would receive are never
+// invoked, so stub the builder to sidestep that wiring entirely.
+vi.mock("../cli/commands/manage/maintenance-step-runners.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../cli/commands/manage/maintenance-step-runners.js")>();
+  return {
+    ...actual,
+    buildCliMaintenanceRunners: () => new Map(),
+  };
+});
+
+function makeMinimalBindings(): ManageBindings {
+  return {
+    cfg: {},
+    factsDb: { getRawDb: () => ({}) },
+  } as unknown as ManageBindings;
+}
+
+function mockOrchestratorResult(overrides: {
+  stepName: string;
+  status: "ok" | "skipped_guard" | "skipped_gate";
+  summary: string;
+}) {
+  const nowIso = new Date().toISOString();
+  runMaintenanceOrchestratorMock.mockResolvedValue({
+    tierLabel: "full",
+    steps: [{ name: overrides.stepName, status: overrides.status, summary: overrides.summary, durationMs: 0 }],
+    exitCode: 0,
+    summaryLine: "Maintenance full — 1 steps",
+    runId: "job-test-run",
+    startedAt: nowIso,
+    finishedAt: nowIso,
+    durationMs: 5,
+  });
+}
 
 describe("maintenance steps CLI step count", () => {
   afterEach(() => {
@@ -67,5 +115,156 @@ describe("maintenance step <step> CLI (#2028)", () => {
     expect(stepCmd).toBeDefined();
     // The required positional makes `maintenance step` (no name) fail argument parsing.
     expect(stepCmd?.usage()).toContain("<step>");
+  });
+});
+
+describe("maintenance step <step> exits non-zero when the selected step did not run (#2031)", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    runMaintenanceOrchestratorMock.mockReset();
+    process.exitCode = 0;
+  });
+
+  it("exits non-zero when the only selected step is skipped_guard (e.g. locked by a concurrent run)", async () => {
+    const stepName = listMaintenanceSteps()[0]?.name as string;
+    mockOrchestratorResult({
+      stepName,
+      status: "skipped_guard",
+      summary: "locked by a concurrent maintenance run (pid=123 host=test held=5s stale=false lock=/tmp/x.lock)",
+    });
+
+    const mem = new Command("hybrid-mem");
+    mem.exitOverride();
+    const maintenance = mem.command("maintenance");
+    registerMaintenanceOrchestratorCommands(maintenance, makeMinimalBindings());
+
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    const errLines: string[] = [];
+    vi.spyOn(console, "error").mockImplementation((...args: unknown[]) => {
+      errLines.push(args.map((a) => String(a)).join(" "));
+    });
+
+    await mem.parseAsync(["maintenance", "step", stepName, "--force"], { from: "user" });
+
+    expect(process.exitCode).toBe(3);
+    expect(errLines.some((l) => l.includes("selected step(s) did not run") && l.includes("skipped_guard"))).toBe(true);
+  });
+
+  it("leaves exit code untouched when --allow-skip is passed for a skipped selected step", async () => {
+    const stepName = listMaintenanceSteps()[0]?.name as string;
+    mockOrchestratorResult({ stepName, status: "skipped_guard", summary: "locked by a concurrent maintenance run" });
+
+    const mem = new Command("hybrid-mem");
+    mem.exitOverride();
+    const maintenance = mem.command("maintenance");
+    registerMaintenanceOrchestratorCommands(maintenance, makeMinimalBindings());
+
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await mem.parseAsync(["maintenance", "step", stepName, "--force", "--allow-skip"], { from: "user" });
+
+    expect(process.exitCode).toBeFalsy();
+  });
+
+  it("leaves exit code untouched when the selected step actually ran (status=ok)", async () => {
+    const stepName = listMaintenanceSteps()[0]?.name as string;
+    mockOrchestratorResult({ stepName, status: "ok", summary: "done" });
+
+    const mem = new Command("hybrid-mem");
+    mem.exitOverride();
+    const maintenance = mem.command("maintenance");
+    registerMaintenanceOrchestratorCommands(maintenance, makeMinimalBindings());
+
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await mem.parseAsync(["maintenance", "step", stepName, "--force"], { from: "user" });
+
+    expect(process.exitCode).toBeFalsy();
+  });
+});
+
+describe("maintenance cycle/nightly/full --include --force share the same skip protection (#2031)", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    runMaintenanceOrchestratorMock.mockReset();
+    process.exitCode = 0;
+  });
+
+  it("exits non-zero when `cycle --include <step> --force` skips the only requested step", async () => {
+    const stepName = listMaintenanceSteps()[0]?.name as string;
+    mockOrchestratorResult({ stepName, status: "skipped_guard", summary: "locked by a concurrent maintenance run" });
+
+    const mem = new Command("hybrid-mem");
+    mem.exitOverride();
+    const maintenance = mem.command("maintenance");
+    registerMaintenanceOrchestratorCommands(maintenance, makeMinimalBindings());
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await mem.parseAsync(["maintenance", "cycle", "--include", stepName, "--force"], { from: "user" });
+
+    expect(process.exitCode).toBe(3);
+  });
+
+  it("does NOT flag a skip on `cycle --include <step>` without --force (ordinary cadence-guard skip stays exit 0)", async () => {
+    const stepName = listMaintenanceSteps()[0]?.name as string;
+    mockOrchestratorResult({ stepName, status: "skipped_guard", summary: "guard (ran 2h ago)" });
+
+    const mem = new Command("hybrid-mem");
+    mem.exitOverride();
+    const maintenance = mem.command("maintenance");
+    registerMaintenanceOrchestratorCommands(maintenance, makeMinimalBindings());
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await mem.parseAsync(["maintenance", "cycle", "--include", stepName], { from: "user" });
+
+    expect(process.exitCode).toBeFalsy();
+  });
+});
+
+describe("maintenance step <step> bounds runtime by default (#2032)", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    runMaintenanceOrchestratorMock.mockReset();
+    process.exitCode = 0;
+  });
+
+  it("passes a default 15-minute maxRuntimeMs when --max-runtime-min is not given", async () => {
+    const stepName = listMaintenanceSteps()[0]?.name as string;
+    mockOrchestratorResult({ stepName, status: "ok", summary: "done" });
+
+    const mem = new Command("hybrid-mem");
+    mem.exitOverride();
+    const maintenance = mem.command("maintenance");
+    registerMaintenanceOrchestratorCommands(maintenance, makeMinimalBindings());
+    vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await mem.parseAsync(["maintenance", "step", stepName, "--force"], { from: "user" });
+
+    expect(runMaintenanceOrchestratorMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ maxRuntimeMs: 15 * 60_000 }),
+    );
+  });
+
+  it("honors an explicit --max-runtime-min override", async () => {
+    const stepName = listMaintenanceSteps()[0]?.name as string;
+    mockOrchestratorResult({ stepName, status: "ok", summary: "done" });
+
+    const mem = new Command("hybrid-mem");
+    mem.exitOverride();
+    const maintenance = mem.command("maintenance");
+    registerMaintenanceOrchestratorCommands(maintenance, makeMinimalBindings());
+    vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await mem.parseAsync(["maintenance", "step", stepName, "--force", "--max-runtime-min", "5"], { from: "user" });
+
+    expect(runMaintenanceOrchestratorMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ maxRuntimeMs: 5 * 60_000 }),
+    );
   });
 });

--- a/packages/openclaw-hybrid-memory-install/package.json
+++ b/packages/openclaw-hybrid-memory-install/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-hybrid-memory-install",
-  "version": "2026.7.50",
+  "version": "2026.7.51",
   "description": "Standalone installer for openclaw-hybrid-memory. Use when OpenClaw config validation fails.",
   "bin": {
     "openclaw-hybrid-memory-install": "./install.js"


### PR DESCRIPTION
## Summary

Fixes all 3 open issues in the maintenance orchestrator subsystem, and bumps the plugin version to `2026.7.51`.

Closes #2031, #2032, #2033

- **#2031 — `maintenance step <name> --force` exits 0 while skipping the selected step as locked.** `maintenance step <name>` (and `cycle`/`nightly`/`full --include x --force`, which share the same explicit-forced-targeted-run semantics) now exit non-zero when the selected step(s) never actually executed (`skipped_guard`/`skipped_gate`/`skipped_dep`/`skipped_missing_runner`), unless `--allow-skip` is passed. Step lock files now carry JSON owner metadata (pid, hostname) instead of a bare timestamp (with backward-compatible parsing of the legacy format), and the `skipped_guard` summary/`maintenance status` both surface that metadata (pid/host/held-duration/staleness/lock path) so an operator can tell a real concurrent run from an abandoned lock.
- **#2032 — `maintenance step passive-observer --force` can run indefinitely with no bounded completion or progress.** `maintenance step <name>` now defaults `--max-runtime-min` to 15 (overridable) for these isolated diagnostic runs. `passive-observer` now logs per-session phase/counter progress (`session N/M ... chunksProcessed=... factsStored=...`), and a run truncated by the maintenance-run deadline is now counted as an error (consistent with the existing chunk-level truncation handling) instead of silently returning "ok" and hiding unprocessed sessions.
- **#2033 — `maintenance status` reports all jobs healthy while `analyze-maintenance-logs` has strict failing findings.** `maintenance status` now folds in a 24h log-health check (reusing the same analyzer `analyze-maintenance-logs` already uses) and no longer prints the unconditional "All maintenance jobs healthy" line when strict findings exist. Text and `--json` output both now distinguish scheduler/cron-cadence freshness from log/semantic health, and `status` also lists any active/stale maintenance step locks.

**Version:** bumped plugin, `openclaw.plugin.json`, and `openclaw-hybrid-memory-install` package to **2026.7.51**.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor / internal improvement (no behavior change)
- [ ] Documentation update
- [ ] CI / tooling change

## Quality Checklist

- [x] `cd extensions/memory-hybrid && npx tsc --noEmit` (via `npm run typecheck:gate`) passes with no errors
- [x] `cd extensions/memory-hybrid && npm run lint` — no new warnings introduced (pre-existing unrelated warnings untouched)
- [x] `cd extensions/memory-hybrid && npm test` passes (all tests green; 3 pre-existing failures in unrelated files — `crystallization-proposer.test.ts`, `implicit-feedback-routing.test.ts`, `memory-recall-timeline.test.ts` — confirmed present on `main` before this change too)
- [x] No secrets, credentials, or API keys committed
- [x] No `console.log` debug statements left in production code

## Documentation Impact

- [x] Inline code comments updated for modified functions and types
- [x] `CHANGELOG.md` updated with a `2026.7.51` entry
- [ ] No other `docs/`/`README.md` changes needed — these are CLI behavior/bugfixes, no new surface

## Testing

- [x] Unit tests added/updated: `cron-guard.test.ts` (lock owner metadata), `maintenance-orchestrator.test.ts` (lock detail in `skipped_guard` summary), `passive-observer.test.ts` (deadline-truncation counted as error), `register-maintenance-health-cli.test.ts` (log-health folding + lock listing in `status`), `register-maintenance-orchestrator-steps.test.ts` (exit-code on skip, `--allow-skip`, bounded default runtime, `cycle --include --force` parity)
- [ ] Integration tests added / updated
- [ ] Manually verified against a running OpenClaw instance

## Notes for Reviewer

Ran a full self-review pass (8 independent finder angles + adversarial verification) against this diff before opening the PR. Two real gaps found and fixed:
- The lock-detail formatting was duplicated between `maintenance-orchestrator.ts` and `register-maintenance-health.ts` — extracted a shared `formatStepLockDetail()` in `cron-guard.ts`.
- The #2031 exit-code fix was originally scoped only to the new `step <name>` command; broadened into the shared `runTier()` helper (gated on `--include` + `--force` together) so `cycle`/`nightly`/`full --include x --force` get the same protection instead of reintroducing the same false-success bug through a sibling command.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FUPMSbCtzdfwCxsPQcg6mJ)_