### PR TITLE
fix: catch partial --include skips and deferred status, bump to 2026.7.53

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ---
 
+## [2026.7.53] - 2026-07-05
+
+### Fixed
+
+- **`--include`/`--force` skip-check only fired when *all* requested steps failed to run:** the #2031/#2032 diagnostic on `maintenance cycle/nightly/full --include x,y --force` used `every(...)` over the requested step names, so a partial run — e.g. two named steps where one ran fine and the other was locked — silently reported success. It now flags **any** requested step that didn't run.
+- **`deferred` status wasn't treated as "didn't run":** a requested step pushed as `deferred` (time budget exceeded, or preemptively deferred by the rate-limit circuit breaker before its runner was ever invoked) fell through to the generic exit code instead of the specific "selected step(s) did not run" diagnostic. `deferred` now joins the missing/`skipped_*` cases; `failed`/`rate_limited` are intentionally excluded since those did invoke the runner and are already reflected in the exit code.
+- Removed a pre-existing unused import (`readStepGuardTimestampMs`) in `register-maintenance-orchestrator.ts`, found during this review pass.
+
+### Changed
+
+- Bumped plugin, `openclaw.plugin.json`, and `openclaw-hybrid-memory-install` package versions to **2026.7.53**.
+
+---
+
 ## [2026.7.52] - 2026-07-05
 
 ### Fixed

--- a/extensions/memory-hybrid/cli/commands/manage/register-maintenance-orchestrator.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/register-maintenance-orchestrator.ts
@@ -5,7 +5,7 @@
 import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
-import { readStepGuardTimestampMs, stepGuardEligible } from "../../../services/cron-guard.js";
+import { stepGuardEligible } from "../../../services/cron-guard.js";
 import {
   effectiveCadenceLabel,
   formatMaintenanceSummary,

--- a/extensions/memory-hybrid/cli/commands/manage/register-maintenance-orchestrator.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/register-maintenance-orchestrator.ts
@@ -128,12 +128,20 @@ export function registerMaintenanceOrchestratorCommands(maintenance: Chainable, 
       // Look up each requested name individually rather than filtering result.steps down to the
       // matches — a name that belongs to a tier not requested (e.g. `cycle --include <nightly-step>
       // --force`) or that --exclude also removed never produces a step result at all, so it would
-      // otherwise vanish from `selected` entirely and slip past the "every(...)" check below with a
-      // false "didn't run" report never firing (an even quieter version of the bug #2031 closes).
+      // otherwise vanish from a filtered list entirely and slip past a not-run check.
       const requested = includeNames.map((name) => ({ name, result: result.steps.find((s) => s.name === name) }));
-      const didNotRun = requested.every((r) => !r.result || r.result.status.startsWith("skipped"));
-      if (didNotRun) {
-        const detail = requested
+      // "didn't run" = no result at all, a skipped_* status, or "deferred" (pushed before the
+      // runner was ever invoked — time budget exceeded or the rate-limit circuit breaker
+      // preemptively deferred it). "failed"/"rate_limited" DID invoke the runner, so they're
+      // excluded here; those are already reflected in process.exitCode via computeExitCode() above.
+      // Flag ANY requested step that didn't run, not just when all of them didn't — a partial
+      // --include run where only one of several explicitly-named steps silently didn't execute is
+      // exactly the false-success #2031 closes for the single-step case.
+      const notRun = requested.filter(
+        (r) => !r.result || r.result.status.startsWith("skipped") || r.result.status === "deferred",
+      );
+      if (notRun.length > 0) {
+        const detail = notRun
           .map((r) =>
             r.result
               ? `${r.name}: ${r.result.status} — ${r.result.summary}`

--- a/extensions/memory-hybrid/openclaw.plugin.json
+++ b/extensions/memory-hybrid/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "openclaw-hybrid-memory",
   "kind": "memory",
-  "version": "2026.7.52",
+  "version": "2026.7.53",
   "contracts": {
     "tools": [
       "active_task_checkpoint",

--- a/extensions/memory-hybrid/package-lock.json
+++ b/extensions/memory-hybrid/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openclaw-hybrid-memory",
-  "version": "2026.7.52",
+  "version": "2026.7.53",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openclaw-hybrid-memory",
-      "version": "2026.7.52",
+      "version": "2026.7.53",
       "hasInstallScript": true,
       "dependencies": {
         "@lancedb/lancedb": "^0.30.0",

--- a/extensions/memory-hybrid/package.json
+++ b/extensions/memory-hybrid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-hybrid-memory",
-  "version": "2026.7.52",
+  "version": "2026.7.53",
   "type": "module",
   "description": "Give your OpenClaw agent lasting memory: structured facts, semantic search, auto-capture & recall, decay, optional credential vault. Part of Hybrid Memory v3.",
   "files": [

--- a/extensions/memory-hybrid/tests/register-maintenance-orchestrator-steps.test.ts
+++ b/extensions/memory-hybrid/tests/register-maintenance-orchestrator-steps.test.ts
@@ -56,6 +56,23 @@ function mockOrchestratorResult(overrides: {
   });
 }
 
+function mockOrchestratorSteps(
+  steps: Array<{ name: string; status: string; summary: string }>,
+  exitCode: 0 | 1 | 2 = 0,
+) {
+  const nowIso = new Date().toISOString();
+  runMaintenanceOrchestratorMock.mockResolvedValue({
+    tierLabel: "full",
+    steps: steps.map((s) => ({ ...s, durationMs: 0 })),
+    exitCode,
+    summaryLine: `Maintenance full — ${steps.length} steps`,
+    runId: "job-test-run",
+    startedAt: nowIso,
+    finishedAt: nowIso,
+    durationMs: 5,
+  });
+}
+
 describe("maintenance steps CLI step count", () => {
   afterEach(() => {
     vi.restoreAllMocks();
@@ -256,6 +273,57 @@ describe("maintenance cycle/nightly/full --include --force share the same skip p
 
     expect(process.exitCode).toBe(3);
     expect(errLines.some((l) => l.includes("no result (wrong tier, excluded, or unregistered runner)"))).toBe(true);
+  });
+
+  it("flags a partial skip: only ONE of several --include'd steps failed to run (round-3 review finding)", async () => {
+    // A naive `.every(...)` over the requested names only fires when ALL of them failed to run,
+    // silently accepting the case where some (but not all) explicitly-requested steps didn't
+    // execute — exactly as false-success as the single-step case #2031 closes.
+    mockOrchestratorSteps([
+      { name: "prune", status: "ok", summary: "pruned=3 semantic=success" },
+      { name: "distill", status: "skipped_guard", summary: "locked by a concurrent maintenance run" },
+    ]);
+
+    const mem = new Command("hybrid-mem");
+    mem.exitOverride();
+    const maintenance = mem.command("maintenance");
+    registerMaintenanceOrchestratorCommands(maintenance, makeMinimalBindings());
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    const errLines: string[] = [];
+    vi.spyOn(console, "error").mockImplementation((...args: unknown[]) => {
+      errLines.push(args.map((a) => String(a)).join(" "));
+    });
+
+    await mem.parseAsync(["maintenance", "cycle", "--include", "prune,distill", "--force"], { from: "user" });
+
+    expect(process.exitCode).toBe(3);
+    expect(errLines.some((l) => l.includes("distill: skipped_guard"))).toBe(true);
+    expect(errLines.some((l) => l.includes("prune"))).toBe(false);
+  });
+
+  it('flags a requested step whose status is "deferred" (time budget / rate-limit circuit breaker) as not run', async () => {
+    // "deferred" is pushed before the runner is ever invoked (time budget exceeded, or the
+    // rate-limit circuit breaker preemptively defers it) — it belongs in the same "didn't run"
+    // bucket as skipped_*, unlike "failed"/"rate_limited" which DID invoke the runner.
+    mockOrchestratorSteps(
+      [{ name: "self-correction-run", status: "deferred", summary: "rate-limit circuit breaker" }],
+      2,
+    );
+
+    const mem = new Command("hybrid-mem");
+    mem.exitOverride();
+    const maintenance = mem.command("maintenance");
+    registerMaintenanceOrchestratorCommands(maintenance, makeMinimalBindings());
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    const errLines: string[] = [];
+    vi.spyOn(console, "error").mockImplementation((...args: unknown[]) => {
+      errLines.push(args.map((a) => String(a)).join(" "));
+    });
+
+    await mem.parseAsync(["maintenance", "full", "--include", "self-correction-run", "--force"], { from: "user" });
+
+    expect(process.exitCode).toBe(2); // computeExitCode()'s own deferred/rate_limited exit code stands
+    expect(errLines.some((l) => l.includes("self-correction-run: deferred — rate-limit circuit breaker"))).toBe(true);
   });
 });
 

--- a/packages/openclaw-hybrid-memory-install/package.json
+++ b/packages/openclaw-hybrid-memory-install/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-hybrid-memory-install",
-  "version": "2026.7.52",
+  "version": "2026.7.53",
   "description": "Standalone installer for openclaw-hybrid-memory. Use when OpenClaw config validation fails.",
   "bin": {
     "openclaw-hybrid-memory-install": "./install.js"


### PR DESCRIPTION
## Summary

Third round of a self-review loop over the #2031-#2033 maintenance-orchestrator work (following #2034 and #2035, both merged). Fresh finder + verify passes over the full current file content found two more real gaps in the `--include`/`--force` skip-check added in #2034/#2035, plus a pre-existing cleanup item.

### Fixed

- **`--include`/`--force` skip-check only fired when *all* requested steps failed to run.** The check used `every(...)` over the requested step names, so a partial run — e.g. `cycle --include stepA,stepB --force` where stepA ran fine and stepB was locked by a concurrent run — silently reported success, exactly the false-success #2031 was meant to close (just for a multi-name request instead of a single one). It now flags **any** requested step that didn't run.
- **`deferred` status wasn't treated as "didn't run".** A requested step pushed with status `deferred` (time budget exceeded, or preemptively deferred by the rate-limit circuit breaker before its runner was ever invoked) fell through to the generic orchestrator exit code instead of the specific "selected step(s) did not run" diagnostic. `deferred` now joins the missing-result/`skipped_*` cases. `failed`/`rate_limited` are intentionally excluded — those did invoke the runner and are already reflected in the exit code.
- Removed a pre-existing unused import (`readStepGuardTimestampMs`) in `register-maintenance-orchestrator.ts`, caught in the same pass.

**Version:** bumped plugin, `openclaw.plugin.json`, and `openclaw-hybrid-memory-install` package to **2026.7.53**.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor / internal improvement (no behavior change)
- [ ] Documentation update
- [ ] CI / tooling change

## Quality Checklist

- [x] `cd extensions/memory-hybrid && npx tsc --noEmit` (via `npm run typecheck:gate`) passes with no errors
- [x] `cd extensions/memory-hybrid && npm run lint` — no new warnings (pre-existing unrelated warnings untouched)
- [x] `cd extensions/memory-hybrid && npm test` — targeted maintenance-orchestrator suite green (145 passed); full suite run separately: 8624 passed, same 3 pre-existing/unrelated flaky failures as `main` (`crystallization-proposer.test.ts`, `implicit-feedback-routing.test.ts`, `memory-recall-timeline.test.ts`), none touching this diff
- [x] No secrets, credentials, or API keys committed
- [x] No `console.log` debug statements left in production code

## Documentation Impact

- [x] Inline code comments updated for modified functions and types
- [x] `CHANGELOG.md` updated with a `2026.7.53` entry
- [ ] No other `docs/`/`README.md` changes needed

## Testing

- [x] Unit tests added in `register-maintenance-orchestrator-steps.test.ts`: partial-skip (one of two `--include`'d steps didn't run) now flags exit 3, and a `deferred`-status requested step now surfaces the specific diagnostic message

## Notes for Reviewer

Part of an ongoing self-review loop: reset the branch from `main` after each merge, then re-review the full (not diff-scoped) content of the touched files. This round's two remaining candidate findings — a hardcoded step-name special case in `resolveStepGuardIntervalMs` and duplicated staleness logic between `maintenance status`/`cron-health` — were judged pre-existing, architectural, and unrelated to #2031-#2033, so left out of scope.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FUPMSbCtzdfwCxsPQcg6mJ)_