### PR TITLE
fix: re-check passive-observer progress throttle inside chunk loop, bump to 2026.7.54

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ---
 
+## [2026.7.54] - 2026-07-05
+
+### Fixed
+
+- **`passive-observer` progress logging went silent for the entire span of a single multi-chunk session:** the throttle added for #2032 was only re-checked once per session (at the top of the outer loop), so a session with many chunks — each a full LLM round-trip via `chatCompleteWithRetry` plus an embedding call — could run for its entire multi-minute duration with zero progress lines, reproducing the exact "live run indistinguishable from a hung one" problem this logging exists to close. The throttle is now also re-checked inside the per-chunk loop.
+
+### Changed
+
+- Bumped plugin, `openclaw.plugin.json`, and `openclaw-hybrid-memory-install` package versions to **2026.7.54**.
+
+---
+
 ## [2026.7.53] - 2026-07-05
 
 ### Fixed

--- a/extensions/memory-hybrid/openclaw.plugin.json
+++ b/extensions/memory-hybrid/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "openclaw-hybrid-memory",
   "kind": "memory",
-  "version": "2026.7.53",
+  "version": "2026.7.54",
   "contracts": {
     "tools": [
       "active_task_checkpoint",

--- a/extensions/memory-hybrid/package-lock.json
+++ b/extensions/memory-hybrid/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openclaw-hybrid-memory",
-  "version": "2026.7.53",
+  "version": "2026.7.54",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openclaw-hybrid-memory",
-      "version": "2026.7.53",
+      "version": "2026.7.54",
       "hasInstallScript": true,
       "dependencies": {
         "@lancedb/lancedb": "^0.30.0",

--- a/extensions/memory-hybrid/package.json
+++ b/extensions/memory-hybrid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-hybrid-memory",
-  "version": "2026.7.53",
+  "version": "2026.7.54",
   "type": "module",
   "description": "Give your OpenClaw agent lasting memory: structured facts, semantic search, auto-capture & recall, decay, optional credential vault. Part of Hybrid Memory v3.",
   "files": [

--- a/extensions/memory-hybrid/services/passive-observer.ts
+++ b/extensions/memory-hybrid/services/passive-observer.ts
@@ -602,6 +602,20 @@ export async function runPassiveObserver(
       if (!chunk.trim()) continue;
       chunksAttempted++;
       result.chunksProcessed++;
+      // Re-check the throttle here too, not just at the top of the session loop (#2032 follow-up):
+      // a single session with many chunks (each a full LLM round-trip via chatCompleteWithRetry
+      // plus an embedding call) can otherwise run for its entire duration between two per-session
+      // log lines, silently reproducing the "live run indistinguishable from a hung one" problem
+      // this progress logging was added to close.
+      const chunkProgressNowMs = Date.now();
+      if (chunkProgressNowMs - lastProgressLogMs >= PASSIVE_OBSERVER_PROGRESS_LOG_INTERVAL_MS) {
+        lastProgressLogMs = chunkProgressNowMs;
+        logger.info(
+          `memory-hybrid: passive-observer — progress: session ${sessionIdx + 1}/${sessions.length} (${sessionId}) ` +
+            `chunk ${chunksAttempted}/${chunks.length} chunksProcessed=${result.chunksProcessed} ` +
+            `factsExtracted=${result.factsExtracted} factsStored=${result.factsStored}`,
+        );
+      }
 
       const filledPrompt = fillPrompt(prompt, {
         categories: allCategories.join(", "),

--- a/extensions/memory-hybrid/tests/passive-observer.test.ts
+++ b/extensions/memory-hybrid/tests/passive-observer.test.ts
@@ -8,19 +8,19 @@ import { randomUUID } from "node:crypto";
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from "vitest";
 import * as chat from "../services/chat.js";
 import {
+  deriveObserverSessionKey,
   type ExtractedFact,
-  type PassiveObserverConfig,
   extractTextFromJsonlChunk,
   getCursorsPath,
   isIdentityFact,
   isPassiveObserverTranscriptCandidate,
-  loadCursors,
-  parseObserverResponse,
-  deriveObserverSessionKey,
   listPassiveObserverSessionFilePaths,
+  loadCursors,
+  type PassiveObserverConfig,
+  parseObserverResponse,
   runPassiveObserver,
   saveCursors,
 } from "../services/passive-observer.js";
@@ -469,6 +469,49 @@ describe("runPassiveObserver", () => {
     }
   });
 
+  it("re-checks the progress-log throttle inside the chunk loop, not just once per session (round-4 review finding)", async () => {
+    // A single session with many chunks (each a full LLM round-trip) previously logged progress
+    // only once, at the top of the session loop — silently going quiet for the entire multi-chunk
+    // span even though the 60s throttle interval had long since elapsed, reproducing the "live run
+    // indistinguishable from a hung one" problem this progress logging exists to close.
+    const longText = Array.from({ length: 8 }, (_, i) => `Message ${i}: ${"x".repeat(80)}`).join("\n");
+    writeFileSync(
+      join(sessionsDir, "long-session.jsonl"),
+      `${JSON.stringify({ message: { role: "user", content: longText } })}\n`,
+    );
+
+    vi.useFakeTimers();
+    try {
+      let callCount = 0;
+      vi.spyOn(chat, "chatCompleteWithRetry").mockImplementation(async () => {
+        callCount++;
+        vi.advanceTimersByTime(61_000); // exceed the 60s throttle interval on every chunk
+        return "[]";
+      });
+
+      const cfg = makeConfig({ sessionsDir, maxCharsPerChunk: 100 });
+      const logger = makeLogger();
+      await runPassiveObserver(
+        makeFactsDb() as never,
+        makeVectorDb() as never,
+        makeEmbeddings() as never,
+        makeOpenAI(),
+        cfg,
+        ["fact"],
+        { model: "test-model", dbDir: tmpDir },
+        logger,
+      );
+
+      expect(callCount).toBeGreaterThan(1); // sanity: the session actually split into multiple chunks
+      const progressLines = logger.info.mock.calls.map((c) => String(c[0])).filter((l) => l.includes("— progress:"));
+      // A progress line referencing a chunk index beyond the first proves the throttle re-fires
+      // inside the chunk loop, not only once when the session started.
+      expect(progressLines.some((l) => /chunk [2-9]\d*\/\d+/.test(l))).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("respects minImportance threshold — skips low-importance facts", async () => {
     const categories = ["fact", "preference", "decision", "entity", "pattern", "rule", "other"];
     const llmResponse = JSON.stringify([
@@ -516,11 +559,13 @@ describe("runPassiveObserver", () => {
     const factsDb = makeFactsDb({
       detectContradictions: vi.fn(),
       setEmbeddingModel: vi.fn(),
-      getById: vi.fn().mockImplementation((id: string) =>
-        id === "existing-fact-id"
-          ? { id, scope: "session", scopeTarget: "dedup-test", supersededAt: null, expiresAt: null }
-          : null,
-      ),
+      getById: vi
+        .fn()
+        .mockImplementation((id: string) =>
+          id === "existing-fact-id"
+            ? { id, scope: "session", scopeTarget: "dedup-test", supersededAt: null, expiresAt: null }
+            : null,
+        ),
     });
 
     const cfg = makeConfig({ sessionsDir });
@@ -759,11 +804,13 @@ describe("runPassiveObserver — LanceDB dedup (Issue #499)", () => {
     const vectorDb = makeVectorDb(matchResult);
     const factsDb = makeFactsDb({
       boostConfidence: vi.fn().mockReturnValue(true),
-      getById: vi.fn().mockImplementation((id: string) =>
-        id === matchedFactId
-          ? { id, scope: "session", scopeTarget: "reinforce-test", supersededAt: null, expiresAt: null }
-          : null,
-      ),
+      getById: vi
+        .fn()
+        .mockImplementation((id: string) =>
+          id === matchedFactId
+            ? { id, scope: "session", scopeTarget: "reinforce-test", supersededAt: null, expiresAt: null }
+            : null,
+        ),
     });
     const cfg = makeConfig({ sessionsDir });
 

--- a/packages/openclaw-hybrid-memory-install/package.json
+++ b/packages/openclaw-hybrid-memory-install/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-hybrid-memory-install",
-  "version": "2026.7.53",
+  "version": "2026.7.54",
   "description": "Standalone installer for openclaw-hybrid-memory. Use when OpenClaw config validation fails.",
   "bin": {
     "openclaw-hybrid-memory-install": "./install.js"


### PR DESCRIPTION
## Summary

Fourth round of a self-review loop over the #2031-#2033 maintenance-orchestrator work (following #2034, #2035, #2036, all merged). This round's finder found one real gap in the passive-observer progress logging added in #2034.

### Fixed

- **`passive-observer` progress logging went silent for the entire span of a single multi-chunk session.** The throttle added for #2032 was only re-checked once per session, at the top of the outer session loop. A session with many chunks — each a full LLM round-trip via `chatCompleteWithRetry` plus an embedding call — could therefore run for its entire multi-minute duration with zero progress lines, reproducing the exact "live run indistinguishable from a hung one" problem this logging exists to close. The throttle is now also re-checked inside the per-chunk loop, so a long single session still surfaces periodic progress.

**Version:** bumped plugin, `openclaw.plugin.json`, and `openclaw-hybrid-memory-install` package to **2026.7.54**.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor / internal improvement (no behavior change)
- [ ] Documentation update
- [ ] CI / tooling change

## Quality Checklist

- [x] `cd extensions/memory-hybrid && npx tsc --noEmit` (via `npm run typecheck:gate`) passes with no errors
- [x] `cd extensions/memory-hybrid && npm run lint` — no new warnings (pre-existing unrelated warnings untouched)
- [x] `cd extensions/memory-hybrid && npm test` — `passive-observer.test.ts` green (84 passed) plus the full targeted maintenance-orchestrator suite (146 passed)
- [x] No secrets, credentials, or API keys committed
- [x] No `console.log` debug statements left in production code

## Documentation Impact

- [x] Inline code comments updated
- [x] `CHANGELOG.md` updated with a `2026.7.54` entry

## Testing

- [x] Unit test added: uses fake timers to advance the mocked clock past the throttle interval on every chunk's LLM call, then asserts a progress line referencing a chunk index beyond the first appears — proving the throttle re-fires mid-session instead of only once

## Notes for Reviewer

Same iterative loop as the prior three PRs: reset from `main` after each merge, re-review the full current content of the touched files with fresh finder + verify passes. This round's finder returned only this one finding (all others from prior rounds are already closed), which is a good signal the loop is converging.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FUPMSbCtzdfwCxsPQcg6mJ)_