### PR TITLE
chore: dedupe passive-observer progress-log throttle, bump to 2026.7.55

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ---
 
+## [2026.7.55] - 2026-07-05
+
+### Changed
+
+- **De-duplicated `passive-observer`'s progress-log throttle:** the per-session and per-chunk progress log call sites (added across #2032 and its follow-up) each re-implemented the same "compute now, compare against last-logged time, update, log" logic independently, risking the two drifting out of sync (e.g. one throttled correctly while the other floods again after an unrelated edit). Both now call a single shared `logThrottledObserverProgress()` closure. No behavior change.
+- Bumped plugin, `openclaw.plugin.json`, and `openclaw-hybrid-memory-install` package versions to **2026.7.55**.
+
+---
+
 ## [2026.7.54] - 2026-07-05
 
 ### Fixed

--- a/extensions/memory-hybrid/openclaw.plugin.json
+++ b/extensions/memory-hybrid/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "openclaw-hybrid-memory",
   "kind": "memory",
-  "version": "2026.7.54",
+  "version": "2026.7.55",
   "contracts": {
     "tools": [
       "active_task_checkpoint",

--- a/extensions/memory-hybrid/package-lock.json
+++ b/extensions/memory-hybrid/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openclaw-hybrid-memory",
-  "version": "2026.7.54",
+  "version": "2026.7.55",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openclaw-hybrid-memory",
-      "version": "2026.7.54",
+      "version": "2026.7.55",
       "hasInstallScript": true,
       "dependencies": {
         "@lancedb/lancedb": "^0.30.0",

--- a/extensions/memory-hybrid/package.json
+++ b/extensions/memory-hybrid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-hybrid-memory",
-  "version": "2026.7.54",
+  "version": "2026.7.55",
   "type": "module",
   "description": "Give your OpenClaw agent lasting memory: structured facts, semantic search, auto-capture & recall, decay, optional credential vault. Part of Hybrid Memory v3.",
   "files": [

--- a/extensions/memory-hybrid/services/passive-observer.ts
+++ b/extensions/memory-hybrid/services/passive-observer.ts
@@ -495,8 +495,20 @@ export async function runPassiveObserver(
   // ---------------------------------------------------------------------------
   // Progress is throttled to the same cadence as the orchestrator's per-step heartbeat (#2026's
   // ORCHESTRATOR_STEP_HEARTBEAT_MS) so a large multi-agent backlog logs a couple dozen lines over
-  // the default 15-minute step budget instead of one line per session (#2032).
+  // the default 15-minute step budget instead of one line per session (#2032). Shared by both the
+  // per-session and per-chunk call sites below so the throttle condition and log format can't drift
+  // out of sync between them (round-5 review finding).
   let lastProgressLogMs = 0;
+  const logThrottledObserverProgress = (idx: number, sid: string, extra?: string): void => {
+    const nowMs = Date.now();
+    if (lastProgressLogMs !== 0 && nowMs - lastProgressLogMs < PASSIVE_OBSERVER_PROGRESS_LOG_INTERVAL_MS) return;
+    lastProgressLogMs = nowMs;
+    const suffix = extra ? ` ${extra}` : "";
+    logger.info(
+      `memory-hybrid: passive-observer — progress: session ${idx + 1}/${sessions.length} (${sid})${suffix} ` +
+        `chunksProcessed=${result.chunksProcessed} factsExtracted=${result.factsExtracted} factsStored=${result.factsStored}`,
+    );
+  };
   for (const [sessionIdx, { filePath, sessionId, fileBytelen, cursor }] of sessions.entries()) {
     if (maintenanceRunDeadlineReached()) {
       // Deadline stops mid-run are counted as an error so the caller's summary (and
@@ -511,14 +523,7 @@ export async function runPassiveObserver(
       break;
     }
     if (cursor >= fileBytelen) continue; // Nothing new
-    const progressNowMs = Date.now();
-    if (lastProgressLogMs === 0 || progressNowMs - lastProgressLogMs >= PASSIVE_OBSERVER_PROGRESS_LOG_INTERVAL_MS) {
-      lastProgressLogMs = progressNowMs;
-      logger.info(
-        `memory-hybrid: passive-observer — progress: session ${sessionIdx + 1}/${sessions.length} (${sessionId}) ` +
-          `chunksProcessed=${result.chunksProcessed} factsExtracted=${result.factsExtracted} factsStored=${result.factsStored}`,
-      );
-    }
+    logThrottledObserverProgress(sessionIdx, sessionId);
 
     let rawBuf: Buffer;
     let segmentEnd = fileBytelen;
@@ -607,15 +612,7 @@ export async function runPassiveObserver(
       // plus an embedding call) can otherwise run for its entire duration between two per-session
       // log lines, silently reproducing the "live run indistinguishable from a hung one" problem
       // this progress logging was added to close.
-      const chunkProgressNowMs = Date.now();
-      if (chunkProgressNowMs - lastProgressLogMs >= PASSIVE_OBSERVER_PROGRESS_LOG_INTERVAL_MS) {
-        lastProgressLogMs = chunkProgressNowMs;
-        logger.info(
-          `memory-hybrid: passive-observer — progress: session ${sessionIdx + 1}/${sessions.length} (${sessionId}) ` +
-            `chunk ${chunksAttempted}/${chunks.length} chunksProcessed=${result.chunksProcessed} ` +
-            `factsExtracted=${result.factsExtracted} factsStored=${result.factsStored}`,
-        );
-      }
+      logThrottledObserverProgress(sessionIdx, sessionId, `chunk ${chunksAttempted}/${chunks.length}`);
 
       const filledPrompt = fillPrompt(prompt, {
         categories: allCategories.join(", "),

--- a/packages/openclaw-hybrid-memory-install/package.json
+++ b/packages/openclaw-hybrid-memory-install/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-hybrid-memory-install",
-  "version": "2026.7.54",
+  "version": "2026.7.55",
   "description": "Standalone installer for openclaw-hybrid-memory. Use when OpenClaw config validation fails.",
   "bin": {
     "openclaw-hybrid-memory-install": "./install.js"


### PR DESCRIPTION
## Summary

Fifth round of a self-review loop over the #2031-#2033 maintenance-orchestrator work (following #2034, #2035, #2036, #2037, all merged). This round's cleanup finder returned exactly one finding — the correctness finder returned nothing new, a good sign the loop is converging.

### Changed

- **De-duplicated `passive-observer`'s progress-log throttle.** The per-session and per-chunk progress-log call sites (added across #2032 and its chunk-loop follow-up in #2037) each re-implemented the same "compute now, compare against last-logged time, update, log" logic independently. A future change to the throttle interval or log format could easily be applied to only one, leaving the two drifting out of sync (e.g. one correctly throttled while the other floods again). Both call sites now share a single `logThrottledObserverProgress()` closure. No behavior change — verified via the existing throttle regression tests (all 84 `passive-observer.test.ts` tests pass unchanged).

**Version:** bumped plugin, `openclaw.plugin.json`, and `openclaw-hybrid-memory-install` package to **2026.7.55**.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactor / internal improvement (no behavior change)
- [ ] Documentation update
- [ ] CI / tooling change

## Quality Checklist

- [x] `cd extensions/memory-hybrid && npx tsc --noEmit` (via `npm run typecheck:gate`) passes with no errors
- [x] `cd extensions/memory-hybrid && npm run lint` — no new warnings
- [x] `cd extensions/memory-hybrid && npm test` — targeted maintenance-orchestrator suite green (146 passed), `passive-observer.test.ts` unchanged behavior (84 passed)
- [x] No secrets, credentials, or API keys committed
- [x] No `console.log` debug statements left in production code

## Documentation Impact

- [x] Inline code comments updated
- [x] `CHANGELOG.md` updated with a `2026.7.55` entry

## Testing

- [x] No new tests needed — this is a pure refactor; existing progress-log throttle tests (added in prior rounds) continue to pass unchanged, confirming behavior is preserved

## Notes for Reviewer

Same iterative loop as the prior four PRs: reset this branch from `main` after each merge, re-review the full current content of the touched files with fresh finder + verify passes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FUPMSbCtzdfwCxsPQcg6mJ)_