### PR TITLE
fix: distill/enrich-entities/extract-implicit progress diagnostics, bump to 2026.7.56

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,27 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ---
 
+## [2026.7.56] - 2026-07-05
+
+### Fixed
+
+- **`--max-runtime-min` bypassed the default cap on an empty string (#2031 follow-up):** `??` only falls back on null/undefined, so `--max-runtime-min=""` (e.g. a script interpolating an unset variable) silently produced no time budget at all for `maintenance step <name>`, instead of the intended 15-minute default.
+- **`passive-observer` could report a false-positive truncated run (#2032 follow-up):** the maintenance-run deadline was checked before confirming a session actually had pending content, so hitting the deadline while only already-caught-up trailing sessions remained still reported an errored/truncated run even though no work was actually lost. The pending-content check now runs first.
+- **`distill`'s heartbeat couldn't distinguish a retried batch from new content (#2038):** on failure, distill shrinks the batch and retries the *same* block range without advancing its cursor, but the heartbeat's "batch N" counter still incremented every attempt — so "batch 1, batch 2, batch 3" in the logs looked like forward progress through 1268 blocks when it was actually the same stuck range being retried 3 times. The heartbeat now also reports the block index the current attempt starts at, so an operator can see it staying constant across "batch" numbers.
+- **`enrich-entities` and `extract-implicit` only surfaced the generic orchestrator heartbeat (#2038):** unlike `distill` and `passive-observer`, a `maintenance step enrich-entities`/`extract-implicit --force --verbose` run showed no counters of its own for the whole step duration. Both functions already accepted an `onProgress` callback; the maintenance step-runner registrations now wire a throttled-logging callback into it (same ~60s cadence as `passive-observer`'s progress log), so long runs report `processed=N/M`-style counters instead of only "still running after Ns".
+
+### Notes
+
+- Retroactively closed #2032 and #2033: both were already fixed by #2034 (shipped in 2026.7.51) and refined by later PRs in this series, but the PR bodies referenced the issues by number without a closing keyword, so they never auto-closed.
+- #2038's remaining acceptance criteria (distill completing within a tight default verification budget, or exposing a dedicated smoke-test work limit) are not addressed here: every step run via `maintenance step <name>` is already bounded to a 15-minute default (overridable via `--max-runtime-min`, e.g. `--max-runtime-min 4` for a ~240s smoke check) and exits non-zero with an actionable reason when that budget is exceeded — operators who need a tighter check should pass that flag explicitly.
+- An initial hypothesis attributing distill's stuck-batch symptom to a stale `MiniMax-M2.7-highspeed` context-window catalog entry was investigated and **rejected**: `tests/m27-live-catalog-limits.test.ts` empirically verified against the live API (dated after the release notes that motivated the hypothesis) shows `-highspeed` matches full `MiniMax-M2.7`'s 262k input / 128k output ceiling, so no catalog change was made.
+
+### Changed
+
+- Bumped plugin, `openclaw.plugin.json`, and `openclaw-hybrid-memory-install` package versions to **2026.7.56**.
+
+---
+
 ## [2026.7.55] - 2026-07-05
 
 ### Changed

--- a/extensions/memory-hybrid/cli/cmd-distill.ts
+++ b/extensions/memory-hybrid/cli/cmd-distill.ts
@@ -20,21 +20,15 @@ import {
 } from "../config.js";
 import {
   ADAPTIVE_MODEL_LIMITS_VERSION,
-  adaptiveFailureShrinkRatios,
   type AdaptiveFailureKind,
+  adaptiveFailureShrinkRatios,
   getEffectiveModelLimits,
   loadAdaptiveModelLimits,
   recordAdaptiveFailure,
   recordAdaptiveSuccess,
   saveAdaptiveModelLimits,
 } from "../services/adaptive-model-limits.js";
-import { tryParseCredentialForVault, isStructuredCredentialCandidate } from "../services/auto-capture.js";
-import {
-  buildCredentialPointerText,
-  ensureCredentialVaultPointer,
-  abortCredentialVaultWriteOnPointerDedupe,
-  rollbackVaultCredentialWrite,
-} from "../services/credential-vault-pointer.js";
+import { isStructuredCredentialCandidate, tryParseCredentialForVault } from "../services/auto-capture.js";
 import {
   chatCompleteWithRetryDetailed,
   distillBatchTokenLimit,
@@ -47,40 +41,43 @@ import {
   resolveMaintenanceChatTimeoutMs,
 } from "../services/chat.js";
 import { CostFeature } from "../services/cost-feature-labels.js";
-import { capturePluginError } from "../services/error-reporter.js";
-import { preFilterSessions } from "../services/session-pre-filter.js";
-import { cleanupEvictedVector } from "../services/vector-maintenance.js";
-import { BATCH_STORE_IMPORTANCE, DISTILL_DEDUP_THRESHOLD } from "../utils/constants.js";
-import { formatDateUtc, formatTimestampUtcFromMs, nowIso } from "../utils/dates.js";
-import { getEnv } from "../utils/env-manager.js";
 import {
-  capTimeoutByMaintenanceRunDeadline,
-  getMaintenanceRunAbortSignal,
-  maintenanceRunDeadlineReached,
-} from "../utils/maintenance-run-deadline.js";
-import { redactMaintenancePrivateText } from "../utils/maintenance-privacy.js";
-import { resolveTierPreferenceWithSources } from "../utils/llm-selection.js";
-import { loadPrompt } from "../utils/prompt-loader.js";
-import { extractTags } from "../utils/tags.js";
-import { chunkSessionText, estimateTokens } from "../utils/text.js";
-import { getMaxMtime } from "./cmd-extract.js";
-import { buildPreFilterConfig, createProgressReporter } from "./cmd-install.js";
-import { extractTextFromSessionJsonl } from "./distill-session-jsonl.js";
-import type { HandlerContext } from "./handlers.js";
+  abortCredentialVaultWriteOnPointerDedupe,
+  buildCredentialPointerText,
+  ensureCredentialVaultPointer,
+  rollbackVaultCredentialWrite,
+} from "../services/credential-vault-pointer.js";
+import { capturePluginError } from "../services/error-reporter.js";
+import type { MaintenanceJobRun } from "../services/maintenance-job-run/job-run.js";
 import {
   createLightJobRun,
   finishLightJobRun,
   type LightJobRunParams,
 } from "../services/maintenance-job-run/light-job-run-bridge.js";
-import type { MaintenanceJobRun } from "../services/maintenance-job-run/job-run.js";
+import { preFilterSessions } from "../services/session-pre-filter.js";
+import { cleanupEvictedVector } from "../services/vector-maintenance.js";
+import { BATCH_STORE_IMPORTANCE, DISTILL_DEDUP_THRESHOLD } from "../utils/constants.js";
+import { formatDateUtc, formatTimestampUtcFromMs, nowIso } from "../utils/dates.js";
+import { getEnv } from "../utils/env-manager.js";
+import { resolveTierPreferenceWithSources } from "../utils/llm-selection.js";
+import { redactMaintenancePrivateText } from "../utils/maintenance-privacy.js";
+import {
+  capTimeoutByMaintenanceRunDeadline,
+  getMaintenanceRunAbortSignal,
+  maintenanceRunDeadlineReached,
+} from "../utils/maintenance-run-deadline.js";
+import { loadPrompt } from "../utils/prompt-loader.js";
+import { extractTags } from "../utils/tags.js";
+import { chunkSessionText, estimateTokens } from "../utils/text.js";
+import { getMaxMtime } from "./cmd-extract.js";
+import { buildPreFilterConfig, createProgressReporter } from "./cmd-install.js";
+import { startDistillProgress } from "./distill-progress.js";
+import { extractTextFromSessionJsonl } from "./distill-session-jsonl.js";
+import type { HandlerContext } from "./handlers.js";
 import { resolveScanMaintenanceOverrides } from "./maintenance-overrides.js";
 import { acquireScanSlot, clearScanLock } from "./shared.js";
 import type { DistillCliResult, DistillCliSink, DistillWindowResult, RecordDistillResult } from "./types.js";
-import {
-  classifyStoreDedupeMode,
-  resolveDistillVectorCandidates,
-} from "./vector-dedupe-helpers.js";
-import { startDistillProgress } from "./distill-progress.js";
+import { classifyStoreDedupeMode, resolveDistillVectorCandidates } from "./vector-dedupe-helpers.js";
 
 // Constants used only by distill functions
 const FULL_DISTILL_MAX_DAYS = 90;
@@ -535,7 +532,7 @@ export async function runDistillForCli(
       logger,
       sessions: filesToProcess.length,
       totalBlocks: blocks.length,
-      getState: () => ({ batch: batchNum, processedBlocks }),
+      getState: () => ({ batch: batchNum, processedBlocks, cursorBlock }),
     });
 
     while (cursorBlock < blocks.length) {
@@ -603,9 +600,7 @@ export async function runDistillForCli(
           feature: CostFeature.distillCli,
           thinkingMode: resolveDistillThinkingMode(cfg),
           timeoutMsPerModel: (m) =>
-            capTimeoutByMaintenanceRunDeadline(
-              resolveMaintenanceChatTimeoutMs(m, resolveDistillThinkingMode(cfg)),
-            ),
+            capTimeoutByMaintenanceRunDeadline(resolveMaintenanceChatTimeoutMs(m, resolveDistillThinkingMode(cfg))),
           signal: getMaintenanceRunAbortSignal(),
         });
         const outputTruncated = detail.finishReason?.toLowerCase() === "length";

--- a/extensions/memory-hybrid/cli/commands/manage/maintenance-step-runners.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/maintenance-step-runners.ts
@@ -3,36 +3,42 @@
  */
 
 import { existsSync, writeFileSync } from "node:fs";
-import { dirname, join } from "node:path";
 import { homedir } from "node:os";
+import { dirname, join } from "node:path";
 import { EventBus } from "../../../backends/event-bus.js";
 import type { FactsDB } from "../../../backends/facts-db.js";
 import type { VectorDB } from "../../../backends/vector-db.js";
 import type { HybridMemoryConfig } from "../../../config.js";
-import { getDefaultCronModel, getCronModelConfig } from "../../../config.js";
-import { CrystallizationProposer } from "../../../services/crystallization-proposer.js";
+import { getCronModelConfig, getDefaultCronModel } from "../../../config.js";
+import { runAutoClassify } from "../../../services/auto-classifier.js";
 import {
   DEFAULT_AMBIGUOUS_BACKLOG_DEGRADED_THRESHOLD,
   ORCHESTRATOR_CONTRADICTION_DEGRADED_CONSECUTIVE_THRESHOLD,
   runContradictionMaintenanceAutoStep,
 } from "../../../services/contradiction-progress-summary.js";
-import { syncLifecycleFromGitHub } from "../../../services/lifecycle/github-adapter.js";
-import { runAnalyzeMaintenanceLogs } from "./register-analyze-maintenance-logs.js";
-import { buildAuditHealthReport } from "./storage-stats-helpers.js";
-import { recordStorageGrowthSample } from "./storage-stats-helpers.js";
-import { runPendingDigestAutopilotCron } from "../../../services/pending-digest-autopilot-cron.js";
-import { buildPendingReviewDigestReport } from "../../../services/pending-review-digest.js";
-import { reconcileOrphanVectors } from "../../../services/vector-maintenance.js";
-import { sweepAll } from "../../../services/sensor-sweep.js";
-import { runAutoClassify } from "../../../services/auto-classifier.js";
+import { CrystallizationProposer } from "../../../services/crystallization-proposer.js";
 import {
   entityEnrichmentSemanticStatus,
   isEntityEnrichmentHardFailure,
 } from "../../../services/entity-enrichment-adaptive.js";
-import { runPassiveObserver } from "../../../services/passive-observer.js";
-import { deleteVectorsForFactIds } from "../../../services/vector-maintenance.js";
+import { syncLifecycleFromGitHub } from "../../../services/lifecycle/github-adapter.js";
+import {
+  parseSemanticTokenFromSummary,
+  semanticOutcomeBlocksOrchestratorGuard,
+  semanticOutcomeIsPartialFailure,
+} from "../../../services/maintenance-job-run/index.js";
 import type { MaintenanceStepRunner } from "../../../services/maintenance-orchestrator.js";
+import { runPassiveObserver } from "../../../services/passive-observer.js";
+import { runPendingDigestAutopilotCron } from "../../../services/pending-digest-autopilot-cron.js";
+import { buildPendingReviewDigestReport } from "../../../services/pending-review-digest.js";
+import { sweepAll } from "../../../services/sensor-sweep.js";
+import { deleteVectorsForFactIds, reconcileOrphanVectors } from "../../../services/vector-maintenance.js";
+import { nowIso } from "../../../utils/dates.js";
+import { maintenanceRunDeadlineReached } from "../../../utils/maintenance-run-deadline.js";
+import { cleanupImplicitFeedbackDuplicates } from "../../cmd-feedback.js";
+import { resolveScanMaintenanceOverrides, type ScanMaintenanceOverrideInput } from "../../maintenance-overrides.js";
 import type { ManageBindings } from "./bindings.js";
+import { extractImplicitSemanticOutcome, isGracefulExtractImplicitPartial } from "./dream-cycle-followup.js";
 import {
   buildDreamCycleFollowUpDepsFromBindings,
   runClosedLoopAnalysisStep,
@@ -43,16 +49,8 @@ import {
   runExtractImplicitStep,
   runToolEffectivenessStep,
 } from "./dream-cycle-followup-steps.js";
-import { extractImplicitSemanticOutcome, isGracefulExtractImplicitPartial } from "./dream-cycle-followup.js";
-import { cleanupImplicitFeedbackDuplicates } from "../../cmd-feedback.js";
-import { resolveScanMaintenanceOverrides, type ScanMaintenanceOverrideInput } from "../../maintenance-overrides.js";
-import { nowIso } from "../../../utils/dates.js";
-import { maintenanceRunDeadlineReached } from "../../../utils/maintenance-run-deadline.js";
-import {
-  parseSemanticTokenFromSummary,
-  semanticOutcomeBlocksOrchestratorGuard,
-  semanticOutcomeIsPartialFailure,
-} from "../../../services/maintenance-job-run/index.js";
+import { runAnalyzeMaintenanceLogs } from "./register-analyze-maintenance-logs.js";
+import { buildAuditHealthReport, recordStorageGrowthSample } from "./storage-stats-helpers.js";
 
 function reflectRulesDiagnosticsIndicateFailure(
   d:
@@ -117,6 +115,27 @@ function scanForceFlags(opts: BuildCliRunnersOptions): { force?: boolean; full?:
   return { force: true, full: true };
 }
 
+/**
+ * Throttled step-progress logger, matching the ~60s cadence passive-observer already uses
+ * (logThrottledObserverProgress in services/passive-observer.ts) — used by long LLM-tier steps that
+ * otherwise only surface the orchestrator's generic "still running after Ns" heartbeat, leaving an
+ * operator unable to tell live forward progress from a hang (#2038).
+ */
+function makeThrottledStepProgressLogger(
+  logger: { info?: (s: string) => void } | undefined,
+  stepName: string,
+  intervalMs = 60_000,
+): (message: string) => void {
+  let lastLogMs = 0;
+  return (message: string) => {
+    if (!logger?.info) return;
+    const nowMs = Date.now();
+    if (lastLogMs !== 0 && nowMs - lastLogMs < intervalMs) return;
+    lastLogMs = nowMs;
+    logger.info(`memory-hybrid: ${stepName} — progress: ${message}`);
+  };
+}
+
 function noopLog(): void {}
 
 async function runSensorSweepForCli(b: ManageBindings): Promise<string> {
@@ -124,7 +143,7 @@ async function runSensorSweepForCli(b: ManageBindings): Promise<string> {
   const eventBusPath = b.resolvedSqlitePath ? join(dirname(b.resolvedSqlitePath), "event-bus.db") : null;
   if (!eventBusPath) return "skipped (no event bus path)";
 
-  let eventBus: EventBus = b.eventBus ?? new EventBus(eventBusPath);
+  const eventBus: EventBus = b.eventBus ?? new EventBus(eventBusPath);
   const ownsBus = !b.eventBus;
   try {
     const r = await sweepAll(eventBus, b.cfg.sensorSweep, b.factsDb, {
@@ -435,11 +454,18 @@ export function buildCliMaintenanceRunners(
   });
 
   set("enrich-entities", async () => {
+    const logger = (b as unknown as { logger?: { info?: (s: string) => void; warn?: (s: string) => void } }).logger;
+    const logProgress = makeThrottledStepProgressLogger(logger, "enrich-entities");
     const r = await b.runEntityEnrichment({
       limit: 200,
       dryRun: false,
       adaptiveCatchUp: true,
       verbose,
+      onProgress: (p) =>
+        logProgress(
+          `processed=${p.processed}/${p.total} factsEnriched=${p.factsEnriched} mentions=${p.mentions} ` +
+            `accepted=${p.accepted} rejected=${p.rejected} llmFailures=${p.llmFailures}`,
+        ),
     });
     const summary = formatEntityEnrichmentSummary(r);
     assertEntityEnrichmentNotPartial(r, summary);
@@ -448,11 +474,18 @@ export function buildCliMaintenanceRunners(
 
   set("extract-implicit", async () => {
     if (b.runExtractImplicitFeedback) {
+      const logger = (b as unknown as { logger?: { info?: (s: string) => void; warn?: (s: string) => void } }).logger;
+      const logProgress = makeThrottledStepProgressLogger(logger, "extract-implicit");
       const res = await b.runExtractImplicitFeedback({
         dryRun: false,
         includeClosedLoop: false,
         verbose,
         ...scanFlags,
+        onProgress: (snap) =>
+          logProgress(
+            `stage=${snap.stage} sessions=${snap.sessionsVisited}/${snap.sessionsDiscovered} ` +
+              `processed=${snap.sessionsProcessed} signalsExtracted=${snap.signalsExtracted}`,
+          ),
       });
       const summary = formatExtractImplicitSummary(res);
       assertExtractImplicitNotPartial(res, summary);
@@ -950,7 +983,7 @@ export function buildPluginCycleRunners(deps: PluginCycleRunnerDeps): Map<string
     );
   }
 
-  runners.  set("evolution-pass", async () => {
+  runners.set("evolution-pass", async () => {
     if (typeof deps.factsDb.getRawDb !== "function") return "skipped (factsDb unavailable)";
     const { runEvolutionPass } = await import("../../../services/evolution-pass.js");
     const { resolveReflectionModelAndFallbacks } = await import("../../../config/index.js");

--- a/extensions/memory-hybrid/cli/commands/manage/register-maintenance-orchestrator.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/register-maintenance-orchestrator.ts
@@ -242,7 +242,11 @@ export function registerMaintenanceOrchestratorCommands(maintenance: Chainable, 
         ...opts,
         include: stepName,
         force: true,
-        maxRuntimeMin: opts?.maxRuntimeMin ?? DEFAULT_STEP_MAX_RUNTIME_MIN,
+        // `??` only falls back on null/undefined — an empty string (e.g. from a script
+        // interpolating an unset variable as `--max-runtime-min="$VAR"`) is neither, so it would
+        // silently pass through as "", which runTier's `opts?.maxRuntimeMin ? ... : undefined`
+        // then treats as no budget at all, defeating the intended default cap (round-5 review finding).
+        maxRuntimeMin: opts?.maxRuntimeMin?.trim() || DEFAULT_STEP_MAX_RUNTIME_MIN,
         verbose: !!opts?.verbose || readHybridMemVerbose(cmd),
       });
     }),

--- a/extensions/memory-hybrid/cli/distill-progress.ts
+++ b/extensions/memory-hybrid/cli/distill-progress.ts
@@ -12,10 +12,16 @@
 export const DISTILL_HEARTBEAT_INTERVAL_MS = 30_000;
 
 export interface DistillProgressState {
-  /** 1-based index of the batch currently being processed. */
+  /** 1-based index of the batch/retry attempt currently in flight — increments on every retry,
+   *  including a shrink-and-retry of the SAME block range, so it is not itself proof of forward
+   *  progress (#2038). */
   batch: number;
   /** Blocks fully processed so far. */
   processedBlocks: number;
+  /** Block index the current batch/retry starts at. Unchanged across repeated retries of the same
+   *  batch — surfacing it lets an operator tell "batch N is new content" from "batch N is a
+   *  relabeled retry of the same still-stuck block range" (#2038). */
+  cursorBlock: number;
 }
 
 export interface DistillDoneSummary {
@@ -56,10 +62,11 @@ export function startDistillProgress(opts: {
   const startedMs = Date.now();
   log(`memory-hybrid: distill start — sessions=${opts.sessions} blocks=${opts.totalBlocks}`);
   const heartbeat = setInterval(() => {
-    const { batch, processedBlocks } = opts.getState();
+    const { batch, processedBlocks, cursorBlock } = opts.getState();
     const elapsedSec = Math.floor((Date.now() - startedMs) / 1000);
     log(
-      `memory-hybrid: distill — still running: batch ${batch} processed ${processedBlocks}/${opts.totalBlocks} blocks (elapsed ${elapsedSec}s)`,
+      `memory-hybrid: distill — still running: batch ${batch} (block ${cursorBlock}/${opts.totalBlocks}) ` +
+        `processed ${processedBlocks}/${opts.totalBlocks} blocks (elapsed ${elapsedSec}s)`,
     );
   }, opts.intervalMs ?? DISTILL_HEARTBEAT_INTERVAL_MS);
   heartbeat.unref?.();

--- a/extensions/memory-hybrid/openclaw.plugin.json
+++ b/extensions/memory-hybrid/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "openclaw-hybrid-memory",
   "kind": "memory",
-  "version": "2026.7.55",
+  "version": "2026.7.56",
   "contracts": {
     "tools": [
       "active_task_checkpoint",

--- a/extensions/memory-hybrid/package-lock.json
+++ b/extensions/memory-hybrid/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openclaw-hybrid-memory",
-  "version": "2026.7.55",
+  "version": "2026.7.56",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openclaw-hybrid-memory",
-      "version": "2026.7.55",
+      "version": "2026.7.56",
       "hasInstallScript": true,
       "dependencies": {
         "@lancedb/lancedb": "^0.30.0",

--- a/extensions/memory-hybrid/package.json
+++ b/extensions/memory-hybrid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-hybrid-memory",
-  "version": "2026.7.55",
+  "version": "2026.7.56",
   "type": "module",
   "description": "Give your OpenClaw agent lasting memory: structured facts, semantic search, auto-capture & recall, decay, optional credential vault. Part of Hybrid Memory v3.",
   "files": [

--- a/extensions/memory-hybrid/services/passive-observer.ts
+++ b/extensions/memory-hybrid/services/passive-observer.ts
@@ -510,6 +510,10 @@ export async function runPassiveObserver(
     );
   };
   for (const [sessionIdx, { filePath, sessionId, fileBytelen, cursor }] of sessions.entries()) {
+    // Check for pending content BEFORE the deadline (round-5 review finding): an already-caught-up
+    // trailing session costs nothing to skip, so it shouldn't be able to trip the deadline check and
+    // report a false-positive truncated/errored run when there was actually no work left to lose.
+    if (cursor >= fileBytelen) continue; // Nothing new
     if (maintenanceRunDeadlineReached()) {
       // Deadline stops mid-run are counted as an error so the caller's summary (and
       // assertPassiveObserverSummaryDoesNotBlock) surface a truncated run as a failure
@@ -522,7 +526,6 @@ export async function runPassiveObserver(
       );
       break;
     }
-    if (cursor >= fileBytelen) continue; // Nothing new
     logThrottledObserverProgress(sessionIdx, sessionId);
 
     let rawBuf: Buffer;

--- a/extensions/memory-hybrid/tests/distill-progress.test.ts
+++ b/extensions/memory-hybrid/tests/distill-progress.test.ts
@@ -10,7 +10,7 @@ describe("distill progress heartbeat (#2029)", () => {
     vi.useFakeTimers();
     const lines: string[] = [];
     const logger = { info: (m: string) => lines.push(m) };
-    let state = { batch: 1, processedBlocks: 0 };
+    let state = { batch: 1, processedBlocks: 0, cursorBlock: 0 };
 
     const reporter = startDistillProgress({
       verbose: true,
@@ -25,11 +25,13 @@ describe("distill progress heartbeat (#2029)", () => {
     expect(lines[0]).toBe("memory-hybrid: distill start — sessions=358 blocks=12");
 
     // Advance into a long batch → at least one heartbeat with current block counts + elapsed.
-    state = { batch: 1, processedBlocks: 3 };
+    state = { batch: 1, processedBlocks: 3, cursorBlock: 3 };
     vi.advanceTimersByTime(30_000);
-    expect(lines.some((l) => /distill — still running: batch 1 processed 3\/12 blocks \(elapsed 30s\)/.test(l))).toBe(
-      true,
-    );
+    expect(
+      lines.some((l) =>
+        /distill — still running: batch 1 \(block 3\/12\) processed 3\/12 blocks \(elapsed 30s\)/.test(l),
+      ),
+    ).toBe(true);
 
     reporter.done({ status: "partial", extracted: 0, processedBlocks: 3, batchFailures: 1, truncatedBatches: 0 });
     const doneLine = lines.at(-1) ?? "";
@@ -47,7 +49,7 @@ describe("distill progress heartbeat (#2029)", () => {
       logger: { info: (m: string) => lines.push(m) },
       sessions: 1,
       totalBlocks: 1,
-      getState: () => ({ batch: 1, processedBlocks: 1 }),
+      getState: () => ({ batch: 1, processedBlocks: 1, cursorBlock: 1 }),
       intervalMs: 30_000,
     });
     reporter.done({ status: "ok", extracted: 5, processedBlocks: 1, batchFailures: 0, truncatedBatches: 0 });
@@ -63,7 +65,7 @@ describe("distill progress heartbeat (#2029)", () => {
       logger: { info: (m: string) => lines.push(m) },
       sessions: 10,
       totalBlocks: 5,
-      getState: () => ({ batch: 1, processedBlocks: 0 }),
+      getState: () => ({ batch: 1, processedBlocks: 0, cursorBlock: 0 }),
     });
     reporter.done({ status: "ok", extracted: 1, processedBlocks: 5, batchFailures: 0, truncatedBatches: 0 });
     reporter.stop();
@@ -78,7 +80,7 @@ describe("distill progress heartbeat (#2029)", () => {
       logger: { info: (m: string) => lines.push(m) },
       sessions: 2,
       totalBlocks: 4,
-      getState: () => ({ batch: 2, processedBlocks: 2 }),
+      getState: () => ({ batch: 2, processedBlocks: 2, cursorBlock: 2 }),
       intervalMs: 10_000,
     });
     vi.advanceTimersByTime(10_000);
@@ -87,5 +89,40 @@ describe("distill progress heartbeat (#2029)", () => {
     for (const line of lines) {
       expect(line.startsWith("memory-hybrid: distill")).toBe(true);
     }
+  });
+
+  it("surfaces cursorBlock so a retried batch (same block range) is distinguishable from new content (#2038)", () => {
+    // Reproduces the #2038 symptom: "batch" keeps incrementing (a shrink-and-retry loop) while the
+    // block range being attempted never advances. Before this fix, the heartbeat only showed
+    // "batch N processed 0/1268", which looked identical whether batch N was new content or the 8th
+    // retry of the same stuck block range.
+    vi.useFakeTimers();
+    const lines: string[] = [];
+    let state = { batch: 1, processedBlocks: 0, cursorBlock: 0 };
+    const reporter = startDistillProgress({
+      verbose: true,
+      logger: { info: (m: string) => lines.push(m) },
+      sessions: 358,
+      totalBlocks: 1268,
+      getState: () => state,
+      intervalMs: 30_000,
+    });
+
+    state = { batch: 2, processedBlocks: 0, cursorBlock: 0 }; // batch incremented, cursorBlock did NOT
+    vi.advanceTimersByTime(30_000);
+    state = { batch: 3, processedBlocks: 0, cursorBlock: 0 }; // still the same stuck range
+    vi.advanceTimersByTime(30_000);
+
+    reporter.done({ status: "partial", extracted: 0, processedBlocks: 0, batchFailures: 1, truncatedBatches: 0 });
+
+    const heartbeatLines = lines.filter((l) => l.includes("still running"));
+    expect(heartbeatLines).toHaveLength(2);
+    // Both heartbeats report the identical block range despite the incrementing batch number —
+    // exactly the signal an operator needs to tell "stuck retry" from "advancing through new blocks".
+    for (const line of heartbeatLines) {
+      expect(line).toContain("(block 0/1268)");
+    }
+    expect(heartbeatLines[0]).toContain("batch 2");
+    expect(heartbeatLines[1]).toContain("batch 3");
   });
 });

--- a/extensions/memory-hybrid/tests/maintenance-step-runners-progress-logging.test.ts
+++ b/extensions/memory-hybrid/tests/maintenance-step-runners-progress-logging.test.ts
@@ -1,0 +1,93 @@
+/**
+ * `enrich-entities` and `extract-implicit`, run via `maintenance step <name>`, previously only
+ * surfaced the orchestrator's generic "still running after Ns" heartbeat for the whole step
+ * duration — no phase/counter progress of their own, unlike distill and passive-observer (#2038).
+ * Both already accept an `onProgress` callback; the step-runner registrations now wire a
+ * throttled-logging callback into it.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ManageBindings } from "../cli/commands/manage/bindings.js";
+import { buildCliMaintenanceRunners } from "../cli/commands/manage/maintenance-step-runners.js";
+
+describe("enrich-entities / extract-implicit step-runner progress logging (#2038)", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("logs throttled progress for enrich-entities via the onProgress callback wired into runEntityEnrichment", async () => {
+    const logLines: string[] = [];
+    const logger = { info: (s: string) => logLines.push(s), warn: () => {} };
+
+    const bindings = {
+      factsDb: { getRawDb: () => ({}) },
+      cfg: {},
+      logger,
+      runEntityEnrichment: vi.fn(async (opts: { onProgress?: (p: unknown) => void }) => {
+        opts.onProgress?.({ processed: 3, total: 10, factsEnriched: 2, mentions: 1, accepted: 2, rejected: 0 });
+        return { processed: 10, factsEnriched: 4, llmFailures: 0, stopReason: "completed" };
+      }),
+    } as unknown as ManageBindings;
+
+    const runner = buildCliMaintenanceRunners(bindings).get("enrich-entities");
+    expect(runner).toBeDefined();
+    await runner?.();
+
+    expect(logLines.some((l) => l.includes("enrich-entities — progress:") && l.includes("processed=3/10"))).toBe(true);
+  });
+
+  it("logs throttled progress for extract-implicit via the onProgress callback wired into runExtractImplicitFeedback", async () => {
+    const logLines: string[] = [];
+    const logger = { info: (s: string) => logLines.push(s), warn: () => {} };
+
+    const bindings = {
+      factsDb: { getRawDb: () => ({}) },
+      cfg: {},
+      logger,
+      runExtractImplicitFeedback: vi.fn(async (opts: { onProgress?: (p: unknown) => void }) => {
+        opts.onProgress?.({
+          stage: "scan-sessions",
+          sessionsDiscovered: 20,
+          sessionsVisited: 5,
+          sessionsProcessed: 4,
+          signalsExtracted: 7,
+        });
+        return {
+          signalsExtracted: 7,
+          positiveCount: 5,
+          negativeCount: 2,
+          trajectoriesBuilt: 0,
+          sessionsScanned: 20,
+          sessionsVisited: 20,
+          sessionsProcessed: 20,
+          sessionsSkipped: 0,
+          sessionsDeferred: 0,
+          backlogSessionsEstimate: 0,
+        };
+      }),
+    } as unknown as ManageBindings;
+
+    const runner = buildCliMaintenanceRunners(bindings).get("extract-implicit");
+    expect(runner).toBeDefined();
+    await runner?.();
+
+    expect(
+      logLines.some(
+        (l) => l.includes("extract-implicit — progress:") && l.includes("sessions=5/20") && l.includes("processed=4"),
+      ),
+    ).toBe(true);
+  });
+
+  it("does not throw when no logger is available on bindings (progress logging is best-effort)", async () => {
+    const bindings = {
+      factsDb: { getRawDb: () => ({}) },
+      cfg: {},
+      runEntityEnrichment: vi.fn(async (opts: { onProgress?: (p: unknown) => void }) => {
+        opts.onProgress?.({ processed: 1, total: 1, factsEnriched: 0, mentions: 0, accepted: 0, rejected: 0 });
+        return { processed: 1, factsEnriched: 0, llmFailures: 0, stopReason: "completed" };
+      }),
+    } as unknown as ManageBindings;
+
+    const runner = buildCliMaintenanceRunners(bindings).get("enrich-entities");
+    await expect(runner?.()).resolves.not.toThrow();
+  });
+});

--- a/extensions/memory-hybrid/tests/register-maintenance-orchestrator-steps.test.ts
+++ b/extensions/memory-hybrid/tests/register-maintenance-orchestrator-steps.test.ts
@@ -390,4 +390,25 @@ describe("maintenance step <step> bounds runtime by default (#2032)", () => {
       expect.objectContaining({ maxRuntimeMs: undefined }),
     );
   });
+
+  it("falls back to the 15-minute default when --max-runtime-min is an empty string (round-5 review finding)", async () => {
+    // `??` only falls back on null/undefined; an empty string (e.g. a script interpolating an
+    // unset variable as --max-runtime-min="$VAR") would otherwise slip through as "" and resolve to
+    // no budget at all in runTier, silently defeating the intended default cap.
+    const stepName = listMaintenanceSteps()[0]?.name as string;
+    mockOrchestratorResult({ stepName, status: "ok", summary: "done" });
+
+    const mem = new Command("hybrid-mem");
+    mem.exitOverride();
+    const maintenance = mem.command("maintenance");
+    registerMaintenanceOrchestratorCommands(maintenance, makeMinimalBindings());
+    vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await mem.parseAsync(["maintenance", "step", stepName, "--force", "--max-runtime-min", ""], { from: "user" });
+
+    expect(runMaintenanceOrchestratorMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ maxRuntimeMs: 15 * 60_000 }),
+    );
+  });
 });

--- a/packages/openclaw-hybrid-memory-install/package.json
+++ b/packages/openclaw-hybrid-memory-install/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-hybrid-memory-install",
-  "version": "2026.7.55",
+  "version": "2026.7.56",
   "description": "Standalone installer for openclaw-hybrid-memory. Use when OpenClaw config validation fails.",
   "bin": {
     "openclaw-hybrid-memory-install": "./install.js"


### PR DESCRIPTION
## Summary

Fixes #2038.

### Root cause of #2038's distill symptom

The verification harness's `distill` runs showed `"batch 1 processed 0/1268"`, then `"batch 2 processed 0/1268"`, `"batch 3 processed 0/1268"` across 210+ seconds — looking like slow-but-real progress through 1268 blocks. Reading the batch loop: `batchNum` increments on **every loop iteration**, including a shrink-and-retry of the *same* block range when both the primary and fallback model calls fail. `cursorBlock` (and `processedBlocks`) only advance on the success path. So "batch 1, 2, 3" wasn't three different chunks of content — it was one stuck block range being retried 3 times, relabeled by an ever-incrementing counter, until the retry budget (8 attempts) was exhausted.

An initial hypothesis attributed this to a stale `MiniMax-M2.7-highspeed` context-window catalog entry (a `~40K` ceiling documented in March 2026 release notes, vs. the catalog's `150K`). I investigated this, found the theory plausible, started implementing a catalog fix — then found `tests/m27-live-catalog-limits.test.ts` (added in late June, three months after those release notes), which empirically re-probes the live MiniMax API and shows `-highspeed` now matches full M2.7's 262k input / 128k output ceiling. The release notes were stale; the catalog was already correct. **Reverted that change** rather than ship a regression based on outdated documentation.

### Fixed

- **`distill`'s heartbeat couldn't distinguish a retried batch from new content.** The heartbeat now also reports the block index (`cursorBlock`) the current attempt starts at, so an operator can see it staying constant across incrementing "batch" numbers — directly surfacing "this is a stuck retry, not progress."
- **`enrich-entities` and `extract-implicit` only showed the generic orchestrator heartbeat.** Both already accept an `onProgress` callback (used for real progress data internally); the maintenance step-runner registrations now wire a throttled-logging callback into it, matching `passive-observer`'s ~60s cadence, so `maintenance step enrich-entities/extract-implicit --force --verbose` now reports `processed=N/M`-style counters.
- **`--max-runtime-min=""` bypassed the default 15-minute cap** (round-5 review finding): `??` only falls back on null/undefined, so a script interpolating an unset variable as `--max-runtime-min="$VAR"` silently produced no budget at all.
- **`passive-observer` could report a false-positive truncated run** (round-5 review finding): the deadline check ran before confirming a session had pending content, so hitting the deadline while only already-caught-up trailing sessions remained still reported an errored run with no actual work lost.

### Not addressed here (documented as a gap)

#2038's other acceptance criteria — distill completing within a very tight default verification budget, or a dedicated smoke-test work limit — aren't tackled in this PR. Every step run via `maintenance step <name>` is already bounded to a 15-minute default (from #2034, overridable via `--max-runtime-min`) and exits non-zero with an actionable reason when exceeded; an operator running a tight external harness (the issue used 240s) should pass `--max-runtime-min 4` explicitly rather than rely on the default.

### Also

Retroactively closed #2032 and #2033 — both already fixed by #2034 (shipped 2026.7.51) and refined by later PRs in this series, but never auto-closed since those PR bodies referenced the issue numbers without a closing keyword.

**Version:** bumped plugin, `openclaw.plugin.json`, and `openclaw-hybrid-memory-install` package to **2026.7.56**.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor / internal improvement (no behavior change)
- [ ] Documentation update
- [ ] CI / tooling change

## Quality Checklist

- [x] `cd extensions/memory-hybrid && npx tsc --noEmit` (via `npm run typecheck:gate`) passes with no errors
- [x] `cd extensions/memory-hybrid && npm run lint` — no new warnings (pre-existing unrelated warnings untouched)
- [x] `cd extensions/memory-hybrid && npm test` — full suite: 8632 passed, 3 pre-existing/unrelated flaky failures (`crystallization-proposer.test.ts`, `implicit-feedback-routing.test.ts`, `memory-recall-timeline.test.ts` — none touch this diff, reproduced on `main` before this branch existed)
- [x] No secrets, credentials, or API keys committed
- [x] No `console.log` debug statements left in production code

## Documentation Impact

- [x] Inline code comments updated
- [x] `CHANGELOG.md` updated with a `2026.7.56` entry

## Testing

- [x] `tests/distill-progress.test.ts`: new test proves the heartbeat shows the same `cursorBlock` across incrementing "batch" numbers when a retry doesn't advance
- [x] `tests/maintenance-step-runners-progress-logging.test.ts` (new file): proves `enrich-entities`/`extract-implicit` progress logs fire via the wired `onProgress` callback, and that missing a logger doesn't throw
- [x] `tests/register-maintenance-orchestrator-steps.test.ts`: new test for the `--max-runtime-min=""` fallback
- [x] `tests/model-capabilities-minimax.test.ts`: unchanged (confirms the catalog revert left this file untouched)

## Notes for Reviewer

This continues the iterative review-loop pattern from #2034-#2039: this round was driven by a fresh user-filed issue (#2038) rather than a self-review pass, requiring root-cause investigation via background research agents before implementing. The MiniMax catalog false start is left in the commit message/PR description for transparency, even though it was reverted before commit.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FUPMSbCtzdfwCxsPQcg6mJ)_