### PR TITLE
fix: resolve maintenance partial-failure semantics for #2043

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ---
 
+## [2026.7.58] - 2026-07-05
+
+### Fixed
+
+- **`passive-observer` reported a deadline-limited stop as a hard failure (#2043):** a maintenance-run-deadline stop mid-scan incremented the same `errors` counter used for real per-session failures (stat/read errors), so a healthy truncated run (`stored=54 scanned=487 errors=1`) was indistinguishable from an actual error and always failed the step. `ObserverRunResult` now tracks `deadlineStopped` separately from `errors`; a deadline-only stop reports `semantic=monitoring` (non-blocking) instead of `semantic=partial`, while real per-session errors still fail the step as before (`services/passive-observer.ts`, `setup/plugin-service.ts`, `setup/cli-context/cli-services.ts`).
+- **`distill` made zero progress across multiple batches before exhausting its deadline (#2043):** every batch retried the primary model from scratch even after it had already timed out earlier in the same run, burning ~90s of retry/fallback cost per batch on a model already known to be unavailable and leaving the fallback too little of the remaining budget to ever complete a block. `runDistillForCli` now remembers a primary timeout/connection-error for the rest of the run and routes subsequent batches straight to the fallback chain (`cli/cmd-distill.ts`).
+- **`enrich-entities` failed on a healthy, mostly-successful, budget-limited stop (#2043):** any nonzero `llmFailures` unconditionally counted as a hard failure, so a run that processed 90 facts with 2 transient LLM errors (`stopReason=time_budget`) failed the step exactly like a run that made no progress at all. `isEntityEnrichmentHardFailure` now tolerates a small LLM-failure rate (≤5%) on a budget-limited stop with real progress, and `entityEnrichmentSemanticStatus` reports a clean budget-limited stop as `monitoring` (resumable, checkpointed) rather than `success` or a hard failure (`services/entity-enrichment-adaptive.ts`).
+- **`reflect-rules` reported `semantic=success` despite a real model-output parse failure (#2043):** `zero_rules_reason=invalid_response_format` (the model responded but its output couldn't be parsed at all) was explicitly exempted from failure whenever `status=degraded` and the model returned some output — silently reporting a broken week's rule extraction as `ok`. This carve-out is removed from all three places it was duplicated (`cli/commands/manage/maintenance-step-runners.ts`, `services/maintenance-job-run/semantic-outcome.ts`, `services/cron-exit-validator.ts`); `invalid_response_format` is now treated the same as any other degraded run, while the legitimate "nothing to extract" cases (`insufficient_patterns`, `valid_no_actionable_rules`) remain non-failing.
+
+### Changed
+
+- Bumped plugin, `openclaw.plugin.json`, and `openclaw-hybrid-memory-install` package versions to **2026.7.58**.
+
+---
+
 ## [2026.7.57] - 2026-07-05
 
 ### Fixed

--- a/extensions/memory-hybrid/cli/cmd-distill.ts
+++ b/extensions/memory-hybrid/cli/cmd-distill.ts
@@ -456,6 +456,11 @@ export async function runDistillForCli(
     let cursorBlock = 0;
     let shrinkBudget = 8;
     let truncatedBatches = 0;
+    // Once the primary model times out/connection-errors once this run, every subsequent batch skips
+    // straight to the fallback chain instead of re-paying the primary's full retry+timeout cost first
+    // (#2043) — a stalled primary otherwise burns ~90s/batch on a call that's already shown it won't
+    // succeed, leaving the fallback too little of the deadline to ever complete a single block.
+    let primaryUnavailableThisRun = false;
     let nonAdaptiveBatchFactor = 1;
     let nonAdaptiveOutFactor = 1;
     const minBatchForModel = Math.max(2048, promptTokens + 256);
@@ -608,7 +613,14 @@ export async function runDistillForCli(
         logger.warn?.(
           `memory-hybrid: distill batch ${batchNum} primary ${model} cannot fit ~${inputTokens} tokens (limit ${primaryInputLimit}); using ${callModel} first`,
         );
+      } else if (primaryUnavailableThisRun && callFallbacks.length > 0) {
+        callModel = callFallbacks[0];
+        callFallbacks = callFallbacks.slice(1);
+        logger.info?.(
+          `memory-hybrid: distill batch ${batchNum} skipping primary ${model} (timed out earlier this run); using ${callModel} first`,
+        );
       }
+      const usedPrimaryThisAttempt = callModel === model;
       try {
         const detail = await chatCompleteWithRetryDetailed({
           model: callModel,
@@ -742,6 +754,12 @@ export async function runDistillForCli(
           typeof (e as Error & { lastAttemptedModel?: string }).lastAttemptedModel === "string"
             ? (e as Error & { lastAttemptedModel: string }).lastAttemptedModel
             : model;
+        // chatCompleteWithRetryDetailed only throws after every model in the chain (primary + all
+        // fallbackModels passed to this call) has failed, so a timeout/connection error while the
+        // primary was in the chain means the primary itself is confirmed down for this run.
+        if (usedPrimaryThisAttempt && (isTimeout || isConn)) {
+          primaryUnavailableThisRun = true;
+        }
         shrinkForRetry(kind, failureModel);
         const retryAfterMs = parseRetryAfterMs(e);
         if ((isRateLimit || isQuota) && retryAfterMs != null && retryAfterMs > 0) {

--- a/extensions/memory-hybrid/cli/commands/manage/maintenance-step-runners.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/maintenance-step-runners.ts
@@ -71,9 +71,10 @@ function reflectRulesDiagnosticsIndicateFailure(
   if (d.zeroRulesReason === "insufficient_patterns" || d.zeroRulesReason === "valid_no_actionable_rules") {
     return false;
   }
-  if (d.zeroRulesReason === "invalid_response_format" && d.status === "degraded" && (d.modelResponseChars ?? 0) > 0) {
-    return false;
-  }
+  // invalid_response_format means the model responded but its output could not be parsed at all — a
+  // real pipeline break (prompt drift, provider format change), not "nothing to extract". This used
+  // to be tolerated as a one-off flake and reported as semantic=success, which silently hid a broken
+  // week's worth of rule extraction (#2043) — treat it the same as any other degraded run.
   if (d.status === "degraded") return true;
   if (d.status === "ok") return false;
   return !d.parseSuccess || rulesStored === 0;

--- a/extensions/memory-hybrid/openclaw.plugin.json
+++ b/extensions/memory-hybrid/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "openclaw-hybrid-memory",
   "kind": "memory",
-  "version": "2026.7.57",
+  "version": "2026.7.58",
   "contracts": {
     "tools": [
       "active_task_checkpoint",

--- a/extensions/memory-hybrid/package-lock.json
+++ b/extensions/memory-hybrid/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openclaw-hybrid-memory",
-  "version": "2026.7.57",
+  "version": "2026.7.58",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openclaw-hybrid-memory",
-      "version": "2026.7.57",
+      "version": "2026.7.58",
       "hasInstallScript": true,
       "dependencies": {
         "@lancedb/lancedb": "^0.30.0",

--- a/extensions/memory-hybrid/package.json
+++ b/extensions/memory-hybrid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-hybrid-memory",
-  "version": "2026.7.57",
+  "version": "2026.7.58",
   "type": "module",
   "description": "Give your OpenClaw agent lasting memory: structured facts, semantic search, auto-capture & recall, decay, optional credential vault. Part of Hybrid Memory v3.",
   "files": [

--- a/extensions/memory-hybrid/services/cron-exit-validator.ts
+++ b/extensions/memory-hybrid/services/cron-exit-validator.ts
@@ -801,16 +801,9 @@ function collectMaintenanceTelemetryIssues(params: {
   const reflectParseFailed = /\bparse[_\s-]?success\s*[=:]\s*(false|0)\b/i.test(reflectRulesLog);
   const reflectStored = parsePositiveMetric(reflectRulesLog, "stored");
   const reflectInsufficientPatterns = /\bzero_rules_reason\s*[=:]\s*insufficient_patterns\b/i.test(reflectRulesLog);
-  const reflectDegradedFlake =
-    /\bzero_rules_reason\s*[=:]\s*invalid_response_format\b/i.test(reflectRulesLog) &&
-    /\bstatus\s*[=:]\s*degraded\b/i.test(reflectRulesLog) &&
-    (parsePositiveMetric(reflectRulesLog, "model_response_chars") ?? 0) > 0;
-  if (
-    reflectRulesDetected &&
-    (reflectParseFailed || reflectStored === 0) &&
-    !reflectInsufficientPatterns &&
-    !reflectDegradedFlake
-  ) {
+  // invalid_response_format is a genuine parse failure, not a benign flake — it must surface here too
+  // instead of being waved through, consistent with the orchestrator-side fix for #2043.
+  if (reflectRulesDetected && (reflectParseFailed || reflectStored === 0) && !reflectInsufficientPatterns) {
     addMaintenanceIssue(
       issues,
       buildMaintenanceIssue({

--- a/extensions/memory-hybrid/services/entity-enrichment-adaptive.ts
+++ b/extensions/memory-hybrid/services/entity-enrichment-adaptive.ts
@@ -254,25 +254,48 @@ export type EntityEnrichmentOutcomeInput = {
 };
 
 /**
+ * Tolerated LLM-failure rate for a budget-limited stop with real progress (#2043). Deliberately low
+ * (5%) — it exists to absorb the occasional transient provider blip on a large run (e.g. 2/90), not
+ * to mask a meaningfully elevated failure rate (e.g. 2/20 remains a hard failure).
+ */
+const BUDGET_STOP_LLM_FAILURE_TOLERANCE_RATIO = 0.05;
+
+function isEntityEnrichmentBudgetStop(stopReason: string): boolean {
+  return stopReason === "time_budget" || stopReason === "provider_budget";
+}
+
+/**
  * True when enrichment should fail maintenance/CLI guards (#2009).
  * Healthy bounded catch-up (`stopReason=exhausted`, `processed>0`, `llmFailures=0`)
  * is not a hard failure — only LLM errors or zero-progress budget stops are.
+ *
+ * A deadline/provider-budget stop with real progress and only a small fraction of LLM
+ * failures (e.g. 2 of 90) is expected, resumable, checkpointed work, not a pipeline
+ * failure — only a failure rate above the tolerance (or any failures on a run that
+ * wasn't budget-limited) counts as a hard failure (#2043).
  */
 export function isEntityEnrichmentHardFailure(input: EntityEnrichmentOutcomeInput): boolean {
   const llmFailures = input.llmFailures ?? 0;
   const processed = input.processed;
   const stopReason = input.stopReason ?? "completed";
-  if (llmFailures > 0) return true;
-  if (
-    processed === 0 &&
-    (stopReason === "exhausted" || stopReason === "time_budget" || stopReason === "provider_budget")
-  ) {
+  const isBudgetStop = isEntityEnrichmentBudgetStop(stopReason);
+  if (processed === 0 && (stopReason === "exhausted" || isBudgetStop)) {
+    return true;
+  }
+  if (llmFailures > 0) {
+    if (isBudgetStop && processed && llmFailures / processed <= BUDGET_STOP_LLM_FAILURE_TOLERANCE_RATIO) {
+      return false;
+    }
     return true;
   }
   return false;
 }
 
-/** Summary semantic token for enrich-entities logs (#2009). */
-export function entityEnrichmentSemanticStatus(input: EntityEnrichmentOutcomeInput): "partial" | "success" {
-  return isEntityEnrichmentHardFailure(input) ? "partial" : "success";
+/** Summary semantic token for enrich-entities logs (#2009, #2043). */
+export function entityEnrichmentSemanticStatus(input: EntityEnrichmentOutcomeInput): "partial" | "monitoring" | "success" {
+  if (isEntityEnrichmentHardFailure(input)) return "partial";
+  const stopReason = input.stopReason ?? "completed";
+  // A budget-limited stop is resumable, checkpointed work-in-progress — surface it distinctly from a
+  // clean "nothing left to do" success so operators can tell the run didn't finish (#2043).
+  return isEntityEnrichmentBudgetStop(stopReason) ? "monitoring" : "success";
 }

--- a/extensions/memory-hybrid/services/maintenance-job-run/semantic-outcome.ts
+++ b/extensions/memory-hybrid/services/maintenance-job-run/semantic-outcome.ts
@@ -101,11 +101,8 @@ function parseMetricFromMaintenanceSummary(summary: string, key: string): number
 export function reflectRulesStepSummaryIndicatesFailure(summary: string): boolean {
   if (/\bzero_rules_reason=valid_no_actionable_rules\b/i.test(summary)) return false;
   if (/\bzero_rules_reason=insufficient_patterns\b/i.test(summary)) return false;
-  const degradedFlake =
-    /\bzero_rules_reason=invalid_response_format\b/i.test(summary) &&
-    /\bstatus=degraded\b/i.test(summary) &&
-    (parseMetricFromMaintenanceSummary(summary, "model_response_chars") ?? 0) > 0;
-  if (degradedFlake) return false;
+  // invalid_response_format is a genuine parse failure (the model responded but its output couldn't
+  // be parsed), not a benign "nothing to extract" case — it must not be waved through as success (#2043).
   if (/\bstatus=ok\b/i.test(summary) && !/\bparse_success=false\b/i.test(summary)) return false;
   const parseFailed = /\bparse_success=false\b/i.test(summary);
   const rulesStored =

--- a/extensions/memory-hybrid/services/passive-observer.ts
+++ b/extensions/memory-hybrid/services/passive-observer.ts
@@ -76,6 +76,10 @@ interface ObserverRunResult {
   factsStored: number;
   factsReinforced: number;
   errors: number;
+  /** Set when the maintenance-run deadline cut the scan short with no per-session errors (#2043) —
+   * a truncated-but-healthy run, distinct from `errors`, so callers can report it as a non-blocking
+   * "monitoring" outcome instead of a hard failure. */
+  deadlineStopped: boolean;
 }
 
 // Track consecutive failures across runs to prevent infinite retries on bad session files.
@@ -373,6 +377,7 @@ export async function runPassiveObserver(
     factsStored: 0,
     factsReinforced: 0,
     errors: 0,
+    deadlineStopped: false,
   };
 
   const explicitSessionsDir = config.sessionsDir ?? opts.proceduresSessionsDir;
@@ -524,13 +529,13 @@ export async function runPassiveObserver(
     // report a false-positive truncated/errored run when there was actually no work left to lose.
     if (cursor >= fileBytelen) continue; // Nothing new
     if (maintenanceRunDeadlineReached()) {
-      // Deadline stops mid-run are counted as an error so the caller's summary (and
-      // assertPassiveObserverSummaryDoesNotBlock) surface a truncated run as a failure
-      // instead of a silent "ok" that hides unprocessed sessions (#2032).
-      result.errors++;
+      // Deadline stops mid-run are surfaced via deadlineStopped (not errors) so the caller's summary
+      // reports a truncated-but-healthy run as a non-blocking "monitoring" outcome rather than a hard
+      // failure indistinguishable from a real per-session error (#2043, refining #2032's original fix).
+      result.deadlineStopped = true;
       logger.warn(
         "memory-hybrid: passive-observer — maintenance run deadline reached; stopping session scan " +
-          `(processed ${sessionIdx}/${sessions.length} sessions, sessionsScanned=${result.sessionsScanned}, ` +
+          `(processed ${sessionIdx}/${sessions.length} sessions, sessionsDiscovered=${sessions.length}, ` +
           `chunksProcessed=${result.chunksProcessed}, factsStored=${result.factsStored})`,
       );
       break;
@@ -613,7 +618,7 @@ export async function runPassiveObserver(
           `memory-hybrid: passive-observer — maintenance run deadline reached; deferring session ${sessionId}`,
         );
         deadlineStopped = true;
-        result.errors++;
+        result.deadlineStopped = true;
         break;
       }
       if (!chunk.trim()) continue;

--- a/extensions/memory-hybrid/setup/cli-context/cli-services.ts
+++ b/extensions/memory-hybrid/setup/cli-context/cli-services.ts
@@ -607,7 +607,8 @@ export function buildCliContextServices(
         },
         pluginLogger,
       );
-      const summary = `stored=${result.factsStored} scanned=${result.sessionsScanned} errors=${result.errors} semantic=${result.errors > 0 ? "partial" : "success"}`;
+      const semantic = result.errors > 0 ? "partial" : result.deadlineStopped ? "monitoring" : "success";
+      const summary = `stored=${result.factsStored} scanned=${result.sessionsScanned} errors=${result.errors} semantic=${semantic}`;
       if (result.errors > 0) {
         throw new Error(`passive-observer errors=${result.errors} (${summary})`);
       }

--- a/extensions/memory-hybrid/setup/plugin-service.ts
+++ b/extensions/memory-hybrid/setup/plugin-service.ts
@@ -768,7 +768,8 @@ export function createPluginService(ctx: PluginServiceContext) {
               },
               api.logger,
             );
-            const summary = `stored=${result.factsStored} scanned=${result.sessionsScanned} errors=${result.errors} semantic=${result.errors > 0 ? "partial" : "success"}`;
+            const semantic = result.errors > 0 ? "partial" : result.deadlineStopped ? "monitoring" : "success";
+            const summary = `stored=${result.factsStored} scanned=${result.sessionsScanned} errors=${result.errors} semantic=${semantic}`;
             if (result.errors > 0) {
               throw new Error(`passive-observer errors=${result.errors} (${summary})`);
             }

--- a/extensions/memory-hybrid/tests/entity-enrichment-adaptive.test.ts
+++ b/extensions/memory-hybrid/tests/entity-enrichment-adaptive.test.ts
@@ -160,4 +160,25 @@ describe("isEntityEnrichmentHardFailure (#2009)", () => {
       isEntityEnrichmentHardFailure({ llmFailures: 0, stopReason: "time_budget" }),
     ).toBe(false);
   });
+
+  it("tolerates a low llmFailures rate on a budget-limited stop with real progress (#2043)", () => {
+    expect(isEntityEnrichmentHardFailure({ processed: 90, llmFailures: 2, stopReason: "time_budget" })).toBe(
+      false,
+    );
+    expect(entityEnrichmentSemanticStatus({ processed: 90, llmFailures: 2, stopReason: "time_budget" })).toBe(
+      "monitoring",
+    );
+  });
+
+  it("still fails a budget-limited stop when the failure rate is high", () => {
+    expect(isEntityEnrichmentHardFailure({ processed: 10, llmFailures: 5, stopReason: "time_budget" })).toBe(
+      true,
+    );
+  });
+
+  it("reports monitoring (not success) for a clean budget-limited stop with remaining work", () => {
+    expect(entityEnrichmentSemanticStatus({ processed: 25, llmFailures: 0, stopReason: "time_budget" })).toBe(
+      "monitoring",
+    );
+  });
 });

--- a/extensions/memory-hybrid/tests/maintenance-orchestrator.test.ts
+++ b/extensions/memory-hybrid/tests/maintenance-orchestrator.test.ts
@@ -486,7 +486,10 @@ describe("maintenance-orchestrator", () => {
     expect(result.exitCode).toBe(1);
   });
 
-  it("accepts reflect-rules tolerated invalid_response_format flake without aborting nightly", async () => {
+  it("fails reflect-rules on invalid_response_format instead of tolerating it as a flake (#2043)", async () => {
+    // invalid_response_format means the model responded but its output couldn't be parsed — a real
+    // pipeline break, not a benign "nothing to extract" case. This used to be waved through as
+    // semantic=success (masking the failure); it must now surface as a failed step.
     openclawDir = mkdtempSync(join(tmpdir(), "hm-orch-"));
     const flakeSummary =
       "rulesStored=0 rulesExtracted=0 parse_success=false zero_rules_reason=invalid_response_format status=degraded model_response_chars=128 semantic=success";
@@ -506,10 +509,9 @@ describe("maintenance-orchestrator", () => {
     );
     expect(result.steps).toHaveLength(3);
     const reflectRules = result.steps.find((s) => s.name === "reflect-rules");
-    expect(reflectRules?.status).toBe("ok");
-    expect(reflectRules?.semanticOutcome).toBe("success");
+    expect(reflectRules?.status).toBe("failed");
     expect(result.steps.find((s) => s.name === "reflect-meta")?.status).toBe("ok");
-    expect(result.exitCode).toBe(0);
+    expect(result.exitCode).toBe(1);
   });
 
   it("fails reflect-rules when runner summary has parse_success=false without semantic token", async () => {

--- a/extensions/memory-hybrid/tests/maintenance-step-runners-reflect-rules.test.ts
+++ b/extensions/memory-hybrid/tests/maintenance-step-runners-reflect-rules.test.ts
@@ -15,7 +15,10 @@ function minimalBindings(runReflectionRules: ManageBindings["runReflectionRules"
 }
 
 describe("maintenance-step-runners reflect-rules", () => {
-  it("does not throw for tolerated invalid_response_format flake with model output", async () => {
+  it("throws for invalid_response_format even when the model returned output (#2043)", async () => {
+    // invalid_response_format means the model responded but its output couldn't be parsed at all — a
+    // real pipeline break, not a benign "nothing to extract" case. It used to be tolerated as a
+    // one-off flake and reported as semantic=success, hiding a broken extraction run.
     const runReflectionRules = vi.fn().mockResolvedValue({
       rulesStored: 0,
       rulesExtracted: 0,
@@ -29,11 +32,7 @@ describe("maintenance-step-runners reflect-rules", () => {
     const runner = buildCliMaintenanceRunners(minimalBindings(runReflectionRules)).get("reflect-rules");
     expect(runner).toBeDefined();
 
-    const summary = await runner!();
-
-    expect(summary).toContain("zero_rules_reason=invalid_response_format");
-    expect(summary).toContain("model_response_chars=128");
-    expect(summary).toContain("semantic=success");
+    await expect(runner!()).rejects.toThrow(/reflect-rules semantic failure/);
   });
 
   it("throws for genuine reflect-rules semantic failures", async () => {

--- a/extensions/memory-hybrid/tests/passive-observer.test.ts
+++ b/extensions/memory-hybrid/tests/passive-observer.test.ts
@@ -438,7 +438,7 @@ describe("runPassiveObserver", () => {
     expect(result.chunksProcessed).toBe(0);
   });
 
-  it("counts a run truncated by the maintenance run deadline as errored, not silently ok (#2032)", async () => {
+  it("counts a run truncated by the maintenance run deadline as deadlineStopped, not silently ok (#2032, refined #2043)", async () => {
     writeFileSync(
       join(sessionsDir, "session-1.jsonl"),
       `${JSON.stringify({ message: { role: "user", content: "Hello, this session has new content." } })}\n`,
@@ -459,9 +459,12 @@ describe("runPassiveObserver", () => {
         logger,
       );
 
-      // A deadline-truncated run must be visible as an error, not returned as a clean "ok" that
-      // silently hides unprocessed sessions from the caller's summary/assertions.
-      expect(result.errors).toBeGreaterThan(0);
+      // A deadline-truncated run must be visible via deadlineStopped, not returned as a clean "ok"
+      // that silently hides unprocessed sessions from the caller's summary/assertions — but it's also
+      // not a real per-session error, so it must not be conflated with `errors` (#2043): a truncated-
+      // but-healthy run should surface as a non-blocking "monitoring" outcome, not a hard failure.
+      expect(result.deadlineStopped).toBe(true);
+      expect(result.errors).toBe(0);
       expect(result.chunksProcessed).toBe(0);
       expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("maintenance run deadline reached"));
     } finally {

--- a/packages/openclaw-hybrid-memory-install/package.json
+++ b/packages/openclaw-hybrid-memory-install/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-hybrid-memory-install",
-  "version": "2026.7.57",
+  "version": "2026.7.58",
   "description": "Standalone installer for openclaw-hybrid-memory. Use when OpenClaw config validation fails.",
   "bin": {
     "openclaw-hybrid-memory-install": "./install.js"


### PR DESCRIPTION
## Summary

Closes #2043

A forced verbose maintenance verification pass found four steps that reported hard `failed` results for what were actually healthy, deadline-limited, or low-severity-transient runs. All four shared the same root cause pattern: a truncated-but-healthy or low-failure-rate run was reported using the same signal as a genuine implementation error, so the orchestrator's blanket "any error/`semantic=partial` → `failed`" rule couldn't tell them apart.

- **`passive-observer`** (`services/passive-observer.ts`, `setup/plugin-service.ts`, `setup/cli-context/cli-services.ts`): a maintenance-run-deadline stop mid-scan incremented the same `errors` counter used for real per-session stat/read failures, so a healthy truncated run (`stored=54 scanned=487 errors=1`) always failed the step. `ObserverRunResult` now tracks `deadlineStopped` separately; a deadline-only stop reports `semantic=monitoring` (non-blocking) instead of `semantic=partial`, while real per-session errors still fail the step exactly as before.

- **`distill`** (`cli/cmd-distill.ts`): every batch re-attempted the primary model from scratch even after it had already timed out earlier in the same run — burning ~90s of retry/fallback cost per batch on a model already known to be unavailable, so the fallback never got enough of the remaining deadline to complete a single block (`processed 0/1279` across 3 batches). `runDistillForCli` now remembers a primary timeout/connection-error for the rest of the run and routes subsequent batches straight to the fallback chain.

- **`enrich-entities`** (`services/entity-enrichment-adaptive.ts`): any nonzero `llmFailures` was an unconditional hard failure, so a run that processed 90 facts with 2 transient LLM errors (`stopReason=time_budget`) failed identically to a run that made zero progress. `isEntityEnrichmentHardFailure` now tolerates a small LLM-failure rate (≤5%) on a budget-limited stop with real progress, and `entityEnrichmentSemanticStatus` reports a clean budget-limited stop as `monitoring` (resumable/checkpointed) instead of `success` or a hard failure.

- **`reflect-rules`** (`cli/commands/manage/maintenance-step-runners.ts`, `services/maintenance-job-run/semantic-outcome.ts`, `services/cron-exit-validator.ts`): `zero_rules_reason=invalid_response_format` — a genuine parse failure where the model responded but its output couldn't be parsed at all — was explicitly exempted from failure (duplicated across all three files) whenever `status=degraded` and the model returned some output, silently reporting a broken week's rule extraction as `semantic=success`. The exemption is removed everywhere; this case is now treated the same as any other degraded run, while legitimate "nothing to extract" cases (`insufficient_patterns`, `valid_no_actionable_rules`) remain non-failing.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor / internal improvement (no behavior change)
- [ ] Documentation update
- [ ] CI / tooling change

## Quality Checklist

- [x] `cd extensions/memory-hybrid && npx tsc --noEmit` passes with no errors
- [x] `cd extensions/memory-hybrid && npm run lint` — no *new* warnings introduced (pre-existing warnings in touched files, e.g. `noNonNullAssertion` in `maintenance-step-runners-reflect-rules.test.ts`, were already present before this change)
- [x] `cd extensions/memory-hybrid && npm test` passes (all tests green; 3 pre-existing unrelated failures — `crystallization-proposer.test.ts`, `implicit-feedback-routing.test.ts`, `memory-recall-timeline.test.ts` — reproduce identically on `main` with no changes applied, confirmed via `git stash`)
- [x] No secrets, credentials, or API keys committed
- [x] No `console.log` debug statements left in production code

## Documentation Impact

- [x] Inline code comments updated for modified functions (root-cause context on the new `deadlineStopped` field, tolerance ratio, and removed carve-outs)
- [x] CHANGELOG.md updated with a new `2026.7.58` entry
- [ ] No broader `docs/` changes needed — this is an internal semantic-classification fix, not a user-facing behavior/config change

## Testing

- [x] Unit tests added/updated: new coverage in `entity-enrichment-adaptive.test.ts` (tolerance ratio + monitoring outcome), updated `maintenance-step-runners-reflect-rules.test.ts`, `maintenance-orchestrator.test.ts`, and `passive-observer.test.ts` to assert the corrected behavior instead of the old bug
- [x] Full extension test suite run (`npm test`): 8638 passed, 3 pre-existing unrelated failures, 23 skipped
- [ ] Not manually verified against a live OpenClaw instance (no such environment available in this session)

## Notes for Reviewer

- `distill`'s primary-skip fix has no dedicated unit test — `runDistillForCli`'s batch loop has no existing test harness that mocks the LLM call chain, and building one from scratch was out of scope for a minimal fix. The change is small and isolated (a boolean flag gating which model is tried first); please give it extra scrutiny.
- Version bumped to **2026.7.58** across `package.json`, `package-lock.json`, `openclaw.plugin.json`, and `packages/openclaw-hybrid-memory-install/package.json`, following the pattern of prior fix PRs (#2042, #2040, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01CZ4o8JwD5orZdMhLaQLuG4)_