### PR TITLE
fix: close distill deadline-monitoring gap found in #2044 code review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ---
 
+## [2026.7.59] - 2026-07-05
+
+### Fixed
+
+- **`distill` still reported a hard `failed` status for a deadline-limited stop with real progress (#2043 follow-up):** 2026.7.58 fixed distill's wasted retries on a known-bad primary model, but a code-review pass over that PR found the step's *semantic outcome* was never touched — a run that stopped solely because the maintenance-run deadline was reached (with no other model/batch error) still incremented the same `batchFailures` counter used for genuine errors, so it always resolved to `semantic=partial` and failed the orchestrator step, reproducing the exact symptom #2043 reported. `cmd-distill.ts` now tracks genuine implementation/model errors (`hardBatchFailures`) separately from deadline-only stops (`deadlineTruncated`); a deadline-only stop with no hard failure now reports `semantic=monitoring` (non-blocking) via a new `monitoring` flag on the shared `LightJobRunParams`/`resolveLightJobRunOutcome` bridge (`services/maintenance-job-run/light-job-run-bridge.ts`), while cursor-advancement and "last successful run" bookkeeping remain conservative (still gated on any stoppage, deadline or error, exactly as before).
+- **`cron-exit-validator`'s reflect-rules check was missing the `valid_no_actionable_rules` exemption (#2043 follow-up):** `maintenance-step-runners.ts` and `semantic-outcome.ts` both exempt `zero_rules_reason=insufficient_patterns` and `zero_rules_reason=valid_no_actionable_rules` from failure (the model ran fine and legitimately found nothing to extract), but `cron-exit-validator.ts`'s post-hoc log check only exempted `insufficient_patterns` — a pre-existing inconsistency surfaced by the same code-review pass. A healthy `valid_no_actionable_rules` run could be flagged as a semantic failure by this validator while the orchestrator and CLI paths correctly treated it as success. Both reasons are now exempted consistently across all three copies of this check.
+
+### Changed
+
+- Bumped plugin, `openclaw.plugin.json`, and `openclaw-hybrid-memory-install` package versions to **2026.7.59**.
+
+---
+
 ## [2026.7.58] - 2026-07-05
 
 ### Fixed

--- a/extensions/memory-hybrid/cli/cmd-distill.ts
+++ b/extensions/memory-hybrid/cli/cmd-distill.ts
@@ -536,6 +536,12 @@ export async function runDistillForCli(
     };
 
     let batchFailures = 0;
+    // batchFailures also counts deadline stops (below) so cursor-advancement stays conservative — a
+    // truncated run must not skip unprocessed sessions. hardBatchFailures counts only genuine
+    // implementation/model errors, so the step's semantic outcome can distinguish "ran out of time
+    // with real progress" (monitoring, non-blocking) from an actual failure (partial, blocking) (#2043).
+    let hardBatchFailures = 0;
+    let deadlineTruncated = false;
     // Preserve the first concrete batch failure cause so maintenance surfaces the real reason
     // (model/error kind/message) instead of only `semantic=partial` (#2024).
     let batchFailureReason: string | undefined;
@@ -544,6 +550,7 @@ export async function runDistillForCli(
 
     if (filesScanTruncatedAt >= 0) {
       batchFailures++;
+      deadlineTruncated = true;
       batchFailureReason ??= `session scan aborted: maintenance run deadline reached at ${filesScanTruncatedAt}/${filesToProcess.length} sessions read`;
     }
 
@@ -565,6 +572,7 @@ export async function runDistillForCli(
       if (maintenanceRunDeadlineReached()) {
         sink.warn("memory-hybrid: distill: maintenance run deadline reached; stopping batch loop");
         batchFailures++;
+        deadlineTruncated = true;
         batchFailureReason ??= `batch ${batchNum + 1} aborted: maintenance run deadline reached before completion`;
         break;
       }
@@ -605,6 +613,7 @@ export async function runDistillForCli(
             `memory-hybrid: distill batch ${batchNum} input (~${inputTokens} tokens) exceeds primary limit (${primaryInputLimit}) with no compatible fallbacks`,
           );
           batchFailures++;
+          hardBatchFailures++;
           batchFailureReason ??= `batch ${batchNum} input (~${inputTokens} tokens) exceeds primary model ${model} limit (${primaryInputLimit}) and all fallbacks were context-incompatible${skippedFallbacks.length > 0 ? ` (skipped: ${skippedFallbacks.join(", ")})` : ""}`;
           break;
         }
@@ -781,6 +790,7 @@ export async function runDistillForCli(
         sink.warn(`memory-hybrid: distill batch ${batchNum} failed: ${e}`);
         capturePluginError(e, { subsystem: "cli", operation: "runDistillForCli:llm-batch" });
         batchFailures++;
+        hardBatchFailures++;
         batchFailureReason ??= `batch ${batchNum} ${kind} error on model ${failureModel}: ${e.message}`;
         if (!adaptiveEnabled) {
           nonAdaptiveBatchFactor = 1;
@@ -1081,7 +1091,11 @@ export async function runDistillForCli(
         `memory-hybrid: distill DEGRADED — vector neighbour search unavailable${usedHasDuplicateFallback ? "; used hasDuplicate fallback where applicable" : ""}`,
       );
     }
-    const partialFailure = batchFailures > 0 || truncatedBatches > 0;
+    // Only genuine implementation/model errors (hardBatchFailures) and output-truncation quality
+    // issues fail the step. A run that stopped solely because the maintenance-run deadline was
+    // reached — with no other error — is resumable, checkpointed work-in-progress, not a failure (#2043).
+    const partialFailure = hardBatchFailures > 0 || truncatedBatches > 0;
+    const deadlineLimitedOnly = !partialFailure && deadlineTruncated;
     const resolvedFailureReason =
       batchFailureReason ??
       (truncatedBatches > 0
@@ -1101,7 +1115,11 @@ export async function runDistillForCli(
         dedupeDegraded,
         distillDedupeMode,
       },
-      partialFailure ? { reason: resolvedFailureReason } : undefined,
+      partialFailure
+        ? { reason: resolvedFailureReason }
+        : deadlineLimitedOnly
+          ? { monitoring: true, reason: batchFailureReason }
+          : undefined,
     );
   } finally {
     if (shouldAcquireLock && !opts.dryRun) clearScanLock(SCAN_TYPE);

--- a/extensions/memory-hybrid/cli/commands/manage/maintenance-step-runners.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/maintenance-step-runners.ts
@@ -437,12 +437,13 @@ export function buildCliMaintenanceRunners(
   set("distill", async () => {
     if (!b.runDistill) throw new Error("distill unavailable");
     const r = await b.runDistill({ dryRun: false, verbose, days: maxCatchUpDays, ...scanFlags }, sink);
-    const summary = `stored=${r.stored} sessions=${r.sessionsScanned} jobRunId=${r.jobRunId ?? "-"} semantic=${r.semanticOutcome ?? "unknown"}`;
+    // Surface the concrete cause (model/error kind/message, or a deadline-truncation reason) in the
+    // ledger instead of only `semantic=partial`/`semantic=monitoring`, so health state and operators
+    // watching a monitoring-only run can see why it didn't finish (#2024, #2043).
+    const cause = r.batchFailureReason ? ` cause=${r.batchFailureReason}` : "";
+    const summary = `stored=${r.stored} sessions=${r.sessionsScanned} jobRunId=${r.jobRunId ?? "-"} semantic=${r.semanticOutcome ?? "unknown"}${cause}`;
     if (r.partialFailure) {
-      // Surface the concrete batch cause (model/error kind/message) in the ledger instead of only
-      // `semantic=partial`, so health state points at the real distill failure (#2024).
-      const cause = r.batchFailureReason ? ` cause=${r.batchFailureReason}` : "";
-      throw new Error(`distill partial failure (${summary}${cause})`);
+      throw new Error(`distill partial failure (${summary})`);
     }
     assertSemanticOutcomeDoesNotBlockStep("distill", r.semanticOutcome, summary);
     return summary;

--- a/extensions/memory-hybrid/openclaw.plugin.json
+++ b/extensions/memory-hybrid/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "openclaw-hybrid-memory",
   "kind": "memory",
-  "version": "2026.7.58",
+  "version": "2026.7.59",
   "contracts": {
     "tools": [
       "active_task_checkpoint",

--- a/extensions/memory-hybrid/package-lock.json
+++ b/extensions/memory-hybrid/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openclaw-hybrid-memory",
-  "version": "2026.7.58",
+  "version": "2026.7.59",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openclaw-hybrid-memory",
-      "version": "2026.7.58",
+      "version": "2026.7.59",
       "hasInstallScript": true,
       "dependencies": {
         "@lancedb/lancedb": "^0.30.0",

--- a/extensions/memory-hybrid/package.json
+++ b/extensions/memory-hybrid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-hybrid-memory",
-  "version": "2026.7.58",
+  "version": "2026.7.59",
   "type": "module",
   "description": "Give your OpenClaw agent lasting memory: structured facts, semantic search, auto-capture & recall, decay, optional credential vault. Part of Hybrid Memory v3.",
   "files": [

--- a/extensions/memory-hybrid/services/cron-exit-validator.ts
+++ b/extensions/memory-hybrid/services/cron-exit-validator.ts
@@ -801,9 +801,21 @@ function collectMaintenanceTelemetryIssues(params: {
   const reflectParseFailed = /\bparse[_\s-]?success\s*[=:]\s*(false|0)\b/i.test(reflectRulesLog);
   const reflectStored = parsePositiveMetric(reflectRulesLog, "stored");
   const reflectInsufficientPatterns = /\bzero_rules_reason\s*[=:]\s*insufficient_patterns\b/i.test(reflectRulesLog);
+  // "valid_no_actionable_rules" means the model ran fine and legitimately found nothing to extract —
+  // not a failure. maintenance-step-runners.ts and semantic-outcome.ts already exempt this reason
+  // alongside insufficient_patterns; this check was missing it, so a healthy run could be flagged here
+  // while the orchestrator/CLI paths correctly treated it as success.
+  const reflectValidNoActionableRules = /\bzero_rules_reason\s*[=:]\s*valid_no_actionable_rules\b/i.test(
+    reflectRulesLog,
+  );
   // invalid_response_format is a genuine parse failure, not a benign flake — it must surface here too
   // instead of being waved through, consistent with the orchestrator-side fix for #2043.
-  if (reflectRulesDetected && (reflectParseFailed || reflectStored === 0) && !reflectInsufficientPatterns) {
+  if (
+    reflectRulesDetected &&
+    (reflectParseFailed || reflectStored === 0) &&
+    !reflectInsufficientPatterns &&
+    !reflectValidNoActionableRules
+  ) {
     addMaintenanceIssue(
       issues,
       buildMaintenanceIssue({

--- a/extensions/memory-hybrid/services/maintenance-job-run/light-job-run-bridge.ts
+++ b/extensions/memory-hybrid/services/maintenance-job-run/light-job-run-bridge.ts
@@ -8,6 +8,10 @@ export type LightJobRunParams = {
   dryRun?: boolean;
   semanticEmpty?: boolean;
   partialFailure?: boolean;
+  /** Set when the only reason the run didn't finish is a maintenance-run-deadline stop with no other
+   * implementation error — reported as non-blocking "monitoring" instead of "partial" (#2043). Ignored
+   * when partialFailure is also set. */
+  monitoring?: boolean;
   inputsProcessed?: number;
   outputsProduced?: number;
   /** Concrete failure cause persisted into the job-run summary's semanticReason (#2024). */
@@ -18,6 +22,7 @@ export function resolveLightJobRunOutcome(params: LightJobRunParams): JobRunSema
   if (params.skipped) return "skipped";
   if (params.dryRun) return "skipped";
   if (params.partialFailure) return "partial";
+  if (params.monitoring) return "monitoring";
   if (params.semanticEmpty) return "failed_semantic_empty";
   const inputs = params.inputsProcessed ?? 0;
   const outputs = params.outputsProduced ?? 0;
@@ -42,7 +47,8 @@ export function finishLightJobRun(
     semanticOutcome === "success" ||
     semanticOutcome === "empty" ||
     semanticOutcome === "skipped" ||
-    semanticOutcome === "success_with_review";
+    semanticOutcome === "success_with_review" ||
+    semanticOutcome === "monitoring";
   jobRun.endPhase("run", phaseOk ? "completed" : "failed");
   const jobRunId = finishBatchJobRun(jobRun, semanticOutcome, { clearCheckpoint: true, reason: params.reason });
   return { jobRunId, semanticOutcome };

--- a/extensions/memory-hybrid/tests/cron-exit-validator.test.ts
+++ b/extensions/memory-hybrid/tests/cron-exit-validator.test.ts
@@ -701,6 +701,26 @@ error: unknown command 'bar'
       expect(second.reportableIssues[0]?.fingerprint.join(":")).toBe(first.reportableIssues[0]?.fingerprint.join(":"));
     });
 
+    it("does not flag reflect-rules zero_rules_reason=valid_no_actionable_rules as a semantic failure (#2043)", () => {
+      // The model ran fine and legitimately found nothing to extract — maintenance-step-runners.ts and
+      // semantic-outcome.ts already treat this as success; this validator must agree.
+      const tmpDir = mkdtempSync(join(tmpdir(), "cron-test-"));
+      const exitPath = join(tmpDir, "weekly-reflection-20260508T021500Z-111.exit.txt");
+      const logPath = join(tmpDir, "reflect.log");
+      writeFileSync(exitPath, "2026-05-08T02:15:30Z reflect-rules exit=0\n");
+      writeFileSync(
+        logPath,
+        "reflect-rules — diagnostics: model_response_chars=1200 parse_success=true parsed_candidates=0 " +
+          "rejected_duplicates=0 rejected_low_confidence=0 stored=0 status=ok zero_rules_reason=valid_no_actionable_rules\n",
+      );
+
+      const result = validateMaintenanceExecution(exitPath, logPath, ["reflect-rules"]);
+
+      expect(
+        result.reportableIssues.some((i) => i.stepName === "reflect-rules" && i.failureCategory === "semantic_failure"),
+      ).toBe(false);
+    });
+
     it("detects self-correction failed_partial semantic failures", () => {
       const tmpDir = mkdtempSync(join(tmpdir(), "cron-test-"));
       const exitPath = join(tmpDir, "self-correction-partial.exit.txt");

--- a/extensions/memory-hybrid/tests/light-job-run-bridge.test.ts
+++ b/extensions/memory-hybrid/tests/light-job-run-bridge.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveLightJobRunOutcome } from "../services/maintenance-job-run/light-job-run-bridge.js";
+
+describe("resolveLightJobRunOutcome monitoring outcome (#2043)", () => {
+  it("reports monitoring for a deadline-limited stop with no other error", () => {
+    expect(
+      resolveLightJobRunOutcome({
+        monitoring: true,
+        inputsProcessed: 10,
+        outputsProduced: 5,
+      }),
+    ).toBe("monitoring");
+  });
+
+  it("still reports partial when a genuine failure is present, even if monitoring is also set", () => {
+    expect(
+      resolveLightJobRunOutcome({
+        partialFailure: true,
+        monitoring: true,
+        inputsProcessed: 10,
+        outputsProduced: 5,
+      }),
+    ).toBe("partial");
+  });
+
+  it("reports success when neither partialFailure nor monitoring is set and work was produced", () => {
+    expect(
+      resolveLightJobRunOutcome({
+        inputsProcessed: 10,
+        outputsProduced: 5,
+      }),
+    ).toBe("success");
+  });
+
+  it("skipped/dryRun still take priority over monitoring", () => {
+    expect(resolveLightJobRunOutcome({ skipped: true, monitoring: true })).toBe("skipped");
+    expect(resolveLightJobRunOutcome({ dryRun: true, monitoring: true })).toBe("skipped");
+  });
+});

--- a/packages/openclaw-hybrid-memory-install/package.json
+++ b/packages/openclaw-hybrid-memory-install/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-hybrid-memory-install",
-  "version": "2026.7.58",
+  "version": "2026.7.59",
   "description": "Standalone installer for openclaw-hybrid-memory. Use when OpenClaw config validation fails.",
   "bin": {
     "openclaw-hybrid-memory-install": "./install.js"


### PR DESCRIPTION
## Summary

Follow-up to #2044 (which fixed #2043). A full code review of #2044's diff — run after that PR merged — found two real gaps that undercut its own fix:

- **`distill`'s core reported symptom was never actually fixed.** #2044 fixed distill's *wasted retries* on a known-bad primary model (the `processed 0/1279` stall), but never touched its *semantic-outcome classification*. A deadline-only stop with real progress and no other error still incremented the same `batchFailures` counter used for genuine model/batch errors, so it always resolved to `semantic=partial` and failed the orchestrator step — reproducing the exact "deadline-limited work reported as failed" symptom #2043 complained about, just for `distill` specifically. `cmd-distill.ts` now tracks genuine implementation/model errors (`hardBatchFailures`) separately from deadline-only stops (`deadlineTruncated`); a deadline-only stop with no hard failure now reports `semantic=monitoring` (non-blocking) via a new `monitoring` flag threaded through the shared `LightJobRunParams`/`resolveLightJobRunOutcome` bridge (`services/maintenance-job-run/light-job-run-bridge.ts`). Cursor-advancement and "last successful run" bookkeeping remain conservative and unchanged — still gated on any stoppage, deadline or error.

- **`cron-exit-validator.ts`'s reflect-rules check was missing the `valid_no_actionable_rules` exemption** that the other two copies of this same check (`maintenance-step-runners.ts`, `semantic-outcome.ts`) already have — a pre-existing inconsistency the #2044 diff touched but didn't reconcile. A healthy `valid_no_actionable_rules` run could be flagged as a semantic failure by this validator while the orchestrator/CLI paths correctly treat it as success. All three copies now exempt the same two reasons consistently.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor / internal improvement (no behavior change)
- [ ] Documentation update
- [ ] CI / tooling change

## Quality Checklist

- [x] `cd extensions/memory-hybrid && npx tsc --noEmit` passes with no errors
- [x] `cd extensions/memory-hybrid && npm run lint` — no new warnings introduced
- [x] `cd extensions/memory-hybrid && npm test` passes (all tests green; 3 pre-existing unrelated failures — `crystallization-proposer.test.ts`, `implicit-feedback-routing.test.ts`, `memory-recall-timeline.test.ts` — reproduce identically with no changes applied, confirmed via `git stash`)
- [x] No secrets, credentials, or API keys committed
- [x] No `console.log` debug statements left in production code

## Documentation Impact

- [x] Inline code comments updated for modified functions (root-cause context on the `hardBatchFailures`/`deadlineTruncated` split and the new `monitoring` flag)
- [x] CHANGELOG.md updated with a new `2026.7.59` entry
- [ ] No broader `docs/` changes needed — internal semantic-classification fix, not a user-facing behavior/config change

## Testing

- [x] Unit tests added: new `tests/light-job-run-bridge.test.ts` covering the `monitoring` outcome precedence rules, plus a new `cron-exit-validator.test.ts` case for the `valid_no_actionable_rules` exemption
- [x] Full extension test suite run (`npm test`): all passing except the 3 pre-existing unrelated failures noted above
- [ ] Not manually verified against a live OpenClaw instance (no such environment available in this session)

## Notes for Reviewer

- This PR was produced by a full 8-angle parallel code review (correctness, removed-behavior, cross-file, reuse, simplification, efficiency, altitude, conventions) of #2044's merged diff. Most findings from that review were minor style/duplication observations (not fixed here to keep this PR minimal); the two fixed here were the only ones that represented actual unaddressed bugs relative to #2043's acceptance criteria.
- Two lower-severity gaps surfaced by the same review were **not** fixed here, left as follow-up if desired: (1) distill's primary-skip-after-timeout logic only tracks the primary model, not intermediate fallbacks in a 2+-model fallback chain, and its timeout/connection-error detection is based on the *last* model attempted in a chain rather than necessarily the primary's own failure mode; (2) `entity-enrichment-adaptive.ts`'s new 5% LLM-failure tolerance ratio is a fixed threshold rather than a principled retryable/transient classification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01CZ4o8JwD5orZdMhLaQLuG4)_