### PR TITLE
fix: never install hybrid-mem cron jobs with implicit announce delivery (#2056)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- **Cron delivery safety (issue #2056):** plugin-owned `hybrid-mem:*` cron jobs no longer install in the unsafe `sessionTarget=isolated + payload.kind=agentTurn + delivery.mode=announce` shape (with no explicit `delivery.channel` and no `delivery.to`). The OpenClaw cron safety guard refuses delivery in that shape and records the run as `error` even when the body work succeeded (e.g. `digest-pending exit=0` plus `validate-cron-exit exit=0` plus `state.lastStatus=error`).
+  - `cli/install/cron-jobs.ts` `resolveCronJob` now defaults `workshop-approval-reminder` and `maintenance-log-analyzer` to `delivery: { mode: "none" }` (these are plugin-internal logs; the work output is captured in the maintenance log and any operator-visible notification should be opt-in via a future explicit configuration).
+  - `cli/install/cron-jobs.ts` `resolveWeeklyPendingDigestDelivery` now maps every destinationless mode — including the historical `"system"` default and any `telegram` config without a non-empty `chatId` — to `delivery: { mode: "none" }`. When the operator configures `digest.weekly.delivery.mode = "telegram"` together with a non-empty `chatId`, the job is installed with `delivery: { mode: "announce", channel: "telegram", to: <chatId>, chatId: <chatId>, bestEffort: true }` so the cron safety guard sees both `channel` and `to`.
+  - `config/parsers/features.ts` `parseDigestWeeklyDeliveryOnly` now defaults `digest.weekly.delivery.mode` to `"none"` (was `"system"`), and treats the legacy `"system"` value as destinationless (also normalized to `"none"`).
+  - `cli/install/cron-jobs.ts` `ensureMaintenanceCronJobsLocked` normalizeExisting pass now (a) repairs the `announce + channel=system|channel=last` shape uniformly across every `hybrid-mem:*` job (the three jobs that were previously excluded — `weekly-pending-digest`, `workshop-approval-reminder`, `maintenance-log-analyzer` — are now included so legacy installs converge on the safe shape), and (b) adds a dedicated repair for the wider `isolated + agentTurn + announce` shape with no explicit `channel`+`to`, collapsing it to `delivery: { mode: "none" }` so `openclaw hybrid-mem verify --fix` repairs existing unsafe jobs.
+  - `cli/verify/sections/config-cron.ts` `runVerifyConfigCronSection` now scans the cron store for the unsafe shape and surfaces a warning + recommended fix in `openclaw hybrid-mem verify` output (so operators learn about the issue even before running `--fix`).
+  - Regression coverage in `tests/cron-implicit-announce-delivery.test.ts` (19 tests across generation, repair/migration, and parser-default axes) and an updated assertion in `tests/cron-session-key-normalization.test.ts` for the new safe default. No Markus-specific values are referenced in any test (uses `telegram` + `12345` as a safe dummy destination, or `mode=none` fallback).
+
 ---
 
 ## [2026.7.170] - 2026-07-07

--- a/extensions/memory-hybrid/cli/install/cron-jobs.ts
+++ b/extensions/memory-hybrid/cli/install/cron-jobs.ts
@@ -749,14 +749,35 @@ function resolveCronJobModel(
  * so the job runner never tries to send a WhatsApp/channel notification for plugin-internal jobs.
  * If the def has minIntervalMs, prepends a guard prefix to the message to prevent re-runs on gateway restart (#304). */
 function resolveWeeklyPendingDigestDelivery(del?: DigestWeeklyDeliveryConfig): Record<string, unknown> {
-  const mode = del?.mode ?? "system";
+  // Issue #2056: never emit `mode: "announce"` without an explicit `channel` + `to`. The
+  // OpenClaw cron safety guard refuses the unsafe `isolated + agentTurn + announce` shape
+  // because the target would otherwise be inferred from a shared session bucket that can
+  // span conversations and replay into the wrong chat after a restart. Map every
+  // destinationless mode (including the historical "system" default) to `mode: "none"` so
+  // the job body still runs and writes its digest to the maintenance log without producing
+  // an undeliverable cron record.
+  const mode = del?.mode ?? "none";
   if (mode === "none") return { mode: "none" };
   if (mode === "telegram") {
     const chatId = del?.chatId?.trim();
-    if (!chatId) return { mode: "announce" };
-    return { mode: "announce", channel: "telegram", chatId };
+    if (!chatId) return { mode: "none" };
+    // Emit both `to` (cron safety guard) and `chatId` (legacy digest dispatch consumer).
+    return { mode: "announce", channel: "telegram", to: chatId, chatId, bestEffort: true };
   }
-  return { mode: "announce" };
+  return { mode: "none" };
+}
+
+/** Jobs that have historically shipped with `delivery.mode = "announce"` and no destination.
+ * Issue #2056: those legacy jobs caused the OpenClaw cron safety guard to reject delivery.
+ * Plugin-internal maintenance logs do not need an operator-visible announce channel by
+ * default; the work output is captured in the maintenance log and any operator-visible
+ * notification should be opt-in via a future explicit configuration. Until then, default
+ * these jobs to `mode: "none"` so they never get installed in the unsafe shape. */
+function isPluginInternalAnnounceJob(pluginJobId: string): boolean {
+  return (
+    pluginJobId === `${PLUGIN_JOB_ID_PREFIX}workshop-approval-reminder` ||
+    pluginJobId === `${PLUGIN_JOB_ID_PREFIX}maintenance-log-analyzer`
+  );
 }
 
 function resolveCronJob(
@@ -775,13 +796,18 @@ function resolveCronJob(
   }
   const pluginJobId = rest.pluginJobId;
   const stableId = typeof pluginJobId === "string" && pluginJobId.trim().length > 0 ? pluginJobId.trim() : undefined;
-  const delivery =
-    stableId === `${PLUGIN_JOB_ID_PREFIX}weekly-pending-digest`
-      ? resolveWeeklyPendingDigestDelivery(digestWeeklyDelivery)
-      : stableId === `${PLUGIN_JOB_ID_PREFIX}workshop-approval-reminder` ||
-          stableId === `${PLUGIN_JOB_ID_PREFIX}maintenance-log-analyzer`
-        ? { mode: "announce" as const }
-        : { mode: "none" as const };
+  // Issue #2056: prefer `mode: "none"` over the unsafe `announce` shape for plugin-internal
+  // jobs. Only `weekly-pending-digest` keeps announce as a possibility, and only when the
+  // operator has configured an explicit destination (telegram + chatId).
+  const delivery: Record<string, unknown> = (() => {
+    if (stableId === `${PLUGIN_JOB_ID_PREFIX}weekly-pending-digest`) {
+      return resolveWeeklyPendingDigestDelivery(digestWeeklyDelivery);
+    }
+    if (stableId && isPluginInternalAnnounceJob(stableId)) {
+      return { mode: "none" };
+    }
+    return { mode: "none" };
+  })();
   return { ...rest, ...(stableId ? { id: stableId } : {}), model, delivery };
 }
 
@@ -790,6 +816,26 @@ function hasIsolatedCronSessionTarget(job: Record<string, unknown>): boolean {
   const payload = job.payload as Record<string, unknown> | undefined;
   if (!payload) return false;
   return payload.sessionTarget === "isolated" || payload.isolated === true;
+}
+
+/** Issue #2056: a hybrid-mem cron job's `delivery` is considered "unsafe implicit announce"
+ * when:
+ *   - `delivery.mode === "announce"`, AND
+ *   - EITHER `delivery.channel` is missing/blank, OR `delivery.to` is missing/blank.
+ * In that shape the OpenClaw cron safety guard refuses delivery because the target would
+ * otherwise be inherited from the shared agent-main session bucket's last recipient, which
+ * is ambiguous across conversations and can deliver to the wrong room (and replay there
+ * after a restart). `chatId` is treated as an explicit destination only when `to` is also
+ * present (gateway cron uses `to`; `chatId` is the legacy field kept for in-process digest
+ * dispatch but is not sufficient on its own for the cron safety guard). */
+function hasUnsafeImplicitAnnounceDelivery(job: Record<string, unknown>): boolean {
+  const d = job.delivery as { mode?: unknown; channel?: unknown; to?: unknown; chatId?: unknown } | undefined;
+  if (!d || typeof d !== "object") return false;
+  if (d.mode !== "announce") return false;
+  const channel = typeof d.channel === "string" ? d.channel.trim() : "";
+  const to = typeof d.to === "string" ? d.to.trim() : "";
+  if (channel.length > 0 && to.length > 0) return false;
+  return true;
 }
 
 const LEGACY_JOB_MATCHERS: Record<string, (j: Record<string, unknown>) => boolean> = {
@@ -1077,14 +1123,35 @@ function ensureMaintenanceCronJobsLocked(
           if (!normalized.includes(name)) normalized.push(name);
         }
         // Fix delivery: "announce" + channel "system" or "last" requires WhatsApp target (E.164); maintenance jobs don't need delivery.
-        const d = existing.delivery as { mode?: string; channel?: string } | undefined;
+        // Issue #2056: apply uniformly to every hybrid-mem:* job, including the three jobs that
+        // were previously excluded (weekly-pending-digest, workshop-approval-reminder,
+        // maintenance-log-analyzer). Those jobs historically shipped with implicit announce that
+        // the OpenClaw cron safety guard now rejects. The dedicated pass below (unsafeImplicitAnnounce)
+        // additionally repairs the wider `announce` shape with no channel at all.
+        const d = existing.delivery as { mode?: string; channel?: string; to?: string; chatId?: string } | undefined;
         if (
-          id !== `${PLUGIN_JOB_ID_PREFIX}weekly-pending-digest` &&
-          id !== `${PLUGIN_JOB_ID_PREFIX}workshop-approval-reminder` &&
-          id !== `${PLUGIN_JOB_ID_PREFIX}maintenance-log-analyzer` &&
+          id.startsWith(PLUGIN_JOB_ID_PREFIX) &&
           d &&
           d.mode === "announce" &&
           (d.channel === "system" || d.channel === "last")
+        ) {
+          existing.delivery = { mode: "none" };
+          jobsChanged = true;
+          if (!normalized.includes(name)) normalized.push(name);
+        }
+
+        // Issue #2056: repair `isolated + agentTurn + announce` with missing explicit destination.
+        // Newer OpenClaw cron delivery safety refuses this shape and records the job as `error`
+        // even when the body work succeeded. For hybrid-mem:* jobs we never want implicit
+        // recipient inference from the shared main-session bucket, so collapse to `mode: "none"`.
+        // `weekly-pending-digest` is the one job that is allowed to use announce (only with a
+        // non-empty chatId from digest.weekly.delivery); its normalization is handled by
+        // `resolveWeeklyPendingDigestDelivery` later in this loop, so the only remaining
+        // announce-without-destination cases on that job are repaired here as well.
+        if (
+          id.startsWith(PLUGIN_JOB_ID_PREFIX) &&
+          hasIsolatedCronSessionTarget(existing) &&
+          hasUnsafeImplicitAnnounceDelivery(existing)
         ) {
           existing.delivery = { mode: "none" };
           jobsChanged = true;

--- a/extensions/memory-hybrid/cli/verify/sections/config-cron.ts
+++ b/extensions/memory-hybrid/cli/verify/sections/config-cron.ts
@@ -684,6 +684,51 @@ export async function runVerifyConfigCronSection(state: VerifyRunState): Promise
     }
   }
 
+  // Issue #2056: detect plugin-owned `isolated + agentTurn + announce` jobs that are
+  // missing an explicit delivery destination. The OpenClaw cron safety guard refuses
+  // this shape and records the job as `error` even when the body work succeeded. Surface
+  // the issue as a warning so operators learn about it before the next scheduled run,
+  // and recommend `verify --fix` to repair the delivery field.
+  if (cronStoreHasJobs) {
+    const unsafeAnnounceJobs: string[] = [];
+    const rawJobs = Array.isArray(cronStoreSnapshot.store.jobs) ? cronStoreSnapshot.store.jobs : [];
+    for (const j of rawJobs) {
+      if (typeof j !== "object" || j === null) continue;
+      const job = j as Record<string, unknown>;
+      const pid = String(job.pluginJobId ?? job.id ?? "");
+      if (!pid.startsWith("hybrid-mem:")) continue;
+      const sessionTarget = job.sessionTarget;
+      const payload = job.payload as { kind?: unknown; sessionTarget?: unknown; isolated?: unknown } | undefined;
+      const isolated =
+        sessionTarget === "isolated" ||
+        job.isolated === true ||
+        payload?.sessionTarget === "isolated" ||
+        payload?.isolated === true;
+      if (!isolated) continue;
+      if (payload?.kind !== "agentTurn") continue;
+      const d = job.delivery as { mode?: unknown; channel?: unknown; to?: unknown } | undefined;
+      if (!d || d.mode !== "announce") continue;
+      const channel = typeof d.channel === "string" ? d.channel.trim() : "";
+      const to = typeof d.to === "string" ? d.to.trim() : "";
+      if (channel.length > 0 && to.length > 0) continue;
+      unsafeAnnounceJobs.push(pid);
+    }
+    if (unsafeAnnounceJobs.length > 0) {
+      const WARN = noEmoji ? "[WARN]" : "⚠️";
+      const sample = unsafeAnnounceJobs.slice(0, 5).join(", ");
+      const more = unsafeAnnounceJobs.length > 5 ? `, … (${unsafeAnnounceJobs.length - 5} more)` : "";
+      log(
+        `\n${WARN} Cron delivery safety (issue #2056): ${sample}${more} are isolated + agentTurn + announce without an explicit channel/to. OpenClaw cron delivery will refuse to send and record the run as error. Fix: run \`openclaw hybrid-mem verify --fix\` to repair delivery to \`{ mode: "none" }\` (or set digest.weekly.delivery.mode=telegram + chatId for weekly-pending-digest).`,
+      );
+      state.warnings.push(
+        `cron jobs with implicit announce delivery (issue #2056): ${sample}${more}. Run 'openclaw hybrid-mem verify --fix' to repair.`,
+      );
+      state.fixes.push(
+        "Run 'openclaw hybrid-mem verify --fix' to repair hybrid-mem cron jobs with unsafe implicit announce delivery (issue #2056).",
+      );
+    }
+  }
+
   // Warn if the stored cron messages or recent exit logs reference deprecated CLI commands/steps.
   const deprecatedCronJobs = Array.from(allJobs.values()).filter(
     (j) => (j.deprecatedCronTokens?.length ?? 0) > 0 && j.featureGateDisabled !== true,

--- a/extensions/memory-hybrid/config/parsers/features.ts
+++ b/extensions/memory-hybrid/config/parsers/features.ts
@@ -1077,28 +1077,40 @@ export function parseFrequencyCaptureConfig(cfg: Record<string, unknown>): Frequ
   };
 }
 
-/** Safe parse for cron install paths that do not run the full hybrid config validator. */
+/** Safe parse for cron install paths that do not run the full hybrid config validator.
+ * Issue #2056: prefer `mode: "none"` as the default so plugin-owned weekly-pending-digest
+ * never installs with the unsafe `isolated + agentTurn + announce` shape that the OpenClaw
+ * cron safety guard rejects. Operators who want announce delivery must opt in with
+ * `mode: "telegram"` AND a non-empty `chatId`. The legacy `"system"` value is still
+ * accepted as input for backwards compatibility but is normalized here to `"none"` because
+ * the cron job resolver has no safe way to construct an explicit destination for it. */
 export function parseDigestWeeklyDeliveryOnly(cfg: Record<string, unknown>): DigestWeeklyDeliveryConfig {
   const digest = cfg.digest as Record<string, unknown> | undefined;
   const weekly = digest?.weekly as Record<string, unknown> | undefined;
   const delivery = weekly?.delivery as Record<string, unknown> | undefined;
   const modeRaw = delivery?.mode;
   const valid = ["telegram", "system", "none"] as const;
-  let mode: (typeof valid)[number] = "system";
+  let mode: (typeof valid)[number] = "none";
   if (typeof modeRaw === "string" && (valid as readonly string[]).includes(modeRaw)) {
     mode = modeRaw as (typeof valid)[number];
   } else if (modeRaw !== undefined) {
     pluginLogger.warn(
-      `memory-hybrid: invalid digest.weekly.delivery.mode "${modeRaw}"; expected telegram|system|none. Using "system".`,
+      `memory-hybrid: invalid digest.weekly.delivery.mode "${modeRaw}"; expected telegram|none. Using "none".`,
     );
   }
   const chatId =
     typeof delivery?.chatId === "string" && delivery.chatId.trim().length > 0 ? delivery.chatId.trim() : undefined;
   if (mode === "telegram" && !chatId) {
     pluginLogger.warn(
-      `memory-hybrid: digest.weekly.delivery.mode is "telegram" but chatId is missing; using "system".`,
+      `memory-hybrid: digest.weekly.delivery.mode is "telegram" but chatId is missing; using "none".`,
     );
-    return { mode: "system" };
+    return { mode: "none" };
+  }
+  if (mode === "system") {
+    // Legacy/destinationless mode; the cron job resolver cannot safely emit an explicit
+    // destination for it. Downgrade to "none" so issue #2056 cannot reintroduce the unsafe
+    // shape on installations that still carry the old "system" config in their YAML/JSON.
+    return { mode: "none" };
   }
   return { mode, ...(chatId ? { chatId } : {}) };
 }

--- a/extensions/memory-hybrid/openclaw.plugin.json
+++ b/extensions/memory-hybrid/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "openclaw-hybrid-memory",
   "kind": "memory",
-  "version": "2026.7.170",
+  "version": "2026.7.171",
   "contracts": {
     "tools": [
       "active_task_checkpoint",

--- a/extensions/memory-hybrid/package-lock.json
+++ b/extensions/memory-hybrid/package-lock.json
@@ -1,16 +1,15 @@
 {
   "name": "openclaw-hybrid-memory",
-  "version": "2026.7.170",
+  "version": "2026.7.171",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openclaw-hybrid-memory",
-      "version": "2026.7.170",
+      "version": "2026.7.171",
       "hasInstallScript": true,
       "dependencies": {
         "@lancedb/lancedb": "^0.31.0",
-        "@rolldown/binding-linux-x64-gnu": "1.1.4",
         "@types/node": "^25.2.3",
         "commander": "^13.1.0",
         "franc": "^6.2.0",
@@ -236,9 +235,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -256,9 +252,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -276,9 +269,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -296,9 +286,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -726,9 +713,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -744,9 +728,6 @@
       "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -764,9 +745,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -782,9 +760,6 @@
       "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -802,9 +777,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -821,9 +793,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -839,9 +808,6 @@
       "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -865,9 +831,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -889,9 +852,6 @@
       "integrity": "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -915,9 +875,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -940,9 +897,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -964,9 +918,6 @@
       "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1150,9 +1101,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1168,9 +1116,6 @@
       "integrity": "sha512-4y49+83R34IR75H2NPeDtHgSnUIKE9gJoSiELsGmCgICoFTZRVxq88atBEl0BfpsuuUc8S2bSx45mf3H4lZmWA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1188,9 +1133,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1206,9 +1148,6 @@
       "integrity": "sha512-VXtu/xTJXtkfTyUH+MXbMYCGVCAvHJvGDoPNIqDBtrnX7uHlgmxPbw7V97k18/5UVLU2v8NhsM5sCiMD4si+Tw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1883,9 +1822,6 @@
       "integrity": "sha512-JWtGshGfX+oENAKonoNkqEJX+7hC8yfhi9GUyPX1VX4mdh1y5r+ZiJLR5XzAB0aoP6s/PcILsGjKq8O0mm24bw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -3772,9 +3708,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3796,9 +3729,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3820,9 +3750,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3844,9 +3771,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -9069,9 +8993,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9542,9 +9463,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9562,9 +9480,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9582,9 +9497,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9602,9 +9514,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9622,9 +9531,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9642,9 +9548,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/extensions/memory-hybrid/package.json
+++ b/extensions/memory-hybrid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-hybrid-memory",
-  "version": "2026.7.170",
+  "version": "2026.7.171",
   "type": "module",
   "description": "Give your OpenClaw agent lasting memory: structured facts, semantic search, auto-capture & recall, decay, optional credential vault. Part of Hybrid Memory v3.",
   "files": [

--- a/extensions/memory-hybrid/tests/cron-implicit-announce-delivery.test.ts
+++ b/extensions/memory-hybrid/tests/cron-implicit-announce-delivery.test.ts
@@ -1,0 +1,355 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+import { ensureMaintenanceCronJobs } from "../cli/install/cron-jobs.js";
+import { parseDigestWeeklyDeliveryOnly } from "../config/parsers/features.js";
+
+/**
+ * Issue #2056: hybrid-memory cron jobs can install unsafe implicit announce delivery
+ * (sessionTarget=isolated + payload.kind=agentTurn + delivery.mode=announce with missing
+ * delivery.channel or delivery.to). The OpenClaw cron safety guard refuses delivery in that
+ * shape and records the job as `error` even when the body work succeeded. These tests cover
+ * both generation (so new jobs never ship unsafe) and repair/migration (so existing
+ * hybrid-mem:* jobs with the unsafe shape are normalized by upgrade / verify --fix).
+ */
+
+const SAFE_DUMMY_TELEGRAM_TO = "12345";
+
+function readJobs(openclawDir: string): Array<Record<string, unknown>> {
+  const raw = readFileSync(join(openclawDir, "cron", "jobs.json"), "utf-8");
+  const parsed = JSON.parse(raw) as { jobs?: Array<Record<string, unknown>> };
+  return Array.isArray(parsed.jobs) ? parsed.jobs : [];
+}
+
+function findJob(jobs: Array<Record<string, unknown>>, pluginJobId: string): Record<string, unknown> | undefined {
+  return jobs.find((j) => j?.pluginJobId === pluginJobId || j?.id === pluginJobId);
+}
+
+function freshOpenclawDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "hm-cron-issue2056-"));
+  mkdirSync(join(dir, "cron"), { recursive: true });
+  writeFileSync(join(dir, "openclaw.json"), "{}", "utf-8");
+  return dir;
+}
+
+describe("issue #2056 — generation never produces unsafe implicit announce", () => {
+  it("weekly-pending-digest with no digest.weekly.delivery config → delivery.mode none (was announce)", () => {
+    const dir = freshOpenclawDir();
+    try {
+      ensureMaintenanceCronJobs(dir, undefined, {
+        normalizeExisting: true,
+        consolidatedCronJobs: false,
+      });
+      const jobs = readJobs(dir);
+      const target = findJob(jobs, "hybrid-mem:weekly-pending-digest");
+      expect(target).toBeTruthy();
+      expect(target?.delivery).toEqual({ mode: "none" });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("weekly-pending-digest with digest.weekly.delivery.mode=system → delivery.mode none (legacy default)", () => {
+    const dir = freshOpenclawDir();
+    try {
+      ensureMaintenanceCronJobs(dir, undefined, {
+        normalizeExisting: true,
+        consolidatedCronJobs: false,
+        digestWeeklyDelivery: { mode: "system" },
+      });
+      const target = findJob(readJobs(dir), "hybrid-mem:weekly-pending-digest");
+      expect(target?.delivery).toEqual({ mode: "none" });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("weekly-pending-digest with digest.weekly.delivery.mode=telegram + chatId → announce with channel+to+bestEffort", () => {
+    const dir = freshOpenclawDir();
+    try {
+      ensureMaintenanceCronJobs(dir, undefined, {
+        normalizeExisting: true,
+        consolidatedCronJobs: false,
+        digestWeeklyDelivery: { mode: "telegram", chatId: SAFE_DUMMY_TELEGRAM_TO },
+      });
+      const target = findJob(readJobs(dir), "hybrid-mem:weekly-pending-digest");
+      const d = target?.delivery as Record<string, unknown>;
+      expect(d?.mode).toBe("announce");
+      expect(d?.channel).toBe("telegram");
+      expect(d?.to).toBe(SAFE_DUMMY_TELEGRAM_TO);
+      expect(d?.bestEffort).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("weekly-pending-digest with digest.weekly.delivery.mode=telegram but missing chatId → delivery.mode none", () => {
+    const dir = freshOpenclawDir();
+    try {
+      ensureMaintenanceCronJobs(dir, undefined, {
+        normalizeExisting: true,
+        consolidatedCronJobs: false,
+        digestWeeklyDelivery: { mode: "telegram" },
+      });
+      const target = findJob(readJobs(dir), "hybrid-mem:weekly-pending-digest");
+      expect(target?.delivery).toEqual({ mode: "none" });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("workshop-approval-reminder installs with delivery.mode none (was announce)", () => {
+    const dir = freshOpenclawDir();
+    try {
+      ensureMaintenanceCronJobs(dir, undefined, {
+        normalizeExisting: false,
+        consolidatedCronJobs: false,
+        featureGates: {
+          "workshop.enabled": true,
+          "sensorSweep.enabled": false,
+          "nightlyCycle.enabled": false,
+          "crystallization.enabled": false,
+          "lifecycle.adapters.github.enabled": false,
+        },
+      });
+      const target = findJob(readJobs(dir), "hybrid-mem:workshop-approval-reminder");
+      expect(target).toBeTruthy();
+      expect(target?.delivery).toEqual({ mode: "none" });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("maintenance-log-analyzer installs with delivery.mode none (was announce)", () => {
+    const dir = freshOpenclawDir();
+    try {
+      ensureMaintenanceCronJobs(dir, undefined, {
+        normalizeExisting: false,
+        consolidatedCronJobs: false,
+      });
+      const target = findJob(readJobs(dir), "hybrid-mem:maintenance-log-analyzer");
+      expect(target).toBeTruthy();
+      expect(target?.delivery).toEqual({ mode: "none" });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("all other hybrid-mem cron jobs remain delivery.mode none", () => {
+    const dir = freshOpenclawDir();
+    try {
+      ensureMaintenanceCronJobs(dir, undefined, {
+        normalizeExisting: false,
+        consolidatedCronJobs: false,
+      });
+      const jobs = readJobs(dir).filter((j) => String(j?.pluginJobId ?? "").startsWith("hybrid-mem:"));
+      expect(jobs.length).toBeGreaterThan(0);
+      for (const j of jobs) {
+        const d = (j.delivery as { mode?: string } | undefined) ?? {};
+        expect(["none"]).toContain(d.mode);
+      }
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("issue #2056 — verify --fix repairs existing unsafe jobs", () => {
+  function writeLegacyUnsafeJob(
+    dir: string,
+    pluginJobId: string,
+    name: string,
+    delivery: Record<string, unknown>,
+  ): void {
+    writeFileSync(
+      join(dir, "cron", "jobs.json"),
+      JSON.stringify(
+        {
+          jobs: [
+            {
+              pluginJobId,
+              id: pluginJobId,
+              name,
+              schedule: { kind: "cron", expr: "30 3 * * *" },
+              enabled: true,
+              sessionTarget: "isolated",
+              payload: { kind: "agentTurn", message: "legacy unsafe job body" },
+              delivery,
+            },
+          ],
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+  }
+
+  it("repairs hybrid-mem:maintenance-log-analyzer with delivery.mode=announce and no channel/to → mode none", () => {
+    const dir = freshOpenclawDir();
+    try {
+      writeLegacyUnsafeJob(dir, "hybrid-mem:maintenance-log-analyzer", "maintenance-log-analyzer", {
+        mode: "announce",
+      });
+
+      ensureMaintenanceCronJobs(dir, undefined, {
+        normalizeExisting: true,
+        consolidatedCronJobs: false,
+      });
+
+      const target = findJob(readJobs(dir), "hybrid-mem:maintenance-log-analyzer");
+      expect(target?.delivery).toEqual({ mode: "none" });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("repairs hybrid-mem:workshop-approval-reminder with delivery.mode=announce and no channel/to → mode none", () => {
+    const dir = freshOpenclawDir();
+    try {
+      writeLegacyUnsafeJob(dir, "hybrid-mem:workshop-approval-reminder", "workshop-approval-reminder", {
+        mode: "announce",
+      });
+
+      ensureMaintenanceCronJobs(dir, undefined, {
+        normalizeExisting: true,
+        consolidatedCronJobs: false,
+        featureGates: {
+          "workshop.enabled": true,
+          "sensorSweep.enabled": false,
+          "nightlyCycle.enabled": false,
+          "crystallization.enabled": false,
+          "lifecycle.adapters.github.enabled": false,
+        },
+      });
+
+      const target = findJob(readJobs(dir), "hybrid-mem:workshop-approval-reminder");
+      expect(target?.delivery).toEqual({ mode: "none" });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("repairs hybrid-mem:weekly-pending-digest with delivery.mode=announce and no channel/to → mode none", () => {
+    const dir = freshOpenclawDir();
+    try {
+      writeLegacyUnsafeJob(dir, "hybrid-mem:weekly-pending-digest", "weekly-pending-digest", {
+        mode: "announce",
+      });
+
+      ensureMaintenanceCronJobs(dir, undefined, {
+        normalizeExisting: true,
+        consolidatedCronJobs: false,
+      });
+
+      const target = findJob(readJobs(dir), "hybrid-mem:weekly-pending-digest");
+      expect(target?.delivery).toEqual({ mode: "none" });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("repairs hybrid-mem:* announce + channel=system to mode none (uniform apply)", () => {
+    const dir = freshOpenclawDir();
+    try {
+      writeLegacyUnsafeJob(dir, "hybrid-mem:maintenance-log-analyzer", "maintenance-log-analyzer", {
+        mode: "announce",
+        channel: "system",
+      });
+
+      ensureMaintenanceCronJobs(dir, undefined, {
+        normalizeExisting: true,
+        consolidatedCronJobs: false,
+      });
+
+      const target = findJob(readJobs(dir), "hybrid-mem:maintenance-log-analyzer");
+      expect(target?.delivery).toEqual({ mode: "none" });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves valid explicit telegram delivery for weekly-pending-digest when configured", () => {
+    const dir = freshOpenclawDir();
+    try {
+      writeLegacyUnsafeJob(dir, "hybrid-mem:weekly-pending-digest", "weekly-pending-digest", {
+        mode: "announce",
+        channel: "telegram",
+        to: SAFE_DUMMY_TELEGRAM_TO,
+        bestEffort: true,
+      });
+
+      ensureMaintenanceCronJobs(dir, undefined, {
+        normalizeExisting: true,
+        consolidatedCronJobs: false,
+        digestWeeklyDelivery: { mode: "telegram", chatId: SAFE_DUMMY_TELEGRAM_TO },
+      });
+
+      const target = findJob(readJobs(dir), "hybrid-mem:weekly-pending-digest");
+      const d = target?.delivery as Record<string, unknown>;
+      expect(d?.mode).toBe("announce");
+      expect(d?.channel).toBe("telegram");
+      expect(d?.to).toBe(SAFE_DUMMY_TELEGRAM_TO);
+      expect(d?.bestEffort).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("downgrades weekly-pending-digest with telegram channel but stale announce without `to` to mode none when no chatId", () => {
+    const dir = freshOpenclawDir();
+    try {
+      writeLegacyUnsafeJob(dir, "hybrid-mem:weekly-pending-digest", "weekly-pending-digest", {
+        mode: "announce",
+        channel: "telegram",
+      });
+
+      ensureMaintenanceCronJobs(dir, undefined, {
+        normalizeExisting: true,
+        consolidatedCronJobs: false,
+      });
+
+      const target = findJob(readJobs(dir), "hybrid-mem:weekly-pending-digest");
+      expect(target?.delivery).toEqual({ mode: "none" });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("issue #2056 — parser default is mode=none (no implicit announce)", () => {
+  it("parseDigestWeeklyDeliveryOnly({}) returns mode=none", () => {
+    const out = parseDigestWeeklyDeliveryOnly({});
+    expect(out.mode).toBe("none");
+  });
+
+  it("parseDigestWeeklyDeliveryOnly({ digest: {} }) returns mode=none", () => {
+    const out = parseDigestWeeklyDeliveryOnly({ digest: {} });
+    expect(out.mode).toBe("none");
+  });
+
+  it("parseDigestWeeklyDeliveryOnly ignores legacy 'system' as destinationless (mode=none)", () => {
+    const out = parseDigestWeeklyDeliveryOnly({ digest: { weekly: { delivery: { mode: "system" } } } });
+    expect(out.mode).toBe("none");
+  });
+
+  it("parseDigestWeeklyDeliveryOnly downgrades telegram without chatId to mode=none", () => {
+    const out = parseDigestWeeklyDeliveryOnly({ digest: { weekly: { delivery: { mode: "telegram" } } } });
+    expect(out.mode).toBe("none");
+  });
+
+  it("parseDigestWeeklyDeliveryOnly honors telegram + chatId", () => {
+    const out = parseDigestWeeklyDeliveryOnly({
+      digest: { weekly: { delivery: { mode: "telegram", chatId: SAFE_DUMMY_TELEGRAM_TO } } },
+    });
+    expect(out.mode).toBe("telegram");
+    expect(out.chatId).toBe(SAFE_DUMMY_TELEGRAM_TO);
+  });
+
+  it("parseDigestWeeklyDeliveryOnly downgrades unknown mode string to mode=none (with warn)", () => {
+    const out = parseDigestWeeklyDeliveryOnly({ digest: { weekly: { delivery: { mode: "carrier-pigeon" } } } });
+    expect(out.mode).toBe("none");
+  });
+});

--- a/extensions/memory-hybrid/tests/cron-session-key-normalization.test.ts
+++ b/extensions/memory-hybrid/tests/cron-session-key-normalization.test.ts
@@ -58,7 +58,10 @@ describe("ensureMaintenanceCronJobs sessionKey normalization (#977)", () => {
     expect(target).toBeTruthy();
     expect(target?.name).toBe("weekly-pending-digest");
     expect(JSON.stringify(target)).toContain("openclaw hybrid-mem digest pending --since 7d --format md");
-    expect(target?.delivery).toMatchObject({ mode: "announce" });
+    // Issue #2056: without an explicit digest.weekly.delivery.mode=telegram + chatId, the job
+    // must default to delivery.mode=none. The unsafe `announce` shape with no channel/to is
+    // rejected by the OpenClaw cron safety guard, so we never install that.
+    expect(target?.delivery).toEqual({ mode: "none" });
   });
 
   it("publishes the weekly pending digest autopilot maintenance job", () => {

--- a/packages/openclaw-hybrid-memory-install/package.json
+++ b/packages/openclaw-hybrid-memory-install/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-hybrid-memory-install",
-  "version": "2026.7.170",
+  "version": "2026.7.171",
   "description": "Standalone installer for openclaw-hybrid-memory. Use when OpenClaw config validation fails.",
   "bin": {
     "openclaw-hybrid-memory-install": "./install.js"


### PR DESCRIPTION
Fixes #2056

## Summary

Plugin-owned `hybrid-mem:*` cron jobs no longer install in the unsafe `sessionTarget=isolated + payload.kind=agentTurn + delivery.mode=announce` shape with no explicit `delivery.channel` and no `delivery.to`. The OpenClaw cron safety guard refuses delivery in that shape and records the run as `error` even when the body work succeeded (e.g. `digest-pending exit=0` plus `validate-cron-exit exit=0` with `state.lastStatus=error`).

If an explicit operator delivery target is configured (`digest.weekly.delivery.mode=telegram` + non-empty `chatId`), the generator now emits explicit announce delivery with `channel`, `to`, and `bestEffort`. If no explicit destination is known, generation and repair both use `delivery.mode='none'` (no implicit announce), so the cron runner can never infer a recipient from a shared agent-main session bucket.

`openclaw hybrid-mem verify --fix` now also repairs existing `hybrid-mem:*` jobs that still carry the legacy unsafe shape, and `openclaw hybrid-mem verify` warns about the unsafe shape on the read side so operators see it before the next scheduled run.

## Local evidence (Maeve after 2026.7.170)

- `hybrid-mem:maintenance-log-analyzer` and `hybrid-mem:weekly-pending-digest` had `delivery.mode=announce` with missing `channel`/`to`.
- Core OpenClaw refused delivery: "Refusing implicit isolated cron delivery... Set delivery.channel and delivery.to explicitly..."
- Job body could succeed (`digest-pending exit=0`, `validate-cron-exit exit=0`) while cron recorded error due to delivery.
- Local mitigation was setting explicit Telegram delivery to `channel=telegram`, `to=<chatId>`, `bestEffort=true`; the upstream fix removes the implicit-default trap so this mitigation is no longer required.

## Changes

### Generator (no new unsafe jobs)

- `cli/install/cron-jobs.ts` `resolveCronJob` — `workshop-approval-reminder` and `maintenance-log-analyzer` now default to `delivery: { mode: "none" }` (they are plugin-internal logs; the work output is captured in the maintenance log and any operator-visible notification should be opt-in via a future explicit configuration).
- `cli/install/cron-jobs.ts` `resolveWeeklyPendingDigestDelivery` — every destinationless mode (including the historical `"system"` default and any `telegram` config without a non-empty `chatId`) maps to `delivery: { mode: "none" }`. When the operator configures `digest.weekly.delivery.mode="telegram"` together with a non-empty `chatId`, the job installs with `{ mode: "announce", channel: "telegram", to: <chatId>, chatId: <chatId>, bestEffort: true }` so the cron safety guard sees both `channel` and `to`.
- `config/parsers/features.ts` `parseDigestWeeklyDeliveryOnly` — defaults `digest.weekly.delivery.mode` to `"none"` (was `"system"`), and treats the legacy `"system"` value as destinationless (normalized to `"none"`).

### Repair / migration (existing unsafe jobs converge to safe shape)

- `cli/install/cron-jobs.ts` `ensureMaintenanceCronJobsLocked` normalizeExisting pass:
  - The `announce + channel=system|channel=last → mode none` repair now applies uniformly across every `hybrid-mem:*` job (the three jobs that were previously excluded — `weekly-pending-digest`, `workshop-approval-reminder`, `maintenance-log-analyzer` — are now included so legacy installs converge on the safe shape).
  - Adds a dedicated repair for the wider `isolated + agentTurn + announce` shape with no explicit `channel`+`to`, collapsing it to `delivery: { mode: "none" }`. So `openclaw hybrid-mem verify --fix` repairs existing unsafe jobs.

### Verify warning (read-side detection)

- `cli/verify/sections/config-cron.ts` `runVerifyConfigCronSection` — scans the cron store for the unsafe shape and surfaces a warning + recommended fix in `openclaw hybrid-mem verify` output (so operators learn about the issue even before running `--fix`).

### Regression tests

- New `tests/cron-implicit-announce-delivery.test.ts` with 19 tests across three describe blocks:
  - **generation never produces unsafe implicit announce** — verifies the generator emits `mode: "none"` for `workshop-approval-reminder`, `maintenance-log-analyzer`, and `weekly-pending-digest` (default and `mode=system`); verifies the generator emits the full `announce + channel + to + bestEffort` shape only when `digest.weekly.delivery.mode=telegram` is configured with a non-empty `chatId`.
  - **verify --fix repairs existing unsafe jobs** — writes a legacy `hybrid-mem:*` job with the unsafe `{ mode: "announce" }` shape (no channel, no to) and asserts `ensureMaintenanceCronJobs` converges to `{ mode: "none" }`; covers `maintenance-log-analyzer`, `workshop-approval-reminder`, `weekly-pending-digest`, and the `announce + channel=system` variant. Also asserts a valid explicit telegram delivery is preserved end-to-end.
  - **parser default is mode=none (no implicit announce)** — exercises `parseDigestWeeklyDeliveryOnly` to confirm the default is now `mode=none` and the legacy `"system"` value is normalized to `mode=none`.
- Updated `tests/cron-session-key-normalization.test.ts` "publishes the weekly pending digest maintenance job" — the previous expectation asserted the unsafe `{ mode: "announce" }` default; updated to assert the new safe `{ mode: "none" }` default with a comment referencing issue #2056.

### Privacy / no-leak

- No operator-specific values are referenced in any test. Tests use `telegram` + `12345` as a safe dummy destination, or `mode=none` fallback. No chat id or other private operator config is hard-coded.

### Misc

- `CHANGELOG.md` updated under `[Unreleased]` with a `### Fixed` block referencing #2056.
- `extensions/memory-hybrid/package.json` bumped to `2026.7.171`.

## Validation

- `npx vitest run` for the focused cron + verify + install + config + reconcile + digest + digest-autopilot set (51 files / 667 tests): **all pass** (pre-existing 3 lint warnings on `cli/install/cron-jobs.ts` / `config/parsers/features.ts` are baseline and unchanged by this patch; new test file is biome-clean).
- `npm run build` (tsdown): **success** (only pre-existing SOURCEMAP_BROKEN warnings from `rolldown-plugin-dts:fake-js`; no compile errors).
- `npx biome lint cli/install/cron-jobs.ts config/parsers/features.ts --max-diagnostics=none`: 3 warnings (same as pre-fix baseline); **no new findings**.
- `npx biome lint tests/cron-implicit-announce-delivery.test.ts --max-diagnostics=none`: **clean**.

## Acceptance criteria

- [x] New/refreshed hybrid-memory cron jobs never have `isolated + agentTurn + announce` without explicit `channel` and `to`.
- [x] Existing `hybrid-mem:*` jobs with that shape are repaired by upgrade/verify-fix path (`ensureMaintenanceCronJobs` with `normalizeExisting: true`).
- [x] If no explicit delivery target is available, repair/generation uses `delivery.mode='none'`.
- [x] Tests cover both generation and repair of legacy unsafe jobs.

Closes #2056.