### PR TITLE
fix: reregister reuse of closed DB handles

### DIFF
--- a/extensions/memory-hybrid/setup/reregister-policy.ts
+++ b/extensions/memory-hybrid/setup/reregister-policy.ts
@@ -60,6 +60,53 @@ export function recordReregisterDatabaseReuse(): void {
 
 type PathResolvingApi = { resolvePath: (p: string) => string };
 
+function booleanMethod(target: unknown, method: string): boolean | null {
+  if (!target || typeof target !== "object") return null;
+  const fn = (target as Record<string, unknown>)[method];
+  if (typeof fn !== "function") return null;
+  try {
+    const value = fn.call(target);
+    return typeof value === "boolean" ? value : null;
+  } catch {
+    return false;
+  }
+}
+
+function isReusableStoreOpen(target: unknown): boolean {
+  const isOpen = booleanMethod(target, "isOpen");
+  if (isOpen === false) return false;
+  const isInitialized = booleanMethod(target, "isInitialized");
+  if (isInitialized === false) return false;
+  const lanceAvailable = booleanMethod(target, "isLanceDbAvailable");
+  if (lanceAvailable === false) return false;
+  return true;
+}
+
+function runtimeStoresStillReusable(old: PluginRuntime): boolean {
+  const requiredStores: Array<[string, unknown]> = [
+    ["factsDb", old.factsDb],
+    ["edictStore", old.edictStore],
+    ["vectorDb", old.vectorDb],
+    ["proposalsDb", old.proposalsDb],
+    ["narrativesDb", old.narrativesDb],
+    ["aliasDb", old.aliasDb],
+    ["issueStore", old.issueStore],
+    ["workflowStore", old.workflowStore],
+    ["crystallizationStore", old.crystallizationStore],
+    ["toolProposalStore", old.toolProposalStore],
+    ["verificationStore", old.verificationStore],
+    ["apitapStore", old.apitapStore],
+  ];
+  for (const [, store] of requiredStores) {
+    if (store && !isReusableStoreOpen(store)) return false;
+  }
+  if (old.cfg.credentials?.enabled && old.credentialsDb && !isReusableStoreOpen(old.credentialsDb)) {
+    return false;
+  }
+  if (old.wal && !isReusableStoreOpen(old.wal)) return false;
+  return true;
+}
+
 /** True when re-register may keep existing SQLite/Lance handles (paths unchanged). */
 export function canReuseDatabasesOnReregister(
   old: PluginRuntime | null,
@@ -71,6 +118,12 @@ export function canReuseDatabasesOnReregister(
   // Reuse only after donor bootstrap has fully settled. If bootstrap is still in flight when
   // generation bumps, supersession can skip one-shot init work (vault/migration checks).
   if (!old.bootstrapSettledRef || old.bootstrapSettledRef.value !== true) return false;
+  // A settled donor can still be unusable if teardown/shutdown already closed one of its
+  // SQLite/Lance handles. Reusing such a donor poisons the new registration: tools,
+  // Workboard sync, credentials checks, compaction hooks, and lifecycle hooks inherit
+  // stores that immediately throw "The database connection is not open". Treat any
+  // closed/failed donor handle as non-reusable and fall back to a full fresh open.
+  if (!runtimeStoresStillReusable(old)) return false;
   const nextSqlite = api.resolvePath(cfg.sqlitePath);
   const nextLance = api.resolvePath(cfg.lanceDbPath);
   if (old.resolvedSqlitePath !== nextSqlite || old.resolvedLancePath !== nextLance) return false;

--- a/extensions/memory-hybrid/tests/reregister-policy.test.ts
+++ b/extensions/memory-hybrid/tests/reregister-policy.test.ts
@@ -221,3 +221,76 @@ describe("reregister-policy", () => {
     expect(reregisterMetrics.databaseReuses).toBe(1);
   });
 });
+
+describe("reregister-policy closed donor handle guard", () => {
+  beforeEach(() => {
+    vi.stubEnv("OPENCLAW_HYBRID_MEM_REREGISTER_POLICY", "reuse-databases");
+    resetReregisterPolicyForTests();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    resetReregisterPolicyForTests();
+  });
+
+  function store(open = true) {
+    return { isOpen: () => open };
+  }
+
+  function vector(open = true) {
+    return { isInitialized: () => open, isLanceDbAvailable: () => open };
+  }
+
+  function runtimeWithStores(cfg: HybridMemoryConfig, api: { resolvePath: (p: string) => string }, overrides = {}) {
+    return {
+      cfg,
+      parsedCfgSnapshot: cfg,
+      resolvedSqlitePath: api.resolvePath(cfg.sqlitePath),
+      resolvedLancePath: api.resolvePath(cfg.lanceDbPath),
+      bootstrapSettledRef: { value: true },
+      factsDb: store(true),
+      edictStore: store(true),
+      vectorDb: vector(true),
+      credentialsDb: store(true),
+      wal: store(true),
+      proposalsDb: store(true),
+      narrativesDb: store(true),
+      aliasDb: store(true),
+      issueStore: store(true),
+      workflowStore: store(true),
+      crystallizationStore: store(true),
+      toolProposalStore: store(true),
+      verificationStore: store(true),
+      apitapStore: store(true),
+      ...overrides,
+    } as PluginRuntime;
+  }
+
+  it("allows reuse when donor config and handles are still open", () => {
+    const api = { resolvePath: (p: string) => `/home/markus/.openclaw/${p}` };
+    const cfg = minimalCfg();
+    expect(canReuseDatabasesOnReregister(runtimeWithStores(cfg, api), cfg, api)).toBe(true);
+  });
+
+  it("rejects reuse when the donor facts DB is closed", () => {
+    const api = { resolvePath: (p: string) => `/home/markus/.openclaw/${p}` };
+    const cfg = minimalCfg();
+    expect(canReuseDatabasesOnReregister(runtimeWithStores(cfg, api, { factsDb: store(false) }), cfg, api)).toBe(false);
+  });
+
+  it("rejects reuse when the donor vector DB is closed", () => {
+    const api = { resolvePath: (p: string) => `/home/markus/.openclaw/${p}` };
+    const cfg = minimalCfg();
+    expect(canReuseDatabasesOnReregister(runtimeWithStores(cfg, api, { vectorDb: vector(false) }), cfg, api)).toBe(false);
+  });
+
+  it("rejects reuse when the enabled credentials vault is closed", () => {
+    const api = { resolvePath: (p: string) => `/home/markus/.openclaw/${p}` };
+    const cfg = minimalCfg();
+    (cfg as { credentials?: { enabled: boolean; encryptionKey: string } }).credentials = {
+      enabled: true,
+      encryptionKey: "k",
+    };
+    expect(canReuseDatabasesOnReregister(runtimeWithStores(cfg, api, { credentialsDb: store(false) }), cfg, api)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #2058.

Prevents hot reload / re-register from reusing a donor hybrid-memory runtime whose database handles have already been closed.

The existing `reuse-databases` policy checked config/path compatibility and bootstrap settlement, but it did not verify that the donor stores were still open. During reload/shutdown sequencing this can reuse stale SQLite/Lance/credentials handles and poison the next plugin registration with errors like:

```text
The database connection is not open
```

That then cascades into Workboard sync, credentials checks, compaction/capture hooks, and lifecycle hook failures.

## Changes

- Adds a lightweight donor-store liveness guard in `setup/reregister-policy.ts`.
- Checks store methods when available:
  - `isOpen()` for SQLite-style stores
  - `isInitialized()` / `isLanceDbAvailable()` for vector DB
- Includes credentials DB when credentials are enabled.
- Includes WAL when present.
- Falls back to full fresh DB open if any donor handle reports closed/unavailable or throws.
- Preserves the existing fast reuse path when donor handles are still healthy.
- Adds regression coverage without deleting existing reregister-policy tests.

## Validation

Ran in `extensions/memory-hybrid`:

```text
npm test -- tests/reregister-policy.test.ts
# 1 file passed, 13 tests passed

npm run build:check
# tsdown build succeeded
# verify-publish passed
# publish-dist vitest smoke passed
```

## Local incident evidence

This was found during Maeve gateway restart/cutover work. Local logs showed repeated hybrid-memory re-registers with `policy=reuse-databases`, followed by `The database connection is not open` errors in Workboard/credentials/compaction/hook paths. A local runtime hotfix with the same guard passed a direct self-test before this upstream PR was prepared.
