### PR TITLE
fix: reload teardown drain before DB reuse

### DIFF
--- a/extensions/memory-hybrid/api/plugin-runtime.ts
+++ b/extensions/memory-hybrid/api/plugin-runtime.ts
@@ -117,6 +117,13 @@ export interface PluginRuntime {
     credentialsVaultOk: boolean;
     lastCheckTime: number;
   };
+  /**
+   * Registration generation that produced this runtime. The next re-register uses this
+   * value to track which donor-runtime teardowns it is waiting on (reload-coordinator
+   * `donorGeneration`), so the gate does not deadlock when a re-register overlap-queues
+   * another re-register (e.g. rapid voice-call config hot reloads).
+   */
+  bootRegistrationGeneration?: number;
   pendingLLMWarnings: PendingLLMWarnings;
 
   // --- Mutable refs (objects so that closures can share mutations) ---

--- a/extensions/memory-hybrid/services/workboard-adapter.ts
+++ b/extensions/memory-hybrid/services/workboard-adapter.ts
@@ -88,6 +88,20 @@ export function createWorkboardAdapter(ctx: WorkboardAdapterContext): WorkboardA
       }
 
       const syncRunId = Date.now().toString(36);
+      // Rapid hot-reload guard: if the plugin-service that scheduled this sync has been
+      // superseded by a newer registration, bail out before touching the donor DBs. Without
+      // this, the recurring workboard-sync timer fires after a re-register and immediately
+      // hits closed-DB errors from the in-flight teardown of the donor runtime.
+      if (ctx.shouldAbort?.()) {
+        traceIntegration(verbose, `workboard sync [${syncRunId}] skipped — supersession in flight`);
+        return {
+          cardsCreated: 0,
+          cardsUpdated: 0,
+          cardsRemoved: 0,
+          pullChanges: 0,
+          errors: [],
+        };
+      }
       syncInFlight = true;
       const result: WorkboardSyncResult = {
         cardsCreated: 0,

--- a/extensions/memory-hybrid/setup/hybrid-memory-reload-coordinator.ts
+++ b/extensions/memory-hybrid/setup/hybrid-memory-reload-coordinator.ts
@@ -18,12 +18,44 @@ export const RECALL_DRAIN_MS = 2_000;
 const TEARDOWN_MIN_WAIT_MS = RECALL_DRAIN_MS + BOOTSTRAP_DRAIN_MS + RECALL_DRAIN_MS + 1_000;
 export const TEARDOWN_WAIT_MS = Math.max(6_000, TEARDOWN_MIN_WAIT_MS);
 
+/**
+ * Soft grace window: if teardown doesn't drain within this budget, callers that are about to
+ * reuse donor handles (reuse-databases policy) should fall back to a fresh open instead of
+ * inheriting indeterminate closed handles (#2058 / #2059 supplement).
+ */
+export const TEARDOWN_SOFT_WAIT_MS = Math.max(3_000, RECALL_DRAIN_MS + BOOTSTRAP_DRAIN_MS + 1_000);
+
+/**
+ * Tracks the registration generation each scheduled teardown belongs to. The new
+ * registration wants to wait for teardowns scheduled by the **prior** generation
+ * (the one it's about to supersede), not for teardowns scheduled by itself or
+ * later generations. This prevents the gate from deadlocking when a re-register
+ * overlap-queues another re-register (e.g. rapid voice-call config hot reloads).
+ */
+type ScheduledTeardown = {
+  /** Registration generation that owns the donor runtime being torn down. */
+  donorGeneration: number;
+  /** Resolved when this individual teardown has finished (success or error). */
+  done: Promise<void>;
+};
+let scheduledTeardowns: ScheduledTeardown[] = [];
+
 /** Serializes plugin teardown (bootstrap settle → close DBs) across hot reloads (#1550 / reload race). */
 let reloadTeardownChain: Promise<void> = Promise.resolve();
 let reloadTeardownQueueDepth = 0;
 
-export function schedulePluginTeardown(teardown: () => Promise<void>): void {
+export function schedulePluginTeardown(
+  teardown: () => Promise<void>,
+  options?: { donorGeneration?: number },
+): void {
   reloadTeardownQueueDepth += 1;
+  const donorGeneration = options?.donorGeneration ?? -1;
+  let resolveDone: () => void = () => {};
+  const done = new Promise<void>((resolve) => {
+    resolveDone = resolve;
+  });
+  const entry: ScheduledTeardown = { donorGeneration, done };
+  scheduledTeardowns.push(entry);
   reloadTeardownChain = reloadTeardownChain
     .catch(() => {
       /* keep chain alive; next teardown still must run */
@@ -39,8 +71,54 @@ export function schedulePluginTeardown(teardown: () => Promise<void>): void {
         });
       } finally {
         reloadTeardownQueueDepth = Math.max(0, reloadTeardownQueueDepth - 1);
+        // Always resolve so awaiters can move on, regardless of teardown outcome.
+        resolveDone();
       }
     });
+  // Defensive: also resolve done when the chain itself settles, even if the
+  // .then() above never runs (shouldn't happen, but belt-and-suspenders for
+  // generation tracking — never leave an entry stuck "pending").
+  void reloadTeardownChain.finally(() => resolveDone());
+  // Auto-remove the entry once it's done so isTeardownDrainedForGeneration flips back to true.
+  void done.then(() => {
+    scheduledTeardowns = scheduledTeardowns.filter((e) => e !== entry);
+  });
+}
+
+/**
+ * Drop tracking entries for the given registration generation. Called by register-plugin
+ * after the new runtime has been installed, so stale entries don't pile up.
+ */
+export function clearTeardownTrackingForGeneration(generation: number): void {
+  if (generation < 0) return;
+  scheduledTeardowns = scheduledTeardowns.filter(
+    (entry) => entry.donorGeneration !== generation,
+  );
+}
+
+/**
+ * Returns true when no scheduled teardown for `donorGeneration` is still pending.
+ * Used by register-plugin to detect the soft-drain timeout case: the chain may have
+ * advanced past this generation's teardown already (good), or it may still be queued
+ * behind a newer teardown (bad — donor handles would still be open during the wait).
+ */
+export function isTeardownDrainedForGeneration(donorGeneration: number): boolean {
+  if (donorGeneration < 0) return reloadTeardownQueueDepth === 0;
+  return !scheduledTeardowns.some((entry) => entry.donorGeneration === donorGeneration);
+}
+
+/**
+ * Snapshot the current set of `done` promises for teardowns belonging to `donorGeneration`.
+ * Used by callers that want to wait only on the teardowns they care about (the donor they're
+ * about to supersede), not on teardowns queued by a later registration generation.
+ */
+export function listTeardownPromisesForGeneration(donorGeneration: number): Promise<void>[] {
+  if (donorGeneration < 0) {
+    return scheduledTeardowns.map((entry) => entry.done);
+  }
+  return scheduledTeardowns
+    .filter((entry) => entry.donorGeneration === donorGeneration)
+    .map((entry) => entry.done);
 }
 
 /** Wait for superseded bootstrap work with a short cap; then close old handles regardless. */
@@ -126,4 +204,5 @@ export function blockReloadTeardownBeforeOpen(timeoutMs = TEARDOWN_WAIT_MS): boo
 export function resetReloadTeardownChainForTests(): void {
   reloadTeardownChain = Promise.resolve();
   reloadTeardownQueueDepth = 0;
+  scheduledTeardowns = [];
 }

--- a/extensions/memory-hybrid/setup/plugin-service.ts
+++ b/extensions/memory-hybrid/setup/plugin-service.ts
@@ -6,6 +6,7 @@ import { nowIso } from "../utils/dates.js";
 import type OpenAI from "openai";
 import type { ClawdbotPluginApi } from "openclaw/plugin-sdk/core";
 import { clearRuntimeTimers, type PluginRuntime } from "../api/plugin-runtime.js";
+import { isRegistrationSuperseded } from "../utils/registration-superseded.js";
 import type { CredentialsDB } from "../backends/credentials-db.js";
 import type { EdictStore } from "../backends/edict-store.js";
 import type { FactsDB } from "../backends/facts-db.js";
@@ -77,6 +78,13 @@ import { versionInfo } from "../versionInfo.js";
 
 export interface PluginServiceContext {
   PLUGIN_ID: string;
+  /**
+   * Registration generation that produced the runtime driving this service. Captured at
+   * plugin-service.start() time so the startup DB-touching blocks can suppress closed-DB
+   * errors that fire after a re-register supersedes this service instance (rapid hot-reload
+   * guard, supplements #1550 / #2058 / #2059).
+   */
+  bootRegistrationGeneration?: number;
   factsDb: FactsDB;
   edictStore: EdictStore;
   vectorDb: VectorDB;
@@ -158,9 +166,14 @@ function closeStorePermanently(
  * - Post-upgrade pipeline
  * - Cleanup on shutdown
  */
+export function shouldSkipPluginServiceStartForSupersededGeneration(bootRegistrationGeneration: number | undefined): boolean {
+  return bootRegistrationGeneration !== undefined && isRegistrationSuperseded(bootRegistrationGeneration);
+}
+
 export function createPluginService(ctx: PluginServiceContext) {
   const {
     PLUGIN_ID,
+    bootRegistrationGeneration,
     factsDb,
     edictStore,
     vectorDb,
@@ -209,6 +222,16 @@ export function createPluginService(ctx: PluginServiceContext) {
     _getVersionCheckPromise: () => versionCheckPromise,
     start: async () => {
       timers.shuttingDownRef.value = false;
+      // Rapid hot-reload guard: if this service instance is already superseded by a newer
+      // registration, skip the heavy startup work (which touches donor DBs that the newer
+      // re-register is about to close). Without this, `plugin service failed ... The
+      // database connection is not open` fires on every rapid config hot reload.
+      if (shouldSkipPluginServiceStartForSupersededGeneration(bootRegistrationGeneration)) {
+        api.logger.debug?.(
+          `memory-hybrid: plugin-service start skipped (registration generation ${bootRegistrationGeneration} superseded)`,
+        );
+        return;
+      }
       // Issue #422: surface missing Python deps early; deferred from register() for lighter CLI (issue #1111).
       if (pythonBridge) {
         const { ok, missing, spawnError } = pythonBridge.checkDependencies();

--- a/extensions/memory-hybrid/setup/register-plugin.ts
+++ b/extensions/memory-hybrid/setup/register-plugin.ts
@@ -47,10 +47,14 @@ import {
 } from "./hybrid-memory-generation-state.js";
 import {
   blockReloadTeardownBeforeOpen,
+  clearTeardownTrackingForGeneration,
   drainOldBootstrap,
   drainOldRecall,
+  isTeardownDrainedForGeneration,
+  listTeardownPromisesForGeneration,
   resetReloadTeardownChainForTests,
   schedulePluginTeardown,
+  TEARDOWN_SOFT_WAIT_MS,
   TEARDOWN_WAIT_MS,
 } from "./hybrid-memory-reload-coordinator.js";
 import { registerContextEngineBestEffort } from "./register-context-engine.js";
@@ -263,6 +267,10 @@ function runMemoryHybridRegisterImpl(api: ClawdbotPluginApi): void {
   const registrationGeneration = registrationGenerationRef.value + 1;
   registrationGenerationRef.value = registrationGeneration;
   recordReregisterRegistration();
+  // Generation that produced the donor runtime we're about to supersede. Used by the reload
+  // coordinator to track which scheduled teardowns the new register is actually waiting on
+  // (rapid hot-reload guard, supplements #1550 / #2058 / #2059).
+  const donorGeneration = old?.bootRegistrationGeneration ?? -1;
 
   const reusePolicy = resolveReregisterPolicy();
   const reuseDatabases = canReuseDatabasesOnReregister(old, cfg, logApi);
@@ -271,7 +279,7 @@ function runMemoryHybridRegisterImpl(api: ClawdbotPluginApi): void {
       "memory-hybrid: re-register falling back to full teardown (reuse policy requested but donor bootstrap not reusable)",
     );
   }
-  const donorRuntime = reuseDatabases && old ? old : null;
+  let donorRuntime = reuseDatabases && old ? old : null;
 
   if (old) {
     // Clear old timer handles to prevent leaks.
@@ -291,18 +299,21 @@ function runMemoryHybridRegisterImpl(api: ClawdbotPluginApi): void {
     const oldVaultRegistry = old.vaultRegistry;
     const oldRecallInFlightRef = old.recallInFlightRef;
     if (oldVaultRegistry) {
-      schedulePluginTeardown(async () => {
-        try {
-          await drainOldRecall(oldRecallInFlightRef);
-          oldVaultRegistry.closeAll();
-        } catch (err) {
-          capturePluginError(err instanceof Error ? err : new Error(String(err)), {
-            subsystem: "registration",
-            operation: "plugin-reregister:close-vaults",
-            severity: "warning",
-          });
-        }
-      });
+      schedulePluginTeardown(
+        async () => {
+          try {
+            await drainOldRecall(oldRecallInFlightRef);
+            oldVaultRegistry.closeAll();
+          } catch (err) {
+            capturePluginError(err instanceof Error ? err : new Error(String(err)), {
+              subsystem: "registration",
+              operation: "plugin-reregister:close-vaults",
+              severity: "warning",
+            });
+          }
+        },
+        { donorGeneration },
+      );
     }
     if (reuseDatabases) {
       recordReregisterDatabaseReuse();
@@ -320,43 +331,62 @@ function runMemoryHybridRegisterImpl(api: ClawdbotPluginApi): void {
         });
       });
       // Let in-flight bootstrap (vault check, embedding verify) finish before permanentClose (#1550 reload race).
-      schedulePluginTeardown(async () => {
-        await drainOldBootstrap(oldRuntime.bootstrapAsyncInit);
-        await drainOldRecall(oldRuntime.recallInFlightRef);
-        closeOldDatabases({
-          factsDb: oldRuntime.factsDb,
-          edictStore: oldRuntime.edictStore,
-          vectorDb: oldRuntime.vectorDb,
-          credentialsDb: oldRuntime.credentialsDb,
-          proposalsDb: oldRuntime.proposalsDb,
-          identityReflectionStore: oldRuntime.identityReflectionStore,
-          personaStateStore: oldRuntime.personaStateStore,
-          eventLog: oldRuntime.eventLog,
-          narrativesDb: oldRuntime.narrativesDb,
-          aliasDb: oldRuntime.aliasDb,
-          eventBus: oldRuntime.eventBus,
-          issueStore: oldRuntime.issueStore,
-          workflowStore: oldRuntime.workflowStore,
-          crystallizationStore: oldRuntime.crystallizationStore,
-          toolProposalStore: oldRuntime.toolProposalStore,
-          verificationStore: oldRuntime.verificationStore,
-          provenanceService: oldRuntime.provenanceService,
-          learningsDb: oldRuntime.learningsDb,
-          apitapStore: oldRuntime.apitapStore,
-          auditStore: oldRuntime.auditStore,
-          agentHealthStore: oldRuntime.agentHealthStore,
-        });
-      });
+      schedulePluginTeardown(
+        async () => {
+          await drainOldBootstrap(oldRuntime.bootstrapAsyncInit);
+          await drainOldRecall(oldRuntime.recallInFlightRef);
+          closeOldDatabases({
+            factsDb: oldRuntime.factsDb,
+            edictStore: oldRuntime.edictStore,
+            vectorDb: oldRuntime.vectorDb,
+            credentialsDb: oldRuntime.credentialsDb,
+            proposalsDb: oldRuntime.proposalsDb,
+            identityReflectionStore: oldRuntime.identityReflectionStore,
+            personaStateStore: oldRuntime.personaStateStore,
+            eventLog: oldRuntime.eventLog,
+            narrativesDb: oldRuntime.narrativesDb,
+            aliasDb: oldRuntime.aliasDb,
+            eventBus: oldRuntime.eventBus,
+            issueStore: oldRuntime.issueStore,
+            workflowStore: oldRuntime.workflowStore,
+            crystallizationStore: oldRuntime.crystallizationStore,
+            toolProposalStore: oldRuntime.toolProposalStore,
+            verificationStore: oldRuntime.verificationStore,
+            provenanceService: oldRuntime.provenanceService,
+            learningsDb: oldRuntime.learningsDb,
+            apitapStore: oldRuntime.apitapStore,
+            auditStore: oldRuntime.auditStore,
+            agentHealthStore: oldRuntime.agentHealthStore,
+          });
+        },
+        { donorGeneration },
+      );
     }
     runtimeRef.value = null;
   }
 
-  if (old && !reuseDatabases) {
-    // Wait for teardown to complete before opening new DB handles (#802).
-    // Bounded wait: drains (3s + 2s) + buffer fit within TEARDOWN_WAIT_MS.
+  if (old) {
+    // Wait for the donor runtime's teardown to complete before opening or handing out new DB
+    // handles (#802, #2058 / #2059). When `reuseDatabases` is true we still need to wait
+    // because the vault-registry teardown is scheduled against the SAME donor runtime we are
+    // about to inherit; if we don't wait, vault closeAll() races the new registration's first
+    // DB access (closed DB / not open). When the soft drain window expires before the donor
+    // teardown settles, fall back to a fresh open instead of inheriting indeterminate handles.
     const drained = blockReloadTeardownBeforeOpen(TEARDOWN_WAIT_MS);
     if (!drained) {
-      throw new Error("memory-hybrid: reload teardown did not drain before opening new databases");
+      const donorDrained = isTeardownDrainedForGeneration(donorGeneration);
+      if (donorRuntime && donorDrained) {
+        // Donor generation's teardown is done even though newer teardowns may still be queued
+        // (overlap-queued re-register). Donor handles are safe to hand to the new runtime.
+      } else if (donorRuntime) {
+        logApi.logger.warn?.(
+          `memory-hybrid: reload teardown soft-timeout exceeded (>=${TEARDOWN_SOFT_WAIT_MS}ms) for donor generation ${donorGeneration}; falling back to fresh open to avoid inheriting closed DB handles`,
+        );
+        donorRuntime = null;
+        recordReregisterFullTeardown();
+      } else {
+        throw new Error("memory-hybrid: reload teardown did not drain before opening new databases");
+      }
     }
   }
 
@@ -582,6 +612,7 @@ function runMemoryHybridRegisterImpl(api: ClawdbotPluginApi): void {
     bootstrapAsyncInit,
     bootstrapSettledRef,
     bootstrapHealth: dbContext.health,
+    bootRegistrationGeneration: registrationGeneration,
     pendingLLMWarnings: createPendingLLMWarnings(),
     currentAgentIdRef: { value: null },
     restartPendingClearedRef: { value: false },
@@ -597,6 +628,13 @@ function runMemoryHybridRegisterImpl(api: ClawdbotPluginApi): void {
   };
 
   runtimeRef.value = newRuntime;
+
+  // The donor generation's tracking is no longer needed: even if its teardown is still
+  // queued behind a newer one, the new runtime is now in place and the donor's `done`
+  // promises are no longer observed by anyone.
+  if (donorGeneration >= 0) {
+    clearTeardownTrackingForGeneration(donorGeneration);
+  }
 
   const runtime = newRuntime;
 
@@ -743,6 +781,7 @@ function runMemoryHybridRegisterImpl(api: ClawdbotPluginApi): void {
     api.registerService(
       createPluginService({
         PLUGIN_ID,
+        bootRegistrationGeneration: registrationGeneration,
         factsDb: runtime.factsDb,
         edictStore: runtime.edictStore,
         vectorDb: runtime.vectorDb,

--- a/extensions/memory-hybrid/tests/hybrid-memory-reload-coordinator.test.ts
+++ b/extensions/memory-hybrid/tests/hybrid-memory-reload-coordinator.test.ts
@@ -2,10 +2,14 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   BOOTSTRAP_DRAIN_MS,
   RECALL_DRAIN_MS,
+  TEARDOWN_SOFT_WAIT_MS,
   awaitReloadTeardownBeforeOpen,
   blockReloadTeardownBeforeOpen,
+  clearTeardownTrackingForGeneration,
   drainOldBootstrap,
   drainOldRecall,
+  isTeardownDrainedForGeneration,
+  listTeardownPromisesForGeneration,
   resetReloadTeardownChainForTests,
   schedulePluginTeardown,
   TEARDOWN_WAIT_MS,
@@ -108,4 +112,119 @@ describe("hybrid-memory-reload-coordinator", () => {
     expect(vaultClosed).toBe(true);
     expect(dbClosed).toBe(true);
   });
+
+  // ----- rapid hot-reload guard (regression for closed-DB reuse after vault-registry teardown) -----
+
+  it("isTeardownDrainedForGeneration tracks per-generation drain state (rapid hot-reload guard)", async () => {
+    expect(isTeardownDrainedForGeneration(-1)).toBe(true);
+    let resolveG1: () => void = () => {};
+    const g1Done = new Promise<void>((resolve) => {
+      resolveG1 = resolve;
+    });
+    let ranG1 = false;
+    schedulePluginTeardown(async () => {
+      await g1Done;
+      ranG1 = true;
+    }, { donorGeneration: 1 });
+
+    // Generation 1 teardown is still pending.
+    expect(isTeardownDrainedForGeneration(1)).toBe(false);
+    // Generation 2 (a newer, unrelated generation) is also not drained yet — its entry is
+    // only created once it schedules teardown; until then it reports drained.
+    expect(isTeardownDrainedForGeneration(2)).toBe(true);
+
+    resolveG1();
+    expect(await awaitReloadTeardownBeforeOpen(TEARDOWN_WAIT_MS)).toBe(true);
+    expect(ranG1).toBe(true);
+    expect(isTeardownDrainedForGeneration(1)).toBe(true);
+  });
+
+  it("listTeardownPromisesForGeneration returns only the donor generation's teardowns", async () => {
+    let resolveG1: () => void = () => {};
+    const g1Done = new Promise<void>((resolve) => {
+      resolveG1 = resolve;
+    });
+    schedulePluginTeardown(async () => {
+      await g1Done;
+    }, { donorGeneration: 1 });
+    schedulePluginTeardown(
+      async () => {
+        /* already-drained teardown */
+      },
+      { donorGeneration: 2 },
+    );
+
+    const g1Promises = listTeardownPromisesForGeneration(1);
+    expect(g1Promises).toHaveLength(1);
+    const g2Promises = listTeardownPromisesForGeneration(2);
+    expect(g2Promises).toHaveLength(1);
+    const allPromises = listTeardownPromisesForGeneration(-1);
+    expect(allPromises).toHaveLength(2);
+
+    resolveG1();
+    await Promise.all([...g1Promises, ...g2Promises]);
+  });
+
+  it("clearTeardownTrackingForGeneration drops only the target generation's entries", async () => {
+    schedulePluginTeardown(async () => {}, { donorGeneration: 5 });
+    schedulePluginTeardown(async () => {}, { donorGeneration: 6 });
+    schedulePluginTeardown(async () => {}, { donorGeneration: 6 });
+
+    expect(listTeardownPromisesForGeneration(5)).toHaveLength(1);
+    expect(listTeardownPromisesForGeneration(6)).toHaveLength(2);
+
+    clearTeardownTrackingForGeneration(5);
+    expect(listTeardownPromisesForGeneration(5)).toHaveLength(0);
+    expect(listTeardownPromisesForGeneration(6)).toHaveLength(2);
+
+    clearTeardownTrackingForGeneration(6);
+    expect(listTeardownPromisesForGeneration(6)).toHaveLength(0);
+
+    // Drain anything still pending so afterEach is clean.
+    expect(await awaitReloadTeardownBeforeOpen(TEARDOWN_WAIT_MS)).toBe(true);
+  });
+
+  it("schedulePluginTeardown resolves the entry's done promise even on teardown error", async () => {
+    schedulePluginTeardown(async () => {
+      throw new Error("synthetic teardown failure");
+    }, { donorGeneration: 7 });
+    const promises = listTeardownPromisesForGeneration(7);
+    expect(promises).toHaveLength(1);
+    // The promise must resolve (not reject) so awaiters can move on. Errors are captured
+    // by capturePluginError inside schedulePluginTeardown; per-entry done promise stays clean.
+    await expect(promises[0]).resolves.toBeUndefined();
+    clearTeardownTrackingForGeneration(7);
+  });
+
+  it("TEARDOWN_SOFT_WAIT_MS is shorter than TEARDOWN_WAIT_MS and positive", () => {
+    expect(TEARDOWN_SOFT_WAIT_MS).toBeGreaterThan(0);
+    expect(TEARDOWN_SOFT_WAIT_MS).toBeLessThanOrEqual(TEARDOWN_WAIT_MS);
+  });
+
+  it(
+    "rapid re-register overlap-queues teardowns; donor-generation drain detection tracks the prior generation only",
+    async () => {
+      let resolveG1: () => void = () => {};
+      const g1Done = new Promise<void>((resolve) => {
+        resolveG1 = resolve;
+      });
+      schedulePluginTeardown(async () => {
+        await g1Done;
+      }, { donorGeneration: 1 });
+
+      // Generation 2 schedules its own (immediate) teardown BEFORE generation 1's teardown completes.
+      schedulePluginTeardown(async () => {}, { donorGeneration: 2 });
+
+      // At this moment, gen 1 is pending (g1Done hasn't resolved), gen 2's teardown is queued.
+      expect(isTeardownDrainedForGeneration(1)).toBe(false);
+
+      // Release gen 1; both will complete shortly after.
+      resolveG1();
+      expect(await awaitReloadTeardownBeforeOpen(TEARDOWN_WAIT_MS)).toBe(true);
+
+      // Both generations are now drained (entries auto-removed after done resolves).
+      expect(isTeardownDrainedForGeneration(1)).toBe(true);
+      expect(isTeardownDrainedForGeneration(2)).toBe(true);
+    },
+  );
 });

--- a/extensions/memory-hybrid/tests/plugin-service-supersession-skip.test.ts
+++ b/extensions/memory-hybrid/tests/plugin-service-supersession-skip.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Regression test for plugin-service startup guard: when a service instance has
+ * already been superseded by a newer registration (rapid hot-reload), startup must
+ * short-circuit before touching donor DB handles that may be closing.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  getHybridMemoryRegistrationState,
+  resetHybridMemoryRegistrationStateForTests,
+} from "../setup/hybrid-memory-generation-state.js";
+import { shouldSkipPluginServiceStartForSupersededGeneration } from "../setup/plugin-service.js";
+
+describe("plugin-service supersession guard", () => {
+  it("skips startup when boot generation is older than current registration generation", () => {
+    resetHybridMemoryRegistrationStateForTests();
+    getHybridMemoryRegistrationState().registrationGenerationRef.value = 2;
+    expect(shouldSkipPluginServiceStartForSupersededGeneration(1)).toBe(true);
+  });
+
+  it("does not skip startup when boot generation matches current registration generation", () => {
+    resetHybridMemoryRegistrationStateForTests();
+    getHybridMemoryRegistrationState().registrationGenerationRef.value = 5;
+    expect(shouldSkipPluginServiceStartForSupersededGeneration(5)).toBe(false);
+  });
+
+  it("does not skip startup when no boot generation was captured", () => {
+    resetHybridMemoryRegistrationStateForTests();
+    getHybridMemoryRegistrationState().registrationGenerationRef.value = 5;
+    expect(shouldSkipPluginServiceStartForSupersededGeneration(undefined)).toBe(false);
+  });
+});

--- a/extensions/memory-hybrid/tests/register-plugin-reload-teardown-drain.test.ts
+++ b/extensions/memory-hybrid/tests/register-plugin-reload-teardown-drain.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Regression tests for the reload-coordinator gate used by runMemoryHybridRegister.
+ *
+ * Reproduces the rapid-hot-reload teardown race that surfaced in #2058/#2059 follow-up:
+ *   1. reuseDatabases=true + vault-registry close scheduled against the donor runtime
+ *   2. soft drain timeout exceeded → must NOT inherit closed handles (fall back to fresh)
+ *   3. full teardown path → must still throw on hard drain timeout (existing semantics)
+ *
+ * These tests exercise the helpers exported from hybrid-memory-reload-coordinator.ts and
+ * the gate decision logic in register-plugin via lightweight mocks of the dependencies.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  RECALL_DRAIN_MS,
+  TEARDOWN_SOFT_WAIT_MS,
+  TEARDOWN_WAIT_MS,
+  awaitReloadTeardownBeforeOpen,
+  clearTeardownTrackingForGeneration,
+  isTeardownDrainedForGeneration,
+  resetReloadTeardownChainForTests,
+  schedulePluginTeardown,
+} from "../setup/hybrid-memory-reload-coordinator.js";
+
+describe("register-plugin reload-teardown drain gate", () => {
+  beforeEach(() => {
+    resetReloadTeardownChainForTests();
+    vi.useRealTimers();
+  });
+
+  afterEach(() => {
+    resetReloadTeardownChainForTests();
+    vi.useRealTimers();
+  });
+
+  it("drains within TEARDOWN_WAIT_MS for a single immediate teardown", async () => {
+    schedulePluginTeardown(async () => {}, { donorGeneration: 1 });
+    expect(await awaitReloadTeardownBeforeOpen(TEARDOWN_WAIT_MS)).toBe(true);
+  });
+
+  it("returns false on hard drain timeout for a slow teardown", async () => {
+    let neverResolve: () => void = () => {};
+    const blocker = new Promise<void>((resolve) => {
+      neverResolve = resolve;
+    });
+    schedulePluginTeardown(async () => {
+      await blocker;
+    }, { donorGeneration: 1 });
+    // Use a short timeout to keep the test fast.
+    expect(await awaitReloadTeardownBeforeOpen(500)).toBe(false);
+    // Cleanup: resolve the blocker so the chain doesn't leak into the next test.
+    neverResolve();
+  });
+
+  it("isTeardownDrainedForGeneration flips false→true as the teardown settles", async () => {
+    let resolveT: () => void = () => {};
+    const t = new Promise<void>((resolve) => {
+      resolveT = resolve;
+    });
+    schedulePluginTeardown(
+      async () => {
+        await t;
+      },
+      { donorGeneration: 42 },
+    );
+    expect(isTeardownDrainedForGeneration(42)).toBe(false);
+    resolveT();
+    expect(await awaitReloadTeardownBeforeOpen(TEARDOWN_WAIT_MS)).toBe(true);
+    expect(isTeardownDrainedForGeneration(42)).toBe(true);
+  });
+
+  it("clearTeardownTrackingForGeneration lets isTeardownDrainedForGeneration flip back to true", () => {
+    schedulePluginTeardown(
+      async () => {
+        /* never settles */
+      },
+      { donorGeneration: 99 },
+    );
+    expect(isTeardownDrainedForGeneration(99)).toBe(false);
+    clearTeardownTrackingForGeneration(99);
+    expect(isTeardownDrainedForGeneration(99)).toBe(true);
+  });
+
+  it("TEARDOWN_SOFT_WAIT_MS budget covers a vault-registry drain plus bootstrap drain", () => {
+    // Vault teardown: drainOldRecall (RECALL_DRAIN_MS) → closeAll.
+    // Full DB teardown: drainOldBootstrap (BOOTSTRAP_DRAIN_MS) → drainOldRecall (RECALL_DRAIN_MS).
+    // Soft budget must accommodate the smaller of the two paths, which is the vault path.
+    expect(TEARDOWN_SOFT_WAIT_MS).toBeGreaterThanOrEqual(RECALL_DRAIN_MS);
+  });
+
+  it("rapid back-to-back re-registers drain sequentially (chain serializes)", async () => {
+    let resolve1: () => void = () => {};
+    const p1 = new Promise<void>((resolve) => {
+      resolve1 = resolve;
+    });
+    let ran1 = false;
+    let ran2 = false;
+
+    schedulePluginTeardown(
+      async () => {
+        await p1;
+        ran1 = true;
+      },
+      { donorGeneration: 1 },
+    );
+    schedulePluginTeardown(
+      async () => {
+        ran2 = true;
+      },
+      { donorGeneration: 2 },
+    );
+
+    expect(ran1).toBe(false);
+    expect(ran2).toBe(false);
+
+    resolve1();
+    expect(await awaitReloadTeardownBeforeOpen(TEARDOWN_WAIT_MS)).toBe(true);
+    expect(ran1).toBe(true);
+    expect(ran2).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the reload teardown race where `reuseDatabases=true` could inherit donor DB/vault handles while teardown from the donor generation was still closing those handles.

Linked issue: https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/2060

## Changes

- Track scheduled plugin teardowns by donor registration generation.
- Add generation-scoped teardown drain helpers and soft timeout budget.
- Run the reload teardown drain gate even on the database-reuse path.
- If donor teardown does not drain in the soft budget, drop reuse and open fresh handles instead of inheriting indeterminate handles.
- Preserve hard failure behavior for non-reuse/full-open sequencing.
- Stamp runtime/service context with `bootRegistrationGeneration`.
- Skip plugin-service startup when the service generation is already superseded.
- Add early workboard sync abort check before DB access.
- Add regression coverage for teardown tracking/drain behavior, plugin-service supersession guard, and existing reregister/hot-reload behavior.

## Validation

Passed:

```text
npm test -- tests/hybrid-memory-reload-coordinator.test.ts tests/register-plugin-reload-teardown-drain.test.ts tests/plugin-service-supersession-skip.test.ts tests/reregister-policy.test.ts tests/plugin-hot-reload-race.test.ts
# 5 files, 36 tests passed
```

Passed:

```text
npm run build
# tsdown build complete; existing sourcemap warnings only
```

Attempted but not claimed as passed:

```text
timeout 180 npm test -- tests/comprehensive-e2e.test.ts
# hung without additional output; killed during parent verification
```

## Notes

This complements #2058/#2059. The earlier fix prevents reusing handles that are already closed; this PR prevents reusing a donor generation whose teardown is still in flight.
