### PR TITLE
fix: harden MiniMax chat response handling

### DIFF
--- a/extensions/memory-hybrid/services/chat.ts
+++ b/extensions/memory-hybrid/services/chat.ts
@@ -33,6 +33,7 @@ import {
   requiresMaxCompletionTokens,
   shouldOmitSamplingParams,
   resolveWireApi,
+  resolveModelAlias,
 } from "./model-capabilities.js";
 import { callResponsesApi, mapResponsesFinishReason } from "./responses-adapter.js";
 import { recordProviderHttpAttempt, formatRecentHttpAttemptsForRateLimitLog } from "./recent-http-attempts.js";
@@ -512,7 +513,7 @@ export async function chatCompleteDetailed(opts: {
   thinkingMode?: MiniMaxThinkingMode;
 }): Promise<ChatCompleteDetailedResult> {
   const {
-    model,
+    model: requestedModel,
     content,
     temperature = 0.2,
     maxTokens,
@@ -523,6 +524,7 @@ export async function chatCompleteDetailed(opts: {
     responseFormat,
     thinkingMode,
   } = opts;
+  const model = resolveModelAlias(requestedModel);
   const effectiveMaxTokens = maxTokens ?? distillMaxOutputTokens(model);
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), timeoutMs);

--- a/extensions/memory-hybrid/services/model-capabilities.ts
+++ b/extensions/memory-hybrid/services/model-capabilities.ts
@@ -234,6 +234,18 @@ const CAPABILITIES: Array<{ match: Matcher; cap: ModelCapabilities }> = [
   },
 ];
 
+
+/** Resolve provider shorthand aliases that are accepted by local config but not by every OpenAI-compatible gateway. */
+export function resolveModelAlias(model: string): string {
+  const trimmed = model.trim();
+  const segments = trimmed.split("/").filter(Boolean);
+  const leaf = segments.at(-1)?.toLowerCase();
+  const provider = segments.length > 1 ? segments.slice(0, -1).join("/") : "";
+  if (leaf === "m3") return provider ? `${provider}/MiniMax-M3` : "MiniMax-M3";
+  if (leaf === "m2.7" || leaf === "m27") return provider ? `${provider}/MiniMax-M2.7` : "MiniMax-M2.7";
+  return model;
+}
+
 /**
  * Return capabilities for the given model id (with or without provider prefix), or null if unknown.
  */

--- a/extensions/memory-hybrid/tests/chat.test.ts
+++ b/extensions/memory-hybrid/tests/chat.test.ts
@@ -130,6 +130,20 @@ describe("chatComplete", () => {
     );
   });
 
+  it("resolves shorthand MiniMax M3 model aliases", async () => {
+    await chatComplete({
+      model: "minimax/m3",
+      content: "test",
+      openai: mockOpenai,
+    });
+    expect(mockOpenai.chat.completions.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: "minimax/MiniMax-M3",
+      }),
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+  });
+
   it("uses max_completion_tokens and thinking disabled for MiniMax M3", async () => {
     await chatComplete({
       model: "minimax/MiniMax-M3",

--- a/extensions/memory-hybrid/tests/llm-message.test.ts
+++ b/extensions/memory-hybrid/tests/llm-message.test.ts
@@ -23,6 +23,32 @@ describe("extractAssistantMessageText", () => {
     });
   });
 
+
+  it("strips leading MiniMax reasoning blocks from content", () => {
+    expect(
+      extractAssistantMessageText({
+        content: '<think>\nprivate chain of thought\n</think>\n[{"remediationType":"NO_ACTION"}]',
+      }),
+    ).toEqual({
+      text: '[{"remediationType":"NO_ACTION"}]',
+      source: "content",
+    });
+  });
+
+  it("strips leading MiniMax reasoning blocks from content blocks", () => {
+    expect(
+      extractAssistantMessageText({
+        content: [
+          { type: "thinking", thinking: "private reasoning" },
+          { type: "text", text: '<reasoning>hidden</reasoning>\n{"items":[]}' },
+        ],
+      }),
+    ).toEqual({
+      text: '{"items":[]}',
+      source: "content_blocks",
+    });
+  });
+
   it("uses native tool_calls arguments when content is empty", () => {
     expect(
       extractAssistantMessageText({

--- a/extensions/memory-hybrid/utils/llm-message.ts
+++ b/extensions/memory-hybrid/utils/llm-message.ts
@@ -10,9 +10,21 @@ export type AssistantMessageTextResult = {
   source: AssistantMessageTextSource;
 };
 
+function stripLeadingReasoningBlocks(value: string): string {
+  let text = value.trim();
+  for (;;) {
+    const next = text
+      .replace(/^(?:<think>|<thinking>|<reasoning>|<analysis>)\s*[\s\S]*?\s*<\/(?:think|thinking|reasoning|analysis)>\s*/i, "")
+      .replace(/^```(?:think|thinking|reasoning|analysis)\s*[\s\S]*?```\s*/i, "")
+      .trim();
+    if (next === text) return text;
+    text = next;
+  }
+}
+
 function trimNonEmpty(value: unknown): string | null {
   if (typeof value !== "string") return null;
-  const trimmed = value.trim();
+  const trimmed = stripLeadingReasoningBlocks(value);
   return trimmed.length > 0 ? trimmed : null;
 }
 
@@ -24,11 +36,13 @@ function contentBlocksToString(content: unknown): string | null {
     const block = part as Record<string, unknown>;
     const type = typeof block.type === "string" ? block.type : "";
     if (type === "text" && typeof block.text === "string" && block.text.trim()) {
-      parts.push(block.text.trim());
+      const text = trimNonEmpty(block.text);
+      if (text) parts.push(text);
       continue;
     }
     if (typeof block.text === "string" && block.text.trim()) {
-      parts.push(block.text.trim());
+      const text = trimNonEmpty(block.text);
+      if (text) parts.push(text);
     }
   }
   const joined = parts.join("\n").trim();


### PR DESCRIPTION
## Summary
- strip leading reasoning/thinking wrappers from assistant message text before downstream parsing
- resolve shorthand MiniMax M3/M2.7 model aliases before issuing chat completions
- add regression coverage for MiniMax reasoning wrappers and shorthand aliases

## Audit notes
Local patch scripts reviewed:
- `patch-hybrid-memory-minimax-m3-chat-content.cjs`: still partially needed for leading `<think>`/reasoning content; implemented here in source with tests.
- `patch-hybrid-memory-minimax-m3-support.cjs`: most behavior already upstream (assistant prefill, tool choice/tool args, M3 self-correction hardening); only shorthand alias resolution was missing and is included here.
- `patch-hybrid-memory-minimax-m3-think-json.cjs`: already upstream via shared JSON extraction/parser tests; no source change needed beyond message-content stripping above.
- `patch-hybrid-memory-procedure-skill-generator-dist.cjs`: already upstream; TS source and publish-dist coverage already enforce the policy-gated generator/frontmatter behavior.

Checked existing open PRs including #2063 before opening; this PR is limited to missing MiniMax chat hardening.

## Tests
- `pnpm vitest run tests/llm-message.test.ts tests/chat.test.ts`
- `pnpm vitest run tests/llm-message.test.ts tests/chat.test.ts tests/self-correction-m3-hardening-1876.test.ts tests/llm-json-array.test.ts tests/procedure-skill-generator.test.ts tests/publish-dist-procedure-skill-generator.test.ts` (publish-dist tests are skipped unless `RUN_PUBLISH_DIST_TESTS=1`)