### PR TITLE
fix(memory): require session context for timeline recall

### DIFF
--- a/extensions/memory-hybrid/tests/memory-recall-timeline.test.ts
+++ b/extensions/memory-hybrid/tests/memory-recall-timeline.test.ts
@@ -218,18 +218,9 @@ describe("memory_session_observability tool", () => {
 /**
  * Smoke tests for OpenClaw gateway recall behavior (fix hybrid-memory recall/search smoke).
  *
- * Reproduces failures observed in Maeve main session on 2026-06-21:
- *   - memory_recall_timeline throwing "requires an authenticated session context"
- *     when invoked from normal OpenClaw tool context that does not inject
- *     api.context.sessionId.
- *
- * Verifies:
- *   - When api.context.sessionId is missing AND no caller sessionId is supplied,
- *     the tool falls back to cross-session timeline recall (recency-windowed,
- *     default 14 days) instead of throwing.
- *   - The existing security invariant is preserved: a caller-supplied sessionId
- *     must still match the authenticated context, and is rejected when no
- *     authenticated context is available (would-be data exposure vector).
+ * Verifies the security invariant for gateway contexts that do not inject
+ * api.context.sessionId: memory_recall_timeline must fail closed instead of
+ * falling back to cross-session narrative recall.
  */
 describe("memory_recall_timeline smoke (OpenClaw gateway context)", () => {
   let dir: string;
@@ -270,7 +261,7 @@ describe("memory_recall_timeline smoke (OpenClaw gateway context)", () => {
     rmSync(dir, { recursive: true, force: true });
   });
 
-  it("does not throw when api.context.sessionId is missing (graceful cross-session recall)", async () => {
+  it("rejects timeline recall when api.context.sessionId is missing", async () => {
     const api = makeApiWithoutSessionContext();
     registerMemoryTools(
       {
@@ -297,55 +288,9 @@ describe("memory_recall_timeline smoke (OpenClaw gateway context)", () => {
 
     const tool = api.getTool("memory_recall_timeline");
     expect(tool).toBeTruthy();
-    const result = (await tool?.execute("tool-call", { query: "anything", limit: 1 })) as {
-      content?: { type: string; text: string }[];
-      details?: { count: number; narratives: unknown[] };
-    };
-    expect(result).toBeTruthy();
-    expect(result.details?.count).toBe(0);
-    expect(result.content?.[0]?.text).toContain("No narrative summary");
-  });
-
-  it("returns cross-session narrative summaries when no authenticated context", async () => {
-    const api = makeApiWithoutSessionContext();
-    narrativesDb.store({
-      sessionId: "older-session",
-      periodStart: Math.floor(Date.parse("2026-06-20T10:00:00.000Z") / 1000),
-      periodEnd: Math.floor(Date.parse("2026-06-20T10:30:00.000Z") / 1000),
-      tag: "session",
-      narrativeText: "Deployed hybrid-memory recall smoke fix to staging.",
-    });
-    registerMemoryTools(
-      {
-        factsDb,
-        vectorDb: makeMockVectorDb(),
-        cfg: makeCfg(),
-        embeddings: makeMockEmbeddings(),
-        embeddingRegistry: null,
-        openai: {} as never,
-        wal: null,
-        credentialsDb: null,
-        eventLog,
-        narrativesDb,
-        lastProgressiveIndexIds: [],
-        currentAgentIdRef: { value: null },
-        pendingLLMWarnings: createPendingLLMWarnings(),
-      },
-      api as never,
-      noopScopeFilter as never,
-      walWrite,
-      walRemove,
-      findSimilarByEmbedding as never,
+    await expect(tool?.execute("tool-call", { query: "anything", limit: 1 })).rejects.toThrow(
+      /requires an authenticated session context/i,
     );
-
-    const tool = api.getTool("memory_recall_timeline");
-    const result = (await tool?.execute("tool-call", { query: "deployment", limit: 5 })) as {
-      content?: { type: string; text: string }[];
-      details?: { count: number; narratives: Array<{ sessionId: string; text: string }> };
-    };
-    expect(result.details?.count).toBe(1);
-    expect(result.details?.narratives[0]?.sessionId).toBe("older-session");
-    expect(result.content?.[0]?.text).toContain("hybrid-memory");
   });
 
   it("still rejects caller-supplied sessionId without authenticated context (data exposure guard)", async () => {
@@ -375,7 +320,7 @@ describe("memory_recall_timeline smoke (OpenClaw gateway context)", () => {
 
     const tool = api.getTool("memory_recall_timeline");
     await expect(tool?.execute("tool-call", { sessionId: "attacker-controlled" })).rejects.toThrow(
-      /no authenticated session context/i,
+      /requires an authenticated session context/i,
     );
   });
 
@@ -439,36 +384,4 @@ describe("memory_recall_timeline smoke (OpenClaw gateway context)", () => {
     );
   });
 
-  it("uses cross-session wording when timeline recall returns no results", async () => {
-    const api = makeApiWithoutSessionContext();
-    registerMemoryTools(
-      {
-        factsDb,
-        vectorDb: makeMockVectorDb(),
-        cfg: makeCfg(),
-        embeddings: makeMockEmbeddings(),
-        embeddingRegistry: null,
-        openai: {} as never,
-        wal: null,
-        credentialsDb: null,
-        eventLog,
-        narrativesDb,
-        lastProgressiveIndexIds: [],
-        currentAgentIdRef: { value: null },
-        pendingLLMWarnings: createPendingLLMWarnings(),
-      },
-      api as never,
-      noopScopeFilter as never,
-      walWrite,
-      walRemove,
-      findSimilarByEmbedding as never,
-    );
-
-    const tool = api.getTool("memory_recall_timeline");
-    const result = (await tool?.execute("tool-call", {})) as {
-      content: Array<{ text: string }>;
-    };
-    expect(result.content[0]?.text).toMatch(/across recent sessions/i);
-    expect(result.content[0]?.text).not.toMatch(/session null/i);
-  });
 });

--- a/extensions/memory-hybrid/tools/memory/register-recall-tools.ts
+++ b/extensions/memory-hybrid/tools/memory/register-recall-tools.ts
@@ -278,23 +278,18 @@ export function registerRecallTools(runtime: MemoryToolRuntime): void {
           typeof api.context?.sessionId === "string" && api.context.sessionId.trim().length > 0
             ? api.context.sessionId.trim()
             : null;
-        // Security invariant: if the caller specifies a sessionId, it MUST match the
-        // authenticated context session. If the caller does NOT specify a sessionId,
-        // we fall back to cross-session timeline recall (recency-windowed, default
-        // 14 days) so the tool still works in OpenClaw gateway invocations that do
-        // not inject an authenticated sessionId. We only reject when a caller
-        // supplied sessionId cannot be verified against the authenticated context.
-        if (requestedSessionId) {
-          if (!contextSessionId) {
-            throw new Error(
-              "memory_recall_timeline: a sessionId parameter was supplied but no authenticated " +
-                "session context is available; pass the same sessionId the gateway exposed in " +
-                "api.context.sessionId, or omit sessionId to recall across recent sessions.",
-            );
-          }
-          if (requestedSessionId !== contextSessionId) {
-            throw new Error("memory_recall_timeline sessionId must match the authenticated session context");
-          }
+        // Security invariant: timeline recall is scoped to the authenticated session.
+        // Without an authenticated context there is no safe session boundary, and
+        // falling back to recent cross-session recall would expose other sessions'
+        // narrative text and log paths.
+        if (!contextSessionId) {
+          throw new Error(
+            "memory_recall_timeline requires an authenticated session context; invoke from a " +
+              "session-aware gateway context that exposes api.context.sessionId.",
+          );
+        }
+        if (requestedSessionId && requestedSessionId !== contextSessionId) {
+          throw new Error("memory_recall_timeline sessionId must match the authenticated session context");
         }
         const sessionId = contextSessionId;
 


### PR DESCRIPTION
### Motivation
- A recent change removed the authenticated-session requirement for `memory_recall_timeline`, allowing callers without `api.context.sessionId` to receive recent narrative summaries from other sessions and leak sensitive text and session log paths.
- The intent of this PR is to restore the security invariant by failing closed when no authenticated session context is available, while preserving the existing guard for caller-supplied `sessionId` values.

### Description
- Require an authenticated `api.context.sessionId` in `memory_recall_timeline` and throw a clear error when the gateway context lacks a session id, preventing cross-session recall.
- Preserve and tighten the existing check that a caller-supplied `sessionId` must match the authenticated session context. 
- Update the OpenClaw gateway smoke tests in `memory-recall-timeline.test.ts` to assert fail-closed behavior for missing `api.context.sessionId` and to expect the updated error wording.

### Testing
- Ran `npm --prefix extensions/memory-hybrid test -- tests/memory-recall-timeline.test.ts --reporter=verbose` and all tests in that file passed.
- Ran `npm --prefix extensions/memory-hybrid test -- tests/memory-search-episodes-smoke.test.ts --reporter=verbose` and all tests in that file passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3ba2fbcde883269ea1e81703bfe2b3)