### PR TITLE
fix: keep scoped contact profile data private

### DIFF
--- a/extensions/memory-hybrid/backends/facts-db/entity-layer.ts
+++ b/extensions/memory-hybrid/backends/facts-db/entity-layer.ts
@@ -630,8 +630,11 @@ export function replaceFactEntityMentions(
           insOrgLink.run(org.id, factId, now);
         }
       } else if (m.label === "PERSON") {
-        const allowNewContact = options.requireSurnameForNewContacts !== true || hasSurname(m.surfaceText) || hasOrgMention;
-        const con = allowNewContact ? upsertContact(db, m.surfaceText, null, { source: "ner", updatedBy: "ner" }) : null;
+        const allowNewContact =
+          options.requireSurnameForNewContacts !== true || hasSurname(m.surfaceText) || hasOrgMention;
+        const con = allowNewContact
+          ? upsertContact(db, m.surfaceText, null, { source: "ner", updatedBy: "ner" })
+          : null;
         if (con) {
           contactId = con.id;
           personRows.push({ surface: m.surfaceText, contactId: con.id });
@@ -693,6 +696,11 @@ export function applyContactProfileEnrichmentForFact(
   factText: string,
   source: ContactProfileEnrichmentSource,
 ): ContactProfileEnrichmentResult | null {
+  const factScope = db.prepare("SELECT scope FROM facts WHERE id = ?").get(factId) as
+    | { scope: string | null }
+    | undefined;
+  if (!factScope || (factScope.scope ?? "global") !== "global") return null;
+
   const personRows = db
     .prepare(
       `SELECT DISTINCT contact_id FROM fact_entity_mentions
@@ -869,7 +877,10 @@ function applyContactProfileFields(db: DatabaseSync, contactId: string, fields: 
   let nextNotes = row.notes;
   const noteLine = fields.notes?.trim();
   if (noteLine) {
-    const existingLines = (row.notes ?? "").split("\n").map((l) => l.trim()).filter(Boolean);
+    const existingLines = (row.notes ?? "")
+      .split("\n")
+      .map((l) => l.trim())
+      .filter(Boolean);
     if (!existingLines.includes(noteLine)) {
       nextNotes = [...existingLines, noteLine].join("\n");
     }
@@ -880,7 +891,19 @@ function applyContactProfileFields(db: DatabaseSync, contactId: string, fields: 
     `UPDATE contacts SET email = ?, phone = ?, mobile = ?, role = ?, board_status = ?, notes = ?,
        source = COALESCE(?, source), source_date = ?, updated_by = COALESCE(?, updated_by), updated_at = ?
      WHERE id = ?`,
-  ).run(nextEmail, nextPhone, nextMobile, nextRole, nextBoardStatus, nextNotes, fields.source ?? null, now, fields.updatedBy ?? null, now, contactId);
+  ).run(
+    nextEmail,
+    nextPhone,
+    nextMobile,
+    nextRole,
+    nextBoardStatus,
+    nextNotes,
+    fields.source ?? null,
+    now,
+    fields.updatedBy ?? null,
+    now,
+    contactId,
+  );
 }
 
 /** True when one name's tokens are a contiguous prefix or suffix run of the other's (#2014). */
@@ -905,9 +928,7 @@ export function findContactMergeCandidates(db: DatabaseSync, normalizedKey: stri
       ? db.prepare("SELECT * FROM contacts WHERE id != ?").all(excludeId)
       : db.prepare("SELECT * FROM contacts").all()
   ) as Array<Record<string, unknown>>;
-  return rows
-    .filter((row) => isTokenPrefixOrSuffix(normalizedKey, row.normalized_key as string))
-    .map(rowToContact);
+  return rows.filter((row) => isTokenPrefixOrSuffix(normalizedKey, row.normalized_key as string)).map(rowToContact);
 }
 
 export function listFactIdsForOrg(db: DatabaseSync, orgId: string, limit: number): string[] {

--- a/extensions/memory-hybrid/tests/contacts-profile-enrichment.test.ts
+++ b/extensions/memory-hybrid/tests/contacts-profile-enrichment.test.ts
@@ -63,6 +63,42 @@ describe("contact profile enrichment and merge (#2014)", () => {
     expect(contacts[0].boardStatus).toBe("management");
   });
 
+  it("does not enrich global contact profile fields from scoped facts", () => {
+    const text = "Jane Private email jane.private@secret.example phone +1 555 010 4242";
+    const fact = db.store({
+      text,
+      entity: null,
+      key: null,
+      value: null,
+      category: "other",
+      importance: 0.5,
+      source: "test",
+      scope: "user",
+      scopeTarget: "alice",
+    });
+    db.applyEntityEnrichment(
+      fact.id,
+      [
+        {
+          label: "PERSON",
+          surfaceText: "Jane Private",
+          normalizedSurface: "jane private",
+          startOffset: 0,
+          endOffset: "Jane Private".length,
+          confidence: 0.9,
+        },
+      ],
+      "eng",
+    );
+
+    const result = db.applyContactProfileEnrichment(fact.id, text, "ner");
+    expect(result).toBeNull();
+
+    const jane = db.listContactsByNamePrefix("Jane", 10)[0];
+    expect(jane.email).toBeNull();
+    expect(jane.phone).toBeNull();
+  });
+
   it("does not enrich when a fact mentions more than one person (ambiguous attribution)", () => {
     const fact = db.store({
       text: "Alice alice@example.com and Bob bob@example.com discussed the roadmap.",
@@ -76,8 +112,22 @@ describe("contact profile enrichment and merge (#2014)", () => {
     db.applyEntityEnrichment(
       fact.id,
       [
-        { label: "PERSON", surfaceText: "Alice", normalizedSurface: "alice", startOffset: 0, endOffset: 5, confidence: 0.9 },
-        { label: "PERSON", surfaceText: "Bob", normalizedSurface: "bob", startOffset: 29, endOffset: 32, confidence: 0.9 },
+        {
+          label: "PERSON",
+          surfaceText: "Alice",
+          normalizedSurface: "alice",
+          startOffset: 0,
+          endOffset: 5,
+          confidence: 0.9,
+        },
+        {
+          label: "PERSON",
+          surfaceText: "Bob",
+          normalizedSurface: "bob",
+          startOffset: 29,
+          endOffset: 32,
+          confidence: 0.9,
+        },
       ],
       "eng",
     );
@@ -141,7 +191,16 @@ describe("contact profile enrichment and merge (#2014)", () => {
     });
     db.applyEntityEnrichment(
       fact.id,
-      [{ label: "PERSON", surfaceText: "Erik", normalizedSurface: "erik", startOffset: 0, endOffset: 4, confidence: 0.9 }],
+      [
+        {
+          label: "PERSON",
+          surfaceText: "Erik",
+          normalizedSurface: "erik",
+          startOffset: 0,
+          endOffset: 4,
+          confidence: 0.9,
+        },
+      ],
       "eng",
       { requireSurnameForNewContacts: true },
     );
@@ -161,8 +220,22 @@ describe("contact profile enrichment and merge (#2014)", () => {
     db.applyEntityEnrichment(
       fact.id,
       [
-        { label: "PERSON", surfaceText: "Erik", normalizedSurface: "erik", startOffset: 0, endOffset: 4, confidence: 0.9 },
-        { label: "ORG", surfaceText: "Acme Corp", normalizedSurface: "acme corp", startOffset: 10, endOffset: 19, confidence: 0.9 },
+        {
+          label: "PERSON",
+          surfaceText: "Erik",
+          normalizedSurface: "erik",
+          startOffset: 0,
+          endOffset: 4,
+          confidence: 0.9,
+        },
+        {
+          label: "ORG",
+          surfaceText: "Acme Corp",
+          normalizedSurface: "acme corp",
+          startOffset: 10,
+          endOffset: 19,
+          confidence: 0.9,
+        },
       ],
       "eng",
       { requireSurnameForNewContacts: true },
@@ -185,7 +258,9 @@ describe("contact profile enrichment and merge (#2014)", () => {
     if (!result.ok) throw new Error("expected ok");
     expect(result.mergedFactMentions).toBeGreaterThanOrEqual(1);
 
-    const remaining = db.listContactsByNamePrefix("", 20).filter((c) => c.id === alphaContact.id || c.id === betaContact.id);
+    const remaining = db
+      .listContactsByNamePrefix("", 20)
+      .filter((c) => c.id === alphaContact.id || c.id === betaContact.id);
     expect(remaining).toHaveLength(1);
     expect(remaining[0].id).toBe(betaContact.id);
     expect(remaining[0].email).toBe("alpha@example.com");


### PR DESCRIPTION
### Motivation
- Contact profile enrichment could parse email/phone/role/board-status from any stored fact and write those fields into the global `contacts` table, leaking PII from user/agent/session-scoped facts into an unscoped directory.
- The goal is to preserve existing enrichment functionality for global facts while preventing cross-scope leakage of sensitive contact fields.

### Description
- Add a scope check to `applyContactProfileEnrichmentForFact` so enrichment returns without writing profile fields unless the originating fact's `scope` is `global` (file: `extensions/memory-hybrid/backends/facts-db/entity-layer.ts`).
- Add a regression test that stores a `user`-scoped fact containing a person email/phone and verifies `applyContactProfileEnrichment` returns `null` and the global contact row has no email/phone populated (file: `extensions/memory-hybrid/tests/contacts-profile-enrichment.test.ts`).
- Minor formatting cleanups in the entity layer helper logic (non-functional changes to whitespace/line-wrapping).

### Testing
- Ran the focused unit tests with `cd extensions/memory-hybrid && npm test -- tests/contacts-profile-enrichment.test.ts` and the test file passed (all tests in that suite passed).
- Ran TypeScript validation with `cd extensions/memory-hybrid && npm run typecheck:gate` and `tsc --noEmit -p tsconfig.gate.json` completed without errors.
- Formatted touched files with `npm exec --prefix extensions/memory-hybrid -- biome format --write` prior to testing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a461a4943b88326b771181ec0ebcbfb)