### PR TITLE
Enforce scope-filtering in ContextEngine to prevent cross-session memory injection

### DIFF
--- a/extensions/memory-hybrid/services/context-engine.ts
+++ b/extensions/memory-hybrid/services/context-engine.ts
@@ -20,7 +20,7 @@ import type { FactsDB } from "../backends/facts-db.js";
 import type { VectorDB } from "../backends/vector-db.js";
 import type { WriteAheadLog } from "../backends/wal.js";
 import type { HybridMemoryConfig } from "../config.js";
-import type { MemoryEntry } from "../types/memory.js";
+import type { MemoryEntry, ScopeFilter } from "../types/memory.js";
 import type { EmbeddingProvider } from "./embeddings.js";
 import { trimBlockToBudget } from "./context-block-trim.js";
 import { capturePluginError } from "./error-reporter.js";
@@ -309,6 +309,16 @@ export function buildContextBlock(
   return lines.join("\n");
 }
 
+function scopeFilterForSession(sessionId: string | undefined): ScopeFilter | null {
+  const trimmed = sessionId?.trim();
+  return trimmed ? { sessionId: trimmed } : null;
+}
+
+function listScopedFacts(factsDb: FactsDB, limit: number, scopeFilter: ScopeFilter | null): MemoryEntry[] {
+  if (!scopeFilter) return [];
+  return factsDb.getAll({ scopeFilter }).slice(0, limit);
+}
+
 /**
  * Minimal ContextEngine that integrates hybrid-memory into the OpenClaw
  * context lifecycle. Designed for backward compatibility — every method
@@ -365,15 +375,17 @@ export class HybridMemoryContextEngine implements MinimalContextEngine {
       let facts: MemoryEntry[] = [];
       if (query && query.length >= 5) {
         const tierFilter = cfg.memoryTiering?.enabled ? ("warm" as const) : ("all" as const);
+        const scopeFilter = scopeFilterForSession(params.sessionId);
         const results = factsDb.search(query, Math.min(limit, 15), {
           tierFilter,
+          scopeFilter,
           interactiveFtsFastPath: true,
           deferAccessRefresh: true,
         });
         facts = results.map((r) => r.entry);
       }
       if (facts.length === 0) {
-        facts = factsDb.list(Math.min(limit, 15));
+        facts = listScopedFacts(factsDb, Math.min(limit, 15), scopeFilterForSession(params.sessionId));
       }
 
       if (facts.length === 0) {
@@ -478,7 +490,7 @@ export class HybridMemoryContextEngine implements MinimalContextEngine {
         sessionFacts = factsDb.getCount();
         // after_compaction hook owns post-compaction injection when auto-recall is on (#957).
         if (!this.opts.cfg.autoRecall?.enabled) {
-          topFacts = factsDb.list(8);
+          topFacts = listScopedFacts(factsDb, 8, scopeFilterForSession(_params.sessionId));
           const block = buildContextBlock(
             topFacts,
             "post-compaction memory summary",
@@ -541,7 +553,7 @@ export class HybridMemoryContextEngine implements MinimalContextEngine {
 
       // Fetch top-N recent/important facts to seed the sub-agent's context
       const limit = cfg.autoRecall?.limit ?? 10;
-      let topFacts = factsDb.list(Math.min(limit, 15));
+      let topFacts = listScopedFacts(factsDb, Math.min(limit, 15), scopeFilterForSession(params.parentSessionKey));
       topFacts = filterFactsNotYetInjected(this.opts.injectedFactIdsBySession, params.childSessionKey, topFacts);
 
       if (topFacts.length === 0) {

--- a/extensions/memory-hybrid/tests/context-engine.test.ts
+++ b/extensions/memory-hybrid/tests/context-engine.test.ts
@@ -321,6 +321,52 @@ describe("HybridMemoryContextEngine.prepareSubagentSpawn()", () => {
     expect(extended.contextAddition).toContain("child-session-xyz");
   });
 
+  it("only injects parent-session and global facts for subagents", async () => {
+    factsDb.store({
+      entity: null,
+      key: null,
+      value: null,
+      text: "Parent session scoped memory",
+      category: "fact",
+      importance: 0.85,
+      source: "parent",
+      scope: "session",
+      scopeTarget: "parent-session-abc",
+    });
+    factsDb.store({
+      entity: null,
+      key: null,
+      value: null,
+      text: "Global memory visible to all sessions",
+      category: "fact",
+      importance: 0.8,
+      source: "parent",
+      scope: "global",
+    });
+    factsDb.store({
+      entity: null,
+      key: null,
+      value: null,
+      text: "Victim session secret must not leak",
+      category: "fact",
+      importance: 0.95,
+      source: "victim",
+      scope: "session",
+      scopeTarget: "victim-session",
+    });
+
+    const engine = makeEngine({ cfg: makeSubagentSpawnConfig() });
+    const prep = await engine.prepareSubagentSpawn?.({
+      parentSessionKey: "parent-session-abc",
+      childSessionKey: "child-session-xyz",
+    });
+
+    const extended = prep as { contextAddition?: string };
+    expect(extended.contextAddition).toContain("Parent session scoped memory");
+    expect(extended.contextAddition).toContain("Global memory visible to all sessions");
+    expect(extended.contextAddition).not.toContain("Victim session secret must not leak");
+  });
+
   it("returns rollback-only preparation when no facts in store", async () => {
     const engine = makeEngine({ cfg: makeSubagentSpawnConfig() });
     const prep = await engine.prepareSubagentSpawn?.({
@@ -541,6 +587,61 @@ describe("HybridMemoryContextEngine.assemble()", () => {
     expect(result.systemPromptAddition).toContain("memory-hybrid: session-context");
     expect(result.systemPromptAddition).toContain("User prefers TypeScript over JavaScript");
     expect(result.estimatedTokens).toBeGreaterThan(0);
+  });
+
+  it("only injects same-session and global facts from search and fallback list paths", async () => {
+    factsDb.store({
+      entity: null,
+      key: null,
+      value: null,
+      text: "Shared project codename alpha",
+      category: "fact",
+      importance: 0.7,
+      source: "global",
+      scope: "global",
+    });
+    factsDb.store({
+      entity: null,
+      key: null,
+      value: null,
+      text: "Attacker session codename beta",
+      category: "fact",
+      importance: 0.8,
+      source: "attacker",
+      scope: "session",
+      scopeTarget: "attacker-session",
+    });
+    factsDb.store({
+      entity: null,
+      key: null,
+      value: null,
+      text: "Victim session codename gamma secret",
+      category: "fact",
+      importance: 0.95,
+      source: "victim",
+      scope: "session",
+      scopeTarget: "victim-session",
+    });
+
+    const engine = makeEngine({
+      cfg: { ...makeMinimalConfig(), autoRecall: { ...makeMinimalConfig().autoRecall, enabled: false } } as never,
+    });
+
+    const searchResult = await engine.assemble({
+      sessionId: "attacker-session",
+      messages: [{ role: "user", content: "codename gamma secret" }],
+      tokenBudget: 2000,
+    });
+    expect(searchResult.systemPromptAddition).not.toContain("Victim session codename gamma secret");
+
+    const fallbackResult = await engine.assemble({
+      sessionId: "attacker-session",
+      messages: [],
+      tokenBudget: 2000,
+    });
+    expect(fallbackResult.systemPromptAddition).toContain("Shared project codename alpha");
+    expect(fallbackResult.systemPromptAddition).toContain("Attacker session codename beta");
+    expect(fallbackResult.systemPromptAddition).not.toContain("Victim session codename gamma secret");
   });
 
   it("skips facts already injected this turn for the session", async () => {


### PR DESCRIPTION
### Motivation

- The ContextEngine paths (`assemble`, `prepareSubagentSpawn`, and compact post-summary) could read unscoped FactsDB results when the engine is registered by the host API, which can cause session/agent/user-scoped facts from other tenants to be injected into a session's prompt.  
- The change aims to ensure ContextEngine memory reads only surface global facts and facts explicitly scoped to the current session, preventing unintended cross-session disclosure while preserving existing functionality.

### Description

- Add `scopeFilterForSession(sessionId)` and `listScopedFacts(...)` helpers to derive a scoped `ScopeFilter` and fetch only facts visible to that session.  
- Apply the derived `scopeFilter` to `assemble()`'s semantic `search(...)` call and fallback list retrieval so search and fallback paths only return global and same-session facts.  
- Use the same scoped retrieval for compact-time memory summaries and for `prepareSubagentSpawn()` so subagent context injection only includes parent-session and global facts.  
- Add regression tests to `extensions/memory-hybrid/tests/context-engine.test.ts` that verify both `assemble()` and `prepareSubagentSpawn()` no longer inject unrelated session-scoped facts while still including global and matching-session facts.

### Testing

- Ran unit/integration tests with Vitest: `npm exec --prefix extensions/memory-hybrid -- vitest run tests/context-engine.test.ts --reporter=verbose`, and the test file passed (all tests succeeded).  
- Ran TypeScript gate typecheck: `npm run --prefix extensions/memory-hybrid typecheck:gate`, and the typecheck completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a45f348e96883268f34472bde5f8796)