### PR TITLE
fix(memory): omit contradiction previews from store details

### DIFF
--- a/extensions/memory-hybrid/tests/memory-store-variant-queue.test.ts
+++ b/extensions/memory-hybrid/tests/memory-store-variant-queue.test.ts
@@ -297,3 +297,65 @@ describe("memory_store — variant queue integration (Issue #159)", () => {
     expect(variants.length).toBeGreaterThan(0);
   });
 });
+
+describe("memory_store — contradiction disclosure", () => {
+  it("does not return old fact previews in contradiction details", async () => {
+    const api = makeMockApi();
+    const vectorDb = makeMockVectorDb();
+    const embeddings = makeMockEmbeddings();
+    const cfg = makeBaseCfg();
+
+    registerMemoryTools(
+      {
+        factsDb: factsDb as never,
+        edictStore: null as any,
+        vectorDb: vectorDb as never,
+        cfg: cfg as never,
+        embeddings: embeddings as never,
+        openai: {} as never,
+        wal: null,
+        credentialsDb: null,
+        eventLog: null,
+        lastProgressiveIndexIds: [],
+        currentAgentIdRef: { value: "test-agent" },
+        pendingLLMWarnings: { drain: vi.fn().mockReturnValue([]) } as never,
+        aliasDb: null,
+        variantQueue: null,
+      },
+      api as never,
+      (_params, _currentAgent, _cfg) => undefined,
+      (_op, _data, _logger) => "wal-id",
+      (_id, _logger) => undefined,
+      async (_vdb, _fdb, _vec, _limit) => [],
+    );
+
+    const storeTool = api.getTool("memory_store");
+    expect(storeTool).toBeDefined();
+
+    await storeTool?.execute("victim-store", {
+      text: "Victim deployment code is BLUE ORCHID 42",
+      importance: 0.8,
+      category: "technical",
+      entity: "deployment",
+      key: "code",
+      value: "BLUE ORCHID 42",
+      scope: "user",
+      scopeTarget: "victim-user",
+    });
+
+    const result = (await storeTool?.execute("attacker-store", {
+      text: "Victim deployment code is RED TULIP 99",
+      importance: 0.8,
+      category: "technical",
+      entity: "deployment",
+      key: "code",
+      value: "RED TULIP 99",
+      scope: "user",
+      scopeTarget: "victim-user",
+    })) as { details: { contradictions?: Array<Record<string, unknown>> } };
+
+    expect(result.details.contradictions).toHaveLength(1);
+    expect(result.details.contradictions?.[0]).not.toHaveProperty("preview");
+    expect(JSON.stringify(result.details.contradictions)).not.toContain("BLUE ORCHID 42");
+  });
+});

--- a/extensions/memory-hybrid/tools/memory/register-store-tools.ts
+++ b/extensions/memory-hybrid/tools/memory/register-store-tools.ts
@@ -1270,7 +1270,6 @@ export function registerStoreTools(runtime: MemoryToolRuntime): void {
                         fact_id: c.oldFactId,
                         score: c.score,
                         heuristicSignals: c.heuristicSignals,
-                        preview: c.preview,
                       })),
                     }
                   : {}),


### PR DESCRIPTION
### Motivation
- Prevent cross-scope content disclosure where `memory_store` could return a truncated preview of an existing fact when a caller supplies `scope`/`scopeTarget`, exposing confidential text from other tenants or users.

### Description
- Stop returning the `preview` string in `memory_store` response details by removing the `preview: c.preview` mapping in `register-store-tools.ts` so contradiction metadata no longer contains old fact text.
- Add a regression test `memory_store — contradiction disclosure` in `memory-store-variant-queue.test.ts` that stores a victim-scoped fact then writes a conflicting fact and asserts the tool response omits any `preview` and does not contain the victim value.
- Preserve contradiction identifiers, scores, and `heuristicSignals` in the response so detection metadata remains available without leaking content.

### Testing
- Ran `npm test -- memory-store-variant-queue.test.ts` and the test file passed (1 file, 4 tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3140660aa08326bf936a3d1ce583f7)