### PR TITLE
fix(security): gate workshop agent mutations

### DIFF
--- a/extensions/memory-hybrid/config/parsers/features.ts
+++ b/extensions/memory-hybrid/config/parsers/features.ts
@@ -436,6 +436,8 @@ export function parseWorkshopConfig(cfg: Record<string, unknown>): WorkshopConfi
   const out: WorkshopConfig = {};
   if (raw.enabled === true) out.enabled = true;
   if (raw.enabled === false) out.enabled = false;
+  if (raw.allowAgentMutations === true) out.allowAgentMutations = true;
+  if (raw.allowAgentMutations === false) out.allowAgentMutations = false;
   if (typeof raw.maxPending === "number" && raw.maxPending >= 0) {
     out.maxPending = Math.floor(raw.maxPending);
   }

--- a/extensions/memory-hybrid/config/types/agents.ts
+++ b/extensions/memory-hybrid/config/types/agents.ts
@@ -58,6 +58,11 @@ export type PersonaProposalsConfig = {
 export type WorkshopConfig = {
   /** Master switch for workshop tool, HTTP/gateway routes, and dashboard tab integration. */
   enabled?: boolean;
+  /**
+   * Allow the LLM-callable memory_workshop tool to perform persistent mutations
+   * such as approve/reject/quarantine/undo/revert. Default: false (read-only tool).
+   */
+  allowAgentMutations?: boolean;
   /** Max pending items across all proposal backlogs (default: 50, 0 = unlimited). */
   maxPending?: number;
   /** Session key for change-feed events from Mission Control / dashboard actions. */

--- a/extensions/memory-hybrid/openclaw.plugin.json
+++ b/extensions/memory-hybrid/openclaw.plugin.json
@@ -1437,6 +1437,10 @@
           "sessionKey": {
             "type": "string",
             "description": "Change-feed session key for Mission Control / dashboard workshop actions (default: mission-control)"
+          },
+          "allowAgentMutations": {
+            "type": "boolean",
+            "description": "Allow the LLM-callable memory_workshop tool to perform persistent mutations (approve/reject/quarantine/undo/revert). Default: false; use trusted dashboard/gateway for human-reviewed mutations."
           }
         },
         "description": "Unified memory workshop — proposal review queue across persona, crystallization, tool, and procedure-skill backlogs"

--- a/extensions/memory-hybrid/services/workshop-config.ts
+++ b/extensions/memory-hybrid/services/workshop-config.ts
@@ -58,6 +58,15 @@ export function isWorkshopEnabled(cfg?: HybridMemoryConfig): boolean {
   );
 }
 
+/**
+ * The in-chat memory_workshop tool is LLM-callable, so persistent mutations must
+ * be an explicit operator opt-in. Dashboard/gateway review flows remain governed
+ * by isWorkshopEnabled().
+ */
+export function isWorkshopToolMutationEnabled(cfg?: HybridMemoryConfig): boolean {
+  return cfg?.workshop?.allowAgentMutations === true;
+}
+
 export function resolveWorkshopMaxPending(cfg?: HybridMemoryConfig): number {
   const fromWorkshop = cfg?.workshop?.maxPending;
   if (typeof fromWorkshop === "number" && fromWorkshop >= 0) return Math.floor(fromWorkshop);

--- a/extensions/memory-hybrid/tests/workshop-config.test.ts
+++ b/extensions/memory-hybrid/tests/workshop-config.test.ts
@@ -3,6 +3,7 @@ import { parseWorkshopConfig } from "../config/parsers/features.js";
 import {
   DEFAULT_WORKSHOP_MAX_PENDING,
   isWorkshopEnabled,
+  isWorkshopToolMutationEnabled,
   listWorkshopDashboardChangeFeedSessions,
   MISSION_CONTROL_SESSION_KEY,
   resolveWorkshopAppliedSessionKey,
@@ -25,6 +26,12 @@ describe("workshop-config", () => {
     expect(isWorkshopEnabled({ selfExtension: { enabled: true } } as never)).toBe(true);
     expect(isWorkshopEnabled({ procedures: { enabled: true } } as never)).toBe(true);
     expect(isWorkshopEnabled({ procedures: { enabled: false } } as never)).toBe(false);
+  });
+
+  it("isWorkshopToolMutationEnabled requires explicit opt-in", () => {
+    expect(isWorkshopToolMutationEnabled({ workshop: { enabled: true } } as never)).toBe(false);
+    expect(isWorkshopToolMutationEnabled({ procedures: { enabled: true } } as never)).toBe(false);
+    expect(isWorkshopToolMutationEnabled({ workshop: { allowAgentMutations: true } } as never)).toBe(true);
   });
 
   it("resolveWorkshopMaxPending prefers workshop.maxPending", () => {
@@ -66,9 +73,9 @@ describe("parseWorkshopConfig", () => {
   it("parses enabled, maxPending, and sessionKey", () => {
     expect(
       parseWorkshopConfig({
-        workshop: { enabled: true, maxPending: 40, sessionKey: "  ops-desk  " },
+        workshop: { enabled: true, allowAgentMutations: true, maxPending: 40, sessionKey: "  ops-desk  " },
       }),
-    ).toEqual({ enabled: true, maxPending: 40, sessionKey: "ops-desk" });
+    ).toEqual({ enabled: true, allowAgentMutations: true, maxPending: 40, sessionKey: "ops-desk" });
   });
 
   it("returns undefined when workshop block is absent or empty", () => {

--- a/extensions/memory-hybrid/tests/workshop-tool-security.test.ts
+++ b/extensions/memory-hybrid/tests/workshop-tool-security.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import type { ClawdbotPluginApi } from "openclaw/plugin-sdk/core";
+
+import { registerWorkshopTools, type WorkshopToolsContext } from "../tools/workshop-tool.js";
+
+type CapturedWorkshopTool = {
+  description: string;
+  parameters: unknown;
+  execute: (toolCallId: string, params: Record<string, unknown>) => Promise<unknown>;
+};
+
+function captureWorkshopTool(cfg: WorkshopToolsContext["cfg"]): CapturedWorkshopTool {
+  let registeredTool: CapturedWorkshopTool | null = null;
+  const api = {
+    registerTool(tool: CapturedWorkshopTool) {
+      registeredTool = tool;
+    },
+    logger: {},
+    context: {},
+  } as unknown as ClawdbotPluginApi;
+
+  registerWorkshopTools(
+    {
+      cfg,
+      factsDb: {} as never,
+      resolvedSqlitePath: ":memory:",
+    },
+    api,
+  );
+
+  if (!registeredTool) throw new Error("memory_workshop was not registered");
+  return registeredTool;
+}
+
+describe("memory_workshop agent mutation guard", () => {
+  it("blocks mutating tool actions unless explicitly opted in", async () => {
+    const tool = captureWorkshopTool({ workshop: { enabled: true }, procedures: { enabled: true } } as never);
+
+    expect(tool.description).toContain("Read-only");
+    const actionSchema = (tool.parameters as { properties: { action: unknown } }).properties.action;
+    expect(JSON.stringify(actionSchema)).not.toContain('"approve"');
+    const result = (await tool.execute("call-1", { action: "approve", id: "procedure-skill:abc" })) as {
+      details: { ok: boolean; error: string };
+      content: Array<{ text: string }>;
+    };
+
+    expect(result.details).toEqual({ ok: false, error: "workshop_agent_mutations_disabled" });
+    expect(result.content[0].text).toContain("disabled for agent tool calls");
+  });
+
+  it("advertises mutating actions only after explicit opt-in", () => {
+    const tool = captureWorkshopTool({ workshop: { enabled: true, allowAgentMutations: true } } as never);
+
+    expect(tool.description).toContain("approve");
+    expect(tool.description).not.toContain("Read-only");
+    const actionSchema = (tool.parameters as { properties: { action: unknown } }).properties.action;
+    expect(JSON.stringify(actionSchema)).toContain('"approve"');
+  });
+});

--- a/extensions/memory-hybrid/tools/workshop-tool.ts
+++ b/extensions/memory-hybrid/tools/workshop-tool.ts
@@ -13,7 +13,11 @@ import type { WorkflowStore } from "../backends/workflow-store.js";
 import type { HybridMemoryConfig } from "../config.js";
 import { capturePluginError } from "../services/error-reporter.js";
 import { buildWorkshopDigestReport } from "../services/unified-proposals.js";
-import { DEFAULT_WORKSHOP_TOOL_LIST_LIMIT, resolveWorkshopRevertSessionKey } from "../services/workshop-config.js";
+import {
+  DEFAULT_WORKSHOP_TOOL_LIST_LIMIT,
+  isWorkshopToolMutationEnabled,
+  resolveWorkshopRevertSessionKey,
+} from "../services/workshop-config.js";
 import { revertChangeByOrdinal, buildChangeRevertContext } from "../services/change-feed-revert.js";
 import type { ChangeFeed } from "../services/change-feed.js";
 import type { SessionState } from "../lifecycle/types.js";
@@ -55,38 +59,72 @@ function buildWorkshopCtx(ctx: WorkshopToolsContext, api: ClawdbotPluginApi): Wo
   });
 }
 
+const READ_ONLY_WORKSHOP_ACTIONS = [Type.Literal("list"), Type.Literal("inspect"), Type.Literal("digest")];
+const MUTATING_WORKSHOP_ACTION_NAMES = [
+  "approve",
+  "reject",
+  "quarantine",
+  "revise",
+  "undo",
+  "revert_by_ordinal",
+] as const;
+const MUTATING_WORKSHOP_ACTIONS = MUTATING_WORKSHOP_ACTION_NAMES.map((action) => Type.Literal(action));
+
+function workshopMutationDisabledResponse(action: string) {
+  return {
+    content: [
+      {
+        type: "text",
+        text: `memory_workshop action '${action}' is disabled for agent tool calls. Review and mutate proposals from the trusted dashboard/gateway, or set workshop.allowAgentMutations=true to opt in.`,
+      },
+    ],
+    details: { ok: false, error: "workshop_agent_mutations_disabled" },
+  };
+}
+
 export function registerWorkshopTools(ctx: WorkshopToolsContext, api: ClawdbotPluginApi): void {
+  const allowMutations = isWorkshopToolMutationEnabled(ctx.cfg);
   api.registerTool({
     name: "memory_workshop",
     label: "Memory Workshop",
-    description:
-      "Unified review queue for persona proposals, crystallization skills, tool proposals, and procedure-skill promotions. Actions: list, inspect, approve, reject, quarantine, revise, undo, revert_by_ordinal, digest.",
+    description: allowMutations
+      ? "Unified review queue for persona proposals, crystallization skills, tool proposals, and procedure-skill promotions. Actions: list, inspect, approve, reject, quarantine, revise, undo, revert_by_ordinal, digest."
+      : "Read-only unified review queue for persona proposals, crystallization skills, tool proposals, and procedure-skill promotions. Actions: list, inspect, digest. Mutating actions are disabled unless workshop.allowAgentMutations=true.",
     parameters: Type.Object({
       action: Type.Union(
-        [
-          Type.Literal("list"),
-          Type.Literal("inspect"),
-          Type.Literal("approve"),
-          Type.Literal("reject"),
-          Type.Literal("quarantine"),
-          Type.Literal("revise"),
-          Type.Literal("undo"),
-          Type.Literal("revert_by_ordinal"),
-          Type.Literal("digest"),
-        ],
-        { description: "Workshop action to perform." },
+        allowMutations ? [...READ_ONLY_WORKSHOP_ACTIONS, ...MUTATING_WORKSHOP_ACTIONS] : READ_ONLY_WORKSHOP_ACTIONS,
+        {
+          description: allowMutations
+            ? "Workshop action to perform."
+            : "Read-only workshop action to perform. Mutating actions are disabled unless workshop.allowAgentMutations=true.",
+        },
       ),
-      id: Type.Optional(Type.String({ description: "Unified proposal key (type:storeId) for inspect/approve/reject/etc." })),
-      ordinal: Type.Optional(Type.Integer({ minimum: 1, description: "Change feed ordinal (#N) for revert_by_ordinal." })),
-      sessionKey: Type.Optional(Type.String({ description: "Session key for revert_by_ordinal (defaults to current session)." })),
+      id: Type.Optional(
+        Type.String({ description: "Unified proposal key (type:storeId) for inspect/approve/reject/etc." }),
+      ),
+      ordinal: Type.Optional(
+        Type.Integer({ minimum: 1, description: "Change feed ordinal (#N) for revert_by_ordinal." }),
+      ),
+      sessionKey: Type.Optional(
+        Type.String({ description: "Session key for revert_by_ordinal (defaults to current session)." }),
+      ),
       reason: Type.Optional(Type.String({ description: "Rejection or quarantine reason." })),
       revision: Type.Optional(Type.String({ description: "Revised suggested_change body (persona proposals only)." })),
-      limit: Type.Optional(Type.Integer({ minimum: 1, maximum: 100, description: `Max proposals for list (default ${DEFAULT_WORKSHOP_TOOL_LIST_LIMIT}).` })),
+      limit: Type.Optional(
+        Type.Integer({
+          minimum: 1,
+          maximum: 100,
+          description: `Max proposals for list (default ${DEFAULT_WORKSHOP_TOOL_LIST_LIMIT}).`,
+        }),
+      ),
     }),
     async execute(_toolCallId: string, params: Record<string, unknown>) {
       const action = params.action as string;
       const workshopCtx = buildWorkshopCtx(ctx, api);
       try {
+        if (MUTATING_WORKSHOP_ACTION_NAMES.some((mutatingAction) => mutatingAction === action) && !allowMutations) {
+          return workshopMutationDisabledResponse(action);
+        }
         switch (action) {
           case "list": {
             const items = workshopList(workshopCtx, {
@@ -114,7 +152,8 @@ export function registerWorkshopTools(ctx: WorkshopToolsContext, api: ClawdbotPl
             const id = params.id as string | undefined;
             if (!id) return { content: [{ type: "text", text: "id is required for inspect" }], details: { ok: false } };
             const item = workshopInspect(workshopCtx, id);
-            if (!item) return { content: [{ type: "text", text: `Proposal not found: ${id}` }], details: { ok: false } };
+            if (!item)
+              return { content: [{ type: "text", text: `Proposal not found: ${id}` }], details: { ok: false } };
             return {
               content: [{ type: "text", text: `${item.type} ${item.title}\n\n${item.fullContent ?? item.preview}` }],
               details: item,
@@ -140,7 +179,8 @@ export function registerWorkshopTools(ctx: WorkshopToolsContext, api: ClawdbotPl
           }
           case "quarantine": {
             const id = params.id as string | undefined;
-            if (!id) return { content: [{ type: "text", text: "id is required for quarantine" }], details: { ok: false } };
+            if (!id)
+              return { content: [{ type: "text", text: "id is required for quarantine" }], details: { ok: false } };
             const result = workshopQuarantine(workshopCtx, id, params.reason as string | undefined);
             return {
               content: [{ type: "text", text: result.ok ? result.message : result.error }],
@@ -151,7 +191,10 @@ export function registerWorkshopTools(ctx: WorkshopToolsContext, api: ClawdbotPl
             const id = params.id as string | undefined;
             const revision = params.revision as string | undefined;
             if (!id || !revision) {
-              return { content: [{ type: "text", text: "id and revision are required for revise" }], details: { ok: false } };
+              return {
+                content: [{ type: "text", text: "id and revision are required for revise" }],
+                details: { ok: false },
+              };
             }
             const result = workshopRevise(workshopCtx, id, revision);
             return {
@@ -183,8 +226,7 @@ export function registerWorkshopTools(ctx: WorkshopToolsContext, api: ClawdbotPl
               };
             }
             const chatSessionKey =
-              (api.context?.sessionKey as string | undefined) ??
-              (api.context?.sessionId as string | undefined);
+              (api.context?.sessionKey as string | undefined) ?? (api.context?.sessionId as string | undefined);
             const sessionKey = resolveWorkshopRevertSessionKey(
               ctx.cfg,
               params.sessionKey as string | undefined,


### PR DESCRIPTION
### Motivation
- The LLM-callable `memory_workshop` tool was being auto-enabled via procedures/persona defaults and exposed mutating actions (approve/revert/undo/etc.), enabling prompt-injection-driven persistent state changes. 
- Prevent unauthorized agent-driven persistent mutations by requiring an explicit operator opt-in for in-chat tool calls.

### Description
- Add a new opt-in config flag `workshop.allowAgentMutations?: boolean` with parser and plugin schema support so mutation-capable tool usage is disabled by default. 
- Add `isWorkshopToolMutationEnabled()` to centralize the read-only-by-default decision for in-chat tool calls. 
- Update `registerWorkshopTools()` so the registered `memory_workshop` tool advertises only read-only actions (`list`, `inspect`, `digest`) by default and omits/masks mutating actions; mutating actions are blocked at runtime with a clear error unless `workshop.allowAgentMutations` is true. 
- Add regression tests that assert default-deny behavior and explicit opt-in exposure, and update the plugin schema and config parsers accordingly.

### Testing
- Ran targeted unit tests: `extensions/memory-hybrid` `vitest` for `workshop-config.test.ts` and `workshop-tool-security.test.ts`; both test files passed (all assertions succeeded). 
- Performed a local build (`tsdown`/`npm run build`) of the extension; the build completed successfully. 
- Ran project type-checking: full repo `tsc --noEmit` surfaces pre-existing repo-wide type errors unrelated to these changes; the modified files introduced no new diagnostics in the focused checks and the added tests compiled and ran cleanly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a22d2cd1e8483268a7f57d06d38de63)