### PR TITLE
fix(memory): prevent stale public routes on DB reuse

### DIFF
--- a/extensions/memory-hybrid/setup/register-tools.ts
+++ b/extensions/memory-hybrid/setup/register-tools.ts
@@ -81,6 +81,10 @@ export function createGenerationGuardedToolsApi(
   const ownerGeneration = ctx.registrationGeneration ?? ctx.currentRegistrationGenerationRef?.value ?? -1;
   const generationRef = ctx.currentRegistrationGenerationRef ?? { value: ownerGeneration };
   const baseRegisterTool = api.registerTool.bind(api) as (...args: unknown[]) => unknown;
+  const baseRegisterHttpRoute =
+    typeof api.registerHttpRoute === "function"
+      ? (api.registerHttpRoute.bind(api) as (...args: unknown[]) => unknown)
+      : undefined;
   const disposeCandidates: Array<() => void> = [];
   let disposed = false;
 
@@ -121,9 +125,19 @@ export function createGenerationGuardedToolsApi(
     return registrationResult;
   };
 
+  const guardedRegisterHttpRoute = (...args: unknown[]): unknown => {
+    if (!baseRegisterHttpRoute) return undefined;
+    const registrationResult = baseRegisterHttpRoute(...args);
+    collectUnregister(disposeCandidates, registrationResult);
+    return registrationResult;
+  };
+
   const guardedApi = {
     ...api,
     registerTool: guardedRegisterTool as ClawdbotPluginApi["registerTool"],
+    ...(baseRegisterHttpRoute
+      ? { registerHttpRoute: guardedRegisterHttpRoute as ClawdbotPluginApi["registerHttpRoute"] }
+      : {}),
   } as ClawdbotPluginApi;
 
   return {

--- a/extensions/memory-hybrid/setup/reregister-policy.ts
+++ b/extensions/memory-hybrid/setup/reregister-policy.ts
@@ -101,6 +101,11 @@ export function canReuseDatabasesOnReregister(
   // Compare credentials.encryptionKey to detect when vault key has changed
   if (oldCfg.credentials?.encryptionKey !== cfg.credentials?.encryptionKey) return false;
 
+  // Compare HTTP route security settings so auth hardening or route disablement
+  // cannot keep stale public/dashboard handlers alive on reused database handles.
+  if (oldCfg.health?.enabled !== cfg.health?.enabled) return false;
+  if (oldCfg.health?.authenticated !== cfg.health?.authenticated) return false;
+
   return true;
 }
 

--- a/extensions/memory-hybrid/tests/reregister-policy.test.ts
+++ b/extensions/memory-hybrid/tests/reregister-policy.test.ts
@@ -80,6 +80,44 @@ describe("reregister-policy", () => {
     expect(canReuseDatabasesOnReregister(old, cfg, api)).toBe(false);
   });
 
+  it("reuse-databases declines when public route security settings change", () => {
+    vi.stubEnv("OPENCLAW_HYBRID_MEM_REREGISTER_POLICY", "reuse-databases");
+    const api = {
+      resolvePath: (p: string) => `/home/markus/.openclaw/${p}`,
+    };
+    const oldCfg = minimalCfg();
+    oldCfg.health = { enabled: true, authenticated: false } as HybridMemoryConfig["health"];
+    const newCfg = minimalCfg();
+    newCfg.health = { enabled: true, authenticated: true } as HybridMemoryConfig["health"];
+    const old = mockOldRuntime(
+      {
+        sqlite: api.resolvePath(oldCfg.sqlitePath),
+        lance: api.resolvePath(oldCfg.lanceDbPath),
+      },
+      oldCfg,
+    );
+    expect(canReuseDatabasesOnReregister(old, newCfg, api)).toBe(false);
+  });
+
+  it("reuse-databases declines when public routes are disabled", () => {
+    vi.stubEnv("OPENCLAW_HYBRID_MEM_REREGISTER_POLICY", "reuse-databases");
+    const api = {
+      resolvePath: (p: string) => `/home/markus/.openclaw/${p}`,
+    };
+    const oldCfg = minimalCfg();
+    oldCfg.health = { enabled: true, authenticated: false } as HybridMemoryConfig["health"];
+    const newCfg = minimalCfg();
+    newCfg.health = { enabled: false, authenticated: false } as HybridMemoryConfig["health"];
+    const old = mockOldRuntime(
+      {
+        sqlite: api.resolvePath(oldCfg.sqlitePath),
+        lance: api.resolvePath(oldCfg.lanceDbPath),
+      },
+      oldCfg,
+    );
+    expect(canReuseDatabasesOnReregister(old, newCfg, api)).toBe(false);
+  });
+
   it("reuse-databases declines when encryption key changes", () => {
     vi.stubEnv("OPENCLAW_HYBRID_MEM_REREGISTER_POLICY", "reuse-databases");
     const api = {

--- a/extensions/memory-hybrid/tests/tool-registration-generation-guard.test.ts
+++ b/extensions/memory-hybrid/tests/tool-registration-generation-guard.test.ts
@@ -174,6 +174,35 @@ describe("tool registration generation guard", () => {
     expect(unregisterFn).toHaveBeenCalledTimes(1);
   });
 
+  it("disposes unregister handles returned by registerHttpRoute", () => {
+    const state = getHybridMemoryRegistrationState();
+    const disposeRoute = vi.fn();
+    const registerHttpRoute = vi.fn(() => ({ dispose: disposeRoute }));
+    const { api } = makeRegisterToolApi();
+    const apiWithRoutes = {
+      ...api,
+      registerHttpRoute,
+    };
+
+    state.registrationGenerationRef.value = 4;
+    const registration = createGenerationGuardedToolsApi(
+      {
+        registrationGeneration: 4,
+        currentRegistrationGenerationRef: state.registrationGenerationRef,
+      },
+      apiWithRoutes as never,
+    );
+
+    registration.api.registerHttpRoute?.({ path: "/plugins/memory-public/export" } as never);
+    expect(registerHttpRoute).toHaveBeenCalledTimes(1);
+
+    registration.handle.dispose();
+    expect(disposeRoute).toHaveBeenCalledTimes(1);
+
+    registration.handle.dispose();
+    expect(disposeRoute).toHaveBeenCalledTimes(1);
+  });
+
   it("keeps generation state on globalThis across module reload", async () => {
     vi.resetModules();
     const moduleA = await import("../setup/hybrid-memory-generation-state.js");


### PR DESCRIPTION
### Motivation
- Prevent a security regression where `reuse-databases` hot-reload keeps old public/dashboard HTTP routes (and their captured DB handles) alive after an auth-hardening or route-disablement reload, allowing unauthenticated access to memory exports.

### Description
- Require `canReuseDatabasesOnReregister` to compare `cfg.health.enabled` and `cfg.health.authenticated` and decline reuse when those settings change so a full teardown is forced. (`extensions/memory-hybrid/setup/reregister-policy.ts`)
- Extend the generation-guarded registration API to wrap `registerHttpRoute`, collect any returned unregister/dispose handles, and dispose them together with tool unregisters on generation teardown. (`extensions/memory-hybrid/setup/register-tools.ts`)
- Add regression tests covering: route-security changes blocking DB reuse and that `registerHttpRoute` disposers are invoked on `dispose`. (`extensions/memory-hybrid/tests/reregister-policy.test.ts`, `extensions/memory-hybrid/tests/tool-registration-generation-guard.test.ts`)
- Relevant files modified: `setup/reregister-policy.ts`, `setup/register-tools.ts`, and two test files.

### Testing
- Ran formatter: `biome format --write` on the modified files — formatted/updated files successfully.
- Unit tests: `vitest run tests/reregister-policy.test.ts tests/tool-registration-generation-guard.test.ts` — 2 test files ran; all new and existing assertions in those files passed (12 tests total passed).
- Typecheck: `tsc --noEmit -p tsconfig.test.json` was executed but reported failures due to an external `openclaw/plugin-sdk/core` typing/export mismatch in the installed dependency (not introduced by this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1c86c4466083268da67de89d8fee70)