### PR TITLE
fix(cli): avoid untrusted command execution in Ollama detection

### DIFF
--- a/extensions/memory-hybrid/cli/cmd-install.ts
+++ b/extensions/memory-hybrid/cli/cmd-install.ts
@@ -13,10 +13,9 @@
  * - runUpgradeForCli
  */
 
-import { spawnSync } from "node:child_process";
 import { cpSync, existsSync, mkdirSync, readFileSync, realpathSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { basename, dirname, isAbsolute, join, relative, resolve as pathResolve } from "node:path";
+import { basename, delimiter, dirname, isAbsolute, join, relative, resolve as pathResolve } from "node:path";
 
 import { getEnv } from "../utils/env-manager.js";
 import { expandTilde } from "../utils/path.js";
@@ -1566,6 +1565,29 @@ function inspectExistingEmbeddingSetup(root: Record<string, unknown>): Embedding
   };
 }
 
+function hasTrustedPathExecutable(command: string): boolean {
+  const rawPath = readString(process.env.PATH);
+  if (!rawPath) return false;
+
+  const cwd = process.cwd();
+  const pathExt =
+    process.platform === "win32"
+      ? (readString(process.env.PATHEXT)?.split(";").filter(Boolean) ?? [".EXE", ".CMD", ".BAT", ".COM"])
+      : [""];
+
+  for (const entry of rawPath.split(delimiter).map((part) => part.trim())) {
+    if (!entry || entry === ".") continue;
+    const resolvedEntry = pathResolve(entry);
+    if (resolvedEntry === cwd || !isAbsolute(resolvedEntry)) continue;
+
+    for (const ext of pathExt) {
+      if (existsSync(join(resolvedEntry, `${command}${ext}`))) return true;
+    }
+  }
+
+  return false;
+}
+
 export function detectRecommendedEmbeddingSetup(
   root: Record<string, unknown>,
   pluginRootDir: string,
@@ -1602,7 +1624,7 @@ export function detectRecommendedEmbeddingSetup(
   const ollamaInstalled =
     existsSync(join(homedir(), ".ollama")) ||
     readString(process.env.OLLAMA_HOST) !== undefined ||
-    spawnSync("ollama", ["--version"], { stdio: "ignore" }).status === 0;
+    hasTrustedPathExecutable("ollama");
   if (ollamaInstalled) {
     return {
       provider: "ollama",


### PR DESCRIPTION
### Motivation
- Prevent executing an unqualified `ollama --version` from the process PATH during embedding-provider auto-detection to avoid arbitrary code execution or hangs when PATH/cwd can be influenced by an attacker.

### Description
- Removed direct `spawnSync("ollama", ["--version"])` usage and replaced it with a non-executing `hasTrustedPathExecutable` helper that scans `PATH` entries without running binaries.
- `hasTrustedPathExecutable` skips `.` and non-absolute or cwd PATH entries and respects Windows `PATHEXT` when checking for candidate files.
- Replaced the ollama presence check in `detectRecommendedEmbeddingSetup` to use the new helper and added `delimiter` to the `node:path` imports.

### Testing
- Ran `npm -C extensions/memory-hybrid run -s format -- cli/cmd-install.ts` which completed successfully.
- Ran `cd extensions/memory-hybrid && npx biome format --write cli/cmd-install.ts && npx biome lint cli/cmd-install.ts` which completed successfully (linter emitted a pre-existing unrelated warning).
- Ran targeted unit tests with `cd extensions/memory-hybrid && npm test -- -t detectRecommendedEmbeddingSetup` which completed and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a02ba82dc348326920a545ff9e3127b)