### PR TITLE
fix(memory-public): redact provenanceJson in public API responses

### DIFF
--- a/extensions/memory-hybrid/services/public-export-bundle.ts
+++ b/extensions/memory-hybrid/services/public-export-bundle.ts
@@ -65,6 +65,13 @@ export interface BuildPublicExportBundleOptions {
 const DEFAULT_LIMIT = 100;
 const MAX_LIMIT = 2000;
 
+function redactFactForPublicApi(fact: MemoryEntry): MemoryEntry {
+  return {
+    ...fact,
+    provenanceJson: null,
+  };
+}
+
 function parseLimit(value: number | undefined, fallback = DEFAULT_LIMIT): number {
   if (value == null) return fallback;
   if (!Number.isFinite(value)) return fallback;
@@ -118,7 +125,7 @@ export function buildPublicExportBundle(
   const linksLimit = parseLimit(options.linksLimit);
   const scopeFilter = options.scopeFilter ?? null;
 
-  const facts = factsDb.getAll({ scopeFilter }).slice(0, factsLimit);
+  const facts = factsDb.getAll({ scopeFilter }).slice(0, factsLimit).map(redactFactForPublicApi);
   const scopedFactIds = new Set(facts.map((f) => f.id));
   const episodes = factsDb
     .searchEpisodes({ limit: MAX_LIMIT })

--- a/extensions/memory-hybrid/tests/public-api-routes.test.ts
+++ b/extensions/memory-hybrid/tests/public-api-routes.test.ts
@@ -91,6 +91,7 @@ describe("registerPublicApiRoutes", () => {
       key: "public_api",
       value: "enabled",
       source: "conversation",
+      provenanceJson: JSON.stringify({ sourceFacts: [{ text: "secret" }] }),
     });
 
     factsDb.recordEpisode({
@@ -152,7 +153,9 @@ describe("registerPublicApiRoutes", () => {
       fakeReq(`${PUBLIC_API_PREFIX}${PUBLIC_API_PATHS.export}?limit=10`),
     );
     expect(exportRes.status).toBe(200);
-    expect(JSON.parse(exportRes.body).manifest.counts.facts).toBeGreaterThanOrEqual(1);
+    const exportBody = JSON.parse(exportRes.body);
+    expect(exportBody.manifest.counts.facts).toBeGreaterThanOrEqual(1);
+    expect(exportBody.facts.every((f: { provenanceJson: string | null }) => f.provenanceJson === null)).toBe(true);
 
     const fact = routes.find((r) => r.path === `${PUBLIC_API_PREFIX}${PUBLIC_API_PATHS.fact}`)!;
     const factRes = await invokeNodeHttpRoute(
@@ -160,7 +163,9 @@ describe("registerPublicApiRoutes", () => {
       fakeReq(`${PUBLIC_API_PREFIX}${PUBLIC_API_PATHS.fact}?id=${stored.id}`),
     );
     expect(factRes.status).toBe(200);
-    expect(JSON.parse(factRes.body).id).toBe(stored.id);
+    const factBody = JSON.parse(factRes.body);
+    expect(factBody.id).toBe(stored.id);
+    expect(factBody.fact.provenanceJson).toBeNull();
 
     const badSearchRes = await invokeNodeHttpRoute(
       search.handler,

--- a/extensions/memory-hybrid/tests/public-export-bundle.test.ts
+++ b/extensions/memory-hybrid/tests/public-export-bundle.test.ts
@@ -30,6 +30,7 @@ describe("buildPublicExportBundle", () => {
       key: "style",
       value: "concise",
       source: "conversation",
+      provenanceJson: JSON.stringify({ sourceFacts: [{ text: "secret" }] }),
     });
 
     const factB = factsDb.store({
@@ -78,6 +79,7 @@ describe("buildPublicExportBundle", () => {
     expect(bundle.manifest.bundleVersion).toBe(1);
     expect(bundle.version.pluginVersion).toBeTruthy();
     expect(bundle.facts.length).toBeGreaterThanOrEqual(2);
+    expect(bundle.facts.every((f) => f.provenanceJson === null)).toBe(true);
     expect(bundle.episodes.length).toBe(1);
     expect(bundle.procedures.length).toBe(1);
     expect(bundle.narratives.length).toBe(1);

--- a/extensions/memory-hybrid/tools/public-api-routes.ts
+++ b/extensions/memory-hybrid/tools/public-api-routes.ts
@@ -42,6 +42,13 @@ function toJson(status: number, body: unknown): { status: number; headers: Recor
   return { status, headers: { ...JSON_HEADERS }, body: JSON.stringify(body) };
 }
 
+function redactFactForPublicApi<T extends { provenanceJson?: string | null }>(fact: T): T {
+  return {
+    ...fact,
+    provenanceJson: null,
+  };
+}
+
 function parseReqUrl(url: string): URL {
   return new URL(url, "http://localhost");
 }
@@ -140,7 +147,9 @@ export function registerPublicApiRoutes(ctx: PublicApiRoutesContext, api: Clawdb
       });
     }
 
-    const results = ctx.factsDb.search(query, limit, { tierFilter: "all", scopeFilter });
+    const results = ctx.factsDb
+      .search(query, limit, { tierFilter: "all", scopeFilter })
+      .map((result) => ({ ...result, entry: redactFactForPublicApi(result.entry) }));
     return toJson(200, {
       query,
       limit,
@@ -153,7 +162,7 @@ export function registerPublicApiRoutes(ctx: PublicApiRoutesContext, api: Clawdb
     const url = parseReqUrl(req.url);
     const limit = parseLimitParam(url.searchParams.get("limit"), 20, 200);
     const scopeFilter = resolveScopeFilter(req);
-    const facts = ctx.factsDb.getAll({ scopeFilter }).slice(0, limit);
+    const facts = ctx.factsDb.getAll({ scopeFilter }).slice(0, limit).map(redactFactForPublicApi);
 
     return toJson(200, {
       limit,
@@ -271,7 +280,7 @@ export function registerPublicApiRoutes(ctx: PublicApiRoutesContext, api: Clawdb
 
     return toJson(200, {
       id: resolvedId,
-      fact,
+      fact: redactFactForPublicApi(fact),
       links: {
         outgoing: filteredOutgoingLinks,
         incoming: filteredIncomingLinks,


### PR DESCRIPTION
### Motivation

- Prevent disclosure of scoped/source fact excerpts embedded in `provenanceJson` on globally visible cross-agent facts that could bypass scope protections and leak sensitive text.

### Description

- Add `redactFactForPublicApi` to `services/public-export-bundle.ts` and `tools/public-api-routes.ts` and apply it to facts returned by `buildPublicExportBundle`, `search`, `timeline`, and `fact` endpoints so `provenanceJson` is always set to `null` for public responses.
- Update public API tests to include facts with `provenanceJson` and assert the exported and route responses do not expose the provenance payload.
- Files changed: `extensions/memory-hybrid/services/public-export-bundle.ts`, `extensions/memory-hybrid/tools/public-api-routes.ts`, and related test files in `extensions/memory-hybrid/tests`.

### Testing

- Ran the public API tests with Vitest: `NO_COLOR=1 npm --prefix extensions/memory-hybrid exec -- vitest run tests/public-export-bundle.test.ts tests/public-api-routes.test.ts`. 
- Result: both test files passed (2 test files, 7 tests total), confirming `provenanceJson` is redacted in public bundles and route responses.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fd1b86e14c8326bf2b4f0bfa1da05f)