### PR TITLE
feat(proactive-research): ground insight synthesis in goals and identity, fix routine-miner UTC bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [2026.7.214] - 2026-07-12
+
+### Fixed — `verify --fix` could downgrade a newer managed plugin install ([#2077](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/2077))
+
+`syncKnownNpmProjectPinWhenExtensionsCanonical` (the pin-sync fallback `verify --fix` and `upgrade` reach when the sibling npm-project-tree-removal guard refuses to delete a *newer* npm-project copy) read the npm-project's installed version but never compared its direction against the version it was about to write — so it could `npm install openclaw-hybrid-memory@<older>` over an actively newer managed install, immediately (not just "on next restart," the on-disk code changed synchronously). The correct "never delete a newer install" guard already existed one function over (`removeRedundantNpmProjectTreeWhenExtensionsCanonical`'s `npm-project-not-older` check) — its refusal was just silently discarded by both callers before falling through to the unguarded pin write.
+
+- `cli/install/workspace.ts`: `syncKnownNpmProjectPinWhenExtensionsCanonical` now compares versions (`utils/version-check.ts`'s `compareVersions`, already used elsewhere for this CalVer scheme) before writing the pin, and refuses with `skippedReason: "npm-project-not-older"` when the npm-project copy is newer — mirroring the sibling removal guard exactly, so the two guards can't drift out of sync with each other again. New `buildNpmProjectNewerGuidance` gives direction-correct cleanup guidance (suggests removing the *extensions* copy) for this reversed scenario, since the existing `buildDualInstallReconciliationGuidance` hardcodes the opposite assumption.
+- `cli/verify/sections/infrastructure.ts`: a refused downgrade during `verify --fix` is now a hard issue (`Refusing to downgrade npm-project openclaw-hybrid-memory X -> Y during verify --fix: ...`), not a silent log line — new `VerifyRunState.installReconcileOk` (folded into `config-cron.ts`'s `allOk` computation) makes `verify` exit non-zero when this happens.
+- `cli/install/run-install.ts`: the `upgrade` command logs the same refusal loudly without failing the command — the primary upgrade (of the canonical extensions copy) already succeeded by this point; the npm-project pin is a secondary, best-effort reconciliation step.
+
+Tests: 2 new in `tests/run-upgrade.test.ts` — the exact reported version pair (npm-project 2026.7.212 vs extensions 2026.7.172) refuses with the pin left byte-for-byte untouched, plus a `buildNpmProjectNewerGuidance` content check. Full suite green (713 files / 9371 tests), tsc/lint/verify:gate clean.
+
 ## [2026.7.213] - 2026-07-12
 
 ### Added — Proactive research grounded in ambitions and identity ([PROACTIVE-RESEARCH.md](docs/PROACTIVE-RESEARCH.md))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [2026.7.213] - 2026-07-12
+
+### Added — Proactive research grounded in ambitions and identity ([PROACTIVE-RESEARCH.md](docs/PROACTIVE-RESEARCH.md))
+
+Insight synthesis previously reasoned only from friction signals (negative valence, frustration, routines, patterns). It now also reads the user's **active goals** (goal registry) and the assistant's own **durable identity reflections** on the relationship — two current-state sources, not windowed like the rest — so an insight can name a stalled ambition or connect a behavioral pattern to what the assistant has learned about the relationship, not just recurring friction.
+
+- **Goal evidence** (`G#` refs): up to 10 active (non-terminal) goals, ranked by priority then recency, each rendered as one line (label, priority, status, age, last-assessed, blockers). Frozen into the insight's provenance at synthesis time, since goal state can change before the research loop re-reads it. Skips cleanly when goal stewardship is off.
+- **Identity evidence** (`I#` refs): the latest **durable** identity-reflection entry per fixed question (≤5 total); `temporary` entries are excluded since the store's own signal says they shouldn't anchor a research decision. Skips cleanly when identity reflection is off.
+- New insight `topic`: `growth`, for insights grounded mainly in goal/ambition evidence.
+- `research-trigger`'s evidence gate and `research pick`/`research status`'s evidence hydration both extended to count/surface goal and identity evidence alongside facts and signals — an insight backed only by goal/identity evidence is no longer wrongly rejected as under-evidenced.
+- No new config keys; gated by the same `goalStewardship.enabled`/`autoEnableWhenGoalsPresent` and identity-reflection availability already governing those subsystems.
+
+### Fixed — Routine mining now buckets by local time, not UTC ([LIVING-MEMORY.md](docs/LIVING-MEMORY.md))
+
+`routine-miner` bucketed recall timestamps by `getUTCHours()`/`getUTCDay()`, so a "night" routine meant 00:00–06:00 UTC regardless of the user's actual timezone — the exact "sleep procrastination" pattern this loop was built to catch could be mislabeled for anyone outside UTC. New `maintenance.routineMining.timezone` config (IANA zone, default `"UTC"` — unchanged default behavior) buckets weekday/hour-of-day via `Intl`-based local-time resolution (`services/quiet-window.ts`'s existing DST-safe helper, extended with a weekday+hour variant), reusing the same technique already proven for maintenance quiet-windows.
+
 ## [2026.7.212] - 2026-07-11
 
 ### Added — Proactive research loop ([PROACTIVE-RESEARCH.md](docs/PROACTIVE-RESEARCH.md))

--- a/docs/LIVING-MEMORY.md
+++ b/docs/LIVING-MEMORY.md
@@ -73,10 +73,12 @@ config knob added by the living-memory upgrade (all **on by default** unless mar
   the frustration detector's per-session signals stamp a confidence-weighted **valence** (−1..1)
   and `affect_source` onto facts formed in that session's window. Memory formation carries
   emotional state; nothing runs on the hot path.
-- **Routine mining** (`maintenance.routineMining { enabled: true, maxPerRun: 2 }`, nightly): recall
-  patterns recurring ≥3 times across ≥3 distinct weeks in the same weekday/time-band become
-  ordinary decayable `routine` facts ("Routine: on Tuesday mornings, a recurring focus is …").
-  Routines that stop recurring decay out — learned from interaction, not programmed.
+- **Routine mining** (`maintenance.routineMining { enabled: true, maxPerRun: 2, timezone: "UTC" }`,
+  nightly): recall patterns recurring ≥3 times across ≥3 distinct weeks in the same weekday/time-band
+  become ordinary decayable `routine` facts ("Routine: on Tuesday mornings, a recurring focus is …").
+  Weekday/time-band bucketing uses `timezone` (an IANA zone, default `"UTC"`) — set it to the user's
+  local timezone so a "night" routine means local late-night, not 00:00-06:00 UTC. Routines that stop
+  recurring decay out — learned from interaction, not programmed.
 
 ## Free-text contradictions (shipped)
 

--- a/docs/PROACTIVE-RESEARCH.md
+++ b/docs/PROACTIVE-RESEARCH.md
@@ -16,7 +16,8 @@ with every step auditable back to the memories that triggered it.
 ┌──────────────────────┐   ┌───────────────┐  ┌────────────────┐   ┌──────────────────────────┐   ┌─────────────┐
 │ valence-stamped facts│ → │ insight-      │→ │ research-      │ → │ research-overnight job:   │ → │ 🔎 briefing │
 │ routines, patterns,  │   │ synthesis     │  │ trigger        │   │ pick → web research →     │   │ block (once │
-│ frustration signals  │   │ (LLM, ≤2/run) │  │ (no LLM, ≤1/n) │   │ research store (briefing) │   │ per session)│
+│ frustration signals, │   │ (LLM, ≤2/run) │  │ (no LLM, ≤1/n) │   │ research store (briefing) │   │ per session)│
+│ goals, identity refl.│   │               │  │                │   │                           │   │             │
 └──────────────────────┘   └───────────────┘  └────────────────┘   └──────────────────────────┘   └─────────────┘
 ```
 
@@ -24,11 +25,20 @@ with every step auditable back to the memories that triggered it.
 
 1. **Insight synthesis** (`insight-synthesis`, nightly LLM step): reads the last 7 days of
    person-signals — negative-valence memories, mined routines, frustration signals, behavioral
-   patterns — and writes at most 2 evidence-linked `insight` facts ("User repeatedly works past
-   midnight and expresses fatigue — sleep procrastination may be hurting focus"). The model can
-   only cite numbered evidence references that map back to real memory ids; an insight citing
-   unknown references is dropped, so hallucinated evidence chains are structurally impossible.
-   Insights are ordinary decayable memories tagged `needs-review`.
+   patterns — plus two current-state (not windowed) sources: the user's **active goals** (goal
+   registry) and the assistant's own **durable identity reflections** on the relationship
+   ("what patterns define good partnership with the user?"). It writes at most 2 evidence-linked
+   `insight` facts ("User repeatedly works past midnight and expresses fatigue — sleep
+   procrastination may be hurting focus"; "User's goal to ship the v2 API has stalled for 18 days
+   despite being high priority"). The model can only cite numbered evidence references (`F#`/`S#`
+   for facts/signals, `G#`/`I#` for goals/identity reflections) that map back to real ids; an
+   insight citing an unknown reference is dropped, so hallucinated evidence chains are
+   structurally impossible. Insights are ordinary decayable memories tagged `needs-review`, with
+   `topic` one of `wellbeing`/`productivity`/`growth`/`tooling`/`relationship`/`other` — `growth`
+   marks insights grounded mainly in the user's stated ambitions. Goal/identity evidence text is
+   frozen into the insight's provenance at synthesis time (goal state can change before the
+   research loop re-reads it days later), while fact/signal evidence is re-read live downstream.
+   Both sources are optional and skip cleanly when goal stewardship or identity reflection is off.
 2. **Trigger policy** (`research-trigger`, nightly, deterministic — no LLM): at most one insight
    per night graduates to research. Gates: importance ≥ 0.74 (salience ≥ 0.6), evidence count,
    topic blocklist plus a sensitive-text regex (credentials never leave the machine), and a

--- a/extensions/memory-hybrid/cli/commands/manage/maintenance-step-runners.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/maintenance-step-runners.ts
@@ -341,7 +341,10 @@ export function buildCliMaintenanceRunners(
   });
 
   set("routine-mining", async () => {
-    const r = runRoutineMining(b.factsDb, { maxPerRun: b.cfg.maintenance?.routineMining?.maxPerRun ?? 2 });
+    const r = runRoutineMining(b.factsDb, {
+      maxPerRun: b.cfg.maintenance?.routineMining?.maxPerRun ?? 2,
+      timezone: b.cfg.maintenance?.routineMining?.timezone,
+    });
     return `candidates=${r.candidates} stored=${r.stored} semantic=success`;
   });
 

--- a/extensions/memory-hybrid/cli/commands/register-research-group.ts
+++ b/extensions/memory-hybrid/cli/commands/register-research-group.ts
@@ -54,7 +54,33 @@ function parseSourceEventIds(provenanceJson: string | null): string[] {
   }
 }
 
-/** Walk queue fact → insight → evidence facts/signals into displayable items. */
+/**
+ * Goal/identity evidence is stored pre-rendered on the insight's own provenance (frozen at
+ * synthesis time — see services/insight-synthesis.ts), unlike facts/signals which are re-read live
+ * from their tables above. No extra DB/filesystem reads needed here.
+ */
+function parsePrerenderedEvidence(
+  provenanceJson: string | null,
+  field: "sourceGoalEvidence" | "sourceIdentityEvidence",
+): EvidenceItem[] {
+  if (!provenanceJson) return [];
+  try {
+    const parsed = JSON.parse(provenanceJson) as Record<string, unknown>;
+    const arr = parsed[field];
+    if (!Array.isArray(arr)) return [];
+    const out: EvidenceItem[] = [];
+    for (const item of arr) {
+      if (!item || typeof item !== "object") continue;
+      const obj = item as Record<string, unknown>;
+      if (typeof obj.id === "string" && typeof obj.text === "string") out.push({ id: obj.id, text: obj.text });
+    }
+    return out;
+  } catch {
+    return [];
+  }
+}
+
+/** Walk queue fact → insight → evidence facts/signals/goals/identity into displayable items. */
 function hydrateEvidence(
   b: ManageBindings,
   insightId: string | null,
@@ -81,6 +107,8 @@ function hydrateEvidence(
       });
     }
   }
+  evidence.push(...parsePrerenderedEvidence(insight.provenanceJson ?? null, "sourceGoalEvidence").slice(0, 10));
+  evidence.push(...parsePrerenderedEvidence(insight.provenanceJson ?? null, "sourceIdentityEvidence").slice(0, 10));
   return { insight: insight.text, evidence };
 }
 

--- a/extensions/memory-hybrid/cli/install/run-install.ts
+++ b/extensions/memory-hybrid/cli/install/run-install.ts
@@ -725,6 +725,15 @@ export async function runUpgradeForCli(
       });
       if (staleSync.updated) {
         logger?.info?.(`memory-hybrid: upgrade — reconciled stale npm-project pin to ${installedVersion} (#2008)`);
+      } else if (staleSync.skippedReason === "npm-project-not-older") {
+        // The just-upgraded extensions copy is OLDER than the existing npm-project install —
+        // leave the npm-project pin untouched rather than downgrade it (#2077). The primary
+        // upgrade (extensions copy) already succeeded, so this does not fail the command, but
+        // it is loud: a stale npm-project copy silently left ahead of the extensions copy is
+        // exactly the confusing dual-install state operators need to reconcile manually.
+        logger?.warn?.(
+          `memory-hybrid: upgrade — refusing to downgrade npm-project ${PLUGIN_ID} ${staleSync.npmVersion} -> ${installedVersion}: npm-project copy is newer than the just-upgraded extensions copy.${staleSync.guidance ? ` ${staleSync.guidance}` : ""}`,
+        );
       } else if (staleSync.attempted && staleSync.error) {
         logger?.warn?.(
           `memory-hybrid: upgrade — could not reconcile npm-project pin: ${staleSync.error}${staleSync.guidance ? ` (${staleSync.guidance})` : ""}`,

--- a/extensions/memory-hybrid/cli/install/workspace.ts
+++ b/extensions/memory-hybrid/cli/install/workspace.ts
@@ -26,6 +26,7 @@ import { atomicWriteFile } from "../../utils/atomic-write.js";
 import { getEnv } from "../../utils/env-manager.js";
 import { expandTilde } from "../../utils/path.js";
 import { escapeRegExp } from "../../utils/text.js";
+import { compareVersions } from "../../utils/version-check.js";
 import {
   loadOpenclawRootForWorkspace,
   resolveAgentWorkspaceRoot,
@@ -195,14 +196,51 @@ export function buildDualInstallReconciliationGuidance(
 }
 
 /**
+ * Operator guidance for the REVERSE of {@link buildDualInstallReconciliationGuidance}'s
+ * assumption: the npm-project copy is confirmed newer, so the extensions copy is the stale
+ * leftover here, not the other way around (#2077). Must not reuse the other guidance text —
+ * it hardcodes "extensions is canonical" framing that would be actively wrong in this direction.
+ */
+export function buildNpmProjectNewerGuidance(opts: {
+  npmProjectPluginDir: string;
+  npmVersion: string;
+  extensionsPluginDir: string;
+  extVersion: string;
+}): string {
+  return (
+    `The npm-project copy (${opts.npmVersion} at ${opts.npmProjectPluginDir}) is newer than the extensions copy ` +
+    `(${opts.extVersion} at ${opts.extensionsPluginDir}). Confirm which path the running gateway actually loaded ` +
+    '(check startup logs for "memory-hybrid: registered"); if it is the npm-project copy, the extensions copy is ' +
+    `a stale leftover and can be removed once confirmed: rm -rf ${opts.extensionsPluginDir}. ` +
+    "Do not run verify --fix again until this is resolved — it will keep refusing to touch the npm-project pin."
+  );
+}
+
+/**
  * When upgrade targets extensions but a stale npm-project copy exists, align its pin (#2008).
+ *
+ * Refuses to write a pin that would downgrade the npm-project install (#2077): the extensions
+ * copy is treated as canonical by construction throughout this module, but that assumption can be
+ * wrong — a host may genuinely be running the npm-project copy while a stale, never-cleaned-up
+ * extensions copy sits at an older version on disk. Writing `extVer` into the npm-project pin in
+ * that case would downgrade an active newer install, silently, the moment `npm install` completes
+ * (not just "on next restart" — the on-disk code changes immediately).
  */
 export function syncKnownNpmProjectPinWhenExtensionsCanonical(opts: {
   extensionsPluginDir: string;
   version: string;
   /** npm-project plugin dir detected by verify/upgrade (defaults to Maeve layout). */
   npmProjectPluginDir?: string;
-}): { attempted: boolean; updated: boolean; error?: string; guidance?: string } {
+}): {
+  attempted: boolean;
+  updated: boolean;
+  error?: string;
+  guidance?: string;
+  /** Populated when the sync was intentionally refused (guard tripped). */
+  skippedReason?: "npm-project-not-older";
+  /** The npm-project's currently-installed version, populated alongside `skippedReason`. */
+  npmVersion?: string;
+} {
   if (isNpmProjectPluginLayout(opts.extensionsPluginDir)) {
     return { attempted: false, updated: false };
   }
@@ -216,6 +254,24 @@ export function syncKnownNpmProjectPinWhenExtensionsCanonical(opts: {
     return { attempted: false, updated: false };
   }
   const npmVer = readPluginPackageVersion(npmPluginDir);
+  if (npmVer && compareVersions(npmVer, extVer) > 0) {
+    // The npm-project copy is newer than the version we're about to pin to — refuse (#2077).
+    // Mirrors removeRedundantNpmProjectTreeWhenExtensionsCanonical's "npm-project-not-older"
+    // guard, which already refuses to delete a newer npm-project tree; this closes the gap
+    // where its refusal fell through to this function's previously-unguarded pin write.
+    return {
+      attempted: false,
+      updated: false,
+      skippedReason: "npm-project-not-older",
+      npmVersion: npmVer,
+      guidance: buildNpmProjectNewerGuidance({
+        npmProjectPluginDir: npmPluginDir,
+        npmVersion: npmVer,
+        extensionsPluginDir: opts.extensionsPluginDir,
+        extVersion: extVer,
+      }),
+    };
+  }
   const pinError = verifyNpmProjectDependencyPin(projectRoot, extVer);
   if (!pinError && npmVer === extVer) {
     return { attempted: false, updated: false };

--- a/extensions/memory-hybrid/cli/verify/sections/config-cron.ts
+++ b/extensions/memory-hybrid/cli/verify/sections/config-cron.ts
@@ -905,6 +905,7 @@ export async function runVerifyConfigCronSection(state: VerifyRunState): Promise
     state.lanceOk &&
     state.embeddingOk &&
     state.embeddingAlignmentOk &&
+    state.installReconcileOk &&
     (!cfg.credentials.enabled || state.credentialsOk) &&
     // Only gate on llmOk when --test-llm actually ran live tests — llmOk degrades to a plain
     // credential-presence check outside --test-llm, and requiring LLM credentials unconditionally

--- a/extensions/memory-hybrid/cli/verify/sections/infrastructure.ts
+++ b/extensions/memory-hybrid/cli/verify/sections/infrastructure.ts
@@ -25,8 +25,17 @@ import {
   removeRedundantNpmProjectTreeWhenExtensionsCanonical,
   resolveCanonicalLivePluginPathForInstallIndex,
 } from "../../install/install-index-reconcile.js";
-import { capturePluginError, isErrorReporterActive, resolvePendingErrorReportCount } from "../../../services/error-reporter.js";
-import { listQuarantinedGoalIds, resolveGoalsDir, auditGoalIndexDrift, rebuildGoalIndex } from "../../../services/goal-registry.js";
+import {
+  capturePluginError,
+  isErrorReporterActive,
+  resolvePendingErrorReportCount,
+} from "../../../services/error-reporter.js";
+import {
+  listQuarantinedGoalIds,
+  resolveGoalsDir,
+  auditGoalIndexDrift,
+  rebuildGoalIndex,
+} from "../../../services/goal-registry.js";
 import { PLUGIN_ID } from "../../../utils/constants.js";
 import { workspaceRootForCli } from "../../config-feature-summaries.js";
 import {
@@ -73,8 +82,7 @@ export async function runVerifyInfrastructureSection(state: VerifyRunState): Pro
   log("\n───── Infrastructure ─────");
 
   const extensionsPluginDir = join(openclawDir, "extensions", PLUGIN_ID);
-  const npmProjectPluginDir =
-    resolveNpmProjectPluginDirFromLayout(extDir) ?? resolveKnownNpmProjectPluginDir();
+  const npmProjectPluginDir = resolveNpmProjectPluginDirFromLayout(extDir) ?? resolveKnownNpmProjectPluginDir();
   if (npmProjectPluginDir) {
     const dualInstall =
       buildDualInstallReconciliationGuidance(npmProjectPluginDir, extensionsPluginDir) ??
@@ -112,6 +120,15 @@ export async function runVerifyInfrastructureSection(state: VerifyRunState): Pro
               log(
                 `  → Synced npm-project dependency pin to ${extVer} (legacy install-index sidecar is checked separately below)`,
               );
+            } else if (sync.skippedReason === "npm-project-not-older") {
+              // The extensions copy we were about to pin to is OLDER than the currently
+              // installed npm-project copy — writing it would silently downgrade a newer,
+              // possibly-active install (#2077). Fail closed and surface a real issue rather
+              // than a warning, so `verify` (with or without --fix) reports non-zero.
+              const msg = `Refusing to downgrade npm-project ${PLUGIN_ID} ${sync.npmVersion} -> ${extVer} during verify --fix: npm-project copy at ${npmProjectPluginDir} is newer than the extensions copy at ${extensionsPluginDir}.${sync.guidance ? ` ${sync.guidance}` : ""}`;
+              issues.push(msg);
+              state.installReconcileOk = false;
+              log(`${FAIL} ${msg}`);
             } else if (sync.error) {
               log(`  → Could not sync npm-project pin: ${sync.error}`);
             }
@@ -165,7 +182,9 @@ export async function runVerifyInfrastructureSection(state: VerifyRunState): Pro
     if (isErrorReporterActive() || pendingReports > 0) {
       if (pendingReports > 0) {
         warnings.push(`Error reporter has ${pendingReports} pending telemetry report(s)`);
-        log(`${WARN_LINE} Error reporter: ${pendingReports} pending report(s) in queue (retries on startup/shutdown flush)`);
+        log(
+          `${WARN_LINE} Error reporter: ${pendingReports} pending report(s) in queue (retries on startup/shutdown flush)`,
+        );
       } else {
         log(`${OK} Error reporter: pending queue empty`);
       }
@@ -188,8 +207,7 @@ export async function runVerifyInfrastructureSection(state: VerifyRunState): Pro
       );
     }
     const drift = await auditGoalIndexDrift(goalsDir);
-    const driftCount =
-      drift.missingInIndex.length + drift.orphanInIndex.length + drift.staleFields.length;
+    const driftCount = drift.missingInIndex.length + drift.orphanInIndex.length + drift.staleFields.length;
     if (driftCount > 0) {
       const parts: string[] = [];
       if (drift.missingInIndex.length > 0) {
@@ -202,7 +220,9 @@ export async function runVerifyInfrastructureSection(state: VerifyRunState): Pro
         parts.push(`${drift.staleFields.length} stale field(s)`);
       }
       warnings.push(`Goal index drift detected (${parts.join("; ")})`);
-      log(`${WARN_LINE} Goals: index drift — ${parts.join("; ")}. Run \`openclaw hybrid-mem verify --fix\` to rebuild _index.json.`);
+      log(
+        `${WARN_LINE} Goals: index drift — ${parts.join("; ")}. Run \`openclaw hybrid-mem verify --fix\` to rebuild _index.json.`,
+      );
       if (opts.fix) {
         await rebuildGoalIndex(goalsDir);
         log(`  → Rebuilt goals/_index.json`);

--- a/extensions/memory-hybrid/cli/verify/verify-run-state.ts
+++ b/extensions/memory-hybrid/cli/verify/verify-run-state.ts
@@ -61,6 +61,8 @@ export type VerifyRunState = {
   embeddingAlignmentOk: boolean;
   /** True when at least one credentialed LLM provider is available; with --test-llm, requires an actual configured-model test to succeed. */
   llmOk: boolean;
+  /** False when install reconciliation refused an unsafe action (e.g. would downgrade a newer npm-project install, #2077). */
+  installReconcileOk: boolean;
   loadBlocking: string[];
   extDir: string;
   defaultConfigPath: string;
@@ -135,6 +137,7 @@ export function createVerifyRunState(ctx: HandlerContext, opts: VerifyRunOpts, s
     embeddingOk: false,
     embeddingAlignmentOk: true,
     llmOk: false,
+    installReconcileOk: true,
     loadBlocking: [],
     extDir,
     defaultConfigPath,

--- a/extensions/memory-hybrid/config/parsers/maintenance.ts
+++ b/extensions/memory-hybrid/config/parsers/maintenance.ts
@@ -268,6 +268,7 @@ export function parseMaintenanceConfig(cfg: Record<string, unknown>): Maintenanc
         : 1,
   };
   const decayRaw = maintenanceRaw?.decay as Record<string, unknown> | undefined;
+  const routineMiningRaw = maintenanceRaw?.routineMining as Record<string, unknown> | undefined;
   return {
     monthlyReview,
     cronReliability: parseCronReliabilityConfig(cfg),
@@ -280,12 +281,15 @@ export function parseMaintenanceConfig(cfg: Record<string, unknown>): Maintenanc
       secondChance: decayRaw?.secondChance !== false,
     },
     routineMining: {
-      enabled: (maintenanceRaw?.routineMining as Record<string, unknown> | undefined)?.enabled !== false,
+      enabled: routineMiningRaw?.enabled !== false,
       maxPerRun:
-        typeof (maintenanceRaw?.routineMining as Record<string, unknown> | undefined)?.maxPerRun === "number" &&
-        ((maintenanceRaw?.routineMining as Record<string, unknown>).maxPerRun as number) > 0
-          ? Math.floor((maintenanceRaw?.routineMining as Record<string, unknown>).maxPerRun as number)
+        typeof routineMiningRaw?.maxPerRun === "number" && (routineMiningRaw.maxPerRun as number) > 0
+          ? Math.floor(routineMiningRaw.maxPerRun as number)
           : 2,
+      timezone:
+        typeof routineMiningRaw?.timezone === "string" && routineMiningRaw.timezone.trim().length > 0
+          ? routineMiningRaw.timezone.trim()
+          : "UTC",
     },
     contradictions: parseContradictionsConfig(maintenanceRaw?.contradictions as Record<string, unknown> | undefined),
   };

--- a/extensions/memory-hybrid/config/types/maintenance.ts
+++ b/extensions/memory-hybrid/config/types/maintenance.ts
@@ -209,6 +209,11 @@ export type MaintenanceConfig = {
     enabled: boolean;
     /** Max routine facts stored per run (default 2). */
     maxPerRun: number;
+    /**
+     * IANA timezone for day/hour-of-day bucketing (default "UTC"). Set to the user's local
+     * timezone so "night" routines mean local late-night, not 00:00-06:00 UTC.
+     */
+    timezone: string;
   };
   /** Free-text contradiction candidates: nightly vector-neighbor + NLI pass (living-memory B1). */
   contradictions: {

--- a/extensions/memory-hybrid/package-lock.json
+++ b/extensions/memory-hybrid/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openclaw-hybrid-memory",
-  "version": "2026.7.212",
+  "version": "2026.7.213",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openclaw-hybrid-memory",
-      "version": "2026.7.212",
+      "version": "2026.7.213",
       "hasInstallScript": true,
       "dependencies": {
         "@lancedb/lancedb": "^0.31.0",

--- a/extensions/memory-hybrid/package-lock.json
+++ b/extensions/memory-hybrid/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openclaw-hybrid-memory",
-  "version": "2026.7.213",
+  "version": "2026.7.214",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openclaw-hybrid-memory",
-      "version": "2026.7.213",
+      "version": "2026.7.214",
       "hasInstallScript": true,
       "dependencies": {
         "@lancedb/lancedb": "^0.31.0",

--- a/extensions/memory-hybrid/package.json
+++ b/extensions/memory-hybrid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-hybrid-memory",
-  "version": "2026.7.212",
+  "version": "2026.7.213",
   "type": "module",
   "description": "Give your OpenClaw agent lasting memory: structured facts, semantic search, auto-capture & recall, decay, optional credential vault. Part of Hybrid Memory v3.",
   "files": [

--- a/extensions/memory-hybrid/package.json
+++ b/extensions/memory-hybrid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-hybrid-memory",
-  "version": "2026.7.213",
+  "version": "2026.7.214",
   "type": "module",
   "description": "Give your OpenClaw agent lasting memory: structured facts, semantic search, auto-capture & recall, decay, optional credential vault. Part of Hybrid Memory v3.",
   "files": [

--- a/extensions/memory-hybrid/prompts/insight-synthesis.txt
+++ b/extensions/memory-hybrid/prompts/insight-synthesis.txt
@@ -1,6 +1,6 @@
-You are synthesizing insights about the USER of an AI assistant from observed person-signals: memories stamped with negative emotional valence, mined routines, frustration signals, and behavioral patterns from the last {{window}} days.
+You are synthesizing insights about the USER of an AI assistant from observed person-signals: memories stamped with negative emotional valence, mined routines, frustration signals, behavioral patterns, the user's active goals, and the assistant's own durable identity reflections on the relationship — over the last {{window}} days (goals and identity reflections are current-state snapshots, not windowed).
 
-An insight names a recurring friction, an unmet need, or a notable behavior shift that would genuinely help the user if understood better (example: "User repeatedly works past midnight and expresses fatigue the next morning — sleep procrastination may be hurting their focus").
+An insight names a recurring friction, an unmet need, a notable behavior shift, or a disconnect between a stated ambition and observed behavior that would genuinely help the user if understood better. Examples: "User repeatedly works past midnight and expresses fatigue the next morning — sleep procrastination may be hurting their focus." "User's goal to ship the v2 API has had no progress in 18 days despite being marked high priority, and recent sessions show rising frustration with the same blocker — worth surfacing directly."
 
 Return JSON only, in this exact shape:
 {"insights": [{"insight": "...", "whyItMatters": "...", "salience": 0.0, "topic": "wellbeing", "evidence": ["F1", "S3"]}]}
@@ -9,8 +9,8 @@ Field rules:
 - insight: 1-2 sentences, concrete and specific about the user (20-500 chars).
 - whyItMatters: 1 sentence on why this deserves attention.
 - salience: 0-1, how strongly the evidence supports it AND how much addressing it would help.
-- topic: exactly one of "wellbeing", "productivity", "tooling", "relationship", "other".
-- evidence: the reference codes (F#/S#) of the specific items below that support the insight. Cite at least {{minEvidence}}. Only cite codes that exist below.
+- topic: exactly one of "wellbeing", "productivity", "growth", "tooling", "relationship", "other". Use "growth" for insights grounded mainly in the user's stated goals/ambitions (G# evidence).
+- evidence: the reference codes (F#/S#/G#/I#) of the specific items below that support the insight. Cite at least {{minEvidence}}. Only cite codes that exist below.
 
 Hard rules:
 - Return at most {{maxPerRun}} insights. Zero is a valid answer ({"insights": []}) — do not invent patterns.
@@ -29,3 +29,9 @@ Recent behavioral patterns (F# codes):
 
 Frustration signals (S# codes):
 {{signals}}
+
+User's active goals (G# codes):
+{{goals}}
+
+Assistant's durable identity reflections on the relationship (I# codes):
+{{identity}}

--- a/extensions/memory-hybrid/services/insight-synthesis.ts
+++ b/extensions/memory-hybrid/services/insight-synthesis.ts
@@ -2,15 +2,18 @@
  * Insight synthesis (proactive research loop, step A1 — docs/PROACTIVE-RESEARCH.md).
  *
  * Nightly LLM pass over person-signals the living-memory layer already captures — negative-valence
- * facts, mined routines, frustration signals, behavioral patterns — synthesizing at most a couple
- * of evidence-linked `insight` facts about the USER ("recurring friction X deserves attention").
- * Evidence is presented to the model as numbered reference codes and mapped back to real ids on
- * parse; insights citing unknown refs are dropped wholesale, so hallucinated evidence chains are
- * structurally impossible. Insights are ordinary decayable facts: if the pattern stops recurring
- * (or the research loop resolves it), they age out.
+ * facts, mined routines, frustration signals, behavioral patterns, the user's active goals, and the
+ * assistant's own durable identity reflections on the relationship — synthesizing at most a couple
+ * of evidence-linked `insight` facts about the USER ("recurring friction X deserves attention", or
+ * "stated ambition Y has stalled despite being a priority"). Evidence is presented to the model as
+ * numbered reference codes and mapped back to real ids on parse; insights citing unknown refs are
+ * dropped wholesale, so hallucinated evidence chains are structurally impossible. Insights are
+ * ordinary decayable facts: if the pattern stops recurring (or the research loop resolves it), they
+ * age out.
  */
 import type { DatabaseSync } from "node:sqlite";
 import type OpenAI from "openai";
+import type { IdentityReflectionStore } from "../backends/identity-reflection-store.js";
 import {
   capTimeoutByMaintenanceRunDeadline,
   getMaintenanceRunAbortSignal,
@@ -20,8 +23,11 @@ import { fillPrompt, loadPrompt } from "../utils/prompt-loader.js";
 import { chatCompleteWithRetry, LLMRetryError, resolveMaintenanceChatTimeoutMs } from "./chat.js";
 import { CostFeature } from "./cost-feature-labels.js";
 import { capturePluginError } from "./error-reporter.js";
+import { listActiveGoals } from "./goal-registry.js";
+import type { Goal } from "./goal-stewardship-types.js";
+import { DEFAULT_IDENTITY_REFLECTION_QUESTIONS } from "./identity-reflection.js";
 
-export const INSIGHT_TOPICS = ["wellbeing", "productivity", "tooling", "relationship", "other"] as const;
+export const INSIGHT_TOPICS = ["wellbeing", "productivity", "growth", "tooling", "relationship", "other"] as const;
 export type InsightTopic = (typeof INSIGHT_TOPICS)[number];
 
 export interface InsightSynthesisFactsDb {
@@ -59,8 +65,16 @@ export interface InsightSynthesisResult {
 }
 
 interface EvidenceRef {
-  kind: "fact" | "signal";
+  kind: "fact" | "signal" | "goal" | "identity";
   id: string;
+  /**
+   * Frozen display text for goal/identity refs. Facts/signals are re-read live from their tables
+   * downstream (research-trigger, `research pick`), which is fine — those rows are stable. Goal
+   * state and identity reflections can change by the time the research loop re-reads provenance
+   * (a queue fact can sit `in-progress` up to 24h), so their evidence text is captured once, here,
+   * at synthesis time — provenance should show what was actually true when the pattern was noticed.
+   */
+  text?: string;
 }
 
 interface ParsedInsight {
@@ -85,6 +99,70 @@ export function slugifyInsight(text: string): string {
 function oneLine(text: string, maxChars = 200): string {
   const collapsed = text.replace(/\s+/g, " ").trim();
   return collapsed.length > maxChars ? `${collapsed.slice(0, maxChars - 1)}…` : collapsed;
+}
+
+function daysSince(iso: string | null, nowSec: number): number | null {
+  if (!iso) return null;
+  const ms = Date.parse(iso);
+  if (Number.isNaN(ms)) return null;
+  return Math.max(0, (nowSec - ms / 1000) / 86_400);
+}
+
+function formatGoalEvidence(g: Goal, nowSec: number): string {
+  const ageDays = daysSince(g.createdAt, nowSec);
+  const assessedDays = daysSince(g.lastAssessedAt, nowSec);
+  const assessed = assessedDays === null ? "never assessed" : `last assessed ${Math.floor(assessedDays)}d ago`;
+  const blockers =
+    g.currentBlockers.length > 0 ? `; blockers: ${oneLine(g.currentBlockers.join("; "), 120)}` : "; no blockers";
+  return `Goal "${oneLine(g.label, 80)}" (priority: ${g.priority}, status: ${g.status}, active ${ageDays === null ? "?" : Math.floor(ageDays)}d, ${assessed}${blockers})`;
+}
+
+const GOAL_PRIORITY_RANK: Record<Goal["priority"], number> = { critical: 0, high: 1, normal: 2, low: 3 };
+
+/**
+ * Active (non-terminal) goals as evidence — grounds insights in what the user is actually working
+ * toward, not just friction (goal-registry is file-based; a read failure must not sink the whole
+ * nightly run, so this is best-effort like every other optional evidence source here).
+ *
+ * `listActiveGoals` returns files in `readdir()` order, which is not a meaningful ranking and isn't
+ * guaranteed stable across filesystems — sort by priority then recency before capping to the top 10
+ * so which goals get surfaced is deterministic and actually reflects urgency, not directory order.
+ */
+async function loadActiveGoalsSafely(
+  goalsDir: string,
+  nowSec: number,
+  logger: { warn(m: string): void },
+): Promise<Array<{ id: string; text: string }>> {
+  try {
+    const active = await listActiveGoals(goalsDir);
+    active.sort((a, b) => {
+      const byPriority = GOAL_PRIORITY_RANK[a.priority] - GOAL_PRIORITY_RANK[b.priority];
+      if (byPriority !== 0) return byPriority;
+      return (Date.parse(b.createdAt) || 0) - (Date.parse(a.createdAt) || 0);
+    });
+    return active.slice(0, 10).map((g) => ({ id: g.id, text: formatGoalEvidence(g, nowSec) }));
+  } catch (err) {
+    logger.warn(`memory-hybrid: insight-synthesis — goal evidence unavailable: ${err}`);
+    return [];
+  }
+}
+
+/**
+ * The assistant's own durable self-model (identity-reflection answers "what patterns define good
+ * partnership with the user?", "what do I reliably protect?", ...) as evidence — this is the
+ * "grounded in who I am and how that relates to who I want to be" half of the loop. Only
+ * `durability: "durable"` entries qualify; `"temporary"` ones are the store's own signal that they
+ * shouldn't anchor a research decision. Bounded to one entry per fixed question (<=5 total).
+ */
+function loadDurableIdentityEntries(store: IdentityReflectionStore): Array<{ id: string; text: string }> {
+  const out: Array<{ id: string; text: string }> = [];
+  for (const q of DEFAULT_IDENTITY_REFLECTION_QUESTIONS) {
+    const entry = store.getLatestByQuestion(q.key);
+    if (entry && entry.durability === "durable") {
+      out.push({ id: entry.id, text: `[${entry.questionKey}] ${q.prompt} → ${oneLine(entry.insight, 220)}` });
+    }
+  }
+  return out;
 }
 
 function parseInsightResponse(raw: string): { insights: ParsedInsight[]; parseOk: boolean } {
@@ -122,7 +200,15 @@ export async function runInsightSynthesis(
   factsDb: InsightSynthesisFactsDb,
   openai: OpenAI,
   cfg: InsightSynthesisConfig,
-  opts: { dryRun: boolean; verbose?: boolean; nowSec?: number },
+  opts: {
+    dryRun: boolean;
+    verbose?: boolean;
+    nowSec?: number;
+    /** Absolute path to the goal registry dir. Omit/null to skip goal evidence (goal stewardship off). */
+    goalsDir?: string | null;
+    /** Identity-reflection store. Omit/null to skip identity evidence (identity reflection off). */
+    identityStore?: IdentityReflectionStore | null;
+  },
   logger: { info(m: string): void; warn(m: string): void },
 ): Promise<InsightSynthesisResult> {
   const none: InsightSynthesisResult = {
@@ -180,14 +266,19 @@ export async function runInsightSynthesis(
     user_message: string | null;
     created_at: number;
   }>;
+  // Goals/identity are current-state snapshots, not windowed like the four sources above — an
+  // active goal or a durable self-model entry is relevant regardless of when it was created.
+  const goals = opts.goalsDir ? await loadActiveGoalsSafely(opts.goalsDir, nowSec, logger) : [];
+  const identityEntries = opts.identityStore ? loadDurableIdentityEntries(opts.identityStore) : [];
 
-  const evidenceItems = negValence.length + routines.length + patterns.length + signals.length;
+  const evidenceItems =
+    negValence.length + routines.length + patterns.length + signals.length + goals.length + identityEntries.length;
   if (evidenceItems < 5) {
     logger.info(`memory-hybrid: insight-synthesis — insufficient evidence (${evidenceItems}/5); skipping`);
     return { ...none, evidenceItems };
   }
 
-  // Numbered reference codes: the model cites F#/S#, the parser maps them back to real ids.
+  // Numbered reference codes: the model cites F#/S#/G#/I#, the parser maps them back to real ids.
   const refs = new Map<string, EvidenceRef>();
   let factRef = 0;
   const factLine = (id: string, text: string, suffix = ""): string => {
@@ -207,6 +298,20 @@ export async function runInsightSynthesis(
       return `- ${code}: ${s.signal_type} (${s.polarity ?? "negative"}, conf ${(s.confidence ?? 0).toFixed(2)}, ${when}): ${oneLine(s.user_message ?? "", 160)}`;
     })
     .join("\n");
+  const goalBlock = goals
+    .map((g, i) => {
+      const code = `G${i + 1}`;
+      refs.set(code, { kind: "goal", id: g.id, text: g.text });
+      return `- ${code}: ${g.text}`;
+    })
+    .join("\n");
+  const identityBlock = identityEntries
+    .map((e, i) => {
+      const code = `I${i + 1}`;
+      refs.set(code, { kind: "identity", id: e.id, text: e.text });
+      return `- ${code}: ${e.text}`;
+    })
+    .join("\n");
 
   const prompt = fillPrompt(loadPrompt("insight-synthesis"), {
     window: String(cfg.windowDays),
@@ -216,6 +321,8 @@ export async function runInsightSynthesis(
     routines: routineBlock || "- (none)",
     patterns: patternBlock || "- (none)",
     signals: signalBlock || "- (none)",
+    goals: goalBlock || "- (none)",
+    identity: identityBlock || "- (none)",
   });
 
   let rawResponse: string;
@@ -271,10 +378,14 @@ export async function runInsightSynthesis(
     }
     const sourceFactIds: string[] = [];
     const sourceEventIds: string[] = [];
+    const sourceGoalEvidence: Array<{ id: string; text: string }> = [];
+    const sourceIdentityEvidence: Array<{ id: string; text: string }> = [];
     for (const code of item.evidence) {
       const ref = refs.get(code) as EvidenceRef;
       if (ref.kind === "fact") sourceFactIds.push(ref.id);
-      else sourceEventIds.push(`implicit_signal:${ref.id}`);
+      else if (ref.kind === "signal") sourceEventIds.push(`implicit_signal:${ref.id}`);
+      else if (ref.kind === "goal") sourceGoalEvidence.push({ id: ref.id, text: ref.text ?? "" });
+      else sourceIdentityEvidence.push({ id: ref.id, text: ref.text ?? "" });
     }
     const entry = factsDb.store({
       text: item.whyItMatters ? `Insight: ${item.insight} — ${item.whyItMatters}` : `Insight: ${item.insight}`,
@@ -290,6 +401,8 @@ export async function runInsightSynthesis(
         salience: item.salience,
         sourceFactIds,
         sourceEventIds,
+        sourceGoalEvidence,
+        sourceIdentityEvidence,
       }),
     });
     stored++;

--- a/extensions/memory-hybrid/services/quiet-window.ts
+++ b/extensions/memory-hybrid/services/quiet-window.ts
@@ -33,6 +33,33 @@ export function localMinutesInTimeZone(at: Date, timeZone: string): number {
   }
 }
 
+const WEEKDAY_SHORT_UTC0 = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+/**
+ * Local weekday (0=Sunday..6=Saturday, matching `Date#getUTCDay`) and hour-of-day in `timeZone`.
+ * Used by behavioral time-of-day mining (routine-miner) where bucketing in UTC instead of the
+ * user's local time silently mislabels "late at night" for anyone outside UTC.
+ */
+export function localWeekdayAndHourInTimeZone(at: Date, timeZone: string): { weekday: number; hour: number } {
+  try {
+    const formatter = new Intl.DateTimeFormat("en-US", {
+      timeZone: timeZone || "UTC",
+      weekday: "short",
+      hour: "2-digit",
+      hour12: false,
+      hourCycle: "h23",
+    });
+    const parts = formatter.formatToParts(at);
+    const weekdayStr = parts.find((p) => p.type === "weekday")?.value ?? "";
+    let hour = Number.parseInt(parts.find((p) => p.type === "hour")?.value ?? "0", 10);
+    if (hour === 24) hour = 0;
+    const weekday = WEEKDAY_SHORT_UTC0.indexOf(weekdayStr);
+    return { weekday: weekday >= 0 ? weekday : at.getUTCDay(), hour };
+  } catch {
+    return { weekday: at.getUTCDay(), hour: at.getUTCHours() };
+  }
+}
+
 /** Returns true when wall-clock time in `qw.tz` is inside [start, end). */
 export function isInQuietWindowAt(qw: NonNullable<WorkerLeasesConfig["quietWindow"]>, at: Date): boolean {
   if (!qw.enabled) return false;

--- a/extensions/memory-hybrid/services/research-trigger.ts
+++ b/extensions/memory-hybrid/services/research-trigger.ts
@@ -53,10 +53,17 @@ function insightSlug(entity: string | null): string | null {
 function countEvidence(provenanceJson: string | null): number {
   if (!provenanceJson) return 0;
   try {
-    const parsed = JSON.parse(provenanceJson) as { sourceFactIds?: unknown; sourceEventIds?: unknown };
+    const parsed = JSON.parse(provenanceJson) as {
+      sourceFactIds?: unknown;
+      sourceEventIds?: unknown;
+      sourceGoalEvidence?: unknown;
+      sourceIdentityEvidence?: unknown;
+    };
     const facts = Array.isArray(parsed.sourceFactIds) ? parsed.sourceFactIds.length : 0;
     const events = Array.isArray(parsed.sourceEventIds) ? parsed.sourceEventIds.length : 0;
-    return facts + events;
+    const goals = Array.isArray(parsed.sourceGoalEvidence) ? parsed.sourceGoalEvidence.length : 0;
+    const identity = Array.isArray(parsed.sourceIdentityEvidence) ? parsed.sourceIdentityEvidence.length : 0;
+    return facts + events + goals + identity;
   } catch {
     return 0;
   }

--- a/extensions/memory-hybrid/services/routine-miner.ts
+++ b/extensions/memory-hybrid/services/routine-miner.ts
@@ -10,6 +10,7 @@
  * normalized query head; dedupe by entity=routine:<slug> keeps re-runs idempotent.
  */
 import type { DatabaseSync } from "node:sqlite";
+import { localWeekdayAndHourInTimeZone } from "./quiet-window.js";
 
 const HOUR_BANDS = ["night", "morning", "afternoon", "evening"] as const; // 0-6, 6-12, 12-18, 18-24
 const DOW_NAMES = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"] as const;
@@ -37,12 +38,13 @@ function normalizeTopic(query: string): string | null {
 /** Deterministic candidate detection over recall_events (last `sinceDays`). */
 export function findRoutineCandidates(
   db: DatabaseSync,
-  opts?: { sinceDays?: number; minOccasions?: number; minWeeks?: number; nowSec?: number },
+  opts?: { sinceDays?: number; minOccasions?: number; minWeeks?: number; nowSec?: number; timezone?: string },
 ): RoutineCandidate[] {
   const nowSec = opts?.nowSec ?? Math.floor(Date.now() / 1000);
   const sinceSec = nowSec - (opts?.sinceDays ?? 42) * 86_400;
   const minOccasions = opts?.minOccasions ?? 3;
   const minWeeks = opts?.minWeeks ?? 3;
+  const timezone = opts?.timezone ?? "UTC";
 
   const rows = db
     .prepare(
@@ -57,9 +59,10 @@ export function findRoutineCandidates(
   for (const row of rows) {
     const topic = normalizeTopic(row.query);
     if (!topic) continue;
-    const d = new Date(row.occurred_at * 1000);
-    const dayOfWeek = d.getUTCDay();
-    const band = HOUR_BANDS[Math.floor(d.getUTCHours() / 6)];
+    // Bucketed in `timezone` (default UTC), not necessarily the server's local time — a "night"
+    // routine should mean the user's local late-night, not 00:00-06:00 UTC.
+    const { weekday: dayOfWeek, hour } = localWeekdayAndHourInTimeZone(new Date(row.occurred_at * 1000), timezone);
+    const band = HOUR_BANDS[Math.floor(hour / 6)];
     const week = Math.floor(row.occurred_at / (7 * 86_400));
     const key = `${dayOfWeek}\u0000${band}\u0000${topic}`;
     const bucket = buckets.get(key) ?? {
@@ -106,7 +109,7 @@ export interface RoutineMinerFactsDb {
 /** Mine + store up to `maxPerRun` routine facts (entity-keyed dedupe keeps re-runs idempotent). */
 export function runRoutineMining(
   factsDb: RoutineMinerFactsDb,
-  opts?: { maxPerRun?: number; sinceDays?: number; nowSec?: number },
+  opts?: { maxPerRun?: number; sinceDays?: number; nowSec?: number; timezone?: string },
 ): { candidates: number; stored: number } {
   const db = factsDb.getRawDb();
   const candidates = findRoutineCandidates(db, opts);

--- a/extensions/memory-hybrid/setup/cli-context/cli-services.ts
+++ b/extensions/memory-hybrid/setup/cli-context/cli-services.ts
@@ -1,6 +1,7 @@
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import type { ClawdbotPluginApi } from "openclaw/plugin-sdk/core";
+import { workspaceRootForCli } from "../../cli/config-feature-summaries.js";
 import type { HandlerContext } from "../../cli/handlers.js";
 import type { HybridMemCliContext } from "../../cli/register.js";
 import type { FindDuplicatesResult } from "../../cli/types.js";
@@ -21,6 +22,7 @@ import { type DreamCycleResult, makeDreamCycleRunId, runDreamCycle } from "../..
 import { runEntityEnrichmentForCli } from "../../services/entity-enrichment-cli.js";
 import { runExport } from "../../services/export-memory.js";
 import { runFindDuplicates } from "../../services/find-duplicates.js";
+import { resolveGoalsDir } from "../../services/goal-registry.js";
 import { runIdentityReflection } from "../../services/identity-reflection.js";
 import { runInsightSynthesis } from "../../services/insight-synthesis.js";
 import { runBuildLanguageKeywords } from "../../services/language-keywords-build.js";
@@ -386,6 +388,13 @@ export function buildCliContextServices(
       await guardWalUnlessDryRun("cli_insight_synthesis", opts.dryRun);
       const requestedModel = cfg.research.insights.model;
       const { defaultModel, fallbackModels } = resolveReflectionModelAndFallbacks(cfg, "maintenance", requestedModel);
+      // Goal/identity evidence grounds insights in ambitions and the relationship, not just
+      // friction — same enable semantics as goal context injection (autoEnableWhenGoalsPresent
+      // lets ad-hoc goals count even without opting into full stewardship).
+      const goalsDir =
+        cfg.goalStewardship.enabled || cfg.goalStewardship.autoEnableWhenGoalsPresent
+          ? resolveGoalsDir(workspaceRootForCli(), cfg.goalStewardship.goalsDir)
+          : null;
       return runInsightSynthesis(
         factsDb,
         openai,
@@ -396,7 +405,7 @@ export function buildCliContextServices(
           model: requestedModel ?? defaultModel,
           fallbackModels: fallbackModels ?? [],
         },
-        opts,
+        { ...opts, goalsDir, identityStore: ctx.identityReflectionStore },
         logSink,
       );
     },

--- a/extensions/memory-hybrid/tests/insight-synthesis.test.ts
+++ b/extensions/memory-hybrid/tests/insight-synthesis.test.ts
@@ -1,15 +1,19 @@
 /**
  * Proactive research loop A1: insight synthesis. The LLM only ever cites numbered evidence refs
- * (F#/S#) that the service maps back to real fact/signal ids — hallucinated evidence is dropped
- * wholesale, insights dedupe by slug entity, and caps/windows are enforced deterministically.
+ * (F#/S#/G#/I#) that the service maps back to real fact/signal/goal/identity-reflection ids —
+ * hallucinated evidence is dropped wholesale, insights dedupe by slug entity, and caps/windows are
+ * enforced deterministically.
  */
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { IdentityReflectionStore } from "../backends/identity-reflection-store.js";
 import { FactsDB } from "../backends/facts-db.js";
 import { parseResearchConfig } from "../config/parsers/research.js";
+import { writeGoal } from "../services/goal-registry.js";
 import { runInsightSynthesis, slugifyInsight } from "../services/insight-synthesis.js";
+import { baseGoal } from "./helpers/goal-helpers.js";
 
 let dir: string;
 let db: FactsDB;
@@ -215,6 +219,139 @@ describe("insight synthesis", () => {
 
     const r = await runInsightSynthesis(db, mockOpenai(insightJson([])), cfg, { dryRun: false }, logger);
     expect(r.evidenceItems).toBe(5); // the two out-of-window items are not offered
+  });
+});
+
+describe("insight synthesis — goal/identity evidence", () => {
+  it("counts active goals toward the evidence floor and cites them as G# refs", async () => {
+    const goalsDir = join(dir, "goals");
+    // Distinct createdAt per goal (descending as i increases) makes the priority+recency sort in
+    // loadActiveGoalsSafely fully deterministic — G1/G2 must resolve to goal-0/goal-1 regardless
+    // of the filesystem's unspecified readdir() order.
+    for (let i = 0; i < 5; i++) {
+      await writeGoal(
+        goalsDir,
+        baseGoal({
+          id: `goal-${i}`,
+          label: `ship feature ${i}`,
+          status: "active",
+          priority: "high",
+          createdAt: `2026-01-0${5 - i}T00:00:00.000Z`,
+          currentBlockers: i === 0 ? ["waiting on design review"] : [],
+        }),
+      );
+    }
+    const goalInsight = {
+      insight: "User has five active high-priority goals with little visible progress lately",
+      whyItMatters: "Surfacing the backlog may help re-prioritize",
+      salience: 0.7,
+      topic: "growth",
+      evidence: ["G1", "G2"],
+    };
+
+    const r = await runInsightSynthesis(
+      db,
+      mockOpenai(insightJson([goalInsight])),
+      cfg,
+      { dryRun: false, goalsDir },
+      logger,
+    );
+
+    expect(r.evidenceItems).toBe(5);
+    expect(r.stored).toBe(1);
+    const row = db.getRawDb().prepare("SELECT value, provenance_json FROM facts WHERE category = 'insight'").get() as {
+      value: string;
+      provenance_json: string;
+    };
+    expect(row.value).toBe("growth");
+    const prov = JSON.parse(row.provenance_json);
+    expect(prov.sourceGoalEvidence).toHaveLength(2);
+    expect(prov.sourceGoalEvidence[0].id).toBe("goal-0");
+    expect(prov.sourceGoalEvidence[0].text).toContain("ship feature 0");
+    expect(prov.sourceGoalEvidence[0].text).toContain("waiting on design review");
+    expect(prov.sourceFactIds).toEqual([]);
+    expect(prov.sourceEventIds).toEqual([]);
+  });
+
+  it("skips terminal goals and tolerates a missing goals dir", async () => {
+    const goalsDir = join(dir, "goals");
+    await writeGoal(goalsDir, baseGoal({ id: "done-goal", status: "completed" }));
+    seedBaseline(Math.floor(Date.now() / 1000));
+
+    const withGoals = await runInsightSynthesis(
+      db,
+      mockOpenai(insightJson([])),
+      cfg,
+      { dryRun: false, goalsDir },
+      logger,
+    );
+    expect(withGoals.evidenceItems).toBe(5); // the completed goal is not active evidence
+
+    const withMissingDir = await runInsightSynthesis(
+      db,
+      mockOpenai(insightJson([])),
+      cfg,
+      { dryRun: false, goalsDir: join(dir, "does-not-exist") },
+      logger,
+    );
+    expect(withMissingDir.evidenceItems).toBe(5); // best-effort: a missing dir yields zero goals, not an error
+  });
+
+  it("cites only durable identity reflections, excluding temporary ones", async () => {
+    const identityStore = new IdentityReflectionStore(join(dir, "identity.db"));
+    try {
+      identityStore.create({
+        runId: "run-1",
+        questionKey: "partnership",
+        questionText: "What patterns define good partnership with the user?",
+        insight: "The user responds well to direct, concise updates rather than long explanations",
+        durability: "durable",
+        confidence: 0.8,
+      });
+      identityStore.create({
+        runId: "run-1",
+        questionKey: "tradeoffs",
+        questionText: "What kinds of tradeoffs do I keep making?",
+        insight: "This week leaned toward speed over thoroughness on minor fixes",
+        durability: "temporary",
+        confidence: 0.5,
+      });
+      seedBaseline(Math.floor(Date.now() / 1000));
+
+      const identityInsight = {
+        insight: "The user's preference for concise updates connects to their late-night frustration",
+        whyItMatters: "Terser check-ins at night may reduce friction",
+        salience: 0.6,
+        topic: "relationship",
+        evidence: ["F1", "I1"],
+      };
+
+      const r = await runInsightSynthesis(
+        db,
+        mockOpenai(insightJson([identityInsight])),
+        cfg,
+        { dryRun: false, identityStore },
+        logger,
+      );
+
+      expect(r.evidenceItems).toBe(6); // 5 baseline + 1 durable identity entry (temporary excluded)
+      expect(r.stored).toBe(1);
+      const row = db.getRawDb().prepare("SELECT provenance_json FROM facts WHERE category = 'insight'").get() as {
+        provenance_json: string;
+      };
+      const prov = JSON.parse(row.provenance_json);
+      expect(prov.sourceIdentityEvidence).toHaveLength(1);
+      expect(prov.sourceIdentityEvidence[0].text).toContain("direct, concise updates");
+    } finally {
+      identityStore.close();
+    }
+  });
+
+  it("remains fully backward compatible when goalsDir/identityStore are omitted", async () => {
+    seedBaseline(Math.floor(Date.now() / 1000));
+    const r = await runInsightSynthesis(db, mockOpenai(insightJson([])), cfg, { dryRun: false }, logger);
+    expect(r.evidenceItems).toBe(5);
+    expect(r.semanticOutcome).toBe("success");
   });
 });
 

--- a/extensions/memory-hybrid/tests/research-cli.test.ts
+++ b/extensions/memory-hybrid/tests/research-cli.test.ts
@@ -129,6 +129,45 @@ describe("research pick", () => {
     expect(lastJson().topicId).toBe(first.topicId); // same-night retry gets the same topic
   });
 
+  it("includes pre-rendered goal/identity evidence alongside facts, with no extra reads needed", async () => {
+    const evidenceId = db.store({
+      text: "Working past midnight again, exhausted",
+      entity: null,
+      key: null,
+      value: null,
+      category: "fact",
+      importance: 0.5,
+      source: "test",
+      tags: [],
+    } as never).id;
+    db.store({
+      text: "Insight: user's active goal has stalled alongside late-night work",
+      entity: "insight:goal-and-sleep",
+      key: "concern",
+      value: "growth",
+      category: "insight",
+      importance: 0.9,
+      source: "insight-synthesis",
+      tags: ["insight", "auto"],
+      provenanceJson: JSON.stringify({
+        method: "insight-synthesis",
+        sourceFactIds: [evidenceId],
+        sourceEventIds: [],
+        sourceGoalEvidence: [{ id: "goal-1", text: 'Goal "ship v2" (priority: high, status: active, active 40d)' }],
+        sourceIdentityEvidence: [{ id: "id-1", text: "[partnership] concise updates work best" }],
+      }),
+    } as never);
+    expect(runResearchTrigger(db, policy).picked).toBe(1);
+
+    await registry.get("research pick")?.();
+    const out = lastJson();
+    expect(out.evidence).toEqual([
+      { id: evidenceId, text: "Working past midnight again, exhausted" },
+      { id: "goal-1", text: 'Goal "ship v2" (priority: high, status: active, active 40d)' },
+      { id: "id-1", text: "[partnership] concise updates work best" },
+    ]);
+  });
+
   it("ignores stale in-progress topics older than 24h", async () => {
     seedPickedTopic();
     await registry.get("research pick")?.();

--- a/extensions/memory-hybrid/tests/research-trigger.test.ts
+++ b/extensions/memory-hybrid/tests/research-trigger.test.ts
@@ -130,4 +130,32 @@ describe("research trigger policy", () => {
     expect(r.eligible).toBe(2);
     expect(queueFacts()[0].entity).toBe("research:concern-a");
   });
+
+  it("counts goal/identity evidence toward the evidence gate — a goal-only insight is still eligible", () => {
+    db.store({
+      text: "Insight: user's active goals show a stagnation pattern",
+      entity: "insight:goal-stagnation",
+      key: "concern",
+      value: "growth",
+      category: "insight",
+      importance: 0.9,
+      source: "insight-synthesis",
+      tags: ["insight", "auto"],
+      provenanceJson: JSON.stringify({
+        method: "insight-synthesis",
+        sourceFactIds: [],
+        sourceEventIds: [],
+        sourceGoalEvidence: [
+          { id: "goal-1", text: 'Goal "ship v2" (priority: high, status: active, active 40d, ...)' },
+        ],
+        sourceIdentityEvidence: [{ id: "id-1", text: "[partnership] ... durable" }],
+      }),
+    } as never);
+
+    const r = runResearchTrigger(db, policy);
+
+    expect(r.picked).toBe(1);
+    expect(r.skippedEvidence).toBe(0);
+    expect(queueFacts()[0].entity).toBe("research:goal-stagnation");
+  });
 });

--- a/extensions/memory-hybrid/tests/routine-mining.test.ts
+++ b/extensions/memory-hybrid/tests/routine-mining.test.ts
@@ -61,6 +61,23 @@ describe("routine mining", () => {
     expect(candidates[0].distinctWeeks).toBe(4);
   });
 
+  it("buckets by the configured local timezone, not UTC", () => {
+    // 09:00 UTC Tuesday = "morning" in UTC, but 04:00 Tuesday ("night") five hours west
+    // (Etc/GMT+5 is a fixed UTC-5 offset — no DST, deterministic).
+    seedWeekly("late check in before bed", 4, TUESDAY_9AM);
+
+    const utcCandidates = findRoutineCandidates(db.getRawDb(), { nowSec: TUESDAY_9AM + 5 * WEEK });
+    expect(utcCandidates[0]?.band).toBe("morning");
+
+    const localCandidates = findRoutineCandidates(db.getRawDb(), {
+      nowSec: TUESDAY_9AM + 5 * WEEK,
+      timezone: "Etc/GMT+5",
+    });
+    expect(localCandidates).toHaveLength(1);
+    expect(localCandidates[0].dayOfWeek).toBe(2); // still Tuesday at 04:00 local
+    expect(localCandidates[0].band).toBe("night");
+  });
+
   it("stores routine facts as decayable memories, idempotently, respecting the cap", () => {
     seedWeekly("weekly status report preparation", 4, TUESDAY_9AM);
     seedWeekly("sprint retro follow ups", 3, TUESDAY_9AM + 6 * 3600); // Tuesday afternoon

--- a/extensions/memory-hybrid/tests/run-upgrade.test.ts
+++ b/extensions/memory-hybrid/tests/run-upgrade.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -11,6 +11,7 @@ import {
   readPluginPackageVersion,
   detectDualPluginInstallVersionMismatch,
   buildDualInstallReconciliationGuidance,
+  buildNpmProjectNewerGuidance,
   syncKnownNpmProjectPinWhenExtensionsCanonical,
   removeRedundantNpmProjectTreeWhenExtensionsCanonical,
   UPGRADE_REQUIRED_BUNDLE_PATHS,
@@ -221,7 +222,10 @@ describe("runUpgrade helpers", () => {
     const projectRoot = join(tmp, "npm", "projects", "openclaw-hybrid-memory");
     const pluginDir = join(projectRoot, "node_modules", "openclaw-hybrid-memory");
     mkdirSync(pluginDir, { recursive: true });
-    writeFileSync(join(projectRoot, "package.json"), JSON.stringify({ dependencies: { "openclaw-hybrid-memory": "2026.6.291" } }));
+    writeFileSync(
+      join(projectRoot, "package.json"),
+      JSON.stringify({ dependencies: { "openclaw-hybrid-memory": "2026.6.291" } }),
+    );
     writeFileSync(join(pluginDir, "openclaw.plugin.json"), "{}");
     writeFileSync(join(pluginDir, "package.json"), JSON.stringify({ version: "2026.6.291" }));
     const res = syncKnownNpmProjectPinWhenExtensionsCanonical({
@@ -240,7 +244,10 @@ describe("runUpgrade helpers", () => {
       mkdirSync(dir, { recursive: true });
       writeFileSync(join(dir, "openclaw.plugin.json"), "{}");
     }
-    writeFileSync(join(projectRoot, "package.json"), JSON.stringify({ dependencies: { "openclaw-hybrid-memory": "2026.6.291" } }));
+    writeFileSync(
+      join(projectRoot, "package.json"),
+      JSON.stringify({ dependencies: { "openclaw-hybrid-memory": "2026.6.291" } }),
+    );
     writeFileSync(join(npmPluginDir, "package.json"), JSON.stringify({ version: "2026.6.291" }));
     writeFileSync(join(extDir, "package.json"), JSON.stringify({ version: "2026.6.291" }));
 
@@ -254,13 +261,68 @@ describe("runUpgrade helpers", () => {
     expect(synced.attempted).toBe(false);
     expect(synced.updated).toBe(false);
 
-    writeFileSync(join(projectRoot, "package.json"), JSON.stringify({ dependencies: { "openclaw-hybrid-memory": "2026.6.261" } }));
+    writeFileSync(
+      join(projectRoot, "package.json"),
+      JSON.stringify({ dependencies: { "openclaw-hybrid-memory": "2026.6.261" } }),
+    );
     writeFileSync(join(npmPluginDir, "package.json"), JSON.stringify({ version: "2026.6.261" }));
     const withoutDetected = syncKnownNpmProjectPinWhenExtensionsCanonical({
       extensionsPluginDir: extDir,
       version: "2026.6.291",
     });
     expect(withoutDetected.attempted).toBe(false);
+  });
+
+  it("syncKnownNpmProjectPinWhenExtensionsCanonical refuses to downgrade a newer npm-project install (#2077)", () => {
+    // Reproduces the exact version pair from the reported issue: gateway is actively running
+    // npm-project 2026.7.212, extensions is a stale leftover at 2026.7.172.
+    const projectRoot = join(tmp, "npm-projects", "openclaw-hybrid-memory");
+    const npmPluginDir = join(projectRoot, "node_modules", "openclaw-hybrid-memory");
+    const extDir = join(tmp, "extensions", "openclaw-hybrid-memory");
+    for (const dir of [npmPluginDir, extDir]) {
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(join(dir, "openclaw.plugin.json"), "{}");
+    }
+    writeFileSync(
+      join(projectRoot, "package.json"),
+      JSON.stringify({ dependencies: { "openclaw-hybrid-memory": "2026.7.212" } }),
+    );
+    writeFileSync(join(npmPluginDir, "package.json"), JSON.stringify({ version: "2026.7.212" }));
+    writeFileSync(join(extDir, "package.json"), JSON.stringify({ version: "2026.7.172" }));
+
+    const res = syncKnownNpmProjectPinWhenExtensionsCanonical({
+      extensionsPluginDir: extDir,
+      version: "2026.7.172",
+      npmProjectPluginDir: npmPluginDir,
+    });
+
+    expect(res.attempted).toBe(false);
+    expect(res.updated).toBe(false);
+    expect(res.skippedReason).toBe("npm-project-not-older");
+    expect(res.npmVersion).toBe("2026.7.212");
+    expect(res.guidance).toMatch(/2026\.7\.212/);
+    expect(res.guidance).toMatch(/2026\.7\.172/);
+    expect(res.guidance).toMatch(/rm -rf/);
+
+    // No npm install was ever spawned — the pin must be byte-for-byte untouched.
+    const pkgAfter = JSON.parse(readFileSync(join(projectRoot, "package.json"), "utf-8")) as {
+      dependencies: Record<string, string>;
+    };
+    expect(pkgAfter.dependencies["openclaw-hybrid-memory"]).toBe("2026.7.212");
+  });
+
+  it("buildNpmProjectNewerGuidance points at the extensions copy as the stale leftover, not npm-project (#2077)", () => {
+    const guidance = buildNpmProjectNewerGuidance({
+      npmProjectPluginDir: "/home/x/.openclaw/npm/projects/openclaw-hybrid-memory/node_modules/openclaw-hybrid-memory",
+      npmVersion: "2026.7.212",
+      extensionsPluginDir: "/home/x/.openclaw/extensions/openclaw-hybrid-memory",
+      extVersion: "2026.7.172",
+    });
+    expect(guidance).toMatch(/2026\.7\.212/);
+    expect(guidance).toMatch(/2026\.7\.172/);
+    expect(guidance).toMatch(/rm -rf \/home\/x\/\.openclaw\/extensions\/openclaw-hybrid-memory/);
+    // Must not tell the operator to remove the npm-project copy — that's the newer one here.
+    expect(guidance).not.toMatch(/rm -rf \/home\/x\/\.openclaw\/npm/);
   });
 
   it("verifyUpgradePluginBundle passes for the live plugin root", () => {

--- a/extensions/memory-hybrid/tests/validate-cron-exit-cli-1225.test.ts
+++ b/extensions/memory-hybrid/tests/validate-cron-exit-cli-1225.test.ts
@@ -265,7 +265,7 @@ Error: LanceDB commit conflict detected
         },
         maintenance: {
           decay: { mode: "half-life" as const, secondChance: true },
-          routineMining: { enabled: true, maxPerRun: 2 },
+          routineMining: { enabled: true, maxPerRun: 2, timezone: "UTC" },
           contradictions: { freeText: true, similarityFloor: 0.85, maxPairsPerRun: 40, minConfidence: 0.7 },
           failureReporting: {
             enabled: true,


### PR DESCRIPTION
Insight synthesis previously reasoned only from friction signals (negative
valence, frustration, routines, patterns). It now also reads the user's
active goals (goal registry) and the assistant's own durable identity
reflections on the relationship, so an insight can name a stalled ambition
or connect a pattern to the relationship, not just recurring friction.

- services/insight-synthesis.ts: G#/I# evidence refs alongside F#/S#, new
  "growth" topic, goal/identity evidence frozen into provenance at synthesis
  time (goal state can change before the research loop re-reads it days
  later). Goals ranked by priority then recency before capping to top 10 —
  readdir() order is not a meaningful ranking. Both sources optional, skip
  cleanly when goal stewardship/identity reflection are off.
- services/research-trigger.ts, cli/commands/register-research-group.ts:
  evidence-count gate and research pick/status hydration extended so a
  goal/identity-only insight isn't wrongly rejected as under-evidenced.
- setup/cli-context/cli-services.ts: wires goalsDir + identityReflectionStore
  into the runInsightSynthesis call site.

Also fixes routine-miner bucketing recall timestamps by getUTCHours()/
getUTCDay(), mislabeling "night" routines for anyone outside UTC — the
exact sleep-procrastination pattern this loop targets. New
maintenance.routineMining.timezone config (default "UTC", unchanged
default behavior) drives Intl-based local-time bucketing via a new
localWeekdayAndHourInTimeZone() helper in quiet-window.ts.

Tests: 9 new/extended (goal evidence + ordering, durable-vs-temporary
identity filtering, backward compatibility, evidence-count parity across
research-trigger and research pick, timezone bucketing). Full suite green
(713 files / 9369 tests), tsc --noEmit clean, verify:gate clean, biome
lint/format clean.

Bumped to 2026.7.213 with a CHANGELOG entry.