### PR TITLE
chore(release): 2026.7.216 — changelog, release notes, version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,36 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [2026.7.216] - 2026-07-14
+
+### Fixed / Added — Open issue sweep (#2088, #2091, #2093, #2095, #2098, #2099, #2104–#2108)
+
+Eleven issues — the tail of the #2079–#2100 sweep plus four filed after it shipped — fixed together in one PR.
+
+**Storage & dedupe**
+- Fixed ([#2093](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/2093)): added `vectorlessActiveFactsByCategory()` alongside the existing by-source breakdown, surfaced in `storage stats` and `storage reembed` output, so an operator can tell "mostly structured-adjacent categories" apart from a genuine indexing gap.
+- Fixed ([#2091](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/2091)): `services/consolidation.ts`'s merged-fact store call always degraded to lexical-only dedupe even with `cfg.store.fuzzyDedupe` enabled, because no embedding existed yet at store time. The embed is now computed before the store call and real LanceDB neighbour candidates are resolved and passed through, reusing the same vector for the post-store upsert instead of re-embedding. The shared candidate-resolution helper moved from `cli/vector-dedupe-helpers.ts` to `services/vector-dedupe-helpers.ts` (old path is a re-export shim) so a `services/` file can use it without inverting the documented `cli → services` layer direction.
+
+**Credentials**
+- Added ([#2104](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/2104)): historical revision support for the credential vault. Overwriting an existing credential (same `service`+`type`) now preserves the replaced value as a revision instead of discarding it — 30-day retention by default, extended on access, pinnable, purgeable. New `credential_revisions`/`credential_revision_audit` tables (same encryption as current values; `enableEncryptionAtRest`/`encryptVaultSafe`/`rekeyVaultSafe` re-encrypt revisions too), 5 new agent tools (`credential_revision_list/get/restore/purge/pin`), and matching `credentials revisions list/get/restore/purge/pin` CLI commands. Scoped to the issue's "Must have" (credential/vault history); structured fact/entity history is a follow-up.
+- Fixed ([#2099](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/2099)): the legacy-literal-`file:`-key vault warning fired on every `hybrid-mem` invocation regardless of subcommand; now scoped to `credentials`/`doctor`/`verify` or `--verbose`. `rekey-vault --dry-run` also gained a non-mutating preflight (backup-directory writability, target key-file readability).
+
+**CLI surface**
+- Added ([#2088](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/2088)): `smoke e2e` gained `--no-cleanup` (leave disposable artifacts for inspection) and a `graph-autolink` step verifying the auto-link pipeline actually creates a `RELATED_TO` edge, not just that the command exits 0.
+- Added ([#2095](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/2095)): `--quiet`/`-q` flag (plus `OPENCLAW_HYBRID_MEM_QUIET=1`) suppresses bootstrap-time log noise.
+- Added ([#2098](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/2098)): `digest batch-reject` bulk-rejects stale/low-confidence pending-review candidates across the persona/tools/crystallization queues, with duplicate detection and a dry-run preview.
+
+**Verify / doctor / observability**
+- Fixed ([#2105](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/2105)): `verify --fix --reconcile --verbose` silently dropped `--verbose` before it reached the reconcile section, and neither the vector-orphan delete path nor the SQLite-orphan rebuild loop logged anything mid-operation — a genuinely long repair looked hung for minutes. `--verbose` now threads through properly, both loops are wrapped in a 20s-cadence progress heartbeat (reusing the existing `runMaintenanceHeartbeat` helper), and the rebuild loop checks the orchestrator-wide maintenance run deadline each iteration and stops early instead of ignoring it.
+- Fixed ([#2108](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/2108)): `doctor`'s "Maintenance health" check compared every job against one flat 48-hour cutoff regardless of its actual guard cadence (1 hour to 5 days), so any longer-cadence step was guaranteed to look stale, contradicting `maintenance status`'s cadence-aware model. Now compares each job against its own guard interval (3x tolerance).
+- Added ([#2106](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/2106)): [`docs/CLI-OBSERVABILITY-CONTRACT.md`](docs/CLI-OBSERVABILITY-CONTRACT.md) documents the heartbeat/phase/summary/interruption conventions for long-running mutating commands, with a compliance audit across command families. Streaming JSON progress events are explicitly out of scope for this pass (documented decision, not an oversight).
+- Investigated ([#2107](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/2107)): the gateway's "no loaded plugin registered a memory embedding provider" warning comes from the gateway's own, architecturally separate built-in `memory-core` embedding registry — hybrid-memory intentionally replaces that subsystem rather than plugging into its provider contract. Documented the discrepancy in [`docs/LLM-AND-PROVIDERS.md`](docs/LLM-AND-PROVIDERS.md) (which diagnostics actually reflect hybrid-memory's health); a real adapter registration is a considered, deferred follow-up rather than an unverified implementation against a gateway this environment can't test against.
+
+### Notes
+- No `schemaVersion` bump — the new `credential_revisions`/`credential_revision_audit` tables are additive and created idempotently on open, matching the precedent set by prior credential-schema additions.
+- No agent-tool contract removals — 5 new tool names added (`credential_revision_list/get/restore/purge/pin`), registered in both `contracts/agent-tool-names.ts` and `openclaw.plugin.json`.
+- Full local gate green: `npx tsc --noEmit`, `npm run lint`, `npm test` (742 files / 9694 tests), `npm run verify:gate`; CI green on both Node 22 and Node 24.
+
 ## [2026.7.215] - 2026-07-12
 
 ### Fixed — Open issue sweep from a live storage-repair incident and memory smoke sweep (#2079–#2100)

--- a/extensions/memory-hybrid/package-lock.json
+++ b/extensions/memory-hybrid/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openclaw-hybrid-memory",
-  "version": "2026.7.215",
+  "version": "2026.7.216",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openclaw-hybrid-memory",
-      "version": "2026.7.215",
+      "version": "2026.7.216",
       "hasInstallScript": true,
       "dependencies": {
         "@lancedb/lancedb": "^0.31.0",

--- a/extensions/memory-hybrid/package.json
+++ b/extensions/memory-hybrid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-hybrid-memory",
-  "version": "2026.7.215",
+  "version": "2026.7.216",
   "type": "module",
   "description": "Give your OpenClaw agent lasting memory: structured facts, semantic search, auto-capture & recall, decay, optional credential vault. Part of Hybrid Memory v3.",
   "files": [

--- a/release-notes/release-notes-2026.7.216.md
+++ b/release-notes/release-notes-2026.7.216.md
@@ -1,0 +1,35 @@
+# Release v2026.7.216
+
+This release closes 11 issues: the tail of the #2079–#2100 sweep (#2088, #2091, #2093, #2095, #2098, #2099) plus four filed after it shipped (#2104–#2108).
+
+## Fixed
+
+- **Storage & dedupe** — added a by-category vectorless breakdown alongside the existing by-source one, surfaced in `storage stats`/`storage reembed` (#2093). `services/consolidation.ts`'s merged-fact store call now computes its embedding before storing and passes real LanceDB neighbour candidates into write-time dedupe instead of always degrading to lexical-only (#2091).
+- **Credentials** — the legacy-literal-`file:`-key vault warning no longer fires on every CLI invocation, only on `credentials`/`doctor`/`verify` or `--verbose`; `rekey-vault --dry-run` gained a non-mutating preflight check (#2099).
+- **`verify --fix --reconcile`** — `--verbose` was silently dropped before reaching the reconcile section, and the vector-orphan delete and SQLite-orphan rebuild loops logged nothing mid-operation, making a genuinely long repair look hung for minutes. `--verbose` now threads through, both loops emit a 20s-cadence progress heartbeat, and the rebuild loop respects the orchestrator-wide maintenance run deadline (#2105).
+- **`doctor`** — "Maintenance health" compared every job against one flat 48-hour cutoff regardless of its real cadence, false-flagging longer-cadence steps (up to 5 days) as stale and contradicting `maintenance status`. Now compares each job against its own guard interval (#2108).
+
+## Added
+
+- **Credential vault revision history** (#2104) — overwriting an existing credential preserves the replaced value as a historical revision (30-day retention by default, extended on access, pinnable, purgeable) instead of discarding it immediately. New `credential_revision_list/get/restore/purge/pin` agent tools and matching `credentials revisions ...` CLI commands; revisions are encrypted the same as current values and covered by vault rekey/encrypt. Scoped to the issue's "Must have" section.
+- `smoke e2e --no-cleanup` and a `graph-autolink` verification step that checks the auto-link pipeline actually creates a `RELATED_TO` edge (#2088).
+- `--quiet`/`-q` flag (and `OPENCLAW_HYBRID_MEM_QUIET=1`) to suppress bootstrap-time log noise (#2095).
+- `digest batch-reject` — bulk-reject stale/low-confidence pending-review candidates across the persona/tools/crystallization queues, with duplicate detection and a dry-run preview (#2098).
+- [`docs/CLI-OBSERVABILITY-CONTRACT.md`](../docs/CLI-OBSERVABILITY-CONTRACT.md) — documents the heartbeat/phase/summary/interruption conventions for long-running mutating commands, with a compliance audit across command families (#2106).
+
+## Investigated, documented (no code fix)
+
+- (#2107) The gateway's "no loaded plugin registered a memory embedding provider" warning comes from the gateway's own, separate built-in `memory-core` embedding registry — hybrid-memory intentionally replaces that subsystem rather than plugging into its provider contract. Documented in [`docs/LLM-AND-PROVIDERS.md`](../docs/LLM-AND-PROVIDERS.md) which diagnostics actually reflect hybrid-memory's health; a real adapter registration is a considered, deferred follow-up rather than an implementation this environment could verify against a live gateway.
+
+## Notes
+
+- No `schemaVersion` bump — the new revision-history tables are additive and created idempotently on vault open, matching the precedent of prior credential-schema additions.
+- No agent-tool contract removals — 5 new tool names added, registered in both `contracts/agent-tool-names.ts` and `openclaw.plugin.json`.
+- ~15 `storeWithResult()` call sites that still don't pass `vectorCandidates` (#2091's broader scope) were investigated individually and found to have structural reasons not to wire trivially (existing exact-hash dedup, synchronous transaction closures, inherently-unique timestamped content) — left as a documented follow-up.
+- `storage repair`'s pipeline and the credential vault migration/rekey/encrypt commands' fully-silent per-row loops are flagged in the new observability contract doc as the next heartbeat follow-up targets.
+
+## Validation before release bump
+
+- Full local gate green: `npx tsc --noEmit`, `npm run lint`, `npm test` (742 files / 9694 tests, 0 failures), `npm run verify:gate`.
+- CI green on both Node 22 and Node 24 for the merged PR.
+- Dedicated regression tests for every fix (consolidation vector-candidate wiring, credentials revision DB layer + agent tools + CLI, smoke e2e auto-link/no-cleanup, digest batch-reject, credentials legacy-key scoping/preflight, verify --fix --reconcile heartbeat/deadline behavior, doctor per-step cadence staleness).


### PR DESCRIPTION
## Summary

PR #2109 (the #2088-#2108 issue sweep) merged without a version bump, so `tag-release-after-ci.yml` will find `v2026.7.215` already tagged on main and skip cutting a new release for that work. This PR closes that gap:

- Bumps `extensions/memory-hybrid/package.json` (+ lockfile) from `2026.7.215` → `2026.7.216`.
- Adds the matching `CHANGELOG.md` section and `release-notes/release-notes-2026.7.216.md`, summarizing the #2088-#2108 sweep already on `main`.

No functional code changes — this is a version/docs-only follow-up. Once merged, `tag-release-after-ci.yml` should tag `v2026.7.216` and dispatch the Release workflow (npm publish + GitHub Release) on the next successful CI run on `main`.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor / internal improvement
- [x] Documentation update
- [x] CI / tooling change (release versioning)

## Quality Checklist

- [x] `cd extensions/memory-hybrid && npx tsc --noEmit` passes with no errors
- [x] `cd extensions/memory-hybrid && npm run lint` passes with no errors/warnings in changed files
- [x] `cd extensions/memory-hybrid && npm run verify:gate` passes
- [x] No secrets, credentials, or API keys committed

## Documentation Impact

- [x] `CHANGELOG.md` and `release-notes/release-notes-2026.7.216.md` added/updated for this version

## Testing

- [ ] Unit tests added/updated — not applicable (version/docs bump only)
- [ ] Manually verified against a running OpenClaw instance — not applicable

## Notes for Reviewer

This PR is intentionally left unmerged pending your go-ahead, since merging it triggers the automated tag + npm publish + GitHub Release pipeline.


---
_Generated by [Claude Code](https://claude.ai/code/session_018d6wrTRKquFdYFe7YohyU8)_