### PR TITLE
fix: reload/teardown lifecycle regressions (#2111, #2112, #2113)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [2026.7.217] - 2026-07-14
+
+### Fixed — Reload/teardown lifecycle regressions (#2111, #2112, #2113)
+
+Three production-log regressions in the hot-reload/teardown path, fixed together with dedicated regression tests.
+
+**Plugin re-registration ([#2111](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/2111))**
+- The reload gate threw `memory-hybrid: reload teardown did not drain before opening new databases` whenever the prior teardown had not finished draining within the wait budget on the **full-teardown** path (no donor handles to inherit). That failed plugin initialization outright and repeated on every reload attempt — reproduced on two hosts. The gate now recovers to a fresh open instead of throwing: the donor's handles are being permanently closed on a separate teardown chain, so the new registration safely opens its own fresh handles. The decision logic was extracted into a pure, unit-tested `decideReloadTeardownGate()` helper, and a new `reregisterMetrics.teardownTimeoutRecoveries` counter records each recovery for observability. The reuse and soft-timeout paths are unchanged.
+
+**Context engine lifecycle ([#2112](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/2112))**
+- `onSubagentEnded` (and `prepareSubagentSpawn`) could run on a superseded plugin generation whose `FactsDB` had already been `permanentClose()`d by a reload, logging repeated `onSubagentEnded failed (non-fatal): Error: The database connection is not open`. Both callbacks are now generation-safe: a new `BaseSqliteStore.isPermanentlyClosed()` predicate lets them no-op cleanly (debug breadcrumb, no telemetry) when the captured DB handle is torn down, and a late "connection is not open" error mid-callback is treated as the same benign case rather than a warning.
+
+**Error reporter ([#2113](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/2113))**
+- Startup drain and shutdown flush emitted alarming `Startup drain incomplete` / `flush incomplete` warnings when the only problem was an unreachable telemetry endpoint, and a permanently-offline endpoint kept the same pending reports queued forever (re-warning on every restart). Delivery failures are now classified (`network` vs `http` vs `other`); a transient connectivity failure logs at info level with wording that makes clear the backlog is retained for retry, while genuine local-queue problems keep the louder warn wording (shared `describePendingTelemetryDrain()` helper). Pending reports older than a 14-day retention window are now aged out on load so the queue makes forward progress even when delivery never succeeds.
+
 ## [2026.7.216] - 2026-07-14
 
 ### Fixed / Added — Open issue sweep (#2088, #2091, #2093, #2095, #2098, #2099, #2104–#2108)

--- a/extensions/memory-hybrid/backends/base-sqlite-store.ts
+++ b/extensions/memory-hybrid/backends/base-sqlite-store.ts
@@ -161,6 +161,18 @@ export abstract class BaseSqliteStore {
   }
 
   /**
+   * True once the store has been **permanently** closed via {@link permanentClose} (runtime
+   * teardown / plugin re-registration). Unlike `isOpen()`, this stays false for a deferClose
+   * store whose native handle was merely closed by background maintenance and can still lazily
+   * reopen on the next access. Lifecycle hooks that may fire after teardown (e.g. a context
+   * engine's `onSubagentEnded` on a superseded plugin generation, #2112) use this to no-op
+   * cleanly instead of throwing "The database connection is not open".
+   */
+  isPermanentlyClosed(): boolean {
+    return this.closePhase === "shutdown";
+  }
+
+  /**
    * Permanently close this store, preventing any future reopening via `liveDb`.
    *
    * Unlike `close()`, which is designed for background maintenance and allows

--- a/extensions/memory-hybrid/package.json
+++ b/extensions/memory-hybrid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-hybrid-memory",
-  "version": "2026.7.216",
+  "version": "2026.7.217",
   "type": "module",
   "description": "Give your OpenClaw agent lasting memory: structured facts, semantic search, auto-capture & recall, decay, optional credential vault. Part of Hybrid Memory v3.",
   "files": [

--- a/extensions/memory-hybrid/services/context-engine.ts
+++ b/extensions/memory-hybrid/services/context-engine.ts
@@ -347,6 +347,18 @@ export class HybridMemoryContextEngine implements MinimalContextEngine {
     this.info.version = opts.pluginVersion;
   }
 
+  /**
+   * True when the FactsDB this engine captured at construction has been permanently closed by a
+   * runtime teardown / plugin re-registration (#2112). OpenClaw can retain a reference to a
+   * superseded ContextEngine instance and still invoke its lifecycle callbacks (e.g. a subagent
+   * that started under the old generation ends after the reload). Those callbacks must no-op
+   * cleanly rather than touching a closed SQLite handle and logging repeated non-fatal errors.
+   */
+  private isFactsDbTornDown(): boolean {
+    const factsDb = this.opts.factsDb as { isPermanentlyClosed?: () => boolean } | undefined;
+    return typeof factsDb?.isPermanentlyClosed === "function" && factsDb.isPermanentlyClosed();
+  }
+
   /** no-op: SessionManager handles message persistence. */
   async ingest(_params: { sessionId: string; message: unknown }): Promise<IngestResult> {
     return { ingested: false };
@@ -557,6 +569,14 @@ export class HybridMemoryContextEngine implements MinimalContextEngine {
     ttlMs?: number;
   }): Promise<SubagentSpawnPreparation | undefined> {
     const { factsDb, cfg, logger } = this.opts;
+    // Generation-safety (#2112): a superseded engine can still receive spawn callbacks after
+    // reload teardown closed its FactsDB. No-op cleanly rather than reading a closed handle.
+    if (this.isFactsDbTornDown()) {
+      logger.debug?.(
+        `memory-hybrid: prepareSubagentSpawn — skipped for child=${params.childSessionKey} (runtime generation torn down; DB handle closed)`,
+      );
+      return { rollback: async () => {} };
+    }
     try {
       if (cfg.autoRecall?.enabled) {
         logger.debug?.(
@@ -648,6 +668,15 @@ export class HybridMemoryContextEngine implements MinimalContextEngine {
    */
   async onSubagentEnded(params: { childSessionKey: string; reason: string }): Promise<void> {
     const { factsDb, logger } = this.opts;
+    // Generation-safety (#2112): if the plugin generation that registered this engine has been
+    // superseded/torn down, the captured FactsDB handle is permanently closed. No-op cleanly
+    // instead of accessing a closed connection and emitting a repeated non-fatal error log.
+    if (this.isFactsDbTornDown()) {
+      logger.debug?.(
+        `memory-hybrid: context-engine onSubagentEnded — skipped for child=${params.childSessionKey} (runtime generation torn down; DB handle closed)`,
+      );
+      return;
+    }
     try {
       // Count facts captured from the child session (written to the shared store by the
       // child's own agent_end autoCapture hook while the child session was running).
@@ -682,6 +711,16 @@ export class HybridMemoryContextEngine implements MinimalContextEngine {
       //       inside the child's session and writes directly to the shared FactsDB)
       //   (b) The typed subagent_ended hook in lifecycle/stage-cleanup.ts (ACTIVE-TASKS.md only; issue #966)
     } catch (err) {
+      // A teardown can race between the isFactsDbTornDown() guard above and the DB read. Treat a
+      // "connection is not open" failure as the same benign torn-down case (#2112): log at debug
+      // and skip telemetry so a normal subagent completion during reload stays quiet.
+      const message = err instanceof Error ? err.message : String(err);
+      if (this.isFactsDbTornDown() || /not open|connection is not open/i.test(message)) {
+        logger.debug?.(
+          `memory-hybrid: context-engine onSubagentEnded — skipped for child=${params.childSessionKey} (DB closed during teardown)`,
+        );
+        return;
+      }
       capturePluginError(err instanceof Error ? err : new Error(String(err)), {
         subsystem: "context-engine",
         operation: "on-subagent-ended",

--- a/extensions/memory-hybrid/services/error-reporter.ts
+++ b/extensions/memory-hybrid/services/error-reporter.ts
@@ -41,6 +41,39 @@ const MAX_BREADCRUMBS = 10;
 const MAX_PENDING_REPORTS = 200;
 
 /**
+ * Max age a pending telemetry report is retained before being aged out (#2113). Without this,
+ * a permanently unreachable reporting endpoint keeps the same reports queued forever, so every
+ * restart re-warns about the identical "stuck" backlog. Bounded retention lets the queue make
+ * forward progress (eventually empties) even when delivery never succeeds.
+ */
+const MAX_PENDING_REPORT_AGE_MS = 14 * 24 * 60 * 60 * 1000;
+
+/**
+ * Classification of the most recent telemetry delivery outcome, used to distinguish a transient
+ * remote-endpoint problem (offline/unreachable GlitchTip) from a local queue issue when logging
+ * an incomplete drain/flush (#2113).
+ * - `none`    — last send succeeded.
+ * - `network` — the HTTP request itself failed to complete (DNS, connection refused, TLS,
+ *               timeout/abort). Almost always transient and operator-actionable only if the
+ *               endpoint is expected to be reachable.
+ * - `http`    — the endpoint responded but rejected the event (4xx/5xx).
+ * - `other`   — any other delivery error.
+ */
+export type TelemetrySendFailureKind = "none" | "network" | "http" | "other";
+
+/** Whether a thrown fetch error represents a connectivity failure rather than an HTTP rejection. */
+function isNetworkDeliveryError(err: unknown): boolean {
+  if (err instanceof Error) {
+    const name = err.name;
+    if (name === "AbortError" || name === "TimeoutError" || name === "TypeError") return true;
+    if (/ENOTFOUND|ECONNREFUSED|ECONNRESET|EAI_AGAIN|ETIMEDOUT|network|fetch failed|timed out|timeout/i.test(err.message)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
  * Default GlitchTip DSN for anonymous crash reporting.
  * This DSN is safe to expose publicly — it only allows ingest (write), not read.
  * Users can opt out by setting errorReporting.consent: false or errorReporting.enabled: false.
@@ -79,6 +112,12 @@ export interface ErrorReporterConfig {
   pendingQueuePath?: string;
   /** Optional cap for persistent pending reports. Oldest entries are pruned first. */
   maxPendingReports?: number;
+  /**
+   * Optional max age (ms) a pending report is retained before being aged out. Defaults to
+   * {@link MAX_PENDING_REPORT_AGE_MS}. Prevents a permanently unreachable endpoint from
+   * pinning the same reports in the queue forever (#2113).
+   */
+  maxPendingReportAgeMs?: number;
 }
 
 /** Hardcoded DSN for community error reporting (anonymous telemetry) */
@@ -141,6 +180,8 @@ class GlitchTipReporter {
   private readonly resolvedIssues: Record<string, string>;
   private readonly pendingQueuePath?: string;
   private readonly maxPendingReports: number;
+  private readonly maxPendingReportAgeMs: number;
+  private lastSendFailureKind: TelemetrySendFailureKind = "none";
   private serverName?: string;
 
   private globalTags: Record<string, string> = {};
@@ -166,6 +207,7 @@ class GlitchTipReporter {
     resolvedIssues?: Record<string, string>,
     pendingQueuePath?: string,
     maxPendingReports?: number,
+    maxPendingReportAgeMs?: number,
   ) {
     const url = new URL(dsn);
     this.publicKey = url.username;
@@ -185,6 +227,14 @@ class GlitchTipReporter {
       typeof maxPendingReports === "number" && Number.isFinite(maxPendingReports) && maxPendingReports > 0
         ? Math.floor(maxPendingReports)
         : MAX_PENDING_REPORTS;
+    this.maxPendingReportAgeMs =
+      typeof maxPendingReportAgeMs === "number" && Number.isFinite(maxPendingReportAgeMs) && maxPendingReportAgeMs > 0
+        ? Math.floor(maxPendingReportAgeMs)
+        : MAX_PENDING_REPORT_AGE_MS;
+  }
+
+  getLastSendFailureKind(): TelemetrySendFailureKind {
+    return this.lastSendFailureKind;
   }
 
   setTag(key: string, value: string): void {
@@ -503,6 +553,19 @@ class GlitchTipReporter {
 
   private prunePendingReportsLocked(): number {
     let pruned = 0;
+    // Age-out first: drop reports older than the retention window so a permanently unreachable
+    // endpoint cannot pin the same backlog across every restart (#2113).
+    if (this.maxPendingReportAgeMs > 0 && this.pendingReports.size > 0) {
+      const cutoff = Date.now() - this.maxPendingReportAgeMs;
+      for (const [id, record] of this.pendingReports) {
+        if (record.enqueuedAt < cutoff) {
+          this.forgetPendingFingerprint(record.event);
+          this.pendingReports.delete(id);
+          pruned++;
+        }
+      }
+    }
+    // Then enforce the size cap: drop oldest first.
     while (this.pendingReports.size > this.maxPendingReports) {
       const oldestId = this.pendingReports.keys().next().value as string | undefined;
       if (!oldestId) break;
@@ -571,19 +634,29 @@ class GlitchTipReporter {
   private async send(event: GlitchTipEvent): Promise<void> {
     const timestamp = Math.floor(Date.now() / 1000);
     const authHeader = `Sentry sentry_version=7, sentry_timestamp=${timestamp}, sentry_client=openclaw-hybrid-memory/native, sentry_key=${this.publicKey}`;
-    const resp = await fetch(this.storeUrl, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "X-Sentry-Auth": authHeader,
-      },
-      body: JSON.stringify(event),
-      signal: AbortSignal.timeout(5000),
-    });
+    let resp: Response;
+    try {
+      resp = await fetch(this.storeUrl, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Sentry-Auth": authHeader,
+        },
+        body: JSON.stringify(event),
+        signal: AbortSignal.timeout(5000),
+      });
+    } catch (err) {
+      // fetch rejects for connectivity failures (DNS, refused, TLS, timeout/abort). Classify as
+      // network so an offline endpoint is reported as transient rather than local corruption (#2113).
+      this.lastSendFailureKind = isNetworkDeliveryError(err) ? "network" : "other";
+      throw err;
+    }
     const body = await resp.text();
     if (!resp.ok) {
+      this.lastSendFailureKind = "http";
       throw new Error(`GlitchTip rejected event: HTTP ${resp.status} ${body}`);
     }
+    this.lastSendFailureKind = "none";
   }
 }
 
@@ -688,6 +761,7 @@ export async function initErrorReporter(
       config.resolvedIssues,
       config.pendingQueuePath,
       config.maxPendingReports,
+      config.maxPendingReportAgeMs,
     );
   } catch (err) {
     logger.warn?.(
@@ -751,6 +825,49 @@ export function computeShutdownFlushTimeoutMs(pendingCount: number): number {
 
 export function getPendingErrorReportCount(): number {
   return reporter?.getPendingCount() ?? 0;
+}
+
+/** Classification of the most recent telemetry delivery outcome (#2113). */
+export function getLastErrorReportSendFailureKind(): TelemetrySendFailureKind {
+  return reporter?.getLastSendFailureKind() ?? "none";
+}
+
+/**
+ * Build the log line for an incomplete telemetry drain/flush (#2113). A transient
+ * network-unreachable failure is reported at info level with wording that makes clear the
+ * backlog is retained for retry (not local corruption); any other failure keeps the louder
+ * warn-level wording so genuine queue problems remain visible.
+ */
+export function describePendingTelemetryDrain(params: {
+  phase: "startup" | "shutdown";
+  pendingCount: number;
+  failureKind: TelemetrySendFailureKind;
+}): { level: "info" | "warn"; message: string } {
+  const { phase, pendingCount, failureKind } = params;
+  // Each phase carries its own idiomatic log prefix so callers can log the message verbatim:
+  // the startup drain runs under the error-reporter's own logger ("[ErrorReporter] …"), while the
+  // shutdown flush runs under the plugin's api.logger ("memory-hybrid: …").
+  const prefix = phase === "startup" ? "[ErrorReporter]" : "memory-hybrid:";
+  if (failureKind === "network") {
+    const detail =
+      phase === "startup"
+        ? `${pendingCount} report(s) retained for retry on next startup`
+        : `${pendingCount} report(s) persisted locally and will retry on next startup`;
+    return {
+      level: "info",
+      message: `${prefix} telemetry endpoint unreachable; ${detail} (expected when the reporting endpoint is offline)`,
+    };
+  }
+  if (phase === "shutdown") {
+    return {
+      level: "warn",
+      message: `${prefix} error reporter flush incomplete (${pendingCount} pending); pending reports will retry on next startup`,
+    };
+  }
+  return {
+    level: "warn",
+    message: `${prefix} Startup drain incomplete (${pendingCount} pending); run \`openclaw hybrid-mem verify\` to inspect the telemetry queue`,
+  };
 }
 
 /** Default on-disk pending queue path next to the SQLite memory DB. */
@@ -881,7 +998,15 @@ export interface OneShotErrorReportFlushResult {
 export async function attemptOneShotErrorReportFlush(
   config: Pick<
     ErrorReporterConfig,
-    "enabled" | "dsn" | "mode" | "consent" | "environment" | "sampleRate" | "resolvedIssues" | "maxPendingReports"
+    | "enabled"
+    | "dsn"
+    | "mode"
+    | "consent"
+    | "environment"
+    | "sampleRate"
+    | "resolvedIssues"
+    | "maxPendingReports"
+    | "maxPendingReportAgeMs"
   >,
   pendingQueuePath: string | undefined,
   pluginVersion: string,
@@ -911,6 +1036,7 @@ export async function attemptOneShotErrorReportFlush(
       config.resolvedIssues,
       pendingQueuePath,
       config.maxPendingReports,
+      config.maxPendingReportAgeMs,
     );
   } catch (err) {
     return {
@@ -954,9 +1080,16 @@ function scheduleStartupErrorReporterDrain(): void {
       }
       const remaining = reporter?.getPendingCount() ?? 0;
       if (remaining > 0) {
-        logger.warn?.(
-          `[ErrorReporter] Startup drain incomplete (${remaining} pending); run \`openclaw hybrid-mem verify\` to inspect the telemetry queue`,
-        );
+        const drainState = describePendingTelemetryDrain({
+          phase: "startup",
+          pendingCount: remaining,
+          failureKind: reporter?.getLastSendFailureKind() ?? "other",
+        });
+        if (drainState.level === "info") {
+          logger.info?.(drainState.message);
+        } else {
+          logger.warn?.(drainState.message);
+        }
       }
     } catch (err) {
       logger.debug?.(`[ErrorReporter] Startup drain failed: ${err instanceof Error ? err.message : String(err)}`);

--- a/extensions/memory-hybrid/setup/hybrid-memory-reload-coordinator.ts
+++ b/extensions/memory-hybrid/setup/hybrid-memory-reload-coordinator.ts
@@ -200,6 +200,47 @@ export function blockReloadTeardownBeforeOpen(timeoutMs = TEARDOWN_WAIT_MS): boo
   return reloadTeardownQueueDepth === 0;
 }
 
+/**
+ * Decision for the register-time reload gate: after {@link blockReloadTeardownBeforeOpen}
+ * returns, describe what the new registration should do with the donor's DB handles.
+ *
+ * - `reuse` — donor teardown drained (or the donor generation's teardown is done); the new
+ *   registration may inherit the donor's still-open handles.
+ * - `fresh` — no donor handles to inherit and teardown has drained; open fresh handles.
+ * - `fresh-soft-timeout` — a donor was available but its teardown did not drain in time, so
+ *   inheriting its handles risks a closed-DB race; fall back to a fresh open.
+ * - `fresh-hard-timeout` — full-teardown path (no donor to inherit) where teardown has not
+ *   drained. The donor's handles are being permanently closed on a **separate** teardown
+ *   chain and the new registration opens its own fresh handles, so it is safe to proceed.
+ *   Previously this case threw and failed plugin initialization outright (#2111); it now
+ *   recovers to a fresh open and records the timeout for observability.
+ */
+export type ReloadTeardownGateDecision = "reuse" | "fresh" | "fresh-soft-timeout" | "fresh-hard-timeout";
+
+/**
+ * Pure gate-decision logic shared by register-plugin. Kept side-effect-free (no blocking, no
+ * logging) so it can be unit-tested exhaustively; the caller performs the actual synchronous
+ * teardown wait and acts on the returned decision.
+ *
+ * @param hasDonor    Whether a donor runtime whose handles could be reused is available.
+ * @param drained     Result of the synchronous teardown wait (queue fully drained in time).
+ * @param donorDrained Whether the specific donor generation's teardown has finished, even if
+ *                     newer teardowns are still queued (overlap-queued re-register).
+ */
+export function decideReloadTeardownGate(params: {
+  hasDonor: boolean;
+  drained: boolean;
+  donorDrained: boolean;
+}): ReloadTeardownGateDecision {
+  const { hasDonor, drained, donorDrained } = params;
+  if (drained) return hasDonor ? "reuse" : "fresh";
+  if (hasDonor) return donorDrained ? "reuse" : "fresh-soft-timeout";
+  // No donor runtime to inherit (full-teardown path). The old handles are being closed on a
+  // separate chain; opening fresh handles is safe. Never throw here (#2111) — a hard failure
+  // repeats on every reload attempt and leaves the plugin unregistered.
+  return "fresh-hard-timeout";
+}
+
 /** Reset chain for unit tests only. */
 export function resetReloadTeardownChainForTests(): void {
   reloadTeardownChain = Promise.resolve();

--- a/extensions/memory-hybrid/setup/plugin-service.ts
+++ b/extensions/memory-hybrid/setup/plugin-service.ts
@@ -30,7 +30,10 @@ import { syncCronLastRunFromGuards } from "../services/cron-guard.js";
 import type { EmbeddingRegistry } from "../services/embedding-registry.js";
 import {
   capturePluginError,
+  describePendingTelemetryDrain,
   flushErrorReporter,
+  getLastErrorReportSendFailureKind,
+  getPendingErrorReportCount,
   initErrorReporter,
   isErrorReporterActive,
   setErrorReporterMuted,
@@ -1186,7 +1189,18 @@ export function createPluginService(ctx: PluginServiceContext) {
       if (isErrorReporterActive()) {
         const flushed = await flushErrorReporter().catch(() => false);
         if (!flushed) {
-          api.logger.warn("memory-hybrid: error reporter flush incomplete; pending reports will retry on next startup");
+          // Distinguish a transient offline endpoint (info, expected) from a genuine local queue
+          // problem (warn) so restarts against an unreachable GlitchTip don't look like errors (#2113).
+          const drainState = describePendingTelemetryDrain({
+            phase: "shutdown",
+            pendingCount: getPendingErrorReportCount(),
+            failureKind: getLastErrorReportSendFailureKind(),
+          });
+          if (drainState.level === "info") {
+            api.logger.info?.(drainState.message);
+          } else {
+            api.logger.warn(drainState.message);
+          }
         }
       }
       if (dashboardServer) {

--- a/extensions/memory-hybrid/setup/register-plugin.ts
+++ b/extensions/memory-hybrid/setup/register-plugin.ts
@@ -58,6 +58,7 @@ import {
 import {
   blockReloadTeardownBeforeOpen,
   clearTeardownTrackingForGeneration,
+  decideReloadTeardownGate,
   drainOldBootstrap,
   drainOldRecall,
   isTeardownDrainedForGeneration,
@@ -76,6 +77,7 @@ import {
   recordReregisterDatabaseReuse,
   recordReregisterFullTeardown,
   recordReregisterRegistration,
+  recordReregisterTeardownTimeoutRecovery,
   resetReregisterPolicyForTests,
   resolveReregisterPolicy,
 } from "./reregister-policy.js";
@@ -474,17 +476,30 @@ function runMemoryHybridRegisterImpl(api: ClawdbotPluginApi): void {
     const drained = blockReloadTeardownBeforeOpen(TEARDOWN_WAIT_MS);
     if (!drained) {
       const donorDrained = isTeardownDrainedForGeneration(donorGeneration);
-      if (donorRuntime && donorDrained) {
+      const decision = decideReloadTeardownGate({
+        hasDonor: Boolean(donorRuntime),
+        drained,
+        donorDrained,
+      });
+      if (decision === "reuse") {
         // Donor generation's teardown is done even though newer teardowns may still be queued
         // (overlap-queued re-register). Donor handles are safe to hand to the new runtime.
-      } else if (donorRuntime) {
+      } else if (decision === "fresh-soft-timeout") {
         logApi.logger.warn?.(
           `memory-hybrid: reload teardown soft-timeout exceeded (>=${TEARDOWN_SOFT_WAIT_MS}ms) for donor generation ${donorGeneration}; falling back to fresh open to avoid inheriting closed DB handles`,
         );
         donorRuntime = null;
         recordReregisterFullTeardown();
-      } else {
-        throw new Error("memory-hybrid: reload teardown did not drain before opening new databases");
+      } else if (decision === "fresh-hard-timeout") {
+        // Full-teardown path (#2111): the donor's DB handles are being permanently closed on a
+        // separate teardown chain. The new registration opens its own fresh handles, so it is
+        // safe to proceed even though the prior teardown has not finished draining. Previously
+        // this threw and failed plugin initialization on every reload attempt; recover to a
+        // fresh open instead and record the timeout for observability.
+        logApi.logger.warn?.(
+          `memory-hybrid: reload teardown did not drain within ${TEARDOWN_WAIT_MS}ms for donor generation ${donorGeneration}; opening fresh databases anyway (prior teardown continues on its own chain)`,
+        );
+        recordReregisterTeardownTimeoutRecovery();
       }
     }
   }

--- a/extensions/memory-hybrid/setup/reregister-policy.ts
+++ b/extensions/memory-hybrid/setup/reregister-policy.ts
@@ -10,6 +10,12 @@ export type ReregisterMetrics = {
   registrations: number;
   fullTeardowns: number;
   databaseReuses: number;
+  /**
+   * Count of registrations that opened fresh databases even though the prior teardown had not
+   * finished draining within the wait budget (#2111). A non-zero value indicates the reload
+   * gate is recovering from slow teardowns rather than failing plugin initialization.
+   */
+  teardownTimeoutRecoveries: number;
 };
 
 export const reregisterMetrics: ReregisterMetrics = {
@@ -17,6 +23,7 @@ export const reregisterMetrics: ReregisterMetrics = {
   registrations: 0,
   fullTeardowns: 0,
   databaseReuses: 0,
+  teardownTimeoutRecoveries: 0,
 };
 
 /** Resolved once per process from OPENCLAW_HYBRID_MEM_REREGISTER_POLICY. */
@@ -43,6 +50,7 @@ export function resetReregisterPolicyForTests(): void {
   reregisterMetrics.registrations = 0;
   reregisterMetrics.fullTeardowns = 0;
   reregisterMetrics.databaseReuses = 0;
+  reregisterMetrics.teardownTimeoutRecoveries = 0;
 }
 
 export function recordReregisterRegistration(): void {
@@ -56,6 +64,10 @@ export function recordReregisterFullTeardown(): void {
 
 export function recordReregisterDatabaseReuse(): void {
   reregisterMetrics.databaseReuses += 1;
+}
+
+export function recordReregisterTeardownTimeoutRecovery(): void {
+  reregisterMetrics.teardownTimeoutRecoveries += 1;
 }
 
 type PathResolvingApi = { resolvePath: (p: string) => string };

--- a/extensions/memory-hybrid/tests/context-engine.test.ts
+++ b/extensions/memory-hybrid/tests/context-engine.test.ts
@@ -263,6 +263,23 @@ describe("HybridMemoryContextEngine.compact()", () => {
 // ---------------------------------------------------------------------------
 
 describe("HybridMemoryContextEngine.prepareSubagentSpawn()", () => {
+  // Regression: #2112 — a superseded engine can still receive spawn callbacks after teardown.
+  it("no-ops without DB access when the FactsDB was permanently closed by teardown", async () => {
+    const engine = makeEngine({ cfg: makeSubagentSpawnConfig() });
+    factsDb.permanentClose();
+
+    const prep = await engine.prepareSubagentSpawn?.({
+      parentSessionKey: "parent-session",
+      childSessionKey: "child-session-torn-down",
+    });
+
+    // Returns a well-formed no-op preparation (rollback present, no injected context).
+    expect(prep).toBeDefined();
+    const extended = prep as { contextAddition?: string; rollback: () => void };
+    expect(extended.contextAddition).toBeUndefined();
+    await expect(Promise.resolve(extended.rollback())).resolves.not.toThrow();
+  });
+
   it("skips injection when autoRecall is enabled", async () => {
     factsDb.store({
       entity: null,
@@ -559,6 +576,52 @@ describe("HybridMemoryContextEngine.onSubagentEnded()", () => {
         engine.onSubagentEnded?.({ childSessionKey: `child-${randomUUID()}`, reason }),
       ).resolves.not.toThrow();
     }
+  });
+
+  // Regression: #2112 — a subagent that started under a prior plugin generation can end after
+  // the hybrid-memory runtime was torn down (reload/teardown permanentClose'd the FactsDB).
+  // The stale engine must no-op cleanly instead of hitting a closed connection and warning.
+  it("no-ops cleanly (no DB access, no warn) when the FactsDB was permanently closed by teardown", async () => {
+    const childSessionKey = `child-torn-down-${randomUUID()}`;
+    const logger = makeLogger();
+    const engine = makeEngine({ logger });
+
+    // Simulate runtime teardown: closeOldDatabases() calls permanentClose() on the store.
+    factsDb.permanentClose();
+    expect(factsDb.isPermanentlyClosed()).toBe(true);
+
+    await expect(
+      engine.onSubagentEnded?.({ childSessionKey, reason: "completed" }),
+    ).resolves.not.toThrow();
+
+    // No warning noise for a normal subagent completion during teardown.
+    const warnCalls = logger.warn.mock.calls.map((c: unknown[]) => String(c[0]));
+    expect(warnCalls.some((msg: string) => msg.includes("onSubagentEnded failed"))).toBe(false);
+
+    // A debug breadcrumb explaining the skip is expected.
+    const debugCalls = logger.debug.mock.calls.map((c: unknown[]) => String(c[0]));
+    expect(debugCalls.some((msg: string) => msg.includes(childSessionKey) && /torn down|DB closed/i.test(msg))).toBe(
+      true,
+    );
+  });
+
+  it("treats a late 'connection is not open' error as the benign torn-down case (debug, not warn)", async () => {
+    // The DB reports open at the guard check but throws mid-read (teardown races the callback).
+    const racyFactsDb = {
+      isPermanentlyClosed: vi.fn().mockReturnValue(false),
+      countBySource: vi.fn().mockImplementation(() => {
+        throw new Error("The database connection is not open");
+      }),
+    };
+    const logger = makeLogger();
+    const engine = makeEngine({ factsDb: racyFactsDb as never, logger });
+
+    await expect(
+      engine.onSubagentEnded?.({ childSessionKey: "racy-child", reason: "completed" }),
+    ).resolves.not.toThrow();
+
+    const warnCalls = logger.warn.mock.calls.map((c: unknown[]) => String(c[0]));
+    expect(warnCalls.some((msg: string) => msg.includes("onSubagentEnded failed"))).toBe(false);
   });
 });
 

--- a/extensions/memory-hybrid/tests/error-reporter-persistence.test.ts
+++ b/extensions/memory-hybrid/tests/error-reporter-persistence.test.ts
@@ -159,6 +159,161 @@ describe("error reporter persistent pending queue", () => {
     expect(reporter.countPendingErrorReportsOnDisk(queuePath)).toBe(2);
     expect(reporter.resolvePendingErrorReportCount(join(tempDir, "memory.db"))).toBe(2);
   });
+
+  // Regression: #2113 — a permanently unreachable endpoint must not pin the same reports in the
+  // queue forever. Reports older than the retention window are aged out on load so the queue
+  // eventually empties even when delivery never succeeds.
+  it("ages out stale pending reports older than the retention window on load", async () => {
+    fetchMock.mockRejectedValue(new Error("network down"));
+    // Two records: one ancient (epoch ms 1, ~1970) and one enqueued now. Give them distinct
+    // fingerprints so neither is dropped as a duplicate.
+    const ancient = {
+      id: "ancient",
+      enqueuedAt: 1,
+      event: { event_id: "ancient", exception: { values: [{ type: "Error", value: "old failure" }] } },
+    };
+    const fresh = {
+      id: "fresh",
+      enqueuedAt: Date.now(),
+      event: { event_id: "fresh", exception: { values: [{ type: "Error", value: "recent failure" }] } },
+    };
+    writeFileSync(queuePath, `${JSON.stringify(ancient)}\n${JSON.stringify(fresh)}\n`);
+
+    const reporter = (await import("../services/error-reporter.js")) as ErrorReporterModule;
+    await reporter.initErrorReporter(
+      {
+        enabled: true,
+        consent: true,
+        mode: "community",
+        dsn: "https://testkey@example.com/1",
+        maxBreadcrumbs: 0,
+        sampleRate: 1,
+        pendingQueuePath: queuePath,
+      },
+      "test-build",
+    );
+
+    // Only the fresh record should survive; the ancient one is aged out.
+    const records = readQueueRecords(queuePath);
+    expect(records.map((r) => r.id)).toEqual(["fresh"]);
+  });
+
+  it("respects a custom maxPendingReportAgeMs when aging out reports", async () => {
+    fetchMock.mockRejectedValue(new Error("network down"));
+    const now = Date.now();
+    const stale = {
+      id: "stale",
+      enqueuedAt: now - 10_000,
+      event: { event_id: "stale", exception: { values: [{ type: "Error", value: "stale failure" }] } },
+    };
+    const recent = {
+      id: "recent",
+      enqueuedAt: now - 500,
+      event: { event_id: "recent", exception: { values: [{ type: "Error", value: "recent failure" }] } },
+    };
+    writeFileSync(queuePath, `${JSON.stringify(stale)}\n${JSON.stringify(recent)}\n`);
+
+    const reporter = (await import("../services/error-reporter.js")) as ErrorReporterModule;
+    await reporter.initErrorReporter(
+      {
+        enabled: true,
+        consent: true,
+        mode: "community",
+        dsn: "https://testkey@example.com/1",
+        maxBreadcrumbs: 0,
+        sampleRate: 1,
+        pendingQueuePath: queuePath,
+        maxPendingReportAgeMs: 2_000,
+      },
+      "test-build",
+    );
+
+    const records = readQueueRecords(queuePath);
+    expect(records.map((r) => r.id)).toEqual(["recent"]);
+  });
+
+  it("classifies a connectivity failure as a transient network failure kind", async () => {
+    fetchMock.mockRejectedValue(new Error("fetch failed"));
+    const reporter = (await import("../services/error-reporter.js")) as ErrorReporterModule;
+    await reporter.initErrorReporter(
+      {
+        enabled: true,
+        consent: true,
+        mode: "community",
+        dsn: "https://testkey@example.com/1",
+        maxBreadcrumbs: 0,
+        sampleRate: 1,
+        pendingQueuePath: queuePath,
+      },
+      "test-build",
+    );
+
+    reporter.capturePluginError(new Error("connectivity classify test"), {
+      operation: "classify",
+      subsystem: "tests",
+    });
+    await expect(reporter.flushErrorReporter(500)).resolves.toBe(false);
+    expect(reporter.getLastErrorReportSendFailureKind()).toBe("network");
+  });
+
+  it("classifies an HTTP rejection distinctly from a network failure", async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 500, text: async () => "server error" });
+    const reporter = (await import("../services/error-reporter.js")) as ErrorReporterModule;
+    await reporter.initErrorReporter(
+      {
+        enabled: true,
+        consent: true,
+        mode: "community",
+        dsn: "https://testkey@example.com/1",
+        maxBreadcrumbs: 0,
+        sampleRate: 1,
+        pendingQueuePath: queuePath,
+      },
+      "test-build",
+    );
+
+    reporter.capturePluginError(new Error("http classify test"), { operation: "classify", subsystem: "tests" });
+    await expect(reporter.flushErrorReporter(500)).resolves.toBe(false);
+    expect(reporter.getLastErrorReportSendFailureKind()).toBe("http");
+  });
+});
+
+describe("describePendingTelemetryDrain (#2113)", () => {
+  let mod: ErrorReporterModule;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    mod = (await import("../services/error-reporter.js")) as ErrorReporterModule;
+  });
+
+  it("reports a transient offline endpoint at info level for the startup phase", () => {
+    const state = mod.describePendingTelemetryDrain({ phase: "startup", pendingCount: 4, failureKind: "network" });
+    expect(state.level).toBe("info");
+    expect(state.message).toMatch(/unreachable/i);
+    expect(state.message).toContain("4 report(s)");
+    expect(state.message).not.toMatch(/incomplete/i);
+  });
+
+  it("reports a transient offline endpoint at info level for the shutdown phase", () => {
+    const state = mod.describePendingTelemetryDrain({ phase: "shutdown", pendingCount: 2, failureKind: "network" });
+    expect(state.level).toBe("info");
+    expect(state.message).toMatch(/memory-hybrid:/);
+    expect(state.message).toMatch(/unreachable/i);
+  });
+
+  it("keeps the louder warn wording for a non-network startup drain failure", () => {
+    const state = mod.describePendingTelemetryDrain({ phase: "startup", pendingCount: 3, failureKind: "http" });
+    expect(state.level).toBe("warn");
+    expect(state.message).toMatch(/Startup drain incomplete/);
+    expect(state.message).toContain("hybrid-mem verify");
+  });
+
+  it("keeps the louder warn wording for a non-network shutdown flush failure", () => {
+    const state = mod.describePendingTelemetryDrain({ phase: "shutdown", pendingCount: 5, failureKind: "other" });
+    expect(state.level).toBe("warn");
+    expect(state.message).toMatch(/flush incomplete/i);
+    expect(state.message).toMatch(/retry on next startup/i);
+  });
 });
 
 describe("error-reports CLI helpers (#2082)", () => {
@@ -269,7 +424,8 @@ describe("error-reports CLI helpers (#2082)", () => {
   it("attemptOneShotErrorReportFlush delivers queued records without touching module-level reporter state", async () => {
     fetchMock.mockResolvedValue({ ok: true, status: 200, text: async () => "" });
     const reporter = (await import("../services/error-reporter.js")) as ErrorReporterModule;
-    writeRecord("a", 1000, "queued failure");
+    // Recent timestamp so the report is not aged out by the retention window (#2113).
+    writeRecord("a", Date.now(), "queued failure");
 
     expect(reporter.isErrorReporterActive()).toBe(false);
     const result = await reporter.attemptOneShotErrorReportFlush(
@@ -292,7 +448,8 @@ describe("error-reports CLI helpers (#2082)", () => {
   it("attemptOneShotErrorReportFlush reports pendingAfter unchanged when delivery fails", async () => {
     fetchMock.mockRejectedValue(new Error("network down"));
     const reporter = (await import("../services/error-reporter.js")) as ErrorReporterModule;
-    writeRecord("a", 1000, "queued failure");
+    // Recent timestamp so the report is not aged out by the retention window (#2113).
+    writeRecord("a", Date.now(), "queued failure");
 
     const result = await reporter.attemptOneShotErrorReportFlush(
       { enabled: true, dsn: "https://testkey@example.com/1", mode: "community", consent: true, sampleRate: 1 },

--- a/extensions/memory-hybrid/tests/error-reports-cli.test.ts
+++ b/extensions/memory-hybrid/tests/error-reports-cli.test.ts
@@ -204,7 +204,8 @@ describe("error-reports CLI (#2082)", () => {
 
     it("delivers queued reports and reports the before/after pending count", async () => {
       fetchMock.mockResolvedValue({ ok: true, status: 200, text: async () => "" });
-      writeRecord(queuePath, "a", 1_000, "queued failure");
+      // Recent timestamp so the report is not aged out by the retention window (#2113).
+      writeRecord(queuePath, "a", Date.now(), "queued failure");
       const mem = makeProgram(sqlitePath, {
         enabled: true,
         consent: true,
@@ -222,7 +223,8 @@ describe("error-reports CLI (#2082)", () => {
 
     it("--json emits attempted/pendingBefore/pendingAfter/flushed", async () => {
       fetchMock.mockResolvedValue({ ok: true, status: 200, text: async () => "" });
-      writeRecord(queuePath, "a", 1_000, "queued failure");
+      // Recent timestamp so the report is not aged out by the retention window (#2113).
+      writeRecord(queuePath, "a", Date.now(), "queued failure");
       const mem = makeProgram(sqlitePath, {
         enabled: true,
         consent: true,

--- a/extensions/memory-hybrid/tests/register-plugin-reload-teardown-drain.test.ts
+++ b/extensions/memory-hybrid/tests/register-plugin-reload-teardown-drain.test.ts
@@ -4,7 +4,8 @@
  * Reproduces the rapid-hot-reload teardown race that surfaced in #2058/#2059 follow-up:
  *   1. reuseDatabases=true + vault-registry close scheduled against the donor runtime
  *   2. soft drain timeout exceeded → must NOT inherit closed handles (fall back to fresh)
- *   3. full teardown path → must still throw on hard drain timeout (existing semantics)
+ *   3. full teardown path with a hard drain timeout → must recover to a fresh open instead of
+ *      throwing and failing plugin initialization (#2111).
  *
  * These tests exercise the helpers exported from hybrid-memory-reload-coordinator.ts and
  * the gate decision logic in register-plugin via lightweight mocks of the dependencies.
@@ -17,6 +18,7 @@ import {
   TEARDOWN_WAIT_MS,
   awaitReloadTeardownBeforeOpen,
   clearTeardownTrackingForGeneration,
+  decideReloadTeardownGate,
   isTeardownDrainedForGeneration,
   resetReloadTeardownChainForTests,
   schedulePluginTeardown,
@@ -117,5 +119,50 @@ describe("register-plugin reload-teardown drain gate", () => {
     expect(await awaitReloadTeardownBeforeOpen(TEARDOWN_WAIT_MS)).toBe(true);
     expect(ran1).toBe(true);
     expect(ran2).toBe(true);
+  });
+});
+
+describe("decideReloadTeardownGate (#2111)", () => {
+  it("reuses donor handles when teardown drained in time", () => {
+    expect(decideReloadTeardownGate({ hasDonor: true, drained: true, donorDrained: true })).toBe("reuse");
+  });
+
+  it("opens fresh when no donor and teardown drained", () => {
+    expect(decideReloadTeardownGate({ hasDonor: false, drained: true, donorDrained: true })).toBe("fresh");
+  });
+
+  it("reuses donor handles when the donor generation's teardown is done despite a hard timeout", () => {
+    // Overlap-queued re-register: the chain didn't fully drain, but the donor generation we are
+    // about to supersede is finished, so its handles are safe to inherit.
+    expect(decideReloadTeardownGate({ hasDonor: true, drained: false, donorDrained: true })).toBe("reuse");
+  });
+
+  it("falls back to a fresh open (soft timeout) when a donor is present but its teardown is still pending", () => {
+    expect(decideReloadTeardownGate({ hasDonor: true, drained: false, donorDrained: false })).toBe(
+      "fresh-soft-timeout",
+    );
+  });
+
+  it("recovers to a fresh open instead of throwing on the full-teardown hard-timeout path", () => {
+    // Regression for #2111: the full-teardown path (no donor to inherit) used to throw
+    // "reload teardown did not drain before opening new databases", failing plugin init on every
+    // reload. It must now signal a fresh-open recovery instead.
+    expect(decideReloadTeardownGate({ hasDonor: false, drained: false, donorDrained: false })).toBe(
+      "fresh-hard-timeout",
+    );
+    expect(decideReloadTeardownGate({ hasDonor: false, drained: false, donorDrained: true })).toBe(
+      "fresh-hard-timeout",
+    );
+  });
+
+  it("never returns a throwing/unknown decision for any input combination", () => {
+    const valid = new Set(["reuse", "fresh", "fresh-soft-timeout", "fresh-hard-timeout"]);
+    for (const hasDonor of [true, false]) {
+      for (const drained of [true, false]) {
+        for (const donorDrained of [true, false]) {
+          expect(valid.has(decideReloadTeardownGate({ hasDonor, drained, donorDrained }))).toBe(true);
+        }
+      }
+    }
   });
 });

--- a/release-notes/release-notes-2026.7.217.md
+++ b/release-notes/release-notes-2026.7.217.md
@@ -1,0 +1,25 @@
+# Release v2026.7.217
+
+This release closes three reload/teardown-lifecycle regressions reported from production logs on the `2026.7.215` line: #2111, #2112, and #2113. Each fix ships with dedicated regression tests.
+
+## Fixed
+
+- **Plugin re-registration no longer fails on a slow teardown** (#2111) — the reload gate threw `memory-hybrid: reload teardown did not drain before opening new databases` on the full-teardown path (no donor handles to inherit) whenever the prior teardown had not finished draining within the wait budget. That failed plugin `register()` outright and repeated on every reload attempt (reproduced on two hosts, Maeve and Doris). Because the donor's databases are being permanently closed on a *separate* teardown chain, the new registration can safely open its own fresh handles — so the gate now recovers to a fresh open (with a warning + a `teardownTimeoutRecoveries` metric) instead of throwing. The reuse and soft-timeout fallback paths are unchanged.
+- **`onSubagentEnded` is generation-safe after teardown** (#2112) — a subagent that started under a prior plugin generation could end after a reload had permanently closed the hybrid-memory `FactsDB`, producing repeated `onSubagentEnded failed (non-fatal): Error: The database connection is not open` log noise. Both `onSubagentEnded` and `prepareSubagentSpawn` now no-op cleanly when the captured DB handle has been torn down, using a new `BaseSqliteStore.isPermanentlyClosed()` predicate, and treat a late "connection is not open" error mid-callback as the same benign case.
+- **Error-reporter drain/flush no longer looks like a local failure when the endpoint is just offline** (#2113) — startup drain and shutdown flush emitted `Startup drain incomplete` / `flush incomplete` warnings even when the sole cause was an unreachable GlitchTip endpoint, and a permanently-offline endpoint kept the identical pending reports queued forever, re-warning on every restart. Delivery failures are now classified as `network` (transient connectivity), `http` (endpoint rejected the event), or `other`; a transient network failure logs at info level with wording that makes clear the backlog is retained for retry, while genuine local-queue problems keep the louder warn wording. Pending reports older than a 14-day retention window are aged out on load, so the queue makes forward progress even when delivery never succeeds.
+
+## Implementation notes
+
+- `decideReloadTeardownGate()` (in `setup/hybrid-memory-reload-coordinator.ts`) is a new pure helper that captures the gate's four outcomes (`reuse` / `fresh` / `fresh-soft-timeout` / `fresh-hard-timeout`), unit-tested across every input combination so the "never throw on the full-teardown path" invariant is locked in.
+- `BaseSqliteStore.isPermanentlyClosed()` returns true only after `permanentClose()` (or terminal shutdown) — distinct from `isOpen()`, which also returns false for a deferred-close store whose native handle was merely closed by background maintenance and can still lazily reopen.
+- The error-reporter retention window is `maxPendingReportAgeMs` (default 14 days), configurable via `ErrorReporterConfig`. Failure classification is exposed as `getLastErrorReportSendFailureKind()`, and the shared log-message builder is `describePendingTelemetryDrain()`.
+
+## Notes
+
+- No `schemaVersion` bump — no storage-schema changes.
+- No agent-tool contract changes.
+
+## Validation before release bump
+
+- Full local gate green: `npx tsc --noEmit`, `npm run verify:gate`, `npm test` (742 files / 9711 tests passed, 24 skipped, 0 failures).
+- Dedicated regression tests added for all three fixes: `decideReloadTeardownGate` coverage in `tests/register-plugin-reload-teardown-drain.test.ts`; torn-down `onSubagentEnded`/`prepareSubagentSpawn` cases in `tests/context-engine.test.ts`; failure-kind classification, age-out, and `describePendingTelemetryDrain` messaging in `tests/error-reporter-persistence.test.ts`.


### PR DESCRIPTION
## Summary

Fixes the three open issues, each a reload/teardown-lifecycle regression reported from production logs on the `2026.7.215` line. Every fix ships with dedicated regression tests. Version bumped to `2026.7.217` with matching changelog + release notes.

Closes #2111
Closes #2112
Closes #2113

### #2111 — plugin re-registration no longer fails on a slow teardown
The reload gate threw `memory-hybrid: reload teardown did not drain before opening new databases` on the **full-teardown** path (no donor handles to inherit) whenever the prior teardown had not finished draining within the wait budget. That failed plugin `register()` outright and repeated on every reload attempt — reproduced on two hosts (Maeve and Doris). Because the donor databases are permanently closed on a **separate** teardown chain, the new registration can safely open its own fresh handles, so the gate now recovers to a fresh open (warning + a new `reregisterMetrics.teardownTimeoutRecoveries` counter) instead of throwing. The reuse and soft-timeout fallback paths are unchanged. Gate logic was extracted into a pure, unit-tested `decideReloadTeardownGate()` helper.

### #2112 — `onSubagentEnded` is generation-safe after teardown
A subagent that started under a prior plugin generation could end after a reload had `permanentClose()`d the hybrid-memory `FactsDB`, producing repeated `onSubagentEnded failed (non-fatal): Error: The database connection is not open` log noise. Added `BaseSqliteStore.isPermanentlyClosed()`; `onSubagentEnded` and `prepareSubagentSpawn` now no-op cleanly (debug breadcrumb, no telemetry) when the captured handle is torn down, and a late "connection is not open" error mid-callback is treated as the same benign case.

### #2113 — error-reporter drain/flush distinguishes an offline endpoint from a local queue problem
Startup drain and shutdown flush warned as if the local queue were broken when the telemetry endpoint was merely unreachable, and a permanently-offline endpoint kept the same pending reports queued forever (re-warning on every restart). Delivery failures are now classified (`network` / `http` / `other`); a transient network failure logs at **info** level with retained-for-retry wording (shared `describePendingTelemetryDrain()` helper), while genuine local-queue problems keep the louder **warn** wording. Pending reports older than a 14-day retention window are aged out on load so the queue makes forward progress even when delivery never succeeds.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Quality Checklist

- [x] `cd extensions/memory-hybrid && npx tsc --noEmit` passes with no errors
- [x] `cd extensions/memory-hybrid && npm test` passes (742 files / 9711 tests passed, 24 skipped, 0 failures) + `npm run verify:gate` green
- [x] `npm run lint` — no new findings introduced by this change (pre-existing repo lint findings are unchanged by this diff, verified against the base branch)
- [x] No secrets, credentials, or API keys committed
- [x] No `console.log` debug statements left in production code

## Documentation Impact (REQUIRED)

- [x] Inline code comments (JSDoc) updated for modified/new functions and types
- [x] `docs/`/`README.md` — no update needed; changes are internal lifecycle/log behavior with no new user-facing surface, and no docs referenced the affected log strings
- [x] Cross-referenced functions/services checked for outdated documentation

## Testing

- [x] Unit tests added / updated
  - `decideReloadTeardownGate()` decision matrix — `tests/register-plugin-reload-teardown-drain.test.ts`
  - Torn-down `onSubagentEnded` / `prepareSubagentSpawn` no-op + late "not open" race — `tests/context-engine.test.ts`
  - Failure-kind classification, 14-day age-out, and `describePendingTelemetryDrain` messaging — `tests/error-reporter-persistence.test.ts`
- [ ] Manually verified against a running OpenClaw instance (covered by the reproduced-in-prod issue reports + regression tests)

## Notes for Reviewer

- The core #2111 change is the deliberate switch from **throw** to **recover-to-fresh-open** on the full-teardown hard-timeout path. This is safe because the old handles are closed on an independent teardown chain and the new registration opens its own fresh `DatabaseSync` connections; SQLite WAL supports concurrent connections to the same file. The behavior now matches the pre-existing soft-timeout fallback rather than being a hard failure.
- No `schemaVersion` bump and no agent-tool contract changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EQpQyqjJHuJLsjSF9hKufy

---
_Generated by [Claude Code](https://claude.ai/code/session_01EQpQyqjJHuJLsjSF9hKufy)_