### PR TITLE
fix(security): pin transitive yaml >=2.8.3 at repo root

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1276,9 +1276,9 @@
       }
     },
     "node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "dev": true,
       "license": "ISC",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -19,5 +19,8 @@
     "@lancedb/lancedb": "^0.27.1",
     "js-yaml": "^4.2.0",
     "openai": "^6.33.0"
+  },
+  "overrides": {
+    "yaml": ">=2.8.3"
   }
 }


### PR DESCRIPTION
## Summary

Fixes one of the vulnerabilities GitHub's Dependency Graph is flagging on `main`.

`lint-staged@15.5.2` (repo-root devDependency, used for the pre-commit git hook / formatting) declares `"yaml": "^2.7.0"`, but the lockfile had resolved to `yaml@2.8.2`, which is vulnerable to a stack-overflow DoS via deeply nested YAML collections: [GHSA-48c2-rrv3-qjmp](https://github.com/advisories/GHSA-48c2-rrv3-qjmp) (moderate). Fixed in `yaml@2.8.3`+, which already satisfies lint-staged's own declared range — so this is a pure lockfile-resolution fix via `overrides` (matching the existing pattern already used in `extensions/memory-hybrid/package.json` for `axios`/`follow-redirects`/`tar`/etc.), not a lint-staged version bump.

This is a **dev-tooling-only** exposure — the root `package.json` is never published (`extensions/memory-hybrid` is the shipped npm package), so this only affects the local git-hook/formatting toolchain, not runtime/production.

Note: local `npm audit` across all 3 lockfiles in the repo (root, `extensions/memory-hybrid`, `graph-app`) only surfaces this one vulnerability, vs. the 85 GitHub's Dependency Graph currently reports — npm's own advisory API is known to be less complete than GitHub's GHSA-based Dependabot scan, and some of the 85 may be stale (pending rescan after the two dependency-bump rounds that recently merged). This PR fixes what's locally visible; the rest needs the actual Dependabot alert list to triage.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor / internal improvement (no behavior change)
- [ ] Documentation update
- [x] CI / tooling change

## Quality Checklist

- [x] `cd extensions/memory-hybrid && npx tsc --noEmit` passes with no errors — N/A, no changes under `extensions/memory-hybrid`
- [x] `cd extensions/memory-hybrid && npm run lint` passes with no warnings — N/A, no changes under `extensions/memory-hybrid`
- [x] `cd extensions/memory-hybrid && npm test` passes (all tests green) — N/A, no changes under `extensions/memory-hybrid`
- [x] No secrets, credentials, or API keys committed
- [x] No `console.log` debug statements left in production code

## Documentation Impact (REQUIRED)

- [x] N/A — dev-tooling dependency pin only, no architectural or usage changes

## Testing

- `npm audit --json` at repo root: 0 vulnerabilities after the fix (was 1 moderate before)
- `npm ls yaml`: confirms `yaml@2.9.0 overridden` resolved (satisfies `>=2.8.3`)
- `git diff --stat`: scoped to `package.json` (+3 lines) and `package-lock.json` (+6/-3 lines) at repo root only
- Ran `.husky/pre-commit` (→ `npx lint-staged --debug`) directly end-to-end — completes without error (`No staged files match any configured task.`)

## Notes for Reviewer

Root package has no test suite (it's just git-hook plumbing per its own description), so the verification above is the extent of what's checkable — this is a minimal, well-understood transitive-dependency pin.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HpBafZ4f4KqAj9b6V2v3w3)_