### PR TITLE
fix: resolve 5 open production issues (#2135–#2139), bump to 2026.7.220

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,46 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [2026.7.220] - 2026-07-16
+
+Closes all five open production issues filed from live Maeve/Doris hosts (#2135–#2139), each fixed at the root cause with regression tests.
+
+### Fixed — Memory graph & supersession tooling (#2139)
+
+- **`memory_store` rejected `supersedes` as an array; `memory_link` threw a raw SQLite bind error ([#2139](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/2139))** — the plugin runtime does not enforce TypeBox parameter schemas, so a caller passing `supersedes: [id1, id2]` reached `supersedes.trim()` and threw `supersedes?.trim is not a function`, and a `memory_link` caller using `from`/`to`/`type` (instead of `sourceFact`/`targetFact`/`linkType`) reached `factsDb.getById(undefined)` and threw `Provided value cannot be bound to SQLite parameter 1.` `memory_store.supersedes` now accepts a single id **or an array of ids** (superseding each in-scope target independently) via `normalizeSupersedesInput`, and returns a structured `invalid_supersedes` error for any other shape. `memory_link` now resolves the common aliases (`from`/`to`/`type`, `source`/`target`), upper-cases the link type, validates every field before touching the DB, and returns a structured, parameter-named `invalid_input` error instead of an opaque SQLite exception.
+
+### Fixed — Credential vault false-positives (#2138)
+
+- **`memory_store` diverted ordinary infrastructure facts into bogus credential vault entries ([#2138](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/2138))** — the bare SSH connection-string pattern (`ssh <host> <user>`) matched ordinary prose like "connect via ssh …"; because `extractCredentialMatch` returned the matched span as a "secret" with `hasPatternMatch=true`, `validateCredentialValue` skipped its natural-language/path guards and accepted it, so an infra note (host/IP/gateway/MAC + stored service names) was written to the credential vault as a fake `ssh` credential. A bare SSH connection string carries no secret, so the pattern is now `detectionOnly`: it may still surface a user prompt via `detectCredentialPatterns`, but it never feeds `extractCredentialMatch` or `isStructuredCredentialCandidate`, so the fact is stored as a fact. Real SSH secrets (private-key blocks, `sshpass -p <pw>` passwords, connection strings with an embedded password) are unaffected.
+
+### Fixed — Nightly maintenance analyzer recursion (#2137)
+
+- **`maintenance-log-analyzer` still failed nightly on its own artifacts after #2131/#2132 ([#2137](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/2137))** — two self-reference escape routes remained. (A) Synthetic `orchestration-*` steps derived from the analyzer's own empty/stale/missing exit ledger were classified as the strict `orchestration-bug` class and were never in the self-referential step set, forcing exit=2 → `validate-cron-exit` exit=1 → `maintenance_failed` → new stale artifacts → loop. (B) The analyzer's own `analyze-maintenance-logs exit=2` (strict-fail) and `validate-cron-exit` rows re-classified as a strict class because their shared `logContent` is the analyzer's own re-read digest, full of *other* jobs' failure phrases. The self-suppression now recognizes the analyzer job's own `orchestration-*` synthetic steps and its strict-fail `exit=2` / validation rows regardless of the (contaminated) classification, while still reporting a genuine analyzer crash (`analyze exit=1` with a real classified stack) and every other job's failures.
+
+### Fixed — Reuse-databases teardown observability (#2136)
+
+- **`reuse-databases` full teardowns were unexplained ([#2136](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/2136))** — the reuse eligibility gate collapsed ~20 distinct decline reasons into a bare boolean and only logged a generic `debug` line, so an operator seeing `fullTeardowns > 0` under `reuse-databases` had no way to tell an intentional teardown (config changed) from a policy violation. `evaluateReregisterReuse` now returns a stable reason code (`bootstrap_not_settled`, `donor_handle_closed`, `sqlite_path_changed`, `config_drift:<field>`, `teardown_soft_timeout`, …); `recordReregisterFullTeardown(reason)` tallies a new `fullTeardownReasons` breakdown on `reregisterMetrics`; the fallback is now a `warn` naming the reason; and the `plugin_reregister_full_teardown_despite_reuse_policy` leak hint reports the per-reason counts instead of the old "check bootstrapSettledRef or config drift" nudge. Adds a regression test that repeated re-registers under `reuse-databases` keep `fullTeardowns`/`teardownTimeoutRecoveries` at 0.
+
+### Fixed — Staging plugin-load hardening (#2135)
+
+- **Gateway SIGBUS'd while loading the plugin from a hot-upgrade staging path ([#2135](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/2135))** — a native abort inside the LanceDB binding or an mmapped data file cannot be caught by a JS `try/catch` once execution enters native code. The register flow now runs a filesystem-only preflight (`preflightExtensionIntegrity`) before the first native store init: a structurally incomplete staging copy (missing / zero-byte / corrupt `openclaw.plugin.json` / `package.json`, or a missing / zero-byte compiled `dist/index.js` entry when a build is present) is rejected as a recoverable `PluginLoadPreflightError` instead of proceeding into the native path. Plugin-load and DB-init errors now carry a load-diagnostics context (package version, resolved extension path, staging flag, last-successful extension path, reload/teardown-drain state), and the last-known-good extension path is recorded after each successful registration. Scoped to the fresh-open path; the reuse path inherits already-open handles and performs no native connect. This is a necessary-but-not-sufficient guard — it cannot detect a present-but-internally-corrupt native binding, which would require child-process isolation.
+
+### Hardened — QA follow-up on this release's own fixes
+
+A full adversarial code review of this release's diff, before merge, closed several residual edge cases (all with regression tests):
+
+- **Multi-id supersede reporting (#2139)** — a partial multi-id supersede (`supersedes:[A,B]` where B is out-of-scope) silently dropped B. The response now surfaces `supersedeBlocked` for every requested-but-not-applied id, on partial and total failures alike.
+- **Misleading `dedupe-merge` reason (#2139)** — when a new fact was created but its supersede target was blocked/unknown, the message and `details.reason` wrongly said `dedupe-merge` (no merge happened). Blocked targets now report `reason: "targets_blocked_or_not_found"` with an accurate message; a genuine dedupe-merge is still labeled as such.
+- **Phantom `supersedes_id` lineage (#2139)** — the new fact's `supersedes_id` column was written before the scope check, so a blocked cross-scope target left a forward pointer to a fact whose `superseded_by` was never set. Supersede targets are now scope-validated *before* the write, so the persisted lineage only ever points at an in-scope target (or is null).
+- **`memory_link` alias shadowing (#2139)** — a blank canonical key (`sourceFact: ""`) no longer shadows a populated alias (`from: "<id>"`).
+- **Analyzer self-suppression trade-off (#2137)** — clarified in-code that suppressing the analyzer's own `orchestration-*` synthetics necessarily forgoes self-reporting of its own incomplete/hung prior runs (detected out-of-band instead), and that this matches the issue's request.
+- **Diagnostics snapshot aliasing (#2136)** — `buildGatewayMemoryDiagnostics` deep-copies `fullTeardownReasons` so a returned snapshot is a true point-in-time value rather than an alias of the live, still-mutating counter map.
+
+### Notes
+
+- No `schemaVersion` bump — no storage-schema changes.
+- No agent-tool contract changes; `memory_store` / `memory_link` accept a superset of their prior inputs.
+
 ## [2026.7.219] - 2026-07-15
 
 ### Fixed — Cron harness & maintenance observability (#2133, #2131, #2132)

--- a/extensions/memory-hybrid/openclaw.plugin.json
+++ b/extensions/memory-hybrid/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "openclaw-hybrid-memory",
   "kind": "memory",
-  "version": "2026.7.219",
+  "version": "2026.7.220",
   "contracts": {
     "tools": [
       "active_task_checkpoint",

--- a/extensions/memory-hybrid/package-lock.json
+++ b/extensions/memory-hybrid/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openclaw-hybrid-memory",
-  "version": "2026.7.218",
+  "version": "2026.7.220",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openclaw-hybrid-memory",
-      "version": "2026.7.218",
+      "version": "2026.7.220",
       "hasInstallScript": true,
       "dependencies": {
         "@lancedb/lancedb": "^0.31.0",
@@ -37,7 +37,7 @@
       "peerDependencies": {
         "@sinclair/typebox": "^0.34.52",
         "openai": "^6.46.0",
-        "openclaw": "^2026.7.1"
+        "openclaw": ">=2026.5.0 <2027"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -930,6 +930,7 @@
       "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
       "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "minipass": "^7.0.4"
       },
@@ -3377,6 +3378,7 @@
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
       "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
       "license": "BlueOak-1.0.0",
+      "optional": true,
       "engines": {
         "node": ">=18"
       }
@@ -4658,6 +4660,7 @@
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
       "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
       "license": "BlueOak-1.0.0",
+      "optional": true,
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
@@ -4667,6 +4670,7 @@
       "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
       "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "minipass": "^7.1.2"
       },
@@ -8917,6 +8921,7 @@
       "version": "1.61.1",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
       "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
@@ -9279,6 +9284,7 @@
       "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.19.tgz",
       "integrity": "sha512-4LeEWl96twnS2Q7Bz4MGqgazLqO+hJN63GZxXoIqh1T3VweYD997gbU1ItNsQafqqXTXd5WFyFdReLtwvRBNiw==",
       "license": "BlueOak-1.0.0",
+      "optional": true,
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
         "chownr": "^3.0.0",
@@ -10437,6 +10443,7 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
       "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
       "license": "BlueOak-1.0.0",
+      "optional": true,
       "engines": {
         "node": ">=18"
       }
@@ -10520,6 +10527,7 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "devOptional": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/extensions/memory-hybrid/package.json
+++ b/extensions/memory-hybrid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-hybrid-memory",
-  "version": "2026.7.219",
+  "version": "2026.7.220",
   "type": "module",
   "description": "Give your OpenClaw agent lasting memory: structured facts, semantic search, auto-capture & recall, decay, optional credential vault. Part of Hybrid Memory v3.",
   "files": [

--- a/extensions/memory-hybrid/services/auto-capture.ts
+++ b/extensions/memory-hybrid/services/auto-capture.ts
@@ -32,8 +32,18 @@ export const SENSITIVE_PATTERNS = [
 /** Patterns for capture filtering - uses broader /token/i instead of /token\s+is/i for security */
 export const CAPTURE_FILTER_PATTERNS = [...SENSITIVE_PATTERNS.slice(0, 3), /token/i, ...SENSITIVE_PATTERNS.slice(4)];
 
-/** Patterns that suggest a credential value - for auto-detect prompt to store */
-const CREDENTIAL_PATTERNS: Array<{ regex: RegExp; type: string; hint: string }> = [
+/**
+ * Patterns that suggest a credential value - for auto-detect prompt to store.
+ *
+ * `detectionOnly` patterns are used ONLY to nudge the user ("this looks credential-related,
+ * store it?"); they must NEVER route content into the credential vault. A bare SSH connection
+ * string (`ssh user@host …`) carries no secret material — the host and username are not secrets —
+ * so treating the matched span as an extractable `secretValue` produced bogus vault entries from
+ * ordinary infrastructure notes (#2138). Real SSH secrets are captured elsewhere: private-key
+ * blocks match the `-----BEGIN … PRIVATE KEY-----` pattern below, and `sshpass -p <pw>` command
+ * passwords are handled by services/credential-scanner.ts.
+ */
+const CREDENTIAL_PATTERNS: Array<{ regex: RegExp; type: string; hint: string; detectionOnly?: boolean }> = [
   { regex: /Bearer\s+eyJ[A-Za-z0-9_-]+\.eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/i, type: "bearer", hint: "Bearer/JWT token" },
   // Bare JWT (no "Bearer " prefix) — same shape, distinct entry since extractCredentialMatch
   // strips a leading "Bearer " but a bare JWT has none to strip. Negative lookbehind avoids
@@ -54,7 +64,8 @@ const CREDENTIAL_PATTERNS: Array<{ regex: RegExp; type: string; hint: string }> 
     type: "password",
     hint: "Connection string with embedded password",
   },
-  { regex: /ssh\s+[\w@.-]+\s+[\w@.-]+/i, type: "ssh", hint: "SSH connection string" },
+  // detectionOnly: a bare SSH connection string is not a secret (see block comment above).
+  { regex: /ssh\s+[\w@.-]+\s+[\w@.-]+/i, type: "ssh", hint: "SSH connection string", detectionOnly: true },
   {
     regex: /[\w.-]+@[\w.-]+\.\w+.*(?:password|passwd|token|key)\s*[:=]\s*(\S+)/i,
     type: "password",
@@ -79,7 +90,10 @@ const MAX_SECRET_VALUE_LENGTH = 8192;
 
 /** First credential-like match in text; used to extract secret for vault. */
 export function extractCredentialMatch(text: string): { type: string; secretValue: string } | null {
-  for (const { regex, type } of CREDENTIAL_PATTERNS) {
+  for (const { regex, type, detectionOnly } of CREDENTIAL_PATTERNS) {
+    // detectionOnly patterns (e.g. a bare SSH connection string) never yield a vault secret —
+    // the matched span is connection metadata, not credential material (#2138).
+    if (detectionOnly) continue;
     const match = regex.exec(text);
     if (match) {
       // Prefer a capture group when the pattern has one (the connection-string and
@@ -111,7 +125,10 @@ export function isStructuredCredentialCandidate(
   const e = (entity ?? "").toLowerCase();
   if (["api_key", "password", "token", "secret", "bearer"].some((x) => k.includes(x) || e.includes(x))) return true;
   if (value && value.length >= 8 && /^(eyJ|sk-|ghp_|gho_|xox[baprs]-)/i.test(value)) return true;
-  return CREDENTIAL_PATTERNS.some((p) => p.regex.test(text));
+  // Vault routing must ignore detectionOnly patterns: a bare SSH connection string is not a
+  // credential candidate, so infrastructure notes mentioning `ssh <host> <user>` stay ordinary
+  // facts instead of being diverted into a bogus vault entry (#2138).
+  return CREDENTIAL_PATTERNS.some((p) => !p.detectionOnly && p.regex.test(text));
 }
 
 /** True if content looks credential-related (broad or narrow). Used by auto-capture filters, not vault gating. */

--- a/extensions/memory-hybrid/services/gateway-memory-diagnostics.ts
+++ b/extensions/memory-hybrid/services/gateway-memory-diagnostics.ts
@@ -151,7 +151,20 @@ function buildLeakHints(opts: {
     hints.push("plugin_reregister_full_teardown: set OPENCLAW_HYBRID_MEM_REREGISTER_POLICY=reuse-databases");
   }
   if (opts.reregisterMetrics.fullTeardowns > 0 && opts.policy === "reuse-databases") {
-    hints.push("plugin_reregister_full_teardown_despite_reuse_policy: check bootstrapSettledRef or config drift");
+    // Attribute the teardowns to their named reasons (#2136) instead of the old generic
+    // "check bootstrapSettledRef or config drift" nudge, so an operator can immediately tell an
+    // intentional teardown (config_drift:<field>) from a policy violation (bootstrap_not_settled,
+    // donor_handle_closed, teardown_soft_timeout, …).
+    const reasons = opts.reregisterMetrics.fullTeardownReasons ?? {};
+    const breakdown = Object.entries(reasons)
+      .sort((a, b) => b[1] - a[1])
+      .map(([reason, count]) => `${reason}=${count}`)
+      .join(", ");
+    hints.push(
+      `plugin_reregister_full_teardown_despite_reuse_policy: ${
+        breakdown || "reason unrecorded"
+      } (config_drift:* is expected on config change; bootstrap_not_settled / donor_handle_closed / teardown_*_timeout indicate a reload-timing issue)`,
+    );
   }
   if (nativeMb > 2048 && opts.reregisterMetrics.databaseReuses > 0) {
     hints.push(
@@ -260,7 +273,9 @@ export async function buildGatewayMemoryDiagnostics(
       recallInFlight: ctx.recallInFlightRef?.value ?? 0,
       variantQueuePending: ctx.variantQueuePending ?? null,
       reregisterPolicy: policy,
-      reregisterMetrics: { ...reregisterMetrics },
+      // Deep-copy the nested reason map so the snapshot is a true point-in-time value and does
+      // not alias the live, still-mutating reregisterMetrics.fullTeardownReasons (#2136 QA).
+      reregisterMetrics: { ...reregisterMetrics, fullTeardownReasons: { ...reregisterMetrics.fullTeardownReasons } },
       vectorObservability: vectorObs,
     },
     eventLoop: {

--- a/extensions/memory-hybrid/services/maintenance-log-analyzer.ts
+++ b/extensions/memory-hybrid/services/maintenance-log-analyzer.ts
@@ -979,24 +979,57 @@ export function findingFromStep(step: MaintenanceLogStep, rule = classifyMainten
 
 /** The maintenance-log-analyzer cron job's own slug; see cli/install/cron-jobs.ts (#2132). */
 const ANALYZER_JOB_NAME = "maintenance-log-analyzer";
-/**
- * Step names within the analyzer job's own exit ledger that only ever record "the analyzer ran
- * and (possibly) strict-failed while reporting a root-cause finding" — not a distinct new
- * incident. `validate-cron-exit` is the harness's universal terminal row (every job gets one), so
- * this is scoped to ANALYZER_JOB_NAME specifically; other jobs' validate-cron-exit failures are
- * unrelated and must still be reported normally.
- */
-const ANALYZER_SELF_REFERENTIAL_STEPS = new Set(["analyze-maintenance-logs", "validate-cron-exit"]);
 
 /**
- * True when a step is the maintenance-log-analyzer job's own step/validation exit row from a
- * PRIOR completed run, resurfaced by a later scan. Rescanning these as fresh findings created a
- * self-amplifying failure loop: run B fails while reporting root cause A, then run C rescans B's
- * own `analyze-maintenance-logs exit=2` / `validate-cron-exit exit=1` rows as new "unclassified"
- * noise and fails again, compounding daily for as long as the artifacts remain on disk (#2132).
+ * The exit code `analyze-maintenance-logs` uses when it strict-fails while reporting a root-cause
+ * finding (register-analyze-maintenance-logs.ts sets `process.exitCode = 2`). This is the ONLY path
+ * that exits 2, so a `maintenance-log-analyzer / analyze-maintenance-logs exit=2` row is always the
+ * analyzer's own strict-fail self-reference — never a distinct new incident. A genuine crash of the
+ * analyze command exits 1 (or dies on a signal), so real crashes are still classified and reported.
  */
-function isDerivedAnalyzerSelfFailureStep(step: MaintenanceLogStep): boolean {
-  return step.job === ANALYZER_JOB_NAME && ANALYZER_SELF_REFERENTIAL_STEPS.has(step.step);
+const ANALYZER_STRICT_FAIL_EXIT_CODE = 2;
+
+/**
+ * True when a step is the maintenance-log-analyzer job's own step/validation/orchestration exit row
+ * from a PRIOR run, resurfaced by a later scan. Rescanning these as fresh findings created a
+ * self-amplifying failure loop: run B strict-fails while reporting root cause A, then run C rescans
+ * B's own artifacts as new failures and strict-fails again, compounding nightly for as long as the
+ * artifacts remain on disk (#2132, #2137). This is scoped to ANALYZER_JOB_NAME so other jobs'
+ * validate-cron-exit / orchestration failures are unaffected and still reported normally.
+ *
+ * Two recursion substrates are suppressed here (#2137):
+ *  - Hole A: synthetic `orchestration-*` steps that buildOrchestrationSyntheticStep derives from the
+ *    analyzer's OWN empty/stale/missing exit ledger. Any such synthetic necessarily describes a
+ *    PRIOR analyzer run (the run doing the scanning has not written its own ledger yet), so it is
+ *    always a rescan of a lingering historical artifact — and it classifies as the strict
+ *    `orchestration-bug` class, forcing exit=2 and re-arming the loop every night. Trade-off: the
+ *    analyzer therefore cannot flag its OWN incomplete/hung prior run; that non-completion is instead
+ *    caught out-of-band (a missing fresh digest / external cron liveness), not by the analyzer
+ *    reporting on itself and recursing. This matches the issue's request to stop treating its own
+ *    prior artifacts as fresh failures.
+ *  - Hole B: the analyzer's own `analyze-maintenance-logs exit=2` (strict-fail) and `validate-cron-exit`
+ *    rows re-classifying as a strict class because their shared `logContent` is the analyzer's own
+ *    re-read digest (full of OTHER jobs' failure phrases). These must be suppressed regardless of the
+ *    contaminated classification — hence this predicate no longer depends on `classification` for them.
+ *
+ * `classification` is still consulted for the analyzer's non-strict `analyze-maintenance-logs` rows so
+ * that a genuine, classifiable crash of the analyze command (exit 1 with e.g. a plugin-bug stack) is
+ * still surfaced rather than silenced.
+ */
+function isDerivedAnalyzerSelfFailureStep(step: MaintenanceLogStep, classification: string): boolean {
+  if (step.job !== ANALYZER_JOB_NAME) return false;
+  // Hole A: analyzer-own synthetic orchestration anomaly — always a rescan of its own prior ledger.
+  if (step.step.startsWith("orchestration-")) return true;
+  // The analyzer's terminal validation row fails purely because its analyze step strict-failed.
+  if (step.step === "validate-cron-exit") return true;
+  if (step.step === "analyze-maintenance-logs") {
+    // Hole B: strict-fail self-reference — suppress even if the re-read digest reclassified it.
+    if (step.exitCode === ANALYZER_STRICT_FAIL_EXIT_CODE) return true;
+    // Non-strict analyze rows: keep the prior #2132 behavior — only the unclassified generic
+    // catch-all is self-referential noise; a real classified crash (exit 1) still reports.
+    if (classification === "unclassified") return true;
+  }
+  return false;
 }
 
 export function analyzeMaintenanceSteps(
@@ -1009,10 +1042,10 @@ export function analyzeMaintenanceSteps(
     if (step.exitCode !== 0) {
       if (isBenignNoiseOnlyMaintenanceStep(step)) continue;
       const rule = classifyMaintenanceFailure(step);
-      // Only downgrade the generic catch-all: a genuine crash/plugin-bug/orchestration-bug in the
-      // analyzer job itself (anything that classified as something other than "unclassified") is
-      // still reported normally — this exclusively targets the self-referential recursion.
-      if (rule.classification === "unclassified" && isDerivedAnalyzerSelfFailureStep(step)) continue;
+      // Suppress the analyzer's own strict-fail / validation / orchestration self-references so it
+      // never treats its own prior artifacts as fresh failures (#2132, #2137). A genuine, classified
+      // crash of the analyze command (exit 1) is NOT matched here and is still reported normally.
+      if (isDerivedAnalyzerSelfFailureStep(step, rule.classification)) continue;
       findings.push(findingFromStep(step, rule));
       continue;
     }

--- a/extensions/memory-hybrid/services/memory-link-input.ts
+++ b/extensions/memory-hybrid/services/memory-link-input.ts
@@ -49,8 +49,7 @@ export function resolveMemoryLinkInput(params: Record<string, unknown>): Resolve
   if (!targetFact) {
     return {
       ok: false,
-      error:
-        "targetFact is required and must be a non-empty fact id string (accepted aliases: targetFact, target, to)",
+      error: "targetFact is required and must be a non-empty fact id string (accepted aliases: targetFact, target, to)",
     };
   }
 

--- a/extensions/memory-hybrid/services/memory-link-input.ts
+++ b/extensions/memory-hybrid/services/memory-link-input.ts
@@ -1,0 +1,84 @@
+/**
+ * Input resolution for the memory_link tool.
+ *
+ * The OpenClaw plugin runtime does not enforce TypeBox parameter schemas, so a caller that uses
+ * natural argument names (`from` / `to` / `type`) instead of the canonical ones reaches the tool
+ * body with `sourceFact` / `targetFact` / `linkType` all `undefined`. Those `undefined`s then flowed
+ * straight into `factsDb.getById(undefined, …)`, which threw the opaque SQLite error
+ * `Provided value cannot be bound to SQLite parameter 1.` (#2139). This helper resolves the common
+ * aliases, validates each field, and returns a structured error that names the offending parameter
+ * — so the tool never binds a non-string id to SQLite.
+ */
+
+import { MEMORY_LINK_TYPES, type MemoryLinkType } from "../backends/facts-db/types.js";
+
+export type ResolvedMemoryLinkInput =
+  | { ok: true; sourceFact: string; targetFact: string; linkType: MemoryLinkType; strength: number }
+  | { ok: false; error: string };
+
+const SOURCE_KEYS = ["sourceFact", "sourceFactId", "source", "from", "fromFact", "fromId"] as const;
+const TARGET_KEYS = ["targetFact", "targetFactId", "target", "to", "toFact", "toId"] as const;
+const TYPE_KEYS = ["linkType", "type", "relation", "relationship"] as const;
+const STRENGTH_KEYS = ["strength", "weight"] as const;
+
+function firstDefined(params: Record<string, unknown>, keys: readonly string[]): unknown {
+  for (const key of keys) {
+    const value = params[key];
+    if (value === undefined || value === null) continue;
+    // A blank/whitespace-only canonical key (e.g. a wrapper injecting `sourceFact: ""`) must not
+    // shadow a populated alias (`from: "<id>"`) — the whole point of alias resolution (#2139 QA).
+    if (typeof value === "string" && value.trim() === "") continue;
+    return value;
+  }
+  return undefined;
+}
+
+export function resolveMemoryLinkInput(params: Record<string, unknown>): ResolvedMemoryLinkInput {
+  const rawSource = firstDefined(params, SOURCE_KEYS);
+  const sourceFact = typeof rawSource === "string" ? rawSource.trim() : "";
+  if (!sourceFact) {
+    return {
+      ok: false,
+      error:
+        "sourceFact is required and must be a non-empty fact id string (accepted aliases: sourceFact, source, from)",
+    };
+  }
+
+  const rawTarget = firstDefined(params, TARGET_KEYS);
+  const targetFact = typeof rawTarget === "string" ? rawTarget.trim() : "";
+  if (!targetFact) {
+    return {
+      ok: false,
+      error:
+        "targetFact is required and must be a non-empty fact id string (accepted aliases: targetFact, target, to)",
+    };
+  }
+
+  const rawType = firstDefined(params, TYPE_KEYS);
+  const linkTypeUpper = typeof rawType === "string" ? rawType.trim().toUpperCase() : "";
+  if (!linkTypeUpper) {
+    return {
+      ok: false,
+      error: `linkType is required (accepted aliases: linkType, type). Valid types: ${MEMORY_LINK_TYPES.join(", ")}`,
+    };
+  }
+  if (!(MEMORY_LINK_TYPES as readonly string[]).includes(linkTypeUpper)) {
+    return {
+      ok: false,
+      error: `linkType "${linkTypeUpper}" is not a valid link type. Valid types: ${MEMORY_LINK_TYPES.join(", ")}`,
+    };
+  }
+  const linkType = linkTypeUpper as MemoryLinkType;
+
+  const rawStrength = firstDefined(params, STRENGTH_KEYS);
+  let strength = 1.0;
+  if (rawStrength !== undefined) {
+    const parsed = typeof rawStrength === "number" ? rawStrength : Number(rawStrength);
+    if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) {
+      return { ok: false, error: `strength must be a finite number in [0, 1]; got ${JSON.stringify(rawStrength)}` };
+    }
+    strength = parsed;
+  }
+
+  return { ok: true, sourceFact, targetFact, linkType, strength };
+}

--- a/extensions/memory-hybrid/services/supersedes-input.ts
+++ b/extensions/memory-hybrid/services/supersedes-input.ts
@@ -1,0 +1,39 @@
+/**
+ * Normalization for the memory_store `supersedes` argument.
+ *
+ * The tool schema advertises `supersedes` as a string, but the OpenClaw plugin runtime does not
+ * enforce TypeBox schemas at call time, so callers legitimately pass an array of fact ids (a very
+ * natural shape when correcting several stale facts at once). Previously that array reached
+ * `supersedes.trim()` and threw an opaque `supersedes?.trim is not a function` (#2139). This helper
+ * accepts a string, an array of id strings, or nothing, and returns a de-duplicated list of trimmed
+ * ids. Any other shape yields a structured error so the tool can reply with a clear validation
+ * message instead of a raw JS exception.
+ */
+
+export type NormalizedSupersedes = { ok: true; ids: string[] } | { ok: false; error: string };
+
+const EXPECTED = "supersedes must be a fact id string or an array of fact id strings";
+
+export function normalizeSupersedesInput(input: unknown): NormalizedSupersedes {
+  if (input == null) return { ok: true, ids: [] };
+
+  if (typeof input === "string") {
+    const trimmed = input.trim();
+    return { ok: true, ids: trimmed ? [trimmed] : [] };
+  }
+
+  if (Array.isArray(input)) {
+    const ids: string[] = [];
+    for (const element of input) {
+      if (typeof element !== "string") {
+        const kind = element === null ? "null" : Array.isArray(element) ? "array" : typeof element;
+        return { ok: false, error: `${EXPECTED}; got an array containing a ${kind} element` };
+      }
+      const trimmed = element.trim();
+      if (trimmed && !ids.includes(trimmed)) ids.push(trimmed);
+    }
+    return { ok: true, ids };
+  }
+
+  return { ok: false, error: `${EXPECTED}; got ${typeof input}` };
+}

--- a/extensions/memory-hybrid/setup/plugin-load-preflight.ts
+++ b/extensions/memory-hybrid/setup/plugin-load-preflight.ts
@@ -1,0 +1,185 @@
+/**
+ * Plugin-load preflight & diagnostics (#2135).
+ *
+ * The Gateway crashed with a native SIGBUS immediately after starting to load
+ * `openclaw-hybrid-memory` from a hot-upgrade *staging* directory
+ * (`…/.openclaw-hybrid-memory-staging-<n>/dist/index.js`). A native abort inside the LanceDB
+ * binding or an mmapped data file cannot be caught by a JS `try/catch` once execution enters
+ * native code, so the only safe defense is to (a) reject a structurally incomplete staging copy
+ * *before* the first native touch, and (b) record enough load context up front that any residual
+ * crash is diagnosable ("openclaw-hybrid-memory failed to initialize", with version + staging path
+ * + last-successful path + reload state) instead of an opaque `status=7/BUS`.
+ *
+ * This module is intentionally free of native/DB imports and side-effect-free (apart from the
+ * small module-scoped "last successful extension path" record) so it can run — and be tested —
+ * before any store is opened.
+ *
+ * Scope / limits: this is a *necessary but not sufficient* guard. It catches an interrupted staging
+ * copy whose manifests or compiled entry are missing/truncated/corrupt — the states that reliably
+ * precede a native abort. It cannot detect a native binding (`@lancedb/lancedb`'s `.node`) or an
+ * mmapped Lance data file that is present-but-internally-corrupt; a truncated-but-loadable binding
+ * can still SIGBUS at `lancedb.connect()`. A non-loadable binding, by contrast, throws a catchable
+ * error at the static ESM import long before this runs. Extending coverage to the native binding
+ * would require child-process isolation and is intentionally out of scope here.
+ */
+
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+/** Files that MUST be present and well-formed at the plugin root for a load to be safe to continue. */
+const CRITICAL_MANIFEST_FILES = ["openclaw.plugin.json", "package.json"] as const;
+
+export type ExtensionLoadContext = {
+  /** Absolute plugin-root directory the running module resolved from, or "unknown". */
+  extensionPath: string;
+  /** True when the extension is loaded from an OpenClaw hot-upgrade staging directory. */
+  isStaging: boolean;
+  /** Plugin version read from package.json, or "unknown" if unreadable. */
+  packageVersion: string;
+};
+
+export type PreflightResult = { ok: true } | { ok: false; reason: string; detail: string };
+
+/**
+ * True when a resolved extension path is an OpenClaw hot-upgrade staging directory. Matches any
+ * path segment that looks like `…-staging-<digits>` (e.g. `.openclaw-hybrid-memory-staging-856831`),
+ * which is how the loader names the temporary directory it copies a new version into before swap.
+ */
+export function isStagingExtensionPath(extensionPath: string): boolean {
+  if (!extensionPath) return false;
+  return /[\\/][^\\/]*-staging-\d+(?:[\\/]|$)/.test(extensionPath) || /-staging-\d+$/.test(extensionPath);
+}
+
+/**
+ * Build the load context for diagnostics. `extensionPath` should be the resolved plugin root
+ * (from findPluginRoot); pass "unknown" when it could not be resolved. Never throws.
+ */
+export function buildExtensionLoadContext(extensionPath: string): ExtensionLoadContext {
+  let packageVersion = "unknown";
+  if (extensionPath && extensionPath !== "unknown") {
+    try {
+      const pkgRaw = readFileSync(join(extensionPath, "package.json"), "utf-8");
+      const parsed = JSON.parse(pkgRaw) as { version?: unknown };
+      if (typeof parsed.version === "string" && parsed.version.length > 0) packageVersion = parsed.version;
+    } catch {
+      // Leave "unknown" — a missing/corrupt package.json is itself caught by the preflight below.
+    }
+  }
+  return {
+    extensionPath: extensionPath || "unknown",
+    isStaging: isStagingExtensionPath(extensionPath),
+    packageVersion,
+  };
+}
+
+/**
+ * Validate that the plugin root is a *complete* copy before continuing into native DB init. A
+ * partially copied / interrupted staging swap leaves a manifest missing, zero-byte, or truncated —
+ * exactly the state that precedes a native abort — so we fail closed with a recoverable, named
+ * error instead of proceeding into `lancedb.connect()`. Pure filesystem checks only; no native code.
+ */
+export function preflightExtensionIntegrity(extensionPath: string): PreflightResult {
+  if (!extensionPath || extensionPath === "unknown") {
+    return {
+      ok: false,
+      reason: "plugin_root_unresolved",
+      detail: "could not resolve the plugin root directory from the running module",
+    };
+  }
+  for (const file of CRITICAL_MANIFEST_FILES) {
+    const full = join(extensionPath, file);
+    if (!existsSync(full)) {
+      return { ok: false, reason: "missing_manifest", detail: `${file} is missing at ${extensionPath}` };
+    }
+    let size: number;
+    try {
+      size = statSync(full).size;
+    } catch (err) {
+      return { ok: false, reason: "stat_failed", detail: `${file} could not be stat()'d: ${errText(err)}` };
+    }
+    if (size === 0) {
+      return {
+        ok: false,
+        reason: "empty_manifest",
+        detail: `${file} is zero bytes at ${extensionPath} (partial/interrupted staging copy)`,
+      };
+    }
+    try {
+      JSON.parse(readFileSync(full, "utf-8"));
+    } catch (err) {
+      return { ok: false, reason: "corrupt_manifest", detail: `${file} is not valid JSON: ${errText(err)}` };
+    }
+  }
+
+  // When loaded from a compiled build (prod / hot-upgrade staging), the host imports
+  // `<root>/dist/index.js`; a staging copy that finished the small manifests but truncated the
+  // compiled entry would still crash. Validate the entry is present and non-empty when a `dist/`
+  // build exists. Skipped for a source/TS run (no dist/), which imports `index.ts` directly.
+  const distDir = join(extensionPath, "dist");
+  if (dirExists(distDir)) {
+    const entry = join(distDir, "index.js");
+    if (!existsSync(entry)) {
+      return { ok: false, reason: "missing_entry", detail: `dist/index.js is missing at ${extensionPath}` };
+    }
+    let entrySize: number;
+    try {
+      entrySize = statSync(entry).size;
+    } catch (err) {
+      return { ok: false, reason: "stat_failed", detail: `dist/index.js could not be stat()'d: ${errText(err)}` };
+    }
+    if (entrySize === 0) {
+      return {
+        ok: false,
+        reason: "empty_entry",
+        detail: `dist/index.js is zero bytes at ${extensionPath} (partial/interrupted staging copy)`,
+      };
+    }
+  }
+  return { ok: true };
+}
+
+function dirExists(path: string): boolean {
+  try {
+    return statSync(path).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function errText(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+// --- Last-successful extension path tracking (for crash diagnostics) ---------------------------
+// Recorded only after a registration completes far enough to be considered healthy, so a later
+// crashing staging load can report the path that last worked. Module-scoped on purpose: it must
+// survive across re-registrations within the same process.
+let lastSuccessfulExtensionPath: string | null = null;
+
+export function recordSuccessfulExtensionLoad(extensionPath: string): void {
+  if (extensionPath && extensionPath !== "unknown") lastSuccessfulExtensionPath = extensionPath;
+}
+
+export function getLastSuccessfulExtensionPath(): string | null {
+  return lastSuccessfulExtensionPath;
+}
+
+/** Test-only reset for the module-scoped last-successful path. */
+export function _resetLastSuccessfulExtensionPathForTests(): void {
+  lastSuccessfulExtensionPath = null;
+}
+
+/** Error thrown when the preflight rejects a load; carries the structured reason for diagnostics. */
+export class PluginLoadPreflightError extends Error {
+  readonly reason: string;
+  readonly loadContext: ExtensionLoadContext;
+  constructor(result: Extract<PreflightResult, { ok: false }>, loadContext: ExtensionLoadContext) {
+    super(
+      `memory-hybrid: plugin load preflight failed (${result.reason}): ${result.detail}. ` +
+        `version=${loadContext.packageVersion} staging=${loadContext.isStaging} path=${loadContext.extensionPath}`,
+    );
+    this.name = "PluginLoadPreflightError";
+    this.reason = result.reason;
+    this.loadContext = loadContext;
+  }
+}

--- a/extensions/memory-hybrid/setup/register-plugin.ts
+++ b/extensions/memory-hybrid/setup/register-plugin.ts
@@ -50,6 +50,7 @@ import {
 } from "../utils/language-keywords.js";
 import { applyHybridMemQuietFlagFromArgv, initPluginLogger, pluginLogger } from "../utils/logger.js";
 import { buildToolScopeFilter } from "../utils/scope-filter.js";
+import { findPluginRoot } from "../utils/plugin-root.js";
 import { versionInfo } from "../versionInfo.js";
 import {
   getHybridMemoryRegistrationState,
@@ -67,13 +68,21 @@ import {
   TEARDOWN_SOFT_WAIT_MS,
   TEARDOWN_WAIT_MS,
 } from "./hybrid-memory-reload-coordinator.js";
+import {
+  _resetLastSuccessfulExtensionPathForTests,
+  buildExtensionLoadContext,
+  getLastSuccessfulExtensionPath,
+  PluginLoadPreflightError,
+  preflightExtensionIntegrity,
+  recordSuccessfulExtensionLoad,
+} from "./plugin-load-preflight.js";
 import { createPluginService } from "./plugin-service.js";
 import { registerContextEngineBestEffort } from "./register-context-engine.js";
 import { registerLifecycleHooks } from "./register-hooks.js";
 import { registerTools } from "./register-tools.js";
 import {
-  canReuseDatabasesOnReregister,
   databaseContextFromRuntime,
+  evaluateReregisterReuse,
   recordReregisterDatabaseReuse,
   recordReregisterFullTeardown,
   recordReregisterRegistration,
@@ -374,10 +383,13 @@ function runMemoryHybridRegisterImpl(api: ClawdbotPluginApi): void {
   const donorGeneration = old?.bootRegistrationGeneration ?? -1;
 
   const reusePolicy = resolveReregisterPolicy();
-  const reuseDatabases = canReuseDatabasesOnReregister(old, cfg, logApi);
+  const reuseDecision = evaluateReregisterReuse(old, cfg, logApi);
+  const reuseDatabases = reuseDecision.reuse;
   if (old && reusePolicy === "reuse-databases" && !reuseDatabases) {
-    logApi.logger.debug?.(
-      "memory-hybrid: re-register falling back to full teardown (reuse policy requested but donor bootstrap not reusable)",
+    // Surface the exact named reason (#2136) so a full teardown under reuse-databases is never
+    // unexplained — this is what the `full_teardown_despite_reuse_policy` leak hint points at.
+    logApi.logger.warn?.(
+      `memory-hybrid: re-register falling back to full teardown despite reuse-databases policy (reason=${reuseDecision.reason})`,
     );
   }
   let donorRuntime = reuseDatabases && old ? old : null;
@@ -422,7 +434,7 @@ function runMemoryHybridRegisterImpl(api: ClawdbotPluginApi): void {
         `memory-hybrid: re-register reusing database handles (policy=${resolveReregisterPolicy()})`,
       );
     } else {
-      recordReregisterFullTeardown();
+      recordReregisterFullTeardown(reuseDecision.reason);
       const oldRuntime = old;
       old.pythonBridge?.shutdown().catch((err) => {
         capturePluginError(err instanceof Error ? err : new Error(String(err)), {
@@ -489,7 +501,7 @@ function runMemoryHybridRegisterImpl(api: ClawdbotPluginApi): void {
           `memory-hybrid: reload teardown soft-timeout exceeded (>=${TEARDOWN_SOFT_WAIT_MS}ms) for donor generation ${donorGeneration}; falling back to fresh open to avoid inheriting closed DB handles`,
         );
         donorRuntime = null;
-        recordReregisterFullTeardown();
+        recordReregisterFullTeardown("teardown_soft_timeout");
       } else if (decision === "fresh-hard-timeout") {
         // Full-teardown path (#2111): the donor's DB handles are being permanently closed on a
         // separate teardown chain. The new registration opens its own fresh handles, so it is
@@ -501,6 +513,46 @@ function runMemoryHybridRegisterImpl(api: ClawdbotPluginApi): void {
         );
         recordReregisterTeardownTimeoutRecovery();
       }
+    }
+  }
+
+  // Resolve where this plugin generation was loaded from (staging path awareness, #2135). Diagnostic
+  // context assembled BEFORE any native store init so a subsequent crash is attributable.
+  let extensionPath = "unknown";
+  try {
+    extensionPath = findPluginRoot(import.meta.url);
+  } catch {
+    // Leave "unknown"; the preflight below turns this into a recoverable, named error.
+  }
+  const loadContext = buildExtensionLoadContext(extensionPath);
+  const loadDiagnosticsContext: Record<string, Record<string, unknown>> = {
+    plugin_load: {
+      packageVersion: loadContext.packageVersion,
+      extensionPath: loadContext.extensionPath,
+      isStaging: loadContext.isStaging,
+      lastSuccessfulExtensionPath: getLastSuccessfulExtensionPath(),
+      reusingDonorHandles: Boolean(donorRuntime),
+      donorGenerationTeardownDrained: old ? isTeardownDrainedForGeneration(donorGeneration) : null,
+      registrationGeneration,
+    },
+  };
+
+  // Only preflight a FRESH open — the reuse path inherits already-open donor handles and performs no
+  // native connect, so it cannot SIGBUS on a partial staging copy. A structurally incomplete staging
+  // directory (missing/zero-byte/corrupt manifest) is rejected here, before the native LanceDB path,
+  // converting a would-be native abort into a recoverable plugin-load error (#2135).
+  if (!donorRuntime) {
+    const preflight = preflightExtensionIntegrity(extensionPath);
+    if (!preflight.ok) {
+      const preflightError = new PluginLoadPreflightError(preflight, loadContext);
+      capturePluginError(preflightError, {
+        subsystem: "registration",
+        operation: "plugin-register:load-preflight",
+        tags: { preflight_reason: preflight.reason, staging: loadContext.isStaging },
+        contexts: loadDiagnosticsContext,
+      });
+      logApi.logger.error?.(preflightError.message);
+      throw preflightError;
     }
   }
 
@@ -528,9 +580,14 @@ function runMemoryHybridRegisterImpl(api: ClawdbotPluginApi): void {
       dbContext = initializeDatabases(cfg, logApi, { bootRegistrationGeneration: registrationGeneration });
     }
   } catch (err) {
+    // Attach the load context (#2135) so an init failure during a staging/hot-upgrade load reports
+    // the package version, staging path, last-successful path, and reload/teardown state — instead
+    // of failing (or crashing) with no attribution.
     capturePluginError(err instanceof Error ? err : new Error(String(err)), {
       subsystem: "registration",
       operation: "plugin-register:init-databases",
+      tags: { staging: loadContext.isStaging, package_version: loadContext.packageVersion },
+      contexts: loadDiagnosticsContext,
     });
     throw err;
   }
@@ -1029,6 +1086,10 @@ function runMemoryHybridRegisterImpl(api: ClawdbotPluginApi): void {
       })();
     });
   }
+
+  // Synchronous registration completed without throwing — record this generation's load path as the
+  // last-known-good extension path so a future crashing staging load can report what last worked (#2135).
+  recordSuccessfulExtensionLoad(extensionPath);
 }
 
 export { detectCategory, performHybridMemCliTeardown, runtimeRef, shouldCapture };
@@ -1053,4 +1114,5 @@ export function resetPluginRegistrationStateForTests(): void {
   resetReloadTeardownChainForTests();
   resetReregisterPolicyForTests();
   resetHybridMemoryRegistrationStateForTests();
+  _resetLastSuccessfulExtensionPathForTests();
 }

--- a/extensions/memory-hybrid/setup/reregister-policy.ts
+++ b/extensions/memory-hybrid/setup/reregister-policy.ts
@@ -215,7 +215,8 @@ export function evaluateReregisterReuse(
   // some unrelated field forces a full teardown.
   if (oldCfg.wal?.enabled !== cfg.wal?.enabled) return drift("wal.enabled");
   if (oldCfg.personaProposals?.enabled !== cfg.personaProposals?.enabled) return drift("personaProposals.enabled");
-  if (oldCfg.identityReflection?.enabled !== cfg.identityReflection?.enabled) return drift("identityReflection.enabled");
+  if (oldCfg.identityReflection?.enabled !== cfg.identityReflection?.enabled)
+    return drift("identityReflection.enabled");
   if (oldCfg.identityPromotion?.enabled !== cfg.identityPromotion?.enabled) return drift("identityPromotion.enabled");
   if (oldCfg.nightlyCycle?.enabled !== cfg.nightlyCycle?.enabled) return drift("nightlyCycle.enabled");
   if (oldCfg.graph?.autoSupersede !== cfg.graph?.autoSupersede) return drift("graph.autoSupersede");

--- a/extensions/memory-hybrid/setup/reregister-policy.ts
+++ b/extensions/memory-hybrid/setup/reregister-policy.ts
@@ -16,6 +16,14 @@ export type ReregisterMetrics = {
    * gate is recovering from slow teardowns rather than failing plugin initialization.
    */
   teardownTimeoutRecoveries: number;
+  /**
+   * Per-reason breakdown of why full teardowns happened, keyed by a stable reason code (#2136).
+   * Under `reuse-databases` this is what turns an unexplained `fullTeardowns > 0` into an
+   * actionable diagnostic ("bootstrap_not_settled" vs "config_drift:embedding.model" vs
+   * "teardown_soft_timeout" …) so operators can tell an intentional teardown from a policy
+   * violation without reading source.
+   */
+  fullTeardownReasons: Record<string, number>;
 };
 
 export const reregisterMetrics: ReregisterMetrics = {
@@ -24,7 +32,15 @@ export const reregisterMetrics: ReregisterMetrics = {
   fullTeardowns: 0,
   databaseReuses: 0,
   teardownTimeoutRecoveries: 0,
+  fullTeardownReasons: {},
 };
+
+/**
+ * Structured result of the reuse-vs-teardown decision. `reason` is a stable, low-cardinality code
+ * (e.g. `reusable`, `no_donor`, `policy_not_reuse`, `bootstrap_not_settled`, `donor_handle_closed`,
+ * `sqlite_path_changed`, `config_drift:<field>`) so it can be counted and surfaced in diagnostics.
+ */
+export type ReregisterReuseDecision = { reuse: boolean; reason: string };
 
 /** Resolved once per process from OPENCLAW_HYBRID_MEM_REREGISTER_POLICY. */
 let cachedPolicy: ReregisterPolicy | null = null;
@@ -51,6 +67,7 @@ export function resetReregisterPolicyForTests(): void {
   reregisterMetrics.fullTeardowns = 0;
   reregisterMetrics.databaseReuses = 0;
   reregisterMetrics.teardownTimeoutRecoveries = 0;
+  reregisterMetrics.fullTeardownReasons = {};
 }
 
 export function recordReregisterRegistration(): void {
@@ -58,8 +75,15 @@ export function recordReregisterRegistration(): void {
   reregisterMetrics.registrations += 1;
 }
 
-export function recordReregisterFullTeardown(): void {
+/**
+ * Record a full teardown and, when known, why it happened. The `reason` is a stable code (see
+ * {@link ReregisterReuseDecision}); it is tallied in `fullTeardownReasons` so diagnostics can
+ * explain each teardown instead of leaving an unattributed `fullTeardowns` counter (#2136).
+ */
+export function recordReregisterFullTeardown(reason?: string): void {
   reregisterMetrics.fullTeardowns += 1;
+  const key = reason?.trim() ? reason.trim() : "unspecified";
+  reregisterMetrics.fullTeardownReasons[key] = (reregisterMetrics.fullTeardownReasons[key] ?? 0) + 1;
 }
 
 export function recordReregisterDatabaseReuse(): void {
@@ -120,80 +144,96 @@ function runtimeStoresStillReusable(old: PluginRuntime): boolean {
   return true;
 }
 
-/** True when re-register may keep existing SQLite/Lance handles (paths unchanged). */
-export function canReuseDatabasesOnReregister(
+const REUSABLE: ReregisterReuseDecision = { reuse: true, reason: "reusable" };
+const drift = (field: string): ReregisterReuseDecision => ({ reuse: false, reason: `config_drift:${field}` });
+
+/**
+ * Decide whether a re-register may keep the donor's SQLite/Lance handles, returning a stable
+ * reason code alongside the boolean (#2136). Every decline path names why it declined so a full
+ * teardown under `reuse-databases` is never unexplained. Pure/side-effect-free — callers record
+ * the reason via {@link recordReregisterFullTeardown}.
+ */
+export function evaluateReregisterReuse(
   old: PluginRuntime | null,
   cfg: HybridMemoryConfig,
   api: PathResolvingApi,
-): boolean {
-  if (!old) return false;
-  if (resolveReregisterPolicy() !== "reuse-databases") return false;
+): ReregisterReuseDecision {
+  if (!old) return { reuse: false, reason: "no_donor" };
+  if (resolveReregisterPolicy() !== "reuse-databases") return { reuse: false, reason: "policy_not_reuse" };
   // Reuse only after donor bootstrap has fully settled. If bootstrap is still in flight when
   // generation bumps, supersession can skip one-shot init work (vault/migration checks).
-  if (!old.bootstrapSettledRef || old.bootstrapSettledRef.value !== true) return false;
+  if (old.bootstrapSettledRef?.value !== true) {
+    return { reuse: false, reason: "bootstrap_not_settled" };
+  }
   // A settled donor can still be unusable if teardown/shutdown already closed one of its
   // SQLite/Lance handles. Reusing such a donor poisons the new registration: tools,
   // Workboard sync, credentials checks, compaction hooks, and lifecycle hooks inherit
   // stores that immediately throw "The database connection is not open". Treat any
   // closed/failed donor handle as non-reusable and fall back to a full fresh open.
-  if (!runtimeStoresStillReusable(old)) return false;
+  if (!runtimeStoresStillReusable(old)) return { reuse: false, reason: "donor_handle_closed" };
   const nextSqlite = api.resolvePath(cfg.sqlitePath);
   const nextLance = api.resolvePath(cfg.lanceDbPath);
-  if (old.resolvedSqlitePath !== nextSqlite || old.resolvedLancePath !== nextLance) return false;
+  if (old.resolvedSqlitePath !== nextSqlite) return { reuse: false, reason: "sqlite_path_changed" };
+  if (old.resolvedLancePath !== nextLance) return { reuse: false, reason: "lance_path_changed" };
 
   // Compare parse-time config, not bootstrap-mutated runtime cfg (initializeDatabases may inject llm tiers).
   const oldCfg = old.parsedCfgSnapshot ?? old.cfg;
-  if (!oldCfg?.embedding || !cfg.embedding) return false;
-  if (
-    oldCfg.embedding.provider !== cfg.embedding.provider ||
-    oldCfg.embedding.model !== cfg.embedding.model ||
-    oldCfg.embedding.endpoint !== cfg.embedding.endpoint ||
-    oldCfg.embedding.apiKey !== cfg.embedding.apiKey ||
-    oldCfg.embedding.deployment !== cfg.embedding.deployment
-  ) {
-    return false;
-  }
+  if (!oldCfg?.embedding || !cfg.embedding) return drift("embedding.missing");
+  if (oldCfg.embedding.provider !== cfg.embedding.provider) return drift("embedding.provider");
+  if (oldCfg.embedding.model !== cfg.embedding.model) return drift("embedding.model");
+  if (oldCfg.embedding.endpoint !== cfg.embedding.endpoint) return drift("embedding.endpoint");
+  if (oldCfg.embedding.apiKey !== cfg.embedding.apiKey) return drift("embedding.apiKey");
+  if (oldCfg.embedding.deployment !== cfg.embedding.deployment) return drift("embedding.deployment");
 
   // Compare LLM config to detect model/provider changes that require rebuilding openai client
   const oldLlm = oldCfg.llm;
   const newLlm = cfg.llm;
-  if (JSON.stringify(oldLlm?.default) !== JSON.stringify(newLlm?.default)) return false;
-  if (JSON.stringify(oldLlm?.heavy) !== JSON.stringify(newLlm?.heavy)) return false;
-  if (JSON.stringify(oldLlm?.nano) !== JSON.stringify(newLlm?.nano)) return false;
-  if (JSON.stringify(oldLlm?.providers) !== JSON.stringify(newLlm?.providers)) return false;
+  if (JSON.stringify(oldLlm?.default) !== JSON.stringify(newLlm?.default)) return drift("llm.default");
+  if (JSON.stringify(oldLlm?.heavy) !== JSON.stringify(newLlm?.heavy)) return drift("llm.heavy");
+  if (JSON.stringify(oldLlm?.nano) !== JSON.stringify(newLlm?.nano)) return drift("llm.nano");
+  if (JSON.stringify(oldLlm?.providers) !== JSON.stringify(newLlm?.providers)) return drift("llm.providers");
 
   // Compare credentials.enabled to detect when vault should be opened or closed.
-  if (oldCfg.credentials?.enabled !== cfg.credentials?.enabled) return false;
+  if (oldCfg.credentials?.enabled !== cfg.credentials?.enabled) return drift("credentials.enabled");
   // encryptionKey is non-enumerable on parsed config. A cloned snapshot can lose the key,
   // so fall back to the donor runtime cfg before treating missing as empty. Otherwise a
   // hot reload from a valid key to a missing/empty key could incorrectly reuse the old
   // CredentialsDB and keep decrypted credentials accessible until process restart.
   const oldEncKey = oldCfg.credentials?.encryptionKey ?? old.cfg.credentials?.encryptionKey ?? "";
   const newEncKey = cfg.credentials?.encryptionKey ?? "";
-  if (oldEncKey !== newEncKey) return false;
+  if (oldEncKey !== newEncKey) return drift("credentials.encryptionKey");
 
   // Compare HTTP route security settings so auth hardening or route disablement
   // cannot keep stale public/dashboard handlers alive on reused database handles.
-  if (oldCfg.health?.enabled !== cfg.health?.enabled) return false;
-  if (oldCfg.health?.authenticated !== cfg.health?.authenticated) return false;
+  if (oldCfg.health?.enabled !== cfg.health?.enabled) return drift("health.enabled");
+  if (oldCfg.health?.authenticated !== cfg.health?.authenticated) return drift("health.authenticated");
 
   // Compare every flag that gates a conditionally-constructed store in bootstrap-optional.ts.
   // Without this, flipping one of these on/off in config has no effect on a reuse-databases
   // reload — the donor's store handle (often still null) is carried over unchanged, so the
   // feature silently stays off (or, for wal.enabled, writes silently keep bypassing WAL) until
   // some unrelated field forces a full teardown.
-  if (oldCfg.wal?.enabled !== cfg.wal?.enabled) return false;
-  if (oldCfg.personaProposals?.enabled !== cfg.personaProposals?.enabled) return false;
-  if (oldCfg.identityReflection?.enabled !== cfg.identityReflection?.enabled) return false;
-  if (oldCfg.identityPromotion?.enabled !== cfg.identityPromotion?.enabled) return false;
-  if (oldCfg.nightlyCycle?.enabled !== cfg.nightlyCycle?.enabled) return false;
-  if (oldCfg.graph?.autoSupersede !== cfg.graph?.autoSupersede) return false;
-  if (oldCfg.passiveObserver?.enabled !== cfg.passiveObserver?.enabled) return false;
-  if (oldCfg.aliases?.enabled !== cfg.aliases?.enabled) return false;
-  if (oldCfg.verification?.enabled !== cfg.verification?.enabled) return false;
-  if (oldCfg.provenance?.enabled !== cfg.provenance?.enabled) return false;
+  if (oldCfg.wal?.enabled !== cfg.wal?.enabled) return drift("wal.enabled");
+  if (oldCfg.personaProposals?.enabled !== cfg.personaProposals?.enabled) return drift("personaProposals.enabled");
+  if (oldCfg.identityReflection?.enabled !== cfg.identityReflection?.enabled) return drift("identityReflection.enabled");
+  if (oldCfg.identityPromotion?.enabled !== cfg.identityPromotion?.enabled) return drift("identityPromotion.enabled");
+  if (oldCfg.nightlyCycle?.enabled !== cfg.nightlyCycle?.enabled) return drift("nightlyCycle.enabled");
+  if (oldCfg.graph?.autoSupersede !== cfg.graph?.autoSupersede) return drift("graph.autoSupersede");
+  if (oldCfg.passiveObserver?.enabled !== cfg.passiveObserver?.enabled) return drift("passiveObserver.enabled");
+  if (oldCfg.aliases?.enabled !== cfg.aliases?.enabled) return drift("aliases.enabled");
+  if (oldCfg.verification?.enabled !== cfg.verification?.enabled) return drift("verification.enabled");
+  if (oldCfg.provenance?.enabled !== cfg.provenance?.enabled) return drift("provenance.enabled");
 
-  return true;
+  return REUSABLE;
+}
+
+/** True when re-register may keep existing SQLite/Lance handles (paths unchanged). */
+export function canReuseDatabasesOnReregister(
+  old: PluginRuntime | null,
+  cfg: HybridMemoryConfig,
+  api: PathResolvingApi,
+): boolean {
+  return evaluateReregisterReuse(old, cfg, api).reuse;
 }
 
 /** Snapshot of initializeDatabases() return shape for register-plugin when reusing handles. */

--- a/extensions/memory-hybrid/tests/credential-ssh-connection-string.test.ts
+++ b/extensions/memory-hybrid/tests/credential-ssh-connection-string.test.ts
@@ -34,9 +34,7 @@ describe("SSH connection strings are not vault-routable credentials (#2138)", ()
   it("tryParseCredentialForVault returns null for infra text mentioning ssh + service names", () => {
     expect(tryParseCredentialForVault(infraText, "DorisVM", "runtime_host_and_network", null)).toBeNull();
     // Even with requirePatternMatch off, a value that is just narrative infra text is not a secret.
-    expect(
-      tryParseCredentialForVault(infraText, "DorisVM", "runtime_host_and_network", infraText),
-    ).toBeNull();
+    expect(tryParseCredentialForVault(infraText, "DorisVM", "runtime_host_and_network", infraText)).toBeNull();
   });
 
   it("still routes a REAL secret to the vault (JWT / sk- / connection-string password)", () => {

--- a/extensions/memory-hybrid/tests/credential-ssh-connection-string.test.ts
+++ b/extensions/memory-hybrid/tests/credential-ssh-connection-string.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Regression tests for #2138: `memory_store` diverted ordinary infrastructure facts into bogus
+ * credential vault entries. Root cause — the bare SSH connection-string pattern
+ * (`ssh <host> <user>`) matched ordinary prose, and because extractCredentialMatch returned the
+ * connection string as a "secret" with hasPatternMatch=true, validateCredentialValue skipped its
+ * natural-language guard and accepted it. A bare SSH connection string carries no secret, so it is
+ * now `detectionOnly`: it may still prompt the user, but it never routes into the vault.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  detectCredentialPatterns,
+  extractCredentialMatch,
+  isStructuredCredentialCandidate,
+  tryParseCredentialForVault,
+} from "../services/auto-capture.js";
+
+describe("SSH connection strings are not vault-routable credentials (#2138)", () => {
+  // The concrete shape from the issue: infrastructure fact for DorisVM referencing stored service
+  // names (doris-windows-host, doris-vm-ssh) and an ssh access method — but no secret payload.
+  const infraText =
+    "DorisVM runtime: Hyper-V host maevevm, VM IP 192.168.1.42, gateway port 8443, static MAC " +
+    "00:15:5d:01:02:03. Connect via ssh doris-vm-ssh service; stored service doris-windows-host.";
+
+  it("extractCredentialMatch no longer treats a bare SSH connection string as a secret", () => {
+    expect(extractCredentialMatch("ssh root@192.168.1.1 deploy-server")).toBeNull();
+    expect(extractCredentialMatch(infraText)).toBeNull();
+  });
+
+  it("isStructuredCredentialCandidate returns false for a bare SSH connection string / infra note", () => {
+    expect(isStructuredCredentialCandidate("ssh root@192.168.1.1 deploy-server")).toBe(false);
+    expect(isStructuredCredentialCandidate(infraText, "DorisVM", "runtime_host_and_network", null)).toBe(false);
+  });
+
+  it("tryParseCredentialForVault returns null for infra text mentioning ssh + service names", () => {
+    expect(tryParseCredentialForVault(infraText, "DorisVM", "runtime_host_and_network", null)).toBeNull();
+    // Even with requirePatternMatch off, a value that is just narrative infra text is not a secret.
+    expect(
+      tryParseCredentialForVault(infraText, "DorisVM", "runtime_host_and_network", infraText),
+    ).toBeNull();
+  });
+
+  it("still routes a REAL secret to the vault (JWT / sk- / connection-string password)", () => {
+    const jwt =
+      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
+    const parsedJwt = tryParseCredentialForVault(`Authorization: Bearer ${jwt}`, null, null, null);
+    expect(parsedJwt?.type).toBe("bearer");
+
+    const parsedConn = tryParseCredentialForVault(
+      "mongodb://svc-user:s3cr3t-pw-example@db.internal:27017/app",
+      null,
+      null,
+      null,
+    );
+    expect(parsedConn?.type).toBe("password");
+    expect(parsedConn?.secretValue).toBe("s3cr3t-pw-example");
+  });
+
+  it("still surfaces a bare SSH connection string as a detection-only prompt hint", () => {
+    // detectCredentialPatterns is the user-facing nudge (never a vault write); it may still flag ssh.
+    const detected = detectCredentialPatterns("ssh root@192.168.1.1 deploy-server");
+    expect(detected.some((d) => d.type === "ssh")).toBe(true);
+  });
+});

--- a/extensions/memory-hybrid/tests/gateway-memory-diagnostics.test.ts
+++ b/extensions/memory-hybrid/tests/gateway-memory-diagnostics.test.ts
@@ -8,7 +8,7 @@ import {
   buildProcessMemorySnapshot,
   sanitizePublicMemoryDiagnostics,
 } from "../services/gateway-memory-diagnostics.js";
-import { resetReregisterPolicyForTests } from "../setup/reregister-policy.js";
+import { recordReregisterFullTeardown, resetReregisterPolicyForTests } from "../setup/reregister-policy.js";
 import { setEnv } from "../utils/env-manager.js";
 import { resetEventLoopLagMonitorForTests, startEventLoopLagMonitor } from "../utils/event-loop-health.js";
 
@@ -57,6 +57,25 @@ describe("gateway-memory-diagnostics", () => {
     expect(diag.eventLoop.health).toBe("healthy");
     expect(diag.eventLoop.lagMaxMs).not.toBeNull();
     expect(diag.eventLoop.degradedThresholdMs).toBe(200);
+  });
+
+  it("attributes a reuse-policy full teardown to its named reason in leak hints (#2136)", async () => {
+    setEnv("OPENCLAW_HYBRID_MEM_REREGISTER_POLICY", "reuse-databases");
+    // Simulate a teardown that happened despite the reuse policy, with a specific cause.
+    recordReregisterFullTeardown("config_drift:embedding.model");
+    const vectorDb = { getPath: () => join(tmp, "lancedb"), count: async () => 0, isInitialized: () => false };
+    const diag = await buildGatewayMemoryDiagnostics({
+      factsDb,
+      vectorDb: vectorDb as never,
+      resolvedSqlitePath: join(tmp, "facts.db"),
+      resolvedLancePath: join(tmp, "lancedb"),
+      recallInFlightRef: { value: 0 },
+    });
+    const hint = diag.leakHints.find((h) => h.startsWith("plugin_reregister_full_teardown_despite_reuse_policy"));
+    expect(hint).toBeDefined();
+    // The generic "check bootstrapSettledRef or config drift" nudge is replaced by the real reason.
+    expect(hint).toContain("config_drift:embedding.model=1");
+    expect(diag.hybridMemory.reregisterMetrics.fullTeardownReasons).toEqual({ "config_drift:embedding.model": 1 });
   });
 
   it("buildProcessMemorySnapshot includes event loop lag fields", () => {

--- a/extensions/memory-hybrid/tests/maintenance-log-analyzer.test.ts
+++ b/extensions/memory-hybrid/tests/maintenance-log-analyzer.test.ts
@@ -1108,6 +1108,77 @@ describe("maintenance log analyzer", () => {
     expect(findings[0]?.job).toBe("nightly-memory-sweep");
   });
 
+  // #2137: the analyzer kept strict-failing nightly on its OWN artifacts after #2131/#2132.
+  // Two escape routes remained: (A) synthetic `orchestration-*` steps derived from the analyzer's
+  // own empty/stale exit ledger were classified as the strict `orchestration-bug` class (never in
+  // the self-referential step set), and (B) the analyzer's own strict-fail rows re-classified as a
+  // strict class because their shared logContent is the analyzer's re-read digest.
+  const analyzerOrchestrationStep = {
+    occurredAt: Math.floor(Date.now() / 1000),
+    iso: new Date().toISOString(),
+    job: "maintenance-log-analyzer",
+    step: "orchestration-stale-empty-exit",
+    exitCode: 1,
+    exitPath: "x.exit.txt",
+    logPath: "x.log",
+    logContent: "",
+    line: "orchestration anomaly: empty exit ledger appears stale (no mtime/progress updates for 7200s); stale=yes",
+  };
+
+  it("Hole A: suppresses the analyzer's OWN synthetic orchestration-* self-reference (no strict fail)", () => {
+    // Sanity: this step really does classify as the strict orchestration-bug class.
+    expect(classifyMaintenanceFailure(analyzerOrchestrationStep).classification).toBe("orchestration-bug");
+    const findings = analyzeMaintenanceSteps([analyzerOrchestrationStep]);
+    expect(findings).toHaveLength(0);
+    expect(shouldMaintenanceStrictFail(findings)).toBe(false);
+  });
+
+  it("still reports the SAME orchestration anomaly for a DIFFERENT (external) job", () => {
+    const externalStep = { ...analyzerOrchestrationStep, job: "nightly-memory-sweep" };
+    const findings = analyzeMaintenanceSteps([externalStep]);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.job).toBe("nightly-memory-sweep");
+    expect(findings[0]?.classification).toBe("orchestration-bug");
+  });
+
+  it("Hole B: suppresses the analyzer's own analyze exit=2 even when the re-read digest contaminates classification", () => {
+    // exit=2 is the analyzer's strict-fail sentinel; the logContent is its own digest quoting
+    // another job's TypeError, which WOULD otherwise reclassify this row as a strict plugin-bug.
+    const contaminatedSelfRow = {
+      occurredAt: Math.floor(Date.now() / 1000),
+      iso: new Date().toISOString(),
+      job: "maintenance-log-analyzer",
+      step: "analyze-maintenance-logs",
+      exitCode: 2,
+      exitPath: "x.exit.txt",
+      logPath: "x.log",
+      logContent:
+        "Maintenance digest\n- nightly-memory-sweep/distill: TypeError: Cannot read properties of undefined (reading 'x')",
+      line: "2026-07-16T03:33:02Z analyze-maintenance-logs exit=2 status=failed reason=nonzero_exit",
+    };
+    // Confirm the contamination WOULD have classified it as a strict class without the guard.
+    expect(classifyMaintenanceFailure(contaminatedSelfRow).classification).toBe("plugin-bug");
+    const findings = analyzeMaintenanceSteps([contaminatedSelfRow]);
+    expect(findings).toHaveLength(0);
+  });
+
+  it("still reports a genuine analyzer crash (analyze exit=1 with a real classified stack)", () => {
+    const crash = {
+      occurredAt: Math.floor(Date.now() / 1000),
+      iso: new Date().toISOString(),
+      job: "maintenance-log-analyzer",
+      step: "analyze-maintenance-logs",
+      exitCode: 1,
+      exitPath: "x.exit.txt",
+      logPath: "x.log",
+      logContent: "TypeError: Cannot read properties of undefined (reading 'foo')\n    at analyzeLogs (index.js:1:1)",
+      line: "2026-07-16T03:33:02Z analyze-maintenance-logs exit=1",
+    };
+    const findings = analyzeMaintenanceSteps([crash]);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.classification).toBe("plugin-bug");
+  });
+
   it("summarizeMaintenanceLogAnalysis marks strict=fail when findings include strict classes", () => {
     const root = tmpRoot();
     const exitPath = join(root, "nightly-memory-sweep-20260511T030000Z-555.exit.txt");

--- a/extensions/memory-hybrid/tests/memory-link-input.test.ts
+++ b/extensions/memory-hybrid/tests/memory-link-input.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Regression tests for #2139: memory_link's real parameters are sourceFact/targetFact/linkType,
+ * but a caller using from/to/type reached factsDb.getById(undefined) and threw the opaque
+ * "Provided value cannot be bound to SQLite parameter 1." resolveMemoryLinkInput now resolves the
+ * common aliases and returns a structured, parameter-named error for anything it can't interpret.
+ */
+import { describe, expect, it } from "vitest";
+import { resolveMemoryLinkInput } from "../services/memory-link-input.js";
+
+describe("resolveMemoryLinkInput (#2139)", () => {
+  const SRC = "b9cc40ed-1675-47af-93eb-97e9e33b847d";
+  const TGT = "047efc02-b019-4236-8843-5cf4724e3db0";
+
+  it("resolves the canonical parameter names", () => {
+    const result = resolveMemoryLinkInput({ sourceFact: SRC, targetFact: TGT, linkType: "SUPERSEDES" });
+    expect(result).toEqual({ ok: true, sourceFact: SRC, targetFact: TGT, linkType: "SUPERSEDES", strength: 1.0 });
+  });
+
+  it("accepts the from/to/type aliases the issue caller used, without a SQLite bind error", () => {
+    const result = resolveMemoryLinkInput({
+      from: SRC,
+      to: TGT,
+      type: "SUPERSEDES",
+      why: "Current Doris runtime correction supersedes stale gateway fact.",
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.sourceFact).toBe(SRC);
+      expect(result.targetFact).toBe(TGT);
+      expect(result.linkType).toBe("SUPERSEDES");
+    }
+  });
+
+  it("upper-cases a lowercase link type", () => {
+    const result = resolveMemoryLinkInput({ sourceFact: SRC, targetFact: TGT, linkType: "supersedes" });
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.linkType).toBe("SUPERSEDES");
+  });
+
+  it("returns a named error identifying the missing source (instead of binding undefined)", () => {
+    const result = resolveMemoryLinkInput({ targetFact: TGT, linkType: "SUPERSEDES" });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toContain("sourceFact");
+  });
+
+  it("returns a named error identifying the missing target", () => {
+    const result = resolveMemoryLinkInput({ sourceFact: SRC, linkType: "SUPERSEDES" });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toContain("targetFact");
+  });
+
+  it("rejects an unknown link type and lists the valid ones", () => {
+    const result = resolveMemoryLinkInput({ from: SRC, to: TGT, type: "NOT_A_TYPE" });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("linkType");
+      expect(result.error).toContain("SUPERSEDES");
+    }
+  });
+
+  it("validates strength range", () => {
+    const ok = resolveMemoryLinkInput({ from: SRC, to: TGT, type: "RELATED_TO", strength: 0.5 });
+    expect(ok.ok).toBe(true);
+    if (ok.ok) expect(ok.strength).toBe(0.5);
+
+    const bad = resolveMemoryLinkInput({ from: SRC, to: TGT, type: "RELATED_TO", strength: 5 });
+    expect(bad.ok).toBe(false);
+    if (!bad.ok) expect(bad.error).toContain("strength");
+  });
+
+  it("does not throw for non-string ids — returns a structured error", () => {
+    expect(() => resolveMemoryLinkInput({ from: 42, to: TGT, type: "SUPERSEDES" })).not.toThrow();
+    const result = resolveMemoryLinkInput({ from: 42, to: TGT, type: "SUPERSEDES" });
+    expect(result.ok).toBe(false);
+  });
+});

--- a/extensions/memory-hybrid/tests/memory-link-supersedes-tool.test.ts
+++ b/extensions/memory-hybrid/tests/memory-link-supersedes-tool.test.ts
@@ -38,8 +38,18 @@ function setup(facts: FakeFact[]) {
   return { link: tools.get("memory_link"), factsDb, createLink };
 }
 
-const SRC: FakeFact = { id: "b9cc40ed-1675-47af-93eb-97e9e33b847d", text: "current correction", scope: "global", scopeTarget: null };
-const TGT: FakeFact = { id: "047efc02-b019-4236-8843-5cf4724e3db0", text: "stale gateway fact", scope: "global", scopeTarget: null };
+const SRC: FakeFact = {
+  id: "b9cc40ed-1675-47af-93eb-97e9e33b847d",
+  text: "current correction",
+  scope: "global",
+  scopeTarget: null,
+};
+const TGT: FakeFact = {
+  id: "047efc02-b019-4236-8843-5cf4724e3db0",
+  text: "stale gateway fact",
+  scope: "global",
+  scopeTarget: null,
+};
 
 describe("memory_link SUPERSEDES input handling (#2139)", () => {
   it("creates a SUPERSEDES link between two valid fact UUIDs", async () => {

--- a/extensions/memory-hybrid/tests/memory-link-supersedes-tool.test.ts
+++ b/extensions/memory-hybrid/tests/memory-link-supersedes-tool.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Integration regression for #2139: memory_link must accept two valid fact UUIDs and
+ * type=SUPERSEDES without a SQLite binding error, and must return a structured, parameter-named
+ * error (never bind `undefined` to SQLite) when the caller uses the wrong argument names.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { hybridConfigSchema } from "../config.js";
+import { registerGraphTools } from "../tools/graph-tools.js";
+
+type FakeFact = { id: string; text: string; scope: string; scopeTarget: string | null };
+
+function setup(facts: FakeFact[]) {
+  const factMap = new Map(facts.map((f) => [f.id, f]));
+  const createLink = vi.fn(() => "new-link-id");
+  const getById = vi.fn((id: string) => {
+    // Mirror node:sqlite: binding a non-string/undefined id throws a bind error. This is exactly
+    // the failure the tool must prevent by validating input before it reaches the DB.
+    if (typeof id !== "string") {
+      throw new TypeError("Provided value cannot be bound to SQLite parameter 1.");
+    }
+    return factMap.get(id) ?? null;
+  });
+  const factsDb = { getById, createLink, recordContradiction: vi.fn(() => "c-id") };
+
+  const cfg = hybridConfigSchema.parse({ embedding: { provider: "onnx", model: "bge-m3", dimensions: 1024 } });
+  cfg.graph.enabled = true;
+
+  const tools = new Map<string, { execute: (...a: unknown[]) => unknown }>();
+  const api = {
+    registerTool(opts: Record<string, unknown>) {
+      tools.set(opts.name as string, { execute: opts.execute as (...a: unknown[]) => unknown });
+    },
+  };
+  registerGraphTools(
+    { factsDb: factsDb as never, cfg, currentAgentIdRef: { value: null }, buildToolScopeFilter: () => undefined },
+    api as never,
+  );
+  return { link: tools.get("memory_link"), factsDb, createLink };
+}
+
+const SRC: FakeFact = { id: "b9cc40ed-1675-47af-93eb-97e9e33b847d", text: "current correction", scope: "global", scopeTarget: null };
+const TGT: FakeFact = { id: "047efc02-b019-4236-8843-5cf4724e3db0", text: "stale gateway fact", scope: "global", scopeTarget: null };
+
+describe("memory_link SUPERSEDES input handling (#2139)", () => {
+  it("creates a SUPERSEDES link between two valid fact UUIDs", async () => {
+    const { link, createLink } = setup([SRC, TGT]);
+    const result = (await link?.execute("call-1", {
+      sourceFact: SRC.id,
+      targetFact: TGT.id,
+      linkType: "SUPERSEDES",
+    })) as { details: Record<string, unknown> };
+    expect(createLink).toHaveBeenCalledWith(SRC.id, TGT.id, "SUPERSEDES", 1.0);
+    expect(result.details.linkType).toBe("SUPERSEDES");
+  });
+
+  it("accepts the from/to/type aliases and still links successfully", async () => {
+    const { link, createLink } = setup([SRC, TGT]);
+    const result = (await link?.execute("call-1", {
+      from: SRC.id,
+      to: TGT.id,
+      type: "SUPERSEDES",
+      why: "supersedes stale fact",
+    })) as { details: Record<string, unknown> };
+    expect(createLink).toHaveBeenCalledWith(SRC.id, TGT.id, "SUPERSEDES", 1.0);
+    expect(result.details.linkType).toBe("SUPERSEDES");
+  });
+
+  it("returns a structured validation error (no SQLite bind exception) when ids are missing", async () => {
+    const { link, factsDb, createLink } = setup([SRC, TGT]);
+    let result: { details: Record<string, unknown>; content: Array<{ text: string }> } | undefined;
+    await expect(
+      (async () => {
+        result = (await link?.execute("call-1", { sourceFact: SRC.id, linkType: "SUPERSEDES" })) as typeof result;
+      })(),
+    ).resolves.toBeUndefined();
+    expect(result?.details.error).toBe("invalid_input");
+    expect(result?.content[0]?.text).toContain("targetFact");
+    // Critically: the DB was never touched with an undefined id.
+    expect(factsDb.getById).not.toHaveBeenCalled();
+    expect(createLink).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/memory-hybrid/tests/memory-store-supersedes-multi.test.ts
+++ b/extensions/memory-hybrid/tests/memory-store-supersedes-multi.test.ts
@@ -195,7 +195,13 @@ describe("memory_store supersedes (#2139)", () => {
       text: "Doris correction whose only supersede target is out of scope",
       supersedes: foreign.id,
     })) as {
-      details?: { action?: string; reason?: string; supersedeApplied?: boolean; supersedeBlocked?: string[]; id?: string };
+      details?: {
+        action?: string;
+        reason?: string;
+        supersedeApplied?: boolean;
+        supersedeBlocked?: string[];
+        id?: string;
+      };
     };
     // A new fact was created; the supersede was blocked — reason must reflect that, not dedupe-merge.
     expect(result.details?.action).toBe("created");

--- a/extensions/memory-hybrid/tests/memory-store-supersedes-multi.test.ts
+++ b/extensions/memory-hybrid/tests/memory-store-supersedes-multi.test.ts
@@ -1,0 +1,210 @@
+// @ts-nocheck — registerMemoryTools uses `ClawdbotPluginApi` from `openclaw`, not available in the
+// test environment; consistent with the pattern in memory-tools-cross-scope-mutation.test.ts.
+/**
+ * Regression tests for #2139 (and its QA follow-up): memory_store's `supersedes` must accept a
+ * single id OR an array of ids, applying each in-scope target, reporting blocked/unknown targets,
+ * and never mislabeling a blocked target as a dedupe-merge or writing a phantom `supersedes_id`.
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { _testing } from "../index.js";
+import { registerMemoryTools } from "../tools/memory-tools.js";
+import { buildToolScopeFilter } from "../utils/scope-filter.js";
+
+const { FactsDB } = _testing;
+
+function makeMockApi() {
+  const tools = new Map();
+  return {
+    registerTool(opts) {
+      tools.set(opts.name, { execute: opts.execute });
+    },
+    getTool(name) {
+      return tools.get(name);
+    },
+    logger: { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() },
+    context: { sessionId: "test-session" },
+  };
+}
+
+const makeMockVectorDb = () => ({
+  hasDuplicate: vi.fn().mockResolvedValue(false),
+  store: vi.fn().mockResolvedValue(undefined),
+  delete: vi.fn().mockResolvedValue(true),
+  search: vi.fn().mockResolvedValue([]),
+  count: vi.fn().mockResolvedValue(0),
+  close: vi.fn(),
+});
+
+const makeMockEmbeddings = () => ({
+  embed: vi.fn().mockResolvedValue(new Array(4).fill(0.1)),
+  embedBatch: vi.fn().mockResolvedValue([]),
+  dimensions: 4,
+  modelName: "mock-model",
+});
+
+function makeCfg() {
+  return {
+    captureMaxChars: 2000,
+    categories: ["fact", "preference", "decision"],
+    store: { classifyBeforeWrite: false, fuzzyDedupe: false },
+    multiAgent: { orchestratorId: "main", defaultStoreScope: "global", strictAgentScoping: false },
+    graph: { enabled: false, autoLink: false, autoSupersede: false },
+    graphRetrieval: { enabled: false },
+    credentials: { enabled: false },
+    autoRecall: { scopeFilter: null, summaryThreshold: 0, summaryMaxChars: 500 },
+    distill: { reinforcementBoost: 0.1 },
+    retrieval: { strategies: [], explicitBudgetTokens: 2000, contradictionLatencyWarnMs: 1000 },
+    aliases: { enabled: false },
+    procedures: { enabled: false },
+    verbosity: "normal",
+    clusters: null,
+  };
+}
+
+let tmpDir: string;
+let factsDb: InstanceType<typeof FactsDB>;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "memory-store-supersedes-"));
+  factsDb = new FactsDB(join(tmpDir, "facts.db"));
+});
+
+afterEach(() => {
+  factsDb.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function setupStoreTool() {
+  const api = makeMockApi();
+  registerMemoryTools(
+    {
+      factsDb: factsDb as never,
+      edictStore: null as never,
+      vectorDb: makeMockVectorDb() as never,
+      cfg: makeCfg() as never,
+      embeddings: makeMockEmbeddings() as never,
+      openai: {} as never,
+      wal: null,
+      credentialsDb: null,
+      eventLog: null,
+      lastProgressiveIndexIds: [],
+      currentAgentIdRef: { value: "main" }, // orchestrator → global scope
+      pendingLLMWarnings: { drain: vi.fn().mockReturnValue([]) } as never,
+      aliasDb: null,
+    },
+    api as never,
+    buildToolScopeFilter,
+    async () => "wal-id",
+    async () => {},
+    async () => [],
+  );
+  return api.getTool("memory_store");
+}
+
+const globalFact = (text: string) =>
+  factsDb.store({
+    text,
+    category: "fact",
+    importance: 0.8,
+    entity: null,
+    key: null,
+    value: null,
+    source: "test",
+    scope: "global",
+    scopeTarget: null,
+  });
+
+describe("memory_store supersedes (#2139)", () => {
+  it("rejects a malformed supersedes shape with a structured error, not a thrown exception", async () => {
+    const store = setupStoreTool();
+    const result = (await store.execute("c1", {
+      text: "some new correction fact number one",
+      supersedes: { not: "a string or array" },
+    })) as { details?: { error?: string } };
+    expect(result.details?.error).toBe("invalid_supersedes");
+  });
+
+  it("supersedes a single in-scope target and reports it", async () => {
+    const store = setupStoreTool();
+    const stale = globalFact("Doris gateway is 192.168.1.198 (stale)");
+    const result = (await store.execute("c1", {
+      text: "Doris gateway corrected to 10.0.0.5 current",
+      supersedes: stale.id,
+    })) as { details?: { action?: string; superseded?: string; supersededIds?: string[] } };
+    expect(result.details?.action).toBe("updated");
+    expect(result.details?.superseded).toBe(stale.id);
+    expect(result.details?.supersededIds).toEqual([stale.id]);
+    expect(factsDb.getById(stale.id)?.supersededAt ?? null).not.toBeNull();
+  });
+
+  it("accepts an ARRAY of supersedes ids and supersedes each in-scope target", async () => {
+    const store = setupStoreTool();
+    const a = globalFact("Doris stale fact A 192.168.1.198");
+    const b = globalFact("Doris stale fact B 192.168.1.224");
+    const result = (await store.execute("c1", {
+      text: "Doris current runtime correction supersedes A and B",
+      supersedes: [a.id, b.id],
+    })) as { details?: { action?: string; supersededIds?: string[] } };
+    expect(result.details?.action).toBe("updated");
+    expect(new Set(result.details?.supersededIds)).toEqual(new Set([a.id, b.id]));
+    expect(factsDb.getById(a.id)?.supersededAt ?? null).not.toBeNull();
+    expect(factsDb.getById(b.id)?.supersededAt ?? null).not.toBeNull();
+  });
+
+  it("reports blocked targets on a partial multi-id supersede instead of silently dropping them", async () => {
+    const store = setupStoreTool();
+    const valid = globalFact("Doris stale valid target");
+    const foreign = factsDb.store({
+      text: "another agent's private fact",
+      category: "fact",
+      importance: 0.8,
+      entity: null,
+      key: null,
+      value: null,
+      source: "test",
+      scope: "agent",
+      scopeTarget: "agent-2",
+    });
+    const result = (await store.execute("c1", {
+      text: "Doris correction touching one valid and one out-of-scope target",
+      supersedes: [valid.id, foreign.id],
+    })) as { details?: { supersededIds?: string[]; supersedeBlocked?: string[] } };
+    expect(result.details?.supersededIds).toEqual([valid.id]);
+    expect(result.details?.supersedeBlocked).toEqual([foreign.id]);
+    // The out-of-scope fact must be untouched.
+    expect(factsDb.getById(foreign.id)?.supersededAt ?? null).toBeNull();
+  });
+
+  it("when ALL targets are blocked, reports a blocked reason (not a bogus dedupe-merge) and writes no phantom lineage", async () => {
+    const store = setupStoreTool();
+    const foreign = factsDb.store({
+      text: "foreign fact only",
+      category: "fact",
+      importance: 0.8,
+      entity: null,
+      key: null,
+      value: null,
+      source: "test",
+      scope: "agent",
+      scopeTarget: "agent-2",
+    });
+    const result = (await store.execute("c1", {
+      text: "Doris correction whose only supersede target is out of scope",
+      supersedes: foreign.id,
+    })) as {
+      details?: { action?: string; reason?: string; supersedeApplied?: boolean; supersedeBlocked?: string[]; id?: string };
+    };
+    // A new fact was created; the supersede was blocked — reason must reflect that, not dedupe-merge.
+    expect(result.details?.action).toBe("created");
+    expect(result.details?.supersedeApplied).toBe(false);
+    expect(result.details?.reason).toBe("targets_blocked_or_not_found");
+    expect(result.details?.supersedeBlocked).toEqual([foreign.id]);
+    // The new fact must NOT persist a phantom supersedes_id pointing at the blocked foreign fact.
+    const newFact = factsDb.getById(result.details!.id!);
+    expect(newFact?.supersedesId ?? null).toBeNull();
+    expect(factsDb.getById(foreign.id)?.supersededAt ?? null).toBeNull();
+  });
+});

--- a/extensions/memory-hybrid/tests/plugin-load-preflight.test.ts
+++ b/extensions/memory-hybrid/tests/plugin-load-preflight.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Regression tests for #2135: the Gateway SIGBUS'd while loading openclaw-hybrid-memory from a
+ * hot-upgrade staging directory. A native abort can't be caught once execution enters native code,
+ * so the defense is to reject a structurally incomplete staging copy BEFORE the first native touch
+ * and to record enough load context that any residual crash is attributable. These tests cover the
+ * pure preflight/diagnostics seam (no native/DB code).
+ */
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  _resetLastSuccessfulExtensionPathForTests,
+  buildExtensionLoadContext,
+  getLastSuccessfulExtensionPath,
+  isStagingExtensionPath,
+  PluginLoadPreflightError,
+  preflightExtensionIntegrity,
+  recordSuccessfulExtensionLoad,
+} from "../setup/plugin-load-preflight.js";
+
+let root: string;
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "load-preflight-"));
+  _resetLastSuccessfulExtensionPathForTests();
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+  _resetLastSuccessfulExtensionPathForTests();
+});
+
+function writeHealthyPlugin(dir: string, version = "2026.7.220"): void {
+  writeFileSync(join(dir, "openclaw.plugin.json"), JSON.stringify({ name: "openclaw-hybrid-memory" }));
+  writeFileSync(join(dir, "package.json"), JSON.stringify({ name: "openclaw-hybrid-memory", version }));
+}
+
+describe("isStagingExtensionPath (#2135)", () => {
+  it("recognizes an OpenClaw staging directory", () => {
+    expect(
+      isStagingExtensionPath("/mnt/openclaw/.openclaw/extensions/.openclaw-hybrid-memory-staging-856831"),
+    ).toBe(true);
+    expect(
+      isStagingExtensionPath("/mnt/openclaw/.openclaw/extensions/.openclaw-hybrid-memory-staging-856831/dist"),
+    ).toBe(true);
+  });
+
+  it("does not flag a normal install path", () => {
+    expect(isStagingExtensionPath("/home/user/.openclaw/extensions/openclaw-hybrid-memory")).toBe(false);
+    expect(isStagingExtensionPath("")).toBe(false);
+  });
+});
+
+describe("buildExtensionLoadContext (#2135)", () => {
+  it("reads the package version and flags staging", () => {
+    writeHealthyPlugin(root, "2026.7.220");
+    const ctx = buildExtensionLoadContext(root);
+    expect(ctx.packageVersion).toBe("2026.7.220");
+    expect(ctx.extensionPath).toBe(root);
+    expect(ctx.isStaging).toBe(false);
+  });
+
+  it("never throws and degrades to 'unknown' for an unresolved path", () => {
+    const ctx = buildExtensionLoadContext("unknown");
+    expect(ctx).toEqual({ extensionPath: "unknown", isStaging: false, packageVersion: "unknown" });
+  });
+});
+
+describe("preflightExtensionIntegrity (#2135)", () => {
+  it("passes for a complete plugin directory", () => {
+    writeHealthyPlugin(root);
+    expect(preflightExtensionIntegrity(root)).toEqual({ ok: true });
+  });
+
+  it("fails (recoverably) when the plugin root cannot be resolved", () => {
+    const result = preflightExtensionIntegrity("unknown");
+    expect(result).toMatchObject({ ok: false, reason: "plugin_root_unresolved" });
+  });
+
+  it("fails when a manifest is missing (interrupted staging copy)", () => {
+    writeFileSync(join(root, "package.json"), JSON.stringify({ name: "x", version: "1.0.0" }));
+    // openclaw.plugin.json intentionally absent
+    const result = preflightExtensionIntegrity(root);
+    expect(result).toMatchObject({ ok: false, reason: "missing_manifest" });
+  });
+
+  it("fails when a manifest is zero bytes (truncated copy)", () => {
+    writeFileSync(join(root, "openclaw.plugin.json"), "");
+    writeFileSync(join(root, "package.json"), JSON.stringify({ name: "x", version: "1.0.0" }));
+    const result = preflightExtensionIntegrity(root);
+    expect(result).toMatchObject({ ok: false, reason: "empty_manifest" });
+  });
+
+  it("fails when a manifest is not valid JSON (partial write)", () => {
+    writeFileSync(join(root, "openclaw.plugin.json"), '{ "name": "x"'); // truncated JSON
+    writeFileSync(join(root, "package.json"), JSON.stringify({ name: "x", version: "1.0.0" }));
+    const result = preflightExtensionIntegrity(root);
+    expect(result).toMatchObject({ ok: false, reason: "corrupt_manifest" });
+  });
+
+  it("fails when package.json specifically is the corrupt manifest", () => {
+    writeFileSync(join(root, "openclaw.plugin.json"), JSON.stringify({ name: "x" }));
+    writeFileSync(join(root, "package.json"), "not json at all");
+    const result = preflightExtensionIntegrity(root);
+    expect(result).toMatchObject({ ok: false, reason: "corrupt_manifest" });
+    if (!result.ok) expect(result.detail).toContain("package.json");
+  });
+
+  it("validates the compiled dist/index.js entry when a dist build is present", () => {
+    writeHealthyPlugin(root);
+    mkdirSync(join(root, "dist"));
+    // dist/ exists but the compiled entry is missing (interrupted staging copy).
+    expect(preflightExtensionIntegrity(root)).toMatchObject({ ok: false, reason: "missing_entry" });
+
+    // Zero-byte entry (truncated copy).
+    writeFileSync(join(root, "dist", "index.js"), "");
+    expect(preflightExtensionIntegrity(root)).toMatchObject({ ok: false, reason: "empty_entry" });
+
+    // Complete entry → passes.
+    writeFileSync(join(root, "dist", "index.js"), "export const register = () => {};\n");
+    expect(preflightExtensionIntegrity(root)).toEqual({ ok: true });
+  });
+
+  it("skips the dist entry check for a source (no-dist) layout", () => {
+    writeHealthyPlugin(root);
+    // No dist/ directory — a TS/source run imports index.ts directly; preflight must not require dist.
+    expect(preflightExtensionIntegrity(root)).toEqual({ ok: true });
+  });
+
+  it("a corrupt staging load surfaces as a recoverable error, and a healthy retry then passes (#2135)", () => {
+    // Simulate a staging dir with a half-written manifest — the crash scenario from the issue.
+    writeFileSync(join(root, "openclaw.plugin.json"), '{ "name":');
+    writeFileSync(join(root, "package.json"), JSON.stringify({ name: "x", version: "1.0.0" }));
+    const bad = preflightExtensionIntegrity(root);
+    expect(bad.ok).toBe(false);
+    if (!bad.ok) {
+      // The error is a normal, throwable JS error (recoverable) — not a native abort.
+      const err = new PluginLoadPreflightError(bad, buildExtensionLoadContext(root));
+      expect(err).toBeInstanceOf(Error);
+      expect(err.reason).toBe("corrupt_manifest");
+      expect(err.message).toContain("preflight failed");
+    }
+
+    // Repair (finished copy) → the very next load passes without any lingering failure state.
+    writeHealthyPlugin(root);
+    expect(preflightExtensionIntegrity(root)).toEqual({ ok: true });
+  });
+});
+
+describe("last-successful extension path tracking (#2135)", () => {
+  it("records the last-known-good path and resets for tests", () => {
+    expect(getLastSuccessfulExtensionPath()).toBeNull();
+    recordSuccessfulExtensionLoad("/opt/openclaw/extensions/openclaw-hybrid-memory");
+    expect(getLastSuccessfulExtensionPath()).toBe("/opt/openclaw/extensions/openclaw-hybrid-memory");
+    // "unknown" must never overwrite a real last-known-good path.
+    recordSuccessfulExtensionLoad("unknown");
+    expect(getLastSuccessfulExtensionPath()).toBe("/opt/openclaw/extensions/openclaw-hybrid-memory");
+  });
+});

--- a/extensions/memory-hybrid/tests/plugin-load-preflight.test.ts
+++ b/extensions/memory-hybrid/tests/plugin-load-preflight.test.ts
@@ -38,9 +38,9 @@ function writeHealthyPlugin(dir: string, version = "2026.7.220"): void {
 
 describe("isStagingExtensionPath (#2135)", () => {
   it("recognizes an OpenClaw staging directory", () => {
-    expect(
-      isStagingExtensionPath("/mnt/openclaw/.openclaw/extensions/.openclaw-hybrid-memory-staging-856831"),
-    ).toBe(true);
+    expect(isStagingExtensionPath("/mnt/openclaw/.openclaw/extensions/.openclaw-hybrid-memory-staging-856831")).toBe(
+      true,
+    );
     expect(
       isStagingExtensionPath("/mnt/openclaw/.openclaw/extensions/.openclaw-hybrid-memory-staging-856831/dist"),
     ).toBe(true);

--- a/extensions/memory-hybrid/tests/register-plugin-reuse-databases-teardown-flat.test.ts
+++ b/extensions/memory-hybrid/tests/register-plugin-reuse-databases-teardown-flat.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Regression test for #2136: under OPENCLAW_HYBRID_MEM_REREGISTER_POLICY=reuse-databases, when the
+ * reuse gate approves reuse, repeated hot re-registers must NOT accrue full teardowns or
+ * teardown-timeout recoveries — the donor's SQLite/Lance handles are reused. Before #2136 there was
+ * no test pinning the counter behavior of the register flow on the reuse path.
+ *
+ * The reuse *decision* (bootstrap-settled, no closed handles, no config drift) is covered
+ * deterministically by reregister-policy.test.ts (evaluateReregisterReuse). Here we mock that
+ * decision to always approve reuse — exactly as the sibling variant-queue carryover test does —
+ * so this test isolates register-plugin's counter wiring on the reuse path from network-dependent
+ * bootstrap/embedding I/O.
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../setup/reregister-policy.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../setup/reregister-policy.js")>();
+  return {
+    ...actual,
+    canReuseDatabasesOnReregister: () => true,
+    evaluateReregisterReuse: () => ({ reuse: true, reason: "reusable" }),
+  };
+});
+
+import { resetPluginRegistrationStateForTests } from "../setup/register-plugin.js";
+import { reregisterMetrics } from "../setup/reregister-policy.js";
+import {
+  type FullStackApi,
+  getFullStackConfig,
+  makeFullStackApi,
+  registerFullPlugin,
+} from "./helpers/comprehensive-e2e-harness.js";
+
+let tmpDir: string;
+let api: FullStackApi;
+let originalPolicy: string | undefined;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "reuse-db-teardown-flat-"));
+  api = makeFullStackApi(tmpDir);
+  resetPluginRegistrationStateForTests();
+  originalPolicy = process.env.OPENCLAW_HYBRID_MEM_REREGISTER_POLICY;
+  process.env.OPENCLAW_HYBRID_MEM_REREGISTER_POLICY = "reuse-databases";
+});
+
+afterEach(() => {
+  resetPluginRegistrationStateForTests();
+  rmSync(tmpDir, { recursive: true, force: true });
+  if (originalPolicy === undefined) delete process.env.OPENCLAW_HYBRID_MEM_REREGISTER_POLICY;
+  else process.env.OPENCLAW_HYBRID_MEM_REREGISTER_POLICY = originalPolicy;
+});
+
+describe("reuse-databases keeps full teardowns flat across re-registers (#2136)", () => {
+  it("takes the reuse branch on unchanged-config reloads without incrementing teardown counters", () => {
+    const cfg = () => getFullStackConfig(tmpDir);
+
+    registerFullPlugin(api, cfg());
+    expect(reregisterMetrics.fullTeardowns).toBe(0);
+
+    // Two more re-registers with identical config — both must reuse the donor handles.
+    registerFullPlugin(api, cfg());
+    registerFullPlugin(api, cfg());
+
+    expect(reregisterMetrics.fullTeardowns).toBe(0);
+    expect(reregisterMetrics.teardownTimeoutRecoveries).toBe(0);
+    expect(reregisterMetrics.databaseReuses).toBeGreaterThanOrEqual(2);
+    // No teardown means no teardown-reason tally.
+    expect(reregisterMetrics.fullTeardownReasons).toEqual({});
+  });
+});

--- a/extensions/memory-hybrid/tests/register-plugin-variant-queue-donor-carryover.test.ts
+++ b/extensions/memory-hybrid/tests/register-plugin-variant-queue-donor-carryover.test.ts
@@ -27,7 +27,13 @@ import {
 
 vi.mock("../setup/reregister-policy.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../setup/reregister-policy.js")>();
-  return { ...actual, canReuseDatabasesOnReregister: () => true };
+  // register-plugin.ts consumes evaluateReregisterReuse (the structured-reason variant, #2136);
+  // canReuseDatabasesOnReregister is the thin boolean wrapper. Mock both so reuse is always approved.
+  return {
+    ...actual,
+    canReuseDatabasesOnReregister: () => true,
+    evaluateReregisterReuse: () => ({ reuse: true, reason: "reusable" }),
+  };
 });
 
 let tmpDir: string;

--- a/extensions/memory-hybrid/tests/reregister-policy.test.ts
+++ b/extensions/memory-hybrid/tests/reregister-policy.test.ts
@@ -3,6 +3,7 @@ import type { PluginRuntime } from "../api/plugin-runtime.js";
 import type { HybridMemoryConfig } from "../config.js";
 import {
   canReuseDatabasesOnReregister,
+  evaluateReregisterReuse,
   recordReregisterDatabaseReuse,
   recordReregisterFullTeardown,
   resetReregisterPolicyForTests,
@@ -302,6 +303,71 @@ describe("reregister-policy", () => {
     recordReregisterDatabaseReuse();
     expect(reregisterMetrics.fullTeardowns).toBe(1);
     expect(reregisterMetrics.databaseReuses).toBe(1);
+  });
+
+  // #2136: a full teardown under reuse-databases must always name WHY. evaluateReregisterReuse
+  // returns a stable reason code alongside the boolean so diagnostics can attribute each teardown.
+  describe("evaluateReregisterReuse names the reason (#2136)", () => {
+    const api = { resolvePath: (p: string) => `/home/markus/.openclaw/${p}` };
+    const settledDonor = (cfg: HybridMemoryConfig) =>
+      mockOldRuntime({ sqlite: api.resolvePath(cfg.sqlitePath), lance: api.resolvePath(cfg.lanceDbPath) }, cfg);
+
+    beforeEach(() => vi.stubEnv("OPENCLAW_HYBRID_MEM_REREGISTER_POLICY", "reuse-databases"));
+
+    it("returns reuse:true with reason 'reusable' when nothing drifted", () => {
+      const cfg = minimalCfg();
+      expect(evaluateReregisterReuse(settledDonor(cfg), cfg, api)).toEqual({ reuse: true, reason: "reusable" });
+    });
+
+    it("names no_donor when there is no prior runtime", () => {
+      expect(evaluateReregisterReuse(null, minimalCfg(), api)).toEqual({ reuse: false, reason: "no_donor" });
+    });
+
+    it("names bootstrap_not_settled when the donor bootstrap is still in flight", () => {
+      const cfg = minimalCfg();
+      const donor = settledDonor(cfg);
+      (donor as { bootstrapSettledRef?: { value: boolean } }).bootstrapSettledRef = { value: false };
+      expect(evaluateReregisterReuse(donor, cfg, api)).toEqual({ reuse: false, reason: "bootstrap_not_settled" });
+    });
+
+    it("names the drifted sqlite path", () => {
+      const donor = settledDonor(minimalCfg());
+      const decision = evaluateReregisterReuse(donor, minimalCfg("memory/other.db"), api);
+      expect(decision).toEqual({ reuse: false, reason: "sqlite_path_changed" });
+    });
+
+    it("names the specific drifted config field", () => {
+      const oldCfg = minimalCfg();
+      const donor = settledDonor(oldCfg);
+      const newCfg = minimalCfg();
+      newCfg.embedding.model = "text-embedding-3-large";
+      expect(evaluateReregisterReuse(donor, newCfg, api)).toEqual({
+        reuse: false,
+        reason: "config_drift:embedding.model",
+      });
+    });
+
+    it("stays reusable across repeated re-registers with unchanged config (no phantom teardowns)", () => {
+      const cfg = minimalCfg();
+      const donor = settledDonor(cfg);
+      for (let i = 0; i < 5; i++) {
+        expect(evaluateReregisterReuse(donor, minimalCfg(), api).reuse).toBe(true);
+      }
+    });
+  });
+
+  it("recordReregisterFullTeardown tallies per-reason counters (#2136)", () => {
+    vi.stubEnv("OPENCLAW_HYBRID_MEM_REREGISTER_POLICY", "reuse-databases");
+    recordReregisterFullTeardown("config_drift:embedding.model");
+    recordReregisterFullTeardown("config_drift:embedding.model");
+    recordReregisterFullTeardown("bootstrap_not_settled");
+    recordReregisterFullTeardown(); // unspecified
+    expect(reregisterMetrics.fullTeardowns).toBe(4);
+    expect(reregisterMetrics.fullTeardownReasons).toEqual({
+      "config_drift:embedding.model": 2,
+      bootstrap_not_settled: 1,
+      unspecified: 1,
+    });
   });
 });
 

--- a/extensions/memory-hybrid/tests/supersedes-input.test.ts
+++ b/extensions/memory-hybrid/tests/supersedes-input.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Regression tests for #2139: memory_store `supersedes` accepted only a string, so passing an
+ * array of fact ids (the natural shape when correcting several stale facts) threw
+ * `supersedes?.trim is not a function`. normalizeSupersedesInput now accepts a string, an array of
+ * id strings, or nothing, and returns a structured error for any other shape.
+ */
+import { describe, expect, it } from "vitest";
+import { normalizeSupersedesInput } from "../services/supersedes-input.js";
+
+describe("normalizeSupersedesInput (#2139)", () => {
+  it("returns an empty id list for null/undefined/empty", () => {
+    expect(normalizeSupersedesInput(undefined)).toEqual({ ok: true, ids: [] });
+    expect(normalizeSupersedesInput(null)).toEqual({ ok: true, ids: [] });
+    expect(normalizeSupersedesInput("")).toEqual({ ok: true, ids: [] });
+    expect(normalizeSupersedesInput("   ")).toEqual({ ok: true, ids: [] });
+  });
+
+  it("wraps a single trimmed id string into a one-element list", () => {
+    expect(normalizeSupersedesInput("  047efc02-b019-4236-8843-5cf4724e3db0 ")).toEqual({
+      ok: true,
+      ids: ["047efc02-b019-4236-8843-5cf4724e3db0"],
+    });
+  });
+
+  it("accepts an array of fact ids (the exact shape from the issue)", () => {
+    const result = normalizeSupersedesInput([
+      "047efc02-b019-4236-8843-5cf4724e3db0",
+      "65da78dc-a4be-43c8-b236-f99df8b8db78",
+    ]);
+    expect(result).toEqual({
+      ok: true,
+      ids: ["047efc02-b019-4236-8843-5cf4724e3db0", "65da78dc-a4be-43c8-b236-f99df8b8db78"],
+    });
+  });
+
+  it("trims, drops blank entries, and de-duplicates array ids", () => {
+    const result = normalizeSupersedesInput([" a ", "a", "", "b", "  ", "b"]);
+    expect(result).toEqual({ ok: true, ids: ["a", "b"] });
+  });
+
+  it("returns a structured error (not a thrown exception) for a non-string array element", () => {
+    const result = normalizeSupersedesInput(["a", 42]);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toContain("number");
+  });
+
+  it("returns a structured error for a non-string, non-array value", () => {
+    const objResult = normalizeSupersedesInput({ id: "x" });
+    expect(objResult.ok).toBe(false);
+    if (!objResult.ok) expect(objResult.error).toContain("object");
+
+    const numResult = normalizeSupersedesInput(5);
+    expect(numResult.ok).toBe(false);
+    if (!numResult.ok) expect(numResult.error).toContain("number");
+  });
+
+  it("never throws on the input shapes that previously hit supersedes.trim()", () => {
+    for (const bad of [["a", null], ["a", ["nested"]], true, 0, {}]) {
+      expect(() => normalizeSupersedesInput(bad)).not.toThrow();
+    }
+  });
+});

--- a/extensions/memory-hybrid/tools/graph-tools.ts
+++ b/extensions/memory-hybrid/tools/graph-tools.ts
@@ -10,9 +10,10 @@ import type { ClawdbotPluginApi } from "openclaw/plugin-sdk/core";
 import { stringEnum } from "../utils/typebox.js";
 
 import type { BuildToolScopeFilterFn } from "../api/memory-plugin-api.js";
-import type { FactsDB, MemoryLinkType } from "../backends/facts-db.js";
+import type { FactsDB } from "../backends/facts-db.js";
 import { MEMORY_LINK_TYPES } from "../backends/facts-db.js";
 import type { HybridMemoryConfig } from "../config.js";
+import { resolveMemoryLinkInput } from "../services/memory-link-input.js";
 import { findShortestPath, formatPath, resolveInput, type ShortestPathLookup } from "../services/shortest-path.js";
 
 export interface PluginContext {
@@ -85,17 +86,18 @@ export function registerGraphTools(ctx: PluginContext, api: ClawdbotPluginApi): 
           strength: Type.Optional(Type.Number({ description: "Link strength 0.0-1.0 (default 1.0)" })),
         }),
         async execute(_toolCallId: string, params: Record<string, unknown>) {
-          const {
-            sourceFact,
-            targetFact,
-            linkType,
-            strength = 1.0,
-          } = params as {
-            sourceFact: string;
-            targetFact: string;
-            linkType: MemoryLinkType;
-            strength?: number;
-          };
+          // Resolve/validate input before touching the DB. The runtime does not enforce the
+          // TypeBox schema, so callers using `from`/`to`/`type` (or omitting a field) previously
+          // reached factsDb.getById(undefined) and hit an opaque "cannot be bound to SQLite
+          // parameter 1" error. Fail with a structured, parameter-named message instead (#2139).
+          const resolved = resolveMemoryLinkInput(params);
+          if (!resolved.ok) {
+            return {
+              content: [{ type: "text", text: `memory_link: ${resolved.error}.` }],
+              details: { error: "invalid_input" },
+            };
+          }
+          const { sourceFact, targetFact, linkType, strength } = resolved;
           // SECURITY: both endpoints must be in-scope before linking — otherwise a caller could
           // tie an out-of-scope (another tenant's) fact into their own graph, or discover its id
           // exists, just by guessing/enumerating ids (mirrors the GraphQL createLink guard).

--- a/extensions/memory-hybrid/tools/memory/register-store-tools.ts
+++ b/extensions/memory-hybrid/tools/memory/register-store-tools.ts
@@ -39,6 +39,7 @@ import {
   prepareMemoryTextForStorage,
 } from "../../services/recalled-context-assembler.js";
 import { storeAliases } from "../../services/retrieval-aliases.js";
+import { normalizeSupersedesInput } from "../../services/supersedes-input.js";
 import { mirrorMemoryStoreToActiveTaskLedger } from "../../services/task-ledger-facts.js";
 import { guardAgainstWrapperArgsDropped } from "../../services/tool-args-guard.js";
 import { cleanupEvictedVector, deleteVectorForFactId } from "../../services/vector-maintenance.js";
@@ -208,9 +209,9 @@ export function registerStoreTools(runtime: MemoryToolRuntime): void {
           }),
         ),
         supersedes: Type.Optional(
-          Type.String({
+          Type.Union([Type.String(), Type.Array(Type.String())], {
             description:
-              "Fact id this one supersedes (replaces). Marks the old fact as superseded and links the new one.",
+              "Fact id — or an array of fact ids — this one supersedes (replaces). Marks the old fact(s) as superseded and links the new one.",
           }),
         ),
         scope: Type.Optional(stringEnum(MEMORY_SCOPES as unknown as readonly string[])),
@@ -264,7 +265,7 @@ export function registerStoreTools(runtime: MemoryToolRuntime): void {
             value?: string;
             decayClass?: DecayClass;
             tags?: string[];
-            supersedes?: string;
+            supersedes?: string | string[];
             scope?: "global" | "user" | "agent" | "session";
             scopeTarget?: string;
             verification_tier?: string;
@@ -330,6 +331,20 @@ export function registerStoreTools(runtime: MemoryToolRuntime): void {
               details: { error: "invalid_decay_freeze_until" },
             };
           }
+
+          // `supersedes` may arrive as a string or an array of fact ids (the runtime does not
+          // enforce the TypeBox schema); normalize once here so no downstream code calls `.trim`
+          // on a non-string (#2139). A malformed shape yields a structured validation error rather
+          // than a raw `supersedes?.trim is not a function` exception.
+          const supersedesNorm = normalizeSupersedesInput(supersedes);
+          if (!supersedesNorm.ok) {
+            return {
+              content: [{ type: "text", text: `memory_store: ${supersedesNorm.error}.` }],
+              details: { error: "invalid_supersedes" },
+            };
+          }
+          const supersedesIds = supersedesNorm.ids;
+          const hasSupersedes = supersedesIds.length > 0;
           // --- End early validation ---
 
           const provenanceSessionId = api.context?.sessionId ?? null;
@@ -1079,6 +1094,28 @@ export function registerStoreTools(runtime: MemoryToolRuntime): void {
 
           const nowSec = Math.floor(Date.now() / 1000);
           const storeSessionId = api.context?.sessionId ?? null;
+
+          // Resolve which requested `supersedes` targets are actually in-scope BEFORE the write, so
+          // (a) the persisted `supersedes_id` lineage points only at a real in-scope target rather
+          // than a phantom cross-scope/unknown id, and (b) callers get told which ids were blocked
+          // instead of silently losing them (#2139 QA). Cross-scope / unknown ids are surfaced in
+          // the response, never applied. Mirrors the classify-before-write UPDATE path, which also
+          // validates scope before setting supersedesId.
+          const supersedesScopeValid: string[] = [];
+          const supersedesBlocked: string[] = [];
+          for (const supersededId of supersedesIds) {
+            const target = storeFactsDb.getById(supersededId);
+            if (target && matchesExactScope(target, scope, scopeTarget)) {
+              supersedesScopeValid.push(supersededId);
+            } else {
+              supersedesBlocked.push(supersededId);
+              api.logger.warn?.(
+                `memory-hybrid: blocked cross-scope or unknown memory_store supersedes target ${supersededId}`,
+              );
+            }
+          }
+          const primarySupersedesId = supersedesScopeValid[0] ?? null;
+
           // Plumb vector neighbour candidates into write-time dedupe so the configured vectorThreshold
           // actually runs on the live store path instead of silently degrading to lexical-only (#2027).
           // Reuses the already-computed embedding; candidates are source/scope filtered.
@@ -1089,7 +1126,7 @@ export function registerStoreTools(runtime: MemoryToolRuntime): void {
           // silently losing the update. An explicit supersede must always store, so we do not widen
           // write-time fuzzy dedupe on that path (matches pre-#2027 behaviour for supersede writes).
           let storeVectorCandidates: ReadonlyArray<{ id: string; score: number }> | undefined;
-          if (cfg.store.fuzzyDedupe && vector && !supersedes?.trim()) {
+          if (cfg.store.fuzzyDedupe && vector && !hasSupersedes) {
             const resolvedCandidates = await resolveWriteVectorCandidates({
               fuzzyDedupe: true,
               vector,
@@ -1122,7 +1159,7 @@ export function registerStoreTools(runtime: MemoryToolRuntime): void {
               extractionMethod: "active",
               extractionConfidence: importance,
               decayFreezeUntil: decayFreezeUntil ?? undefined,
-              ...(supersedes?.trim() ? { validFrom: nowSec, supersedesId: supersedes.trim() } : {}),
+              ...(primarySupersedesId ? { validFrom: nowSec, supersedesId: primarySupersedesId } : {}),
             },
             { vectorCandidates: storeVectorCandidates, warnContext: "memory-store" },
           );
@@ -1175,22 +1212,17 @@ export function registerStoreTools(runtime: MemoryToolRuntime): void {
                 entry.scopeTarget,
               );
             }
-            // Only set once the write actually superseded the requested fact. When the write
-            // dedupe-merged into a different existing fact (newlyStored === false), the caller's
-            // `supersedes` request was never applied — the message/details below must reflect
-            // that instead of unconditionally claiming success from `supersedes?.trim()` alone.
-            let supersededAppliedId: string | null = null;
-            if (supersedes?.trim() && storeResult.newlyStored) {
-              const supersededId = supersedes.trim();
-              // The `supersedes` id is caller-supplied and unrelated to the classifier's own
-              // candidate set, so unlike the auto-classification DELETE/UPDATE paths above it
-              // can't reuse validateScopedClassificationTarget's candidate check — but it must
-              // still be blocked from touching a fact outside the current write's scope.
-              const supersedeTarget = storeFactsDb.getById(supersededId);
-              if (supersedeTarget && matchesExactScope(supersedeTarget, scope, scopeTarget)) {
-                supersededAppliedId = supersededId;
+            // Apply the supersession to each pre-validated in-scope target (scope was checked before
+            // the write). `supersede()`'s `superseded_at IS NULL` guard keeps `applied` honest — a
+            // target already superseded by an earlier write is not double-counted. Only runs when a
+            // genuinely new fact was created; a dedupe-merge (newlyStored === false) never applies
+            // the request. Out-of-scope/unknown ids were already collected in supersedesBlocked.
+            const supersededAppliedIds: string[] = [];
+            if (storeResult.newlyStored) {
+              for (const supersededId of supersedesScopeValid) {
                 const applied = storeFactsDb.supersede(supersededId, entry.id);
                 if (applied) {
+                  supersededAppliedIds.push(supersededId);
                   aliasDb?.deleteByFactId(supersededId);
                   await deleteVectorForFactId({
                     vectorDb: storeVectorDb,
@@ -1198,13 +1230,7 @@ export function registerStoreTools(runtime: MemoryToolRuntime): void {
                     logger: api.logger,
                     context: "store-manual-supersede",
                   });
-                } else {
-                  supersededAppliedId = null;
                 }
-              } else {
-                api.logger.warn?.(
-                  `memory-hybrid: blocked cross-scope or unknown memory_store supersedes target ${supersededId}`,
-                );
               }
             }
 
@@ -1474,6 +1500,21 @@ export function registerStoreTools(runtime: MemoryToolRuntime): void {
             }
 
             const totalLinked = autoLinked + entityAutoLinked;
+            // Classify how the supersede request resolved so the message and details never claim
+            // a "dedupe-merge" when the real cause was a blocked/unknown target (#2139 QA):
+            //  - merged: a genuine dedupe-merge into an existing fact (newlyStored === false)
+            //  - blockedOnly: a new fact was created but no requested target could be superseded
+            //    (all cross-scope/unknown, or already superseded)
+            const supersedeMerged = hasSupersedes && supersededAppliedIds.length === 0 && !storeResult.newlyStored;
+            const supersedeBlockedOnly = hasSupersedes && supersededAppliedIds.length === 0 && storeResult.newlyStored;
+            const supersedeMsgNote =
+              supersededAppliedIds.length > 0
+                ? ` (supersedes ${supersededAppliedIds.length} previous fact${supersededAppliedIds.length === 1 ? "" : "s"}${supersedesBlocked.length > 0 ? `; ${supersedesBlocked.length} blocked/not found` : ""})`
+                : supersedeMerged
+                  ? " (dedupe-merged — requested supersede was NOT applied)"
+                  : supersedeBlockedOnly
+                    ? ` (requested supersede NOT applied${supersedesBlocked.length > 0 ? ` — ${supersedesBlocked.length} target${supersedesBlocked.length === 1 ? "" : "s"} blocked/not found` : ""})`
+                    : "";
             const verbosity = cfg.verbosity ?? "normal";
             let storedMsg: string;
             if (isCompactVerbosity(verbosity)) {
@@ -1485,7 +1526,7 @@ export function registerStoreTools(runtime: MemoryToolRuntime): void {
               }`;
             } else {
               // normal / verbose: full details (verbose adds scope/category info)
-              storedMsg = `Stored: "${textToStore.slice(0, 100)}${textToStore.length > 100 ? "..." : ""}"${entity ? ` [entity: ${entity}]` : ""} [decay: ${entry.decayClass}]${supersededAppliedId ? " (supersedes previous fact)" : supersedes?.trim() ? " (dedupe-merged — requested supersede was NOT applied)" : ""}${totalLinked > 0 ? ` (linked to ${totalLinked} related fact${totalLinked === 1 ? "" : "s"})` : ""}${
+              storedMsg = `Stored: "${textToStore.slice(0, 100)}${textToStore.length > 100 ? "..." : ""}"${entity ? ` [entity: ${entity}]` : ""} [decay: ${entry.decayClass}]${supersedeMsgNote}${totalLinked > 0 ? ` (linked to ${totalLinked} related fact${totalLinked === 1 ? "" : "s"})` : ""}${
                 autoSupersededIds.length > 0
                   ? ` (auto-superseded ${autoSupersededIds.length} fact${autoSupersededIds.length === 1 ? "" : "s"})`
                   : ""
@@ -1522,16 +1563,25 @@ export function registerStoreTools(runtime: MemoryToolRuntime): void {
                 },
               ],
               details: {
-                action: supersededAppliedId ? "updated" : "created",
+                action: supersededAppliedIds.length > 0 ? "updated" : "created",
                 id: entry.id,
                 why: whyStored ?? undefined,
                 backend: "both",
                 decayClass: entry.decayClass,
-                ...(supersededAppliedId
-                  ? { superseded: supersededAppliedId }
-                  : supersedes?.trim()
-                    ? { supersedeRequested: supersedes.trim(), supersedeApplied: false, reason: "dedupe-merge" }
+                ...(supersededAppliedIds.length > 0
+                  ? { superseded: supersededAppliedIds[0], supersededIds: supersededAppliedIds }
+                  : hasSupersedes
+                    ? {
+                        supersedeRequested: supersedesIds.length === 1 ? supersedesIds[0] : supersedesIds,
+                        supersedeApplied: false,
+                        // Distinguish a genuine dedupe-merge from blocked/unknown targets so the
+                        // caller fixes the right thing (bad target id vs near-duplicate text) (#2139 QA).
+                        reason: supersedeMerged ? "dedupe-merge" : "targets_blocked_or_not_found",
+                      }
                     : {}),
+                // Always surface targets that were requested but not applied (cross-scope/unknown),
+                // even on a partially-successful multi-id supersede, so nothing is silently dropped.
+                ...(supersedesBlocked.length > 0 ? { supersedeBlocked: supersedesBlocked } : {}),
                 ...(totalLinked > 0 ? { autoLinked: totalLinked } : {}),
                 ...(autoSupersededIds.length > 0 ? { autoSuperseded: autoSupersededIds } : {}),
                 ...(contradictions.length > 0

--- a/packages/openclaw-hybrid-memory-install/package.json
+++ b/packages/openclaw-hybrid-memory-install/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-hybrid-memory-install",
-  "version": "2026.7.219",
+  "version": "2026.7.220",
   "description": "Standalone installer for openclaw-hybrid-memory. Use when OpenClaw config validation fails.",
   "bin": {
     "openclaw-hybrid-memory-install": "./install.js"

--- a/release-notes/release-notes-2026.7.220.md
+++ b/release-notes/release-notes-2026.7.220.md
@@ -1,0 +1,42 @@
+# Release v2026.7.220
+
+Closes all five open production issues surfaced by live Maeve/Doris hosts (#2135–#2139). Each is fixed at the root cause with regression tests.
+
+## Fixed — Memory graph & supersession tooling
+
+- **`memory_store` rejected an array of `supersedes` ids; `memory_link` threw a raw SQLite bind error** (#2139) — the OpenClaw plugin runtime does not enforce TypeBox parameter schemas, so real callers hit two crashes:
+  - `memory_store` with `supersedes: [id1, id2]` reached `supersedes.trim()` → `supersedes?.trim is not a function`.
+  - `memory_link` with `from`/`to`/`type` (instead of `sourceFact`/`targetFact`/`linkType`) reached `factsDb.getById(undefined)` → `Provided value cannot be bound to SQLite parameter 1.`
+
+  `memory_store.supersedes` now accepts a single id **or an array of ids** (each in-scope target is superseded independently) and returns a structured `invalid_supersedes` error for any other shape. `memory_link` resolves the common aliases, upper-cases the link type, validates every field **before** touching the DB, and returns a structured, parameter-named `invalid_input` error — never an opaque SQLite exception.
+
+## Fixed — Credential vault false-positives
+
+- **`memory_store` diverted ordinary infrastructure facts into bogus credential entries** (#2138) — the bare SSH connection-string pattern (`ssh <host> <user>`) matched ordinary prose ("connect via ssh …"), and because the matched span was returned as a "secret" with `hasPatternMatch=true`, the natural-language/path guards were skipped and an infra note (host/IP/gateway/MAC + stored service names, no secret) was written to the vault as a fake `ssh` credential requiring manual cleanup. A bare SSH connection string carries no secret, so the pattern is now **detection-only**: it can still prompt the user, but it never routes into the vault — the fact is stored as a fact. Real SSH secrets (private-key blocks, `sshpass -p <pw>` passwords, connection strings with an embedded password) are unchanged.
+
+## Fixed — Nightly maintenance analyzer recursion
+
+- **`maintenance-log-analyzer` still failed nightly on its own artifacts after #2131/#2132** (#2137) — two self-reference escape routes remained:
+  - **(A)** Synthetic `orchestration-*` steps derived from the analyzer's *own* empty/stale/missing exit ledger classified as the strict `orchestration-bug` class and were never in the self-referential step set, forcing `exit=2` → `validate-cron-exit exit=1` → `maintenance_failed` → new stale artifacts → loop.
+  - **(B)** The analyzer's own `analyze-maintenance-logs exit=2` (strict-fail) and `validate-cron-exit` rows re-classified as a strict class because their shared `logContent` is the analyzer's own re-read digest, full of *other* jobs' failure phrases.
+
+  Self-suppression now recognizes the analyzer job's own `orchestration-*` synthetic steps and its strict-fail `exit=2` / validation rows **regardless of the (contaminated) classification**, while still reporting a genuine analyzer crash (`analyze exit=1` with a real classified stack) and every other job's failures once, with stable fingerprinting.
+
+## Fixed — Reuse-databases teardown observability
+
+- **`reuse-databases` full teardowns were unexplained** (#2136) — the reuse eligibility gate collapsed ~20 distinct decline reasons into a bare boolean with only a generic `debug` line, so `fullTeardowns > 0` under `reuse-databases` could not be attributed. Now `evaluateReregisterReuse` returns a stable reason code (`bootstrap_not_settled`, `donor_handle_closed`, `sqlite_path_changed`, `config_drift:<field>`, `teardown_soft_timeout`, …); `recordReregisterFullTeardown(reason)` tallies a new `fullTeardownReasons` breakdown; the fallback is a `warn` naming the reason; and the `plugin_reregister_full_teardown_despite_reuse_policy` leak hint reports the per-reason counts instead of the old "check bootstrapSettledRef or config drift" nudge. A regression test pins that repeated re-registers under `reuse-databases` keep `fullTeardowns`/`teardownTimeoutRecoveries` at 0.
+
+## Fixed — Staging plugin-load hardening
+
+- **Gateway SIGBUS'd while loading the plugin from a hot-upgrade staging path** (#2135) — a native abort inside the LanceDB binding or an mmapped data file cannot be caught by a JS `try/catch` once execution enters native code. The register flow now runs a filesystem-only preflight before the first native store init: a structurally incomplete staging copy (missing / zero-byte / corrupt `openclaw.plugin.json` or `package.json` — the interrupted-copy state that precedes a native abort) is rejected as a recoverable `PluginLoadPreflightError` instead of proceeding into the native path. Plugin-load and DB-init errors now carry a load-diagnostics context (package version, resolved extension path, staging flag, last-successful extension path, reload/teardown-drain state) so any residual crash is attributable, and the last-known-good extension path is recorded after each successful registration. Scoped to the fresh-open path; the reuse path inherits already-open handles and performs no native connect.
+
+## Hardened — QA follow-up
+
+A full adversarial code review of this release's own diff, before merge, found and closed several residual edge cases (all with regression tests): a partial multi-id supersede silently dropping blocked targets (now surfaced as `supersedeBlocked`); a misleading `dedupe-merge` reason when a supersede target was actually blocked (now `targets_blocked_or_not_found`); a phantom `supersedes_id` lineage pointer written before the scope check (targets are now scope-validated before the write); a blank canonical `memory_link` key shadowing a populated alias; and a diagnostics snapshot aliasing the live `fullTeardownReasons` map (now deep-copied). The `#2135` preflight was also extended to validate the compiled `dist/index.js` entry when a build is present.
+
+## Notes
+
+- No `schemaVersion` bump — no storage-schema changes.
+- No agent-tool contract changes; `memory_store` and `memory_link` accept a superset of their prior inputs.
+- Native RSS growth under `reuse-databases` (#2136) is addressed here as observability/attribution; the underlying native allocator retention in LanceDB/Rust is a separate upstream concern.
+- The `#2135` preflight is a necessary-but-not-sufficient guard: it rejects an incomplete staging copy before the native path, but cannot detect a present-but-internally-corrupt native binding (which would require child-process isolation).


### PR DESCRIPTION
## Summary

Fixes all five currently-open issues filed from live Maeve/Doris production hosts, each at the root cause with regression tests, plus a full adversarial QA review of this diff whose findings are closed in the same change. Version bumped to `2026.7.220`.

- **#2139** — `memory_store.supersedes` now accepts a string **or an array** of fact ids (`normalizeSupersedesInput`), superseding each in-scope target and surfacing blocked/unknown ones; `memory_link` validates input and resolves `from`/`to`/`type` aliases (`resolveMemoryLinkInput`) **before** any DB access. Replaces the `supersedes?.trim is not a function` and `Provided value cannot be bound to SQLite parameter 1` crashes with structured validation errors.
- **#2138** — the bare SSH connection-string credential pattern is marked `detectionOnly`, so infrastructure facts mentioning `ssh`/service names are stored as facts instead of being diverted into a bogus credential-vault entry. Real secrets (JWT, `sk-`, `ghp_`, connection-string passwords, `sshpass`, private keys) still route to the vault.
- **#2137** — `maintenance-log-analyzer` suppresses its own `orchestration-*` synthetic steps and strict-fail `exit=2` / `validate-cron-exit` rows (even under digest-contaminated classification), breaking the nightly recursion while still reporting genuine analyzer crashes and every other job's failures.
- **#2136** — `evaluateReregisterReuse` returns a **named reason** for every declined reuse; `recordReregisterFullTeardown(reason)` tallies `fullTeardownReasons` and the leak hint reports the per-reason breakdown, so a full teardown under `reuse-databases` is never unexplained.
- **#2135** — a filesystem preflight rejects a structurally-incomplete staging copy as a recoverable `PluginLoadPreflightError` before the native LanceDB path, and plugin-load/DB-init errors carry version / staging-path / last-good / reload-state diagnostics.

Closes #2135
Closes #2136
Closes #2137
Closes #2138
Closes #2139

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor / internal improvement (no behavior change)
- [ ] Documentation update
- [ ] CI / tooling change

## Quality Checklist

- [x] `cd extensions/memory-hybrid && npx tsc --noEmit` passes with no errors
- [x] `cd extensions/memory-hybrid && npm run lint` passes (no new warnings introduced; pre-existing warnings in untouched files unchanged)
- [x] `cd extensions/memory-hybrid && npm test` passes — 9871 passed / 24 skipped, 0 failures; `npm run verify:gate` green
- [x] No secrets, credentials, or API keys committed
- [x] No `console.log` debug statements left in production code

## Documentation Impact (REQUIRED)

- [x] Inline code comments (JSDoc) updated for modified functions and types
- [x] `docs/` or `README.md` updated to reflect architectural or usage changes — `CHANGELOG.md` + `release-notes/release-notes-2026.7.220.md` added; changes are internal fixes with no new user-facing config/tooling surface
- [x] Cross-referenced functions/services checked for outdated documentation

## Testing

- [x] Unit tests added / updated — `supersedes-input`, `memory-link-input`, `plugin-load-preflight`, `reregister-policy` (reason attribution), `maintenance-log-analyzer` (Hole A/B), `credential-ssh-connection-string`
- [x] Integration tests added / updated — `memory-store-supersedes-multi`, `memory-link-supersedes-tool`, `register-plugin-reuse-databases-teardown-flat`, `gateway-memory-diagnostics`
- [ ] Manually verified against a running OpenClaw instance

## Notes for Reviewer

- **QA follow-up (all regression-tested):** partial multi-id supersede now surfaces `supersedeBlocked`; a blocked supersede reports `reason: "targets_blocked_or_not_found"` instead of a bogus `dedupe-merge`; supersede targets are scope-validated **before** the write so no phantom `supersedes_id` lineage is persisted; `memory_link` ignores a blank canonical key that would shadow an alias; the diagnostics snapshot deep-copies `fullTeardownReasons`; the preflight also validates the compiled `dist/index.js` entry.
- **#2135 scope:** the preflight is a *necessary-but-not-sufficient* guard — it rejects an incomplete staging copy before the native path, but cannot detect a present-but-internally-corrupt native binding (that would require child-process isolation). Called out in the module comment and release notes.
- **#2137 trade-off:** suppressing the analyzer's own `orchestration-*` synthetics necessarily forgoes self-reporting of its own incomplete/hung prior runs (detected out-of-band instead), matching the issue's explicit request. Documented in-code.
- No `schemaVersion` bump and no agent-tool contract changes — `memory_store`/`memory_link` accept a superset of their prior inputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Aw9VhP1qZpcvdyAXTQzGD

---
_Generated by [Claude Code](https://claude.ai/code/session_014Aw9VhP1qZpcvdyAXTQzGD)_