### PR TITLE
docs: add AGENTS.md with Cursor Cloud environment setup notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,53 @@
+# AGENTS.md
+
+Repository-wide guidance for coding agents. For architecture, commands, style, and Git/PR
+conventions, follow `CLAUDE.md` (the authoritative developer guide). This file only adds
+cloud-environment-specific caveats that are not obvious from `CLAUDE.md`.
+
+## Cursor Cloud specific instructions
+
+Dependencies are already installed on session start by the update script (`npm install` at the
+repo root and in `extensions/memory-hybrid`, `extensions/memory-hybrid/graph-app`, and
+`sdk/openclaw-memory-js`). Do not re-run installs unless `package.json`/lockfiles changed.
+
+### Node version (important, non-obvious)
+
+- The repo requires Node `>=22.16.0` (uses built-in `node:sqlite`). See `CLAUDE.md`.
+- On this VM, `node` on `PATH` resolves to `/exec-daemon/node`, which is **v22.14.0 (below the
+  requirement)**. `nvm` provides a supported Node (default `v22.22.2`, and `v22.16.0` matching
+  `.nvmrc`).
+- All `npm run *` scripts re-exec through `scripts/run-with-supported-node.mjs`, which auto-selects
+  a supported Node (it resolves the `.nvmrc`-pinned `$NVM_DIR/versions/node/v22.16.0/bin/node`, or
+  scans `PATH`). So `npm run build|test|lint`, `npx tsc --noEmit`, etc. work regardless of the
+  `PATH` `node`.
+- For **direct** `node`/`npx` invocations (not via an npm script), first run `nvm use` (or prepend
+  `$HOME/.nvm/versions/node/v22.16.0/bin` to `PATH`); otherwise you get 22.14.0.
+
+### Tests
+
+- `npm test` (from `extensions/memory-hybrid`) runs the full suite (~780 files, ~7 min).
+- A few optimistic-concurrency tests are **flaky**, primarily in `tests/active-task.test.ts`
+  (occasionally `tests/active-task-reconcile-race.test.ts`,
+  `tests/stage-cleanup-markdown-ledger.test.ts`). They simulate a concurrent writer using
+  file-`mtime`-based optimistic-write detection; under CPU/disk contention the mtimes can collide,
+  so the failing set varies run-to-run. This is pre-existing test flakiness, not a code/env defect
+  — re-run the specific file(s) to confirm before investigating.
+
+### Running the product locally (no OpenClaw host required for a smoke test)
+
+The product is an OpenClaw plugin that normally loads inside the OpenClaw gateway. To exercise the
+core memory engine + Mission Control UI locally without a gateway or external embeddings:
+
+- Build first: `npm run build` (and `npm run build:graph-app` so `/graph` serves in prod mode).
+- `FactsDB` and `VectorDB` are exported via `_testing` from the built `dist/index.js`; construct
+  them with a temp path, `factsDb.store({ text, category, source, ... })` to write and
+  `factsDb.search(query, limit)` to recall (SQLite FTS5, no embeddings needed).
+- `createDashboardServer(ctx, 7700)` (from `dist/routes/dashboard-server.js`) starts Mission
+  Control on `127.0.0.1:7700`; the memory viewer (`/api/viewer/*`), the Memory Graph SPA (`/graph`),
+  and `/api/graph` read directly from SQLite.
+- **Embeddings/LLM are required only for vector/semantic recall and LLM features** (auto-capture
+  enrichment, distillation, crystallization) — configure a provider per `docs/LLM-AND-PROVIDERS.md`
+  (`OPENAI_API_KEY`, `GOOGLE_API_KEY`, local Ollama, or ONNX). Structured facts + dashboard work
+  without them.
+- The dashboard **Workshop** panel requires full plugin config (`hybridCfg` with workshop enabled);
+  a bare harness returns `"workshop context is not configured"` — expected, not a bug.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for Cursor Cloud agents and captures the durable, non-obvious caveats in a new `AGENTS.md`. No product code changed — this is a docs/tooling-only change plus the environment update script (registered out-of-band via the Cloud environment config, not committed here).

The core memory engine (SQLite/FTS5 + LanceDB), lint, typecheck, build, and the Mission Control dashboard + Memory Graph SPA were all verified end-to-end in the cloud VM.

## Type of Change

- [x] Documentation update
- [x] CI / tooling change (environment update script)

## What was set up

- Node: repo requires `>=22.16.0`; the VM `PATH` `node` is `/exec-daemon/node` v22.14.0, so `nvm` (default v22.22.2, plus `v22.16.0` matching `.nvmrc`) provides a supported runtime. `scripts/run-with-supported-node.mjs` auto-selects it for all `npm run *` scripts.
- Installed deps at repo root and in `extensions/memory-hybrid` (incl. native `@lancedb/lancedb` rebuild), `extensions/memory-hybrid/graph-app`, and `sdk/openclaw-memory-js`.

## Verification (from `extensions/memory-hybrid`)

- `npx tsc --noEmit` — clean.
- `npm run lint` — passes (warnings only; biome exits 0).
- `npm test` — 774 files / 9961 tests pass, 5 skipped. A handful of optimistic-concurrency race tests in `tests/active-task.test.ts` (occasionally `active-task-reconcile-race.test.ts`, `stage-cleanup-markdown-ledger.test.ts`) are **flaky** (file-`mtime`-based race simulation; failing set varies run-to-run). Documented in `AGENTS.md`; not a code/env defect.
- `npm run build` + `npm run build:graph-app` — both succeed.
- Ran the Mission Control dashboard on `127.0.0.1:7700` against a live SQLite store: stored 5 facts, verified FTS5 recall, and confirmed the dashboard viewer + Memory Graph SPA (`/graph`) render the stored memories.

## Documentation Impact

- [x] Added `AGENTS.md` (references `CLAUDE.md` for standard commands; only adds cloud-specific, non-obvious caveats).

## Notes for Reviewer

Please merge the `AGENTS.md` updates so future cloud agents retain these environment caveats (Node/PATH gotcha, flaky race tests, how to run the dashboard without an OpenClaw host).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b2d5cf30-0430-40e7-9fa5-16c9d5d0f649"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b2d5cf30-0430-40e7-9fa5-16c9d5d0f649"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

