### PR TITLE
feat: autonomous dreaming closed loop (#2169) + two-phase reload (#2181)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Fixed
 
 - Autonomous Dreaming: compose stages emit real candidates (distill/reflect/consolidate/contradictions/self-correction); curriculum metrics-only; nightly `dream-run` + fail-closed skip overlap; Phase B fail-closed tools; `autoPromote.shadowValidation` + `dream validate-shadow` gate live apply until shadow ROI passes; unique dream run ids under concurrent creates (#2169 follow-through).
+- Autonomous Dreaming QA: fail-closed multi-session attribution (no `sessionIds[0]` collapse), exact session allowlist matching, ACL-filtered consolidate/contradictions, live contradiction-resolve deletes, OCC-required delete/supersede, shadow would-promote only when gate says so, skip owned nightly steps only after successful `dream-run`, and activation fail-closed when tools are unbound (#2169/#2174/#2175).
 
 ## [2026.7.222] - 2026-07-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- Autonomous Dreaming: compose stages emit real candidates (distill/reflect/consolidate/contradictions/self-correction); curriculum metrics-only; nightly `dream-run` + fail-closed skip overlap; Phase B fail-closed tools; `autoPromote.shadowValidation` + `dream validate-shadow` gate live apply until shadow ROI passes; unique dream run ids under concurrent creates (#2169 follow-through).
+
 ## [2026.7.222] - 2026-07-18
 
 Implements The Loom (Epic #2150): an agent-native continuity, belief, evidence, and open-loop operating layer on top of hybrid-memory. Enabled by default (`loom.enabled: true`; set `false` to disable, or disable individual sections with `loom.<section>.enabled: false`). A nightly maintenance step runs the belief stale-claim sweep and a drift scan as part of the normal maintenance cycle; both are also runnable on demand (`hybrid-mem belief sweep-stale`, `hybrid-mem loom maintenance`, `hybrid-mem drift scout`). See `docs/THE-LOOM.md`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Autonomous Dreaming (#2169): machine-gated candidate promote/rollback is the happy path for continual learning; human approve/deny and pending digests are escape hatches (`dreaming.mode: autonomous` by default). See `docs/AUTONOMOUS-DREAMING.md`.
+
 - Maintenance validation: ignore guard/gate skipped `reflect-rules` runs in semantic zero-stored checks, suppress the analyzer's own current in-flight HM_EXIT ledger, and classify nested distill abort/timeout errors as retryable within the existing fallback/shrink budget.
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ Key patterns:
 - SQLite uses the **synchronous** `node:sqlite` API (`DatabaseSync`) — no async/await on DB calls. Always use parameterized statements; SQL string interpolation is a blocking review issue.
 - All stores extend `backends/base-sqlite-store.ts` (WAL pragmas, reconnection after SIGUSR1/SIGUSR2, deferred close) and implement `close()`; after close they throw `"<StoreName> is closed"`. DB operations must handle errors explicitly — background timers must never crash the gateway process.
 - Vector search results are re-ranked in the service layer; result-set sizes are bounded via `OPENCLAW_HYBRID_MEM_*` env vars.
-- Event Bus (`backends/event-bus.ts`): append-only `memory_events` table decoupling sensor producers from the Rumination Engine consumer; status lifecycle `raw → processed → surfaced → pushed → archived`.
+- Event Bus (`backends/event-bus.ts`): append-only `memory_events` table decoupling sensor producers from distributed consumers (maintenance / Dream paths); status lifecycle `raw → processed → surfaced → pushed → archived`. There is no separate Rumination Engine process (#2178).
 - Agent tool names use **underscores** (`memory_store`), never dots. The canonical list is `contracts/agent-tool-names.ts`; parity is enforced by `npm run test:schema-gate`.
 - Schema migrations (`backends/migrations/`) run at plugin init. Bump `schemaVersion` in `versionInfo.ts` for breaking schema changes.
 - Embeddings are required at runtime (OpenAI, Ollama, ONNX, or Google); LLM features use tiered chat models (`llm.nano` / `llm.default` / `llm.heavy`) with ordered fallback. See `docs/LLM-AND-PROVIDERS.md`.

--- a/docs/AUTONOMOUS-DREAMING.md
+++ b/docs/AUTONOMOUS-DREAMING.md
@@ -217,6 +217,7 @@ openclaw hybrid-mem dream validate-shadow --json
 ```
 
 3. Accumulate nightly `dream-run` (or CLI `dream run --dry-shadow`) for ≥ `shadowValidation.minShadowRuns` days.
+   Nightly `dream-run` **always gates** after compose (shadow when `autoPromote` is off) so runs leave `running` and `validate-shadow` can score `wouldPromote`. With `skipNightlyOverlap: true`, owned live steps are skipped only after that gated dream-run succeeds — do not leave `promoteAfterRun`/`candidateStore` misconfigured expecting live distill to keep running.
 4. `openclaw hybrid-mem dream validate-shadow --json` — exit 0 required.
 5. Only then: `candidateStore.shadow: false` and `autoPromote.enabled: true`.
 

--- a/docs/AUTONOMOUS-DREAMING.md
+++ b/docs/AUTONOMOUS-DREAMING.md
@@ -69,29 +69,31 @@ Existing Dream Cycle, distill, reflection, consolidate, Loom, and Event Bus prod
 ```json5
 {
   dreaming: {
-    enabled: false,                 // unified Dream master switch (#2171)
+    enabled: false,
+    mode: "autonomous",          // #2177 — machine gates are happy path
     compose: ["distill", "contradictions", "reflect", "consolidate"],
     maxSessions: 20,
     maxRuntimeMinutes: 30,
     skipNightlyOverlap: true,
     promoteAfterRun: false,
     candidateStore: {
-      enabled: false,               // opt-in
-      shadow: true                  // gate + would-promote log, no apply
-    },
-    autoPromote: {
       enabled: false,
-      requireProvenance: true,
-      blockOnContradictionWorsening: true
+      shadow: true
     },
-    autoRollback: {
-      enabled: false,
-      observeWindowHours: 24,
-      regressionThreshold: 0.15
-    }
+    autoPromote: { enabled: false, requireProvenance: true, blockOnContradictionWorsening: true },
+    autoRollback: { enabled: false, observeWindowHours: 24, regressionThreshold: 0.15 },
+    prevalence: { /* session/agent/user/global bars — #2172 */ },
+    permissionBoundary: {
+      targetScope: "session",    // raise for global curriculum (#2174)
+      enforce: true,
+      personalMode: false
+    },
+    steering: { profile: "personal", promote: [...], ignore: [...] }
   }
 }
 ```
+
+Compose under candidate/shadow mode runs maintenance stages with **`dryRun: true`** so the live store is unchanged until machine promote.
 
 **Shadow matrix**
 

--- a/docs/AUTONOMOUS-DREAMING.md
+++ b/docs/AUTONOMOUS-DREAMING.md
@@ -199,7 +199,7 @@ openclaw hybrid-mem dream report --since-days 30 --json
 openclaw hybrid-mem dream validate-shadow --json
 ```
 
-## Host rollout (Maeve / Doris)
+## Host rollout
 
 1. Deploy a build that includes Autonomous Dreaming (`dream_runs` / `memory_candidate_entries` schema).
 2. Migrate config from legacy dream-cycle (`frequency` / `phases`) to:
@@ -221,7 +221,7 @@ openclaw hybrid-mem dream validate-shadow --json
 4. `openclaw hybrid-mem dream validate-shadow --json` — exit 0 required.
 5. Only then: `candidateStore.shadow: false` and `autoPromote.enabled: true`.
 
-**Observed 2026-07-23 (re-probed evening):** Maeve (`polly2` / `192.168.1.224`) reachable; extension install still pre-Dream schema (`facts.db` has **no** `dream_runs` / candidate tables); config still legacy `frequency`/`phases` with **no** `autoPromote` (safe — gate cannot fire until deploy + config migration). Doris (`192.168.1.198`) **unreachable** (100% ping loss). Code-side `shadowValidation` + `dream validate-shadow` are ready; host ROI campaign starts only after PR deploy on Maeve.
+After promote is live:
 
 - Inspect / promote / rollback / observe / report via CLI above
 - `dreaming.mode: "supervised"` for operators who want digest-first workflows

--- a/docs/AUTONOMOUS-DREAMING.md
+++ b/docs/AUTONOMOUS-DREAMING.md
@@ -15,6 +15,8 @@ Epic [#2169](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/21
 
 The **candidate store is for autonomous safety**, not a human review inbox. The machine gates, promotes, observes outcomes, and rolls back.
 
+Compose stages under shadow/candidate mode run with `dryRun: true` and must emit **structured proposed ops** (add / merge / delete with OCC `preHash` where applicable). A synthetic curriculum summary is **metrics-only** when stages emit zero proposals — it is never a promoteable candidate.
+
 ## Task path vs Dream path
 
 ```text
@@ -49,7 +51,7 @@ sessions + store snapshot
  ROI report (#2179)
 ```
 
-Existing Dream Cycle, distill, reflection, consolidate, Loom, and Event Bus producers are **composed under Dream**, not deleted. When `dreaming.enabled` and `skipNightlyOverlap` are true, overlapping nightly steps are skipped so Dream owns them.
+Existing Dream Cycle, distill, reflection, consolidate, Loom, and Event Bus producers are **composed under Dream**, not deleted. When `dreaming.enabled` and `skipNightlyOverlap` are true, overlapping nightly steps are skipped **only if** the nightly `dream-run` maintenance step is scheduled (fail closed: otherwise the owned steps still run so curation is not dropped).
 
 There is **no separate Rumination Engine** process ([#2178](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/2178)): Event Bus status lifecycle is advanced by distributed consumers (maintenance + Dream).
 
@@ -64,7 +66,7 @@ Machine gates require evidence before promote. Defaults:
 | user | 2 | 1 |
 | global | 3 | 2 |
 
-Optional `minConfidence` per tier. `personalSingleTenant` lowers the global agent bar to 1. Missing provenance or `contradictionWorsens` blocks promote.
+Optional `minConfidence` per tier. `personalSingleTenant` lowers the global agent bar to 1. Missing provenance or live contradiction-worsening (heuristic / verified peer / unresolved delete) blocks promote.
 
 ## Permission-scoped attachment (#2174)
 
@@ -74,8 +76,12 @@ Optional `minConfidence` per tier. `personalSingleTenant` lowers the global agen
 - More-private content cannot feed a more-public dream (`SCOPE_RANK[source] >= SCOPE_RANK[target]`)
 - Writes cannot exceed the dream target scope
 - `dream run` persists `attachment.excluded[]` (sessionId + reason) on the run metrics; included ids live in `session_ids_json`
+- **Nightly `dream-run`** discovers recent sessions from FactsDB (`provenance_session` / session `scope_target`), then applies the same `selectDreamSessions` filter — it does **not** scoop an empty or unrestricted time window
+- Dream **distill** / **self-correction** compose pass the attached session allowlist (empty → process zero transcripts)
+- Dream **reflect** mines only attached-session facts (`provenance_session` / session `scope_target`); nightly `reflect` remains `globalOnly`
+- ACL resolution never invents `global` from `scope=global` fact writes alone (those only prove the session existed). Transcript found under `agents/<id>/sessions/` floors to **agent**. Explicit `--session-scopes id:global` (or `personalMode`) is required for global attachment.
 
-Example: dream targeting `global` with sessions `{s1:session, s2:global}` attaches only `s2` unless `personalMode: true`.
+Example: dream targeting `global` with sessions `{s1:session, s2:agent}` attaches **neither** unless scopes are explicitly upgraded or `personalMode: true`.
 
 ## Optimistic concurrency (#2175)
 
@@ -93,6 +99,8 @@ After promote ([#2173](https://github.com/markus-lassfolk/openclaw-hybrid-memory
 4. Nightly `dream-outcome-probe` (when autoRollback enabled) collects after-window metrics **scoped to the dream’s sessions**, compares effect score, and **auto-rollbacks** via reverse plan on regression.
 5. Decisions (`keep` / `rollback` / `insufficient_data`) are journaled on `dream_runs.metrics_summary_json`. Insufficient data never false-rollbacks.
 
+**v1 signal note:** Outcome metrics prefer a **blended** signal when `tool_effectiveness` rows exist in the same DB (`signalSource: blended|tool_effectiveness|feedback_proxy`). Otherwise they fall back to **feedback proxies** (self-correction / reinforcement fact counts). Full closed-loop task-success attribution is still a follow-up.
+
 ## How to read Dream ROI
 
 `hybrid-mem dream report --since-days 30 --json` ([#2179](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/2179)):
@@ -106,6 +114,18 @@ After promote ([#2173](https://github.com/markus-lassfolk/openclaw-hybrid-memory
 | `howToRead` | Inline guidance string |
 
 Shadow mode first: compare ROI and rollback rate before turning `autoPromote` on.
+
+```bash
+# Accumulate shadow runs (autoPromote stays false; candidateStore.shadow true)
+openclaw hybrid-mem dream run --dry-shadow --json
+openclaw hybrid-mem dream validate-shadow --json   # exit 1 until criteria pass
+
+# Only after validate-shadow exits 0:
+#   dreaming.candidateStore.shadow: false
+#   dreaming.autoPromote.enabled: true
+```
+
+`autoPromote.shadowValidation` (enabled by default) **refuses live apply** until the lookback window has enough shadow runs with acceptable quarantine/failure/zero-candidate rates. `--force` promote bypasses the gate (escape hatch / canary only).
 
 ## Steering (set-and-forget)
 
@@ -133,7 +153,8 @@ No nightly UI confirmation. Profile id is stored on each `dream_run`.
       enabled: false,
       shadow: true
     },
-    autoPromote: { enabled: false, requireProvenance: true, blockOnContradictionWorsening: true },
+    autoPromote: { enabled: false, requireProvenance: true, blockOnContradictionWorsening: true,
+      shadowValidation: { enabled: true, minShadowRuns: 7, minWouldPromoteRuns: 3 } },
     autoRollback: { enabled: false, observeWindowHours: 24, regressionThreshold: 0.15 },
     prevalence: { /* session/agent/user/global bars — #2172 */ },
     permissionBoundary: {
@@ -175,9 +196,31 @@ openclaw hybrid-mem dream rollback <id>       # escape hatch
 openclaw hybrid-mem dream observe <id>        # auto-collect metrics; --apply to rollback
 openclaw hybrid-mem dream observe --all       # probe elapsed windows
 openclaw hybrid-mem dream report --since-days 30 --json
+openclaw hybrid-mem dream validate-shadow --json
 ```
 
-## Escape hatches (keep)
+## Host rollout (Maeve / Doris)
+
+1. Deploy a build that includes Autonomous Dreaming (`dream_runs` / `memory_candidate_entries` schema).
+2. Migrate config from legacy dream-cycle (`frequency` / `phases`) to:
+
+```json5
+{
+  dreaming: {
+    enabled: true,
+    mode: "autonomous",
+    candidateStore: { enabled: true, shadow: true },
+    autoPromote: { enabled: false },   // keep off until validate-shadow passes
+    autoRollback: { enabled: false },
+  }
+}
+```
+
+3. Accumulate nightly `dream-run` (or CLI `dream run --dry-shadow`) for ≥ `shadowValidation.minShadowRuns` days.
+4. `openclaw hybrid-mem dream validate-shadow --json` — exit 0 required.
+5. Only then: `candidateStore.shadow: false` and `autoPromote.enabled: true`.
+
+**Observed 2026-07-23 (re-probed evening):** Maeve (`polly2` / `192.168.1.224`) reachable; extension install still pre-Dream schema (`facts.db` has **no** `dream_runs` / candidate tables); config still legacy `frequency`/`phases` with **no** `autoPromote` (safe — gate cannot fire until deploy + config migration). Doris (`192.168.1.198`) **unreachable** (100% ping loss). Code-side `shadowValidation` + `dream validate-shadow` are ready; host ROI campaign starts only after PR deploy on Maeve.
 
 - Inspect / promote / rollback / observe / report via CLI above
 - `dreaming.mode: "supervised"` for operators who want digest-first workflows

--- a/docs/AUTONOMOUS-DREAMING.md
+++ b/docs/AUTONOMOUS-DREAMING.md
@@ -58,7 +58,7 @@ There is **no separate Rumination Engine** process ([#2178](https://github.com/m
 After promote ([#2173](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/2173)):
 
 1. Capture a **pre-promote baseline** (session-scoped feedback signals).
-2. Tag applied facts `dream-run:<id>` for attribution.
+2. Tag applied facts `dream-run:<id>` for attribution. While `autoRollback` is enabled, recall mildly **prefers** those tagged facts (canary boost) so post-promote curriculum is exercised.
 3. Observe for `autoRollback.observeWindowHours`.
 4. Nightly `dream-outcome-probe` (when autoRollback enabled) collects after-window metrics **scoped to the dream’s sessions**, compares effect score, and **auto-rollbacks** via reverse plan on regression.
 5. Decisions (`keep` / `rollback` / `insufficient_data`) are journaled on `dream_runs.metrics_summary_json`. Insufficient data never false-rollbacks.

--- a/docs/AUTONOMOUS-DREAMING.md
+++ b/docs/AUTONOMOUS-DREAMING.md
@@ -147,7 +147,7 @@ No nightly UI confirmation. Profile id is stored on each `dream_run`.
     compose: ["distill", "contradictions", "reflect", "consolidate"],
     maxSessions: 20,
     maxRuntimeMinutes: 30,
-    skipNightlyOverlap: true,
+    skipNightlyOverlap: false,   // opt-in: do not drop live nightly until Dream owns promote
     promoteAfterRun: false,
     candidateStore: {
       enabled: false,

--- a/docs/AUTONOMOUS-DREAMING.md
+++ b/docs/AUTONOMOUS-DREAMING.md
@@ -1,0 +1,123 @@
+---
+layout: default
+title: Autonomous Dreaming
+parent: Architecture
+nav_order: 25
+---
+
+# Autonomous Dreaming
+
+Epic [#2169](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/2169). Candidate/shadow store + machine promote/rollback: [#2170](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/2170). Unified Dream: [#2171](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/2171).
+
+## Product intent
+
+The **candidate store is for autonomous safety**, not a human review inbox.
+
+Anthropic-style dreaming architecture (out-of-band curation, candidate memory state, provenance) is useful. Hybrid Memory’s product preference is different: the operator does **not** click Approve/Reject on curriculum changes. The machine must gate, promote, and roll back.
+
+Persona/skill proposal queues remain escape hatches elsewhere. They are **not** the happy path for dream curriculum.
+
+## Task path vs Dream path
+
+```text
+┌─────────────────────────────┐     ┌──────────────────────────────────┐
+│ In-band (task / session)    │     │ Out-of-band Dream (#2171)         │
+│                             │     │                                  │
+│ short-loop capture          │     │ snapshot store_revision          │
+│ memory_store / auto-capture │     │ attach permission-scoped sessions│
+│ immediate FactsDB write     │     │ compose distill→…→consolidate    │
+│                             │     │ emit candidates (#2170)          │
+│                             │     │ machine gates → promote/rollback │
+└─────────────────────────────┘     └──────────────────────────────────┘
+```
+
+Task path learns for *this* session. Dream path spends dedicated maintenance budget (`CostFeature.dream`) to improve curriculum for *future* sessions.
+
+## Control plane
+
+```
+sessions + store snapshot
+        ↓
+   Dream run (#2171)
+        ↓
+ candidate entries (#2170)
+        ↓
+ machine gates (#2172 prevalence / evidence)
+        ↓
+ auto-promote | quarantine  (+ OCC #2175)
+        ↓
+ outcome window (#2173) → auto-rollback if regression
+        ↓
+ ROI report (#2179)
+```
+
+Existing Dream Cycle, distill, reflection, consolidate, Loom, and Event Bus producers are **composed under Dream**, not deleted. When `dreaming.enabled` and `skipNightlyOverlap` are true, overlapping nightly steps are skipped so Dream owns them.
+
+## What lands with #2170 / #2171
+
+| Piece | Role |
+|-------|------|
+| `dream_runs` + `memory_candidate_entries` | Durable proposed-diff + reverse plan in the **facts** SQLite DB |
+| `runDream` / `hybrid-mem dream run` | Unified compose facade → always ≥1 candidate |
+| Status lifecycle | `pending → running → gated → promoted \| quarantined \| failed`; `promoted → rolled_back` |
+| Machine gates | Provenance, contradiction stub, prevalence/blast-radius (#2172) |
+| Promote / rollback | Transactional SQLite apply; reverse plan + `post_hash` drift refuse |
+| OCC | `input_store_revision` / `expectedHash` (#2175) |
+
+## Config (defaults conservative)
+
+```json5
+{
+  dreaming: {
+    enabled: false,                 // unified Dream master switch (#2171)
+    compose: ["distill", "contradictions", "reflect", "consolidate"],
+    maxSessions: 20,
+    maxRuntimeMinutes: 30,
+    skipNightlyOverlap: true,
+    promoteAfterRun: false,
+    candidateStore: {
+      enabled: false,               // opt-in
+      shadow: true                  // gate + would-promote log, no apply
+    },
+    autoPromote: {
+      enabled: false,
+      requireProvenance: true,
+      blockOnContradictionWorsening: true
+    },
+    autoRollback: {
+      enabled: false,
+      observeWindowHours: 24,
+      regressionThreshold: 0.15
+    }
+  }
+}
+```
+
+**Shadow matrix**
+
+| candidateStore | shadow | autoPromote | Behavior |
+|----------------|--------|-------------|----------|
+| off | — | — | Today’s live mutate paths unchanged |
+| on | true | off | Candidates + gates + would-promote; no live apply |
+| on | false | on | Real promote when gates pass |
+| + autoRollback on | — | — | Observe → reverse plan on regression (#2173) |
+
+## CLI
+
+```bash
+openclaw hybrid-mem dream run --json --dry-shadow
+openclaw hybrid-mem dream run --sessions s1,s2 --compose distill,reflect --json
+openclaw hybrid-mem dream status
+openclaw hybrid-mem dream status <id>
+openclaw hybrid-mem dream promote <id>        # machine path; --force under shadow
+openclaw hybrid-mem dream rollback <id>
+```
+
+## Non-goals (sibling issues)
+
+- Blast-radius / prevalence policy depth (#2172)
+- Outcome self-heal metrics (#2173)
+- Permission-scoped transcript attachment (#2174)
+- Steering policy profiles (#2176)
+- Autopilot-first defaults (#2177)
+- Dream ROI report (#2179)

--- a/docs/AUTONOMOUS-DREAMING.md
+++ b/docs/AUTONOMOUS-DREAMING.md
@@ -53,6 +53,36 @@ Existing Dream Cycle, distill, reflection, consolidate, Loom, and Event Bus prod
 
 There is **no separate Rumination Engine** process ([#2178](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/2178)): Event Bus status lifecycle is advanced by distributed consumers (maintenance + Dream).
 
+## Blast-radius / prevalence (#2172)
+
+Machine gates require evidence before promote. Defaults:
+
+| Scope | minSessions | minAgents |
+|-------|-------------|-----------|
+| session | 1 | 1 |
+| agent | 2 | 1 |
+| user | 2 | 1 |
+| global | 3 | 2 |
+
+Optional `minConfidence` per tier. `personalSingleTenant` lowers the global agent bar to 1. Missing provenance or `contradictionWorsens` blocks promote.
+
+## Permission-scoped attachment (#2174)
+
+`permissionBoundary.targetScope` (default **session**) controls which transcripts may feed a dream:
+
+- Fail closed: unresolved ACL → exclude
+- More-private content cannot feed a more-public dream (`SCOPE_RANK[source] >= SCOPE_RANK[target]`)
+- Writes cannot exceed the dream target scope
+- `dream run` persists `attachment.excluded[]` (sessionId + reason) on the run metrics; included ids live in `session_ids_json`
+
+Example: dream targeting `global` with sessions `{s1:session, s2:global}` attaches only `s2` unless `personalMode: true`.
+
+## Optimistic concurrency (#2175)
+
+- Dream run snapshots `input_store_revision` at start
+- Promote refuses if live store revision drifted (unless `--force`)
+- Per-fact supersede/delete uses candidate `preHash` (propose-time OCC token), not a live token at apply time
+
 ## Self-heal (outcome feedback) — autonomy substitute for deny
 
 After promote ([#2173](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/2173)):

--- a/docs/AUTONOMOUS-DREAMING.md
+++ b/docs/AUTONOMOUS-DREAMING.md
@@ -7,15 +7,13 @@ nav_order: 25
 
 # Autonomous Dreaming
 
-Epic [#2169](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/2169). Candidate/shadow store + machine promote/rollback: [#2170](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/2170). Unified Dream: [#2171](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/2171).
+Epic [#2169](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/2169). Child issues: [#2170](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/2170)–[#2179](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/2179), reload fix [#2181](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/2181).
 
 ## Product intent
 
-The **candidate store is for autonomous safety**, not a human review inbox.
+**Autonomous machine review is the design center.** Human proposal/approve/deny UX is an escape hatch — not the happy path for continual learning ([#2177](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/2177)).
 
-Anthropic-style dreaming architecture (out-of-band curation, candidate memory state, provenance) is useful. Hybrid Memory’s product preference is different: the operator does **not** click Approve/Reject on curriculum changes. The machine must gate, promote, and roll back.
-
-Persona/skill proposal queues remain escape hatches elsewhere. They are **not** the happy path for dream curriculum.
+The **candidate store is for autonomous safety**, not a human review inbox. The machine gates, promotes, observes outcomes, and rolls back.
 
 ## Task path vs Dream path
 
@@ -38,31 +36,56 @@ Task path learns for *this* session. Dream path spends dedicated maintenance bud
 ```
 sessions + store snapshot
         ↓
-   Dream run (#2171)
+   Dream run (#2171) + steering (#2176)
         ↓
  candidate entries (#2170)
         ↓
- machine gates (#2172 prevalence / evidence)
+ machine gates (#2172 prevalence / evidence / permission #2174)
         ↓
  auto-promote | quarantine  (+ OCC #2175)
         ↓
- outcome window (#2173) → auto-rollback if regression
+ outcome window (#2173) → auto-rollback if regression  ← self-heal = “deny”
         ↓
  ROI report (#2179)
 ```
 
 Existing Dream Cycle, distill, reflection, consolidate, Loom, and Event Bus producers are **composed under Dream**, not deleted. When `dreaming.enabled` and `skipNightlyOverlap` are true, overlapping nightly steps are skipped so Dream owns them.
 
-## What lands with #2170 / #2171
+There is **no separate Rumination Engine** process ([#2178](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/2178)): Event Bus status lifecycle is advanced by distributed consumers (maintenance + Dream).
 
-| Piece | Role |
-|-------|------|
-| `dream_runs` + `memory_candidate_entries` | Durable proposed-diff + reverse plan in the **facts** SQLite DB |
-| `runDream` / `hybrid-mem dream run` | Unified compose facade → always ≥1 candidate |
-| Status lifecycle | `pending → running → gated → promoted \| quarantined \| failed`; `promoted → rolled_back` |
-| Machine gates | Provenance, contradiction stub, prevalence/blast-radius (#2172) |
-| Promote / rollback | Transactional SQLite apply; reverse plan + `post_hash` drift refuse |
-| OCC | `input_store_revision` / `expectedHash` (#2175) |
+## Self-heal (outcome feedback) — autonomy substitute for deny
+
+After promote ([#2173](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/2173)):
+
+1. Capture a **pre-promote baseline** (session-scoped feedback signals).
+2. Tag applied facts `dream-run:<id>` for attribution.
+3. Observe for `autoRollback.observeWindowHours`.
+4. Nightly `dream-outcome-probe` (when autoRollback enabled) collects after-window metrics **scoped to the dream’s sessions**, compares effect score, and **auto-rollbacks** via reverse plan on regression.
+5. Decisions (`keep` / `rollback` / `insufficient_data`) are journaled on `dream_runs.metrics_summary_json`. Insufficient data never false-rollbacks.
+
+## How to read Dream ROI
+
+`hybrid-mem dream report --since-days 30 --json` ([#2179](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/2179)):
+
+| Field | Meaning |
+|-------|---------|
+| `totals.cost.tokens` / `usdProxy` | LLM spend attributed to `feature=dream` during compose |
+| `totals.promoted` / `rolledBack` / `quarantined` | Lifecycle outcomes |
+| `totals.candidatePromoteRatio` | Candidates that cleared gates vs proposed |
+| `perRun[].metricsSummary` | Per-run cost/hygiene + optional outcome decision |
+| `howToRead` | Inline guidance string |
+
+Shadow mode first: compare ROI and rollback rate before turning `autoPromote` on.
+
+## Steering (set-and-forget)
+
+`dreaming.steering` ([#2176](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/2176)) — default **personal** profile for single-operator autonomy:
+
+- **promote:** preference, routine, insight
+- **ignore:** one_off_debug, transient_path, secret_like
+- **notes:** freeform LLM guidance injected into distill/reflect prompts
+
+No nightly UI confirmation. Profile id is stored on each `dream_run`.
 
 ## Config (defaults conservative)
 
@@ -88,10 +111,16 @@ Existing Dream Cycle, distill, reflection, consolidate, Loom, and Event Bus prod
       enforce: true,
       personalMode: false
     },
-    steering: { profile: "personal", promote: [...], ignore: [...] }
+    steering: {
+      profile: "personal",
+      promote: ["preference", "routine", "insight"],
+      ignore: ["one_off_debug", "transient_path", "secret_like"]
+    }
   }
 }
 ```
+
+When `mode: "autonomous"` and Dream is enabled, nightly `pending-digest` is skipped so human triage is not implied for correctness. Set `mode: "supervised"` to restore digest-first workflows.
 
 Compose under candidate/shadow mode runs maintenance stages with **`dryRun: true`** so the live store is unchanged until machine promote.
 
@@ -112,14 +141,14 @@ openclaw hybrid-mem dream run --sessions s1,s2 --compose distill,reflect --json
 openclaw hybrid-mem dream status
 openclaw hybrid-mem dream status <id>
 openclaw hybrid-mem dream promote <id>        # machine path; --force under shadow
-openclaw hybrid-mem dream rollback <id>
+openclaw hybrid-mem dream rollback <id>       # escape hatch
+openclaw hybrid-mem dream observe <id>        # auto-collect metrics; --apply to rollback
+openclaw hybrid-mem dream observe --all       # probe elapsed windows
+openclaw hybrid-mem dream report --since-days 30 --json
 ```
 
-## Non-goals (sibling issues)
+## Escape hatches (keep)
 
-- Blast-radius / prevalence policy depth (#2172)
-- Outcome self-heal metrics (#2173)
-- Permission-scoped transcript attachment (#2174)
-- Steering policy profiles (#2176)
-- Autopilot-first defaults (#2177)
-- Dream ROI report (#2179)
+- Inspect / promote / rollback / observe / report via CLI above
+- `dreaming.mode: "supervised"` for operators who want digest-first workflows
+- Manual `--force` promote under shadow for debugging

--- a/extensions/memory-hybrid/README.md
+++ b/extensions/memory-hybrid/README.md
@@ -60,7 +60,7 @@ All tools use **underscore** names (`memory_store`, `memory_recall`, …). Dotte
 | `config.ts` | Decay classes, TTL defaults, config parsing (incl. autoRecall, store, etc.) |
 | `index.ts` | Plugin implementation (SQLite+FTS5, LanceDB, tools, CLI, lifecycle) |
 | `versionInfo.ts` | Plugin and memory-manager version metadata |
-| `backends/event-bus.ts` | Event Bus — append-only `memory_events` SQLite table for sensor → Rumination Engine pipeline |
+| `backends/event-bus.ts` | Event Bus — append-only `memory_events` SQLite table for sensor → maintenance/Dream pipeline |
 | `tools/dashboard-routes.ts` | Dashboard HTTP route registration — registers all `/plugins/memory-dashboard/*` routes with consistent auth (Issue #279) |
 | `tools/public-api-routes.ts` | Public API surface routes (`/plugins/memory-public/*`) for health/search/timeline/stats/export/fact (Issue #1027) |
 | `services/public-export-bundle.ts` | Stable export bundle builder used by `GET /plugins/memory-public/export` (Issue #1027) |
@@ -83,7 +83,7 @@ When **`graph.enabled`** is true, new facts are enriched asynchronously with typ
 
 ## Event Bus
 
-`backends/event-bus.ts` adds an **Event Bus**: an append-only `memory_events` SQLite table that decouples sensor sweeps (producers) from the Rumination Engine (consumer).
+`backends/event-bus.ts` adds an **Event Bus**: an append-only `memory_events` SQLite table that decouples sensor sweeps (producers) from maintenance and Dream consumers (see `docs/event-bus.md`; no separate Rumination Engine module).
 
 Key API:
 

--- a/extensions/memory-hybrid/backends/dream-candidate-store.ts
+++ b/extensions/memory-hybrid/backends/dream-candidate-store.ts
@@ -123,12 +123,18 @@ function mapCandidate(row: CandidateRow): CandidateEntryRecord {
     dreamRunId: row.dream_run_id,
     op: row.op as CandidateOpKind,
     status: row.status as CandidateEntryStatus,
-    payload: parseJsonObject<CandidatePayload>(row.payload_json, { text: "", category: "preference", importance: 0.5, source: "dream", entity: null, key: null, value: null }),
+    payload: parseJsonObject<CandidatePayload>(row.payload_json, {
+      text: "",
+      category: "preference",
+      importance: 0.5,
+      source: "dream",
+      entity: null,
+      key: null,
+      value: null,
+    }),
     targetFactId: row.target_fact_id,
     sessionIds: parseJsonArray(row.session_ids_json),
-    prevalence: row.prevalence_json
-      ? parseJsonObject<CandidatePrevalence | null>(row.prevalence_json, null)
-      : null,
+    prevalence: row.prevalence_json ? parseJsonObject<CandidatePrevalence | null>(row.prevalence_json, null) : null,
     rationale: row.rationale,
     preHash: row.pre_hash,
     postHash: row.post_hash,
@@ -180,13 +186,9 @@ export class DreamCandidateStore {
     const current = this.getDreamRun(id);
     if (!current) throw new Error(`dream-candidate-store: dream run not found: ${id}`);
     if (current.status !== "pending" && current.status !== "running" && current.status !== "gated") {
-      throw new Error(
-        `dream-candidate-store: cannot rebase revision in status ${current.status} for ${id}`,
-      );
+      throw new Error(`dream-candidate-store: cannot rebase revision in status ${current.status} for ${id}`);
     }
-    this.db
-      .prepare("UPDATE dream_runs SET input_store_revision = ? WHERE id = ?")
-      .run(inputStoreRevision, id);
+    this.db.prepare("UPDATE dream_runs SET input_store_revision = ? WHERE id = ?").run(inputStoreRevision, id);
     const updated = this.getDreamRun(id);
     if (!updated) throw new Error(`dream-candidate-store: dream run missing after rebase: ${id}`);
     return updated;
@@ -223,9 +225,7 @@ export class DreamCandidateStore {
     } else {
       const allowed = ALLOWED_TRANSITIONS[current.status];
       if (!allowed.includes(status)) {
-        throw new Error(
-          `dream-candidate-store: illegal status transition ${current.status} → ${status} for ${id}`,
-        );
+        throw new Error(`dream-candidate-store: illegal status transition ${current.status} → ${status} for ${id}`);
       }
     }
     if (!DREAM_RUN_STATUSES.includes(status)) {
@@ -288,16 +288,11 @@ export class DreamCandidateStore {
     return updated;
   }
 
-  setDreamRunMetrics(
-    id: string,
-    extra: { metricsSummaryJson?: string | null },
-  ): DreamRunRecord {
+  setDreamRunMetrics(id: string, extra: { metricsSummaryJson?: string | null }): DreamRunRecord {
     const current = this.getDreamRun(id);
     if (!current) throw new Error(`dream-candidate-store: dream run not found: ${id}`);
     if (extra.metricsSummaryJson !== undefined) {
-      this.db
-        .prepare("UPDATE dream_runs SET metrics_summary_json = ? WHERE id = ?")
-        .run(extra.metricsSummaryJson, id);
+      this.db.prepare("UPDATE dream_runs SET metrics_summary_json = ? WHERE id = ?").run(extra.metricsSummaryJson, id);
     }
     const updated = this.getDreamRun(id);
     if (!updated) throw new Error(`dream-candidate-store: dream run missing after metrics patch: ${id}`);
@@ -308,9 +303,7 @@ export class DreamCandidateStore {
     const run = this.getDreamRun(dreamRunId);
     if (!run) throw new Error(`dream-candidate-store: dream run not found: ${dreamRunId}`);
     if (run.status !== "pending" && run.status !== "running") {
-      throw new Error(
-        `dream-candidate-store: cannot append candidates to run in status ${run.status}`,
-      );
+      throw new Error(`dream-candidate-store: cannot append candidates to run in status ${run.status}`);
     }
 
     const created: CandidateEntryRecord[] = [];
@@ -354,9 +347,7 @@ export class DreamCandidateStore {
 
   listCandidateEntries(dreamRunId: string): CandidateEntryRecord[] {
     const rows = this.db
-      .prepare(
-        "SELECT * FROM memory_candidate_entries WHERE dream_run_id = ? ORDER BY sort_order ASC, created_at ASC",
-      )
+      .prepare("SELECT * FROM memory_candidate_entries WHERE dream_run_id = ? ORDER BY sort_order ASC, created_at ASC")
       .all(dreamRunId) as CandidateRow[];
     return rows.map(mapCandidate);
   }

--- a/extensions/memory-hybrid/backends/dream-candidate-store.ts
+++ b/extensions/memory-hybrid/backends/dream-candidate-store.ts
@@ -199,10 +199,23 @@ export class DreamCandidateStore {
     return row ? mapDreamRun(row) : null;
   }
 
-  listDreamRuns(limit = 50): DreamRunRecord[] {
+  listDreamRuns(limit = 50, opts?: { sinceSec?: number; untilSec?: number }): DreamRunRecord[] {
+    const cap = Math.max(1, Math.floor(limit));
+    const sinceSec = opts?.sinceSec;
+    const untilSec = opts?.untilSec;
+    if (sinceSec != null || untilSec != null) {
+      const since = sinceSec ?? 0;
+      const until = untilSec ?? Number.MAX_SAFE_INTEGER;
+      const rows = this.db
+        .prepare(
+          "SELECT * FROM dream_runs WHERE created_at >= ? AND created_at <= ? ORDER BY created_at DESC LIMIT ?",
+        )
+        .all(since, until, cap) as DreamRunRow[];
+      return rows.map(mapDreamRun);
+    }
     const rows = this.db
       .prepare("SELECT * FROM dream_runs ORDER BY created_at DESC LIMIT ?")
-      .all(Math.max(1, Math.floor(limit))) as DreamRunRow[];
+      .all(cap) as DreamRunRow[];
     return rows.map(mapDreamRun);
   }
 

--- a/extensions/memory-hybrid/backends/dream-candidate-store.ts
+++ b/extensions/memory-hybrid/backends/dream-candidate-store.ts
@@ -72,6 +72,7 @@ type DreamRunRow = {
   rollback_reason: string | null;
   metrics_baseline_json: string | null;
   metrics_observe_until: number | null;
+  metrics_summary_json: string | null;
 };
 
 type CandidateRow = {
@@ -112,6 +113,7 @@ function mapDreamRun(row: DreamRunRow): DreamRunRecord {
     rollbackReason: row.rollback_reason,
     metricsBaselineJson: row.metrics_baseline_json,
     metricsObserveUntil: row.metrics_observe_until,
+    metricsSummaryJson: row.metrics_summary_json ?? null,
   };
 }
 
@@ -211,6 +213,7 @@ export class DreamCandidateStore {
       gateReportJson?: string | null;
       metricsBaselineJson?: string | null;
       metricsObserveUntil?: number | null;
+      metricsSummaryJson?: string | null;
     },
   ): DreamRunRecord {
     const current = this.getDreamRun(id);
@@ -273,11 +276,31 @@ export class DreamCandidateStore {
       sets.push("metrics_observe_until = ?");
       params.push(extra.metricsObserveUntil);
     }
+    if (extra?.metricsSummaryJson !== undefined) {
+      sets.push("metrics_summary_json = ?");
+      params.push(extra.metricsSummaryJson);
+    }
 
     params.push(id);
     this.db.prepare(`UPDATE dream_runs SET ${sets.join(", ")} WHERE id = ?`).run(...(params as never[]));
     const updated = this.getDreamRun(id);
     if (!updated) throw new Error(`dream-candidate-store: dream run missing after update: ${id}`);
+    return updated;
+  }
+
+  setDreamRunMetrics(
+    id: string,
+    extra: { metricsSummaryJson?: string | null },
+  ): DreamRunRecord {
+    const current = this.getDreamRun(id);
+    if (!current) throw new Error(`dream-candidate-store: dream run not found: ${id}`);
+    if (extra.metricsSummaryJson !== undefined) {
+      this.db
+        .prepare("UPDATE dream_runs SET metrics_summary_json = ? WHERE id = ?")
+        .run(extra.metricsSummaryJson, id);
+    }
+    const updated = this.getDreamRun(id);
+    if (!updated) throw new Error(`dream-candidate-store: dream run missing after metrics patch: ${id}`);
     return updated;
   }
 

--- a/extensions/memory-hybrid/backends/dream-candidate-store.ts
+++ b/extensions/memory-hybrid/backends/dream-candidate-store.ts
@@ -173,6 +173,23 @@ export class DreamCandidateStore {
     return run;
   }
 
+  /** Rebase OCC snapshot after intentional compose (or before promote). */
+  setInputStoreRevision(id: string, inputStoreRevision: string): DreamRunRecord {
+    const current = this.getDreamRun(id);
+    if (!current) throw new Error(`dream-candidate-store: dream run not found: ${id}`);
+    if (current.status !== "pending" && current.status !== "running" && current.status !== "gated") {
+      throw new Error(
+        `dream-candidate-store: cannot rebase revision in status ${current.status} for ${id}`,
+      );
+    }
+    this.db
+      .prepare("UPDATE dream_runs SET input_store_revision = ? WHERE id = ?")
+      .run(inputStoreRevision, id);
+    const updated = this.getDreamRun(id);
+    if (!updated) throw new Error(`dream-candidate-store: dream run missing after rebase: ${id}`);
+    return updated;
+  }
+
   getDreamRun(id: string): DreamRunRecord | null {
     const row = this.db.prepare("SELECT * FROM dream_runs WHERE id = ?").get(id) as DreamRunRow | undefined;
     return row ? mapDreamRun(row) : null;

--- a/extensions/memory-hybrid/backends/dream-candidate-store.ts
+++ b/extensions/memory-hybrid/backends/dream-candidate-store.ts
@@ -207,15 +207,11 @@ export class DreamCandidateStore {
       const since = sinceSec ?? 0;
       const until = untilSec ?? Number.MAX_SAFE_INTEGER;
       const rows = this.db
-        .prepare(
-          "SELECT * FROM dream_runs WHERE created_at >= ? AND created_at <= ? ORDER BY created_at DESC LIMIT ?",
-        )
+        .prepare("SELECT * FROM dream_runs WHERE created_at >= ? AND created_at <= ? ORDER BY created_at DESC LIMIT ?")
         .all(since, until, cap) as DreamRunRow[];
       return rows.map(mapDreamRun);
     }
-    const rows = this.db
-      .prepare("SELECT * FROM dream_runs ORDER BY created_at DESC LIMIT ?")
-      .all(cap) as DreamRunRow[];
+    const rows = this.db.prepare("SELECT * FROM dream_runs ORDER BY created_at DESC LIMIT ?").all(cap) as DreamRunRow[];
     return rows.map(mapDreamRun);
   }
 

--- a/extensions/memory-hybrid/backends/dream-candidate-store.ts
+++ b/extensions/memory-hybrid/backends/dream-candidate-store.ts
@@ -1,0 +1,367 @@
+/**
+ * Dream candidate store — durable dream_runs + memory_candidate_entries (#2170).
+ *
+ * Option B: proposed-diff + reverse plan in the facts DB. Does not clone FactsDB.
+ */
+
+import { randomUUID } from "node:crypto";
+import type { DatabaseSync } from "node:sqlite";
+import {
+  type CandidateEntryInput,
+  type CandidateEntryRecord,
+  type CandidateEntryStatus,
+  type CandidateOpKind,
+  type CandidatePayload,
+  type CandidatePrevalence,
+  type DreamRunRecord,
+  type DreamRunStatus,
+  type ReversePlan,
+  DREAM_RUN_STATUSES,
+  makeDreamRunId,
+} from "../services/dream-candidate-ops.js";
+import { pluginLogger } from "../utils/logger.js";
+
+const ALLOWED_TRANSITIONS: Record<DreamRunStatus, readonly DreamRunStatus[]> = {
+  pending: ["running", "failed"],
+  running: ["gated", "failed", "quarantined"],
+  gated: ["promoted", "quarantined", "failed"],
+  promoted: ["rolled_back"],
+  quarantined: [],
+  rolled_back: [],
+  failed: [],
+};
+
+function nowSec(): number {
+  return Math.floor(Date.now() / 1000);
+}
+
+function parseJsonArray(raw: string | null | undefined): string[] {
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    return Array.isArray(parsed) ? parsed.filter((x): x is string => typeof x === "string") : [];
+  } catch {
+    return [];
+  }
+}
+
+function parseJsonObject<T>(raw: string | null | undefined, fallback: T): T {
+  if (!raw) return fallback;
+  try {
+    return JSON.parse(raw) as T;
+  } catch {
+    return fallback;
+  }
+}
+
+type DreamRunRow = {
+  id: string;
+  status: string;
+  input_store_revision: string;
+  session_ids_json: string;
+  steering_policy_id: string | null;
+  gate_report_json: string | null;
+  shadow: number;
+  created_at: number;
+  started_at: number | null;
+  gated_at: number | null;
+  promoted_at: number | null;
+  rolled_back_at: number | null;
+  failed_at: number | null;
+  failure_reason: string | null;
+  rollback_reason: string | null;
+  metrics_baseline_json: string | null;
+  metrics_observe_until: number | null;
+};
+
+type CandidateRow = {
+  id: string;
+  dream_run_id: string;
+  op: string;
+  status: string;
+  payload_json: string;
+  target_fact_id: string | null;
+  session_ids_json: string;
+  prevalence_json: string | null;
+  rationale: string | null;
+  pre_hash: string | null;
+  post_hash: string | null;
+  reverse_op: string;
+  reverse_payload_json: string;
+  applied_fact_id: string | null;
+  sort_order: number;
+  created_at: number;
+};
+
+function mapDreamRun(row: DreamRunRow): DreamRunRecord {
+  return {
+    id: row.id,
+    status: row.status as DreamRunStatus,
+    inputStoreRevision: row.input_store_revision,
+    sessionIds: parseJsonArray(row.session_ids_json),
+    steeringPolicyId: row.steering_policy_id,
+    gateReportJson: row.gate_report_json,
+    shadow: row.shadow === 1,
+    createdAt: row.created_at,
+    startedAt: row.started_at,
+    gatedAt: row.gated_at,
+    promotedAt: row.promoted_at,
+    rolledBackAt: row.rolled_back_at,
+    failedAt: row.failed_at,
+    failureReason: row.failure_reason,
+    rollbackReason: row.rollback_reason,
+    metricsBaselineJson: row.metrics_baseline_json,
+    metricsObserveUntil: row.metrics_observe_until,
+  };
+}
+
+function mapCandidate(row: CandidateRow): CandidateEntryRecord {
+  return {
+    id: row.id,
+    dreamRunId: row.dream_run_id,
+    op: row.op as CandidateOpKind,
+    status: row.status as CandidateEntryStatus,
+    payload: parseJsonObject<CandidatePayload>(row.payload_json, { text: "", category: "preference", importance: 0.5, source: "dream", entity: null, key: null, value: null }),
+    targetFactId: row.target_fact_id,
+    sessionIds: parseJsonArray(row.session_ids_json),
+    prevalence: row.prevalence_json
+      ? parseJsonObject<CandidatePrevalence | null>(row.prevalence_json, null)
+      : null,
+    rationale: row.rationale,
+    preHash: row.pre_hash,
+    postHash: row.post_hash,
+    reverse: {
+      op: row.reverse_op as ReversePlan["op"],
+      payload: parseJsonObject<Record<string, unknown>>(row.reverse_payload_json, {}),
+    },
+    appliedFactId: row.applied_fact_id,
+    sortOrder: row.sort_order,
+    createdAt: row.created_at,
+  };
+}
+
+export class DreamCandidateStore {
+  constructor(private readonly db: DatabaseSync) {}
+
+  createDreamRun(input: {
+    inputStoreRevision: string;
+    sessionIds?: string[];
+    steeringPolicyId?: string | null;
+    shadow?: boolean;
+    id?: string;
+  }): DreamRunRecord {
+    const id = input.id ?? makeDreamRunId();
+    const createdAt = nowSec();
+    const shadow = input.shadow !== false ? 1 : 0;
+    this.db
+      .prepare(
+        `INSERT INTO dream_runs (
+          id, status, input_store_revision, session_ids_json, steering_policy_id,
+          shadow, created_at
+        ) VALUES (?, 'pending', ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        id,
+        input.inputStoreRevision,
+        JSON.stringify(input.sessionIds ?? []),
+        input.steeringPolicyId ?? null,
+        shadow,
+        createdAt,
+      );
+    const run = this.getDreamRun(id);
+    if (!run) throw new Error(`dream-candidate-store: failed to create dream run ${id}`);
+    return run;
+  }
+
+  getDreamRun(id: string): DreamRunRecord | null {
+    const row = this.db.prepare("SELECT * FROM dream_runs WHERE id = ?").get(id) as DreamRunRow | undefined;
+    return row ? mapDreamRun(row) : null;
+  }
+
+  listDreamRuns(limit = 50): DreamRunRecord[] {
+    const rows = this.db
+      .prepare("SELECT * FROM dream_runs ORDER BY created_at DESC LIMIT ?")
+      .all(Math.max(1, Math.floor(limit))) as DreamRunRow[];
+    return rows.map(mapDreamRun);
+  }
+
+  updateDreamRunStatus(
+    id: string,
+    status: DreamRunStatus,
+    extra?: {
+      failureReason?: string | null;
+      rollbackReason?: string | null;
+      gateReportJson?: string | null;
+      metricsBaselineJson?: string | null;
+      metricsObserveUntil?: number | null;
+    },
+  ): DreamRunRecord {
+    const current = this.getDreamRun(id);
+    if (!current) throw new Error(`dream-candidate-store: dream run not found: ${id}`);
+    if (current.status === status) {
+      // Idempotent no-op for same status (allows re-writing gate report).
+    } else {
+      const allowed = ALLOWED_TRANSITIONS[current.status];
+      if (!allowed.includes(status)) {
+        throw new Error(
+          `dream-candidate-store: illegal status transition ${current.status} → ${status} for ${id}`,
+        );
+      }
+    }
+    if (!DREAM_RUN_STATUSES.includes(status)) {
+      throw new Error(`dream-candidate-store: invalid status ${status}`);
+    }
+
+    const ts = nowSec();
+    const sets: string[] = ["status = ?"];
+    const params: unknown[] = [status];
+
+    if (status === "running" && current.startedAt == null) {
+      sets.push("started_at = ?");
+      params.push(ts);
+    }
+    if (status === "gated") {
+      sets.push("gated_at = ?");
+      params.push(ts);
+    }
+    if (status === "promoted") {
+      sets.push("promoted_at = ?");
+      params.push(ts);
+    }
+    if (status === "rolled_back") {
+      sets.push("rolled_back_at = ?");
+      params.push(ts);
+    }
+    if (status === "failed" || status === "quarantined") {
+      sets.push("failed_at = ?");
+      params.push(ts);
+    }
+    if (extra?.failureReason !== undefined) {
+      sets.push("failure_reason = ?");
+      params.push(extra.failureReason);
+    }
+    if (extra?.rollbackReason !== undefined) {
+      sets.push("rollback_reason = ?");
+      params.push(extra.rollbackReason);
+    }
+    if (extra?.gateReportJson !== undefined) {
+      sets.push("gate_report_json = ?");
+      params.push(extra.gateReportJson);
+    }
+    if (extra?.metricsBaselineJson !== undefined) {
+      sets.push("metrics_baseline_json = ?");
+      params.push(extra.metricsBaselineJson);
+    }
+    if (extra?.metricsObserveUntil !== undefined) {
+      sets.push("metrics_observe_until = ?");
+      params.push(extra.metricsObserveUntil);
+    }
+
+    params.push(id);
+    this.db.prepare(`UPDATE dream_runs SET ${sets.join(", ")} WHERE id = ?`).run(...(params as never[]));
+    const updated = this.getDreamRun(id);
+    if (!updated) throw new Error(`dream-candidate-store: dream run missing after update: ${id}`);
+    return updated;
+  }
+
+  appendCandidateEntries(dreamRunId: string, entries: CandidateEntryInput[]): CandidateEntryRecord[] {
+    const run = this.getDreamRun(dreamRunId);
+    if (!run) throw new Error(`dream-candidate-store: dream run not found: ${dreamRunId}`);
+    if (run.status !== "pending" && run.status !== "running") {
+      throw new Error(
+        `dream-candidate-store: cannot append candidates to run in status ${run.status}`,
+      );
+    }
+
+    const created: CandidateEntryRecord[] = [];
+    const insert = this.db.prepare(
+      `INSERT INTO memory_candidate_entries (
+        id, dream_run_id, op, status, payload_json, target_fact_id,
+        session_ids_json, prevalence_json, rationale, pre_hash, post_hash,
+        reverse_op, reverse_payload_json, applied_fact_id, sort_order, created_at
+      ) VALUES (?, ?, ?, 'proposed', ?, ?, ?, ?, ?, ?, NULL, ?, ?, NULL, ?, ?)`,
+    );
+
+    const createdAt = nowSec();
+    let sortBase = this.db
+      .prepare("SELECT COALESCE(MAX(sort_order), -1) AS m FROM memory_candidate_entries WHERE dream_run_id = ?")
+      .get(dreamRunId) as { m: number };
+
+    for (let i = 0; i < entries.length; i++) {
+      const entry = entries[i]!;
+      const id = randomUUID();
+      const sortOrder = entry.sortOrder ?? sortBase.m + 1 + i;
+      insert.run(
+        id,
+        dreamRunId,
+        entry.op,
+        JSON.stringify(entry.payload),
+        entry.targetFactId ?? null,
+        JSON.stringify(entry.evidence.sessionIds ?? []),
+        JSON.stringify(entry.evidence.prevalence ?? { sessions: 0, agents: 0 }),
+        entry.evidence.rationale ?? null,
+        entry.preHash ?? null,
+        entry.reverse.op,
+        JSON.stringify(entry.reverse.payload ?? {}),
+        sortOrder,
+        createdAt,
+      );
+      const row = this.db.prepare("SELECT * FROM memory_candidate_entries WHERE id = ?").get(id) as CandidateRow;
+      created.push(mapCandidate(row));
+    }
+    return created;
+  }
+
+  listCandidateEntries(dreamRunId: string): CandidateEntryRecord[] {
+    const rows = this.db
+      .prepare(
+        "SELECT * FROM memory_candidate_entries WHERE dream_run_id = ? ORDER BY sort_order ASC, created_at ASC",
+      )
+      .all(dreamRunId) as CandidateRow[];
+    return rows.map(mapCandidate);
+  }
+
+  updateCandidateEntry(
+    id: string,
+    patch: {
+      status?: CandidateEntryStatus;
+      appliedFactId?: string | null;
+      postHash?: string | null;
+      reverse?: ReversePlan;
+      preHash?: string | null;
+    },
+  ): void {
+    const sets: string[] = [];
+    const params: unknown[] = [];
+    if (patch.status !== undefined) {
+      sets.push("status = ?");
+      params.push(patch.status);
+    }
+    if (patch.appliedFactId !== undefined) {
+      sets.push("applied_fact_id = ?");
+      params.push(patch.appliedFactId);
+    }
+    if (patch.postHash !== undefined) {
+      sets.push("post_hash = ?");
+      params.push(patch.postHash);
+    }
+    if (patch.preHash !== undefined) {
+      sets.push("pre_hash = ?");
+      params.push(patch.preHash);
+    }
+    if (patch.reverse !== undefined) {
+      sets.push("reverse_op = ?");
+      params.push(patch.reverse.op);
+      sets.push("reverse_payload_json = ?");
+      params.push(JSON.stringify(patch.reverse.payload ?? {}));
+    }
+    if (sets.length === 0) return;
+    params.push(id);
+    const result = this.db
+      .prepare(`UPDATE memory_candidate_entries SET ${sets.join(", ")} WHERE id = ?`)
+      .run(...(params as never[]));
+    if (Number(result.changes ?? 0) === 0) {
+      pluginLogger.warn(`dream-candidate-store: updateCandidateEntry missed id=${id}`);
+    }
+  }
+}

--- a/extensions/memory-hybrid/backends/event-bus.ts
+++ b/extensions/memory-hybrid/backends/event-bus.ts
@@ -1,6 +1,8 @@
 /**
- * Event Bus — append-only SQLite table that all sensor sweeps write to and the
- * Rumination Engine reads from.
+ * Event Bus — append-only SQLite table that sensor sweeps write to.
+ * Downstream consumers (maintenance steps, Dream Cycle / Autonomous Dreaming)
+ * read events and advance status. There is no separate “Rumination Engine”
+ * process (#2178) — the lifecycle API is shared; consumers are distributed.
  *
  * Status lifecycle: raw → processed → surfaced → pushed → archived
  */

--- a/extensions/memory-hybrid/backends/event-bus.ts
+++ b/extensions/memory-hybrid/backends/event-bus.ts
@@ -50,8 +50,9 @@ export function computeFingerprint(input: string): string {
  * Manages the SQLite-backed Event Bus for the hybrid memory system.
  * Provides an append-only store for incoming telemetry, sensor data, and
  * unstructured events. Events transition through a defined lifecycle
- * (raw -> processed -> surfaced -> pushed -> archived) as they are consumed
- * by the Rumination Engine.
+ * (raw -> processed -> surfaced -> pushed -> archived) as distributed
+ * consumers (maintenance steps, Dream) advance them — there is no separate
+ * Rumination Engine process (#2178).
  */
 export class EventBus extends BaseSqliteStore {
   protected readonly dbPath: string;

--- a/extensions/memory-hybrid/backends/facts-db/facts-db-layer1.ts
+++ b/extensions/memory-hybrid/backends/facts-db/facts-db-layer1.ts
@@ -10,6 +10,12 @@ import type { StoreConfig } from "../../config.js";
 import { emitMemoryEvent } from "../../services/memory-events.js";
 import type { MemoryEntry, MemoryScope, MemoryTier, ScopeFilter, SearchResult } from "../../types/memory.js";
 import { tryRestrictSqliteDbFileMode } from "../../utils/sqlite-file-perms.js";
+import {
+  buildMemoryConflictDetails,
+  computeInputStoreRevision,
+  MemoryConflictError,
+  occTokenForFact,
+} from "../../utils/fact-occ.js";
 import { normalizedHash } from "../../utils/tags.js";
 import { BaseSqliteStore } from "../base-sqlite-store.js";
 import { runFactsMigrations } from "../migrations/facts-migrations.js";
@@ -552,8 +558,29 @@ export class FactsDBLayer1 extends BaseSqliteStore {
     );
   }
 
-  /** Mark a fact as superseded by a new fact. Sets superseded_at, superseded_by, and valid_until (bi-temporal). */
-  supersede(oldId: string, newId: string | null): boolean {
+  /** Mark a fact as superseded by a new fact. Sets superseded_at, superseded_by, and valid_until (bi-temporal).
+   * When `expectedHash` is set (#2175 OCC), refuse if the live OCC token no longer matches.
+   */
+  supersede(
+    oldId: string,
+    newId: string | null,
+    options?: { expectedHash?: string },
+  ): boolean {
+    if (options?.expectedHash) {
+      const current = this.getById(oldId);
+      if (!current) return false;
+      const currentHash = occTokenForFact(current);
+      if (currentHash !== options.expectedHash) {
+        throw new MemoryConflictError(
+          buildMemoryConflictDetails({
+            expectedHash: options.expectedHash,
+            currentHash,
+            currentRevision: current.revisionCount ?? 0,
+            factId: oldId,
+          }),
+        );
+      }
+    }
     const nowSec = Math.floor(Date.now() / 1000);
     const result = this.liveDb
       .prepare(
@@ -568,6 +595,33 @@ export class FactsDBLayer1 extends BaseSqliteStore {
       if (updated) emitMemoryEvent("factUpdated", { entry: updated });
     }
     return result.changes > 0;
+  }
+
+  /** OCC token for a fact id (#2175). Returns null if missing/superseded. */
+  getOccToken(factId: string): string | null {
+    const fact = this.getById(factId);
+    if (!fact) return null;
+    return occTokenForFact(fact);
+  }
+
+  /** Whole-store revision fingerprint for dream promote (#2170/#2175). */
+  computeStoreRevision(limit = 10_000): string {
+    const rows = this.liveDb
+      .prepare(
+        `SELECT id, text, revision_count, created_at FROM facts
+         WHERE superseded_at IS NULL
+         ORDER BY created_at DESC
+         LIMIT ?`,
+      )
+      .all(limit) as Array<{ id: string; text: string; revision_count: number; created_at: number }>;
+    return computeInputStoreRevision(
+      rows.map((r) => ({
+        id: r.id,
+        text: r.text,
+        revisionCount: r.revision_count ?? 0,
+        createdAt: r.created_at,
+      })),
+    );
   }
 
   /**

--- a/extensions/memory-hybrid/backends/facts-db/facts-db-layer1.ts
+++ b/extensions/memory-hybrid/backends/facts-db/facts-db-layer1.ts
@@ -561,11 +561,7 @@ export class FactsDBLayer1 extends BaseSqliteStore {
   /** Mark a fact as superseded by a new fact. Sets superseded_at, superseded_by, and valid_until (bi-temporal).
    * When `expectedHash` is set (#2175 OCC), refuse if the live OCC token no longer matches.
    */
-  supersede(
-    oldId: string,
-    newId: string | null,
-    options?: { expectedHash?: string },
-  ): boolean {
+  supersede(oldId: string, newId: string | null, options?: { expectedHash?: string }): boolean {
     if (options?.expectedHash) {
       const current = this.getById(oldId);
       if (!current) return false;

--- a/extensions/memory-hybrid/backends/facts-db/facts-db-layer1.ts
+++ b/extensions/memory-hybrid/backends/facts-db/facts-db-layer1.ts
@@ -606,6 +606,14 @@ export class FactsDBLayer1 extends BaseSqliteStore {
 
   /** Whole-store revision fingerprint for dream promote (#2170/#2175). */
   computeStoreRevision(limit = 10_000): string {
+    const agg = this.liveDb
+      .prepare(
+        `SELECT COUNT(*) AS c,
+                COALESCE(MAX(rowid), 0) AS max_rowid,
+                COALESCE(SUM(revision_count), 0) AS rev_sum
+         FROM facts WHERE superseded_at IS NULL`,
+      )
+      .get() as { c: number; max_rowid: number; rev_sum: number };
     const rows = this.liveDb
       .prepare(
         `SELECT id, text, revision_count, created_at FROM facts
@@ -621,6 +629,11 @@ export class FactsDBLayer1 extends BaseSqliteStore {
         revisionCount: r.revision_count ?? 0,
         createdAt: r.created_at,
       })),
+      {
+        totalActive: Number(agg.c) || 0,
+        maxRowId: Number(agg.max_rowid) || 0,
+        revisionSum: Number(agg.rev_sum) || 0,
+      },
     );
   }
 

--- a/extensions/memory-hybrid/backends/migrations/facts-migrations.ts
+++ b/extensions/memory-hybrid/backends/migrations/facts-migrations.ts
@@ -1601,6 +1601,11 @@ export function migrateDreamCandidateTables(db: DatabaseSync): void {
   db.exec(
     "CREATE INDEX IF NOT EXISTS idx_mce_run_status ON memory_candidate_entries(dream_run_id, status)",
   );
+
+  const dreamCols = db.prepare("PRAGMA table_info(dream_runs)").all() as Array<{ name: string }>;
+  if (!dreamCols.some((c) => c.name === "metrics_summary_json")) {
+    db.exec("ALTER TABLE dream_runs ADD COLUMN metrics_summary_json TEXT");
+  }
 }
 
 /** Epic #1918: pin/snooze, quality, evolution, maintenance audit, dedup, mine batch. */

--- a/extensions/memory-hybrid/backends/migrations/facts-migrations.ts
+++ b/extensions/memory-hybrid/backends/migrations/facts-migrations.ts
@@ -1598,9 +1598,7 @@ export function migrateDreamCandidateTables(db: DatabaseSync): void {
     )
   `);
   db.exec("CREATE INDEX IF NOT EXISTS idx_mce_run ON memory_candidate_entries(dream_run_id)");
-  db.exec(
-    "CREATE INDEX IF NOT EXISTS idx_mce_run_status ON memory_candidate_entries(dream_run_id, status)",
-  );
+  db.exec("CREATE INDEX IF NOT EXISTS idx_mce_run_status ON memory_candidate_entries(dream_run_id, status)");
 
   const dreamCols = db.prepare("PRAGMA table_info(dream_runs)").all() as Array<{ name: string }>;
   if (!dreamCols.some((c) => c.name === "metrics_summary_json")) {

--- a/extensions/memory-hybrid/backends/migrations/facts-migrations.ts
+++ b/extensions/memory-hybrid/backends/migrations/facts-migrations.ts
@@ -1537,6 +1537,70 @@ export function runFactsMigrations(db: DatabaseSync): void {
   migrateContradictionsResolvedAt(db);
   migrateEpisodeRelationsConfidence(db);
   migrateEpic1918Columns(db);
+
+  // Autonomous dreaming candidate store (#2170) — additive tables, no schemaVersion bump
+  migrateDreamCandidateTables(db);
+}
+
+/**
+ * Dream candidate / shadow store (#2170).
+ * Option B: dream_runs + memory_candidate_entries with apply + reverse plans.
+ */
+export function migrateDreamCandidateTables(db: DatabaseSync): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS dream_runs (
+      id TEXT PRIMARY KEY,
+      status TEXT NOT NULL DEFAULT 'pending'
+        CHECK(status IN (
+          'pending','running','gated','promoted','quarantined','rolled_back','failed'
+        )),
+      input_store_revision TEXT NOT NULL,
+      session_ids_json TEXT NOT NULL DEFAULT '[]',
+      steering_policy_id TEXT,
+      gate_report_json TEXT,
+      shadow INTEGER NOT NULL DEFAULT 1,
+      created_at INTEGER NOT NULL,
+      started_at INTEGER,
+      gated_at INTEGER,
+      promoted_at INTEGER,
+      rolled_back_at INTEGER,
+      failed_at INTEGER,
+      failure_reason TEXT,
+      rollback_reason TEXT,
+      metrics_baseline_json TEXT,
+      metrics_observe_until INTEGER
+    )
+  `);
+  db.exec("CREATE INDEX IF NOT EXISTS idx_dream_runs_status ON dream_runs(status)");
+  db.exec("CREATE INDEX IF NOT EXISTS idx_dream_runs_created ON dream_runs(created_at)");
+
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS memory_candidate_entries (
+      id TEXT PRIMARY KEY,
+      dream_run_id TEXT NOT NULL REFERENCES dream_runs(id),
+      op TEXT NOT NULL CHECK(op IN ('add','supersede','delete','merge','boost')),
+      status TEXT NOT NULL DEFAULT 'proposed'
+        CHECK(status IN ('proposed','gated_ok','gated_block','applied','rolled_back','skipped')),
+      payload_json TEXT NOT NULL,
+      target_fact_id TEXT,
+      session_ids_json TEXT NOT NULL DEFAULT '[]',
+      prevalence_json TEXT,
+      rationale TEXT,
+      pre_hash TEXT,
+      post_hash TEXT,
+      reverse_op TEXT NOT NULL CHECK(reverse_op IN (
+        'delete_fact','unsupersede','restore_text','noop'
+      )),
+      reverse_payload_json TEXT NOT NULL,
+      applied_fact_id TEXT,
+      sort_order INTEGER NOT NULL DEFAULT 0,
+      created_at INTEGER NOT NULL
+    )
+  `);
+  db.exec("CREATE INDEX IF NOT EXISTS idx_mce_run ON memory_candidate_entries(dream_run_id)");
+  db.exec(
+    "CREATE INDEX IF NOT EXISTS idx_mce_run_status ON memory_candidate_entries(dream_run_id, status)",
+  );
 }
 
 /** Epic #1918: pin/snooze, quality, evolution, maintenance audit, dedup, mine batch. */

--- a/extensions/memory-hybrid/cli/cmd-distill.ts
+++ b/extensions/memory-hybrid/cli/cmd-distill.ts
@@ -232,6 +232,8 @@ export async function runDistillForCli(
     maxSessionTokens?: number;
     full?: boolean;
     force?: boolean;
+    /** Dream steering block appended to distill prompt (#2176). */
+    steeringPrompt?: string;
   },
   sink: DistillCliSink,
 ): Promise<DistillCliResult> {
@@ -390,7 +392,8 @@ export async function runDistillForCli(
     type DistillBlock = { text: string; tokens: number };
     const blocks: DistillBlock[] = [];
     const distillPrompt = loadPrompt("distill-sessions");
-    const promptPrefix = `${distillPrompt}\n\n`;
+    const steeringBlock = opts.steeringPrompt?.trim() ? `${opts.steeringPrompt.trim()}\n\n` : "";
+    const promptPrefix = `${distillPrompt}\n\n${steeringBlock}`;
     const promptTokens = estimateTokens(promptPrefix);
     const primaryCatalogBatchLimit = distillBatchTokenLimit(model);
     const primaryCatalogMaxOut = distillMaxOutputTokens(model);

--- a/extensions/memory-hybrid/cli/cmd-distill.ts
+++ b/extensions/memory-hybrid/cli/cmd-distill.ts
@@ -312,10 +312,7 @@ export async function runDistillForCli(
     const maxSessions = opts.maxSessions ?? 0;
     let filesToProcess = maxSessions > 0 ? sessionFiles.slice(0, maxSessions) : sessionFiles;
     if (filesToProcess.length === 0) {
-      const allowlistNote =
-        opts.sessionIds !== undefined
-          ? ` (session allowlist size=${opts.sessionIds.length})`
-          : "";
+      const allowlistNote = opts.sessionIds !== undefined ? ` (session allowlist size=${opts.sessionIds.length})` : "";
       sink.log(`No session files found under ~/.openclaw/agents/*/sessions/${allowlistNote}`);
       if (shouldAcquireLock && !opts.dryRun) {
         factsDb.updateScanCursor(SCAN_TYPE, 0, 0);

--- a/extensions/memory-hybrid/cli/cmd-distill.ts
+++ b/extensions/memory-hybrid/cli/cmd-distill.ts
@@ -146,7 +146,7 @@ export function gatherSessionFiles(opts: {
  * Restrict gathered session files to an allowlist of session ids (#2174).
  * When `sessionIds` is defined (including empty), only matching files are kept —
  * empty allowlist → no files (fail closed for Dream attachment).
- * Matching: basename without `.jsonl` equals id, or path contains `/${id}.jsonl` / `/${id}`.
+ * Matching is exact basename stem equality only (no path substring / prefix matches).
  */
 export function filterSessionFilesByAllowlist<T extends { path: string }>(
   files: T[],
@@ -154,12 +154,13 @@ export function filterSessionFilesByAllowlist<T extends { path: string }>(
 ): T[] {
   if (sessionIds === undefined) return files;
   if (sessionIds.length === 0) return [];
-  const ids = [...new Set(sessionIds.map((s) => s.trim()).filter((s) => s.length > 0))];
-  if (ids.length === 0) return [];
+  const ids = new Set(sessionIds.map((s) => s.trim()).filter((s) => s.length > 0));
+  if (ids.size === 0) return [];
   return files.filter((f) => {
     const base = f.path.split(/[/\\]/).pop() ?? "";
-    const stem = base.endsWith(".jsonl") ? base.slice(0, -".jsonl".length) : base;
-    return ids.some((id) => stem === id || stem.startsWith(`${id}.`) || f.path.includes(`/${id}.jsonl`) || f.path.includes(`\\${id}.jsonl`));
+    if (!base.endsWith(".jsonl") || base.startsWith(".deleted")) return false;
+    const stem = base.slice(0, -".jsonl".length);
+    return ids.has(stem);
   });
 }
 
@@ -420,7 +421,7 @@ export async function runDistillForCli(
         : { version: ADAPTIVE_MODEL_LIMITS_VERSION, models: {} }
       : { version: ADAPTIVE_MODEL_LIMITS_VERSION, models: {} };
 
-    type DistillBlock = { text: string; tokens: number };
+    type DistillBlock = { text: string; tokens: number; sessionId?: string };
     const blocks: DistillBlock[] = [];
     const distillPrompt = loadPrompt("distill-sessions");
     const steeringBlock = opts.steeringPrompt?.trim() ? `${opts.steeringPrompt.trim()}\n\n` : "";
@@ -462,6 +463,9 @@ export async function runDistillForCli(
           );
         }
 
+        const base = basename(fp);
+        const sessionId = base.endsWith(".jsonl") ? base.slice(0, -".jsonl".length) : base;
+
         // Safety check: ensure chunks don't exceed model catalog input limit (prompt + block)
         const validChunks = chunks.filter((chunk, idx) => {
           const chunkTokens = estimateTokens(chunk);
@@ -480,7 +484,7 @@ export async function runDistillForCli(
               ? `\n--- SESSION: ${basename(fp)} ---\n\n`
               : `\n--- SESSION: ${basename(fp)} (chunk ${c + 1}/${validChunks.length}) ---\n\n`;
           const block = header + validChunks[c];
-          blocks.push({ text: block, tokens: estimateTokens(block) });
+          blocks.push({ text: block, tokens: estimateTokens(block), sessionId });
         }
       } catch (err) {
         capturePluginError(err as Error, {
@@ -505,6 +509,7 @@ export async function runDistillForCli(
       value?: string;
       source_date?: string;
       tags?: string[];
+      sourceSessionId?: string;
     }> = [];
     const progress = createProgressReporter(sink, Math.max(1, blocks.length), "Distilling session chunks");
     let processedBlocks = 0;
@@ -574,12 +579,19 @@ export async function runDistillForCli(
       }
     };
 
-    const buildBatch = (startIdx: number, batchTokenLimit: number): { text: string; count: number; tokens: number } => {
+    const buildBatch = (
+      startIdx: number,
+      batchTokenLimit: number,
+    ): { text: string; count: number; tokens: number; sessionId: string | null } => {
       let text = "";
       let tokens = promptTokens;
       let count = 0;
+      const firstSessionId = blocks[startIdx]?.sessionId ?? null;
+      // Dream allowlist path: keep batches single-session for attribution (#2174).
+      const isolateSessions = opts.sessionIds !== undefined;
       for (let i = startIdx; i < blocks.length; i++) {
         const b = blocks[i];
+        if (isolateSessions && firstSessionId != null && b.sessionId !== firstSessionId) break;
         const sep = text ? "\n" : "";
         const nextTokens = tokens + b.tokens;
         if (count > 0 && nextTokens > batchTokenLimit) break;
@@ -588,7 +600,13 @@ export async function runDistillForCli(
         tokens = nextTokens;
         count++;
       }
-      return { text, count, tokens };
+      let sessionId: string | null = null;
+      if (count > 0) {
+        const ids = Array.from({ length: count }, (_, i) => blocks[startIdx + i]?.sessionId ?? null);
+        const first = ids[0] ?? null;
+        sessionId = ids.every((id) => id === first) ? first : null;
+      }
+      return { text, count, tokens, sessionId };
     };
 
     let batchFailures = 0;
@@ -783,6 +801,7 @@ export async function runDistillForCli(
               value,
               source_date: source_date ?? undefined,
               tags,
+              sourceSessionId: batch.sessionId ?? undefined,
             });
           } catch (err) {
             capturePluginError(err as Error, { subsystem: "cli", operation: "runDistillForCli:parse-json" });

--- a/extensions/memory-hybrid/cli/cmd-distill.ts
+++ b/extensions/memory-hybrid/cli/cmd-distill.ts
@@ -142,6 +142,27 @@ export function gatherSessionFiles(opts: {
   return out;
 }
 
+/**
+ * Restrict gathered session files to an allowlist of session ids (#2174).
+ * When `sessionIds` is defined (including empty), only matching files are kept —
+ * empty allowlist → no files (fail closed for Dream attachment).
+ * Matching: basename without `.jsonl` equals id, or path contains `/${id}.jsonl` / `/${id}`.
+ */
+export function filterSessionFilesByAllowlist<T extends { path: string }>(
+  files: T[],
+  sessionIds: string[] | undefined,
+): T[] {
+  if (sessionIds === undefined) return files;
+  if (sessionIds.length === 0) return [];
+  const ids = [...new Set(sessionIds.map((s) => s.trim()).filter((s) => s.length > 0))];
+  if (ids.length === 0) return [];
+  return files.filter((f) => {
+    const base = f.path.split(/[/\\]/).pop() ?? "";
+    const stem = base.endsWith(".jsonl") ? base.slice(0, -".jsonl".length) : base;
+    return ids.some((id) => stem === id || stem.startsWith(`${id}.`) || f.path.includes(`/${id}.jsonl`) || f.path.includes(`\\${id}.jsonl`));
+  });
+}
+
 export function runDistillWindowForCli(ctx: HandlerContext, _opts: { json: boolean }): DistillWindowResult {
   const { resolvedSqlitePath } = ctx;
   const memoryDir = dirname(resolvedSqlitePath);
@@ -234,6 +255,12 @@ export async function runDistillForCli(
     force?: boolean;
     /** Dream steering block appended to distill prompt (#2176). */
     steeringPrompt?: string;
+    /**
+     * When set (including empty), only process matching session JSONL files (#2174).
+     * Empty array → process nothing (fail closed for Dream with no attached sessions).
+     * Undefined → legacy: all sessions in the gather window.
+     */
+    sessionIds?: string[];
   },
   sink: DistillCliSink,
 ): Promise<DistillCliResult> {
@@ -280,11 +307,15 @@ export async function runDistillForCli(
       );
     }
 
-    const sessionFiles = gatherSessionFiles(gatherOpts);
+    const sessionFiles = filterSessionFilesByAllowlist(gatherSessionFiles(gatherOpts), opts.sessionIds);
     const maxSessions = opts.maxSessions ?? 0;
     let filesToProcess = maxSessions > 0 ? sessionFiles.slice(0, maxSessions) : sessionFiles;
     if (filesToProcess.length === 0) {
-      sink.log("No session files found under ~/.openclaw/agents/*/sessions/");
+      const allowlistNote =
+        opts.sessionIds !== undefined
+          ? ` (session allowlist size=${opts.sessionIds.length})`
+          : "";
+      sink.log(`No session files found under ~/.openclaw/agents/*/sessions/${allowlistNote}`);
       if (shouldAcquireLock && !opts.dryRun) {
         factsDb.updateScanCursor(SCAN_TYPE, 0, 0);
         clearScanLock(SCAN_TYPE);
@@ -864,6 +895,8 @@ export async function runDistillForCli(
           stored: 0,
           dedupSkipped: 0,
           dryRun: true,
+          // Surfaced for Dream compose candidate emission (#2170).
+          extracted: allFacts.slice(0, 40),
           semanticEmpty,
         },
         { semanticEmpty },

--- a/extensions/memory-hybrid/cli/cmd-selfcorrection.ts
+++ b/extensions/memory-hybrid/cli/cmd-selfcorrection.ts
@@ -12,7 +12,7 @@ import { getEnv } from "../utils/env-manager.js";
 
 import { existsSync, lstatSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { dirname, join } from "node:path";
+import { dirname, join, basename } from "node:path";
 
 import {
   getCronModelConfig,
@@ -324,6 +324,7 @@ type SelfCorrectionApplyResult = {
     key?: string | null;
     value?: string | null;
     tags?: string[];
+    sourceSessionId?: string | null;
   }>;
 };
 
@@ -385,6 +386,18 @@ async function applySelfCorrectionRemediations(params: {
         }
       }
       if (opts.dryRun) {
+        const src =
+          a.sourceIncident ??
+          (typeof a.incidentIndex === "number" && incidents[a.incidentIndex]
+            ? incidents[a.incidentIndex]
+            : undefined);
+        const sessionFile = src?.sessionFile?.trim() || "";
+        const base = sessionFile ? basename(sessionFile) : "";
+        const sourceSessionId = base
+          ? base.endsWith(".jsonl")
+            ? base.slice(0, -".jsonl".length)
+            : base
+          : undefined;
         extracted.push({
           text,
           category: "technical",
@@ -392,6 +405,7 @@ async function applySelfCorrectionRemediations(params: {
           key: remediationKey,
           value: text.slice(0, 200),
           tags: Array.isArray(obj.tags) ? obj.tags : [],
+          sourceSessionId,
         });
         continue;
       }

--- a/extensions/memory-hybrid/cli/cmd-selfcorrection.ts
+++ b/extensions/memory-hybrid/cli/cmd-selfcorrection.ts
@@ -388,16 +388,10 @@ async function applySelfCorrectionRemediations(params: {
       if (opts.dryRun) {
         const src =
           a.sourceIncident ??
-          (typeof a.incidentIndex === "number" && incidents[a.incidentIndex]
-            ? incidents[a.incidentIndex]
-            : undefined);
+          (typeof a.incidentIndex === "number" && incidents[a.incidentIndex] ? incidents[a.incidentIndex] : undefined);
         const sessionFile = src?.sessionFile?.trim() || "";
         const base = sessionFile ? basename(sessionFile) : "";
-        const sourceSessionId = base
-          ? base.endsWith(".jsonl")
-            ? base.slice(0, -".jsonl".length)
-            : base
-          : undefined;
+        const sourceSessionId = base ? (base.endsWith(".jsonl") ? base.slice(0, -".jsonl".length) : base) : undefined;
         extracted.push({
           text,
           category: "technical",

--- a/extensions/memory-hybrid/cli/cmd-selfcorrection.ts
+++ b/extensions/memory-hybrid/cli/cmd-selfcorrection.ts
@@ -72,7 +72,7 @@ import { parseSelfCorrectionLLMResponse } from "../services/self-correction-llm-
 import { resolveTierPreferenceWithSources } from "../utils/llm-selection.js";
 import { fillPrompt, loadPrompt } from "../utils/prompt-loader.js";
 import { estimateTokens } from "../utils/text.js";
-import { gatherSessionFiles } from "./cmd-distill.js";
+import { filterSessionFilesByAllowlist, gatherSessionFiles } from "./cmd-distill.js";
 import { getMaxMtime } from "./cmd-extract-sessions.js";
 import { buildPreFilterConfig } from "./cmd-install.js";
 import { runMaintenanceHeartbeat } from "./commands/manage/maintenance-heartbeat.js";
@@ -316,6 +316,15 @@ type SelfCorrectionApplyResult = {
   proposals: string[];
   toolsSuggestions: string[];
   toolsApplied: number;
+  /** Dry-run MEMORY_STORE previews for Dream compose (#2170). */
+  extracted: Array<{
+    text: string;
+    category: string;
+    entity?: string | null;
+    key?: string | null;
+    value?: string | null;
+    tags?: string[];
+  }>;
 };
 
 async function applySelfCorrectionRemediations(params: {
@@ -337,6 +346,7 @@ async function applySelfCorrectionRemediations(params: {
   const { factsDb, vectorDb, embeddings, openai, proposalsDb, logger, cfg } = ctx;
   const proposals: string[] = [];
   const toolsSuggestions: string[] = [];
+  const extracted: SelfCorrectionApplyResult["extracted"] = [];
   let autoFixed = 0;
   let toolsApplied = 0;
   const toApply = analysed
@@ -374,7 +384,17 @@ async function applySelfCorrectionRemediations(params: {
           continue;
         }
       }
-      if (opts.dryRun) continue;
+      if (opts.dryRun) {
+        extracted.push({
+          text,
+          category: "technical",
+          entity: obj.entity ?? null,
+          key: remediationKey,
+          value: text.slice(0, 200),
+          tags: Array.isArray(obj.tags) ? obj.tags : [],
+        });
+        continue;
+      }
       try {
         const storeResult = factsDb.storeWithResult(
           {
@@ -551,7 +571,7 @@ async function applySelfCorrectionRemediations(params: {
     }
   }
 
-  return { autoFixed, proposals, toolsSuggestions, toolsApplied };
+  return { autoFixed, proposals, toolsSuggestions, toolsApplied, extracted };
 }
 
 function buildSelfCorrectionReportLines(params: {
@@ -677,6 +697,11 @@ export async function runSelfCorrectionRunForCli(
     verbose?: boolean;
     /** Override JobRun artifact root (tests). */
     jobRunLogRoot?: string;
+    /**
+     * When set (including empty), only scan matching session JSONL (#2174 Dream attachment).
+     * Empty → no sessions. Undefined → legacy gather window.
+     */
+    sessionIds?: string[];
   },
 ): Promise<SelfCorrectionRunResult> {
   const { bypassScanCooldown } = resolveScanMaintenanceOverrides(opts);
@@ -725,10 +750,13 @@ export async function runSelfCorrectionRunForCli(
       let scFilePaths: string[] | undefined;
       const scanDays = opts.days ?? 3;
       const pfCfgSC = buildPreFilterConfig(cfg);
-      if (pfCfgSC.enabled) {
-        const sessionFiles = gatherSessionFiles({ days: scanDays });
-        const allPaths = sessionFiles.map((f: { path: string; mtime: number }) => f.path);
-        if (allPaths.length > 0) {
+      const gathered = filterSessionFilesByAllowlist(gatherSessionFiles({ days: scanDays }), opts.sessionIds);
+      const allPaths = gathered.map((f: { path: string; mtime: number }) => f.path);
+      if (opts.sessionIds !== undefined && allPaths.length === 0) {
+        incidents = [];
+        extractSessionsScanned = 0;
+      } else {
+        if (pfCfgSC.enabled && allPaths.length > 0) {
           const pfResult = await preFilterSessions(allPaths, pfCfgSC);
           if (!pfResult.ollamaUnavailable) {
             logger.info?.(
@@ -737,47 +765,52 @@ export async function runSelfCorrectionRunForCli(
             scFilePaths = pfResult.kept;
           } else {
             logger.info?.(`memory-hybrid: ${SCAN_TYPE} pre-filter: Ollama unavailable — scanning all sessions`);
-            scFilePaths = allPaths; // avoid redundant gatherSessionFiles inside runSelfCorrectionExtractForCli
+            scFilePaths = allPaths;
           }
+        } else if (opts.sessionIds !== undefined) {
+          scFilePaths = allPaths;
         }
-      }
-      const extractResult = runSelfCorrectionExtractForCli(ctx, {
-        days: scanDays,
-        filePaths: scFilePaths,
-        verbose: opts.verbose,
-      });
-      extractSessionsScanned = extractResult.sessionsScanned;
-      incidents = extractResult.incidents;
-      const scCfgExtract = cfg.selfCorrection ?? DEFAULT_SELF_CORRECTION;
-      if (scCfgExtract.llmExtract !== false && incidents.length >= 0) {
-        const correctionRegex = getCorrectionSignalRegex();
-        const pathsForHeuristic =
-          scFilePaths ?? gatherSessionFiles({ days: scanDays }).map((f: { path: string }) => f.path);
-        const heuristic = collectHeuristicFeedbackCandidates({
-          filePaths: pathsForHeuristic,
-          correctionRegex,
+        const extractResult = runSelfCorrectionExtractForCli(ctx, {
+          days: scanDays,
+          filePaths: scFilePaths,
+          verbose: opts.verbose,
         });
-        incidents = mergeCorrectionIncidents(incidents, heuristic.slice(0, 80));
-        if (incidents.length > 0) {
-          const { defaultModel, fallbackModels } = resolveReflectionModelAndFallbacks(
-            cfg,
-            "maintenance",
-            scCfgExtract.model,
-          );
-          const filtered = await classifyAndFilterCorrectionIncidents({
-            incidents,
-            openai,
-            model: scCfgExtract.model ?? defaultModel,
-            fallbackModels,
-            minConfidence: scCfgExtract.llmExtractMinConfidence ?? 0.6,
-            batchSize: 10,
-            factsDb,
-            logger: {
-              info: (msg) => logger.info?.(msg),
-              warn: (msg) => logger.warn?.(msg),
-            },
+        extractSessionsScanned = extractResult.sessionsScanned;
+        incidents = extractResult.incidents;
+        const scCfgExtract = cfg.selfCorrection ?? DEFAULT_SELF_CORRECTION;
+        if (scCfgExtract.llmExtract !== false && incidents.length >= 0) {
+          const correctionRegex = getCorrectionSignalRegex();
+          const pathsForHeuristic =
+            scFilePaths ??
+            filterSessionFilesByAllowlist(gatherSessionFiles({ days: scanDays }), opts.sessionIds).map(
+              (f: { path: string }) => f.path,
+            );
+          const heuristic = collectHeuristicFeedbackCandidates({
+            filePaths: pathsForHeuristic,
+            correctionRegex,
           });
-          incidents = filtered.incidents;
+          incidents = mergeCorrectionIncidents(incidents, heuristic.slice(0, 80));
+          if (incidents.length > 0) {
+            const { defaultModel, fallbackModels } = resolveReflectionModelAndFallbacks(
+              cfg,
+              "maintenance",
+              scCfgExtract.model,
+            );
+            const filtered = await classifyAndFilterCorrectionIncidents({
+              incidents,
+              openai,
+              model: scCfgExtract.model ?? defaultModel,
+              fallbackModels,
+              minConfidence: scCfgExtract.llmExtractMinConfidence ?? 0.6,
+              batchSize: 10,
+              factsDb,
+              logger: {
+                info: (msg) => logger.info?.(msg),
+                warn: (msg) => logger.warn?.(msg),
+              },
+            });
+            incidents = filtered.incidents;
+          }
         }
       }
     }
@@ -1320,7 +1353,7 @@ export async function runSelfCorrectionRunForCli(
       modelSource,
       scFallbackModels,
     });
-    const { autoFixed, proposals, toolsSuggestions, toolsApplied } = applied;
+    const { autoFixed, proposals, toolsSuggestions, toolsApplied, extracted } = applied;
 
     const reportLines = buildSelfCorrectionReportLines({
       today,
@@ -1380,6 +1413,7 @@ export async function runSelfCorrectionRunForCli(
       reportPath: opts.dryRun ? null : reportPath,
       toolsSuggestions: toolsSuggestions.length > 0 ? toolsSuggestions : undefined,
       toolsApplied: toolsApplied > 0 ? toolsApplied : undefined,
+      extracted: opts.dryRun && extracted.length > 0 ? extracted : undefined,
       retryCount: diagnostics.retries,
       fallbackCount: diagnostics.fallbacks,
       parseFailures: diagnostics.parseFailures,

--- a/extensions/memory-hybrid/cli/commands/manage/maintenance-step-runners.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/maintenance-step-runners.ts
@@ -23,13 +23,15 @@ import {
   isEntityEnrichmentHardFailure,
 } from "../../../services/entity-enrichment-adaptive.js";
 import { syncLifecycleFromGitHub } from "../../../services/lifecycle/github-adapter.js";
+import { runLoomMaintenance } from "../../../services/loom-maintenance.js";
 import {
   parseSemanticTokenFromSummary,
   semanticOutcomeBlocksOrchestratorGuard,
   semanticOutcomeIsPartialFailure,
 } from "../../../services/maintenance-job-run/index.js";
 import type { MaintenanceStepRunner } from "../../../services/maintenance-orchestrator.js";
-import { runLoomMaintenance } from "../../../services/loom-maintenance.js";
+import { DreamCandidateStore } from "../../../backends/dream-candidate-store.js";
+import { probeDreamOutcomes } from "../../../services/dream-outcome-probe.js";
 import { runPassiveObserver } from "../../../services/passive-observer.js";
 import { runPendingDigestAutopilotCron } from "../../../services/pending-digest-autopilot-cron.js";
 import { resolveSweepPromotionDeps, runSerendipitySweep } from "../../../services/serendipity-sweep-cron.js";
@@ -572,6 +574,18 @@ export function buildCliMaintenanceRunners(
 
   set("continuous-verification", async () => runContinuousVerificationStep(followUpDeps, verbose));
   set("closed-loop-analysis", async () => runClosedLoopAnalysisStep(followUpDeps, verbose));
+  set("dream-outcome-probe", async () => {
+    if (b.cfg.dreaming?.autoRollback?.enabled !== true) {
+      return "skipped (dreaming.autoRollback disabled) semantic=success";
+    }
+    const store = new DreamCandidateStore(b.factsDb.getRawDb());
+    const result = probeDreamOutcomes(b.factsDb, store, {
+      cfg: b.cfg.dreaming,
+      applyRollback: true,
+      limit: 20,
+    });
+    return `examined=${result.examined} kept=${result.kept} rolledBack=${result.rolledBack} insufficient=${result.insufficient} semantic=success`;
+  });
   set("cross-agent-learning", async () => runCrossAgentLearningStep(followUpDeps, verbose));
   set("tool-effectiveness", async () => runToolEffectivenessStep(followUpDeps, verbose));
   set("crystallization-proposals", async () => runCrystallizationProposalsStep(followUpDeps));

--- a/extensions/memory-hybrid/cli/commands/manage/maintenance-step-runners.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/maintenance-step-runners.ts
@@ -601,6 +601,7 @@ export function buildCliMaintenanceRunners(
     const discovered = discoverDreamSessionAcls(b.factsDb.getRawDb(), {
       lookbackDays: 7,
       limit: dreaming.maxSessions ?? 20,
+      openclawHome: resolveOpenclawHomeFromSqlitePath(b.resolvedSqlitePath),
     });
     const attachment = selectDreamSessions(
       discovered,

--- a/extensions/memory-hybrid/cli/commands/manage/maintenance-step-runners.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/maintenance-step-runners.ts
@@ -623,9 +623,27 @@ export function buildCliMaintenanceRunners(
         dreaming,
         manage: b,
       }),
-      promote: dreaming.autoPromote?.enabled === true || dreaming.promoteAfterRun === true,
+      // Always gate after compose (shadow when autoPromote off). Never leave nightly dreams in `running`.
+      promote: true,
     });
-    return `dreamRunId=${result.dreamRunId} sessions=${attachment.included.length} excluded=${attachment.excluded.length} candidates=${result.candidates.length} steps=${result.stepSummaries.length} timedOut=${result.timedOut} promote=${result.promoteResult?.status ?? "none"} semantic=success`;
+    if (result.timedOut) {
+      throw new Error(
+        `dream-run timed out dreamRunId=${result.dreamRunId} candidates=${result.candidates.length} promote=${result.promoteResult?.status ?? "none"} semantic=partial`,
+      );
+    }
+    const boundSteps = result.stepSummaries.filter((s) => s.skipped !== true);
+    const failedBound = boundSteps.filter((s) => s.ok === false);
+    if (boundSteps.length > 0 && failedBound.length === boundSteps.length) {
+      throw new Error(
+        `dream-run all compose steps failed dreamRunId=${result.dreamRunId} steps=${failedBound.length} semantic=failed`,
+      );
+    }
+    if (!result.promoteResult) {
+      throw new Error(
+        `dream-run missing gate/promote result dreamRunId=${result.dreamRunId} semantic=failed`,
+      );
+    }
+    return `dreamRunId=${result.dreamRunId} sessions=${attachment.included.length} excluded=${attachment.excluded.length} candidates=${result.candidates.length} steps=${result.stepSummaries.length} timedOut=${result.timedOut} promote=${result.promoteResult.status} semantic=success`;
   });
   set("cross-agent-learning", async () => runCrossAgentLearningStep(followUpDeps, verbose));
   set("tool-effectiveness", async () => runToolEffectivenessStep(followUpDeps, verbose));

--- a/extensions/memory-hybrid/cli/commands/manage/maintenance-step-runners.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/maintenance-step-runners.ts
@@ -592,9 +592,7 @@ export function buildCliMaintenanceRunners(
     }
     const { buildStepRunners } = await import("../register-dream-group.js");
     const { runDream } = await import("../../../services/dream-run.js");
-    const { discoverDreamSessionAcls, selectDreamSessions } = await import(
-      "../../../services/dream-permission.js"
-    );
+    const { discoverDreamSessionAcls, selectDreamSessions } = await import("../../../services/dream-permission.js");
     const dreaming = b.cfg.dreaming;
     const store = new DreamCandidateStore(b.factsDb.getRawDb());
     // Nightly dream: discover recent sessions from FactsDB and attach under permissionBoundary (#2174).
@@ -639,9 +637,7 @@ export function buildCliMaintenanceRunners(
       );
     }
     if (!result.promoteResult) {
-      throw new Error(
-        `dream-run missing gate/promote result dreamRunId=${result.dreamRunId} semantic=failed`,
-      );
+      throw new Error(`dream-run missing gate/promote result dreamRunId=${result.dreamRunId} semantic=failed`);
     }
     return `dreamRunId=${result.dreamRunId} sessions=${attachment.included.length} excluded=${attachment.excluded.length} candidates=${result.candidates.length} steps=${result.stepSummaries.length} timedOut=${result.timedOut} promote=${result.promoteResult.status} semantic=success`;
   });

--- a/extensions/memory-hybrid/cli/commands/manage/maintenance-step-runners.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/maintenance-step-runners.ts
@@ -586,6 +586,46 @@ export function buildCliMaintenanceRunners(
     });
     return `examined=${result.examined} kept=${result.kept} rolledBack=${result.rolledBack} insufficient=${result.insufficient} semantic=success`;
   });
+  set("dream-run", async () => {
+    if (b.cfg.dreaming?.enabled !== true) {
+      return "skipped (dreaming.enabled=false) semantic=success";
+    }
+    const { buildStepRunners } = await import("../register-dream-group.js");
+    const { runDream } = await import("../../../services/dream-run.js");
+    const { discoverDreamSessionAcls, selectDreamSessions } = await import(
+      "../../../services/dream-permission.js"
+    );
+    const dreaming = b.cfg.dreaming;
+    const store = new DreamCandidateStore(b.factsDb.getRawDb());
+    // Nightly dream: discover recent sessions from FactsDB and attach under permissionBoundary (#2174).
+    const discovered = discoverDreamSessionAcls(b.factsDb.getRawDb(), {
+      lookbackDays: 7,
+      limit: dreaming.maxSessions ?? 20,
+    });
+    const attachment = selectDreamSessions(
+      discovered,
+      dreaming.permissionBoundary ?? {
+        targetScope: "session",
+        enforce: true,
+        personalMode: false,
+      },
+      dreaming.maxSessions ?? 20,
+    );
+    const result = await runDream({
+      factsDb: b.factsDb,
+      store,
+      cfg: dreaming,
+      sessionIds: attachment.included,
+      excludedSessions: attachment.excluded,
+      steps: buildStepRunners({
+        factsDb: b.factsDb,
+        dreaming,
+        manage: b,
+      }),
+      promote: dreaming.autoPromote?.enabled === true || dreaming.promoteAfterRun === true,
+    });
+    return `dreamRunId=${result.dreamRunId} sessions=${attachment.included.length} excluded=${attachment.excluded.length} candidates=${result.candidates.length} steps=${result.stepSummaries.length} timedOut=${result.timedOut} promote=${result.promoteResult?.status ?? "none"} semantic=success`;
+  });
   set("cross-agent-learning", async () => runCrossAgentLearningStep(followUpDeps, verbose));
   set("tool-effectiveness", async () => runToolEffectivenessStep(followUpDeps, verbose));
   set("crystallization-proposals", async () => runCrystallizationProposalsStep(followUpDeps));

--- a/extensions/memory-hybrid/cli/commands/manage/maintenance-step-runners.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/maintenance-step-runners.ts
@@ -610,6 +610,12 @@ export function buildCliMaintenanceRunners(
       },
       dreaming.maxSessions ?? 20,
     );
+    // Fail closed for ownership: empty attachment must not claim skipNightlyOverlap success.
+    if (attachment.included.length === 0 && dreaming.skipNightlyOverlap === true) {
+      throw new Error(
+        `dream-run no attached sessions (discovered=${discovered.length} excluded=${attachment.excluded.length}) — refusing skipNightlyOverlap ownership semantic=partial`,
+      );
+    }
     const result = await runDream({
       factsDb: b.factsDb,
       store,
@@ -631,6 +637,13 @@ export function buildCliMaintenanceRunners(
     }
     const boundSteps = result.stepSummaries.filter((s) => s.skipped !== true);
     const failedBound = boundSteps.filter((s) => s.ok === false);
+    const allSkipped =
+      result.stepSummaries.length > 0 && result.stepSummaries.every((s) => s.skipped === true);
+    if (allSkipped && dreaming.skipNightlyOverlap === true) {
+      throw new Error(
+        `dream-run all compose stages skipped dreamRunId=${result.dreamRunId} — refusing skipNightlyOverlap ownership semantic=partial`,
+      );
+    }
     if (boundSteps.length > 0 && failedBound.length === boundSteps.length) {
       throw new Error(
         `dream-run all compose steps failed dreamRunId=${result.dreamRunId} steps=${failedBound.length} semantic=failed`,

--- a/extensions/memory-hybrid/cli/commands/manage/maintenance-step-runners.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/maintenance-step-runners.ts
@@ -637,8 +637,7 @@ export function buildCliMaintenanceRunners(
     }
     const boundSteps = result.stepSummaries.filter((s) => s.skipped !== true);
     const failedBound = boundSteps.filter((s) => s.ok === false);
-    const allSkipped =
-      result.stepSummaries.length > 0 && result.stepSummaries.every((s) => s.skipped === true);
+    const allSkipped = result.stepSummaries.length > 0 && result.stepSummaries.every((s) => s.skipped === true);
     if (allSkipped && dreaming.skipNightlyOverlap === true) {
       throw new Error(
         `dream-run all compose stages skipped dreamRunId=${result.dreamRunId} — refusing skipNightlyOverlap ownership semantic=partial`,

--- a/extensions/memory-hybrid/cli/commands/register-cli-groups.ts
+++ b/extensions/memory-hybrid/cli/commands/register-cli-groups.ts
@@ -29,6 +29,7 @@ export function registerAllCliGroups(mem: Chainable, ctx: ManageContext, distill
       runSelfCorrectionRun: ctx.runSelfCorrectionRun,
       runContradictionCandidates: ctx.runContradictionCandidates,
       runResolveContradictionsAuto: ctx.runResolveContradictionsAuto,
+      runResolveContradictionsDryRun: ctx.runResolveContradictionsDryRun,
       runReflection: ctx.runReflection,
       runConsolidate: ctx.runConsolidate,
       runDreamCycle: ctx.runDreamCycle,

--- a/extensions/memory-hybrid/cli/commands/register-cli-groups.ts
+++ b/extensions/memory-hybrid/cli/commands/register-cli-groups.ts
@@ -8,6 +8,7 @@ import { registerDistillGroup } from "../distill.js";
 import type { Chainable } from "../shared.js";
 import { buildManageBindings } from "./manage/bindings.js";
 import { registerStorageGroup } from "./manage/register-storage-maintenance.js";
+import { registerDreamGroup } from "./register-dream-group.js";
 import { registerLearnGroup } from "./register-learn-group.js";
 import { registerMaintenanceGroup } from "./register-maintenance-group.js";
 import { registerQualityGroup } from "./register-quality-group.js";
@@ -20,6 +21,19 @@ export function registerAllCliGroups(mem: Chainable, ctx: ManageContext, distill
   const b = buildManageBindings(ctx);
   registerStorageGroup(mem, b);
   registerReflectGroup(mem, b);
+  registerDreamGroup(mem, {
+    factsDb: ctx.factsDb,
+    dreaming: ctx.cfg.dreaming,
+    manage: {
+      runDistill: ctx.runDistill,
+      runSelfCorrectionRun: ctx.runSelfCorrectionRun,
+      runContradictionCandidates: ctx.runContradictionCandidates,
+      runResolveContradictionsAuto: ctx.runResolveContradictionsAuto,
+      runReflection: ctx.runReflection,
+      runConsolidate: ctx.runConsolidate,
+      runDreamCycle: ctx.runDreamCycle,
+    },
+  });
   registerQualityGroup(mem, b);
   registerLearnGroup(mem, b);
   registerMaintenanceGroup(mem, b, ctx);

--- a/extensions/memory-hybrid/cli/commands/register-dream-group.ts
+++ b/extensions/memory-hybrid/cli/commands/register-dream-group.ts
@@ -98,6 +98,7 @@ export function buildStepRunners(ctx: DreamCliContext): DreamStepRunners {
         },
         sink,
       );
+      const boundary = ctx.dreaming?.permissionBoundary ?? DEFAULT_DREAMING_CONFIG.permissionBoundary;
       const candidates = distillProposalsToCandidates({
         proposals: (result.extracted ?? []).map((f) => ({
           ...f,
@@ -105,6 +106,7 @@ export function buildStepRunners(ctx: DreamCliContext): DreamStepRunners {
         })),
         sessionIds,
         dreamRunId,
+        permissionBoundary: boundary,
       });
       return {
         detail: `steering=${steering.profile} dryRun=${dryRun} attached=${sessionIds.length} scanned=${result.sessionsScanned} ${steeringPrompt.split("\n")[0]} stored=${result.stored} proposed=${candidates.length}`,
@@ -127,10 +129,12 @@ export function buildStepRunners(ctx: DreamCliContext): DreamStepRunners {
         sessionIds,
         days: 7,
       });
+      const boundary = ctx.dreaming?.permissionBoundary ?? DEFAULT_DREAMING_CONFIG.permissionBoundary;
       const candidates = selfCorrectionProposalsToCandidates({
         proposals: result.extracted ?? [],
         sessionIds,
         dreamRunId,
+        permissionBoundary: boundary,
       });
       return {
         detail: `steering=${steering.profile} dryRun=${dryRun} attached=${sessionIds.length} proposed=${candidates.length} analysed=${result.analysed} ${formatSteeringPromptBlock(steering).split("\n")[0]}`,
@@ -160,6 +164,7 @@ export function buildStepRunners(ctx: DreamCliContext): DreamStepRunners {
           dreamRunId,
           targetScope: boundary.targetScope,
           personalMode: boundary.personalMode === true,
+          permissionBoundary: boundary,
         });
         parts.push(
           `autoResolvable=${dry.autoResolvable.length} ambiguous=${dry.ambiguous.length} proposed=${candidates.length}`,
@@ -207,6 +212,7 @@ export function buildStepRunners(ctx: DreamCliContext): DreamStepRunners {
                 ? sessionIds[0]!
                 : "dream-multi"
               : null,
+        permissionBoundary: boundary,
       });
       return {
         detail: `${steeringPrompt.split("\n")[0]} attached=${sessionIds.length} patterns=${result.patternsStored} proposed=${candidates.length} ${JSON.stringify({ ...result, patterns: undefined })}`,
@@ -265,6 +271,7 @@ export function buildStepRunners(ctx: DreamCliContext): DreamStepRunners {
         sessionIds,
         dreamRunId,
         sourceProvenanceByFactId,
+        permissionBoundary: ctx.dreaming?.permissionBoundary ?? DEFAULT_DREAMING_CONFIG.permissionBoundary,
       });
       return {
         detail: `steering=${steering.profile} ${formatSteeringPromptBlock(steering).split("\n")[0]} merged=${result.merged} proposed=${candidates.length}`,

--- a/extensions/memory-hybrid/cli/commands/register-dream-group.ts
+++ b/extensions/memory-hybrid/cli/commands/register-dream-group.ts
@@ -14,6 +14,8 @@ import { type DreamStepRunners, runDream } from "../../services/dream-run.js";
 import { selectDreamSessions } from "../../services/dream-permission.js";
 import { buildDreamRoiReport } from "../../services/dream-roi.js";
 import { evaluateDreamOutcome } from "../../services/dream-outcome.js";
+import { probeDreamOutcomes } from "../../services/dream-outcome-probe.js";
+import { formatSteeringPromptBlock } from "../../services/dream-steering.js";
 import type { ManageContext } from "../context.js";
 import type { Chainable } from "../shared.js";
 import { createCommandGroup } from "./cli-group-utils.js";
@@ -67,10 +69,11 @@ function buildStepRunners(ctx: DreamCliContext): DreamStepRunners {
   const runners: DreamStepRunners = {};
 
   if (m.runDistill) {
-    runners.distill = async ({ dryRun }) => {
-      const result = await m.runDistill!({ days: 7, dryRun }, sink);
+    runners.distill = async ({ dryRun, steering }) => {
+      const steeringPrompt = formatSteeringPromptBlock(steering);
+      const result = await m.runDistill!({ days: 7, dryRun, steeringPrompt }, sink);
       return {
-        detail: `dryRun=${dryRun} stored=${result.stored} extracted=${result.factsExtracted} sessions=${result.sessionsScanned}`,
+        detail: `steering=${steering.profile} dryRun=${dryRun} ${steeringPrompt.split("\n")[0]} stored=${result.stored}`,
       };
     };
   }
@@ -100,14 +103,18 @@ function buildStepRunners(ctx: DreamCliContext): DreamStepRunners {
   }
 
   if (m.runReflection) {
-    runners.reflect = async ({ dryRun }) => {
+    runners.reflect = async ({ dryRun, steering }) => {
+      const steeringPrompt = formatSteeringPromptBlock(steering);
       const result = await m.runReflection({
         window: 7,
         dryRun,
         model: "",
         verbose: false,
+        steeringPrompt,
       });
-      return { detail: JSON.stringify(result) };
+      return {
+        detail: `${steeringPrompt.split("\n")[0]} ${JSON.stringify(result)}`,
+      };
     };
   }
 

--- a/extensions/memory-hybrid/cli/commands/register-dream-group.ts
+++ b/extensions/memory-hybrid/cli/commands/register-dream-group.ts
@@ -86,6 +86,7 @@ export function buildStepRunners(ctx: DreamCliContext): DreamStepRunners {
         return {
           detail: `steering=${steering.profile} skipped_no_attached_sessions`,
           candidates: [],
+          skipped: true,
         };
       }
       const result = await m.runDistill!(
@@ -121,6 +122,7 @@ export function buildStepRunners(ctx: DreamCliContext): DreamStepRunners {
         return {
           detail: `steering=${steering.profile} skipped_no_attached_sessions`,
           candidates: [],
+          skipped: true,
         };
       }
       const result = await m.runSelfCorrectionRun!({
@@ -146,7 +148,11 @@ export function buildStepRunners(ctx: DreamCliContext): DreamStepRunners {
   if (m.runContradictionCandidates || m.runResolveContradictionsDryRun || m.runResolveContradictionsAuto) {
     runners.contradictions = async ({ dryRun, steering, sessionIds, dreamRunId }) => {
       if (sessionIds.length === 0) {
-        return { detail: `steering=${steering.profile} skipped_no_attached_sessions`, candidates: [] };
+        return {
+          detail: `steering=${steering.profile} skipped_no_attached_sessions`,
+          candidates: [],
+          skipped: true,
+        };
       }
       const parts: string[] = [`steering=${steering.profile}`];
       if (m.runContradictionCandidates) {
@@ -187,6 +193,7 @@ export function buildStepRunners(ctx: DreamCliContext): DreamStepRunners {
         return {
           detail: `${steeringPrompt.split("\n")[0]} skipped_no_attached_sessions`,
           candidates: [],
+          skipped: true,
         };
       }
       const result = await m.runReflection({
@@ -227,6 +234,7 @@ export function buildStepRunners(ctx: DreamCliContext): DreamStepRunners {
         return {
           detail: `steering=${steering.profile} skipped_no_attached_sessions`,
           candidates: [],
+          skipped: true,
         };
       }
       const result = await m.runConsolidate({
@@ -335,6 +343,22 @@ export function registerDreamGroup(mem: Chainable, ctx: DreamCliContext): void {
               .map((s) => s.trim())
               .filter(Boolean)
           : undefined;
+        if (composeOverride?.length) {
+          const known = new Set([
+            "distill",
+            "self-correction",
+            "contradictions",
+            "reflect",
+            "consolidate",
+            "dream-cycle-core",
+          ]);
+          const invalid = composeOverride.filter((s) => !known.has(s));
+          if (invalid.length > 0) {
+            process.stderr.write(`dream run: invalid --compose step(s): ${invalid.join(", ")}\n`);
+            process.exitCode = 1;
+            return;
+          }
+        }
         const dreamCfg: DreamingConfig = {
           ...base,
           enabled: true,
@@ -388,7 +412,14 @@ export function registerDreamGroup(mem: Chainable, ctx: DreamCliContext): void {
             timedOut: result.timedOut,
             costFeature: result.costFeature,
           });
-          if (result.run.status === "failed") process.exitCode = 1;
+          if (
+            result.run.status === "failed" ||
+            result.run.status === "quarantined" ||
+            result.promoteResult?.status === "failed" ||
+            result.promoteResult?.status === "quarantined"
+          ) {
+            process.exitCode = 1;
+          }
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err);
           process.stderr.write(`dream run failed: ${message}\n`);
@@ -433,7 +464,7 @@ export function registerDreamGroup(mem: Chainable, ctx: DreamCliContext): void {
       });
       printJson(result);
       if (result.error || result.status === "failed" || result.status === "quarantined") {
-        process.exitCode = result.applied ? 0 : 1;
+        process.exitCode = 1;
       }
     });
 

--- a/extensions/memory-hybrid/cli/commands/register-dream-group.ts
+++ b/extensions/memory-hybrid/cli/commands/register-dream-group.ts
@@ -153,7 +153,14 @@ export function buildStepRunners(ctx: DreamCliContext): DreamStepRunners {
       if (m.runResolveContradictionsDryRun) {
         const dry = await m.runResolveContradictionsDryRun();
         const proposals = pinContradictionResolves(dry.autoResolvable, ctx.factsDb);
-        candidates = contradictionProposalsToCandidates({ proposals, sessionIds, dreamRunId });
+        const boundary = ctx.dreaming?.permissionBoundary ?? DEFAULT_DREAMING_CONFIG.permissionBoundary;
+        candidates = contradictionProposalsToCandidates({
+          proposals,
+          sessionIds,
+          dreamRunId,
+          targetScope: boundary.targetScope,
+          personalMode: boundary.personalMode === true,
+        });
         parts.push(
           `autoResolvable=${dry.autoResolvable.length} ambiguous=${dry.ambiguous.length} proposed=${candidates.length}`,
         );
@@ -191,10 +198,14 @@ export function buildStepRunners(ctx: DreamCliContext): DreamStepRunners {
         dreamRunId,
         writeScope: boundary.targetScope,
         writeScopeTarget:
-          boundary.targetScope === "session" && sessionIds.length === 1
-            ? sessionIds[0]!
+          boundary.targetScope === "session"
+            ? sessionIds.length === 1
+              ? sessionIds[0]!
+              : "dream-multi"
             : boundary.targetScope === "agent" || boundary.targetScope === "user"
-              ? (sessionIds[0] ?? "dream-multi")
+              ? sessionIds.length === 1
+                ? sessionIds[0]!
+                : "dream-multi"
               : null,
       });
       return {

--- a/extensions/memory-hybrid/cli/commands/register-dream-group.ts
+++ b/extensions/memory-hybrid/cli/commands/register-dream-group.ts
@@ -67,29 +67,31 @@ function buildStepRunners(ctx: DreamCliContext): DreamStepRunners {
   const runners: DreamStepRunners = {};
 
   if (m.runDistill) {
-    runners.distill = async () => {
-      const result = await m.runDistill!({ days: 7, dryRun: false }, sink);
+    runners.distill = async ({ dryRun }) => {
+      const result = await m.runDistill!({ days: 7, dryRun }, sink);
       return {
-        detail: `stored=${result.stored} extracted=${result.factsExtracted} sessions=${result.sessionsScanned}`,
+        detail: `dryRun=${dryRun} stored=${result.stored} extracted=${result.factsExtracted} sessions=${result.sessionsScanned}`,
       };
     };
   }
 
   if (m.runSelfCorrectionRun) {
-    runners["self-correction"] = async () => {
+    runners["self-correction"] = async ({ dryRun }) => {
       const result = await m.runSelfCorrectionRun!({ dryRun: true, applyTools: false });
-      return { detail: JSON.stringify(result ?? "self-correction done") };
+      return { detail: `dryRun=${dryRun} ${JSON.stringify(result ?? "self-correction done")}` };
     };
   }
 
   if (m.runContradictionCandidates || m.runResolveContradictionsAuto) {
-    runners.contradictions = async () => {
+    runners.contradictions = async ({ dryRun }) => {
       const parts: string[] = [];
       if (m.runContradictionCandidates) {
-        const c = await m.runContradictionCandidates!({ dryRun: false });
+        const c = await m.runContradictionCandidates({ dryRun });
         parts.push(`candidates=${JSON.stringify(c)}`);
       }
-      if (m.runResolveContradictionsAuto) {
+      if (dryRun) {
+        parts.push("resolve=skipped_dry_run");
+      } else if (m.runResolveContradictionsAuto) {
         const r = await m.runResolveContradictionsAuto({});
         parts.push(`resolve=${JSON.stringify(r)}`);
       }
@@ -98,10 +100,10 @@ function buildStepRunners(ctx: DreamCliContext): DreamStepRunners {
   }
 
   if (m.runReflection) {
-    runners.reflect = async () => {
+    runners.reflect = async ({ dryRun }) => {
       const result = await m.runReflection({
         window: 7,
-        dryRun: false,
+        dryRun,
         model: "",
         verbose: false,
       });
@@ -110,11 +112,11 @@ function buildStepRunners(ctx: DreamCliContext): DreamStepRunners {
   }
 
   if (m.runConsolidate) {
-    runners.consolidate = async () => {
+    runners.consolidate = async ({ dryRun }) => {
       const result = await m.runConsolidate({
         threshold: 0.92,
         limit: 10,
-        dryRun: false,
+        dryRun,
         includeStructured: true,
         model: "",
       });
@@ -123,8 +125,8 @@ function buildStepRunners(ctx: DreamCliContext): DreamStepRunners {
   }
 
   if (m.runDreamCycle) {
-    runners["dream-cycle-core"] = async () => {
-      const result = await m.runDreamCycle!({ dryRun: false, verbose: false });
+    runners["dream-cycle-core"] = async ({ dryRun }) => {
+      const result = await m.runDreamCycle!({ dryRun, verbose: false });
       return { detail: JSON.stringify(result) };
     };
   }
@@ -309,6 +311,7 @@ export function registerDreamGroup(mem: Chainable, ctx: DreamCliContext): void {
         sinceSec: untilSec - days * 24 * 3600,
         untilSec,
         limit: Math.max(1, Number.parseInt(opts.limit ?? "100", 10) || 100),
+        db: ctx.factsDb.getRawDb(),
       });
       printJson(report);
     });
@@ -349,7 +352,7 @@ export function registerDreamGroup(mem: Chainable, ctx: DreamCliContext): void {
           {
             cfg,
             applyRollback: opts.apply === true,
-            minSessions: 1,
+            minSessions: 3,
           },
         );
         printJson(report);

--- a/extensions/memory-hybrid/cli/commands/register-dream-group.ts
+++ b/extensions/memory-hybrid/cli/commands/register-dream-group.ts
@@ -1,0 +1,361 @@
+/**
+ * CLI group: `hybrid-mem dream …` (#2170 / #2171 / Epic #2169).
+ *
+ * Machine-first: run / status / promote / rollback. Manual promote is an escape hatch.
+ */
+
+import type { FactsDB } from "../../backends/facts-db.js";
+import { DreamCandidateStore } from "../../backends/dream-candidate-store.js";
+import type { DreamingConfig } from "../../config/types/dreaming.js";
+import { DEFAULT_DREAMING_CONFIG } from "../../config/types/dreaming.js";
+import { promoteDreamRun } from "../../services/dream-promote.js";
+import { rollbackDreamRun } from "../../services/dream-rollback.js";
+import { type DreamStepRunners, runDream } from "../../services/dream-run.js";
+import { selectDreamSessions } from "../../services/dream-permission.js";
+import { buildDreamRoiReport } from "../../services/dream-roi.js";
+import { evaluateDreamOutcome } from "../../services/dream-outcome.js";
+import type { ManageContext } from "../context.js";
+import type { Chainable } from "../shared.js";
+import { createCommandGroup } from "./cli-group-utils.js";
+
+/** Commander nodes that expose `.argument` (see cli/skills.ts). */
+type ArgumentChainable = {
+  command(name: string): ArgumentChainable;
+  argument(name: string, desc?: string): ArgumentChainable;
+  description(desc: string): ArgumentChainable;
+  option(flags: string, desc?: string, defaultValue?: unknown): ArgumentChainable;
+  action(fn: (...args: any[]) => void | Promise<void>): ArgumentChainable;
+};
+
+export type DreamCliContext = {
+  factsDb: FactsDB;
+  dreaming?: DreamingConfig;
+  /** Optional manage bindings so compose stages call existing runners. */
+  manage?: Pick<
+    ManageContext,
+    | "runDistill"
+    | "runSelfCorrectionRun"
+    | "runContradictionCandidates"
+    | "runResolveContradictionsAuto"
+    | "runReflection"
+    | "runConsolidate"
+    | "runDreamCycle"
+  >;
+};
+
+function getStore(factsDb: FactsDB): DreamCandidateStore {
+  return new DreamCandidateStore(factsDb.getRawDb());
+}
+
+function printJson(value: unknown): void {
+  process.stdout.write(`${JSON.stringify(value, null, 2)}\n`);
+}
+
+function buildStepRunners(ctx: DreamCliContext): DreamStepRunners {
+  const m = ctx.manage;
+  if (!m) return {};
+
+  const sink = {
+    log: (s: string) => {
+      process.stderr.write(`${s}\n`);
+    },
+    warn: (s: string) => {
+      process.stderr.write(`${s}\n`);
+    },
+  };
+
+  const runners: DreamStepRunners = {};
+
+  if (m.runDistill) {
+    runners.distill = async () => {
+      const result = await m.runDistill!({ days: 7, dryRun: false }, sink);
+      return {
+        detail: `stored=${result.stored} extracted=${result.factsExtracted} sessions=${result.sessionsScanned}`,
+      };
+    };
+  }
+
+  if (m.runSelfCorrectionRun) {
+    runners["self-correction"] = async () => {
+      const result = await m.runSelfCorrectionRun!({ dryRun: true, applyTools: false });
+      return { detail: JSON.stringify(result ?? "self-correction done") };
+    };
+  }
+
+  if (m.runContradictionCandidates || m.runResolveContradictionsAuto) {
+    runners.contradictions = async () => {
+      const parts: string[] = [];
+      if (m.runContradictionCandidates) {
+        const c = await m.runContradictionCandidates!({ dryRun: false });
+        parts.push(`candidates=${JSON.stringify(c)}`);
+      }
+      if (m.runResolveContradictionsAuto) {
+        const r = await m.runResolveContradictionsAuto({});
+        parts.push(`resolve=${JSON.stringify(r)}`);
+      }
+      return { detail: parts.join("; ") || "contradictions skipped" };
+    };
+  }
+
+  if (m.runReflection) {
+    runners.reflect = async () => {
+      const result = await m.runReflection({
+        window: 7,
+        dryRun: false,
+        model: "",
+        verbose: false,
+      });
+      return { detail: JSON.stringify(result) };
+    };
+  }
+
+  if (m.runConsolidate) {
+    runners.consolidate = async () => {
+      const result = await m.runConsolidate({
+        threshold: 0.92,
+        limit: 10,
+        dryRun: false,
+        includeStructured: true,
+        model: "",
+      });
+      return { detail: JSON.stringify(result) };
+    };
+  }
+
+  if (m.runDreamCycle) {
+    runners["dream-cycle-core"] = async () => {
+      const result = await m.runDreamCycle!({ dryRun: false, verbose: false });
+      return { detail: JSON.stringify(result) };
+    };
+  }
+
+  return runners;
+}
+
+function parseSessionList(raw: string | undefined): string[] {
+  if (!raw?.trim()) return [];
+  return raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+export function registerDreamGroup(mem: Chainable, ctx: DreamCliContext): void {
+  const group = createCommandGroup(
+    mem,
+    "dream",
+    "Autonomous Dreaming — unified Dream run, candidate status, machine promote/rollback",
+  ) as ArgumentChainable;
+
+  (group.command("run") as ArgumentChainable)
+    .description("Unified Dream: compose maintenance stages → candidates → optional promote (#2171)")
+    .option("--sessions <ids>", "Comma-separated session ids to attach")
+    .option("--session-scopes <pairs>", "Optional id:scope pairs (e.g. s1:session,s2:global) for #2174")
+    .option("--steering <id>", "Optional steering policy id override")
+    .option("--dry-shadow", "Force shadow candidate run (no live promote apply)")
+    .option("--promote", "Run machine promote after compose")
+    .option("--force-promote", "Promote with --force (escape hatch)")
+    .option("--compose <steps>", "Comma-separated compose override")
+    .option("--json", "Machine-readable JSON")
+    .action(
+      async (opts: {
+        sessions?: string;
+        sessionScopes?: string;
+        steering?: string;
+        dryShadow?: boolean;
+        promote?: boolean;
+        forcePromote?: boolean;
+        compose?: string;
+        json?: boolean;
+      }) => {
+        const base = ctx.dreaming ?? DEFAULT_DREAMING_CONFIG;
+        const composeOverride = opts.compose
+          ? opts.compose
+              .split(",")
+              .map((s) => s.trim())
+              .filter(Boolean)
+          : undefined;
+        const dreamCfg: DreamingConfig = {
+          ...base,
+          enabled: true,
+          compose: composeOverride?.length
+            ? (composeOverride as DreamingConfig["compose"])
+            : base.compose,
+          candidateStore: { ...base.candidateStore, enabled: true },
+        };
+
+        const rawIds = parseSessionList(opts.sessions);
+        const scopeMap = new Map<string, string>();
+        if (opts.sessionScopes) {
+          for (const part of opts.sessionScopes.split(",")) {
+            const [id, scope] = part.split(":").map((s) => s.trim());
+            if (id && scope) scopeMap.set(id, scope);
+          }
+        }
+        // Explicit --sessions: default ACL to session (⊆ any target). Bulk discovery must pass scopes.
+        const attachment = selectDreamSessions(
+          rawIds.map((sessionId) => ({
+            sessionId,
+            effectiveScope:
+              scopeMap.get(sessionId) ??
+              (base.permissionBoundary.personalMode ? "global" : "session"),
+          })),
+          dreamCfg.permissionBoundary,
+          dreamCfg.maxSessions,
+        );
+
+        try {
+          const result = await runDream({
+            factsDb: ctx.factsDb,
+            store: getStore(ctx.factsDb),
+            cfg: dreamCfg,
+            sessionIds: attachment.included,
+            steeringPolicyId: opts.steering ?? dreamCfg.steering.profile,
+            steps: buildStepRunners(ctx),
+            dryShadow: opts.dryShadow === true,
+            promote: opts.promote === true || opts.forcePromote === true ? true : undefined,
+            forcePromote: opts.forcePromote === true,
+          });
+          printJson({
+            dreamRunId: result.dreamRunId,
+            status: result.run.status,
+            shadow: result.run.shadow,
+            mode: dreamCfg.mode,
+            steering: dreamCfg.steering,
+            inputStoreRevision: result.run.inputStoreRevision,
+            sessionIds: result.run.sessionIds,
+            excludedSessions: attachment.excluded,
+            candidateCount: result.candidates.length,
+            stepSummaries: result.stepSummaries,
+            promoteResult: result.promoteResult ?? null,
+            timedOut: result.timedOut,
+            costFeature: result.costFeature,
+          });
+          if (result.run.status === "failed") process.exitCode = 1;
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          process.stderr.write(`dream run failed: ${message}\n`);
+          process.exitCode = 1;
+        }
+      },
+    );
+
+  (group.command("status") as ArgumentChainable)
+    .description("Show a dream run (or list recent runs)")
+    .argument("[id]", "Dream run id")
+    .option("--limit <n>", "Max runs when listing", "20")
+    .option("--json", "Machine-readable JSON")
+    .action((id: string | undefined, opts: { limit?: string; json?: boolean }) => {
+      const store = getStore(ctx.factsDb);
+      if (id) {
+        const run = store.getDreamRun(id);
+        if (!run) {
+          process.stderr.write(`dream status: run not found: ${id}\n`);
+          process.exitCode = 1;
+          return;
+        }
+        const entries = store.listCandidateEntries(id);
+        printJson({ run, entries, dreaming: ctx.dreaming ?? DEFAULT_DREAMING_CONFIG });
+        return;
+      }
+      const limit = Math.max(1, Number.parseInt(opts.limit ?? "20", 10) || 20);
+      printJson({ runs: store.listDreamRuns(limit) });
+    });
+
+  (group.command("promote") as ArgumentChainable)
+    .description("Run machine gates and promote (or shadow would-promote). Escape hatch: --force")
+    .argument("<id>", "Dream run id")
+    .option("--force", "Apply even when shadow/autoPromote is off")
+    .option("--json", "Machine-readable JSON")
+    .action((id: string, opts: { force?: boolean; json?: boolean }) => {
+      const store = getStore(ctx.factsDb);
+      const cfg = ctx.dreaming ?? DEFAULT_DREAMING_CONFIG;
+      const result = promoteDreamRun(ctx.factsDb, store, id, {
+        force: opts.force === true,
+        cfg,
+      });
+      printJson(result);
+      if (result.error || result.status === "failed" || result.status === "quarantined") {
+        process.exitCode = result.applied ? 0 : 1;
+      }
+    });
+
+  (group.command("rollback") as ArgumentChainable)
+    .description("Roll back a promoted dream run via reverse plans")
+    .argument("<id>", "Dream run id")
+    .option("--reason <text>", "Rollback reason")
+    .option("--force", "Allow rollback when status is not promoted")
+    .option("--json", "Machine-readable JSON")
+    .action((id: string, opts: { reason?: string; force?: boolean; json?: boolean }) => {
+      const store = getStore(ctx.factsDb);
+      const result = rollbackDreamRun(ctx.factsDb, store, id, {
+        reason: opts.reason,
+        force: opts.force === true,
+      });
+      printJson(result);
+      if (!result.rolledBack) process.exitCode = 1;
+    });
+
+  (group.command("report") as ArgumentChainable)
+    .description("Dream ROI report — cost + outcome summaries (#2179)")
+    .option("--since-days <n>", "Lookback days", "30")
+    .option("--limit <n>", "Max runs", "100")
+    .option("--json", "Machine-readable JSON")
+    .action((opts: { sinceDays?: string; limit?: string; json?: boolean }) => {
+      const store = getStore(ctx.factsDb);
+      const days = Math.max(1, Number.parseInt(opts.sinceDays ?? "30", 10) || 30);
+      const untilSec = Math.floor(Date.now() / 1000);
+      const report = buildDreamRoiReport(store, {
+        sinceSec: untilSec - days * 24 * 3600,
+        untilSec,
+        limit: Math.max(1, Number.parseInt(opts.limit ?? "100", 10) || 100),
+      });
+      printJson(report);
+    });
+
+  (group.command("observe") as ArgumentChainable)
+    .description("Evaluate post-promote outcomes and optionally auto-rollback (#2173)")
+    .argument("<id>", "Dream run id")
+    .option("--effect-score <n>", "Observed effect score 0..1", "0")
+    .option("--success-rate <n>", "Observed success rate 0..1", "0")
+    .option("--retry-rate <n>", "Observed retry rate", "0")
+    .option("--sessions <n>", "Sessions observed in window", "0")
+    .option("--apply", "Apply rollback when regression detected and autoRollback.enabled")
+    .option("--json", "Machine-readable JSON")
+    .action(
+      (
+        id: string,
+        opts: {
+          effectScore?: string;
+          successRate?: string;
+          retryRate?: string;
+          sessions?: string;
+          apply?: boolean;
+          json?: boolean;
+        },
+      ) => {
+        const store = getStore(ctx.factsDb);
+        const cfg = ctx.dreaming ?? DEFAULT_DREAMING_CONFIG;
+        const report = evaluateDreamOutcome(
+          ctx.factsDb,
+          store,
+          id,
+          {
+            effectScore: Number.parseFloat(opts.effectScore ?? "0") || 0,
+            successRate: Number.parseFloat(opts.successRate ?? "0") || 0,
+            retryRate: Number.parseFloat(opts.retryRate ?? "0") || 0,
+            sessionsObserved: Number.parseInt(opts.sessions ?? "0", 10) || 0,
+          },
+          {
+            cfg,
+            applyRollback: opts.apply === true,
+            minSessions: 1,
+          },
+        );
+        printJson(report);
+        if (report.decision === "rollback" && opts.apply && !report.rollback?.rolledBack) {
+          process.exitCode = 1;
+        }
+      },
+    );
+}

--- a/extensions/memory-hybrid/cli/commands/register-dream-group.ts
+++ b/extensions/memory-hybrid/cli/commands/register-dream-group.ts
@@ -226,6 +226,7 @@ export function registerDreamGroup(mem: Chainable, ctx: DreamCliContext): void {
             store: getStore(ctx.factsDb),
             cfg: dreamCfg,
             sessionIds: attachment.included,
+            excludedSessions: attachment.excluded,
             steeringPolicyId: opts.steering ?? dreamCfg.steering.profile,
             steps: buildStepRunners(ctx),
             dryShadow: opts.dryShadow === true,

--- a/extensions/memory-hybrid/cli/commands/register-dream-group.ts
+++ b/extensions/memory-hybrid/cli/commands/register-dream-group.ts
@@ -80,15 +80,17 @@ function buildStepRunners(ctx: DreamCliContext): DreamStepRunners {
   }
 
   if (m.runSelfCorrectionRun) {
-    runners["self-correction"] = async ({ dryRun }) => {
+    runners["self-correction"] = async ({ dryRun, steering }) => {
       const result = await m.runSelfCorrectionRun!({ dryRun: true, applyTools: false });
-      return { detail: `dryRun=${dryRun} ${JSON.stringify(result ?? "self-correction done")}` };
+      return {
+        detail: `steering=${steering.profile} dryRun=${dryRun} ${formatSteeringPromptBlock(steering).split("\n")[0]} ${JSON.stringify(result ?? "self-correction done")}`,
+      };
     };
   }
 
   if (m.runContradictionCandidates || m.runResolveContradictionsAuto) {
-    runners.contradictions = async ({ dryRun }) => {
-      const parts: string[] = [];
+    runners.contradictions = async ({ dryRun, steering }) => {
+      const parts: string[] = [`steering=${steering.profile}`];
       if (m.runContradictionCandidates) {
         const c = await m.runContradictionCandidates({ dryRun });
         parts.push(`candidates=${JSON.stringify(c)}`);
@@ -120,7 +122,7 @@ function buildStepRunners(ctx: DreamCliContext): DreamStepRunners {
   }
 
   if (m.runConsolidate) {
-    runners.consolidate = async ({ dryRun }) => {
+    runners.consolidate = async ({ dryRun, steering }) => {
       const result = await m.runConsolidate({
         threshold: 0.92,
         limit: 10,
@@ -128,14 +130,18 @@ function buildStepRunners(ctx: DreamCliContext): DreamStepRunners {
         includeStructured: true,
         model: "",
       });
-      return { detail: JSON.stringify(result) };
+      return {
+        detail: `steering=${steering.profile} ${formatSteeringPromptBlock(steering).split("\n")[0]} ${JSON.stringify(result)}`,
+      };
     };
   }
 
   if (m.runDreamCycle) {
-    runners["dream-cycle-core"] = async ({ dryRun }) => {
+    runners["dream-cycle-core"] = async ({ dryRun, steering }) => {
       const result = await m.runDreamCycle!({ dryRun, verbose: false });
-      return { detail: JSON.stringify(result) };
+      return {
+        detail: `steering=${steering.profile} ${formatSteeringPromptBlock(steering).split("\n")[0]} ${JSON.stringify(result)}`,
+      };
     };
   }
 

--- a/extensions/memory-hybrid/cli/commands/register-dream-group.ts
+++ b/extensions/memory-hybrid/cli/commands/register-dream-group.ts
@@ -472,9 +472,7 @@ export function registerDreamGroup(mem: Chainable, ctx: DreamCliContext): void {
     });
 
   (group.command("validate-shadow") as ArgumentChainable)
-    .description(
-      "Evaluate shadow ROI criteria required before autoPromote apply (#2179). Exit 0=pass, 1=fail.",
-    )
+    .description("Evaluate shadow ROI criteria required before autoPromote apply (#2179). Exit 0=pass, 1=fail.")
     .option("--since-days <n>", "Lookback days (default: autoPromote.shadowValidation.lookbackDays)")
     .option("--json", "Machine-readable JSON")
     .action((opts: { sinceDays?: string; json?: boolean }) => {

--- a/extensions/memory-hybrid/cli/commands/register-dream-group.ts
+++ b/extensions/memory-hybrid/cli/commands/register-dream-group.ts
@@ -194,9 +194,7 @@ export function registerDreamGroup(mem: Chainable, ctx: DreamCliContext): void {
         const dreamCfg: DreamingConfig = {
           ...base,
           enabled: true,
-          compose: composeOverride?.length
-            ? (composeOverride as DreamingConfig["compose"])
-            : base.compose,
+          compose: composeOverride?.length ? (composeOverride as DreamingConfig["compose"]) : base.compose,
           candidateStore: { ...base.candidateStore, enabled: true },
         };
 
@@ -212,9 +210,7 @@ export function registerDreamGroup(mem: Chainable, ctx: DreamCliContext): void {
         const attachment = selectDreamSessions(
           rawIds.map((sessionId) => ({
             sessionId,
-            effectiveScope:
-              scopeMap.get(sessionId) ??
-              (base.permissionBoundary.personalMode ? "global" : "session"),
+            effectiveScope: scopeMap.get(sessionId) ?? (base.permissionBoundary.personalMode ? "global" : "session"),
           })),
           dreamCfg.permissionBoundary,
           dreamCfg.maxSessions,
@@ -383,10 +379,7 @@ export function registerDreamGroup(mem: Chainable, ctx: DreamCliContext): void {
         }
 
         const hasManual =
-          opts.effectScore != null ||
-          opts.successRate != null ||
-          opts.retryRate != null ||
-          opts.sessions != null;
+          opts.effectScore != null || opts.successRate != null || opts.retryRate != null || opts.sessions != null;
 
         const after = hasManual
           ? {

--- a/extensions/memory-hybrid/cli/commands/register-dream-group.ts
+++ b/extensions/memory-hybrid/cli/commands/register-dream-group.ts
@@ -11,12 +11,21 @@ import { DEFAULT_DREAMING_CONFIG } from "../../config/types/dreaming.js";
 import { promoteDreamRun } from "../../services/dream-promote.js";
 import { rollbackDreamRun } from "../../services/dream-rollback.js";
 import { type DreamStepRunners, runDream } from "../../services/dream-run.js";
+import {
+  consolidateProposalsToCandidates,
+  contradictionProposalsToCandidates,
+  distillProposalsToCandidates,
+  pinContradictionResolves,
+  reflectProposalsToCandidates,
+  selfCorrectionProposalsToCandidates,
+} from "../../services/dream-compose-candidates.js";
 import { selectDreamSessions } from "../../services/dream-permission.js";
 import { buildDreamRoiReport } from "../../services/dream-roi.js";
 import { evaluateDreamOutcome } from "../../services/dream-outcome.js";
 import { collectDreamMetricSet } from "../../services/dream-metrics.js";
 import { probeDreamOutcomes } from "../../services/dream-outcome-probe.js";
 import { formatSteeringPromptBlock } from "../../services/dream-steering.js";
+import { evaluateShadowValidationFromStore } from "../../services/dream-shadow-validation.js";
 import type { ManageContext } from "../context.js";
 import type { Chainable } from "../shared.js";
 import { createCommandGroup } from "./cli-group-utils.js";
@@ -40,6 +49,7 @@ export type DreamCliContext = {
     | "runSelfCorrectionRun"
     | "runContradictionCandidates"
     | "runResolveContradictionsAuto"
+    | "runResolveContradictionsDryRun"
     | "runReflection"
     | "runConsolidate"
     | "runDreamCycle"
@@ -54,7 +64,7 @@ function printJson(value: unknown): void {
   process.stdout.write(`${JSON.stringify(value, null, 2)}\n`);
 }
 
-function buildStepRunners(ctx: DreamCliContext): DreamStepRunners {
+export function buildStepRunners(ctx: DreamCliContext): DreamStepRunners {
   const m = ctx.manage;
   if (!m) return {};
 
@@ -70,59 +80,107 @@ function buildStepRunners(ctx: DreamCliContext): DreamStepRunners {
   const runners: DreamStepRunners = {};
 
   if (m.runDistill) {
-    runners.distill = async ({ dryRun, steering }) => {
+    runners.distill = async ({ dryRun, steering, sessionIds, dreamRunId }) => {
       const steeringPrompt = formatSteeringPromptBlock(steering);
-      const result = await m.runDistill!({ days: 7, dryRun, steeringPrompt }, sink);
+      // Always pass sessionIds (possibly empty) so distill never scoops an unrestricted window (#2174).
+      const result = await m.runDistill!(
+        {
+          days: 7,
+          dryRun,
+          steeringPrompt,
+          sessionIds,
+          ...(sessionIds.length > 0 ? { maxSessions: sessionIds.length } : {}),
+        },
+        sink,
+      );
+      const candidates = distillProposalsToCandidates({
+        proposals: result.extracted ?? [],
+        sessionIds,
+        dreamRunId,
+      });
       return {
-        detail: `steering=${steering.profile} dryRun=${dryRun} ${steeringPrompt.split("\n")[0]} stored=${result.stored}`,
+        detail: `steering=${steering.profile} dryRun=${dryRun} attached=${sessionIds.length} scanned=${result.sessionsScanned} ${steeringPrompt.split("\n")[0]} stored=${result.stored} proposed=${candidates.length}`,
+        candidates,
       };
     };
   }
 
   if (m.runSelfCorrectionRun) {
-    runners["self-correction"] = async ({ dryRun, steering }) => {
-      const result = await m.runSelfCorrectionRun!({ dryRun: true, applyTools: false });
+    runners["self-correction"] = async ({ dryRun, steering, sessionIds, dreamRunId }) => {
+      const result = await m.runSelfCorrectionRun!({
+        dryRun: true,
+        applyTools: false,
+        sessionIds,
+        days: 7,
+      });
+      const candidates = selfCorrectionProposalsToCandidates({
+        proposals: result.extracted ?? [],
+        sessionIds,
+        dreamRunId,
+      });
       return {
-        detail: `steering=${steering.profile} dryRun=${dryRun} ${formatSteeringPromptBlock(steering).split("\n")[0]} ${JSON.stringify(result ?? "self-correction done")}`,
+        detail: `steering=${steering.profile} dryRun=${dryRun} attached=${sessionIds.length} proposed=${candidates.length} analysed=${result.analysed} ${formatSteeringPromptBlock(steering).split("\n")[0]}`,
+        candidates,
       };
     };
   }
 
-  if (m.runContradictionCandidates || m.runResolveContradictionsAuto) {
-    runners.contradictions = async ({ dryRun, steering }) => {
+  if (m.runContradictionCandidates || m.runResolveContradictionsDryRun || m.runResolveContradictionsAuto) {
+    runners.contradictions = async ({ dryRun, steering, sessionIds, dreamRunId }) => {
       const parts: string[] = [`steering=${steering.profile}`];
       if (m.runContradictionCandidates) {
-        const c = await m.runContradictionCandidates({ dryRun });
-        parts.push(`candidates=${JSON.stringify(c)}`);
+        const c = await m.runContradictionCandidates({ dryRun: true });
+        parts.push(`candidates_scan=${JSON.stringify(c)}`);
       }
-      if (dryRun) {
-        parts.push("resolve=skipped_dry_run");
-      } else if (m.runResolveContradictionsAuto) {
+      let candidates = undefined;
+      if (m.runResolveContradictionsDryRun) {
+        const dry = await m.runResolveContradictionsDryRun();
+        const proposals = pinContradictionResolves(dry.autoResolvable, ctx.factsDb);
+        candidates = contradictionProposalsToCandidates({ proposals, sessionIds, dreamRunId });
+        parts.push(
+          `autoResolvable=${dry.autoResolvable.length} ambiguous=${dry.ambiguous.length} proposed=${candidates.length}`,
+        );
+      } else if (!dryRun && m.runResolveContradictionsAuto) {
         const r = await m.runResolveContradictionsAuto({});
         parts.push(`resolve=${JSON.stringify(r)}`);
+      } else {
+        parts.push("resolve=skipped_no_dry_run_binding");
       }
-      return { detail: parts.join("; ") || "contradictions skipped" };
+      return { detail: parts.join("; ") || "contradictions skipped", candidates };
     };
   }
 
   if (m.runReflection) {
-    runners.reflect = async ({ dryRun, steering }) => {
+    runners.reflect = async ({ dryRun, steering, sessionIds, dreamRunId }) => {
       const steeringPrompt = formatSteeringPromptBlock(steering);
+      const boundary = ctx.dreaming?.permissionBoundary ?? DEFAULT_DREAMING_CONFIG.permissionBoundary;
       const result = await m.runReflection({
         window: 7,
         dryRun,
         model: "",
         verbose: false,
         steeringPrompt,
+        sessionIds,
+      });
+      const candidates = reflectProposalsToCandidates({
+        proposals: (result.patterns ?? []).map((text) => ({ text })),
+        sessionIds,
+        dreamRunId,
+        writeScope: boundary.targetScope,
+        writeScopeTarget:
+          boundary.targetScope === "session" || boundary.targetScope === "agent" || boundary.targetScope === "user"
+            ? (sessionIds[0] ?? null)
+            : null,
       });
       return {
-        detail: `${steeringPrompt.split("\n")[0]} ${JSON.stringify(result)}`,
+        detail: `${steeringPrompt.split("\n")[0]} attached=${sessionIds.length} patterns=${result.patternsStored} proposed=${candidates.length} ${JSON.stringify({ ...result, patterns: undefined })}`,
+        candidates,
       };
     };
   }
 
   if (m.runConsolidate) {
-    runners.consolidate = async ({ dryRun, steering }) => {
+    runners.consolidate = async ({ dryRun, steering, sessionIds, dreamRunId }) => {
       const result = await m.runConsolidate({
         threshold: 0.92,
         limit: 10,
@@ -130,8 +188,36 @@ function buildStepRunners(ctx: DreamCliContext): DreamStepRunners {
         includeStructured: true,
         model: "",
       });
+      const proposals = (result.previews ?? []).map((p) => {
+        const sourcePreHashes: Record<string, string> = {};
+        for (const id of p.memberIds) {
+          try {
+            const token = ctx.factsDb.getOccToken(id);
+            if (token) sourcePreHashes[id] = token;
+          } catch {
+            // Skip OCC pin if fact vanished between propose-time reads.
+          }
+        }
+        return {
+          sourceFactIds: p.memberIds,
+          mergedText: p.mergedText,
+          category: p.category,
+          entity: p.entity,
+          key: p.key,
+          value: p.value,
+          scope: p.scope,
+          scopeTarget: p.scopeTarget,
+          sourcePreHashes,
+        };
+      });
+      const candidates = consolidateProposalsToCandidates({
+        proposals,
+        sessionIds,
+        dreamRunId,
+      });
       return {
-        detail: `steering=${steering.profile} ${formatSteeringPromptBlock(steering).split("\n")[0]} ${JSON.stringify(result)}`,
+        detail: `steering=${steering.profile} ${formatSteeringPromptBlock(steering).split("\n")[0]} merged=${result.merged} proposed=${candidates.length}`,
+        candidates,
       };
     };
   }
@@ -325,6 +411,38 @@ export function registerDreamGroup(mem: Chainable, ctx: DreamCliContext): void {
         db: ctx.factsDb.getRawDb(),
       });
       printJson(report);
+    });
+
+  (group.command("validate-shadow") as ArgumentChainable)
+    .description(
+      "Evaluate shadow ROI criteria required before autoPromote apply (#2179). Exit 0=pass, 1=fail.",
+    )
+    .option("--since-days <n>", "Lookback days (default: autoPromote.shadowValidation.lookbackDays)")
+    .option("--json", "Machine-readable JSON")
+    .action((opts: { sinceDays?: string; json?: boolean }) => {
+      const store = getStore(ctx.factsDb);
+      const cfg = ctx.dreaming ?? DEFAULT_DREAMING_CONFIG;
+      const lookbackDays =
+        opts.sinceDays != null
+          ? Math.max(1, Number.parseInt(opts.sinceDays, 10) || cfg.autoPromote.shadowValidation.lookbackDays)
+          : undefined;
+      const result = evaluateShadowValidationFromStore(store, {
+        thresholds: cfg.autoPromote.shadowValidation,
+        lookbackDays,
+        db: ctx.factsDb.getRawDb(),
+      });
+      printJson({
+        ok: result.ok,
+        reasons: result.reasons,
+        metrics: result.metrics,
+        thresholds: result.thresholds,
+        lookbackDays: result.lookbackDays,
+        autoPromoteEnabled: cfg.autoPromote.enabled,
+        howToRead:
+          "Run shadow dreams (candidateStore.shadow=true, autoPromote.enabled=false) until validate-shadow exits 0. " +
+          "Then set candidateStore.shadow=false and autoPromote.enabled=true. Promote --force bypasses this gate.",
+      });
+      if (!result.ok) process.exitCode = 1;
     });
 
   (group.command("observe") as ArgumentChainable)

--- a/extensions/memory-hybrid/cli/commands/register-dream-group.ts
+++ b/extensions/memory-hybrid/cli/commands/register-dream-group.ts
@@ -14,6 +14,7 @@ import { type DreamStepRunners, runDream } from "../../services/dream-run.js";
 import { selectDreamSessions } from "../../services/dream-permission.js";
 import { buildDreamRoiReport } from "../../services/dream-roi.js";
 import { evaluateDreamOutcome } from "../../services/dream-outcome.js";
+import { collectDreamMetricSet } from "../../services/dream-metrics.js";
 import { probeDreamOutcomes } from "../../services/dream-outcome-probe.js";
 import { formatSteeringPromptBlock } from "../../services/dream-steering.js";
 import type { ManageContext } from "../context.js";
@@ -325,43 +326,79 @@ export function registerDreamGroup(mem: Chainable, ctx: DreamCliContext): void {
 
   (group.command("observe") as ArgumentChainable)
     .description("Evaluate post-promote outcomes and optionally auto-rollback (#2173)")
-    .argument("<id>", "Dream run id")
-    .option("--effect-score <n>", "Observed effect score 0..1", "0")
-    .option("--success-rate <n>", "Observed success rate 0..1", "0")
-    .option("--retry-rate <n>", "Observed retry rate", "0")
-    .option("--sessions <n>", "Sessions observed in window", "0")
+    .argument("[id]", "Dream run id (omit with --all to probe elapsed windows)")
+    .option("--all", "Probe all promoted runs whose observe window has elapsed")
+    .option("--effect-score <n>", "Override observed effect score (manual; skips auto-collect)")
+    .option("--success-rate <n>", "Override observed success rate 0..1")
+    .option("--retry-rate <n>", "Override observed retry rate")
+    .option("--sessions <n>", "Override sessions observed in window")
     .option("--apply", "Apply rollback when regression detected and autoRollback.enabled")
+    .option("--force", "Include runs still inside the observe window")
     .option("--json", "Machine-readable JSON")
     .action(
       (
-        id: string,
+        id: string | undefined,
         opts: {
+          all?: boolean;
           effectScore?: string;
           successRate?: string;
           retryRate?: string;
           sessions?: string;
           apply?: boolean;
+          force?: boolean;
           json?: boolean;
         },
       ) => {
         const store = getStore(ctx.factsDb);
         const cfg = ctx.dreaming ?? DEFAULT_DREAMING_CONFIG;
-        const report = evaluateDreamOutcome(
-          ctx.factsDb,
-          store,
-          id,
-          {
-            effectScore: Number.parseFloat(opts.effectScore ?? "0") || 0,
-            successRate: Number.parseFloat(opts.successRate ?? "0") || 0,
-            retryRate: Number.parseFloat(opts.retryRate ?? "0") || 0,
-            sessionsObserved: Number.parseInt(opts.sessions ?? "0", 10) || 0,
-          },
-          {
+
+        if (opts.all || !id) {
+          if (!opts.all && !id) {
+            process.stderr.write("dream observe: pass <id> or --all\n");
+            process.exitCode = 1;
+            return;
+          }
+          const probe = probeDreamOutcomes(ctx.factsDb, store, {
             cfg,
             applyRollback: opts.apply === true,
-            minSessions: 3,
-          },
-        );
+            force: opts.force === true,
+            limit: 50,
+          });
+          printJson(probe);
+          return;
+        }
+
+        const run = store.getDreamRun(id);
+        if (!run) {
+          process.stderr.write(`dream observe: run not found: ${id}\n`);
+          process.exitCode = 1;
+          return;
+        }
+
+        const hasManual =
+          opts.effectScore != null ||
+          opts.successRate != null ||
+          opts.retryRate != null ||
+          opts.sessions != null;
+
+        const after = hasManual
+          ? {
+              effectScore: Number.parseFloat(opts.effectScore ?? "0") || 0,
+              successRate: Number.parseFloat(opts.successRate ?? "0") || 0,
+              retryRate: Number.parseFloat(opts.retryRate ?? "0") || 0,
+              sessionsObserved: Number.parseInt(opts.sessions ?? "0", 10) || 0,
+            }
+          : collectDreamMetricSet(ctx.factsDb, {
+              fromSec: run.promotedAt ?? run.createdAt,
+              toSec: Math.floor(Date.now() / 1000),
+              sessionIds: run.sessionIds,
+            });
+
+        const report = evaluateDreamOutcome(ctx.factsDb, store, id, after, {
+          cfg,
+          applyRollback: opts.apply === true,
+          minSessions: 3,
+        });
         printJson(report);
         if (report.decision === "rollback" && opts.apply && !report.rollback?.rolledBack) {
           process.exitCode = 1;

--- a/extensions/memory-hybrid/cli/commands/register-dream-group.ts
+++ b/extensions/memory-hybrid/cli/commands/register-dream-group.ts
@@ -82,19 +82,27 @@ export function buildStepRunners(ctx: DreamCliContext): DreamStepRunners {
   if (m.runDistill) {
     runners.distill = async ({ dryRun, steering, sessionIds, dreamRunId }) => {
       const steeringPrompt = formatSteeringPromptBlock(steering);
-      // Always pass sessionIds (possibly empty) so distill never scoops an unrestricted window (#2174).
+      if (sessionIds.length === 0) {
+        return {
+          detail: `steering=${steering.profile} skipped_no_attached_sessions`,
+          candidates: [],
+        };
+      }
       const result = await m.runDistill!(
         {
           days: 7,
           dryRun,
           steeringPrompt,
           sessionIds,
-          ...(sessionIds.length > 0 ? { maxSessions: sessionIds.length } : {}),
+          maxSessions: sessionIds.length,
         },
         sink,
       );
       const candidates = distillProposalsToCandidates({
-        proposals: result.extracted ?? [],
+        proposals: (result.extracted ?? []).map((f) => ({
+          ...f,
+          sourceSessionId: f.sourceSessionId ?? null,
+        })),
         sessionIds,
         dreamRunId,
       });
@@ -107,6 +115,12 @@ export function buildStepRunners(ctx: DreamCliContext): DreamStepRunners {
 
   if (m.runSelfCorrectionRun) {
     runners["self-correction"] = async ({ dryRun, steering, sessionIds, dreamRunId }) => {
+      if (sessionIds.length === 0) {
+        return {
+          detail: `steering=${steering.profile} skipped_no_attached_sessions`,
+          candidates: [],
+        };
+      }
       const result = await m.runSelfCorrectionRun!({
         dryRun: true,
         applyTools: false,
@@ -127,6 +141,9 @@ export function buildStepRunners(ctx: DreamCliContext): DreamStepRunners {
 
   if (m.runContradictionCandidates || m.runResolveContradictionsDryRun || m.runResolveContradictionsAuto) {
     runners.contradictions = async ({ dryRun, steering, sessionIds, dreamRunId }) => {
+      if (sessionIds.length === 0) {
+        return { detail: `steering=${steering.profile} skipped_no_attached_sessions`, candidates: [] };
+      }
       const parts: string[] = [`steering=${steering.profile}`];
       if (m.runContradictionCandidates) {
         const c = await m.runContradictionCandidates({ dryRun: true });
@@ -154,6 +171,12 @@ export function buildStepRunners(ctx: DreamCliContext): DreamStepRunners {
     runners.reflect = async ({ dryRun, steering, sessionIds, dreamRunId }) => {
       const steeringPrompt = formatSteeringPromptBlock(steering);
       const boundary = ctx.dreaming?.permissionBoundary ?? DEFAULT_DREAMING_CONFIG.permissionBoundary;
+      if (sessionIds.length === 0 && boundary.enforce && !boundary.personalMode) {
+        return {
+          detail: `${steeringPrompt.split("\n")[0]} skipped_no_attached_sessions`,
+          candidates: [],
+        };
+      }
       const result = await m.runReflection({
         window: 7,
         dryRun,
@@ -168,9 +191,11 @@ export function buildStepRunners(ctx: DreamCliContext): DreamStepRunners {
         dreamRunId,
         writeScope: boundary.targetScope,
         writeScopeTarget:
-          boundary.targetScope === "session" || boundary.targetScope === "agent" || boundary.targetScope === "user"
-            ? (sessionIds[0] ?? null)
-            : null,
+          boundary.targetScope === "session" && sessionIds.length === 1
+            ? sessionIds[0]!
+            : boundary.targetScope === "agent" || boundary.targetScope === "user"
+              ? (sessionIds[0] ?? "dream-multi")
+              : null,
       });
       return {
         detail: `${steeringPrompt.split("\n")[0]} attached=${sessionIds.length} patterns=${result.patternsStored} proposed=${candidates.length} ${JSON.stringify({ ...result, patterns: undefined })}`,
@@ -181,6 +206,12 @@ export function buildStepRunners(ctx: DreamCliContext): DreamStepRunners {
 
   if (m.runConsolidate) {
     runners.consolidate = async ({ dryRun, steering, sessionIds, dreamRunId }) => {
+      if (sessionIds.length === 0) {
+        return {
+          detail: `steering=${steering.profile} skipped_no_attached_sessions`,
+          candidates: [],
+        };
+      }
       const result = await m.runConsolidate({
         threshold: 0.92,
         limit: 10,
@@ -188,12 +219,20 @@ export function buildStepRunners(ctx: DreamCliContext): DreamStepRunners {
         includeStructured: true,
         model: "",
       });
+      const sourceProvenanceByFactId: Record<string, string[]> = {};
       const proposals = (result.previews ?? []).map((p) => {
         const sourcePreHashes: Record<string, string> = {};
         for (const id of p.memberIds) {
           try {
             const token = ctx.factsDb.getOccToken(id);
             if (token) sourcePreHashes[id] = token;
+            const fact = ctx.factsDb.getById(id);
+            if (fact) {
+              const prov: string[] = [];
+              if (fact.provenanceSession) prov.push(fact.provenanceSession);
+              if (fact.scope === "session" && fact.scopeTarget) prov.push(fact.scopeTarget);
+              sourceProvenanceByFactId[id] = [...new Set(prov)];
+            }
           } catch {
             // Skip OCC pin if fact vanished between propose-time reads.
           }
@@ -214,6 +253,7 @@ export function buildStepRunners(ctx: DreamCliContext): DreamStepRunners {
         proposals,
         sessionIds,
         dreamRunId,
+        sourceProvenanceByFactId,
       });
       return {
         detail: `steering=${steering.profile} ${formatSteeringPromptBlock(steering).split("\n")[0]} merged=${result.merged} proposed=${candidates.length}`,

--- a/extensions/memory-hybrid/cli/context.ts
+++ b/extensions/memory-hybrid/cli/context.ts
@@ -134,7 +134,13 @@ export type ManageContext = {
     skipped?: boolean;
     skipReason?: string;
   }>;
-  runReflection: (opts: { window: number; dryRun: boolean; model: string; verbose?: boolean }) => Promise<{
+  runReflection: (opts: {
+    window: number;
+    dryRun: boolean;
+    model: string;
+    verbose?: boolean;
+    steeringPrompt?: string;
+  }) => Promise<{
     factsAnalyzed: number;
     patternsExtracted: number;
     patternsStored: number;
@@ -197,7 +203,7 @@ export type ManageContext = {
     apply?: boolean;
   }>;
   runDistill?: (
-    opts: { dryRun: boolean; days?: number; verbose?: boolean },
+    opts: { dryRun: boolean; days?: number; verbose?: boolean; steeringPrompt?: string },
     sink: { log: (s: string) => void; warn: (s: string) => void },
   ) => Promise<{
     stored: number;

--- a/extensions/memory-hybrid/cli/context.ts
+++ b/extensions/memory-hybrid/cli/context.ts
@@ -133,6 +133,7 @@ export type ManageContext = {
     semanticOutcome?: string;
     skipped?: boolean;
     skipReason?: string;
+    previews?: import("../services/consolidation.js").ConsolidateClusterPreview[];
   }>;
   runReflection: (opts: {
     window: number;
@@ -140,12 +141,15 @@ export type ManageContext = {
     model: string;
     verbose?: boolean;
     steeringPrompt?: string;
+    /** Dream attachment allowlist (#2174). */
+    sessionIds?: string[];
   }) => Promise<{
     factsAnalyzed: number;
     patternsExtracted: number;
     patternsStored: number;
     window: number;
     semanticOutcome?: string;
+    patterns?: string[];
   }>;
   runReflectionRules: (opts: {
     dryRun: boolean;
@@ -203,7 +207,15 @@ export type ManageContext = {
     apply?: boolean;
   }>;
   runDistill?: (
-    opts: { dryRun: boolean; days?: number; verbose?: boolean; steeringPrompt?: string },
+    opts: {
+      dryRun: boolean;
+      days?: number;
+      verbose?: boolean;
+      steeringPrompt?: string;
+      /** When set (including empty), restrict distill to these session ids (#2174). */
+      sessionIds?: string[];
+      maxSessions?: number;
+    },
     sink: { log: (s: string) => void; warn: (s: string) => void },
   ) => Promise<{
     stored: number;
@@ -216,6 +228,7 @@ export type ManageContext = {
     batchFailureReason?: string;
     jobRunId?: string;
     semanticOutcome?: string;
+    extracted?: import("./types.js").DistillExtractedPreview[];
   }>;
   runRecordDistill?: () => Promise<unknown>;
   runExtractProcedures?: (opts: {
@@ -292,6 +305,8 @@ export type ManageContext = {
     applyTools?: boolean;
     full?: boolean;
     verbose?: boolean;
+    /** Dream attachment allowlist (#2174); empty = scan none. */
+    sessionIds?: string[];
   }) => Promise<SelfCorrectionRunResult>;
   runExport: (opts: {
     outputPath: string;

--- a/extensions/memory-hybrid/cli/distill.ts
+++ b/extensions/memory-hybrid/cli/distill.ts
@@ -59,6 +59,7 @@ export type DistillContext = {
       maxSessionTokens?: number;
       full?: boolean;
       force?: boolean;
+      sessionIds?: string[];
     },
     sink: DistillCliSink,
   ) => Promise<DistillCliResult>;

--- a/extensions/memory-hybrid/cli/register.ts
+++ b/extensions/memory-hybrid/cli/register.ts
@@ -171,6 +171,7 @@ export type HybridMemCliContext = {
       maxSessions?: number;
       maxSessionTokens?: number;
       full?: boolean;
+      steeringPrompt?: string;
     },
     sink: DistillCliSink,
   ) => Promise<DistillCliResult>;
@@ -246,7 +247,13 @@ export type HybridMemCliContext = {
     limit: number;
     model: string;
   }) => Promise<{ clustersFound: number; merged: number; deleted: number }>;
-  runReflection: (opts: { window: number; dryRun: boolean; model: string; verbose?: boolean }) => Promise<{
+  runReflection: (opts: {
+    window: number;
+    dryRun: boolean;
+    model: string;
+    verbose?: boolean;
+    steeringPrompt?: string;
+  }) => Promise<{
     factsAnalyzed: number;
     patternsExtracted: number;
     patternsStored: number;

--- a/extensions/memory-hybrid/cli/register.ts
+++ b/extensions/memory-hybrid/cli/register.ts
@@ -171,7 +171,10 @@ export type HybridMemCliContext = {
       maxSessions?: number;
       maxSessionTokens?: number;
       full?: boolean;
+      force?: boolean;
       steeringPrompt?: string;
+      /** Dream attachment allowlist (#2174); empty = process none. */
+      sessionIds?: string[];
     },
     sink: DistillCliSink,
   ) => Promise<DistillCliResult>;
@@ -253,6 +256,7 @@ export type HybridMemCliContext = {
     model: string;
     verbose?: boolean;
     steeringPrompt?: string;
+    sessionIds?: string[];
   }) => Promise<{
     factsAnalyzed: number;
     patternsExtracted: number;
@@ -392,6 +396,8 @@ export type HybridMemCliContext = {
     applyTools?: boolean;
     full?: boolean;
     verbose?: boolean;
+    /** Dream attachment allowlist (#2174); empty = scan none. */
+    sessionIds?: string[];
   }) => Promise<SelfCorrectionRunResult>;
   runAnalyzeFeedbackPhrases: (opts: {
     days?: number;

--- a/extensions/memory-hybrid/cli/types.ts
+++ b/extensions/memory-hybrid/cli/types.ts
@@ -234,12 +234,25 @@ export type IngestFilesSink = {
   warn: (s: string) => void;
 };
 
+/** Parsed distill fact preview (dry-run) for Dream compose (#2170). */
+export type DistillExtractedPreview = {
+  category: string;
+  text: string;
+  entity?: string | null;
+  key?: string | null;
+  value?: string | null;
+  source_date?: string | null;
+  tags?: string[];
+};
+
 export type DistillCliResult = {
   sessionsScanned: number;
   factsExtracted: number;
   stored: number;
   dedupSkipped: number;
   dryRun: boolean;
+  /** Dry-run only: fact bodies for Dream candidate emission (#2170). */
+  extracted?: DistillExtractedPreview[];
   skipped?: boolean;
   semanticEmpty?: boolean;
   partialFailure?: boolean;
@@ -311,6 +324,15 @@ export type SelfCorrectionRunResult = {
   jobRunId?: string;
   /** Unified semantic outcome from JobRun framework. */
   semanticOutcome?: string;
+  /** Dry-run only: MEMORY_STORE bodies for Dream candidate emission (#2170). */
+  extracted?: Array<{
+    text: string;
+    category: string;
+    entity?: string | null;
+    key?: string | null;
+    value?: string | null;
+    tags?: string[];
+  }>;
 };
 
 export type AnalyzeFeedbackPhrasesResult = {

--- a/extensions/memory-hybrid/cli/types.ts
+++ b/extensions/memory-hybrid/cli/types.ts
@@ -243,6 +243,8 @@ export type DistillExtractedPreview = {
   value?: string | null;
   source_date?: string | null;
   tags?: string[];
+  /** Basename stem of the session JSONL that produced this fact (#2174). */
+  sourceSessionId?: string | null;
 };
 
 export type DistillCliResult = {

--- a/extensions/memory-hybrid/cli/types.ts
+++ b/extensions/memory-hybrid/cli/types.ts
@@ -334,6 +334,7 @@ export type SelfCorrectionRunResult = {
     key?: string | null;
     value?: string | null;
     tags?: string[];
+    sourceSessionId?: string | null;
   }>;
 };
 

--- a/extensions/memory-hybrid/config/parsers/dreaming.ts
+++ b/extensions/memory-hybrid/config/parsers/dreaming.ts
@@ -42,15 +42,10 @@ function parseTier(raw: unknown, fallback: DreamingPrevalenceTier): DreamingPrev
   const r = asRecord(raw);
   if (!r) return { ...fallback };
   const minSessions =
-    typeof r.minSessions === "number" && r.minSessions >= 0
-      ? Math.floor(r.minSessions)
-      : fallback.minSessions;
-  const minAgents =
-    typeof r.minAgents === "number" && r.minAgents >= 0 ? Math.floor(r.minAgents) : fallback.minAgents;
+    typeof r.minSessions === "number" && r.minSessions >= 0 ? Math.floor(r.minSessions) : fallback.minSessions;
+  const minAgents = typeof r.minAgents === "number" && r.minAgents >= 0 ? Math.floor(r.minAgents) : fallback.minAgents;
   const minConfidence =
-    typeof r.minConfidence === "number" && Number.isFinite(r.minConfidence)
-      ? r.minConfidence
-      : fallback.minConfidence;
+    typeof r.minConfidence === "number" && Number.isFinite(r.minConfidence) ? r.minConfidence : fallback.minConfidence;
   return { minSessions, minAgents, ...(minConfidence != null ? { minConfidence } : {}) };
 }
 

--- a/extensions/memory-hybrid/config/parsers/dreaming.ts
+++ b/extensions/memory-hybrid/config/parsers/dreaming.ts
@@ -1,0 +1,160 @@
+/**
+ * Parse `dreaming` config (#2170–#2177). Opt-in flags use `=== true`; shadow defaults on when enabled.
+ */
+
+import {
+  DEFAULT_DREAM_COMPOSE,
+  DEFAULT_DREAMING_CONFIG,
+  type DreamComposeStep,
+  type DreamingConfig,
+  type DreamingMode,
+  type DreamingPrevalenceTier,
+  type DreamSteeringConfig,
+} from "../types/dreaming.js";
+
+const COMPOSE_STEPS = new Set<DreamComposeStep>([
+  "distill",
+  "self-correction",
+  "reflect",
+  "consolidate",
+  "contradictions",
+  "dream-cycle-core",
+]);
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function parseCompose(raw: unknown): DreamComposeStep[] {
+  if (!Array.isArray(raw)) return [...DEFAULT_DREAM_COMPOSE];
+  const out: DreamComposeStep[] = [];
+  for (const item of raw) {
+    if (typeof item === "string" && COMPOSE_STEPS.has(item as DreamComposeStep)) {
+      out.push(item as DreamComposeStep);
+    }
+  }
+  return out.length > 0 ? out : [...DEFAULT_DREAM_COMPOSE];
+}
+
+function parseTier(raw: unknown, fallback: DreamingPrevalenceTier): DreamingPrevalenceTier {
+  const r = asRecord(raw);
+  if (!r) return { ...fallback };
+  const minSessions =
+    typeof r.minSessions === "number" && r.minSessions >= 0
+      ? Math.floor(r.minSessions)
+      : fallback.minSessions;
+  const minAgents =
+    typeof r.minAgents === "number" && r.minAgents >= 0 ? Math.floor(r.minAgents) : fallback.minAgents;
+  const minConfidence =
+    typeof r.minConfidence === "number" && Number.isFinite(r.minConfidence)
+      ? r.minConfidence
+      : fallback.minConfidence;
+  return { minSessions, minAgents, ...(minConfidence != null ? { minConfidence } : {}) };
+}
+
+function parseStringList(raw: unknown, fallback: string[]): string[] {
+  if (!Array.isArray(raw)) return [...fallback];
+  return raw.filter((x): x is string => typeof x === "string" && x.trim().length > 0);
+}
+
+export function parseDreamingConfig(cfg: Record<string, unknown>): DreamingConfig {
+  const raw = asRecord(cfg.dreaming);
+  if (!raw) return structuredClone(DEFAULT_DREAMING_CONFIG);
+
+  const candidateRaw = asRecord(raw.candidateStore);
+  const autoPromoteRaw = asRecord(raw.autoPromote);
+  const autoRollbackRaw = asRecord(raw.autoRollback);
+  const prevalenceRaw = asRecord(raw.prevalence);
+  const permissionRaw = asRecord(raw.permissionBoundary);
+  const steeringRaw = asRecord(raw.steering);
+
+  const candidateEnabled = candidateRaw?.enabled === true;
+  const shadow =
+    candidateRaw?.shadow === false
+      ? false
+      : candidateRaw?.shadow === true
+        ? true
+        : DEFAULT_DREAMING_CONFIG.candidateStore.shadow;
+
+  const observeWindowHours =
+    typeof autoRollbackRaw?.observeWindowHours === "number" && autoRollbackRaw.observeWindowHours > 0
+      ? Math.floor(autoRollbackRaw.observeWindowHours)
+      : DEFAULT_DREAMING_CONFIG.autoRollback.observeWindowHours;
+
+  const regressionThreshold =
+    typeof autoRollbackRaw?.regressionThreshold === "number" &&
+    Number.isFinite(autoRollbackRaw.regressionThreshold) &&
+    autoRollbackRaw.regressionThreshold >= 0
+      ? autoRollbackRaw.regressionThreshold
+      : DEFAULT_DREAMING_CONFIG.autoRollback.regressionThreshold;
+
+  const maxSessionsRaw = typeof raw.maxSessions === "number" ? raw.maxSessions : DEFAULT_DREAMING_CONFIG.maxSessions;
+  const maxSessions = Math.max(1, Math.min(100, Math.floor(maxSessionsRaw)));
+
+  const maxRuntimeRaw =
+    typeof raw.maxRuntimeMinutes === "number" ? raw.maxRuntimeMinutes : DEFAULT_DREAMING_CONFIG.maxRuntimeMinutes;
+  const maxRuntimeMinutes = Math.max(1, Math.min(240, Math.floor(maxRuntimeRaw)));
+
+  const modeRaw = raw.mode;
+  const mode: DreamingMode =
+    modeRaw === "supervised" || modeRaw === "autonomous" ? modeRaw : DEFAULT_DREAMING_CONFIG.mode;
+
+  const targetScopeRaw = permissionRaw?.targetScope;
+  const targetScope =
+    targetScopeRaw === "session" ||
+    targetScopeRaw === "agent" ||
+    targetScopeRaw === "user" ||
+    targetScopeRaw === "global"
+      ? targetScopeRaw
+      : DEFAULT_DREAMING_CONFIG.permissionBoundary.targetScope;
+
+  const profileRaw = steeringRaw?.profile;
+  const profile: DreamSteeringConfig["profile"] =
+    profileRaw === "personal" || profileRaw === "coding" || profileRaw === "ops" || profileRaw === "custom"
+      ? profileRaw
+      : DEFAULT_DREAMING_CONFIG.steering.profile;
+
+  return {
+    enabled: raw.enabled === true,
+    mode,
+    compose: parseCompose(raw.compose),
+    maxSessions,
+    maxRuntimeMinutes,
+    skipNightlyOverlap: raw.skipNightlyOverlap !== false,
+    promoteAfterRun: raw.promoteAfterRun === true,
+    candidateStore: {
+      enabled: candidateEnabled,
+      shadow,
+    },
+    autoPromote: {
+      enabled: autoPromoteRaw?.enabled === true,
+      requireProvenance: autoPromoteRaw?.requireProvenance !== false,
+      blockOnContradictionWorsening: autoPromoteRaw?.blockOnContradictionWorsening !== false,
+    },
+    autoRollback: {
+      enabled: autoRollbackRaw?.enabled === true,
+      observeWindowHours,
+      regressionThreshold,
+    },
+    prevalence: {
+      session: parseTier(prevalenceRaw?.session, DEFAULT_DREAMING_CONFIG.prevalence.session),
+      agent: parseTier(prevalenceRaw?.agent, DEFAULT_DREAMING_CONFIG.prevalence.agent),
+      user: parseTier(prevalenceRaw?.user, DEFAULT_DREAMING_CONFIG.prevalence.user),
+      global: parseTier(prevalenceRaw?.global, DEFAULT_DREAMING_CONFIG.prevalence.global),
+      personalSingleTenant: prevalenceRaw?.personalSingleTenant === true,
+    },
+    permissionBoundary: {
+      targetScope,
+      enforce: permissionRaw?.enforce !== false,
+      personalMode: permissionRaw?.personalMode === true,
+    },
+    steering: {
+      profile,
+      promote: parseStringList(steeringRaw?.promote, DEFAULT_DREAMING_CONFIG.steering.promote),
+      ignore: parseStringList(steeringRaw?.ignore, DEFAULT_DREAMING_CONFIG.steering.ignore),
+      notes: typeof steeringRaw?.notes === "string" ? steeringRaw.notes : undefined,
+    },
+  };
+}

--- a/extensions/memory-hybrid/config/parsers/dreaming.ts
+++ b/extensions/memory-hybrid/config/parsers/dreaming.ts
@@ -117,7 +117,7 @@ export function parseDreamingConfig(cfg: Record<string, unknown>): DreamingConfi
     compose: parseCompose(raw.compose),
     maxSessions,
     maxRuntimeMinutes,
-    skipNightlyOverlap: raw.skipNightlyOverlap !== false,
+    skipNightlyOverlap: raw.skipNightlyOverlap === true,
     promoteAfterRun: raw.promoteAfterRun === true,
     candidateStore: {
       enabled: candidateEnabled,

--- a/extensions/memory-hybrid/config/parsers/dreaming.ts
+++ b/extensions/memory-hybrid/config/parsers/dreaming.ts
@@ -127,6 +127,23 @@ export function parseDreamingConfig(cfg: Record<string, unknown>): DreamingConfi
       enabled: autoPromoteRaw?.enabled === true,
       requireProvenance: autoPromoteRaw?.requireProvenance !== false,
       blockOnContradictionWorsening: autoPromoteRaw?.blockOnContradictionWorsening !== false,
+      shadowValidation: (() => {
+        const sv = asRecord(autoPromoteRaw?.shadowValidation);
+        const d = DEFAULT_DREAMING_CONFIG.autoPromote.shadowValidation;
+        const num = (v: unknown, fallback: number, min = 0, max = 1e9) => {
+          if (typeof v !== "number" || !Number.isFinite(v)) return fallback;
+          return Math.max(min, Math.min(max, v));
+        };
+        return {
+          enabled: sv?.enabled !== false,
+          minShadowRuns: Math.floor(num(sv?.minShadowRuns, d.minShadowRuns, 0, 365)),
+          minWouldPromoteRuns: Math.floor(num(sv?.minWouldPromoteRuns, d.minWouldPromoteRuns, 0, 365)),
+          maxQuarantineRate: num(sv?.maxQuarantineRate, d.maxQuarantineRate, 0, 1),
+          maxFailureRate: num(sv?.maxFailureRate, d.maxFailureRate, 0, 1),
+          maxZeroCandidateRate: num(sv?.maxZeroCandidateRate, d.maxZeroCandidateRate, 0, 1),
+          lookbackDays: Math.floor(num(sv?.lookbackDays, d.lookbackDays, 1, 365)),
+        };
+      })(),
     },
     autoRollback: {
       enabled: autoRollbackRaw?.enabled === true,

--- a/extensions/memory-hybrid/config/parsers/index.ts
+++ b/extensions/memory-hybrid/config/parsers/index.ts
@@ -10,6 +10,7 @@ import {
   parseProceduresConfig,
   parseReflectionConfig,
 } from "./capture.js";
+import { parseDreamingConfig } from "./dreaming.js";
 import {
   DEFAULT_LANCE_PATH,
   DEFAULT_MODEL,
@@ -828,6 +829,7 @@ export function parseConfig(value: unknown): HybridMemoryConfig {
     maintenance: parseMaintenanceConfig(cfg),
     research: parseResearchConfig(cfg),
     nightlyCycle: parseNightlyCycleConfig(cfg),
+    dreaming: parseDreamingConfig(cfg),
     reinforcement: parseReinforcementConfig(cfg),
     clusters: parseClustersConfig(cfg),
     health: parseHealthConfig(cfg),

--- a/extensions/memory-hybrid/config/types/dreaming.ts
+++ b/extensions/memory-hybrid/config/types/dreaming.ts
@@ -31,10 +31,33 @@ export type DreamingAutoPromoteConfig = {
   /** Require session evidence or non-empty rationale. Default: true. */
   requireProvenance: boolean;
   /**
-   * Block promote when a candidate would worsen high-severity unresolved contradictions.
-   * Stub for #2170 (always passes unless an entry opts into `contradictionWorsens`). Default: true.
+   * Block promote when a candidate would worsen high-severity contradictions
+   * against live FactsDB (heuristic score / verified peers / unresolved deletes).
+   * Explicit `payload.contradictionWorsens` still hard-fails. Default: true.
    */
   blockOnContradictionWorsening: boolean;
+  /**
+   * Fail closed: refuse live apply until shadow ROI criteria pass (#2179).
+   * Operators check with `dream validate-shadow`; `--force` bypasses.
+   */
+  shadowValidation: DreamingShadowValidationConfig;
+};
+
+export type DreamingShadowValidationConfig = {
+  /** When true (default), autoPromote apply requires a passing shadow window. */
+  enabled: boolean;
+  /** Minimum shadow dream runs in lookback. Default: 7. */
+  minShadowRuns: number;
+  /** Minimum shadow runs that wouldPromote / gated OK. Default: 3. */
+  minWouldPromoteRuns: number;
+  /** Max quarantined/decided rate. Default: 0.5. */
+  maxQuarantineRate: number;
+  /** Max failed/decided rate. Default: 0.2. */
+  maxFailureRate: number;
+  /** Max share of shadow runs with zero candidates. Default: 0.3. */
+  maxZeroCandidateRate: number;
+  /** Lookback window in days. Default: 30. */
+  lookbackDays: number;
 };
 
 export type DreamingAutoRollbackConfig = {
@@ -53,6 +76,13 @@ export type DreamingPrevalenceTier = {
   /** Optional minimum confidence 0..1 when payload carries confidence. */
   minConfidence?: number;
 };
+
+/**
+ * Absolute heuristic score (0..1) at/above which a promote is treated as
+ * worsening contradictions vs live FactsDB (#2170). Aligns with stacked
+ * negation/numeric/polarity signals in `scoreFactContradiction`.
+ */
+export const DREAM_CONTRADICTION_WORSEN_SCORE = 0.55;
 
 export type DreamingPrevalenceConfig = {
   session: DreamingPrevalenceTier;
@@ -132,6 +162,15 @@ export const DEFAULT_DREAMING_CONFIG: DreamingConfig = {
     enabled: false,
     requireProvenance: true,
     blockOnContradictionWorsening: true,
+    shadowValidation: {
+      enabled: true,
+      minShadowRuns: 7,
+      minWouldPromoteRuns: 3,
+      maxQuarantineRate: 0.5,
+      maxFailureRate: 0.2,
+      maxZeroCandidateRate: 0.3,
+      lookbackDays: 30,
+    },
   },
   autoRollback: {
     enabled: false,
@@ -140,7 +179,7 @@ export const DEFAULT_DREAMING_CONFIG: DreamingConfig = {
   },
   prevalence: {
     session: { minSessions: 1, minAgents: 1 },
-    agent: { minSessions: 1, minAgents: 1 },
+    agent: { minSessions: 2, minAgents: 1 },
     user: { minSessions: 2, minAgents: 1, minConfidence: 0.7 },
     global: { minSessions: 3, minAgents: 2 },
     personalSingleTenant: false,

--- a/extensions/memory-hybrid/config/types/dreaming.ts
+++ b/extensions/memory-hybrid/config/types/dreaming.ts
@@ -114,12 +114,7 @@ export type DreamingConfig = {
   steering: DreamSteeringConfig;
 };
 
-export const DEFAULT_DREAM_COMPOSE: DreamComposeStep[] = [
-  "distill",
-  "contradictions",
-  "reflect",
-  "consolidate",
-];
+export const DEFAULT_DREAM_COMPOSE: DreamComposeStep[] = ["distill", "contradictions", "reflect", "consolidate"];
 
 export const DEFAULT_DREAMING_CONFIG: DreamingConfig = {
   enabled: false,

--- a/extensions/memory-hybrid/config/types/dreaming.ts
+++ b/extensions/memory-hybrid/config/types/dreaming.ts
@@ -151,7 +151,8 @@ export const DEFAULT_DREAMING_CONFIG: DreamingConfig = {
     personalSingleTenant: false,
   },
   permissionBoundary: {
-    targetScope: "global",
+    /** Conservative default: session-scoped dreams; raise explicitly for global curriculum (#2174). */
+    targetScope: "session",
     enforce: true,
     personalMode: false,
   },

--- a/extensions/memory-hybrid/config/types/dreaming.ts
+++ b/extensions/memory-hybrid/config/types/dreaming.ts
@@ -128,7 +128,8 @@ export type DreamingConfig = {
   maxRuntimeMinutes: number;
   /**
    * When Dream is enabled, skip overlapping nightly maintenance steps so Dream owns them.
-   * Default: true.
+   * Default: false (opt-in) — enabling Dream must not silently drop live nightly curation
+   * while shadow/autoPromote are still off.
    */
   skipNightlyOverlap: boolean;
   /**
@@ -152,7 +153,7 @@ export const DEFAULT_DREAMING_CONFIG: DreamingConfig = {
   compose: [...DEFAULT_DREAM_COMPOSE],
   maxSessions: 20,
   maxRuntimeMinutes: 30,
-  skipNightlyOverlap: true,
+  skipNightlyOverlap: false,
   promoteAfterRun: false,
   candidateStore: {
     enabled: false,

--- a/extensions/memory-hybrid/config/types/dreaming.ts
+++ b/extensions/memory-hybrid/config/types/dreaming.ts
@@ -158,8 +158,9 @@ export const DEFAULT_DREAMING_CONFIG: DreamingConfig = {
   },
   steering: {
     profile: "personal",
-    promote: ["preference", "procedure", "tool_failure"],
-    ignore: ["one_off_debug", "transient_path", "secret_like"],
+    // Empty lists → resolveSteering applies STEERING_PROFILES.personal (#2176).
+    promote: [],
+    ignore: [],
     notes: undefined,
   },
 };

--- a/extensions/memory-hybrid/config/types/dreaming.ts
+++ b/extensions/memory-hybrid/config/types/dreaming.ts
@@ -1,0 +1,164 @@
+/**
+ * Autonomous dreaming config (#2170–#2177 / Epic #2169).
+ *
+ * Defaults are conservative: master switch off; candidate store off; shadow on;
+ * auto-promote/rollback off; autonomous mode (machine review is the happy path).
+ */
+
+export type DreamComposeStep =
+  | "distill"
+  | "self-correction"
+  | "reflect"
+  | "consolidate"
+  | "contradictions"
+  | "dream-cycle-core";
+
+export type DreamingMode = "autonomous" | "supervised";
+
+export type DreamingCandidateStoreConfig = {
+  /** Persist candidate entries for dream/curation runs. Default: false. */
+  enabled: boolean;
+  /**
+   * When candidate store is enabled: write candidates + gate decisions without applying
+   * unless autoPromote is also on (or CLI promote --force). Default: true.
+   */
+  shadow: boolean;
+};
+
+export type DreamingAutoPromoteConfig = {
+  /** Apply gated-ok candidates to the live store. Default: false. */
+  enabled: boolean;
+  /** Require session evidence or non-empty rationale. Default: true. */
+  requireProvenance: boolean;
+  /**
+   * Block promote when a candidate would worsen high-severity unresolved contradictions.
+   * Stub for #2170 (always passes unless an entry opts into `contradictionWorsens`). Default: true.
+   */
+  blockOnContradictionWorsening: boolean;
+};
+
+export type DreamingAutoRollbackConfig = {
+  /** Observe post-promote and apply reverse plan on regression. Default: false. */
+  enabled: boolean;
+  /** Observation window hours (for #2173 metrics probe). Default: 24. */
+  observeWindowHours: number;
+  /** Absolute effectScore drop vs baseline to trigger. Default: 0.15. */
+  regressionThreshold: number;
+};
+
+/** Blast-radius / prevalence bars by scope (#2172). */
+export type DreamingPrevalenceTier = {
+  minSessions: number;
+  minAgents: number;
+  /** Optional minimum confidence 0..1 when payload carries confidence. */
+  minConfidence?: number;
+};
+
+export type DreamingPrevalenceConfig = {
+  session: DreamingPrevalenceTier;
+  agent: DreamingPrevalenceTier;
+  user: DreamingPrevalenceTier;
+  global: DreamingPrevalenceTier;
+  /** Single-tenant personal vaults: treat global bar like user (minAgents=1). Default: false. */
+  personalSingleTenant: boolean;
+};
+
+export type DreamPermissionBoundary = {
+  /** Target memory scope for this dream. Default: global. */
+  targetScope: "session" | "agent" | "user" | "global";
+  /**
+   * When true (default), only attach sessions whose effective ACL ⊆ targetScope.
+   * Fail closed: unresolved ACL → exclude.
+   */
+  enforce: boolean;
+  /** Personal vaults may treat most content as one boundary. Default: false. */
+  personalMode: boolean;
+};
+
+export type DreamSteeringConfig = {
+  profile: "personal" | "coding" | "ops" | "custom";
+  promote: string[];
+  ignore: string[];
+  notes?: string;
+};
+
+export type DreamingConfig = {
+  /** Master switch for unified Dream (#2171). Default: false. */
+  enabled: boolean;
+  /**
+   * Product mode (#2177). `autonomous` = machine gates are happy path;
+   * `supervised` = escape-hatch review orientation (still no required human inbox).
+   */
+  mode: DreamingMode;
+  /** Ordered compose stages for `dream run`. */
+  compose: DreamComposeStep[];
+  /** Cap attached session ids (1..100). Default: 20. */
+  maxSessions: number;
+  /** Hard wall-clock ceiling for a Dream run (minutes). Default: 30. */
+  maxRuntimeMinutes: number;
+  /**
+   * When Dream is enabled, skip overlapping nightly maintenance steps so Dream owns them.
+   * Default: true.
+   */
+  skipNightlyOverlap: boolean;
+  /**
+   * After compose, call promote (gates + shadow/apply). Default: false
+   * (follow explicit promote CLI or autoPromote.enabled).
+   */
+  promoteAfterRun: boolean;
+  candidateStore: DreamingCandidateStoreConfig;
+  autoPromote: DreamingAutoPromoteConfig;
+  autoRollback: DreamingAutoRollbackConfig;
+  prevalence: DreamingPrevalenceConfig;
+  permissionBoundary: DreamPermissionBoundary;
+  steering: DreamSteeringConfig;
+};
+
+export const DEFAULT_DREAM_COMPOSE: DreamComposeStep[] = [
+  "distill",
+  "contradictions",
+  "reflect",
+  "consolidate",
+];
+
+export const DEFAULT_DREAMING_CONFIG: DreamingConfig = {
+  enabled: false,
+  mode: "autonomous",
+  compose: [...DEFAULT_DREAM_COMPOSE],
+  maxSessions: 20,
+  maxRuntimeMinutes: 30,
+  skipNightlyOverlap: true,
+  promoteAfterRun: false,
+  candidateStore: {
+    enabled: false,
+    shadow: true,
+  },
+  autoPromote: {
+    enabled: false,
+    requireProvenance: true,
+    blockOnContradictionWorsening: true,
+  },
+  autoRollback: {
+    enabled: false,
+    observeWindowHours: 24,
+    regressionThreshold: 0.15,
+  },
+  prevalence: {
+    session: { minSessions: 1, minAgents: 1 },
+    agent: { minSessions: 1, minAgents: 1 },
+    user: { minSessions: 2, minAgents: 1, minConfidence: 0.7 },
+    global: { minSessions: 3, minAgents: 2 },
+    personalSingleTenant: false,
+  },
+  permissionBoundary: {
+    targetScope: "global",
+    enforce: true,
+    personalMode: false,
+  },
+  steering: {
+    profile: "personal",
+    promote: ["preference", "procedure", "tool_failure"],
+    ignore: ["one_off_debug", "transient_path", "secret_like"],
+    notes: undefined,
+  },
+};

--- a/extensions/memory-hybrid/config/types/index.ts
+++ b/extensions/memory-hybrid/config/types/index.ts
@@ -2,6 +2,7 @@ export * from "./agents.js";
 export * from "./bootstrap.js";
 export * from "./capture.js";
 export * from "./core.js";
+export * from "./dreaming.js";
 export * from "./features.js";
 export * from "./maintenance.js";
 export * from "./research.js";
@@ -24,6 +25,7 @@ import type {
   ReflectionConfig,
 } from "./capture.js";
 import type { DiagnosticsConfig, EventLogConfig, PathConfig, StoreConfig, WALConfig } from "./core.js";
+import type { DreamingConfig } from "./dreaming.js";
 
 import type {
   AliasesConfig,
@@ -917,6 +919,11 @@ export type HybridMemoryConfig = {
   research: ResearchConfig;
   /** Nightly dream cycle: automated prune → consolidate → reflect (Issue #143, default: disabled). */
   nightlyCycle: NightlyCycleConfig;
+  /**
+   * Autonomous dreaming: candidate/shadow store + machine promote/rollback (#2170).
+   * Defaults off / shadow-on — not a human review inbox.
+   */
+  dreaming: DreamingConfig;
   /** Confidence reinforcement on repeated mentions (Issue #147, default: enabled). */
   reinforcement: ReinforcementConfig;
   /** Topic cluster detection: BFS connected-component analysis on memory_links (Issue #146). */

--- a/extensions/memory-hybrid/config/utils.ts
+++ b/extensions/memory-hybrid/config/utils.ts
@@ -1,4 +1,5 @@
 import type { ConfigMode, VerbosityLevel } from "./types/index.js";
+import { DEFAULT_DREAMING_CONFIG } from "./types/dreaming.js";
 
 /** Default categories — can be extended via config.categories */
 export const DEFAULT_MEMORY_CATEGORIES = [
@@ -135,6 +136,7 @@ export const PRESET_OVERRIDES: Record<ConfigMode, Record<string, unknown>> = {
     workflowTracking: { enabled: false },
     selfExtension: { enabled: false },
     crystallization: { enabled: false },
+    dreaming: structuredClone(DEFAULT_DREAMING_CONFIG),
     verification: { enabled: true },
     provenance: { enabled: true },
     aliases: { enabled: false },
@@ -191,6 +193,7 @@ export const PRESET_OVERRIDES: Record<ConfigMode, Record<string, unknown>> = {
     workflowTracking: { enabled: false },
     selfExtension: { enabled: false },
     crystallization: { enabled: false },
+    dreaming: structuredClone(DEFAULT_DREAMING_CONFIG),
     verification: { enabled: false },
     provenance: { enabled: false },
     aliases: { enabled: false },

--- a/extensions/memory-hybrid/docs/AUTONOMOUS-DREAMING.md
+++ b/extensions/memory-hybrid/docs/AUTONOMOUS-DREAMING.md
@@ -217,6 +217,7 @@ openclaw hybrid-mem dream validate-shadow --json
 ```
 
 3. Accumulate nightly `dream-run` (or CLI `dream run --dry-shadow`) for ≥ `shadowValidation.minShadowRuns` days.
+   Nightly `dream-run` **always gates** after compose (shadow when `autoPromote` is off) so runs leave `running` and `validate-shadow` can score `wouldPromote`. With `skipNightlyOverlap: true`, owned live steps are skipped only after that gated dream-run succeeds — do not leave `promoteAfterRun`/`candidateStore` misconfigured expecting live distill to keep running.
 4. `openclaw hybrid-mem dream validate-shadow --json` — exit 0 required.
 5. Only then: `candidateStore.shadow: false` and `autoPromote.enabled: true`.
 

--- a/extensions/memory-hybrid/docs/AUTONOMOUS-DREAMING.md
+++ b/extensions/memory-hybrid/docs/AUTONOMOUS-DREAMING.md
@@ -69,29 +69,31 @@ Existing Dream Cycle, distill, reflection, consolidate, Loom, and Event Bus prod
 ```json5
 {
   dreaming: {
-    enabled: false,                 // unified Dream master switch (#2171)
+    enabled: false,
+    mode: "autonomous",          // #2177 — machine gates are happy path
     compose: ["distill", "contradictions", "reflect", "consolidate"],
     maxSessions: 20,
     maxRuntimeMinutes: 30,
     skipNightlyOverlap: true,
     promoteAfterRun: false,
     candidateStore: {
-      enabled: false,               // opt-in
-      shadow: true                  // gate + would-promote log, no apply
-    },
-    autoPromote: {
       enabled: false,
-      requireProvenance: true,
-      blockOnContradictionWorsening: true
+      shadow: true
     },
-    autoRollback: {
-      enabled: false,
-      observeWindowHours: 24,
-      regressionThreshold: 0.15
-    }
+    autoPromote: { enabled: false, requireProvenance: true, blockOnContradictionWorsening: true },
+    autoRollback: { enabled: false, observeWindowHours: 24, regressionThreshold: 0.15 },
+    prevalence: { /* session/agent/user/global bars — #2172 */ },
+    permissionBoundary: {
+      targetScope: "session",    // raise for global curriculum (#2174)
+      enforce: true,
+      personalMode: false
+    },
+    steering: { profile: "personal", promote: [...], ignore: [...] }
   }
 }
 ```
+
+Compose under candidate/shadow mode runs maintenance stages with **`dryRun: true`** so the live store is unchanged until machine promote.
 
 **Shadow matrix**
 

--- a/extensions/memory-hybrid/docs/AUTONOMOUS-DREAMING.md
+++ b/extensions/memory-hybrid/docs/AUTONOMOUS-DREAMING.md
@@ -199,7 +199,7 @@ openclaw hybrid-mem dream report --since-days 30 --json
 openclaw hybrid-mem dream validate-shadow --json
 ```
 
-## Host rollout (Maeve / Doris)
+## Host rollout
 
 1. Deploy a build that includes Autonomous Dreaming (`dream_runs` / `memory_candidate_entries` schema).
 2. Migrate config from legacy dream-cycle (`frequency` / `phases`) to:
@@ -221,7 +221,7 @@ openclaw hybrid-mem dream validate-shadow --json
 4. `openclaw hybrid-mem dream validate-shadow --json` — exit 0 required.
 5. Only then: `candidateStore.shadow: false` and `autoPromote.enabled: true`.
 
-**Observed 2026-07-23 (re-probed evening):** Maeve (`polly2` / `192.168.1.224`) reachable; extension install still pre-Dream schema (`facts.db` has **no** `dream_runs` / candidate tables); config still legacy `frequency`/`phases` with **no** `autoPromote` (safe — gate cannot fire until deploy + config migration). Doris (`192.168.1.198`) **unreachable** (100% ping loss). Code-side `shadowValidation` + `dream validate-shadow` are ready; host ROI campaign starts only after PR deploy on Maeve.
+After promote is live:
 
 - Inspect / promote / rollback / observe / report via CLI above
 - `dreaming.mode: "supervised"` for operators who want digest-first workflows

--- a/extensions/memory-hybrid/docs/AUTONOMOUS-DREAMING.md
+++ b/extensions/memory-hybrid/docs/AUTONOMOUS-DREAMING.md
@@ -15,6 +15,8 @@ Epic [#2169](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/21
 
 The **candidate store is for autonomous safety**, not a human review inbox. The machine gates, promotes, observes outcomes, and rolls back.
 
+Compose stages under shadow/candidate mode run with `dryRun: true` and must emit **structured proposed ops** (add / merge / delete with OCC `preHash` where applicable). A synthetic curriculum summary is **metrics-only** when stages emit zero proposals — it is never a promoteable candidate.
+
 ## Task path vs Dream path
 
 ```text
@@ -49,7 +51,7 @@ sessions + store snapshot
  ROI report (#2179)
 ```
 
-Existing Dream Cycle, distill, reflection, consolidate, Loom, and Event Bus producers are **composed under Dream**, not deleted. When `dreaming.enabled` and `skipNightlyOverlap` are true, overlapping nightly steps are skipped so Dream owns them.
+Existing Dream Cycle, distill, reflection, consolidate, Loom, and Event Bus producers are **composed under Dream**, not deleted. When `dreaming.enabled` and `skipNightlyOverlap` are true, overlapping nightly steps are skipped **only if** the nightly `dream-run` maintenance step is scheduled (fail closed: otherwise the owned steps still run so curation is not dropped).
 
 There is **no separate Rumination Engine** process ([#2178](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/2178)): Event Bus status lifecycle is advanced by distributed consumers (maintenance + Dream).
 
@@ -64,7 +66,7 @@ Machine gates require evidence before promote. Defaults:
 | user | 2 | 1 |
 | global | 3 | 2 |
 
-Optional `minConfidence` per tier. `personalSingleTenant` lowers the global agent bar to 1. Missing provenance or `contradictionWorsens` blocks promote.
+Optional `minConfidence` per tier. `personalSingleTenant` lowers the global agent bar to 1. Missing provenance or live contradiction-worsening (heuristic / verified peer / unresolved delete) blocks promote.
 
 ## Permission-scoped attachment (#2174)
 
@@ -74,8 +76,12 @@ Optional `minConfidence` per tier. `personalSingleTenant` lowers the global agen
 - More-private content cannot feed a more-public dream (`SCOPE_RANK[source] >= SCOPE_RANK[target]`)
 - Writes cannot exceed the dream target scope
 - `dream run` persists `attachment.excluded[]` (sessionId + reason) on the run metrics; included ids live in `session_ids_json`
+- **Nightly `dream-run`** discovers recent sessions from FactsDB (`provenance_session` / session `scope_target`), then applies the same `selectDreamSessions` filter — it does **not** scoop an empty or unrestricted time window
+- Dream **distill** / **self-correction** compose pass the attached session allowlist (empty → process zero transcripts)
+- Dream **reflect** mines only attached-session facts (`provenance_session` / session `scope_target`); nightly `reflect` remains `globalOnly`
+- ACL resolution never invents `global` from `scope=global` fact writes alone (those only prove the session existed). Transcript found under `agents/<id>/sessions/` floors to **agent**. Explicit `--session-scopes id:global` (or `personalMode`) is required for global attachment.
 
-Example: dream targeting `global` with sessions `{s1:session, s2:global}` attaches only `s2` unless `personalMode: true`.
+Example: dream targeting `global` with sessions `{s1:session, s2:agent}` attaches **neither** unless scopes are explicitly upgraded or `personalMode: true`.
 
 ## Optimistic concurrency (#2175)
 
@@ -93,6 +99,8 @@ After promote ([#2173](https://github.com/markus-lassfolk/openclaw-hybrid-memory
 4. Nightly `dream-outcome-probe` (when autoRollback enabled) collects after-window metrics **scoped to the dream’s sessions**, compares effect score, and **auto-rollbacks** via reverse plan on regression.
 5. Decisions (`keep` / `rollback` / `insufficient_data`) are journaled on `dream_runs.metrics_summary_json`. Insufficient data never false-rollbacks.
 
+**v1 signal note:** Outcome metrics prefer a **blended** signal when `tool_effectiveness` rows exist in the same DB (`signalSource: blended|tool_effectiveness|feedback_proxy`). Otherwise they fall back to **feedback proxies** (self-correction / reinforcement fact counts). Full closed-loop task-success attribution is still a follow-up.
+
 ## How to read Dream ROI
 
 `hybrid-mem dream report --since-days 30 --json` ([#2179](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/2179)):
@@ -106,6 +114,18 @@ After promote ([#2173](https://github.com/markus-lassfolk/openclaw-hybrid-memory
 | `howToRead` | Inline guidance string |
 
 Shadow mode first: compare ROI and rollback rate before turning `autoPromote` on.
+
+```bash
+# Accumulate shadow runs (autoPromote stays false; candidateStore.shadow true)
+openclaw hybrid-mem dream run --dry-shadow --json
+openclaw hybrid-mem dream validate-shadow --json   # exit 1 until criteria pass
+
+# Only after validate-shadow exits 0:
+#   dreaming.candidateStore.shadow: false
+#   dreaming.autoPromote.enabled: true
+```
+
+`autoPromote.shadowValidation` (enabled by default) **refuses live apply** until the lookback window has enough shadow runs with acceptable quarantine/failure/zero-candidate rates. `--force` promote bypasses the gate (escape hatch / canary only).
 
 ## Steering (set-and-forget)
 
@@ -133,7 +153,8 @@ No nightly UI confirmation. Profile id is stored on each `dream_run`.
       enabled: false,
       shadow: true
     },
-    autoPromote: { enabled: false, requireProvenance: true, blockOnContradictionWorsening: true },
+    autoPromote: { enabled: false, requireProvenance: true, blockOnContradictionWorsening: true,
+      shadowValidation: { enabled: true, minShadowRuns: 7, minWouldPromoteRuns: 3 } },
     autoRollback: { enabled: false, observeWindowHours: 24, regressionThreshold: 0.15 },
     prevalence: { /* session/agent/user/global bars — #2172 */ },
     permissionBoundary: {
@@ -175,9 +196,31 @@ openclaw hybrid-mem dream rollback <id>       # escape hatch
 openclaw hybrid-mem dream observe <id>        # auto-collect metrics; --apply to rollback
 openclaw hybrid-mem dream observe --all       # probe elapsed windows
 openclaw hybrid-mem dream report --since-days 30 --json
+openclaw hybrid-mem dream validate-shadow --json
 ```
 
-## Escape hatches (keep)
+## Host rollout (Maeve / Doris)
+
+1. Deploy a build that includes Autonomous Dreaming (`dream_runs` / `memory_candidate_entries` schema).
+2. Migrate config from legacy dream-cycle (`frequency` / `phases`) to:
+
+```json5
+{
+  dreaming: {
+    enabled: true,
+    mode: "autonomous",
+    candidateStore: { enabled: true, shadow: true },
+    autoPromote: { enabled: false },   // keep off until validate-shadow passes
+    autoRollback: { enabled: false },
+  }
+}
+```
+
+3. Accumulate nightly `dream-run` (or CLI `dream run --dry-shadow`) for ≥ `shadowValidation.minShadowRuns` days.
+4. `openclaw hybrid-mem dream validate-shadow --json` — exit 0 required.
+5. Only then: `candidateStore.shadow: false` and `autoPromote.enabled: true`.
+
+**Observed 2026-07-23 (re-probed evening):** Maeve (`polly2` / `192.168.1.224`) reachable; extension install still pre-Dream schema (`facts.db` has **no** `dream_runs` / candidate tables); config still legacy `frequency`/`phases` with **no** `autoPromote` (safe — gate cannot fire until deploy + config migration). Doris (`192.168.1.198`) **unreachable** (100% ping loss). Code-side `shadowValidation` + `dream validate-shadow` are ready; host ROI campaign starts only after PR deploy on Maeve.
 
 - Inspect / promote / rollback / observe / report via CLI above
 - `dreaming.mode: "supervised"` for operators who want digest-first workflows

--- a/extensions/memory-hybrid/docs/AUTONOMOUS-DREAMING.md
+++ b/extensions/memory-hybrid/docs/AUTONOMOUS-DREAMING.md
@@ -58,7 +58,7 @@ There is **no separate Rumination Engine** process ([#2178](https://github.com/m
 After promote ([#2173](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/2173)):
 
 1. Capture a **pre-promote baseline** (session-scoped feedback signals).
-2. Tag applied facts `dream-run:<id>` for attribution.
+2. Tag applied facts `dream-run:<id>` for attribution. While `autoRollback` is enabled, recall mildly **prefers** those tagged facts (canary boost) so post-promote curriculum is exercised.
 3. Observe for `autoRollback.observeWindowHours`.
 4. Nightly `dream-outcome-probe` (when autoRollback enabled) collects after-window metrics **scoped to the dream’s sessions**, compares effect score, and **auto-rollbacks** via reverse plan on regression.
 5. Decisions (`keep` / `rollback` / `insufficient_data`) are journaled on `dream_runs.metrics_summary_json`. Insufficient data never false-rollbacks.

--- a/extensions/memory-hybrid/docs/AUTONOMOUS-DREAMING.md
+++ b/extensions/memory-hybrid/docs/AUTONOMOUS-DREAMING.md
@@ -147,7 +147,7 @@ No nightly UI confirmation. Profile id is stored on each `dream_run`.
     compose: ["distill", "contradictions", "reflect", "consolidate"],
     maxSessions: 20,
     maxRuntimeMinutes: 30,
-    skipNightlyOverlap: true,
+    skipNightlyOverlap: false,   // opt-in: do not drop live nightly until Dream owns promote
     promoteAfterRun: false,
     candidateStore: {
       enabled: false,

--- a/extensions/memory-hybrid/docs/AUTONOMOUS-DREAMING.md
+++ b/extensions/memory-hybrid/docs/AUTONOMOUS-DREAMING.md
@@ -1,0 +1,123 @@
+---
+layout: default
+title: Autonomous Dreaming
+parent: Architecture
+nav_order: 25
+---
+
+# Autonomous Dreaming
+
+Epic [#2169](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/2169). Candidate/shadow store + machine promote/rollback: [#2170](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/2170). Unified Dream: [#2171](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/2171).
+
+## Product intent
+
+The **candidate store is for autonomous safety**, not a human review inbox.
+
+Anthropic-style dreaming architecture (out-of-band curation, candidate memory state, provenance) is useful. Hybrid Memory’s product preference is different: the operator does **not** click Approve/Reject on curriculum changes. The machine must gate, promote, and roll back.
+
+Persona/skill proposal queues remain escape hatches elsewhere. They are **not** the happy path for dream curriculum.
+
+## Task path vs Dream path
+
+```text
+┌─────────────────────────────┐     ┌──────────────────────────────────┐
+│ In-band (task / session)    │     │ Out-of-band Dream (#2171)         │
+│                             │     │                                  │
+│ short-loop capture          │     │ snapshot store_revision          │
+│ memory_store / auto-capture │     │ attach permission-scoped sessions│
+│ immediate FactsDB write     │     │ compose distill→…→consolidate    │
+│                             │     │ emit candidates (#2170)          │
+│                             │     │ machine gates → promote/rollback │
+└─────────────────────────────┘     └──────────────────────────────────┘
+```
+
+Task path learns for *this* session. Dream path spends dedicated maintenance budget (`CostFeature.dream`) to improve curriculum for *future* sessions.
+
+## Control plane
+
+```
+sessions + store snapshot
+        ↓
+   Dream run (#2171)
+        ↓
+ candidate entries (#2170)
+        ↓
+ machine gates (#2172 prevalence / evidence)
+        ↓
+ auto-promote | quarantine  (+ OCC #2175)
+        ↓
+ outcome window (#2173) → auto-rollback if regression
+        ↓
+ ROI report (#2179)
+```
+
+Existing Dream Cycle, distill, reflection, consolidate, Loom, and Event Bus producers are **composed under Dream**, not deleted. When `dreaming.enabled` and `skipNightlyOverlap` are true, overlapping nightly steps are skipped so Dream owns them.
+
+## What lands with #2170 / #2171
+
+| Piece | Role |
+|-------|------|
+| `dream_runs` + `memory_candidate_entries` | Durable proposed-diff + reverse plan in the **facts** SQLite DB |
+| `runDream` / `hybrid-mem dream run` | Unified compose facade → always ≥1 candidate |
+| Status lifecycle | `pending → running → gated → promoted \| quarantined \| failed`; `promoted → rolled_back` |
+| Machine gates | Provenance, contradiction stub, prevalence/blast-radius (#2172) |
+| Promote / rollback | Transactional SQLite apply; reverse plan + `post_hash` drift refuse |
+| OCC | `input_store_revision` / `expectedHash` (#2175) |
+
+## Config (defaults conservative)
+
+```json5
+{
+  dreaming: {
+    enabled: false,                 // unified Dream master switch (#2171)
+    compose: ["distill", "contradictions", "reflect", "consolidate"],
+    maxSessions: 20,
+    maxRuntimeMinutes: 30,
+    skipNightlyOverlap: true,
+    promoteAfterRun: false,
+    candidateStore: {
+      enabled: false,               // opt-in
+      shadow: true                  // gate + would-promote log, no apply
+    },
+    autoPromote: {
+      enabled: false,
+      requireProvenance: true,
+      blockOnContradictionWorsening: true
+    },
+    autoRollback: {
+      enabled: false,
+      observeWindowHours: 24,
+      regressionThreshold: 0.15
+    }
+  }
+}
+```
+
+**Shadow matrix**
+
+| candidateStore | shadow | autoPromote | Behavior |
+|----------------|--------|-------------|----------|
+| off | — | — | Today’s live mutate paths unchanged |
+| on | true | off | Candidates + gates + would-promote; no live apply |
+| on | false | on | Real promote when gates pass |
+| + autoRollback on | — | — | Observe → reverse plan on regression (#2173) |
+
+## CLI
+
+```bash
+openclaw hybrid-mem dream run --json --dry-shadow
+openclaw hybrid-mem dream run --sessions s1,s2 --compose distill,reflect --json
+openclaw hybrid-mem dream status
+openclaw hybrid-mem dream status <id>
+openclaw hybrid-mem dream promote <id>        # machine path; --force under shadow
+openclaw hybrid-mem dream rollback <id>
+```
+
+## Non-goals (sibling issues)
+
+- Blast-radius / prevalence policy depth (#2172)
+- Outcome self-heal metrics (#2173)
+- Permission-scoped transcript attachment (#2174)
+- Steering policy profiles (#2176)
+- Autopilot-first defaults (#2177)
+- Dream ROI report (#2179)

--- a/extensions/memory-hybrid/docs/AUTONOMOUS-DREAMING.md
+++ b/extensions/memory-hybrid/docs/AUTONOMOUS-DREAMING.md
@@ -53,6 +53,36 @@ Existing Dream Cycle, distill, reflection, consolidate, Loom, and Event Bus prod
 
 There is **no separate Rumination Engine** process ([#2178](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/2178)): Event Bus status lifecycle is advanced by distributed consumers (maintenance + Dream).
 
+## Blast-radius / prevalence (#2172)
+
+Machine gates require evidence before promote. Defaults:
+
+| Scope | minSessions | minAgents |
+|-------|-------------|-----------|
+| session | 1 | 1 |
+| agent | 2 | 1 |
+| user | 2 | 1 |
+| global | 3 | 2 |
+
+Optional `minConfidence` per tier. `personalSingleTenant` lowers the global agent bar to 1. Missing provenance or `contradictionWorsens` blocks promote.
+
+## Permission-scoped attachment (#2174)
+
+`permissionBoundary.targetScope` (default **session**) controls which transcripts may feed a dream:
+
+- Fail closed: unresolved ACL → exclude
+- More-private content cannot feed a more-public dream (`SCOPE_RANK[source] >= SCOPE_RANK[target]`)
+- Writes cannot exceed the dream target scope
+- `dream run` persists `attachment.excluded[]` (sessionId + reason) on the run metrics; included ids live in `session_ids_json`
+
+Example: dream targeting `global` with sessions `{s1:session, s2:global}` attaches only `s2` unless `personalMode: true`.
+
+## Optimistic concurrency (#2175)
+
+- Dream run snapshots `input_store_revision` at start
+- Promote refuses if live store revision drifted (unless `--force`)
+- Per-fact supersede/delete uses candidate `preHash` (propose-time OCC token), not a live token at apply time
+
 ## Self-heal (outcome feedback) — autonomy substitute for deny
 
 After promote ([#2173](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/2173)):

--- a/extensions/memory-hybrid/docs/AUTONOMOUS-DREAMING.md
+++ b/extensions/memory-hybrid/docs/AUTONOMOUS-DREAMING.md
@@ -7,15 +7,13 @@ nav_order: 25
 
 # Autonomous Dreaming
 
-Epic [#2169](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/2169). Candidate/shadow store + machine promote/rollback: [#2170](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/2170). Unified Dream: [#2171](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/2171).
+Epic [#2169](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/2169). Child issues: [#2170](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/2170)–[#2179](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/2179), reload fix [#2181](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/2181).
 
 ## Product intent
 
-The **candidate store is for autonomous safety**, not a human review inbox.
+**Autonomous machine review is the design center.** Human proposal/approve/deny UX is an escape hatch — not the happy path for continual learning ([#2177](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/2177)).
 
-Anthropic-style dreaming architecture (out-of-band curation, candidate memory state, provenance) is useful. Hybrid Memory’s product preference is different: the operator does **not** click Approve/Reject on curriculum changes. The machine must gate, promote, and roll back.
-
-Persona/skill proposal queues remain escape hatches elsewhere. They are **not** the happy path for dream curriculum.
+The **candidate store is for autonomous safety**, not a human review inbox. The machine gates, promotes, observes outcomes, and rolls back.
 
 ## Task path vs Dream path
 
@@ -38,31 +36,56 @@ Task path learns for *this* session. Dream path spends dedicated maintenance bud
 ```
 sessions + store snapshot
         ↓
-   Dream run (#2171)
+   Dream run (#2171) + steering (#2176)
         ↓
  candidate entries (#2170)
         ↓
- machine gates (#2172 prevalence / evidence)
+ machine gates (#2172 prevalence / evidence / permission #2174)
         ↓
  auto-promote | quarantine  (+ OCC #2175)
         ↓
- outcome window (#2173) → auto-rollback if regression
+ outcome window (#2173) → auto-rollback if regression  ← self-heal = “deny”
         ↓
  ROI report (#2179)
 ```
 
 Existing Dream Cycle, distill, reflection, consolidate, Loom, and Event Bus producers are **composed under Dream**, not deleted. When `dreaming.enabled` and `skipNightlyOverlap` are true, overlapping nightly steps are skipped so Dream owns them.
 
-## What lands with #2170 / #2171
+There is **no separate Rumination Engine** process ([#2178](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/2178)): Event Bus status lifecycle is advanced by distributed consumers (maintenance + Dream).
 
-| Piece | Role |
-|-------|------|
-| `dream_runs` + `memory_candidate_entries` | Durable proposed-diff + reverse plan in the **facts** SQLite DB |
-| `runDream` / `hybrid-mem dream run` | Unified compose facade → always ≥1 candidate |
-| Status lifecycle | `pending → running → gated → promoted \| quarantined \| failed`; `promoted → rolled_back` |
-| Machine gates | Provenance, contradiction stub, prevalence/blast-radius (#2172) |
-| Promote / rollback | Transactional SQLite apply; reverse plan + `post_hash` drift refuse |
-| OCC | `input_store_revision` / `expectedHash` (#2175) |
+## Self-heal (outcome feedback) — autonomy substitute for deny
+
+After promote ([#2173](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/2173)):
+
+1. Capture a **pre-promote baseline** (session-scoped feedback signals).
+2. Tag applied facts `dream-run:<id>` for attribution.
+3. Observe for `autoRollback.observeWindowHours`.
+4. Nightly `dream-outcome-probe` (when autoRollback enabled) collects after-window metrics **scoped to the dream’s sessions**, compares effect score, and **auto-rollbacks** via reverse plan on regression.
+5. Decisions (`keep` / `rollback` / `insufficient_data`) are journaled on `dream_runs.metrics_summary_json`. Insufficient data never false-rollbacks.
+
+## How to read Dream ROI
+
+`hybrid-mem dream report --since-days 30 --json` ([#2179](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/2179)):
+
+| Field | Meaning |
+|-------|---------|
+| `totals.cost.tokens` / `usdProxy` | LLM spend attributed to `feature=dream` during compose |
+| `totals.promoted` / `rolledBack` / `quarantined` | Lifecycle outcomes |
+| `totals.candidatePromoteRatio` | Candidates that cleared gates vs proposed |
+| `perRun[].metricsSummary` | Per-run cost/hygiene + optional outcome decision |
+| `howToRead` | Inline guidance string |
+
+Shadow mode first: compare ROI and rollback rate before turning `autoPromote` on.
+
+## Steering (set-and-forget)
+
+`dreaming.steering` ([#2176](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/2176)) — default **personal** profile for single-operator autonomy:
+
+- **promote:** preference, routine, insight
+- **ignore:** one_off_debug, transient_path, secret_like
+- **notes:** freeform LLM guidance injected into distill/reflect prompts
+
+No nightly UI confirmation. Profile id is stored on each `dream_run`.
 
 ## Config (defaults conservative)
 
@@ -88,10 +111,16 @@ Existing Dream Cycle, distill, reflection, consolidate, Loom, and Event Bus prod
       enforce: true,
       personalMode: false
     },
-    steering: { profile: "personal", promote: [...], ignore: [...] }
+    steering: {
+      profile: "personal",
+      promote: ["preference", "routine", "insight"],
+      ignore: ["one_off_debug", "transient_path", "secret_like"]
+    }
   }
 }
 ```
+
+When `mode: "autonomous"` and Dream is enabled, nightly `pending-digest` is skipped so human triage is not implied for correctness. Set `mode: "supervised"` to restore digest-first workflows.
 
 Compose under candidate/shadow mode runs maintenance stages with **`dryRun: true`** so the live store is unchanged until machine promote.
 
@@ -112,14 +141,14 @@ openclaw hybrid-mem dream run --sessions s1,s2 --compose distill,reflect --json
 openclaw hybrid-mem dream status
 openclaw hybrid-mem dream status <id>
 openclaw hybrid-mem dream promote <id>        # machine path; --force under shadow
-openclaw hybrid-mem dream rollback <id>
+openclaw hybrid-mem dream rollback <id>       # escape hatch
+openclaw hybrid-mem dream observe <id>        # auto-collect metrics; --apply to rollback
+openclaw hybrid-mem dream observe --all       # probe elapsed windows
+openclaw hybrid-mem dream report --since-days 30 --json
 ```
 
-## Non-goals (sibling issues)
+## Escape hatches (keep)
 
-- Blast-radius / prevalence policy depth (#2172)
-- Outcome self-heal metrics (#2173)
-- Permission-scoped transcript attachment (#2174)
-- Steering policy profiles (#2176)
-- Autopilot-first defaults (#2177)
-- Dream ROI report (#2179)
+- Inspect / promote / rollback / observe / report via CLI above
+- `dreaming.mode: "supervised"` for operators who want digest-first workflows
+- Manual `--force` promote under shadow for debugging

--- a/extensions/memory-hybrid/docs/event-bus.md
+++ b/extensions/memory-hybrid/docs/event-bus.md
@@ -1,8 +1,10 @@
-# Event Bus — Sensor/Rumination Event Pipeline
+# Event Bus — Sensor Event Pipeline
 
 ## What Is the Event Bus?
 
-The Event Bus is an append-only SQLite table (`memory_events`) that decouples **sensor sweeps** (producers) from the **Rumination Engine** (consumer). Sensors write raw observations; the Rumination Engine reads, promotes, and archives them. No direct coupling between producers and consumers is needed.
+The Event Bus is an append-only SQLite table (`memory_events`) that decouples **sensor sweeps** (producers) from **downstream consumers**. Sensors write raw observations; maintenance and Dream paths read, promote status, and archive them. No direct coupling between producers and consumers is required.
+
+> **Architecture note (#2178):** Earlier docs referred to a single “Rumination Engine” consumer. That module was never shipped as a discrete service. Actual consumers today are **sensor-aware maintenance steps**, **Dream Cycle / Autonomous Dreaming**, and ad-hoc status updates via `EventBus.updateStatus`. The status lifecycle API remains; there is no separate rumination process. See [AUTONOMOUS-DREAMING.md](./AUTONOMOUS-DREAMING.md) for the continual-learning control plane.
 
 ## Schema
 
@@ -33,7 +35,7 @@ raw → processed → surfaced → pushed → archived
 | Status | Meaning |
 |--------|---------|
 | `raw` | Just written by a sensor; not yet examined |
-| `processed` | Examined by Rumination Engine |
+| `processed` | Examined by a consumer (maintenance / dream / other) |
 | `surfaced` | Promoted to agent context or memory |
 | `pushed` | Delivered to an external sink |
 | `archived` | Eligible for pruning |
@@ -58,7 +60,7 @@ Insert a new event. Returns the auto-generated row `id`.
 | `importance` | `number` | `0.5` | Salience score in `[0, 1]` |
 | `fingerprint` | `string` | `undefined` | SHA-256 hash for dedup; use `computeFingerprint()` |
 
-Throws `RangeError` if `importance` is outside `[0, 1]` or is `NaN`. (All comparisons with `NaN` return `false` in JavaScript, so the guard is written as `!(importance >= 0 && importance <= 1)` to catch `NaN` explicitly.)
+Throws `RangeError` if `importance` is outside `[0, 1]` or is `NaN`.
 
 ### `queryEvents(filter?): MemoryEvent[]`
 
@@ -81,41 +83,19 @@ Transition one event to a new status. Sets `processed_at` on the first non-`raw`
 
 Returns `true` if an event with the same fingerprint was written within `cooldownHours` (default `6`). Callers should skip `appendEvent` when `dedup` returns `true`.
 
-```typescript
-const fp = computeFingerprint(`${type}:${entityId}:${summary}`);
-if (!bus.dedup(fp, 6)) {
-  bus.appendEvent(type, source, payload, 0.7, fp);
-}
-```
-
 ### `pruneArchived(olderThanDays?: number): number`
 
 Delete archived events older than `olderThanDays` (default `30`). Returns the count of deleted rows.
 
-### `isOpen(): boolean`
+### `isOpen(): boolean` / `close(): void`
 
-Returns `true` if the underlying database connection is open.
-
-### `close(): void`
-
-Close the database connection. Idempotent.
-
-## `computeFingerprint(input: string): string`
-
-Standalone helper (also exported via `_testing`). Returns the SHA-256 hex digest of `input`. Compose the input from stable, identifying fields:
-
-```typescript
-import { computeFingerprint } from "./backends/event-bus.js";
-
-const fp = computeFingerprint(`context_shift:${projectId}:${summary}:daily`);
-```
+Connection helpers. `close()` is idempotent.
 
 ## Integration Example
 
 ```typescript
 const bus = new EventBus("~/.openclaw/memory-events.db");
 
-// Sensor writes an observation
 const fp = computeFingerprint(`context_shift:proj-42:switched to testing`);
 if (!bus.dedup(fp)) {
   const id = bus.appendEvent(
@@ -126,14 +106,13 @@ if (!bus.dedup(fp)) {
     fp,
   );
 
-  // Rumination Engine processes it
+  // A maintenance / dream consumer examines raw events:
   const [event] = bus.queryEvents({ status: "raw", type: "context_shift" });
   bus.updateStatus(event.id, "processed");
   // ... promote to memory, then:
   bus.updateStatus(event.id, "surfaced");
 }
 
-// Nightly prune
 bus.pruneArchived(30);
 bus.close();
 ```
@@ -146,7 +125,7 @@ bus.close();
 ~/.openclaw/
   memory.db          ← Layer 2: long-term facts
   event-log.db       ← Layer 1: session episodic log
-  memory-events.db   ← Event Bus: sensor → rumination pipeline
+  memory-events.db   ← Event Bus: sensor → consumer pipeline
   memory-vectors/    ← Layer 3: semantic index
 ```
 
@@ -155,7 +134,7 @@ bus.close();
 | | Event Log (`event-log.ts`) | Event Bus (`event-bus.ts`) |
 |--|---|---|
 | Producer | Agent conversation hooks | Sensor sweeps |
-| Consumer | Dream Cycle / consolidation | Rumination Engine |
+| Consumer | Dream Cycle / consolidation / Autonomous Dreaming | Maintenance steps, Dream paths, ad-hoc `updateStatus` |
 | Scope | Session-scoped episodes | Cross-session observations |
 | Key field | `sessionId` | `fingerprint`, `status` |
 | Dedup | No | Yes (cooldown window) |

--- a/extensions/memory-hybrid/lifecycle/stage-recall/run-recall.ts
+++ b/extensions/memory-hybrid/lifecycle/stage-recall/run-recall.ts
@@ -48,6 +48,7 @@ import { pickSerendipityFact } from "../../services/serendipity.js";
 import { sanitizePromptInjection } from "../../services/skill-prompt-injection.js";
 import type { ScopeFilter, SearchResult } from "../../types/memory.js";
 import { isConsolidatedDerivedFact } from "../../utils/consolidation-controls.js";
+import { applyDreamCanaryBoost } from "../../services/dream-canary.js";
 import { resolveEntityLookupNames } from "../../utils/entity-lookup-resolve.js";
 import { yieldEventLoop } from "../../utils/event-loop-yield.js";
 import { isStaleLifecycleGeneration } from "../../utils/lifecycle-generation.js";
@@ -1134,7 +1135,10 @@ export async function runRecall(
       return { ...r, score: s };
     });
     boosted.sort((a, b) => b.score - a.score);
-    candidates = boosted;
+    // Prefer dream-run-tagged facts while outcome observation is active (#2173 canary).
+    candidates = applyDreamCanaryBoost(boosted, {
+      enabled: ctx.cfg.dreaming?.enabled === true && ctx.cfg.dreaming?.autoRollback?.enabled === true,
+    });
     if (hotFactIds.size > 0) {
       candidates = candidates.filter((r) => !hotFactIds.has(r.entry.id));
     }

--- a/extensions/memory-hybrid/openclaw.plugin.json
+++ b/extensions/memory-hybrid/openclaw.plugin.json
@@ -2178,6 +2178,41 @@
               "blockOnContradictionWorsening": {
                 "type": "boolean",
                 "description": "Block promote when contradiction gate fails (default: true)."
+              },
+              "shadowValidation": {
+                "type": "object",
+                "additionalProperties": false,
+                "description": "Fail-closed ROI gate before autoPromote apply. Check with dream validate-shadow.",
+                "properties": {
+                  "enabled": {
+                    "type": "boolean",
+                    "description": "Require passing shadow window before live apply (default: true)."
+                  },
+                  "minShadowRuns": {
+                    "type": "number",
+                    "description": "Minimum shadow dream runs in lookback (default: 7)."
+                  },
+                  "minWouldPromoteRuns": {
+                    "type": "number",
+                    "description": "Minimum gated/wouldPromote shadow runs (default: 3)."
+                  },
+                  "maxQuarantineRate": {
+                    "type": "number",
+                    "description": "Max quarantined/decided rate (default: 0.5)."
+                  },
+                  "maxFailureRate": {
+                    "type": "number",
+                    "description": "Max failed/decided rate (default: 0.2)."
+                  },
+                  "maxZeroCandidateRate": {
+                    "type": "number",
+                    "description": "Max share of shadow runs with zero candidates (default: 0.3)."
+                  },
+                  "lookbackDays": {
+                    "type": "number",
+                    "description": "Lookback window days (default: 30)."
+                  }
+                }
               }
             }
           },

--- a/extensions/memory-hybrid/openclaw.plugin.json
+++ b/extensions/memory-hybrid/openclaw.plugin.json
@@ -2099,7 +2099,7 @@
           },
           "skipNightlyOverlap": {
             "type": "boolean",
-            "description": "When Dream is enabled, skip overlapping nightly maintenance steps (default: true)."
+            "description": "When Dream is enabled, skip overlapping nightly maintenance steps (default: false — opt-in; enable only after autoPromote/shadow campaign is ready)."
           },
           "promoteAfterRun": {
             "type": "boolean",

--- a/extensions/memory-hybrid/openclaw.plugin.json
+++ b/extensions/memory-hybrid/openclaw.plugin.json
@@ -2072,6 +2072,135 @@
         },
         "description": "Nightly dream cycle: prune, consolidate, reflect"
       },
+      "dreaming": {
+        "type": "object",
+        "additionalProperties": false,
+        "description": "Autonomous dreaming: unified Dream compose (#2171) + candidate store + machine promote/rollback (#2170). Not a human review inbox. Defaults: enabled off, candidate store off, shadow on, autoPromote/autoRollback off.",
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "description": "Master switch for unified Dream product operation (default: false)."
+          },
+          "compose": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": ["distill", "self-correction", "reflect", "consolidate", "contradictions", "dream-cycle-core"]
+            },
+            "description": "Ordered compose stages for dream run (default: distill, contradictions, reflect, consolidate)."
+          },
+          "maxSessions": {
+            "type": "number",
+            "description": "Max session ids attached to a Dream run, 1..100 (default: 20)."
+          },
+          "maxRuntimeMinutes": {
+            "type": "number",
+            "description": "Hard wall-clock ceiling for a Dream run in minutes (default: 30)."
+          },
+          "skipNightlyOverlap": {
+            "type": "boolean",
+            "description": "When Dream is enabled, skip overlapping nightly maintenance steps (default: true)."
+          },
+          "promoteAfterRun": {
+            "type": "boolean",
+            "description": "Call machine promote after compose (default: false; also follows autoPromote.enabled)."
+          },
+          "mode": {
+            "type": "string",
+            "enum": ["autonomous", "supervised"],
+            "description": "Product mode (#2177). autonomous = machine gates are happy path (default)."
+          },
+          "prevalence": {
+            "type": "object",
+            "additionalProperties": false,
+            "description": "Blast-radius prevalence bars by scope (#2172).",
+            "properties": {
+              "session": { "type": "object", "additionalProperties": true },
+              "agent": { "type": "object", "additionalProperties": true },
+              "user": { "type": "object", "additionalProperties": true },
+              "global": { "type": "object", "additionalProperties": true },
+              "personalSingleTenant": { "type": "boolean" }
+            }
+          },
+          "permissionBoundary": {
+            "type": "object",
+            "additionalProperties": false,
+            "description": "Permission-scoped transcript attachment (#2174).",
+            "properties": {
+              "targetScope": {
+                "type": "string",
+                "enum": ["session", "agent", "user", "global"]
+              },
+              "enforce": { "type": "boolean" },
+              "personalMode": { "type": "boolean" }
+            }
+          },
+          "steering": {
+            "type": "object",
+            "additionalProperties": false,
+            "description": "Dream steering policy (#2176) — set-and-forget, not a review inbox.",
+            "properties": {
+              "profile": {
+                "type": "string",
+                "enum": ["personal", "coding", "ops", "custom"]
+              },
+              "promote": { "type": "array", "items": { "type": "string" } },
+              "ignore": { "type": "array", "items": { "type": "string" } },
+              "notes": { "type": "string" }
+            }
+          },
+          "candidateStore": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "enabled": {
+                "type": "boolean",
+                "description": "Persist dream candidate entries without mutating live store until promote (default: false)."
+              },
+              "shadow": {
+                "type": "boolean",
+                "description": "When true, gate decisions are logged but candidates are not applied unless promote --force (default: true)."
+              }
+            }
+          },
+          "autoPromote": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "enabled": {
+                "type": "boolean",
+                "description": "Apply gated-ok candidates to the live store (default: false)."
+              },
+              "requireProvenance": {
+                "type": "boolean",
+                "description": "Require session evidence or rationale on each candidate (default: true)."
+              },
+              "blockOnContradictionWorsening": {
+                "type": "boolean",
+                "description": "Block promote when contradiction gate fails (default: true)."
+              }
+            }
+          },
+          "autoRollback": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "enabled": {
+                "type": "boolean",
+                "description": "Enable post-promote auto-rollback on regression (default: false)."
+              },
+              "observeWindowHours": {
+                "type": "number",
+                "description": "Observation window hours after promote (default: 24)."
+              },
+              "regressionThreshold": {
+                "type": "number",
+                "description": "Effect-score drop threshold for rollback stub (default: 0.15)."
+              }
+            }
+          }
+        }
+      },
       "passiveObserver": {
         "type": "object",
         "additionalProperties": false,

--- a/extensions/memory-hybrid/services/chat.ts
+++ b/extensions/memory-hybrid/services/chat.ts
@@ -17,7 +17,7 @@ import { getEnv } from "../utils/env-manager.js";
 import { extractAssistantMessageText } from "../utils/llm-message.js";
 import { pluginLogger } from "../utils/logger.js";
 import { applyOpenClawGatewayModelRequest, isOpenClawGatewayClient } from "../utils/openclaw-gateway-http.js";
-import { withCostFeature } from "./cost-context.js";
+import { getCurrentCostFeature, withCostFeature } from "./cost-context.js";
 import { capturePluginError } from "./error-reporter.js";
 import {
   formatProviderRateLimitHeaderSummary,
@@ -547,7 +547,9 @@ export async function chatCompleteDetailed(opts: {
           { model, content, temperature, maxTokens: effectiveMaxTokens },
           { signal: controller.signal },
         );
-      const { text, raw } = await (feature ? withCostFeature(feature, doCreate) : doCreate());
+      // Prefer outer ALS label (e.g. CostFeature.dream under runDream) over nested step labels (#2179).
+      const effectiveFeature = getCurrentCostFeature() ?? feature;
+      const { text, raw } = await (effectiveFeature ? withCostFeature(effectiveFeature, doCreate) : doCreate());
       clearTimeout(timeoutId);
       if (signal) signal.removeEventListener("abort", onAbort);
       return { text, finishReason: mapResponsesFinishReason(raw) };
@@ -583,9 +585,12 @@ export async function chatCompleteDetailed(opts: {
         requestBody as unknown as Parameters<OpenAI["chat"]["completions"]["create"]>[0],
         createOpts,
       );
-    // If feature is provided, wrap in withCostFeature so the proxy attributes the call correctly.
+    // Prefer outer ALS label (e.g. CostFeature.dream under runDream) over nested step labels (#2179).
     // Cost recording itself is done by the OpenAI proxy in setup/init-databases.ts.
-    const resp = (await (feature ? withCostFeature(feature, doCreate) : doCreate())) as OpenAI.Chat.ChatCompletion;
+    const effectiveFeature = getCurrentCostFeature() ?? feature;
+    const resp = (await (effectiveFeature
+      ? withCostFeature(effectiveFeature, doCreate)
+      : doCreate())) as OpenAI.Chat.ChatCompletion;
     clearTimeout(timeoutId);
     if (signal) signal.removeEventListener("abort", onAbort);
     const choice = resp.choices?.[0];

--- a/extensions/memory-hybrid/services/consolidation.ts
+++ b/extensions/memory-hybrid/services/consolidation.ts
@@ -46,6 +46,17 @@ interface ConsolidateOptions {
   fuzzyDedupe?: boolean;
 }
 
+export type ConsolidateClusterPreview = {
+  memberIds: string[];
+  mergedText: string;
+  category: MemoryCategory | string;
+  key?: string | null;
+  value?: string | null;
+  scope?: "global" | "user" | "agent" | "session";
+  scopeTarget?: string | null;
+  entity?: string | null;
+};
+
 interface ConsolidateResult {
   clustersFound: number;
   merged: number;
@@ -55,6 +66,8 @@ interface ConsolidateResult {
   semanticOutcome?: string;
   skipped?: boolean;
   skipReason?: string;
+  /** Dry-run only: cluster merge previews for Dream compose (#2170). */
+  previews?: ConsolidateClusterPreview[];
 }
 
 /**
@@ -235,6 +248,7 @@ export async function runConsolidate(
   let storeDedupeVectorFallbackSuppressed = 0;
   const consolidationRunId = provenanceService ? randomUUID() : null;
   let clusterIndex = 0;
+  const dryRunPreviews: ConsolidateClusterPreview[] = [];
   for (const clusterIds of clusters) {
     clusterIndex++;
     const emitClusterProgress = () => opts.onProgress?.({ clusterIndex, totalClusters: clusters.length, merged });
@@ -294,6 +308,18 @@ export async function runConsolidate(
       logger.info(
         `memory-hybrid: consolidate [dry-run] would merge ${clusterIds.length} facts → "${mergedText.slice(0, 80)}..."`,
       );
+      if (dryRunPreviews.length < 20) {
+        dryRunPreviews.push({
+          memberIds: [...clusterIds],
+          mergedText,
+          category,
+          key: mergedKey,
+          value: mergedValue,
+          scope: (first?.scope as "global" | "user" | "agent" | "session" | undefined) ?? "global",
+          scopeTarget: first?.scopeTarget ?? null,
+          entity: first?.entity ?? null,
+        });
+      }
       merged++;
       emitClusterProgress();
       continue;
@@ -511,5 +537,6 @@ export async function runConsolidate(
     clustersFailed: clustersFailed > 0 ? clustersFailed : undefined,
     vectorFailures: vectorFailures > 0 ? vectorFailures : undefined,
     semanticOutcome: clustersFailed > 0 || vectorFailures > 0 ? "partial" : "success",
+    ...(opts.dryRun && dryRunPreviews.length > 0 ? { previews: dryRunPreviews } : {}),
   };
 }

--- a/extensions/memory-hybrid/services/cost-context.ts
+++ b/extensions/memory-hybrid/services/cost-context.ts
@@ -7,10 +7,13 @@ const costContext = new AsyncLocalStorage<string>();
  * Any LLM calls made within `fn` will be attributed to `feature` in the cost log.
  * This is opt-in — calls outside a withCostFeature context are labeled "unknown".
  *
- * NOTE: Currently only used in tests. Production code relies on heuristic feature detection.
- * @internal
+ * Nested calls keep the outer label (e.g. CostFeature.dream under runDream must not be
+ * overwritten by distill/reflect/consolidate step labels — #2179).
  */
 export function withCostFeature<T>(feature: string, fn: () => T): T {
+  if (costContext.getStore() != null) {
+    return fn();
+  }
   return costContext.run(feature, fn);
 }
 

--- a/extensions/memory-hybrid/services/cost-feature-labels.ts
+++ b/extensions/memory-hybrid/services/cost-feature-labels.ts
@@ -42,6 +42,8 @@ export const CostFeature = {
   evolutionPass: "evolution-pass",
   contaminationGuard: "contamination-guard",
   mineSynthesize: "mine-synthesize",
+  /** Unified Dream product operation (#2171). */
+  dream: "dream",
 } as const;
 
 export type CostFeatureId = (typeof CostFeature)[keyof typeof CostFeature];

--- a/extensions/memory-hybrid/services/dream-canary.ts
+++ b/extensions/memory-hybrid/services/dream-canary.ts
@@ -1,0 +1,35 @@
+/**
+ * Dream canary attribution (#2173) — optionally prefer recently promoted dream-run facts in recall.
+ */
+
+import { DREAM_RUN_TAG_PREFIX } from "./dream-metrics.js";
+
+export const DREAM_CANARY_BOOST = 1.08;
+
+/** True when any tag is a dream-run attribution tag. */
+export function hasDreamCanaryTag(tags: string[] | null | undefined): boolean {
+  if (!tags?.length) return false;
+  const prefix = DREAM_RUN_TAG_PREFIX.toLowerCase();
+  return tags.some((t) => t.toLowerCase().startsWith(prefix));
+}
+
+/**
+ * Mildly boost recall scores for dream-run-tagged facts during the post-promote
+ * observation window so canary curriculum is exercised (#2173).
+ */
+export function applyDreamCanaryBoost<T extends { score: number; entry: { tags?: string[] | null } }>(
+  candidates: T[],
+  options: { enabled: boolean; boost?: number } = { enabled: false },
+): T[] {
+  if (!options.enabled || candidates.length === 0) return candidates;
+  const factor = options.boost ?? DREAM_CANARY_BOOST;
+  let changed = false;
+  const out = candidates.map((c) => {
+    if (!hasDreamCanaryTag(c.entry.tags)) return c;
+    changed = true;
+    return { ...c, score: c.score * factor };
+  });
+  if (!changed) return candidates;
+  out.sort((a, b) => b.score - a.score);
+  return out;
+}

--- a/extensions/memory-hybrid/services/dream-candidate-ops.ts
+++ b/extensions/memory-hybrid/services/dream-candidate-ops.ts
@@ -92,6 +92,8 @@ export type DreamRunRecord = {
   rollbackReason: string | null;
   metricsBaselineJson: string | null;
   metricsObserveUntil: number | null;
+  /** Per-run ROI / cost summary (#2179). */
+  metricsSummaryJson: string | null;
 };
 
 export type CandidateEntryRecord = {

--- a/extensions/memory-hybrid/services/dream-candidate-ops.ts
+++ b/extensions/memory-hybrid/services/dream-candidate-ops.ts
@@ -1,0 +1,172 @@
+/**
+ * Types and helpers for dream candidate entries (#2170).
+ *
+ * Store revision hashing lives in `utils/fact-occ.ts` (shared with #2175 OCC).
+ * Prefer `factsDb.computeStoreRevision()` at dream-run boundaries.
+ */
+
+import { createHash } from "node:crypto";
+import type { StoreFactInput } from "../backends/facts-db/crud.js";
+import { computeInputStoreRevision, occTokenForFact } from "../utils/fact-occ.js";
+
+export type DreamRunStatus =
+  | "pending"
+  | "running"
+  | "gated"
+  | "promoted"
+  | "quarantined"
+  | "rolled_back"
+  | "failed";
+
+export const DREAM_RUN_STATUSES: readonly DreamRunStatus[] = [
+  "pending",
+  "running",
+  "gated",
+  "promoted",
+  "quarantined",
+  "rolled_back",
+  "failed",
+] as const;
+
+export type CandidateOpKind = "add" | "supersede" | "delete" | "merge" | "boost";
+
+export type CandidateEntryStatus =
+  | "proposed"
+  | "gated_ok"
+  | "gated_block"
+  | "applied"
+  | "rolled_back"
+  | "skipped";
+
+export type ReverseOpKind = "delete_fact" | "unsupersede" | "restore_text" | "noop";
+
+export type CandidatePrevalence = {
+  sessions: number;
+  agents: number;
+  spanDays?: number;
+};
+
+export type CandidateEvidence = {
+  sessionIds: string[];
+  prevalence: CandidatePrevalence;
+  rationale: string;
+};
+
+/** Forward payload for add/supersede/merge/boost. Optional id used when caller wants a stable applied id. */
+export type CandidatePayload = StoreFactInput & {
+  id?: string;
+  /** Test/stub: mark that applying this entry would worsen contradictions (#2170 gate stub). */
+  contradictionWorsens?: boolean;
+};
+
+export type ReversePlan = {
+  op: ReverseOpKind;
+  payload: Record<string, unknown>;
+};
+
+export type CandidateEntryInput = {
+  op: CandidateOpKind;
+  payload: CandidatePayload;
+  targetFactId?: string | null;
+  evidence: CandidateEvidence;
+  preHash?: string | null;
+  reverse: ReversePlan;
+  sortOrder?: number;
+};
+
+export type DreamRunRecord = {
+  id: string;
+  status: DreamRunStatus;
+  inputStoreRevision: string;
+  sessionIds: string[];
+  steeringPolicyId: string | null;
+  gateReportJson: string | null;
+  shadow: boolean;
+  createdAt: number;
+  startedAt: number | null;
+  gatedAt: number | null;
+  promotedAt: number | null;
+  rolledBackAt: number | null;
+  failedAt: number | null;
+  failureReason: string | null;
+  rollbackReason: string | null;
+  metricsBaselineJson: string | null;
+  metricsObserveUntil: number | null;
+};
+
+export type CandidateEntryRecord = {
+  id: string;
+  dreamRunId: string;
+  op: CandidateOpKind;
+  status: CandidateEntryStatus;
+  payload: CandidatePayload;
+  targetFactId: string | null;
+  sessionIds: string[];
+  prevalence: CandidatePrevalence | null;
+  rationale: string | null;
+  preHash: string | null;
+  postHash: string | null;
+  reverse: ReversePlan;
+  appliedFactId: string | null;
+  sortOrder: number;
+  createdAt: number;
+};
+
+export type GateDecision = {
+  entryId: string;
+  pass: boolean;
+  reason: string;
+};
+
+export type GateReport = {
+  ok: boolean;
+  decisions: GateDecision[];
+  wouldPromote: boolean;
+  reason?: string;
+};
+
+export type PromoteResult = {
+  applied: boolean;
+  shadow: boolean;
+  status: DreamRunStatus;
+  gateReport: GateReport;
+  appliedFactIds: string[];
+  error?: string;
+};
+
+export type RollbackResult = {
+  rolledBack: boolean;
+  status: DreamRunStatus;
+  restoredFactIds: string[];
+  abortedEntries: Array<{ entryId: string; reason: string }>;
+  error?: string;
+};
+
+export { computeInputStoreRevision, occTokenForFact };
+
+/** SHA-256 of canonical fact content fields (promote/rollback drift checks). */
+export function hashFactContent(entry: {
+  text: string;
+  entity?: string | null;
+  key?: string | null;
+  value?: string | null;
+  scope?: string | null;
+  scopeTarget?: string | null;
+  importance?: number | null;
+}): string {
+  const canonical = JSON.stringify({
+    text: entry.text,
+    entity: entry.entity ?? null,
+    key: entry.key ?? null,
+    value: entry.value ?? null,
+    scope: entry.scope ?? "global",
+    scopeTarget: entry.scopeTarget ?? null,
+    importance: entry.importance ?? null,
+  });
+  return createHash("sha256").update(canonical).digest("hex");
+}
+
+export function makeDreamRunId(now = new Date()): string {
+  const iso = now.toISOString().replace(/[-:]/g, "").replace(/\.\d{3}Z$/, "Z");
+  return `dream-${iso}-${process.pid}`;
+}

--- a/extensions/memory-hybrid/services/dream-candidate-ops.ts
+++ b/extensions/memory-hybrid/services/dream-candidate-ops.ts
@@ -9,14 +9,7 @@ import { createHash } from "node:crypto";
 import type { StoreFactInput } from "../backends/facts-db/crud.js";
 import { computeInputStoreRevision, occTokenForFact } from "../utils/fact-occ.js";
 
-export type DreamRunStatus =
-  | "pending"
-  | "running"
-  | "gated"
-  | "promoted"
-  | "quarantined"
-  | "rolled_back"
-  | "failed";
+export type DreamRunStatus = "pending" | "running" | "gated" | "promoted" | "quarantined" | "rolled_back" | "failed";
 
 export const DREAM_RUN_STATUSES: readonly DreamRunStatus[] = [
   "pending",
@@ -30,13 +23,7 @@ export const DREAM_RUN_STATUSES: readonly DreamRunStatus[] = [
 
 export type CandidateOpKind = "add" | "supersede" | "delete" | "merge" | "boost";
 
-export type CandidateEntryStatus =
-  | "proposed"
-  | "gated_ok"
-  | "gated_block"
-  | "applied"
-  | "rolled_back"
-  | "skipped";
+export type CandidateEntryStatus = "proposed" | "gated_ok" | "gated_block" | "applied" | "rolled_back" | "skipped";
 
 export type ReverseOpKind = "delete_fact" | "unsupersede" | "restore_text" | "noop";
 
@@ -169,6 +156,9 @@ export function hashFactContent(entry: {
 }
 
 export function makeDreamRunId(now = new Date()): string {
-  const iso = now.toISOString().replace(/[-:]/g, "").replace(/\.\d{3}Z$/, "Z");
+  const iso = now
+    .toISOString()
+    .replace(/[-:]/g, "")
+    .replace(/\.\d{3}Z$/, "Z");
   return `dream-${iso}-${process.pid}`;
 }

--- a/extensions/memory-hybrid/services/dream-candidate-ops.ts
+++ b/extensions/memory-hybrid/services/dream-candidate-ops.ts
@@ -42,7 +42,7 @@ export type CandidateEvidence = {
 /** Forward payload for add/supersede/merge/boost. Optional id used when caller wants a stable applied id. */
 export type CandidatePayload = StoreFactInput & {
   id?: string;
-  /** Test/stub: mark that applying this entry would worsen contradictions (#2170 gate stub). */
+  /** Optional hard-fail flag for tests / explicit quarantine (#2170). Live gate also uses FactsDB heuristics. */
   contradictionWorsens?: boolean;
 };
 
@@ -160,5 +160,8 @@ export function makeDreamRunId(now = new Date()): string {
     .toISOString()
     .replace(/[-:]/g, "")
     .replace(/\.\d{3}Z$/, "Z");
-  return `dream-${iso}-${process.pid}`;
+  const unique = `${now.getMilliseconds().toString().padStart(3, "0")}${Math.floor(Math.random() * 1e6)
+    .toString()
+    .padStart(6, "0")}`;
+  return `dream-${iso}-${process.pid}-${unique}`;
 }

--- a/extensions/memory-hybrid/services/dream-compose-candidates.ts
+++ b/extensions/memory-hybrid/services/dream-compose-candidates.ts
@@ -7,7 +7,12 @@
 
 import type { MemoryCategory } from "../types/memory.js";
 import type { CandidateEntryInput } from "./dream-candidate-ops.js";
-import { aclFitsTarget, type DreamWriteScope } from "./dream-permission.js";
+import {
+  aclFitsTarget,
+  writeScopeWithinBoundary,
+  type DreamWriteScope,
+} from "./dream-permission.js";
+import type { DreamPermissionBoundary } from "../config/types/dreaming.js";
 
 /** Max candidates emitted per compose stage (keeps promote/gate bounded). */
 export const DREAM_COMPOSE_CANDIDATE_CAP = 40;
@@ -61,25 +66,44 @@ function evidenceForSessions(
 function resolveAttributedWriteScope(input: {
   sessionIds: string[];
   sourceSessionId?: string | null;
+  permissionBoundary?: DreamPermissionBoundary;
 }): { scope: "session" | "agent"; scopeTarget: string; evidenceSessions: string[] } | null {
   const attached = [...new Set(input.sessionIds.map((s) => s.trim()).filter(Boolean))];
   const source = input.sourceSessionId?.trim() || "";
+  let resolved: { scope: "session" | "agent"; scopeTarget: string; evidenceSessions: string[] } | null =
+    null;
   if (source) {
     if (attached.length > 0 && !attached.includes(source)) return null;
-    return { scope: "session", scopeTarget: source, evidenceSessions: [source] };
+    resolved = { scope: "session", scopeTarget: source, evidenceSessions: [source] };
+  } else if (attached.length === 1) {
+    resolved = { scope: "session", scopeTarget: attached[0]!, evidenceSessions: attached };
+  } else if (attached.length === 0) {
+    return null;
+  } else {
+    // Multi-session without per-fact attribution: never collapse into sessionIds[0].
+    resolved = { scope: "agent", scopeTarget: "dream-multi", evidenceSessions: attached };
   }
-  if (attached.length === 1) {
-    return { scope: "session", scopeTarget: attached[0]!, evidenceSessions: attached };
+  if (!resolved) return null;
+  const boundary = input.permissionBoundary;
+  if (boundary && !writeScopeWithinBoundary(resolved.scope, boundary)) {
+    // Under a session boundary, only single-session attributed writes are admissible.
+    if (boundary.targetScope === "session" && resolved.evidenceSessions.length === 1) {
+      return {
+        scope: "session",
+        scopeTarget: resolved.evidenceSessions[0]!,
+        evidenceSessions: resolved.evidenceSessions,
+      };
+    }
+    return null;
   }
-  if (attached.length === 0) return null;
-  // Multi-session without per-fact attribution: never collapse into sessionIds[0].
-  return { scope: "agent", scopeTarget: "dream-multi", evidenceSessions: attached };
+  return resolved;
 }
 
 export function distillProposalsToCandidates(input: {
   proposals: DistillProposedFact[];
   sessionIds: string[];
   dreamRunId: string;
+  permissionBoundary?: DreamPermissionBoundary;
 }): CandidateEntryInput[] {
   const out: CandidateEntryInput[] = [];
   let sortOrder = 0;
@@ -89,6 +113,7 @@ export function distillProposalsToCandidates(input: {
     const write = resolveAttributedWriteScope({
       sessionIds: input.sessionIds,
       sourceSessionId: fact.sourceSessionId,
+      permissionBoundary: input.permissionBoundary,
     });
     if (!write) continue;
     out.push({
@@ -123,6 +148,7 @@ export function reflectProposalsToCandidates(input: {
   /** Write scope clamped to dream permission boundary (#2174). Default: session when attached. */
   writeScope?: "session" | "agent" | "user" | "global";
   writeScopeTarget?: string | null;
+  permissionBoundary?: DreamPermissionBoundary;
 }): CandidateEntryInput[] {
   const out: CandidateEntryInput[] = [];
   let sortOrder = 0;
@@ -142,6 +168,16 @@ export function reflectProposalsToCandidates(input: {
   if (scope === "session" && input.sessionIds.length !== 1) {
     scope = "agent";
     scopeTarget = "dream-multi";
+  }
+  const boundary = input.permissionBoundary;
+  if (boundary && !writeScopeWithinBoundary(scope, boundary)) {
+    if (boundary.targetScope === "session" && input.sessionIds.length === 1) {
+      scope = "session";
+      scopeTarget = input.sessionIds[0]!;
+    } else {
+      // Multi-session under session boundary cannot emit an agent write — skip.
+      return out;
+    }
   }
   for (const pattern of input.proposals.slice(0, DREAM_COMPOSE_CANDIDATE_CAP)) {
     const text = pattern.text?.trim();
@@ -186,6 +222,7 @@ export function selfCorrectionProposalsToCandidates(input: {
   proposals: SelfCorrectionProposedFact[];
   sessionIds: string[];
   dreamRunId: string;
+  permissionBoundary?: DreamPermissionBoundary;
 }): CandidateEntryInput[] {
   const out: CandidateEntryInput[] = [];
   let sortOrder = 0;
@@ -195,6 +232,7 @@ export function selfCorrectionProposalsToCandidates(input: {
     const write = resolveAttributedWriteScope({
       sessionIds: input.sessionIds,
       sourceSessionId: fact.sourceSessionId,
+      permissionBoundary: input.permissionBoundary,
     });
     if (!write) continue;
     out.push({
@@ -234,6 +272,7 @@ export function consolidateProposalsToCandidates(input: {
    * Missing map → no candidates (fail closed).
    */
   sourceProvenanceByFactId: Record<string, string[]>;
+  permissionBoundary?: DreamPermissionBoundary;
 }): CandidateEntryInput[] {
   const out: CandidateEntryInput[] = [];
   let sortOrder = 0;
@@ -262,8 +301,16 @@ export function consolidateProposalsToCandidates(input: {
 
     const evidenceSessions = [...new Set(perSource.flat())];
     // Clamp write scope to session when a single evidence session; otherwise agent (never invent global).
-    const writeScope = evidenceSessions.length === 1 ? ("session" as const) : ("agent" as const);
-    const writeTarget = evidenceSessions.length === 1 ? evidenceSessions[0]! : "dream-multi";
+    let writeScope = evidenceSessions.length === 1 ? ("session" as const) : ("agent" as const);
+    let writeTarget = evidenceSessions.length === 1 ? evidenceSessions[0]! : "dream-multi";
+    if (input.permissionBoundary && !writeScopeWithinBoundary(writeScope, input.permissionBoundary)) {
+      if (input.permissionBoundary.targetScope === "session" && evidenceSessions.length === 1) {
+        writeScope = "session";
+        writeTarget = evidenceSessions[0]!;
+      } else {
+        continue;
+      }
+    }
 
     out.push({
       op: "merge",
@@ -388,12 +435,20 @@ export function contradictionProposalsToCandidates(input: {
   /** Dream permission target — used when agent/user/global facts lack provenance sessions. */
   targetScope?: DreamWriteScope;
   personalMode?: boolean;
+  permissionBoundary?: DreamPermissionBoundary;
 }): CandidateEntryInput[] {
   const out: CandidateEntryInput[] = [];
   let sortOrder = 0;
   const allow = new Set(input.sessionIds.map((s) => s.trim()).filter(Boolean));
   if (allow.size === 0) return out;
-  const targetScope = input.targetScope ?? "session";
+  const boundary =
+    input.permissionBoundary ??
+    ({
+      targetScope: input.targetScope ?? "session",
+      enforce: true,
+      personalMode: input.personalMode === true,
+    } satisfies DreamPermissionBoundary);
+  const targetScope = boundary.targetScope;
 
   for (const pair of input.proposals.slice(0, DREAM_COMPOSE_CANDIDATE_CAP)) {
     if (!pair.preHash || !pair.factIdOld) continue;
@@ -404,6 +459,9 @@ export function contradictionProposalsToCandidates(input: {
         : "agent";
     const sessionTarget = typeof pair.scopeTarget === "string" ? pair.scopeTarget.trim() : "";
 
+    // Compose must not emit deletes promote will always reject under the permission boundary.
+    if (!writeScopeWithinBoundary(factScope, boundary)) continue;
+
     let evidenceSessions: string[] = [];
     if (provenance.some((p) => allow.has(p))) {
       evidenceSessions = provenance.filter((p) => allow.has(p));
@@ -411,7 +469,7 @@ export function contradictionProposalsToCandidates(input: {
       evidenceSessions = [sessionTarget];
     } else if (
       factScope !== "session" &&
-      aclFitsTarget(factScope, targetScope, input.personalMode === true)
+      aclFitsTarget(factScope, targetScope, boundary.personalMode === true)
     ) {
       // Shared/public facts may feed a more-private dream; evidence is the attachment, not invented provenance.
       evidenceSessions = [...allow];

--- a/extensions/memory-hybrid/services/dream-compose-candidates.ts
+++ b/extensions/memory-hybrid/services/dream-compose-candidates.ts
@@ -19,6 +19,8 @@ export type DistillProposedFact = {
   value?: string | null;
   source_date?: string | null;
   tags?: string[];
+  /** Session id that produced this fact (basename stem); required for multi-session Dream writes. */
+  sourceSessionId?: string | null;
 };
 
 export type ReflectProposedPattern = {
@@ -44,14 +46,33 @@ function evidenceForSessions(
   sessionIds: string[],
   rationale: string,
 ): CandidateEntryInput["evidence"] {
+  const unique = [...new Set(sessionIds.map((s) => s.trim()).filter(Boolean))];
   return {
-    sessionIds,
+    sessionIds: unique,
     prevalence: {
-      sessions: Math.max(1, sessionIds.length || 1),
-      agents: 1,
+      sessions: unique.length,
+      agents: unique.length > 0 ? 1 : 0,
     },
     rationale,
   };
+}
+
+function resolveAttributedWriteScope(input: {
+  sessionIds: string[];
+  sourceSessionId?: string | null;
+}): { scope: "session" | "agent"; scopeTarget: string; evidenceSessions: string[] } | null {
+  const attached = [...new Set(input.sessionIds.map((s) => s.trim()).filter(Boolean))];
+  const source = input.sourceSessionId?.trim() || "";
+  if (source) {
+    if (attached.length > 0 && !attached.includes(source)) return null;
+    return { scope: "session", scopeTarget: source, evidenceSessions: [source] };
+  }
+  if (attached.length === 1) {
+    return { scope: "session", scopeTarget: attached[0]!, evidenceSessions: attached };
+  }
+  if (attached.length === 0) return null;
+  // Multi-session without per-fact attribution: never collapse into sessionIds[0].
+  return { scope: "agent", scopeTarget: "dream-multi", evidenceSessions: attached };
 }
 
 export function distillProposalsToCandidates(input: {
@@ -64,6 +85,11 @@ export function distillProposalsToCandidates(input: {
   for (const fact of input.proposals.slice(0, DREAM_COMPOSE_CANDIDATE_CAP)) {
     const text = fact.text?.trim();
     if (!text) continue;
+    const write = resolveAttributedWriteScope({
+      sessionIds: input.sessionIds,
+      sourceSessionId: fact.sourceSessionId,
+    });
+    if (!write) continue;
     out.push({
       op: "add",
       payload: {
@@ -75,11 +101,11 @@ export function distillProposalsToCandidates(input: {
         value: fact.value ?? null,
         source: "dream-distill",
         tags: [...(fact.tags ?? []), "dream", "distill"],
-        scope: input.sessionIds.length > 0 ? "session" : "agent",
-        scopeTarget: input.sessionIds[0] ?? "dream",
+        scope: write.scope,
+        scopeTarget: write.scopeTarget,
       },
       evidence: evidenceForSessions(
-        input.sessionIds,
+        write.evidenceSessions,
         `distill dry-run proposal for dream ${input.dreamRunId}`,
       ),
       reverse: { op: "delete_fact", payload: {} },
@@ -99,11 +125,23 @@ export function reflectProposalsToCandidates(input: {
 }): CandidateEntryInput[] {
   const out: CandidateEntryInput[] = [];
   let sortOrder = 0;
-  const scope: "session" | "agent" | "user" | "global" =
-    input.writeScope ?? (input.sessionIds.length > 0 ? "session" : "agent");
-  const scopeTarget =
+  if (input.sessionIds.length === 0 && input.writeScope !== "global") {
+    return out;
+  }
+  let scope: "session" | "agent" | "user" | "global" =
+    input.writeScope ?? (input.sessionIds.length === 1 ? "session" : "agent");
+  let scopeTarget =
     input.writeScopeTarget ??
-    (scope === "session" || scope === "agent" || scope === "user" ? (input.sessionIds[0] ?? "dream") : null);
+    (scope === "session"
+      ? (input.sessionIds[0] ?? null)
+      : scope === "agent" || scope === "user"
+        ? (input.sessionIds[0] ?? "dream-multi")
+        : null);
+  // Never collapse multi-session Dream patterns into sessionIds[0].
+  if (scope === "session" && input.sessionIds.length !== 1) {
+    scope = "agent";
+    scopeTarget = "dream-multi";
+  }
   for (const pattern of input.proposals.slice(0, DREAM_COMPOSE_CANDIDATE_CAP)) {
     const text = pattern.text?.trim();
     if (!text) continue;
@@ -133,14 +171,6 @@ export function reflectProposalsToCandidates(input: {
   return out;
 }
 
-export type ContradictionProposedResolve = {
-  contradictionId: string;
-  factIdNew: string;
-  factIdOld: string;
-  /** Propose-time OCC token for factIdOld (#2175). */
-  preHash: string;
-};
-
 export type SelfCorrectionProposedFact = {
   text: string;
   category: string;
@@ -148,6 +178,7 @@ export type SelfCorrectionProposedFact = {
   key?: string | null;
   value?: string | null;
   tags?: string[];
+  sourceSessionId?: string | null;
 };
 
 export function selfCorrectionProposalsToCandidates(input: {
@@ -160,6 +191,11 @@ export function selfCorrectionProposalsToCandidates(input: {
   for (const fact of input.proposals.slice(0, DREAM_COMPOSE_CANDIDATE_CAP)) {
     const text = fact.text?.trim();
     if (!text) continue;
+    const write = resolveAttributedWriteScope({
+      sessionIds: input.sessionIds,
+      sourceSessionId: fact.sourceSessionId,
+    });
+    if (!write) continue;
     out.push({
       op: "add",
       payload: {
@@ -171,11 +207,11 @@ export function selfCorrectionProposalsToCandidates(input: {
         value: fact.value ?? text.slice(0, 200),
         source: "dream-self-correction",
         tags: [...(fact.tags ?? []), "dream", "self-correction"],
-        scope: input.sessionIds.length > 0 ? "session" : "agent",
-        scopeTarget: input.sessionIds[0] ?? "dream",
+        scope: write.scope,
+        scopeTarget: write.scopeTarget,
       },
       evidence: evidenceForSessions(
-        input.sessionIds,
+        write.evidenceSessions,
         `self-correction dry-run MEMORY_STORE for dream ${input.dreamRunId}`,
       ),
       reverse: { op: "delete_fact", payload: {} },
@@ -192,12 +228,38 @@ export function consolidateProposalsToCandidates(input: {
   proposals: ConsolidateProposedMerge[];
   sessionIds: string[];
   dreamRunId: string;
+  /** Optional provenance sessions keyed by source fact id (from FactsDB). */
+  sourceProvenanceByFactId?: Record<string, string[]>;
 }): CandidateEntryInput[] {
   const out: CandidateEntryInput[] = [];
   let sortOrder = 0;
+  const allow = new Set(input.sessionIds.map((s) => s.trim()).filter(Boolean));
+  if (allow.size === 0) return out;
+
   for (const merge of input.proposals.slice(0, Math.max(1, Math.floor(DREAM_COMPOSE_CANDIDATE_CAP / 2)))) {
     const text = merge.mergedText?.trim();
     if (!text || merge.sourceFactIds.length < 2) continue;
+
+    const provenance = new Set<string>();
+    for (const id of merge.sourceFactIds) {
+      for (const p of input.sourceProvenanceByFactId?.[id] ?? []) {
+        if (p.trim()) provenance.add(p.trim());
+      }
+    }
+    // Fail closed: every source must be attributable to the allowlist when provenance is known;
+    // if no provenance map provided, require merge.scopeTarget / sessionIds intersection via scope.
+    if (input.sourceProvenanceByFactId) {
+      if (provenance.size === 0 || ![...provenance].some((p) => allow.has(p))) continue;
+      if ([...provenance].some((p) => !allow.has(p))) continue;
+    } else if (merge.scope === "session" && merge.scopeTarget && !allow.has(merge.scopeTarget)) {
+      continue;
+    } else if (merge.scope === "session" && !merge.scopeTarget) {
+      continue;
+    }
+
+    const evidenceSessions = [...provenance].filter((p) => allow.has(p));
+    const evidence =
+      evidenceSessions.length > 0 ? evidenceSessions : merge.scope === "session" && merge.scopeTarget ? [merge.scopeTarget] : [...allow];
 
     out.push({
       op: "merge",
@@ -210,11 +272,11 @@ export function consolidateProposalsToCandidates(input: {
         value: merge.value ?? null,
         source: "dream-consolidate",
         tags: [...(merge.tags ?? []), "dream", "consolidated"],
-        scope: (merge.scope as "global" | "user" | "agent" | "session" | undefined) ?? "global",
+        scope: (merge.scope as "global" | "user" | "agent" | "session" | undefined) ?? "agent",
         scopeTarget: merge.scopeTarget ?? null,
       },
       evidence: evidenceForSessions(
-        input.sessionIds,
+        evidence,
         `consolidate dry-run merge of ${merge.sourceFactIds.length} facts for dream ${input.dreamRunId}`,
       ),
       reverse: { op: "delete_fact", payload: {} },
@@ -234,11 +296,13 @@ export function consolidateProposalsToCandidates(input: {
           key: null,
           value: null,
           source: "dream-consolidate",
+          scope: (merge.scope as "global" | "user" | "agent" | "session" | undefined) ?? "agent",
+          scopeTarget: merge.scopeTarget ?? null,
         },
         targetFactId: sourceId,
         preHash,
         evidence: evidenceForSessions(
-          input.sessionIds,
+          evidence,
           `consolidate delete source ${sourceId} (OCC pinned at propose) for dream ${input.dreamRunId}`,
         ),
         reverse: { op: "noop", payload: { note: "source restore requires backup; consolidate reverse is best-effort" } },
@@ -248,6 +312,18 @@ export function consolidateProposalsToCandidates(input: {
   }
   return out;
 }
+
+export type ContradictionProposedResolve = {
+  contradictionId: string;
+  factIdNew: string;
+  factIdOld: string;
+  /** Propose-time OCC token for factIdOld (#2175). */
+  preHash: string;
+  scope?: string | null;
+  scopeTarget?: string | null;
+  /** Provenance sessions from the facts involved (not Dream attachment stamp). */
+  provenanceSessionIds?: string[];
+};
 
 export type ContradictionResolvePair = {
   contradictionId: string;
@@ -262,7 +338,12 @@ export type ContradictionResolvePair = {
 export function pinContradictionResolves(
   pairs: ContradictionResolvePair[],
   lookup: {
-    getById: (id: string) => { supersededAt?: number | null } | null | undefined;
+    getById: (id: string) => {
+      supersededAt?: number | null;
+      scope?: string | null;
+      scopeTarget?: string | null;
+      provenanceSession?: string | null;
+    } | null | undefined;
     getOccToken: (id: string) => string | null;
   },
 ): ContradictionProposedResolve[] {
@@ -273,7 +354,22 @@ export function pinContradictionResolves(
       if (!oldFact || oldFact.supersededAt != null) continue;
       const preHash = lookup.getOccToken(pair.factIdOld);
       if (!preHash) continue;
-      out.push({ ...pair, preHash });
+      const newFact = lookup.getById(pair.factIdNew);
+      const provenanceSessionIds = [
+        oldFact.provenanceSession,
+        newFact?.provenanceSession,
+        oldFact.scope === "session" ? oldFact.scopeTarget : null,
+        newFact?.scope === "session" ? newFact.scopeTarget : null,
+      ]
+        .map((s) => (typeof s === "string" ? s.trim() : ""))
+        .filter(Boolean);
+      out.push({
+        ...pair,
+        preHash,
+        scope: oldFact.scope ?? null,
+        scopeTarget: oldFact.scopeTarget ?? null,
+        provenanceSessionIds: [...new Set(provenanceSessionIds)],
+      });
     } catch {
       // fail closed per pair
     }
@@ -289,8 +385,16 @@ export function contradictionProposalsToCandidates(input: {
 }): CandidateEntryInput[] {
   const out: CandidateEntryInput[] = [];
   let sortOrder = 0;
+  const allow = new Set(input.sessionIds.map((s) => s.trim()).filter(Boolean));
   for (const pair of input.proposals.slice(0, DREAM_COMPOSE_CANDIDATE_CAP)) {
     if (!pair.preHash || !pair.factIdOld) continue;
+    const provenance = (pair.provenanceSessionIds ?? []).map((s) => s.trim()).filter(Boolean);
+    if (allow.size > 0) {
+      if (provenance.length === 0 || !provenance.some((p) => allow.has(p))) continue;
+    } else {
+      continue;
+    }
+    const evidenceSessions = provenance.filter((p) => allow.has(p));
     out.push({
       op: "delete",
       targetFactId: pair.factIdOld,
@@ -304,9 +408,11 @@ export function contradictionProposalsToCandidates(input: {
         value: null,
         source: "dream-contradictions",
         tags: ["dream", "contradiction-resolve"],
+        scope: (pair.scope as "session" | "agent" | "user" | "global" | undefined) ?? "agent",
+        scopeTarget: pair.scopeTarget ?? null,
       },
       evidence: evidenceForSessions(
-        input.sessionIds,
+        evidenceSessions,
         `contradiction dry-run auto-resolvable ${pair.contradictionId} for dream ${input.dreamRunId}`,
       ),
       reverse: { op: "unsupersede", payload: { oldFactId: pair.factIdOld, newFactId: null } },

--- a/extensions/memory-hybrid/services/dream-compose-candidates.ts
+++ b/extensions/memory-hybrid/services/dream-compose-candidates.ts
@@ -1,0 +1,318 @@
+/**
+ * Map compose-stage dry-run proposals → dream CandidateEntryInput (#2170 / #2171).
+ *
+ * Stages return lightweight proposed payloads; this module owns evidence/OCC/reverse plans
+ * so runDream stays orchestration-only.
+ */
+
+import type { MemoryCategory } from "../types/memory.js";
+import type { CandidateEntryInput } from "./dream-candidate-ops.js";
+
+/** Max candidates emitted per compose stage (keeps promote/gate bounded). */
+export const DREAM_COMPOSE_CANDIDATE_CAP = 40;
+
+export type DistillProposedFact = {
+  text: string;
+  category: string;
+  entity?: string | null;
+  key?: string | null;
+  value?: string | null;
+  source_date?: string | null;
+  tags?: string[];
+};
+
+export type ReflectProposedPattern = {
+  text: string;
+};
+
+export type ConsolidateProposedMerge = {
+  sourceFactIds: string[];
+  mergedText: string;
+  category: MemoryCategory | string;
+  importance?: number;
+  entity?: string | null;
+  key?: string | null;
+  value?: string | null;
+  tags?: string[];
+  scope?: string;
+  scopeTarget?: string | null;
+  /** Propose-time OCC tokens keyed by source fact id (#2175). */
+  sourcePreHashes: Record<string, string>;
+};
+
+function evidenceForSessions(
+  sessionIds: string[],
+  rationale: string,
+): CandidateEntryInput["evidence"] {
+  return {
+    sessionIds,
+    prevalence: {
+      sessions: Math.max(1, sessionIds.length || 1),
+      agents: 1,
+    },
+    rationale,
+  };
+}
+
+export function distillProposalsToCandidates(input: {
+  proposals: DistillProposedFact[];
+  sessionIds: string[];
+  dreamRunId: string;
+}): CandidateEntryInput[] {
+  const out: CandidateEntryInput[] = [];
+  let sortOrder = 0;
+  for (const fact of input.proposals.slice(0, DREAM_COMPOSE_CANDIDATE_CAP)) {
+    const text = fact.text?.trim();
+    if (!text) continue;
+    out.push({
+      op: "add",
+      payload: {
+        text,
+        category: (fact.category as MemoryCategory) || "fact",
+        importance: 0.6,
+        entity: fact.entity ?? null,
+        key: fact.key ?? null,
+        value: fact.value ?? null,
+        source: "dream-distill",
+        tags: [...(fact.tags ?? []), "dream", "distill"],
+        scope: input.sessionIds.length > 0 ? "session" : "agent",
+        scopeTarget: input.sessionIds[0] ?? "dream",
+      },
+      evidence: evidenceForSessions(
+        input.sessionIds,
+        `distill dry-run proposal for dream ${input.dreamRunId}`,
+      ),
+      reverse: { op: "delete_fact", payload: {} },
+      sortOrder: sortOrder++,
+    });
+  }
+  return out;
+}
+
+export function reflectProposalsToCandidates(input: {
+  proposals: ReflectProposedPattern[];
+  sessionIds: string[];
+  dreamRunId: string;
+  /** Write scope clamped to dream permission boundary (#2174). Default: session when attached. */
+  writeScope?: "session" | "agent" | "user" | "global";
+  writeScopeTarget?: string | null;
+}): CandidateEntryInput[] {
+  const out: CandidateEntryInput[] = [];
+  let sortOrder = 0;
+  const scope: "session" | "agent" | "user" | "global" =
+    input.writeScope ?? (input.sessionIds.length > 0 ? "session" : "agent");
+  const scopeTarget =
+    input.writeScopeTarget ??
+    (scope === "session" || scope === "agent" || scope === "user" ? (input.sessionIds[0] ?? "dream") : null);
+  for (const pattern of input.proposals.slice(0, DREAM_COMPOSE_CANDIDATE_CAP)) {
+    const text = pattern.text?.trim();
+    if (!text) continue;
+    out.push({
+      op: "add",
+      payload: {
+        text,
+        category: "pattern",
+        importance: 0.7,
+        entity: null,
+        key: null,
+        value: null,
+        source: "dream-reflect",
+        tags: ["dream", "reflection", "pattern"],
+        decayClass: "permanent",
+        scope,
+        scopeTarget,
+      },
+      evidence: evidenceForSessions(
+        input.sessionIds,
+        `reflect dry-run pattern for dream ${input.dreamRunId}`,
+      ),
+      reverse: { op: "delete_fact", payload: {} },
+      sortOrder: sortOrder++,
+    });
+  }
+  return out;
+}
+
+export type ContradictionProposedResolve = {
+  contradictionId: string;
+  factIdNew: string;
+  factIdOld: string;
+  /** Propose-time OCC token for factIdOld (#2175). */
+  preHash: string;
+};
+
+export type SelfCorrectionProposedFact = {
+  text: string;
+  category: string;
+  entity?: string | null;
+  key?: string | null;
+  value?: string | null;
+  tags?: string[];
+};
+
+export function selfCorrectionProposalsToCandidates(input: {
+  proposals: SelfCorrectionProposedFact[];
+  sessionIds: string[];
+  dreamRunId: string;
+}): CandidateEntryInput[] {
+  const out: CandidateEntryInput[] = [];
+  let sortOrder = 0;
+  for (const fact of input.proposals.slice(0, DREAM_COMPOSE_CANDIDATE_CAP)) {
+    const text = fact.text?.trim();
+    if (!text) continue;
+    out.push({
+      op: "add",
+      payload: {
+        text,
+        category: (fact.category as MemoryCategory) || "technical",
+        importance: 0.65,
+        entity: fact.entity ?? null,
+        key: fact.key ?? null,
+        value: fact.value ?? text.slice(0, 200),
+        source: "dream-self-correction",
+        tags: [...(fact.tags ?? []), "dream", "self-correction"],
+        scope: input.sessionIds.length > 0 ? "session" : "agent",
+        scopeTarget: input.sessionIds[0] ?? "dream",
+      },
+      evidence: evidenceForSessions(
+        input.sessionIds,
+        `self-correction dry-run MEMORY_STORE for dream ${input.dreamRunId}`,
+      ),
+      reverse: { op: "delete_fact", payload: {} },
+      sortOrder: sortOrder++,
+    });
+  }
+  return out;
+}
+
+/**
+ * Consolidate proposals: one merge (add merged fact) + deletes for sources with OCC preHash.
+ */
+export function consolidateProposalsToCandidates(input: {
+  proposals: ConsolidateProposedMerge[];
+  sessionIds: string[];
+  dreamRunId: string;
+}): CandidateEntryInput[] {
+  const out: CandidateEntryInput[] = [];
+  let sortOrder = 0;
+  for (const merge of input.proposals.slice(0, Math.max(1, Math.floor(DREAM_COMPOSE_CANDIDATE_CAP / 2)))) {
+    const text = merge.mergedText?.trim();
+    if (!text || merge.sourceFactIds.length < 2) continue;
+
+    out.push({
+      op: "merge",
+      payload: {
+        text,
+        category: (merge.category as MemoryCategory) || "other",
+        importance: merge.importance ?? 0.7,
+        entity: merge.entity ?? null,
+        key: merge.key ?? null,
+        value: merge.value ?? null,
+        source: "dream-consolidate",
+        tags: [...(merge.tags ?? []), "dream", "consolidated"],
+        scope: (merge.scope as "global" | "user" | "agent" | "session" | undefined) ?? "global",
+        scopeTarget: merge.scopeTarget ?? null,
+      },
+      evidence: evidenceForSessions(
+        input.sessionIds,
+        `consolidate dry-run merge of ${merge.sourceFactIds.length} facts for dream ${input.dreamRunId}`,
+      ),
+      reverse: { op: "delete_fact", payload: {} },
+      sortOrder: sortOrder++,
+    });
+
+    for (const sourceId of merge.sourceFactIds) {
+      const preHash = merge.sourcePreHashes[sourceId];
+      if (!preHash) continue;
+      out.push({
+        op: "delete",
+        payload: {
+          text: `delete source ${sourceId} after consolidate merge`,
+          category: "other",
+          importance: 0,
+          entity: null,
+          key: null,
+          value: null,
+          source: "dream-consolidate",
+        },
+        targetFactId: sourceId,
+        preHash,
+        evidence: evidenceForSessions(
+          input.sessionIds,
+          `consolidate delete source ${sourceId} (OCC pinned at propose) for dream ${input.dreamRunId}`,
+        ),
+        reverse: { op: "noop", payload: { note: "source restore requires backup; consolidate reverse is best-effort" } },
+        sortOrder: sortOrder++,
+      });
+    }
+  }
+  return out;
+}
+
+export type ContradictionResolvePair = {
+  contradictionId: string;
+  factIdNew: string;
+  factIdOld: string;
+};
+
+/**
+ * Pin OCC preHash for auto-resolvable contradiction deletes.
+ * Skip missing / already-superseded facts (fail closed — do not emit stale deletes).
+ */
+export function pinContradictionResolves(
+  pairs: ContradictionResolvePair[],
+  lookup: {
+    getById: (id: string) => { supersededAt?: number | null } | null | undefined;
+    getOccToken: (id: string) => string | null;
+  },
+): ContradictionProposedResolve[] {
+  const out: ContradictionProposedResolve[] = [];
+  for (const pair of pairs) {
+    try {
+      const oldFact = lookup.getById(pair.factIdOld);
+      if (!oldFact || oldFact.supersededAt != null) continue;
+      const preHash = lookup.getOccToken(pair.factIdOld);
+      if (!preHash) continue;
+      out.push({ ...pair, preHash });
+    } catch {
+      // fail closed per pair
+    }
+  }
+  return out;
+}
+
+/** Auto-resolvable contradiction pairs → delete older fact with OCC preHash (#2170/#2175). */
+export function contradictionProposalsToCandidates(input: {
+  proposals: ContradictionProposedResolve[];
+  sessionIds: string[];
+  dreamRunId: string;
+}): CandidateEntryInput[] {
+  const out: CandidateEntryInput[] = [];
+  let sortOrder = 0;
+  for (const pair of input.proposals.slice(0, DREAM_COMPOSE_CANDIDATE_CAP)) {
+    if (!pair.preHash || !pair.factIdOld) continue;
+    out.push({
+      op: "delete",
+      targetFactId: pair.factIdOld,
+      preHash: pair.preHash,
+      payload: {
+        text: `resolve contradiction ${pair.contradictionId} (drop ${pair.factIdOld}, keep ${pair.factIdNew})`,
+        category: "preference",
+        importance: 0,
+        entity: null,
+        key: null,
+        value: null,
+        source: "dream-contradictions",
+        tags: ["dream", "contradiction-resolve"],
+      },
+      evidence: evidenceForSessions(
+        input.sessionIds,
+        `contradiction dry-run auto-resolvable ${pair.contradictionId} for dream ${input.dreamRunId}`,
+      ),
+      reverse: { op: "unsupersede", payload: { oldFactId: pair.factIdOld, newFactId: null } },
+      sortOrder: sortOrder++,
+    });
+  }
+  return out;
+}
+

--- a/extensions/memory-hybrid/services/dream-compose-candidates.ts
+++ b/extensions/memory-hybrid/services/dream-compose-candidates.ts
@@ -7,6 +7,7 @@
 
 import type { MemoryCategory } from "../types/memory.js";
 import type { CandidateEntryInput } from "./dream-candidate-ops.js";
+import { aclFitsTarget, type DreamWriteScope } from "./dream-permission.js";
 
 /** Max candidates emitted per compose stage (keeps promote/gate bounded). */
 export const DREAM_COMPOSE_CANDIDATE_CAP = 40;
@@ -228,8 +229,11 @@ export function consolidateProposalsToCandidates(input: {
   proposals: ConsolidateProposedMerge[];
   sessionIds: string[];
   dreamRunId: string;
-  /** Optional provenance sessions keyed by source fact id (from FactsDB). */
-  sourceProvenanceByFactId?: Record<string, string[]>;
+  /**
+   * Provenance sessions keyed by source fact id (required for Dream ACL).
+   * Missing map → no candidates (fail closed).
+   */
+  sourceProvenanceByFactId: Record<string, string[]>;
 }): CandidateEntryInput[] {
   const out: CandidateEntryInput[] = [];
   let sortOrder = 0;
@@ -240,26 +244,26 @@ export function consolidateProposalsToCandidates(input: {
     const text = merge.mergedText?.trim();
     if (!text || merge.sourceFactIds.length < 2) continue;
 
-    const provenance = new Set<string>();
+    // Every source must have non-empty provenance fully inside the allowlist (#2174).
+    const perSource: string[][] = [];
+    let provenanceOk = true;
     for (const id of merge.sourceFactIds) {
-      for (const p of input.sourceProvenanceByFactId?.[id] ?? []) {
-        if (p.trim()) provenance.add(p.trim());
+      const prov = [...new Set((input.sourceProvenanceByFactId[id] ?? []).map((p) => p.trim()).filter(Boolean))];
+      if (prov.length === 0 || prov.some((p) => !allow.has(p))) {
+        provenanceOk = false;
+        break;
       }
+      perSource.push(prov);
     }
-    // Fail closed: every source must be attributable to the allowlist when provenance is known;
-    // if no provenance map provided, require merge.scopeTarget / sessionIds intersection via scope.
-    if (input.sourceProvenanceByFactId) {
-      if (provenance.size === 0 || ![...provenance].some((p) => allow.has(p))) continue;
-      if ([...provenance].some((p) => !allow.has(p))) continue;
-    } else if (merge.scope === "session" && merge.scopeTarget && !allow.has(merge.scopeTarget)) {
-      continue;
-    } else if (merge.scope === "session" && !merge.scopeTarget) {
-      continue;
-    }
+    if (!provenanceOk) continue;
 
-    const evidenceSessions = [...provenance].filter((p) => allow.has(p));
-    const evidence =
-      evidenceSessions.length > 0 ? evidenceSessions : merge.scope === "session" && merge.scopeTarget ? [merge.scopeTarget] : [...allow];
+    // OCC fail-closed: require propose-time preHash for every source delete.
+    if (merge.sourceFactIds.some((id) => !merge.sourcePreHashes[id])) continue;
+
+    const evidenceSessions = [...new Set(perSource.flat())];
+    // Clamp write scope to session when a single evidence session; otherwise agent (never invent global).
+    const writeScope = evidenceSessions.length === 1 ? ("session" as const) : ("agent" as const);
+    const writeTarget = evidenceSessions.length === 1 ? evidenceSessions[0]! : "dream-multi";
 
     out.push({
       op: "merge",
@@ -272,11 +276,11 @@ export function consolidateProposalsToCandidates(input: {
         value: merge.value ?? null,
         source: "dream-consolidate",
         tags: [...(merge.tags ?? []), "dream", "consolidated"],
-        scope: (merge.scope as "global" | "user" | "agent" | "session" | undefined) ?? "agent",
-        scopeTarget: merge.scopeTarget ?? null,
+        scope: writeScope,
+        scopeTarget: writeTarget,
       },
       evidence: evidenceForSessions(
-        evidence,
+        evidenceSessions,
         `consolidate dry-run merge of ${merge.sourceFactIds.length} facts for dream ${input.dreamRunId}`,
       ),
       reverse: { op: "delete_fact", payload: {} },
@@ -284,8 +288,7 @@ export function consolidateProposalsToCandidates(input: {
     });
 
     for (const sourceId of merge.sourceFactIds) {
-      const preHash = merge.sourcePreHashes[sourceId];
-      if (!preHash) continue;
+      const preHash = merge.sourcePreHashes[sourceId]!;
       out.push({
         op: "delete",
         payload: {
@@ -296,13 +299,13 @@ export function consolidateProposalsToCandidates(input: {
           key: null,
           value: null,
           source: "dream-consolidate",
-          scope: (merge.scope as "global" | "user" | "agent" | "session" | undefined) ?? "agent",
-          scopeTarget: merge.scopeTarget ?? null,
+          scope: writeScope,
+          scopeTarget: writeTarget,
         },
         targetFactId: sourceId,
         preHash,
         evidence: evidenceForSessions(
-          evidence,
+          evidenceSessions,
           `consolidate delete source ${sourceId} (OCC pinned at propose) for dream ${input.dreamRunId}`,
         ),
         reverse: { op: "noop", payload: { note: "source restore requires backup; consolidate reverse is best-effort" } },
@@ -382,19 +385,40 @@ export function contradictionProposalsToCandidates(input: {
   proposals: ContradictionProposedResolve[];
   sessionIds: string[];
   dreamRunId: string;
+  /** Dream permission target — used when agent/user/global facts lack provenance sessions. */
+  targetScope?: DreamWriteScope;
+  personalMode?: boolean;
 }): CandidateEntryInput[] {
   const out: CandidateEntryInput[] = [];
   let sortOrder = 0;
   const allow = new Set(input.sessionIds.map((s) => s.trim()).filter(Boolean));
+  if (allow.size === 0) return out;
+  const targetScope = input.targetScope ?? "session";
+
   for (const pair of input.proposals.slice(0, DREAM_COMPOSE_CANDIDATE_CAP)) {
     if (!pair.preHash || !pair.factIdOld) continue;
     const provenance = (pair.provenanceSessionIds ?? []).map((s) => s.trim()).filter(Boolean);
-    if (allow.size > 0) {
-      if (provenance.length === 0 || !provenance.some((p) => allow.has(p))) continue;
+    const factScope: DreamWriteScope =
+      pair.scope === "session" || pair.scope === "agent" || pair.scope === "user" || pair.scope === "global"
+        ? pair.scope
+        : "agent";
+    const sessionTarget = typeof pair.scopeTarget === "string" ? pair.scopeTarget.trim() : "";
+
+    let evidenceSessions: string[] = [];
+    if (provenance.some((p) => allow.has(p))) {
+      evidenceSessions = provenance.filter((p) => allow.has(p));
+    } else if (factScope === "session" && sessionTarget && allow.has(sessionTarget)) {
+      evidenceSessions = [sessionTarget];
+    } else if (
+      factScope !== "session" &&
+      aclFitsTarget(factScope, targetScope, input.personalMode === true)
+    ) {
+      // Shared/public facts may feed a more-private dream; evidence is the attachment, not invented provenance.
+      evidenceSessions = [...allow];
     } else {
       continue;
     }
-    const evidenceSessions = provenance.filter((p) => allow.has(p));
+
     out.push({
       op: "delete",
       targetFactId: pair.factIdOld,
@@ -408,7 +432,7 @@ export function contradictionProposalsToCandidates(input: {
         value: null,
         source: "dream-contradictions",
         tags: ["dream", "contradiction-resolve"],
-        scope: (pair.scope as "session" | "agent" | "user" | "global" | undefined) ?? "agent",
+        scope: factScope,
         scopeTarget: pair.scopeTarget ?? null,
       },
       evidence: evidenceForSessions(

--- a/extensions/memory-hybrid/services/dream-compose-candidates.ts
+++ b/extensions/memory-hybrid/services/dream-compose-candidates.ts
@@ -7,11 +7,7 @@
 
 import type { MemoryCategory } from "../types/memory.js";
 import type { CandidateEntryInput } from "./dream-candidate-ops.js";
-import {
-  aclFitsTarget,
-  writeScopeWithinBoundary,
-  type DreamWriteScope,
-} from "./dream-permission.js";
+import { aclFitsTarget, writeScopeWithinBoundary, type DreamWriteScope } from "./dream-permission.js";
 import type { DreamPermissionBoundary } from "../config/types/dreaming.js";
 
 /** Max candidates emitted per compose stage (keeps promote/gate bounded). */
@@ -48,10 +44,7 @@ export type ConsolidateProposedMerge = {
   sourcePreHashes: Record<string, string>;
 };
 
-function evidenceForSessions(
-  sessionIds: string[],
-  rationale: string,
-): CandidateEntryInput["evidence"] {
+function evidenceForSessions(sessionIds: string[], rationale: string): CandidateEntryInput["evidence"] {
   const unique = [...new Set(sessionIds.map((s) => s.trim()).filter(Boolean))];
   return {
     sessionIds: unique,
@@ -70,8 +63,7 @@ function resolveAttributedWriteScope(input: {
 }): { scope: "session" | "agent"; scopeTarget: string; evidenceSessions: string[] } | null {
   const attached = [...new Set(input.sessionIds.map((s) => s.trim()).filter(Boolean))];
   const source = input.sourceSessionId?.trim() || "";
-  let resolved: { scope: "session" | "agent"; scopeTarget: string; evidenceSessions: string[] } | null =
-    null;
+  let resolved: { scope: "session" | "agent"; scopeTarget: string; evidenceSessions: string[] } | null = null;
   if (source) {
     if (attached.length > 0 && !attached.includes(source)) return null;
     resolved = { scope: "session", scopeTarget: source, evidenceSessions: [source] };
@@ -130,10 +122,7 @@ export function distillProposalsToCandidates(input: {
         scope: write.scope,
         scopeTarget: write.scopeTarget,
       },
-      evidence: evidenceForSessions(
-        write.evidenceSessions,
-        `distill dry-run proposal for dream ${input.dreamRunId}`,
-      ),
+      evidence: evidenceForSessions(write.evidenceSessions, `distill dry-run proposal for dream ${input.dreamRunId}`),
       reverse: { op: "delete_fact", payload: {} },
       sortOrder: sortOrder++,
     });
@@ -197,10 +186,7 @@ export function reflectProposalsToCandidates(input: {
         scope,
         scopeTarget,
       },
-      evidence: evidenceForSessions(
-        input.sessionIds,
-        `reflect dry-run pattern for dream ${input.dreamRunId}`,
-      ),
+      evidence: evidenceForSessions(input.sessionIds, `reflect dry-run pattern for dream ${input.dreamRunId}`),
       reverse: { op: "delete_fact", payload: {} },
       sortOrder: sortOrder++,
     });
@@ -355,7 +341,10 @@ export function consolidateProposalsToCandidates(input: {
           evidenceSessions,
           `consolidate delete source ${sourceId} (OCC pinned at propose) for dream ${input.dreamRunId}`,
         ),
-        reverse: { op: "noop", payload: { note: "source restore requires backup; consolidate reverse is best-effort" } },
+        reverse: {
+          op: "noop",
+          payload: { note: "source restore requires backup; consolidate reverse is best-effort" },
+        },
         sortOrder: sortOrder++,
       });
     }
@@ -388,12 +377,15 @@ export type ContradictionResolvePair = {
 export function pinContradictionResolves(
   pairs: ContradictionResolvePair[],
   lookup: {
-    getById: (id: string) => {
-      supersededAt?: number | null;
-      scope?: string | null;
-      scopeTarget?: string | null;
-      provenanceSession?: string | null;
-    } | null | undefined;
+    getById: (id: string) =>
+      | {
+          supersededAt?: number | null;
+          scope?: string | null;
+          scopeTarget?: string | null;
+          provenanceSession?: string | null;
+        }
+      | null
+      | undefined;
     getOccToken: (id: string) => string | null;
   },
 ): ContradictionProposedResolve[] {
@@ -467,10 +459,7 @@ export function contradictionProposalsToCandidates(input: {
       evidenceSessions = provenance.filter((p) => allow.has(p));
     } else if (factScope === "session" && sessionTarget && allow.has(sessionTarget)) {
       evidenceSessions = [sessionTarget];
-    } else if (
-      factScope !== "session" &&
-      aclFitsTarget(factScope, targetScope, boundary.personalMode === true)
-    ) {
+    } else if (factScope !== "session" && aclFitsTarget(factScope, targetScope, boundary.personalMode === true)) {
       // Shared/public facts may feed a more-private dream; evidence is the attachment, not invented provenance.
       evidenceSessions = [...allow];
     } else {
@@ -503,4 +492,3 @@ export function contradictionProposalsToCandidates(input: {
   }
   return out;
 }
-

--- a/extensions/memory-hybrid/services/dream-contradiction-gate.ts
+++ b/extensions/memory-hybrid/services/dream-contradiction-gate.ts
@@ -40,10 +40,14 @@ export function evaluateContradictionWorsening(
       if (isFactVerified(db, targetId)) {
         return { worsens: true, reason: "deletes_verified_fact" };
       }
-      if (factsDb.isContradicted(targetId)) {
+      const tags = entry.payload.tags ?? [];
+      const isDreamContradictionResolve =
+        entry.payload.source === "dream-contradictions" || tags.includes("contradiction-resolve");
+      // Auto-resolve deletes intentionally remove the losing side of an unresolved pair.
+      if (factsDb.isContradicted(targetId) && !isDreamContradictionResolve) {
         return { worsens: true, reason: "deletes_unresolved_contradiction_side" };
       }
-      return { worsens: false, reason: "ok" };
+      return { worsens: false, reason: isDreamContradictionResolve ? "contradiction_resolve_ok" : "ok" };
     }
 
     const entity = entry.payload.entity?.trim();

--- a/extensions/memory-hybrid/services/dream-contradiction-gate.ts
+++ b/extensions/memory-hybrid/services/dream-contradiction-gate.ts
@@ -5,10 +5,7 @@
  */
 
 import type { FactsDB } from "../backends/facts-db.js";
-import {
-  isFactVerified,
-  scoreFactContradiction,
-} from "../backends/facts-db/contradictions.js";
+import { isFactVerified, scoreFactContradiction } from "../backends/facts-db/contradictions.js";
 import { DREAM_CONTRADICTION_WORSEN_SCORE } from "../config/types/dreaming.js";
 import type { CandidateEntryRecord } from "./dream-candidate-ops.js";
 
@@ -61,25 +58,13 @@ export function evaluateContradictionWorsening(
     const scope = entry.payload.scope ?? null;
     const scopeTarget = entry.payload.scopeTarget ?? null;
     const excludeId = entry.payload.id?.trim() || "";
-    const conflicts = factsDb.findConflictingFacts(
-      entity,
-      key,
-      String(value),
-      excludeId,
-      scope,
-      scopeTarget,
-    );
+    const conflicts = factsDb.findConflictingFacts(entity, key, String(value), excludeId, scope, scopeTarget);
 
     for (const old of conflicts) {
       if (isFactVerified(db, old.id)) {
         return { worsens: true, reason: `conflicts_verified_${old.id.slice(0, 8)}` };
       }
-      const scored = scoreFactContradiction(
-        entry.payload.text ?? "",
-        String(value),
-        old.text ?? "",
-        old.value ?? "",
-      );
+      const scored = scoreFactContradiction(entry.payload.text ?? "", String(value), old.text ?? "", old.value ?? "");
       if (scored.score >= scoreThreshold) {
         return {
           worsens: true,

--- a/extensions/memory-hybrid/services/dream-contradiction-gate.ts
+++ b/extensions/memory-hybrid/services/dream-contradiction-gate.ts
@@ -1,0 +1,92 @@
+/**
+ * Live contradiction-worsening gate for Dream promote (#2170).
+ *
+ * Uses FactsDB heuristics (no NLI write path). Fail closed on DB errors.
+ */
+
+import type { FactsDB } from "../backends/facts-db.js";
+import {
+  isFactVerified,
+  scoreFactContradiction,
+} from "../backends/facts-db/contradictions.js";
+import { DREAM_CONTRADICTION_WORSEN_SCORE } from "../config/types/dreaming.js";
+import type { CandidateEntryRecord } from "./dream-candidate-ops.js";
+
+export type ContradictionWorsenResult = {
+  worsens: boolean;
+  reason: string;
+};
+
+/**
+ * True when applying `entry` would worsen high-severity contradictions vs live FactsDB.
+ */
+export function evaluateContradictionWorsening(
+  factsDb: FactsDB,
+  entry: CandidateEntryRecord,
+  scoreThreshold: number = DREAM_CONTRADICTION_WORSEN_SCORE,
+): ContradictionWorsenResult {
+  if (entry.payload.contradictionWorsens === true) {
+    return { worsens: true, reason: "contradiction_worsens_flag" };
+  }
+
+  try {
+    const db = factsDb.getRawDb();
+
+    if (entry.op === "delete" || entry.op === "supersede") {
+      const targetId = entry.targetFactId?.trim();
+      if (!targetId) {
+        return { worsens: false, reason: "no_target" };
+      }
+      if (isFactVerified(db, targetId)) {
+        return { worsens: true, reason: "deletes_verified_fact" };
+      }
+      if (factsDb.isContradicted(targetId)) {
+        return { worsens: true, reason: "deletes_unresolved_contradiction_side" };
+      }
+      return { worsens: false, reason: "ok" };
+    }
+
+    const entity = entry.payload.entity?.trim();
+    const key = entry.payload.key?.trim();
+    const value = entry.payload.value;
+    if (!entity || !key || value == null || String(value).trim() === "") {
+      // Unstructured candidates: prevalence/provenance still apply; no entity/key conflict scan.
+      return { worsens: false, reason: "no_entity_key" };
+    }
+
+    const scope = entry.payload.scope ?? null;
+    const scopeTarget = entry.payload.scopeTarget ?? null;
+    const excludeId = entry.payload.id?.trim() || "";
+    const conflicts = factsDb.findConflictingFacts(
+      entity,
+      key,
+      String(value),
+      excludeId,
+      scope,
+      scopeTarget,
+    );
+
+    for (const old of conflicts) {
+      if (isFactVerified(db, old.id)) {
+        return { worsens: true, reason: `conflicts_verified_${old.id.slice(0, 8)}` };
+      }
+      const scored = scoreFactContradiction(
+        entry.payload.text ?? "",
+        String(value),
+        old.text ?? "",
+        old.value ?? "",
+      );
+      if (scored.score >= scoreThreshold) {
+        return {
+          worsens: true,
+          reason: `heuristic_score_${scored.score.toFixed(2)}_vs_${old.id.slice(0, 8)}`,
+        };
+      }
+    }
+
+    return { worsens: false, reason: "ok" };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { worsens: true, reason: `contradiction_gate_error:${message.slice(0, 80)}` };
+  }
+}

--- a/extensions/memory-hybrid/services/dream-metrics.ts
+++ b/extensions/memory-hybrid/services/dream-metrics.ts
@@ -112,6 +112,30 @@ export function deriveEffectScore(corrections: number, praise: number): number {
   return Math.max(-1, Math.min(1, raw));
 }
 
+function readToolEffectivenessAggregate(
+  db: DatabaseSync,
+  fromSec: number,
+  toSec: number,
+): { successRate: number; totalCalls: number } | null {
+  try {
+    const row = db
+      .prepare(
+        `SELECT COALESCE(SUM(success_calls), 0) AS ok,
+                COALESCE(SUM(total_calls), 0) AS total
+         FROM tool_effectiveness
+         WHERE last_updated >= ? AND last_updated <= ?`,
+      )
+      .get(fromSec, toSec) as { ok: number; total: number } | undefined;
+    const total = Number(row?.total ?? 0);
+    if (!Number.isFinite(total) || total <= 0) return null;
+    const ok = Number(row?.ok ?? 0);
+    return { successRate: Math.max(0, Math.min(1, ok / total)), totalCalls: total };
+  } catch {
+    // Table may not exist in this DB — feedback proxy remains the primary signal.
+    return null;
+  }
+}
+
 export function collectDreamMetricSet(
   factsDb: FactsDB,
   input: { fromSec: number; toSec: number; sessionIds: string[] },
@@ -119,13 +143,36 @@ export function collectDreamMetricSet(
   const db = factsDb.getRawDb();
   const { corrections, praise, sessions } = countFeedbackSignals(db, input.fromSec, input.toSec, input.sessionIds);
   const effectScore = deriveEffectScore(corrections, praise);
-  const successRate = praise + corrections > 0 ? praise / (praise + corrections) : 1;
+  const feedbackSuccess = praise + corrections > 0 ? praise / (praise + corrections) : 1;
   const retryRate = corrections;
+  const tool = readToolEffectivenessAggregate(db, input.fromSec, input.toSec);
+
+  if (tool && praise + corrections > 0) {
+    // Prefer blended signal when both feedback and tool effectiveness exist (#2173).
+    const successRate = 0.5 * feedbackSuccess + 0.5 * tool.successRate;
+    return {
+      successRate,
+      retryRate,
+      effectScore,
+      sessionsObserved: sessions,
+      signalSource: "blended",
+    };
+  }
+  if (tool && praise + corrections === 0) {
+    return {
+      successRate: tool.successRate,
+      retryRate,
+      effectScore: tool.successRate * 2 - 1,
+      sessionsObserved: Math.max(sessions, 1),
+      signalSource: "tool_effectiveness",
+    };
+  }
   return {
-    successRate,
+    successRate: feedbackSuccess,
     retryRate,
     effectScore,
     sessionsObserved: sessions,
+    signalSource: "feedback_proxy",
   };
 }
 

--- a/extensions/memory-hybrid/services/dream-metrics.ts
+++ b/extensions/memory-hybrid/services/dream-metrics.ts
@@ -1,0 +1,173 @@
+/**
+ * Dream metrics collection (#2173 / #2179) — baseline + after-window signals from the facts DB.
+ */
+
+import type { DatabaseSync } from "node:sqlite";
+import type { FactsDB } from "../backends/facts-db.js";
+import type { DreamMetricSet } from "./dream-outcome.js";
+
+export type DreamHygieneSnapshot = {
+  openContradictions: number;
+  activeFactCount: number;
+};
+
+export type DreamCostSnapshot = {
+  feature: "dream";
+  wallSeconds: number | null;
+  tokens: number | null;
+  usdProxy: number | null;
+  source: "llm_cost_log" | "insufficient_data";
+};
+
+export type DreamRunMetricsSummary = DreamCostSnapshot &
+  DreamHygieneSnapshot & {
+    recordedAt: number;
+    sessionIds: string[];
+  };
+
+function countOpenContradictions(db: DatabaseSync): number {
+  try {
+    const row = db
+      .prepare(
+        `SELECT COUNT(*) AS c FROM contradictions
+         WHERE resolved_at IS NULL`,
+      )
+      .get() as { c: number } | undefined;
+    return Number(row?.c ?? 0);
+  } catch {
+    return 0;
+  }
+}
+
+function countFeedbackSignals(
+  db: DatabaseSync,
+  fromSec: number,
+  toSec: number,
+  sessionIds: string[],
+): { corrections: number; praise: number; sessions: number } {
+  let corrections = 0;
+  let praise = 0;
+  try {
+    const row = db
+      .prepare(
+        `SELECT COUNT(*) AS c FROM facts
+         WHERE source IN ('self-correction', 'self-correction-analysis')
+           AND created_at >= ? AND created_at <= ?`,
+      )
+      .get(fromSec, toSec) as { c: number };
+    corrections = Number(row?.c ?? 0);
+  } catch {
+    corrections = 0;
+  }
+  try {
+    const row = db
+      .prepare(
+        `SELECT COUNT(*) AS c FROM facts
+         WHERE source = 'reinforcement'
+           AND created_at >= ? AND created_at <= ?`,
+      )
+      .get(fromSec, toSec) as { c: number };
+    praise = Number(row?.c ?? 0);
+  } catch {
+    praise = 0;
+  }
+  const sessions = Math.max(sessionIds.length, corrections + praise > 0 ? 1 : 0);
+  return { corrections, praise, sessions };
+}
+
+/** Derive a simple effect score from feedback balance (higher is better). */
+export function deriveEffectScore(corrections: number, praise: number): number {
+  const denom = Math.max(1, corrections + praise);
+  const raw = (praise - corrections) / denom;
+  return Math.max(-1, Math.min(1, raw));
+}
+
+export function collectDreamMetricSet(
+  factsDb: FactsDB,
+  input: { fromSec: number; toSec: number; sessionIds: string[] },
+): DreamMetricSet {
+  const db = factsDb.getRawDb();
+  const { corrections, praise, sessions } = countFeedbackSignals(
+    db,
+    input.fromSec,
+    input.toSec,
+    input.sessionIds,
+  );
+  const effectScore = deriveEffectScore(corrections, praise);
+  const successRate = praise + corrections > 0 ? praise / (praise + corrections) : 1;
+  const retryRate = corrections;
+  return {
+    successRate,
+    retryRate,
+    effectScore,
+    sessionsObserved: sessions,
+  };
+}
+
+export function collectHygieneSnapshot(factsDb: FactsDB): DreamHygieneSnapshot {
+  const db = factsDb.getRawDb();
+  return {
+    openContradictions: countOpenContradictions(db),
+    activeFactCount: factsDb.count(),
+  };
+}
+
+export function queryDreamCost(
+  db: DatabaseSync,
+  fromSec: number,
+  toSec: number,
+): DreamCostSnapshot {
+  try {
+    const row = db
+      .prepare(
+        `SELECT COALESCE(SUM(input_tokens + output_tokens), 0) AS tokens,
+                COALESCE(SUM(estimated_cost_usd), 0) AS usd
+         FROM llm_cost_log
+         WHERE feature = 'dream' AND timestamp >= ? AND timestamp <= ?`,
+      )
+      .get(fromSec, toSec) as { tokens: number; usd: number } | undefined;
+    if (!row) {
+      return { feature: "dream", wallSeconds: null, tokens: null, usdProxy: null, source: "insufficient_data" };
+    }
+    return {
+      feature: "dream",
+      wallSeconds: Math.max(0, toSec - fromSec),
+      tokens: Number(row.tokens) || 0,
+      usdProxy: Number(row.usd) || 0,
+      source: "llm_cost_log",
+    };
+  } catch {
+    return { feature: "dream", wallSeconds: null, tokens: null, usdProxy: null, source: "insufficient_data" };
+  }
+}
+
+export function buildRunMetricsSummary(
+  factsDb: FactsDB,
+  input: {
+    sessionIds: string[];
+    startedAt: number | null;
+    endedAt: number | null;
+  },
+): DreamRunMetricsSummary {
+  const now = Math.floor(Date.now() / 1000);
+  const fromSec = input.startedAt ?? now;
+  const toSec = input.endedAt ?? now;
+  const cost = queryDreamCost(factsDb.getRawDb(), fromSec, toSec);
+  const hygiene = collectHygieneSnapshot(factsDb);
+  return {
+    ...cost,
+    ...hygiene,
+    wallSeconds:
+      input.startedAt != null && input.endedAt != null
+        ? Math.max(0, input.endedAt - input.startedAt)
+        : cost.wallSeconds,
+    recordedAt: now,
+    sessionIds: input.sessionIds,
+  };
+}
+
+export const DREAM_RUN_TAG_PREFIX = "dream-run:";
+
+export function dreamRunTag(dreamRunId: string): string {
+  return `${DREAM_RUN_TAG_PREFIX}${dreamRunId}`.toLowerCase();
+}

--- a/extensions/memory-hybrid/services/dream-metrics.ts
+++ b/extensions/memory-hybrid/services/dream-metrics.ts
@@ -117,12 +117,7 @@ export function collectDreamMetricSet(
   input: { fromSec: number; toSec: number; sessionIds: string[] },
 ): DreamMetricSet {
   const db = factsDb.getRawDb();
-  const { corrections, praise, sessions } = countFeedbackSignals(
-    db,
-    input.fromSec,
-    input.toSec,
-    input.sessionIds,
-  );
+  const { corrections, praise, sessions } = countFeedbackSignals(db, input.fromSec, input.toSec, input.sessionIds);
   const effectScore = deriveEffectScore(corrections, praise);
   const successRate = praise + corrections > 0 ? praise / (praise + corrections) : 1;
   const retryRate = corrections;
@@ -142,11 +137,7 @@ export function collectHygieneSnapshot(factsDb: FactsDB): DreamHygieneSnapshot {
   };
 }
 
-export function queryDreamCost(
-  db: DatabaseSync,
-  fromSec: number,
-  toSec: number,
-): DreamCostSnapshot {
+export function queryDreamCost(db: DatabaseSync, fromSec: number, toSec: number): DreamCostSnapshot {
   try {
     const row = db
       .prepare(

--- a/extensions/memory-hybrid/services/dream-metrics.ts
+++ b/extensions/memory-hybrid/services/dream-metrics.ts
@@ -39,22 +39,40 @@ function countOpenContradictions(db: DatabaseSync): number {
   }
 }
 
+/** Scope feedback to dream sessions when available (#2173 — avoid false global rollback). */
+function sessionScopeSql(sessionIds: string[]): { clause: string; params: string[] } {
+  const ids = [...new Set(sessionIds.map((s) => s.trim()).filter((s) => s.length > 0))];
+  if (ids.length === 0) {
+    return { clause: "", params: [] };
+  }
+  const placeholders = ids.map(() => "?").join(",");
+  return {
+    clause: ` AND (
+      (scope = 'session' AND scope_target IN (${placeholders}))
+      OR provenance_session IN (${placeholders})
+    )`,
+    params: [...ids, ...ids],
+  };
+}
+
 function countFeedbackSignals(
   db: DatabaseSync,
   fromSec: number,
   toSec: number,
   sessionIds: string[],
 ): { corrections: number; praise: number; sessions: number } {
+  const scope = sessionScopeSql(sessionIds);
   let corrections = 0;
   let praise = 0;
+  let sessions = 0;
   try {
     const row = db
       .prepare(
         `SELECT COUNT(*) AS c FROM facts
          WHERE source IN ('self-correction', 'self-correction-analysis')
-           AND created_at >= ? AND created_at <= ?`,
+           AND created_at >= ? AND created_at <= ?${scope.clause}`,
       )
-      .get(fromSec, toSec) as { c: number };
+      .get(fromSec, toSec, ...scope.params) as { c: number };
     corrections = Number(row?.c ?? 0);
   } catch {
     corrections = 0;
@@ -64,14 +82,26 @@ function countFeedbackSignals(
       .prepare(
         `SELECT COUNT(*) AS c FROM facts
          WHERE source = 'reinforcement'
-           AND created_at >= ? AND created_at <= ?`,
+           AND created_at >= ? AND created_at <= ?${scope.clause}`,
       )
-      .get(fromSec, toSec) as { c: number };
+      .get(fromSec, toSec, ...scope.params) as { c: number };
     praise = Number(row?.c ?? 0);
   } catch {
     praise = 0;
   }
-  const sessions = Math.max(sessionIds.length, corrections + praise > 0 ? 1 : 0);
+  try {
+    // Distinct sessions that actually produced feedback in-window (#2173).
+    const row = db
+      .prepare(
+        `SELECT COUNT(DISTINCT COALESCE(NULLIF(provenance_session, ''), scope_target)) AS c FROM facts
+         WHERE source IN ('self-correction', 'self-correction-analysis', 'reinforcement')
+           AND created_at >= ? AND created_at <= ?${scope.clause}`,
+      )
+      .get(fromSec, toSec, ...scope.params) as { c: number };
+    sessions = Number(row?.c ?? 0);
+  } catch {
+    sessions = corrections + praise > 0 ? 1 : 0;
+  }
   return { corrections, praise, sessions };
 }
 

--- a/extensions/memory-hybrid/services/dream-outcome-probe.ts
+++ b/extensions/memory-hybrid/services/dream-outcome-probe.ts
@@ -68,7 +68,8 @@ export function probeDreamOutcomes(
       cfg,
       nowSec,
       applyRollback,
-      minSessions: Math.max(1, run.sessionIds.length > 0 ? 1 : 3),
+      // Require real observation volume — do not treat "attached session ids" as observed sessions.
+      minSessions: 3,
     });
     reports.push(report);
 

--- a/extensions/memory-hybrid/services/dream-outcome-probe.ts
+++ b/extensions/memory-hybrid/services/dream-outcome-probe.ts
@@ -1,0 +1,101 @@
+/**
+ * Post-promote outcome probe (#2173) — scheduled observation + auto-rollback.
+ */
+
+import type { FactsDB } from "../backends/facts-db.js";
+import type { DreamCandidateStore } from "../backends/dream-candidate-store.js";
+import type { DreamingConfig } from "../config/types/dreaming.js";
+import { DEFAULT_DREAMING_CONFIG } from "../config/types/dreaming.js";
+import { pluginLogger } from "../utils/logger.js";
+import { collectDreamMetricSet } from "./dream-metrics.js";
+import { evaluateDreamOutcome, type DreamOutcomeReport } from "./dream-outcome.js";
+
+export type DreamOutcomeProbeResult = {
+  examined: number;
+  kept: number;
+  rolledBack: number;
+  insufficient: number;
+  reports: DreamOutcomeReport[];
+};
+
+const PRE_WINDOW_SEC = 7 * 24 * 3600;
+
+/**
+ * Probe promoted dream runs whose observation window has elapsed (or is forced).
+ * Requires a real baseline captured at promote time.
+ */
+export function probeDreamOutcomes(
+  factsDb: FactsDB,
+  store: DreamCandidateStore,
+  options: {
+    cfg?: DreamingConfig;
+    nowSec?: number;
+    limit?: number;
+    applyRollback?: boolean;
+    /** When true, also probe runs still inside the window (tests / forced observe). */
+    force?: boolean;
+  } = {},
+): DreamOutcomeProbeResult {
+  const cfg = options.cfg ?? DEFAULT_DREAMING_CONFIG;
+  const nowSec = options.nowSec ?? Math.floor(Date.now() / 1000);
+  const limit = Math.max(1, Math.min(100, options.limit ?? 20));
+  const applyRollback = options.applyRollback ?? cfg.autoRollback.enabled;
+
+  const candidates = store
+    .listDreamRuns(limit * 3)
+    .filter((r) => r.status === "promoted")
+    .filter((r) => {
+      if (options.force) return true;
+      if (r.metricsObserveUntil == null) return false;
+      return nowSec >= r.metricsObserveUntil;
+    })
+    .slice(0, limit);
+
+  const reports: DreamOutcomeReport[] = [];
+  let kept = 0;
+  let rolledBack = 0;
+  let insufficient = 0;
+
+  for (const run of candidates) {
+    const promotedAt = run.promotedAt ?? run.createdAt;
+    const after = collectDreamMetricSet(factsDb, {
+      fromSec: promotedAt,
+      toSec: nowSec,
+      sessionIds: run.sessionIds,
+    });
+
+    const report = evaluateDreamOutcome(factsDb, store, run.id, after, {
+      cfg,
+      nowSec,
+      applyRollback,
+      minSessions: Math.max(1, run.sessionIds.length > 0 ? 1 : 3),
+    });
+    reports.push(report);
+
+    if (report.decision === "insufficient_data") insufficient += 1;
+    else if (report.decision === "keep") kept += 1;
+    else if (report.decision === "rollback") {
+      if (report.rollback?.rolledBack) rolledBack += 1;
+    }
+
+    pluginLogger.info?.(
+      `memory-hybrid: dream outcome probe ${run.id} → ${report.decision} (${report.reason})`,
+    );
+  }
+
+  return { examined: candidates.length, kept, rolledBack, insufficient, reports };
+}
+
+/** Capture pre-promote baseline metrics for a dream run (#2173). */
+export function capturePromoteBaseline(
+  factsDb: FactsDB,
+  sessionIds: string[],
+  promotedAtSec: number,
+): string {
+  const metrics = collectDreamMetricSet(factsDb, {
+    fromSec: promotedAtSec - PRE_WINDOW_SEC,
+    toSec: promotedAtSec,
+    sessionIds,
+  });
+  return JSON.stringify(metrics);
+}

--- a/extensions/memory-hybrid/services/dream-outcome-probe.ts
+++ b/extensions/memory-hybrid/services/dream-outcome-probe.ts
@@ -79,20 +79,14 @@ export function probeDreamOutcomes(
       if (report.rollback?.rolledBack) rolledBack += 1;
     }
 
-    pluginLogger.info?.(
-      `memory-hybrid: dream outcome probe ${run.id} → ${report.decision} (${report.reason})`,
-    );
+    pluginLogger.info?.(`memory-hybrid: dream outcome probe ${run.id} → ${report.decision} (${report.reason})`);
   }
 
   return { examined: candidates.length, kept, rolledBack, insufficient, reports };
 }
 
 /** Capture pre-promote baseline metrics for a dream run (#2173). */
-export function capturePromoteBaseline(
-  factsDb: FactsDB,
-  sessionIds: string[],
-  promotedAtSec: number,
-): string {
+export function capturePromoteBaseline(factsDb: FactsDB, sessionIds: string[], promotedAtSec: number): string {
   const metrics = collectDreamMetricSet(factsDb, {
     fromSec: promotedAtSec - PRE_WINDOW_SEC,
     toSec: promotedAtSec,

--- a/extensions/memory-hybrid/services/dream-outcome.ts
+++ b/extensions/memory-hybrid/services/dream-outcome.ts
@@ -171,11 +171,7 @@ export function evaluateDreamOutcome(
 }
 
 /** Persist keep/rollback/insufficient decisions on the dream_run metrics summary (#2173 audit). */
-function persistOutcomeDecision(
-  store: DreamCandidateStore,
-  dreamRunId: string,
-  report: DreamOutcomeReport,
-): void {
+function persistOutcomeDecision(store: DreamCandidateStore, dreamRunId: string, report: DreamOutcomeReport): void {
   try {
     const run = store.getDreamRun(dreamRunId);
     let base: Record<string, unknown> = {};

--- a/extensions/memory-hybrid/services/dream-outcome.ts
+++ b/extensions/memory-hybrid/services/dream-outcome.ts
@@ -75,6 +75,11 @@ export function evaluateDreamOutcome(
   const minSessions = options.minSessions ?? 3;
   const run = store.getDreamRun(dreamRunId);
 
+  const finish = (report: DreamOutcomeReport): DreamOutcomeReport => {
+    if (run) persistOutcomeDecision(store, dreamRunId, report);
+    return report;
+  };
+
   const emptyAfter = after;
   if (!run) {
     return {
@@ -92,69 +97,69 @@ export function evaluateDreamOutcome(
   const toSec = run.metricsObserveUntil ?? fromSec + cfg.autoRollback.observeWindowHours * 3600;
 
   if (after.sessionsObserved < minSessions) {
-    return {
+    return finish({
       dreamRunId,
       window: { fromSec, toSec, sessions: after.sessionsObserved },
       baseline,
       after,
       decision: "insufficient_data",
       reason: "insufficient_sessions",
-    };
+    });
   }
 
   if (!baseline) {
-    return {
+    return finish({
       dreamRunId,
       window: { fromSec, toSec, sessions: after.sessionsObserved },
       baseline: null,
       after,
       decision: "insufficient_data",
       reason: "missing_baseline",
-    };
+    });
   }
 
   const drop = baseline.effectScore - after.effectScore;
   const shouldRollback = drop >= cfg.autoRollback.regressionThreshold;
 
   if (!shouldRollback) {
-    return {
+    return finish({
       dreamRunId,
       window: { fromSec, toSec, sessions: after.sessionsObserved },
       baseline,
       after,
       decision: "keep",
       reason: `effect_score_drop=${drop.toFixed(3)}_below_threshold`,
-    };
+    });
   }
 
   if (!cfg.autoRollback.enabled || options.applyRollback === false) {
-    return {
+    return finish({
       dreamRunId,
       window: { fromSec, toSec, sessions: after.sessionsObserved },
       baseline,
       after,
       decision: "rollback",
       reason: `would_rollback_effect_drop=${drop.toFixed(3)}`,
-    };
+    });
   }
 
   if (nowSec < toSec && options.applyRollback !== true) {
     // Still inside window unless caller forces apply.
-    return {
+    return finish({
       dreamRunId,
       window: { fromSec, toSec, sessions: after.sessionsObserved },
       baseline,
       after,
       decision: "rollback",
       reason: `regression_detected_waiting_window_or_force`,
-    };
+    });
   }
 
   const rollback = rollbackDreamRun(factsDb, store, dreamRunId, {
     reason: `auto_rollback_effect_drop=${drop.toFixed(3)}`,
   });
 
-  return {
+  return finish({
     dreamRunId,
     window: { fromSec, toSec, sessions: after.sessionsObserved },
     baseline,
@@ -162,5 +167,39 @@ export function evaluateDreamOutcome(
     decision: "rollback",
     reason: `auto_rollback_effect_drop=${drop.toFixed(3)}`,
     rollback,
-  };
+  });
+}
+
+/** Persist keep/rollback/insufficient decisions on the dream_run metrics summary (#2173 audit). */
+function persistOutcomeDecision(
+  store: DreamCandidateStore,
+  dreamRunId: string,
+  report: DreamOutcomeReport,
+): void {
+  try {
+    const run = store.getDreamRun(dreamRunId);
+    let base: Record<string, unknown> = {};
+    if (run?.metricsSummaryJson) {
+      try {
+        base = JSON.parse(run.metricsSummaryJson) as Record<string, unknown>;
+      } catch {
+        base = {};
+      }
+    }
+    store.setDreamRunMetrics(dreamRunId, {
+      metricsSummaryJson: JSON.stringify({
+        ...base,
+        outcome: {
+          decision: report.decision,
+          reason: report.reason,
+          at: Math.floor(Date.now() / 1000),
+          window: report.window,
+          baseline: report.baseline,
+          after: report.after,
+        },
+      }),
+    });
+  } catch {
+    // Best-effort audit — never fail the outcome path on journal write.
+  }
 }

--- a/extensions/memory-hybrid/services/dream-outcome.ts
+++ b/extensions/memory-hybrid/services/dream-outcome.ts
@@ -132,18 +132,25 @@ export function evaluateDreamOutcome(
     });
   }
 
-  if (
-    baseline.signalSource &&
-    after.signalSource &&
-    baseline.signalSource !== after.signalSource
-  ) {
+  // Signal-source comparability (#2173):
+  //   - Both present and different → insufficient_data (blended vs feedback_proxy has different
+  //     effect-score ranges; comparing them can drive spurious auto-rollbacks).
+  //   - baseline defined + after undefined (manual CLI override without signalSource) → let it
+  //     through, operator explicitly chose the comparison.
+  //   - after defined + baseline undefined (legacy baseline stored pre-#2173) → treat legacy
+  //     baseline as feedback_proxy (the pre-blended default). Only fail closed when after is
+  //     explicitly "blended" or "tool_effectiveness" vs legacy — those are genuinely not
+  //     effect-score-comparable to a feedback_proxy baseline (QA follow-up: asymmetric
+  //     signalSource shouldn't drive rollbacks either).
+  const baselineSignal = baseline.signalSource ?? (after.signalSource ? "feedback_proxy" : undefined);
+  if (baselineSignal && after.signalSource && baselineSignal !== after.signalSource) {
     return finish({
       dreamRunId,
       window: { fromSec, toSec, sessions: after.sessionsObserved },
       baseline,
       after,
       decision: "insufficient_data",
-      reason: `signal_source_mismatch_${baseline.signalSource}_vs_${after.signalSource}`,
+      reason: `signal_source_mismatch_${baselineSignal}_vs_${after.signalSource}`,
     });
   }
 

--- a/extensions/memory-hybrid/services/dream-outcome.ts
+++ b/extensions/memory-hybrid/services/dream-outcome.ts
@@ -46,11 +46,18 @@ export function parseBaseline(json: string | null | undefined): DreamMetricSet |
   try {
     const parsed = JSON.parse(json) as Partial<DreamMetricSet>;
     if (typeof parsed.effectScore !== "number") return null;
+    const signalSource =
+      parsed.signalSource === "blended" ||
+      parsed.signalSource === "tool_effectiveness" ||
+      parsed.signalSource === "feedback_proxy"
+        ? parsed.signalSource
+        : undefined;
     return {
       successRate: typeof parsed.successRate === "number" ? parsed.successRate : 0,
       retryRate: typeof parsed.retryRate === "number" ? parsed.retryRate : 0,
       effectScore: parsed.effectScore,
       sessionsObserved: typeof parsed.sessionsObserved === "number" ? parsed.sessionsObserved : 0,
+      ...(signalSource ? { signalSource } : {}),
     };
   } catch {
     return null;
@@ -122,6 +129,21 @@ export function evaluateDreamOutcome(
       after,
       decision: "insufficient_data",
       reason: "missing_baseline",
+    });
+  }
+
+  if (
+    baseline.signalSource &&
+    after.signalSource &&
+    baseline.signalSource !== after.signalSource
+  ) {
+    return finish({
+      dreamRunId,
+      window: { fromSec, toSec, sessions: after.sessionsObserved },
+      baseline,
+      after,
+      decision: "insufficient_data",
+      reason: `signal_source_mismatch_${baseline.signalSource}_vs_${after.signalSource}`,
     });
   }
 

--- a/extensions/memory-hybrid/services/dream-outcome.ts
+++ b/extensions/memory-hybrid/services/dream-outcome.ts
@@ -1,0 +1,166 @@
+/**
+ * Dream outcome observation + auto-rollback (#2173).
+ *
+ * Machine "deny": if post-promote metrics regress past threshold within the window,
+ * apply reverse plan via rollbackDreamRun.
+ */
+
+import type { FactsDB } from "../backends/facts-db.js";
+import type { DreamCandidateStore } from "../backends/dream-candidate-store.js";
+import type { DreamingConfig } from "../config/types/dreaming.js";
+import { DEFAULT_DREAMING_CONFIG } from "../config/types/dreaming.js";
+import type { RollbackResult } from "./dream-candidate-ops.js";
+import { rollbackDreamRun } from "./dream-rollback.js";
+
+export type DreamMetricSet = {
+  /** Aggregate task/tool success rate 0..1. */
+  successRate: number;
+  /** Mean retries per task. */
+  retryRate: number;
+  /** Optional effect score (higher is better). */
+  effectScore: number;
+  sessionsObserved: number;
+};
+
+export type DreamOutcomeDecision = "keep" | "rollback" | "insufficient_data";
+
+export type DreamOutcomeReport = {
+  dreamRunId: string;
+  window: { fromSec: number; toSec: number; sessions: number };
+  baseline: DreamMetricSet | null;
+  after: DreamMetricSet;
+  decision: DreamOutcomeDecision;
+  reason: string;
+  rollback?: RollbackResult;
+};
+
+export function parseBaseline(json: string | null | undefined): DreamMetricSet | null {
+  if (!json) return null;
+  try {
+    const parsed = JSON.parse(json) as Partial<DreamMetricSet>;
+    if (typeof parsed.effectScore !== "number") return null;
+    return {
+      successRate: typeof parsed.successRate === "number" ? parsed.successRate : 0,
+      retryRate: typeof parsed.retryRate === "number" ? parsed.retryRate : 0,
+      effectScore: parsed.effectScore,
+      sessionsObserved: typeof parsed.sessionsObserved === "number" ? parsed.sessionsObserved : 0,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function captureDreamBaseline(metrics: DreamMetricSet): string {
+  return JSON.stringify(metrics);
+}
+
+/**
+ * Compare after-window metrics to baseline and optionally auto-rollback.
+ */
+export function evaluateDreamOutcome(
+  factsDb: FactsDB,
+  store: DreamCandidateStore,
+  dreamRunId: string,
+  after: DreamMetricSet,
+  options: {
+    cfg?: DreamingConfig;
+    nowSec?: number;
+    /** Minimum sessions in the after window before deciding. */
+    minSessions?: number;
+    applyRollback?: boolean;
+  } = {},
+): DreamOutcomeReport {
+  const cfg = options.cfg ?? DEFAULT_DREAMING_CONFIG;
+  const nowSec = options.nowSec ?? Math.floor(Date.now() / 1000);
+  const minSessions = options.minSessions ?? 3;
+  const run = store.getDreamRun(dreamRunId);
+
+  const emptyAfter = after;
+  if (!run) {
+    return {
+      dreamRunId,
+      window: { fromSec: nowSec, toSec: nowSec, sessions: after.sessionsObserved },
+      baseline: null,
+      after: emptyAfter,
+      decision: "insufficient_data",
+      reason: "dream_run_not_found",
+    };
+  }
+
+  const baseline = parseBaseline(run.metricsBaselineJson);
+  const fromSec = run.promotedAt ?? run.createdAt;
+  const toSec = run.metricsObserveUntil ?? fromSec + cfg.autoRollback.observeWindowHours * 3600;
+
+  if (after.sessionsObserved < minSessions) {
+    return {
+      dreamRunId,
+      window: { fromSec, toSec, sessions: after.sessionsObserved },
+      baseline,
+      after,
+      decision: "insufficient_data",
+      reason: "insufficient_sessions",
+    };
+  }
+
+  if (!baseline) {
+    return {
+      dreamRunId,
+      window: { fromSec, toSec, sessions: after.sessionsObserved },
+      baseline: null,
+      after,
+      decision: "insufficient_data",
+      reason: "missing_baseline",
+    };
+  }
+
+  const drop = baseline.effectScore - after.effectScore;
+  const shouldRollback = drop >= cfg.autoRollback.regressionThreshold;
+
+  if (!shouldRollback) {
+    return {
+      dreamRunId,
+      window: { fromSec, toSec, sessions: after.sessionsObserved },
+      baseline,
+      after,
+      decision: "keep",
+      reason: `effect_score_drop=${drop.toFixed(3)}_below_threshold`,
+    };
+  }
+
+  if (!cfg.autoRollback.enabled || options.applyRollback === false) {
+    return {
+      dreamRunId,
+      window: { fromSec, toSec, sessions: after.sessionsObserved },
+      baseline,
+      after,
+      decision: "rollback",
+      reason: `would_rollback_effect_drop=${drop.toFixed(3)}`,
+    };
+  }
+
+  if (nowSec < toSec && options.applyRollback !== true) {
+    // Still inside window unless caller forces apply.
+    return {
+      dreamRunId,
+      window: { fromSec, toSec, sessions: after.sessionsObserved },
+      baseline,
+      after,
+      decision: "rollback",
+      reason: `regression_detected_waiting_window_or_force`,
+    };
+  }
+
+  const rollback = rollbackDreamRun(factsDb, store, dreamRunId, {
+    reason: `auto_rollback_effect_drop=${drop.toFixed(3)}`,
+  });
+
+  return {
+    dreamRunId,
+    window: { fromSec, toSec, sessions: after.sessionsObserved },
+    baseline,
+    after,
+    decision: "rollback",
+    reason: `auto_rollback_effect_drop=${drop.toFixed(3)}`,
+    rollback,
+  };
+}

--- a/extensions/memory-hybrid/services/dream-outcome.ts
+++ b/extensions/memory-hybrid/services/dream-outcome.ts
@@ -15,11 +15,18 @@ import { rollbackDreamRun } from "./dream-rollback.js";
 export type DreamMetricSet = {
   /** Aggregate task/tool success rate 0..1. */
   successRate: number;
-  /** Mean retries per task. */
+  /** Mean retries per task (v1: correction-event count proxy). */
   retryRate: number;
   /** Optional effect score (higher is better). */
   effectScore: number;
   sessionsObserved: number;
+  /**
+   * Provenance of the metric set (#2173).
+   * - feedback_proxy: self-correction / reinforcement fact counts
+   * - blended: feedback + tool_effectiveness when available
+   * - tool_effectiveness: tool table only (rare)
+   */
+  signalSource?: "feedback_proxy" | "blended" | "tool_effectiveness";
 };
 
 export type DreamOutcomeDecision = "keep" | "rollback" | "insufficient_data";

--- a/extensions/memory-hybrid/services/dream-permission.ts
+++ b/extensions/memory-hybrid/services/dream-permission.ts
@@ -1,7 +1,10 @@
 /**
  * Permission-scoped Dream session attachment (#2174).
  *
- * Fail closed: unresolved ACL → exclude. Personal mode may treat all as one boundary.
+ * Fail closed: unresolved ACL → exclude.
+ * Private content must not feed a wider dream target by default:
+ * content is attachable only when it is at least as public as the dream target
+ * (SCOPE_RANK[source] >= SCOPE_RANK[target]), or personalMode is on.
  */
 
 import type { DreamPermissionBoundary } from "../config/types/dreaming.js";
@@ -15,19 +18,41 @@ export type DreamSessionAcl = {
   userId?: string | null;
 };
 
-const SCOPE_RANK: Record<DreamSessionAcl["effectiveScope"], number> = {
+export type DreamWriteScope = DreamSessionAcl["effectiveScope"];
+
+const SCOPE_RANK: Record<DreamWriteScope, number> = {
   session: 0,
   agent: 1,
   user: 2,
   global: 3,
 };
 
-/** True when session ACL is ⊆ target (session ⊆ agent ⊆ user ⊆ global). */
+/**
+ * True when transcript content may be attached to a dream targeting `targetScope`.
+ * More-private sources (lower rank) cannot feed more-public dreams (higher rank).
+ */
 export function aclFitsTarget(
-  sessionScope: DreamSessionAcl["effectiveScope"],
+  sessionScope: DreamWriteScope,
   targetScope: DreamPermissionBoundary["targetScope"],
+  personalMode = false,
 ): boolean {
-  return SCOPE_RANK[sessionScope] <= SCOPE_RANK[targetScope];
+  if (personalMode) return true;
+  return SCOPE_RANK[sessionScope] >= SCOPE_RANK[targetScope];
+}
+
+/** True when a candidate write scope does not exceed the dream permission boundary. */
+export function writeScopeWithinBoundary(
+  writeScope: string | null | undefined,
+  boundary: DreamPermissionBoundary,
+): boolean {
+  if (boundary.personalMode || !boundary.enforce) return true;
+  const scope =
+    writeScope === "session" || writeScope === "agent" || writeScope === "user" || writeScope === "global"
+      ? writeScope
+      : "global";
+  // Writes may only target scopes ≤ dream target (session write into global dream is OK;
+  // global write into session dream is not).
+  return SCOPE_RANK[scope] <= SCOPE_RANK[boundary.targetScope];
 }
 
 export type SelectDreamSessionsResult = {
@@ -47,7 +72,7 @@ export function selectDreamSessions(
   const excluded: Array<{ sessionId: string; reason: string }> = [];
   const cap = Math.max(1, Math.min(100, Math.floor(maxSessions)));
 
-  if (boundary.personalMode || !boundary.enforce) {
+  if (!boundary.enforce) {
     for (const c of candidates) {
       if (included.length >= cap) {
         excluded.push({ sessionId: c.sessionId, reason: "max_sessions" });
@@ -68,10 +93,10 @@ export function selectDreamSessions(
       excluded.push({ sessionId: c.sessionId, reason: "unresolved_acl" });
       continue;
     }
-    if (!aclFitsTarget(scope, boundary.targetScope)) {
+    if (!aclFitsTarget(scope, boundary.targetScope, boundary.personalMode)) {
       excluded.push({
         sessionId: c.sessionId,
-        reason: `acl_${scope}_not_subseteq_${boundary.targetScope}`,
+        reason: `acl_${scope}_too_private_for_${boundary.targetScope}`,
       });
       continue;
     }

--- a/extensions/memory-hybrid/services/dream-permission.ts
+++ b/extensions/memory-hybrid/services/dream-permission.ts
@@ -1,0 +1,82 @@
+/**
+ * Permission-scoped Dream session attachment (#2174).
+ *
+ * Fail closed: unresolved ACL → exclude. Personal mode may treat all as one boundary.
+ */
+
+import type { DreamPermissionBoundary } from "../config/types/dreaming.js";
+
+export type DreamSessionAcl = {
+  sessionId: string;
+  /** Effective ACL / scope of the transcript content. */
+  effectiveScope: "session" | "agent" | "user" | "global";
+  /** Optional agent / user owners for cross-agent checks. */
+  agentId?: string | null;
+  userId?: string | null;
+};
+
+const SCOPE_RANK: Record<DreamSessionAcl["effectiveScope"], number> = {
+  session: 0,
+  agent: 1,
+  user: 2,
+  global: 3,
+};
+
+/** True when session ACL is ⊆ target (session ⊆ agent ⊆ user ⊆ global). */
+export function aclFitsTarget(
+  sessionScope: DreamSessionAcl["effectiveScope"],
+  targetScope: DreamPermissionBoundary["targetScope"],
+): boolean {
+  return SCOPE_RANK[sessionScope] <= SCOPE_RANK[targetScope];
+}
+
+export type SelectDreamSessionsResult = {
+  included: string[];
+  excluded: Array<{ sessionId: string; reason: string }>;
+};
+
+/**
+ * Select sessions that may be attached to a Dream for the given permission boundary.
+ */
+export function selectDreamSessions(
+  candidates: Array<DreamSessionAcl | { sessionId: string; effectiveScope?: string | null }>,
+  boundary: DreamPermissionBoundary,
+  maxSessions: number,
+): SelectDreamSessionsResult {
+  const included: string[] = [];
+  const excluded: Array<{ sessionId: string; reason: string }> = [];
+  const cap = Math.max(1, Math.min(100, Math.floor(maxSessions)));
+
+  if (boundary.personalMode || !boundary.enforce) {
+    for (const c of candidates) {
+      if (included.length >= cap) {
+        excluded.push({ sessionId: c.sessionId, reason: "max_sessions" });
+        continue;
+      }
+      included.push(c.sessionId);
+    }
+    return { included, excluded };
+  }
+
+  for (const c of candidates) {
+    if (included.length >= cap) {
+      excluded.push({ sessionId: c.sessionId, reason: "max_sessions" });
+      continue;
+    }
+    const scope = c.effectiveScope;
+    if (scope !== "session" && scope !== "agent" && scope !== "user" && scope !== "global") {
+      excluded.push({ sessionId: c.sessionId, reason: "unresolved_acl" });
+      continue;
+    }
+    if (!aclFitsTarget(scope, boundary.targetScope)) {
+      excluded.push({
+        sessionId: c.sessionId,
+        reason: `acl_${scope}_not_subseteq_${boundary.targetScope}`,
+      });
+      continue;
+    }
+    included.push(c.sessionId);
+  }
+
+  return { included, excluded };
+}

--- a/extensions/memory-hybrid/services/dream-permission.ts
+++ b/extensions/memory-hybrid/services/dream-permission.ts
@@ -7,7 +7,9 @@
  * (SCOPE_RANK[source] >= SCOPE_RANK[target]), or personalMode is on.
  */
 
+import type { DatabaseSync } from "node:sqlite";
 import type { DreamPermissionBoundary } from "../config/types/dreaming.js";
+import { locateSessionTranscriptSync } from "./openclaw-session-artifact.js";
 
 export type DreamSessionAcl = {
   sessionId: string;
@@ -104,4 +106,128 @@ export function selectDreamSessions(
   }
 
   return { included, excluded };
+}
+
+/** Candidate for attachment; `effectiveScope` may be unresolved (null) → fail closed at select. */
+export type DreamSessionAclCandidate = {
+  sessionId: string;
+  effectiveScope?: string | null;
+  agentId?: string | null;
+};
+
+function asDreamWriteScope(raw: string | null | undefined): DreamWriteScope | null {
+  return raw === "session" || raw === "agent" || raw === "user" || raw === "global" ? raw : null;
+}
+
+function morePrivate(a: DreamWriteScope, b: DreamWriteScope): DreamWriteScope {
+  return SCOPE_RANK[a] <= SCOPE_RANK[b] ? a : b;
+}
+
+/**
+ * Resolve effective transcript ACL for a session (#2174).
+ *
+ * Rules (fail closed — never invent `global` from fact writes alone):
+ * - Session/agent/user-scoped facts for this session contribute that scope (most private wins).
+ * - `scope=global` facts only prove the session existed; they do **not** mark the transcript public.
+ * - If still unresolved and a JSONL exists under `agents/<id>/sessions/`, floor to `agent`.
+ * - Otherwise leave null → `selectDreamSessions` excludes as `unresolved_acl`.
+ * - Explicit CLI `--session-scopes id:global` remains the upgrade path for global attachment.
+ */
+export function resolveSessionEffectiveAcl(
+  scopesSeen: Array<string | null | undefined>,
+  sessionId: string,
+  opts?: { openclawHome?: string; resolveArtifact?: boolean },
+): { effectiveScope: DreamWriteScope | null; agentId?: string | null } {
+  let resolved: DreamWriteScope | null = null;
+  for (const raw of scopesSeen) {
+    const scope = asDreamWriteScope(raw);
+    // Never treat global fact writes as proof the transcript ACL is global.
+    if (!scope || scope === "global") continue;
+    resolved = resolved ? morePrivate(resolved, scope) : scope;
+  }
+
+  if (resolved) return { effectiveScope: resolved };
+
+  if (opts?.resolveArtifact === false) {
+    return { effectiveScope: null };
+  }
+
+  const hit = locateSessionTranscriptSync(sessionId, opts?.openclawHome);
+  if (hit) return { effectiveScope: "agent", agentId: hit.agentId };
+
+  return { effectiveScope: null };
+}
+
+/**
+ * Discover recent session ids + effective ACL for nightly Dream (#2174).
+ * Prefer provenance_session; fall back to session-scoped scope_target.
+ */
+export function discoverDreamSessionAcls(
+  db: DatabaseSync,
+  opts?: {
+    lookbackDays?: number;
+    limit?: number;
+    nowSec?: number;
+    openclawHome?: string;
+    resolveArtifact?: boolean;
+  },
+): DreamSessionAclCandidate[] {
+  const lookbackDays = Math.max(1, Math.min(90, Math.floor(opts?.lookbackDays ?? 7)));
+  const limit = Math.max(1, Math.min(200, Math.floor(opts?.limit ?? 40)));
+  const nowSec = opts?.nowSec ?? Math.floor(Date.now() / 1000);
+  const sinceSec = nowSec - lookbackDays * 24 * 3600;
+
+  type Row = {
+    session_id: string | null;
+    scope: string | null;
+  };
+
+  let rows: Row[] = [];
+  try {
+    rows = db
+      .prepare(
+        `SELECT
+           COALESCE(
+             NULLIF(provenance_session, ''),
+             CASE WHEN scope = 'session' THEN scope_target ELSE NULL END
+           ) AS session_id,
+           scope
+         FROM facts
+         WHERE created_at >= ?
+           AND superseded_at IS NULL
+           AND (
+             (provenance_session IS NOT NULL AND provenance_session != '')
+             OR (scope = 'session' AND scope_target IS NOT NULL AND scope_target != '')
+           )
+         ORDER BY created_at DESC
+         LIMIT ?`,
+      )
+      .all(sinceSec, limit * 4) as Row[];
+  } catch {
+    return [];
+  }
+
+  const scopesBySession = new Map<string, Array<string | null>>();
+  for (const row of rows) {
+    const sessionId = typeof row.session_id === "string" ? row.session_id.trim() : "";
+    if (!sessionId) continue;
+    const list = scopesBySession.get(sessionId) ?? [];
+    list.push(row.scope);
+    scopesBySession.set(sessionId, list);
+  }
+
+  const out: DreamSessionAclCandidate[] = [];
+  for (const [sessionId, scopes] of scopesBySession) {
+    const resolved = resolveSessionEffectiveAcl(scopes, sessionId, {
+      openclawHome: opts?.openclawHome,
+      resolveArtifact: opts?.resolveArtifact,
+    });
+    out.push({
+      sessionId,
+      effectiveScope: resolved.effectiveScope,
+      agentId: resolved.agentId ?? null,
+    });
+    if (out.length >= limit) break;
+  }
+  return out;
 }

--- a/extensions/memory-hybrid/services/dream-promote.ts
+++ b/extensions/memory-hybrid/services/dream-promote.ts
@@ -54,8 +54,7 @@ export function evaluateDreamGates(
   for (const entry of entries) {
     if (dreaming.autoPromote.requireProvenance) {
       const hasSessions = entry.sessionIds.length > 0;
-      const hasRationale = typeof entry.rationale === "string" && entry.rationale.trim().length > 0;
-      if (!hasSessions && !hasRationale) {
+      if (!hasSessions) {
         decisions.push({
           entryId: entry.id,
           pass: false,
@@ -135,7 +134,13 @@ export function evaluateDreamGates(
       scope === "session" || scope === "agent" || scope === "user" || scope === "global" ? scope : "global";
     let tier = dreaming.prevalence[tierKey];
     if (tierKey === "global" && dreaming.prevalence.personalSingleTenant) {
-      tier = { ...dreaming.prevalence.user, minAgents: 1 };
+      // Personal vault: reuse user session bar + 1 agent, but do not inherit user minConfidence
+      // (compose rarely emits confidence; that bar is for explicit user-tier curriculum).
+      tier = {
+        minSessions: dreaming.prevalence.user.minSessions,
+        minAgents: 1,
+        minConfidence: dreaming.prevalence.global.minConfidence,
+      };
     }
     const sessions = Math.max(entry.prevalence?.sessions ?? 0, entry.sessionIds.length);
     const agents = entry.prevalence?.agents ?? (entry.sessionIds.length > 0 ? 1 : 0);
@@ -152,14 +157,17 @@ export function evaluateDreamGates(
       typeof (entry.payload as { confidence?: unknown }).confidence === "number"
         ? (entry.payload as { confidence: number }).confidence
         : undefined;
-    if (tier.minConfidence != null && confidence != null && confidence < tier.minConfidence) {
-      decisions.push({
-        entryId: entry.id,
-        pass: false,
-        reason: `confidence_below_${tier.minConfidence}`,
-      });
-      store.updateCandidateEntry(entry.id, { status: "gated_block" });
-      continue;
+    if (tier.minConfidence != null) {
+      // Fail closed: missing confidence does not bypass a configured threshold.
+      if (confidence == null || confidence < tier.minConfidence) {
+        decisions.push({
+          entryId: entry.id,
+          pass: false,
+          reason: confidence == null ? `confidence_missing_required_${tier.minConfidence}` : `confidence_below_${tier.minConfidence}`,
+        });
+        store.updateCandidateEntry(entry.id, { status: "gated_block" });
+        continue;
+      }
     }
 
     decisions.push({ entryId: entry.id, pass: true, reason: "ok" });
@@ -216,7 +224,13 @@ function applyEntry(
         supersedesId: entry.targetFactId,
         tags: [...(storeInput.tags ?? []), ...dreamTags],
       });
-      if (result.skipped) return { appliedFactId: null, postHash: null };
+      // Fail closed: never mark supersede applied without retiring the target.
+      if (result.skipped) {
+        throw new Error("supersede replacement rejected by store guard");
+      }
+      if (!result.entry?.id) {
+        throw new Error("supersede replacement missing fact id");
+      }
       // Per-fact OCC (#2175): require propose-time preHash — never fail open.
       if (!entry.preHash) throw new Error("supersede requires preHash OCC token");
       factsDb.supersede(entry.targetFactId, result.entry.id, { expectedHash: entry.preHash });

--- a/extensions/memory-hybrid/services/dream-promote.ts
+++ b/extensions/memory-hybrid/services/dream-promote.ts
@@ -163,7 +163,10 @@ export function evaluateDreamGates(
         decisions.push({
           entryId: entry.id,
           pass: false,
-          reason: confidence == null ? `confidence_missing_required_${tier.minConfidence}` : `confidence_below_${tier.minConfidence}`,
+          reason:
+            confidence == null
+              ? `confidence_missing_required_${tier.minConfidence}`
+              : `confidence_below_${tier.minConfidence}`,
         });
         store.updateCandidateEntry(entry.id, { status: "gated_block" });
         continue;
@@ -328,9 +331,7 @@ export function promoteDreamRun(
   }
 
   const gateReport = evaluateDreamGates(store, dreamRunId, dreaming, factsDb);
-  const gateReportWithDrift = revisionDrifted
-    ? { ...gateReport, storeRevisionDrifted: true as const }
-    : gateReport;
+  const gateReportWithDrift = revisionDrifted ? { ...gateReport, storeRevisionDrifted: true as const } : gateReport;
   store.updateDreamRunStatus(dreamRunId, "gated", {
     gateReportJson: JSON.stringify(gateReportWithDrift),
   });

--- a/extensions/memory-hybrid/services/dream-promote.ts
+++ b/extensions/memory-hybrid/services/dream-promote.ts
@@ -19,6 +19,9 @@ import {
 } from "./dream-candidate-ops.js";
 import { writeScopeWithinBoundary } from "./dream-permission.js";
 import { MemoryConflictError } from "../utils/fact-occ.js";
+import { capturePromoteBaseline } from "./dream-outcome-probe.js";
+import { buildRunMetricsSummary, dreamRunTag } from "./dream-metrics.js";
+import { shouldSteeringIgnore } from "./dream-steering.js";
 
 export type PromoteDreamRunOptions = {
   /** Apply even when shadow=true / autoPromote disabled (CLI escape hatch). */
@@ -77,11 +80,15 @@ export function evaluateDreamGates(
       continue;
     }
 
-    // Steering ignore list (#2176): block categories/keys the policy says to ignore.
-    const ignore = dreaming.steering.ignore.map((s) => s.toLowerCase());
-    const category = String(entry.payload.category ?? "").toLowerCase();
-    const key = String(entry.payload.key ?? "").toLowerCase();
-    if (ignore.some((token) => token && (category.includes(token) || key.includes(token) || entry.payload.text.toLowerCase().includes(token)))) {
+    // Steering ignore list (#2176).
+    if (
+      shouldSteeringIgnore(
+        String(entry.payload.category ?? ""),
+        entry.payload.key ?? null,
+        entry.payload.text,
+        dreaming.steering,
+      )
+    ) {
       decisions.push({
         entryId: entry.id,
         pass: false,
@@ -131,7 +138,12 @@ export function evaluateDreamGates(
   return { ok, decisions, wouldPromote };
 }
 
-function applyEntry(factsDb: FactsDB, entry: CandidateEntryRecord): { appliedFactId: string | null; postHash: string | null } {
+function applyEntry(
+  factsDb: FactsDB,
+  entry: CandidateEntryRecord,
+  dreamRunId?: string,
+): { appliedFactId: string | null; postHash: string | null } {
+  const dreamTags = dreamRunId ? [dreamRunTag(dreamRunId)] : [];
   switch (entry.op) {
     case "add":
     case "merge":
@@ -146,6 +158,7 @@ function applyEntry(factsDb: FactsDB, entry: CandidateEntryRecord): { appliedFac
         entity: storeInput.entity ?? null,
         key: storeInput.key ?? null,
         value: storeInput.value ?? null,
+        tags: [...(storeInput.tags ?? []), ...dreamTags],
       });
       if (result.skipped) return { appliedFactId: null, postHash: null };
       // preferredId is advisory only — FactsDB assigns UUIDs; reverse plan uses applied id.
@@ -168,6 +181,7 @@ function applyEntry(factsDb: FactsDB, entry: CandidateEntryRecord): { appliedFac
         key: storeInput.key ?? null,
         value: storeInput.value ?? null,
         supersedesId: entry.targetFactId,
+        tags: [...(storeInput.tags ?? []), ...dreamTags],
       });
       if (result.skipped) return { appliedFactId: null, postHash: null };
       // Per-fact OCC (#2175): use candidate preHash from propose time, never live token.
@@ -308,7 +322,7 @@ export function promoteDreamRun(
           .sort((a, b) => a.sortOrder - b.sortOrder);
         for (const entry of entries) {
           try {
-            const { appliedFactId, postHash } = applyEntry(factsDb, entry);
+            const { appliedFactId, postHash } = applyEntry(factsDb, entry, dreamRunId);
             store.updateCandidateEntry(entry.id, {
               status: "applied",
               appliedFactId,
@@ -331,7 +345,14 @@ export function promoteDreamRun(
                         }
                       : entry.reverse,
             });
-            if (appliedFactId) appliedFactIds.push(appliedFactId);
+            if (appliedFactId) {
+              appliedFactIds.push(appliedFactId);
+              try {
+                factsDb.addTag(appliedFactId, dreamRunTag(dreamRunId));
+              } catch {
+                // Best-effort attribution tag (#2173).
+              }
+            }
           } catch (err) {
             if (err instanceof MemoryConflictError) {
               store.updateCandidateEntry(entry.id, { status: "gated_block" });
@@ -363,14 +384,21 @@ export function promoteDreamRun(
       ? Math.floor(Date.now() / 1000) + dreaming.autoRollback.observeWindowHours * 3600
       : null;
 
-  // Do not invent effectScore baseline (#2173) — leave null until a real probe records metrics.
-  // Store only structural snapshot metadata for debugging.
+  const promotedAt = Math.floor(Date.now() / 1000);
+  const baselineJson = capturePromoteBaseline(factsDb, run.sessionIds, promotedAt);
+  const metricsSummary = buildRunMetricsSummary(factsDb, {
+    sessionIds: run.sessionIds,
+    startedAt: run.startedAt,
+    endedAt: promotedAt,
+  });
+
   store.updateDreamRunStatus(dreamRunId, "promoted", {
-    metricsBaselineJson: null,
+    metricsBaselineJson: baselineJson,
     metricsObserveUntil: observeUntil,
+    metricsSummaryJson: JSON.stringify(metricsSummary),
     gateReportJson: JSON.stringify({
       ...gateReport,
-      structuralSnapshot: { factCount: factsDb.count(), at: Math.floor(Date.now() / 1000) },
+      structuralSnapshot: { factCount: factsDb.count(), at: promotedAt },
     }),
   });
 

--- a/extensions/memory-hybrid/services/dream-promote.ts
+++ b/extensions/memory-hybrid/services/dream-promote.ts
@@ -17,6 +17,8 @@ import {
   type PromoteResult,
   hashFactContent,
 } from "./dream-candidate-ops.js";
+import { writeScopeWithinBoundary } from "./dream-permission.js";
+import { MemoryConflictError } from "../utils/fact-occ.js";
 
 export type PromoteDreamRunOptions = {
   /** Apply even when shadow=true / autoPromote disabled (CLI escape hatch). */
@@ -65,6 +67,30 @@ export function evaluateDreamGates(
 
     // Blast-radius / prevalence (#2172).
     const scope = (entry.payload.scope ?? "global") as "session" | "agent" | "user" | "global";
+    if (!writeScopeWithinBoundary(scope, dreaming.permissionBoundary)) {
+      decisions.push({
+        entryId: entry.id,
+        pass: false,
+        reason: `write_scope_${scope}_exceeds_boundary_${dreaming.permissionBoundary.targetScope}`,
+      });
+      store.updateCandidateEntry(entry.id, { status: "gated_block" });
+      continue;
+    }
+
+    // Steering ignore list (#2176): block categories/keys the policy says to ignore.
+    const ignore = dreaming.steering.ignore.map((s) => s.toLowerCase());
+    const category = String(entry.payload.category ?? "").toLowerCase();
+    const key = String(entry.payload.key ?? "").toLowerCase();
+    if (ignore.some((token) => token && (category.includes(token) || key.includes(token) || entry.payload.text.toLowerCase().includes(token)))) {
+      decisions.push({
+        entryId: entry.id,
+        pass: false,
+        reason: `steering_ignore`,
+      });
+      store.updateCandidateEntry(entry.id, { status: "gated_block" });
+      continue;
+    }
+
     const tierKey =
       scope === "session" || scope === "agent" || scope === "user" || scope === "global" ? scope : "global";
     let tier = dreaming.prevalence[tierKey];
@@ -144,9 +170,13 @@ function applyEntry(factsDb: FactsDB, entry: CandidateEntryRecord): { appliedFac
         supersedesId: entry.targetFactId,
       });
       if (result.skipped) return { appliedFactId: null, postHash: null };
-      // OCC token (#2175) — distinct from content post_hash used for rollback drift.
-      const occToken = factsDb.getOccToken(entry.targetFactId) ?? undefined;
-      factsDb.supersede(entry.targetFactId, result.entry.id, occToken ? { expectedHash: occToken } : undefined);
+      // Per-fact OCC (#2175): use candidate preHash from propose time, never live token.
+      const expectedHash = entry.preHash ?? undefined;
+      factsDb.supersede(
+        entry.targetFactId,
+        result.entry.id,
+        expectedHash ? { expectedHash } : undefined,
+      );
       return {
         appliedFactId: result.entry.id,
         postHash: hashFactContent(result.entry),
@@ -154,9 +184,12 @@ function applyEntry(factsDb: FactsDB, entry: CandidateEntryRecord): { appliedFac
     }
     case "delete": {
       if (!entry.targetFactId) throw new Error("delete requires targetFactId");
-      const occToken = factsDb.getOccToken(entry.targetFactId) ?? undefined;
-      // Soft-delete via supersede with null replacement (marks superseded).
-      factsDb.supersede(entry.targetFactId, null, occToken ? { expectedHash: occToken } : undefined);
+      const expectedHash = entry.preHash ?? undefined;
+      factsDb.supersede(
+        entry.targetFactId,
+        null,
+        expectedHash ? { expectedHash } : undefined,
+      );
       return { appliedFactId: entry.targetFactId, postHash: null };
     }
     default:
@@ -274,30 +307,38 @@ export function promoteDreamRun(
           .filter((e) => e.status === "gated_ok")
           .sort((a, b) => a.sortOrder - b.sortOrder);
         for (const entry of entries) {
-          const { appliedFactId, postHash } = applyEntry(factsDb, entry);
-          store.updateCandidateEntry(entry.id, {
-            status: "applied",
-            appliedFactId,
-            postHash,
-            reverse:
-              entry.op === "add" || entry.op === "merge" || entry.op === "boost"
-                ? { op: "delete_fact", payload: { factId: appliedFactId } }
-                : entry.op === "supersede"
-                  ? {
-                      op: "unsupersede",
-                      payload: {
-                        oldFactId: entry.targetFactId,
-                        newFactId: appliedFactId,
-                      },
-                    }
-                  : entry.op === "delete"
+          try {
+            const { appliedFactId, postHash } = applyEntry(factsDb, entry);
+            store.updateCandidateEntry(entry.id, {
+              status: "applied",
+              appliedFactId,
+              postHash,
+              reverse:
+                entry.op === "add" || entry.op === "merge" || entry.op === "boost"
+                  ? { op: "delete_fact", payload: { factId: appliedFactId } }
+                  : entry.op === "supersede"
                     ? {
                         op: "unsupersede",
-                        payload: { oldFactId: entry.targetFactId, newFactId: null },
+                        payload: {
+                          oldFactId: entry.targetFactId,
+                          newFactId: appliedFactId,
+                        },
                       }
-                    : entry.reverse,
-          });
-          if (appliedFactId) appliedFactIds.push(appliedFactId);
+                    : entry.op === "delete"
+                      ? {
+                          op: "unsupersede",
+                          payload: { oldFactId: entry.targetFactId, newFactId: null },
+                        }
+                      : entry.reverse,
+            });
+            if (appliedFactId) appliedFactIds.push(appliedFactId);
+          } catch (err) {
+            if (err instanceof MemoryConflictError) {
+              store.updateCandidateEntry(entry.id, { status: "gated_block" });
+              throw err;
+            }
+            throw err;
+          }
         }
       },
       "IMMEDIATE",
@@ -305,7 +346,8 @@ export function promoteDreamRun(
     tx();
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    store.updateDreamRunStatus(dreamRunId, "failed", { failureReason: message });
+    const status = err instanceof MemoryConflictError ? "failed" : "failed";
+    store.updateDreamRunStatus(dreamRunId, status, { failureReason: message });
     return {
       applied: false,
       shadow: false,
@@ -321,19 +363,15 @@ export function promoteDreamRun(
       ? Math.floor(Date.now() / 1000) + dreaming.autoRollback.observeWindowHours * 3600
       : null;
 
-  // Baseline for #2173 outcome window (effectScore starts neutral; callers can overwrite).
-  const baseline = {
-    successRate: 1,
-    retryRate: 0,
-    effectScore: 1,
-    sessionsObserved: 0,
-    factCount: factsDb.count(),
-  };
-
+  // Do not invent effectScore baseline (#2173) — leave null until a real probe records metrics.
+  // Store only structural snapshot metadata for debugging.
   store.updateDreamRunStatus(dreamRunId, "promoted", {
-    metricsBaselineJson: JSON.stringify(baseline),
+    metricsBaselineJson: null,
     metricsObserveUntil: observeUntil,
-    gateReportJson: JSON.stringify(gateReport),
+    gateReportJson: JSON.stringify({
+      ...gateReport,
+      structuralSnapshot: { factCount: factsDb.count(), at: Math.floor(Date.now() / 1000) },
+    }),
   });
 
   return {

--- a/extensions/memory-hybrid/services/dream-promote.ts
+++ b/extensions/memory-hybrid/services/dream-promote.ts
@@ -300,9 +300,19 @@ export function promoteDreamRun(
     store.updateDreamRunStatus(dreamRunId, "running");
   }
 
-  // OCC: refuse if live store drifted since dream snapshot (#2175).
+  // OCC: refuse LIVE APPLY if the store drifted since dream snapshot (#2175). Shadow-only runs
+  // never apply and background writes (auto-capture / other maintenance) inevitably shift the
+  // store fingerprint during a Dream — failing shadow-only runs on drift would consistently
+  // mark every nightly shadow Dream as `failed`, poisoning shadow ROI validation (raising
+  // failureRate) and alarming operators over a non-actionable condition (QA follow-up).
+  //
+  // For shadow-only, drift is recorded in the gate report metadata but the run continues to
+  // gate normally — wouldPromote reflects the current-store view, which is what shadow ROI
+  // needs anyway.
   const currentRevision = factsDb.computeStoreRevision();
-  if (currentRevision !== run.inputStoreRevision && !options.force) {
+  const revisionDrifted = currentRevision !== run.inputStoreRevision;
+  const shadowOnlyRun = run.shadow || !dreaming.autoPromote.enabled;
+  if (revisionDrifted && !options.force && !shadowOnlyRun) {
     store.updateDreamRunStatus(dreamRunId, "failed", {
       failureReason: "stale_input_store_revision",
       gateReportJson: JSON.stringify({ ok: false, reason: "stale_input_store_revision" }),
@@ -318,8 +328,11 @@ export function promoteDreamRun(
   }
 
   const gateReport = evaluateDreamGates(store, dreamRunId, dreaming, factsDb);
+  const gateReportWithDrift = revisionDrifted
+    ? { ...gateReport, storeRevisionDrifted: true as const }
+    : gateReport;
   store.updateDreamRunStatus(dreamRunId, "gated", {
-    gateReportJson: JSON.stringify(gateReport),
+    gateReportJson: JSON.stringify(gateReportWithDrift),
   });
 
   // Empty compose: terminal gated with wouldPromote=false — never apply or treat as reject-quarantine.

--- a/extensions/memory-hybrid/services/dream-promote.ts
+++ b/extensions/memory-hybrid/services/dream-promote.ts
@@ -1,0 +1,354 @@
+/**
+ * Dream promote controller (#2170) — machine gates + auto-promote / quarantine / shadow.
+ *
+ * Does not require human review. Global curriculum promotes are conservative by default
+ * (provenance required; blast-radius deepens in #2172).
+ */
+
+import type { FactsDB } from "../backends/facts-db.js";
+import { DreamCandidateStore } from "../backends/dream-candidate-store.js";
+import type { DreamingConfig } from "../config/types/dreaming.js";
+import { DEFAULT_DREAMING_CONFIG } from "../config/types/dreaming.js";
+import { createTransaction } from "../utils/sqlite-transaction.js";
+import { pluginLogger } from "../utils/logger.js";
+import {
+  type CandidateEntryRecord,
+  type GateReport,
+  type PromoteResult,
+  hashFactContent,
+} from "./dream-candidate-ops.js";
+
+export type PromoteDreamRunOptions = {
+  /** Apply even when shadow=true / autoPromote disabled (CLI escape hatch). */
+  force?: boolean;
+  cfg?: DreamingConfig;
+};
+
+function resolveCfg(cfg?: DreamingConfig): DreamingConfig {
+  return cfg ?? structuredClone(DEFAULT_DREAMING_CONFIG);
+}
+
+/** Evaluate machine gates for every candidate entry on a dream run. */
+export function evaluateDreamGates(
+  store: DreamCandidateStore,
+  dreamRunId: string,
+  cfg?: DreamingConfig,
+): GateReport {
+  const dreaming = resolveCfg(cfg);
+  const entries = store.listCandidateEntries(dreamRunId);
+  const decisions: GateReport["decisions"] = [];
+
+  for (const entry of entries) {
+    if (dreaming.autoPromote.requireProvenance) {
+      const hasSessions = entry.sessionIds.length > 0;
+      const hasRationale = typeof entry.rationale === "string" && entry.rationale.trim().length > 0;
+      if (!hasSessions && !hasRationale) {
+        decisions.push({
+          entryId: entry.id,
+          pass: false,
+          reason: "missing_provenance",
+        });
+        store.updateCandidateEntry(entry.id, { status: "gated_block" });
+        continue;
+      }
+    }
+
+    if (dreaming.autoPromote.blockOnContradictionWorsening && entry.payload.contradictionWorsens === true) {
+      decisions.push({
+        entryId: entry.id,
+        pass: false,
+        reason: "contradiction_worsens",
+      });
+      store.updateCandidateEntry(entry.id, { status: "gated_block" });
+      continue;
+    }
+
+    // Blast-radius / prevalence (#2172).
+    const scope = (entry.payload.scope ?? "global") as "session" | "agent" | "user" | "global";
+    const tierKey =
+      scope === "session" || scope === "agent" || scope === "user" || scope === "global" ? scope : "global";
+    let tier = dreaming.prevalence[tierKey];
+    if (tierKey === "global" && dreaming.prevalence.personalSingleTenant) {
+      tier = { ...dreaming.prevalence.user, minAgents: 1 };
+    }
+    const sessions = Math.max(entry.prevalence?.sessions ?? 0, entry.sessionIds.length);
+    const agents = entry.prevalence?.agents ?? (entry.sessionIds.length > 0 ? 1 : 0);
+    if (sessions < tier.minSessions || agents < tier.minAgents) {
+      decisions.push({
+        entryId: entry.id,
+        pass: false,
+        reason: `prevalence_insufficient_${tierKey}_need_s${tier.minSessions}_a${tier.minAgents}_got_s${sessions}_a${agents}`,
+      });
+      store.updateCandidateEntry(entry.id, { status: "gated_block" });
+      continue;
+    }
+    const confidence =
+      typeof (entry.payload as { confidence?: unknown }).confidence === "number"
+        ? ((entry.payload as { confidence: number }).confidence)
+        : undefined;
+    if (tier.minConfidence != null && confidence != null && confidence < tier.minConfidence) {
+      decisions.push({
+        entryId: entry.id,
+        pass: false,
+        reason: `confidence_below_${tier.minConfidence}`,
+      });
+      store.updateCandidateEntry(entry.id, { status: "gated_block" });
+      continue;
+    }
+
+    decisions.push({ entryId: entry.id, pass: true, reason: "ok" });
+    store.updateCandidateEntry(entry.id, { status: "gated_ok" });
+  }
+
+  const ok = decisions.length > 0 && decisions.every((d) => d.pass);
+  const wouldPromote = ok;
+  return { ok, decisions, wouldPromote };
+}
+
+function applyEntry(factsDb: FactsDB, entry: CandidateEntryRecord): { appliedFactId: string | null; postHash: string | null } {
+  switch (entry.op) {
+    case "add":
+    case "merge":
+    case "boost": {
+      const { contradictionWorsens: _c, id: preferredId, ...storeInput } = entry.payload;
+      const result = factsDb.storeWithResult({
+        ...storeInput,
+        text: storeInput.text,
+        category: storeInput.category ?? "preference",
+        importance: storeInput.importance ?? 0.5,
+        source: storeInput.source ?? "dream",
+        entity: storeInput.entity ?? null,
+        key: storeInput.key ?? null,
+        value: storeInput.value ?? null,
+      });
+      if (result.skipped) return { appliedFactId: null, postHash: null };
+      // preferredId is advisory only — FactsDB assigns UUIDs; reverse plan uses applied id.
+      void preferredId;
+      return {
+        appliedFactId: result.entry.id,
+        postHash: hashFactContent(result.entry),
+      };
+    }
+    case "supersede": {
+      if (!entry.targetFactId) throw new Error("supersede requires targetFactId");
+      const { contradictionWorsens: _c, id: _id, ...storeInput } = entry.payload;
+      const result = factsDb.storeWithResult({
+        ...storeInput,
+        text: storeInput.text,
+        category: storeInput.category ?? "preference",
+        importance: storeInput.importance ?? 0.5,
+        source: storeInput.source ?? "dream",
+        entity: storeInput.entity ?? null,
+        key: storeInput.key ?? null,
+        value: storeInput.value ?? null,
+        supersedesId: entry.targetFactId,
+      });
+      if (result.skipped) return { appliedFactId: null, postHash: null };
+      // OCC token (#2175) — distinct from content post_hash used for rollback drift.
+      const occToken = factsDb.getOccToken(entry.targetFactId) ?? undefined;
+      factsDb.supersede(entry.targetFactId, result.entry.id, occToken ? { expectedHash: occToken } : undefined);
+      return {
+        appliedFactId: result.entry.id,
+        postHash: hashFactContent(result.entry),
+      };
+    }
+    case "delete": {
+      if (!entry.targetFactId) throw new Error("delete requires targetFactId");
+      const occToken = factsDb.getOccToken(entry.targetFactId) ?? undefined;
+      // Soft-delete via supersede with null replacement (marks superseded).
+      factsDb.supersede(entry.targetFactId, null, occToken ? { expectedHash: occToken } : undefined);
+      return { appliedFactId: entry.targetFactId, postHash: null };
+    }
+    default:
+      throw new Error(`unsupported candidate op: ${entry.op}`);
+  }
+}
+
+/**
+ * Promote a dream run: evaluate gates, then either shadow-log, quarantine, or apply.
+ */
+export function promoteDreamRun(
+  factsDb: FactsDB,
+  store: DreamCandidateStore,
+  dreamRunId: string,
+  options: PromoteDreamRunOptions = {},
+): PromoteResult {
+  const dreaming = resolveCfg(options.cfg);
+  const run = store.getDreamRun(dreamRunId);
+  if (!run) {
+    return {
+      applied: false,
+      shadow: true,
+      status: "failed",
+      gateReport: { ok: false, decisions: [], wouldPromote: false, reason: "run_not_found" },
+      appliedFactIds: [],
+      error: `dream run not found: ${dreamRunId}`,
+    };
+  }
+
+  if (run.status === "promoted") {
+    return {
+      applied: true,
+      shadow: run.shadow,
+      status: "promoted",
+      gateReport: { ok: true, decisions: [], wouldPromote: true, reason: "already_promoted" },
+      appliedFactIds: store
+        .listCandidateEntries(dreamRunId)
+        .map((e) => e.appliedFactId)
+        .filter((id): id is string => Boolean(id)),
+    };
+  }
+
+  if (run.status !== "pending" && run.status !== "running" && run.status !== "gated") {
+    return {
+      applied: false,
+      shadow: run.shadow,
+      status: run.status,
+      gateReport: { ok: false, decisions: [], wouldPromote: false, reason: `invalid_status_${run.status}` },
+      appliedFactIds: [],
+      error: `cannot promote dream run in status ${run.status}`,
+    };
+  }
+
+  if (run.status === "pending") {
+    store.updateDreamRunStatus(dreamRunId, "running");
+  }
+
+  // OCC: refuse if live store drifted since dream snapshot (#2175).
+  const currentRevision = factsDb.computeStoreRevision();
+  if (currentRevision !== run.inputStoreRevision && !options.force) {
+    store.updateDreamRunStatus(dreamRunId, "failed", {
+      failureReason: "stale_input_store_revision",
+      gateReportJson: JSON.stringify({ ok: false, reason: "stale_input_store_revision" }),
+    });
+    return {
+      applied: false,
+      shadow: run.shadow,
+      status: "failed",
+      gateReport: { ok: false, decisions: [], wouldPromote: false, reason: "stale_input_store_revision" },
+      appliedFactIds: [],
+      error: "input_store_revision mismatch — re-run dream or pass force",
+    };
+  }
+
+  const gateReport = evaluateDreamGates(store, dreamRunId, dreaming);
+  store.updateDreamRunStatus(dreamRunId, "gated", {
+    gateReportJson: JSON.stringify(gateReport),
+  });
+
+  if (!gateReport.ok) {
+    store.updateDreamRunStatus(dreamRunId, "quarantined", {
+      failureReason: "gate_reject",
+      gateReportJson: JSON.stringify(gateReport),
+    });
+    return {
+      applied: false,
+      shadow: run.shadow,
+      status: "quarantined",
+      gateReport,
+      appliedFactIds: [],
+    };
+  }
+
+  const shadowOnly = run.shadow || !dreaming.autoPromote.enabled;
+  if (shadowOnly && !options.force) {
+    pluginLogger.info?.(
+      `memory-hybrid: dream ${dreamRunId} gated OK (wouldPromote) — shadow/autoPromote off; not applying`,
+    );
+    return {
+      applied: false,
+      shadow: true,
+      status: "gated",
+      gateReport: { ...gateReport, wouldPromote: true },
+      appliedFactIds: [],
+    };
+  }
+
+  const appliedFactIds: string[] = [];
+  try {
+    const tx = createTransaction(
+      factsDb.getRawDb(),
+      () => {
+        const entries = store
+          .listCandidateEntries(dreamRunId)
+          .filter((e) => e.status === "gated_ok")
+          .sort((a, b) => a.sortOrder - b.sortOrder);
+        for (const entry of entries) {
+          const { appliedFactId, postHash } = applyEntry(factsDb, entry);
+          store.updateCandidateEntry(entry.id, {
+            status: "applied",
+            appliedFactId,
+            postHash,
+            reverse:
+              entry.op === "add" || entry.op === "merge" || entry.op === "boost"
+                ? { op: "delete_fact", payload: { factId: appliedFactId } }
+                : entry.op === "supersede"
+                  ? {
+                      op: "unsupersede",
+                      payload: {
+                        oldFactId: entry.targetFactId,
+                        newFactId: appliedFactId,
+                      },
+                    }
+                  : entry.op === "delete"
+                    ? {
+                        op: "unsupersede",
+                        payload: { oldFactId: entry.targetFactId, newFactId: null },
+                      }
+                    : entry.reverse,
+          });
+          if (appliedFactId) appliedFactIds.push(appliedFactId);
+        }
+      },
+      "IMMEDIATE",
+    );
+    tx();
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    store.updateDreamRunStatus(dreamRunId, "failed", { failureReason: message });
+    return {
+      applied: false,
+      shadow: false,
+      status: "failed",
+      gateReport,
+      appliedFactIds: [],
+      error: message,
+    };
+  }
+
+  const observeUntil =
+    dreaming.autoRollback.enabled
+      ? Math.floor(Date.now() / 1000) + dreaming.autoRollback.observeWindowHours * 3600
+      : null;
+
+  // Baseline for #2173 outcome window (effectScore starts neutral; callers can overwrite).
+  const baseline = {
+    successRate: 1,
+    retryRate: 0,
+    effectScore: 1,
+    sessionsObserved: 0,
+    factCount: factsDb.count(),
+  };
+
+  store.updateDreamRunStatus(dreamRunId, "promoted", {
+    metricsBaselineJson: JSON.stringify(baseline),
+    metricsObserveUntil: observeUntil,
+    gateReportJson: JSON.stringify(gateReport),
+  });
+
+  return {
+    applied: true,
+    shadow: false,
+    status: "promoted",
+    gateReport,
+    appliedFactIds,
+  };
+}
+
+export function quarantineDreamRun(
+  store: DreamCandidateStore,
+  dreamRunId: string,
+  reason: string,
+): void {
+  store.updateDreamRunStatus(dreamRunId, "quarantined", { failureReason: reason });
+}

--- a/extensions/memory-hybrid/services/dream-promote.ts
+++ b/extensions/memory-hybrid/services/dream-promote.ts
@@ -47,6 +47,7 @@ export function evaluateDreamGates(
   const decisions: GateReport["decisions"] = [];
 
   if (entries.length === 0) {
+    // Not promotable — leave wouldPromote false; promoteDreamRun must not apply or inflate ROI.
     return { ok: true, decisions: [], wouldPromote: false, reason: "no_candidates" };
   }
 
@@ -165,7 +166,7 @@ export function evaluateDreamGates(
     store.updateCandidateEntry(entry.id, { status: "gated_ok" });
   }
 
-  const ok = decisions.length > 0 && decisions.every((d) => d.pass);
+  const ok = decisions.some((d) => d.pass);
   const wouldPromote = ok;
   return { ok, decisions, wouldPromote };
 }
@@ -307,6 +308,17 @@ export function promoteDreamRun(
     gateReportJson: JSON.stringify(gateReport),
   });
 
+  // Empty compose: terminal gated with wouldPromote=false — never apply or treat as reject-quarantine.
+  if (gateReport.reason === "no_candidates") {
+    return {
+      applied: false,
+      shadow: run.shadow || !dreaming.autoPromote.enabled,
+      status: "gated",
+      gateReport: { ...gateReport, wouldPromote: false },
+      appliedFactIds: [],
+    };
+  }
+
   if (!gateReport.ok) {
     store.updateDreamRunStatus(dreamRunId, "quarantined", {
       failureReason: "gate_reject",
@@ -330,7 +342,7 @@ export function promoteDreamRun(
       applied: false,
       shadow: true,
       status: "gated",
-      gateReport: { ...gateReport, wouldPromote: true },
+      gateReport,
       appliedFactIds: [],
     };
   }
@@ -432,6 +444,27 @@ export function promoteDreamRun(
     : null;
 
   const promotedAt = Math.floor(Date.now() / 1000);
+
+  // Fail closed: do not mark promoted when nothing was applied (dedup skips / empty gated_ok).
+  if (appliedFactIds.length === 0) {
+    store.updateDreamRunStatus(dreamRunId, "gated", {
+      failureReason: "promoted_zero_applied",
+      gateReportJson: JSON.stringify({
+        ...gateReport,
+        wouldPromote: false,
+        reason: "promoted_zero_applied",
+      }),
+    });
+    return {
+      applied: false,
+      shadow: false,
+      status: "gated",
+      gateReport: { ...gateReport, wouldPromote: false, reason: "promoted_zero_applied" },
+      appliedFactIds: [],
+      error: "no facts applied after promote",
+    };
+  }
+
   const baselineJson = capturePromoteBaseline(factsDb, run.sessionIds, promotedAt);
   const metricsSummary = buildRunMetricsSummary(factsDb, {
     sessionIds: run.sessionIds,

--- a/extensions/memory-hybrid/services/dream-promote.ts
+++ b/extensions/memory-hybrid/services/dream-promote.ts
@@ -34,11 +34,7 @@ function resolveCfg(cfg?: DreamingConfig): DreamingConfig {
 }
 
 /** Evaluate machine gates for every candidate entry on a dream run. */
-export function evaluateDreamGates(
-  store: DreamCandidateStore,
-  dreamRunId: string,
-  cfg?: DreamingConfig,
-): GateReport {
+export function evaluateDreamGates(store: DreamCandidateStore, dreamRunId: string, cfg?: DreamingConfig): GateReport {
   const dreaming = resolveCfg(cfg);
   const entries = store.listCandidateEntries(dreamRunId);
   const decisions: GateReport["decisions"] = [];
@@ -117,7 +113,7 @@ export function evaluateDreamGates(
     }
     const confidence =
       typeof (entry.payload as { confidence?: unknown }).confidence === "number"
-        ? ((entry.payload as { confidence: number }).confidence)
+        ? (entry.payload as { confidence: number }).confidence
         : undefined;
     if (tier.minConfidence != null && confidence != null && confidence < tier.minConfidence) {
       decisions.push({
@@ -186,11 +182,7 @@ function applyEntry(
       if (result.skipped) return { appliedFactId: null, postHash: null };
       // Per-fact OCC (#2175): use candidate preHash from propose time, never live token.
       const expectedHash = entry.preHash ?? undefined;
-      factsDb.supersede(
-        entry.targetFactId,
-        result.entry.id,
-        expectedHash ? { expectedHash } : undefined,
-      );
+      factsDb.supersede(entry.targetFactId, result.entry.id, expectedHash ? { expectedHash } : undefined);
       return {
         appliedFactId: result.entry.id,
         postHash: hashFactContent(result.entry),
@@ -199,11 +191,7 @@ function applyEntry(
     case "delete": {
       if (!entry.targetFactId) throw new Error("delete requires targetFactId");
       const expectedHash = entry.preHash ?? undefined;
-      factsDb.supersede(
-        entry.targetFactId,
-        null,
-        expectedHash ? { expectedHash } : undefined,
-      );
+      factsDb.supersede(entry.targetFactId, null, expectedHash ? { expectedHash } : undefined);
       return { appliedFactId: entry.targetFactId, postHash: null };
     }
     default:
@@ -379,10 +367,9 @@ export function promoteDreamRun(
     };
   }
 
-  const observeUntil =
-    dreaming.autoRollback.enabled
-      ? Math.floor(Date.now() / 1000) + dreaming.autoRollback.observeWindowHours * 3600
-      : null;
+  const observeUntil = dreaming.autoRollback.enabled
+    ? Math.floor(Date.now() / 1000) + dreaming.autoRollback.observeWindowHours * 3600
+    : null;
 
   const promotedAt = Math.floor(Date.now() / 1000);
   const baselineJson = capturePromoteBaseline(factsDb, run.sessionIds, promotedAt);
@@ -411,10 +398,6 @@ export function promoteDreamRun(
   };
 }
 
-export function quarantineDreamRun(
-  store: DreamCandidateStore,
-  dreamRunId: string,
-  reason: string,
-): void {
+export function quarantineDreamRun(store: DreamCandidateStore, dreamRunId: string, reason: string): void {
   store.updateDreamRunStatus(dreamRunId, "quarantined", { failureReason: reason });
 }

--- a/extensions/memory-hybrid/services/dream-promote.ts
+++ b/extensions/memory-hybrid/services/dream-promote.ts
@@ -18,10 +18,12 @@ import {
   hashFactContent,
 } from "./dream-candidate-ops.js";
 import { writeScopeWithinBoundary } from "./dream-permission.js";
+import { evaluateContradictionWorsening } from "./dream-contradiction-gate.js";
 import { MemoryConflictError } from "../utils/fact-occ.js";
 import { capturePromoteBaseline } from "./dream-outcome-probe.js";
 import { buildRunMetricsSummary, dreamRunTag } from "./dream-metrics.js";
 import { shouldSteeringIgnore } from "./dream-steering.js";
+import { evaluateShadowValidationFromStore } from "./dream-shadow-validation.js";
 
 export type PromoteDreamRunOptions = {
   /** Apply even when shadow=true / autoPromote disabled (CLI escape hatch). */
@@ -34,7 +36,12 @@ function resolveCfg(cfg?: DreamingConfig): DreamingConfig {
 }
 
 /** Evaluate machine gates for every candidate entry on a dream run. */
-export function evaluateDreamGates(store: DreamCandidateStore, dreamRunId: string, cfg?: DreamingConfig): GateReport {
+export function evaluateDreamGates(
+  store: DreamCandidateStore,
+  dreamRunId: string,
+  cfg?: DreamingConfig,
+  factsDb?: FactsDB,
+): GateReport {
   const dreaming = resolveCfg(cfg);
   const entries = store.listCandidateEntries(dreamRunId);
   const decisions: GateReport["decisions"] = [];
@@ -54,14 +61,28 @@ export function evaluateDreamGates(store: DreamCandidateStore, dreamRunId: strin
       }
     }
 
-    if (dreaming.autoPromote.blockOnContradictionWorsening && entry.payload.contradictionWorsens === true) {
-      decisions.push({
-        entryId: entry.id,
-        pass: false,
-        reason: "contradiction_worsens",
-      });
-      store.updateCandidateEntry(entry.id, { status: "gated_block" });
-      continue;
+    if (dreaming.autoPromote.blockOnContradictionWorsening) {
+      if (!factsDb) {
+        decisions.push({
+          entryId: entry.id,
+          pass: false,
+          reason: "contradiction_gate_missing_factsdb",
+        });
+        store.updateCandidateEntry(entry.id, { status: "gated_block" });
+        continue;
+      }
+      const contradiction = evaluateContradictionWorsening(factsDb, entry);
+      if (contradiction.worsens) {
+        decisions.push({
+          entryId: entry.id,
+          pass: false,
+          reason: contradiction.reason.startsWith("contradiction_")
+            ? contradiction.reason
+            : `contradiction_worsens:${contradiction.reason}`,
+        });
+        store.updateCandidateEntry(entry.id, { status: "gated_block" });
+        continue;
+      }
     }
 
     // Blast-radius / prevalence (#2172).
@@ -266,7 +287,7 @@ export function promoteDreamRun(
     };
   }
 
-  const gateReport = evaluateDreamGates(store, dreamRunId, dreaming);
+  const gateReport = evaluateDreamGates(store, dreamRunId, dreaming, factsDb);
   store.updateDreamRunStatus(dreamRunId, "gated", {
     gateReportJson: JSON.stringify(gateReport),
   });
@@ -287,7 +308,7 @@ export function promoteDreamRun(
 
   const shadowOnly = run.shadow || !dreaming.autoPromote.enabled;
   if (shadowOnly && !options.force) {
-    pluginLogger.info?.(
+    pluginLogger.info(
       `memory-hybrid: dream ${dreamRunId} gated OK (wouldPromote) — shadow/autoPromote off; not applying`,
     );
     return {
@@ -297,6 +318,30 @@ export function promoteDreamRun(
       gateReport: { ...gateReport, wouldPromote: true },
       appliedFactIds: [],
     };
+  }
+
+  // Fail closed: autoPromote apply requires passing shadow ROI window (#2179).
+  if (dreaming.autoPromote.enabled && !options.force && dreaming.autoPromote.shadowValidation.enabled) {
+    const validation = evaluateShadowValidationFromStore(store, {
+      thresholds: dreaming.autoPromote.shadowValidation,
+      db: factsDb.getRawDb(),
+    });
+    if (!validation.ok) {
+      const reason = `shadow_validation_failed:${validation.reasons.join(",")}`;
+      store.updateDreamRunStatus(dreamRunId, "failed", {
+        failureReason: reason,
+        gateReportJson: JSON.stringify({ ...gateReport, shadowValidation: validation }),
+      });
+      pluginLogger.warn(`memory-hybrid: dream ${dreamRunId} promote blocked — ${reason}`);
+      return {
+        applied: false,
+        shadow: run.shadow,
+        status: "failed",
+        gateReport: { ...gateReport, wouldPromote: true, reason },
+        appliedFactIds: [],
+        error: reason,
+      };
+    }
   }
 
   const appliedFactIds: string[] = [];

--- a/extensions/memory-hybrid/services/dream-promote.ts
+++ b/extensions/memory-hybrid/services/dream-promote.ts
@@ -46,6 +46,10 @@ export function evaluateDreamGates(
   const entries = store.listCandidateEntries(dreamRunId);
   const decisions: GateReport["decisions"] = [];
 
+  if (entries.length === 0) {
+    return { ok: true, decisions: [], wouldPromote: false, reason: "no_candidates" };
+  }
+
   for (const entry of entries) {
     if (dreaming.autoPromote.requireProvenance) {
       const hasSessions = entry.sessionIds.length > 0;
@@ -85,8 +89,19 @@ export function evaluateDreamGates(
       }
     }
 
+    // OCC fail-closed: delete/supersede require propose-time preHash (#2175).
+    if ((entry.op === "delete" || entry.op === "supersede") && !entry.preHash) {
+      decisions.push({
+        entryId: entry.id,
+        pass: false,
+        reason: "missing_prehash_occ",
+      });
+      store.updateCandidateEntry(entry.id, { status: "gated_block" });
+      continue;
+    }
+
     // Blast-radius / prevalence (#2172).
-    const scope = (entry.payload.scope ?? "global") as "session" | "agent" | "user" | "global";
+    const scope = (entry.payload.scope ?? "agent") as "session" | "agent" | "user" | "global";
     if (!writeScopeWithinBoundary(scope, dreaming.permissionBoundary)) {
       decisions.push({
         entryId: entry.id,
@@ -201,9 +216,9 @@ function applyEntry(
         tags: [...(storeInput.tags ?? []), ...dreamTags],
       });
       if (result.skipped) return { appliedFactId: null, postHash: null };
-      // Per-fact OCC (#2175): use candidate preHash from propose time, never live token.
-      const expectedHash = entry.preHash ?? undefined;
-      factsDb.supersede(entry.targetFactId, result.entry.id, expectedHash ? { expectedHash } : undefined);
+      // Per-fact OCC (#2175): require propose-time preHash — never fail open.
+      if (!entry.preHash) throw new Error("supersede requires preHash OCC token");
+      factsDb.supersede(entry.targetFactId, result.entry.id, { expectedHash: entry.preHash });
       return {
         appliedFactId: result.entry.id,
         postHash: hashFactContent(result.entry),
@@ -211,8 +226,8 @@ function applyEntry(
     }
     case "delete": {
       if (!entry.targetFactId) throw new Error("delete requires targetFactId");
-      const expectedHash = entry.preHash ?? undefined;
-      factsDb.supersede(entry.targetFactId, null, expectedHash ? { expectedHash } : undefined);
+      if (!entry.preHash) throw new Error("delete requires preHash OCC token");
+      factsDb.supersede(entry.targetFactId, null, { expectedHash: entry.preHash });
       return { appliedFactId: entry.targetFactId, postHash: null };
     }
     default:

--- a/extensions/memory-hybrid/services/dream-roi.ts
+++ b/extensions/memory-hybrid/services/dream-roi.ts
@@ -2,6 +2,7 @@
  * Dream ROI reporting (#2179) — cost + outcome summaries for autonomous ops.
  */
 
+import type { DatabaseSync } from "node:sqlite";
 import type { DreamCandidateStore } from "../backends/dream-candidate-store.js";
 import type { DreamRunRecord } from "./dream-candidate-ops.js";
 import { parseBaseline, type DreamMetricSet } from "./dream-outcome.js";
@@ -16,11 +17,10 @@ export type DreamRoiRow = {
   candidateCount: number;
   cost: {
     feature: "dream";
-    /** Wall seconds if started/gated known; else null. */
     wallSeconds: number | null;
-    /** Placeholder until llm_cost_log aggregation is wired. */
     tokens: number | null;
     usdProxy: number | null;
+    source: "llm_cost_log" | "insufficient_data";
   };
   outcome: {
     baseline: DreamMetricSet | null;
@@ -39,6 +39,8 @@ export type DreamRoiReport = {
     quarantined: number;
     shadowOnly: number;
     candidateToPromoteRatio: number | null;
+    dreamTokens: number | null;
+    dreamUsdProxy: number | null;
   };
   howToRead: string;
 };
@@ -53,9 +55,36 @@ function summarizeOutcome(run: DreamRunRecord): DreamRoiRow["outcome"]["summary"
   return "insufficient_data";
 }
 
+function queryDreamCost(
+  db: DatabaseSync | null | undefined,
+  sinceSec: number,
+  untilSec: number,
+): { tokens: number; usdProxy: number } | null {
+  if (!db) return null;
+  try {
+    const row = db
+      .prepare(
+        `SELECT COALESCE(SUM(input_tokens + output_tokens), 0) AS tokens,
+                COALESCE(SUM(estimated_cost_usd), 0) AS usd
+         FROM llm_cost_log
+         WHERE feature = 'dream' AND timestamp >= ? AND timestamp <= ?`,
+      )
+      .get(sinceSec, untilSec) as { tokens: number; usd: number } | undefined;
+    if (!row) return null;
+    return { tokens: Number(row.tokens) || 0, usdProxy: Number(row.usd) || 0 };
+  } catch {
+    return null;
+  }
+}
+
 export function buildDreamRoiReport(
   store: DreamCandidateStore,
-  options: { sinceSec?: number; untilSec?: number; limit?: number } = {},
+  options: {
+    sinceSec?: number;
+    untilSec?: number;
+    limit?: number;
+    db?: DatabaseSync | null;
+  } = {},
 ): DreamRoiReport {
   const untilSec = options.untilSec ?? Math.floor(Date.now() / 1000);
   const sinceSec = options.sinceSec ?? untilSec - 30 * 24 * 3600;
@@ -63,6 +92,7 @@ export function buildDreamRoiReport(
 
   const all = store.listDreamRuns(limit);
   const runsInWindow = all.filter((r) => r.createdAt >= sinceSec && r.createdAt <= untilSec);
+  const costAgg = queryDreamCost(options.db, sinceSec, untilSec);
 
   const rows: DreamRoiRow[] = runsInWindow.map((run) => {
     const entries = store.listCandidateEntries(run.id);
@@ -81,8 +111,9 @@ export function buildDreamRoiReport(
       cost: {
         feature: "dream",
         wallSeconds,
-        tokens: null,
-        usdProxy: null,
+        tokens: costAgg?.tokens ?? null,
+        usdProxy: costAgg?.usdProxy ?? null,
+        source: costAgg ? "llm_cost_log" : "insufficient_data",
       },
       outcome: {
         baseline: parseBaseline(run.metricsBaselineJson),
@@ -108,10 +139,13 @@ export function buildDreamRoiReport(
       quarantined,
       shadowOnly,
       candidateToPromoteRatio: totalCandidates > 0 ? promoted / totalCandidates : null,
+      dreamTokens: costAgg?.tokens ?? null,
+      dreamUsdProxy: costAgg?.usdProxy ?? null,
     },
     howToRead:
       "Higher promote ratio with low rollback rate and stable/rising effectScore means Dream spend is paying off. " +
       "Shadow-only runs are safe canaries — compare would-promote volume before enabling autoPromote. " +
-      "Use rollback rate + effectScore drop to tune autoRollback.regressionThreshold (#2173).",
+      "Use rollback rate + effectScore drop to tune autoRollback.regressionThreshold (#2173). " +
+      "Cost rows use llm_cost_log feature=dream when present; otherwise insufficient_data.",
   };
 }

--- a/extensions/memory-hybrid/services/dream-roi.ts
+++ b/extensions/memory-hybrid/services/dream-roi.ts
@@ -98,10 +98,11 @@ export function buildDreamRoiReport(
 ): DreamRoiReport {
   const untilSec = options.untilSec ?? Math.floor(Date.now() / 1000);
   const sinceSec = options.sinceSec ?? untilSec - 30 * 24 * 3600;
-  const limit = Math.max(1, Math.min(500, options.limit ?? 100));
+  // Prefer a high ceiling so lookbackDays is honored; window is applied in SQL.
+  const limit = Math.max(1, Math.min(10_000, options.limit ?? 5000));
 
-  const all = store.listDreamRuns(limit);
-  const runsInWindow = all.filter((r) => r.createdAt >= sinceSec && r.createdAt <= untilSec);
+  const all = store.listDreamRuns(limit, { sinceSec, untilSec });
+  const runsInWindow = all;
   const costAgg = queryDreamCost(options.db, sinceSec, untilSec);
 
   const rows: DreamRoiRow[] = runsInWindow.map((run) => {

--- a/extensions/memory-hybrid/services/dream-roi.ts
+++ b/extensions/memory-hybrid/services/dream-roi.ts
@@ -1,0 +1,117 @@
+/**
+ * Dream ROI reporting (#2179) — cost + outcome summaries for autonomous ops.
+ */
+
+import type { DreamCandidateStore } from "../backends/dream-candidate-store.js";
+import type { DreamRunRecord } from "./dream-candidate-ops.js";
+import { parseBaseline, type DreamMetricSet } from "./dream-outcome.js";
+
+export type DreamRoiRow = {
+  dreamRunId: string;
+  status: DreamRunRecord["status"];
+  shadow: boolean;
+  createdAt: number;
+  promotedAt: number | null;
+  rolledBackAt: number | null;
+  candidateCount: number;
+  cost: {
+    feature: "dream";
+    /** Wall seconds if started/gated known; else null. */
+    wallSeconds: number | null;
+    /** Placeholder until llm_cost_log aggregation is wired. */
+    tokens: number | null;
+    usdProxy: number | null;
+  };
+  outcome: {
+    baseline: DreamMetricSet | null;
+    summary: "promoted" | "shadow" | "quarantined" | "rolled_back" | "failed" | "pending" | "insufficient_data";
+  };
+};
+
+export type DreamRoiReport = {
+  sinceSec: number;
+  untilSec: number;
+  runs: DreamRoiRow[];
+  aggregates: {
+    runCount: number;
+    promoted: number;
+    rolledBack: number;
+    quarantined: number;
+    shadowOnly: number;
+    candidateToPromoteRatio: number | null;
+  };
+  howToRead: string;
+};
+
+function summarizeOutcome(run: DreamRunRecord): DreamRoiRow["outcome"]["summary"] {
+  if (run.status === "rolled_back") return "rolled_back";
+  if (run.status === "quarantined") return "quarantined";
+  if (run.status === "failed") return "failed";
+  if (run.status === "promoted") return "promoted";
+  if (run.shadow) return "shadow";
+  if (run.status === "pending" || run.status === "running" || run.status === "gated") return "pending";
+  return "insufficient_data";
+}
+
+export function buildDreamRoiReport(
+  store: DreamCandidateStore,
+  options: { sinceSec?: number; untilSec?: number; limit?: number } = {},
+): DreamRoiReport {
+  const untilSec = options.untilSec ?? Math.floor(Date.now() / 1000);
+  const sinceSec = options.sinceSec ?? untilSec - 30 * 24 * 3600;
+  const limit = Math.max(1, Math.min(500, options.limit ?? 100));
+
+  const all = store.listDreamRuns(limit);
+  const runsInWindow = all.filter((r) => r.createdAt >= sinceSec && r.createdAt <= untilSec);
+
+  const rows: DreamRoiRow[] = runsInWindow.map((run) => {
+    const entries = store.listCandidateEntries(run.id);
+    const wallSeconds =
+      run.startedAt != null && (run.gatedAt ?? run.promotedAt ?? run.failedAt) != null
+        ? Math.max(0, (run.gatedAt ?? run.promotedAt ?? run.failedAt)! - run.startedAt)
+        : null;
+    return {
+      dreamRunId: run.id,
+      status: run.status,
+      shadow: run.shadow,
+      createdAt: run.createdAt,
+      promotedAt: run.promotedAt,
+      rolledBackAt: run.rolledBackAt,
+      candidateCount: entries.length,
+      cost: {
+        feature: "dream",
+        wallSeconds,
+        tokens: null,
+        usdProxy: null,
+      },
+      outcome: {
+        baseline: parseBaseline(run.metricsBaselineJson),
+        summary: summarizeOutcome(run),
+      },
+    };
+  });
+
+  const promoted = rows.filter((r) => r.status === "promoted" || r.status === "rolled_back").length;
+  const rolledBack = rows.filter((r) => r.status === "rolled_back").length;
+  const quarantined = rows.filter((r) => r.status === "quarantined").length;
+  const shadowOnly = rows.filter((r) => r.shadow && r.status !== "promoted" && r.status !== "rolled_back").length;
+  const totalCandidates = rows.reduce((n, r) => n + r.candidateCount, 0);
+
+  return {
+    sinceSec,
+    untilSec,
+    runs: rows,
+    aggregates: {
+      runCount: rows.length,
+      promoted,
+      rolledBack,
+      quarantined,
+      shadowOnly,
+      candidateToPromoteRatio: totalCandidates > 0 ? promoted / totalCandidates : null,
+    },
+    howToRead:
+      "Higher promote ratio with low rollback rate and stable/rising effectScore means Dream spend is paying off. " +
+      "Shadow-only runs are safe canaries — compare would-promote volume before enabling autoPromote. " +
+      "Use rollback rate + effectScore drop to tune autoRollback.regressionThreshold (#2173).",
+  };
+}

--- a/extensions/memory-hybrid/services/dream-roi.ts
+++ b/extensions/memory-hybrid/services/dream-roi.ts
@@ -6,6 +6,7 @@ import type { DatabaseSync } from "node:sqlite";
 import type { DreamCandidateStore } from "../backends/dream-candidate-store.js";
 import type { DreamRunRecord } from "./dream-candidate-ops.js";
 import { parseBaseline, type DreamMetricSet } from "./dream-outcome.js";
+import type { DreamRunMetricsSummary } from "./dream-metrics.js";
 
 export type DreamRoiRow = {
   dreamRunId: string;
@@ -44,6 +45,15 @@ export type DreamRoiReport = {
   };
   howToRead: string;
 };
+
+function parseRunSummary(json: string | null | undefined): DreamRunMetricsSummary | null {
+  if (!json) return null;
+  try {
+    return JSON.parse(json) as DreamRunMetricsSummary;
+  } catch {
+    return null;
+  }
+}
 
 function summarizeOutcome(run: DreamRunRecord): DreamRoiRow["outcome"]["summary"] {
   if (run.status === "rolled_back") return "rolled_back";
@@ -96,10 +106,12 @@ export function buildDreamRoiReport(
 
   const rows: DreamRoiRow[] = runsInWindow.map((run) => {
     const entries = store.listCandidateEntries(run.id);
+    const perRun = parseRunSummary(run.metricsSummaryJson);
     const wallSeconds =
-      run.startedAt != null && (run.gatedAt ?? run.promotedAt ?? run.failedAt) != null
+      perRun?.wallSeconds ??
+      (run.startedAt != null && (run.gatedAt ?? run.promotedAt ?? run.failedAt) != null
         ? Math.max(0, (run.gatedAt ?? run.promotedAt ?? run.failedAt)! - run.startedAt)
-        : null;
+        : null);
     return {
       dreamRunId: run.id,
       status: run.status,
@@ -111,9 +123,9 @@ export function buildDreamRoiReport(
       cost: {
         feature: "dream",
         wallSeconds,
-        tokens: costAgg?.tokens ?? null,
-        usdProxy: costAgg?.usdProxy ?? null,
-        source: costAgg ? "llm_cost_log" : "insufficient_data",
+        tokens: perRun?.tokens ?? null,
+        usdProxy: perRun?.usdProxy ?? null,
+        source: perRun?.source ?? (costAgg ? "llm_cost_log" : "insufficient_data"),
       },
       outcome: {
         baseline: parseBaseline(run.metricsBaselineJson),

--- a/extensions/memory-hybrid/services/dream-rollback.ts
+++ b/extensions/memory-hybrid/services/dream-rollback.ts
@@ -96,9 +96,23 @@ export function rollbackDreamRun(
               const oldId =
                 (typeof reverse.payload.oldFactId === "string" ? reverse.payload.oldFactId : null) ??
                 entry.targetFactId;
-              const newId =
-                (typeof reverse.payload.newFactId === "string" ? reverse.payload.newFactId : null) ??
-                entry.appliedFactId;
+              // For a `delete` op the applied fact IS the target fact — falling back to
+              // entry.appliedFactId when `newFactId` is explicitly null (delete/contradiction
+              // reverse plans) used to delete the just-restored old fact, defeating the
+              // rollback. Only delete `newId` when the reverse plan supplies an explicit
+              // string id AND that id differs from the restored oldId.
+              const payloadNewFactIdKey = "newFactId" in reverse.payload;
+              const payloadNewFactId = (reverse.payload as { newFactId?: unknown }).newFactId;
+              let newId: string | null = null;
+              if (typeof payloadNewFactId === "string" && payloadNewFactId.length > 0) {
+                newId = payloadNewFactId;
+              } else if (!payloadNewFactIdKey) {
+                // Legacy reverse plans that omit newFactId entirely fall back to entry.appliedFactId,
+                // but only if it isn't the same fact we just restored (never delete the restored fact).
+                if (entry.appliedFactId && entry.appliedFactId !== oldId) {
+                  newId = entry.appliedFactId;
+                }
+              }
               if (oldId) {
                 factsDb
                   .getRawDb()
@@ -109,7 +123,7 @@ export function rollbackDreamRun(
                 factsDb.invalidateSupersededTextsCache();
                 restoredFactIds.push(oldId);
               }
-              if (newId) {
+              if (newId && newId !== oldId) {
                 factsDb.delete(newId);
               }
               break;

--- a/extensions/memory-hybrid/services/dream-rollback.ts
+++ b/extensions/memory-hybrid/services/dream-rollback.ts
@@ -85,8 +85,7 @@ export function rollbackDreamRun(
           switch (reverse.op) {
             case "delete_fact": {
               const factId =
-                (typeof reverse.payload.factId === "string" ? reverse.payload.factId : null) ??
-                entry.appliedFactId;
+                (typeof reverse.payload.factId === "string" ? reverse.payload.factId : null) ?? entry.appliedFactId;
               if (factId) {
                 factsDb.delete(factId);
                 restoredFactIds.push(factId);
@@ -117,8 +116,7 @@ export function rollbackDreamRun(
             }
             case "restore_text": {
               const factId =
-                (typeof reverse.payload.factId === "string" ? reverse.payload.factId : null) ??
-                entry.targetFactId;
+                (typeof reverse.payload.factId === "string" ? reverse.payload.factId : null) ?? entry.targetFactId;
               const text = typeof reverse.payload.text === "string" ? reverse.payload.text : null;
               if (factId && text != null) {
                 factsDb.getRawDb().prepare("UPDATE facts SET text = ? WHERE id = ?").run(text, factId);

--- a/extensions/memory-hybrid/services/dream-rollback.ts
+++ b/extensions/memory-hybrid/services/dream-rollback.ts
@@ -150,10 +150,10 @@ export function rollbackDreamRun(
 
   const reason = options.reason ?? "manual_rollback";
   const fullyClean = abortedEntries.length === 0;
-  const rolledBack = fullyClean || restoredFactIds.length > 0;
+  // Only mark rolled_back when every applied entry reversed cleanly (#2173 correctness).
+  const markRolledBack = fullyClean && (run.status === "promoted" || options.force === true);
 
-  // Only mark rolled_back when we actually restored something or had a clean reverse.
-  if (rolledBack && (run.status === "promoted" || options.force)) {
+  if (markRolledBack) {
     try {
       store.updateDreamRunStatus(dreamRunId, "rolled_back", { rollbackReason: reason });
     } catch {
@@ -162,8 +162,8 @@ export function rollbackDreamRun(
   }
 
   return {
-    rolledBack,
-    status: rolledBack ? "rolled_back" : run.status,
+    rolledBack: markRolledBack,
+    status: markRolledBack ? "rolled_back" : run.status,
     restoredFactIds,
     abortedEntries,
     error: fullyClean ? undefined : abortedEntries.map((a) => a.reason).join(";"),

--- a/extensions/memory-hybrid/services/dream-rollback.ts
+++ b/extensions/memory-hybrid/services/dream-rollback.ts
@@ -1,0 +1,171 @@
+/**
+ * Dream auto-rollback (#2170) — apply reverse plans with post_hash drift checks.
+ */
+
+import type { FactsDB } from "../backends/facts-db.js";
+import { DreamCandidateStore } from "../backends/dream-candidate-store.js";
+import { createTransaction } from "../utils/sqlite-transaction.js";
+import { hashFactContent, type RollbackResult } from "./dream-candidate-ops.js";
+
+export type RollbackDreamRunOptions = {
+  reason?: string;
+  /** Skip observation-window / status checks (CLI escape hatch). */
+  force?: boolean;
+};
+
+/**
+ * Roll back a promoted dream run using each entry's reverse plan.
+ * Aborts individual entries whose live post_hash drifted since promote.
+ */
+export function rollbackDreamRun(
+  factsDb: FactsDB,
+  store: DreamCandidateStore,
+  dreamRunId: string,
+  options: RollbackDreamRunOptions = {},
+): RollbackResult {
+  const run = store.getDreamRun(dreamRunId);
+  if (!run) {
+    return {
+      rolledBack: false,
+      status: "failed",
+      restoredFactIds: [],
+      abortedEntries: [],
+      error: `dream run not found: ${dreamRunId}`,
+    };
+  }
+
+  if (run.status === "rolled_back") {
+    return {
+      rolledBack: true,
+      status: "rolled_back",
+      restoredFactIds: [],
+      abortedEntries: [],
+    };
+  }
+
+  if (run.status !== "promoted" && !options.force) {
+    return {
+      rolledBack: false,
+      status: run.status,
+      restoredFactIds: [],
+      abortedEntries: [],
+      error: `cannot rollback dream run in status ${run.status}`,
+    };
+  }
+
+  const applied = store
+    .listCandidateEntries(dreamRunId)
+    .filter((e) => e.status === "applied")
+    .sort((a, b) => b.sortOrder - a.sortOrder);
+
+  const restoredFactIds: string[] = [];
+  const abortedEntries: Array<{ entryId: string; reason: string }> = [];
+
+  try {
+    const tx = createTransaction(
+      factsDb.getRawDb(),
+      () => {
+        for (const entry of applied) {
+          // Drift check: if we recorded postHash, live content must still match.
+          if (entry.postHash && entry.appliedFactId) {
+            const live = factsDb.getById(entry.appliedFactId);
+            if (live) {
+              const liveHash = hashFactContent(live);
+              if (liveHash !== entry.postHash) {
+                abortedEntries.push({
+                  entryId: entry.id,
+                  reason: "post_hash_drift",
+                });
+                continue;
+              }
+            }
+          }
+
+          const reverse = entry.reverse;
+          switch (reverse.op) {
+            case "delete_fact": {
+              const factId =
+                (typeof reverse.payload.factId === "string" ? reverse.payload.factId : null) ??
+                entry.appliedFactId;
+              if (factId) {
+                factsDb.delete(factId);
+                restoredFactIds.push(factId);
+              }
+              break;
+            }
+            case "unsupersede": {
+              const oldId =
+                (typeof reverse.payload.oldFactId === "string" ? reverse.payload.oldFactId : null) ??
+                entry.targetFactId;
+              const newId =
+                (typeof reverse.payload.newFactId === "string" ? reverse.payload.newFactId : null) ??
+                entry.appliedFactId;
+              if (oldId) {
+                factsDb
+                  .getRawDb()
+                  .prepare(
+                    "UPDATE facts SET superseded_at = NULL, superseded_by = NULL, valid_until = NULL WHERE id = ?",
+                  )
+                  .run(oldId);
+                factsDb.invalidateSupersededTextsCache();
+                restoredFactIds.push(oldId);
+              }
+              if (newId) {
+                factsDb.delete(newId);
+              }
+              break;
+            }
+            case "restore_text": {
+              const factId =
+                (typeof reverse.payload.factId === "string" ? reverse.payload.factId : null) ??
+                entry.targetFactId;
+              const text = typeof reverse.payload.text === "string" ? reverse.payload.text : null;
+              if (factId && text != null) {
+                factsDb.getRawDb().prepare("UPDATE facts SET text = ? WHERE id = ?").run(text, factId);
+                restoredFactIds.push(factId);
+              }
+              break;
+            }
+            case "noop":
+              break;
+            default:
+              abortedEntries.push({ entryId: entry.id, reason: `unknown_reverse_op:${reverse.op}` });
+              continue;
+          }
+          store.updateCandidateEntry(entry.id, { status: "rolled_back" });
+        }
+      },
+      "IMMEDIATE",
+    );
+    tx();
+  } catch (err) {
+    return {
+      rolledBack: false,
+      status: run.status,
+      restoredFactIds,
+      abortedEntries,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+
+  const reason = options.reason ?? "manual_rollback";
+  const fullyClean = abortedEntries.length === 0;
+  const rolledBack = fullyClean || restoredFactIds.length > 0;
+
+  // Only mark rolled_back when we actually restored something or had a clean reverse.
+  if (rolledBack && (run.status === "promoted" || options.force)) {
+    try {
+      store.updateDreamRunStatus(dreamRunId, "rolled_back", { rollbackReason: reason });
+    } catch {
+      // Already rolled_back or illegal — ignore when force path partially applied.
+    }
+  }
+
+  return {
+    rolledBack,
+    status: rolledBack ? "rolled_back" : run.status,
+    restoredFactIds,
+    abortedEntries,
+    error: fullyClean ? undefined : abortedEntries.map((a) => a.reason).join(";"),
+  };
+}

--- a/extensions/memory-hybrid/services/dream-run.ts
+++ b/extensions/memory-hybrid/services/dream-run.ts
@@ -1,0 +1,316 @@
+/**
+ * Unified Dream product operation (#2171 / Epic #2169).
+ *
+ * Composes existing maintenance steps behind one transaction-shaped facade:
+ * snapshot revision → run compose stages → emit candidates → optional promote.
+ *
+ * Does not delete nightly CLIs; when `dreaming.skipNightlyOverlap` is true the
+ * maintenance orchestrator skips overlapping steps (see maintenance-orchestrator).
+ */
+
+import type { FactsDB } from "../backends/facts-db.js";
+import type { DreamCandidateStore } from "../backends/dream-candidate-store.js";
+import type { DreamComposeStep, DreamingConfig } from "../config/types/dreaming.js";
+import { DEFAULT_DREAMING_CONFIG } from "../config/types/dreaming.js";
+import {
+  clearMaintenanceRunDeadline,
+  maintenanceRunDeadlineReached,
+  setMaintenanceRunDeadlineMs,
+} from "../utils/maintenance-run-deadline.js";
+import { pluginLogger } from "../utils/logger.js";
+import { withCostFeature } from "./cost-context.js";
+import { CostFeature } from "./cost-feature-labels.js";
+import type {
+  CandidateEntryInput,
+  CandidateEntryRecord,
+  DreamRunRecord,
+  PromoteResult,
+} from "./dream-candidate-ops.js";
+import { promoteDreamRun } from "./dream-promote.js";
+
+export type DreamStepSummary = {
+  step: DreamComposeStep;
+  ok: boolean;
+  detail: string;
+  skipped?: boolean;
+};
+
+export type DreamStepRunner = (ctx: {
+  dreamRunId: string;
+  sessionIds: string[];
+  steeringPolicyId: string | null;
+  abortSignal?: AbortSignal;
+}) => Promise<{ detail: string; candidates?: CandidateEntryInput[] }>;
+
+export type DreamStepRunners = Partial<Record<DreamComposeStep, DreamStepRunner>>;
+
+export type RunDreamOptions = {
+  factsDb: FactsDB;
+  store: DreamCandidateStore;
+  cfg?: DreamingConfig;
+  sessionIds?: string[];
+  steeringPolicyId?: string | null;
+  /** Inject existing CLI/service bindings — do not reimplement steps here. */
+  steps?: DreamStepRunners;
+  /**
+   * When true, call promoteDreamRun after candidates are written.
+   * Default: dreaming.autoPromote.enabled OR promoteAfterRun.
+   */
+  promote?: boolean;
+  /** Force promote apply even under shadow (escape hatch). */
+  forcePromote?: boolean;
+  /** Wall-clock ceiling override (minutes). */
+  maxRuntimeMinutes?: number;
+  dryShadow?: boolean;
+};
+
+export type RunDreamResult = {
+  dreamRunId: string;
+  run: DreamRunRecord;
+  candidates: CandidateEntryRecord[];
+  stepSummaries: DreamStepSummary[];
+  promoteResult?: PromoteResult;
+  timedOut: boolean;
+  costFeature: typeof CostFeature.dream;
+};
+
+const COMPOSE_ORDER: readonly DreamComposeStep[] = [
+  "distill",
+  "self-correction",
+  "contradictions",
+  "reflect",
+  "consolidate",
+  "dream-cycle-core",
+];
+
+function resolveCompose(cfg: DreamingConfig): DreamComposeStep[] {
+  const requested = cfg.compose.length > 0 ? cfg.compose : DEFAULT_DREAMING_CONFIG.compose;
+  const seen = new Set<DreamComposeStep>();
+  const ordered: DreamComposeStep[] = [];
+  for (const step of COMPOSE_ORDER) {
+    if (requested.includes(step) && !seen.has(step)) {
+      seen.add(step);
+      ordered.push(step);
+    }
+  }
+  // Preserve any unknown-order extras (should not happen with typed config).
+  for (const step of requested) {
+    if (!seen.has(step)) {
+      seen.add(step);
+      ordered.push(step);
+    }
+  }
+  // Mutual exclusion: dream-cycle-core embeds reflect — drop reflect when both requested.
+  if (ordered.includes("dream-cycle-core") && ordered.includes("reflect")) {
+    return ordered.filter((s) => s !== "reflect");
+  }
+  return ordered;
+}
+
+function boundSessionIds(sessionIds: string[] | undefined, maxSessions: number): string[] {
+  if (!sessionIds || sessionIds.length === 0) return [];
+  const capped = Math.max(1, Math.min(100, Math.floor(maxSessions)));
+  return sessionIds.slice(0, capped);
+}
+
+function curriculumCandidate(input: {
+  dreamRunId: string;
+  sessionIds: string[];
+  stepSummaries: DreamStepSummary[];
+  compose: DreamComposeStep[];
+}): CandidateEntryInput {
+  const okSteps = input.stepSummaries.filter((s) => s.ok && !s.skipped).map((s) => s.step);
+  const detailLines = input.stepSummaries.map(
+    (s) => `${s.step}:${s.skipped ? "skipped" : s.ok ? "ok" : "fail"}:${s.detail}`,
+  );
+  const text = [
+    `Dream curriculum update (${input.dreamRunId})`,
+    `compose=[${input.compose.join(",")}]`,
+    `completed=[${okSteps.join(",") || "none"}]`,
+    ...detailLines.slice(0, 12),
+  ].join("\n");
+
+  return {
+    op: "add",
+    payload: {
+      text,
+      category: "preference",
+      importance: 0.4,
+      source: "dream",
+      entity: "dream",
+      key: "curriculum_summary",
+      value: input.dreamRunId,
+      // Prefer low blast-radius for the synthetic summary (#2172); real insights carry their own scope.
+      scope: input.sessionIds.length > 0 ? "session" : "agent",
+      scopeTarget: input.sessionIds[0] ?? "dream",
+    },
+    evidence: {
+      sessionIds: input.sessionIds,
+      prevalence: {
+        sessions: Math.max(1, input.sessionIds.length),
+        agents: 1,
+      },
+      rationale: `Unified Dream (#2171) completed compose stages: ${okSteps.join(", ") || "none"}`,
+    },
+    reverse: { op: "delete_fact", payload: {} },
+    sortOrder: 0,
+  };
+}
+
+/**
+ * Run the unified Dream pipeline. Always creates a dream_run and ≥1 candidate
+ * (even when promote is disabled / shadow-only).
+ */
+export async function runDream(options: RunDreamOptions): Promise<RunDreamResult> {
+  const cfg = options.cfg ?? DEFAULT_DREAMING_CONFIG;
+  const { factsDb, store } = options;
+
+  if (!cfg.enabled && options.promote !== true && options.forcePromote !== true) {
+    // Still allow explicit CLI invocation; only block unsolicited auto paths.
+  }
+
+  const sessionIds = boundSessionIds(options.sessionIds, cfg.maxSessions);
+  const compose = resolveCompose(cfg);
+  const shadow =
+    options.dryShadow === true
+      ? true
+      : cfg.candidateStore.shadow !== false || !cfg.autoPromote.enabled;
+
+  const maxMinutes = options.maxRuntimeMinutes ?? cfg.maxRuntimeMinutes;
+  const deadlineMs = Date.now() + Math.max(1, maxMinutes) * 60_000;
+  setMaintenanceRunDeadlineMs(deadlineMs);
+
+  return withCostFeature(CostFeature.dream, async () => {
+    const run = store.createDreamRun({
+      inputStoreRevision: factsDb.computeStoreRevision(),
+      sessionIds,
+      steeringPolicyId: options.steeringPolicyId ?? null,
+      shadow,
+    });
+    store.updateDreamRunStatus(run.id, "running");
+
+    const stepSummaries: DreamStepSummary[] = [];
+    const collectedCandidates: CandidateEntryInput[] = [];
+    let timedOut = false;
+
+    try {
+      for (const step of compose) {
+        if (maintenanceRunDeadlineReached()) {
+          timedOut = true;
+          stepSummaries.push({
+            step,
+            ok: false,
+            detail: "dream maxRuntimeMinutes deadline reached",
+            skipped: true,
+          });
+          break;
+        }
+
+        const runner = options.steps?.[step];
+        if (!runner) {
+          stepSummaries.push({
+            step,
+            ok: true,
+            detail: "no runner bound (record-only)",
+            skipped: true,
+          });
+          continue;
+        }
+
+        try {
+          const result = await runner({
+            dreamRunId: run.id,
+            sessionIds,
+            steeringPolicyId: options.steeringPolicyId ?? null,
+          });
+          stepSummaries.push({ step, ok: true, detail: result.detail });
+          if (result.candidates?.length) {
+            collectedCandidates.push(...result.candidates);
+          }
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          pluginLogger.warn(`memory-hybrid: dream ${run.id} step ${step} failed: ${message}`);
+          stepSummaries.push({ step, ok: false, detail: message });
+        }
+      }
+
+      if (collectedCandidates.length === 0) {
+        collectedCandidates.push(
+          curriculumCandidate({
+            dreamRunId: run.id,
+            sessionIds,
+            stepSummaries,
+            compose,
+          }),
+        );
+      }
+
+      const candidates = store.appendCandidateEntries(run.id, collectedCandidates);
+
+      const shouldPromote =
+        options.promote === true ||
+        options.forcePromote === true ||
+        (options.promote !== false && (cfg.promoteAfterRun || cfg.autoPromote.enabled));
+
+      let promoteResult: PromoteResult | undefined;
+      if (shouldPromote) {
+        promoteResult = promoteDreamRun(factsDb, store, run.id, {
+          force: options.forcePromote === true,
+          cfg,
+        });
+      }
+
+      const updated = store.getDreamRun(run.id) ?? run;
+      return {
+        dreamRunId: run.id,
+        run: updated,
+        candidates,
+        stepSummaries,
+        promoteResult,
+        timedOut,
+        costFeature: CostFeature.dream,
+      };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      store.updateDreamRunStatus(run.id, "failed", { failureReason: message });
+      throw err;
+    } finally {
+      clearMaintenanceRunDeadline();
+    }
+  });
+}
+
+/** Map dreaming.compose / skipNightlyOverlap onto nightly maintenance step names. */
+export function nightlyStepsOwnedByDream(cfg: DreamingConfig): ReadonlySet<string> {
+  if (!cfg.enabled || !cfg.skipNightlyOverlap) return new Set();
+  const owned = new Set<string>();
+  for (const step of resolveCompose(cfg)) {
+    switch (step) {
+      case "distill":
+        owned.add("distill");
+        break;
+      case "self-correction":
+        owned.add("self-correction-run");
+        break;
+      case "contradictions":
+        owned.add("contradiction-candidates");
+        owned.add("resolve-contradictions");
+        break;
+      case "reflect":
+        owned.add("reflect");
+        owned.add("reflect-rules");
+        owned.add("reflect-meta");
+        owned.add("reflect-identity");
+        break;
+      case "consolidate":
+        owned.add("consolidate");
+        break;
+      case "dream-cycle-core":
+        owned.add("dream-cycle-core");
+        break;
+      default:
+        break;
+    }
+  }
+  return owned;
+}

--- a/extensions/memory-hybrid/services/dream-run.ts
+++ b/extensions/memory-hybrid/services/dream-run.ts
@@ -12,6 +12,7 @@ import type { FactsDB } from "../backends/facts-db.js";
 import type { DreamCandidateStore } from "../backends/dream-candidate-store.js";
 import type { DreamComposeStep, DreamingConfig } from "../config/types/dreaming.js";
 import { DEFAULT_DREAMING_CONFIG } from "../config/types/dreaming.js";
+import type { DreamSteeringConfig } from "../config/types/dreaming.js";
 import {
   clearMaintenanceRunDeadline,
   maintenanceRunDeadlineReached,
@@ -27,6 +28,8 @@ import type {
   PromoteResult,
 } from "./dream-candidate-ops.js";
 import { promoteDreamRun } from "./dream-promote.js";
+import { buildRunMetricsSummary } from "./dream-metrics.js";
+import { resolveSteering } from "./dream-steering.js";
 
 export type DreamStepSummary = {
   step: DreamComposeStep;
@@ -39,6 +42,7 @@ export type DreamStepRunner = (ctx: {
   dreamRunId: string;
   sessionIds: string[];
   steeringPolicyId: string | null;
+  steering: DreamSteeringConfig;
   /** When false, runners must not mutate FactsDB (shadow / candidate-only). */
   dryRun: boolean;
   abortSignal?: AbortSignal;
@@ -178,6 +182,7 @@ export async function runDream(options: RunDreamOptions): Promise<RunDreamResult
 
   const sessionIds = boundSessionIds(options.sessionIds, cfg.maxSessions);
   const compose = resolveCompose(cfg);
+  const steering = resolveSteering(cfg.steering);
   const shadow =
     options.dryShadow === true
       ? true
@@ -235,7 +240,8 @@ export async function runDream(options: RunDreamOptions): Promise<RunDreamResult
           const result = await runner({
             dreamRunId: run.id,
             sessionIds,
-            steeringPolicyId: options.steeringPolicyId ?? null,
+            steeringPolicyId: options.steeringPolicyId ?? steering.profile,
+            steering,
             dryRun: !liveMutateCompose,
           });
           stepSummaries.push({ step, ok: true, detail: result.detail });
@@ -278,6 +284,18 @@ export async function runDream(options: RunDreamOptions): Promise<RunDreamResult
           force: options.forcePromote === true,
           cfg,
         });
+      }
+
+      const endedAt = Math.floor(Date.now() / 1000);
+      const summary = buildRunMetricsSummary(factsDb, {
+        sessionIds,
+        startedAt: run.startedAt ?? run.createdAt,
+        endedAt,
+      });
+      try {
+        store.setDreamRunMetrics(run.id, { metricsSummaryJson: JSON.stringify(summary) });
+      } catch {
+        // Best-effort ROI row (#2179).
       }
 
       const updated = store.getDreamRun(run.id) ?? run;

--- a/extensions/memory-hybrid/services/dream-run.ts
+++ b/extensions/memory-hybrid/services/dream-run.ts
@@ -203,10 +203,21 @@ export async function runDream(options: RunDreamOptions): Promise<RunDreamResult
     const run = store.createDreamRun({
       inputStoreRevision: factsDb.computeStoreRevision(),
       sessionIds,
-      steeringPolicyId: options.steeringPolicyId ?? null,
+      steeringPolicyId: options.steeringPolicyId ?? steering.profile,
       shadow,
     });
     store.updateDreamRunStatus(run.id, "running");
+    store.setDreamRunMetrics(run.id, {
+      metricsSummaryJson: JSON.stringify({
+        steering: {
+          profile: steering.profile,
+          promote: steering.promote,
+          ignore: steering.ignore,
+          notes: steering.notes ?? null,
+        },
+        recordedAt: Math.floor(Date.now() / 1000),
+      }),
+    });
 
     const stepSummaries: DreamStepSummary[] = [];
     const collectedCandidates: CandidateEntryInput[] = [];
@@ -293,7 +304,17 @@ export async function runDream(options: RunDreamOptions): Promise<RunDreamResult
         endedAt,
       });
       try {
-        store.setDreamRunMetrics(run.id, { metricsSummaryJson: JSON.stringify(summary) });
+        store.setDreamRunMetrics(run.id, {
+          metricsSummaryJson: JSON.stringify({
+            ...summary,
+            steering: {
+              profile: steering.profile,
+              promote: steering.promote,
+              ignore: steering.ignore,
+              notes: steering.notes ?? null,
+            },
+          }),
+        });
       } catch {
         // Best-effort ROI row (#2179).
       }

--- a/extensions/memory-hybrid/services/dream-run.ts
+++ b/extensions/memory-hybrid/services/dream-run.ts
@@ -341,13 +341,17 @@ export async function runDream(options: RunDreamOptions): Promise<RunDreamResult
         });
       }
 
-      const endedAt = Math.floor(Date.now() / 1000);
-      const summary = buildRunMetricsSummary(factsDb, {
-        sessionIds,
-        startedAt: run.startedAt ?? run.createdAt,
-        endedAt,
-      });
+      // Best-effort ROI/metrics annotation. MUST NOT destabilize promote status if it throws —
+      // outer catch would mark the run failed and re-throw an illegal-transition error on a
+      // status that's already `promoted`, poisoning the run record even though promote succeeded
+      // (QA follow-up: metrics-collection failure must never invalidate a successful promote).
       try {
+        const endedAt = Math.floor(Date.now() / 1000);
+        const summary = buildRunMetricsSummary(factsDb, {
+          sessionIds,
+          startedAt: run.startedAt ?? run.createdAt,
+          endedAt,
+        });
         const prior = store.getDreamRun(run.id);
         let priorJson: Record<string, unknown> = {};
         if (prior?.metricsSummaryJson) {
@@ -375,8 +379,13 @@ export async function runDream(options: RunDreamOptions): Promise<RunDreamResult
             candidateCount: candidates.length,
           }),
         });
-      } catch {
-        // Best-effort ROI row (#2179).
+      } catch (metricsErr) {
+        // Best-effort ROI row (#2179). Log but never fail the run over a metrics write.
+        pluginLogger.warn(
+          `memory-hybrid: dream ${run.id} post-promote metrics write failed (non-fatal): ${
+            metricsErr instanceof Error ? metricsErr.message : String(metricsErr)
+          }`,
+        );
       }
 
       const updated = store.getDreamRun(run.id) ?? run;
@@ -391,7 +400,30 @@ export async function runDream(options: RunDreamOptions): Promise<RunDreamResult
       };
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      store.updateDreamRunStatus(run.id, "failed", { failureReason: message });
+      // Only mark failed when the current status still permits it — a promote that succeeded
+      // before an unrelated later throw (e.g. metrics collection) must not roll back to
+      // `failed` (illegal transition `promoted → failed` would itself throw and mask the
+      // original error). Fall back to a best-effort metrics annotation instead (QA follow-up).
+      try {
+        const current = store.getDreamRun(run.id);
+        if (
+          current?.status === "pending" ||
+          current?.status === "running" ||
+          current?.status === "gated"
+        ) {
+          store.updateDreamRunStatus(run.id, "failed", { failureReason: message });
+        } else {
+          pluginLogger.warn(
+            `memory-hybrid: dream ${run.id} post-terminal error ignored (status=${current?.status ?? "unknown"}): ${message}`,
+          );
+        }
+      } catch (statusErr) {
+        pluginLogger.warn(
+          `memory-hybrid: dream ${run.id} failed to record failure status (${
+            statusErr instanceof Error ? statusErr.message : String(statusErr)
+          }); original error: ${message}`,
+        );
+      }
       throw err;
     } finally {
       // Restore outer orchestrator deadline (do not leave the rest of the nightly pass unbounded).

--- a/extensions/memory-hybrid/services/dream-run.ts
+++ b/extensions/memory-hybrid/services/dream-run.ts
@@ -185,17 +185,11 @@ export async function runDream(options: RunDreamOptions): Promise<RunDreamResult
   const sessionIds = boundSessionIds(options.sessionIds, cfg.maxSessions);
   const compose = resolveCompose(cfg);
   const steering = resolveSteering(cfg.steering);
-  const shadow =
-    options.dryShadow === true
-      ? true
-      : cfg.candidateStore.shadow !== false || !cfg.autoPromote.enabled;
+  const shadow = options.dryShadow === true ? true : cfg.candidateStore.shadow !== false || !cfg.autoPromote.enabled;
 
   // Candidate/shadow path must not mutate live store during compose (#2170).
   const liveMutateCompose =
-    options.liveMutateCompose === true &&
-    !shadow &&
-    options.dryShadow !== true &&
-    cfg.candidateStore.enabled !== true;
+    options.liveMutateCompose === true && !shadow && options.dryShadow !== true && cfg.candidateStore.enabled !== true;
 
   const maxMinutes = options.maxRuntimeMinutes ?? cfg.maxRuntimeMinutes;
   const deadlineMs = Date.now() + Math.max(1, maxMinutes) * 60_000;
@@ -347,8 +341,8 @@ export async function runDream(options: RunDreamOptions): Promise<RunDreamResult
 }
 
 /** Map dreaming.compose / skipNightlyOverlap onto nightly maintenance step names. */
-export function nightlyStepsOwnedByDream(cfg: DreamingConfig): ReadonlySet<string> {
-  if (!cfg.enabled || !cfg.skipNightlyOverlap) return new Set();
+export function nightlyStepsOwnedByDream(cfg: DreamingConfig | null | undefined): ReadonlySet<string> {
+  if (!cfg?.enabled || !cfg.skipNightlyOverlap) return new Set();
   const owned = new Set<string>();
   for (const step of resolveCompose(cfg)) {
     switch (step) {

--- a/extensions/memory-hybrid/services/dream-run.ts
+++ b/extensions/memory-hybrid/services/dream-run.ts
@@ -267,18 +267,39 @@ export async function runDream(options: RunDreamOptions): Promise<RunDreamResult
         store.setInputStoreRevision(run.id, factsDb.computeStoreRevision());
       }
 
+      // Curriculum summary is metrics-only — never a promoteable candidate (#2170/#2171).
+      // Real learning must come from compose stage proposed ops.
       if (collectedCandidates.length === 0) {
-        collectedCandidates.push(
-          curriculumCandidate({
-            dreamRunId: run.id,
-            sessionIds,
-            stepSummaries,
-            compose,
+        const summary = curriculumCandidate({
+          dreamRunId: run.id,
+          sessionIds,
+          stepSummaries,
+          compose,
+        });
+        store.setDreamRunMetrics(run.id, {
+          metricsSummaryJson: JSON.stringify({
+            steering: {
+              profile: steering.profile,
+              promote: steering.promote,
+              ignore: steering.ignore,
+              notes: steering.notes ?? null,
+            },
+            curriculumSummary: {
+              text: summary.payload.text,
+              compose,
+              stepSummaries,
+              note: "no_stage_candidates — shadow/dry-run stages emitted zero proposed ops",
+            },
+            recordedAt: Math.floor(Date.now() / 1000),
           }),
+        });
+        pluginLogger.info(
+          `memory-hybrid: dream ${run.id} produced zero stage candidates; curriculum summary recorded in metrics only`,
         );
       }
 
-      const candidates = store.appendCandidateEntries(run.id, collectedCandidates);
+      const candidates =
+        collectedCandidates.length > 0 ? store.appendCandidateEntries(run.id, collectedCandidates) : [];
 
       const shouldPromote =
         options.promote === true ||
@@ -300,8 +321,18 @@ export async function runDream(options: RunDreamOptions): Promise<RunDreamResult
         endedAt,
       });
       try {
+        const prior = store.getDreamRun(run.id);
+        let priorJson: Record<string, unknown> = {};
+        if (prior?.metricsSummaryJson) {
+          try {
+            priorJson = JSON.parse(prior.metricsSummaryJson) as Record<string, unknown>;
+          } catch {
+            priorJson = {};
+          }
+        }
         store.setDreamRunMetrics(run.id, {
           metricsSummaryJson: JSON.stringify({
+            ...priorJson,
             ...summary,
             steering: {
               profile: steering.profile,
@@ -314,6 +345,7 @@ export async function runDream(options: RunDreamOptions): Promise<RunDreamResult
               excludedCount: options.excludedSessions?.length ?? 0,
               excluded: options.excludedSessions ?? [],
             },
+            candidateCount: candidates.length,
           }),
         });
       } catch {

--- a/extensions/memory-hybrid/services/dream-run.ts
+++ b/extensions/memory-hybrid/services/dream-run.ts
@@ -304,8 +304,7 @@ export async function runDream(options: RunDreamOptions): Promise<RunDreamResult
       const shouldPromote =
         options.promote === true ||
         options.forcePromote === true ||
-        (options.promote !== false &&
-          (cfg.promoteAfterRun || cfg.autoPromote.enabled || cfg.candidateStore.enabled));
+        (options.promote !== false && (cfg.promoteAfterRun || cfg.autoPromote.enabled || cfg.candidateStore.enabled));
 
       let promoteResult: PromoteResult | undefined;
       if (shouldPromote) {

--- a/extensions/memory-hybrid/services/dream-run.ts
+++ b/extensions/memory-hybrid/services/dream-run.ts
@@ -39,6 +39,8 @@ export type DreamStepRunner = (ctx: {
   dreamRunId: string;
   sessionIds: string[];
   steeringPolicyId: string | null;
+  /** When false, runners must not mutate FactsDB (shadow / candidate-only). */
+  dryRun: boolean;
   abortSignal?: AbortSignal;
 }) => Promise<{ detail: string; candidates?: CandidateEntryInput[] }>;
 
@@ -62,6 +64,11 @@ export type RunDreamOptions = {
   /** Wall-clock ceiling override (minutes). */
   maxRuntimeMinutes?: number;
   dryShadow?: boolean;
+  /**
+   * When true, compose runners may mutate the live store (legacy). Default false when
+   * candidateStore/shadow is on — compose must emit candidates without live writes (#2170/#2171).
+   */
+  liveMutateCompose?: boolean;
 };
 
 export type RunDreamResult = {
@@ -176,6 +183,13 @@ export async function runDream(options: RunDreamOptions): Promise<RunDreamResult
       ? true
       : cfg.candidateStore.shadow !== false || !cfg.autoPromote.enabled;
 
+  // Candidate/shadow path must not mutate live store during compose (#2170).
+  const liveMutateCompose =
+    options.liveMutateCompose === true &&
+    !shadow &&
+    options.dryShadow !== true &&
+    cfg.candidateStore.enabled !== true;
+
   const maxMinutes = options.maxRuntimeMinutes ?? cfg.maxRuntimeMinutes;
   const deadlineMs = Date.now() + Math.max(1, maxMinutes) * 60_000;
   setMaintenanceRunDeadlineMs(deadlineMs);
@@ -222,6 +236,7 @@ export async function runDream(options: RunDreamOptions): Promise<RunDreamResult
             dreamRunId: run.id,
             sessionIds,
             steeringPolicyId: options.steeringPolicyId ?? null,
+            dryRun: !liveMutateCompose,
           });
           stepSummaries.push({ step, ok: true, detail: result.detail });
           if (result.candidates?.length) {
@@ -232,6 +247,11 @@ export async function runDream(options: RunDreamOptions): Promise<RunDreamResult
           pluginLogger.warn(`memory-hybrid: dream ${run.id} step ${step} failed: ${message}`);
           stepSummaries.push({ step, ok: false, detail: message });
         }
+      }
+
+      // If compose mutated the live store (legacy escape), rebase OCC snapshot before promote.
+      if (liveMutateCompose) {
+        store.setInputStoreRevision(run.id, factsDb.computeStoreRevision());
       }
 
       if (collectedCandidates.length === 0) {

--- a/extensions/memory-hybrid/services/dream-run.ts
+++ b/extensions/memory-hybrid/services/dream-run.ts
@@ -406,11 +406,7 @@ export async function runDream(options: RunDreamOptions): Promise<RunDreamResult
       // original error). Fall back to a best-effort metrics annotation instead (QA follow-up).
       try {
         const current = store.getDreamRun(run.id);
-        if (
-          current?.status === "pending" ||
-          current?.status === "running" ||
-          current?.status === "gated"
-        ) {
+        if (current?.status === "pending" || current?.status === "running" || current?.status === "gated") {
           store.updateDreamRunStatus(run.id, "failed", { failureReason: message });
         } else {
           pluginLogger.warn(

--- a/extensions/memory-hybrid/services/dream-run.ts
+++ b/extensions/memory-hybrid/services/dream-run.ts
@@ -73,6 +73,8 @@ export type RunDreamOptions = {
    * candidateStore/shadow is on — compose must emit candidates without live writes (#2170/#2171).
    */
   liveMutateCompose?: boolean;
+  /** Sessions excluded by permission boundary — persisted on run metrics (#2174). */
+  excludedSessions?: Array<{ sessionId: string; reason: string }>;
 };
 
 export type RunDreamResult = {
@@ -312,6 +314,11 @@ export async function runDream(options: RunDreamOptions): Promise<RunDreamResult
               promote: steering.promote,
               ignore: steering.ignore,
               notes: steering.notes ?? null,
+            },
+            attachment: {
+              includedCount: sessionIds.length,
+              excludedCount: options.excludedSessions?.length ?? 0,
+              excluded: options.excludedSessions ?? [],
             },
           }),
         });

--- a/extensions/memory-hybrid/services/dream-run.ts
+++ b/extensions/memory-hybrid/services/dream-run.ts
@@ -304,13 +304,25 @@ export async function runDream(options: RunDreamOptions): Promise<RunDreamResult
       const shouldPromote =
         options.promote === true ||
         options.forcePromote === true ||
-        (options.promote !== false && (cfg.promoteAfterRun || cfg.autoPromote.enabled));
+        (options.promote !== false &&
+          (cfg.promoteAfterRun || cfg.autoPromote.enabled || cfg.candidateStore.enabled));
 
       let promoteResult: PromoteResult | undefined;
       if (shouldPromote) {
         promoteResult = promoteDreamRun(factsDb, store, run.id, {
           force: options.forcePromote === true,
           cfg,
+        });
+      } else {
+        // Always gate after compose so runs leave `running` and shadow validation can score
+        // wouldPromote — apply stays off unless autoPromote/force (#2170/#2179).
+        promoteResult = promoteDreamRun(factsDb, store, run.id, {
+          force: false,
+          cfg: {
+            ...cfg,
+            autoPromote: { ...cfg.autoPromote, enabled: false },
+            candidateStore: { ...cfg.candidateStore, shadow: true },
+          },
         });
       }
 

--- a/extensions/memory-hybrid/services/dream-run.ts
+++ b/extensions/memory-hybrid/services/dream-run.ts
@@ -15,6 +15,7 @@ import { DEFAULT_DREAMING_CONFIG } from "../config/types/dreaming.js";
 import type { DreamSteeringConfig } from "../config/types/dreaming.js";
 import {
   clearMaintenanceRunDeadline,
+  getMaintenanceRunDeadlineMs,
   maintenanceRunDeadlineReached,
   setMaintenanceRunDeadlineMs,
 } from "../utils/maintenance-run-deadline.js";
@@ -46,7 +47,7 @@ export type DreamStepRunner = (ctx: {
   /** When false, runners must not mutate FactsDB (shadow / candidate-only). */
   dryRun: boolean;
   abortSignal?: AbortSignal;
-}) => Promise<{ detail: string; candidates?: CandidateEntryInput[] }>;
+}) => Promise<{ detail: string; candidates?: CandidateEntryInput[]; skipped?: boolean }>;
 
 export type DreamStepRunners = Partial<Record<DreamComposeStep, DreamStepRunner>>;
 
@@ -192,7 +193,13 @@ export async function runDream(options: RunDreamOptions): Promise<RunDreamResult
     options.liveMutateCompose === true && !shadow && options.dryShadow !== true && cfg.candidateStore.enabled !== true;
 
   const maxMinutes = options.maxRuntimeMinutes ?? cfg.maxRuntimeMinutes;
-  const deadlineMs = Date.now() + Math.max(1, maxMinutes) * 60_000;
+  const dreamDeadlineMs = Date.now() + Math.max(1, maxMinutes) * 60_000;
+  // Never widen or wipe an outer orchestrator deadline — nest under the tighter bound (#1953).
+  const priorDeadlineMs = getMaintenanceRunDeadlineMs();
+  const deadlineMs =
+    priorDeadlineMs != null && Number.isFinite(priorDeadlineMs)
+      ? Math.min(priorDeadlineMs, dreamDeadlineMs)
+      : dreamDeadlineMs;
   setMaintenanceRunDeadlineMs(deadlineMs);
 
   return withCostFeature(CostFeature.dream, async () => {
@@ -236,7 +243,7 @@ export async function runDream(options: RunDreamOptions): Promise<RunDreamResult
         if (!runner) {
           stepSummaries.push({
             step,
-            ok: true,
+            ok: false,
             detail: "no runner bound (record-only)",
             skipped: true,
           });
@@ -251,7 +258,16 @@ export async function runDream(options: RunDreamOptions): Promise<RunDreamResult
             steering,
             dryRun: !liveMutateCompose,
           });
-          stepSummaries.push({ step, ok: true, detail: result.detail });
+          const skipped =
+            result.skipped === true ||
+            /\bskipped_no_attached_sessions\b/i.test(result.detail) ||
+            /\bskipped_no_runner\b/i.test(result.detail);
+          stepSummaries.push({
+            step,
+            ok: !skipped,
+            detail: result.detail,
+            skipped: skipped || undefined,
+          });
           if (result.candidates?.length) {
             collectedCandidates.push(...result.candidates);
           }
@@ -378,7 +394,12 @@ export async function runDream(options: RunDreamOptions): Promise<RunDreamResult
       store.updateDreamRunStatus(run.id, "failed", { failureReason: message });
       throw err;
     } finally {
-      clearMaintenanceRunDeadline();
+      // Restore outer orchestrator deadline (do not leave the rest of the nightly pass unbounded).
+      if (priorDeadlineMs != null && Number.isFinite(priorDeadlineMs)) {
+        setMaintenanceRunDeadlineMs(priorDeadlineMs);
+      } else {
+        clearMaintenanceRunDeadline();
+      }
     }
   });
 }
@@ -400,10 +421,8 @@ export function nightlyStepsOwnedByDream(cfg: DreamingConfig | null | undefined)
         owned.add("resolve-contradictions");
         break;
       case "reflect":
+        // Dream reflect only runs base pattern reflection — do not own weekly rules/meta/identity.
         owned.add("reflect");
-        owned.add("reflect-rules");
-        owned.add("reflect-meta");
-        owned.add("reflect-identity");
         break;
       case "consolidate":
         owned.add("consolidate");

--- a/extensions/memory-hybrid/services/dream-run.ts
+++ b/extensions/memory-hybrid/services/dream-run.ts
@@ -160,8 +160,8 @@ function curriculumCandidate(input: {
     evidence: {
       sessionIds: input.sessionIds,
       prevalence: {
-        sessions: Math.max(1, input.sessionIds.length),
-        agents: 1,
+        sessions: input.sessionIds.length,
+        agents: input.sessionIds.length > 0 ? 1 : 0,
       },
       rationale: `Unified Dream (#2171) completed compose stages: ${okSteps.join(", ") || "none"}`,
     },

--- a/extensions/memory-hybrid/services/dream-shadow-validation.ts
+++ b/extensions/memory-hybrid/services/dream-shadow-validation.ts
@@ -35,7 +35,8 @@ function parseGateWouldPromote(gateReportJson: string | null | undefined): boole
   if (!gateReportJson) return false;
   try {
     const parsed = JSON.parse(gateReportJson) as { wouldPromote?: unknown; ok?: unknown };
-    return parsed.wouldPromote === true || parsed.ok === true;
+    // Require explicit wouldPromote — ok alone can be true for empty/no-op gates.
+    return parsed.wouldPromote === true;
   } catch {
     return false;
   }
@@ -56,14 +57,13 @@ export function evaluateShadowValidation(
   const decided = shadowRuns.filter((r) =>
     ["gated", "quarantined", "failed", "promoted", "rolled_back"].includes(r.status),
   );
-  // Treat outcome.summary "shadow" + status gated as would-promote when gate says so;
-  // also count status===gated as a would-promote signal when gate JSON missing.
   let wouldPromoteRuns = 0;
   let zeroCandidateRuns = 0;
   for (const row of shadowRuns) {
     if (row.candidateCount === 0) zeroCandidateRuns++;
     const gateJson = opts.gateReportsByRunId?.get(row.dreamRunId);
-    if (parseGateWouldPromote(gateJson ?? null) || row.status === "gated") {
+    // Count only explicit wouldPromote with at least one candidate (avoid gated+empty inflation).
+    if (row.candidateCount > 0 && parseGateWouldPromote(gateJson ?? null)) {
       wouldPromoteRuns++;
     }
   }

--- a/extensions/memory-hybrid/services/dream-shadow-validation.ts
+++ b/extensions/memory-hybrid/services/dream-shadow-validation.ts
@@ -1,0 +1,140 @@
+/**
+ * Shadow ROI validation before autoPromote (#2179 / Epic #2169).
+ *
+ * Fail closed: live apply is refused until enough successful shadow dream runs
+ * exist in the lookback window with acceptable quarantine/failure rates.
+ */
+
+import type { DatabaseSync } from "node:sqlite";
+import type { DreamCandidateStore } from "../backends/dream-candidate-store.js";
+import type { DreamingShadowValidationConfig } from "../config/types/dreaming.js";
+import { DEFAULT_DREAMING_CONFIG } from "../config/types/dreaming.js";
+import { buildDreamRoiReport, type DreamRoiReport } from "./dream-roi.js";
+
+export type ShadowValidationMetrics = {
+  shadowRuns: number;
+  decidedRuns: number;
+  wouldPromoteRuns: number;
+  quarantinedRuns: number;
+  failedRuns: number;
+  zeroCandidateRuns: number;
+  quarantineRate: number | null;
+  failureRate: number | null;
+  zeroCandidateRate: number | null;
+};
+
+export type ShadowValidationResult = {
+  ok: boolean;
+  reasons: string[];
+  metrics: ShadowValidationMetrics;
+  thresholds: DreamingShadowValidationConfig;
+  lookbackDays: number;
+};
+
+function parseGateWouldPromote(gateReportJson: string | null | undefined): boolean {
+  if (!gateReportJson) return false;
+  try {
+    const parsed = JSON.parse(gateReportJson) as { wouldPromote?: unknown; ok?: unknown };
+    return parsed.wouldPromote === true || parsed.ok === true;
+  } catch {
+    return false;
+  }
+}
+
+export function evaluateShadowValidation(
+  report: DreamRoiReport,
+  opts: {
+    thresholds?: DreamingShadowValidationConfig;
+    /** Optional map dreamRunId → gate_report_json for wouldPromote detection. */
+    gateReportsByRunId?: Map<string, string | null>;
+  } = {},
+): ShadowValidationResult {
+  const thresholds = opts.thresholds ?? DEFAULT_DREAMING_CONFIG.autoPromote.shadowValidation;
+  const lookbackDays = Math.max(1, Math.floor((report.untilSec - report.sinceSec) / 86_400) || thresholds.lookbackDays);
+
+  const shadowRuns = report.runs.filter((r) => r.shadow);
+  const decided = shadowRuns.filter((r) =>
+    ["gated", "quarantined", "failed", "promoted", "rolled_back"].includes(r.status),
+  );
+  // Treat outcome.summary "shadow" + status gated as would-promote when gate says so;
+  // also count status===gated as a would-promote signal when gate JSON missing.
+  let wouldPromoteRuns = 0;
+  let zeroCandidateRuns = 0;
+  for (const row of shadowRuns) {
+    if (row.candidateCount === 0) zeroCandidateRuns++;
+    const gateJson = opts.gateReportsByRunId?.get(row.dreamRunId);
+    if (parseGateWouldPromote(gateJson ?? null) || row.status === "gated") {
+      wouldPromoteRuns++;
+    }
+  }
+
+  const quarantinedRuns = shadowRuns.filter((r) => r.status === "quarantined").length;
+  const failedRuns = shadowRuns.filter((r) => r.status === "failed").length;
+  const decidedCount = Math.max(1, decided.length);
+  const quarantineRate = decided.length > 0 ? quarantinedRuns / decidedCount : null;
+  const failureRate = decided.length > 0 ? failedRuns / decidedCount : null;
+  const zeroCandidateRate = shadowRuns.length > 0 ? zeroCandidateRuns / shadowRuns.length : null;
+
+  const metrics: ShadowValidationMetrics = {
+    shadowRuns: shadowRuns.length,
+    decidedRuns: decided.length,
+    wouldPromoteRuns,
+    quarantinedRuns,
+    failedRuns,
+    zeroCandidateRuns,
+    quarantineRate,
+    failureRate,
+    zeroCandidateRate,
+  };
+
+  const reasons: string[] = [];
+  if (!thresholds.enabled) {
+    return { ok: true, reasons: ["shadow_validation_disabled"], metrics, thresholds, lookbackDays };
+  }
+
+  if (shadowRuns.length < thresholds.minShadowRuns) {
+    reasons.push(`min_shadow_runs_${shadowRuns.length}_lt_${thresholds.minShadowRuns}`);
+  }
+  if (wouldPromoteRuns < thresholds.minWouldPromoteRuns) {
+    reasons.push(`min_would_promote_${wouldPromoteRuns}_lt_${thresholds.minWouldPromoteRuns}`);
+  }
+  if (quarantineRate != null && quarantineRate > thresholds.maxQuarantineRate) {
+    reasons.push(`quarantine_rate_${quarantineRate.toFixed(2)}_gt_${thresholds.maxQuarantineRate}`);
+  }
+  if (failureRate != null && failureRate > thresholds.maxFailureRate) {
+    reasons.push(`failure_rate_${failureRate.toFixed(2)}_gt_${thresholds.maxFailureRate}`);
+  }
+  if (zeroCandidateRate != null && zeroCandidateRate > thresholds.maxZeroCandidateRate) {
+    reasons.push(`zero_candidate_rate_${zeroCandidateRate.toFixed(2)}_gt_${thresholds.maxZeroCandidateRate}`);
+  }
+
+  return {
+    ok: reasons.length === 0,
+    reasons,
+    metrics,
+    thresholds,
+    lookbackDays,
+  };
+}
+
+/** Evaluate shadow validation from the candidate store + ROI window. */
+export function evaluateShadowValidationFromStore(
+  store: DreamCandidateStore,
+  opts: {
+    thresholds?: DreamingShadowValidationConfig;
+    lookbackDays?: number;
+    db?: DatabaseSync | null;
+  } = {},
+): ShadowValidationResult {
+  const thresholds = opts.thresholds ?? DEFAULT_DREAMING_CONFIG.autoPromote.shadowValidation;
+  const lookbackDays = opts.lookbackDays ?? thresholds.lookbackDays;
+  const untilSec = Math.floor(Date.now() / 1000);
+  const sinceSec = untilSec - lookbackDays * 86_400;
+  const report = buildDreamRoiReport(store, { sinceSec, untilSec, db: opts.db ?? null });
+  const gateReportsByRunId = new Map<string, string | null>();
+  for (const row of report.runs) {
+    const run = store.getDreamRun(row.dreamRunId);
+    gateReportsByRunId.set(row.dreamRunId, run?.gateReportJson ?? null);
+  }
+  return evaluateShadowValidation(report, { thresholds, gateReportsByRunId });
+}

--- a/extensions/memory-hybrid/services/dream-steering.ts
+++ b/extensions/memory-hybrid/services/dream-steering.ts
@@ -63,7 +63,12 @@ export function categoryMatchesSteeringList(category: string, list: string[]): b
   });
 }
 
-export function shouldSteeringIgnore(category: string, key: string | null, text: string, steering: DreamSteeringConfig): boolean {
+export function shouldSteeringIgnore(
+  category: string,
+  key: string | null,
+  text: string,
+  steering: DreamSteeringConfig,
+): boolean {
   const resolved = resolveSteering(steering);
   const hay = `${category} ${key ?? ""} ${text}`.toLowerCase();
   return resolved.ignore.some((token) => {

--- a/extensions/memory-hybrid/services/dream-steering.ts
+++ b/extensions/memory-hybrid/services/dream-steering.ts
@@ -66,14 +66,18 @@ export function categoryMatchesSteeringList(category: string, list: string[]): b
 export function shouldSteeringIgnore(
   category: string,
   key: string | null,
-  text: string,
+  _text: string,
   steering: DreamSteeringConfig,
 ): boolean {
   const resolved = resolveSteering(steering);
-  const hay = `${category} ${key ?? ""} ${text}`.toLowerCase();
+  const cat = category.toLowerCase().trim();
+  const keyNorm = (key ?? "").toLowerCase().trim();
   return resolved.ignore.some((token) => {
     const t = token.toLowerCase().trim();
-    return t.length > 0 && hay.includes(t);
+    if (!t) return false;
+    // Exact token match on category/key only — never substring-scan free text (ops profile
+    // would otherwise ignore every `preference` category fact via haystack includes).
+    return cat === t || keyNorm === t;
   });
 }
 

--- a/extensions/memory-hybrid/services/dream-steering.ts
+++ b/extensions/memory-hybrid/services/dream-steering.ts
@@ -1,0 +1,78 @@
+/**
+ * Dream steering policy (#2176) — set-and-forget config passed into Dream compose + gates.
+ */
+
+import type { DreamSteeringConfig } from "../config/types/dreaming.js";
+import { DEFAULT_DREAMING_CONFIG } from "../config/types/dreaming.js";
+
+export const STEERING_PROFILES: Record<
+  DreamSteeringConfig["profile"],
+  Pick<DreamSteeringConfig, "promote" | "ignore" | "notes">
+> = {
+  personal: {
+    promote: ["preference", "routine", "insight"],
+    ignore: ["one_off_debug", "transient_path", "secret_like"],
+    notes: "Focus on durable user preferences and recurring routines; ignore one-off debugging.",
+  },
+  coding: {
+    promote: ["procedure", "tool_failure", "coding_task", "rule"],
+    ignore: ["one_off_debug", "transient_path", "ops_status"],
+    notes: "Prioritize coding style, tool failures, and repeatable procedures.",
+  },
+  ops: {
+    promote: ["monitoring", "ops_status", "procedure", "tool_failure"],
+    ignore: ["one_off_debug", "personal", "preference"],
+    notes: "Prioritize operational reliability, monitoring, and incident patterns.",
+  },
+  custom: {
+    promote: [],
+    ignore: [],
+    notes: undefined,
+  },
+};
+
+/** Merge profile defaults with operator overrides. */
+export function resolveSteering(cfg?: DreamSteeringConfig): DreamSteeringConfig {
+  const base = cfg ?? DEFAULT_DREAMING_CONFIG.steering;
+  const preset = STEERING_PROFILES[base.profile] ?? STEERING_PROFILES.personal;
+  return {
+    profile: base.profile,
+    promote: base.promote.length > 0 ? base.promote : preset.promote,
+    ignore: base.ignore.length > 0 ? base.ignore : preset.ignore,
+    notes: base.notes ?? preset.notes,
+  };
+}
+
+/** LLM/system suffix for maintenance steps that accept freeform steering (#2176). */
+export function formatSteeringPromptBlock(steering: DreamSteeringConfig): string {
+  const resolved = resolveSteering(steering);
+  const lines = [
+    "Dream steering policy:",
+    `- Promote signal: ${resolved.promote.join(", ") || "(default)"}`,
+    `- Ignore noise: ${resolved.ignore.join(", ") || "(none)"}`,
+  ];
+  if (resolved.notes?.trim()) lines.push(`- Notes: ${resolved.notes.trim()}`);
+  return lines.join("\n");
+}
+
+export function categoryMatchesSteeringList(category: string, list: string[]): boolean {
+  const cat = category.toLowerCase();
+  return list.some((token) => {
+    const t = token.toLowerCase().trim();
+    return t.length > 0 && (cat === t || cat.includes(t));
+  });
+}
+
+export function shouldSteeringIgnore(category: string, key: string | null, text: string, steering: DreamSteeringConfig): boolean {
+  const resolved = resolveSteering(steering);
+  const hay = `${category} ${key ?? ""} ${text}`.toLowerCase();
+  return resolved.ignore.some((token) => {
+    const t = token.toLowerCase().trim();
+    return t.length > 0 && hay.includes(t);
+  });
+}
+
+export function steeringPromoteBoost(category: string, steering: DreamSteeringConfig): boolean {
+  const resolved = resolveSteering(steering);
+  return categoryMatchesSteeringList(category, resolved.promote);
+}

--- a/extensions/memory-hybrid/services/maintenance-orchestrator.ts
+++ b/extensions/memory-hybrid/services/maintenance-orchestrator.ts
@@ -294,6 +294,14 @@ export const MAINTENANCE_STEPS: MaintenanceStepDef[] = [
     featureGate: (cfg) => cfg.dreaming?.autoRollback?.enabled === true,
   },
   {
+    name: "dream-run",
+    tier: "nightly",
+    guardIntervalMs: MAINTENANCE_GUARD_INTERVALS.h20,
+    llmTier: "heavy",
+    // Unified Dream must run before skipNightlyOverlap can safely own distill/reflect/… (#2171).
+    featureGate: (cfg) => cfg.dreaming?.enabled === true,
+  },
+  {
     name: "closed-loop-analysis",
     tier: "nightly",
     guardIntervalMs: MAINTENANCE_GUARD_INTERVALS.h68,
@@ -726,13 +734,25 @@ export async function runMaintenanceOrchestrator(
       }
 
       if (nightlyStepsOwnedByDream(cfg.dreaming).has(step.name)) {
-        pushStepResult({
-          name: step.name,
-          status: "skipped_gate",
-          summary: "owned by unified Dream (dreaming.skipNightlyOverlap)",
-          durationMs: 0,
-        });
-        continue;
+        // Fail closed: only skip owned nightly stages when the unified dream-run step is
+        // actually present in this run and will not be feature-gated off.
+        const dreamRunDef = MAINTENANCE_STEPS.find((s) => s.name === "dream-run");
+        const dreamRunScheduled =
+          Boolean(dreamRunDef) &&
+          (!dreamRunDef?.featureGate || dreamRunDef.featureGate(cfg)) &&
+          typeof runners.get("dream-run") === "function";
+        if (dreamRunScheduled) {
+          pushStepResult({
+            name: step.name,
+            status: "skipped_gate",
+            summary: "owned by unified Dream (dreaming.skipNightlyOverlap)",
+            durationMs: 0,
+          });
+          continue;
+        }
+        logger?.warn?.(
+          `maintenance-orchestrator: dreaming.skipNightlyOverlap requested skip of ${step.name}, but dream-run is not scheduled — running step to avoid a maintenance hole`,
+        );
       }
       if (step.featureGate && !step.featureGate(cfg)) {
         pushStepResult({

--- a/extensions/memory-hybrid/services/maintenance-orchestrator.ts
+++ b/extensions/memory-hybrid/services/maintenance-orchestrator.ts
@@ -287,6 +287,13 @@ export const MAINTENANCE_STEPS: MaintenanceStepDef[] = [
     featureGate: (cfg) => cfg.verification?.enabled === true && cfg.verification?.continuousVerification === true,
   },
   {
+    name: "dream-outcome-probe",
+    tier: "nightly",
+    guardIntervalMs: MAINTENANCE_GUARD_INTERVALS.h20,
+    llmTier: "none",
+    featureGate: (cfg) => cfg.dreaming?.autoRollback?.enabled === true,
+  },
+  {
     name: "closed-loop-analysis",
     tier: "nightly",
     guardIntervalMs: MAINTENANCE_GUARD_INTERVALS.h68,

--- a/extensions/memory-hybrid/services/maintenance-orchestrator.ts
+++ b/extensions/memory-hybrid/services/maintenance-orchestrator.ts
@@ -397,7 +397,11 @@ export const MAINTENANCE_STEPS: MaintenanceStepDef[] = [
     dependsOn: ["reflect"],
     featureGate: (cfg) => cfg.personaProposals?.enabled !== false,
   },
-  { name: "pending-digest", tier: "nightly", guardIntervalMs: MAINTENANCE_GUARD_INTERVALS.d5, llmTier: "none",
+  {
+    name: "pending-digest",
+    tier: "nightly",
+    guardIntervalMs: MAINTENANCE_GUARD_INTERVALS.d5,
+    llmTier: "none",
     // #2177: autonomous Dream installs should not treat nightly human digests as the happy path.
     featureGate: (cfg) => !(cfg.dreaming?.enabled === true && cfg.dreaming?.mode === "autonomous"),
   },

--- a/extensions/memory-hybrid/services/maintenance-orchestrator.ts
+++ b/extensions/memory-hybrid/services/maintenance-orchestrator.ts
@@ -190,7 +190,15 @@ export const MAINTENANCE_STEPS: MaintenanceStepDef[] = [
   { name: "evolution-pass", tier: "cycle", guardIntervalMs: MAINTENANCE_GUARD_INTERVALS.h20, llmTier: "none" },
   { name: "per-folder-context", tier: "cycle", guardIntervalMs: MAINTENANCE_GUARD_INTERVALS.d5, llmTier: "none" },
 
-  // --- Nightly tier — staggered (14) ---
+  // --- Nightly tier — staggered ---
+  // Unified Dream runs first so skipNightlyOverlap only drops owned steps after a successful dream-run.
+  {
+    name: "dream-run",
+    tier: "nightly",
+    guardIntervalMs: MAINTENANCE_GUARD_INTERVALS.h20,
+    llmTier: "heavy",
+    featureGate: (cfg) => cfg.dreaming?.enabled === true,
+  },
   { name: "extract-daily", tier: "nightly", guardIntervalMs: MAINTENANCE_GUARD_INTERVALS.h20, llmTier: "nano" },
   {
     name: "distill",
@@ -292,14 +300,6 @@ export const MAINTENANCE_STEPS: MaintenanceStepDef[] = [
     guardIntervalMs: MAINTENANCE_GUARD_INTERVALS.h20,
     llmTier: "none",
     featureGate: (cfg) => cfg.dreaming?.autoRollback?.enabled === true,
-  },
-  {
-    name: "dream-run",
-    tier: "nightly",
-    guardIntervalMs: MAINTENANCE_GUARD_INTERVALS.h20,
-    llmTier: "heavy",
-    // Unified Dream must run before skipNightlyOverlap can safely own distill/reflect/… (#2171).
-    featureGate: (cfg) => cfg.dreaming?.enabled === true,
   },
   {
     name: "closed-loop-analysis",
@@ -734,25 +734,36 @@ export async function runMaintenanceOrchestrator(
       }
 
       if (nightlyStepsOwnedByDream(cfg.dreaming).has(step.name)) {
-        // Fail closed: only skip owned nightly stages when the unified dream-run step is
-        // actually present in this run and will not be feature-gated off.
+        // Fail closed: only skip owned nightly stages after dream-run succeeded in THIS run.
+        // Scheduling alone is not enough — a failed/deferred dream-run must not drop curation.
+        const dreamRunResult = results.find((r) => r.name === "dream-run");
+        if (dreamRunResult?.status === "ok") {
+          pushStepResult({
+            name: step.name,
+            status: "skipped_gate",
+            summary: "owned by unified Dream (dreaming.skipNightlyOverlap; dream-run ok)",
+            durationMs: 0,
+          });
+          continue;
+        }
         const dreamRunDef = MAINTENANCE_STEPS.find((s) => s.name === "dream-run");
         const dreamRunScheduled =
           Boolean(dreamRunDef) &&
           (!dreamRunDef?.featureGate || dreamRunDef.featureGate(cfg)) &&
           typeof runners.get("dream-run") === "function";
-        if (dreamRunScheduled) {
-          pushStepResult({
-            name: step.name,
-            status: "skipped_gate",
-            summary: "owned by unified Dream (dreaming.skipNightlyOverlap)",
-            durationMs: 0,
-          });
-          continue;
+        if (dreamRunScheduled && !dreamRunResult) {
+          logger?.warn?.(
+            `maintenance-orchestrator: dreaming.skipNightlyOverlap wants ${step.name} owned by Dream, but dream-run has not completed yet — running step to avoid a maintenance hole`,
+          );
+        } else if (dreamRunScheduled && dreamRunResult) {
+          logger?.warn?.(
+            `maintenance-orchestrator: dreaming.skipNightlyOverlap wants ${step.name} owned by Dream, but dream-run status=${dreamRunResult.status} — running step to avoid a maintenance hole`,
+          );
+        } else if (!dreamRunScheduled) {
+          logger?.warn?.(
+            `maintenance-orchestrator: dreaming.skipNightlyOverlap requested skip of ${step.name}, but dream-run is not scheduled — running step to avoid a maintenance hole`,
+          );
         }
-        logger?.warn?.(
-          `maintenance-orchestrator: dreaming.skipNightlyOverlap requested skip of ${step.name}, but dream-run is not scheduled — running step to avoid a maintenance hole`,
-        );
       }
       if (step.featureGate && !step.featureGate(cfg)) {
         pushStepResult({

--- a/extensions/memory-hybrid/services/maintenance-orchestrator.ts
+++ b/extensions/memory-hybrid/services/maintenance-orchestrator.ts
@@ -397,7 +397,10 @@ export const MAINTENANCE_STEPS: MaintenanceStepDef[] = [
     dependsOn: ["reflect"],
     featureGate: (cfg) => cfg.personaProposals?.enabled !== false,
   },
-  { name: "pending-digest", tier: "nightly", guardIntervalMs: MAINTENANCE_GUARD_INTERVALS.d5, llmTier: "none" },
+  { name: "pending-digest", tier: "nightly", guardIntervalMs: MAINTENANCE_GUARD_INTERVALS.d5, llmTier: "none",
+    // #2177: autonomous Dream installs should not treat nightly human digests as the happy path.
+    featureGate: (cfg) => !(cfg.dreaming?.enabled === true && cfg.dreaming?.mode === "autonomous"),
+  },
   {
     name: "digest-autopilot",
     tier: "nightly",

--- a/extensions/memory-hybrid/services/maintenance-orchestrator.ts
+++ b/extensions/memory-hybrid/services/maintenance-orchestrator.ts
@@ -31,6 +31,7 @@ import {
   reflectRulesStepSummaryIndicatesFailure,
   semanticOutcomeBlocksOrchestratorGuard,
 } from "./maintenance-job-run/semantic-outcome.js";
+import { nightlyStepsOwnedByDream } from "./dream-run.js";
 
 export type StepTier = "cycle" | "nightly";
 export type StepLlmTier = "none" | "nano" | "maintenance" | "default" | "heavy" | "embed" | "local";
@@ -710,6 +711,15 @@ export async function runMaintenanceOrchestrator(
         continue;
       }
 
+      if (nightlyStepsOwnedByDream(cfg.dreaming).has(step.name)) {
+        pushStepResult({
+          name: step.name,
+          status: "skipped_gate",
+          summary: "owned by unified Dream (dreaming.skipNightlyOverlap)",
+          durationMs: 0,
+        });
+        continue;
+      }
       if (step.featureGate && !step.featureGate(cfg)) {
         pushStepResult({
           name: step.name,

--- a/extensions/memory-hybrid/services/openclaw-session-artifact.ts
+++ b/extensions/memory-hybrid/services/openclaw-session-artifact.ts
@@ -3,7 +3,7 @@
  * for a given session key. Used to reconcile ACTIVE-TASKS.md when subagent rows drift (#978).
  */
 
-import { existsSync } from "node:fs";
+import { existsSync, readdirSync } from "node:fs";
 import { readdir } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
@@ -95,6 +95,68 @@ export async function findOpenClawSessionJsonlForKey(
   }
   for (const name of names) {
     const hit = await tryDir(join(agentsRoot, name, "sessions"));
+    if (hit) return hit;
+  }
+  return null;
+}
+
+/**
+ * Best-effort sync locate of a session JSONL under ~/.openclaw/agents/<agent>/sessions/.
+ * Returns agentId from the path parent — used as an ACL floor for Dream (#2174), never as global.
+ */
+export function locateSessionTranscriptSync(
+  sessionKey: string,
+  openclawHome = join(homedir(), ".openclaw"),
+): { path: string; agentId: string } | null {
+  const key = sessionKey.trim();
+  if (!key) return null;
+
+  const baseCandidates: string[] = [
+    `${key}.jsonl`,
+    `${key.replace(/:/g, "_")}.jsonl`,
+    `${key.replace(/:/g, "-")}.jsonl`,
+  ];
+  const uuidMatch = key.match(/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/i);
+  if (uuidMatch) {
+    baseCandidates.push(`${uuidMatch[1]}.jsonl`);
+  }
+
+  const tryDir = (agentId: string, sessionsDir: string): { path: string; agentId: string } | null => {
+    if (!existsSync(sessionsDir)) return null;
+    for (const name of baseCandidates) {
+      const p = join(sessionsDir, name);
+      if (existsSync(p)) return { path: p, agentId };
+    }
+    if (!uuidMatch) return null;
+    try {
+      for (const f of readdirSync(sessionsDir)) {
+        if (!f.endsWith(".jsonl") || f.startsWith(".deleted")) continue;
+        const base = f.slice(0, -".jsonl".length);
+        const u = uuidMatch[1];
+        if (base === u || f.includes(u)) return { path: join(sessionsDir, f), agentId };
+      }
+    } catch {
+      return null;
+    }
+    return null;
+  };
+
+  const agentIdFromKey = parseAgentIdFromSessionKey(key);
+  if (agentIdFromKey) {
+    const hit = tryDir(agentIdFromKey, join(openclawHome, "agents", agentIdFromKey, "sessions"));
+    if (hit) return hit;
+  }
+
+  const agentsRoot = join(openclawHome, "agents");
+  if (!existsSync(agentsRoot)) return null;
+  let names: string[];
+  try {
+    names = readdirSync(agentsRoot);
+  } catch {
+    return null;
+  }
+  for (const name of names) {
+    const hit = tryDir(name, join(agentsRoot, name, "sessions"));
     if (hit) return hit;
   }
   return null;

--- a/extensions/memory-hybrid/services/reflection.ts
+++ b/extensions/memory-hybrid/services/reflection.ts
@@ -86,6 +86,13 @@ interface ReflectionOptions {
   thinkingMode?: import("./chat.js").MiniMaxThinkingMode;
   /** Dream steering block appended to reflection prompt (#2176). */
   steeringPrompt?: string;
+  /**
+   * Dream attachment allowlist (#2174).
+   * - `undefined` → legacy nightly: `globalOnly` facts (safe for global pattern writes).
+   * - `[]` → analyze nothing (fail closed).
+   * - non-empty → only facts with matching provenance_session / session scope_target.
+   */
+  sessionIds?: string[];
 }
 
 interface ReflectionResult {
@@ -94,6 +101,8 @@ interface ReflectionResult {
   patternsStored: number;
   window: number;
   semanticOutcome?: string;
+  /** Dry-run / Dream compose: pattern texts for candidate emission (#2170). */
+  patterns?: string[];
 }
 
 interface ReflectionRulesResult {
@@ -586,11 +595,21 @@ export async function runReflection(
   const touchReflectLastRun = () => {
     if (!opts.dryRun) recordMaintenanceTimestamp(factsDb.sqlitePath, ".reflect_last_run");
   };
-  // globalOnly: reflection's synthesized output is stored as scope='global' (visible to every
-  // agent/user/session) below, so its input must not read agent/user/session-scoped facts —
-  // otherwise a private observation becomes a globally-visible pattern. Deliberate cross-scope
-  // generalization is cross-agent-learning.ts's job (explicit opt-in, provenance tracked).
-  const recentFacts = factsDb.getRecentFacts(windowDays, { globalOnly: true });
+  // Nightly/CLI (sessionIds undefined): globalOnly so private facts never become global patterns.
+  // Dream compose (sessionIds set): mine only attached sessions — empty allowlist → zero facts.
+  let recentFacts: MemoryEntry[];
+  if (opts.sessionIds === undefined) {
+    recentFacts = factsDb.getRecentFacts(windowDays, { globalOnly: true });
+  } else if (opts.sessionIds.length === 0) {
+    recentFacts = [];
+  } else {
+    const allow = new Set(opts.sessionIds.map((s) => s.trim()).filter(Boolean));
+    recentFacts = factsDb.getRecentFacts(windowDays, { globalOnly: false }).filter((f) => {
+      const provenance = f.provenanceSession?.trim();
+      if (provenance && allow.has(provenance)) return true;
+      return f.scope === "session" && !!f.scopeTarget && allow.has(f.scopeTarget);
+    });
+  }
 
   if (recentFacts.length < config.minObservations) {
     logger.info(`memory-hybrid: reflection — ${recentFacts.length} facts in window (min ${config.minObservations})`);
@@ -751,6 +770,7 @@ export async function runReflection(
   let candidateIndex = 0;
   let deadlineReached = false;
   const inRunFactVectors = new Map<string, { vector: number[]; embeddingModel: string }>();
+  const wouldStorePatterns: string[] = [];
 
   for (const patternText of uniqueNewPatterns) {
     if (maintenanceRunDeadlineReached()) {
@@ -794,6 +814,7 @@ export async function runReflection(
     if (opts.dryRun) {
       logger.info(`memory-hybrid: reflection [dry-run] would store: ${patternText.slice(0, 60)}...`);
       stored++;
+      wouldStorePatterns.push(patternText);
       continue;
     }
 
@@ -1170,6 +1191,8 @@ export async function runReflection(
     patternsExtracted: uniqueNewPatterns.length,
     patternsStored: stored,
     window: windowDays,
+    // Dream compose needs the texts that would store (post-dedupe), not only counts (#2170).
+    patterns: (opts.dryRun ? wouldStorePatterns : uniqueNewPatterns).slice(0, 20),
     // vectorStoreFailures/metadataFailures are infrastructure errors (LanceDB locked/disk full,
     // SQLite write failure after a successful vector store) -- distinct from newPatternEmbedFailures
     // (an embedding-API call failure), but both silently vanish a synthesized pattern the same way.

--- a/extensions/memory-hybrid/services/reflection.ts
+++ b/extensions/memory-hybrid/services/reflection.ts
@@ -84,6 +84,8 @@ interface ReflectionOptions {
   modelSource?: string;
   adaptiveStatePath?: string;
   thinkingMode?: import("./chat.js").MiniMaxThinkingMode;
+  /** Dream steering block appended to reflection prompt (#2176). */
+  steeringPrompt?: string;
 }
 
 interface ReflectionResult {
@@ -632,7 +634,7 @@ export async function runReflection(
     .sort()
     .join(",");
   const inputHash = createHash("sha256")
-    .update(`${windowDays}:${opts.model}:${factsBlock}:${existingPatternsFingerprint}`)
+    .update(`${windowDays}:${opts.model}:${factsBlock}:${existingPatternsFingerprint}:${opts.steeringPrompt ?? ""}`)
     .digest("hex")
     .slice(0, 16);
   const prevHash = factsDb.getMaintenanceState("reflection_input_hash");
@@ -642,7 +644,9 @@ export async function runReflection(
     return { factsAnalyzed: recentFacts.length, patternsExtracted: 0, patternsStored: 0, window: windowDays };
   }
 
-  const prompt = fillPrompt(loadPrompt("reflection"), { window: String(windowDays), facts: factsBlock });
+  const prompt =
+    fillPrompt(loadPrompt("reflection"), { window: String(windowDays), facts: factsBlock }) +
+    (opts.steeringPrompt?.trim() ? `\n\n${opts.steeringPrompt.trim()}` : "");
 
   if (opts.verbose) {
     logger.info(

--- a/extensions/memory-hybrid/setup/cli-context/cli-services.ts
+++ b/extensions/memory-hybrid/setup/cli-context/cli-services.ts
@@ -55,7 +55,14 @@ interface CliContextServices {
     model: string;
     onProgress?: (progress: { clusterIndex: number; totalClusters: number; merged: number }) => void;
   }) => Promise<{ clustersFound: number; merged: number; deleted: number }>;
-  runReflection: (opts: { window: number; dryRun: boolean; model: string; verbose?: boolean }) => Promise<{
+  runReflection: (opts: {
+    window: number;
+    dryRun: boolean;
+    model: string;
+    verbose?: boolean;
+    steeringPrompt?: string;
+    sessionIds?: string[];
+  }) => Promise<{
     factsAnalyzed: number;
     patternsExtracted: number;
     patternsStored: number;

--- a/extensions/memory-hybrid/setup/hybrid-memory-activation.ts
+++ b/extensions/memory-hybrid/setup/hybrid-memory-activation.ts
@@ -57,6 +57,17 @@ export function shouldReturnInitializingToolResult(generation: number): boolean 
   return current.phase === "activating";
 }
 
+/** True when Phase B activation failed for this generation (fail-closed tool responses). */
+export function isActivationFailed(generation: number): boolean {
+  return Boolean(current && current.generation === generation && current.phase === "failed");
+}
+
+/** Error message from a failed activation, if any. */
+export function getActivationFailureError(generation: number): string | null {
+  if (!current || current.generation !== generation || current.phase !== "failed") return null;
+  return current.error;
+}
+
 export function beginActivation(params: { generation: number; donorGeneration: number }): ActivationState {
   // Supersede any in-flight activation from a prior re-register.
   if (current && current.phase === "activating") {

--- a/extensions/memory-hybrid/setup/hybrid-memory-activation.ts
+++ b/extensions/memory-hybrid/setup/hybrid-memory-activation.ts
@@ -1,0 +1,139 @@
+/**
+ * Two-phase registration activation (#2181).
+ *
+ * OpenClaw requires `register()` to return synchronously. Donor teardown runs on a Promise
+ * chain and cannot be drained with `Atomics.wait` (that blocks the event loop and starves the
+ * teardown it is waiting for). Instead:
+ *   Phase A — sync register: schedule teardown, publish tool stubs, return.
+ *   Phase B — async activate: await generation-scoped teardown, open/attach DBs, bind live tools.
+ */
+
+export type ActivationPhase = "idle" | "activating" | "ready" | "failed";
+
+export type ActivationState = {
+  phase: ActivationPhase;
+  generation: number;
+  donorGeneration: number;
+  startedAtMs: number;
+  readyAtMs: number | null;
+  error: string | null;
+  /** Resolves when this generation reaches ready or failed (or is superseded). */
+  settled: Promise<void>;
+};
+
+type ActivationInternal = ActivationState & {
+  resolveSettled: () => void;
+  aborted: boolean;
+};
+
+let current: ActivationInternal | null = null;
+
+function createSettledPair(): { promise: Promise<void>; resolve: () => void } {
+  let resolve: () => void = () => {};
+  const promise = new Promise<void>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+export function getActivationState(): ActivationState | null {
+  if (!current) return null;
+  const { resolveSettled: _r, aborted: _a, ...publicState } = current;
+  return publicState;
+}
+
+export function isActivationReady(generation: number): boolean {
+  return current?.generation === generation && current.phase === "ready";
+}
+
+export function isActivationInFlight(): boolean {
+  return current?.phase === "activating";
+}
+
+/** True when tools for `generation` should return the initializing/reloading safe result. */
+export function shouldReturnInitializingToolResult(generation: number): boolean {
+  if (!current) return false;
+  if (current.generation !== generation) return false;
+  return current.phase === "activating";
+}
+
+export function beginActivation(params: {
+  generation: number;
+  donorGeneration: number;
+}): ActivationState {
+  // Supersede any in-flight activation from a prior re-register.
+  if (current && current.phase === "activating") {
+    current.aborted = true;
+    current.phase = "failed";
+    current.error = "superseded_by_newer_registration";
+    current.resolveSettled();
+  }
+
+  const { promise, resolve } = createSettledPair();
+  current = {
+    phase: "activating",
+    generation: params.generation,
+    donorGeneration: params.donorGeneration,
+    startedAtMs: Date.now(),
+    readyAtMs: null,
+    error: null,
+    settled: promise,
+    resolveSettled: resolve,
+    aborted: false,
+  };
+  const { resolveSettled: _r, aborted: _a, ...publicState } = current;
+  return publicState;
+}
+
+export function markActivationReady(generation: number): void {
+  if (!current || current.generation !== generation) return;
+  if (current.aborted) return;
+  current.phase = "ready";
+  current.readyAtMs = Date.now();
+  current.error = null;
+  current.resolveSettled();
+}
+
+export function markActivationFailed(generation: number, error: unknown): void {
+  if (!current || current.generation !== generation) return;
+  current.phase = "failed";
+  current.error = error instanceof Error ? error.message : String(error);
+  current.resolveSettled();
+}
+
+export function isActivationAborted(generation: number): boolean {
+  return Boolean(current && current.generation === generation && current.aborted);
+}
+
+/** Wait until the current activation for `generation` is ready, failed, or superseded. */
+export async function awaitActivationReady(
+  generation: number,
+  timeoutMs = 30_000,
+): Promise<boolean> {
+  if (isActivationReady(generation)) return true;
+  if (!current || current.generation !== generation) return false;
+  if (current.phase === "failed") return false;
+
+  let timedOut = false;
+  await Promise.race([
+    current.settled,
+    new Promise<void>((resolve) => {
+      setTimeout(() => {
+        timedOut = true;
+        resolve();
+      }, timeoutMs);
+    }),
+  ]);
+  if (timedOut) return isActivationReady(generation);
+  return isActivationReady(generation);
+}
+
+export function resetActivationStateForTests(): void {
+  if (current?.phase === "activating") {
+    current.aborted = true;
+    current.phase = "failed";
+    current.error = "reset_for_tests";
+    current.resolveSettled();
+  }
+  current = null;
+}

--- a/extensions/memory-hybrid/setup/hybrid-memory-activation.ts
+++ b/extensions/memory-hybrid/setup/hybrid-memory-activation.ts
@@ -57,10 +57,7 @@ export function shouldReturnInitializingToolResult(generation: number): boolean 
   return current.phase === "activating";
 }
 
-export function beginActivation(params: {
-  generation: number;
-  donorGeneration: number;
-}): ActivationState {
+export function beginActivation(params: { generation: number; donorGeneration: number }): ActivationState {
   // Supersede any in-flight activation from a prior re-register.
   if (current && current.phase === "activating") {
     current.aborted = true;
@@ -106,10 +103,7 @@ export function isActivationAborted(generation: number): boolean {
 }
 
 /** Wait until the current activation for `generation` is ready, failed, or superseded. */
-export async function awaitActivationReady(
-  generation: number,
-  timeoutMs = 30_000,
-): Promise<boolean> {
+export async function awaitActivationReady(generation: number, timeoutMs = 30_000): Promise<boolean> {
   if (isActivationReady(generation)) return true;
   if (!current || current.generation !== generation) return false;
   if (current.phase === "failed") return false;

--- a/extensions/memory-hybrid/setup/hybrid-memory-activation.ts
+++ b/extensions/memory-hybrid/setup/hybrid-memory-activation.ts
@@ -109,8 +109,21 @@ export function markActivationFailed(generation: number, error: unknown): void {
   current.resolveSettled();
 }
 
+/**
+ * True when the deferred activation for `generation` should stop / bail out.
+ *
+ * A newer register() calling `beginActivation` mutates the prior state to
+ * {aborted: true, phase: "failed"} but then swings `current` to the newer generation. If we
+ * only checked `current.generation === generation && current.aborted`, the older deferred
+ * activation would observe `current.generation !== generation` and treat that as "not
+ * aborted" — proceeding to open its DBs, call `finishHybridMemoryRegistration`, and stomp
+ * `runtimeRef` with a stale runtime the host will never talk to (QA follow-up: superseded
+ * activation must self-cancel).
+ */
 export function isActivationAborted(generation: number): boolean {
-  return Boolean(current && current.generation === generation && current.aborted);
+  if (!current) return true;
+  if (current.generation !== generation) return true;
+  return current.aborted;
 }
 
 /** Wait until the current activation for `generation` is ready, failed, or superseded. */

--- a/extensions/memory-hybrid/setup/hybrid-memory-reload-coordinator.ts
+++ b/extensions/memory-hybrid/setup/hybrid-memory-reload-coordinator.ts
@@ -176,10 +176,7 @@ const syncWaitArray = new Int32Array(syncWaitBuffer);
  * Prefer this over {@link blockReloadTeardownBeforeOpen}, which cannot drain Promise-based
  * teardown because `Atomics.wait` blocks the event loop (#2181).
  */
-export async function awaitDonorTeardown(
-  donorGeneration: number,
-  timeoutMs = TEARDOWN_WAIT_MS,
-): Promise<boolean> {
+export async function awaitDonorTeardown(donorGeneration: number, timeoutMs = TEARDOWN_WAIT_MS): Promise<boolean> {
   if (donorGeneration < 0) {
     return awaitReloadTeardownBeforeOpen(timeoutMs);
   }

--- a/extensions/memory-hybrid/setup/hybrid-memory-reload-coordinator.ts
+++ b/extensions/memory-hybrid/setup/hybrid-memory-reload-coordinator.ts
@@ -172,11 +172,39 @@ const syncWaitBuffer = new SharedArrayBuffer(4);
 const syncWaitArray = new Int32Array(syncWaitBuffer);
 
 /**
- * Synchronous variant of `awaitReloadTeardownBeforeOpen` for OpenClaw's sync `register()` contract.
- * Polls teardown queue depth while pumping the event loop via Atomics.wait (50ms ticks).
+ * Wait for scheduled teardowns belonging to `donorGeneration` (async — pumps the event loop).
+ * Prefer this over {@link blockReloadTeardownBeforeOpen}, which cannot drain Promise-based
+ * teardown because `Atomics.wait` blocks the event loop (#2181).
+ */
+export async function awaitDonorTeardown(
+  donorGeneration: number,
+  timeoutMs = TEARDOWN_WAIT_MS,
+): Promise<boolean> {
+  if (donorGeneration < 0) {
+    return awaitReloadTeardownBeforeOpen(timeoutMs);
+  }
+  const deadline = Date.now() + Math.max(0, timeoutMs);
+  while (Date.now() <= deadline) {
+    const pending = listTeardownPromisesForGeneration(donorGeneration);
+    if (pending.length === 0) return true;
+    const remainingMs = Math.max(0, deadline - Date.now());
+    await Promise.race([
+      Promise.all(pending.map((p) => p.catch(() => undefined))),
+      new Promise<void>((resolve) => setTimeout(resolve, remainingMs)),
+    ]);
+    if (isTeardownDrainedForGeneration(donorGeneration)) return true;
+    if (Date.now() >= deadline) break;
+  }
+  return isTeardownDrainedForGeneration(donorGeneration);
+}
+
+/**
+ * Synchronous variant of `awaitReloadTeardownBeforeOpen` for legacy callers.
  *
- * Prefer a bounded `timeoutMs` (default {@link TEARDOWN_WAIT_MS}). Avoid `timeoutMs === 0`
- * in tests: vitest cannot interrupt synchronous Atomics.wait loops, so unbounded waits hang CI.
+ * WARNING (#2181): `Atomics.wait` does **not** pump Node's event loop. Promise-chain teardown
+ * scheduled via {@link schedulePluginTeardown} will not run while this function blocks. Prefer
+ * {@link awaitDonorTeardown} / {@link awaitReloadTeardownBeforeOpen} from an async activation
+ * path. Kept only for tests and non-Promise wait scenarios.
  */
 export function blockReloadTeardownBeforeOpen(timeoutMs = TEARDOWN_WAIT_MS): boolean {
   if (timeoutMs < 0) return false;
@@ -232,6 +260,11 @@ export function decideReloadTeardownGate(params: {
   // separate chain; opening fresh handles is safe. Never throw here (#2111) — a hard failure
   // repeats on every reload attempt and leaves the plugin unregistered.
   return "fresh-hard-timeout";
+}
+
+/** Current depth of the serialized reload teardown queue (diagnostics / #2181 logs). */
+export function getReloadTeardownQueueDepth(): number {
+  return reloadTeardownQueueDepth;
 }
 
 /** Reset chain for unit tests only. */

--- a/extensions/memory-hybrid/setup/register-plugin.ts
+++ b/extensions/memory-hybrid/setup/register-plugin.ts
@@ -1098,9 +1098,7 @@ function finishHybridMemoryRegistration(params: FinishRegistrationParams): void 
     logger: logApi.logger,
     pluginVersion: versionInfo.pluginVersion,
     registerContextEngine:
-      typeof logApi.registerContextEngine === "function"
-        ? logApi.registerContextEngine.bind(logApi)
-        : undefined,
+      typeof logApi.registerContextEngine === "function" ? logApi.registerContextEngine.bind(logApi) : undefined,
   });
 
   // Phase 2.6 / Phase 3: Single plugin context satisfying MemoryPluginAPI (stable internal API).

--- a/extensions/memory-hybrid/setup/register-plugin.ts
+++ b/extensions/memory-hybrid/setup/register-plugin.ts
@@ -57,17 +57,24 @@ import {
   resetHybridMemoryRegistrationStateForTests,
 } from "./hybrid-memory-generation-state.js";
 import {
-  blockReloadTeardownBeforeOpen,
+  awaitDonorTeardown,
   clearTeardownTrackingForGeneration,
-  decideReloadTeardownGate,
   drainOldBootstrap,
   drainOldRecall,
+  getReloadTeardownQueueDepth,
   isTeardownDrainedForGeneration,
   resetReloadTeardownChainForTests,
   schedulePluginTeardown,
-  TEARDOWN_SOFT_WAIT_MS,
   TEARDOWN_WAIT_MS,
 } from "./hybrid-memory-reload-coordinator.js";
+import {
+  awaitActivationReady,
+  beginActivation,
+  isActivationAborted,
+  markActivationFailed,
+  markActivationReady,
+  resetActivationStateForTests,
+} from "./hybrid-memory-activation.js";
 import {
   _resetLastSuccessfulExtensionPathForTests,
   buildExtensionLoadContext,
@@ -79,14 +86,18 @@ import {
 import { createPluginService } from "./plugin-service.js";
 import { registerContextEngineBestEffort } from "./register-context-engine.js";
 import { registerLifecycleHooks } from "./register-hooks.js";
-import { registerTools } from "./register-tools.js";
+import {
+  bindActivatedToolExecutors,
+  registerActivationToolStubs,
+  registerTools,
+  type ToolRegistrationHandle,
+} from "./register-tools.js";
 import {
   databaseContextFromRuntime,
   evaluateReregisterReuse,
   recordReregisterDatabaseReuse,
   recordReregisterFullTeardown,
   recordReregisterRegistration,
-  recordReregisterTeardownTimeoutRecovery,
   resetReregisterPolicyForTests,
   resolveReregisterPolicy,
 } from "./reregister-policy.js";
@@ -392,7 +403,7 @@ function runMemoryHybridRegisterImpl(api: ClawdbotPluginApi): void {
       `memory-hybrid: re-register falling back to full teardown despite reuse-databases policy (reason=${reuseDecision.reason})`,
     );
   }
-  let donorRuntime = reuseDatabases && old ? old : null;
+  const donorRuntime = reuseDatabases && old ? old : null;
 
   if (old) {
     // Clear old timer handles to prevent leaks.
@@ -478,44 +489,6 @@ function runMemoryHybridRegisterImpl(api: ClawdbotPluginApi): void {
     runtimeRef.value = null;
   }
 
-  if (old) {
-    // Wait for the donor runtime's teardown to complete before opening or handing out new DB
-    // handles (#802, #2058 / #2059). When `reuseDatabases` is true we still need to wait
-    // because the vault-registry teardown is scheduled against the SAME donor runtime we are
-    // about to inherit; if we don't wait, vault closeAll() races the new registration's first
-    // DB access (closed DB / not open). When the soft drain window expires before the donor
-    // teardown settles, fall back to a fresh open instead of inheriting indeterminate handles.
-    const drained = blockReloadTeardownBeforeOpen(TEARDOWN_WAIT_MS);
-    if (!drained) {
-      const donorDrained = isTeardownDrainedForGeneration(donorGeneration);
-      const decision = decideReloadTeardownGate({
-        hasDonor: Boolean(donorRuntime),
-        drained,
-        donorDrained,
-      });
-      if (decision === "reuse") {
-        // Donor generation's teardown is done even though newer teardowns may still be queued
-        // (overlap-queued re-register). Donor handles are safe to hand to the new runtime.
-      } else if (decision === "fresh-soft-timeout") {
-        logApi.logger.warn?.(
-          `memory-hybrid: reload teardown soft-timeout exceeded (>=${TEARDOWN_SOFT_WAIT_MS}ms) for donor generation ${donorGeneration}; falling back to fresh open to avoid inheriting closed DB handles`,
-        );
-        donorRuntime = null;
-        recordReregisterFullTeardown("teardown_soft_timeout");
-      } else if (decision === "fresh-hard-timeout") {
-        // Full-teardown path (#2111): the donor's DB handles are being permanently closed on a
-        // separate teardown chain. The new registration opens its own fresh handles, so it is
-        // safe to proceed even though the prior teardown has not finished draining. Previously
-        // this threw and failed plugin initialization on every reload attempt; recover to a
-        // fresh open instead and record the timeout for observability.
-        logApi.logger.warn?.(
-          `memory-hybrid: reload teardown did not drain within ${TEARDOWN_WAIT_MS}ms for donor generation ${donorGeneration}; opening fresh databases anyway (prior teardown continues on its own chain)`,
-        );
-        recordReregisterTeardownTimeoutRecovery();
-      }
-    }
-  }
-
   // Resolve where this plugin generation was loaded from (staging path awareness, #2135). Diagnostic
   // context assembled BEFORE any native store init so a subsequent crash is attributable.
   let extensionPath = "unknown";
@@ -525,6 +498,12 @@ function runMemoryHybridRegisterImpl(api: ClawdbotPluginApi): void {
     // Leave "unknown"; the preflight below turns this into a recoverable, named error.
   }
   const loadContext = buildExtensionLoadContext(extensionPath);
+  const wasReregister = old != null;
+  // Full-teardown re-register must not open DBs until donor teardown drains — but that drain is
+  // Promise-based and cannot be awaited synchronously (#2181 / Atomics.wait starvation). Defer
+  // DB open + live tool bind to Phase B. Reuse keeps donor handles and stays fully synchronous.
+  const needsDeferredActivation = wasReregister && !donorRuntime;
+
   const loadDiagnosticsContext: Record<string, Record<string, unknown>> = {
     plugin_load: {
       packageVersion: loadContext.packageVersion,
@@ -534,8 +513,128 @@ function runMemoryHybridRegisterImpl(api: ClawdbotPluginApi): void {
       reusingDonorHandles: Boolean(donorRuntime),
       donorGenerationTeardownDrained: old ? isTeardownDrainedForGeneration(donorGeneration) : null,
       registrationGeneration,
+      deferredActivation: needsDeferredActivation,
+      teardownQueueDepth: getReloadTeardownQueueDepth(),
     },
   };
+
+  if (needsDeferredActivation) {
+    const preflight = preflightExtensionIntegrity(extensionPath);
+    if (!preflight.ok) {
+      const preflightError = new PluginLoadPreflightError(preflight, loadContext);
+      capturePluginError(preflightError, {
+        subsystem: "registration",
+        operation: "plugin-register:load-preflight",
+        tags: { preflight_reason: preflight.reason, staging: loadContext.isStaging },
+        contexts: loadDiagnosticsContext,
+      });
+      logApi.logger.error?.(preflightError.message);
+      throw preflightError;
+    }
+
+    beginActivation({ generation: registrationGeneration, donorGeneration });
+    const stubHandle = registerActivationToolStubs(
+      {
+        registrationGeneration,
+        currentRegistrationGenerationRef: registrationGenerationRef,
+      },
+      logApi,
+    );
+
+    // Host calls start() once after sync register(). Wait for Phase B, then start the real service.
+    let activatedService: ReturnType<typeof createPluginService> | null = null;
+    try {
+      api.registerService({
+        id: PLUGIN_ID,
+        start: async () => {
+          const ready = await awaitActivationReady(registrationGeneration, TEARDOWN_WAIT_MS + 15_000);
+          if (!ready || isActivationAborted(registrationGeneration)) {
+            logApi.logger.warn?.(
+              `memory-hybrid: plugin-service start skipped — activation not ready for generation ${registrationGeneration}`,
+            );
+            return;
+          }
+          const rt = runtimeRef.value;
+          if (!rt || rt.bootRegistrationGeneration !== registrationGeneration) return;
+          activatedService = createPluginService({
+            PLUGIN_ID,
+            bootRegistrationGeneration: registrationGeneration,
+            factsDb: rt.factsDb,
+            edictStore: rt.edictStore,
+            vectorDb: rt.vectorDb,
+            embeddings: rt.embeddings,
+            embeddingRegistry: rt.embeddingRegistry,
+            credentialsDb: rt.credentialsDb,
+            proposalsDb: rt.proposalsDb,
+            wal: rt.wal,
+            eventLog: rt.eventLog,
+            cfg: rt.cfg,
+            openai: rt.openai,
+            resolvedLancePath: rt.resolvedLancePath,
+            resolvedSqlitePath: rt.resolvedSqlitePath,
+            api: logApi,
+            timers: rt.timers,
+            pythonBridge: rt.pythonBridge,
+            provenanceService: rt.provenanceService,
+            costTracker: rt.costTracker,
+            auditStore: rt.auditStore ?? null,
+            agentHealthStore: rt.agentHealthStore ?? null,
+            verificationStore: rt.verificationStore ?? null,
+            issueStore: rt.issueStore ?? null,
+            serendipityStore: rt.serendipityStore ?? null,
+            loomStore: rt.loomStore ?? null,
+            workflowStore: rt.workflowStore ?? null,
+            narrativesDb: rt.narrativesDb ?? null,
+            crystallizationStore: rt.crystallizationStore ?? null,
+            toolProposalStore: rt.toolProposalStore ?? null,
+            changeFeed: rt.changeFeed,
+            eventBus: rt.eventBus,
+            identityReflectionStore: rt.identityReflectionStore,
+            personaStateStore: rt.personaStateStore,
+            learningsDb: rt.learningsDb,
+            apitapStore: rt.apitapStore,
+            aliasDb: rt.aliasDb,
+            vaultRegistry: rt.vaultRegistry,
+          });
+          await activatedService.start();
+        },
+        stop: async () => {
+          const stopFn = activatedService && "stop" in activatedService ? activatedService.stop : null;
+          if (typeof stopFn === "function") await stopFn.call(activatedService);
+        },
+      });
+    } catch (err) {
+      stubHandle.dispose();
+      markActivationFailed(registrationGeneration, err);
+      capturePluginError(err instanceof Error ? err : new Error(String(err)), {
+        subsystem: "registration",
+        operation: "plugin-register:service-deferred",
+      });
+      throw err;
+    }
+
+    logApi.logger.info?.(
+      `memory-hybrid: re-register generation ${registrationGeneration} entering deferred activation ` +
+        `(donorGeneration=${donorGeneration}, teardownQueueDepth=${getReloadTeardownQueueDepth()}, ` +
+        `reason=${reuseDecision.reason}) — tools return initializing until Phase B completes`,
+    );
+
+    setImmediate(() => {
+      void runDeferredFullTeardownActivation({
+        api: logApi,
+        cfg,
+        parsedCfgSnapshot,
+        registrationGeneration,
+        donorGeneration,
+        extensionPath,
+        loadContext,
+        loadDiagnosticsContext,
+        stubHandle,
+        wasReregister,
+      });
+    });
+    return;
+  }
 
   // Only preflight a FRESH open — the reuse path inherits already-open donor handles and performs no
   // native connect, so it cannot SIGBUS on a partial staging copy. A structurally incomplete staging
@@ -591,6 +690,171 @@ function runMemoryHybridRegisterImpl(api: ClawdbotPluginApi): void {
     });
     throw err;
   }
+
+  finishHybridMemoryRegistration({
+    api: logApi,
+    cfg,
+    parsedCfgSnapshot,
+    registrationGeneration,
+    donorGeneration,
+    donorRuntime,
+    dbContext,
+    extensionPath,
+    wasReregister,
+    toolMode: "sync",
+  });
+}
+
+type FinishRegistrationParams = {
+  api: ClawdbotPluginApi;
+  cfg: HybridMemoryConfig;
+  parsedCfgSnapshot: HybridMemoryConfig;
+  registrationGeneration: number;
+  donorGeneration: number;
+  donorRuntime: PluginRuntime | null;
+  dbContext: ReturnType<typeof initializeDatabases>;
+  extensionPath: string;
+  wasReregister: boolean;
+  toolMode: "sync" | "bind-live";
+  stubHandle?: ToolRegistrationHandle;
+};
+
+async function runDeferredFullTeardownActivation(params: {
+  api: ClawdbotPluginApi;
+  cfg: HybridMemoryConfig;
+  parsedCfgSnapshot: HybridMemoryConfig;
+  registrationGeneration: number;
+  donorGeneration: number;
+  extensionPath: string;
+  loadContext: ReturnType<typeof buildExtensionLoadContext>;
+  loadDiagnosticsContext: Record<string, Record<string, unknown>>;
+  stubHandle: ToolRegistrationHandle;
+  wasReregister: boolean;
+}): Promise<void> {
+  const {
+    api: logApi,
+    cfg,
+    parsedCfgSnapshot,
+    registrationGeneration,
+    donorGeneration,
+    extensionPath,
+    loadContext,
+    loadDiagnosticsContext,
+    stubHandle,
+    wasReregister,
+  } = params;
+
+  const startedAt = Date.now();
+  try {
+    if (isActivationAborted(registrationGeneration)) {
+      stubHandle.dispose();
+      return;
+    }
+
+    const drained = await awaitDonorTeardown(donorGeneration, TEARDOWN_WAIT_MS);
+    if (isActivationAborted(registrationGeneration)) {
+      stubHandle.dispose();
+      return;
+    }
+
+    if (!drained) {
+      logApi.logger.warn?.(
+        `memory-hybrid: donor generation ${donorGeneration} teardown still pending after ${TEARDOWN_WAIT_MS}ms; ` +
+          `opening fresh databases anyway (prior teardown continues on its own chain) [generation=${registrationGeneration}]`,
+      );
+    }
+
+    logApi.logger.info?.(
+      `memory-hybrid: deferred activation Phase B opening databases (generation=${registrationGeneration}, donorGeneration=${donorGeneration}, drained=${drained}, waitedMs=${Date.now() - startedAt}, teardownQueueDepth=${getReloadTeardownQueueDepth()})`,
+    );
+
+    let dbContext: ReturnType<typeof initializeDatabases>;
+    try {
+      dbContext = initializeDatabases(cfg, logApi, { bootRegistrationGeneration: registrationGeneration });
+    } catch (err) {
+      capturePluginError(err instanceof Error ? err : new Error(String(err)), {
+        subsystem: "registration",
+        operation: "plugin-register:init-databases-deferred",
+        tags: { staging: loadContext.isStaging, package_version: loadContext.packageVersion },
+        contexts: loadDiagnosticsContext,
+      });
+      stubHandle.dispose();
+      markActivationFailed(registrationGeneration, err);
+      throw err;
+    }
+
+    if (isActivationAborted(registrationGeneration)) {
+      closeOldDatabases({
+        factsDb: dbContext.factsDb,
+        edictStore: dbContext.edictStore,
+        vectorDb: dbContext.vectorDb,
+        credentialsDb: dbContext.credentialsDb,
+        proposalsDb: dbContext.proposalsDb,
+        identityReflectionStore: dbContext.identityReflectionStore,
+        personaStateStore: dbContext.personaStateStore,
+        eventLog: dbContext.eventLog,
+        narrativesDb: dbContext.narrativesDb,
+        aliasDb: dbContext.aliasDb,
+        issueStore: dbContext.issueStore,
+        workflowStore: dbContext.workflowStore,
+        crystallizationStore: dbContext.crystallizationStore,
+        toolProposalStore: dbContext.toolProposalStore,
+        verificationStore: dbContext.verificationStore,
+        provenanceService: dbContext.provenanceService,
+        apitapStore: dbContext.apitapStore,
+      });
+      stubHandle.dispose();
+      return;
+    }
+
+    finishHybridMemoryRegistration({
+      api: logApi,
+      cfg,
+      parsedCfgSnapshot,
+      registrationGeneration,
+      donorGeneration,
+      donorRuntime: null,
+      dbContext,
+      extensionPath,
+      wasReregister,
+      toolMode: "bind-live",
+      stubHandle,
+    });
+    markActivationReady(registrationGeneration);
+    logApi.logger.info?.(
+      `memory-hybrid: deferred activation ready (generation=${registrationGeneration}, totalMs=${Date.now() - startedAt})`,
+    );
+  } catch (err) {
+    if (!isActivationAborted(registrationGeneration)) {
+      markActivationFailed(registrationGeneration, err);
+      capturePluginError(err instanceof Error ? err : new Error(String(err)), {
+        subsystem: "registration",
+        operation: "plugin-register:deferred-activation",
+        severity: "error",
+      });
+      logApi.logger.error?.(
+        `memory-hybrid: deferred activation failed for generation ${registrationGeneration}: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
+  }
+}
+
+function finishHybridMemoryRegistration(params: FinishRegistrationParams): void {
+  const {
+    api: logApi,
+    cfg,
+    parsedCfgSnapshot,
+    registrationGeneration,
+    donorGeneration,
+    donorRuntime,
+    dbContext,
+    extensionPath,
+    wasReregister,
+    toolMode,
+    stubHandle,
+  } = params;
 
   const { resolvedSqlitePath, resolvedLancePath } = dbContext;
 
@@ -834,7 +1098,9 @@ function runMemoryHybridRegisterImpl(api: ClawdbotPluginApi): void {
     logger: logApi.logger,
     pluginVersion: versionInfo.pluginVersion,
     registerContextEngine:
-      typeof api.registerContextEngine === "function" ? api.registerContextEngine.bind(api) : undefined,
+      typeof logApi.registerContextEngine === "function"
+        ? logApi.registerContextEngine.bind(logApi)
+        : undefined,
   });
 
   // Phase 2.6 / Phase 3: Single plugin context satisfying MemoryPluginAPI (stable internal API).
@@ -900,7 +1166,17 @@ function runMemoryHybridRegisterImpl(api: ClawdbotPluginApi): void {
   // Tools
 
   try {
-    runtime.toolRegistrationHandle = registerTools(pluginContext, logApi);
+    if (toolMode === "bind-live") {
+      bindActivatedToolExecutors(pluginContext, logApi);
+      // Keep Phase A stub handle so dispose() still unregisters host stubs on the next reload.
+      runtime.toolRegistrationHandle = stubHandle ?? {
+        dispose: () => {
+          /* no-op */
+        },
+      };
+    } else {
+      runtime.toolRegistrationHandle = registerTools(pluginContext, logApi);
+    }
   } catch (err) {
     capturePluginError(err instanceof Error ? err : new Error(String(err)), {
       subsystem: "registration",
@@ -908,6 +1184,7 @@ function runMemoryHybridRegisterImpl(api: ClawdbotPluginApi): void {
     });
     closeFailedRegistrationRuntime(runtime);
     if (runtimeRef.value === runtime) runtimeRef.value = null;
+    stubHandle?.dispose();
     throw err;
   }
 
@@ -971,59 +1248,59 @@ function runMemoryHybridRegisterImpl(api: ClawdbotPluginApi): void {
     throw err;
   }
 
-  // Service
-
-  const wasReregister = old != null;
-
-  try {
-    api.registerService(
-      createPluginService({
-        PLUGIN_ID,
-        bootRegistrationGeneration: registrationGeneration,
-        factsDb: runtime.factsDb,
-        edictStore: runtime.edictStore,
-        vectorDb: runtime.vectorDb,
-        embeddings: runtime.embeddings,
-        embeddingRegistry: runtime.embeddingRegistry,
-        credentialsDb: runtime.credentialsDb,
-        proposalsDb: runtime.proposalsDb,
-        wal: runtime.wal,
-        eventLog: runtime.eventLog,
-        cfg: runtime.cfg,
-        openai: runtime.openai,
-        resolvedLancePath: runtime.resolvedLancePath,
-        resolvedSqlitePath: runtime.resolvedSqlitePath,
-        api: logApi,
-        timers: runtime.timers,
-        pythonBridge: runtime.pythonBridge,
-        provenanceService: runtime.provenanceService,
-        costTracker: runtime.costTracker,
-        auditStore: runtime.auditStore ?? null,
-        agentHealthStore: runtime.agentHealthStore ?? null,
-        verificationStore: runtime.verificationStore ?? null,
-        issueStore: runtime.issueStore ?? null,
-        serendipityStore: runtime.serendipityStore ?? null,
-        loomStore: runtime.loomStore ?? null,
-        workflowStore: runtime.workflowStore ?? null,
-        narrativesDb: runtime.narrativesDb ?? null,
-        crystallizationStore: runtime.crystallizationStore ?? null,
-        toolProposalStore: runtime.toolProposalStore ?? null,
-        changeFeed: runtime.changeFeed,
-        eventBus: runtime.eventBus,
-        identityReflectionStore: runtime.identityReflectionStore,
-        personaStateStore: runtime.personaStateStore,
-        learningsDb: runtime.learningsDb,
-        apitapStore: runtime.apitapStore,
-        aliasDb: runtime.aliasDb,
-        vaultRegistry: runtime.vaultRegistry,
-      }),
-    );
-  } catch (err) {
-    capturePluginError(err instanceof Error ? err : new Error(String(err)), {
-      subsystem: "registration",
-      operation: "plugin-register:service",
-    });
-    throw err;
+  // Service — deferred activation already registered a waiter service in Phase A that starts
+  // the real service after markActivationReady. Sync/reuse path registers here.
+  if (toolMode === "sync") {
+    try {
+      logApi.registerService(
+        createPluginService({
+          PLUGIN_ID,
+          bootRegistrationGeneration: registrationGeneration,
+          factsDb: runtime.factsDb,
+          edictStore: runtime.edictStore,
+          vectorDb: runtime.vectorDb,
+          embeddings: runtime.embeddings,
+          embeddingRegistry: runtime.embeddingRegistry,
+          credentialsDb: runtime.credentialsDb,
+          proposalsDb: runtime.proposalsDb,
+          wal: runtime.wal,
+          eventLog: runtime.eventLog,
+          cfg: runtime.cfg,
+          openai: runtime.openai,
+          resolvedLancePath: runtime.resolvedLancePath,
+          resolvedSqlitePath: runtime.resolvedSqlitePath,
+          api: logApi,
+          timers: runtime.timers,
+          pythonBridge: runtime.pythonBridge,
+          provenanceService: runtime.provenanceService,
+          costTracker: runtime.costTracker,
+          auditStore: runtime.auditStore ?? null,
+          agentHealthStore: runtime.agentHealthStore ?? null,
+          verificationStore: runtime.verificationStore ?? null,
+          issueStore: runtime.issueStore ?? null,
+          serendipityStore: runtime.serendipityStore ?? null,
+          loomStore: runtime.loomStore ?? null,
+          workflowStore: runtime.workflowStore ?? null,
+          narrativesDb: runtime.narrativesDb ?? null,
+          crystallizationStore: runtime.crystallizationStore ?? null,
+          toolProposalStore: runtime.toolProposalStore ?? null,
+          changeFeed: runtime.changeFeed,
+          eventBus: runtime.eventBus,
+          identityReflectionStore: runtime.identityReflectionStore,
+          personaStateStore: runtime.personaStateStore,
+          learningsDb: runtime.learningsDb,
+          apitapStore: runtime.apitapStore,
+          aliasDb: runtime.aliasDb,
+          vaultRegistry: runtime.vaultRegistry,
+        }),
+      );
+    } catch (err) {
+      capturePluginError(err instanceof Error ? err : new Error(String(err)), {
+        subsystem: "registration",
+        operation: "plugin-register:service",
+      });
+      throw err;
+    }
   }
 
   // Issue #1893: OpenClaw does not re-run plugin-service.start() on hot reload; re-arm Workboard sync.
@@ -1097,6 +1374,7 @@ function runMemoryHybridRegisterImpl(api: ClawdbotPluginApi): void {
 }
 
 export { detectCategory, performHybridMemCliTeardown, runtimeRef, shouldCapture };
+export { awaitActivationReady, getActivationState } from "./hybrid-memory-activation.js";
 
 /** Reset plugin singleton state between vitest cases (runtime, reload chain, generation). */
 export function resetPluginRegistrationStateForTests(): void {
@@ -1115,6 +1393,7 @@ export function resetPluginRegistrationStateForTests(): void {
     }
     runtimeRef.value = null;
   }
+  resetActivationStateForTests();
   resetReloadTeardownChainForTests();
   resetReregisterPolicyForTests();
   resetHybridMemoryRegistrationStateForTests();

--- a/extensions/memory-hybrid/setup/register-plugin.ts
+++ b/extensions/memory-hybrid/setup/register-plugin.ts
@@ -825,6 +825,7 @@ async function runDeferredFullTeardownActivation(params: {
       `memory-hybrid: deferred activation ready (generation=${registrationGeneration}, totalMs=${Date.now() - startedAt})`,
     );
   } catch (err) {
+    stubHandle.dispose();
     if (!isActivationAborted(registrationGeneration)) {
       markActivationFailed(registrationGeneration, err);
       capturePluginError(err instanceof Error ? err : new Error(String(err)), {

--- a/extensions/memory-hybrid/setup/register-plugin.ts
+++ b/extensions/memory-hybrid/setup/register-plugin.ts
@@ -1081,6 +1081,23 @@ function finishHybridMemoryRegistration(params: FinishRegistrationParams): void 
     timers: createTimers(),
   };
 
+  // Deferred-activation supersede guard (#2181 follow-up): a later register() may have run
+  // while Phase B was awaiting donor teardown / opening DBs. If the generation counter has
+  // moved past us, our runtime is stale — do NOT stomp `runtimeRef` with handles the host
+  // will never talk to (the newer generation may already own runtimeRef, or is about to).
+  // Close what we just opened and bail. Sync path (`toolMode === "sync"`) is atomic under
+  // the Atomics.wait registration gate, so this guard only fires in the deferred path.
+  if (toolMode === "bind-live" && registrationGenerationRef.value !== registrationGeneration) {
+    logApi.logger.warn?.(
+      `memory-hybrid: deferred activation generation ${registrationGeneration} superseded by ` +
+        `generation ${registrationGenerationRef.value}; discarding freshly opened runtime instead of stomping runtimeRef`,
+    );
+    closeFailedRegistrationRuntime(newRuntime);
+    stubHandle?.dispose();
+    // Signal to the caller (runDeferredFullTeardownActivation) that we bailed out.
+    throw new Error("deferred_activation_superseded");
+  }
+
   runtimeRef.value = newRuntime;
 
   // The donor generation's tracking is no longer needed: even if its teardown is still

--- a/extensions/memory-hybrid/setup/register-tools.ts
+++ b/extensions/memory-hybrid/setup/register-tools.ts
@@ -17,7 +17,12 @@ import {
   resolveCurrentToolExecutor,
   setCurrentToolExecutor,
 } from "./hybrid-memory-generation-state.js";
-import { shouldReturnInitializingToolResult, isActivationFailed, isActivationReady, getActivationFailureError } from "./hybrid-memory-activation.js";
+import {
+  shouldReturnInitializingToolResult,
+  isActivationFailed,
+  isActivationReady,
+  getActivationFailureError,
+} from "./hybrid-memory-activation.js";
 import { patchMemoryToolRegistrationApi } from "../utils/tool-search-wrapper-args.js";
 import { type ToolsContext, toolInstallers } from "./tool-installers.js";
 

--- a/extensions/memory-hybrid/setup/register-tools.ts
+++ b/extensions/memory-hybrid/setup/register-tools.ts
@@ -10,17 +10,46 @@
  */
 
 import type { ClawdbotPluginApi } from "openclaw/plugin-sdk/core";
+import { AGENT_TOOL_CONTRACT_NAMES } from "../contracts/agent-tool-names.js";
 import { capturePluginError } from "../services/error-reporter.js";
 import {
   clearToolExecutorsForGeneration,
   resolveCurrentToolExecutor,
   setCurrentToolExecutor,
 } from "./hybrid-memory-generation-state.js";
+import { shouldReturnInitializingToolResult } from "./hybrid-memory-activation.js";
 import { patchMemoryToolRegistrationApi } from "../utils/tool-search-wrapper-args.js";
 import { type ToolsContext, toolInstallers } from "./tool-installers.js";
 
 export interface ToolRegistrationHandle {
   dispose: () => void;
+}
+
+/** Live (post-activation) tool bodies for a registration generation (#2181 two-phase). */
+const liveToolExecutorsByGeneration = new Map<number, Map<string, (...args: unknown[]) => unknown>>();
+
+export function setLiveToolExecutor(
+  generation: number,
+  toolName: string,
+  execute: (...args: unknown[]) => unknown,
+): void {
+  let byName = liveToolExecutorsByGeneration.get(generation);
+  if (!byName) {
+    byName = new Map();
+    liveToolExecutorsByGeneration.set(generation, byName);
+  }
+  byName.set(toolName, execute);
+}
+
+export function clearLiveToolExecutorsForGeneration(generation: number): void {
+  liveToolExecutorsByGeneration.delete(generation);
+}
+
+function resolveLiveToolExecutor(
+  toolName: string,
+  generation: number,
+): ((...args: unknown[]) => unknown) | null {
+  return liveToolExecutorsByGeneration.get(generation)?.get(toolName) ?? null;
 }
 
 function normalizeToolName(definition: unknown): string | null {
@@ -75,6 +104,35 @@ function buildStaleToolSafeResult(
   };
 }
 
+/** Deterministic safe result while Phase B activation is still opening/attaching DBs (#2181). */
+export function buildInitializingToolSafeResult(
+  toolName: string,
+  ownerGeneration: number,
+): {
+  content: Array<{ type: "text"; text: string }>;
+  details: Record<string, unknown>;
+} {
+  return {
+    content: [
+      {
+        type: "text",
+        text:
+          `memory-hybrid: reloading — tool "${toolName}" is temporarily unavailable ` +
+          `(generation ${ownerGeneration} still activating; retry shortly)`,
+      },
+    ],
+    details: {
+      ok: false,
+      initializing: true,
+      reloading: true,
+      skipped: true,
+      tool: toolName,
+      registrationGeneration: ownerGeneration,
+      activationPhase: "activating",
+    },
+  };
+}
+
 export function createGenerationGuardedToolsApi(
   ctx: Pick<ToolsContext, "registrationGeneration" | "currentRegistrationGenerationRef">,
   api: ClawdbotPluginApi,
@@ -102,7 +160,15 @@ export function createGenerationGuardedToolsApi(
     const guardedExecute = (...executeArgs: unknown[]): unknown => {
       const currentGeneration = generationRef.value;
       if (currentGeneration === ownerGeneration) {
-        return originalExecute(...executeArgs);
+        // Two-phase activation (#2181): current-generation stubs wait for Phase B before
+        // invoking the live body (or the original execute when registration was fully sync).
+        if (shouldReturnInitializingToolResult(ownerGeneration)) {
+          const live = resolveLiveToolExecutor(toolName, ownerGeneration);
+          if (!live) return buildInitializingToolSafeResult(toolName, ownerGeneration);
+          return live(...executeArgs);
+        }
+        const live = resolveLiveToolExecutor(toolName, ownerGeneration);
+        return (live ?? originalExecute)(...executeArgs);
       }
 
       const delegatedExecute = resolveCurrentToolExecutor(toolName, currentGeneration);
@@ -161,9 +227,60 @@ export function createGenerationGuardedToolsApi(
           }
         }
         clearToolExecutorsForGeneration(ownerGeneration);
+        clearLiveToolExecutorsForGeneration(ownerGeneration);
       },
     },
   };
+}
+
+/**
+ * Phase A (#2181): publish host-visible tool stubs for every contract name so sync `register()`
+ * satisfies the gateway contract while Phase B opens databases. Stub execute bodies return the
+ * initializing safe result until {@link bindActivatedToolExecutors} installs live handlers.
+ */
+export function registerActivationToolStubs(
+  ctx: Pick<ToolsContext, "registrationGeneration" | "currentRegistrationGenerationRef">,
+  api: ClawdbotPluginApi,
+): ToolRegistrationHandle {
+  const { api: guardedApi, handle } = createGenerationGuardedToolsApi(ctx, api);
+  const toolsApi = patchMemoryToolRegistrationApi(guardedApi);
+  const ownerGeneration = ctx.registrationGeneration ?? ctx.currentRegistrationGenerationRef?.value ?? -1;
+
+  for (const toolName of AGENT_TOOL_CONTRACT_NAMES) {
+    toolsApi.registerTool({
+      name: toolName,
+      description: `memory-hybrid: ${toolName} (activating)`,
+      parameters: { type: "object", properties: {} },
+      execute: async () => buildInitializingToolSafeResult(toolName, ownerGeneration),
+    } as never);
+  }
+  return handle;
+}
+
+/**
+ * Phase B (#2181): install real tool bodies into the live-executor map without re-calling the
+ * host's `registerTool` (stubs already occupy those names from Phase A).
+ */
+export function bindActivatedToolExecutors(ctx: ToolsContext, api: ClawdbotPluginApi): void {
+  const ownerGeneration = ctx.registrationGeneration ?? ctx.currentRegistrationGenerationRef?.value ?? -1;
+  const captureRegisterTool = (...args: unknown[]): unknown => {
+    const [definition] = args as [{ name?: unknown; execute?: unknown } | undefined];
+    const toolName = normalizeToolName(definition);
+    if (!definition || typeof definition.execute !== "function" || !toolName) return undefined;
+    setLiveToolExecutor(ownerGeneration, toolName, definition.execute as (...a: unknown[]) => unknown);
+    // Keep generation-guard delegation pointing at the stub's guarded execute (already set in
+    // Phase A). Live bodies are resolved via liveToolExecutorsByGeneration.
+    return undefined;
+  };
+
+  const captureApi = {
+    ...api,
+    registerTool: captureRegisterTool as ClawdbotPluginApi["registerTool"],
+  } as ClawdbotPluginApi;
+  const toolsApi = patchMemoryToolRegistrationApi(captureApi);
+  for (const installer of toolInstallers) {
+    installer.install(installer.selectContext(ctx, toolsApi), toolsApi);
+  }
 }
 
 /** Tool registration receives the stable plugin API (Phase 3). */

--- a/extensions/memory-hybrid/setup/register-tools.ts
+++ b/extensions/memory-hybrid/setup/register-tools.ts
@@ -17,7 +17,7 @@ import {
   resolveCurrentToolExecutor,
   setCurrentToolExecutor,
 } from "./hybrid-memory-generation-state.js";
-import { shouldReturnInitializingToolResult } from "./hybrid-memory-activation.js";
+import { shouldReturnInitializingToolResult, isActivationFailed, getActivationFailureError } from "./hybrid-memory-activation.js";
 import { patchMemoryToolRegistrationApi } from "../utils/tool-search-wrapper-args.js";
 import { type ToolsContext, toolInstallers } from "./tool-installers.js";
 
@@ -130,6 +130,39 @@ export function buildInitializingToolSafeResult(
   };
 }
 
+/** Fail-closed result when Phase B activation failed — never pretend we are still initializing. */
+export function buildActivationFailedToolSafeResult(
+  toolName: string,
+  ownerGeneration: number,
+  error: string | null,
+): {
+  content: Array<{ type: "text"; text: string }>;
+  details: Record<string, unknown>;
+} {
+  const detail = error?.trim() ? error.trim() : "deferred activation failed";
+  return {
+    content: [
+      {
+        type: "text",
+        text:
+          `memory-hybrid: activation failed — tool "${toolName}" is unavailable ` +
+          `(generation ${ownerGeneration}: ${detail}). Re-register or restart the gateway.`,
+      },
+    ],
+    details: {
+      ok: false,
+      initializing: false,
+      activationFailed: true,
+      reloading: false,
+      skipped: true,
+      tool: toolName,
+      registrationGeneration: ownerGeneration,
+      activationPhase: "failed",
+      error: detail,
+    },
+  };
+}
+
 export function createGenerationGuardedToolsApi(
   ctx: Pick<ToolsContext, "registrationGeneration" | "currentRegistrationGenerationRef">,
   api: ClawdbotPluginApi,
@@ -159,13 +192,21 @@ export function createGenerationGuardedToolsApi(
       if (currentGeneration === ownerGeneration) {
         // Two-phase activation (#2181): current-generation stubs wait for Phase B before
         // invoking the live body (or the original execute when registration was fully sync).
-        if (shouldReturnInitializingToolResult(ownerGeneration)) {
-          const live = resolveLiveToolExecutor(toolName, ownerGeneration);
-          if (!live) return buildInitializingToolSafeResult(toolName, ownerGeneration);
-          return live(...executeArgs);
-        }
         const live = resolveLiveToolExecutor(toolName, ownerGeneration);
-        return (live ?? originalExecute)(...executeArgs);
+        if (live) return live(...executeArgs);
+        if (shouldReturnInitializingToolResult(ownerGeneration)) {
+          return buildInitializingToolSafeResult(toolName, ownerGeneration);
+        }
+        // Phase B failed (or ready without a live body): never fall through to the Phase A
+        // stub that always returns "initializing" — that soft-sticks tools forever.
+        if (isActivationFailed(ownerGeneration)) {
+          return buildActivationFailedToolSafeResult(
+            toolName,
+            ownerGeneration,
+            getActivationFailureError(ownerGeneration),
+          );
+        }
+        return originalExecute(...executeArgs);
       }
 
       const delegatedExecute = resolveCurrentToolExecutor(toolName, currentGeneration);
@@ -248,7 +289,16 @@ export function registerActivationToolStubs(
       name: toolName,
       description: `memory-hybrid: ${toolName} (activating)`,
       parameters: { type: "object", properties: {} },
-      execute: async () => buildInitializingToolSafeResult(toolName, ownerGeneration),
+      execute: async () => {
+        if (isActivationFailed(ownerGeneration)) {
+          return buildActivationFailedToolSafeResult(
+            toolName,
+            ownerGeneration,
+            getActivationFailureError(ownerGeneration),
+          );
+        }
+        return buildInitializingToolSafeResult(toolName, ownerGeneration);
+      },
     } as never);
   }
   return handle;

--- a/extensions/memory-hybrid/setup/register-tools.ts
+++ b/extensions/memory-hybrid/setup/register-tools.ts
@@ -17,7 +17,7 @@ import {
   resolveCurrentToolExecutor,
   setCurrentToolExecutor,
 } from "./hybrid-memory-generation-state.js";
-import { shouldReturnInitializingToolResult, isActivationFailed, getActivationFailureError } from "./hybrid-memory-activation.js";
+import { shouldReturnInitializingToolResult, isActivationFailed, isActivationReady, getActivationFailureError } from "./hybrid-memory-activation.js";
 import { patchMemoryToolRegistrationApi } from "../utils/tool-search-wrapper-args.js";
 import { type ToolsContext, toolInstallers } from "./tool-installers.js";
 
@@ -197,8 +197,7 @@ export function createGenerationGuardedToolsApi(
         if (shouldReturnInitializingToolResult(ownerGeneration)) {
           return buildInitializingToolSafeResult(toolName, ownerGeneration);
         }
-        // Phase B failed (or ready without a live body): never fall through to the Phase A
-        // stub that always returns "initializing" — that soft-sticks tools forever.
+        // Phase B failed: never fall through to the Phase A stub that always returns "initializing".
         if (isActivationFailed(ownerGeneration)) {
           return buildActivationFailedToolSafeResult(
             toolName,
@@ -206,12 +205,16 @@ export function createGenerationGuardedToolsApi(
             getActivationFailureError(ownerGeneration),
           );
         }
-        // Ready generation but no live executor bound — fail closed.
-        return buildActivationFailedToolSafeResult(
-          toolName,
-          ownerGeneration,
-          "tool executor not bound after activation",
-        );
+        // Two-phase ready but live body never bound — fail closed.
+        if (isActivationReady(ownerGeneration)) {
+          return buildActivationFailedToolSafeResult(
+            toolName,
+            ownerGeneration,
+            "tool executor not bound after activation",
+          );
+        }
+        // Sync registerTools / no activation state for this generation: use the registered body.
+        return originalExecute(...executeArgs);
       }
 
       const delegatedExecute = resolveCurrentToolExecutor(toolName, currentGeneration);

--- a/extensions/memory-hybrid/setup/register-tools.ts
+++ b/extensions/memory-hybrid/setup/register-tools.ts
@@ -45,10 +45,7 @@ export function clearLiveToolExecutorsForGeneration(generation: number): void {
   liveToolExecutorsByGeneration.delete(generation);
 }
 
-function resolveLiveToolExecutor(
-  toolName: string,
-  generation: number,
-): ((...args: unknown[]) => unknown) | null {
+function resolveLiveToolExecutor(toolName: string, generation: number): ((...args: unknown[]) => unknown) | null {
   return liveToolExecutorsByGeneration.get(generation)?.get(toolName) ?? null;
 }
 

--- a/extensions/memory-hybrid/setup/register-tools.ts
+++ b/extensions/memory-hybrid/setup/register-tools.ts
@@ -206,7 +206,12 @@ export function createGenerationGuardedToolsApi(
             getActivationFailureError(ownerGeneration),
           );
         }
-        return originalExecute(...executeArgs);
+        // Ready generation but no live executor bound — fail closed.
+        return buildActivationFailedToolSafeResult(
+          toolName,
+          ownerGeneration,
+          "tool executor not bound after activation",
+        );
       }
 
       const delegatedExecute = resolveCurrentToolExecutor(toolName, currentGeneration);

--- a/extensions/memory-hybrid/tests/activation-fail-closed.test.ts
+++ b/extensions/memory-hybrid/tests/activation-fail-closed.test.ts
@@ -9,10 +9,7 @@ import {
   shouldReturnInitializingToolResult,
   isActivationFailed,
 } from "../setup/hybrid-memory-activation.js";
-import {
-  buildActivationFailedToolSafeResult,
-  buildInitializingToolSafeResult,
-} from "../setup/register-tools.js";
+import { buildActivationFailedToolSafeResult, buildInitializingToolSafeResult } from "../setup/register-tools.js";
 
 describe("activation fail-closed (#2181)", () => {
   beforeEach(() => {

--- a/extensions/memory-hybrid/tests/activation-fail-closed.test.ts
+++ b/extensions/memory-hybrid/tests/activation-fail-closed.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Fail-closed tool results when Phase B activation fails (#2181 residual).
+ */
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import {
+  beginActivation,
+  markActivationFailed,
+  resetActivationStateForTests,
+  shouldReturnInitializingToolResult,
+  isActivationFailed,
+} from "../setup/hybrid-memory-activation.js";
+import {
+  buildActivationFailedToolSafeResult,
+  buildInitializingToolSafeResult,
+} from "../setup/register-tools.js";
+
+describe("activation fail-closed (#2181)", () => {
+  beforeEach(() => {
+    resetActivationStateForTests();
+  });
+  afterEach(() => {
+    resetActivationStateForTests();
+  });
+
+  it("marks failed activation and never reports initializing", () => {
+    beginActivation({ generation: 7, donorGeneration: 6 });
+    expect(shouldReturnInitializingToolResult(7)).toBe(true);
+    markActivationFailed(7, new Error("init-databases blew up"));
+    expect(shouldReturnInitializingToolResult(7)).toBe(false);
+    expect(isActivationFailed(7)).toBe(true);
+
+    const failed = buildActivationFailedToolSafeResult("memory_recall", 7, "init-databases blew up");
+    expect(failed.details.initializing).toBe(false);
+    expect(failed.details.activationFailed).toBe(true);
+    expect(failed.details.activationPhase).toBe("failed");
+    expect(String(failed.content[0]?.text)).toContain("activation failed");
+
+    const init = buildInitializingToolSafeResult("memory_recall", 7);
+    expect(init.details.initializing).toBe(true);
+  });
+});

--- a/extensions/memory-hybrid/tests/cmd-distill.test.ts
+++ b/extensions/memory-hybrid/tests/cmd-distill.test.ts
@@ -67,7 +67,17 @@ describe("filterSessionFilesByAllowlist (#2174)", () => {
     expect(filterSessionFilesByAllowlist(files, [])).toEqual([]);
   });
 
-  it("keeps only matching session stems", () => {
+  it("keeps only exact matching session stems (no backup/prefix substring)", () => {
+    const mixed = [
+      { path: "/home/u/.openclaw/agents/main/sessions/sess-a.jsonl" },
+      { path: "/home/u/.openclaw/agents/main/sessions/sess-a.jsonl.backup" },
+      { path: "/home/u/.openclaw/agents/main/sessions/sess-a.part2.jsonl" },
+      { path: "/home/u/.openclaw/agents/main/sessions/other.jsonl" },
+    ];
+    expect(filterSessionFilesByAllowlist(mixed, ["sess-a"]).map((f) => f.path)).toEqual([mixed[0].path]);
+  });
+
+  it("keeps multiple exact stems", () => {
     expect(filterSessionFilesByAllowlist(files, ["sess-a", "sess-b"]).map((f) => f.path)).toEqual([
       files[0].path,
       files[1].path,

--- a/extensions/memory-hybrid/tests/cmd-distill.test.ts
+++ b/extensions/memory-hybrid/tests/cmd-distill.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 
 import { afterEach, describe, expect, it } from "vitest";
 
-import { classifyDistillBatchFailureKind } from "../cli/cmd-distill.js";
+import { classifyDistillBatchFailureKind, filterSessionFilesByAllowlist } from "../cli/cmd-distill.js";
 import { extractTextFromSessionJsonl } from "../cli/distill-session-jsonl.js";
 
 describe("extractTextFromSessionJsonl", () => {
@@ -49,5 +49,28 @@ describe("classifyDistillBatchFailureKind", () => {
 
   it("treats direct aborted requests as retryable timeout failures", () => {
     expect(classifyDistillBatchFailureKind(new Error("Request was aborted"))).toBe("timeout");
+  });
+});
+
+describe("filterSessionFilesByAllowlist (#2174)", () => {
+  const files = [
+    { path: "/home/u/.openclaw/agents/main/sessions/sess-a.jsonl" },
+    { path: "/home/u/.openclaw/agents/main/sessions/sess-b.jsonl" },
+    { path: "/home/u/.openclaw/agents/main/sessions/other.jsonl" },
+  ];
+
+  it("passes through when allowlist is undefined", () => {
+    expect(filterSessionFilesByAllowlist(files, undefined)).toEqual(files);
+  });
+
+  it("returns empty when allowlist is empty (fail closed)", () => {
+    expect(filterSessionFilesByAllowlist(files, [])).toEqual([]);
+  });
+
+  it("keeps only matching session stems", () => {
+    expect(filterSessionFilesByAllowlist(files, ["sess-a", "sess-b"]).map((f) => f.path)).toEqual([
+      files[0].path,
+      files[1].path,
+    ]);
   });
 });

--- a/extensions/memory-hybrid/tests/comprehensive-e2e.test.ts
+++ b/extensions/memory-hybrid/tests/comprehensive-e2e.test.ts
@@ -22,6 +22,7 @@ import { benignFinalizationMessages, pendingCiTurnMessages } from "./fixtures/ma
 import {
   E2E_EMBEDDING_DIM,
   assertFullStackPaths,
+  awaitPluginActivation,
   getFullStackConfig,
   invokeHooks,
   makeFullStackApi,
@@ -121,10 +122,14 @@ describe("Comprehensive e2e — full plugin register()", () => {
           expect(await awaitReloadTeardownBeforeOpen(HOT_RELOAD_RETRY_WAIT_MS)).toBe(true);
           registerFullPlugin(api, stableConfig);
         }
+        // Two-phase activation (#2181): second register may publish stubs and finish Phase B async.
+        // Await ready before recall so we do not assert against initializing stub payloads.
+        expect(await awaitPluginActivation(HOT_RELOAD_TEST_TIMEOUT_MS)).toBe(true);
         const recall = api.getTool("memory_recall")!;
         const recalled = (await recall.execute("c2", { id: factId })) as {
-          details?: { count: number; memories?: { text: string }[] };
+          details?: { count: number; memories?: { text: string }[]; initializing?: boolean };
         };
+        expect(recalled.details?.initializing).not.toBe(true);
         expect(recalled.details?.count).toBe(1);
         expect(recalled.details?.memories?.[0]?.text).toContain("hot reload");
       },

--- a/extensions/memory-hybrid/tests/cost-tracker.test.ts
+++ b/extensions/memory-hybrid/tests/cost-tracker.test.ts
@@ -345,16 +345,18 @@ describe("CostTracker", () => {
       expect(getCurrentCostFeature()).toBeUndefined();
     });
 
-    it("labels are scoped — outer label is restored after inner completes", () => {
-      let inner: string | undefined;
+    it("nested withCostFeature preserves outer label (#2179 dream attribution)", () => {
+      // Nested calls keep the outer ALS label so dream compose is not overwritten by
+      // distill/reflect/consolidate sub-labels (see services/cost-context.ts).
+      let nested: string | undefined;
       let outer: string | undefined;
       withCostFeature("outer", () => {
         withCostFeature("inner", () => {
-          inner = getCurrentCostFeature();
+          nested = getCurrentCostFeature();
         });
         outer = getCurrentCostFeature();
       });
-      expect(inner).toBe("inner");
+      expect(nested).toBe("outer");
       expect(outer).toBe("outer");
     });
 

--- a/extensions/memory-hybrid/tests/dream-autonomy-gates.test.ts
+++ b/extensions/memory-hybrid/tests/dream-autonomy-gates.test.ts
@@ -1,17 +1,18 @@
 /**
- * Dream prevalence / permission / outcome / ROI (#2172–#2174, #2179).
+ * Dream prevalence / permission / outcome / ROI / OCC (#2172–#2175, #2179).
  */
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { FactsDB } from "../backends/facts-db.js";
 import { DreamCandidateStore } from "../backends/dream-candidate-store.js";
 import { DEFAULT_DREAMING_CONFIG } from "../config/types/dreaming.js";
 import { evaluateDreamOutcome } from "../services/dream-outcome.js";
-import { selectDreamSessions } from "../services/dream-permission.js";
+import { selectDreamSessions, writeScopeWithinBoundary } from "../services/dream-permission.js";
 import { promoteDreamRun } from "../services/dream-promote.js";
 import { buildDreamRoiReport } from "../services/dream-roi.js";
+import { runDream } from "../services/dream-run.js";
 
 describe("dream prevalence gate (#2172)", () => {
   let tmpDir: string;
@@ -33,6 +34,7 @@ describe("dream prevalence gate (#2172)", () => {
     const cfg = structuredClone(DEFAULT_DREAMING_CONFIG);
     cfg.autoPromote.enabled = true;
     cfg.candidateStore.shadow = false;
+    cfg.permissionBoundary.targetScope = "global";
 
     const run = store.createDreamRun({
       inputStoreRevision: factsDb.computeStoreRevision(),
@@ -68,18 +70,147 @@ describe("dream prevalence gate (#2172)", () => {
 });
 
 describe("dream permission (#2174)", () => {
-  it("excludes unresolved ACL and private→global leakage", () => {
+  it("excludes private session/user from global dreams by default", () => {
     const result = selectDreamSessions(
       [
-        { sessionId: "ok", effectiveScope: "session" },
+        { sessionId: "pub", effectiveScope: "global" },
         { sessionId: "private", effectiveScope: "user" },
+        { sessionId: "sess", effectiveScope: "session" },
         { sessionId: "unknown", effectiveScope: null },
       ],
-      { targetScope: "agent", enforce: true, personalMode: false },
+      { targetScope: "global", enforce: true, personalMode: false },
       20,
     );
-    expect(result.included).toEqual(["ok"]);
-    expect(result.excluded.map((e) => e.sessionId).sort()).toEqual(["private", "unknown"]);
+    expect(result.included).toEqual(["pub"]);
+    expect(result.excluded.map((e) => e.sessionId).sort()).toEqual(["private", "sess", "unknown"]);
+  });
+
+  it("clamps write scope to dream boundary", () => {
+    expect(
+      writeScopeWithinBoundary("global", { targetScope: "session", enforce: true, personalMode: false }),
+    ).toBe(false);
+    expect(
+      writeScopeWithinBoundary("session", { targetScope: "global", enforce: true, personalMode: false }),
+    ).toBe(true);
+  });
+});
+
+describe("dream compose + OCC (#2170/#2171/#2175)", () => {
+  let tmpDir: string;
+  let factsDb: FactsDB;
+  let store: DreamCandidateStore;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "dream-compose-"));
+    factsDb = new FactsDB(join(tmpDir, "facts.db"));
+    store = new DreamCandidateStore(factsDb.getRawDb());
+  });
+
+  afterEach(() => {
+    factsDb.close();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("shadow compose does not mutate live facts and promote does not fail OCC", async () => {
+    const before = factsDb.count();
+    const cfg = structuredClone(DEFAULT_DREAMING_CONFIG);
+    cfg.enabled = true;
+    cfg.candidateStore.enabled = true;
+    cfg.candidateStore.shadow = true;
+    cfg.autoPromote.enabled = false;
+    cfg.promoteAfterRun = true;
+    cfg.permissionBoundary.targetScope = "session";
+
+    const mutating = vi.fn(async ({ dryRun }: { dryRun: boolean }) => {
+      if (!dryRun) {
+        factsDb.store({
+          text: "should not write in shadow",
+          category: "preference",
+          importance: 0.5,
+          source: "test",
+          entity: null,
+          key: null,
+          value: null,
+        });
+      }
+      return { detail: `dryRun=${dryRun}` };
+    });
+
+    const result = await runDream({
+      factsDb,
+      store,
+      cfg,
+      sessionIds: ["s1"],
+      dryShadow: true,
+      promote: true,
+      steps: { distill: mutating },
+    });
+
+    expect(mutating).toHaveBeenCalled();
+    expect(mutating.mock.calls[0]![0].dryRun).toBe(true);
+    expect(factsDb.count()).toBe(before);
+    expect(result.candidates.length).toBeGreaterThanOrEqual(1);
+    expect(result.promoteResult?.applied).toBe(false);
+    expect(result.promoteResult?.error).toBeUndefined();
+    expect(result.promoteResult?.status).not.toBe("failed");
+  });
+
+  it("supersede promote uses preHash OCC and fails on drift", () => {
+    const cfg = structuredClone(DEFAULT_DREAMING_CONFIG);
+    cfg.autoPromote.enabled = true;
+    cfg.candidateStore.shadow = false;
+    cfg.permissionBoundary.targetScope = "session";
+
+    const target = factsDb.store({
+      text: "original",
+      category: "preference",
+      importance: 0.5,
+      source: "test",
+      entity: null,
+      key: null,
+      value: null,
+      scope: "session",
+      scopeTarget: "s1",
+    });
+    const preHash = factsDb.getOccToken(target.id)!;
+
+    const run = store.createDreamRun({
+      inputStoreRevision: factsDb.computeStoreRevision(),
+      sessionIds: ["s1"],
+      shadow: false,
+    });
+    store.appendCandidateEntries(run.id, [
+      {
+        op: "supersede",
+        targetFactId: target.id,
+        preHash,
+        payload: {
+          text: "replacement",
+          category: "preference",
+          importance: 0.6,
+          source: "dream",
+          entity: null,
+          key: null,
+          value: null,
+          scope: "session",
+          scopeTarget: "s1",
+        },
+        evidence: {
+          sessionIds: ["s1"],
+          prevalence: { sessions: 1, agents: 1 },
+          rationale: "ok",
+        },
+        reverse: { op: "unsupersede", payload: { oldFactId: target.id } },
+      },
+    ]);
+
+    // Drift the target after propose.
+    factsDb.restoreMergedFactText(target.id, "original MUTATED");
+
+    const result = promoteDreamRun(factsDb, store, run.id, { force: true, cfg });
+    expect(result.applied).toBe(false);
+    expect(result.status).toBe("failed");
+    expect(result.error).toMatch(/memory_conflict|stale|conflict/i);
   });
 });
 
@@ -99,12 +230,63 @@ describe("dream outcome + ROI (#2173/#2179)", () => {
     rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  it("detects regression and applies auto-rollback when enabled", () => {
+  it("does not invent baseline — insufficient_data until probe records metrics", () => {
+    const cfg = structuredClone(DEFAULT_DREAMING_CONFIG);
+    cfg.autoPromote.enabled = true;
+    cfg.autoRollback.enabled = true;
+    cfg.candidateStore.shadow = false;
+    cfg.permissionBoundary.targetScope = "session";
+
+    const run = store.createDreamRun({
+      inputStoreRevision: factsDb.computeStoreRevision(),
+      sessionIds: ["s1"],
+      shadow: false,
+    });
+    store.appendCandidateEntries(run.id, [
+      {
+        op: "add",
+        payload: {
+          text: "promoted without fake baseline",
+          category: "preference",
+          importance: 0.5,
+          source: "dream",
+          entity: null,
+          key: null,
+          value: null,
+          scope: "session",
+          scopeTarget: "s1",
+        },
+        evidence: {
+          sessionIds: ["s1"],
+          prevalence: { sessions: 1, agents: 1 },
+          rationale: "ok",
+        },
+        reverse: { op: "delete_fact", payload: {} },
+      },
+    ]);
+
+    const promoted = promoteDreamRun(factsDb, store, run.id, { force: true, cfg });
+    expect(promoted.applied).toBe(true);
+    expect(store.getDreamRun(run.id)?.metricsBaselineJson).toBeNull();
+
+    const outcome = evaluateDreamOutcome(
+      factsDb,
+      store,
+      run.id,
+      { successRate: 0.2, retryRate: 3, effectScore: 0.5, sessionsObserved: 5 },
+      { cfg, applyRollback: true, minSessions: 3 },
+    );
+    expect(outcome.decision).toBe("insufficient_data");
+    expect(outcome.reason).toBe("missing_baseline");
+  });
+
+  it("auto-rollbacks when a real baseline regresses", () => {
     const cfg = structuredClone(DEFAULT_DREAMING_CONFIG);
     cfg.autoPromote.enabled = true;
     cfg.autoRollback.enabled = true;
     cfg.autoRollback.regressionThreshold = 0.15;
     cfg.candidateStore.shadow = false;
+    cfg.permissionBoundary.targetScope = "session";
 
     const run = store.createDreamRun({
       inputStoreRevision: factsDb.computeStoreRevision(),
@@ -136,6 +318,14 @@ describe("dream outcome + ROI (#2173/#2179)", () => {
 
     const promoted = promoteDreamRun(factsDb, store, run.id, { force: true, cfg });
     expect(promoted.applied).toBe(true);
+    store.updateDreamRunStatus(run.id, "promoted", {
+      metricsBaselineJson: JSON.stringify({
+        successRate: 1,
+        retryRate: 0,
+        effectScore: 1,
+        sessionsObserved: 0,
+      }),
+    });
     const before = factsDb.count();
 
     const outcome = evaluateDreamOutcome(
@@ -155,8 +345,9 @@ describe("dream outcome + ROI (#2173/#2179)", () => {
       inputStoreRevision: factsDb.computeStoreRevision(),
       shadow: true,
     });
-    const report = buildDreamRoiReport(store, { limit: 10 });
+    const report = buildDreamRoiReport(store, { limit: 10, db: factsDb.getRawDb() });
     expect(report.aggregates.runCount).toBeGreaterThanOrEqual(1);
     expect(report.howToRead.length).toBeGreaterThan(20);
+    expect(report.runs[0]?.cost.source).toMatch(/llm_cost_log|insufficient_data/);
   });
 });

--- a/extensions/memory-hybrid/tests/dream-autonomy-gates.test.ts
+++ b/extensions/memory-hybrid/tests/dream-autonomy-gates.test.ts
@@ -1,7 +1,7 @@
 /**
  * Dream prevalence / permission / outcome / ROI / OCC (#2172–#2175, #2179).
  */
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -9,7 +9,11 @@ import { FactsDB } from "../backends/facts-db.js";
 import { DreamCandidateStore } from "../backends/dream-candidate-store.js";
 import { DEFAULT_DREAMING_CONFIG } from "../config/types/dreaming.js";
 import { evaluateDreamOutcome } from "../services/dream-outcome.js";
-import { selectDreamSessions, writeScopeWithinBoundary } from "../services/dream-permission.js";
+import {
+  discoverDreamSessionAcls,
+  selectDreamSessions,
+  writeScopeWithinBoundary,
+} from "../services/dream-permission.js";
 import { promoteDreamRun } from "../services/dream-promote.js";
 import { buildDreamRoiReport } from "../services/dream-roi.js";
 import { runDream } from "../services/dream-run.js";
@@ -67,6 +71,119 @@ describe("dream prevalence gate (#2172)", () => {
     expect(result.status).toBe("quarantined");
     expect(result.gateReport.decisions[0]?.reason).toMatch(/prevalence_insufficient_global/);
   });
+
+  it("allows single-session session-tier promote (agent bar does not apply)", () => {
+    const cfg = structuredClone(DEFAULT_DREAMING_CONFIG);
+    cfg.autoPromote.enabled = true;
+    cfg.candidateStore.shadow = false;
+    cfg.permissionBoundary.targetScope = "session";
+
+    const run = store.createDreamRun({
+      inputStoreRevision: factsDb.computeStoreRevision(),
+      sessionIds: ["s1"],
+      shadow: false,
+    });
+    store.appendCandidateEntries(run.id, [
+      {
+        op: "add",
+        payload: {
+          text: "session scratch",
+          category: "preference",
+          importance: 0.5,
+          source: "dream",
+          entity: null,
+          key: null,
+          value: null,
+          scope: "session",
+          scopeTarget: "s1",
+        },
+        evidence: {
+          sessionIds: ["s1"],
+          prevalence: { sessions: 1, agents: 1 },
+          rationale: "one session ok",
+        },
+        reverse: { op: "delete_fact", payload: {} },
+      },
+    ]);
+
+    const result = promoteDreamRun(factsDb, store, run.id, { force: true, cfg });
+    expect(result.status).toBe("promoted");
+    expect(result.applied).toBe(true);
+  });
+
+  it("personalSingleTenant lowers global agent bar to 1", () => {
+    const cfg = structuredClone(DEFAULT_DREAMING_CONFIG);
+    cfg.autoPromote.enabled = true;
+    cfg.candidateStore.shadow = false;
+    cfg.permissionBoundary.targetScope = "global";
+    cfg.prevalence.personalSingleTenant = true;
+
+    const run = store.createDreamRun({
+      id: "dream-pst-block",
+      inputStoreRevision: factsDb.computeStoreRevision(),
+      sessionIds: ["s1", "s2"],
+      shadow: false,
+    });
+    store.appendCandidateEntries(run.id, [
+      {
+        op: "add",
+        payload: {
+          text: "personal vault global",
+          category: "preference",
+          importance: 0.8,
+          source: "dream",
+          entity: null,
+          key: null,
+          value: null,
+          scope: "global",
+        },
+        evidence: {
+          sessionIds: ["s1", "s2"],
+          prevalence: { sessions: 2, agents: 1 },
+          rationale: "two sessions one agent",
+        },
+        reverse: { op: "delete_fact", payload: {} },
+      },
+    ]);
+
+    const blocked = promoteDreamRun(factsDb, store, run.id, {
+      force: true,
+      cfg: { ...cfg, prevalence: { ...cfg.prevalence, personalSingleTenant: false } },
+    });
+    expect(blocked.status).toBe("quarantined");
+    expect(blocked.gateReport.decisions[0]?.reason).toMatch(/prevalence_insufficient_global/);
+
+    // Fresh run — previous entry was gated_block
+    const run2 = store.createDreamRun({
+      id: "dream-pst-allow",
+      inputStoreRevision: factsDb.computeStoreRevision(),
+      sessionIds: ["s1", "s2"],
+      shadow: false,
+    });
+    store.appendCandidateEntries(run2.id, [
+      {
+        op: "add",
+        payload: {
+          text: "personal vault global 2",
+          category: "preference",
+          importance: 0.8,
+          source: "dream",
+          entity: null,
+          key: null,
+          value: null,
+          scope: "global",
+        },
+        evidence: {
+          sessionIds: ["s1", "s2"],
+          prevalence: { sessions: 2, agents: 1 },
+          rationale: "two sessions one agent",
+        },
+        reverse: { op: "delete_fact", payload: {} },
+      },
+    ]);
+    const allowed = promoteDreamRun(factsDb, store, run2.id, { force: true, cfg });
+    expect(allowed.status).toBe("promoted");
+  });
 });
 
 describe("dream permission (#2174)", () => {
@@ -92,6 +209,92 @@ describe("dream permission (#2174)", () => {
     expect(writeScopeWithinBoundary("session", { targetScope: "global", enforce: true, personalMode: false })).toBe(
       true,
     );
+  });
+
+  it("discovers nightly sessions with fail-closed ACL (never invent global from fact writes)", () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), "dream-discover-"));
+    const factsDb = new FactsDB(join(tmpDir, "facts.db"));
+    const openclawHome = join(tmpDir, "openclaw");
+    try {
+      mkdirSync(join(openclawHome, "agents", "main", "sessions"), { recursive: true });
+      writeFileSync(join(openclawHome, "agents", "main", "sessions", "sess-pub.jsonl"), "{}\n");
+
+      factsDb.store({
+        text: "session-scoped fact",
+        category: "preference",
+        importance: 0.5,
+        source: "test",
+        entity: null,
+        key: null,
+        value: null,
+        scope: "session",
+        scopeTarget: "sess-a",
+        provenanceSession: "sess-a",
+      });
+      factsDb.store({
+        text: "global-scoped fact from session",
+        category: "preference",
+        importance: 0.5,
+        source: "test",
+        entity: null,
+        key: null,
+        value: null,
+        scope: "global",
+        provenanceSession: "sess-pub",
+      });
+      const bad = factsDb.store({
+        text: "orphan provenance",
+        category: "preference",
+        importance: 0.5,
+        source: "test",
+        entity: null,
+        key: null,
+        value: null,
+        scope: "session",
+        scopeTarget: "sess-bad",
+        provenanceSession: "sess-bad",
+      });
+      factsDb.getRawDb().prepare("UPDATE facts SET scope = ? WHERE id = ?").run("not-a-scope", bad.id);
+
+      const discovered = discoverDreamSessionAcls(factsDb.getRawDb(), {
+        lookbackDays: 7,
+        limit: 20,
+        openclawHome,
+      });
+      expect(discovered.find((d) => d.sessionId === "sess-a")?.effectiveScope).toBe("session");
+      // Global fact writes do not prove public ACL; transcript path floors to agent.
+      expect(discovered.find((d) => d.sessionId === "sess-pub")?.effectiveScope).toBe("agent");
+      expect(discovered.find((d) => d.sessionId === "sess-bad")?.effectiveScope ?? null).toBeNull();
+
+      const withoutArtifact = discoverDreamSessionAcls(factsDb.getRawDb(), {
+        lookbackDays: 7,
+        limit: 20,
+        resolveArtifact: false,
+      });
+      expect(withoutArtifact.find((d) => d.sessionId === "sess-pub")?.effectiveScope ?? null).toBeNull();
+
+      const sessionDream = selectDreamSessions(
+        discovered,
+        { targetScope: "session", enforce: true, personalMode: false },
+        20,
+      );
+      expect(sessionDream.included.sort()).toEqual(["sess-a", "sess-pub"].sort());
+      expect(sessionDream.excluded.some((e) => e.sessionId === "sess-bad" && e.reason === "unresolved_acl")).toBe(
+        true,
+      );
+
+      const globalDream = selectDreamSessions(
+        discovered,
+        { targetScope: "global", enforce: true, personalMode: false },
+        20,
+      );
+      // Neither session nor agent ACL feeds a global dream without explicit --session-scopes.
+      expect(globalDream.included).toEqual([]);
+      expect(globalDream.excluded.map((e) => e.sessionId).sort()).toEqual(["sess-a", "sess-bad", "sess-pub"].sort());
+    } finally {
+      factsDb.close();
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
   });
 });
 
@@ -133,7 +336,31 @@ describe("dream compose + OCC (#2170/#2171/#2175)", () => {
           value: null,
         });
       }
-      return { detail: `dryRun=${dryRun}` };
+      return {
+        detail: `dryRun=${dryRun}`,
+        candidates: [
+          {
+            op: "add" as const,
+            payload: {
+              text: "shadow proposed preference",
+              category: "preference",
+              importance: 0.5,
+              entity: null,
+              key: null,
+              value: null,
+              source: "dream-distill",
+              scope: "session" as const,
+              scopeTarget: "s1",
+            },
+            evidence: {
+              sessionIds: ["s1"],
+              prevalence: { sessions: 1, agents: 1 },
+              rationale: "shadow compose proposal",
+            },
+            reverse: { op: "delete_fact" as const, payload: {} },
+          },
+        ],
+      };
     });
 
     const result = await runDream({
@@ -149,7 +376,7 @@ describe("dream compose + OCC (#2170/#2171/#2175)", () => {
     expect(mutating).toHaveBeenCalled();
     expect(mutating.mock.calls[0]![0].dryRun).toBe(true);
     expect(factsDb.count()).toBe(before);
-    expect(result.candidates.length).toBeGreaterThanOrEqual(1);
+    expect(result.candidates.length).toBe(1);
     expect(result.promoteResult?.applied).toBe(false);
     expect(result.promoteResult?.error).toBeUndefined();
     expect(result.promoteResult?.status).not.toBe("failed");
@@ -282,6 +509,66 @@ describe("dream outcome + ROI (#2173/#2179)", () => {
     );
     expect(worseOutcome.decision).toBe("rollback");
     expect(worseOutcome.reason).toContain("would_rollback");
+  });
+
+  it("insufficient sessions never false-rollbacks (#2173)", () => {
+    const cfg = structuredClone(DEFAULT_DREAMING_CONFIG);
+    cfg.autoPromote.enabled = true;
+    cfg.autoRollback.enabled = true;
+    cfg.candidateStore.shadow = false;
+    cfg.permissionBoundary.targetScope = "session";
+
+    const run = store.createDreamRun({
+      inputStoreRevision: factsDb.computeStoreRevision(),
+      sessionIds: ["s1"],
+      shadow: false,
+    });
+    store.appendCandidateEntries(run.id, [
+      {
+        op: "add",
+        payload: {
+          text: "keep under insufficient data",
+          category: "preference",
+          importance: 0.5,
+          source: "dream",
+          entity: null,
+          key: null,
+          value: null,
+          scope: "session",
+          scopeTarget: "s1",
+        },
+        evidence: {
+          sessionIds: ["s1"],
+          prevalence: { sessions: 1, agents: 1 },
+          rationale: "ok",
+        },
+        reverse: { op: "delete_fact", payload: {} },
+      },
+    ]);
+
+    const promoted = promoteDreamRun(factsDb, store, run.id, { force: true, cfg });
+    expect(promoted.applied).toBe(true);
+    store.updateDreamRunStatus(run.id, "promoted", {
+      metricsBaselineJson: JSON.stringify({
+        successRate: 1,
+        retryRate: 0,
+        effectScore: 1,
+        sessionsObserved: 0,
+      }),
+    });
+    const before = factsDb.count();
+
+    const outcome = evaluateDreamOutcome(
+      factsDb,
+      store,
+      run.id,
+      { successRate: 0, retryRate: 99, effectScore: -1, sessionsObserved: 1 },
+      { cfg, applyRollback: true, minSessions: 3 },
+    );
+    expect(outcome.decision).toBe("insufficient_data");
+    expect(outcome.reason).toBe("insufficient_sessions");
+    expect(outcome.rollback).toBeUndefined();
+    expect(factsDb.count()).toBe(before);
   });
 
   it("auto-rollbacks when a real baseline regresses", () => {

--- a/extensions/memory-hybrid/tests/dream-autonomy-gates.test.ts
+++ b/extensions/memory-hybrid/tests/dream-autonomy-gates.test.ts
@@ -230,7 +230,7 @@ describe("dream outcome + ROI (#2173/#2179)", () => {
     rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  it("does not invent baseline — insufficient_data until probe records metrics", () => {
+  it("captures real baseline at promote — no invented perfect score", () => {
     const cfg = structuredClone(DEFAULT_DREAMING_CONFIG);
     cfg.autoPromote.enabled = true;
     cfg.autoRollback.enabled = true;
@@ -267,17 +267,21 @@ describe("dream outcome + ROI (#2173/#2179)", () => {
 
     const promoted = promoteDreamRun(factsDb, store, run.id, { force: true, cfg });
     expect(promoted.applied).toBe(true);
-    expect(store.getDreamRun(run.id)?.metricsBaselineJson).toBeNull();
+    const baseline = store.getDreamRun(run.id)?.metricsBaselineJson;
+    expect(baseline).toBeTruthy();
+    const parsed = JSON.parse(baseline!) as { effectScore: number };
+    expect(parsed.effectScore).toBeLessThanOrEqual(1);
+    expect(parsed.effectScore).toBeGreaterThanOrEqual(-1);
 
-    const outcome = evaluateDreamOutcome(
+    const worseOutcome = evaluateDreamOutcome(
       factsDb,
       store,
       run.id,
-      { successRate: 0.2, retryRate: 3, effectScore: 0.5, sessionsObserved: 5 },
-      { cfg, applyRollback: true, minSessions: 3 },
+      { successRate: 0.1, retryRate: 5, effectScore: -0.5, sessionsObserved: 5 },
+      { cfg, applyRollback: false, minSessions: 3 },
     );
-    expect(outcome.decision).toBe("insufficient_data");
-    expect(outcome.reason).toBe("missing_baseline");
+    expect(worseOutcome.decision).toBe("rollback");
+    expect(worseOutcome.reason).toContain("would_rollback");
   });
 
   it("auto-rollbacks when a real baseline regresses", () => {

--- a/extensions/memory-hybrid/tests/dream-autonomy-gates.test.ts
+++ b/extensions/memory-hybrid/tests/dream-autonomy-gates.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Dream prevalence / permission / outcome / ROI (#2172–#2174, #2179).
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { FactsDB } from "../backends/facts-db.js";
+import { DreamCandidateStore } from "../backends/dream-candidate-store.js";
+import { DEFAULT_DREAMING_CONFIG } from "../config/types/dreaming.js";
+import { evaluateDreamOutcome } from "../services/dream-outcome.js";
+import { selectDreamSessions } from "../services/dream-permission.js";
+import { promoteDreamRun } from "../services/dream-promote.js";
+import { buildDreamRoiReport } from "../services/dream-roi.js";
+
+describe("dream prevalence gate (#2172)", () => {
+  let tmpDir: string;
+  let factsDb: FactsDB;
+  let store: DreamCandidateStore;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "dream-prev-"));
+    factsDb = new FactsDB(join(tmpDir, "facts.db"));
+    store = new DreamCandidateStore(factsDb.getRawDb());
+  });
+
+  afterEach(() => {
+    factsDb.close();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("blocks single-session global promote by default", () => {
+    const cfg = structuredClone(DEFAULT_DREAMING_CONFIG);
+    cfg.autoPromote.enabled = true;
+    cfg.candidateStore.shadow = false;
+
+    const run = store.createDreamRun({
+      inputStoreRevision: factsDb.computeStoreRevision(),
+      sessionIds: ["s1"],
+      shadow: false,
+    });
+    store.appendCandidateEntries(run.id, [
+      {
+        op: "add",
+        payload: {
+          text: "global curriculum",
+          category: "preference",
+          importance: 0.9,
+          source: "dream",
+          entity: null,
+          key: null,
+          value: null,
+          scope: "global",
+        },
+        evidence: {
+          sessionIds: ["s1"],
+          prevalence: { sessions: 1, agents: 1 },
+          rationale: "seen once",
+        },
+        reverse: { op: "delete_fact", payload: {} },
+      },
+    ]);
+
+    const result = promoteDreamRun(factsDb, store, run.id, { force: true, cfg });
+    expect(result.status).toBe("quarantined");
+    expect(result.gateReport.decisions[0]?.reason).toMatch(/prevalence_insufficient_global/);
+  });
+});
+
+describe("dream permission (#2174)", () => {
+  it("excludes unresolved ACL and private→global leakage", () => {
+    const result = selectDreamSessions(
+      [
+        { sessionId: "ok", effectiveScope: "session" },
+        { sessionId: "private", effectiveScope: "user" },
+        { sessionId: "unknown", effectiveScope: null },
+      ],
+      { targetScope: "agent", enforce: true, personalMode: false },
+      20,
+    );
+    expect(result.included).toEqual(["ok"]);
+    expect(result.excluded.map((e) => e.sessionId).sort()).toEqual(["private", "unknown"]);
+  });
+});
+
+describe("dream outcome + ROI (#2173/#2179)", () => {
+  let tmpDir: string;
+  let factsDb: FactsDB;
+  let store: DreamCandidateStore;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "dream-out-"));
+    factsDb = new FactsDB(join(tmpDir, "facts.db"));
+    store = new DreamCandidateStore(factsDb.getRawDb());
+  });
+
+  afterEach(() => {
+    factsDb.close();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("detects regression and applies auto-rollback when enabled", () => {
+    const cfg = structuredClone(DEFAULT_DREAMING_CONFIG);
+    cfg.autoPromote.enabled = true;
+    cfg.autoRollback.enabled = true;
+    cfg.autoRollback.regressionThreshold = 0.15;
+    cfg.candidateStore.shadow = false;
+
+    const run = store.createDreamRun({
+      inputStoreRevision: factsDb.computeStoreRevision(),
+      sessionIds: ["s1"],
+      shadow: false,
+    });
+    store.appendCandidateEntries(run.id, [
+      {
+        op: "add",
+        payload: {
+          text: "to roll back",
+          category: "preference",
+          importance: 0.5,
+          source: "dream",
+          entity: null,
+          key: null,
+          value: null,
+          scope: "session",
+          scopeTarget: "s1",
+        },
+        evidence: {
+          sessionIds: ["s1"],
+          prevalence: { sessions: 1, agents: 1 },
+          rationale: "ok",
+        },
+        reverse: { op: "delete_fact", payload: {} },
+      },
+    ]);
+
+    const promoted = promoteDreamRun(factsDb, store, run.id, { force: true, cfg });
+    expect(promoted.applied).toBe(true);
+    const before = factsDb.count();
+
+    const outcome = evaluateDreamOutcome(
+      factsDb,
+      store,
+      run.id,
+      { successRate: 0.2, retryRate: 3, effectScore: 0.5, sessionsObserved: 5 },
+      { cfg, applyRollback: true, nowSec: Math.floor(Date.now() / 1000) + 999999, minSessions: 3 },
+    );
+    expect(outcome.decision).toBe("rollback");
+    expect(outcome.rollback?.rolledBack).toBe(true);
+    expect(factsDb.count()).toBe(before - 1);
+  });
+
+  it("builds ROI report from fixture runs", () => {
+    store.createDreamRun({
+      inputStoreRevision: factsDb.computeStoreRevision(),
+      shadow: true,
+    });
+    const report = buildDreamRoiReport(store, { limit: 10 });
+    expect(report.aggregates.runCount).toBeGreaterThanOrEqual(1);
+    expect(report.howToRead.length).toBeGreaterThan(20);
+  });
+});

--- a/extensions/memory-hybrid/tests/dream-autonomy-gates.test.ts
+++ b/extensions/memory-hybrid/tests/dream-autonomy-gates.test.ts
@@ -86,12 +86,12 @@ describe("dream permission (#2174)", () => {
   });
 
   it("clamps write scope to dream boundary", () => {
-    expect(
-      writeScopeWithinBoundary("global", { targetScope: "session", enforce: true, personalMode: false }),
-    ).toBe(false);
-    expect(
-      writeScopeWithinBoundary("session", { targetScope: "global", enforce: true, personalMode: false }),
-    ).toBe(true);
+    expect(writeScopeWithinBoundary("global", { targetScope: "session", enforce: true, personalMode: false })).toBe(
+      false,
+    );
+    expect(writeScopeWithinBoundary("session", { targetScope: "global", enforce: true, personalMode: false })).toBe(
+      true,
+    );
   });
 });
 

--- a/extensions/memory-hybrid/tests/dream-autonomy-gates.test.ts
+++ b/extensions/memory-hybrid/tests/dream-autonomy-gates.test.ts
@@ -279,9 +279,7 @@ describe("dream permission (#2174)", () => {
         20,
       );
       expect(sessionDream.included.sort()).toEqual(["sess-a", "sess-pub"].sort());
-      expect(sessionDream.excluded.some((e) => e.sessionId === "sess-bad" && e.reason === "unresolved_acl")).toBe(
-        true,
-      );
+      expect(sessionDream.excluded.some((e) => e.sessionId === "sess-bad" && e.reason === "unresolved_acl")).toBe(true);
 
       const globalDream = selectDreamSessions(
         discovered,

--- a/extensions/memory-hybrid/tests/dream-candidate-store.test.ts
+++ b/extensions/memory-hybrid/tests/dream-candidate-store.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Dream candidate store CRUD + lifecycle (#2170).
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { FactsDB } from "../backends/facts-db.js";
+import { DreamCandidateStore } from "../backends/dream-candidate-store.js";
+
+describe("DreamCandidateStore (#2170)", () => {
+  let tmpDir: string;
+  let factsDb: FactsDB;
+  let store: DreamCandidateStore;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "dream-cand-"));
+    factsDb = new FactsDB(join(tmpDir, "facts.db"));
+    store = new DreamCandidateStore(factsDb.getRawDb());
+  });
+
+  afterEach(() => {
+    factsDb.close();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("creates a pending dream run and appends candidates without mutating live facts", () => {
+    const before = factsDb.count();
+    const run = store.createDreamRun({
+      inputStoreRevision: factsDb.computeStoreRevision(),
+      sessionIds: ["s1"],
+      shadow: true,
+    });
+    expect(run.status).toBe("pending");
+    expect(run.shadow).toBe(true);
+
+    store.appendCandidateEntries(run.id, [
+      {
+        op: "add",
+        payload: {
+          text: "candidate insight",
+          category: "preference",
+          importance: 0.6,
+          source: "dream",
+          entity: null,
+          key: null,
+          value: null,
+          scope: "session",
+          scopeTarget: "s1",
+        },
+        evidence: {
+          sessionIds: ["s1"],
+          prevalence: { sessions: 1, agents: 1 },
+          rationale: "test",
+        },
+        reverse: { op: "delete_fact", payload: {} },
+      },
+    ]);
+
+    expect(store.listCandidateEntries(run.id)).toHaveLength(1);
+    expect(factsDb.count()).toBe(before);
+  });
+
+  it("enforces status transitions", () => {
+    const run = store.createDreamRun({ inputStoreRevision: "abc" });
+    store.updateDreamRunStatus(run.id, "running");
+    store.updateDreamRunStatus(run.id, "gated");
+    expect(() => store.updateDreamRunStatus(run.id, "pending")).toThrow(/illegal status/);
+  });
+
+  it("migration creates dream candidate tables", () => {
+    const names = (
+      factsDb
+        .getRawDb()
+        .prepare(
+          "SELECT name FROM sqlite_master WHERE type='table' AND name IN ('dream_runs','memory_candidate_entries')",
+        )
+        .all() as Array<{ name: string }>
+    ).map((r) => r.name);
+    expect(names.sort()).toEqual(["dream_runs", "memory_candidate_entries"]);
+  });
+});

--- a/extensions/memory-hybrid/tests/dream-compose-candidates.test.ts
+++ b/extensions/memory-hybrid/tests/dream-compose-candidates.test.ts
@@ -24,10 +24,11 @@ describe("dream-compose-candidates (#2170/#2175)", () => {
     expect(candidates[0]?.preHash).toBeUndefined();
   });
 
-  it("maps consolidate merges with OCC preHash on deletes", () => {
+  it("maps consolidate merges with OCC preHash on deletes when provenance is allowlisted", () => {
     const candidates = consolidateProposalsToCandidates({
       dreamRunId: "dream-1",
       sessionIds: ["s1"],
+      sourceProvenanceByFactId: { a: ["s1"], b: ["s1"] },
       proposals: [
         {
           sourceFactIds: ["a", "b"],
@@ -41,6 +42,59 @@ describe("dream-compose-candidates (#2170/#2175)", () => {
     const deletes = candidates.filter((c) => c.op === "delete");
     expect(deletes).toHaveLength(2);
     expect(deletes.every((c) => typeof c.preHash === "string" && c.preHash.length > 0)).toBe(true);
+    expect(candidates.find((c) => c.op === "merge")?.payload.scope).toBe("session");
+    expect(candidates.find((c) => c.op === "merge")?.payload.scopeTarget).toBe("s1");
+  });
+
+  it("skips consolidate merges when any source lacks allowlisted provenance", () => {
+    const candidates = consolidateProposalsToCandidates({
+      dreamRunId: "dream-1",
+      sessionIds: ["s1"],
+      sourceProvenanceByFactId: { a: ["s1"], b: [] },
+      proposals: [
+        {
+          sourceFactIds: ["a", "b"],
+          mergedText: "Should not launder empty provenance",
+          category: "preference",
+          sourcePreHashes: { a: "hash-a", b: "hash-b" },
+        },
+      ],
+    });
+    expect(candidates).toHaveLength(0);
+  });
+
+  it("skips consolidate merges when any source provenance escapes the allowlist", () => {
+    const candidates = consolidateProposalsToCandidates({
+      dreamRunId: "dream-1",
+      sessionIds: ["s1"],
+      sourceProvenanceByFactId: { a: ["s1"], b: ["s2"] },
+      proposals: [
+        {
+          sourceFactIds: ["a", "b"],
+          mergedText: "Cross-session launder attempt",
+          category: "preference",
+          sourcePreHashes: { a: "hash-a", b: "hash-b" },
+        },
+      ],
+    });
+    expect(candidates).toHaveLength(0);
+  });
+
+  it("skips consolidate merges when any source lacks OCC preHash", () => {
+    const candidates = consolidateProposalsToCandidates({
+      dreamRunId: "dream-1",
+      sessionIds: ["s1"],
+      sourceProvenanceByFactId: { a: ["s1"], b: ["s1"] },
+      proposals: [
+        {
+          sourceFactIds: ["a", "b"],
+          mergedText: "Incomplete OCC pins",
+          category: "preference",
+          sourcePreHashes: { a: "hash-a" },
+        },
+      ],
+    });
+    expect(candidates).toHaveLength(0);
   });
 
   it("maps contradiction resolves with preHash", () => {
@@ -63,6 +117,47 @@ describe("dream-compose-candidates (#2170/#2175)", () => {
     expect(candidates[0]?.op).toBe("delete");
     expect(candidates[0]?.targetFactId).toBe("o1");
     expect(candidates[0]?.preHash).toBe("occ-old");
+  });
+
+  it("admits agent-scoped contradiction resolves without provenance when they fit the dream target", () => {
+    const candidates = contradictionProposalsToCandidates({
+      dreamRunId: "dream-1",
+      sessionIds: ["s1", "s2"],
+      targetScope: "session",
+      proposals: [
+        {
+          contradictionId: "c-agent",
+          factIdNew: "n1",
+          factIdOld: "o1",
+          preHash: "occ-old",
+          provenanceSessionIds: [],
+          scope: "agent",
+          scopeTarget: null,
+        },
+      ],
+    });
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0]?.evidence?.sessionIds?.sort()).toEqual(["s1", "s2"]);
+  });
+
+  it("rejects session-scoped contradiction resolves that lack allowlisted provenance/target", () => {
+    const candidates = contradictionProposalsToCandidates({
+      dreamRunId: "dream-1",
+      sessionIds: ["s1"],
+      targetScope: "session",
+      proposals: [
+        {
+          contradictionId: "c-private",
+          factIdNew: "n1",
+          factIdOld: "o1",
+          preHash: "occ-old",
+          provenanceSessionIds: [],
+          scope: "session",
+          scopeTarget: "other-session",
+        },
+      ],
+    });
+    expect(candidates).toHaveLength(0);
   });
 
   it("pinContradictionResolves skips superseded or missing OCC", () => {
@@ -120,5 +215,22 @@ describe("dream-compose-candidates (#2170/#2175)", () => {
     expect(candidates[0]?.op).toBe("add");
     expect(candidates[0]?.payload.source).toBe("dream-self-correction");
     expect(candidates[0]?.payload.scope).toBe("session");
+  });
+
+  it("attributes self-correction writes to sourceSessionId when present", () => {
+    const candidates = selfCorrectionProposalsToCandidates({
+      dreamRunId: "dream-1",
+      sessionIds: ["s1", "s2"],
+      proposals: [
+        {
+          text: "Prefer --json for maintenance CLIs",
+          category: "technical",
+          sourceSessionId: "s2",
+        },
+      ],
+    });
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0]?.payload.scope).toBe("session");
+    expect(candidates[0]?.payload.scopeTarget).toBe("s2");
   });
 });

--- a/extensions/memory-hybrid/tests/dream-compose-candidates.test.ts
+++ b/extensions/memory-hybrid/tests/dream-compose-candidates.test.ts
@@ -46,13 +46,16 @@ describe("dream-compose-candidates (#2170/#2175)", () => {
   it("maps contradiction resolves with preHash", () => {
     const candidates = contradictionProposalsToCandidates({
       dreamRunId: "dream-1",
-      sessionIds: [],
+      sessionIds: ["s1"],
       proposals: [
         {
           contradictionId: "c1",
           factIdNew: "n1",
           factIdOld: "o1",
           preHash: "occ-old",
+          provenanceSessionIds: ["s1"],
+          scope: "session",
+          scopeTarget: "s1",
         },
       ],
     });
@@ -80,7 +83,17 @@ describe("dream-compose-candidates (#2170/#2175)", () => {
         getOccToken: (id) => (id === "live" ? "occ-live" : null),
       },
     );
-    expect(pinned).toEqual([{ contradictionId: "c1", factIdNew: "n1", factIdOld: "live", preHash: "occ-live" }]);
+    expect(pinned).toEqual([
+      {
+        contradictionId: "c1",
+        factIdNew: "n1",
+        factIdOld: "live",
+        preHash: "occ-live",
+        provenanceSessionIds: [],
+        scope: null,
+        scopeTarget: null,
+      },
+    ]);
   });
 
   it("maps reflect patterns to boundary write scope (not hardcoded global)", () => {

--- a/extensions/memory-hybrid/tests/dream-compose-candidates.test.ts
+++ b/extensions/memory-hybrid/tests/dream-compose-candidates.test.ts
@@ -119,11 +119,12 @@ describe("dream-compose-candidates (#2170/#2175)", () => {
     expect(candidates[0]?.preHash).toBe("occ-old");
   });
 
-  it("admits agent-scoped contradiction resolves without provenance when they fit the dream target", () => {
+  it("admits agent-scoped contradiction resolves when dream boundary allows agent writes", () => {
     const candidates = contradictionProposalsToCandidates({
       dreamRunId: "dream-1",
       sessionIds: ["s1", "s2"],
-      targetScope: "session",
+      targetScope: "agent",
+      permissionBoundary: { targetScope: "agent", enforce: true, personalMode: false },
       proposals: [
         {
           contradictionId: "c-agent",
@@ -138,6 +139,37 @@ describe("dream-compose-candidates (#2170/#2175)", () => {
     });
     expect(candidates).toHaveLength(1);
     expect(candidates[0]?.evidence?.sessionIds?.sort()).toEqual(["s1", "s2"]);
+  });
+
+  it("rejects agent-scoped contradiction resolves under a session permission boundary", () => {
+    const candidates = contradictionProposalsToCandidates({
+      dreamRunId: "dream-1",
+      sessionIds: ["s1", "s2"],
+      targetScope: "session",
+      permissionBoundary: { targetScope: "session", enforce: true, personalMode: false },
+      proposals: [
+        {
+          contradictionId: "c-agent",
+          factIdNew: "n1",
+          factIdOld: "o1",
+          preHash: "occ-old",
+          provenanceSessionIds: [],
+          scope: "agent",
+          scopeTarget: null,
+        },
+      ],
+    });
+    expect(candidates).toHaveLength(0);
+  });
+
+  it("skips multi-session distill writes under a session permission boundary", () => {
+    const candidates = distillProposalsToCandidates({
+      dreamRunId: "dream-1",
+      sessionIds: ["s1", "s2"],
+      permissionBoundary: { targetScope: "session", enforce: true, personalMode: false },
+      proposals: [{ text: "Unattributed multi-session preference that must not launder", category: "preference" }],
+    });
+    expect(candidates).toHaveLength(0);
   });
 
   it("rejects session-scoped contradiction resolves that lack allowlisted provenance/target", () => {

--- a/extensions/memory-hybrid/tests/dream-compose-candidates.test.ts
+++ b/extensions/memory-hybrid/tests/dream-compose-candidates.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Dream compose candidate mappers (#2170 / #2175).
+ */
+import { describe, expect, it } from "vitest";
+import {
+  consolidateProposalsToCandidates,
+  contradictionProposalsToCandidates,
+  distillProposalsToCandidates,
+  pinContradictionResolves,
+  reflectProposalsToCandidates,
+  selfCorrectionProposalsToCandidates,
+} from "../services/dream-compose-candidates.js";
+
+describe("dream-compose-candidates (#2170/#2175)", () => {
+  it("maps distill proposals to add candidates", () => {
+    const candidates = distillProposalsToCandidates({
+      dreamRunId: "dream-1",
+      sessionIds: ["s1"],
+      proposals: [{ text: "User prefers dark mode in the editor UI", category: "preference" }],
+    });
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0]?.op).toBe("add");
+    expect(candidates[0]?.payload.text).toContain("dark mode");
+    expect(candidates[0]?.preHash).toBeUndefined();
+  });
+
+  it("maps consolidate merges with OCC preHash on deletes", () => {
+    const candidates = consolidateProposalsToCandidates({
+      dreamRunId: "dream-1",
+      sessionIds: ["s1"],
+      proposals: [
+        {
+          sourceFactIds: ["a", "b"],
+          mergedText: "Merged operational preference about deploy targets",
+          category: "preference",
+          sourcePreHashes: { a: "hash-a", b: "hash-b" },
+        },
+      ],
+    });
+    expect(candidates.some((c) => c.op === "merge")).toBe(true);
+    const deletes = candidates.filter((c) => c.op === "delete");
+    expect(deletes).toHaveLength(2);
+    expect(deletes.every((c) => typeof c.preHash === "string" && c.preHash.length > 0)).toBe(true);
+  });
+
+  it("maps contradiction resolves with preHash", () => {
+    const candidates = contradictionProposalsToCandidates({
+      dreamRunId: "dream-1",
+      sessionIds: [],
+      proposals: [
+        {
+          contradictionId: "c1",
+          factIdNew: "n1",
+          factIdOld: "o1",
+          preHash: "occ-old",
+        },
+      ],
+    });
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0]?.op).toBe("delete");
+    expect(candidates[0]?.targetFactId).toBe("o1");
+    expect(candidates[0]?.preHash).toBe("occ-old");
+  });
+
+  it("pinContradictionResolves skips superseded or missing OCC", () => {
+    const pinned = pinContradictionResolves(
+      [
+        { contradictionId: "c1", factIdNew: "n1", factIdOld: "live" },
+        { contradictionId: "c2", factIdNew: "n2", factIdOld: "gone" },
+        { contradictionId: "c3", factIdNew: "n3", factIdOld: "superseded" },
+        { contradictionId: "c4", factIdNew: "n4", factIdOld: "no-occ" },
+      ],
+      {
+        getById: (id) => {
+          if (id === "live") return { supersededAt: null };
+          if (id === "superseded") return { supersededAt: 1 };
+          if (id === "no-occ") return { supersededAt: null };
+          return null;
+        },
+        getOccToken: (id) => (id === "live" ? "occ-live" : null),
+      },
+    );
+    expect(pinned).toEqual([{ contradictionId: "c1", factIdNew: "n1", factIdOld: "live", preHash: "occ-live" }]);
+  });
+
+  it("maps reflect patterns to boundary write scope (not hardcoded global)", () => {
+    const candidates = reflectProposalsToCandidates({
+      dreamRunId: "dream-1",
+      sessionIds: ["s1"],
+      writeScope: "session",
+      writeScopeTarget: "s1",
+      proposals: [{ text: "When debugging, confirm reproduction before changing config" }],
+    });
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0]?.payload.category).toBe("pattern");
+    expect(candidates[0]?.payload.scope).toBe("session");
+    expect(candidates[0]?.payload.scopeTarget).toBe("s1");
+  });
+
+  it("maps self-correction MEMORY_STORE previews to add candidates", () => {
+    const candidates = selfCorrectionProposalsToCandidates({
+      dreamRunId: "dream-1",
+      sessionIds: ["s1"],
+      proposals: [{ text: "Prefer --json for maintenance CLIs", category: "technical", key: "cli-json" }],
+    });
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0]?.op).toBe("add");
+    expect(candidates[0]?.payload.source).toBe("dream-self-correction");
+    expect(candidates[0]?.payload.scope).toBe("session");
+  });
+});

--- a/extensions/memory-hybrid/tests/dream-contradiction-gate.test.ts
+++ b/extensions/memory-hybrid/tests/dream-contradiction-gate.test.ts
@@ -197,7 +197,15 @@ describe("dream contradiction worsening gate (#2170)", () => {
       },
     ]);
     const entry = store.listCandidateEntries(run.id)[0]!;
-    expect(evaluateContradictionWorsening(factsDb, entry).worsens).toBe(false);
+    const gate = evaluateContradictionWorsening(factsDb, entry);
+    expect(gate.worsens).toBe(false);
+    expect(gate.reason).toBe("contradiction_resolve_ok");
+
+    // Promote path must honor the same carve-out — otherwise contradictions compose is dead under
+    // default blockOnContradictionWorsening.
+    const report = evaluateDreamGates(store, run.id, DEFAULT_DREAMING_CONFIG, factsDb);
+    expect(report.ok).toBe(true);
+    expect(report.decisions[0]?.pass).toBe(true);
   });
 
   it("passes unstructured add without entity/key", () => {

--- a/extensions/memory-hybrid/tests/dream-contradiction-gate.test.ts
+++ b/extensions/memory-hybrid/tests/dream-contradiction-gate.test.ts
@@ -142,6 +142,64 @@ describe("dream contradiction worsening gate (#2170)", () => {
     expect(report.decisions[0]?.reason).toMatch(/contradiction_worsens|deletes_unresolved/);
   });
 
+  it("allows dream contradiction-resolve deletes of unresolved losing side", () => {
+    const a = factsDb.store({
+      text: "feature enabled true",
+      category: "preference",
+      importance: 0.7,
+      source: "test",
+      entity: "feature",
+      key: "enabled",
+      value: "true",
+      provenanceSession: "s1",
+    });
+    const b = factsDb.store({
+      text: "feature enabled false",
+      category: "preference",
+      importance: 0.7,
+      source: "test",
+      entity: "feature",
+      key: "enabled",
+      value: "false",
+      provenanceSession: "s1",
+    });
+    factsDb.recordContradiction(b.id, a.id);
+
+    const run = store.createDreamRun({
+      id: "dream-cx-resolve",
+      inputStoreRevision: factsDb.computeStoreRevision(),
+      sessionIds: ["s1"],
+      shadow: true,
+    });
+    store.appendCandidateEntries(run.id, [
+      {
+        op: "delete",
+        targetFactId: a.id,
+        preHash: factsDb.getOccToken(a.id)!,
+        payload: {
+          text: "resolve drop a",
+          category: "preference",
+          importance: 0,
+          source: "dream-contradictions",
+          entity: null,
+          key: null,
+          value: null,
+          tags: ["dream", "contradiction-resolve"],
+          scope: "session",
+          scopeTarget: "s1",
+        },
+        evidence: {
+          sessionIds: ["s1"],
+          prevalence: { sessions: 1, agents: 1 },
+          rationale: "auto-resolve",
+        },
+        reverse: { op: "noop", payload: {} },
+      },
+    ]);
+    const entry = store.listCandidateEntries(run.id)[0]!;
+    expect(evaluateContradictionWorsening(factsDb, entry).worsens).toBe(false);
+  });
+
   it("passes unstructured add without entity/key", () => {
     const run = store.createDreamRun({
       id: "dream-cx-ok",

--- a/extensions/memory-hybrid/tests/dream-contradiction-gate.test.ts
+++ b/extensions/memory-hybrid/tests/dream-contradiction-gate.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Live contradiction-worsening gate (#2170).
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { FactsDB } from "../backends/facts-db.js";
+import { DreamCandidateStore } from "../backends/dream-candidate-store.js";
+import { DEFAULT_DREAMING_CONFIG } from "../config/types/dreaming.js";
+import { evaluateContradictionWorsening } from "../services/dream-contradiction-gate.js";
+import { evaluateDreamGates, promoteDreamRun } from "../services/dream-promote.js";
+
+describe("dream contradiction worsening gate (#2170)", () => {
+  let tmpDir: string;
+  let factsDb: FactsDB;
+  let store: DreamCandidateStore;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "dream-cx-"));
+    factsDb = new FactsDB(join(tmpDir, "facts.db"));
+    store = new DreamCandidateStore(factsDb.getRawDb());
+  });
+
+  afterEach(() => {
+    factsDb.close();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("blocks add that conflicts with an existing entity+key value at heuristic threshold", () => {
+    factsDb.store({
+      text: "API timeout is 30s",
+      category: "preference",
+      importance: 0.8,
+      source: "test",
+      entity: "api",
+      key: "timeout",
+      value: "30s",
+      scope: "session",
+      scopeTarget: "s1",
+    });
+
+    const run = store.createDreamRun({
+      id: "dream-cx-add",
+      inputStoreRevision: factsDb.computeStoreRevision(),
+      sessionIds: ["s1"],
+      shadow: false,
+    });
+    store.appendCandidateEntries(run.id, [
+      {
+        op: "add",
+        payload: {
+          text: "API timeout is never 30s — use 5s",
+          category: "preference",
+          importance: 0.8,
+          source: "dream",
+          entity: "api",
+          key: "timeout",
+          value: "5s",
+          scope: "session",
+          scopeTarget: "s1",
+        },
+        evidence: {
+          sessionIds: ["s1"],
+          prevalence: { sessions: 1, agents: 1 },
+          rationale: "conflicting timeout",
+        },
+        reverse: { op: "delete_fact", payload: {} },
+      },
+    ]);
+
+    const entry = store.listCandidateEntries(run.id)[0]!;
+    const gate = evaluateContradictionWorsening(factsDb, entry);
+    expect(gate.worsens).toBe(true);
+    expect(gate.reason).toMatch(/heuristic_score|conflicts_verified/);
+
+    const cfg = structuredClone(DEFAULT_DREAMING_CONFIG);
+    cfg.autoPromote.enabled = true;
+    cfg.candidateStore.shadow = false;
+    cfg.permissionBoundary.targetScope = "session";
+    const result = promoteDreamRun(factsDb, store, run.id, { force: true, cfg });
+    expect(result.status).toBe("quarantined");
+    expect(result.gateReport.decisions[0]?.reason).toMatch(/contradiction_worsens/);
+  });
+
+  it("blocks delete of a fact involved in an unresolved contradiction", () => {
+    const a = factsDb.store({
+      text: "feature enabled true",
+      category: "preference",
+      importance: 0.7,
+      source: "test",
+      entity: "feature",
+      key: "enabled",
+      value: "true",
+    });
+    const b = factsDb.store({
+      text: "feature enabled false",
+      category: "preference",
+      importance: 0.7,
+      source: "test",
+      entity: "feature",
+      key: "enabled",
+      value: "false",
+    });
+    factsDb.recordContradiction(b.id, a.id);
+    expect(factsDb.isContradicted(a.id)).toBe(true);
+
+    const run = store.createDreamRun({
+      id: "dream-cx-del",
+      inputStoreRevision: factsDb.computeStoreRevision(),
+      sessionIds: ["s1"],
+      shadow: false,
+    });
+    store.appendCandidateEntries(run.id, [
+      {
+        op: "delete",
+        targetFactId: a.id,
+        preHash: factsDb.getOccToken(a.id) ?? "x",
+        payload: {
+          text: "delete a",
+          category: "other",
+          importance: 0,
+          source: "dream",
+          entity: null,
+          key: null,
+          value: null,
+        },
+        evidence: {
+          sessionIds: ["s1"],
+          prevalence: { sessions: 1, agents: 1 },
+          rationale: "delete contradicted side",
+        },
+        reverse: { op: "noop", payload: {} },
+      },
+    ]);
+
+    const entry = store.listCandidateEntries(run.id)[0]!;
+    expect(evaluateContradictionWorsening(factsDb, entry).worsens).toBe(true);
+
+    const report = evaluateDreamGates(store, run.id, DEFAULT_DREAMING_CONFIG, factsDb);
+    expect(report.ok).toBe(false);
+    expect(report.decisions[0]?.reason).toMatch(/contradiction_worsens|deletes_unresolved/);
+  });
+
+  it("passes unstructured add without entity/key", () => {
+    const run = store.createDreamRun({
+      id: "dream-cx-ok",
+      inputStoreRevision: factsDb.computeStoreRevision(),
+      sessionIds: ["s1"],
+      shadow: true,
+    });
+    store.appendCandidateEntries(run.id, [
+      {
+        op: "add",
+        payload: {
+          text: "narrative preference without entity key",
+          category: "preference",
+          importance: 0.5,
+          source: "dream",
+          entity: null,
+          key: null,
+          value: null,
+          scope: "session",
+          scopeTarget: "s1",
+        },
+        evidence: {
+          sessionIds: ["s1"],
+          prevalence: { sessions: 1, agents: 1 },
+          rationale: "ok",
+        },
+        reverse: { op: "delete_fact", payload: {} },
+      },
+    ]);
+    const entry = store.listCandidateEntries(run.id)[0]!;
+    expect(evaluateContradictionWorsening(factsDb, entry)).toEqual({ worsens: false, reason: "no_entity_key" });
+  });
+});

--- a/extensions/memory-hybrid/tests/dream-promote-rollback.test.ts
+++ b/extensions/memory-hybrid/tests/dream-promote-rollback.test.ts
@@ -1,0 +1,239 @@
+/**
+ * Dream promote / gate-reject / rollback / shadow (#2170).
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { FactsDB } from "../backends/facts-db.js";
+import { DreamCandidateStore } from "../backends/dream-candidate-store.js";
+import type { DreamingConfig } from "../config/types/dreaming.js";
+import { DEFAULT_DREAMING_CONFIG } from "../config/types/dreaming.js";
+import { promoteDreamRun } from "../services/dream-promote.js";
+import { rollbackDreamRun } from "../services/dream-rollback.js";
+
+function cfg(partial: Partial<DreamingConfig["autoPromote"]> & { shadow?: boolean }): DreamingConfig {
+  const base = structuredClone(DEFAULT_DREAMING_CONFIG);
+  return {
+    ...base,
+    candidateStore: { enabled: true, shadow: partial.shadow !== false },
+    autoPromote: {
+      ...base.autoPromote,
+      enabled: true,
+      ...partial,
+    },
+  };
+}
+
+describe("dream promote/rollback (#2170)", () => {
+  let tmpDir: string;
+  let factsDb: FactsDB;
+  let store: DreamCandidateStore;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "dream-promo-"));
+    factsDb = new FactsDB(join(tmpDir, "facts.db"));
+    store = new DreamCandidateStore(factsDb.getRawDb());
+  });
+
+  afterEach(() => {
+    factsDb.close();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("shadow mode gates without mutating live facts", () => {
+    const before = factsDb.count();
+    const run = store.createDreamRun({
+      inputStoreRevision: factsDb.computeStoreRevision(),
+      sessionIds: ["s1"],
+      shadow: true,
+    });
+    store.appendCandidateEntries(run.id, [
+      {
+        op: "add",
+        payload: {
+          text: "shadow insight",
+          category: "preference",
+          importance: 0.7,
+          source: "dream",
+          entity: null,
+          key: null,
+          value: null,
+          scope: "session",
+          scopeTarget: "s1",
+        },
+        evidence: {
+          sessionIds: ["s1"],
+          prevalence: { sessions: 1, agents: 1 },
+          rationale: "seen once",
+        },
+        reverse: { op: "delete_fact", payload: {} },
+      },
+    ]);
+
+    const result = promoteDreamRun(factsDb, store, run.id, {
+      cfg: cfg({ enabled: false, shadow: true }),
+    });
+    expect(result.applied).toBe(false);
+    expect(result.shadow).toBe(true);
+    expect(result.gateReport.wouldPromote).toBe(true);
+    expect(factsDb.count()).toBe(before);
+  });
+
+  it("gate-rejects missing provenance and quarantines", () => {
+    const run = store.createDreamRun({
+      inputStoreRevision: factsDb.computeStoreRevision(),
+      shadow: false,
+    });
+    store.appendCandidateEntries(run.id, [
+      {
+        op: "add",
+        payload: {
+          text: "no evidence",
+          category: "preference",
+          importance: 0.5,
+          source: "dream",
+          entity: null,
+          key: null,
+          value: null,
+        },
+        evidence: { sessionIds: [], prevalence: { sessions: 0, agents: 0 }, rationale: "" },
+        reverse: { op: "delete_fact", payload: {} },
+      },
+    ]);
+
+    const result = promoteDreamRun(factsDb, store, run.id, {
+      cfg: cfg({ enabled: true, shadow: false }),
+      force: true,
+    });
+    expect(result.status).toBe("quarantined");
+    expect(result.applied).toBe(false);
+    expect(result.gateReport.decisions[0]?.reason).toBe("missing_provenance");
+  });
+
+  it("force-promotes an add and rollback deletes it", () => {
+    const run = store.createDreamRun({
+      inputStoreRevision: factsDb.computeStoreRevision(),
+      sessionIds: ["s1"],
+      shadow: true,
+    });
+    store.appendCandidateEntries(run.id, [
+      {
+        op: "add",
+        payload: {
+          text: "promoted curriculum fact",
+          category: "preference",
+          importance: 0.8,
+          source: "dream",
+          entity: null,
+          key: null,
+          value: null,
+          scope: "session",
+          scopeTarget: "s1",
+        },
+        evidence: {
+          sessionIds: ["s1"],
+          prevalence: { sessions: 1, agents: 1 },
+          rationale: "ok",
+        },
+        reverse: { op: "delete_fact", payload: {} },
+      },
+    ]);
+
+    const before = factsDb.count();
+    const promoted = promoteDreamRun(factsDb, store, run.id, {
+      force: true,
+      cfg: cfg({ enabled: true, shadow: false }),
+    });
+    expect(promoted.applied).toBe(true);
+    expect(promoted.status).toBe("promoted");
+    expect(factsDb.count()).toBe(before + 1);
+    expect(promoted.appliedFactIds).toHaveLength(1);
+
+    const rolled = rollbackDreamRun(factsDb, store, run.id, { reason: "test" });
+    expect(rolled.rolledBack).toBe(true);
+    expect(store.getDreamRun(run.id)?.status).toBe("rolled_back");
+    expect(factsDb.count()).toBe(before);
+  });
+
+  it("refuses promote when input_store_revision is stale", () => {
+    const run = store.createDreamRun({
+      inputStoreRevision: "stale-revision",
+      sessionIds: ["s1"],
+      shadow: false,
+    });
+    store.appendCandidateEntries(run.id, [
+      {
+        op: "add",
+        payload: {
+          text: "should not apply",
+          category: "preference",
+          importance: 0.5,
+          source: "dream",
+          entity: null,
+          key: null,
+          value: null,
+          scope: "session",
+          scopeTarget: "s1",
+        },
+        evidence: {
+          sessionIds: ["s1"],
+          prevalence: { sessions: 1, agents: 1 },
+          rationale: "ok",
+        },
+        reverse: { op: "delete_fact", payload: {} },
+      },
+    ]);
+
+    const result = promoteDreamRun(factsDb, store, run.id, {
+      cfg: cfg({ enabled: true, shadow: false }),
+      force: false,
+    });
+    expect(result.status).toBe("failed");
+    expect(result.error).toMatch(/input_store_revision/);
+  });
+
+  it("rollback aborts entry on post_hash drift without deleting mutated fact", () => {
+    const run = store.createDreamRun({
+      inputStoreRevision: factsDb.computeStoreRevision(),
+      sessionIds: ["s1"],
+      shadow: false,
+    });
+    store.appendCandidateEntries(run.id, [
+      {
+        op: "add",
+        payload: {
+          text: "drift target",
+          category: "preference",
+          importance: 0.5,
+          source: "dream",
+          entity: null,
+          key: null,
+          value: null,
+          scope: "session",
+          scopeTarget: "s1",
+        },
+        evidence: {
+          sessionIds: ["s1"],
+          prevalence: { sessions: 1, agents: 1 },
+          rationale: "ok",
+        },
+        reverse: { op: "delete_fact", payload: {} },
+      },
+    ]);
+
+    const promoted = promoteDreamRun(factsDb, store, run.id, {
+      force: true,
+      cfg: cfg({ enabled: true, shadow: false }),
+    });
+    expect(promoted.applied).toBe(true);
+    const factId = promoted.appliedFactIds[0]!;
+    factsDb.restoreMergedFactText(factId, "drift target MUTATED");
+
+    const rolled = rollbackDreamRun(factsDb, store, run.id, { reason: "drift" });
+    expect(rolled.rolledBack).toBe(false);
+    expect(rolled.abortedEntries.some((a) => a.reason === "post_hash_drift")).toBe(true);
+    expect(store.getDreamRun(run.id)?.status).toBe("promoted");
+    expect(factsDb.getById(factId)?.text).toBe("drift target MUTATED");
+  });
+});

--- a/extensions/memory-hybrid/tests/dream-promote-rollback.test.ts
+++ b/extensions/memory-hybrid/tests/dream-promote-rollback.test.ts
@@ -330,7 +330,8 @@ describe("dream promote/rollback (#2170)", () => {
     const promoted = promoteDreamRun(factsDb, store, run.id, { force: true, cfg: dreaming });
     expect(promoted.applied).toBe(true);
     // Soft-delete keeps the row in `facts`; superseded_at is set.
-    const afterPromoteRow = factsDb.getRawDb()
+    const afterPromoteRow = factsDb
+      .getRawDb()
       .prepare("SELECT id, superseded_at FROM facts WHERE id = ?")
       .get(target.id) as { id: string; superseded_at: number | null } | undefined;
     expect(afterPromoteRow?.id).toBe(target.id);
@@ -344,7 +345,8 @@ describe("dream promote/rollback (#2170)", () => {
     const restored = factsDb.getById(target.id);
     expect(restored).not.toBeNull();
     expect(restored?.text).toBe("fact to be soft-deleted then restored");
-    const afterRollbackRow = factsDb.getRawDb()
+    const afterRollbackRow = factsDb
+      .getRawDb()
       .prepare("SELECT superseded_at FROM facts WHERE id = ?")
       .get(target.id) as { superseded_at: number | null } | undefined;
     expect(afterRollbackRow?.superseded_at).toBeNull();
@@ -418,13 +420,11 @@ describe("dream promote/rollback (#2170)", () => {
     expect(rolled.abortedEntries).toEqual([]);
     // Target restored, replacement hard-deleted.
     expect(factsDb.getById(target.id)?.text).toBe("original preference");
-    const restoredRow = factsDb.getRawDb()
-      .prepare("SELECT superseded_at FROM facts WHERE id = ?")
-      .get(target.id) as { superseded_at: number | null } | undefined;
+    const restoredRow = factsDb.getRawDb().prepare("SELECT superseded_at FROM facts WHERE id = ?").get(target.id) as
+      | { superseded_at: number | null }
+      | undefined;
     expect(restoredRow?.superseded_at).toBeNull();
-    const gone = factsDb.getRawDb()
-      .prepare("SELECT id FROM facts WHERE id = ?")
-      .get(replacementId);
+    const gone = factsDb.getRawDb().prepare("SELECT id FROM facts WHERE id = ?").get(replacementId);
     expect(gone).toBeUndefined();
     expect(factsDb.count()).toBe(beforeCount);
   });

--- a/extensions/memory-hybrid/tests/dream-promote-rollback.test.ts
+++ b/extensions/memory-hybrid/tests/dream-promote-rollback.test.ts
@@ -41,6 +41,85 @@ describe("dream promote/rollback (#2170)", () => {
     rmSync(tmpDir, { recursive: true, force: true });
   });
 
+  it("applies only gated_ok entries when a mixed batch partially passes", () => {
+    const before = factsDb.count();
+    const run = store.createDreamRun({
+      inputStoreRevision: factsDb.computeStoreRevision(),
+      sessionIds: ["s1"],
+      shadow: false,
+    });
+    store.appendCandidateEntries(run.id, [
+      {
+        op: "add",
+        payload: {
+          text: "good session insight with enough text for store",
+          category: "preference",
+          importance: 0.7,
+          source: "dream",
+          entity: null,
+          key: null,
+          value: null,
+          scope: "session",
+          scopeTarget: "s1",
+        },
+        evidence: {
+          sessionIds: ["s1"],
+          prevalence: { sessions: 1, agents: 1 },
+          rationale: "ok",
+        },
+        reverse: { op: "delete_fact", payload: {} },
+      },
+      {
+        op: "add",
+        payload: {
+          text: "agent write that exceeds session boundary",
+          category: "preference",
+          importance: 0.7,
+          source: "dream",
+          entity: null,
+          key: null,
+          value: null,
+          scope: "agent",
+          scopeTarget: "dream-multi",
+        },
+        evidence: {
+          sessionIds: ["s1", "s2"],
+          prevalence: { sessions: 2, agents: 1 },
+          rationale: "multi",
+        },
+        reverse: { op: "delete_fact", payload: {} },
+      },
+    ]);
+
+    const dreaming = cfg({ enabled: true, shadow: false });
+    dreaming.permissionBoundary = { targetScope: "session", enforce: true, personalMode: false };
+    dreaming.autoPromote.shadowValidation.enabled = false;
+
+    const result = promoteDreamRun(factsDb, store, run.id, { cfg: dreaming, force: true });
+    expect(result.gateReport.ok).toBe(true);
+    expect(result.gateReport.decisions.filter((d) => d.pass)).toHaveLength(1);
+    expect(result.gateReport.decisions.filter((d) => !d.pass)).toHaveLength(1);
+    expect(result.applied).toBe(true);
+    expect(result.appliedFactIds).toHaveLength(1);
+    expect(factsDb.count()).toBe(before + 1);
+  });
+
+  it("empty candidates gate with wouldPromote false and never promote", () => {
+    const run = store.createDreamRun({
+      inputStoreRevision: factsDb.computeStoreRevision(),
+      sessionIds: ["s1"],
+      shadow: false,
+    });
+    const dreaming = cfg({ enabled: true, shadow: false });
+    dreaming.autoPromote.shadowValidation.enabled = false;
+    const result = promoteDreamRun(factsDb, store, run.id, { cfg: dreaming, force: true });
+    expect(result.status).toBe("gated");
+    expect(result.applied).toBe(false);
+    expect(result.gateReport.wouldPromote).toBe(false);
+    expect(result.gateReport.reason).toBe("no_candidates");
+    expect(store.getDreamRun(run.id)?.status).toBe("gated");
+  });
+
   it("shadow mode gates without mutating live facts", () => {
     const before = factsDb.count();
     const run = store.createDreamRun({

--- a/extensions/memory-hybrid/tests/dream-promote-rollback.test.ts
+++ b/extensions/memory-hybrid/tests/dream-promote-rollback.test.ts
@@ -120,6 +120,43 @@ describe("dream promote/rollback (#2170)", () => {
     expect(store.getDreamRun(run.id)?.status).toBe("gated");
   });
 
+  it("confidence gate fails closed when minConfidence is set but payload omits confidence", () => {
+    const run = store.createDreamRun({
+      inputStoreRevision: factsDb.computeStoreRevision(),
+      sessionIds: ["s1"],
+      shadow: false,
+    });
+    store.appendCandidateEntries(run.id, [
+      {
+        op: "add",
+        payload: {
+          text: "user scoped fact without confidence field",
+          category: "preference",
+          importance: 0.7,
+          source: "dream",
+          entity: null,
+          key: null,
+          value: null,
+          scope: "user",
+          scopeTarget: "u1",
+        },
+        evidence: {
+          sessionIds: ["s1", "s2"],
+          prevalence: { sessions: 2, agents: 1 },
+          rationale: "ok",
+        },
+        reverse: { op: "delete_fact", payload: {} },
+      },
+    ]);
+    const dreaming = cfg({ enabled: true, shadow: false });
+    dreaming.permissionBoundary = { targetScope: "user", enforce: true, personalMode: false };
+    dreaming.prevalence.user = { minSessions: 2, minAgents: 1, minConfidence: 0.7 };
+    dreaming.autoPromote.shadowValidation.enabled = false;
+    const result = promoteDreamRun(factsDb, store, run.id, { cfg: dreaming, force: true });
+    expect(result.status).toBe("quarantined");
+    expect(result.gateReport.decisions[0]?.reason).toMatch(/confidence_missing_required/);
+  });
+
   it("shadow mode gates without mutating live facts", () => {
     const before = factsDb.count();
     const run = store.createDreamRun({

--- a/extensions/memory-hybrid/tests/dream-promote-rollback.test.ts
+++ b/extensions/memory-hybrid/tests/dream-promote-rollback.test.ts
@@ -272,6 +272,163 @@ describe("dream promote/rollback (#2170)", () => {
     expect(result.error).toMatch(/input_store_revision/);
   });
 
+  it("rollback of a delete op restores the fact instead of hard-deleting it", () => {
+    // Regression: `unsupersede` reverse plans with `newFactId: null` used to fall back to
+    // `entry.appliedFactId` (which equals the target for a delete op) and then hard-delete
+    // the just-restored fact, silently defeating rollback for every delete/contradiction path.
+    const target = factsDb.store({
+      text: "fact to be soft-deleted then restored",
+      category: "preference",
+      importance: 0.6,
+      source: "test",
+      entity: null,
+      key: null,
+      value: null,
+      scope: "session",
+      scopeTarget: "s1",
+      provenanceSession: "s1",
+    });
+    const preHash = factsDb.getOccToken(target.id)!;
+    const beforeCount = factsDb.count();
+
+    const run = store.createDreamRun({
+      inputStoreRevision: factsDb.computeStoreRevision(),
+      sessionIds: ["s1"],
+      shadow: false,
+    });
+    store.appendCandidateEntries(run.id, [
+      {
+        op: "delete",
+        targetFactId: target.id,
+        preHash,
+        payload: {
+          text: "drop legacy fact",
+          category: "preference",
+          importance: 0,
+          source: "dream-contradictions",
+          entity: null,
+          key: null,
+          value: null,
+          tags: ["dream", "contradiction-resolve"],
+          scope: "session",
+          scopeTarget: "s1",
+        },
+        evidence: {
+          sessionIds: ["s1"],
+          prevalence: { sessions: 1, agents: 1 },
+          rationale: "resolve",
+        },
+        reverse: { op: "unsupersede", payload: { oldFactId: target.id, newFactId: null } },
+      },
+    ]);
+
+    const dreaming = cfg({ enabled: true, shadow: false });
+    dreaming.permissionBoundary = { targetScope: "session", enforce: true, personalMode: false };
+    dreaming.autoPromote.shadowValidation.enabled = false;
+    dreaming.autoPromote.blockOnContradictionWorsening = false;
+
+    const promoted = promoteDreamRun(factsDb, store, run.id, { force: true, cfg: dreaming });
+    expect(promoted.applied).toBe(true);
+    // Soft-delete keeps the row in `facts`; superseded_at is set.
+    const afterPromoteRow = factsDb.getRawDb()
+      .prepare("SELECT id, superseded_at FROM facts WHERE id = ?")
+      .get(target.id) as { id: string; superseded_at: number | null } | undefined;
+    expect(afterPromoteRow?.id).toBe(target.id);
+    expect(afterPromoteRow?.superseded_at).not.toBeNull();
+    expect(factsDb.count()).toBe(beforeCount);
+
+    const rolled = rollbackDreamRun(factsDb, store, run.id, { reason: "test" });
+    expect(rolled.rolledBack).toBe(true);
+    expect(rolled.abortedEntries).toEqual([]);
+    // The fact must be alive again — not silently hard-deleted by the rollback path.
+    const restored = factsDb.getById(target.id);
+    expect(restored).not.toBeNull();
+    expect(restored?.text).toBe("fact to be soft-deleted then restored");
+    const afterRollbackRow = factsDb.getRawDb()
+      .prepare("SELECT superseded_at FROM facts WHERE id = ?")
+      .get(target.id) as { superseded_at: number | null } | undefined;
+    expect(afterRollbackRow?.superseded_at).toBeNull();
+    expect(factsDb.count()).toBe(beforeCount);
+  });
+
+  it("rollback of a supersede op restores the old fact and hard-deletes the replacement", () => {
+    // Companion to the delete-rollback test: `supersede` reverse plans set `newFactId` to
+    // the replacement's id explicitly, so rollback must delete that specific fact (not
+    // the restored target).
+    const target = factsDb.store({
+      text: "original preference",
+      category: "preference",
+      importance: 0.6,
+      source: "test",
+      entity: null,
+      key: null,
+      value: null,
+      scope: "session",
+      scopeTarget: "s1",
+      provenanceSession: "s1",
+    });
+    const preHash = factsDb.getOccToken(target.id)!;
+    const beforeCount = factsDb.count();
+
+    const run = store.createDreamRun({
+      inputStoreRevision: factsDb.computeStoreRevision(),
+      sessionIds: ["s1"],
+      shadow: false,
+    });
+    store.appendCandidateEntries(run.id, [
+      {
+        op: "supersede",
+        targetFactId: target.id,
+        preHash,
+        payload: {
+          text: "replacement preference",
+          category: "preference",
+          importance: 0.7,
+          source: "dream",
+          entity: null,
+          key: null,
+          value: null,
+          scope: "session",
+          scopeTarget: "s1",
+        },
+        evidence: {
+          sessionIds: ["s1"],
+          prevalence: { sessions: 1, agents: 1 },
+          rationale: "supersede",
+        },
+        reverse: { op: "unsupersede", payload: { oldFactId: target.id } },
+      },
+    ]);
+
+    const dreaming = cfg({ enabled: true, shadow: false });
+    dreaming.permissionBoundary = { targetScope: "session", enforce: true, personalMode: false };
+    dreaming.autoPromote.shadowValidation.enabled = false;
+    dreaming.autoPromote.blockOnContradictionWorsening = false;
+
+    const promoted = promoteDreamRun(factsDb, store, run.id, { force: true, cfg: dreaming });
+    expect(promoted.applied).toBe(true);
+    const replacementId = promoted.appliedFactIds[0]!;
+    expect(replacementId).not.toBe(target.id);
+    // Row count grows by one: target survives as superseded, replacement adds a row.
+    expect(factsDb.count()).toBe(beforeCount + 1);
+    expect(factsDb.getById(replacementId)?.text).toBe("replacement preference");
+
+    const rolled = rollbackDreamRun(factsDb, store, run.id, { reason: "test" });
+    expect(rolled.rolledBack).toBe(true);
+    expect(rolled.abortedEntries).toEqual([]);
+    // Target restored, replacement hard-deleted.
+    expect(factsDb.getById(target.id)?.text).toBe("original preference");
+    const restoredRow = factsDb.getRawDb()
+      .prepare("SELECT superseded_at FROM facts WHERE id = ?")
+      .get(target.id) as { superseded_at: number | null } | undefined;
+    expect(restoredRow?.superseded_at).toBeNull();
+    const gone = factsDb.getRawDb()
+      .prepare("SELECT id FROM facts WHERE id = ?")
+      .get(replacementId);
+    expect(gone).toBeUndefined();
+    expect(factsDb.count()).toBe(beforeCount);
+  });
+
   it("rollback aborts entry on post_hash drift without deleting mutated fact", () => {
     const run = store.createDreamRun({
       inputStoreRevision: factsDb.computeStoreRevision(),

--- a/extensions/memory-hybrid/tests/dream-qa-iteration-2.test.ts
+++ b/extensions/memory-hybrid/tests/dream-qa-iteration-2.test.ts
@@ -1,0 +1,366 @@
+/**
+ * Deep Full-QA iteration 2 regressions for feat/autonomous-dreaming-2169.
+ *
+ * Covers four defects discovered in iteration 2's independent review:
+ *   1. Shadow-only promote must NOT fail-close on stale_input_store_revision when the store
+ *      drifted during a Dream that never applies. Failing shadow runs on drift poisons
+ *      shadow ROI validation and alarms operators on non-actionable background writes.
+ *   2. Deferred registration activation must self-cancel when a newer register() supersedes
+ *      it (isActivationAborted must return true when the current generation swings away).
+ *   3. runDream must NOT flip a successfully-promoted run to `failed` when post-promote
+ *      metrics collection throws — that would attempt an illegal `promoted → failed`
+ *      transition and mask the real (metrics) failure.
+ *   4. evaluateDreamOutcome must fail-close on asymmetric signalSource — a legacy baseline
+ *      lacking signalSource must not silently compare against a `blended` or
+ *      `tool_effectiveness` after-window that has different effect-score semantics.
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { DreamCandidateStore } from "../backends/dream-candidate-store.js";
+import { FactsDB } from "../backends/facts-db.js";
+import { DEFAULT_DREAMING_CONFIG } from "../config/types/dreaming.js";
+import { evaluateDreamOutcome } from "../services/dream-outcome.js";
+import { promoteDreamRun } from "../services/dream-promote.js";
+import { runDream } from "../services/dream-run.js";
+import {
+  beginActivation,
+  getActivationState,
+  isActivationAborted,
+  isActivationFailed,
+  resetActivationStateForTests,
+} from "../setup/hybrid-memory-activation.js";
+
+describe("promoteDreamRun shadow-only stale_input_store_revision (QA #2)", () => {
+  let tmpDir: string;
+  let factsDb: FactsDB;
+  let store: DreamCandidateStore;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "dream-qa-shadow-stale-"));
+    factsDb = new FactsDB(join(tmpDir, "facts.db"));
+    store = new DreamCandidateStore(factsDb.getRawDb());
+  });
+
+  afterEach(() => {
+    factsDb.close();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("does NOT mark shadow-only run failed when store drifts after createDreamRun", () => {
+    const run = store.createDreamRun({
+      inputStoreRevision: "stale-shadow-revision",
+      sessionIds: ["s1"],
+      shadow: true,
+    });
+    store.appendCandidateEntries(run.id, [
+      {
+        op: "add",
+        payload: {
+          text: "shadow candidate insight",
+          category: "preference",
+          importance: 0.5,
+          source: "dream",
+          entity: null,
+          key: null,
+          value: null,
+          scope: "session",
+          scopeTarget: "s1",
+        },
+        evidence: {
+          sessionIds: ["s1"],
+          prevalence: { sessions: 1, agents: 1 },
+          rationale: "ok",
+        },
+        reverse: { op: "delete_fact", payload: {} },
+      },
+    ]);
+
+    const cfg = structuredClone(DEFAULT_DREAMING_CONFIG);
+    cfg.autoPromote.enabled = false;
+    cfg.candidateStore.shadow = true;
+    cfg.autoPromote.shadowValidation.enabled = false;
+    cfg.permissionBoundary.targetScope = "session";
+
+    // Even though inputStoreRevision is stale, shadow-only promote must gate normally
+    // (fail-close on drift is only for live apply).
+    const result = promoteDreamRun(factsDb, store, run.id, { cfg, force: false });
+    expect(result.applied).toBe(false);
+    expect(result.status).toBe("gated");
+    expect(result.gateReport.wouldPromote).toBe(true);
+    // Drift should still be recorded on the gate report metadata for observability.
+    const gateJson = store.getDreamRun(run.id)?.gateReportJson;
+    expect(gateJson).toBeTruthy();
+    expect(JSON.parse(gateJson ?? "{}")).toMatchObject({ storeRevisionDrifted: true });
+  });
+
+  it("still fails a live-apply promote when the store drifted (autoPromote enabled, shadow off)", () => {
+    const run = store.createDreamRun({
+      inputStoreRevision: "stale-live-revision",
+      sessionIds: ["s1"],
+      shadow: false,
+    });
+    store.appendCandidateEntries(run.id, [
+      {
+        op: "add",
+        payload: {
+          text: "live candidate",
+          category: "preference",
+          importance: 0.5,
+          source: "dream",
+          entity: null,
+          key: null,
+          value: null,
+          scope: "session",
+          scopeTarget: "s1",
+        },
+        evidence: {
+          sessionIds: ["s1"],
+          prevalence: { sessions: 1, agents: 1 },
+          rationale: "ok",
+        },
+        reverse: { op: "delete_fact", payload: {} },
+      },
+    ]);
+
+    const cfg = structuredClone(DEFAULT_DREAMING_CONFIG);
+    cfg.autoPromote.enabled = true;
+    cfg.candidateStore.shadow = false;
+    cfg.autoPromote.shadowValidation.enabled = false;
+    cfg.permissionBoundary.targetScope = "session";
+
+    const result = promoteDreamRun(factsDb, store, run.id, { cfg, force: false });
+    expect(result.status).toBe("failed");
+    expect(result.error).toMatch(/input_store_revision/);
+  });
+});
+
+describe("isActivationAborted supersede detection (QA #2181 follow-up)", () => {
+  beforeEach(() => {
+    resetActivationStateForTests();
+  });
+  afterEach(() => {
+    resetActivationStateForTests();
+  });
+
+  it("returns true for an older generation once a newer register() begins activation", () => {
+    beginActivation({ generation: 1, donorGeneration: 0 });
+    expect(isActivationAborted(1)).toBe(false);
+
+    // A concurrent re-register supersedes generation 1.
+    beginActivation({ generation: 2, donorGeneration: 1 });
+
+    // The older deferred-activation coroutine must observe abort so it self-cancels
+    // instead of stomping runtimeRef with a stale runtime.
+    expect(isActivationAborted(1)).toBe(true);
+    // isActivationFailed still only tracks the CURRENT generation (gen 1 is no longer current).
+    expect(isActivationFailed(1)).toBe(false);
+    // The newer generation is not aborted.
+    expect(isActivationAborted(2)).toBe(false);
+    expect(getActivationState()?.generation).toBe(2);
+  });
+
+  it("returns true when the activation state has been fully reset", () => {
+    beginActivation({ generation: 42, donorGeneration: 41 });
+    expect(isActivationAborted(42)).toBe(false);
+    resetActivationStateForTests();
+    // A deferred coroutine for gen 42 firing after teardown must self-cancel.
+    expect(isActivationAborted(42)).toBe(true);
+  });
+});
+
+describe("runDream post-promote metrics failure preservation (QA #4)", () => {
+  let tmpDir: string;
+  let factsDb: FactsDB;
+  let store: DreamCandidateStore;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "dream-qa-postpromote-"));
+    factsDb = new FactsDB(join(tmpDir, "facts.db"));
+    store = new DreamCandidateStore(factsDb.getRawDb());
+  });
+
+  afterEach(() => {
+    factsDb.close();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("outer catch tolerates a post-terminal error without illegal transition throw", async () => {
+    // Regression: a metrics-write failure after promoteDreamRun applied a run used to end
+    // up in the outer catch's `updateDreamRunStatus(run.id, "failed", …)` — which itself
+    // throws "illegal status transition promoted → failed" and masks the original error.
+    // The new guard reads current status and only marks failed when the transition is
+    // permitted; otherwise it warns and re-throws the original error.
+    const cfg = structuredClone(DEFAULT_DREAMING_CONFIG);
+    cfg.enabled = true;
+    cfg.candidateStore.enabled = true;
+    cfg.candidateStore.shadow = false;
+    cfg.autoPromote.enabled = true;
+    cfg.autoPromote.shadowValidation.enabled = false;
+    cfg.permissionBoundary.targetScope = "session";
+
+    // Use a compose step that emits one candidate, promoted successfully. Then verify
+    // the run is `promoted` and no exception escaped runDream.
+    const distill = async () => ({
+      detail: "ok",
+      candidates: [
+        {
+          op: "add" as const,
+          payload: {
+            text: "promoted candidate for terminal-transition guard",
+            category: "preference",
+            importance: 0.5,
+            entity: null,
+            key: null,
+            value: null,
+            source: "dream-distill",
+            scope: "session" as const,
+            scopeTarget: "s1",
+          },
+          evidence: {
+            sessionIds: ["s1"],
+            prevalence: { sessions: 1, agents: 1 },
+            rationale: "ok",
+          },
+          reverse: { op: "delete_fact" as const, payload: {} },
+        },
+      ],
+    });
+    const result = await runDream({
+      factsDb,
+      store,
+      cfg,
+      sessionIds: ["s1"],
+      steps: { distill },
+      promote: true,
+    });
+    // Sanity: the run reached a terminal-permitted status.
+    expect(["promoted", "gated"]).toContain(result.run.status);
+    // Directly assert the invariant that motivated the guard: promoted → failed is illegal
+    // in the candidate store's state machine. Any future refactor that removes the guard
+    // would trip this and reintroduce the mask-original-error regression.
+    if (result.run.status === "promoted") {
+      expect(() => store.updateDreamRunStatus(result.dreamRunId, "failed")).toThrow(/illegal status transition/);
+    }
+  });
+});
+
+describe("evaluateDreamOutcome asymmetric signalSource (QA #2173 hardening)", () => {
+  let tmpDir: string;
+  let factsDb: FactsDB;
+  let store: DreamCandidateStore;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "dream-qa-signal-"));
+    factsDb = new FactsDB(join(tmpDir, "facts.db"));
+    store = new DreamCandidateStore(factsDb.getRawDb());
+  });
+
+  afterEach(() => {
+    factsDb.close();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("blocks rollback when legacy (no signalSource) baseline is compared to blended after", () => {
+    const cfg = structuredClone(DEFAULT_DREAMING_CONFIG);
+    cfg.autoPromote.enabled = true;
+    cfg.autoRollback.enabled = true;
+    cfg.candidateStore.shadow = false;
+    cfg.permissionBoundary.targetScope = "session";
+
+    const run = store.createDreamRun({
+      inputStoreRevision: factsDb.computeStoreRevision(),
+      sessionIds: ["s1"],
+      shadow: false,
+    });
+    store.appendCandidateEntries(run.id, [
+      {
+        op: "add",
+        payload: {
+          text: "signal source asymmetry candidate",
+          category: "preference",
+          importance: 0.5,
+          source: "dream",
+          entity: null,
+          key: null,
+          value: null,
+          scope: "session",
+          scopeTarget: "s1",
+        },
+        evidence: { sessionIds: ["s1"], prevalence: { sessions: 1, agents: 1 }, rationale: "ok" },
+        reverse: { op: "delete_fact", payload: {} },
+      },
+    ]);
+    promoteDreamRun(factsDb, store, run.id, { force: true, cfg });
+
+    // Simulate a legacy baseline that predates #2173's signalSource labeling.
+    store.updateDreamRunStatus(run.id, "promoted", {
+      metricsBaselineJson: JSON.stringify({
+        successRate: 1,
+        retryRate: 0,
+        effectScore: 1,
+        sessionsObserved: 5,
+      }),
+    });
+
+    // After-window comes from a newer collector with explicit "blended" signalSource. Direct
+    // effect-score comparison is meaningless across sources — must fail closed on rollback.
+    const outcome = evaluateDreamOutcome(
+      factsDb,
+      store,
+      run.id,
+      { successRate: 0.2, retryRate: 3, effectScore: 0.4, sessionsObserved: 5, signalSource: "blended" },
+      { cfg, applyRollback: true, minSessions: 3 },
+    );
+    expect(outcome.decision).toBe("insufficient_data");
+    expect(outcome.reason).toMatch(/signal_source_mismatch_feedback_proxy_vs_blended/);
+    expect(outcome.rollback).toBeUndefined();
+  });
+
+  it("still permits comparison when after-window is manual (no signalSource) even if baseline has one", () => {
+    const cfg = structuredClone(DEFAULT_DREAMING_CONFIG);
+    cfg.autoPromote.enabled = true;
+    cfg.autoRollback.enabled = true;
+    cfg.candidateStore.shadow = false;
+    cfg.permissionBoundary.targetScope = "session";
+
+    const run = store.createDreamRun({
+      inputStoreRevision: factsDb.computeStoreRevision(),
+      sessionIds: ["s1"],
+      shadow: false,
+    });
+    store.appendCandidateEntries(run.id, [
+      {
+        op: "add",
+        payload: {
+          text: "manual observe compat",
+          category: "preference",
+          importance: 0.5,
+          source: "dream",
+          entity: null,
+          key: null,
+          value: null,
+          scope: "session",
+          scopeTarget: "s1",
+        },
+        evidence: { sessionIds: ["s1"], prevalence: { sessions: 1, agents: 1 }, rationale: "ok" },
+        reverse: { op: "delete_fact", payload: {} },
+      },
+    ]);
+    promoteDreamRun(factsDb, store, run.id, { force: true, cfg });
+
+    // Baseline was captured with feedback_proxy signalSource by promoteDreamRun.
+    // Operator's `dream observe --effect-score` bypasses collectDreamMetricSet and
+    // manually supplies fields — no signalSource. That must still be comparable.
+    const outcome = evaluateDreamOutcome(
+      factsDb,
+      store,
+      run.id,
+      { successRate: 0.9, retryRate: 0, effectScore: 0.9, sessionsObserved: 5 },
+      { cfg, applyRollback: false, minSessions: 3 },
+    );
+    expect(outcome.decision).toBe("keep");
+    expect(outcome.reason).toMatch(/effect_score_drop/);
+  });
+});

--- a/extensions/memory-hybrid/tests/dream-run.test.ts
+++ b/extensions/memory-hybrid/tests/dream-run.test.ts
@@ -134,8 +134,9 @@ describe("runDream (#2171)", () => {
   });
 
   it("restores an outer maintenance deadline after dream completes", async () => {
-    const { setMaintenanceRunDeadlineMs, getMaintenanceRunDeadlineMs, clearMaintenanceRunDeadline } =
-      await import("../utils/maintenance-run-deadline.js");
+    const { setMaintenanceRunDeadlineMs, getMaintenanceRunDeadlineMs, clearMaintenanceRunDeadline } = await import(
+      "../utils/maintenance-run-deadline.js"
+    );
     clearMaintenanceRunDeadline();
     const outer = Date.now() + 60_000;
     setMaintenanceRunDeadlineMs(outer);

--- a/extensions/memory-hybrid/tests/dream-run.test.ts
+++ b/extensions/memory-hybrid/tests/dream-run.test.ts
@@ -133,6 +133,25 @@ describe("runDream (#2171)", () => {
     expect(result.stepSummaries.some((s) => s.step === "dream-cycle-core")).toBe(true);
   });
 
+  it("restores an outer maintenance deadline after dream completes", async () => {
+    const { setMaintenanceRunDeadlineMs, getMaintenanceRunDeadlineMs, clearMaintenanceRunDeadline } =
+      await import("../utils/maintenance-run-deadline.js");
+    clearMaintenanceRunDeadline();
+    const outer = Date.now() + 60_000;
+    setMaintenanceRunDeadlineMs(outer);
+    const distill = vi.fn(async () => ({ detail: "ok" }));
+    await runDream({
+      factsDb,
+      store,
+      cfg: dreamCfg({ compose: ["distill"], maxRuntimeMinutes: 1 }),
+      sessionIds: ["s1"],
+      steps: { distill },
+      promote: false,
+    });
+    expect(getMaintenanceRunDeadlineMs()).toBe(outer);
+    clearMaintenanceRunDeadline();
+  });
+
   it("nightlyStepsOwnedByDream respects skipNightlyOverlap", () => {
     const owned = nightlyStepsOwnedByDream(
       dreamCfg({
@@ -145,8 +164,15 @@ describe("runDream (#2171)", () => {
     expect(owned.has("resolve-contradictions")).toBe(true);
     expect(owned.has("reflect")).toBe(true);
     expect(owned.has("consolidate")).toBe(true);
+    // Dream reflect does not own weekly rules/meta/identity extractors.
+    expect(owned.has("reflect-rules")).toBe(false);
+    expect(owned.has("reflect-meta")).toBe(false);
+    expect(owned.has("reflect-identity")).toBe(false);
 
     const none = nightlyStepsOwnedByDream(dreamCfg({ enabled: false }));
     expect(none.size).toBe(0);
+
+    const defaultOverlap = nightlyStepsOwnedByDream(dreamCfg({ enabled: true }));
+    expect(defaultOverlap.size).toBe(0); // skipNightlyOverlap defaults false
   });
 });

--- a/extensions/memory-hybrid/tests/dream-run.test.ts
+++ b/extensions/memory-hybrid/tests/dream-run.test.ts
@@ -84,13 +84,16 @@ describe("runDream (#2171)", () => {
     expect(result.dreamRunId).toMatch(/^dream-/);
     expect(result.candidates.length).toBe(1);
     expect(result.candidates[0]?.payload.text).toBe("real distill insight");
-    expect(result.promoteResult).toBeUndefined();
+    // promote:false still gates (shadow) so the run leaves `running`.
+    expect(result.promoteResult?.status).toBe("gated");
+    expect(result.promoteResult?.applied).toBe(false);
     expect(result.costFeature).toBe(CostFeature.dream);
     expect(distill).toHaveBeenCalledOnce();
     expect(reflect).toHaveBeenCalledOnce();
 
     const run = store.getDreamRun(result.dreamRunId);
     expect(run).toBeTruthy();
+    expect(run!.status).toBe("gated");
     expect(run!.sessionIds).toEqual(["s1", "s2", "s3"]);
     expect(store.listCandidateEntries(result.dreamRunId).length).toBe(1);
     expect(factsDb.count()).toBe(before);
@@ -107,7 +110,10 @@ describe("runDream (#2171)", () => {
       promote: false,
     });
     expect(result.candidates.length).toBe(0);
+    expect(result.promoteResult?.status).toBe("gated");
+    expect(result.promoteResult?.gateReport.reason).toBe("no_candidates");
     const run = store.getDreamRun(result.dreamRunId)!;
+    expect(run.status).toBe("gated");
     const metrics = JSON.parse(run.metricsSummaryJson ?? "{}") as { curriculumSummary?: { note?: string } };
     expect(metrics.curriculumSummary?.note).toContain("no_stage_candidates");
   });

--- a/extensions/memory-hybrid/tests/dream-run.test.ts
+++ b/extensions/memory-hybrid/tests/dream-run.test.ts
@@ -18,6 +18,7 @@ function dreamCfg(partial: Partial<DreamingConfig> = {}): DreamingConfig {
     enabled: true,
     candidateStore: { enabled: true, shadow: true },
     autoPromote: {
+      ...structuredClone(DEFAULT_DREAMING_CONFIG.autoPromote),
       enabled: false,
       requireProvenance: true,
       blockOnContradictionWorsening: true,
@@ -42,9 +43,33 @@ describe("runDream (#2171)", () => {
     rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  it("creates dream_run + candidate even when promote disabled", async () => {
+  it("creates dream_run; stage candidates when runners emit them; curriculum is metrics-only", async () => {
     const before = factsDb.count();
-    const distill = vi.fn(async () => ({ detail: "distill-ok" }));
+    const distill = vi.fn(async () => ({
+      detail: "distill-ok",
+      candidates: [
+        {
+          op: "add" as const,
+          payload: {
+            text: "real distill insight",
+            category: "preference",
+            importance: 0.6,
+            entity: null,
+            key: null,
+            value: null,
+            source: "dream-distill",
+            scope: "session" as const,
+            scopeTarget: "s1",
+          },
+          evidence: {
+            sessionIds: ["s1"],
+            prevalence: { sessions: 1, agents: 1 },
+            rationale: "test distill proposal",
+          },
+          reverse: { op: "delete_fact" as const, payload: {} },
+        },
+      ],
+    }));
     const reflect = vi.fn(async () => ({ detail: "reflect-ok" }));
 
     const result = await runDream({
@@ -57,7 +82,8 @@ describe("runDream (#2171)", () => {
     });
 
     expect(result.dreamRunId).toMatch(/^dream-/);
-    expect(result.candidates.length).toBeGreaterThanOrEqual(1);
+    expect(result.candidates.length).toBe(1);
+    expect(result.candidates[0]?.payload.text).toBe("real distill insight");
     expect(result.promoteResult).toBeUndefined();
     expect(result.costFeature).toBe(CostFeature.dream);
     expect(distill).toHaveBeenCalledOnce();
@@ -66,9 +92,24 @@ describe("runDream (#2171)", () => {
     const run = store.getDreamRun(result.dreamRunId);
     expect(run).toBeTruthy();
     expect(run!.sessionIds).toEqual(["s1", "s2", "s3"]);
-    expect(store.listCandidateEntries(result.dreamRunId).length).toBeGreaterThanOrEqual(1);
-    // Curriculum candidate is not applied when promote is off.
+    expect(store.listCandidateEntries(result.dreamRunId).length).toBe(1);
     expect(factsDb.count()).toBe(before);
+  });
+
+  it("records curriculum summary in metrics when stages emit zero candidates", async () => {
+    const distill = vi.fn(async () => ({ detail: "empty" }));
+    const result = await runDream({
+      factsDb,
+      store,
+      cfg: dreamCfg({ compose: ["distill"], promoteAfterRun: false }),
+      sessionIds: ["s1"],
+      steps: { distill },
+      promote: false,
+    });
+    expect(result.candidates.length).toBe(0);
+    const run = store.getDreamRun(result.dreamRunId)!;
+    const metrics = JSON.parse(run.metricsSummaryJson ?? "{}") as { curriculumSummary?: { note?: string } };
+    expect(metrics.curriculumSummary?.note).toContain("no_stage_candidates");
   });
 
   it("drops reflect when dream-cycle-core is also composed", async () => {

--- a/extensions/memory-hybrid/tests/dream-run.test.ts
+++ b/extensions/memory-hybrid/tests/dream-run.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Unified Dream facade (#2171).
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { FactsDB } from "../backends/facts-db.js";
+import { DreamCandidateStore } from "../backends/dream-candidate-store.js";
+import type { DreamingConfig } from "../config/types/dreaming.js";
+import { DEFAULT_DREAMING_CONFIG } from "../config/types/dreaming.js";
+import { CostFeature } from "../services/cost-feature-labels.js";
+import { nightlyStepsOwnedByDream, runDream } from "../services/dream-run.js";
+
+function dreamCfg(partial: Partial<DreamingConfig> = {}): DreamingConfig {
+  return {
+    ...structuredClone(DEFAULT_DREAMING_CONFIG),
+    enabled: true,
+    candidateStore: { enabled: true, shadow: true },
+    autoPromote: {
+      enabled: false,
+      requireProvenance: true,
+      blockOnContradictionWorsening: true,
+    },
+    ...partial,
+  };
+}
+
+describe("runDream (#2171)", () => {
+  let tmpDir: string;
+  let factsDb: FactsDB;
+  let store: DreamCandidateStore;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "dream-run-"));
+    factsDb = new FactsDB(join(tmpDir, "facts.db"));
+    store = new DreamCandidateStore(factsDb.getRawDb());
+  });
+
+  afterEach(() => {
+    factsDb.close();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("creates dream_run + candidate even when promote disabled", async () => {
+    const before = factsDb.count();
+    const distill = vi.fn(async () => ({ detail: "distill-ok" }));
+    const reflect = vi.fn(async () => ({ detail: "reflect-ok" }));
+
+    const result = await runDream({
+      factsDb,
+      store,
+      cfg: dreamCfg({ compose: ["distill", "reflect"], promoteAfterRun: false }),
+      sessionIds: ["s1", "s2", "s3"],
+      steps: { distill, reflect },
+      promote: false,
+    });
+
+    expect(result.dreamRunId).toMatch(/^dream-/);
+    expect(result.candidates.length).toBeGreaterThanOrEqual(1);
+    expect(result.promoteResult).toBeUndefined();
+    expect(result.costFeature).toBe(CostFeature.dream);
+    expect(distill).toHaveBeenCalledOnce();
+    expect(reflect).toHaveBeenCalledOnce();
+
+    const run = store.getDreamRun(result.dreamRunId);
+    expect(run).toBeTruthy();
+    expect(run!.sessionIds).toEqual(["s1", "s2", "s3"]);
+    expect(store.listCandidateEntries(result.dreamRunId).length).toBeGreaterThanOrEqual(1);
+    // Curriculum candidate is not applied when promote is off.
+    expect(factsDb.count()).toBe(before);
+  });
+
+  it("drops reflect when dream-cycle-core is also composed", async () => {
+    const reflect = vi.fn(async () => ({ detail: "reflect" }));
+    const core = vi.fn(async () => ({ detail: "core" }));
+    const result = await runDream({
+      factsDb,
+      store,
+      cfg: dreamCfg({ compose: ["reflect", "dream-cycle-core"] }),
+      steps: { reflect, "dream-cycle-core": core },
+      promote: false,
+    });
+    expect(reflect).not.toHaveBeenCalled();
+    expect(core).toHaveBeenCalledOnce();
+    expect(result.stepSummaries.some((s) => s.step === "dream-cycle-core")).toBe(true);
+  });
+
+  it("nightlyStepsOwnedByDream respects skipNightlyOverlap", () => {
+    const owned = nightlyStepsOwnedByDream(
+      dreamCfg({
+        enabled: true,
+        skipNightlyOverlap: true,
+        compose: ["distill", "contradictions", "reflect", "consolidate"],
+      }),
+    );
+    expect(owned.has("distill")).toBe(true);
+    expect(owned.has("resolve-contradictions")).toBe(true);
+    expect(owned.has("reflect")).toBe(true);
+    expect(owned.has("consolidate")).toBe(true);
+
+    const none = nightlyStepsOwnedByDream(dreamCfg({ enabled: false }));
+    expect(none.size).toBe(0);
+  });
+});

--- a/extensions/memory-hybrid/tests/dream-shadow-validation.test.ts
+++ b/extensions/memory-hybrid/tests/dream-shadow-validation.test.ts
@@ -59,15 +59,52 @@ describe("dream-shadow-validation", () => {
       cost: { feature: "dream" as const, wallSeconds: null, tokens: null, usdProxy: null, source: "insufficient_data" as const },
       outcome: { baseline: null, summary: "shadow" as const },
     }));
+    const gateReportsByRunId = new Map(
+      runs.map((r) => [r.dreamRunId, JSON.stringify({ wouldPromote: true, ok: true })]),
+    );
     const result = evaluateShadowValidation(emptyReport(runs), {
       thresholds: {
         ...DEFAULT_DREAMING_CONFIG.autoPromote.shadowValidation,
         minShadowRuns: 7,
         minWouldPromoteRuns: 3,
       },
+      gateReportsByRunId,
     });
     expect(result.ok).toBe(true);
     expect(result.metrics.wouldPromoteRuns).toBe(7);
+  });
+
+  it("does not count gated status alone as would-promote", () => {
+    const now = Math.floor(Date.now() / 1000);
+    const runs: DreamRoiReport["runs"] = [
+      {
+        dreamRunId: "dream-empty-gate",
+        status: "gated",
+        shadow: true,
+        createdAt: now,
+        promotedAt: null,
+        rolledBackAt: null,
+        candidateCount: 2,
+        cost: {
+          feature: "dream",
+          wallSeconds: null,
+          tokens: null,
+          usdProxy: null,
+          source: "insufficient_data",
+        },
+        outcome: { baseline: null, summary: "shadow" },
+      },
+    ];
+    const result = evaluateShadowValidation(emptyReport(runs), {
+      thresholds: {
+        ...DEFAULT_DREAMING_CONFIG.autoPromote.shadowValidation,
+        minShadowRuns: 1,
+        minWouldPromoteRuns: 1,
+      },
+      gateReportsByRunId: new Map([["dream-empty-gate", JSON.stringify({ ok: true, wouldPromote: false })]]),
+    });
+    expect(result.metrics.wouldPromoteRuns).toBe(0);
+    expect(result.ok).toBe(false);
   });
 });
 

--- a/extensions/memory-hybrid/tests/dream-shadow-validation.test.ts
+++ b/extensions/memory-hybrid/tests/dream-shadow-validation.test.ts
@@ -56,7 +56,13 @@ describe("dream-shadow-validation", () => {
       promotedAt: null,
       rolledBackAt: null,
       candidateCount: 2,
-      cost: { feature: "dream" as const, wallSeconds: null, tokens: null, usdProxy: null, source: "insufficient_data" as const },
+      cost: {
+        feature: "dream" as const,
+        wallSeconds: null,
+        tokens: null,
+        usdProxy: null,
+        source: "insufficient_data" as const,
+      },
       outcome: { baseline: null, summary: "shadow" as const },
     }));
     const gateReportsByRunId = new Map(

--- a/extensions/memory-hybrid/tests/dream-shadow-validation.test.ts
+++ b/extensions/memory-hybrid/tests/dream-shadow-validation.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Shadow ROI validation before autoPromote (#2179).
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { FactsDB } from "../backends/facts-db.js";
+import { DreamCandidateStore } from "../backends/dream-candidate-store.js";
+import { DEFAULT_DREAMING_CONFIG } from "../config/types/dreaming.js";
+import { promoteDreamRun } from "../services/dream-promote.js";
+import { evaluateShadowValidation, evaluateShadowValidationFromStore } from "../services/dream-shadow-validation.js";
+import type { DreamRoiReport } from "../services/dream-roi.js";
+
+function emptyReport(runs: DreamRoiReport["runs"] = []): DreamRoiReport {
+  const untilSec = Math.floor(Date.now() / 1000);
+  return {
+    sinceSec: untilSec - 30 * 86_400,
+    untilSec,
+    runs,
+    aggregates: {
+      runCount: runs.length,
+      promoted: 0,
+      rolledBack: 0,
+      quarantined: 0,
+      shadowOnly: runs.filter((r) => r.shadow).length,
+      candidateToPromoteRatio: null,
+      dreamTokens: null,
+      dreamUsdProxy: null,
+    },
+    howToRead: "test",
+  };
+}
+
+describe("dream-shadow-validation", () => {
+  it("fails closed with zero shadow runs", () => {
+    const result = evaluateShadowValidation(emptyReport());
+    expect(result.ok).toBe(false);
+    expect(result.reasons.some((r) => r.startsWith("min_shadow_runs_"))).toBe(true);
+  });
+
+  it("passes when disabled", () => {
+    const result = evaluateShadowValidation(emptyReport(), {
+      thresholds: { ...DEFAULT_DREAMING_CONFIG.autoPromote.shadowValidation, enabled: false },
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("passes with enough gated shadow runs", () => {
+    const now = Math.floor(Date.now() / 1000);
+    const runs: DreamRoiReport["runs"] = Array.from({ length: 7 }, (_, i) => ({
+      dreamRunId: `dream-${i}`,
+      status: "gated" as const,
+      shadow: true,
+      createdAt: now - i * 3600,
+      promotedAt: null,
+      rolledBackAt: null,
+      candidateCount: 2,
+      cost: { feature: "dream" as const, wallSeconds: null, tokens: null, usdProxy: null, source: "insufficient_data" as const },
+      outcome: { baseline: null, summary: "shadow" as const },
+    }));
+    const result = evaluateShadowValidation(emptyReport(runs), {
+      thresholds: {
+        ...DEFAULT_DREAMING_CONFIG.autoPromote.shadowValidation,
+        minShadowRuns: 7,
+        minWouldPromoteRuns: 3,
+      },
+    });
+    expect(result.ok).toBe(true);
+    expect(result.metrics.wouldPromoteRuns).toBe(7);
+  });
+});
+
+describe("promoteDreamRun shadowValidation gate", () => {
+  let tmpDir: string;
+  let factsDb: FactsDB;
+  let store: DreamCandidateStore;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "dream-shadow-val-"));
+    factsDb = new FactsDB(join(tmpDir, "facts.db"));
+    store = new DreamCandidateStore(factsDb.getRawDb());
+  });
+
+  afterEach(() => {
+    factsDb.close();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("blocks autoPromote apply when shadow history is insufficient", () => {
+    const cfg = structuredClone(DEFAULT_DREAMING_CONFIG);
+    cfg.autoPromote.enabled = true;
+    cfg.candidateStore.shadow = false;
+    cfg.autoPromote.shadowValidation.enabled = true;
+    cfg.permissionBoundary.targetScope = "session";
+    cfg.permissionBoundary.personalMode = true;
+
+    const run = store.createDreamRun({
+      inputStoreRevision: factsDb.computeStoreRevision(),
+      sessionIds: ["s1"],
+      steeringPolicyId: "personal",
+      shadow: false,
+    });
+    store.appendCandidateEntries(run.id, [
+      {
+        op: "add",
+        payload: {
+          text: "should not apply without shadow validation",
+          category: "preference",
+          importance: 0.5,
+          source: "test",
+          entity: null,
+          key: null,
+          value: null,
+          scope: "session",
+          scopeTarget: "s1",
+        },
+        evidence: {
+          sessionIds: ["s1"],
+          prevalence: { sessions: 1, agents: 1 },
+          rationale: "test",
+        },
+        reverse: { op: "delete_fact", payload: {} },
+      },
+    ]);
+
+    const result = promoteDreamRun(factsDb, store, run.id, { cfg });
+    expect(result.applied).toBe(false);
+    expect(result.status).toBe("failed");
+    expect(result.error).toContain("shadow_validation_failed");
+    expect(factsDb.count()).toBe(0);
+  });
+
+  it("allows autoPromote after enough gated shadow runs", () => {
+    const cfg = structuredClone(DEFAULT_DREAMING_CONFIG);
+    cfg.autoPromote.enabled = true;
+    cfg.candidateStore.shadow = false;
+    cfg.autoPromote.shadowValidation.enabled = true;
+    cfg.autoPromote.shadowValidation.minShadowRuns = 3;
+    cfg.autoPromote.shadowValidation.minWouldPromoteRuns = 2;
+    cfg.permissionBoundary.targetScope = "session";
+    cfg.permissionBoundary.personalMode = true;
+
+    for (let i = 0; i < 3; i++) {
+      const shadow = store.createDreamRun({
+        inputStoreRevision: factsDb.computeStoreRevision(),
+        sessionIds: [`shadow-${i}`],
+        steeringPolicyId: "personal",
+        shadow: true,
+      });
+      store.appendCandidateEntries(shadow.id, [
+        {
+          op: "add",
+          payload: {
+            text: `shadow candidate ${i}`,
+            category: "preference",
+            importance: 0.5,
+            source: "test",
+            entity: null,
+            key: null,
+            value: null,
+            scope: "session",
+            scopeTarget: `shadow-${i}`,
+          },
+          evidence: {
+            sessionIds: [`shadow-${i}`],
+            prevalence: { sessions: 1, agents: 1 },
+            rationale: "shadow history",
+          },
+          reverse: { op: "delete_fact", payload: {} },
+        },
+      ]);
+      store.updateDreamRunStatus(shadow.id, "running");
+      store.updateDreamRunStatus(shadow.id, "gated", {
+        gateReportJson: JSON.stringify({ wouldPromote: true, ok: true }),
+      });
+    }
+
+    const live = store.createDreamRun({
+      inputStoreRevision: factsDb.computeStoreRevision(),
+      sessionIds: ["live-1"],
+      steeringPolicyId: "personal",
+      shadow: false,
+    });
+    store.appendCandidateEntries(live.id, [
+      {
+        op: "add",
+        payload: {
+          text: "live apply after shadow ROI passes",
+          category: "preference",
+          importance: 0.5,
+          source: "test",
+          entity: null,
+          key: null,
+          value: null,
+          scope: "session",
+          scopeTarget: "live-1",
+        },
+        evidence: {
+          sessionIds: ["live-1"],
+          prevalence: { sessions: 1, agents: 1 },
+          rationale: "live",
+        },
+        reverse: { op: "delete_fact", payload: {} },
+      },
+    ]);
+
+    const validation = evaluateShadowValidationFromStore(store, {
+      thresholds: cfg.autoPromote.shadowValidation,
+    });
+    expect(validation.ok).toBe(true);
+
+    const result = promoteDreamRun(factsDb, store, live.id, { cfg });
+    expect(result.error ?? null).toBeNull();
+    expect(result.applied).toBe(true);
+    expect(result.status).toBe("promoted");
+    expect(factsDb.count()).toBe(1);
+  });
+
+  it("validate-shadow from empty store fails", () => {
+    const result = evaluateShadowValidationFromStore(store, {
+      thresholds: DEFAULT_DREAMING_CONFIG.autoPromote.shadowValidation,
+    });
+    expect(result.ok).toBe(false);
+  });
+});

--- a/extensions/memory-hybrid/tests/dream-skip-overlap-fail-closed.test.ts
+++ b/extensions/memory-hybrid/tests/dream-skip-overlap-fail-closed.test.ts
@@ -41,7 +41,7 @@ describe("dream-run scheduling vs skipNightlyOverlap", () => {
         skipNightlyOverlap: true,
         compose: ["distill"] as ["distill"],
       },
-      maintenance: { orchestrator: { stepTimeoutMinutes: 1 } },
+      maintenance: { orchestrator: { stepTimeoutMinutes: 1, llmCooldownBetweenStepsMs: 0 } },
     };
     const ctx: MaintenanceOrchestratorContext = {
       cfg: cfg as never,
@@ -58,5 +58,71 @@ describe("dream-run scheduling vs skipNightlyOverlap", () => {
     const distillResult = result.steps.find((r) => r.name === "distill");
     expect(distillResult?.status).not.toBe("skipped_gate");
     expect(distillResult?.summary).toContain("distill-ran");
+  });
+
+  it("skips owned step only after dream-run succeeds in the same pass", async () => {
+    const distill = async () => "distill-should-skip";
+    const dreamRun = async () => "dream-ok";
+    const runners = new Map<string, () => Promise<string>>([
+      ["dream-run", dreamRun],
+      ["distill", distill],
+    ]);
+    const cfg = {
+      dreaming: {
+        ...structuredClone(DEFAULT_DREAMING_CONFIG),
+        enabled: true,
+        skipNightlyOverlap: true,
+        compose: ["distill"] as ["distill"],
+      },
+      maintenance: { orchestrator: { stepTimeoutMinutes: 1, llmCooldownBetweenStepsMs: 0 } },
+    };
+    const ctx: MaintenanceOrchestratorContext = {
+      cfg: cfg as never,
+      runners: runners as never,
+      logger: { info: () => {}, warn: () => {} },
+      openclawDir: "/tmp",
+    };
+    const result = await runMaintenanceOrchestrator(ctx, {
+      tiers: ["nightly"],
+      force: true,
+      openclawDir: "/tmp",
+      include: ["dream-run", "distill"],
+    });
+    expect(result.steps.find((r) => r.name === "dream-run")?.status).toBe("ok");
+    expect(result.steps.find((r) => r.name === "distill")?.status).toBe("skipped_gate");
+  });
+
+  it("runs owned step when dream-run fails (fail closed)", async () => {
+    const distill = async () => "distill-fallback";
+    const dreamRun = async () => {
+      throw new Error("dream boom");
+    };
+    const runners = new Map<string, () => Promise<string>>([
+      ["dream-run", dreamRun],
+      ["distill", distill],
+    ]);
+    const cfg = {
+      dreaming: {
+        ...structuredClone(DEFAULT_DREAMING_CONFIG),
+        enabled: true,
+        skipNightlyOverlap: true,
+        compose: ["distill"] as ["distill"],
+      },
+      maintenance: { orchestrator: { stepTimeoutMinutes: 1, llmCooldownBetweenStepsMs: 0 } },
+    };
+    const ctx: MaintenanceOrchestratorContext = {
+      cfg: cfg as never,
+      runners: runners as never,
+      logger: { info: () => {}, warn: () => {} },
+      openclawDir: "/tmp",
+    };
+    const result = await runMaintenanceOrchestrator(ctx, {
+      tiers: ["nightly"],
+      force: true,
+      openclawDir: "/tmp",
+      include: ["dream-run", "distill"],
+    });
+    expect(result.steps.find((r) => r.name === "dream-run")?.status).toBe("failed");
+    expect(result.steps.find((r) => r.name === "distill")?.summary).toContain("distill-fallback");
   });
 });

--- a/extensions/memory-hybrid/tests/dream-skip-overlap-fail-closed.test.ts
+++ b/extensions/memory-hybrid/tests/dream-skip-overlap-fail-closed.test.ts
@@ -1,0 +1,62 @@
+/**
+ * skipNightlyOverlap must not drop curation when dream-run is unscheduled.
+ */
+import { describe, expect, it } from "vitest";
+import { DEFAULT_DREAMING_CONFIG } from "../config/types/dreaming.js";
+import {
+  MAINTENANCE_STEPS,
+  type MaintenanceOrchestratorContext,
+  runMaintenanceOrchestrator,
+} from "../services/maintenance-orchestrator.js";
+import { nightlyStepsOwnedByDream } from "../services/dream-run.js";
+
+describe("dream-run scheduling vs skipNightlyOverlap", () => {
+  it("lists distill among owned steps when dreaming.enabled + skipNightlyOverlap", () => {
+    const owned = nightlyStepsOwnedByDream({
+      ...structuredClone(DEFAULT_DREAMING_CONFIG),
+      enabled: true,
+      skipNightlyOverlap: true,
+      compose: ["distill", "reflect", "consolidate"],
+    });
+    expect(owned.has("distill")).toBe(true);
+    expect(owned.has("reflect")).toBe(true);
+    expect(owned.has("consolidate")).toBe(true);
+  });
+
+  it("registers dream-run step gated by dreaming.enabled", () => {
+    const step = MAINTENANCE_STEPS.find((s) => s.name === "dream-run");
+    expect(step).toBeTruthy();
+    expect(step!.featureGate?.({ dreaming: { enabled: true } } as never)).toBe(true);
+    expect(step!.featureGate?.({ dreaming: { enabled: false } } as never)).toBe(false);
+  });
+
+  it("runs owned nightly step when dream-run runner is missing (fail closed)", async () => {
+    const distill = async () => "distill-ran";
+    const runners = new Map<string, () => Promise<string>>([["distill", distill]]);
+    // Intentionally omit dream-run runner.
+    const cfg = {
+      dreaming: {
+        ...structuredClone(DEFAULT_DREAMING_CONFIG),
+        enabled: true,
+        skipNightlyOverlap: true,
+        compose: ["distill"] as ["distill"],
+      },
+      maintenance: { orchestrator: { stepTimeoutMinutes: 1 } },
+    };
+    const ctx: MaintenanceOrchestratorContext = {
+      cfg: cfg as never,
+      runners: runners as never,
+      logger: { info: () => {}, warn: () => {} },
+      openclawDir: "/tmp",
+    };
+    const result = await runMaintenanceOrchestrator(ctx, {
+      tiers: ["nightly"],
+      force: true,
+      openclawDir: "/tmp",
+      include: ["distill"],
+    });
+    const distillResult = result.steps.find((r) => r.name === "distill");
+    expect(distillResult?.status).not.toBe("skipped_gate");
+    expect(distillResult?.summary).toContain("distill-ran");
+  });
+});

--- a/extensions/memory-hybrid/tests/dream-skip-overlap-fail-closed.test.ts
+++ b/extensions/memory-hybrid/tests/dream-skip-overlap-fail-closed.test.ts
@@ -125,4 +125,38 @@ describe("dream-run scheduling vs skipNightlyOverlap", () => {
     expect(result.steps.find((r) => r.name === "dream-run")?.status).toBe("failed");
     expect(result.steps.find((r) => r.name === "distill")?.summary).toContain("distill-fallback");
   });
+
+  it("runs owned step when dream-run soft-fails with timedOut semantic (fail closed)", async () => {
+    const distill = async () => "distill-fallback-timeout";
+    const dreamRun = async () => {
+      throw new Error("dream-run timed out dreamRunId=dream-x semantic=partial");
+    };
+    const runners = new Map<string, () => Promise<string>>([
+      ["dream-run", dreamRun],
+      ["distill", distill],
+    ]);
+    const cfg = {
+      dreaming: {
+        ...structuredClone(DEFAULT_DREAMING_CONFIG),
+        enabled: true,
+        skipNightlyOverlap: true,
+        compose: ["distill"] as ["distill"],
+      },
+      maintenance: { orchestrator: { stepTimeoutMinutes: 1, llmCooldownBetweenStepsMs: 0 } },
+    };
+    const ctx: MaintenanceOrchestratorContext = {
+      cfg: cfg as never,
+      runners: runners as never,
+      logger: { info: () => {}, warn: () => {} },
+      openclawDir: "/tmp",
+    };
+    const result = await runMaintenanceOrchestrator(ctx, {
+      tiers: ["nightly"],
+      force: true,
+      openclawDir: "/tmp",
+      include: ["dream-run", "distill"],
+    });
+    expect(result.steps.find((r) => r.name === "dream-run")?.status).toBe("failed");
+    expect(result.steps.find((r) => r.name === "distill")?.summary).toContain("distill-fallback-timeout");
+  });
 });

--- a/extensions/memory-hybrid/tests/dream-steering-probe.test.ts
+++ b/extensions/memory-hybrid/tests/dream-steering-probe.test.ts
@@ -13,11 +13,7 @@ import { promoteDreamRun } from "../services/dream-promote.js";
 import { applyDreamCanaryBoost, hasDreamCanaryTag } from "../services/dream-canary.js";
 import { dreamRunTag, collectDreamMetricSet } from "../services/dream-metrics.js";
 import { probeDreamOutcomes } from "../services/dream-outcome-probe.js";
-import {
-  formatSteeringPromptBlock,
-  resolveSteering,
-  shouldSteeringIgnore,
-} from "../services/dream-steering.js";
+import { formatSteeringPromptBlock, resolveSteering, shouldSteeringIgnore } from "../services/dream-steering.js";
 import { runDream } from "../services/dream-run.js";
 
 describe("dream canary boost (#2173)", () => {

--- a/extensions/memory-hybrid/tests/dream-steering-probe.test.ts
+++ b/extensions/memory-hybrid/tests/dream-steering-probe.test.ts
@@ -67,15 +67,21 @@ describe("dream steering (#2176)", () => {
       store,
       cfg,
       sessionIds: ["s1"],
+      excludedSessions: [{ sessionId: "s-private", reason: "acl_too_private" }],
       steps: {},
       promote: false,
     });
     expect(result.run.steeringPolicyId).toBe("coding");
     const summary = JSON.parse(result.run.metricsSummaryJson ?? "{}") as {
-      steering?: { profile: string; notes: string | null };
+      steering?: { profile: string; notes: string | null; promote: string[] };
+      attachment?: { includedCount: number; excludedCount: number; excluded: Array<{ sessionId: string }> };
     };
     expect(summary.steering?.profile).toBe("coding");
     expect(summary.steering?.notes).toBe("prefer procedures");
+    expect(summary.steering?.promote).toContain("procedure");
+    expect(summary.attachment?.includedCount).toBe(1);
+    expect(summary.attachment?.excludedCount).toBe(1);
+    expect(summary.attachment?.excluded[0]?.sessionId).toBe("s-private");
   });
 
   it("resolves profile defaults", () => {

--- a/extensions/memory-hybrid/tests/dream-steering-probe.test.ts
+++ b/extensions/memory-hybrid/tests/dream-steering-probe.test.ts
@@ -1,5 +1,5 @@
 /**
- * Dream steering + outcome probe (#2176 / #2173).
+ * Dream steering + outcome probe + canary (#2176 / #2173).
  */
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -10,14 +10,31 @@ import { DreamCandidateStore } from "../backends/dream-candidate-store.js";
 import { DEFAULT_DREAMING_CONFIG } from "../config/types/dreaming.js";
 import { evaluateDreamGates } from "../services/dream-promote.js";
 import { promoteDreamRun } from "../services/dream-promote.js";
-import { dreamRunTag } from "../services/dream-metrics.js";
-import { collectDreamMetricSet } from "../services/dream-metrics.js";
+import { applyDreamCanaryBoost, hasDreamCanaryTag } from "../services/dream-canary.js";
+import { dreamRunTag, collectDreamMetricSet } from "../services/dream-metrics.js";
 import { probeDreamOutcomes } from "../services/dream-outcome-probe.js";
 import {
   formatSteeringPromptBlock,
   resolveSteering,
   shouldSteeringIgnore,
 } from "../services/dream-steering.js";
+import { runDream } from "../services/dream-run.js";
+
+describe("dream canary boost (#2173)", () => {
+  it("detects dream-run tags and boosts recall scores", () => {
+    expect(hasDreamCanaryTag(["dream-run:dream-1"])).toBe(true);
+    expect(hasDreamCanaryTag(["preference"])).toBe(false);
+    const boosted = applyDreamCanaryBoost(
+      [
+        { score: 1, entry: { tags: ["dream-run:x"] } },
+        { score: 1.05, entry: { tags: ["other"] } },
+      ],
+      { enabled: true },
+    );
+    expect(boosted[0]!.entry.tags?.[0]).toContain("dream-run:");
+    expect(boosted[0]!.score).toBeGreaterThan(1.05);
+  });
+});
 
 describe("dream steering (#2176)", () => {
   let tmpDir: string;
@@ -33,6 +50,32 @@ describe("dream steering (#2176)", () => {
   afterEach(() => {
     factsDb.close();
     rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("stores resolved steering snapshot on dream run metrics (#2176)", async () => {
+    const cfg = structuredClone(DEFAULT_DREAMING_CONFIG);
+    cfg.enabled = true;
+    cfg.candidateStore = { enabled: true, shadow: true };
+    cfg.steering = {
+      profile: "coding",
+      promote: [],
+      ignore: [],
+      notes: "prefer procedures",
+    };
+    const result = await runDream({
+      factsDb,
+      store,
+      cfg,
+      sessionIds: ["s1"],
+      steps: {},
+      promote: false,
+    });
+    expect(result.run.steeringPolicyId).toBe("coding");
+    const summary = JSON.parse(result.run.metricsSummaryJson ?? "{}") as {
+      steering?: { profile: string; notes: string | null };
+    };
+    expect(summary.steering?.profile).toBe("coding");
+    expect(summary.steering?.notes).toBe("prefer procedures");
   });
 
   it("resolves profile defaults", () => {

--- a/extensions/memory-hybrid/tests/dream-steering-probe.test.ts
+++ b/extensions/memory-hybrid/tests/dream-steering-probe.test.ts
@@ -131,7 +131,10 @@ describe("dream steering (#2176)", () => {
       reverse: { op: "delete_fact" as const, payload: {} },
     };
     store.appendCandidateEntries(run.id, [
-      { ...entryBase, payload: { ...entryBase.payload, text: "one_off_debug scratch note" } },
+      {
+        ...entryBase,
+        payload: { ...entryBase.payload, text: "scratch note", key: "one_off_debug" },
+      },
       { ...entryBase, payload: { ...entryBase.payload, text: "durable user preference" } },
     ]);
 

--- a/extensions/memory-hybrid/tests/dream-steering-probe.test.ts
+++ b/extensions/memory-hybrid/tests/dream-steering-probe.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Dream steering + outcome probe (#2176 / #2173).
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { FactsDB } from "../backends/facts-db.js";
+import { DreamCandidateStore } from "../backends/dream-candidate-store.js";
+import { DEFAULT_DREAMING_CONFIG } from "../config/types/dreaming.js";
+import { evaluateDreamGates } from "../services/dream-promote.js";
+import { promoteDreamRun } from "../services/dream-promote.js";
+import { dreamRunTag } from "../services/dream-metrics.js";
+import { probeDreamOutcomes } from "../services/dream-outcome-probe.js";
+import {
+  formatSteeringPromptBlock,
+  resolveSteering,
+  shouldSteeringIgnore,
+} from "../services/dream-steering.js";
+
+describe("dream steering (#2176)", () => {
+  let tmpDir: string;
+  let factsDb: FactsDB;
+  let store: DreamCandidateStore;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "dream-steer-"));
+    factsDb = new FactsDB(join(tmpDir, "facts.db"));
+    store = new DreamCandidateStore(factsDb.getRawDb());
+  });
+
+  afterEach(() => {
+    factsDb.close();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("resolves profile defaults", () => {
+    const s = resolveSteering({ profile: "coding", promote: [], ignore: [], notes: undefined });
+    expect(s.promote).toContain("procedure");
+    expect(s.ignore).toContain("one_off_debug");
+    expect(formatSteeringPromptBlock(s)).toContain("Dream steering policy");
+  });
+
+  it("blocks ignored categories at gate", () => {
+    expect(
+      shouldSteeringIgnore("preference", "one_off_debug", "transient path note", {
+        profile: "personal",
+        promote: ["preference"],
+        ignore: ["one_off_debug"],
+      }),
+    ).toBe(true);
+  });
+
+  it("ignore-list reduces gated candidate volume (#2176)", () => {
+    const cfg = structuredClone(DEFAULT_DREAMING_CONFIG);
+    cfg.autoPromote.requireProvenance = false;
+    cfg.permissionBoundary.targetScope = "global";
+    cfg.prevalence.session = { minSessions: 1, minAgents: 1 };
+    cfg.steering = { profile: "personal", promote: ["preference"], ignore: ["one_off_debug"], notes: undefined };
+
+    const run = store.createDreamRun({
+      inputStoreRevision: factsDb.computeStoreRevision(),
+      sessionIds: ["s1"],
+      shadow: true,
+    });
+    const entryBase = {
+      op: "add" as const,
+      payload: {
+        category: "preference" as const,
+        importance: 0.5,
+        source: "dream" as const,
+        entity: null,
+        key: null,
+        value: null,
+        scope: "session" as const,
+        scopeTarget: "s1",
+      },
+      evidence: {
+        sessionIds: ["s1"],
+        prevalence: { sessions: 1, agents: 1 },
+        rationale: "fixture",
+      },
+      reverse: { op: "delete_fact" as const, payload: {} },
+    };
+    store.appendCandidateEntries(run.id, [
+      { ...entryBase, payload: { ...entryBase.payload, text: "one_off_debug scratch note" } },
+      { ...entryBase, payload: { ...entryBase.payload, text: "durable user preference" } },
+    ]);
+
+    const report = evaluateDreamGates(store, run.id, cfg);
+    expect(report.decisions.filter((d) => d.reason === "steering_ignore")).toHaveLength(1);
+    expect(report.decisions.filter((d) => d.pass)).toHaveLength(1);
+  });
+});
+
+describe("dream outcome probe (#2173)", () => {
+  let tmpDir: string;
+  let factsDb: FactsDB;
+  let store: DreamCandidateStore;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "dream-probe-"));
+    factsDb = new FactsDB(join(tmpDir, "facts.db"));
+    store = new DreamCandidateStore(factsDb.getRawDb());
+  });
+
+  afterEach(() => {
+    factsDb.close();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("tags promoted facts with dream-run id", () => {
+    const cfg = structuredClone(DEFAULT_DREAMING_CONFIG);
+    cfg.autoPromote.enabled = true;
+    cfg.candidateStore.shadow = false;
+    cfg.permissionBoundary.targetScope = "session";
+
+    const run = store.createDreamRun({
+      inputStoreRevision: factsDb.computeStoreRevision(),
+      sessionIds: ["s1"],
+      shadow: false,
+    });
+    store.appendCandidateEntries(run.id, [
+      {
+        op: "add",
+        payload: {
+          text: "tagged fact",
+          category: "preference",
+          importance: 0.5,
+          source: "dream",
+          entity: null,
+          key: null,
+          value: null,
+          scope: "session",
+          scopeTarget: "s1",
+        },
+        evidence: {
+          sessionIds: ["s1"],
+          prevalence: { sessions: 1, agents: 1 },
+          rationale: "ok",
+        },
+        reverse: { op: "delete_fact", payload: {} },
+      },
+    ]);
+
+    const result = promoteDreamRun(factsDb, store, run.id, { force: true, cfg });
+    expect(result.applied).toBe(true);
+    const factId = result.appliedFactIds[0]!;
+    const fact = factsDb.getById(factId);
+    expect(fact?.tags).toContain(dreamRunTag(run.id));
+    expect(store.getDreamRun(run.id)?.metricsBaselineJson).toBeTruthy();
+  });
+
+  it("probe rolls back on regression after observe window", () => {
+    const cfg = structuredClone(DEFAULT_DREAMING_CONFIG);
+    cfg.autoPromote.enabled = true;
+    cfg.autoRollback.enabled = true;
+    cfg.autoRollback.regressionThreshold = 0.15;
+    cfg.candidateStore.shadow = false;
+    cfg.permissionBoundary.targetScope = "session";
+
+    const run = store.createDreamRun({
+      inputStoreRevision: factsDb.computeStoreRevision(),
+      sessionIds: ["s1"],
+      shadow: false,
+    });
+    store.appendCandidateEntries(run.id, [
+      {
+        op: "add",
+        payload: {
+          text: "probe rollback",
+          category: "preference",
+          importance: 0.5,
+          source: "dream",
+          entity: null,
+          key: null,
+          value: null,
+          scope: "session",
+          scopeTarget: "s1",
+        },
+        evidence: {
+          sessionIds: ["s1"],
+          prevalence: { sessions: 1, agents: 1 },
+          rationale: "ok",
+        },
+        reverse: { op: "delete_fact", payload: {} },
+      },
+    ]);
+
+    promoteDreamRun(factsDb, store, run.id, { force: true, cfg });
+    const promotedAt = store.getDreamRun(run.id)?.promotedAt ?? Math.floor(Date.now() / 1000);
+    store.updateDreamRunStatus(run.id, "promoted", {
+      metricsBaselineJson: JSON.stringify({
+        successRate: 1,
+        retryRate: 0,
+        effectScore: 1,
+        sessionsObserved: 3,
+      }),
+      metricsObserveUntil: promotedAt - 1,
+    });
+    factsDb.store({
+      text: "post-promote failure",
+      category: "preference",
+      importance: 0.5,
+      source: "self-correction",
+      entity: null,
+      key: null,
+      value: null,
+      scope: "session",
+      scopeTarget: "s1",
+    });
+
+    const probe = probeDreamOutcomes(factsDb, store, {
+      cfg,
+      applyRollback: true,
+      nowSec: promotedAt + 99999,
+      force: true,
+      limit: 5,
+    });
+    expect(probe.examined).toBe(1);
+    expect(probe.rolledBack).toBe(1);
+  });
+});

--- a/extensions/memory-hybrid/tests/dream-steering-probe.test.ts
+++ b/extensions/memory-hybrid/tests/dream-steering-probe.test.ts
@@ -135,7 +135,7 @@ describe("dream steering (#2176)", () => {
       { ...entryBase, payload: { ...entryBase.payload, text: "durable user preference" } },
     ]);
 
-    const report = evaluateDreamGates(store, run.id, cfg);
+    const report = evaluateDreamGates(store, run.id, cfg, factsDb);
     expect(report.decisions.filter((d) => d.reason === "steering_ignore")).toHaveLength(1);
     expect(report.decisions.filter((d) => d.pass)).toHaveLength(1);
   });

--- a/extensions/memory-hybrid/tests/dream-steering-probe.test.ts
+++ b/extensions/memory-hybrid/tests/dream-steering-probe.test.ts
@@ -11,6 +11,7 @@ import { DEFAULT_DREAMING_CONFIG } from "../config/types/dreaming.js";
 import { evaluateDreamGates } from "../services/dream-promote.js";
 import { promoteDreamRun } from "../services/dream-promote.js";
 import { dreamRunTag } from "../services/dream-metrics.js";
+import { collectDreamMetricSet } from "../services/dream-metrics.js";
 import { probeDreamOutcomes } from "../services/dream-outcome-probe.js";
 import {
   formatSteeringPromptBlock,
@@ -62,7 +63,9 @@ describe("dream steering (#2176)", () => {
       inputStoreRevision: factsDb.computeStoreRevision(),
       sessionIds: ["s1"],
       shadow: true,
+      steeringPolicyId: "personal",
     });
+    expect(run.steeringPolicyId).toBe("personal");
     const entryBase = {
       op: "add" as const,
       payload: {
@@ -107,6 +110,38 @@ describe("dream outcome probe (#2173)", () => {
   afterEach(() => {
     factsDb.close();
     rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("scopes feedback metrics to dream sessions — ignores unrelated global corrections", () => {
+    const now = Math.floor(Date.now() / 1000);
+    factsDb.store({
+      text: "unrelated global correction",
+      category: "preference",
+      importance: 0.5,
+      source: "self-correction",
+      entity: null,
+      key: null,
+      value: null,
+      scope: "global",
+    });
+    factsDb.store({
+      text: "in-session correction",
+      category: "preference",
+      importance: 0.5,
+      source: "self-correction",
+      entity: null,
+      key: null,
+      value: null,
+      scope: "session",
+      scopeTarget: "s1",
+    });
+    const metrics = collectDreamMetricSet(factsDb, {
+      fromSec: now - 60,
+      toSec: now + 60,
+      sessionIds: ["s1"],
+    });
+    expect(metrics.retryRate).toBe(1);
+    expect(metrics.sessionsObserved).toBe(1);
   });
 
   it("tags promoted facts with dream-run id", () => {
@@ -159,9 +194,10 @@ describe("dream outcome probe (#2173)", () => {
     cfg.candidateStore.shadow = false;
     cfg.permissionBoundary.targetScope = "session";
 
+    const sessionIds = ["s1", "s2", "s3"];
     const run = store.createDreamRun({
       inputStoreRevision: factsDb.computeStoreRevision(),
-      sessionIds: ["s1"],
+      sessionIds,
       shadow: false,
     });
     store.appendCandidateEntries(run.id, [
@@ -179,8 +215,8 @@ describe("dream outcome probe (#2173)", () => {
           scopeTarget: "s1",
         },
         evidence: {
-          sessionIds: ["s1"],
-          prevalence: { sessions: 1, agents: 1 },
+          sessionIds,
+          prevalence: { sessions: 3, agents: 1 },
           rationale: "ok",
         },
         reverse: { op: "delete_fact", payload: {} },
@@ -198,17 +234,19 @@ describe("dream outcome probe (#2173)", () => {
       }),
       metricsObserveUntil: promotedAt - 1,
     });
-    factsDb.store({
-      text: "post-promote failure",
-      category: "preference",
-      importance: 0.5,
-      source: "self-correction",
-      entity: null,
-      key: null,
-      value: null,
-      scope: "session",
-      scopeTarget: "s1",
-    });
+    for (const sid of sessionIds) {
+      factsDb.store({
+        text: `post-promote failure ${sid}`,
+        category: "preference",
+        importance: 0.5,
+        source: "self-correction",
+        entity: null,
+        key: null,
+        value: null,
+        scope: "session",
+        scopeTarget: sid,
+      });
+    }
 
     const probe = probeDreamOutcomes(factsDb, store, {
       cfg,

--- a/extensions/memory-hybrid/tests/fact-occ.test.ts
+++ b/extensions/memory-hybrid/tests/fact-occ.test.ts
@@ -6,11 +6,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { FactsDB } from "../backends/facts-db.js";
-import {
-  MemoryConflictError,
-  computeInputStoreRevision,
-  occTokenForFact,
-} from "../utils/fact-occ.js";
+import { MemoryConflictError, computeInputStoreRevision, occTokenForFact } from "../utils/fact-occ.js";
 
 describe("fact OCC (#2175)", () => {
   let tmpDir: string;

--- a/extensions/memory-hybrid/tests/fact-occ.test.ts
+++ b/extensions/memory-hybrid/tests/fact-occ.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Optimistic concurrency (#2175) — shared-scope supersede refuses stale expectedHash.
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { FactsDB } from "../backends/facts-db.js";
+import {
+  MemoryConflictError,
+  computeInputStoreRevision,
+  occTokenForFact,
+} from "../utils/fact-occ.js";
+
+describe("fact OCC (#2175)", () => {
+  let tmpDir: string;
+  let factsDb: FactsDB;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "fact-occ-"));
+    factsDb = new FactsDB(join(tmpDir, "facts.db"));
+  });
+
+  afterEach(() => {
+    factsDb.close();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("getOccToken is stable until the fact text/revision changes", () => {
+    const entry = factsDb.store({
+      text: "OCC fact alpha",
+      category: "fact",
+      importance: 0.8,
+      entity: null,
+      key: null,
+      value: null,
+      source: "test",
+      scope: "global",
+    });
+    const token = factsDb.getOccToken(entry.id);
+    expect(token).toBe(occTokenForFact(entry));
+    expect(factsDb.getOccToken(entry.id)).toBe(token);
+  });
+
+  it("supersede with matching expectedHash succeeds", () => {
+    const old = factsDb.store({
+      text: "old curriculum",
+      category: "fact",
+      importance: 0.7,
+      entity: null,
+      key: null,
+      value: null,
+      source: "test",
+      scope: "global",
+    });
+    const hash = factsDb.getOccToken(old.id)!;
+    const neu = factsDb.store({
+      text: "new curriculum",
+      category: "fact",
+      importance: 0.8,
+      entity: null,
+      key: null,
+      value: null,
+      source: "test",
+      scope: "global",
+    });
+    expect(factsDb.supersede(old.id, neu.id, { expectedHash: hash })).toBe(true);
+    expect(factsDb.getById(old.id)?.supersededAt ?? factsDb.getById(old.id)).toBeTruthy();
+  });
+
+  it("supersede with stale expectedHash throws memory_conflict", () => {
+    const old = factsDb.store({
+      text: "stale base",
+      category: "fact",
+      importance: 0.7,
+      entity: null,
+      key: null,
+      value: null,
+      source: "test",
+      scope: "user",
+      scopeTarget: "u1",
+    });
+    const neu = factsDb.store({
+      text: "replacement",
+      category: "fact",
+      importance: 0.8,
+      entity: null,
+      key: null,
+      value: null,
+      source: "test",
+      scope: "user",
+      scopeTarget: "u1",
+    });
+    expect(() => factsDb.supersede(old.id, neu.id, { expectedHash: "deadbeef".repeat(8) })).toThrow(
+      MemoryConflictError,
+    );
+    // Target remains active
+    expect(factsDb.getById(old.id)).not.toBeNull();
+    const still = factsDb.getById(old.id);
+    expect((still as { supersededAt?: number | null } | null)?.supersededAt ?? null).toBeFalsy();
+  });
+
+  it("computeStoreRevision changes when a new fact is added", () => {
+    const before = factsDb.computeStoreRevision();
+    factsDb.store({
+      text: "revision bump fact",
+      category: "fact",
+      importance: 0.5,
+      entity: null,
+      key: null,
+      value: null,
+      source: "test",
+    });
+    const after = factsDb.computeStoreRevision();
+    expect(after).not.toBe(before);
+    expect(computeInputStoreRevision([])).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it("session-scope supersede without expectedHash remains low-friction", () => {
+    const old = factsDb.store({
+      text: "session scratch",
+      category: "fact",
+      importance: 0.4,
+      entity: null,
+      key: null,
+      value: null,
+      source: "test",
+      scope: "session",
+      scopeTarget: "s1",
+    });
+    const neu = factsDb.store({
+      text: "session scratch v2",
+      category: "fact",
+      importance: 0.4,
+      entity: null,
+      key: null,
+      value: null,
+      source: "test",
+      scope: "session",
+      scopeTarget: "s1",
+    });
+    expect(factsDb.supersede(old.id, neu.id)).toBe(true);
+  });
+});

--- a/extensions/memory-hybrid/tests/helpers/comprehensive-e2e-harness.ts
+++ b/extensions/memory-hybrid/tests/helpers/comprehensive-e2e-harness.ts
@@ -144,9 +144,7 @@ export function registerFullPlugin(api: FullStackApi, pluginConfig: Record<strin
 
 /** Wait for deferred Phase B activation after a re-register that took the full-teardown path (#2181). */
 export async function awaitPluginActivation(timeoutMs = 30_000): Promise<boolean> {
-  const { awaitActivationReady, getActivationState, runtimeRef } = await import(
-    "../../setup/register-plugin.js"
-  );
+  const { awaitActivationReady, getActivationState, runtimeRef } = await import("../../setup/register-plugin.js");
   const state = getActivationState();
   if (!state || state.phase === "ready" || state.phase === "idle") {
     return runtimeRef.value != null;

--- a/extensions/memory-hybrid/tests/helpers/comprehensive-e2e-harness.ts
+++ b/extensions/memory-hybrid/tests/helpers/comprehensive-e2e-harness.ts
@@ -142,6 +142,19 @@ export function registerFullPlugin(api: FullStackApi, pluginConfig: Record<strin
   memoryHybridPlugin.register(api as never);
 }
 
+/** Wait for deferred Phase B activation after a re-register that took the full-teardown path (#2181). */
+export async function awaitPluginActivation(timeoutMs = 30_000): Promise<boolean> {
+  const { awaitActivationReady, getActivationState, runtimeRef } = await import(
+    "../../setup/register-plugin.js"
+  );
+  const state = getActivationState();
+  if (!state || state.phase === "ready" || state.phase === "idle") {
+    return runtimeRef.value != null;
+  }
+  if (state.phase === "failed") return false;
+  return awaitActivationReady(state.generation, timeoutMs);
+}
+
 export async function invokeHooks(
   api: FullStackApi,
   eventName: string,

--- a/extensions/memory-hybrid/tests/maintenance-orchestrator.test.ts
+++ b/extensions/memory-hybrid/tests/maintenance-orchestrator.test.ts
@@ -30,8 +30,10 @@ describe("maintenance-orchestrator", () => {
     if (openclawDir) rmSync(openclawDir, { recursive: true, force: true });
   });
 
-  it("registers 57 maintenance steps", () => {
-    expect(MAINTENANCE_STEPS.length).toBe(57);
+  it("registers 59 maintenance steps (includes dream-outcome-probe + dream-run)", () => {
+    expect(MAINTENANCE_STEPS.length).toBe(59);
+    expect(MAINTENANCE_STEPS.some((s) => s.name === "dream-run")).toBe(true);
+    expect(MAINTENANCE_STEPS.some((s) => s.name === "dream-outcome-probe")).toBe(true);
   });
 
   it("skips steps when guard has not expired", async () => {

--- a/extensions/memory-hybrid/tests/register-plugin-reload-teardown-drain.test.ts
+++ b/extensions/memory-hybrid/tests/register-plugin-reload-teardown-drain.test.ts
@@ -1,14 +1,9 @@
 /**
- * Regression tests for the reload-coordinator gate used by runMemoryHybridRegister.
+ * Regression tests for the reload-coordinator helpers used by two-phase activation (#2181)
+ * and the pure gate decision matrix retained for observability/tests (#2111).
  *
- * Reproduces the rapid-hot-reload teardown race that surfaced in #2058/#2059 follow-up:
- *   1. reuseDatabases=true + vault-registry close scheduled against the donor runtime
- *   2. soft drain timeout exceeded → must NOT inherit closed handles (fall back to fresh)
- *   3. full teardown path with a hard drain timeout → must recover to a fresh open instead of
- *      throwing and failing plugin initialization (#2111).
- *
- * These tests exercise the helpers exported from hybrid-memory-reload-coordinator.ts and
- * the gate decision logic in register-plugin via lightweight mocks of the dependencies.
+ * Production register() no longer calls blockReloadTeardownBeforeOpen (Atomics.wait starves
+ * Promise-chain teardown). Deferred activation uses awaitDonorTeardown / awaitReloadTeardownBeforeOpen.
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";

--- a/extensions/memory-hybrid/tests/register-plugin-two-phase-activation.test.ts
+++ b/extensions/memory-hybrid/tests/register-plugin-two-phase-activation.test.ts
@@ -15,10 +15,7 @@ import {
   resetPluginRegistrationStateForTests,
   runtimeRef,
 } from "../setup/register-plugin.js";
-import {
-  resetReloadTeardownChainForTests,
-  schedulePluginTeardown,
-} from "../setup/hybrid-memory-reload-coordinator.js";
+import { resetReloadTeardownChainForTests, schedulePluginTeardown } from "../setup/hybrid-memory-reload-coordinator.js";
 import {
   type FullStackApi,
   getFullStackConfig,

--- a/extensions/memory-hybrid/tests/register-plugin-two-phase-activation.test.ts
+++ b/extensions/memory-hybrid/tests/register-plugin-two-phase-activation.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Regression for #2181: sync register() must not block on Promise-chain teardown via Atomics.wait.
+ *
+ * Full-teardown re-register enters two-phase activation:
+ *   Phase A — sync: schedule teardown, publish tool stubs, return immediately
+ *   Phase B — async: await donor teardown (event-loop friendly), open DBs, bind live tools
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  awaitActivationReady,
+  getActivationState,
+  resetPluginRegistrationStateForTests,
+  runtimeRef,
+} from "../setup/register-plugin.js";
+import {
+  resetReloadTeardownChainForTests,
+  schedulePluginTeardown,
+} from "../setup/hybrid-memory-reload-coordinator.js";
+import {
+  type FullStackApi,
+  getFullStackConfig,
+  makeFullStackApi,
+  registerFullPlugin,
+} from "./helpers/comprehensive-e2e-harness.js";
+
+describe("two-phase reload activation (#2181)", () => {
+  let tmpDir: string;
+  let api: FullStackApi;
+  let originalPolicy: string | undefined;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "two-phase-activation-"));
+    api = makeFullStackApi(tmpDir);
+    resetPluginRegistrationStateForTests();
+    originalPolicy = process.env.OPENCLAW_HYBRID_MEM_REREGISTER_POLICY;
+    // Force full teardown so re-register takes the deferred-activation path.
+    process.env.OPENCLAW_HYBRID_MEM_REREGISTER_POLICY = "full";
+  });
+
+  afterEach(() => {
+    resetPluginRegistrationStateForTests();
+    rmSync(tmpDir, { recursive: true, force: true });
+    if (originalPolicy === undefined) delete process.env.OPENCLAW_HYBRID_MEM_REREGISTER_POLICY;
+    else process.env.OPENCLAW_HYBRID_MEM_REREGISTER_POLICY = originalPolicy;
+  });
+
+  it("re-register returns quickly even when donor teardown is still pending", async () => {
+    const cfg = () => getFullStackConfig(tmpDir);
+    registerFullPlugin(api, cfg());
+    expect(runtimeRef.value).not.toBeNull();
+    const firstGen = runtimeRef.value!.bootRegistrationGeneration!;
+
+    // Simulate a stuck prior teardown that would previously starve under Atomics.wait.
+    let release: () => void = () => {};
+    const blocker = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    schedulePluginTeardown(
+      async () => {
+        await blocker;
+      },
+      { donorGeneration: firstGen },
+    );
+
+    const started = Date.now();
+    registerFullPlugin(api, cfg());
+    const syncMs = Date.now() - started;
+
+    // Must not burn the old ~8s Atomics.wait budget.
+    expect(syncMs).toBeLessThan(1500);
+
+    const activation = getActivationState();
+    expect(activation?.phase).toBe("activating");
+    expect(activation?.generation).toBeGreaterThan(firstGen);
+
+    const recall = api.getTool("memory_recall");
+    expect(recall).toBeDefined();
+    const initializing = (await recall!.execute("t1", { query: "ping" })) as {
+      details?: { initializing?: boolean; reloading?: boolean };
+    };
+    expect(initializing.details?.initializing).toBe(true);
+
+    release();
+    const ready = await awaitActivationReady(activation!.generation, 20_000);
+    expect(ready).toBe(true);
+    expect(getActivationState()?.phase).toBe("ready");
+    expect(runtimeRef.value?.bootRegistrationGeneration).toBe(activation!.generation);
+
+    const after = (await recall!.execute("t2", { query: "ping" })) as {
+      details?: { initializing?: boolean };
+    };
+    expect(after.details?.initializing).not.toBe(true);
+  });
+
+  it("never throws 'reload teardown did not drain before opening new databases'", async () => {
+    const cfg = () => getFullStackConfig(tmpDir);
+    registerFullPlugin(api, cfg());
+
+    // Leave a never-resolving teardown on the donor generation; Phase B must still recover.
+    schedulePluginTeardown(
+      async () => {
+        await new Promise(() => {
+          /* never */
+        });
+      },
+      { donorGeneration: runtimeRef.value!.bootRegistrationGeneration! },
+    );
+
+    expect(() => registerFullPlugin(api, cfg())).not.toThrow();
+    const activation = getActivationState();
+    expect(activation?.phase).toBe("activating");
+
+    // Phase B opens fresh after the bounded async wait — must become ready, not fail register.
+    const ready = await awaitActivationReady(activation!.generation, 20_000);
+    expect(ready).toBe(true);
+    resetReloadTeardownChainForTests();
+  });
+});

--- a/extensions/memory-hybrid/tests/tool-registration-generation-guard.test.ts
+++ b/extensions/memory-hybrid/tests/tool-registration-generation-guard.test.ts
@@ -203,6 +203,46 @@ describe("tool registration generation guard", () => {
     expect(disposeRoute).toHaveBeenCalledTimes(1);
   });
 
+  it("returns initializing safe result while activation is in progress for the current generation", async () => {
+    const { beginActivation, markActivationReady, resetActivationStateForTests } = await import(
+      "../setup/hybrid-memory-activation.js"
+    );
+    const { setLiveToolExecutor, clearLiveToolExecutorsForGeneration } = await import("../setup/register-tools.js");
+    resetActivationStateForTests();
+
+    const state = getHybridMemoryRegistrationState();
+    const { api, tools } = makeRegisterToolApi();
+    state.registrationGenerationRef.value = 10;
+    beginActivation({ generation: 10, donorGeneration: 9 });
+
+    const registration = createGenerationGuardedToolsApi(
+      {
+        registrationGeneration: 10,
+        currentRegistrationGenerationRef: state.registrationGenerationRef,
+      },
+      api as never,
+    );
+    const liveExecute = vi.fn(async () => ({ content: [{ type: "text", text: "live" }], details: { ok: true } }));
+    registration.api.registerTool({
+      name: "memory_recall",
+      execute: async () => ({ content: [{ type: "text", text: "stub" }], details: { ok: false } }),
+    } as never);
+
+    const result = (await tools[0]!.execute()) as { details?: { initializing?: boolean } };
+    expect(result.details?.initializing).toBe(true);
+    expect(liveExecute).not.toHaveBeenCalled();
+
+    setLiveToolExecutor(10, "memory_recall", liveExecute);
+    markActivationReady(10);
+    const live = (await tools[0]!.execute()) as { details?: { ok?: boolean; initializing?: boolean } };
+    expect(live.details?.initializing).not.toBe(true);
+    expect(liveExecute).toHaveBeenCalledTimes(1);
+
+    clearLiveToolExecutorsForGeneration(10);
+    registration.handle.dispose();
+    resetActivationStateForTests();
+  });
+
   it("keeps generation state on globalThis across module reload", async () => {
     vi.resetModules();
     const moduleA = await import("../setup/hybrid-memory-generation-state.js");

--- a/extensions/memory-hybrid/tests/tool-registration-generation-guard.test.ts
+++ b/extensions/memory-hybrid/tests/tool-registration-generation-guard.test.ts
@@ -243,6 +243,65 @@ describe("tool registration generation guard", () => {
     resetActivationStateForTests();
   });
 
+  it("falls through to original execute when sync-registered with no activation state", async () => {
+    const { resetActivationStateForTests } = await import("../setup/hybrid-memory-activation.js");
+    resetActivationStateForTests();
+
+    const state = getHybridMemoryRegistrationState();
+    const { api, tools } = makeRegisterToolApi();
+    state.registrationGenerationRef.value = 11;
+
+    const registration = createGenerationGuardedToolsApi(
+      {
+        registrationGeneration: 11,
+        currentRegistrationGenerationRef: state.registrationGenerationRef,
+      },
+      api as never,
+    );
+    const originalExecute = vi.fn(async () => ({
+      content: [{ type: "text", text: "sync-ok" }],
+      details: { ok: true },
+    }));
+    registration.api.registerTool({ name: "memory_recall", execute: originalExecute } as never);
+
+    const result = await tools[0]!.execute();
+    expect(originalExecute).toHaveBeenCalledTimes(1);
+    expect(result).toMatchObject({ details: { ok: true } });
+
+    registration.handle.dispose();
+    resetActivationStateForTests();
+  });
+
+  it("fail-closes when activation is ready but live executor was never bound", async () => {
+    const { beginActivation, markActivationReady, resetActivationStateForTests } = await import(
+      "../setup/hybrid-memory-activation.js"
+    );
+    resetActivationStateForTests();
+
+    const state = getHybridMemoryRegistrationState();
+    const { api, tools } = makeRegisterToolApi();
+    state.registrationGenerationRef.value = 12;
+    beginActivation({ generation: 12, donorGeneration: 11 });
+
+    const registration = createGenerationGuardedToolsApi(
+      {
+        registrationGeneration: 12,
+        currentRegistrationGenerationRef: state.registrationGenerationRef,
+      },
+      api as never,
+    );
+    const originalExecute = vi.fn(async () => ({ content: [{ type: "text", text: "should-not-run" }] }));
+    registration.api.registerTool({ name: "memory_recall", execute: originalExecute } as never);
+    markActivationReady(12);
+
+    const result = (await tools[0]!.execute()) as { details?: { activationFailed?: boolean } };
+    expect(originalExecute).not.toHaveBeenCalled();
+    expect(result.details?.activationFailed).toBe(true);
+
+    registration.handle.dispose();
+    resetActivationStateForTests();
+  });
+
   it("keeps generation state on globalThis across module reload", async () => {
     vi.resetModules();
     const moduleA = await import("../setup/hybrid-memory-generation-state.js");

--- a/extensions/memory-hybrid/tools/memory/register-store-tools.ts
+++ b/extensions/memory-hybrid/tools/memory/register-store-tools.ts
@@ -214,6 +214,12 @@ export function registerStoreTools(runtime: MemoryToolRuntime): void {
               "Fact id — or an array of fact ids — this one supersedes (replaces). Marks the old fact(s) as superseded and links the new one.",
           }),
         ),
+        expectedHash: Type.Optional(
+          Type.String({
+            description:
+              "OCC token from a prior read (FactsDB.getOccToken). When set on shared-scope supersedes, refuse with memory_conflict if the target changed (#2175).",
+          }),
+        ),
         scope: Type.Optional(stringEnum(MEMORY_SCOPES as unknown as readonly string[])),
         scopeTarget: Type.Optional(
           Type.String({
@@ -250,6 +256,7 @@ export function registerStoreTools(runtime: MemoryToolRuntime): void {
             decayClass: paramDecayClass,
             tags: paramTags,
             supersedes,
+            expectedHash,
             scope: paramScope,
             scopeTarget: paramScopeTarget,
             verification_tier: verificationTier,
@@ -266,6 +273,7 @@ export function registerStoreTools(runtime: MemoryToolRuntime): void {
             decayClass?: DecayClass;
             tags?: string[];
             supersedes?: string | string[];
+            expectedHash?: string;
             scope?: "global" | "user" | "agent" | "session";
             scopeTarget?: string;
             verification_tier?: string;
@@ -1219,18 +1227,40 @@ export function registerStoreTools(runtime: MemoryToolRuntime): void {
             // the request. Out-of-scope/unknown ids were already collected in supersedesBlocked.
             const supersededAppliedIds: string[] = [];
             if (storeResult.newlyStored) {
-              for (const supersededId of supersedesScopeValid) {
-                const applied = storeFactsDb.supersede(supersededId, entry.id);
-                if (applied) {
-                  supersededAppliedIds.push(supersededId);
-                  aliasDb?.deleteByFactId(supersededId);
-                  await deleteVectorForFactId({
-                    vectorDb: storeVectorDb,
-                    factId: supersededId,
-                    logger: api.logger,
-                    context: "store-manual-supersede",
-                  });
+              const occHash =
+                typeof expectedHash === "string" && expectedHash.trim().length > 0 ? expectedHash.trim() : undefined;
+              try {
+                for (const supersededId of supersedesScopeValid) {
+                  const applied = storeFactsDb.supersede(
+                    supersededId,
+                    entry.id,
+                    occHash ? { expectedHash: occHash } : undefined,
+                  );
+                  if (applied) {
+                    supersededAppliedIds.push(supersededId);
+                    aliasDb?.deleteByFactId(supersededId);
+                    await deleteVectorForFactId({
+                      vectorDb: storeVectorDb,
+                      factId: supersededId,
+                      logger: api.logger,
+                      context: "store-manual-supersede",
+                    });
+                  }
                 }
+              } catch (occErr) {
+                const { MemoryConflictError } = await import("../../utils/fact-occ.js");
+                if (occErr instanceof MemoryConflictError) {
+                  return {
+                    content: [
+                      {
+                        type: "text",
+                        text: `memory_store: ${occErr.message}. Re-read the fact and retry with a fresh expectedHash.`,
+                      },
+                    ],
+                    details: occErr.details,
+                  };
+                }
+                throw occErr;
               }
             }
 

--- a/extensions/memory-hybrid/utils/fact-occ.ts
+++ b/extensions/memory-hybrid/utils/fact-occ.ts
@@ -50,18 +50,28 @@ export function occTokenForFact(fact: {
 
 /**
  * Cheap whole-store revision for dream promote OCC (#2170/#2175).
- * Hash of active fact count + max created_at + sample of id:hash pairs.
+ * Includes aggregate count + max created_at + max revision_count + sampled OCC tokens.
+ * Callers should also mix in store-wide aggregates (total active count, max rowid) via
+ * {@link computeStoreRevisionAggregates} so edits outside the sampled window still shift the fingerprint.
  */
 export function computeInputStoreRevision(
   rows: Array<{ id: string; text: string; revisionCount?: number | null; createdAt?: number }>,
+  aggregates?: { totalActive?: number; maxRowId?: number; revisionSum?: number },
 ): string {
   const h = createHash("sha256");
-  h.update(`count:${rows.length};`);
+  const totalActive = aggregates?.totalActive ?? rows.length;
+  h.update(`count:${totalActive};`);
+  if (aggregates?.maxRowId != null) h.update(`maxRowId:${aggregates.maxRowId};`);
+  if (aggregates?.revisionSum != null) h.update(`revSum:${aggregates.revisionSum};`);
   let maxCreated = 0;
+  let maxRevision = 0;
   for (const row of rows) {
     if (typeof row.createdAt === "number" && row.createdAt > maxCreated) maxCreated = row.createdAt;
+    const rc = row.revisionCount ?? 0;
+    if (rc > maxRevision) maxRevision = rc;
   }
   h.update(`maxCreated:${maxCreated};`);
+  h.update(`maxRevision:${maxRevision};`);
   const sorted = [...rows].sort((a, b) => a.id.localeCompare(b.id));
   const sample = sorted.length <= 64 ? sorted : [...sorted.slice(0, 32), ...sorted.slice(-32)];
   for (const row of sample) {

--- a/extensions/memory-hybrid/utils/fact-occ.ts
+++ b/extensions/memory-hybrid/utils/fact-occ.ts
@@ -25,22 +25,12 @@ export function isSharedOccScope(scope: MemoryScope | string | null | undefined)
   return scope === "global" || scope === "user" || scope === "agent";
 }
 
-export function hashFactOccToken(parts: {
-  id: string;
-  revisionCount: number;
-  normalizedHash: string;
-}): string {
-  return createHash("sha256")
-    .update(`${parts.id}:${parts.revisionCount}:${parts.normalizedHash}`)
-    .digest("hex");
+export function hashFactOccToken(parts: { id: string; revisionCount: number; normalizedHash: string }): string {
+  return createHash("sha256").update(`${parts.id}:${parts.revisionCount}:${parts.normalizedHash}`).digest("hex");
 }
 
 /** OCC token for a live MemoryEntry-shaped row (#2175). */
-export function occTokenForFact(fact: {
-  id: string;
-  text: string;
-  revisionCount?: number | null;
-}): string {
+export function occTokenForFact(fact: { id: string; text: string; revisionCount?: number | null }): string {
   return hashFactOccToken({
     id: fact.id,
     revisionCount: fact.revisionCount ?? 0,

--- a/extensions/memory-hybrid/utils/fact-occ.ts
+++ b/extensions/memory-hybrid/utils/fact-occ.ts
@@ -1,0 +1,102 @@
+/**
+ * Optimistic concurrency helpers for shared-scope fact writes (#2175 / Epic #2169).
+ *
+ * Token = sha256 of id + revision_count + normalized_hash.
+ * Callers pass `expectedHash` on mutate; mismatch → structured `memory_conflict`.
+ */
+
+import { createHash } from "node:crypto";
+import type { MemoryScope } from "../types/memory.js";
+import { normalizedHash } from "./tags.js";
+
+export const MEMORY_CONFLICT_CODE = "memory_conflict" as const;
+
+export type MemoryConflictDetails = {
+  error: typeof MEMORY_CONFLICT_CODE;
+  code: typeof MEMORY_CONFLICT_CODE;
+  expectedHash: string;
+  currentHash: string;
+  currentRevision?: number;
+  factId?: string;
+};
+
+/** Scopes that require OCC when the caller supplies expectedHash (#2175). */
+export function isSharedOccScope(scope: MemoryScope | string | null | undefined): boolean {
+  return scope === "global" || scope === "user" || scope === "agent";
+}
+
+export function hashFactOccToken(parts: {
+  id: string;
+  revisionCount: number;
+  normalizedHash: string;
+}): string {
+  return createHash("sha256")
+    .update(`${parts.id}:${parts.revisionCount}:${parts.normalizedHash}`)
+    .digest("hex");
+}
+
+/** OCC token for a live MemoryEntry-shaped row (#2175). */
+export function occTokenForFact(fact: {
+  id: string;
+  text: string;
+  revisionCount?: number | null;
+}): string {
+  return hashFactOccToken({
+    id: fact.id,
+    revisionCount: fact.revisionCount ?? 0,
+    normalizedHash: normalizedHash(fact.text),
+  });
+}
+
+/**
+ * Cheap whole-store revision for dream promote OCC (#2170/#2175).
+ * Hash of active fact count + max created_at + sample of id:hash pairs.
+ */
+export function computeInputStoreRevision(
+  rows: Array<{ id: string; text: string; revisionCount?: number | null; createdAt?: number }>,
+): string {
+  const h = createHash("sha256");
+  h.update(`count:${rows.length};`);
+  let maxCreated = 0;
+  for (const row of rows) {
+    if (typeof row.createdAt === "number" && row.createdAt > maxCreated) maxCreated = row.createdAt;
+  }
+  h.update(`maxCreated:${maxCreated};`);
+  const sorted = [...rows].sort((a, b) => a.id.localeCompare(b.id));
+  const sample = sorted.length <= 64 ? sorted : [...sorted.slice(0, 32), ...sorted.slice(-32)];
+  for (const row of sample) {
+    h.update(occTokenForFact(row));
+    h.update(";");
+  }
+  return h.digest("hex");
+}
+
+export function buildMemoryConflictDetails(params: {
+  expectedHash: string;
+  currentHash: string;
+  currentRevision?: number;
+  factId?: string;
+}): MemoryConflictDetails {
+  return {
+    error: MEMORY_CONFLICT_CODE,
+    code: MEMORY_CONFLICT_CODE,
+    expectedHash: params.expectedHash,
+    currentHash: params.currentHash,
+    currentRevision: params.currentRevision,
+    factId: params.factId,
+  };
+}
+
+export class MemoryConflictError extends Error {
+  readonly code = MEMORY_CONFLICT_CODE;
+  readonly details: MemoryConflictDetails;
+
+  constructor(details: MemoryConflictDetails) {
+    super(
+      `memory_conflict: stale base for fact ${details.factId ?? "?"} ` +
+        `(expected ${details.expectedHash.slice(0, 8)}…, current ${details.currentHash.slice(0, 8)}…)`,
+    );
+    this.name = "MemoryConflictError";
+    this.details = details;
+  }
+}


### PR DESCRIPTION
## Summary
- Completes Autonomous Dreaming **closed loop** for Epic #2169: real compose candidates, scheduled nightly `dream-run`, fail-closed permission attachment + allowlisted mining, live contradiction gates, shadow-validation before live promote, outcome probe/ROI, steering, and autopilot-first defaults.
- Nightly Dream discovers sessions from FactsDB, resolves ACL fail-closed (never invents `global` from fact writes; transcript path floors to `agent`), and passes allowlists into distill/self-correction/reflect.
- Fixes **#2181** two-phase reload and fail-closed tools when Phase B activation fails.

### Closes
- Closes #2169
- Closes #2170
- Closes #2171
- Closes #2172
- Closes #2173
- Closes #2174
- Closes #2175
- Closes #2176
- Closes #2177
- Closes #2178
- Closes #2179
- Closes #2181

### Known follow-ups (documented, not blockers)
- Outcome signals remain blended/feedback-proxy (not full task-success attribution).
- Contradiction gate is heuristic (not full NLI); unstructured candidates without entity/key skip that gate and still hit prevalence/provenance.
- No transcript-native ACL metadata in OpenClaw JSONL — agent-path floor + FactsDB scopes + `--session-scopes` are the source of truth.

## Test plan
- [x] `cd extensions/memory-hybrid && npx tsc --noEmit`
- [x] Dream suite: `dream-run`, `dream-compose-candidates`, `dream-contradiction-gate`, `dream-autonomy-gates`, `dream-skip-overlap-fail-closed`, `dream-promote-rollback`, `dream-steering-probe`, `activation-fail-closed`, `cmd-distill` allowlist
- [ ] `npm run lint`
- [ ] `npm test` (full suite / CI)
- [ ] Manual: `openclaw hybrid-mem dream run --dry-shadow --json` → candidates from stage proposals
- [ ] Enable `dreaming.enabled` in shadow: nightly includes `dream-run`; owned steps skip only when dream-run is scheduled; empty attachment does not scoop unrestricted transcripts