### PR TITLE
fix(dream): complete #2182 task-success outcome loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Fixed
+- Dream outcome probes now use session-allowlisted terminal workflow success/failure traces for full closed-loop task-success attribution; feedback remains a fallback when no terminal trace exists.
+
+### Changed
+- Bump memory-hybrid release version to `2026.7.223`.
+
 - Autonomous Dreaming (#2169): machine-gated candidate promote/rollback is the happy path for continual learning; human approve/deny and pending digests are escape hatches (`dreaming.mode: autonomous` by default). See `docs/AUTONOMOUS-DREAMING.md`.
 
 - Maintenance validation: ignore guard/gate skipped `reflect-rules` runs in semantic zero-stored checks, suppress the analyzer's own current in-flight HM_EXIT ledger, and classify nested distill abort/timeout errors as retryable within the existing fallback/shrink budget.

--- a/docs/AUTONOMOUS-DREAMING.md
+++ b/docs/AUTONOMOUS-DREAMING.md
@@ -99,7 +99,7 @@ After promote ([#2173](https://github.com/markus-lassfolk/openclaw-hybrid-memory
 4. Nightly `dream-outcome-probe` (when autoRollback enabled) collects after-window metrics **scoped to the dream’s sessions**, compares effect score, and **auto-rollbacks** via reverse plan on regression.
 5. Decisions (`keep` / `rollback` / `insufficient_data`) are journaled on `dream_runs.metrics_summary_json`. Insufficient data never false-rollbacks.
 
-**v1 signal note:** Outcome metrics prefer a **blended** signal when `tool_effectiveness` rows exist in the same DB (`signalSource: blended|tool_effectiveness|feedback_proxy`). Otherwise they fall back to **feedback proxies** (self-correction / reinforcement fact counts). Full closed-loop task-success attribution is still a follow-up.
+**Outcome signal:** Outcome metrics now read terminal `success`/`failure` workflow traces from the dedicated workflow-traces database, strictly allowlisted to the dream's attached sessions (`signalSource: task_success`). When explicit feedback is also present, the report is a task-success-weighted `blended` signal. Unknown traces never count as success; feedback remains the safe fallback when no terminal task outcome exists.
 
 ## How to read Dream ROI
 

--- a/extensions/memory-hybrid/docs/AUTONOMOUS-DREAMING.md
+++ b/extensions/memory-hybrid/docs/AUTONOMOUS-DREAMING.md
@@ -99,7 +99,7 @@ After promote ([#2173](https://github.com/markus-lassfolk/openclaw-hybrid-memory
 4. Nightly `dream-outcome-probe` (when autoRollback enabled) collects after-window metrics **scoped to the dream’s sessions**, compares effect score, and **auto-rollbacks** via reverse plan on regression.
 5. Decisions (`keep` / `rollback` / `insufficient_data`) are journaled on `dream_runs.metrics_summary_json`. Insufficient data never false-rollbacks.
 
-**v1 signal note:** Outcome metrics prefer a **blended** signal when `tool_effectiveness` rows exist in the same DB (`signalSource: blended|tool_effectiveness|feedback_proxy`). Otherwise they fall back to **feedback proxies** (self-correction / reinforcement fact counts). Full closed-loop task-success attribution is still a follow-up.
+**Outcome signal:** Outcome metrics now read terminal `success`/`failure` workflow traces from the dedicated workflow-traces database, strictly allowlisted to the dream's attached sessions (`signalSource: task_success`). When explicit feedback is also present, the report is a task-success-weighted `blended` signal. Unknown traces never count as success; feedback remains the safe fallback when no terminal task outcome exists.
 
 ## How to read Dream ROI
 

--- a/extensions/memory-hybrid/openclaw.plugin.json
+++ b/extensions/memory-hybrid/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "openclaw-hybrid-memory",
   "kind": "memory",
-  "version": "2026.7.222",
+  "version": "2026.7.223",
   "contracts": {
     "tools": [
       "active_task_checkpoint",

--- a/extensions/memory-hybrid/package.json
+++ b/extensions/memory-hybrid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-hybrid-memory",
-  "version": "2026.7.222",
+  "version": "2026.7.223",
   "type": "module",
   "description": "Give your OpenClaw agent lasting memory: structured facts, semantic search, auto-capture & recall, decay, optional credential vault. Part of Hybrid Memory v3.",
   "files": [

--- a/extensions/memory-hybrid/services/dream-metrics.ts
+++ b/extensions/memory-hybrid/services/dream-metrics.ts
@@ -2,7 +2,9 @@
  * Dream metrics collection (#2173 / #2179) — baseline + after-window signals from the facts DB.
  */
 
-import type { DatabaseSync } from "node:sqlite";
+import { DatabaseSync } from "node:sqlite";
+import { existsSync } from "node:fs";
+import { defaultWorkflowDbPath } from "./maintenance-coverage.js";
 import type { FactsDB } from "../backends/facts-db.js";
 import type { DreamMetricSet } from "./dream-outcome.js";
 
@@ -112,68 +114,69 @@ export function deriveEffectScore(corrections: number, praise: number): number {
   return Math.max(-1, Math.min(1, raw));
 }
 
-function readToolEffectivenessAggregate(
-  db: DatabaseSync,
+/**
+ * Read actual task outcomes from workflow traces, which are persisted separately
+ * from facts/tool-effectiveness.  This is deliberately session-allowlisted: a
+ * dream must never judge a promotion using unrelated users' task outcomes.
+ */
+function readTaskSuccessAggregate(
   fromSec: number,
   toSec: number,
-): { successRate: number; totalCalls: number } | null {
+  sessionIds: string[],
+  workflowDbPath = defaultWorkflowDbPath(),
+): { successRate: number; total: number; sessions: number } | null {
+  const ids = [...new Set(sessionIds.map((id) => id.trim()).filter(Boolean))];
+  if (ids.length === 0 || !existsSync(workflowDbPath)) return null;
+  let db: DatabaseSync | null = null;
   try {
+    db = new DatabaseSync(workflowDbPath, { readOnly: true });
+    const placeholders = ids.map(() => "?").join(",");
+    const from = new Date(fromSec * 1000).toISOString();
+    const to = new Date(toSec * 1000).toISOString();
     const row = db
       .prepare(
-        `SELECT COALESCE(SUM(success_calls), 0) AS ok,
-                COALESCE(SUM(total_calls), 0) AS total
-         FROM tool_effectiveness
-         WHERE last_updated >= ? AND last_updated <= ?`,
+        `SELECT
+           SUM(CASE WHEN outcome = 'success' THEN 1 ELSE 0 END) AS ok,
+           COUNT(*) AS total,
+           COUNT(DISTINCT session_id) AS sessions
+         FROM workflow_traces
+         WHERE created_at >= ? AND created_at <= ?
+           AND session_id IN (${placeholders})
+           AND outcome IN ('success', 'failure')`,
       )
-      .get(fromSec, toSec) as { ok: number; total: number } | undefined;
+      .get(from, to, ...ids) as { ok: number; total: number; sessions: number } | undefined;
     const total = Number(row?.total ?? 0);
-    if (!Number.isFinite(total) || total <= 0) return null;
-    const ok = Number(row?.ok ?? 0);
-    return { successRate: Math.max(0, Math.min(1, ok / total)), totalCalls: total };
+    if (!Number.isFinite(total) || total === 0) return null;
+    return { successRate: Math.max(0, Math.min(1, Number(row?.ok ?? 0) / total)), total, sessions: Number(row?.sessions ?? 0) };
   } catch {
-    // Table may not exist in this DB — feedback proxy remains the primary signal.
+    // The workflow database is optional and may be unavailable during reload.
     return null;
+  } finally {
+    db?.close();
   }
 }
 
 export function collectDreamMetricSet(
   factsDb: FactsDB,
-  input: { fromSec: number; toSec: number; sessionIds: string[] },
+  input: { fromSec: number; toSec: number; sessionIds: string[]; workflowDbPath?: string },
 ): DreamMetricSet {
   const db = factsDb.getRawDb();
   const { corrections, praise, sessions } = countFeedbackSignals(db, input.fromSec, input.toSec, input.sessionIds);
-  const effectScore = deriveEffectScore(corrections, praise);
   const feedbackSuccess = praise + corrections > 0 ? praise / (praise + corrections) : 1;
+  const task = readTaskSuccessAggregate(input.fromSec, input.toSec, input.sessionIds, input.workflowDbPath);
   const retryRate = corrections;
-  const tool = readToolEffectivenessAggregate(db, input.fromSec, input.toSec);
 
-  if (tool && praise + corrections > 0) {
-    // Prefer blended signal when both feedback and tool effectiveness exist (#2173).
-    const successRate = 0.5 * feedbackSuccess + 0.5 * tool.successRate;
-    return {
-      successRate,
-      retryRate,
-      effectScore,
-      sessionsObserved: sessions,
-      signalSource: "blended",
-    };
+  // A completed task's success/failure is the primary closed-loop outcome. Blend
+  // it with explicit feedback only when both signals exist; unknown traces never
+  // create a false success signal.
+  if (task && praise + corrections > 0) {
+    const successRate = 0.75 * task.successRate + 0.25 * feedbackSuccess;
+    return { successRate, retryRate, effectScore: successRate * 2 - 1, sessionsObserved: Math.max(sessions, task.sessions), signalSource: "blended" };
   }
-  if (tool && praise + corrections === 0) {
-    return {
-      successRate: tool.successRate,
-      retryRate,
-      effectScore: tool.successRate * 2 - 1,
-      sessionsObserved: Math.max(sessions, 1),
-      signalSource: "tool_effectiveness",
-    };
+  if (task) {
+    return { successRate: task.successRate, retryRate, effectScore: task.successRate * 2 - 1, sessionsObserved: Math.max(sessions, task.sessions), signalSource: "task_success" };
   }
-  return {
-    successRate: feedbackSuccess,
-    retryRate,
-    effectScore,
-    sessionsObserved: sessions,
-    signalSource: "feedback_proxy",
-  };
+  return { successRate: feedbackSuccess, retryRate, effectScore: deriveEffectScore(corrections, praise), sessionsObserved: sessions, signalSource: "feedback_proxy" };
 }
 
 export function collectHygieneSnapshot(factsDb: FactsDB): DreamHygieneSnapshot {

--- a/extensions/memory-hybrid/services/dream-outcome.ts
+++ b/extensions/memory-hybrid/services/dream-outcome.ts
@@ -26,7 +26,7 @@ export type DreamMetricSet = {
    * - blended: feedback + tool_effectiveness when available
    * - tool_effectiveness: tool table only (rare)
    */
-  signalSource?: "feedback_proxy" | "blended" | "tool_effectiveness";
+  signalSource?: "feedback_proxy" | "blended" | "task_success" | "tool_effectiveness";
 };
 
 export type DreamOutcomeDecision = "keep" | "rollback" | "insufficient_data";
@@ -49,6 +49,7 @@ export function parseBaseline(json: string | null | undefined): DreamMetricSet |
     const signalSource =
       parsed.signalSource === "blended" ||
       parsed.signalSource === "tool_effectiveness" ||
+      parsed.signalSource === "task_success" ||
       parsed.signalSource === "feedback_proxy"
         ? parsed.signalSource
         : undefined;

--- a/extensions/memory-hybrid/tests/dream-steering-probe.test.ts
+++ b/extensions/memory-hybrid/tests/dream-steering-probe.test.ts
@@ -4,6 +4,7 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { WorkflowStore } from "../backends/workflow-store.js";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { FactsDB } from "../backends/facts-db.js";
 import { DreamCandidateStore } from "../backends/dream-candidate-store.js";
@@ -36,14 +37,19 @@ describe("dream steering (#2176)", () => {
   let tmpDir: string;
   let factsDb: FactsDB;
   let store: DreamCandidateStore;
+  let workflowStore: WorkflowStore;
+  let workflowDbPath: string;
 
   beforeEach(() => {
     tmpDir = mkdtempSync(join(tmpdir(), "dream-steer-"));
     factsDb = new FactsDB(join(tmpDir, "facts.db"));
     store = new DreamCandidateStore(factsDb.getRawDb());
+    workflowDbPath = join(tmpDir, "workflow-traces.db");
+    workflowStore = new WorkflowStore(workflowDbPath);
   });
 
   afterEach(() => {
+    workflowStore.close();
     factsDb.close();
     rmSync(tmpDir, { recursive: true, force: true });
   });
@@ -78,6 +84,22 @@ describe("dream steering (#2176)", () => {
     expect(summary.attachment?.includedCount).toBe(1);
     expect(summary.attachment?.excludedCount).toBe(1);
     expect(summary.attachment?.excluded[0]?.sessionId).toBe("s-private");
+  });
+
+  it("uses attached-session terminal workflow outcomes before feedback proxies (#2173)", () => {
+    const now = Date.now();
+    workflowStore.record({ goal: "attached success", toolSequence: ["read"], outcome: "success", sessionId: "s1" });
+    workflowStore.record({ goal: "attached failure", toolSequence: ["read"], outcome: "failure", sessionId: "s1" });
+    workflowStore.record({ goal: "unattached failure", toolSequence: ["read"], outcome: "failure", sessionId: "other" });
+    const metrics = collectDreamMetricSet(factsDb, {
+      fromSec: Math.floor(now / 1000) - 5,
+      toSec: Math.floor(now / 1000) + 5,
+      sessionIds: ["s1"],
+      workflowDbPath,
+    });
+    expect(metrics.signalSource).toBe("task_success");
+    expect(metrics.successRate).toBe(0.5);
+    expect(metrics.sessionsObserved).toBe(1);
   });
 
   it("resolves profile defaults", () => {
@@ -148,11 +170,15 @@ describe("dream outcome probe (#2173)", () => {
   let tmpDir: string;
   let factsDb: FactsDB;
   let store: DreamCandidateStore;
+  let workflowStore: WorkflowStore;
+  let workflowDbPath: string;
 
   beforeEach(() => {
     tmpDir = mkdtempSync(join(tmpdir(), "dream-probe-"));
     factsDb = new FactsDB(join(tmpDir, "facts.db"));
     store = new DreamCandidateStore(factsDb.getRawDb());
+    workflowDbPath = join(tmpDir, "workflow-traces.db");
+    workflowStore = new WorkflowStore(workflowDbPath);
   });
 
   afterEach(() => {

--- a/packages/openclaw-hybrid-memory-install/package.json
+++ b/packages/openclaw-hybrid-memory-install/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-hybrid-memory-install",
-  "version": "2026.7.222",
+  "version": "2026.7.223",
   "description": "Standalone installer for openclaw-hybrid-memory. Use when OpenClaw config validation fails.",
   "bin": {
     "openclaw-hybrid-memory-install": "./install.js"


### PR DESCRIPTION
## Summary

Follow-up to #2182. This PR closes the only real residual implementation gap found in the live #2182 claim set: its documented #2173 outcome loop said that full closed-loop task-success attribution was still a follow-up.

Dream outcome metrics now read terminal `success`/`failure` workflow traces from the dedicated workflow-traces database, limited to the exact sessions attached to the dream run. Terminal task outcomes are primary; explicit feedback is blended only when present; feedback remains the conservative fallback if no terminal outcome exists. Unrelated sessions and unknown outcomes are excluded.

Release version is bumped from `2026.7.222` to `2026.7.223` using the project's authoritative `extensions/memory-hybrid/package.json` plus the required synced plugin manifest and installer package.

## #2182 completeness matrix

| #2182 claimed requirement | Status after this PR | Evidence / test |
|---|---|---|
| #2169: autonomous dreaming default, governed candidate lifecycle | Complete in #2182 | Existing autonomous config, candidate store and gate tests |
| #2170: safe shadow → gated promote path and rollbackability | Complete in #2182 | Existing `dream-autonomy-gates` coverage |
| #2171: composable dream pipeline/curriculum execution | Complete in #2182 | Existing `dream-run.test.ts` coverage |
| #2172: session-aware attachment, privacy/ACL boundary | Complete in #2182 | Existing attachment/permission policy and tests |
| #2173: observe outcomes and rollback regressions | **Completed here** | `dream-metrics.ts` queries only attached-session terminal workflow traces; focused test proves an unrelated failed session is excluded |
| #2174: human-review/proposal escape hatch | Complete in #2182 | Existing candidate-review flow and docs |
| #2175: deterministic machine gates/OCC safeguards | Complete in #2182 | Existing gate/OCC tests |
| #2176: steering profiles and ignored-category policy | Complete in #2182 | Existing steering tests |
| #2177: explainability/audit records | Complete in #2182 | Existing `dream_runs` metrics/journal output |
| #2178: ROI and cost/hygiene reporting | Complete in #2182 | Existing metrics/ROI reports |
| #2179: success/retry/effect baseline comparison | Complete in #2182, with #2173 source now real | Existing probe tests plus new task-success source |

**Residual #2182 work:** none. Live inspection of #2182 body, linked issues, commits/files, comments/reviews/review threads, and checks found no other partial/deferred implementation item directly attributable to #2182. This PR deliberately does not fold unrelated backlog work.

## Validation

- `npm run format -- --write`
- `npm run lint` (passes; repository has pre-existing warnings)
- `npm run typecheck:gate`
- `npx vitest run tests/dream-steering-probe.test.ts tests/dream-autonomy-gates.test.ts tests/dream-run.test.ts` — 26 passed
- `npm run sync:version -- --check`
- `npm run build`
