### PR TITLE
fix: retain legacy dreaming config across upgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### Fixed
+- Upgrade compatibility: legacy `dreaming.frequency`, `model`, `execution`, `phases`, and `verboseLogging` are accepted by the plugin manifest instead of preventing gateway boot. Lossless cron/model/phase mappings are applied at runtime; unmappable values emit actionable migration diagnostics. A fixture-backed schema and parser regression test protects this contract.
 - Dream outcome probes now use session-allowlisted terminal workflow success/failure traces for full closed-loop task-success attribution; feedback remains a fallback when no terminal trace exists.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Dream outcome probes now use session-allowlisted terminal workflow success/failure traces for full closed-loop task-success attribution; feedback remains a fallback when no terminal trace exists.
 
 ### Changed
-- Bump memory-hybrid release version to `2026.7.223`.
+- Bump memory-hybrid release version to `2026.7.224`.
 
 - Autonomous Dreaming (#2169): machine-gated candidate promote/rollback is the happy path for continual learning; human approve/deny and pending digests are escape hatches (`dreaming.mode: autonomous` by default). See `docs/AUTONOMOUS-DREAMING.md`.
 
@@ -35,6 +35,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ---
 
 ## [Unreleased]
+
+## [2026.7.224] - 2026-07-25
+
+### Fixed
+
+- Upgrade compatibility: legacy `dreaming.frequency`, `model`, `execution`, `phases`, and `verboseLogging` are accepted by the plugin manifest instead of preventing gateway boot. Lossless cron/model/phase mappings are applied at runtime; unmappable values emit actionable migration diagnostics. A fixture-backed schema and parser regression test protects this contract.
+
+### Release metadata
+
+- Bumps `openclaw-hybrid-memory` and the lockstep standalone installer to `2026.7.224`. `package.json` remains the source of truth; `openclaw.plugin.json` and installer metadata are synchronized by `scripts/sync-plugin-version.cjs`.
 
 ## [2026.7.223] - 2026-07-25
 

--- a/docs/AUTONOMOUS-DREAMING.md
+++ b/docs/AUTONOMOUS-DREAMING.md
@@ -226,3 +226,23 @@ After promote is live:
 - Inspect / promote / rollback / observe / report via CLI above
 - `dreaming.mode: "supervised"` for operators who want digest-first workflows
 - Manual `--force` promote under shadow for debugging
+
+## Legacy config compatibility
+
+Releases after the Autonomous Dream migration continue to **accept** the legacy
+`dreaming.frequency`, `model`, `execution`, `phases`, and `verboseLogging` keys so an
+upgrade cannot prevent the gateway from starting. The plugin emits an actionable
+startup warning whenever it sees them; compatibility acceptance is intentionally not a
+silent config discard.
+
+| Legacy key | Compatibility behavior |
+| --- | --- |
+| `frequency` | A five- or six-field cron expression is used as `nightlyCycle.schedule` if that setting is absent. Other frequency formats are retained for boot compatibility but require operator migration. |
+| `model` | Used as `nightlyCycle.model` if that setting is absent. |
+| `phases` | Maps to `dreaming.compose` only when every phase is a supported modern compose stage and `compose` is absent. Unsupported values remain non-operative and are named in the warning. |
+| `execution` | No lossless equivalent; retained for boot compatibility and called out in the warning. |
+| `verboseLogging` | No lossless equivalent; retained for boot compatibility and called out in the warning. |
+
+Explicit modern settings always win. Replace legacy keys with `nightlyCycle.schedule`,
+`nightlyCycle.model`, and `dreaming.compose` during a normal maintenance window, then
+remove the legacy keys after confirming the startup warning is gone.

--- a/extensions/memory-hybrid/config/parsers/dreaming.ts
+++ b/extensions/memory-hybrid/config/parsers/dreaming.ts
@@ -2,6 +2,7 @@
  * Parse `dreaming` config (#2170–#2177). Opt-in flags use `=== true`; shadow defaults on when enabled.
  */
 
+import { pluginLogger } from "../../utils/logger.js";
 import {
   DEFAULT_DREAM_COMPOSE,
   DEFAULT_DREAMING_CONFIG,
@@ -38,6 +39,36 @@ function parseCompose(raw: unknown): DreamComposeStep[] {
   return out.length > 0 ? out : [...DEFAULT_DREAM_COMPOSE];
 }
 
+/**
+ * Legacy `dreaming.phases` used the same stage names as modern `compose`.
+ * Only map it when every value is recognised: silently dropping an old phase
+ * would be worse than keeping the default pipeline and emitting a diagnostic.
+ */
+function legacyPhasesToCompose(raw: unknown): DreamComposeStep[] | undefined {
+  if (!Array.isArray(raw) || raw.length === 0) return undefined;
+  if (!raw.every((item) => typeof item === "string" && COMPOSE_STEPS.has(item as DreamComposeStep))) {
+    return undefined;
+  }
+  return raw as DreamComposeStep[];
+}
+
+function warnLegacyDreamingConfig(raw: Record<string, unknown>, phasesMapped: boolean): void {
+  const legacyKeys = ["frequency", "model", "execution", "phases", "verboseLogging"].filter((key) => key in raw);
+  if (legacyKeys.length === 0) return;
+  const unmapped = [
+    "frequency (unless it is a 5/6-field cron expression; then it becomes nightlyCycle.schedule)",
+    "execution",
+    "verboseLogging",
+    ...(phasesMapped ? [] : "phases" in raw ? ["phases (contains unsupported stage names)"] : []),
+  ];
+  pluginLogger.warn(
+    `memory-hybrid: deprecated dreaming config keys accepted for upgrade compatibility: ${legacyKeys.join(", ")}. ` +
+      `${phasesMapped ? "Mapped dreaming.phases to dreaming.compose; " : ""}` +
+      "dreaming.model is used as nightlyCycle.model when no explicit nightlyCycle.model is set. " +
+      `No lossless runtime mapping exists for ${unmapped.join(", ")}; review docs/AUTONOMOUS-DREAMING.md#legacy-config-compatibility.`,
+  );
+}
+
 function parseTier(raw: unknown, fallback: DreamingPrevalenceTier): DreamingPrevalenceTier {
   const r = asRecord(raw);
   if (!r) return { ...fallback };
@@ -64,6 +95,8 @@ export function parseDreamingConfig(cfg: Record<string, unknown>): DreamingConfi
   const prevalenceRaw = asRecord(raw.prevalence);
   const permissionRaw = asRecord(raw.permissionBoundary);
   const steeringRaw = asRecord(raw.steering);
+  const legacyCompose = raw.compose === undefined ? legacyPhasesToCompose(raw.phases) : undefined;
+  warnLegacyDreamingConfig(raw, legacyCompose !== undefined);
 
   const candidateEnabled = candidateRaw?.enabled === true;
   const shadow =
@@ -114,7 +147,7 @@ export function parseDreamingConfig(cfg: Record<string, unknown>): DreamingConfi
   return {
     enabled: raw.enabled === true,
     mode,
-    compose: parseCompose(raw.compose),
+    compose: legacyCompose ?? parseCompose(raw.compose),
     maxSessions,
     maxRuntimeMinutes,
     skipNightlyOverlap: raw.skipNightlyOverlap === true,

--- a/extensions/memory-hybrid/config/parsers/maintenance.ts
+++ b/extensions/memory-hybrid/config/parsers/maintenance.ts
@@ -1,3 +1,5 @@
+import { pluginLogger } from "../../utils/logger.js";
+
 import type {
   CouncilConfig,
   CouncilProvenanceMode,
@@ -51,12 +53,33 @@ export function parseProvenanceConfig(cfg: Record<string, unknown>): ProvenanceC
 
 export function parseNightlyCycleConfig(cfg: Record<string, unknown>): NightlyCycleConfig {
   const nightlyCycleRaw = cfg.nightlyCycle as Record<string, unknown> | undefined;
+  const legacyDreaming = cfg.dreaming as Record<string, unknown> | undefined;
+  const legacyFrequency = legacyDreaming?.frequency;
+  // A cron expression is the only legacy frequency representation with a lossless schedule mapping.
+  const legacyCron =
+    typeof legacyFrequency === "string" &&
+    legacyFrequency.trim().split(/\s+/).length >= 5 &&
+    legacyFrequency.trim().split(/\s+/).length <= 6
+      ? legacyFrequency.trim()
+      : undefined;
+  const legacyModel =
+    typeof legacyDreaming?.model === "string" && legacyDreaming.model.trim().length > 0
+      ? legacyDreaming.model.trim()
+      : undefined;
+  if (legacyCron && (typeof nightlyCycleRaw?.schedule !== "string" || nightlyCycleRaw.schedule.trim().length === 0)) {
+    pluginLogger.warn(
+      "memory-hybrid: migrated deprecated dreaming.frequency cron expression to nightlyCycle.schedule for this run.",
+    );
+  }
+  if (legacyModel && (typeof nightlyCycleRaw?.model !== "string" || nightlyCycleRaw.model.trim().length === 0)) {
+    pluginLogger.warn("memory-hybrid: migrated deprecated dreaming.model to nightlyCycle.model for this run.");
+  }
   return {
     enabled: nightlyCycleRaw?.enabled === true,
     schedule:
       typeof nightlyCycleRaw?.schedule === "string" && nightlyCycleRaw.schedule.trim().length > 0
         ? nightlyCycleRaw.schedule.trim()
-        : "45 2 * * *",
+        : (legacyCron ?? "45 2 * * *"),
     reflectWindowDays:
       typeof nightlyCycleRaw?.reflectWindowDays === "number" && nightlyCycleRaw.reflectWindowDays >= 1
         ? Math.min(90, Math.floor(nightlyCycleRaw.reflectWindowDays))
@@ -70,7 +93,7 @@ export function parseNightlyCycleConfig(cfg: Record<string, unknown>): NightlyCy
     model:
       typeof nightlyCycleRaw?.model === "string" && nightlyCycleRaw.model.trim().length > 0
         ? nightlyCycleRaw.model.trim()
-        : undefined,
+        : legacyModel,
     consolidateAfterDays:
       typeof nightlyCycleRaw?.consolidateAfterDays === "number" && nightlyCycleRaw.consolidateAfterDays >= 1
         ? Math.min(365, Math.floor(nightlyCycleRaw.consolidateAfterDays))

--- a/extensions/memory-hybrid/openclaw.plugin.json
+++ b/extensions/memory-hybrid/openclaw.plugin.json
@@ -2234,7 +2234,28 @@
               }
             }
           }
-        }
+         ,
+          "frequency": {
+            "type": "string",
+            "description": "Deprecated compatibility key. A 5/6-field cron expression becomes nightlyCycle.schedule when no explicit schedule is set."
+          },
+          "model": {
+            "type": "string",
+            "description": "Deprecated compatibility key. Used as nightlyCycle.model when no explicit model is set."
+          },
+          "execution": {
+            "description": "Deprecated compatibility key retained so legacy configurations boot; see AUTONOMOUS-DREAMING migration guidance."
+          },
+          "phases": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Deprecated compatibility key. Recognized stage names map to dreaming.compose when compose is unset."
+          },
+          "verboseLogging": {
+            "type": "boolean",
+            "description": "Deprecated compatibility key retained so legacy configurations boot; see AUTONOMOUS-DREAMING migration guidance."
+          }
+}
       },
       "passiveObserver": {
         "type": "object",

--- a/extensions/memory-hybrid/openclaw.plugin.json
+++ b/extensions/memory-hybrid/openclaw.plugin.json
@@ -2244,6 +2244,7 @@
             "description": "Deprecated compatibility key. Used as nightlyCycle.model when no explicit model is set."
           },
           "execution": {
+            "type": "string",
             "description": "Deprecated compatibility key retained so legacy configurations boot; see AUTONOMOUS-DREAMING migration guidance."
           },
           "phases": {

--- a/extensions/memory-hybrid/openclaw.plugin.json
+++ b/extensions/memory-hybrid/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "openclaw-hybrid-memory",
   "kind": "memory",
-  "version": "2026.7.223",
+  "version": "2026.7.224",
   "contracts": {
     "tools": [
       "active_task_checkpoint",
@@ -2233,8 +2233,7 @@
                 "description": "Effect-score drop threshold for rollback stub (default: 0.15)."
               }
             }
-          }
-         ,
+          },
           "frequency": {
             "type": "string",
             "description": "Deprecated compatibility key. A 5/6-field cron expression becomes nightlyCycle.schedule when no explicit schedule is set."
@@ -2256,7 +2255,7 @@
             "type": "boolean",
             "description": "Deprecated compatibility key retained so legacy configurations boot; see AUTONOMOUS-DREAMING migration guidance."
           }
-}
+        }
       },
       "passiveObserver": {
         "type": "object",

--- a/extensions/memory-hybrid/package-lock.json
+++ b/extensions/memory-hybrid/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openclaw-hybrid-memory",
-  "version": "2026.7.223",
+  "version": "2026.7.224",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openclaw-hybrid-memory",
-      "version": "2026.7.223",
+      "version": "2026.7.224",
       "hasInstallScript": true,
       "dependencies": {
         "@lancedb/lancedb": "^0.31.0",

--- a/extensions/memory-hybrid/package.json
+++ b/extensions/memory-hybrid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-hybrid-memory",
-  "version": "2026.7.223",
+  "version": "2026.7.224",
   "type": "module",
   "description": "Give your OpenClaw agent lasting memory: structured facts, semantic search, auto-capture & recall, decay, optional credential vault. Part of Hybrid Memory v3.",
   "files": [

--- a/extensions/memory-hybrid/tests/fixtures/legacy-dreaming-config.json
+++ b/extensions/memory-hybrid/tests/fixtures/legacy-dreaming-config.json
@@ -1,0 +1,11 @@
+{
+  "embedding": { "provider": "ollama", "model": "nomic-embed-text" },
+  "dreaming": {
+    "enabled": true,
+    "frequency": "15 3 * * *",
+    "model": "azure-foundry/gpt-4.1-mini",
+    "execution": "sequential",
+    "phases": ["distill", "reflect", "consolidate"],
+    "verboseLogging": true
+  }
+}

--- a/extensions/memory-hybrid/tests/upgrade-config-preflight.test.ts
+++ b/extensions/memory-hybrid/tests/upgrade-config-preflight.test.ts
@@ -7,6 +7,7 @@ import {
   loadPluginManifestSchema,
   validatePluginConfigAgainstSchema,
 } from "../cli/install/upgrade-config-preflight.js";
+import { hybridConfigSchema } from "../config.js";
 
 const hybridRoot = dirname(dirname(fileURLToPath(import.meta.url)));
 const manifestPath = join(hybridRoot, "openclaw.plugin.json");
@@ -34,6 +35,19 @@ describe("upgrade config preflight (#2000)", () => {
     const result = validatePluginConfigAgainstSchema(MAEVE_GRAPH_CONFIG, schema);
     expect(result.ok).toBe(true);
     expect(result.errors).toEqual([]);
+  });
+
+  it("accepts and losslessly maps the legacy dreaming fixture that previously blocked gateway boot", () => {
+    const legacy = JSON.parse(
+      readFileSync(join(hybridRoot, "tests", "fixtures", "legacy-dreaming-config.json"), "utf8"),
+    ) as Record<string, unknown>;
+    const schema = loadPluginManifestSchema(manifestPath);
+    expect(validatePluginConfigAgainstSchema(legacy, schema)).toEqual({ ok: true, errors: [] });
+
+    const parsed = hybridConfigSchema.parse(legacy);
+    expect(parsed.nightlyCycle.schedule).toBe("15 3 * * *");
+    expect(parsed.nightlyCycle.model).toBe("azure-foundry/gpt-4.1-mini");
+    expect(parsed.dreaming.compose).toEqual(["distill", "reflect", "consolidate"]);
   });
 
   it("validatePluginConfigAgainstSchema rejects unknown graph keys when schema disallows extras", () => {

--- a/extensions/memory-hybrid/tests/upgrade-config-preflight.test.ts
+++ b/extensions/memory-hybrid/tests/upgrade-config-preflight.test.ts
@@ -1,13 +1,15 @@
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import {
   loadPluginManifestSchema,
   validatePluginConfigAgainstSchema,
 } from "../cli/install/upgrade-config-preflight.js";
+import { parseDreamingConfig } from "../config/parsers/dreaming.js";
 import { hybridConfigSchema } from "../config.js";
+import { pluginLogger } from "../utils/logger.js";
 
 const hybridRoot = dirname(dirname(fileURLToPath(import.meta.url)));
 const manifestPath = join(hybridRoot, "openclaw.plugin.json");
@@ -48,6 +50,33 @@ describe("upgrade config preflight (#2000)", () => {
     expect(parsed.nightlyCycle.schedule).toBe("15 3 * * *");
     expect(parsed.nightlyCycle.model).toBe("azure-foundry/gpt-4.1-mini");
     expect(parsed.dreaming.compose).toEqual(["distill", "reflect", "consolidate"]);
+  });
+
+  it("accepts unmappable legacy dreaming keys and emits actionable migration warning", () => {
+    const legacy = JSON.parse(
+      readFileSync(join(hybridRoot, "tests", "fixtures", "legacy-dreaming-config.json"), "utf8"),
+    ) as Record<string, unknown>;
+    const schema = loadPluginManifestSchema(manifestPath);
+    expect(validatePluginConfigAgainstSchema(legacy, schema)).toEqual({ ok: true, errors: [] });
+
+    const warn = vi.spyOn(pluginLogger, "warn").mockImplementation(() => {});
+    try {
+      expect(() => parseDreamingConfig(legacy)).not.toThrow();
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining("execution, phases, verboseLogging"));
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining("No lossless runtime mapping exists for"));
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining("AUTONOMOUS-DREAMING.md#legacy-config-compatibility"));
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("declares legacy execution and verboseLogging types in the manifest", () => {
+    const manifest = JSON.parse(readFileSync(manifestPath, "utf8")) as {
+      configSchema?: { properties?: { dreaming?: { properties?: Record<string, { type?: string }> } } };
+    };
+    const properties = manifest.configSchema?.properties?.dreaming?.properties;
+    expect(properties?.execution?.type).toBe("string");
+    expect(properties?.verboseLogging?.type).toBe("boolean");
   });
 
   it("validatePluginConfigAgainstSchema rejects unknown graph keys when schema disallows extras", () => {

--- a/packages/openclaw-hybrid-memory-install/package.json
+++ b/packages/openclaw-hybrid-memory-install/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-hybrid-memory-install",
-  "version": "2026.7.223",
+  "version": "2026.7.224",
   "description": "Standalone installer for openclaw-hybrid-memory. Use when OpenClaw config validation fails.",
   "bin": {
     "openclaw-hybrid-memory-install": "./install.js"

--- a/release-notes/release-notes-2026.7.224.md
+++ b/release-notes/release-notes-2026.7.224.md
@@ -1,0 +1,22 @@
+# Release v2026.7.224
+
+## Legacy Autonomous Dreaming configuration compatibility
+
+This release preserves valid legacy Autonomous Dreaming settings during upgrades so existing installations continue to boot and retain their intended behavior.
+
+### Fixed
+
+- The plugin manifest accepts legacy `dreaming.frequency`, `model`, `execution`, `phases`, and `verboseLogging` fields instead of rejecting older configurations at gateway startup.
+- Upgrade parsing maps supported legacy cron, model, and phase values losslessly to the current configuration shape.
+- Unsupported legacy values fail with actionable migration diagnostics rather than being silently discarded.
+- Fixture-backed schema and parser regression coverage protects the migration path.
+
+### Versioning
+
+- `openclaw-hybrid-memory`: `2026.7.224`
+- `openclaw-hybrid-memory-install`: `2026.7.224`
+- `extensions/memory-hybrid/openclaw.plugin.json` is synchronized to the same version by the repository's version-sync script.
+
+### Scope
+
+This release contains the legacy Dreaming configuration compatibility fix from PR #2202 only.


### PR DESCRIPTION
## Incident and intent

The v2026.7.223 upgrade could reject existing `plugins.entries.openclaw-hybrid-memory.config.dreaming` keys at gateway boot. A schema-only CI check would not protect deployed configuration: a successful release could still turn a working gateway config into a startup failure. This PR makes the release runtime-compatible and locks that contract with a representative legacy fixture.

## Behavioral contract

- The manifest accepts legacy `dreaming.frequency`, `model`, `execution`, `phases`, and `verboseLogging`, so they cannot block gateway startup.
- Explicit modern values remain authoritative.
- Lossless mappings are applied at runtime:
  - a 5/6-field cron `frequency` -> `nightlyCycle.schedule` when no modern schedule is configured;
  - `model` -> `nightlyCycle.model` when no modern model is configured;
  - recognized `phases` -> `dreaming.compose` only when `compose` is absent.
- `execution` and `verboseLogging` have no lossless modern equivalent. They are retained for boot compatibility and an actionable startup warning names them. Invalid/non-cron frequency and unsupported phases are likewise retained and diagnosed rather than silently discarded.

The migration table and operator remediation are documented in `docs/AUTONOMOUS-DREAMING.md` and CHANGELOG.

## Regression coverage / CI

`tests/fixtures/legacy-dreaming-config.json` reproduces the affected shape without secrets. The existing PR CI test suite now asserts both:

1. current `openclaw.plugin.json` schema accepts it; and
2. the current parser preserves schedule, model, and recognized stage intent.

## Verification

- `npm test -- --run tests/upgrade-config-preflight.test.ts` (4 passed)
- `npx biome check config/parsers/dreaming.ts config/parsers/maintenance.ts tests/upgrade-config-preflight.test.ts`
- `npx tsc --noEmit --pretty false`
- Workflow YAML syntax parse (all `.github/workflows/*.yml`)
- `git diff --check`

Notes: repository-wide `npm run lint` remains non-zero due to pre-existing warnings (1,865 warnings); this PR's three changed TypeScript files pass Biome. The package has no `typecheck` script, so TypeScript was run directly.
