### PR TITLE
fix: harden deferred activation DB path defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+
+## [2026.7.225]
+
+### Fixed
+- Prevented deferred generation-2 activation from passing omitted database paths to the host path resolver; bootstrap now falls back to documented defaults and warns safely.
+- Added deferred full-teardown regression coverage for omitted paths with legacy dreaming configuration, plus source-context error logging.
+
 ## [2026.7.224] - 2026-07-25
 
 ### Fixed

--- a/extensions/memory-hybrid/openclaw.plugin.json
+++ b/extensions/memory-hybrid/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "openclaw-hybrid-memory",
   "kind": "memory",
-  "version": "2026.7.224",
+  "version": "2026.7.225",
   "contracts": {
     "tools": [
       "active_task_checkpoint",

--- a/extensions/memory-hybrid/package-lock.json
+++ b/extensions/memory-hybrid/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openclaw-hybrid-memory",
-  "version": "2026.7.224",
+  "version": "2026.7.225",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openclaw-hybrid-memory",
-      "version": "2026.7.224",
+      "version": "2026.7.225",
       "hasInstallScript": true,
       "dependencies": {
         "@lancedb/lancedb": "^0.31.0",

--- a/extensions/memory-hybrid/package.json
+++ b/extensions/memory-hybrid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-hybrid-memory",
-  "version": "2026.7.224",
+  "version": "2026.7.225",
   "type": "module",
   "description": "Give your OpenClaw agent lasting memory: structured facts, semantic search, auto-capture & recall, decay, optional credential vault. Part of Hybrid Memory v3.",
   "files": [

--- a/extensions/memory-hybrid/setup/bootstrap-databases.ts
+++ b/extensions/memory-hybrid/setup/bootstrap-databases.ts
@@ -19,7 +19,7 @@ import type { VectorDB } from "../backends/vector-db.js";
 import type { WriteAheadLog } from "../backends/wal.js";
 import type { WorkflowStore } from "../backends/workflow-store.js";
 import type { CredentialType, HybridMemoryConfig } from "../config.js";
-import { normalizeResolvedSecretValue } from "../config/parsers/core.js";
+import { DEFAULT_LANCE_PATH, DEFAULT_SQLITE_PATH, normalizeResolvedSecretValue } from "../config/parsers/core.js";
 import { is403QuotaOrRateLimitLike, is429OrWrapped } from "../services/chat.js";
 import { CREDENTIAL_REDACTION_MIGRATION_FLAG, migrateCredentialsToVault } from "../services/credential-migration.js";
 import { runEmbeddingMaintenance } from "../services/embedding-migration.js";
@@ -395,6 +395,19 @@ export function createReusedDatabaseBootstrap(
   });
 }
 
+function normalizeDatabasePath(
+  value: unknown,
+  fallback: string,
+  field: "lanceDbPath" | "sqlitePath",
+  api: ClawdbotPluginApi,
+): string {
+  if (typeof value === "string" && value.trim()) return value;
+  api.logger.warn?.(
+    `memory-hybrid: database bootstrap received missing or invalid ${field}; using the documented default (${field === "lanceDbPath" ? "DEFAULT_LANCE_PATH" : "DEFAULT_SQLITE_PATH"}).`,
+  );
+  return fallback;
+}
+
 /**
  * Initializes all databases and services for the plugin.
  *
@@ -416,8 +429,12 @@ export function initializeDatabases(
 ): DatabaseContext {
   const bootRegistrationGeneration = opts?.bootRegistrationGeneration ?? -1;
   const isBootstrapSuperseded = (): boolean => isRegistrationSuperseded(bootRegistrationGeneration);
-  const resolvedLancePath = api.resolvePath(cfg.lanceDbPath);
-  const resolvedSqlitePath = api.resolvePath(cfg.sqlitePath);
+  // Config parsing normally supplies these defaults. Keep the bootstrap boundary safe for
+  // deferred activation handoffs that may carry an older or partially reconstructed config.
+  const lanceDbPath = normalizeDatabasePath(cfg.lanceDbPath, DEFAULT_LANCE_PATH, "lanceDbPath", api);
+  const sqlitePath = normalizeDatabasePath(cfg.sqlitePath, DEFAULT_SQLITE_PATH, "sqlitePath", api);
+  const resolvedLancePath = api.resolvePath(lanceDbPath);
+  const resolvedSqlitePath = api.resolvePath(sqlitePath);
   setKeywordsPath(dirname(resolvedSqlitePath));
 
   recordStartupMemoryCheckpoint({

--- a/extensions/memory-hybrid/setup/register-plugin.ts
+++ b/extensions/memory-hybrid/setup/register-plugin.ts
@@ -833,10 +833,12 @@ async function runDeferredFullTeardownActivation(params: {
         operation: "plugin-register:deferred-activation",
         severity: "error",
       });
+      const errorMessage = err instanceof Error ? err.message : String(err);
+      const errorSource = err instanceof Error && err.stack ? `\n${err.stack}` : "";
       logApi.logger.error?.(
-        `memory-hybrid: deferred activation failed for generation ${registrationGeneration}: ${
-          err instanceof Error ? err.message : String(err)
-        }`,
+        `memory-hybrid: deferred activation failed for generation ${registrationGeneration} ` +
+          `(donorGeneration=${donorGeneration}, staged=${loadContext.isStaging}, packageVersion=${loadContext.packageVersion}): ` +
+          `${errorMessage}${errorSource}`,
       );
     }
   }

--- a/extensions/memory-hybrid/tests/bootstrap-startup-memory-checkpoint.test.ts
+++ b/extensions/memory-hybrid/tests/bootstrap-startup-memory-checkpoint.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { hybridConfigSchema } from "../config.js";
+import { DEFAULT_LANCE_PATH, DEFAULT_SQLITE_PATH } from "../config/parsers/core.js";
 import { closeOldDatabases, initializeDatabases } from "../setup/init-databases.js";
 import { resetStartupMemoryAttributionForTests } from "../services/startup-memory-attribution.js";
 
@@ -22,6 +23,35 @@ describe("bootstrap startup memory checkpoints", () => {
     }
     resetStartupMemoryAttributionForTests();
     rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("falls back to documented paths before resolvePath when a deferred handoff omits DB paths", () => {
+    const cfg = hybridConfigSchema.parse({
+      embedding: { apiKey: "sk-test-embed-key-that-is-long-enough", model: "text-embedding-3-small" },
+      credentials: { enabled: false },
+      wal: { enabled: false },
+      personaProposals: { enabled: false },
+      verification: { enabled: false },
+      provenance: { enabled: false },
+      nightlyCycle: { enabled: false },
+    });
+    const resolvePath = vi.fn((path: string) => {
+      if (typeof path !== "string") throw new TypeError('The "path" argument must be of type string.');
+      return join(tmpDir, path.replaceAll("/", "_"));
+    });
+    const api = {
+      resolvePath,
+      logger: { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() },
+      config: {},
+      context: { sessionId: "session-1", agentId: "agent-1" },
+    };
+    const deferredHandoffCfg = { ...cfg, sqlitePath: undefined, lanceDbPath: "  " };
+
+    dbCtx = initializeDatabases(deferredHandoffCfg as never, api as never);
+
+    expect(resolvePath.mock.calls.flat()).toEqual([DEFAULT_LANCE_PATH, DEFAULT_SQLITE_PATH]);
+    expect(api.logger.warn).toHaveBeenCalledWith(expect.stringContaining("missing or invalid lanceDbPath"));
+    expect(api.logger.warn).toHaveBeenCalledWith(expect.stringContaining("missing or invalid sqlitePath"));
   });
 
   it("emits plugin registration memory checkpoints with attribution", () => {

--- a/extensions/memory-hybrid/tests/register-plugin-two-phase-activation.test.ts
+++ b/extensions/memory-hybrid/tests/register-plugin-two-phase-activation.test.ts
@@ -8,7 +8,8 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   awaitActivationReady,
   getActivationState,
@@ -90,6 +91,37 @@ describe("two-phase reload activation (#2181)", () => {
       details?: { initializing?: boolean };
     };
     expect(after.details?.initializing).not.toBe(true);
+  });
+
+  it("activates generation 2 with omitted DB paths without passing undefined to resolvePath", async () => {
+    const legacyDreaming = JSON.parse(
+      readFileSync(join(process.cwd(), "tests", "fixtures", "legacy-dreaming-config.json"), "utf8"),
+    ) as Record<string, unknown>;
+    const resolvePath = vi.fn((path: string) => {
+      if (typeof path !== "string") throw new TypeError('The "path" argument must be of type string.');
+      return path;
+    });
+    api.resolvePath = resolvePath;
+
+    registerFullPlugin(api, getFullStackConfig(tmpDir, legacyDreaming));
+    const firstGeneration = runtimeRef.value!.bootRegistrationGeneration!;
+    const deferredConfig = getFullStackConfig(tmpDir, legacyDreaming);
+    delete deferredConfig.sqlitePath;
+    delete deferredConfig.lanceDbPath;
+
+    registerFullPlugin(api, deferredConfig);
+    const activation = getActivationState();
+    expect(activation?.generation).toBeGreaterThan(firstGeneration);
+    expect(await awaitActivationReady(activation!.generation, 20_000)).toBe(true);
+    expect(runtimeRef.value?.bootRegistrationGeneration).toBe(activation!.generation);
+    expect(resolvePath).toHaveBeenCalled();
+    expect(resolvePath.mock.calls.flat().every((path) => typeof path === "string")).toBe(true);
+
+    // The legacy dreaming migration is parsed independently and remains intact across the handoff.
+    expect(runtimeRef.value?.cfg.dreaming.compose).toEqual(["distill", "reflect", "consolidate"]);
+    expect(runtimeRef.value?.cfg.nightlyCycle.schedule).toBe("15 3 * * *");
+    expect(runtimeRef.value?.cfg.nightlyCycle.model).toBe("azure-foundry/gpt-4.1-mini");
+    expect(getActivationState()?.phase).toBe("ready");
   });
 
   it("never throws 'reload teardown did not drain before opening new databases'", async () => {

--- a/packages/openclaw-hybrid-memory-install/package.json
+++ b/packages/openclaw-hybrid-memory-install/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-hybrid-memory-install",
-  "version": "2026.7.224",
+  "version": "2026.7.225",
   "description": "Standalone installer for openclaw-hybrid-memory. Use when OpenClaw config validation fails.",
   "bin": {
     "openclaw-hybrid-memory-install": "./install.js"

--- a/release-notes/release-notes-2026.7.225.md
+++ b/release-notes/release-notes-2026.7.225.md
@@ -1,0 +1,10 @@
+# v2026.7.225
+
+## Fixed
+
+- Harden deferred full-teardown activation database bootstrap against missing, blank, or non-string `lanceDbPath` and `sqlitePath` handoff values. Bootstrap now uses the documented parser defaults before calling the host path resolver and emits a concise actionable warning when it must fall back.
+- Preserve deferred activation error source context safely in logs (generation, donor generation, staging/package metadata, and stack when available).
+
+## Regression coverage
+
+- Exercises a generation-2 deferred activation with omitted database paths, strict `resolvePath` input validation, and representative legacy dreaming fields; verifies activation reaches ready and legacy migration remains intact.


### PR DESCRIPTION
## Incident

Fixes the Doris v2026.7.224 deferred generation-2 activation failure:

> `deferred activation failed ... The "path" argument must be of type string. Received undefined`

Related reload-teardown incident: #2181.

## Root cause and fix

The parser supplies database-path defaults during ordinary registration, but the deferred full-teardown handoff can reach database bootstrap with a partially reconstructed config. Bootstrap called `api.resolvePath(cfg.lanceDbPath)` / `api.resolvePath(cfg.sqlitePath)` directly, allowing `undefined` to escape to the host resolver.

At the bootstrap boundary this PR now:

- accepts only non-blank string paths unchanged;
- falls back missing, blank, and non-string `lanceDbPath` / `sqlitePath` values to the parser's documented `DEFAULT_LANCE_PATH` / `DEFAULT_SQLITE_PATH` before `resolvePath`;
- emits a concise non-secret, actionable warning when fallback occurs; and
- preserves deferred activation source context in the error log (generation, donor generation, staging/package metadata, and stack when present).

Legacy Dreaming migration behavior is not changed. The regression test uses representative legacy Dreaming fields and asserts their existing runtime migration remains intact.

## Regression coverage

- `register-plugin-two-phase-activation.test.ts`: forces a real generation-2 deferred activation, omits both DB paths, has `resolvePath` throw on non-strings, and verifies ready activation plus legacy Dreaming migration.
- `bootstrap-startup-memory-checkpoint.test.ts`: directly verifies missing/blank paths reach `resolvePath` only as the documented defaults and produce warnings.

## Release metadata

Version bumped monotonically: **2026.7.224 → 2026.7.225**, synchronized across the plugin, installer, manifest, lockfile, changelog, and release note.

## Validation

- `npm test -- --run tests/bootstrap-startup-memory-checkpoint.test.ts tests/register-plugin-two-phase-activation.test.ts` — **5 passed**
- `npm run lint` — **pass** (pre-existing repository warnings only; no errors)
- `npm run format:check` — **pass**
- `npm run build:check` — **pass**, including publish verification and 13 smoke tests
- `git diff --check` — **pass**
- Workflow YAML parsed successfully (**11 files**). `actionlint` is not installed in this environment.

## Exact post-merge rerun plan

1. Deploy/publish v2026.7.225 through the normal release path.
2. On Doris, reload/activate the plugin with the same deferred full-teardown flow that reproduced v2026.7.224.
3. Confirm generation 2 reaches `ready`; confirm no `The "path" argument ... Received undefined` or `deferred activation failed` log entry.
4. If the fallback warning appears, capture its field name and ensure it names only the documented default (no user path/config data); then correct the upstream handoff separately.
5. Run the targeted regression command above on the release artifact and verify existing legacy Dreaming settings still produce the same migration diagnostics/effective nightly-cycle values.
