### PR TITLE
fix: stage installer package before npm activation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [2026.7.226] - 2026-07-25
+
+### Fixed
+
+- Standalone installer now unpacks the complete npm tarball into a private `~/.openclaw/.cache` work tree before invoking `npm install --omit=dev`. It preflights the staged `package.json` with an actionable failure, atomically swaps only the finished plugin into `extensions/`, and keeps staging and rollback directories out of the extension scanner. This fixes the Doris `2026.7.225` upgrade failure (`ENOENT` for a missing staged manifest).
+
+### Release metadata
+
+- Bumps `openclaw-hybrid-memory` and the lockstep standalone installer to `2026.7.226`.
+
 
 ## [2026.7.225]
 

--- a/extensions/memory-hybrid/openclaw.plugin.json
+++ b/extensions/memory-hybrid/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "openclaw-hybrid-memory",
   "kind": "memory",
-  "version": "2026.7.225",
+  "version": "2026.7.226",
   "contracts": {
     "tools": [
       "active_task_checkpoint",

--- a/extensions/memory-hybrid/package-lock.json
+++ b/extensions/memory-hybrid/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openclaw-hybrid-memory",
-  "version": "2026.7.225",
+  "version": "2026.7.226",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openclaw-hybrid-memory",
-      "version": "2026.7.225",
+      "version": "2026.7.226",
       "hasInstallScript": true,
       "dependencies": {
         "@lancedb/lancedb": "^0.31.0",

--- a/extensions/memory-hybrid/package.json
+++ b/extensions/memory-hybrid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-hybrid-memory",
-  "version": "2026.7.225",
+  "version": "2026.7.226",
   "type": "module",
   "description": "Give your OpenClaw agent lasting memory: structured facts, semantic search, auto-capture & recall, decay, optional credential vault. Part of Hybrid Memory v3.",
   "files": [

--- a/packages/openclaw-hybrid-memory-install/install.js
+++ b/packages/openclaw-hybrid-memory-install/install.js
@@ -20,7 +20,13 @@ const extDir =
 	process.env.OPENCLAW_EXTENSIONS_DIR ||
 	path.join(os.homedir(), ".openclaw", "extensions");
 const pluginDir = path.join(extDir, "openclaw-hybrid-memory");
-const tmpDir = path.join(os.tmpdir(), `openclaw-plugin-install-${process.pid}`);
+const installWorkDir = path.join(
+	path.dirname(extDir),
+	".cache",
+	`openclaw-hybrid-memory-installer-${process.pid}`,
+);
+const tmpDir = path.join(installWorkDir, "pack");
+const stagingDir = path.join(installWorkDir, "staging");
 // apache-arrow is a peer dependency of @lancedb/lancedb@0.31 that npm does not
 // auto-install; declare it here so the installer installs it explicitly if the
 // staged tree is missing it (issue #2116).
@@ -98,10 +104,21 @@ function rmPathBestEffort(absPath, label) {
 	}
 }
 
-const stagingDir = path.join(
-	extDir,
-	`.openclaw-hybrid-memory-staging-${process.pid}`,
-);
+function assertInstallablePackage(rootDir) {
+	const manifestPath = path.join(rootDir, "package.json");
+	if (!fs.existsSync(manifestPath)) {
+		throw new Error(
+			`Package manifest is missing from staged package (${manifestPath}). ` +
+				"Refusing to run npm install; the published tarball must include package.json.",
+		);
+	}
+	try {
+		JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		throw new Error(`Package manifest in staged package is invalid (${manifestPath}): ${message}`);
+	}
+}
 
 try {
 	console.log(`Installing openclaw-hybrid-memory@${version} to ${pluginDir}\n`);
@@ -112,9 +129,10 @@ try {
 		`Docs: https://github.com/markus-lassfolk/openclaw-hybrid-memory/blob/main/docs/UPGRADE-PLUGIN.md\n`,
 	);
 
-	if (fs.existsSync(stagingDir)) {
-		fs.rmSync(stagingDir, { recursive: true, force: true });
-	}
+	// Keep all transient trees outside extensions: OpenClaw scans every directory there
+	// and must never discover a half-installed staging or rollback copy as a plugin.
+	fs.mkdirSync(extDir, { recursive: true });
+	fs.mkdirSync(installWorkDir, { recursive: true });
 	fs.mkdirSync(stagingDir, { recursive: true });
 
 	console.log("Fetching via npm pack...");
@@ -129,12 +147,13 @@ try {
 	);
 	const tgzPath = path.join(tmpDir, tgz);
 	run("tar", ["-xzf", tgzPath, "-C", stagingDir, "--strip-components=1"]);
+	assertInstallablePackage(stagingDir);
 
 	console.log("Installing deps and rebuilding native modules in staging...");
 	run("npm", ["install", "--omit=dev"], { cwd: stagingDir });
 	ensureRuntimeDependenciesInstalled(stagingDir);
 
-	const backupDir = `${pluginDir}.bak.${Date.now()}`;
+	const backupDir = path.join(installWorkDir, `rollback-${Date.now()}`);
 	if (fs.existsSync(pluginDir)) {
 		console.log("Swapping staging into place (backing up previous plugin)...");
 		fs.renameSync(pluginDir, backupDir);
@@ -159,14 +178,13 @@ try {
 	}
 
 	console.log("Cleaning up...");
-	rmPathBestEffort(tmpDir, "npm pack temp directory (.tgz and folder)");
+	rmPathBestEffort(installWorkDir, "installer work directory");
 
 	console.log(
 		"\nDone. Restart the gateway: openclaw gateway stop && openclaw gateway start",
 	);
 } catch (err) {
-	rmPathBestEffort(stagingDir, "staging directory");
-	rmPathBestEffort(tmpDir, "npm pack temp directory (.tgz and folder)");
+	rmPathBestEffort(installWorkDir, "installer work directory");
 	console.error("Install failed:", err.message);
 	process.exit(1);
 }

--- a/packages/openclaw-hybrid-memory-install/package.json
+++ b/packages/openclaw-hybrid-memory-install/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-hybrid-memory-install",
-  "version": "2026.7.225",
+  "version": "2026.7.226",
   "description": "Standalone installer for openclaw-hybrid-memory. Use when OpenClaw config validation fails.",
   "bin": {
     "openclaw-hybrid-memory-install": "./install.js"
@@ -19,5 +19,8 @@
     "url": "git+https://github.com/markus-lassfolk/openclaw-hybrid-memory.git",
     "directory": "packages/openclaw-hybrid-memory-install"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "scripts": {
+    "test": "node --test test/*.test.cjs"
+  }
 }

--- a/packages/openclaw-hybrid-memory-install/test/install.integration.test.cjs
+++ b/packages/openclaw-hybrid-memory-install/test/install.integration.test.cjs
@@ -1,0 +1,64 @@
+const assert = require("node:assert/strict");
+const { execFileSync, spawnSync } = require("node:child_process");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+
+const installer = path.resolve(__dirname, "..", "install.js");
+
+function makeTarball(root, includesManifest) {
+  const packageDir = path.join(root, "package");
+  fs.mkdirSync(packageDir, { recursive: true });
+  if (includesManifest) fs.writeFileSync(path.join(packageDir, "package.json"), '{"name":"fixture-plugin","version":"1.0.0"}\n');
+  fs.writeFileSync(path.join(packageDir, "openclaw.plugin.json"), '{"id":"openclaw-hybrid-memory"}\n');
+  const tarball = path.join(root, includesManifest ? "valid.tgz" : "missing-manifest.tgz");
+  execFileSync("tar", ["-czf", tarball, "package"], { cwd: root });
+  return tarball;
+}
+
+function runInstaller(tarball) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "hybrid-installer-test-"));
+  const extensions = path.join(root, ".openclaw", "extensions");
+  const bin = path.join(root, "bin");
+  fs.mkdirSync(bin, { recursive: true });
+  fs.writeFileSync(path.join(bin, "npm"), `#!/usr/bin/env node
+const fs = require("fs"); const path = require("path");
+const args = process.argv.slice(2);
+if (args[0] === "pack") { fs.copyFileSync(process.env.FIXTURE_TARBALL, path.join(process.cwd(), "fixture.tgz")); process.exit(0); }
+if (args[0] === "install") {
+  if (!fs.existsSync(path.join(process.cwd(), "package.json"))) { console.error("ENOENT: missing package.json"); process.exit(42); }
+  fs.appendFileSync(process.env.NPM_CALL_LOG, args.join(" ") + "\\n");
+  for (const dep of ["@lancedb/lancedb", "apache-arrow"]) { const p = path.join(process.cwd(), "node_modules", ...dep.split("/")); fs.mkdirSync(p, { recursive: true }); fs.writeFileSync(path.join(p, "package.json"), "{}"); }
+  process.exit(0);
+}
+process.exit(91);
+`);
+  fs.chmodSync(path.join(bin, "npm"), 0o755);
+  const npmLog = path.join(root, "npm.log");
+  const result = spawnSync(process.execPath, [installer, "fixture"], {
+    encoding: "utf8",
+    env: { ...process.env, OPENCLAW_EXTENSIONS_DIR: extensions, FIXTURE_TARBALL: tarball, NPM_CALL_LOG: npmLog, PATH: `${bin}${path.delimiter}${process.env.PATH}` },
+  });
+  return { root, extensions, npmLog, result };
+}
+
+test("installs an npm-packed package only after staging its manifest outside extensions", () => {
+  const fixture = fs.mkdtempSync(path.join(os.tmpdir(), "hybrid-installer-fixture-"));
+  const run = runInstaller(makeTarball(fixture, true));
+  assert.equal(run.result.status, 0, run.result.stderr);
+  assert.ok(fs.existsSync(path.join(run.extensions, "openclaw-hybrid-memory", "package.json")));
+  assert.match(fs.readFileSync(run.npmLog, "utf8"), /install --omit=dev/);
+  assert.deepEqual(fs.readdirSync(run.extensions), ["openclaw-hybrid-memory"]);
+  assert.deepEqual(fs.readdirSync(path.join(run.root, ".openclaw", ".cache")), []);
+});
+
+test("fails before npm install when a packed package lacks package.json", () => {
+  const fixture = fs.mkdtempSync(path.join(os.tmpdir(), "hybrid-installer-fixture-"));
+  const run = runInstaller(makeTarball(fixture, false));
+  assert.notEqual(run.result.status, 0);
+  assert.match(run.result.stderr, /Package manifest is missing from staged package/);
+  assert.equal(fs.existsSync(run.npmLog), false);
+  assert.deepEqual(fs.readdirSync(run.extensions), []);
+  assert.deepEqual(fs.readdirSync(path.join(run.root, ".openclaw", ".cache")), []);
+});

--- a/release-notes/release-notes-2026.7.226.md
+++ b/release-notes/release-notes-2026.7.226.md
@@ -1,0 +1,7 @@
+# Release notes — 2026.7.226
+
+## Fixed
+
+The lockstep standalone installer now stages a complete package extracted from the npm tarball in `~/.openclaw/.cache` before it runs `npm install --omit=dev`. It verifies that the staged `package.json` exists and is valid JSON, failing before npm with a clear packaging diagnosis when it does not.
+
+Only the completed package is moved into `~/.openclaw/extensions/openclaw-hybrid-memory`; temporary staging and rollback trees remain outside the extension scanner. This resolves the Doris v2026.7.225 upgrade incident, where npm received a staging directory without a manifest and exited `ENOENT` before activation.


### PR DESCRIPTION
## Incident

During Doris's upgrade to `v2026.7.225`, the standalone installer created a staging directory under `~/.openclaw/extensions`, then invoked `npm install --omit=dev` there before an installable package manifest was present. npm exited with `ENOENT` for `package.json`; activation never happened and rollback restored `v2026.7.223`.

## Root cause

The installer relied on extraction into a scanner-visible extension staging directory but had no manifest preflight. A malformed/incomplete packed payload therefore reached npm as an empty/non-package working directory. Staging and backup paths under `extensions/` could also be discovered by the OpenClaw extension scanner while an upgrade was in flight.

## Behavioral contract

- The installer obtains the current release with `npm pack`, extracts the complete tarball, and runs `npm install --omit=dev` only in a private `~/.openclaw/.cache/openclaw-hybrid-memory-installer-*` work tree.
- It checks that staged `package.json` exists and parses before calling npm; absent/invalid manifests fail with an actionable published-tarball diagnostic.
- Only the fully installed plugin is atomically moved into `extensions/`; rollback and staging directories never appear under that scanner-visible directory.
- The existing packed-npm-tarball release convention remains the input path. Version metadata advances monotonically and lockstep to `2026.7.226`.

## Test proof

New installer integration tests create real `tar` archives and invoke the actual installer sequence with a controlled npm shim:

1. a valid packed fixture extracts, passes the manifest preflight, runs `npm install --omit=dev`, activates only the plugin directory, and cleans the private work tree;
2. a package missing `package.json` fails before npm is called, leaves extensions empty, and cleans the work tree.

## Checks

- `npm --prefix packages/openclaw-hybrid-memory-install test` ✅ (2/2)
- `node --check packages/openclaw-hybrid-memory-install/install.js` ✅
- `node extensions/memory-hybrid/scripts/sync-plugin-version.cjs --check` ✅
- `git diff --check` ✅
- Plugin `typecheck:gate` / `lint` / full suite were started after `npm ci`; the environment's concurrent long-running npm processes did not return before PR creation, so GitHub CI remains the authoritative full gate.

No Doris/Maeve files or hosts were touched.
