### PR TITLE
ci: add on-demand GlitchTip open-issues check workflow

### DIFF
--- a/.github/workflows/glitchtip-issues-check.yml
+++ b/.github/workflows/glitchtip-issues-check.yml
@@ -1,6 +1,9 @@
 name: Check GlitchTip Open Issues
 
 on:
+  push:
+    branches:
+      - claude/hybrid-memory-open-issues-4d8bck
   workflow_dispatch:
     inputs:
       org_slug:

--- a/.github/workflows/glitchtip-issues-check.yml
+++ b/.github/workflows/glitchtip-issues-check.yml
@@ -1,0 +1,69 @@
+name: Check GlitchTip Open Issues
+
+on:
+  workflow_dispatch:
+    inputs:
+      org_slug:
+        description: "GlitchTip organization slug"
+        required: false
+        default: "hybrid-memory"
+      project_slug:
+        description: "GlitchTip project slug"
+        required: false
+        default: "openclaw-hybrid-memory"
+      query:
+        description: "GlitchTip issue search query"
+        required: false
+        default: "is:unresolved"
+
+permissions:
+  contents: read
+
+jobs:
+  check-issues:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Query GlitchTip for open issues
+        env:
+          GLITCHTIP_TOKEN: ${{ secrets.GLITCHTIP_TOKEN }}
+          GLITCHTIP_BASE_URL: ${{ secrets.GLITCHTIP_BASE_URL }}
+          ORG_SLUG: ${{ inputs.org_slug }}
+          PROJECT_SLUG: ${{ inputs.project_slug }}
+          QUERY: ${{ inputs.query }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${GLITCHTIP_TOKEN:-}" ] || [ -z "${GLITCHTIP_BASE_URL:-}" ]; then
+            echo "::error::GLITCHTIP_TOKEN or GLITCHTIP_BASE_URL repository secret is not set"
+            exit 1
+          fi
+
+          http_code=$(curl -sS -G \
+            -o response.json -w "%{http_code}" \
+            -H "Authorization: Bearer ${GLITCHTIP_TOKEN}" \
+            --data-urlencode "query=${QUERY}" \
+            --data-urlencode "limit=100" \
+            "${GLITCHTIP_BASE_URL}/api/0/projects/${ORG_SLUG}/${PROJECT_SLUG}/issues/")
+
+          echo "HTTP status: ${http_code}"
+
+          if [ "${http_code}" != "200" ]; then
+            echo "::error::GlitchTip API returned HTTP ${http_code}"
+            cat response.json
+            exit 1
+          fi
+
+          count=$(jq 'length' response.json)
+          echo "Open issues: ${count}"
+
+          {
+            echo "## GlitchTip open issues — ${ORG_SLUG}/${PROJECT_SLUG}"
+            echo
+            echo "Query: \`${QUERY}\` — **${count} open**"
+            echo
+            if [ "${count}" -eq 0 ]; then
+              echo "_No open issues._"
+            else
+              jq -r '.[] | "- **#\(.id)** \(.title) _(level=\(.level), events=\(.count), lastSeen=\(.lastSeen))_"' response.json
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/glitchtip-issues-check.yml
+++ b/.github/workflows/glitchtip-issues-check.yml
@@ -1,9 +1,6 @@
 name: Check GlitchTip Open Issues
 
 on:
-  push:
-    branches:
-      - claude/hybrid-memory-open-issues-4d8bck
   workflow_dispatch:
     inputs:
       org_slug:

--- a/.github/workflows/glitchtip-issues-check.yml
+++ b/.github/workflows/glitchtip-issues-check.yml
@@ -30,9 +30,9 @@ jobs:
         env:
           GLITCHTIP_TOKEN: ${{ secrets.GLITCHTIP_TOKEN }}
           GLITCHTIP_BASE_URL: ${{ secrets.GLITCHTIP_BASE_URL }}
-          ORG_SLUG: ${{ inputs.org_slug }}
-          PROJECT_SLUG: ${{ inputs.project_slug }}
-          QUERY: ${{ inputs.query }}
+          ORG_SLUG: ${{ inputs.org_slug || 'hybrid-memory' }}
+          PROJECT_SLUG: ${{ inputs.project_slug || 'openclaw-hybrid-memory' }}
+          QUERY: ${{ inputs.query || 'is:unresolved' }}
         run: |
           set -euo pipefail
 


### PR DESCRIPTION
## Summary

- Adds a manually-triggered (`workflow_dispatch`) GitHub Actions workflow that queries the GlitchTip API for open issues on the `hybrid-memory` org / `openclaw-hybrid-memory` project, using the `GLITCHTIP_TOKEN` / `GLITCHTIP_BASE_URL` repository secrets, and posts the results (issue IDs, titles, level, event count, last-seen) to the run's job summary.
- Lets anyone with repo write access check open GlitchTip issues on demand without needing the API token pasted into a chat/session again.

Closes #

**PR title:** Must follow [Conventional Commits](https://www.conventionalcommits.org/) — `ci:` used here.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor / internal improvement (no behavior change)
- [ ] Documentation update
- [x] CI / tooling change

## Quality Checklist

This PR only touches `.github/workflows/`, no `extensions/memory-hybrid` source changes, so the code quality trio doesn't apply. Verified separately:

- [x] `actionlint` passes on the new workflow file (same linter as `workflow-sanity.yml` runs in CI)
- [x] No secrets, credentials, or API keys committed — the workflow reads them from `secrets.*` only, never echoes them
- [x] No `console.log` debug statements left in production code (N/A — no source code touched)

## Documentation Impact (REQUIRED)

- [ ] Inline code comments (JSDoc) updated for modified functions and types
- [ ] `docs/` or `README.md` updated to reflect architectural or usage changes
- [x] Cross-referenced functions/services checked for outdated documentation

No user-facing plugin behavior changed — this is a repo-ops workflow, not part of the published `openclaw-hybrid-memory` package.

## Testing

- [x] Manually verified: temporarily added a branch-scoped `push` trigger, confirmed the workflow authenticates against the live GlitchTip API and returns the expected issue count (5), then removed the temporary trigger before opening this PR (see commit history).

## Notes for Reviewer

`workflow_dispatch` runs can only be triggered via the Actions UI/API once the workflow file exists on the default branch (`main`) — that's why this needed a temporary `push` trigger to verify end-to-end from a feature branch. The final state here is `workflow_dispatch`-only, as intended.


---
_Generated by [Claude Code](https://claude.ai/code/session_01S8dqWojkVfWZBAZYx4Utbo)_