### PR TITLE
fix: init error reporter in maintenance orchestrator CLI, enrich reflect-rules failure reason

### DIFF
--- a/extensions/memory-hybrid/cli/commands/manage/register-maintenance-orchestrator.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/register-maintenance-orchestrator.ts
@@ -6,6 +6,8 @@ import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { stepGuardEligible } from "../../../services/cron-guard.js";
+import { initErrorReporter, isErrorReporterActive } from "../../../services/error-reporter.js";
+import { resolveErrorReportQueuePath } from "../../../services/maintenance-failure-reporter.js";
 import {
   effectiveCadenceLabel,
   formatMaintenanceSummary,
@@ -27,6 +29,49 @@ function parseStepList(raw?: string): string[] | undefined {
     .split(",")
     .map((s) => s.trim())
     .filter(Boolean);
+}
+
+/**
+ * Initialize the error reporter for this one-shot maintenance-orchestrator CLI process.
+ *
+ * Without this, the rich diagnostics that services/dream-cycle.ts and services/reflection.ts
+ * already write via capturePluginError() at each stage failure (e.g. reflect-rules'
+ * zeroRulesReason, modelResponseChars, parseSuccess) are silently dropped: capturePluginError()
+ * is a no-op until initErrorReporter() has run in-process, and `cycle`/`nightly`/`full`/`step` are
+ * the CLI commands that actually execute those stages — they never called it. The only other
+ * caller in this CLI path, register-validate-cron-exit.ts's reportMaintenanceFailureIssues(), only
+ * sends a generic post-hoc summary after the fact and runs in a separate process/invocation.
+ *
+ * Mirrors services/maintenance-failure-reporter.ts's ensureMaintenanceReporterReady(): same
+ * `errorReporting.enabled && errorReporting.consent` gate, same idempotency guard via
+ * isErrorReporterActive() (so re-entrant or repeated calls within one process never double-init),
+ * and the same durable on-disk retry queue convention (resolveErrorReportQueuePath) since this is
+ * also a short-lived process with no next-startup drain to recover an in-flight report.
+ */
+async function ensureMaintenanceOrchestratorErrorReporter(b: ManageBindings): Promise<void> {
+  if (isErrorReporterActive()) return;
+  const { errorReporting } = b.cfg;
+  if (!errorReporting?.enabled || !errorReporting?.consent) return;
+  try {
+    await initErrorReporter(
+      {
+        enabled: errorReporting.enabled,
+        dsn: errorReporting.dsn,
+        mode: errorReporting.mode ?? "community",
+        consent: errorReporting.consent,
+        environment: errorReporting.environment,
+        sampleRate: errorReporting.sampleRate ?? 1.0,
+        maxBreadcrumbs: 10,
+        botId: errorReporting.botId,
+        botName: errorReporting.botName,
+        resolvedIssues: errorReporting.resolvedIssues,
+        pendingQueuePath: resolveErrorReportQueuePath(b.resolvedSqlitePath),
+      },
+      b.versionInfo.pluginVersion,
+    );
+  } catch {
+    // Best-effort telemetry setup must never fail the maintenance run itself.
+  }
 }
 
 export function registerMaintenanceOrchestratorCommands(maintenance: Chainable, b: ManageBindings): void {
@@ -53,6 +98,10 @@ export function registerMaintenanceOrchestratorCommands(maintenance: Chainable, 
     if (process.env.HM_RUN_ID) {
       process.env.HM_ORCHESTRATOR_RUN_ID = process.env.HM_RUN_ID;
     }
+    // Must happen before runMaintenanceOrchestrator() below so that any capturePluginError() calls
+    // made by the steps it runs (e.g. dream-cycle's reflect-rules stage) actually reach GlitchTip
+    // instead of silently no-opping.
+    await ensureMaintenanceOrchestratorErrorReporter(b);
     const memoryDir = b.resolvedSqlitePath ? dirname(b.resolvedSqlitePath) : join(homedir(), ".openclaw", "memory");
     const backfillMarker = join(memoryDir, ".backfill-decay-done");
     const runners = buildCliMaintenanceRunners(b, {

--- a/extensions/memory-hybrid/services/dream-cycle.ts
+++ b/extensions/memory-hybrid/services/dream-cycle.ts
@@ -767,8 +767,16 @@ export async function runDreamCycle(
     logger.info(`memory-hybrid: dream-cycle [dry-run] — skipping ${stageLabel} (no preview support; would mutate)`);
   };
   const failedStages: string[] = [];
-  const recordStageFailure = (stage: string, err: unknown): void => {
-    if (!failedStages.includes(stage)) failedStages.push(stage);
+  /**
+   * `stage` drives the capturePluginError `operation` tag, so it stays a small, stable set of
+   * slugs for GlitchTip grouping/filtering. `opts.label` (defaulting to `stage`) is the string
+   * actually pushed into `failedStages` / rendered by buildDigestSummary() — callers that want the
+   * failure *reason* to survive into the human-facing digest (e.g. reflect-rules' zeroRulesReason)
+   * pass a distinct, enriched label here without perturbing the tag.
+   */
+  const recordStageFailure = (stage: string, err: unknown, opts?: { label?: string }): void => {
+    const label = opts?.label ?? stage;
+    if (!failedStages.includes(label)) failedStages.push(label);
     capturePluginError(err instanceof Error ? err : new Error(String(err)), {
       operation: `dream-cycle-${stage.replace(/\s+/g, "-")}`,
       subsystem: "dream-cycle",
@@ -1341,12 +1349,21 @@ export async function runDreamCycle(
         `memory-hybrid: dream-cycle — reflect-rules complete: ${rulesGenerated} rules stored (status=${rulesResult.diagnostics.status}${rulesResult.diagnostics.zeroRulesReason ? `, zero_rules_reason=${rulesResult.diagnostics.zeroRulesReason}` : ""})`,
       );
       if (rulesResult.diagnostics.status === "degraded") {
+        const reason = rulesResult.diagnostics.zeroRulesReason ?? "unknown";
         stageReflectRulesError = new Error(rulesResult.diagnostics.zeroRulesReason ?? "reflect_rules_degraded");
-        recordStageFailure("reflect-rules", stageReflectRulesError);
+        // Carry the failure *reason* into failedStages/the digest summary (not just the bare stage
+        // name) so "N stage(s) failed (reflect-rules)" becomes actionable at a glance instead of
+        // requiring a dig through logs/GlitchTip to learn *why* reflect-rules failed.
+        recordStageFailure("reflect-rules", stageReflectRulesError, { label: `reflect-rules (${reason})` });
       }
     } catch (err) {
       stageReflectRulesError ??= err;
-      recordStageFailure("reflect-rules", err);
+      // Fixed marker (not the raw err.message) — zeroRulesReason values are always short,
+      // comma-free snake_case tokens, and buildDigestSummary() joins failedStages with ", ", so an
+      // arbitrary thrown error message could itself contain commas/parens and corrupt that list
+      // formatting.
+      const reason = "reflect_rules_threw";
+      recordStageFailure("reflect-rules", err, { label: `reflect-rules (${reason})` });
       logger.warn(`memory-hybrid: dream-cycle — reflect-rules step failed: ${err}`);
       reflectionRulesDiagnostics = {
         modelResponseChars: 0,
@@ -1355,7 +1372,7 @@ export async function runDreamCycle(
         rejectedDuplicates: 0,
         rejectedLowConfidence: 0,
         stored: 0,
-        zeroRulesReason: "reflect_rules_threw",
+        zeroRulesReason: reason,
         status: "degraded",
       };
     }

--- a/extensions/memory-hybrid/services/maintenance-failure-reporter.ts
+++ b/extensions/memory-hybrid/services/maintenance-failure-reporter.ts
@@ -43,7 +43,13 @@ export function shouldReportMaintenanceFailures(
   return cfg.errorReporting.enabled === true && cfg.errorReporting.consent === true;
 }
 
-function resolveErrorReportQueuePath(resolvedSqlitePath?: string): string | undefined {
+/**
+ * Exported so other one-shot CLI entry points that also call `initErrorReporter` directly (e.g.
+ * the maintenance orchestrator's `runTier`, register-maintenance-orchestrator.ts) can derive the
+ * same durable on-disk retry queue path from `resolvedSqlitePath` without duplicating the
+ * `:memory:`-aware join logic in a second place.
+ */
+export function resolveErrorReportQueuePath(resolvedSqlitePath?: string): string | undefined {
   if (!resolvedSqlitePath || resolvedSqlitePath === ":memory:") return undefined;
   return join(dirname(resolvedSqlitePath), ".error_reports.pending.jsonl");
 }

--- a/extensions/memory-hybrid/tests/dream-cycle.test.ts
+++ b/extensions/memory-hybrid/tests/dream-cycle.test.ts
@@ -1197,7 +1197,50 @@ describe("runDreamCycle", () => {
     );
 
     expect(result.success).toBe(false);
-    expect(result.failedStages).toContain("reflect-rules");
+    // The bare stage name alone isn't actionable — the failure *reason* (zeroRulesReason) must
+    // survive into failedStages/the digest so an operator doesn't have to dig through logs to
+    // learn why reflect-rules failed.
+    expect(result.failedStages).toContain("reflect-rules (model_empty)");
+    expect(result.failedStages).not.toContain("reflect-rules");
+    expect(result.digestSummary).toContain("reflect-rules (model_empty)");
+  });
+
+  it("marks reflect-rules as failed with a fixed reason marker when the stage throws", async () => {
+    for (let i = 0; i < 3; i++) {
+      factsDb.store({
+        text: `Pattern ${i}`,
+        category: "pattern",
+        importance: 0.7,
+        entity: null,
+        key: null,
+        value: null,
+        source: "test",
+        decayClass: "stable",
+      });
+    }
+    vi.spyOn(reflection, "runReflectionRules").mockRejectedValue(new Error("boom, with a comma"));
+
+    const openaiStub = {
+      chat: { completions: { create: vi.fn().mockRejectedValue(new Error("no key")) } },
+    } as never;
+    const embeddingsStub = { embed: vi.fn().mockRejectedValue(new Error("no key")) } as never;
+
+    const result = await runDreamCycle(
+      factsDb,
+      {} as never,
+      embeddingsStub,
+      openaiStub,
+      null,
+      baseConfig,
+      silentLogger,
+    );
+
+    expect(result.success).toBe(false);
+    // A fixed marker, not the raw (possibly comma-containing) error message — buildDigestSummary()
+    // joins failedStages with ", ", so an arbitrary thrown message could otherwise corrupt the
+    // rendered list.
+    expect(result.failedStages).toContain("reflect-rules (reflect_rules_threw)");
+    expect(result.digestSummary).toContain("reflect-rules (reflect_rules_threw)");
   });
 
   it("removes orphaned vectors and reports reconciliation in the digest", async () => {

--- a/extensions/memory-hybrid/tests/register-maintenance-orchestrator-error-reporting.test.ts
+++ b/extensions/memory-hybrid/tests/register-maintenance-orchestrator-error-reporting.test.ts
@@ -1,0 +1,156 @@
+/**
+ * The maintenance-orchestrator CLI (`maintenance cycle`/`nightly`/`full`/`step`, driven by
+ * runTier() in register-maintenance-orchestrator.ts) is the process that actually executes
+ * dream-cycle's reflect-rules stage and friends. Those stages already call capturePluginError()
+ * directly with rich diagnostics, but capturePluginError() is a silent no-op until
+ * initErrorReporter() has run in-process — and this CLI path never called it, so all of that
+ * diagnostic detail was dropped in production.
+ *
+ * These tests assert runTier() now calls initErrorReporter() before invoking the orchestrator,
+ * gated by the same errorReporting.enabled && errorReporting.consent check used by
+ * services/maintenance-failure-reporter.ts, and that it respects the isErrorReporterActive()
+ * idempotency guard (mirrors tests/maintenance-failure-reporter.test.ts's mocking style).
+ */
+import { Command } from "commander";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ManageBindings } from "../cli/commands/manage/bindings.js";
+import { registerMaintenanceOrchestratorCommands } from "../cli/commands/manage/register-maintenance-orchestrator.js";
+
+const { runMaintenanceOrchestratorMock } = vi.hoisted(() => ({
+  runMaintenanceOrchestratorMock: vi.fn(),
+}));
+
+vi.mock("../services/maintenance-orchestrator.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../services/maintenance-orchestrator.js")>();
+  return {
+    ...actual,
+    runMaintenanceOrchestrator: runMaintenanceOrchestratorMock,
+  };
+});
+
+// The real runner map requires a fully-wired ManageBindings; since runMaintenanceOrchestrator
+// itself is mocked above, the runners it would receive are never invoked.
+vi.mock("../cli/commands/manage/maintenance-step-runners.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../cli/commands/manage/maintenance-step-runners.js")>();
+  return {
+    ...actual,
+    buildCliMaintenanceRunners: () => new Map(),
+  };
+});
+
+function mockOrchestratorResult() {
+  const nowIso = new Date().toISOString();
+  runMaintenanceOrchestratorMock.mockResolvedValue({
+    tierLabel: "cycle",
+    steps: [],
+    exitCode: 0,
+    summaryLine: "Maintenance cycle — 0 steps",
+    runId: "job-test-run",
+    startedAt: nowIso,
+    finishedAt: nowIso,
+    durationMs: 5,
+  });
+}
+
+function buildErrorReportingConfig(overrides?: Partial<{ enabled: boolean; consent: boolean }>) {
+  return {
+    enabled: true,
+    consent: true,
+    mode: "community" as const,
+    dsn: "https://7d641cabffdb4557a7bd2f02c338dc80@glitchtip.lassfolk.cc/1",
+    sampleRate: 1,
+    updateNudge: { enabled: true, intervalHours: 24, cacheTtlHours: 24 },
+    ...overrides,
+  };
+}
+
+function makeBindings(errorReporting: ReturnType<typeof buildErrorReportingConfig>): ManageBindings {
+  return {
+    cfg: { errorReporting },
+    factsDb: { getRawDb: () => ({}) },
+    versionInfo: { pluginVersion: "test-version", memoryManagerVersion: "test", schemaVersion: 1 },
+    resolvedSqlitePath: ":memory:",
+  } as unknown as ManageBindings;
+}
+
+async function runCycle(b: ManageBindings): Promise<void> {
+  const mem = new Command("hybrid-mem");
+  mem.exitOverride();
+  const maintenance = mem.command("maintenance");
+  registerMaintenanceOrchestratorCommands(maintenance, b);
+  vi.spyOn(console, "log").mockImplementation(() => {});
+  vi.spyOn(console, "error").mockImplementation(() => {});
+  await mem.parseAsync(["maintenance", "cycle"], { from: "user" });
+}
+
+describe("register-maintenance-orchestrator error reporter wiring", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+    runMaintenanceOrchestratorMock.mockReset();
+    process.exitCode = 0;
+  });
+
+  it("calls initErrorReporter before running the orchestrator when errorReporting is enabled + consented", async () => {
+    const errorReporterMock = await import("../services/error-reporter.js");
+    const initSpy = vi.spyOn(errorReporterMock, "initErrorReporter").mockResolvedValue();
+    vi.spyOn(errorReporterMock, "isErrorReporterActive").mockReturnValue(false);
+    mockOrchestratorResult();
+
+    await runCycle(makeBindings(buildErrorReportingConfig()));
+
+    expect(initSpy).toHaveBeenCalledTimes(1);
+    const [config, pluginVersion] = initSpy.mock.calls[0]!;
+    expect(config).toMatchObject({ enabled: true, consent: true, mode: "community" });
+    expect(pluginVersion).toBe("test-version");
+    // Must be called before the orchestrator itself runs, so any capturePluginError() calls made
+    // by the steps it invokes are actually captured (not the point of this test to prove ordering
+    // via call order, but the run must have completed without erroring either way).
+    expect(runMaintenanceOrchestratorMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call initErrorReporter when errorReporting.enabled is false", async () => {
+    const errorReporterMock = await import("../services/error-reporter.js");
+    const initSpy = vi.spyOn(errorReporterMock, "initErrorReporter").mockResolvedValue();
+    vi.spyOn(errorReporterMock, "isErrorReporterActive").mockReturnValue(false);
+    mockOrchestratorResult();
+
+    await runCycle(makeBindings(buildErrorReportingConfig({ enabled: false })));
+
+    expect(initSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not call initErrorReporter when errorReporting.consent is false", async () => {
+    const errorReporterMock = await import("../services/error-reporter.js");
+    const initSpy = vi.spyOn(errorReporterMock, "initErrorReporter").mockResolvedValue();
+    vi.spyOn(errorReporterMock, "isErrorReporterActive").mockReturnValue(false);
+    mockOrchestratorResult();
+
+    await runCycle(makeBindings(buildErrorReportingConfig({ consent: false })));
+
+    expect(initSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not re-initialize (or throw) when the reporter is already active in-process", async () => {
+    const errorReporterMock = await import("../services/error-reporter.js");
+    const initSpy = vi.spyOn(errorReporterMock, "initErrorReporter").mockResolvedValue();
+    vi.spyOn(errorReporterMock, "isErrorReporterActive").mockReturnValue(true);
+    mockOrchestratorResult();
+
+    await expect(runCycle(makeBindings(buildErrorReportingConfig()))).resolves.toBeUndefined();
+
+    expect(initSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not fail the maintenance run when initErrorReporter itself rejects", async () => {
+    const errorReporterMock = await import("../services/error-reporter.js");
+    vi.spyOn(errorReporterMock, "initErrorReporter").mockRejectedValue(new Error("reporter init failed"));
+    vi.spyOn(errorReporterMock, "isErrorReporterActive").mockReturnValue(false);
+    mockOrchestratorResult();
+
+    await expect(runCycle(makeBindings(buildErrorReportingConfig()))).resolves.toBeUndefined();
+
+    expect(runMaintenanceOrchestratorMock).toHaveBeenCalledTimes(1);
+    expect(process.exitCode).toBeFalsy();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #2209
Closes #2210

GlitchTip issues 26/36/37 (GlitchTip's own numbering — unrelated to this repo's issue/PR numbers of the same value, tracked here as #2209/#2210/#2211) are three alerts from one underlying event: the nightly `maintenance-nightly` cron job's `reflect-rules` stage (inside `dream-cycle-core`) failed, but none of the alerts carried the actual diagnostics — only `"1 stage(s) failed (reflect-rules)"`.

**Root cause:** the CLI process that runs maintenance steps (`register-maintenance-orchestrator.ts`'s `runTier`, used by `maintenance cycle/nightly/full/step`) never called `initErrorReporter()`. `dream-cycle.ts` and `reflection.ts` already send rich diagnostics via `capturePluginError()` at each stage failure (`zeroRulesReason`, `modelResponseChars`, `parseSuccess`, which model/fallback answered) — but `capturePluginError()` is a silent no-op until `initErrorReporter()` has run in-process, and this CLI path never called it. The only other caller in this path, `register-validate-cron-exit.ts`'s `reportMaintenanceFailureIssues()`, only sends a generic post-hoc summary in a separate process after the fact.

## Changes

- `register-maintenance-orchestrator.ts`: call `initErrorReporter()` near the start of `runTier()`, gated by the same `errorReporting.enabled && errorReporting.consent` check used by `maintenance-failure-reporter.ts`, guarded by `isErrorReporterActive()` so repeated/re-entrant calls never double-init, wrapped in try/catch so a reporter-init failure never fails the maintenance run itself.
- `maintenance-failure-reporter.ts`: export `resolveErrorReportQueuePath()` so the orchestrator CLI can derive the same durable on-disk retry-queue path without duplicating the `:memory:`-aware join logic.
- `dream-cycle.ts`: `recordStageFailure()` now accepts an optional display label distinct from the `capturePluginError` operation tag, so reflect-rules' `failedStages`/digest entry becomes `"reflect-rules (<zeroRulesReason>)"` (or `"reflect-rules (reflect_rules_threw)"` when the stage throws) instead of the bare `"reflect-rules"` — the operation tag itself is unchanged, keeping GlitchTip tag cardinality stable.
- `dream-cycle.test.ts`: updated the existing degraded-diagnostics assertion and added a case covering the thrown-exception branch.
- Added `register-maintenance-orchestrator-error-reporting.test.ts` covering the enabled+consent / disabled / no-consent / already-active / init-failure branches of the new wiring.

**Note on #2195** (the umbrella "maintenance-nightly exited non-zero" wrapper alert): that issue asks for cross-step dedup/suppression across the whole nightly run, which this PR does not implement — it stays open and unaffected by this change.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor / internal improvement (no behavior change)
- [ ] Documentation update
- [ ] CI / tooling change

## Quality Checklist

- [x] `npx tsc --noEmit` passes with no errors
- [x] `npm run lint` passes (exit 0; pre-existing unrelated warnings elsewhere in the repo, none introduced by this diff)
- [x] `npm test` passes (all tests green) — full suite: 791 files / 10,074 tests passed, 5 files / 24 tests skipped (pre-existing skips, unrelated)
- [x] No secrets, credentials, or API keys committed
- [x] No `console.log` debug statements left in production code

## Documentation Impact (REQUIRED)

- [x] Inline code comments (JSDoc) updated for modified functions and types
- [ ] `docs/` or `README.md` updated to reflect architectural or usage changes
- [x] Cross-referenced functions/services checked for outdated documentation

No user-facing config/behavior change — this only affects what reaches GlitchTip during maintenance runs and the wording of an internal digest string.

## Testing

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] Manually verified against a running OpenClaw instance

## Notes for Reviewer

The actual one-off trigger for the July 27 incident (why `reflect-rules` produced zero parseable rules that specific night) can't be retroactively diagnosed — GlitchTip only ever received the generic summary. This PR's value is making the *next* occurrence fully diagnosable (real exception + diagnostics reach GlitchTip) and making the digest string itself carry one extra word of reason even without live reporting.


---
_Generated by [Claude Code](https://claude.ai/code/session_01S8dqWojkVfWZBAZYx4Utbo)_