### PR TITLE
fix: serialize semantic query cache rebuild against concurrent readers

### DIFF
--- a/extensions/memory-hybrid/backends/vector-db/vector-db-class.ts
+++ b/extensions/memory-hybrid/backends/vector-db/vector-db-class.ts
@@ -625,13 +625,30 @@ export class VectorDB {
       if (!this.db) throw new Error("VectorDB connection not initialized.");
       this.semanticQueryCacheSchemaValid = false;
       this.logWarn(`memory-hybrid: rebuilding semantic query cache table due to ${reason}`);
+      // Issue #34 (GlitchTip): mirror optimize()'s and swapShadowTable()'s exclusion
+      // strategy (#768) before dropping the table out from under a concurrent
+      // getSemanticQueryCacheMatch()/storeSemanticQueryCache()/pruneSemanticQueryCache()
+      // read/write that is still in-flight. setOptimizeLock() also excludes new readers
+      // that arrive during this window from joining the drain count (they will simply
+      // observe whichever table generation is current when they run) and — being keyed
+      // by dbPath — serializes this rebuild against a concurrent main-table optimize() or
+      // shadow-table swap on the same path. Safe against self-deadlock: the caller that
+      // triggered this rebuild (getSemanticQueryCacheMatch/storeSemanticQueryCache's catch
+      // block) has already released its own reader slot via try/finally before reaching
+      // this call, so waitForReadersToDrain() below can never be waiting on ourselves.
+      setOptimizeLock(this.dbPath, true);
       try {
-        await this.db.dropTable(SEMANTIC_QUERY_CACHE_TABLE);
-      } catch {
-        /* ignore */
+        await this.waitForReadersToDrain();
+        try {
+          await this.db.dropTable(SEMANTIC_QUERY_CACHE_TABLE);
+        } catch {
+          /* ignore */
+        }
+        this.semanticQueryCacheTable = null;
+        await this.recreateSemanticQueryCacheTable();
+      } finally {
+        setOptimizeLock(this.dbPath, false);
       }
-      this.semanticQueryCacheTable = null;
-      await this.recreateSemanticQueryCacheTable();
     })();
 
     this.semanticQueryCacheRepairPromise = repairPromise;
@@ -1190,11 +1207,19 @@ export class VectorDB {
   private async pruneSemanticQueryCache(filterKey: string): Promise<void> {
     const table = this.getSemanticQueryCacheTable();
     if (!table) return;
-    const rows = await table
-      .query()
-      .where(`filterKey = '${this.escapeSqlString(filterKey)}'`)
-      .select(["id", "cachedAt"])
-      .toArray();
+    // Issue #34 (GlitchTip): hold a shared reader slot across the prune query/delete calls
+    // so a concurrent rebuildSemanticQueryCacheTable() drop waits for these to finish first.
+    const acquired = this.acquireReader();
+    let rows: Array<Record<string, unknown>>;
+    try {
+      rows = await table
+        .query()
+        .where(`filterKey = '${this.escapeSqlString(filterKey)}'`)
+        .select(["id", "cachedAt"])
+        .toArray();
+    } finally {
+      this.releaseReader(acquired);
+    }
 
     if (rows.length <= SEMANTIC_QUERY_CACHE_MAX_ROWS_PER_FILTER_KEY) return;
 
@@ -1213,7 +1238,12 @@ export class VectorDB {
     for (let i = 0; i < staleRows.length; i += IN_CHUNK) {
       const chunk = staleRows.slice(i, i + IN_CHUNK);
       const idList = chunk.map((row) => `'${this.escapeSqlString(row.id)}'`).join(", ");
-      await table.delete(`id IN (${idList})`);
+      const chunkAcquired = this.acquireReader();
+      try {
+        await table.delete(`id IN (${idList})`);
+      } finally {
+        this.releaseReader(chunkAcquired);
+      }
     }
     this.semanticQueryCachePruneTelemetry = {
       lastFilterKey: filterKey,
@@ -1243,51 +1273,60 @@ export class VectorDB {
 
       const cacheTable = this.getSemanticQueryCacheTable();
       if (!cacheTable) return null;
-      const candidates = await cacheTable.vectorSearch(vector).limit(candidateLimit).toArray();
+      // Issue #34 (GlitchTip): hold a shared reader slot for the vectorSearch() stream so
+      // rebuildSemanticQueryCacheTable()'s waitForReadersToDrain() can see this read is
+      // in-flight before dropping the underlying table out from under it (matches the
+      // search()/hasDuplicate() idiom for the main table, issue #768).
+      const acquired = this.acquireReader();
+      try {
+        const candidates = await cacheTable.vectorSearch(vector).limit(candidateLimit).toArray();
 
-      let bestMatch: SemanticQueryCacheEntry | null = null;
-      for (const row of candidates) {
-        if ((row.filterKey as string | undefined) !== filterKey) continue;
+        let bestMatch: SemanticQueryCacheEntry | null = null;
+        for (const row of candidates) {
+          if ((row.filterKey as string | undefined) !== filterKey) continue;
 
-        const cachedAt = Number(row.cachedAt ?? 0);
-        const ageSec = nowSec - cachedAt;
-        if (!Number.isFinite(cachedAt) || ageSec > ttlSec) {
-          continue;
+          const cachedAt = Number(row.cachedAt ?? 0);
+          const ageSec = nowSec - cachedAt;
+          if (!Number.isFinite(cachedAt) || ageSec > ttlSec) {
+            continue;
+          }
+
+          const candidateVector =
+            typeof row.vector?.toArray === "function"
+              ? row.vector.toArray().map(Number)
+              : typeof row.vector?.toJSON === "function"
+                ? row.vector.toJSON().map(Number)
+                : Array.isArray(row.vector)
+                  ? row.vector.map((value: any) => Number(value))
+                  : ArrayBuffer.isView(row.vector)
+                    ? Array.from(row.vector as ArrayLike<number>, (value: number) => Number(value))
+                    : Array.from((row as any).vector ?? []).map((value: any) => Number(value));
+
+          const similarity = this.computeCosineSimilarity(vector, candidateVector);
+          if (similarity < minSimilarity) continue;
+
+          const entry: SemanticQueryCacheEntry = {
+            id: String(row.id),
+            queryText: String(row.queryText ?? ""),
+            filterKey,
+            factIds: this.parseCacheIds(row.factIds),
+            cachedAt,
+            similarity,
+          };
+
+          if (
+            !bestMatch ||
+            entry.similarity > bestMatch.similarity ||
+            (entry.similarity === bestMatch.similarity && entry.cachedAt > bestMatch.cachedAt)
+          ) {
+            bestMatch = entry;
+          }
         }
 
-        const candidateVector =
-          typeof row.vector?.toArray === "function"
-            ? row.vector.toArray().map(Number)
-            : typeof row.vector?.toJSON === "function"
-              ? row.vector.toJSON().map(Number)
-              : Array.isArray(row.vector)
-                ? row.vector.map((value: any) => Number(value))
-                : ArrayBuffer.isView(row.vector)
-                  ? Array.from(row.vector as ArrayLike<number>, (value: number) => Number(value))
-                  : Array.from((row as any).vector ?? []).map((value: any) => Number(value));
-
-        const similarity = this.computeCosineSimilarity(vector, candidateVector);
-        if (similarity < minSimilarity) continue;
-
-        const entry: SemanticQueryCacheEntry = {
-          id: String(row.id),
-          queryText: String(row.queryText ?? ""),
-          filterKey,
-          factIds: this.parseCacheIds(row.factIds),
-          cachedAt,
-          similarity,
-        };
-
-        if (
-          !bestMatch ||
-          entry.similarity > bestMatch.similarity ||
-          (entry.similarity === bestMatch.similarity && entry.cachedAt > bestMatch.cachedAt)
-        ) {
-          bestMatch = entry;
-        }
+        return bestMatch;
+      } finally {
+        this.releaseReader(acquired);
       }
-
-      return bestMatch;
     } catch (err) {
       if (this.isKnownVectorSchemaError(err)) {
         try {
@@ -1322,16 +1361,23 @@ export class VectorDB {
       const filterKey = entry.filterKey ?? "default";
       const cacheTable = this.getSemanticQueryCacheTable();
       if (!cacheTable) return;
-      await cacheTable.add([
-        {
-          id: randomUUID(),
-          queryText: entry.queryText,
-          filterKey,
-          vector: entry.vector,
-          factIds: JSON.stringify(entry.factIds),
-          cachedAt: entry.cachedAt ?? Math.floor(Date.now() / 1000),
-        },
-      ]);
+      // Issue #34 (GlitchTip): hold a shared reader slot across the add() write so a
+      // concurrent rebuildSemanticQueryCacheTable() drop waits for this to finish first.
+      const acquired = this.acquireReader();
+      try {
+        await cacheTable.add([
+          {
+            id: randomUUID(),
+            queryText: entry.queryText,
+            filterKey,
+            vector: entry.vector,
+            factIds: JSON.stringify(entry.factIds),
+            cachedAt: entry.cachedAt ?? Math.floor(Date.now() / 1000),
+          },
+        ]);
+      } finally {
+        this.releaseReader(acquired);
+      }
       await this.pruneSemanticQueryCache(filterKey);
     } catch (err) {
       if (this.isKnownVectorSchemaError(err)) {

--- a/extensions/memory-hybrid/services/error-reporter/noisy-errors.ts
+++ b/extensions/memory-hybrid/services/error-reporter/noisy-errors.ts
@@ -5,6 +5,11 @@ const NOISY_NETWORK_ERROR_RE =
 const NOISY_AUTH_ERROR_RE =
   /\b(?:401\b|403\b|unauthorized|forbidden|incorrect api key|invalid api key|authentication failed|country,\s*region,\s*or\s*territory\s+not\s+supported|PERMISSION_DENIED)\b/i;
 const NOISY_CIRCUIT_BREAKER_RE = /\bcircuit\s+breaker\s+open\b/i;
+// Transient LanceDB read-stream races: a concurrent table rebuild/drop can delete the
+// fragment file a vectorSearch().toArray() stream is mid-read on. This is a known,
+// already-handled cache-miss/retry case (see vector-db-class.ts semantic query cache
+// hot paths) — never actionable on its own, so never send it to GlitchTip.
+const NOISY_LANCE_STREAM_ERROR_RE = /\b(?:failed to get next batch from stream|lance error:\s*not found)\b/i;
 
 function getErrorStatus(err: unknown): number | string | undefined {
   if (!err || typeof err !== "object") return undefined;
@@ -53,6 +58,7 @@ function isDirectNoisyError(err: unknown): boolean {
 
   if (NOISY_NETWORK_ERROR_RE.test(message)) return true;
   if (NOISY_CIRCUIT_BREAKER_RE.test(message)) return true;
+  if (NOISY_LANCE_STREAM_ERROR_RE.test(message)) return true;
   if (NOISY_AUTH_ERROR_RE.test(message) && !isFilePermissionMessage(message)) return true;
 
   return false;
@@ -61,7 +67,8 @@ function isDirectNoisyError(err: unknown): boolean {
 /**
  * Returns true for known noisy, non-actionable errors that should never be sent
  * to GlitchTip: transient transport failures, external-provider auth failures,
- * local Ollama circuit-breaker errors, and aggregates whose nested causes are all noisy.
+ * local Ollama circuit-breaker errors, transient LanceDB read-stream races during
+ * concurrent table rebuild, and aggregates whose nested causes are all noisy.
  */
 export function shouldDropNoisyError(err: unknown, seen = new Set<unknown>()): boolean {
   if (!err || (typeof err !== "object" && !(err instanceof Error))) return false;

--- a/extensions/memory-hybrid/tests/error-reporter-guard.test.ts
+++ b/extensions/memory-hybrid/tests/error-reporter-guard.test.ts
@@ -144,6 +144,25 @@ describe("UnconfiguredProviderError guard with mocked fetch", () => {
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
+  it("capturePluginError suppresses transient LanceDB read-stream races without calling fetch (GlitchTip issue #34)", async () => {
+    const { capturePluginError, flushErrorReporter } = await import("../services/error-reporter.js");
+
+    // The exact class of message getSemanticQueryCacheMatch()/storeSemanticQueryCache() see
+    // when rebuildSemanticQueryCacheTable()'s dropTable() races their in-flight LanceDB read.
+    const result = capturePluginError(
+      new Error(
+        "Failed to get next batch from stream: lance error: Not found: /home/user/.openclaw/memory/lance/" +
+          "semantic_query_cache.lance/data/12345678-abcd-4ef0-9abc-1234567890ab.lance, path not found",
+      ),
+      { operation: "semantic-query-cache-lookup", severity: "info", subsystem: "vector" },
+    );
+
+    await flushErrorReporter(500);
+
+    expect(result).toBeUndefined();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
   it("applies 24h dedupe only to invalid_goal_registry_entry, not other fingerprinted warnings (#1988)", async () => {
     const { capturePluginError, flushErrorReporter, resetErrorDedupForTests } = await import(
       "../services/error-reporter.js"

--- a/extensions/memory-hybrid/tests/error-reporter.test.ts
+++ b/extensions/memory-hybrid/tests/error-reporter.test.ts
@@ -828,6 +828,24 @@ describe("Error Reporter", () => {
       expect(shouldDropNoisyError(new Error("Ollama circuit breaker open — retrying in 30s"))).toBe(true);
     });
 
+    it("drops transient LanceDB read-stream races (GlitchTip issue #34)", async () => {
+      const { shouldDropNoisyError } = await import("../services/error-reporter.js");
+
+      // Actual production message: rebuildSemanticQueryCacheTable()'s dropTable() races a
+      // concurrent vectorSearch().toArray() read on the semantic query cache table.
+      expect(
+        shouldDropNoisyError(
+          new Error(
+            "Failed to get next batch from stream: lance error: Not found: /home/user/.openclaw/memory/lance/" +
+              "semantic_query_cache.lance/data/12345678-abcd-4ef0-9abc-1234567890ab.lance, path not found",
+          ),
+        ),
+      ).toBe(true);
+      // Either half of the message alone should also be recognized.
+      expect(shouldDropNoisyError(new Error("Failed to get next batch from stream"))).toBe(true);
+      expect(shouldDropNoisyError(new Error("lance error: Not found: some/other/path.lance"))).toBe(true);
+    });
+
     it("drops wrapped or aggregate errors only when every cause is noisy", async () => {
       const { shouldDropNoisyError } = await import("../services/error-reporter.js");
 

--- a/extensions/memory-hybrid/tests/vector-db-optimize-cache.test.ts
+++ b/extensions/memory-hybrid/tests/vector-db-optimize-cache.test.ts
@@ -12,6 +12,9 @@ vi.mock("../services/error-reporter.js", () => ({
 }));
 
 import * as errorReporter from "../services/error-reporter.js";
+// Imported directly from the un-mocked submodule (not the mocked "../services/error-reporter.js")
+// so tests can assert on the real noisy-filter classification rather than the test's own stub.
+import { shouldDropNoisyError } from "../services/error-reporter/noisy-errors.js";
 
 import {
   CORRECT_DIM,
@@ -282,6 +285,154 @@ describe("VectorDB semantic query cache — suppress known schema errors", () =>
     ).resolves.toBeUndefined();
 
     await slowRepair;
+    await db.close();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GlitchTip issue #34 — semantic query cache LanceDB read-stream race.
+// rebuildSemanticQueryCacheTable() drops and recreates the cache table with zero
+// synchronization against concurrent readers/writers. A vectorSearch().toArray() call
+// racing that drop surfaces as "Failed to get next batch from stream: lance error: Not
+// found: .../semantic_query_cache.lance/data/....lance". This was (a) needlessly reported
+// to GlitchTip every time (fixed via services/error-reporter/noisy-errors.ts) and (b) an
+// actual race (fixed via acquireReader()/releaseReader()/waitForReadersToDrain() on the
+// cache table hot paths, mirroring the main table's optimize() fix for issue #768).
+// ---------------------------------------------------------------------------
+
+describe("VectorDB semantic query cache — GlitchTip issue #34 stream-read race", () => {
+  let tmpDir: string;
+  let lanceDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "vector-cache-issue-34-test-"));
+    lanceDir = join(tmpDir, "lance");
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("getSemanticQueryCacheMatch() resolves null (no throw) on a transient LanceDB stream-read error, and the error is classified as noisy so it never reaches GlitchTip", async () => {
+    const db = new VectorDB(lanceDir, CORRECT_DIM);
+
+    await db.storeSemanticQueryCache({
+      queryText: "warm query",
+      vector: [1, 0, 0],
+      factIds: ["fact-warm"],
+      filterKey: "test",
+    });
+
+    const streamReadErr = new Error(
+      "Failed to get next batch from stream: lance error: Not found: /home/user/.openclaw/memory/lance/" +
+        "semantic_query_cache.lance/data/12345678-abcd-4ef0-9abc-1234567890ab.lance, path not found",
+    );
+
+    (db as any).semanticQueryCacheTable = {
+      vectorSearch: () => {
+        throw streamReadErr;
+      },
+    };
+
+    const match = await db.getSemanticQueryCacheMatch([1, 0, 0], {
+      filterKey: "test",
+      minSimilarity: 0.95,
+      ttlMs: 60_000,
+    });
+
+    // Must degrade gracefully to a cache miss rather than throwing to the caller.
+    expect(match).toBeNull();
+
+    // capturePluginError() is still invoked by the generic catch branch (this message does
+    // not match isKnownVectorSchemaError), but the noisy-error fix means the REAL
+    // capturePluginError implementation would drop it before it ever reaches the reporter's
+    // captureException/fetch call. Assert that classification directly against the error
+    // that was actually captured, proving the fix covers this exact production message.
+    expect(mockCapturePluginError).toHaveBeenCalledOnce();
+    const [capturedErr] = mockCapturePluginError.mock.calls[0];
+    expect(shouldDropNoisyError(capturedErr)).toBe(true);
+
+    await db.close();
+  });
+
+  it("rebuildSemanticQueryCacheTable() waits for an in-flight getSemanticQueryCacheMatch() read to drain before dropping the table", async () => {
+    const db = new VectorDB(lanceDir, CORRECT_DIM);
+
+    await db.storeSemanticQueryCache({
+      queryText: "warm query",
+      vector: [1, 0, 0],
+      factIds: ["fact-warm"],
+      filterKey: "race",
+    });
+
+    const internal = db as unknown as {
+      getSemanticQueryCacheTable: () => { vectorSearch: (vector: number[]) => any } | null;
+      db: { dropTable: (name: string) => Promise<void> } | null;
+      rebuildSemanticQueryCacheTable: (reason: string) => Promise<void>;
+    };
+
+    const realCacheTable = internal.getSemanticQueryCacheTable();
+    expect(realCacheTable).toBeTruthy();
+    const originalVectorSearch = (realCacheTable as any).vectorSearch.bind(realCacheTable);
+
+    let vectorSearchEntered = false;
+    let releaseRead: (() => void) | undefined;
+    const readGate = new Promise<void>((resolve) => {
+      releaseRead = resolve;
+    });
+
+    // Wrap vectorSearch so the read's toArray() call blocks on a controllable gate — this
+    // simulates a slow/in-flight LanceDB stream read whose reader slot must be held for the
+    // whole call, matching how getSemanticQueryCacheMatch() actually calls it.
+    vi.spyOn(realCacheTable as any, "vectorSearch").mockImplementation((...args: unknown[]) => {
+      vectorSearchEntered = true;
+      const builder = originalVectorSearch(...args);
+      return {
+        limit: (limitN: number) => ({
+          toArray: async () => {
+            await readGate;
+            return builder.limit(limitN).toArray();
+          },
+        }),
+      };
+    });
+
+    const readPromise = db.getSemanticQueryCacheMatch([1, 0, 0], {
+      filterKey: "race",
+      minSimilarity: 0.95,
+      ttlMs: 60_000,
+    });
+
+    // Wait until the read has actually entered vectorSearch (and therefore holds a reader slot)
+    // before triggering the rebuild, so the drain has something real to wait for.
+    await vi.waitFor(() => expect(vectorSearchEntered).toBe(true));
+
+    let dropTableCalled = false;
+    const dbHandle = internal.db;
+    expect(dbHandle).toBeTruthy();
+    const originalDropTable = dbHandle!.dropTable.bind(dbHandle);
+    vi.spyOn(dbHandle as any, "dropTable").mockImplementation(async (...args: unknown[]) => {
+      dropTableCalled = true;
+      return originalDropTable(...(args as [string]));
+    });
+
+    const rebuildPromise = internal.rebuildSemanticQueryCacheTable("test: forced rebuild for race test");
+
+    // Give the rebuild a chance to reach (and block on) waitForReadersToDrain(). It must NOT
+    // have called dropTable yet, because the read above still holds its reader slot.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(dropTableCalled).toBe(false);
+
+    // Release the in-flight read — its reader slot is released in getSemanticQueryCacheMatch()'s
+    // finally block, which should let the drain complete and the rebuild proceed.
+    releaseRead?.();
+    const match = await readPromise;
+    expect(match?.factIds).toEqual(["fact-warm"]);
+
+    await rebuildPromise;
+    expect(dropTableCalled).toBe(true);
+
     await db.close();
   });
 });


### PR DESCRIPTION
## Summary

Closes #2213

GlitchTip issue 34 (GlitchTip's own numbering, tracked here as #2213): `rebuildSemanticQueryCacheTable()` dropped and recreated the LanceDB semantic query cache table with no synchronization against concurrent readers/writers, so an in-flight `vectorSearch().toArray()` stream in `getSemanticQueryCacheMatch()` could race the drop and surface as `Error: Failed to get next batch from stream: lance error: Not found: .../semantic_query_cache.lance/data/....lance`.

## Changes

- `backends/vector-db/vector-db-class.ts`: wrap the cache table's hot paths (`getSemanticQueryCacheMatch`, `storeSemanticQueryCache`, `pruneSemanticQueryCache`) with the existing `acquireReader()`/`releaseReader()` reader-count idiom (the same one already used for the main table's `search()`/`hasDuplicate()`, from issue #768), and make `rebuildSemanticQueryCacheTable()` take `setOptimizeLock()` + `await this.waitForReadersToDrain()` before `dropTable()`, mirroring `optimize()` and `swapShadowTable()`. Verified no self-deadlock: every caller releases its own reader slot via `try/finally` before its catch block invokes the rebuild.
- `services/error-reporter/noisy-errors.ts`: classify the transient LanceDB stream-read message as noisy so `capturePluginError()` no longer forwards this already-handled cache-miss case to GlitchTip as a full exception (the lookup path already returns `null` gracefully and the caller re-runs the query fresh — this was never a crash, just noisy reporting of a safe cache miss).
- Tests: coverage for the noisy-error classification (unit + mocked-fetch guard proving the transport is never called for this message), the graceful-degradation behavior of `getSemanticQueryCacheMatch()` on this error, and a concurrency test proving `rebuildSemanticQueryCacheTable()` now waits for an in-flight read to drain before calling `dropTable()`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor / internal improvement (no behavior change)
- [ ] Documentation update
- [ ] CI / tooling change

## Quality Checklist

- [x] `npx tsc --noEmit` passes with no errors
- [x] `npm run lint` passes (exit 0; pre-existing unrelated warnings, none introduced by this diff)
- [x] `npm test` passes (all tests green) — full suite: 790 files / 10,069 tests passed, 5 files / 24 tests skipped (pre-existing skips, unrelated)
- [x] No secrets, credentials, or API keys committed
- [x] No `console.log` debug statements left in production code

## Documentation Impact (REQUIRED)

- [x] Inline code comments (JSDoc) updated for modified functions and types
- [ ] `docs/` or `README.md` updated to reflect architectural or usage changes
- [x] Cross-referenced functions/services checked for outdated documentation

Internal storage-layer hardening only — no config or user-facing behavior change (the cache still behaves identically on the happy path; this only fixes what happens during a rare concurrent rebuild).

## Testing

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] Manually verified against a running OpenClaw instance

## Notes for Reviewer

This is the same failure class as issue #768 (fixed for the main `memories` table's `optimize()` path) — the semantic query cache table just never got the same reader-drain protection when it added its own drop-and-recreate self-repair path. The fix mirrors that existing pattern rather than inventing a new locking scheme.


---
_Generated by [Claude Code](https://claude.ai/code/session_01S8dqWojkVfWZBAZYx4Utbo)_