### PR TITLE
refactor: guard reregister-policy path resolution against undefined config

### DIFF
--- a/extensions/memory-hybrid/setup/reregister-policy.ts
+++ b/extensions/memory-hybrid/setup/reregister-policy.ts
@@ -1,5 +1,6 @@
 /** @module reregister-policy — Hot-reload DB teardown vs reuse (OPENCLAW_HYBRID_MEM_REREGISTER_POLICY). */
 import type { PluginRuntime } from "../api/plugin-runtime.js";
+import { DEFAULT_LANCE_PATH, DEFAULT_SQLITE_PATH } from "../config/parsers/core.js";
 import type { HybridMemoryConfig } from "../config.js";
 import { getEnv } from "../utils/env-manager.js";
 
@@ -94,7 +95,32 @@ export function recordReregisterTeardownTimeoutRecovery(): void {
   reregisterMetrics.teardownTimeoutRecoveries += 1;
 }
 
-type PathResolvingApi = { resolvePath: (p: string) => string };
+type PathResolvingApi = {
+  resolvePath: (p: string) => string;
+  logger?: { warn?: (msg: string) => void };
+};
+
+/**
+ * Guards `api.resolvePath()` against a missing/blank `sqlitePath`/`lanceDbPath`, mirroring the
+ * `normalizeDatabasePath()` guard in bootstrap-databases.ts (GlitchTip #33 was the same shape of
+ * bug — an undefined path reaching a `node:path` call — already fixed on the `initializeDatabases`
+ * path by PR #2203; this is defense-in-depth for the other raw `resolvePath(cfg.*Path)` caller).
+ * Today the normalized value only feeds a `!==` string comparison in `evaluateReregisterReuse`, but
+ * guarding here means a future stricter `resolvePath` (or a future caller of the comparison result)
+ * can't silently reintroduce the crash.
+ */
+function normalizeReregisterPath(
+  value: unknown,
+  fallback: string,
+  field: "lanceDbPath" | "sqlitePath",
+  api: PathResolvingApi,
+): string {
+  if (typeof value === "string" && value.trim()) return value;
+  api.logger?.warn?.(
+    `memory-hybrid: reregister policy received missing or invalid ${field}; using the documented default (${field === "lanceDbPath" ? "DEFAULT_LANCE_PATH" : "DEFAULT_SQLITE_PATH"}).`,
+  );
+  return fallback;
+}
 
 function booleanMethod(target: unknown, method: string): boolean | null {
   if (!target || typeof target !== "object") return null;
@@ -151,8 +177,9 @@ const drift = (field: string): ReregisterReuseDecision => ({ reuse: false, reaso
 /**
  * Decide whether a re-register may keep the donor's SQLite/Lance handles, returning a stable
  * reason code alongside the boolean (#2136). Every decline path names why it declined so a full
- * teardown under `reuse-databases` is never unexplained. Pure/side-effect-free — callers record
- * the reason via {@link recordReregisterFullTeardown}.
+ * teardown under `reuse-databases` is never unexplained. Otherwise side-effect-free — callers
+ * record the reason via {@link recordReregisterFullTeardown} — aside from an optional logger
+ * warning from {@link normalizeReregisterPath} when the incoming config's path fields are missing.
  */
 export function evaluateReregisterReuse(
   old: PluginRuntime | null,
@@ -172,8 +199,10 @@ export function evaluateReregisterReuse(
   // stores that immediately throw "The database connection is not open". Treat any
   // closed/failed donor handle as non-reusable and fall back to a full fresh open.
   if (!runtimeStoresStillReusable(old)) return { reuse: false, reason: "donor_handle_closed" };
-  const nextSqlite = api.resolvePath(cfg.sqlitePath);
-  const nextLance = api.resolvePath(cfg.lanceDbPath);
+  // Config parsing normally supplies these defaults; guard the same way as bootstrap-databases.ts
+  // does before initializeDatabases, since this can also see a deferred/reconstructed config.
+  const nextSqlite = api.resolvePath(normalizeReregisterPath(cfg.sqlitePath, DEFAULT_SQLITE_PATH, "sqlitePath", api));
+  const nextLance = api.resolvePath(normalizeReregisterPath(cfg.lanceDbPath, DEFAULT_LANCE_PATH, "lanceDbPath", api));
   if (old.resolvedSqlitePath !== nextSqlite) return { reuse: false, reason: "sqlite_path_changed" };
   if (old.resolvedLancePath !== nextLance) return { reuse: false, reason: "lance_path_changed" };
 

--- a/extensions/memory-hybrid/tests/reregister-policy.test.ts
+++ b/extensions/memory-hybrid/tests/reregister-policy.test.ts
@@ -1,14 +1,15 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { PluginRuntime } from "../api/plugin-runtime.js";
+import { DEFAULT_LANCE_PATH, DEFAULT_SQLITE_PATH } from "../config/parsers/core.js";
 import type { HybridMemoryConfig } from "../config.js";
 import {
   canReuseDatabasesOnReregister,
   evaluateReregisterReuse,
   recordReregisterDatabaseReuse,
   recordReregisterFullTeardown,
+  reregisterMetrics,
   resetReregisterPolicyForTests,
   resolveReregisterPolicy,
-  reregisterMetrics,
   shouldFullTeardownOnReregister,
 } from "../setup/reregister-policy.js";
 
@@ -353,6 +354,36 @@ describe("reregister-policy", () => {
       for (let i = 0; i < 5; i++) {
         expect(evaluateReregisterReuse(donor, minimalCfg(), api).reuse).toBe(true);
       }
+    });
+
+    // Defense-in-depth adjacent to GlitchTip #33 (a "path must be a string" TypeError out of
+    // node:path's dirname(), thrown from initializeDatabases and already fixed there by PR #2203
+    // via normalizeDatabasePath()). evaluateReregisterReuse has its own raw resolvePath(cfg.*Path)
+    // calls that were never guarded; this asserts they can no longer receive a non-string either.
+    it("falls back to documented paths before resolvePath when sqlitePath/lanceDbPath are missing", () => {
+      const warn = vi.fn();
+      const resolvePath = vi.fn((p: string) => {
+        if (typeof p !== "string") throw new TypeError('The "path" argument must be of type string.');
+        return `/home/markus/.openclaw/${p}`;
+      });
+      const guardedApi = { resolvePath, logger: { warn } };
+      const cfg = minimalCfg();
+      const donor = mockOldRuntime(
+        { sqlite: guardedApi.resolvePath(DEFAULT_SQLITE_PATH), lance: guardedApi.resolvePath(DEFAULT_LANCE_PATH) },
+        cfg,
+      );
+      const malformedCfg = { ...cfg, sqlitePath: undefined, lanceDbPath: "  " } as unknown as HybridMemoryConfig;
+
+      let decision: ReturnType<typeof evaluateReregisterReuse> | undefined;
+      expect(() => {
+        decision = evaluateReregisterReuse(donor, malformedCfg, guardedApi);
+      }).not.toThrow();
+
+      expect(decision).toEqual({ reuse: true, reason: "reusable" });
+      expect(resolvePath.mock.calls.map((call) => call[0])).toContain(DEFAULT_SQLITE_PATH);
+      expect(resolvePath.mock.calls.map((call) => call[0])).toContain(DEFAULT_LANCE_PATH);
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining("missing or invalid sqlitePath"));
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining("missing or invalid lanceDbPath"));
     });
   });
 


### PR DESCRIPTION
## Summary

Closes #

This is **not** a fix for a live bug — see Notes for Reviewer. No issue to auto-close.

`evaluateReregisterReuse()` in `setup/reregister-policy.ts` called `api.resolvePath(cfg.sqlitePath)` / `api.resolvePath(cfg.lanceDbPath)` directly, without the `normalizeDatabasePath()` guard that `setup/bootstrap-databases.ts` already applies before its own `resolvePath()`/`dirname()` calls (added in PR #2203, adjacent to GlitchTip issue 34 — GlitchTip's own numbering, unrelated to this repo's issue/PR numbers of the same value; tracked here as #2212, already closed since that exact bug is already fixed on `main`).

Today this path only feeds a `!==` string comparison in the reuse-vs-teardown decision, so a non-string value can't crash it the way GlitchTip issue 33 crashed `dirname()`. But it's an unguarded caller of the same raw, potentially-undefined config fields, and leaving it unguarded would quietly reintroduce risk if `resolvePath()` or a future caller of the comparison result ever assumes a valid path.

## Changes

- Adds a small `normalizeReregisterPath()` helper (mirroring `normalizeDatabasePath`'s behavior: warn and fall back to the documented `DEFAULT_SQLITE_PATH`/`DEFAULT_LANCE_PATH`) rather than importing `normalizeDatabasePath` directly, since that function's signature is pinned to the full `ClawdbotPluginApi` (mandatory `logger`) while `reregister-policy`'s `PathResolvingApi` is intentionally narrower for testability (~15 existing test mocks use the narrow shape). No import cycle exists between the two modules, but duplicating this ~10-line guard keeps the change smaller than widening `PathResolvingApi` (and every existing test's api mock) to match `ClawdbotPluginApi`.
- No behavior change for any well-formed config; only changes what happens when `cfg.sqlitePath`/`cfg.lanceDbPath` would otherwise have been undefined or blank.
- Test added: `tests/reregister-policy.test.ts` — asserts a config with missing/blank `sqlitePath`/`lanceDbPath` never results in `resolvePath` being called with a non-string, both warnings fire, and the decision still resolves correctly.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactor / internal improvement (no behavior change)
- [ ] Documentation update
- [ ] CI / tooling change

## Quality Checklist

- [x] `npx tsc --noEmit` passes with no errors
- [x] `npm run lint` passes (exit 0; Biome's import-sorter auto-fixed import ordering in the two changed files, no new errors)
- [x] `npm test` passes (all tests green) — full suite: 790 files / 10,069 tests passed, 5 files / 24 tests skipped (pre-existing skips, unrelated)
- [x] No secrets, credentials, or API keys committed
- [x] No `console.log` debug statements left in production code

## Documentation Impact (REQUIRED)

- [x] Inline code comments (JSDoc) updated for modified functions and types
- [ ] `docs/` or `README.md` updated to reflect architectural or usage changes
- [x] Cross-referenced functions/services checked for outdated documentation

Internal hardening only — no config or user-facing behavior change.

## Testing

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] Manually verified against a running OpenClaw instance

## Notes for Reviewer

**This does not fix a live bug.** While investigating GlitchTip issue 33 (`TypeError: The "path" argument must be of type string. Received undefined`, tracked as #2212), the exact reported crash turned out to already be fixed on `main` by PR #2203 before this session started — confirmed via `git merge-base --is-ancestor` and the `normalizeDatabasePath()` guard already present in `bootstrap-databases.ts`. #2212 has been closed as resolved by that prior PR. This PR only extends the same defensive pattern to an adjacent, currently-non-crashing caller for consistency, in case future changes to `resolvePath()` or its callers ever assume a valid path.


---
_Generated by [Claude Code](https://claude.ai/code/session_01S8dqWojkVfWZBAZYx4Utbo)_