### PR TITLE
chore(release): bump memory-hybrid to 2026.7.227

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [2026.7.227] - 2026-07-27
+
+### Fixed
+
+- Maintenance orchestrator CLI (`maintenance cycle/nightly/full/step`) now initializes the error reporter before running steps, so diagnostics `dream-cycle.ts`/`reflection.ts` already capture for a failed `reflect-rules` stage (parse failure reason, model/fallback used) actually reach GlitchTip instead of being silently dropped. The stage's failure label now also carries the reason (e.g. `reflect-rules (invalid_response_format)`) instead of the bare stage name.
+- Semantic query cache (LanceDB) no longer races its own table-rebuild self-repair against an in-flight cache read/write, which could surface as `Failed to get next batch from stream: lance error: Not found: .../semantic_query_cache.lance/...`. The rebuild now waits for in-flight reads to drain first, mirroring the existing protection on the main table; the same transient message is also no longer reported as a GlitchTip exception, since it was already handled as a safe cache miss.
+- Cron harness now invokes the supported `maintenance validate-exit` command instead of the deprecated `validate-cron-exit` alias, and the guard-file write is now fully mechanical (gated on wrapped-step exit code, validator exit code, parsed validation status, and independent re-verification of every required step in the exit ledger) instead of relying on the executing agent's own judgment.
+- `VectorDB` no longer uses a runtime `import()` for `withEmbedWriteLock`, which could fail to resolve under OpenClaw's custom plugin loader; it's now a static import resolved at module load time.
+- `FactsDB.runCompaction` no longer throws `The database connection is not open` when the capture lifecycle stage triggers compaction while the store is mid-teardown; it now no-ops safely.
+- `memory_loop_list` and five sibling stores (learnings, beliefs, serendipity findings, issues, drift) no longer crash with `filter.status.map is not a function` when a bare string is passed for an array-typed filter field; scalar values are now coerced to arrays at both the tool layer and the store layer.
+- Nightly maintenance telemetry: LLM-call failures in insight-synthesis and generate-proposals are now tagged with a coarse failure class (timeout/provider error/invalid response/empty response); distill batch-failure counts and analyze-maintenance-logs finding titles are now included in GlitchTip issue tags/messages instead of only a summary count.
+
+### Changed
+
+- Nightly maintenance telemetry no longer reports a redundant generic "step exited non-zero" GlitchTip issue when a more specific issue already explains the same step's failure in the same run, and no longer reports the top-level "job exited non-zero" umbrella issue when other issues already reported the same run's failures — both only suppress when a more informative sibling genuinely exists in the same validation pass.
+
 ## [2026.7.226] - 2026-07-25
 
 ### Fixed

--- a/extensions/memory-hybrid/openclaw.plugin.json
+++ b/extensions/memory-hybrid/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "openclaw-hybrid-memory",
   "kind": "memory",
-  "version": "2026.7.226",
+  "version": "2026.7.227",
   "contracts": {
     "tools": [
       "active_task_checkpoint",

--- a/extensions/memory-hybrid/package-lock.json
+++ b/extensions/memory-hybrid/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openclaw-hybrid-memory",
-  "version": "2026.7.226",
+  "version": "2026.7.227",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openclaw-hybrid-memory",
-      "version": "2026.7.226",
+      "version": "2026.7.227",
       "hasInstallScript": true,
       "dependencies": {
         "@lancedb/lancedb": "^0.31.0",

--- a/extensions/memory-hybrid/package.json
+++ b/extensions/memory-hybrid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-hybrid-memory",
-  "version": "2026.7.226",
+  "version": "2026.7.227",
   "type": "module",
   "description": "Give your OpenClaw agent lasting memory: structured facts, semantic search, auto-capture & recall, decay, optional credential vault. Part of Hybrid Memory v3.",
   "files": [

--- a/packages/openclaw-hybrid-memory-install/package.json
+++ b/packages/openclaw-hybrid-memory-install/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-hybrid-memory-install",
-  "version": "2026.7.226",
+  "version": "2026.7.227",
   "description": "Standalone installer for openclaw-hybrid-memory. Use when OpenClaw config validation fails.",
   "bin": {
     "openclaw-hybrid-memory-install": "./install.js"

--- a/release-notes/release-notes-2026.7.227.md
+++ b/release-notes/release-notes-2026.7.227.md
@@ -1,0 +1,19 @@
+# Release notes — 2026.7.227
+
+## Fixed
+
+- The nightly maintenance orchestrator CLI now initializes the error reporter before running steps, so a failing `reflect-rules` stage reports its real diagnostics (parse failure reason, which model/fallback answered) to GlitchTip instead of only a generic "stage failed" summary.
+- The semantic query cache's table-rebuild self-repair no longer races an in-flight cache read/write, which could surface as a LanceDB "stream not found" error; that specific transient message is also no longer reported as an exception, since it was already handled as a safe cache miss.
+- The generated cron harness now runs the supported `maintenance validate-exit` command instead of the deprecated `validate-cron-exit` alias, and writes its guard file mechanically — gated on the wrapped step, the validator's own exit code, its parsed status, and an independent recheck of every required step in the exit ledger — instead of trusting the executing agent to write it correctly.
+- `VectorDB` no longer resolves a helper via a runtime `import()` that could fail under OpenClaw's custom plugin loader; it's now a static import.
+- Compaction no longer crashes with a "database connection is not open" error if it runs while the store is mid-teardown; it now no-ops safely.
+- `memory_loop_list` and five sibling stores (learnings, beliefs, serendipity findings, issues, drift) no longer crash when an array-typed filter field is passed a bare string instead of an array — a pattern reachable from ordinary LLM tool use.
+- Nightly maintenance telemetry now tags LLM-call failures with a coarse failure class, and includes distill batch-failure counts and analyzer finding titles directly in GlitchTip issue data instead of only summary counts.
+
+## Changed
+
+- Nightly maintenance telemetry no longer fires redundant GlitchTip issues for the same underlying failure — a generic "step exited non-zero" issue is dropped when a more specific issue already explains it, and the top-level "job exited non-zero" issue is dropped when other issues from the same run already explain what happened.
+
+## Release metadata
+
+- Bumps `openclaw-hybrid-memory` and the lockstep standalone installer to `2026.7.227`.


### PR DESCRIPTION
## Summary

Version-bump release PR for `2026.7.227`. Bumps `extensions/memory-hybrid/package.json`, `extensions/memory-hybrid/openclaw.plugin.json`, `packages/openclaw-hybrid-memory-install/package.json`, and `extensions/memory-hybrid/package-lock.json` in lockstep, and adds the `CHANGELOG.md` section plus `release-notes/release-notes-2026.7.227.md` covering everything merged since the last release (PRs #2214, #2215, #2216, #2217): reflect-rules diagnostics reporting, the semantic query cache rebuild race, the cron harness's deprecated command + weak guard-file write, `VectorDB`'s dynamic-import fragility, a compaction teardown crash, six stores' array-filter crash on scalar input, and the maintenance-telemetry diagnostics/dedup overhaul.

Closes #

**PR title:** follows Conventional Commits (`chore(release): …`).

Merging this PR to `main` triggers the repo's automated `tag-release-after-ci.yml` workflow, which tags `v2026.7.227` and dispatches the Release workflow (GitHub Release + npm publish) once CI is green — flagging this since it's a one-way action.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor / internal improvement (no behavior change)
- [ ] Documentation update
- [x] CI / tooling change

## Quality Checklist

- [x] `cd extensions/memory-hybrid && npx tsc --noEmit` passes with no errors
- [x] `cd extensions/memory-hybrid && npm run lint` passes with no warnings
- [x] `cd extensions/memory-hybrid && npm test` passes (all tests green — 794 files / 10,146 tests)
- [x] No secrets, credentials, or API keys committed
- [x] No `console.log` debug statements left in production code

Also ran `npm run format:check`, `node scripts/verify-publish.cjs`, and `npm run verify:gate` — all pass.

## Documentation Impact (REQUIRED)

- [ ] Inline code comments (JSDoc) updated for modified functions and types
- [x] `docs/` or `README.md` updated to reflect architectural or usage changes (`CHANGELOG.md` + new `release-notes/release-notes-2026.7.227.md`)
- [ ] Cross-referenced functions/services checked for outdated documentation

## Testing

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] Manually verified against a running OpenClaw instance

This is a version-bump-only change; no source behavior changes accompany it (all functional changes were already tested and merged in their originating PRs).

## Notes for Reviewer

`package-lock.json` shows only the two version-string updates versus `main` — verified explicitly with `git diff main -- extensions/memory-hybrid/package-lock.json` after an earlier accidental `npm install`-induced lockfile diff (stripped `libc` fields on optional deps) was caught and corrected.


---
_Generated by [Claude Code](https://claude.ai/code/session_01S8dqWojkVfWZBAZYx4Utbo)_