### PR TITLE
feat: run GlitchTip sync twice daily and push GitHub closures back to GlitchTip

### DIFF
--- a/.github/scripts/sync-glitchtip-issues.mjs
+++ b/.github/scripts/sync-glitchtip-issues.mjs
@@ -1,10 +1,16 @@
 #!/usr/bin/env node
 /**
- * Mirror unresolved GlitchTip issues into GitHub issues, deduped by GlitchTip issue ID.
+ * Bidirectional sync between GlitchTip issues and GitHub issues:
  *
- * This repo is public, so the body is built from an explicit field allowlist rather than
- * dumping the raw GlitchTip event — see ALLOWED_TAG_KEYS / DENY_KEY_PATTERN below. Breadcrumbs,
- * user/request/extra contexts, and the GlitchTip host itself are never included.
+ *   1. GlitchTip -> GitHub: mirror unresolved GlitchTip issues into GitHub issues, deduped by
+ *      GlitchTip issue ID.
+ *   2. GitHub -> GlitchTip: for previously-synced GitHub issues that have been closed, push the
+ *      resolution back onto the GlitchTip issue (`completed` -> resolved; `not_planned` or
+ *      `duplicate` -> ignored). Issues still open on GitHub are left alone on the GlitchTip side.
+ *
+ * This repo is public, so the GitHub issue body is built from an explicit field allowlist rather
+ * than dumping the raw GlitchTip event — see ALLOWED_TAG_KEYS / DENY_KEY_PATTERN below.
+ * Breadcrumbs, user/request/extra contexts, and the GlitchTip host itself are never included.
  *
  * Env: GLITCHTIP_TOKEN, GLITCHTIP_BASE_URL, ORG_SLUG, PROJECT_SLUG, QUERY, DRY_RUN ("true"/"false"),
  *      GITHUB_REPOSITORY (owner/repo, provided by Actions).
@@ -68,6 +74,36 @@ async function glitchtipGet(path, params) {
     throw new Error(`GlitchTip API ${url.pathname} returned HTTP ${res.status}`);
   }
   return res.json();
+}
+
+async function glitchtipSetStatus(issueId, status) {
+  // The flat /api/0/issues/{id}/ route is read/delete only (confirmed via OPTIONS: "Allow: DELETE,
+  // GET"). Status mutation lives on the org-scoped route instead ("Allow: PUT, DELETE, GET").
+  const url = new URL(`${GLITCHTIP_BASE_URL}/api/0/organizations/${ORG_SLUG}/issues/${issueId}/`);
+  const res = await fetch(url, {
+    method: "PUT",
+    headers: {
+      Authorization: `Bearer ${GLITCHTIP_TOKEN}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ status }),
+  });
+  if (!res.ok) {
+    throw new Error(`GlitchTip API PUT ${url.pathname} returned HTTP ${res.status}`);
+  }
+  return res.json();
+}
+
+// Only closed GitHub issues drive a GlitchTip status change; open issues are left alone so that
+// manual triage done directly in GlitchTip (snoozing, etc.) isn't clobbered every run.
+const IGNORED_CLOSE_REASONS = new Set(["not_planned", "duplicate"]);
+
+function resolveTargetGlitchTipStatus(ghIssue) {
+  if ((ghIssue.state ?? "").toLowerCase() !== "closed") return null;
+  const reason = (ghIssue.stateReason ?? "").toLowerCase();
+  // "not_planned" (won't fix) and "duplicate" (tracked elsewhere, not separately fixed) both mean
+  // the underlying error isn't confirmed fixed, so they map to "ignored" rather than "resolved".
+  return IGNORED_CLOSE_REASONS.has(reason) ? "ignored" : "resolved";
 }
 
 function gh(args, input) {
@@ -167,7 +203,7 @@ async function main() {
     "--state",
     "all",
     "--json",
-    "number,body",
+    "number,body,state,stateReason",
     "--limit",
     "200",
   ]);
@@ -231,6 +267,44 @@ async function main() {
   }
 
   summaryLines.push("", `**${created} ${DRY_RUN ? "would be created" : "created"}, ${skipped} already synced (skipped).**`);
+
+  summaryLines.push("", `## GlitchTip status sync (GitHub → GlitchTip)${DRY_RUN ? " (dry run)" : ""}`, "");
+  let statusUpdated = 0;
+  let statusSkipped = 0;
+
+  for (const ghIssue of existing) {
+    const glitchtipId = /<!-- glitchtip-id: (\d+) -->/.exec(ghIssue.body ?? "")?.[1];
+    if (!glitchtipId) continue;
+
+    const targetStatus = resolveTargetGlitchTipStatus(ghIssue);
+    if (!targetStatus) continue; // still open on GitHub — leave GlitchTip status alone
+
+    const current = await glitchtipGet(`/api/0/issues/${glitchtipId}/`);
+    if (current.status === targetStatus) {
+      statusSkipped++;
+      continue;
+    }
+
+    if (DRY_RUN) {
+      summaryLines.push(
+        `- would set GlitchTip #${glitchtipId} \`${current.status}\` → \`${targetStatus}\` ` +
+          `(GitHub #${ghIssue.number} closed as ${ghIssue.stateReason ?? "completed"})`,
+      );
+      statusUpdated++;
+      continue;
+    }
+
+    await glitchtipSetStatus(glitchtipId, targetStatus);
+    summaryLines.push(
+      `- set GlitchTip #${glitchtipId} \`${current.status}\` → \`${targetStatus}\` (GitHub #${ghIssue.number})`,
+    );
+    statusUpdated++;
+  }
+
+  summaryLines.push(
+    "",
+    `**${statusUpdated} ${DRY_RUN ? "would be updated" : "updated"}, ${statusSkipped} already in sync.**`,
+  );
 
   const summaryPath = process.env.GITHUB_STEP_SUMMARY;
   if (summaryPath) {

--- a/.github/workflows/glitchtip-issue-sync.yml
+++ b/.github/workflows/glitchtip-issue-sync.yml
@@ -1,6 +1,9 @@
 name: Sync GlitchTip Issues to GitHub
 
 on:
+  schedule:
+    # Twice a day, live (not dry-run) — 06:00 and 18:00 UTC.
+    - cron: "0 6,18 * * *"
   workflow_dispatch:
     inputs:
       org_slug:
@@ -16,7 +19,7 @@ on:
         required: false
         default: "is:unresolved"
       dry_run:
-        description: "Preview only — do not create any GitHub issues"
+        description: "Preview only — do not create GitHub issues or update GlitchTip issue status"
         type: boolean
         required: false
         default: true
@@ -37,6 +40,7 @@ jobs:
           ORG_SLUG: ${{ inputs.org_slug || 'hybrid-memory' }}
           PROJECT_SLUG: ${{ inputs.project_slug || 'openclaw-hybrid-memory' }}
           QUERY: ${{ inputs.query || 'is:unresolved' }}
-          DRY_RUN: ${{ inputs.dry_run }}
+          # Scheduled runs are always live; manual dispatch keeps the dry-run-by-default safety net.
+          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || 'false' }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: node .github/scripts/sync-glitchtip-issues.mjs


### PR DESCRIPTION
## Summary

Closes #

Two changes to `.github/workflows/glitchtip-issue-sync.yml` / `.github/scripts/sync-glitchtip-issues.mjs`:

1. **Schedule**: adds a `schedule` trigger running twice a day (06:00 / 18:00 UTC), always live (not dry-run). Manual `workflow_dispatch` is unchanged — still defaults to `dry_run: true`.
2. **Reverse sync (GitHub → GlitchTip)**: for GitHub issues previously synced from GlitchTip (has the `<!-- glitchtip-id: N -->` marker) that have since been **closed**, push the resolution back onto the GlitchTip issue:
   - closed as `completed` → GlitchTip `resolved`
   - closed as `not_planned` (won't fix) or `duplicate` → GlitchTip `ignored`
   - still **open** on GitHub → left alone on the GlitchTip side (so manual triage/snoozing done directly in GlitchTip isn't clobbered every run)

Only issues where the current GlitchTip status differs from the target are updated (a cheap per-issue GET first), so steady-state runs are no-ops once everything is in sync.

### A production API detail found during testing

GlitchTip's `/api/0/issues/{id}/` route only allows `GET`/`DELETE` on this instance (confirmed via `OPTIONS` — `Allow: DELETE, GET`); the status-mutating route is the org-scoped `/api/0/organizations/{org}/issues/{id}/` (`Allow: PUT, DELETE, GET`). The code uses the correct one.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor / internal improvement (no behavior change)
- [ ] Documentation update
- [x] CI / tooling change

## Quality Checklist

- [x] `node --check` on the modified script passes with no errors
- [x] No secrets, credentials, or API keys committed
- [x] No `console.log` debug statements left in production code (this script intentionally logs to stdout for the Action's job summary, consistent with the existing script's style)

This change lives entirely under `.github/`, outside the `extensions/memory-hybrid` package, so the package's `tsc`/`lint`/`test` gates don't apply; `npm test` was not re-run for this PR.

## Documentation Impact (REQUIRED)

- [ ] Inline code comments (JSDoc) updated for modified functions and types
- [ ] `docs/` or `README.md` updated to reflect architectural or usage changes
- [ ] Cross-referenced functions/services checked for outdated documentation

No user-facing docs cover this internal ops workflow; the workflow's own `dry_run` input description and inline code comments were updated instead.

## Testing

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] Manually verified against a running OpenClaw instance

Verified live against this repo's real GlitchTip project via a temporary branch-scoped `push` trigger (removed before opening this PR):
- Confirmed via `OPTIONS` probing which GlitchTip routes actually accept `PUT` before wiring up the real call.
- Ran a dry-run pass showing correct "would set" output for all 5 currently-synced/closed issues, including the `duplicate` → `ignored` mapping for GitHub #2211.
- Ran one deliberate live pass: all 5 GlitchTip issues (37, 36, 26, 33, 34) updated successfully with zero errors — #26 → `ignored` (duplicate), the other 4 → `resolved`.

## Notes for Reviewer

The first live run this PR triggers already applied the intended real-world state change (the 5 already-closed/already-fixed issues from this session's earlier GlitchTip work), so the twice-daily schedule should be a no-op (0 updated) on its next run barring new issue activity.


---
_Generated by [Claude Code](https://claude.ai/code/session_01S8dqWojkVfWZBAZYx4Utbo)_