### PR TITLE
fix: fall back to same-tier pricing for unrecognized model versions

### DIFF
--- a/extensions/memory-hybrid/services/model-pricing.ts
+++ b/extensions/memory-hybrid/services/model-pricing.ts
@@ -42,8 +42,34 @@ const MODEL_PRICING_LOWER: Record<string, ModelPricing> = Object.fromEntries(
 );
 
 /**
- * Look up pricing for a model. Returns null if the model is not in the table.
- * Model name is matched case-insensitively.
+ * Tier-family fallback for model IDs not in MODEL_PRICING. Exact-match-only lookup silently
+ * excludes every call from cost totals whenever a provider ships a new model version before
+ * this static table is updated (observed: ~99% of calls unpriced after an untracked model
+ * bump) — understating spend rather than overstating it, which is the worse failure mode for
+ * a cost report. Matched most-specific-pattern-first against a known tier anchor already in
+ * MODEL_PRICING, so a later version in the same price tier still gets an approximate estimate
+ * instead of being dropped. Still just an estimate — see the disclaimer above.
+ */
+const TIER_FALLBACKS: ReadonlyArray<{ pattern: RegExp; anchor: string }> = [
+  { pattern: /nano/i, anchor: "openai/gpt-4.1-nano" },
+  { pattern: /4o-mini/i, anchor: "openai/gpt-4o-mini" },
+  { pattern: /\bmini\b/i, anchor: "openai/gpt-4.1-mini" },
+  { pattern: /\b4o\b/i, anchor: "openai/gpt-4o" },
+  { pattern: /o3-mini/i, anchor: "openai/o3-mini" },
+  { pattern: /\bo3\b/i, anchor: "openai/o3" },
+  { pattern: /gpt-5/i, anchor: "openai/gpt-5.4" },
+  { pattern: /flash-lite/i, anchor: "google/gemini-2.5-flash-lite" },
+  { pattern: /flash/i, anchor: "google/gemini-2.0-flash" },
+  { pattern: /gemini.*pro|pro.*gemini/i, anchor: "google/gemini-3.1-pro-preview" },
+  { pattern: /haiku/i, anchor: "anthropic/claude-haiku-3.5" },
+  { pattern: /opus/i, anchor: "anthropic/claude-opus-4-6" },
+  { pattern: /sonnet|fable/i, anchor: "anthropic/claude-sonnet-4-6" },
+  { pattern: /minimax/i, anchor: "minimax/MiniMax-M2.5" },
+];
+
+/**
+ * Look up pricing for a model. Returns null only when neither an exact match nor a
+ * recognizable tier family is found. Model name is matched case-insensitively.
  * Local Ollama models always return $0 (no API cost).
  */
 export function getModelPricing(model: string): ModelPricing | null {
@@ -52,7 +78,14 @@ export function getModelPricing(model: string): ModelPricing | null {
   // Direct match first (fastest path)
   if (model in MODEL_PRICING) return MODEL_PRICING[model]!;
   // O(1) case-insensitive lookup via pre-built lowercase index
-  return MODEL_PRICING_LOWER[model.toLowerCase()] ?? null;
+  const exact = MODEL_PRICING_LOWER[model.toLowerCase()];
+  if (exact) return exact;
+  // Fall back to the same-tier anchor so an unrecognized model version still gets an
+  // approximate estimate rather than silently dropping out of cost totals.
+  for (const { pattern, anchor } of TIER_FALLBACKS) {
+    if (pattern.test(model)) return MODEL_PRICING[anchor]!;
+  }
+  return null;
 }
 
 /**

--- a/extensions/memory-hybrid/tests/model-pricing.test.ts
+++ b/extensions/memory-hybrid/tests/model-pricing.test.ts
@@ -45,6 +45,29 @@ describe("getModelPricing", () => {
     const p = getModelPricing("OpenAI/GPT-4.1-NANO");
     expect(p).not.toBeNull();
   });
+
+  describe("tier fallback for unrecognized model versions", () => {
+    it("matches a newer Claude generation to the same-tier anchor instead of returning null", () => {
+      expect(getModelPricing("anthropic/claude-sonnet-5")).toEqual(getModelPricing("anthropic/claude-sonnet-4-6"));
+      expect(getModelPricing("anthropic/claude-opus-5")).toEqual(getModelPricing("anthropic/claude-opus-4-6"));
+      expect(getModelPricing("anthropic/claude-haiku-4-5-20251001")).toEqual(
+        getModelPricing("anthropic/claude-haiku-3.5"),
+      );
+    });
+
+    it("matches a newer OpenAI nano/mini generation to the same-tier anchor", () => {
+      expect(getModelPricing("openai/gpt-6.1-nano")).toEqual(getModelPricing("openai/gpt-4.1-nano"));
+      expect(getModelPricing("openai/gpt-6-mini")).toEqual(getModelPricing("openai/gpt-4.1-mini"));
+    });
+
+    it("still returns null when no tier keyword is recognizable at all", () => {
+      expect(getModelPricing("unknown/some-model-v9")).toBeNull();
+    });
+
+    it("checks more specific patterns before generic ones (4o-mini before bare mini/4o)", () => {
+      expect(getModelPricing("openai/gpt-4o-mini-2027")).toEqual(getModelPricing("openai/gpt-4o-mini"));
+    });
+  });
 });
 
 describe("estimateCost", () => {


### PR DESCRIPTION
## Summary

Closes #

Found while gathering real stats for a README rewrite: a live production instance's `cost-report --days 30 --model` showed 28,139 LLM calls but **99.3% (27,941) used unpriced model IDs**, meaning the measured "$3.48/30 days" figure only covered the 0.7% of calls that happened to match an exact entry in `MODEL_PRICING`.

`services/model-pricing.ts`'s `MODEL_PRICING` is a small hardcoded table keyed by exact `provider/model` string. Every time a provider ships a new model version, any call using it falls through to `null` and is **silently excluded from cost totals** rather than flagged — the worse failure mode for a cost report, since it makes spend look far lower than it is instead of erroring loudly.

### The fix

Added a tier-family fallback in `getModelPricing`: when the exact model string isn't in the table, match known tier keywords (`nano`, `mini`, `4o`, `o3`, `flash-lite`, `flash`, `haiku`, `sonnet`, `opus`, ...) against the model string and reuse the pricing already in `MODEL_PRICING` for that tier's anchor entry. A later model version in the same price tier now gets an approximate estimate instead of being dropped — self-healing across future model bumps instead of requiring a table edit release-by-release.

- Exact matches (existing behavior) still take priority and are unaffected.
- A genuinely unrecognizable model string (no tier keyword at all) still correctly returns `null` — didn't weaken the "unknown model" signal, just widened what counts as "known."
- Kept the file's existing disclaimer ("rough estimates... do not use for billing") — this is a better estimate, not a claim of billing-grade accuracy.

### Not changed, and why

I initially also planned to fix "persona proposals lack a scope filter" (flagged by the same instance's `audit health --strict`), but traced it to `cli/commands/manage/register-storage-graph-audit.ts:150` (issue #1809) — it's a **working-as-designed configuration warning**, not a code defect: `personaProposals.enabled` without `autoRecall.scopeFilter` set. There's already a hard-fail escape hatch (`personaProposals.requireScopeFilter: true`) implemented at the actual proposal-generation guard in `cli/cmd-extract-proposals.ts:109`. Writing a code change for this would have been solving a problem that doesn't exist in the repo — the real remediation is a config change on the affected instance, not a PR here.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor / internal improvement (no behavior change)
- [ ] Documentation update
- [ ] CI / tooling change

## Quality Checklist

- [x] `cd extensions/memory-hybrid && npx tsc --noEmit` passes with no errors
- [x] `cd extensions/memory-hybrid && npm run lint` passes with no warnings (repo has pre-existing warnings elsewhere; zero in the changed files)
- [x] `cd extensions/memory-hybrid && npm test` — targeted run: `tests/model-pricing.test.ts` + `tests/cost-tracker.test.ts`, 61/61 passing
- [x] No secrets, credentials, or API keys committed
- [x] No `console.log` debug statements left in production code

## Documentation Impact (REQUIRED)

- [ ] Inline code comments (JSDoc) updated for modified functions and types
- [ ] `docs/` or `README.md` updated to reflect architectural or usage changes
- [ ] Cross-referenced functions/services checked for outdated documentation

Internal cost-estimation heuristic only; no user-facing config or CLI surface changed. The function's own doc comment was updated to describe the new fallback behavior.

## Testing

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] Manually verified against a running OpenClaw instance

Added 4 new cases to `tests/model-pricing.test.ts` covering: newer Claude generation → same-tier match, newer OpenAI nano/mini generation → same-tier match, an unrecognizable model string still returns `null`, and pattern-ordering (a `4o-mini` variant matches the `4o-mini` anchor, not the generic `mini` or `4o` anchors). Existing `"returns null for unknown model"` test (`"unknown/some-model-v9"`) still passes unmodified — verified it doesn't collide with any new tier keyword.

## Notes for Reviewer

The tier-keyword list is intentionally derived from the family names already present in `MODEL_PRICING`'s own keys, not invented — I don't have visibility into anyone's actual configured model IDs, so I built the fallback to generalize by keyword rather than guess at and hardcode specific new exact strings that might not match what's really deployed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01S8dqWojkVfWZBAZYx4Utbo)_