### PR TITLE
fix: guard api.resolvePath() return value in database bootstrap (GlitchTip #33)

### DIFF
--- a/extensions/memory-hybrid/setup/bootstrap-databases.ts
+++ b/extensions/memory-hybrid/setup/bootstrap-databases.ts
@@ -18,39 +18,40 @@ import type { ToolProposalStore } from "../backends/tool-proposal-store.js";
 import type { VectorDB } from "../backends/vector-db.js";
 import type { WriteAheadLog } from "../backends/wal.js";
 import type { WorkflowStore } from "../backends/workflow-store.js";
-import type { CredentialType, HybridMemoryConfig } from "../config.js";
 import { DEFAULT_LANCE_PATH, DEFAULT_SQLITE_PATH, normalizeResolvedSecretValue } from "../config/parsers/core.js";
+import type { CredentialType, HybridMemoryConfig } from "../config.js";
 import { is403QuotaOrRateLimitLike, is429OrWrapped } from "../services/chat.js";
 import { CREDENTIAL_REDACTION_MIGRATION_FLAG, migrateCredentialsToVault } from "../services/credential-migration.js";
 import { runEmbeddingMaintenance } from "../services/embedding-migration.js";
 import type { EmbeddingRegistry } from "../services/embedding-registry.js";
-import type { EmbeddingProvider } from "../services/embeddings.js";
 import { formatOpenAiEmbeddingDisplayLabel, shouldSuppressEmbeddingError } from "../services/embeddings/shared.js";
+import type { EmbeddingProvider } from "../services/embeddings.js";
 import { capturePluginError } from "../services/error-reporter.js";
 import { installCoreBootstrapServices, installOptionalBootstrapServices } from "../services/index.js";
 import type { ProvenanceService } from "../services/provenance.js";
 import type { AliasDB } from "../services/retrieval-aliases.js";
-import { recordStartupMemoryCheckpoint } from "../services/startup-memory-attribution.js";
 import { invalidateClusterCache } from "../services/retrieval-orchestrator.js";
+import { recordStartupMemoryCheckpoint } from "../services/startup-memory-attribution.js";
 import type { VerificationStore } from "../services/verification-store.js";
 import { hasOAuthProfiles } from "../utils/auth.js";
 import { getEnv } from "../utils/env-manager.js";
 import { setKeywordsPath } from "../utils/language-keywords.js";
+import { isHeavyModel, isLightModel, isNanoModel } from "../utils/model-tier.js";
 import { spawn } from "../utils/process-runner.js";
 import { isDbClosedError, isRegistrationSuperseded } from "../utils/registration-superseded.js";
-import { isHeavyModel, isLightModel, isNanoModel } from "../utils/model-tier.js";
 import {
-  OLLAMA_DEFAULT_BASE_URL,
-  ROUTABLE_BUILTIN_PROVIDERS,
   buildMultiProviderOpenAI,
   clearOllamaHealthCacheEntry,
   extractGatewayConfig,
   gatewayLogInfoOnce,
   getGatewayModelsProviders,
   mergeGatewayProviderCredentialsIntoLlmProvidersMap,
+  OLLAMA_DEFAULT_BASE_URL,
   patchEmbeddingEndpointFromGatewayProviders,
   probeOllamaEndpoint,
+  ROUTABLE_BUILTIN_PROVIDERS,
 } from "./provider-router.js";
+
 interface HealthStatus {
   embeddingsOk: boolean;
   credentialsVaultOk: boolean;
@@ -409,6 +410,25 @@ function normalizeDatabasePath(
 }
 
 /**
+ * Resolves a (already-normalized, guaranteed non-empty) path through `api.resolvePath()` and
+ * guards its return value before anything downstream calls `dirname()`/`join()` on it. GlitchTip
+ * #33 recurred multiple times (post-2026.7.226 and post-2026.7.227) despite #2203 and #2216
+ * already guarding every known caller's *input* to `resolvePath()` — the plugin host's
+ * `resolvePath` is an external boundary this repo doesn't control, so a value it returns is not
+ * more trustworthy than the value fed into it. If it ever hands back something other than a
+ * non-empty string, fall back to the pre-resolve path (still usable, just possibly relative)
+ * instead of letting a native `node:path` TypeError crash the registration.
+ */
+function resolveDatabasePath(rawPath: string, field: "lanceDbPath" | "sqlitePath", api: ClawdbotPluginApi): string {
+  const resolved: unknown = api.resolvePath(rawPath);
+  if (typeof resolved === "string" && resolved.trim()) return resolved;
+  api.logger.warn?.(
+    `memory-hybrid: api.resolvePath() returned an invalid value for ${field} (${JSON.stringify(resolved)}); falling back to the unresolved path "${rawPath}".`,
+  );
+  return rawPath;
+}
+
+/**
  * Initializes all databases and services for the plugin.
  *
  * This includes:
@@ -433,8 +453,8 @@ export function initializeDatabases(
   // deferred activation handoffs that may carry an older or partially reconstructed config.
   const lanceDbPath = normalizeDatabasePath(cfg.lanceDbPath, DEFAULT_LANCE_PATH, "lanceDbPath", api);
   const sqlitePath = normalizeDatabasePath(cfg.sqlitePath, DEFAULT_SQLITE_PATH, "sqlitePath", api);
-  const resolvedLancePath = api.resolvePath(lanceDbPath);
-  const resolvedSqlitePath = api.resolvePath(sqlitePath);
+  const resolvedLancePath = resolveDatabasePath(lanceDbPath, "lanceDbPath", api);
+  const resolvedSqlitePath = resolveDatabasePath(sqlitePath, "sqlitePath", api);
   setKeywordsPath(dirname(resolvedSqlitePath));
 
   recordStartupMemoryCheckpoint({

--- a/extensions/memory-hybrid/tests/bootstrap-startup-memory-checkpoint.test.ts
+++ b/extensions/memory-hybrid/tests/bootstrap-startup-memory-checkpoint.test.ts
@@ -2,10 +2,10 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { hybridConfigSchema } from "../config.js";
 import { DEFAULT_LANCE_PATH, DEFAULT_SQLITE_PATH } from "../config/parsers/core.js";
-import { closeOldDatabases, initializeDatabases } from "../setup/init-databases.js";
+import { hybridConfigSchema } from "../config.js";
 import { resetStartupMemoryAttributionForTests } from "../services/startup-memory-attribution.js";
+import { closeOldDatabases, initializeDatabases } from "../setup/init-databases.js";
 
 describe("bootstrap startup memory checkpoints", () => {
   let tmpDir: string;
@@ -52,6 +52,42 @@ describe("bootstrap startup memory checkpoints", () => {
     expect(resolvePath.mock.calls.flat()).toEqual([DEFAULT_LANCE_PATH, DEFAULT_SQLITE_PATH]);
     expect(api.logger.warn).toHaveBeenCalledWith(expect.stringContaining("missing or invalid lanceDbPath"));
     expect(api.logger.warn).toHaveBeenCalledWith(expect.stringContaining("missing or invalid sqlitePath"));
+  });
+
+  it("falls back to the unresolved path when api.resolvePath() itself returns a non-string value (GlitchTip #33 recurrence)", () => {
+    // #2203 and #2216 guarded every known caller's *input* to api.resolvePath(), but GlitchTip
+    // #33 kept recurring afterward — the plugin host's resolvePath is an external boundary this
+    // repo doesn't control, so its return value needs the same defense-in-depth as its input.
+    const cfg = hybridConfigSchema.parse({
+      embedding: { apiKey: "sk-test-embed-key-that-is-long-enough", model: "text-embedding-3-small" },
+      sqlitePath: join(tmpDir, "facts.db"),
+      lanceDbPath: join(tmpDir, "lancedb"),
+      credentials: { enabled: false },
+      wal: { enabled: false },
+      personaProposals: { enabled: false },
+      verification: { enabled: false },
+      provenance: { enabled: false },
+      nightlyCycle: { enabled: false },
+    });
+    const api = {
+      // Simulates a host resolvePath() that misbehaves under a hot-reload race and hands back
+      // undefined even though it was called with a guaranteed-valid, non-empty string.
+      resolvePath: vi.fn(() => undefined as unknown as string),
+      logger: { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() },
+      config: {},
+      context: { sessionId: "session-1", agentId: "agent-1" },
+    };
+
+    expect(() => {
+      dbCtx = initializeDatabases(cfg, api as never);
+    }).not.toThrow();
+
+    expect(api.logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining("api.resolvePath() returned an invalid value for lanceDbPath"),
+    );
+    expect(api.logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining("api.resolvePath() returned an invalid value for sqlitePath"),
+    );
   });
 
   it("emits plugin registration memory checkpoints with attribution", () => {


### PR DESCRIPTION
## Summary

Closes #2212 (again — see below)

GlitchTip issue #33 (`TypeError: The "path" argument must be of type string. Received undefined`, tag `plugin-register:init-databases-deferred`) was previously tracked as GitHub #2212 and believed fixed by #2203 (merged, shipped in v2026.7.226), with a defense-in-depth follow-up in #2216 (shipped in v2026.7.227). Both fixes guard the config fields (`cfg.sqlitePath` / `cfg.lanceDbPath`) fed into `api.resolvePath()`.

Re-querying GlitchTip after #2212 was closed shows the exact same error recurring **3 more times** after both fixes shipped — event count grew from 4 (at close time) to 7, with the latest occurrence timestamped after the v2026.7.227 release. So the input-side guard alone wasn't sufficient.

`api.resolvePath()` is implemented by the plugin host, outside this repo. Its return value was never validated before being passed into `dirname()` in `initializeDatabases()` — if it ever hands back something other than a non-empty string (e.g. under a timing edge case during the deferred/hot-reload activation path), `dirname()` throws exactly this error. This PR adds the same normalize-or-fallback guard to `resolvePath()`'s *output* that #2203/#2216 already applied to its *input*, so a misbehaving host call logs a warning and falls back to the unresolved path instead of crashing the deferred registration.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Quality Checklist

- [x] `cd extensions/memory-hybrid && npx tsc --noEmit` passes with no errors
- [x] `cd extensions/memory-hybrid && npm run lint` passes with no warnings
- [x] `cd extensions/memory-hybrid && npm test` passes (all tests green) — ran the targeted suite (bootstrap/reregister/e2e); full suite left to CI
- [x] No secrets, credentials, or API keys committed
- [x] No `console.log` debug statements left in production code

## Documentation Impact (REQUIRED)

- [x] Inline code comments (JSDoc) updated for modified functions and types
- [ ] `docs/` or `README.md` updated to reflect architectural or usage changes — not needed, purely an internal defensive guard with no user-facing behavior change
- [x] Cross-referenced functions/services checked for outdated documentation

## Testing

- [x] Unit tests added / updated — new regression test simulating a host `resolvePath()` that returns `undefined` given valid input, asserting `initializeDatabases()` no longer throws
- [ ] Integration tests added / updated
- [ ] Manually verified against a running OpenClaw instance

## Notes for Reviewer

This closes the loop on GlitchTip #33 as far as this repo can control it — the underlying trigger lives in the plugin host's `resolvePath()`, which isn't something we can fix here. This PR makes the crash unreachable regardless of what the host returns. Will keep watching GlitchTip after this ships to confirm no further recurrences.

---
_Generated by [Claude Code](https://claude.ai/code/session_01S8dqWojkVfWZBAZYx4Utbo)_