### PR TITLE
feat: resolve GlitchTip issues in-release instead of bare resolved

### DIFF
--- a/.github/scripts/sync-glitchtip-issues.mjs
+++ b/.github/scripts/sync-glitchtip-issues.mjs
@@ -16,6 +16,7 @@
  *      GITHUB_REPOSITORY (owner/repo, provided by Actions).
  */
 import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
 
 const GLITCHTIP_TOKEN = requireEnv("GLITCHTIP_TOKEN");
 const GLITCHTIP_BASE_URL = requireEnv("GLITCHTIP_BASE_URL");
@@ -24,6 +25,15 @@ const PROJECT_SLUG = process.env.PROJECT_SLUG || "openclaw-hybrid-memory";
 const QUERY = process.env.QUERY || "is:unresolved";
 const DRY_RUN = (process.env.DRY_RUN ?? "true") !== "false";
 const SYNC_LABEL = "glitchtip-sync";
+
+// "Resolved in release <tag>" instead of a bare "resolved" lets GlitchTip's own regression
+// detection do the version-awareness for us: a later event tagged with this release (or newer)
+// flips the issue back to unresolved as a genuine regression, while an event from an older
+// release (a client that hasn't upgraded yet) does not — see the release tag format already
+// emitted by capturePluginError(), e.g. "openclaw-hybrid-memory@2026.7.226".
+const PACKAGE_JSON_PATH = new URL("../../extensions/memory-hybrid/package.json", import.meta.url);
+const { name: PACKAGE_NAME, version: PACKAGE_VERSION } = JSON.parse(readFileSync(PACKAGE_JSON_PATH, "utf8"));
+const RELEASE_TAG = `${PACKAGE_NAME}@${PACKAGE_VERSION}`;
 
 const ALLOWED_TAG_KEYS = new Set([
   "job_name",
@@ -76,9 +86,12 @@ async function glitchtipGet(path, params) {
   return res.json();
 }
 
-async function glitchtipSetStatus(issueId, status) {
+async function glitchtipSetStatus(issueId, status, statusDetails) {
   // The flat /api/0/issues/{id}/ route is read/delete only (confirmed via OPTIONS: "Allow: DELETE,
-  // GET"). Status mutation lives on the org-scoped route instead ("Allow: PUT, DELETE, GET").
+  // GET"). Status mutation lives on the org-scoped route instead ("Allow: PUT, DELETE, GET") —
+  // this also matters for statusDetails specifically: Sentry's older per-issue endpoint is known to
+  // silently ignore statusDetails and just resolve in the current release, while the org-scoped
+  // endpoint we already use here honors it.
   const url = new URL(`${GLITCHTIP_BASE_URL}/api/0/organizations/${ORG_SLUG}/issues/${issueId}/`);
   const res = await fetch(url, {
     method: "PUT",
@@ -86,7 +99,7 @@ async function glitchtipSetStatus(issueId, status) {
       Authorization: `Bearer ${GLITCHTIP_TOKEN}`,
       "Content-Type": "application/json",
     },
-    body: JSON.stringify({ status }),
+    body: JSON.stringify(statusDetails ? { status, statusDetails } : { status }),
   });
   if (!res.ok) {
     throw new Error(`GlitchTip API PUT ${url.pathname} returned HTTP ${res.status}`);
@@ -278,6 +291,9 @@ async function main() {
 
     const targetStatus = resolveTargetGlitchTipStatus(ghIssue);
     if (!targetStatus) continue; // still open on GitHub — leave GlitchTip status alone
+    // Only "resolved" has a meaningful fix version; "ignored" (won't-fix/duplicate) has no
+    // release to be regression-checked against.
+    const statusDetails = targetStatus === "resolved" ? { inRelease: RELEASE_TAG } : undefined;
 
     const current = await glitchtipGet(`/api/0/issues/${glitchtipId}/`);
     if (current.status === targetStatus) {
@@ -287,14 +303,15 @@ async function main() {
 
     if (DRY_RUN) {
       summaryLines.push(
-        `- would set GlitchTip #${glitchtipId} \`${current.status}\` → \`${targetStatus}\` ` +
+        `- would set GlitchTip #${glitchtipId} \`${current.status}\` → \`${targetStatus}\`` +
+          `${statusDetails ? ` (inRelease: \`${statusDetails.inRelease}\`)` : ""} ` +
           `(GitHub #${ghIssue.number} closed as ${ghIssue.stateReason ?? "completed"})`,
       );
       statusUpdated++;
       continue;
     }
 
-    await glitchtipSetStatus(glitchtipId, targetStatus);
+    await glitchtipSetStatus(glitchtipId, targetStatus, statusDetails);
     summaryLines.push(
       `- set GlitchTip #${glitchtipId} \`${current.status}\` → \`${targetStatus}\` (GitHub #${ghIssue.number})`,
     );


### PR DESCRIPTION
## Summary

Follow-up to the GlitchTip #33 investigation (see #2223): a bare `{"status": "resolved"}` can't distinguish a stale, un-upgraded client repeating an already-fixed error from a genuine regression on the current release — both just flip the GlitchTip issue back to `unresolved` on the next matching event, with no way to tell them apart from the outside.

GlitchTip (Sentry-API-compatible) supports **"resolved in release"** semantics: `PUT` with `{"status": "resolved", "statusDetails": {"inRelease": "<release-tag>"}}`. GlitchTip's own regression detection then does the version-aware comparison for us — a later event tagged with that release or newer is flagged as a real regression, while one tagged with an older release (a client that hasn't upgraded yet) is not. Our sync script already uses the org-scoped issues endpoint (`/api/0/organizations/{org}/issues/{id}/`), which is the one known to honor `statusDetails` — Sentry's older per-issue endpoint is documented as silently ignoring it.

Changes to `.github/scripts/sync-glitchtip-issues.mjs`:
- `glitchtipSetStatus()` now takes an optional `statusDetails` param.
- When a closed GitHub issue maps to a GlitchTip `resolved` transition, we now pass `statusDetails: { inRelease: "<pkg-name>@<pkg-version>" }`, reading the current version from `extensions/memory-hybrid/package.json` at sync time — matching the release tag format GlitchTip already emits on events (e.g. `openclaw-hybrid-memory@2026.7.226`).
- `ignored` transitions (won't-fix/duplicate) are unaffected — there's no meaningful "fix version" for those.
- Dry-run preview output now shows the `inRelease` value that would be set.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Quality Checklist

- [x] `node --check .github/scripts/sync-glitchtip-issues.mjs` passes
- [x] No secrets, credentials, or API keys committed
- [x] No `console.log` debug statements left in production code
- N/A `extensions/memory-hybrid` typecheck/lint/test — this change is confined to `.github/scripts/`, outside that package

## Documentation Impact (REQUIRED)

- [ ] `docs/` or `README.md` updated — not needed, this is internal repo-ops tooling with no user-facing behavior change
- [x] Inline comments updated to explain the new semantics

## Testing

- [ ] Unit tests — no test harness exists for `.github/scripts/*.mjs` (operational scripts, outside the `extensions/memory-hybrid` vitest suite)
- [x] Manually verified: confirmed `PACKAGE_JSON_PATH` resolves correctly and yields `openclaw-hybrid-memory@2026.7.227` from the current `package.json`
- [ ] Will do a live `workflow_dispatch` dry-run (then a real run) against the actual GlitchTip instance once this merges, to confirm the instance's GlitchTip version actually honors `statusDetails.inRelease` rather than silently ignoring it (this feature is fairly recent in GlitchTip, ~6.1/March 2026) — will report back what I find.

## Notes for Reviewer

If it turns out this specific GlitchTip instance doesn't honor `statusDetails` yet, this change is a no-op (falls back to bare `resolved` behavior, same as today) rather than breaking anything — worth confirming live regardless.

---
_Generated by [Claude Code](https://claude.ai/code/session_01S8dqWojkVfWZBAZYx4Utbo)_