### PR TITLE
chore(release): bump memory-hybrid to 2026.7.228

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [2026.7.228] - 2026-07-29
+
+### Fixed
+
+- Database bootstrap (`initializeDatabases`) no longer crashes with `TypeError: The "path" argument must be of type string. Received undefined` when `api.resolvePath()` — implemented by the plugin host, outside this repo — returns something other than a non-empty string during the deferred/hot-reload activation path. #2203 and #2216 already guarded every known caller's *input* to `resolvePath()`; this closes the same gap on its *output*, falling back to the unresolved path (with a warning) instead. GlitchTip #33 had recurred after both prior fixes shipped, tracing back to this residual gap.
+
+### Changed
+
+- `.github/scripts/sync-glitchtip-issues.mjs` now resolves synced GlitchTip issues with release-scoped `statusDetails.inRelease` instead of a bare `resolved` status, so GlitchTip's own regression detection can distinguish a genuine regression on the current release from a stale, not-yet-upgraded client repeating an already-fixed error.
+
 ## [2026.7.227] - 2026-07-27
 
 ### Fixed

--- a/extensions/memory-hybrid/openclaw.plugin.json
+++ b/extensions/memory-hybrid/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "openclaw-hybrid-memory",
   "kind": "memory",
-  "version": "2026.7.227",
+  "version": "2026.7.228",
   "contracts": {
     "tools": [
       "active_task_checkpoint",

--- a/extensions/memory-hybrid/package-lock.json
+++ b/extensions/memory-hybrid/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openclaw-hybrid-memory",
-  "version": "2026.7.227",
+  "version": "2026.7.228",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openclaw-hybrid-memory",
-      "version": "2026.7.227",
+      "version": "2026.7.228",
       "hasInstallScript": true,
       "dependencies": {
         "@lancedb/lancedb": "^0.31.0",

--- a/extensions/memory-hybrid/package.json
+++ b/extensions/memory-hybrid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-hybrid-memory",
-  "version": "2026.7.227",
+  "version": "2026.7.228",
   "type": "module",
   "description": "Give your OpenClaw agent lasting memory: structured facts, semantic search, auto-capture & recall, decay, optional credential vault. Part of Hybrid Memory v3.",
   "files": [

--- a/packages/openclaw-hybrid-memory-install/package.json
+++ b/packages/openclaw-hybrid-memory-install/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-hybrid-memory-install",
-  "version": "2026.7.227",
+  "version": "2026.7.228",
   "description": "Standalone installer for openclaw-hybrid-memory. Use when OpenClaw config validation fails.",
   "bin": {
     "openclaw-hybrid-memory-install": "./install.js"

--- a/release-notes/release-notes-2026.7.228.md
+++ b/release-notes/release-notes-2026.7.228.md
@@ -1,0 +1,13 @@
+# Release notes — 2026.7.228
+
+## Fixed
+
+- Database bootstrap no longer crashes with `TypeError: The "path" argument must be of type string. Received undefined` when the plugin host's `resolvePath()` returns something other than a non-empty string during a deferred/hot-reload activation. Two earlier fixes (2026.7.226, 2026.7.227) guarded every known caller's *input* to `resolvePath()`; this guards its *output* too, falling back to the unresolved path (with a warning) instead of crashing.
+
+## Changed
+
+- The GlitchTip issue-sync automation now resolves issues with a release-scoped status instead of a bare "resolved," so GlitchTip's own regression detection can tell a genuine regression on the current release apart from a stale client still running an older, already-fixed version.
+
+## Release metadata
+
+- Bumps `openclaw-hybrid-memory` and the lockstep standalone installer to `2026.7.228`.


### PR DESCRIPTION
## Summary

Version bump to start the release pipeline for what's shipped on `main` since 2026.7.227:

- #2223 — guard `api.resolvePath()`'s return value in database bootstrap (closes the residual GlitchTip #33 recurrence that survived both #2203 and #2216)
- #2224 — resolve GlitchTip issues with release-scoped `statusDetails.inRelease` instead of a bare `resolved`, so GlitchTip's own regression detection can tell a genuine regression apart from a stale, not-yet-upgraded client

Bumps `openclaw-hybrid-memory` (`package.json`, `openclaw.plugin.json`, `package-lock.json`) and the lockstep standalone installer (`packages/openclaw-hybrid-memory-install/package.json`) to `2026.7.228`, adds the `CHANGELOG.md` entry and `release-notes/release-notes-2026.7.228.md`, following the same shape as the prior release-bump PR (#2218).

Once this merges, `tag-release-after-ci.yml` should push the `v2026.7.228` tag after CI is green on `main`, and the Release workflow publishes the GitHub Release + npm package.

## Type of Change

- [x] CI / tooling change (release process)

## Quality Checklist

- [x] `cd extensions/memory-hybrid && npx tsc --noEmit` passes with no errors
- [x] `cd extensions/memory-hybrid && npm run lint` passes (pre-existing warnings only, no errors — nothing in this diff touches lintable source)
- [ ] `cd extensions/memory-hybrid && npm test` — no source code changed in this PR (version strings + docs only); relying on CI's full run
- [x] No secrets, credentials, or API keys committed
- [x] No `console.log` debug statements left in production code

## Documentation Impact (REQUIRED)

- [x] `docs/` or `README.md` updated — N/A, `CHANGELOG.md` and `release-notes/release-notes-2026.7.228.md` added per the existing release convention
- [x] Cross-referenced functions/services checked for outdated documentation — N/A, no behavior changed beyond what #2223/#2224 already documented

## Testing

- [x] Manually verified: all four bumped JSON files (`package.json`, `openclaw.plugin.json`, `package-lock.json`, installer `package.json`) parse correctly and now read `2026.7.228`

## Notes for Reviewer

Pure version-bump PR — no source changes beyond what already merged in #2223/#2224. Requesting squash-merge to kick off the release pipeline per usual convention.

---
_Generated by [Claude Code](https://claude.ai/code/session_01S8dqWojkVfWZBAZYx4Utbo)_