### PR TITLE
chore(release): bump memory-hybrid to 2026.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [2026.8.1] - 2026-08-02
+
+### Fixed
+
+- Goal-dispatch authorization now fails closed: direct managed dispatch is denied unless the requester has an explicit, matching authorization policy. The core dispatch bridge and broker apply the policy consistently and emit audit-safe denial context.
+
+### Release metadata
+
+- Bumps `openclaw-hybrid-memory` and the lockstep standalone installer to `2026.8.1`. `package.json` remains the source of truth; derived plugin and installer version metadata are synchronized by `scripts/sync-plugin-version.cjs`.
+
 ## [2026.7.228] - 2026-07-29
 
 ### Fixed

--- a/extensions/memory-hybrid/openclaw.plugin.json
+++ b/extensions/memory-hybrid/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "openclaw-hybrid-memory",
   "kind": "memory",
-  "version": "2026.7.228",
+  "version": "2026.8.1",
   "contracts": {
     "tools": [
       "active_task_checkpoint",

--- a/extensions/memory-hybrid/package-lock.json
+++ b/extensions/memory-hybrid/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openclaw-hybrid-memory",
-  "version": "2026.7.228",
+  "version": "2026.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openclaw-hybrid-memory",
-      "version": "2026.7.228",
+      "version": "2026.8.1",
       "hasInstallScript": true,
       "dependencies": {
         "@lancedb/lancedb": "^0.31.0",

--- a/extensions/memory-hybrid/package.json
+++ b/extensions/memory-hybrid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-hybrid-memory",
-  "version": "2026.7.228",
+  "version": "2026.8.1",
   "type": "module",
   "description": "Give your OpenClaw agent lasting memory: structured facts, semantic search, auto-capture & recall, decay, optional credential vault. Part of Hybrid Memory v3.",
   "files": [

--- a/packages/openclaw-hybrid-memory-install/package.json
+++ b/packages/openclaw-hybrid-memory-install/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-hybrid-memory-install",
-  "version": "2026.7.228",
+  "version": "2026.8.1",
   "description": "Standalone installer for openclaw-hybrid-memory. Use when OpenClaw config validation fails.",
   "bin": {
     "openclaw-hybrid-memory-install": "./install.js"

--- a/release-notes/release-notes-2026.8.1.md
+++ b/release-notes/release-notes-2026.8.1.md
@@ -1,0 +1,9 @@
+# Release notes — 2026.8.1
+
+## Fixed
+
+- Goal-dispatch authorization now fails closed: direct managed dispatch is denied unless the requester has an explicit, matching authorization policy. The core dispatch bridge and broker apply that policy consistently and provide audit-safe denial context.
+
+## Release metadata
+
+- Bumps `openclaw-hybrid-memory` and the lockstep standalone installer to `2026.8.1`.


### PR DESCRIPTION
Release 2026.8.1 for the merged fail-closed goal-dispatch authorization fix. Includes synchronized plugin/installer version metadata and release notes.