### PR TITLE
fix(ci): annotate artifact retention-days on coverage upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,7 +215,7 @@ jobs:
           name: coverage-report
           path: extensions/memory-hybrid/coverage/
           if-no-files-found: warn
-          retention-days: 14
+          retention-days: 14   # Coverage artifacts auto-expire after 14 days to prevent storage accumulation
 
   dead-code:
     name: Dead Code Analysis (knip)


### PR DESCRIPTION
## Summary

Adds an explicit documentation comment on the `coverage-report` artifact upload step in `ci.yml` to make the 14-day retention policy self-evident directly in the workflow YAML.

## What changed

- `.github/workflows/ci.yml`: Added inline comment on the `retention-days: 14` setting of the `upload-artifact` action in the `test-coverage` job

## Why

The `test-coverage` job (in the `ci.yml` workflow) uploads a coverage report artifact on every push to `main`. The `retention-days: 14` setting was already present, but the retention policy was not visible without reading the full workflow — making it easy for future changes to drift.

This PR adds a documentation guard that:
1. Makes the 14-day policy self-documenting in the YAML
2. Signals to future editors that changing `retention-days` requires justification

## Verification

```bash
grep -A6 'Upload coverage report' .github/workflows/ci.yml
```

Expected output includes `retention-days: 14` and the new comment.

## Notes

- The `retention-days` guard was already in place; this is a documentation-only reinforcement
- No functional change to CI behavior
- Do not merge until deletion of 2,761 expired artifacts (batch async) is confirmed