### PR TITLE
ci: add scheduled Actions storage cleanup and PR-close cache purge

### DIFF
--- a/.github/workflows/actions-storage-cleanup.yml
+++ b/.github/workflows/actions-storage-cleanup.yml
@@ -1,0 +1,132 @@
+# Reclaims billed GitHub Actions storage (workflow run logs + artifacts) by deleting
+# completed runs past a retention window. Deleting a run removes its logs *and* any
+# artifacts it uploaded in one call, which is the most reliable way to shrink account
+# storage — it doesn't depend on the repo's (UI-only, non-scriptable) log retention
+# setting, and it also sweeps up any artifact that predates a per-upload retention-days
+# value.
+#
+# Safety: for every workflow, the single most recent run on each branch is always kept
+# (it may back a currently open PR's required status check), and the N most recent
+# completed runs workflow-wide are always kept regardless of age (recent history for
+# debugging). Only runs outside both of those sets and older than retention_days are
+# deleted.
+name: Actions Storage Cleanup
+
+on:
+  schedule:
+    # Daily, off-peak — after most of the day's CI activity has settled.
+    - cron: '15 3 * * *'
+  workflow_dispatch:
+    inputs:
+      retention_days:
+        description: 'Delete eligible completed runs older than this many days'
+        required: false
+        default: '14'
+      keep_minimum_runs:
+        description: 'Always keep at least this many recent completed runs per workflow'
+        required: false
+        default: '5'
+      dry_run:
+        description: 'List what would be deleted without deleting anything'
+        type: boolean
+        required: false
+        default: false
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  cleanup:
+    name: Delete old workflow runs (logs + artifacts)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Purge completed runs past retention
+        uses: actions/github-script@v9
+        env:
+          RETENTION_DAYS: ${{ inputs.retention_days || '14' }}
+          KEEP_MINIMUM_RUNS: ${{ inputs.keep_minimum_runs || '5' }}
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const retentionDays = Number(process.env.RETENTION_DAYS);
+            const keepMinimumRuns = Number(process.env.KEEP_MINIMUM_RUNS);
+            const dryRun = process.env.DRY_RUN === 'true';
+            const cutoff = Date.now() - retentionDays * 24 * 60 * 60 * 1000;
+
+            const workflows = await github.paginate(github.rest.actions.listRepoWorkflows, {
+              owner, repo, per_page: 100,
+            });
+
+            let deleted = 0;
+            let kept = 0;
+            let failed = 0;
+            const summaryRows = [];
+
+            for (const workflow of workflows) {
+              const runs = await github.paginate(github.rest.actions.listWorkflowRuns, {
+                owner, repo, workflow_id: workflow.id, per_page: 100,
+              });
+              if (runs.length === 0) continue;
+
+              // Always protect the latest run per branch — it may back a live PR's required status check.
+              const latestByBranch = new Map();
+              for (const run of runs) {
+                const key = run.head_branch || `sha:${run.head_sha}`;
+                const current = latestByBranch.get(key);
+                if (!current || new Date(run.created_at) > new Date(current.created_at)) {
+                  latestByBranch.set(key, run);
+                }
+              }
+              const protectedIds = new Set([...latestByBranch.values()].map((r) => r.id));
+
+              // Always protect the N most recent completed runs workflow-wide, regardless of branch.
+              runs
+                .filter((r) => r.status === 'completed')
+                .sort((a, b) => new Date(b.created_at) - new Date(a.created_at))
+                .slice(0, keepMinimumRuns)
+                .forEach((r) => protectedIds.add(r.id));
+
+              let workflowDeleted = 0;
+              for (const run of runs) {
+                if (run.status !== 'completed' || protectedIds.has(run.id) || new Date(run.created_at).getTime() >= cutoff) {
+                  kept++;
+                  continue;
+                }
+
+                if (dryRun) {
+                  console.log(`[dry-run] would delete run ${run.id} (${workflow.name}, ${run.head_branch}, ${run.created_at})`);
+                  deleted++;
+                  workflowDeleted++;
+                  continue;
+                }
+
+                try {
+                  await github.rest.actions.deleteWorkflowRun({ owner, repo, run_id: run.id });
+                  deleted++;
+                  workflowDeleted++;
+                } catch (err) {
+                  console.log(`Failed to delete run ${run.id} (${workflow.name}): ${err.message}`);
+                  failed++;
+                }
+              }
+              if (workflowDeleted > 0) summaryRows.push([workflow.name, String(workflowDeleted)]);
+            }
+
+            const summary = core.summary
+              .addHeading('Actions Storage Cleanup', 2)
+              .addRaw(`Mode: ${dryRun ? 'dry run' : 'live'} — retention ${retentionDays}d, keep-minimum ${keepMinimumRuns}/workflow\n\n`)
+              .addRaw(`Deleted: ${deleted}  Kept: ${kept}  Failed: ${failed}\n\n`);
+            if (summaryRows.length > 0) {
+              summary.addTable([[{ data: 'Workflow', header: true }, { data: 'Runs deleted', header: true }], ...summaryRows]);
+            }
+            await summary.write();
+
+            console.log(`Done. Deleted ${deleted}, kept ${kept}, failed ${failed}.`);

--- a/.github/workflows/cache-cleanup-on-pr-close.yml
+++ b/.github/workflows/cache-cleanup-on-pr-close.yml
@@ -1,0 +1,48 @@
+# Deletes GitHub Actions caches scoped to a PR once it closes (merged or not).
+# Caches keyed to a PR's branch (refs/pull/<n>/merge, and refs/heads/<branch> for the
+# push-triggered branch prefixes CI also runs on — see ci.yml) are never reused again
+# once the branch is gone, so leaving them just eats into the repo's 10 GB Actions
+# cache budget until GitHub's LRU eviction gets around to them. Purging on close keeps
+# that budget available for caches that are actually still in use.
+# See: https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#force-deleting-cache-entries
+name: Cache Cleanup on PR Close
+
+on:
+  pull_request:
+    types: [closed]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  cleanup:
+    name: Purge caches for closed PR
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Delete caches scoped to this PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_MERGE_REF: refs/pull/${{ github.event.pull_request.number }}/merge
+          PR_HEAD_REF: refs/heads/${{ github.event.pull_request.head.ref }}
+        run: |
+          set +e  # a ref with no caches, or a race with LRU eviction, must not fail the job
+          for ref in "$PR_MERGE_REF" "$PR_HEAD_REF"; do
+            echo "Fetching caches for $ref"
+            cacheIds=$(gh cache list --repo "$REPO" --ref "$ref" --limit 100 --json id --jq '.[].id')
+            if [ -z "$cacheIds" ]; then
+              echo "No caches found for $ref"
+              continue
+            fi
+            echo "Deleting caches for $ref..."
+            for cacheId in $cacheIds; do
+              gh cache delete "$cacheId" --repo "$REPO"
+            done
+          done
+          echo "Done"


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Why? -->

The account has hit 100% of its included GitHub Actions storage. This adds two workflows to reclaim and cap it going forward:

- **`actions-storage-cleanup.yml`** — daily scheduled job (also `workflow_dispatch`-able for an immediate manual pass) that deletes *completed* workflow runs older than a retention window (default 14 days). Deleting a run removes **both its logs and its artifacts** in a single API call, which is the most reliable lever we have — it reclaims storage directly rather than depending on the repo's UI-only log-retention setting, and it also sweeps up any pre-existing artifacts that predate the `retention-days: 14` already set on the `coverage-report` upload in `ci.yml`.
  - Safety: for every workflow, the single most recent run on each branch is always kept (it may back an open PR's required status check), and the `keep_minimum_runs` (default 5) most recent completed runs are always kept workflow-wide regardless of age.
  - Supports `dry_run: true` for a preview before deleting anything.
- **`cache-cleanup-on-pr-close.yml`** — on PR close (merged or not), purges Actions caches scoped to that PR's `refs/pull/<n>/merge` and `refs/heads/<branch>` refs, following [GitHub's documented pattern](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#force-deleting-cache-entries). Branch-scoped caches are dead weight the moment the branch disappears; this keeps the repo's 10 GB Actions cache budget available for caches still in use instead of waiting on LRU eviction.

Existing cache hygiene was already good — the repo already enforces (`verify-dependency-cache-storage.mjs`) that CI only caches npm's download store via `setup-node`'s built-in cache, never `node_modules`. These two workflows close the remaining gap: nothing was purging old run logs/artifacts or PR-scoped caches.

Closes #

**PR title:** Must follow [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `fix: …`, `chore: merge develop into main`). CI validates the title via the **Conventional Commits** check.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor / internal improvement (no behavior change)
- [ ] Documentation update
- [x] CI / tooling change

## Quality Checklist

- [x] `actionlint` passes on both new workflow files (ran the same binary/version `workflow-sanity.yml` uses)
- [x] `node .github/scripts/verify-dependency-cache-storage.mjs` still passes (untouched by this change)
- [x] No secrets, credentials, or API keys committed
- [x] No `console.log` debug statements left in production code (workflow scripts use `console.log` intentionally for CI run logs, consistent with existing workflows like `copilot-automerge.yml`)

## Documentation Impact (REQUIRED)

No product/plugin behavior changed — this is CI/ops tooling only (`.github/workflows/`), not the published package.

- [ ] Inline code comments (JSDoc) updated for modified functions and types
- [ ] `docs/` or `README.md` updated to reflect architectural or usage changes
- [ ] Cross-referenced functions/services checked for outdated documentation

## Testing

<!-- Describe how you tested this change. -->

- [x] Validated both workflow files with `actionlint` (same version pinned in `workflow-sanity.yml`) — no findings
- [x] Validated YAML syntax with `yaml.safe_load`
- [ ] Live run not yet exercised (needs to run on GitHub-hosted runners — recommend triggering `Actions Storage Cleanup` via `workflow_dispatch` with `dry_run: true` first after merge to confirm the deletion plan looks right before letting it run live)

## Notes for Reviewer

<!-- Anything specific to review, tricky parts, open questions, etc. -->

- `retention_days` (default 14) and `keep_minimum_runs` (default 5) are `workflow_dispatch` inputs, so a one-off aggressive pass (e.g. `retention_days: 3`) can be triggered manually to bring storage down immediately without waiting for the nightly schedule or lowering the long-term default.
- Both new jobs use `permissions: actions: write` (same pattern already used in `ci.yml`), scoped to their own job — no broader token privileges added.
- Considered a third-party action (`Mattraks/delete-workflow-runs`) for the run-cleanup piece but implemented it with `actions/github-script` instead, since that's already the repo's established pattern (used in `forge-feedback-loop.yml`, `pr-checks.yml`, `copilot-automerge.yml`, `auto-create-pr.yml`) and avoids adding a new third-party trust boundary.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Eb78N8a8yCMgVT2pY1K3QE)_