### PR TITLE
feat(goals): add configurable target stewardship guardrails

### DIFF
--- a/extensions/memory-hybrid/docs/TARGET-STEWARDSHIP-GUARDRAILS.md
+++ b/extensions/memory-hybrid/docs/TARGET-STEWARDSHIP-GUARDRAILS.md
@@ -1,0 +1,9 @@
+# Configurable target stewardship guardrails
+Canonical targets are caller-supplied `goal.dispatchPolicy` data: the plugin has no production default repository, PR, branch, head, or model. Write dispatches fail closed unless requests exactly match configured PR, branch, remote head, agent, scope, and no-new-PR/no-new-branch rules. The existing locked dispatch ledger stores target metadata, owner/run/session leases, expiry recovery, and receipts. Receipts require requested/resolved model, `modelApplied`, start/end head, outcome, and evidence. Progress requires a source `TASKS` reference plus direct implementation and verification evidence; diff scope is configurable.
+
+The following verified mappings are examples only, not defaults. Existing PR only; no new PR.
+
+| Work item | Repository | PR / branch / head | Required model |
+| --- | --- | --- | --- |
+| M-CCA | `markus-lassfolk/ts-sh-armor-mvp` | #909 `feat/m-cca-minimax-m3-authority` `42e6c31bff52e85c37577bd766e480fd203e92d3` | Furnace-M3 exact MiniMax M3 |
+| M-IAT | `markus-lassfolk/ts-sh-armor-mvp` | #940 `feat/m-iat-investigation-atlas-v2` `527d5bfc74e4398c3340e77171e53063cd0b062d` | Furnace exact MiniMax M2.7 |

--- a/extensions/memory-hybrid/services/goal-dispatch-authorization.ts
+++ b/extensions/memory-hybrid/services/goal-dispatch-authorization.ts
@@ -94,7 +94,11 @@ export function evaluateGoalDispatch(
     return { allowed: true, reason: "authorized read-only dispatch", at: new Date().toISOString(), request };
 
   const canonical = classPolicy.canonical!;
-  if (request.repository !== canonical.repository || request.prNumber !== canonical.prNumber || request.branch !== canonical.branch)
+  if (
+    request.repository !== canonical.repository ||
+    request.prNumber !== canonical.prNumber ||
+    request.branch !== canonical.branch
+  )
     return fail(request, "non-canonical repository, PR, or branch");
   if (!request.liveRemoteHead || request.liveRemoteHead !== canonical.remoteHead)
     return fail(request, "canonical remote head is absent or stale");
@@ -176,19 +180,17 @@ export function reconcileTargetProgress(
   scope: DiffScopeSanity = {},
 ): { allowed: boolean; reason: string } {
   if (!evidence.sourceTasksReference?.trim()) return { allowed: false, reason: "source TASKS reference required" };
-  if (!evidence.implementationEvidence?.some((x) => x.trim())) return { allowed: false, reason: "direct implementation evidence required" };
-  if (!evidence.verificationEvidence?.some((x) => x.trim())) return { allowed: false, reason: "direct verification evidence required" };
+  if (!evidence.implementationEvidence?.some((x) => x.trim()))
+    return { allowed: false, reason: "direct implementation evidence required" };
+  if (!evidence.verificationEvidence?.some((x) => x.trim()))
+    return { allowed: false, reason: "direct verification evidence required" };
   const paths = evidence.changedPaths ?? [];
-  if (scope.maxFiles !== undefined && paths.length > scope.maxFiles) return { allowed: false, reason: "diff scope exceeds maxFiles" };
+  if (scope.maxFiles !== undefined && paths.length > scope.maxFiles)
+    return { allowed: false, reason: "diff scope exceeds maxFiles" };
   if (scope.deny?.some((prefix) => paths.some((path) => path === prefix || path.startsWith(`${prefix}/`))))
     return { allowed: false, reason: "diff scope contains denied path" };
-  if (scope.allow && paths.some((path) => !scope.allow.some((prefix) => path === prefix || path.startsWith(`${prefix}/`))))
+  const allow = scope.allow;
+  if (allow && paths.some((path) => !allow.some((prefix) => path === prefix || path.startsWith(`${prefix}/`))))
     return { allowed: false, reason: "diff scope contains non-allowlisted path" };
   return { allowed: true, reason: "manifest evidence reconciled" };
 }
-
-/**
- * Evidence required before a target manifest may advance. This is deliberately a
- * pure, caller-configured check: the plugin never embeds another repository's
- * identity as a production default.
- */

--- a/extensions/memory-hybrid/services/goal-dispatch-authorization.ts
+++ b/extensions/memory-hybrid/services/goal-dispatch-authorization.ts
@@ -2,7 +2,7 @@
 import { appendFile, mkdir } from "node:fs/promises";
 import { join } from "node:path";
 
-export type GoalDispatchCanonical = { prNumber: number; branch: string; remoteHead: string };
+export type GoalDispatchCanonical = { repository: string; prNumber: number; branch: string; remoteHead: string };
 export type GoalDispatchClassPolicy = {
   /** Exact agent ids allowed to receive this class of work. */
   allowedAgents: string[];
@@ -24,6 +24,7 @@ export type GoalDispatchRequest = {
   taskClass: string;
   requestedAgent: string;
   actualAgent: string;
+  repository?: string;
   prNumber?: number;
   branch?: string;
   liveRemoteHead?: string;
@@ -44,6 +45,8 @@ function validCanonical(value: unknown): value is GoalDispatchCanonical {
   if (!value || typeof value !== "object") return false;
   const canonical = value as Record<string, unknown>;
   return (
+    typeof canonical.repository === "string" &&
+    /^[^/\s]+\/[^/\s]+$/.test(canonical.repository) &&
     Number.isSafeInteger(canonical.prNumber) &&
     (canonical.prNumber as number) > 0 &&
     typeof canonical.branch === "string" &&
@@ -91,8 +94,8 @@ export function evaluateGoalDispatch(
     return { allowed: true, reason: "authorized read-only dispatch", at: new Date().toISOString(), request };
 
   const canonical = classPolicy.canonical!;
-  if (request.prNumber !== canonical.prNumber || request.branch !== canonical.branch)
-    return fail(request, "non-canonical PR or branch");
+  if (request.repository !== canonical.repository || request.prNumber !== canonical.prNumber || request.branch !== canonical.branch)
+    return fail(request, "non-canonical repository, PR, or branch");
   if (!request.liveRemoteHead || request.liveRemoteHead !== canonical.remoteHead)
     return fail(request, "canonical remote head is absent or stale");
   if (!nonEmptyStrings(request.writeScope)) return fail(request, "explicit non-empty write scope required");
@@ -143,6 +146,7 @@ export function dispatchRequestFromToolParams(params: Record<string, unknown>): 
       taskClass,
       requestedAgent,
       actualAgent,
+      repository: str("repository"),
       prNumber: typeof declaration.prNumber === "number" ? declaration.prNumber : undefined,
       branch: str("branch"),
       liveRemoteHead: str("liveRemoteHead"),
@@ -153,3 +157,38 @@ export function dispatchRequestFromToolParams(params: Record<string, unknown>): 
     },
   };
 }
+
+/**
+ * Evidence required before a target manifest may advance. This is deliberately a
+ * pure, caller-configured check: the plugin never embeds another repository's
+ * identity as a production default.
+ */
+export type TargetProgressEvidence = {
+  sourceTasksReference?: string;
+  implementationEvidence?: string[];
+  verificationEvidence?: string[];
+  changedPaths?: string[];
+};
+export type DiffScopeSanity = { allow?: string[]; deny?: string[]; maxFiles?: number };
+
+export function reconcileTargetProgress(
+  evidence: TargetProgressEvidence,
+  scope: DiffScopeSanity = {},
+): { allowed: boolean; reason: string } {
+  if (!evidence.sourceTasksReference?.trim()) return { allowed: false, reason: "source TASKS reference required" };
+  if (!evidence.implementationEvidence?.some((x) => x.trim())) return { allowed: false, reason: "direct implementation evidence required" };
+  if (!evidence.verificationEvidence?.some((x) => x.trim())) return { allowed: false, reason: "direct verification evidence required" };
+  const paths = evidence.changedPaths ?? [];
+  if (scope.maxFiles !== undefined && paths.length > scope.maxFiles) return { allowed: false, reason: "diff scope exceeds maxFiles" };
+  if (scope.deny?.some((prefix) => paths.some((path) => path === prefix || path.startsWith(`${prefix}/`))))
+    return { allowed: false, reason: "diff scope contains denied path" };
+  if (scope.allow && paths.some((path) => !scope.allow.some((prefix) => path === prefix || path.startsWith(`${prefix}/`))))
+    return { allowed: false, reason: "diff scope contains non-allowlisted path" };
+  return { allowed: true, reason: "manifest evidence reconciled" };
+}
+
+/**
+ * Evidence required before a target manifest may advance. This is deliberately a
+ * pure, caller-configured check: the plugin never embeds another repository's
+ * identity as a production default.
+ */

--- a/extensions/memory-hybrid/services/goal-dispatch-broker.ts
+++ b/extensions/memory-hybrid/services/goal-dispatch-broker.ts
@@ -109,7 +109,8 @@ export class GoalDispatchBroker {
     return this.withLedger((l) => {
       this.expire(l);
       const r = l.dispatches[id];
-      if (!r || !["reserved", "launched"].includes(r.status) || r.owner !== owner || (r.runId && r.runId !== runId)) return false;
+      if (!r || !["reserved", "launched"].includes(r.status) || r.owner !== owner || (r.runId && r.runId !== runId))
+        return false;
       r.runId = runId;
       r.expiresAt = new Date(this.now().getTime() + ttlMs).toISOString();
       r.updatedAt = this.now().toISOString();
@@ -121,8 +122,23 @@ export class GoalDispatchBroker {
     return this.withLedger((l) => {
       this.expire(l);
       const r = l.dispatches[id];
-      if (!r || r.status !== "launched" || r.owner !== receipt.owner || r.runId !== receipt.runId || r.sessionId !== receipt.sessionId) return false;
-      if (!receipt.modelApplied || !receipt.requestedModel || !receipt.resolvedModel || !receipt.startingHead || !receipt.endingHead || receipt.evidence.length === 0) return false;
+      if (
+        !r ||
+        r.status !== "launched" ||
+        r.owner !== receipt.owner ||
+        r.runId !== receipt.runId ||
+        r.sessionId !== receipt.sessionId
+      )
+        return false;
+      if (
+        !receipt.modelApplied ||
+        !receipt.requestedModel ||
+        !receipt.resolvedModel ||
+        !receipt.startingHead ||
+        !receipt.endingHead ||
+        receipt.evidence.length === 0
+      )
+        return false;
       r.receipt = { ...receipt, recordedAt: this.now().toISOString() };
       r.updatedAt = this.now().toISOString();
       return true;

--- a/extensions/memory-hybrid/services/goal-dispatch-broker.ts
+++ b/extensions/memory-hybrid/services/goal-dispatch-broker.ts
@@ -11,6 +11,25 @@ export type DispatchBudget = {
   maxDispatchTokens?: number;
   maxWallTimeMs?: number;
 };
+export type CanonicalTarget = {
+  repository: string;
+  prNumber: number;
+  branch: string;
+  remoteHead: string;
+};
+export type ExecutionReceipt = {
+  owner: string;
+  runId: string;
+  sessionId: string;
+  requestedModel: string;
+  resolvedModel: string;
+  modelApplied: boolean;
+  startingHead: string;
+  endingHead: string;
+  outcome: "success" | "failed" | "cancelled";
+  evidence: string[];
+  recordedAt: string;
+};
 export type DispatchRecord = {
   id: string;
   goalId: string;
@@ -22,6 +41,10 @@ export type DispatchRecord = {
   createdAt: string;
   updatedAt: string;
   runId?: string;
+  owner?: string;
+  sessionId?: string;
+  target?: CanonicalTarget;
+  receipt?: ExecutionReceipt;
   reason?: string;
 };
 type Ledger = { dispatches: Record<string, DispatchRecord> };
@@ -47,9 +70,13 @@ export class GoalDispatchBroker {
     runtime: "subagent" | "acp";
     budget: DispatchBudget;
     ttlMs: number;
+    owner?: string;
+    sessionId?: string;
+    target?: CanonicalTarget;
   }): Promise<DispatchRecord | null> {
     return this.withLedger((ledger) => {
       this.expire(ledger);
+      // A goal's canonical target is part of the same locked reservation decision.
       const active = Object.values(ledger.dispatches).filter(
         (x) => x.goalId === input.goalId && ["reserved", "launched"].includes(x.status),
       );
@@ -66,6 +93,9 @@ export class GoalDispatchBroker {
         createdAt: at,
         updatedAt: at,
         expiresAt: new Date(this.now().getTime() + input.ttlMs).toISOString(),
+        owner: input.owner,
+        sessionId: input.sessionId,
+        target: input.target,
       };
       ledger.dispatches[id] = r;
       return r;
@@ -73,6 +103,30 @@ export class GoalDispatchBroker {
   }
   async launch(id: string, runId: string): Promise<boolean> {
     return this.mutate(id, "launched", { runId });
+  }
+  /** Renew only the exact active reservation. Duplicate/stale heartbeats fail closed. */
+  async heartbeat(id: string, owner: string, runId: string, ttlMs: number): Promise<boolean> {
+    return this.withLedger((l) => {
+      this.expire(l);
+      const r = l.dispatches[id];
+      if (!r || !["reserved", "launched"].includes(r.status) || r.owner !== owner || (r.runId && r.runId !== runId)) return false;
+      r.runId = runId;
+      r.expiresAt = new Date(this.now().getTime() + ttlMs).toISOString();
+      r.updatedAt = this.now().toISOString();
+      return true;
+    });
+  }
+  /** Receipt is accepted only from the leased owner/run/session with complete evidence. */
+  async recordReceipt(id: string, receipt: ExecutionReceipt): Promise<boolean> {
+    return this.withLedger((l) => {
+      this.expire(l);
+      const r = l.dispatches[id];
+      if (!r || r.status !== "launched" || r.owner !== receipt.owner || r.runId !== receipt.runId || r.sessionId !== receipt.sessionId) return false;
+      if (!receipt.modelApplied || !receipt.requestedModel || !receipt.resolvedModel || !receipt.startingHead || !receipt.endingHead || receipt.evidence.length === 0) return false;
+      r.receipt = { ...receipt, recordedAt: this.now().toISOString() };
+      r.updatedAt = this.now().toISOString();
+      return true;
+    });
   }
   async release(id: string, reason: string): Promise<boolean> {
     return this.mutate(id, "released", { reason });

--- a/extensions/memory-hybrid/tests/goal-dispatch-authorization.test.ts
+++ b/extensions/memory-hybrid/tests/goal-dispatch-authorization.test.ts
@@ -15,7 +15,12 @@ const policy: GoalDispatchPolicy = {
     implement: {
       allowedAgents: ["implementer-a", "escalator-a"],
       readOnly: false,
-      canonical: { prNumber: 2232, branch: "fix/goal-dispatch-authorization", remoteHead: "abc123" },
+      canonical: {
+        repository: "acme/repo",
+        prNumber: 2232,
+        branch: "fix/goal-dispatch-authorization",
+        remoteHead: "abc123",
+      },
       writeScope: ["extensions/memory-hybrid"],
       forbidNewPr: true,
       forbidNewBranch: true,
@@ -24,7 +29,12 @@ const policy: GoalDispatchPolicy = {
     escalate: {
       allowedAgents: ["escalator-a"],
       readOnly: false,
-      canonical: { prNumber: 2232, branch: "fix/goal-dispatch-authorization", remoteHead: "abc123" },
+      canonical: {
+        repository: "acme/repo",
+        prNumber: 2232,
+        branch: "fix/goal-dispatch-authorization",
+        remoteHead: "abc123",
+      },
       writeScope: ["docs"],
       forbidNewPr: true,
       forbidNewBranch: true,
@@ -36,6 +46,7 @@ const write = (changes: Partial<GoalDispatchRequest> = {}): GoalDispatchRequest 
   requestedAgent: "implementer-a",
   actualAgent: "implementer-a",
   readOnly: false,
+  repository: "acme/repo",
   prNumber: 2232,
   branch: "fix/goal-dispatch-authorization",
   liveRemoteHead: "abc123",

--- a/extensions/memory-hybrid/tests/goal-dispatch-broker-policy.test.ts
+++ b/extensions/memory-hybrid/tests/goal-dispatch-broker-policy.test.ts
@@ -28,7 +28,7 @@ const policy: GoalDispatchPolicy = {
     canonical_write: {
       allowedAgents: ["writer"],
       readOnly: false,
-      canonical: { prNumber: 77, branch: "fix/dispatch", remoteHead: "sha77" },
+      canonical: { repository: "example/repo", prNumber: 77, branch: "fix/dispatch", remoteHead: "sha77" },
       writeScope: ["extensions/memory-hybrid"],
       forbidNewPr: true,
       forbidNewBranch: true,
@@ -139,6 +139,7 @@ describe("goal_dispatch broker policy selection", () => {
         ...base(g.id, "writer"),
         task_class: "canonical_write",
         read_only: false,
+        repository: "example/repo",
         pr_number: 77,
         branch: "fix/dispatch",
         live_remote_head: "sha77",

--- a/extensions/memory-hybrid/tests/goal-dispatch-stewardship-guardrails.test.ts
+++ b/extensions/memory-hybrid/tests/goal-dispatch-stewardship-guardrails.test.ts
@@ -1,0 +1,21 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { GoalDispatchBroker } from "../services/goal-dispatch-broker.js";
+import { evaluateGoalDispatch, reconcileTargetProgress, type GoalDispatchPolicy } from "../services/goal-dispatch-authorization.js";
+const policy: GoalDispatchPolicy = { version: 1, classes: { write: { allowedAgents: ["writer"], readOnly: false, canonical: { repository: "owner/repo", prNumber: 909, branch: "feat/example", remoteHead: "abc" }, writeScope: ["src"], forbidNewPr: true, forbidNewBranch: true } } };
+const request = { taskClass: "write", requestedAgent: "writer", actualAgent: "writer", readOnly: false, repository: "owner/repo", prNumber: 909, branch: "feat/example", liveRemoteHead: "abc", writeScope: ["src/file.ts"], createsPr: false, createsBranch: false };
+describe("target stewardship guardrails", () => {
+  it("fences wrong canonical targets and diff scope", () => {
+    expect(evaluateGoalDispatch(policy, { ...request, branch: "wrong" }).allowed).toBe(false);
+    expect(reconcileTargetProgress({ sourceTasksReference: "TASKS.md#M", implementationEvidence: ["commit"], verificationEvidence: ["test"], changedPaths: ["outside/x"] }, { allow: ["src"] }).allowed).toBe(false);
+  });
+  it("requires each manifest evidence category", () => {
+    expect(reconcileTargetProgress({ implementationEvidence: ["commit"], verificationEvidence: ["test"] }).allowed).toBe(false);
+    expect(reconcileTargetProgress({ sourceTasksReference: "TASKS#M", implementationEvidence: ["commit"], verificationEvidence: ["test"], changedPaths: ["src/x"] }, { allow: ["src"] }).allowed).toBe(true);
+  });
+  it("uses owner/run/session leases and rejects stale or wrong receipts", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "broker-")); try { let t = 1_000; const broker = new GoalDispatchBroker(dir, () => new Date(t)); const r = await broker.reserve({ goalId: "goal", targetAgent: "writer", runtime: "subagent", budget: {}, ttlMs: 100, owner: "owner", sessionId: "session" }); expect(r).not.toBeNull(); await broker.launch(r!.id, "run"); expect(await broker.heartbeat(r!.id, "other", "run", 100)).toBe(false); expect(await broker.recordReceipt(r!.id, { owner: "other", runId: "run", sessionId: "session", requestedModel: "m", resolvedModel: "m", modelApplied: true, startingHead: "a", endingHead: "b", outcome: "success", evidence: ["test"], recordedAt: "" })).toBe(false); expect(await broker.recordReceipt(r!.id, { owner: "owner", runId: "run", sessionId: "session", requestedModel: "m", resolvedModel: "m", modelApplied: true, startingHead: "a", endingHead: "b", outcome: "success", evidence: [], recordedAt: "" })).toBe(false); expect(await broker.heartbeat(r!.id, "owner", "run", 100)).toBe(true); t += 101; expect(await broker.heartbeat(r!.id, "owner", "run", 100)).toBe(false); } finally { await rm(dir, { recursive: true, force: true }); }
+  });
+});

--- a/extensions/memory-hybrid/tests/goal-dispatch-stewardship-guardrails.test.ts
+++ b/extensions/memory-hybrid/tests/goal-dispatch-stewardship-guardrails.test.ts
@@ -3,19 +3,120 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { GoalDispatchBroker } from "../services/goal-dispatch-broker.js";
-import { evaluateGoalDispatch, reconcileTargetProgress, type GoalDispatchPolicy } from "../services/goal-dispatch-authorization.js";
-const policy: GoalDispatchPolicy = { version: 1, classes: { write: { allowedAgents: ["writer"], readOnly: false, canonical: { repository: "owner/repo", prNumber: 909, branch: "feat/example", remoteHead: "abc" }, writeScope: ["src"], forbidNewPr: true, forbidNewBranch: true } } };
-const request = { taskClass: "write", requestedAgent: "writer", actualAgent: "writer", readOnly: false, repository: "owner/repo", prNumber: 909, branch: "feat/example", liveRemoteHead: "abc", writeScope: ["src/file.ts"], createsPr: false, createsBranch: false };
+import {
+  evaluateGoalDispatch,
+  reconcileTargetProgress,
+  type GoalDispatchPolicy,
+} from "../services/goal-dispatch-authorization.js";
+const policy: GoalDispatchPolicy = {
+  version: 1,
+  classes: {
+    write: {
+      allowedAgents: ["writer"],
+      readOnly: false,
+      canonical: { repository: "owner/repo", prNumber: 909, branch: "feat/example", remoteHead: "abc" },
+      writeScope: ["src"],
+      forbidNewPr: true,
+      forbidNewBranch: true,
+    },
+  },
+};
+const request = {
+  taskClass: "write",
+  requestedAgent: "writer",
+  actualAgent: "writer",
+  readOnly: false,
+  repository: "owner/repo",
+  prNumber: 909,
+  branch: "feat/example",
+  liveRemoteHead: "abc",
+  writeScope: ["src/file.ts"],
+  createsPr: false,
+  createsBranch: false,
+};
 describe("target stewardship guardrails", () => {
   it("fences wrong canonical targets and diff scope", () => {
     expect(evaluateGoalDispatch(policy, { ...request, branch: "wrong" }).allowed).toBe(false);
-    expect(reconcileTargetProgress({ sourceTasksReference: "TASKS.md#M", implementationEvidence: ["commit"], verificationEvidence: ["test"], changedPaths: ["outside/x"] }, { allow: ["src"] }).allowed).toBe(false);
+    expect(
+      reconcileTargetProgress(
+        {
+          sourceTasksReference: "TASKS.md#M",
+          implementationEvidence: ["commit"],
+          verificationEvidence: ["test"],
+          changedPaths: ["outside/x"],
+        },
+        { allow: ["src"] },
+      ).allowed,
+    ).toBe(false);
   });
   it("requires each manifest evidence category", () => {
-    expect(reconcileTargetProgress({ implementationEvidence: ["commit"], verificationEvidence: ["test"] }).allowed).toBe(false);
-    expect(reconcileTargetProgress({ sourceTasksReference: "TASKS#M", implementationEvidence: ["commit"], verificationEvidence: ["test"], changedPaths: ["src/x"] }, { allow: ["src"] }).allowed).toBe(true);
+    expect(
+      reconcileTargetProgress({ implementationEvidence: ["commit"], verificationEvidence: ["test"] }).allowed,
+    ).toBe(false);
+    expect(
+      reconcileTargetProgress(
+        {
+          sourceTasksReference: "TASKS#M",
+          implementationEvidence: ["commit"],
+          verificationEvidence: ["test"],
+          changedPaths: ["src/x"],
+        },
+        { allow: ["src"] },
+      ).allowed,
+    ).toBe(true);
   });
   it("uses owner/run/session leases and rejects stale or wrong receipts", async () => {
-    const dir = await mkdtemp(join(tmpdir(), "broker-")); try { let t = 1_000; const broker = new GoalDispatchBroker(dir, () => new Date(t)); const r = await broker.reserve({ goalId: "goal", targetAgent: "writer", runtime: "subagent", budget: {}, ttlMs: 100, owner: "owner", sessionId: "session" }); expect(r).not.toBeNull(); await broker.launch(r!.id, "run"); expect(await broker.heartbeat(r!.id, "other", "run", 100)).toBe(false); expect(await broker.recordReceipt(r!.id, { owner: "other", runId: "run", sessionId: "session", requestedModel: "m", resolvedModel: "m", modelApplied: true, startingHead: "a", endingHead: "b", outcome: "success", evidence: ["test"], recordedAt: "" })).toBe(false); expect(await broker.recordReceipt(r!.id, { owner: "owner", runId: "run", sessionId: "session", requestedModel: "m", resolvedModel: "m", modelApplied: true, startingHead: "a", endingHead: "b", outcome: "success", evidence: [], recordedAt: "" })).toBe(false); expect(await broker.heartbeat(r!.id, "owner", "run", 100)).toBe(true); t += 101; expect(await broker.heartbeat(r!.id, "owner", "run", 100)).toBe(false); } finally { await rm(dir, { recursive: true, force: true }); }
+    const dir = await mkdtemp(join(tmpdir(), "broker-"));
+    try {
+      let t = 1_000;
+      const broker = new GoalDispatchBroker(dir, () => new Date(t));
+      const r = await broker.reserve({
+        goalId: "goal",
+        targetAgent: "writer",
+        runtime: "subagent",
+        budget: {},
+        ttlMs: 100,
+        owner: "owner",
+        sessionId: "session",
+      });
+      expect(r).not.toBeNull();
+      await broker.launch(r!.id, "run");
+      expect(await broker.heartbeat(r!.id, "other", "run", 100)).toBe(false);
+      expect(
+        await broker.recordReceipt(r!.id, {
+          owner: "other",
+          runId: "run",
+          sessionId: "session",
+          requestedModel: "m",
+          resolvedModel: "m",
+          modelApplied: true,
+          startingHead: "a",
+          endingHead: "b",
+          outcome: "success",
+          evidence: ["test"],
+          recordedAt: "",
+        }),
+      ).toBe(false);
+      expect(
+        await broker.recordReceipt(r!.id, {
+          owner: "owner",
+          runId: "run",
+          sessionId: "session",
+          requestedModel: "m",
+          resolvedModel: "m",
+          modelApplied: true,
+          startingHead: "a",
+          endingHead: "b",
+          outcome: "success",
+          evidence: [],
+          recordedAt: "",
+        }),
+      ).toBe(false);
+      expect(await broker.heartbeat(r!.id, "owner", "run", 100)).toBe(true);
+      t += 101;
+      expect(await broker.heartbeat(r!.id, "owner", "run", 100)).toBe(false);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/extensions/memory-hybrid/tools/goal-tools.ts
+++ b/extensions/memory-hybrid/tools/goal-tools.ts
@@ -122,6 +122,7 @@ export function registerGoalTools(ctx: GoalToolsContext, api: ClawdbotPluginApi)
         /** Explicit policy declaration. Omitting task_class only selects legacy `managed`; it never bypasses validation. */
         task_class: Type.Optional(Type.String()),
         read_only: Type.Optional(Type.Boolean()),
+        repository: Type.Optional(Type.String({ description: "Canonical owner/repository for write dispatches." })),
         pr_number: Type.Optional(Type.Number()),
         branch: Type.Optional(Type.String()),
         live_remote_head: Type.Optional(Type.String()),
@@ -175,6 +176,7 @@ export function registerGoalTools(ctx: GoalToolsContext, api: ClawdbotPluginApi)
           requestedAgent: agent,
           actualAgent: agent,
           readOnly: typeof p.read_only === "boolean" ? p.read_only : undefined,
+          repository: typeof p.repository === "string" ? p.repository : undefined,
           prNumber: typeof p.pr_number === "number" ? p.pr_number : undefined,
           branch: typeof p.branch === "string" ? p.branch : undefined,
           liveRemoteHead: typeof p.live_remote_head === "string" ? p.live_remote_head : undefined,
@@ -199,7 +201,12 @@ export function registerGoalTools(ctx: GoalToolsContext, api: ClawdbotPluginApi)
           maxWallTimeMs: typeof p.budget?.max_wall_time_ms === "number" ? p.budget.max_wall_time_ms : undefined,
         };
         const broker = new GoalDispatchBroker(goalsDir);
-        const record = await broker.reserve({ goalId, targetAgent: agent, runtime, budget, ttlMs: 5 * 60_000 });
+        const canonical = goal.dispatchPolicy?.classes[taskClass]?.canonical;
+        const record = await broker.reserve({
+          goalId, targetAgent: agent, runtime, budget, ttlMs: 5 * 60_000,
+          owner: agent, sessionId: p.session_key,
+          target: canonical ? { repository: canonical.repository, prNumber: canonical.prNumber, branch: canonical.branch, remoteHead: canonical.remoteHead } : undefined,
+        });
         if (!record)
           return {
             content: [{ type: "text" as const, text: "Dispatch budget exhausted." }],

--- a/extensions/memory-hybrid/tools/goal-tools.ts
+++ b/extensions/memory-hybrid/tools/goal-tools.ts
@@ -203,9 +203,21 @@ export function registerGoalTools(ctx: GoalToolsContext, api: ClawdbotPluginApi)
         const broker = new GoalDispatchBroker(goalsDir);
         const canonical = goal.dispatchPolicy?.classes[taskClass]?.canonical;
         const record = await broker.reserve({
-          goalId, targetAgent: agent, runtime, budget, ttlMs: 5 * 60_000,
-          owner: agent, sessionId: p.session_key,
-          target: canonical ? { repository: canonical.repository, prNumber: canonical.prNumber, branch: canonical.branch, remoteHead: canonical.remoteHead } : undefined,
+          goalId,
+          targetAgent: agent,
+          runtime,
+          budget,
+          ttlMs: 5 * 60_000,
+          owner: agent,
+          sessionId: p.session_key,
+          target: canonical
+            ? {
+                repository: canonical.repository,
+                prNumber: canonical.prNumber,
+                branch: canonical.branch,
+                remoteHead: canonical.remoteHead,
+              }
+            : undefined,
         });
         if (!record)
           return {


### PR DESCRIPTION
## Summary
- fence configured repository/PR/branch/head on canonical writes
- persist owner/run/session target leases and evidence-gated execution receipts in the existing dispatch ledger
- add manifest evidence reconciliation and configurable diff-scope checks
- document verified Armor target mappings as examples only (never production defaults), including the no-new-PR rule

## Verification
- `npm test -- --run tests/goal-dispatch-stewardship-guardrails.test.ts tests/goal-dispatch-broker-policy.test.ts`
- `npm run typecheck:gate`
- `npm run build`
- `git diff --check`

## Scope boundary
The public `goal_dispatch` API reserves and forwards target lease data. Receipt recording / manifest advancement is exposed as broker/authorization service mechanisms; no new host runtime callback was added, because the plugin cannot safely observe a child's actual model/head/evidence without a host-provided request-scoped completion binding.