### PR TITLE
fix(telemetry): do not mute GlitchTip reporting for outdated releases

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1792,8 +1792,11 @@ See [ERROR-REPORTING.md](ERROR-REPORTING.md) for full privacy and audit details.
 | `sampleRate` | `1.0` | Sampling rate (0.0–1.0) |
 | `botId` | *(unset)* | Optional identifier tag (string) for grouping errors by agent (`agent_id` / `bot_id`) |
 | `botName` | *(unset)* | Optional friendly name tag for grouping errors by agent (`agent_name` / `bot_name`) |
+| `resolvedIssues` | *(unset)* | Optional map of error fingerprint → the version it was fixed in; drops events matching that fingerprint from releases older than the fix. See [ERROR-REPORTING.md § Outdated releases still report telemetry](ERROR-REPORTING.md#outdated-releases-still-report-telemetry-2228) |
 
 The reporter also sets `server_name` and a `node` tag automatically from `OPENCLAW_NODE_NAME` when present.
+
+Every event is tagged with `release` (`openclaw-hybrid-memory@<plugin-version>`) whether or not that version is the latest published one — the plugin does **not** mute telemetry just because it is running an outdated release; see [ERROR-REPORTING.md § Outdated releases still report telemetry](ERROR-REPORTING.md#outdated-releases-still-report-telemetry-2228) for how to filter/group stale-release noise in GlitchTip instead.
 
 ---
 

--- a/docs/ERROR-REPORTING.md
+++ b/docs/ERROR-REPORTING.md
@@ -64,6 +64,7 @@ You can also switch to a **self-hosted** GlitchTip or Sentry instance by setting
 | `sampleRate` | number | No | `1.0` | Sample rate (0.0–1.0). 1.0 = report all errors |
 | `botId` | string | No | — | **Optional.** Stable identifier for this bot instance (for example a UUID like `550e8400-e29b-41d4-a716-446655440000` or a human-readable ID such as `agent-706`). Sent as `agent_id` / `bot_id` tags so GlitchTip can **group and filter errors by agent**. Omit to not tag by agent. If unset, the plugin uses OpenClaw's runtime context (`api.context.agentId`) when available. |
 | `botName` | string | No | — | **Optional.** Friendly name for this bot. Sent as `agent_name` / `bot_name` tags so reports show a readable name in GlitchTip. Max 64 characters. |
+| `resolvedIssues` | object (map) | No | — | **Optional.** Map of `"<ErrorType>:<message-prefix>"` fingerprint → the plugin version that fixed it. Events matching the fingerprint whose `release` is older than the fix version are dropped. This is the mechanism for suppressing noise from a specific known-fixed bug — see [Outdated releases still report telemetry](#outdated-releases-still-report-telemetry-2228). |
 
 At plugin init the reporter applies `server_name` plus `node`, `agent_id`, `agent_name`, `bot_id`, and `bot_name` tags. `server_name` / `node` resolve from `OPENCLAW_NODE_NAME` when set. Example filters: `node:Maeve`, `agent_name:Doris`.
 
@@ -173,6 +174,54 @@ Omit either or both if you do not need them.
 - ❌ Device identifiers beyond the configured node label (the reporter sends only `server_name` / `node`, not full device metadata)
 
 **Note on “user identity”:** the plugin does not set a Sentry user, but if an upstream host process ever provides `event.user`, the reporter **scrubs and forwards only** `user.id` and `user.username` (to support GlitchTip "Users Affected"). No emails/IPs are ever sent.
+
+---
+
+## Outdated releases still report telemetry (#2228)
+
+Every event carries a `release` tag — `openclaw-hybrid-memory@<plugin-version>` (e.g. `openclaw-hybrid-memory@2026.7.226`) — regardless of whether that version is the latest one published. **Being behind the latest release does not silence error reporting.**
+
+An earlier version of the plugin muted *all* telemetry from an install the moment it noticed a newer version had been published. That global mute has been removed: it was silencing operationally valuable production failures on exactly the hosts most likely to need attention — outdated ones (see [#2228](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/2228)).
+
+What still happens when your install is behind the latest published version:
+
+- **Telemetry keeps flowing.** New/unmapped errors from an outdated install are still sent to GlitchTip, tagged with the installed plugin's `release` and (when configured) `agent_id`/`bot_id`/`node`.
+- **The update nudge is unchanged.** A log-only "update available" message (`errorReporting.updateNudge`) still appears periodically in your OpenClaw gateway logs. It only logs locally — it never affects what is sent to GlitchTip.
+- **Known-fixed noise is still filtered**, but only per-fingerprint via `errorReporting.resolvedIssues` (below), never by muting an entire release wholesale.
+
+### Filtering/grouping stale-release noise in GlitchTip
+
+Since every event's `release` tag identifies the exact plugin version that produced it, use GlitchTip's own filtering/alerting instead of relying on the plugin to mute anything:
+
+- **Filter a saved search or alert policy** on `release:openclaw-hybrid-memory@<version>` to view, or silence notifications for, events from one specific version.
+- **Group the issue list by `release`** to see whether a spike in errors is concentrated on old, already-updated versions versus the current one.
+- **Combine with `agent_id` / `bot_id` / `node`** tags to scope down to "which hosts on old versions are still failing".
+
+### Suppressing a specific known-fixed error (`resolvedIssues`)
+
+If a specific bug is fixed in a later release and you don't want continued reports of it from hosts still running an older version, add it to `errorReporting.resolvedIssues` — a map from error fingerprint (`"<ErrorType>:<message-prefix>"`, matching GlitchTip's own grouping key) to the version it was fixed in:
+
+```json
+{
+  "plugins": {
+    "openclaw-hybrid-memory": {
+      "errorReporting": {
+        "resolvedIssues": {
+          "TypeError:Cannot read properties of null": "2026.3.110"
+        }
+      }
+    }
+  }
+}
+```
+
+Or via the CLI:
+
+```bash
+openclaw hybrid-mem config-set errorReporting.resolvedIssues '{"TypeError:Cannot read properties of null":"2026.3.110"}'
+```
+
+An event is dropped **only** when its own fingerprint matches an entry *and* its `release` version is older than the fix version listed for that fingerprint. Every other error from that same outdated release — including ones nobody has triaged yet — is still reported. This is intentionally narrow: it suppresses one specific, already-understood bug rather than an entire release's worth of telemetry.
 
 ---
 

--- a/extensions/memory-hybrid/services/error-reporter.ts
+++ b/extensions/memory-hybrid/services/error-reporter.ts
@@ -669,7 +669,6 @@ let initialized = false;
 let logger: any = console; // Default fallback to console
 const errorDedup = new Map<string, number>(); // Rate limiting: fingerprint -> timestamp
 const CHRONIC_FINGERPRINT_DEDUPE_MS = 24 * 60 * 60 * 1000;
-let telemetryMuteReason: string | null = null;
 
 /** Test-only: clear in-memory rate-limit state between cases. */
 export function resetErrorDedupForTests(): void {
@@ -678,14 +677,6 @@ export function resetErrorDedupForTests(): void {
 
 function buildFingerprintKey(fingerprint: string[]): string {
   return fingerprint.map((part) => scrubString(String(part))).join(":");
-}
-
-export function setErrorReporterMuted(muted: boolean, reason?: string): void {
-  telemetryMuteReason = muted ? (reason ?? "muted") : null;
-}
-
-export function getErrorReporterMuteReason(): string | null {
-  return telemetryMuteReason;
 }
 
 function resolveNodeName(env: NodeJS.ProcessEnv = process.env): string | undefined {
@@ -1123,7 +1114,6 @@ export function capturePluginError(
   },
 ): string | undefined {
   if (shouldDropNoisyError(error)) return undefined;
-  if (telemetryMuteReason) return undefined;
 
   if (!initialized || !reporter) {
     return undefined;
@@ -1226,9 +1216,6 @@ export function testErrorReporter(): { ok: boolean; error?: string } {
  * Capture a test error to verify reporting works
  */
 export function captureTestError(): string | null {
-  if (telemetryMuteReason) {
-    return null;
-  }
   if (!initialized || !reporter) {
     return null;
   }

--- a/extensions/memory-hybrid/setup/plugin-service.ts
+++ b/extensions/memory-hybrid/setup/plugin-service.ts
@@ -36,7 +36,6 @@ import {
   getPendingErrorReportCount,
   initErrorReporter,
   isErrorReporterActive,
-  setErrorReporterMuted,
 } from "../services/error-reporter.js";
 import { resolveGoalsDir, runGoalHealthCheck } from "../services/goal-stewardship.js";
 import { runBuildLanguageKeywords } from "../services/language-keywords-build.js";
@@ -335,7 +334,9 @@ export function createPluginService(ctx: PluginServiceContext) {
         isPluginOutdated(versionInfo.pluginVersion, cachedVersionCheck.latestVersion) &&
         isVersionCheckCacheFresh(cachedVersionCheck, cfg.errorReporting.updateNudge.cacheTtlHours)
       ) {
-        setErrorReporterMuted(true, `outdated-plugin:${cachedVersionCheck.latestVersion}`);
+        // Note: being outdated no longer mutes telemetry (#2228) — it only drives the log-only
+        // update nudge below. Outdated instances keep reporting sanitized errors, tagged with
+        // `release` (plugin version), so stale-release noise can be filtered/grouped in GlitchTip.
         const nextCachedVersionCheck = maybeLogOutdatedVersionNudge(
           versionInfo.pluginVersion,
           cachedVersionCheck,
@@ -352,8 +353,6 @@ export function createPluginService(ctx: PluginServiceContext) {
           }
           cachedVersionCheck = nextCachedVersionCheck;
         }
-      } else {
-        setErrorReporterMuted(false);
       }
 
       // ========================================================================
@@ -400,13 +399,6 @@ export function createPluginService(ctx: PluginServiceContext) {
         try {
           const latestPublished = await fetchLatestPublishedVersion();
           if (!latestPublished.latestVersion || !latestPublished.source) {
-            if (
-              cachedVersionCheck &&
-              isPluginOutdated(versionInfo.pluginVersion, cachedVersionCheck.latestVersion) &&
-              isVersionCheckCacheFresh(cachedVersionCheck, cfg.errorReporting.updateNudge.cacheTtlHours)
-            ) {
-              setErrorReporterMuted(true, `outdated-plugin:${cachedVersionCheck.latestVersion}`);
-            }
             return;
           }
 
@@ -420,15 +412,12 @@ export function createPluginService(ctx: PluginServiceContext) {
           if (shuttingDown) return;
 
           if (isPluginOutdated(versionInfo.pluginVersion, latestPublished.latestVersion)) {
-            setErrorReporterMuted(true, `outdated-plugin:${latestPublished.latestVersion}`);
             cacheEntry = maybeLogOutdatedVersionNudge(
               versionInfo.pluginVersion,
               cacheEntry,
               cfg.errorReporting.updateNudge,
               api.logger,
             );
-          } else {
-            setErrorReporterMuted(false);
           }
 
           if (shuttingDown) return;
@@ -445,13 +434,6 @@ export function createPluginService(ctx: PluginServiceContext) {
           api.logger.debug?.(
             `memory-hybrid: latest-version check failed: ${err instanceof Error ? err.message : String(err)}`,
           );
-          if (
-            cachedVersionCheck &&
-            isPluginOutdated(versionInfo.pluginVersion, cachedVersionCheck.latestVersion) &&
-            isVersionCheckCacheFresh(cachedVersionCheck, cfg.errorReporting.updateNudge.cacheTtlHours)
-          ) {
-            setErrorReporterMuted(true, `outdated-plugin:${cachedVersionCheck.latestVersion}`);
-          }
         }
       })();
 

--- a/extensions/memory-hybrid/tests/error-reporter-guard.test.ts
+++ b/extensions/memory-hybrid/tests/error-reporter-guard.test.ts
@@ -215,3 +215,110 @@ describe("UnconfiguredProviderError guard with mocked fetch", () => {
     vi.useRealTimers();
   });
 });
+
+describe("Outdated-release telemetry policy (#2228)", () => {
+  beforeAll(() => {
+    // The preceding describe block's afterAll() calls vi.unstubAllGlobals(), which would
+    // detach `fetch` from `mockFetch` before these tests run — re-stub it here.
+    vi.stubGlobal("fetch", mockFetch);
+  });
+
+  beforeEach(() => {
+    mockFetch.mockClear();
+    setEnv("OPENCLAW_NODE_NAME", undefined);
+  });
+
+  afterAll(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("still reports a new/unmapped error when the installed release is behind the latest published version", async () => {
+    const { initErrorReporter, capturePluginError, flushErrorReporter, resetErrorDedupForTests } = await import(
+      "../services/error-reporter.js"
+    );
+    resetErrorDedupForTests();
+
+    // Simulate an outdated install: this reporter is only ever told its own version — being
+    // "behind latest" is a property plugin-service.ts detects separately (npm/GitHub lookup)
+    // and, per #2228, no longer feeds back into muting the reporter.
+    await initErrorReporter(
+      {
+        enabled: true,
+        consent: true,
+        mode: "community",
+        dsn: "https://testguardkey@example.com/1",
+        maxBreadcrumbs: 0,
+        sampleRate: 1.0,
+      },
+      "2026.7.226", // outdated plugin version (latest published was 2026.7.228 in the issue)
+    );
+
+    const eventId = capturePluginError(new Error("brand new failure, not previously seen"), {
+      operation: "test-outdated-still-reports",
+    });
+    expect(eventId).toEqual(expect.any(String));
+
+    await flushErrorReporter(500);
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [, requestInit] = mockFetch.mock.calls[0];
+    const payload = JSON.parse(String(requestInit?.body ?? "{}"));
+    // Every event retains a release/plugin-version tag for GlitchTip filtering and grouping.
+    expect(payload.release).toBe("openclaw-hybrid-memory@2026.7.226");
+  });
+
+  it("still drops a fingerprint that resolvedIssues marks fixed in a later release (existing noise control, unaffected)", async () => {
+    const { initErrorReporter, capturePluginError, flushErrorReporter, resetErrorDedupForTests } = await import(
+      "../services/error-reporter.js"
+    );
+    resetErrorDedupForTests();
+
+    await initErrorReporter(
+      {
+        enabled: true,
+        consent: true,
+        mode: "community",
+        dsn: "https://testguardkey@example.com/1",
+        maxBreadcrumbs: 0,
+        sampleRate: 1.0,
+        resolvedIssues: { "Error:Known flaky timeout": "2026.7.228" },
+      },
+      "2026.7.226", // outdated, and the reporting fingerprint was fixed in 2026.7.228
+    );
+
+    capturePluginError(new Error("Known flaky timeout"), { operation: "test-resolved-issue-still-dropped" });
+    await flushErrorReporter(500);
+
+    // Fingerprint-scoped suppression (shouldDropForResolvedIssue) still applies — this is the
+    // narrow mechanism the issue asks to keep, unlike the removed release-wide mute.
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("reports an unrelated error from the same outdated release even when resolvedIssues has an entry for a different fingerprint", async () => {
+    const { initErrorReporter, capturePluginError, flushErrorReporter, resetErrorDedupForTests } = await import(
+      "../services/error-reporter.js"
+    );
+    resetErrorDedupForTests();
+
+    await initErrorReporter(
+      {
+        enabled: true,
+        consent: true,
+        mode: "community",
+        dsn: "https://testguardkey@example.com/1",
+        maxBreadcrumbs: 0,
+        sampleRate: 1.0,
+        resolvedIssues: { "Error:Known flaky timeout": "2026.7.228" },
+      },
+      "2026.7.226",
+    );
+
+    const eventId = capturePluginError(new Error("totally unrelated failure"), {
+      operation: "test-unrelated-error-not-suppressed",
+    });
+    expect(eventId).toEqual(expect.any(String));
+
+    await flushErrorReporter(500);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/extensions/memory-hybrid/tests/plugin-service-startup.test.ts
+++ b/extensions/memory-hybrid/tests/plugin-service-startup.test.ts
@@ -13,7 +13,7 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { hybridConfigSchema } from "../config.js";
 import { _testing } from "../index.js";
-import { capturePluginError, getErrorReporterMuteReason, setErrorReporterMuted } from "../services/error-reporter.js";
+import { capturePluginError } from "../services/error-reporter.js";
 import * as errorReporter from "../services/error-reporter.js";
 import * as eventLoopHealth from "../utils/event-loop-health.js";
 import { type PluginServiceContext, createPluginService } from "../setup/plugin-service.js";
@@ -178,7 +178,6 @@ describe("createPluginService startup — version check wiring", () => {
   });
 
   afterEach(() => {
-    setErrorReporterMuted(false);
     vi.unstubAllGlobals();
     clearTimers(timers);
     rmSync(tmpDir, { recursive: true, force: true });
@@ -244,7 +243,7 @@ describe("createPluginService startup — version check wiring", () => {
     (ctx.vectorDb as InstanceType<typeof VectorDB>).close();
   });
 
-  it("mutes telemetry and warns when the published plugin version is newer", async () => {
+  it("keeps telemetry active (release-tagged) and warns when the published plugin version is newer (#2228)", async () => {
     const api = makeMockApi(MIN_OPENCLAW_VERSION);
     // Must stay numerically above package.json plugin version so the "outdated" path still fires after each release bump.
     const publishedNewer = "2099.1.1";
@@ -256,6 +255,7 @@ describe("createPluginService startup — version check wiring", () => {
       if (new URL(url).hostname === "api.github.com") {
         return new Response(JSON.stringify({ tag_name: `v${publishedNewer}` }), { status: 200 });
       }
+      // Any other host (the GlitchTip store endpoint) — simulate a successful delivery.
       return new Response("", { status: 200 });
     });
     vi.stubGlobal("fetch", fetchMock);
@@ -267,9 +267,15 @@ describe("createPluginService startup — version check wiring", () => {
     await service.start();
     await service._getVersionCheckPromise();
 
-    expect(getErrorReporterMuteReason()).toContain(`outdated-plugin:${publishedNewer}`);
-    expect(capturePluginError(new Error("should stay local"), { operation: "startup-version-check" })).toBeUndefined();
+    // Being outdated must NOT globally mute telemetry (#2228) — a new/unmapped error reported
+    // while the plugin is behind the latest published release should still get an event ID
+    // (i.e. still reach the reporter), carrying a release/plugin-version tag for GlitchTip.
+    const eventId = capturePluginError(new Error("new unmapped error while outdated"), {
+      operation: "startup-version-check",
+    });
+    expect(eventId).toEqual(expect.any(String));
 
+    // The log-only "update available" nudge is untouched and still fires.
     const warnCalls = api.logger.warn.mock.calls.map((c: unknown[]) => c[0] as string);
     expect(warnCalls.some((msg) => msg.includes("update available") && msg.includes(publishedNewer))).toBe(true);
 


### PR DESCRIPTION
## Summary

Closes #2228

The error reporter globally muted **all** GlitchTip/error-reporting telemetry whenever the installed plugin version was behind the latest published version. DorisVM audit evidence showed telemetry explicitly muted for an outdated install right around a window of unexplained hybrid-memory maintenance cron failures — this silenced exactly the failures operators most needed to see, on exactly the hosts most likely to need attention.

- Removed the global mute mechanism (`setErrorReporterMuted` / `getErrorReporterMuteReason` / `telemetryMuteReason` in `services/error-reporter.ts`) entirely, and the 6 call sites in `setup/plugin-service.ts` that muted/unmuted telemetry based on `isPluginOutdated(...)`. Confirmed via repo-wide grep that these exports had **no other callers** (no CLI status/doctor output, no other subsystem), so deletion is safe rather than a partial mitigation.
- Outdated installs now keep reporting sanitized errors. Every event already carried `release: openclaw-hybrid-memory@<plugin-version>` unconditionally at reporter construction (`initErrorReporter` → `GlitchTipReporter` constructor) — that was never gated on being outdated, so no change was needed there, just verified.
- `shouldDropForResolvedIssue()` (in `services/error-reporter/sanitize.ts`, called from `GlitchTipReporter.captureException()`) is left untouched as the **sole** noise-control mechanism: it drops an event only when its own fingerprint matches a `resolvedIssues` entry *and* the event's release is older than the version listed as the fix — fingerprint-scoped, not release-wide, exactly matching the issue's proposed alternative.
- The log-only "update available" nudge (`maybeLogOutdatedVersionNudge`) is untouched — it still logs locally to the operator; it never fed into what gets sent to GlitchTip even before this change.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor / internal improvement (no behavior change)
- [ ] Documentation update
- [ ] CI / tooling change

## Quality Checklist

- [x] `cd extensions/memory-hybrid && npx tsc --noEmit` passes with no errors
- [x] `cd extensions/memory-hybrid && npm run lint` passes with no warnings in changed files (pre-existing warnings in untouched files are unrelated to this change)
- [x] `cd extensions/memory-hybrid && npm test` — `tests/error-reporter.test.ts`, `tests/error-reporter-guard.test.ts`, `tests/error-reporter-persistence.test.ts`, `tests/plugin-service-startup.test.ts` all green (105/105). A full-suite run (700+ files) was kicked off and had not finished by the time this PR was opened; the change is scoped to the mute/unmute call sites only, and everything importing from the touched modules is covered by the targeted files above.
- [x] No secrets, credentials, or API keys committed
- [x] No `console.log` debug statements left in production code

## Documentation Impact (REQUIRED)

- [x] Inline code comments updated at the removed call sites in `plugin-service.ts` explaining the new behavior
- [x] `docs/ERROR-REPORTING.md`: new "Outdated releases still report telemetry (#2228)" section explaining the removed behavior, how to filter/group by `release` tag in GlitchTip, and how `resolvedIssues` still suppresses specific known-fixed fingerprints. Also added the previously-undocumented `resolvedIssues` config field to the Config Fields table.
- [x] `docs/CONFIGURATION.md`: added `resolvedIssues` to the `errorReporting` config table and a note that outdated releases are no longer muted, cross-referencing ERROR-REPORTING.md.
- [x] Cross-referenced functions/services checked for outdated documentation (grepped `docs/` for `resolvedIssues`, `outdated-plugin`, `GlitchTip`, `error reporting` — no other doc referenced the old mute behavior)

## Testing

- [x] Unit tests added / updated:
  - `tests/plugin-service-startup.test.ts`: rewrote the "mutes telemetry ... when the published plugin version is newer" test into "keeps telemetry active (release-tagged) and warns when the published plugin version is newer (#2228)" — asserts `capturePluginError` for a new/unmapped error while outdated returns a real event ID (not muted), and the log-only update nudge still fires.
  - `tests/error-reporter-guard.test.ts`: added a new "Outdated-release telemetry policy (#2228)" describe block with 3 tests:
    1. An outdated release (`initErrorReporter(..., "2026.7.226")`, mirroring the issue's DorisVM evidence) still delivers a brand-new/unmapped error, and the delivered payload's `release` tag is `openclaw-hybrid-memory@2026.7.226`.
    2. A fingerprint present in `resolvedIssues` for a version newer than the installed one is still dropped (existing `shouldDropForResolvedIssue` behavior, confirmed end-to-end through `capturePluginError` → mocked fetch, not just at the unit level).
    3. An *unrelated* error from that same outdated release, with `resolvedIssues` configured for a *different* fingerprint, is still delivered — proving suppression stays narrowly fingerprint-scoped rather than release-wide.
- [x] Integration tests updated (`plugin-service-startup.test.ts` covers the plugin startup wiring end-to-end)
- [ ] Manually verified against a running OpenClaw instance

## Notes for Reviewer

- **Judgment call:** deleted `setErrorReporterMuted`/`getErrorReporterMuteReason`/`telemetryMuteReason` outright rather than keeping a no-op/deprecated shim, since a repo-wide grep confirmed zero other callers (`setup/plugin-service.ts` and `services/error-reporter.ts` were the only two files, plus the tests I updated). Happy to keep a deprecated shim if there's an external consumer I'm not seeing (e.g. via the plugin SDK surface), but I found no evidence of one.
- **Existing gap noted, not fixed (kept scope tight):** there is no explicit "OpenClaw version" tag sent today — only `node`/`agent_id`/`agent_name`/`bot_id`/`bot_name` and the plugin's own `release` tag. Adding one would be a new feature outside this issue's scope; flagging it here per the issue's ask.
- No config schema changes — `resolvedIssues` already existed and worked correctly; it was just undocumented until this PR.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Eb78N8a8yCMgVT2pY1K3QE)_