### PR TITLE
fix(vector-db): self-heal semantic query cache missing-fragment errors

### DIFF
--- a/docs/ERROR-REPORTING.md
+++ b/docs/ERROR-REPORTING.md
@@ -533,6 +533,14 @@ If you're auditing this feature for security/privacy compliance, verify:
 2. Add try/catch blocks to handle expected errors gracefully
 3. Use rate limiting in GlitchTip/Sentry
 
+### `Failed to get next batch from stream: lance error: Not found: ....lance` never shows up in GlitchTip, even though `openclaw hybrid-mem verify` warns about it
+
+**Cause:** This is the LanceDB semantic-query-cache "missing fragment" read-stream error (GlitchTip #34 / issue #2213, recurred as #2227) — a stale version manifest for the `semantic_query_cache.lance` table still references a data fragment file no longer on disk. `services/error-reporter/noisy-errors.ts` intentionally drops this exact message from GlitchTip on every occurrence (`shouldDropNoisyError` / `isLanceMissingFragmentError`), because `backends/vector-db/vector-db-class.ts` self-heals it automatically: on the first occurrence it calls `checkoutLatest()` to re-resolve the table handle to the latest version manifest (which, per this failure's own diagnosis, does not reference the missing fragment), falling back to a full drop+recreate rebuild if `checkoutLatest()` itself fails — rate-limited so a persistently broken manifest is repaired once per cooldown window rather than on every cache lookup/store call.
+
+**Impact while self-healing:** cache lookups/stores fail silently and fall back to a direct (uncached) vector search — slower, but no data loss (the semantic query cache is a pure performance optimization, not source-of-truth data).
+
+**How to check it happened:** `openclaw hybrid-mem verify` reports a warning ("Semantic query cache self-heal triggered N time(s)...") whenever the self-heal path has run, and fires a single, deduplicated `subsystem=vector operation=semantic-query-cache-integrity` GlitchTip alert via `services/vector-backend-observability.ts`'s `reportSemanticQueryCacheIntegrityIssue()` — this is the intended way to observe the condition, not the per-call raw LanceDB error.
+
 ---
 
 ## References

--- a/extensions/memory-hybrid/backends/vector-db/vector-db-class.ts
+++ b/extensions/memory-hybrid/backends/vector-db/vector-db-class.ts
@@ -10,11 +10,13 @@ import * as lancedb from "@lancedb/lancedb";
 import type { DecayClass, MemoryCategory } from "../../config.js";
 import { withEmbedWriteLock } from "../../services/embeddings/shared.js";
 import { capturePluginError } from "../../services/error-reporter.js";
+import { isLanceMissingFragmentError } from "../../services/error-reporter/noisy-errors.js";
 import type { SearchResult } from "../../types/memory.js";
 import {
   LANCE_NO_VECTOR_COL_MSG,
   LANCE_VECTOR_SEARCH_MAX_LIMIT,
   VECTORDB_COUNT_TIMEOUT_MS,
+  VECTORDB_FRAGMENT_RECOVERY_COOLDOWN_MS,
   VECTORDB_GET_VECTORS_TIMEOUT_MS,
   VECTORDB_INIT_MAX_RETRIES,
   VECTORDB_INIT_RETRY_DELAY_MS,
@@ -157,6 +159,31 @@ export class VectorDB {
     lastFilterKey: null,
     lastRemovedRows: 0,
     lastPrunedAtEpochMs: null,
+  };
+  /**
+   * Tracks the LanceDB "missing fragment" read-stream failure on the semantic query cache table
+   * (GlitchTip #34 / issue #2213, recurred as #2227: a stale version manifest still references a
+   * data fragment file that is absent from disk). Used to rate-limit self-heal attempts
+   * (checkoutLatest()/rebuild — see attemptSemanticCacheFragmentRecovery()) and to surface a
+   * health-check signal (services/vector-backend-observability.ts) since the per-call error itself
+   * is intentionally filtered out of GlitchTip as noisy/expected (services/error-reporter/noisy-errors.ts).
+   */
+  private semanticCacheFragmentErrorState: {
+    /** Total occurrences observed since this VectorDB instance was constructed. */
+    occurrences: number;
+    firstAtEpochMs: number | null;
+    lastAtEpochMs: number | null;
+    /** Epoch ms of the last self-heal attempt, for cooldown rate-limiting. */
+    lastRecoveryAttemptEpochMs: number | null;
+    lastRecoveryAction: "checkout" | "rebuild" | null;
+    lastRecoverySucceeded: boolean | null;
+  } = {
+    occurrences: 0,
+    firstAtEpochMs: null,
+    lastAtEpochMs: null,
+    lastRecoveryAttemptEpochMs: null,
+    lastRecoveryAction: null,
+    lastRecoverySucceeded: null,
   };
   /** Last successful optimize() run result for observability surfaces. */
   private lastOptimizeTelemetry: {
@@ -664,6 +691,75 @@ export class VectorDB {
 
   private isKnownVectorSchemaError(err: unknown): boolean {
     return err instanceof Error && err.message.includes(LANCE_NO_VECTOR_COL_MSG);
+  }
+
+  /**
+   * Self-heal for the LanceDB "missing fragment" read-stream error on the semantic query cache
+   * table (GlitchTip #34 / issue #2213, recurred as #2227). Called from getSemanticQueryCacheMatch()
+   * and storeSemanticQueryCache()'s catch blocks when isLanceMissingFragmentError() matches.
+   *
+   * Issue #2213's original fix only serialized the cache rebuild against concurrent readers/writers
+   * (a real but different race) and classified the error as noisy so it stopped reaching GlitchTip.
+   * Neither change helps when the *current* table handle is genuinely stuck resolving a stale
+   * version manifest that references a fragment file no longer on disk — every call fails the same
+   * way, forever, just silently. This method instead tries to recover:
+   *
+   *  1. `checkoutLatest()` — cheap, in-place, non-destructive. Per #2227's root-cause analysis,
+   *     newer table versions do not reference the missing fragment, so re-resolving the handle to
+   *     the latest version manifest is expected to fix the common case without losing any rows.
+   *  2. If that itself throws (e.g. no readable manifest at all), fall back to the existing
+   *     drop+recreate rebuildSemanticQueryCacheTable() repair path used for schema errors. This
+   *     loses cached rows, but the semantic query cache is a pure performance optimization, never
+   *     source-of-truth data, so an empty cache is an acceptable cost for restoring availability.
+   *
+   * Rate-limited via VECTORDB_FRAGMENT_RECOVERY_COOLDOWN_MS so a persistently broken manifest
+   * triggers one repair attempt per cooldown window rather than one per cache lookup/store call.
+   */
+  private async attemptSemanticCacheFragmentRecovery(err: unknown): Promise<void> {
+    const state = this.semanticCacheFragmentErrorState;
+    const now = Date.now();
+    state.occurrences += 1;
+    if (state.firstAtEpochMs === null) state.firstAtEpochMs = now;
+    state.lastAtEpochMs = now;
+
+    if (
+      state.lastRecoveryAttemptEpochMs !== null &&
+      now - state.lastRecoveryAttemptEpochMs < VECTORDB_FRAGMENT_RECOVERY_COOLDOWN_MS
+    ) {
+      // A repair attempt already ran within the cooldown window — skip hammering
+      // checkoutLatest()/rebuild on every call while the table is (still) broken.
+      return;
+    }
+    state.lastRecoveryAttemptEpochMs = now;
+
+    const table = this.semanticQueryCacheTable;
+    if (!table) return;
+
+    try {
+      await table.checkoutLatest();
+      state.lastRecoveryAction = "checkout";
+      state.lastRecoverySucceeded = true;
+      this.logWarn(
+        `memory-hybrid: semantic query cache self-heal: checked out latest table version after a ` +
+          `missing-fragment read error (${state.occurrences} occurrence(s) so far): ${err}`,
+      );
+      return;
+    } catch (checkoutErr) {
+      this.logWarn(
+        `memory-hybrid: semantic query cache checkoutLatest() self-heal failed (${checkoutErr}); ` +
+          "falling back to full rebuild.",
+      );
+    }
+
+    try {
+      await this.rebuildSemanticQueryCacheTable(`missing-fragment read error (self-heal): ${String(err)}`);
+      state.lastRecoveryAction = "rebuild";
+      state.lastRecoverySucceeded = true;
+    } catch (rebuildErr) {
+      state.lastRecoveryAction = "rebuild";
+      state.lastRecoverySucceeded = false;
+      this.logWarn(`memory-hybrid: semantic query cache rebuild self-heal also failed: ${rebuildErr}`);
+    }
   }
 
   /**
@@ -1335,6 +1431,13 @@ export class VectorDB {
         } catch (repairErr) {
           this.logWarn(`memory-hybrid: semantic query cache repair failed: ${repairErr}`);
         }
+      } else if (isLanceMissingFragmentError(err)) {
+        // GlitchTip #34 / issue #2213, recurred as #2227: this message is intentionally dropped
+        // by shouldDropNoisyError() (never reaches GlitchTip on its own), so unlike the branch
+        // below we don't call capturePluginError here — instead trigger self-heal. Persistence of
+        // this condition is surfaced separately via getSemanticCacheFragmentErrorTelemetry() /
+        // services/vector-backend-observability.ts's health check, not per-call reporting.
+        await this.attemptSemanticCacheFragmentRecovery(err);
       } else {
         capturePluginError(err as Error, {
           operation: "semantic-query-cache-lookup",
@@ -1387,6 +1490,10 @@ export class VectorDB {
         } catch (repairErr) {
           this.logWarn(`memory-hybrid: semantic query cache repair failed: ${repairErr}`);
         }
+      } else if (isLanceMissingFragmentError(err)) {
+        // See the matching branch in getSemanticQueryCacheMatch() above for why this triggers
+        // self-heal instead of capturePluginError (GlitchTip #34 / #2213, recurred as #2227).
+        await this.attemptSemanticCacheFragmentRecovery(err);
       } else {
         capturePluginError(err as Error, {
           operation: "semantic-query-cache-store",
@@ -2313,6 +2420,24 @@ export class VectorDB {
       lastRemovedRows: this.semanticQueryCachePruneTelemetry.lastRemovedRows,
       lastPrunedAtEpochMs: this.semanticQueryCachePruneTelemetry.lastPrunedAtEpochMs,
     };
+  }
+
+  /**
+   * Semantic query cache "missing fragment" read-stream error telemetry (GlitchTip #34 / issue
+   * #2213, recurred as #2227). `occurrences` stays 0 for a healthy cache; a non-zero count with
+   * `lastRecoverySucceeded: false` (or a recent `lastAtEpochMs` after a self-heal attempt) means
+   * self-heal has not been able to fully clear the condition and it's worth alerting an operator —
+   * see services/vector-backend-observability.ts's health check, which surfaces exactly this.
+   */
+  getSemanticCacheFragmentErrorTelemetry(): {
+    occurrences: number;
+    firstAtEpochMs: number | null;
+    lastAtEpochMs: number | null;
+    lastRecoveryAttemptEpochMs: number | null;
+    lastRecoveryAction: "checkout" | "rebuild" | null;
+    lastRecoverySucceeded: boolean | null;
+  } {
+    return { ...this.semanticCacheFragmentErrorState };
   }
 
   /**

--- a/extensions/memory-hybrid/cli/verify/sections/infrastructure.ts
+++ b/extensions/memory-hybrid/cli/verify/sections/infrastructure.ts
@@ -20,6 +20,7 @@ import {
   rebuildGoalIndex,
   resolveGoalsDir,
 } from "../../../services/goal-registry.js";
+import { reportSemanticQueryCacheIntegrityIssue } from "../../../services/vector-backend-observability.js";
 import { atomicWriteFile } from "../../../utils/atomic-write.js";
 import { PLUGIN_ID } from "../../../utils/constants.js";
 import {
@@ -417,6 +418,25 @@ export async function runVerifyInfrastructureSection(state: VerifyRunState): Pro
       );
       state.warnings.push(
         `LanceDB degraded mode active${degradedState.reason ? ` (${degradedState.reason})` : ""}; vector retrieval may be unavailable`,
+      );
+    }
+
+    // GlitchTip #34 / issue #2213, recurred as #2227: the semantic query cache's per-call
+    // "missing fragment" read errors are intentionally dropped as noisy (never reach GlitchTip on
+    // their own) so VectorDB can self-heal without spamming — this is the health-check surface
+    // that reports it instead, once, if self-heal has had to run at all this session.
+    const cacheIntegrity = reportSemanticQueryCacheIntegrityIssue(vectorDb);
+    if (cacheIntegrity.occurrences > 0) {
+      const WARN = noEmoji ? "[WARN]" : "⚠️";
+      log(
+        `${WARN} Semantic query cache: hit the LanceDB missing-fragment read error ${cacheIntegrity.occurrences} ` +
+          `time(s) this session (self-heal action=${cacheIntegrity.lastRecoveryAction ?? "none"}, ` +
+          `succeeded=${cacheIntegrity.lastRecoverySucceeded ?? "unknown"}).`,
+      );
+      state.warnings.push(
+        `Semantic query cache self-heal triggered ${cacheIntegrity.occurrences} time(s) after a LanceDB ` +
+          "missing-fragment read error; cache lookups fall back to direct search meanwhile (no data loss). " +
+          `See GlitchTip subsystem=vector operation=semantic-query-cache-integrity.`,
       );
     }
   } catch (e) {

--- a/extensions/memory-hybrid/services/error-reporter.ts
+++ b/extensions/memory-hybrid/services/error-reporter.ts
@@ -19,7 +19,7 @@ import type {
   ReportStacktrace,
 } from "./error-reporter/types.js";
 
-export { shouldDropNoisyError } from "./error-reporter/noisy-errors.js";
+export { isLanceMissingFragmentError, shouldDropNoisyError } from "./error-reporter/noisy-errors.js";
 export { compareVersions, extractVersion, sanitizeEvent, sanitizePath, scrubString, shouldDropForResolvedIssue };
 
 /**

--- a/extensions/memory-hybrid/services/error-reporter/noisy-errors.ts
+++ b/extensions/memory-hybrid/services/error-reporter/noisy-errors.ts
@@ -65,6 +65,24 @@ function isDirectNoisyError(err: unknown): boolean {
 }
 
 /**
+ * True for the specific LanceDB "missing fragment" read-stream failure (GlitchTip #34 / issue
+ * #2213, recurred as #2227): `Failed to get next batch from stream: lance error: Not found:
+ * .../<fragment>.lance`. A stale version manifest still references a fragment file that is
+ * absent from the data directory.
+ *
+ * `shouldDropNoisyError` below treats this message as non-actionable and never forwards it to
+ * GlitchTip per call — but #2227 showed that alone just makes 14 repeated failures silent instead
+ * of fixing them. This predicate is exported separately so a caller can *react* to the error
+ * (trigger a self-heal / count it for a health check) rather than only ever swallowing it. See
+ * `VectorDB`'s semantic query cache lookup/store paths (backends/vector-db/vector-db-class.ts).
+ */
+export function isLanceMissingFragmentError(err: unknown): boolean {
+  const message = getErrorMessage(err);
+  if (!message) return false;
+  return NOISY_LANCE_STREAM_ERROR_RE.test(message);
+}
+
+/**
  * Returns true for known noisy, non-actionable errors that should never be sent
  * to GlitchTip: transient transport failures, external-provider auth failures,
  * local Ollama circuit-breaker errors, transient LanceDB read-stream races during

--- a/extensions/memory-hybrid/services/vector-backend-observability.ts
+++ b/extensions/memory-hybrid/services/vector-backend-observability.ts
@@ -2,6 +2,21 @@ import { existsSync, lstatSync, readdirSync, readFileSync, readlinkSync } from "
 import { join, resolve } from "node:path";
 import type { VectorDB } from "../backends/vector-db.js";
 import { nowIso } from "../utils/dates.js";
+import { capturePluginError } from "./error-reporter.js";
+
+/**
+ * Semantic query cache "missing fragment" read-stream error telemetry shape, shared by
+ * `VectorDB.getSemanticCacheFragmentErrorTelemetry()`, the observability snapshot, and the
+ * integrity check below (GlitchTip #34 / issue #2213, recurred as #2227).
+ */
+export type SemanticCacheFragmentErrorTelemetry = {
+  occurrences: number;
+  firstAtEpochMs: number | null;
+  lastAtEpochMs: number | null;
+  lastRecoveryAttemptEpochMs: number | null;
+  lastRecoveryAction: "checkout" | "rebuild" | null;
+  lastRecoverySucceeded: boolean | null;
+};
 
 type ProcStatusSnapshot = {
   vmRssKb: number | null;
@@ -72,6 +87,12 @@ export type VectorBackendObservability = {
       lastRemovedRows: number;
       lastPrunedAtEpochMs: number | null;
     } | null;
+    /**
+     * LanceDB "missing fragment" read-stream error telemetry on the semantic query cache table
+     * (GlitchTip #34 / issue #2213, recurred as #2227). `occurrences: 0` means healthy. See
+     * `evaluateSemanticQueryCacheIntegrity` / `reportSemanticQueryCacheIntegrityIssue` below.
+     */
+    cacheFragmentErrors: SemanticCacheFragmentErrorTelemetry | null;
     lastOptimize: {
       ranAtEpochMs: number | null;
       compacted: number;
@@ -253,6 +274,7 @@ export async function collectVectorBackendObservability(opts: {
       lastRemovedRows: number;
       lastPrunedAtEpochMs: number | null;
     };
+    getSemanticCacheFragmentErrorTelemetry?: () => SemanticCacheFragmentErrorTelemetry;
     getLastOptimizeTelemetry?: () => {
       ranAtEpochMs: number | null;
       compacted: number;
@@ -284,6 +306,7 @@ export async function collectVectorBackendObservability(opts: {
   const cacheSize = basePath ? measurePathBytes(cachePath) : { bytes: null, scannedEntries: 0, truncated: false };
   const totalSizeBytes = opts.lanceBytes ?? null;
   const cacheTelemetry = vectorDbWithObs.getSemanticQueryCacheTelemetry?.() ?? null;
+  const cacheFragmentErrorTelemetry = vectorDbWithObs.getSemanticCacheFragmentErrorTelemetry?.() ?? null;
 
   return {
     capturedAt: nowIso(),
@@ -316,6 +339,7 @@ export async function collectVectorBackendObservability(opts: {
               lastRemovedRows: cacheTelemetry.lastRemovedRows,
               lastPrunedAtEpochMs: cacheTelemetry.lastPrunedAtEpochMs,
             },
+      cacheFragmentErrors: cacheFragmentErrorTelemetry,
       lastOptimize: vectorDbWithObs.getLastOptimizeTelemetry?.() ?? null,
       bounds: vectorDbWithObs.getRuntimeBounds?.() ?? null,
     },
@@ -344,4 +368,68 @@ export async function collectVectorBackendObservability(opts: {
         : [],
     },
   };
+}
+
+export type SemanticCacheIntegrityStatus = SemanticCacheFragmentErrorTelemetry & {
+  /** True when no missing-fragment error has been observed since this VectorDB instance started. */
+  healthy: boolean;
+};
+
+const EMPTY_FRAGMENT_ERROR_TELEMETRY: SemanticCacheFragmentErrorTelemetry = {
+  occurrences: 0,
+  firstAtEpochMs: null,
+  lastAtEpochMs: null,
+  lastRecoveryAttemptEpochMs: null,
+  lastRecoveryAction: null,
+  lastRecoverySucceeded: null,
+};
+
+/**
+ * Reads the semantic query cache's "missing fragment" self-heal telemetry (GlitchTip #34 / issue
+ * #2213, recurred as #2227) off a VectorDB instance without side effects. `healthy` is true only
+ * when no occurrence has been observed at all — a self-heal that *succeeded* still shows
+ * `occurrences > 0` (informational: the table was repaired) but is reported as `healthy: true` via
+ * `lastRecoverySucceeded`.
+ */
+export function evaluateSemanticQueryCacheIntegrity(vectorDb: VectorDB): SemanticCacheIntegrityStatus {
+  const vectorDbWithTelemetry = vectorDb as unknown as {
+    getSemanticCacheFragmentErrorTelemetry?: () => SemanticCacheFragmentErrorTelemetry;
+  };
+  const telemetry = vectorDbWithTelemetry.getSemanticCacheFragmentErrorTelemetry?.() ?? EMPTY_FRAGMENT_ERROR_TELEMETRY;
+  return {
+    ...telemetry,
+    healthy: telemetry.occurrences === 0 || telemetry.lastRecoverySucceeded === true,
+  };
+}
+
+/**
+ * Health check for remediation idea #4 from issue #2227: fire a single, deduplicated GlitchTip
+ * alert when the semantic query cache has had to run its "missing fragment" self-heal path, since
+ * the underlying per-call error is intentionally dropped as noisy
+ * (services/error-reporter/noisy-errors.ts) and would otherwise never reach an operator. Intended
+ * to be called from a periodic surface (maintenance/health cron, `openclaw hybrid-mem verify`) —
+ * capturePluginError's own fingerprint-based dedupe keeps repeated calls from spamming GlitchTip.
+ *
+ * A no-op (no report, `healthy: true`) when the cache has never hit this error class.
+ */
+export function reportSemanticQueryCacheIntegrityIssue(vectorDb: VectorDB): SemanticCacheIntegrityStatus {
+  const status = evaluateSemanticQueryCacheIntegrity(vectorDb);
+  if (status.occurrences === 0) return status;
+
+  const first = status.firstAtEpochMs ? new Date(status.firstAtEpochMs).toISOString() : "unknown";
+  const last = status.lastAtEpochMs ? new Date(status.lastAtEpochMs).toISOString() : "unknown";
+  capturePluginError(
+    new Error(
+      `Semantic query cache hit the LanceDB "missing fragment" read-stream error ${status.occurrences} ` +
+        `time(s) (first=${first}, last=${last}). Last self-heal action=${status.lastRecoveryAction ?? "none"} ` +
+        `succeeded=${status.lastRecoverySucceeded ?? "unknown"}.`,
+    ),
+    {
+      operation: "semantic-query-cache-integrity",
+      subsystem: "vector",
+      severity: status.healthy ? "warning" : "error",
+      fingerprint: ["semantic-query-cache-integrity"],
+    },
+  );
+  return status;
 }

--- a/extensions/memory-hybrid/tests/error-reporter.test.ts
+++ b/extensions/memory-hybrid/tests/error-reporter.test.ts
@@ -869,6 +869,43 @@ describe("Error Reporter", () => {
       expect(shouldDropNoisyError(new Error("Access denied to file /tmp/test.txt"))).toBe(false);
     });
   });
+
+  describe("isLanceMissingFragmentError (GlitchTip #34 / issue #2213, recurred as #2227)", () => {
+    it("matches the LanceDB missing-fragment read-stream error message", async () => {
+      const { isLanceMissingFragmentError } = await import("../services/error-reporter.js");
+
+      expect(
+        isLanceMissingFragmentError(
+          new Error(
+            "Failed to get next batch from stream: lance error: Not found: /home/user/.openclaw/memory/lance/" +
+              "semantic_query_cache.lance/data/12345678-abcd-4ef0-9abc-1234567890ab.lance, path not found",
+          ),
+        ),
+      ).toBe(true);
+      expect(isLanceMissingFragmentError(new Error("Failed to get next batch from stream"))).toBe(true);
+      expect(isLanceMissingFragmentError(new Error("lance error: Not found: some/other/path.lance"))).toBe(true);
+    });
+
+    it("does not match unrelated errors", async () => {
+      const { isLanceMissingFragmentError } = await import("../services/error-reporter.js");
+
+      expect(isLanceMissingFragmentError(new Error("ECONNREFUSED"))).toBe(false);
+      expect(isLanceMissingFragmentError(new TypeError("Cannot read properties of undefined"))).toBe(false);
+      expect(isLanceMissingFragmentError(new Error("No vector column found"))).toBe(false);
+      expect(isLanceMissingFragmentError(undefined)).toBe(false);
+      expect(isLanceMissingFragmentError("not an error")).toBe(false);
+    });
+
+    it("classifies every case shouldDropNoisyError treats as this signature identically (they share the same detection regex by design)", async () => {
+      const { isLanceMissingFragmentError, shouldDropNoisyError } = await import("../services/error-reporter.js");
+
+      const err = new Error(
+        "Failed to get next batch from stream: lance error: Not found: .../data/frag.lance, path not found",
+      );
+      expect(isLanceMissingFragmentError(err)).toBe(true);
+      expect(shouldDropNoisyError(err)).toBe(true);
+    });
+  });
 });
 
 describe("UnconfiguredProviderError suppression", () => {

--- a/extensions/memory-hybrid/tests/vector-backend-observability-cache-integrity.test.ts
+++ b/extensions/memory-hybrid/tests/vector-backend-observability-cache-integrity.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Tests for the semantic query cache integrity health check in
+ * services/vector-backend-observability.ts (GlitchTip #34 / issue #2213, recurred as #2227,
+ * remediation idea #4: "add a health check ... and fire a GlitchTip error").
+ *
+ * The per-call "missing fragment" error is intentionally dropped as noisy
+ * (services/error-reporter/noisy-errors.ts) so VectorDB can self-heal without spamming GlitchTip
+ * on every cache lookup/store — these functions are the surface that instead reports it once,
+ * from a periodic health/verify surface, when self-heal has had to run at all.
+ */
+import { vi } from "vitest";
+
+const { mockCapturePluginError } = vi.hoisted(() => ({
+  mockCapturePluginError: vi.fn(),
+}));
+
+vi.mock("../services/error-reporter.js", () => ({
+  capturePluginError: mockCapturePluginError,
+}));
+
+import { beforeEach, describe, expect, it } from "vitest";
+import type { VectorDB } from "../backends/vector-db.js";
+import {
+  collectVectorBackendObservability,
+  evaluateSemanticQueryCacheIntegrity,
+  reportSemanticQueryCacheIntegrityIssue,
+  type SemanticCacheFragmentErrorTelemetry,
+} from "../services/vector-backend-observability.js";
+
+function makeFakeVectorDb(telemetry?: SemanticCacheFragmentErrorTelemetry, withPath = false): VectorDB {
+  const fake: Record<string, unknown> = {};
+  if (telemetry) {
+    fake.getSemanticCacheFragmentErrorTelemetry = () => telemetry;
+  }
+  if (withPath) {
+    fake.getPath = () => "/tmp/does-not-exist-vector-backend-observability-test";
+  }
+  return fake as unknown as VectorDB;
+}
+
+const HEALTHY_TELEMETRY: SemanticCacheFragmentErrorTelemetry = {
+  occurrences: 0,
+  firstAtEpochMs: null,
+  lastAtEpochMs: null,
+  lastRecoveryAttemptEpochMs: null,
+  lastRecoveryAction: null,
+  lastRecoverySucceeded: null,
+};
+
+const RECOVERED_TELEMETRY: SemanticCacheFragmentErrorTelemetry = {
+  occurrences: 2,
+  firstAtEpochMs: 1000,
+  lastAtEpochMs: 5000,
+  lastRecoveryAttemptEpochMs: 5000,
+  lastRecoveryAction: "checkout",
+  lastRecoverySucceeded: true,
+};
+
+const UNRECOVERED_TELEMETRY: SemanticCacheFragmentErrorTelemetry = {
+  occurrences: 5,
+  firstAtEpochMs: 1000,
+  lastAtEpochMs: 9000,
+  lastRecoveryAttemptEpochMs: 9000,
+  lastRecoveryAction: "rebuild",
+  lastRecoverySucceeded: false,
+};
+
+describe("evaluateSemanticQueryCacheIntegrity", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("reports healthy with zero occurrences when the VectorDB has no fragment-error telemetry getter", () => {
+    const status = evaluateSemanticQueryCacheIntegrity(makeFakeVectorDb());
+    expect(status.healthy).toBe(true);
+    expect(status.occurrences).toBe(0);
+  });
+
+  it("reports healthy with zero occurrences when the cache has never hit the error", () => {
+    const status = evaluateSemanticQueryCacheIntegrity(makeFakeVectorDb(HEALTHY_TELEMETRY));
+    expect(status.healthy).toBe(true);
+    expect(status.occurrences).toBe(0);
+  });
+
+  it("reports healthy (but with a non-zero occurrence count) when self-heal succeeded", () => {
+    const status = evaluateSemanticQueryCacheIntegrity(makeFakeVectorDb(RECOVERED_TELEMETRY));
+    expect(status.healthy).toBe(true);
+    expect(status.occurrences).toBe(2);
+    expect(status.lastRecoveryAction).toBe("checkout");
+  });
+
+  it("reports unhealthy when self-heal did not succeed", () => {
+    const status = evaluateSemanticQueryCacheIntegrity(makeFakeVectorDb(UNRECOVERED_TELEMETRY));
+    expect(status.healthy).toBe(false);
+    expect(status.occurrences).toBe(5);
+    expect(status.lastRecoveryAction).toBe("rebuild");
+  });
+});
+
+describe("reportSemanticQueryCacheIntegrityIssue", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does not call capturePluginError when the cache has never hit the error", () => {
+    const status = reportSemanticQueryCacheIntegrityIssue(makeFakeVectorDb(HEALTHY_TELEMETRY));
+    expect(status.occurrences).toBe(0);
+    expect(mockCapturePluginError).not.toHaveBeenCalled();
+  });
+
+  it("does not call capturePluginError when there is no telemetry getter at all", () => {
+    reportSemanticQueryCacheIntegrityIssue(makeFakeVectorDb());
+    expect(mockCapturePluginError).not.toHaveBeenCalled();
+  });
+
+  it("reports a single GlitchTip alert (severity=warning) when self-heal already succeeded", () => {
+    reportSemanticQueryCacheIntegrityIssue(makeFakeVectorDb(RECOVERED_TELEMETRY));
+
+    expect(mockCapturePluginError).toHaveBeenCalledOnce();
+    const [err, context] = mockCapturePluginError.mock.calls[0];
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toContain("2 time(s)");
+    expect(context).toMatchObject({
+      operation: "semantic-query-cache-integrity",
+      subsystem: "vector",
+      severity: "warning",
+      fingerprint: ["semantic-query-cache-integrity"],
+    });
+  });
+
+  it("reports a GlitchTip alert (severity=error) when self-heal has not succeeded", () => {
+    reportSemanticQueryCacheIntegrityIssue(makeFakeVectorDb(UNRECOVERED_TELEMETRY));
+
+    expect(mockCapturePluginError).toHaveBeenCalledOnce();
+    const [, context] = mockCapturePluginError.mock.calls[0];
+    expect(context).toMatchObject({
+      operation: "semantic-query-cache-integrity",
+      subsystem: "vector",
+      severity: "error",
+      fingerprint: ["semantic-query-cache-integrity"],
+    });
+  });
+
+  it("uses a stable fingerprint so GlitchTip/capturePluginError's own dedupe collapses repeated calls, rather than reporting once per occurrence (14x under issue #2227)", () => {
+    reportSemanticQueryCacheIntegrityIssue(makeFakeVectorDb(UNRECOVERED_TELEMETRY));
+    reportSemanticQueryCacheIntegrityIssue(makeFakeVectorDb(UNRECOVERED_TELEMETRY));
+
+    expect(mockCapturePluginError).toHaveBeenCalledTimes(2);
+    const [, firstContext] = mockCapturePluginError.mock.calls[0];
+    const [, secondContext] = mockCapturePluginError.mock.calls[1];
+    expect(firstContext.fingerprint).toEqual(secondContext.fingerprint);
+  });
+});
+
+describe("collectVectorBackendObservability — cacheFragmentErrors field", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("includes fragment-error telemetry when the VectorDB exposes it", async () => {
+    const vectorDb = makeFakeVectorDb(UNRECOVERED_TELEMETRY, true);
+
+    const snapshot = await collectVectorBackendObservability({ vectorDb });
+    expect(snapshot.vectorDb.cacheFragmentErrors).toEqual(UNRECOVERED_TELEMETRY);
+  });
+
+  it("is null when the VectorDB does not expose fragment-error telemetry", async () => {
+    const vectorDb = makeFakeVectorDb(undefined, true);
+
+    const snapshot = await collectVectorBackendObservability({ vectorDb });
+    expect(snapshot.vectorDb.cacheFragmentErrors).toBeNull();
+  });
+});

--- a/extensions/memory-hybrid/tests/vector-db-optimize-cache.test.ts
+++ b/extensions/memory-hybrid/tests/vector-db-optimize-cache.test.ts
@@ -290,17 +290,25 @@ describe("VectorDB semantic query cache — suppress known schema errors", () =>
 });
 
 // ---------------------------------------------------------------------------
-// GlitchTip issue #34 — semantic query cache LanceDB read-stream race.
+// GlitchTip issue #34 — semantic query cache LanceDB read-stream race, recurred as issue #2227.
+//
 // rebuildSemanticQueryCacheTable() drops and recreates the cache table with zero
 // synchronization against concurrent readers/writers. A vectorSearch().toArray() call
 // racing that drop surfaces as "Failed to get next batch from stream: lance error: Not
-// found: .../semantic_query_cache.lance/data/....lance". This was (a) needlessly reported
-// to GlitchTip every time (fixed via services/error-reporter/noisy-errors.ts) and (b) an
-// actual race (fixed via acquireReader()/releaseReader()/waitForReadersToDrain() on the
-// cache table hot paths, mirroring the main table's optimize() fix for issue #768).
+// found: .../semantic_query_cache.lance/data/....lance". Issue #2213's fix addressed (a)
+// needless GlitchTip reporting (services/error-reporter/noisy-errors.ts) and (b) that
+// specific concurrent-drop race (acquireReader()/releaseReader()/waitForReadersToDrain(),
+// mirroring the main table's optimize() fix for issue #768) — but #2227 showed the same
+// message can also mean the *current* table handle is durably stuck on a stale version
+// manifest that references a fragment no longer on disk, independent of any in-process
+// race: every call fails identically, forever, just silently (per (a) above). The fix here
+// is attemptSemanticCacheFragmentRecovery(): checkoutLatest() first (cheap, re-resolves to
+// the latest manifest, which #2227's own diagnosis says doesn't reference the missing
+// fragment), falling back to the existing drop+recreate rebuild if that itself fails —
+// rate-limited so a persistently broken manifest doesn't get hammered on every call.
 // ---------------------------------------------------------------------------
 
-describe("VectorDB semantic query cache — GlitchTip issue #34 stream-read race", () => {
+describe("VectorDB semantic query cache — GlitchTip issue #34 / #2213 / #2227 missing-fragment self-heal", () => {
   let tmpDir: string;
   let lanceDir: string;
 
@@ -314,7 +322,14 @@ describe("VectorDB semantic query cache — GlitchTip issue #34 stream-read race
     rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  it("getSemanticQueryCacheMatch() resolves null (no throw) on a transient LanceDB stream-read error, and the error is classified as noisy so it never reaches GlitchTip", async () => {
+  function makeStreamReadErr(): Error {
+    return new Error(
+      "Failed to get next batch from stream: lance error: Not found: /home/user/.openclaw/memory/lance/" +
+        "semantic_query_cache.lance/data/12345678-abcd-4ef0-9abc-1234567890ab.lance, path not found",
+    );
+  }
+
+  it("getSemanticQueryCacheMatch() resolves null (no throw) on a missing-fragment error and never reports it to GlitchTip directly (self-heal handles it instead)", async () => {
     const db = new VectorDB(lanceDir, CORRECT_DIM);
 
     await db.storeSemanticQueryCache({
@@ -324,15 +339,13 @@ describe("VectorDB semantic query cache — GlitchTip issue #34 stream-read race
       filterKey: "test",
     });
 
-    const streamReadErr = new Error(
-      "Failed to get next batch from stream: lance error: Not found: /home/user/.openclaw/memory/lance/" +
-        "semantic_query_cache.lance/data/12345678-abcd-4ef0-9abc-1234567890ab.lance, path not found",
-    );
-
+    const streamReadErr = makeStreamReadErr();
+    const checkoutLatest = vi.fn(async () => {});
     (db as any).semanticQueryCacheTable = {
       vectorSearch: () => {
         throw streamReadErr;
       },
+      checkoutLatest,
     };
 
     const match = await db.getSemanticQueryCacheMatch([1, 0, 0], {
@@ -344,14 +357,136 @@ describe("VectorDB semantic query cache — GlitchTip issue #34 stream-read race
     // Must degrade gracefully to a cache miss rather than throwing to the caller.
     expect(match).toBeNull();
 
-    // capturePluginError() is still invoked by the generic catch branch (this message does
-    // not match isKnownVectorSchemaError), but the noisy-error fix means the REAL
-    // capturePluginError implementation would drop it before it ever reaches the reporter's
-    // captureException/fetch call. Assert that classification directly against the error
-    // that was actually captured, proving the fix covers this exact production message.
-    expect(mockCapturePluginError).toHaveBeenCalledOnce();
-    const [capturedErr] = mockCapturePluginError.mock.calls[0];
-    expect(shouldDropNoisyError(capturedErr)).toBe(true);
+    // Unlike the generic (unclassified) branch, this specific error class is never handed to
+    // capturePluginError at all — it is intentionally noisy-filtered (shouldDropNoisyError), so
+    // reporting per call would just be a silent no-op that duplicates the health-check surface
+    // (services/vector-backend-observability.ts's reportSemanticQueryCacheIntegrityIssue).
+    expect(mockCapturePluginError).not.toHaveBeenCalled();
+    expect(shouldDropNoisyError(streamReadErr)).toBe(true);
+
+    // Self-heal attempted the cheap, non-destructive path first.
+    expect(checkoutLatest).toHaveBeenCalledOnce();
+
+    const telemetry = db.getSemanticCacheFragmentErrorTelemetry();
+    expect(telemetry.occurrences).toBe(1);
+    expect(telemetry.lastRecoveryAction).toBe("checkout");
+    expect(telemetry.lastRecoverySucceeded).toBe(true);
+
+    await db.close();
+  });
+
+  it("storeSemanticQueryCache() also self-heals on a missing-fragment error instead of throwing or reporting to GlitchTip", async () => {
+    const db = new VectorDB(lanceDir, CORRECT_DIM);
+    await db.storeSemanticQueryCache({
+      queryText: "warm",
+      vector: [1, 0, 0],
+      factIds: ["warm"],
+      filterKey: "test",
+    });
+
+    const streamReadErr = makeStreamReadErr();
+    const checkoutLatest = vi.fn(async () => {});
+    (db as any).semanticQueryCacheTable = {
+      add: () => {
+        throw streamReadErr;
+      },
+      checkoutLatest,
+    };
+
+    await expect(
+      db.storeSemanticQueryCache({
+        queryText: "new query",
+        vector: [0, 1, 0],
+        factIds: ["fact-new"],
+        filterKey: "test",
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(mockCapturePluginError).not.toHaveBeenCalled();
+    expect(checkoutLatest).toHaveBeenCalledOnce();
+    expect(db.getSemanticCacheFragmentErrorTelemetry().occurrences).toBe(1);
+
+    await db.close();
+  });
+
+  it("falls back to a full table rebuild when checkoutLatest() itself fails, and the cache is usable again afterward", async () => {
+    const db = new VectorDB(lanceDir, CORRECT_DIM);
+    await db.storeSemanticQueryCache({
+      queryText: "warm query",
+      vector: [1, 0, 0],
+      factIds: ["fact-warm"],
+      filterKey: "test",
+    });
+
+    const streamReadErr = makeStreamReadErr();
+    const checkoutLatest = vi.fn(async () => {
+      throw new Error("checkout failed: no readable manifest");
+    });
+    (db as any).semanticQueryCacheTable = {
+      vectorSearch: () => {
+        throw streamReadErr;
+      },
+      checkoutLatest,
+    };
+
+    const match = await db.getSemanticQueryCacheMatch([1, 0, 0], {
+      filterKey: "test",
+      minSimilarity: 0.95,
+      ttlMs: 60_000,
+    });
+    expect(match).toBeNull();
+    expect(checkoutLatest).toHaveBeenCalledOnce();
+
+    const telemetry = db.getSemanticCacheFragmentErrorTelemetry();
+    expect(telemetry.lastRecoveryAction).toBe("rebuild");
+    expect(telemetry.lastRecoverySucceeded).toBe(true);
+
+    // The rebuild replaced the broken stub with a fresh, real, empty table — the cache must be
+    // fully usable again (self-heal, not just a graceful-degrade fallback).
+    await db.storeSemanticQueryCache({
+      queryText: "post-heal query",
+      vector: [0, 0, 1],
+      factIds: ["fact-post-heal"],
+      filterKey: "test",
+    });
+    const healedMatch = await db.getSemanticQueryCacheMatch([0, 0, 1], {
+      filterKey: "test",
+      minSimilarity: 0.95,
+      ttlMs: 60_000,
+    });
+    expect(healedMatch?.factIds).toEqual(["fact-post-heal"]);
+    expect(mockCapturePluginError).not.toHaveBeenCalled();
+
+    await db.close();
+  });
+
+  it("rate-limits repeated self-heal attempts within the cooldown window instead of hammering checkoutLatest() on every call", async () => {
+    const db = new VectorDB(lanceDir, CORRECT_DIM);
+    await db.storeSemanticQueryCache({
+      queryText: "warm query",
+      vector: [1, 0, 0],
+      factIds: ["fact-warm"],
+      filterKey: "test",
+    });
+
+    const streamReadErr = makeStreamReadErr();
+    const checkoutLatest = vi.fn(async () => {});
+    (db as any).semanticQueryCacheTable = {
+      vectorSearch: () => {
+        throw streamReadErr;
+      },
+      checkoutLatest,
+    };
+
+    // Three calls in quick succession while the table is (still) broken — checkoutLatest() must
+    // only run once; the other two occurrences are still tallied for telemetry/health-check
+    // purposes but skip the actual repair attempt (cooldown not yet elapsed).
+    for (let i = 0; i < 3; i++) {
+      await db.getSemanticQueryCacheMatch([1, 0, 0], { filterKey: "test", minSimilarity: 0.95, ttlMs: 60_000 });
+    }
+
+    expect(checkoutLatest).toHaveBeenCalledOnce();
+    expect(db.getSemanticCacheFragmentErrorTelemetry().occurrences).toBe(3);
 
     await db.close();
   });

--- a/extensions/memory-hybrid/utils/constants.ts
+++ b/extensions/memory-hybrid/utils/constants.ts
@@ -128,6 +128,14 @@ export const LANCE_NO_VECTOR_COL_MSG = "No vector column found";
 /** Timeout (ms) for vectorDB reader drain. */
 export const VECTORDB_READER_DRAIN_TIMEOUT_MS = 30_000;
 
+/**
+ * Rate limit (ms) between semantic query cache self-heal attempts (checkoutLatest()/rebuild)
+ * after the LanceDB "missing fragment" read-stream error (GlitchTip #34 / issue #2213, recurred
+ * as #2227). Without this, a persistently broken version manifest would trigger a repair attempt
+ * on every single cache lookup/store call instead of self-healing once and backing off.
+ */
+export const VECTORDB_FRAGMENT_RECOVERY_COOLDOWN_MS = 60_000;
+
 /** Timeout (ms) for VectorDB initialization (connect + table open). */
 export const VECTORDB_INIT_TIMEOUT_MS = 60_000;
 


### PR DESCRIPTION
## Summary

Closes #2227.

This is a **recurrence of #2213** (GlitchTip #34, closed 2026-07-27). The semantic query cache table (`semantic_query_cache.lance`) can get durably stuck resolving a stale LanceDB version manifest that references a data fragment file no longer on disk — every cache lookup/store then fails identically with `Failed to get next batch from stream: lance error: Not found: .../<fragment>.lance`, forever, until something forces the table handle to re-resolve.

### What #2213's fix (#2215) actually did, and why it wasn't sufficient

`#2215` made two changes, both real but neither addressing this failure mode:

1. **Concurrency fix**: added `acquireReader()`/`releaseReader()`/`waitForReadersToDrain()` around the cache table's read/write hot paths so `rebuildSemanticQueryCacheTable()`'s `dropTable()` can't race a concurrent read. This fixes a genuine race, but #2227's own diagnosis (fragment "still absent" across the *same* manifest, in "4 distinct time clusters") isn't a race — it's a table handle stuck on a manifest that was broken well before any of these calls ran.
2. **Noise suppression**: added `NOISY_LANCE_STREAM_ERROR_RE` to `services/error-reporter/noisy-errors.ts` so this exact message is dropped from GlitchTip on every occurrence.

(2) is the part that made the recurrence *look* fixed — GlitchTip stopped receiving new events for this class of error, but the plugin kept hitting the same read failure on every single cache lookup/store, silently, with no self-heal and no operator-visible signal. #2227 shows this: 14 occurrences over one day, same missing fragment, never surfaced.

### What this PR changes

1. **Self-heal** (`backends/vector-db/vector-db-class.ts`, `attemptSemanticCacheFragmentRecovery`): the first time `getSemanticQueryCacheMatch()`/`storeSemanticQueryCache()` hits this specific error class, it now:
   - calls the LanceDB table's `checkoutLatest()` — cheap, in-place, non-destructive; re-resolves the handle to the latest version manifest, which (per the issue's own diagnosis) does not reference the missing fragment;
   - falls back to the existing drop+recreate `rebuildSemanticQueryCacheTable()` repair path if `checkoutLatest()` itself throws.
   - Rate-limited via `VECTORDB_FRAGMENT_RECOVERY_COOLDOWN_MS` (60s) so a persistently broken manifest gets one repair attempt per cooldown window, not one per query.
   - `checkoutLatest()`/`checkout()`/`restore()`/`optimize()` are all real, documented `@lancedb/lancedb` `Table` methods (`node_modules/@lancedb/lancedb/dist/table.d.ts`) — no LanceDB internals were reimplemented.

2. **Detection helper**: `isLanceMissingFragmentError()` exported from `services/error-reporter/noisy-errors.ts` (same detection regex `shouldDropNoisyError` already used, split out so a caller can *react* instead of only swallowing).

3. **Health check** (remediation idea #4): `services/vector-backend-observability.ts` exposes `evaluateSemanticQueryCacheIntegrity()` / `reportSemanticQueryCacheIntegrityIssue()`, which fires a single, deduplicated `capturePluginError` (`subsystem="vector"`, `operation="semantic-query-cache-integrity"`, stable fingerprint) whenever self-heal has had to run at all — since the raw per-call error is intentionally noisy-filtered, this is the surface that actually reaches GlitchTip/an operator. Wired into `openclaw hybrid-mem verify` (`cli/verify/sections/infrastructure.ts`), which now prints a warning line when this has happened.

4. **Regression tests**: `tests/vector-db-optimize-cache.test.ts` (self-heal via `checkoutLatest()`, fallback to rebuild when `checkoutLatest()` fails, rate-limiting, symmetry for both lookup and store paths, telemetry), `tests/error-reporter.test.ts` (`isLanceMissingFragmentError` classification), and a new `tests/vector-backend-observability-cache-integrity.test.ts` (health-check reporting behavior, including that it uses a stable fingerprint instead of reporting once per occurrence).

### Is this a full fix or a mitigation?

I'd call this a **durable mitigation with a real self-heal, not a proven root-cause fix**. `checkoutLatest()` addresses the exact mechanism the issue itself diagnoses (a stale manifest reference to an already-absent fragment, where newer versions don't have this problem) without requiring any change to LanceDB itself, and the system now recovers automatically instead of failing the same way forever. What it does *not* do is explain *why* the fragment went missing in the first place (an interrupted write/crash before fsync, per the issue's own hypothesis) — that's upstream LanceDB write-path behavior with no JS-API-exposed pre-commit integrity check to add on our side. Per the task's own remediation framing, I focused on making the failure mode good (self-heal + one alert instead of 14 silent failures) rather than claiming to have fixed LanceDB's write path.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Quality Checklist

- [x] `cd extensions/memory-hybrid && npx tsc --noEmit` passes with no errors
- [x] `cd extensions/memory-hybrid && npm run lint` passes (0 errors; pre-existing warning baseline unchanged, none in touched files)
- [x] `cd extensions/memory-hybrid && npm test` — all directly relevant suites green (`tests/vector-db*.test.ts` full glob: 120/120; `error-reporter*.test.ts`, `vector-db-semantic-cache-uninitialized`, `vector-db-optimize-timeout`, `vector-db-write-conflict`, new `vector-backend-observability-cache-integrity.test.ts`: 107/107). Full 700+ file suite was kicked off but did not finish within this session's window under heavy shared-runner contention — no reason to expect it's affected given the change surface, but flagging honestly rather than claiming a full green run I didn't observe.
- [x] No secrets, credentials, or API keys committed
- [x] No `console.log` debug statements left in production code

## Documentation Impact

- [x] Inline code comments (JSDoc) updated for modified functions and types
- [x] `docs/` updated — added a troubleshooting entry to `docs/ERROR-REPORTING.md` explaining why this error never reaches GlitchTip directly and where to look instead (`verify` output / the new health-check alert)
- [x] Cross-referenced functions/services checked for outdated documentation

## Testing

- [x] Unit tests added / updated (see above)
- [ ] Integration tests added / updated
- [ ] Manually verified against a running OpenClaw instance

## Notes for Reviewer

- I deliberately did **not** touch the existing `NOISY_LANCE_STREAM_ERROR_RE` noise-suppression behavior — the per-call raw error is still dropped from GlitchTip by design (it's expected during self-heal), and the new health-check function is the intended replacement signal.
- Judgment call: I based the health-check's cadence entirely on `capturePluginError`'s existing fingerprint dedupe rather than adding new scheduling — it's called from `verify`, which is already a periodic/health surface in this codebase, rather than inventing a new "health cron" concept that doesn't otherwise exist here.
- Judgment call: on `checkoutLatest()` failure I fall back to the existing destructive drop+recreate rebuild (losing cached rows) rather than leaving the cache in a broken state — the semantic query cache is pure-performance data, never source of truth, so I considered this an acceptable trade for restored availability.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Eb78N8a8yCMgVT2pY1K3QE)_