### PR TITLE
feat(backup): bounded retention, atomic writes, and health alerting

### DIFF
--- a/docs/BACKUP.md
+++ b/docs/BACKUP.md
@@ -56,6 +56,85 @@ Bootstrap files (AGENTS.md, SOUL.md, USER.md, TOOLS.md, MEMORY.md, etc.) are als
 
 ---
 
+## Automated snapshot backups (`hybrid-mem backup`)
+
+The plugin also ships a self-managed snapshot backup command that captures SQLite (via
+`VACUUM INTO`, safe on a live WAL-mode database) and the LanceDB directory into a timestamped
+folder — no need to stop the gateway.
+
+```bash
+# Create a snapshot: ~/.openclaw/backups/memory/<timestamp>/
+openclaw hybrid-mem backup
+
+# Verify SQLite integrity without creating a new backup
+openclaw hybrid-mem backup verify
+
+# Retention + health audit: completed/retained/stale-partial counts, bytes, last success/failure
+openclaw hybrid-mem backup status
+
+# Deterministically clean up stale/partial artifacts and enforce retention on demand
+openclaw hybrid-mem backup prune
+
+# Install a weekly cron entry (defaults to Sunday 04:00; configurable via
+# maintenance.cronReliability.weeklyBackupCron)
+openclaw hybrid-mem backup schedule
+```
+
+### Bounded retention (Issue #2229)
+
+Every successful `backup` run atomically promotes a hidden `.backup-tmp-*` working directory to
+its final timestamped name only once SQLite, LanceDB, and the manifest have all been written
+successfully — a crash or `kill -9` mid-backup can never leave a directory that looks like a
+completed snapshot, and any abandoned working directory or stray artifact is cleaned up on the
+next run (or on demand via `backup prune`).
+
+After a successful run, older completed snapshots are pruned per `maintenance.backup` config:
+
+```yaml
+maintenance:
+  backup:
+    retentionCount: 7      # keep the 7 newest completed snapshots (0 disables count-based pruning)
+    retentionAgeDays: 30   # prune snapshots older than 30 days (0 disables age-based pruning)
+```
+
+The newest completed snapshot is **never** pruned, even if it's the only one on disk and older
+than `retentionAgeDays` — losing the sole valid backup because it aged out would defeat the
+purpose of having one. `openclaw hybrid-mem backup status` reports completed/retained/stale
+counts, total bytes, and the newest/oldest snapshot; `openclaw hybrid-mem backup prune` applies
+the policy deterministically without creating a new backup.
+
+### Health alerting (Issue #2230)
+
+Each run records its outcome to `~/.openclaw/state/memory-backup-last.json` (`ok`, timestamp,
+error, failure reason category, consecutive-failure count, last verified success). This state
+feeds three surfaces:
+
+- `openclaw hybrid-mem health` — a `Backup` traffic-light indicator.
+- `openclaw hybrid-mem audit health` / `graph health` — a `backupHealth` field with status,
+  reason category, and age since last verified success (read-only; never fires an alert itself).
+- The weekly `audit-health` maintenance cron step — the actual heartbeat tick, which fires a
+  **deduplicated** alert (via the same error-reporter pipeline used for other plugin errors) when
+  the backup has failed or when the last verified success is older than
+  `maintenance.backup.alerting.staleAfterHours` (default 192h / 8 days — one day of grace past the
+  default weekly cadence). Repeated failures only re-alert after
+  `maintenance.backup.alerting.dedupeWindowHours` (default 24h) elapses; a later successful backup
+  immediately clears the stale failure state from all three surfaces.
+
+```yaml
+maintenance:
+  backup:
+    alerting:
+      enabled: true          # set false to disable backup health alerting entirely
+      staleAfterHours: 192   # alert if no verified success in this many hours
+      dedupeWindowHours: 24  # minimum time between repeated alerts for the same persisting issue
+```
+
+Failure reason categories (`disk_full`, `permission_denied`, `path_not_found`,
+`integrity_check_failed`, `unknown`) are derived from the error message and come with
+non-sensitive remediation guidance (e.g. "free disk space on the backup volume").
+
+---
+
 ## Simple backup (tar)
 
 **Stop the gateway first** so SQLite and LanceDB are not in use:

--- a/extensions/memory-hybrid/cli/backup.ts
+++ b/extensions/memory-hybrid/cli/backup.ts
@@ -21,6 +21,7 @@
  * Cron automation for scheduled backups should be managed via openclaw.yaml.
  */
 
+import { randomBytes } from "node:crypto";
 import {
   copyFileSync,
   cpSync,
@@ -28,9 +29,11 @@ import {
   mkdirSync,
   readdirSync,
   readlinkSync,
+  renameSync,
   rmSync,
   statSync,
   symlinkSync,
+  unlinkSync,
   writeFileSync,
 } from "node:fs";
 import { homedir } from "node:os";
@@ -84,6 +87,57 @@ export type BackupVerifyResult =
   | { ok: false; error: string };
 
 // ---------------------------------------------------------------------------
+// Retention / pruning (Issue #2229)
+// ---------------------------------------------------------------------------
+
+/** Bounded retention policy applied to completed backup snapshots. */
+export type BackupRetentionOptions = {
+  /** Max number of completed snapshots to retain. 0 or negative disables count-based pruning. Default 7. */
+  retentionCount?: number;
+  /** Max age in days a completed snapshot may reach before it's prune-eligible. 0 or negative disables age-based pruning. Default 30. */
+  retentionAgeDays?: number;
+  /**
+   * Grace period (ms) a `.backup-tmp-*` working directory or unrecognized root artifact must sit
+   * untouched before it's treated as abandoned and safe to remove — protects a concurrently
+   * running backup's in-progress temp dir from being pruned out from under it. Default 1 hour.
+   */
+  partialGraceMs?: number;
+};
+
+export const DEFAULT_BACKUP_RETENTION_COUNT = 7;
+export const DEFAULT_BACKUP_RETENTION_AGE_DAYS = 30;
+const DEFAULT_PARTIAL_GRACE_MS = 60 * 60 * 1000;
+
+export type BackupPruneReport = {
+  root: string;
+  retainedCompleted: string[];
+  prunedCompleted: string[];
+  prunedPartial: string[];
+  prunedOrphaned: string[];
+  errors: string[];
+};
+
+export type BackupStatusEntry = { name: string; createdAt: string; bytes: number };
+
+export type BackupStatusReport = {
+  root: string;
+  /** Completed snapshots currently on disk. */
+  completedCount: number;
+  /** Completed snapshots that satisfy the retention policy right now (i.e. would survive a prune). */
+  retainedCount: number;
+  /** In-progress (`.backup-tmp-*`) working directories currently on disk. */
+  partialCount: number;
+  /** Unrecognized files/directories sitting directly under the backup root (e.g. legacy orphaned artifacts). */
+  orphanedCount: number;
+  /** partialCount + orphanedCount — artifacts that are neither a completed snapshot nor prunable safely yet. */
+  stalePartialCount: number;
+  /** Total bytes across all completed snapshots. */
+  totalBytes: number;
+  newest: BackupStatusEntry | null;
+  oldest: BackupStatusEntry | null;
+};
+
+// ---------------------------------------------------------------------------
 // Context
 // ---------------------------------------------------------------------------
 
@@ -92,11 +146,26 @@ interface BackupContext {
   resolvedLancePath: string;
   /** Override default backup destination (~/.openclaw/backups/memory/). */
   backupDir?: string;
+  /** Bounded retention applied after a successful backup (Issue #2229). Omit to skip pruning. */
+  retention?: BackupRetentionOptions;
 }
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+/** Prefix for the hidden working directory a backup writes into before it's promoted (renamed) into place. */
+const TEMP_BACKUP_PREFIX = ".backup-tmp-";
+/** Name pattern for a completed, atomically-promoted backup snapshot directory. */
+const COMPLETED_BACKUP_DIR_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-\d{3}Z$/;
+
+function isCompletedBackupDirName(name: string): boolean {
+  return COMPLETED_BACKUP_DIR_PATTERN.test(name);
+}
+
+function isPartialBackupDirName(name: string): boolean {
+  return name.startsWith(TEMP_BACKUP_PREFIX);
+}
 
 function defaultBackupRoot(): string {
   return join(homedir(), ".openclaw", "backups", "memory");
@@ -168,6 +237,171 @@ function copyDirSync(src: string, dest: string): void {
   }
 }
 
+/** Hidden sibling working directory a backup writes into before being promoted (renamed) into place. */
+function tempBackupDir(root: string): string {
+  return join(root, `${TEMP_BACKUP_PREFIX}${process.pid}-${randomBytes(6).toString("hex")}`);
+}
+
+// ---------------------------------------------------------------------------
+// Retention / pruning (Issue #2229)
+// ---------------------------------------------------------------------------
+
+type ClassifiedEntry = { name: string; path: string; mtimeMs: number };
+
+type BackupRootClassification = {
+  completed: Array<ClassifiedEntry & { bytes: number }>;
+  partial: ClassifiedEntry[];
+  orphaned: ClassifiedEntry[];
+};
+
+/** List and classify everything directly under the backup root. Never mutates the filesystem. */
+function classifyBackupRoot(root: string): BackupRootClassification {
+  const result: BackupRootClassification = { completed: [], partial: [], orphaned: [] };
+  if (!existsSync(root)) return result;
+
+  let entries: import("node:fs").Dirent[];
+  try {
+    entries = readdirSync(root, { withFileTypes: true });
+  } catch {
+    return result;
+  }
+
+  for (const entry of entries) {
+    const fullPath = join(root, entry.name);
+    let mtimeMs = 0;
+    try {
+      mtimeMs = statSync(fullPath).mtimeMs;
+    } catch {
+      continue; // vanished between readdir and stat; skip
+    }
+    if (entry.isDirectory() && isCompletedBackupDirName(entry.name)) {
+      result.completed.push({ name: entry.name, path: fullPath, mtimeMs, bytes: dirSizeSync(fullPath) });
+    } else if (entry.isDirectory() && isPartialBackupDirName(entry.name)) {
+      result.partial.push({ name: entry.name, path: fullPath, mtimeMs });
+    } else {
+      // Anything else directly under the root — loose files or unrecognized directories (e.g. the
+      // orphaned pre-sync SQLite snapshots reported in #2229) — is neither a completed snapshot
+      // nor an in-progress working dir.
+      result.orphaned.push({ name: entry.name, path: fullPath, mtimeMs });
+    }
+  }
+  return result;
+}
+
+/**
+ * Decide which completed snapshots survive retention. The newest snapshot is always retained,
+ * even if it exceeds retentionAgeDays and even when it's the only one on disk — deleting the
+ * sole valid backup because it aged out would defeat the purpose of having one (#2229).
+ */
+function planRetention(
+  completed: BackupRootClassification["completed"],
+  opts: BackupRetentionOptions,
+): { retain: Set<string>; prune: Set<string> } {
+  const retentionCount = opts.retentionCount ?? DEFAULT_BACKUP_RETENTION_COUNT;
+  const retentionAgeDays = opts.retentionAgeDays ?? DEFAULT_BACKUP_RETENTION_AGE_DAYS;
+  const ageCutoffMs = retentionAgeDays > 0 ? Date.now() - retentionAgeDays * 24 * 60 * 60 * 1000 : null;
+  const sorted = [...completed].sort((a, b) => b.mtimeMs - a.mtimeMs);
+
+  const retain = new Set<string>();
+  const prune = new Set<string>();
+  sorted.forEach((backup, index) => {
+    const isNewest = index === 0;
+    const overCount = retentionCount > 0 && index >= retentionCount;
+    const overAge = ageCutoffMs !== null && backup.mtimeMs < ageCutoffMs;
+    if (!isNewest && (overCount || overAge)) {
+      prune.add(backup.name);
+    } else {
+      retain.add(backup.name);
+    }
+  });
+  return { retain, prune };
+}
+
+/**
+ * Apply bounded retention to a backup root: prunes old completed snapshots per policy, removes
+ * abandoned `.backup-tmp-*` working directories left by a crashed/killed run, and removes stale
+ * orphaned artifacts sitting directly under the root (e.g. legacy loose SQLite files). Only
+ * artifacts older than `partialGraceMs` are ever touched for partial/orphaned cleanup, so a
+ * concurrently running backup's in-progress temp dir is never disturbed.
+ */
+export function pruneBackups(root: string, opts: BackupRetentionOptions = {}): BackupPruneReport {
+  const partialGraceMs = opts.partialGraceMs ?? DEFAULT_PARTIAL_GRACE_MS;
+  const report: BackupPruneReport = {
+    root,
+    retainedCompleted: [],
+    prunedCompleted: [],
+    prunedPartial: [],
+    prunedOrphaned: [],
+    errors: [],
+  };
+  const classified = classifyBackupRoot(root);
+  const now = Date.now();
+
+  const { retain, prune } = planRetention(classified.completed, opts);
+  for (const backup of classified.completed) {
+    if (prune.has(backup.name)) {
+      try {
+        rmSync(backup.path, { recursive: true, force: true });
+        report.prunedCompleted.push(backup.name);
+      } catch (err) {
+        report.errors.push(`Failed to prune old backup ${backup.name}: ${err}`);
+      }
+    } else if (retain.has(backup.name)) {
+      report.retainedCompleted.push(backup.name);
+    }
+  }
+
+  for (const entry of classified.partial) {
+    if (now - entry.mtimeMs < partialGraceMs) continue; // may still be an active run — leave alone
+    try {
+      rmSync(entry.path, { recursive: true, force: true });
+      report.prunedPartial.push(entry.name);
+    } catch (err) {
+      report.errors.push(`Failed to remove stale partial backup ${entry.name}: ${err}`);
+    }
+  }
+
+  for (const entry of classified.orphaned) {
+    if (now - entry.mtimeMs < partialGraceMs) continue;
+    try {
+      const st = statSync(entry.path);
+      if (st.isDirectory()) {
+        rmSync(entry.path, { recursive: true, force: true });
+      } else {
+        unlinkSync(entry.path);
+      }
+      report.prunedOrphaned.push(entry.name);
+    } catch (err) {
+      report.errors.push(`Failed to remove orphaned backup artifact ${entry.name}: ${err}`);
+    }
+  }
+
+  return report;
+}
+
+/** Read-only status/audit summary of a backup root: no filesystem mutation (Issue #2229). */
+export function getBackupStatus(root: string, opts: BackupRetentionOptions = {}): BackupStatusReport {
+  const classified = classifyBackupRoot(root);
+  const { retain } = planRetention(classified.completed, opts);
+  const sorted = [...classified.completed].sort((a, b) => b.mtimeMs - a.mtimeMs);
+  const toEntry = (e: (typeof sorted)[number]): BackupStatusEntry => ({
+    name: e.name,
+    createdAt: new Date(e.mtimeMs).toISOString(),
+    bytes: e.bytes,
+  });
+  return {
+    root,
+    completedCount: classified.completed.length,
+    retainedCount: retain.size,
+    partialCount: classified.partial.length,
+    orphanedCount: classified.orphaned.length,
+    stalePartialCount: classified.partial.length + classified.orphaned.length,
+    totalBytes: classified.completed.reduce((sum, e) => sum + e.bytes, 0),
+    newest: sorted.length > 0 ? toEntry(sorted[0]) : null,
+    oldest: sorted.length > 0 ? toEntry(sorted[sorted.length - 1]) : null,
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Main backup function
 // ---------------------------------------------------------------------------
@@ -175,21 +409,29 @@ function copyDirSync(src: string, dest: string): void {
 /**
  * Create a point-in-time backup of the hybrid-memory data stores.
  * Uses VACUUM INTO for a consistent SQLite copy and recursive copy for LanceDB.
+ *
+ * Atomicity (#2229): all copying happens inside a hidden `.backup-tmp-*` working directory. Only
+ * once every step (SQLite, LanceDB, manifest) has succeeded is that directory atomically renamed
+ * to the final timestamped name. A crash or kill at any point before that rename leaves only the
+ * hidden temp dir behind — never a directory that looks like a completed snapshot — so pruning
+ * and status tooling can never mistake a partial backup for a verified one.
  */
 export async function runBackup(ctx: BackupContext): Promise<BackupCliResult> {
   const start = Date.now();
   const root = ctx.backupDir ?? defaultBackupRoot();
-  const dest = timestampedDir(root);
+  const finalDest = timestampedDir(root);
+  const dest = tempBackupDir(root);
 
   try {
     mkdirSync(dest, { recursive: true });
   } catch (err) {
-    return { ok: false, error: `Failed to create backup directory ${dest}: ${err}` };
+    return { ok: false, error: `Failed to create backup directory ${finalDest}: ${err}` };
   }
 
-  /** Remove the half-written backup directory before reporting a failure — otherwise a stale,
-   * incomplete backup (e.g. valid memory.db but missing/partial lancedb) is left on disk looking
-   * like a legitimate timestamped backup, with no marker that it's incomplete. */
+  /** Remove the half-written working directory before reporting a failure — otherwise a stale,
+   * incomplete backup (e.g. valid memory.db but missing/partial lancedb) is left on disk. Because
+   * this directory never reached its final (non-`.backup-tmp-*`) name, it can never be mistaken
+   * for a legitimate completed snapshot even if this best-effort cleanup itself fails. */
   const cleanupAndFail = (error: string): { ok: false; error: string } => {
     try {
       rmSync(dest, { recursive: true, force: true });
@@ -283,10 +525,35 @@ export async function runBackup(ctx: BackupContext): Promise<BackupCliResult> {
     });
   }
 
+  // Atomic promotion (#2229): only after every step above succeeded does the working directory
+  // become a real, discoverable snapshot. If this rename itself fails (e.g. disk full), the
+  // backup did not complete — clean up and report failure rather than leaving a dangling temp dir.
+  try {
+    renameSync(dest, finalDest);
+  } catch (err) {
+    capturePluginError(err instanceof Error ? err : new Error(String(err)), {
+      subsystem: "backup",
+      operation: "finalize-backup",
+    });
+    return cleanupAndFail(`Failed to finalize backup directory: ${err}`);
+  }
+
+  // Bounded retention (#2229): best-effort, never blocks reporting success even if pruning fails.
+  if (ctx.retention) {
+    const pruneReport = pruneBackups(root, ctx.retention);
+    if (pruneReport.errors.length > 0) {
+      capturePluginError(new Error(pruneReport.errors.join("; ")), {
+        subsystem: "backup",
+        operation: "prune-backups",
+        severity: "warning",
+      });
+    }
+  }
+
   const durationMs = Date.now() - start;
   return {
     ok: true,
-    backupDir: dest,
+    backupDir: finalDest,
     sqliteSize,
     lancedbSize,
     durationMs,

--- a/extensions/memory-hybrid/cli/cmd-health.ts
+++ b/extensions/memory-hybrid/cli/cmd-health.ts
@@ -8,6 +8,12 @@ import type { FactsDB } from "../backends/facts-db.js";
 import type { VectorDB } from "../backends/vector-db.js";
 import type { WriteAheadLog } from "../backends/wal.js";
 import type { HybridMemoryConfig } from "../config.js";
+import {
+  DEFAULT_BACKUP_HEALTH_ALERT_POLICY,
+  defaultBackupStateFilePath,
+  evaluateBackupHealth,
+  readBackupStateFile,
+} from "../services/backup-health.js";
 import { getWalCircuitBreakerState } from "../services/wal-helpers.js";
 import { detectAvailableProviders } from "../utils/provider-detection.js";
 import { formatBytes, WAL_SIZE_WARN_BYTES } from "../utils/format.js";
@@ -274,6 +280,32 @@ export function registerHealthCommand(
           status: "warn",
           detail: "Could not inspect vector bounds",
         });
+      }
+
+      // Backup health (Issue #2230): surface a failed/stale backup as a traffic-light indicator.
+      try {
+        const backupHealth = evaluateBackupHealth(
+          readBackupStateFile(defaultBackupStateFilePath()),
+          Date.now(),
+          cfg.maintenance?.backup?.alerting ?? DEFAULT_BACKUP_HEALTH_ALERT_POLICY,
+        );
+        if (backupHealth.status === "ok") {
+          indicators.push({
+            name: "Backup",
+            status: "good",
+            detail: backupHealth.lastSuccessAt ? `last success ${backupHealth.lastSuccessAt}` : "ok",
+          });
+        } else if (backupHealth.status === "unknown") {
+          indicators.push({ name: "Backup", status: "warn", detail: "no backup has run yet" });
+        } else {
+          indicators.push({
+            name: "Backup",
+            status: backupHealth.status === "failed" ? "error" : "warn",
+            detail: `${backupHealth.status}${backupHealth.reasonCategory ? ` (${backupHealth.reasonCategory})` : ""}, last success ${backupHealth.lastSuccessAt ?? "never"}`,
+          });
+        }
+      } catch (_error) {
+        indicators.push({ name: "Backup", status: "warn", detail: "Could not read backup state" });
       }
 
       // Overall status — computed once so --json reflects the same exit code as human-readable output.

--- a/extensions/memory-hybrid/cli/commands/manage/maintenance-step-runners.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/maintenance-step-runners.ts
@@ -13,6 +13,11 @@ import { getCronModelConfig, getDefaultCronModel } from "../../../config.js";
 import { runAffectStamp } from "../../../services/affect-stamping.js";
 import { runAutoClassify } from "../../../services/auto-classifier.js";
 import {
+  DEFAULT_BACKUP_HEALTH_ALERT_POLICY,
+  defaultBackupStateFilePath,
+  evaluateAndMaybeAlertBackupHealth,
+} from "../../../services/backup-health.js";
+import {
   DEFAULT_AMBIGUOUS_BACKLOG_DEGRADED_THRESHOLD,
   ORCHESTRATOR_CONTRADICTION_DEGRADED_CONSECUTIVE_THRESHOLD,
   runContradictionMaintenanceAutoStep,
@@ -887,17 +892,27 @@ export function buildCliMaintenanceRunners(
   });
 
   set("audit-health", async () => {
+    // Heartbeat/maintenance backup health alert (Issue #2230): this weekly cron step is the
+    // actual "heartbeat" tick, so it's the one place that fires the deduplicated alert (dedup
+    // window from maintenance.backup.alerting.dedupeWindowHours) — the one-shot `audit health`
+    // CLI stays read-only and only surfaces the current status.
+    const backupAlert = evaluateAndMaybeAlertBackupHealth(
+      defaultBackupStateFilePath(),
+      b.cfg.maintenance?.backup?.alerting ?? DEFAULT_BACKUP_HEALTH_ALERT_POLICY,
+    );
     const report = buildAuditHealthReport(
       b.factsDb,
       b.getMemoryCategories,
       b.cfg.entityExtraction?.stopWords ?? [],
       b.cfg.graph?.hubDegreeCap,
+      { backupHealth: backupAlert.health },
     );
     if (report.errorCount > 0) {
       throw new Error(`${report.errorCount} error(s) present`);
     }
     const semantic = report.warningCount > 0 ? "monitoring" : "success";
-    return `warnings=${report.warningCount} errors=${report.errorCount} semantic=${semantic}`;
+    const backupNote = backupAlert.alerted ? ` backupAlert=${backupAlert.health.status}` : "";
+    return `warnings=${report.warningCount} errors=${report.errorCount} semantic=${semantic}${backupNote}`;
   });
 
   set("crystallization-rescan", async () => {

--- a/extensions/memory-hybrid/cli/commands/manage/register-procedure-lifecycle.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/register-procedure-lifecycle.ts
@@ -9,6 +9,22 @@ import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 
 import type { LoomStore } from "../../../backends/loom-store.js";
+import type { HybridMemoryConfig } from "../../../config.js";
+import { formatBytes } from "../../../utils/format.js";
+import {
+  DEFAULT_BACKUP_RETENTION_AGE_DAYS,
+  DEFAULT_BACKUP_RETENTION_COUNT,
+  getBackupStatus,
+  pruneBackups,
+  type BackupRetentionOptions,
+} from "../../backup.js";
+import {
+  type BackupHealthAlertPolicy,
+  DEFAULT_BACKUP_HEALTH_ALERT_POLICY,
+  defaultBackupStateFilePath,
+  evaluateAndMaybeAlertBackupHealth,
+  recordBackupOutcome,
+} from "../../../services/backup-health.js";
 import { capturePluginError } from "../../../services/error-reporter.js";
 import {
   createProcedurePromotionItem,
@@ -33,6 +49,23 @@ import type { ManageBindings } from "./bindings.js";
 function shellQuotePathForCron(path: string): string {
   if (/^[\w@%+./:-]+$/.test(path)) return path;
   return `'${path.replace(/'/g, `'\\''`)}'`;
+}
+
+/**
+ * Resolve backup retention options from config, tolerating a partial/mocked `cfg.maintenance`
+ * (e.g. narrow test harnesses that only stub the bindings a given test exercises) by falling
+ * back to the same defaults the config parser applies.
+ */
+function resolveBackupRetentionOptions(cfg: Pick<HybridMemoryConfig, "maintenance">): BackupRetentionOptions {
+  return {
+    retentionCount: cfg.maintenance?.backup?.retentionCount ?? DEFAULT_BACKUP_RETENTION_COUNT,
+    retentionAgeDays: cfg.maintenance?.backup?.retentionAgeDays ?? DEFAULT_BACKUP_RETENTION_AGE_DAYS,
+  };
+}
+
+/** Resolve the backup health alerting policy from config, with the same partial-config tolerance. */
+function resolveBackupAlertPolicy(cfg: Pick<HybridMemoryConfig, "maintenance">): BackupHealthAlertPolicy {
+  return cfg.maintenance?.backup?.alerting ?? DEFAULT_BACKUP_HEALTH_ALERT_POLICY;
 }
 
 /** Ranked procedure triage (#2147) persists decisions in the Loom store. */
@@ -525,9 +558,9 @@ export function registerManageProcedureAndLifecycle(mem: Chainable, b: ManageBin
         console.log("Creating memory backup…");
         const res = await runBackup({ backupDir: opts?.dest });
 
-        // State file path for heartbeat monitoring (Issue #276, Gap 5)
-        const stateDir = join(homedir(), ".openclaw", "state");
-        const backupStateFile = join(stateDir, "memory-backup-last.json");
+        // State file for heartbeat monitoring + health alerting (Issue #276 Gap 5; #2229/#2230).
+        const backupStateFile = defaultBackupStateFilePath();
+        const alertPolicy = resolveBackupAlertPolicy(cfg);
 
         if (res.ok) {
           const sqliteKb = (res.sqliteSize / 1024).toFixed(1);
@@ -547,52 +580,102 @@ export function registerManageProcedureAndLifecycle(mem: Chainable, b: ManageBin
               `⚠ SQLite and LanceDB snapshots were taken ${res.snapshotSkewMs}ms apart; a write during that window may not be reflected consistently in both halves.`,
             );
           }
-          // Record successful backup state for heartbeat monitoring
-          try {
-            mkdirSync(stateDir, { recursive: true });
-            writeFileSync(
-              backupStateFile,
-              `${JSON.stringify(
-                {
-                  ok: true,
-                  timestamp: nowIso(),
-                  backupDir: res.backupDir,
-                  sqliteSize: res.sqliteSize,
-                  lancedbSize: res.lancedbSize,
-                  durationMs: res.durationMs,
-                  integrityOk: res.integrityOk,
-                  snapshotSkewMs: res.snapshotSkewMs,
-                },
-                null,
-                2,
-              )}\n`,
-            );
-          } catch {
-            // Non-fatal — state file is advisory only
-          }
+          recordBackupOutcome(backupStateFile, {
+            ok: true,
+            timestamp: nowIso(),
+            backupDir: res.backupDir,
+            sqliteSize: res.sqliteSize,
+            lancedbSize: res.lancedbSize,
+            durationMs: res.durationMs,
+            integrityOk: res.integrityOk,
+            snapshotSkewMs: res.snapshotSkewMs,
+          });
+          // A fresh success supersedes any stale failure/alert state (#2230) — nothing further to do.
         } else {
           console.error(`✗ Backup failed: ${res.error}`);
-          // Write failure state so heartbeat monitoring can detect and alert (Issue #276, Gap 5)
-          try {
-            mkdirSync(stateDir, { recursive: true });
-            writeFileSync(
-              backupStateFile,
-              `${JSON.stringify(
-                {
-                  ok: false,
-                  timestamp: nowIso(),
-                  error: res.error,
-                },
-                null,
-                2,
-              )}\n`,
-            );
-            console.error(`  ⚠ Backup failure recorded to: ${backupStateFile}`);
-            console.error("  Add to HEARTBEAT.md to get alerted:");
-            console.error("    Check ~/.openclaw/state/memory-backup-last.json — if ok=false, alert Markus.");
-          } catch {
-            // Non-fatal
+          recordBackupOutcome(backupStateFile, { ok: false, timestamp: nowIso(), error: res.error });
+          console.error(`  ⚠ Backup failure recorded to: ${backupStateFile}`);
+          const { alerted, alertMessage } = evaluateAndMaybeAlertBackupHealth(backupStateFile, alertPolicy);
+          if (alerted && alertMessage) {
+            console.error("");
+            console.error(alertMessage);
           }
+          process.exitCode = 1;
+        }
+      }),
+    );
+
+  backup
+    .command("status")
+    .description(
+      "Backup retention + health audit: completed/retained/stale-partial snapshot counts, bytes, and last success/failure (Issues #2229, #2230).",
+    )
+    .option("--dest <dir>", "Backup root to inspect (default: ~/.openclaw/backups/memory/)")
+    .option("--json", "Emit JSON")
+    .action(
+      withExit(async (opts?: { dest?: string; json?: boolean }) => {
+        const root = opts?.dest ?? join(homedir(), ".openclaw", "backups", "memory");
+        const retentionOpts = resolveBackupRetentionOptions(cfg);
+        const status = getBackupStatus(root, retentionOpts);
+        const stateFile = defaultBackupStateFilePath();
+        const health = evaluateAndMaybeAlertBackupHealth(stateFile, {
+          ...resolveBackupAlertPolicy(cfg),
+          enabled: false, // status is a read-only audit view — never fire an alert as a side effect
+        }).health;
+
+        if (opts?.json) {
+          console.log(JSON.stringify({ retention: retentionOpts, status, health }, null, 2));
+          return;
+        }
+
+        console.log(`# Backup status (${root})`);
+        console.log("");
+        console.log(`Completed snapshots: ${status.completedCount} (retained by policy: ${status.retainedCount})`);
+        console.log(`Stale/partial artifacts: ${status.stalePartialCount} (partial=${status.partialCount}, orphaned=${status.orphanedCount})`);
+        console.log(`Total bytes (completed): ${formatBytes(status.totalBytes)}`);
+        if (status.newest) console.log(`Newest: ${status.newest.name} (${formatBytes(status.newest.bytes)})`);
+        if (status.oldest) console.log(`Oldest: ${status.oldest.name} (${formatBytes(status.oldest.bytes)})`);
+        console.log("");
+        console.log(`Health: ${health.status}${health.reasonCategory ? ` (${health.reasonCategory})` : ""}`);
+        console.log(`Last verified success: ${health.lastSuccessAt ?? "never"}`);
+        if (health.lastFailureAt) console.log(`Last failure: ${health.lastFailureAt} (consecutive: ${health.consecutiveFailures})`);
+        if (health.ageSinceLastSuccessHours !== null) {
+          console.log(`Age since last success: ${health.ageSinceLastSuccessHours.toFixed(1)}h`);
+        }
+        if (health.remediation.length > 0) {
+          console.log("Next remediation:");
+          for (const r of health.remediation) console.log(`  - ${r}`);
+        }
+        if (status.stalePartialCount > 0) {
+          console.log(`Run \`openclaw hybrid-mem backup prune --dest ${root}\` to clean up stale/partial artifacts.`);
+        }
+        if (health.status === "failed" || health.status === "stale") process.exitCode = 1;
+      }),
+    );
+
+  backup
+    .command("prune")
+    .description(
+      "Deterministically clean up stale/partial backup artifacts and enforce retention (Issue #2229). Never deletes the newest completed snapshot.",
+    )
+    .option("--dest <dir>", "Backup root to prune (default: ~/.openclaw/backups/memory/)")
+    .option("--json", "Emit JSON")
+    .action(
+      withExit(async (opts?: { dest?: string; json?: boolean }) => {
+        const root = opts?.dest ?? join(homedir(), ".openclaw", "backups", "memory");
+        const report = pruneBackups(root, resolveBackupRetentionOptions(cfg));
+        if (opts?.json) {
+          console.log(JSON.stringify(report, null, 2));
+          if (report.errors.length > 0) process.exitCode = 1;
+          return;
+        }
+        console.log(`Retained: ${report.retainedCompleted.length}`);
+        console.log(`Pruned completed (retention): ${report.prunedCompleted.length}`);
+        console.log(`Pruned partial (abandoned runs): ${report.prunedPartial.length}`);
+        console.log(`Pruned orphaned artifacts: ${report.prunedOrphaned.length}`);
+        if (report.errors.length > 0) {
+          console.log("Errors:");
+          for (const e of report.errors) console.log(`  - ${e}`);
           process.exitCode = 1;
         }
       }),
@@ -683,8 +766,13 @@ export function registerManageProcedureAndLifecycle(mem: Chainable, b: ManageBin
           console.log(`  Log: ${logFile}`);
           console.log(`  State: ${join(homedir(), ".openclaw", "state", "memory-backup-last.json")}`);
           console.log("");
-          console.log("Add to HEARTBEAT.md to get alerted on failure:");
-          console.log("  Check ~/.openclaw/state/memory-backup-last.json — if ok=false, alert Markus.");
+          console.log(
+            "Backup health is monitored automatically: `openclaw hybrid-mem health` and `audit health`\n" +
+              "surface a failed/stale backup, and the weekly audit-health maintenance job fires a\n" +
+              "deduplicated alert (see maintenance.backup.alerting in config; docs/BACKUP.md). You can also\n" +
+              "add a manual HEARTBEAT.md check as a belt-and-suspenders fallback:\n" +
+              "  Check ~/.openclaw/state/memory-backup-last.json — if ok=false, alert Markus.",
+          );
         } catch (err) {
           console.error(`✗ Failed to install crontab: ${err}`);
           console.log("");

--- a/extensions/memory-hybrid/cli/commands/manage/register-procedure-lifecycle.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/register-procedure-lifecycle.ts
@@ -631,14 +631,17 @@ export function registerManageProcedureAndLifecycle(mem: Chainable, b: ManageBin
         console.log(`# Backup status (${root})`);
         console.log("");
         console.log(`Completed snapshots: ${status.completedCount} (retained by policy: ${status.retainedCount})`);
-        console.log(`Stale/partial artifacts: ${status.stalePartialCount} (partial=${status.partialCount}, orphaned=${status.orphanedCount})`);
+        console.log(
+          `Stale/partial artifacts: ${status.stalePartialCount} (partial=${status.partialCount}, orphaned=${status.orphanedCount})`,
+        );
         console.log(`Total bytes (completed): ${formatBytes(status.totalBytes)}`);
         if (status.newest) console.log(`Newest: ${status.newest.name} (${formatBytes(status.newest.bytes)})`);
         if (status.oldest) console.log(`Oldest: ${status.oldest.name} (${formatBytes(status.oldest.bytes)})`);
         console.log("");
         console.log(`Health: ${health.status}${health.reasonCategory ? ` (${health.reasonCategory})` : ""}`);
         console.log(`Last verified success: ${health.lastSuccessAt ?? "never"}`);
-        if (health.lastFailureAt) console.log(`Last failure: ${health.lastFailureAt} (consecutive: ${health.consecutiveFailures})`);
+        if (health.lastFailureAt)
+          console.log(`Last failure: ${health.lastFailureAt} (consecutive: ${health.consecutiveFailures})`);
         if (health.ageSinceLastSuccessHours !== null) {
           console.log(`Age since last success: ${health.ageSinceLastSuccessHours.toFixed(1)}h`);
         }

--- a/extensions/memory-hybrid/cli/commands/manage/register-storage-graph-audit.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/register-storage-graph-audit.ts
@@ -11,6 +11,12 @@ import { DASHBOARD_TIER_FILTER } from "../../../backends/facts-db/stats.js";
 import { hasAnyScopeFilter } from "../../../backends/scope-filter-sql.js";
 import { isValidCategory } from "../../../config.js";
 import { buildAuditFailureArtifact, buildAuditHealthExitInfo } from "../../../services/audit-health-exit-info.js";
+import {
+  DEFAULT_BACKUP_HEALTH_ALERT_POLICY,
+  defaultBackupStateFilePath,
+  evaluateBackupHealth,
+  readBackupStateFile,
+} from "../../../services/backup-health.js";
 import { listDumpTypeAliases, runSqliteTableDump } from "../../../services/cli-sql-dump.js";
 import {
   decideDiscoveredCategory,
@@ -236,6 +242,14 @@ export function registerManageStorageGraphAudit(mem: Chainable, b: ManageBinding
       const lastReembedProgress = ctx.resolvedSqlitePath
         ? readReembedVectorlessMetrics(defaultReembedVectorlessMetricsPath(ctx.resolvedSqlitePath))
         : null;
+      // Read-only backup health snapshot (Issue #2230) — `audit health` is documented as
+      // one-shot/non-destructive, so this never fires the deduplicated alert itself (that's the
+      // weekly `audit-health` maintenance cron step's job); it only surfaces current status.
+      const backupHealth = evaluateBackupHealth(
+        readBackupStateFile(defaultBackupStateFilePath()),
+        Date.now(),
+        cfg.maintenance?.backup?.alerting ?? DEFAULT_BACKUP_HEALTH_ALERT_POLICY,
+      );
       const report = buildAuditHealthReport(
         factsDb,
         getMemoryCategories,
@@ -265,6 +279,7 @@ export function registerManageStorageGraphAudit(mem: Chainable, b: ManageBinding
                 ).getDegradedState()
               : { active: false, reason: null },
           lastReembedProgress,
+          backupHealth,
         },
       );
       // #2226: a false/degraded graph-schema check previously never reached GlitchTip or a

--- a/extensions/memory-hybrid/cli/commands/manage/storage-stats-helpers.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/storage-stats-helpers.ts
@@ -8,6 +8,7 @@ import { dirname, join } from "node:path";
 import type { GraphSchemaSnapshot } from "../../../backends/facts-db/housekeeping.js";
 import type { GraphConnectedStats } from "../../../backends/facts-db/links.js";
 import type { ProcedurePromotionBlockReason } from "../../../backends/facts-db/procedures.js";
+import type { BackupHealthStatus } from "../../../services/backup-health.js";
 import { expandGraph, type GraphExpansionStats, resolveGraphHubDegreeCap } from "../../../services/graph-retrieval.js";
 import type { MemoryEntry, ScopeFilter } from "../../../types/memory.js";
 import { nowIso } from "../../../utils/dates.js";
@@ -568,6 +569,8 @@ export type AuditHealthReport = {
     entryCount: number;
     migrationRequired: boolean;
   } | null;
+  /** Backup health summary (Issue #2230). Null when no backup state file has ever been written. */
+  backupHealth: BackupHealthStatus | null;
   /** Optional operator budget used for audit-health command execution. */
   timeoutMs?: number;
   /** Elapsed wall-clock time spent building the report. */
@@ -605,6 +608,8 @@ export function buildAuditHealthReport(
       migrationRequired: boolean;
     } | null;
     lastReembedProgress?: ReembedVectorlessLastRunMetrics | null;
+    /** Backup health summary (Issue #2230), pre-computed by the caller (read-only, non-mutating). */
+    backupHealth?: BackupHealthStatus | null;
   },
 ): AuditHealthReport {
   const startedAtMs = options?.startedAtMs ?? Date.now();
@@ -1076,6 +1081,19 @@ export function buildAuditHealthReport(
     );
   }
 
+  // Backup health (Issue #2230): surface a failed/stale backup directly in the audit-health report.
+  const backupHealth = options?.backupHealth ?? null;
+  if (backupHealth && (backupHealth.status === "failed" || backupHealth.status === "stale")) {
+    const ageNote =
+      backupHealth.ageSinceLastSuccessHours !== null
+        ? ` (last verified success ${backupHealth.ageSinceLastSuccessHours.toFixed(1)}h ago)`
+        : " (no verified success on record)";
+    warnings.push(
+      `Backup health is ${backupHealth.status}${backupHealth.reasonCategory ? ` (${backupHealth.reasonCategory})` : ""}${ageNote}.`,
+    );
+    remediation.push(...backupHealth.remediation);
+  }
+
   // #1806: entity enrichment backlog — warn when eta_runs exceeds threshold.
   const ENTITY_ENRICHMENT_DEFAULT_LIMIT = 200;
   const ENTITY_ENRICHMENT_ETA_WARN_THRESHOLD = 100;
@@ -1199,6 +1217,7 @@ export function buildAuditHealthReport(
     remediation,
     errors,
     credentials: options?.credentialsStatus ?? null,
+    backupHealth,
     timeoutMs: options?.timeoutMs,
     elapsedMs: Date.now() - startedAtMs,
   };
@@ -1320,6 +1339,13 @@ export function printAuditHealthMarkdown(report: AuditHealthReport): void {
       ? `encrypted (kdf_version=${c.kdfVersion})`
       : `plaintext (kdf_version=${c.kdfVersion})`;
     console.log(`Credentials vault: ${encLabel}, entries=${c.entryCount}, migration_required=${c.migrationRequired}`);
+  }
+  if (report.backupHealth != null) {
+    const bh = report.backupHealth;
+    const age = bh.ageSinceLastSuccessHours !== null ? `${bh.ageSinceLastSuccessHours.toFixed(1)}h ago` : "never";
+    console.log(
+      `Backup health: ${bh.status}${bh.reasonCategory ? ` (${bh.reasonCategory})` : ""}, last success=${age}, consecutive_failures=${bh.consecutiveFailures}`,
+    );
   }
   console.log("");
   if (report.errors.length > 0) {

--- a/extensions/memory-hybrid/config/parsers/maintenance.ts
+++ b/extensions/memory-hybrid/config/parsers/maintenance.ts
@@ -1,6 +1,7 @@
 import { pluginLogger } from "../../utils/logger.js";
 
 import type {
+  BackupMaintenanceConfig,
   CouncilConfig,
   CouncilProvenanceMode,
   CronReliabilityConfig,
@@ -186,6 +187,34 @@ function parseCronReliabilityConfig(cfg: Record<string, unknown>): CronReliabili
   };
 }
 
+/** Backup artifact retention + health alerting (Issues #2229, #2230). */
+function parseBackupMaintenanceConfig(cfg: Record<string, unknown>): BackupMaintenanceConfig {
+  const maintenanceRaw = cfg.maintenance as Record<string, unknown> | undefined;
+  const backupRaw = maintenanceRaw?.backup as Record<string, unknown> | undefined;
+  const alertingRaw = backupRaw?.alerting as Record<string, unknown> | undefined;
+  return {
+    retentionCount:
+      typeof backupRaw?.retentionCount === "number" && backupRaw.retentionCount >= 0
+        ? Math.floor(backupRaw.retentionCount)
+        : 7,
+    retentionAgeDays:
+      typeof backupRaw?.retentionAgeDays === "number" && backupRaw.retentionAgeDays >= 0
+        ? Math.floor(backupRaw.retentionAgeDays)
+        : 30,
+    alerting: {
+      enabled: alertingRaw?.enabled !== false,
+      staleAfterHours:
+        typeof alertingRaw?.staleAfterHours === "number" && alertingRaw.staleAfterHours > 0
+          ? Math.floor(alertingRaw.staleAfterHours)
+          : 192,
+      dedupeWindowHours:
+        typeof alertingRaw?.dedupeWindowHours === "number" && alertingRaw.dedupeWindowHours >= 0
+          ? Math.floor(alertingRaw.dedupeWindowHours)
+          : 24,
+    },
+  };
+}
+
 function parseMaintenanceFailureReportingConfig(cfg: Record<string, unknown>): MaintenanceFailureReportingConfig {
   const maintenanceRaw = cfg.maintenance as Record<string, unknown> | undefined;
   const failureReportingRaw = maintenanceRaw?.failureReporting as Record<string, unknown> | undefined;
@@ -299,6 +328,7 @@ export function parseMaintenanceConfig(cfg: Record<string, unknown>): Maintenanc
   return {
     monthlyReview,
     cronReliability: parseCronReliabilityConfig(cfg),
+    backup: parseBackupMaintenanceConfig(cfg),
     failureReporting: parseMaintenanceFailureReportingConfig(cfg),
     privacyRedaction: parseMaintenancePrivacyRedactionConfig(cfg),
     council: parseCouncilConfig(cfg),

--- a/extensions/memory-hybrid/config/types/maintenance.ts
+++ b/extensions/memory-hybrid/config/types/maintenance.ts
@@ -191,6 +191,8 @@ export type MaintenanceConfig = {
   monthlyReview: MonthlyReviewConfig;
   /** Cron reliability settings for memory maintenance jobs (Issue #281). */
   cronReliability: CronReliabilityConfig;
+  /** Backup artifact retention + health alerting (Issues #2229, #2230). */
+  backup: BackupMaintenanceConfig;
   /** Grouped GlitchTip/Sentry-compatible reporting for maintenance failures (Issue #1836). */
   failureReporting: MaintenanceFailureReportingConfig;
   /** Redaction of emails/paths/private-IPs from maintenance-extracted fact text (Issue #2055). */
@@ -280,4 +282,39 @@ export type CronReliabilityConfig = {
    * Applies only to daily/nightly jobs; weekly jobs use 7 days.
    */
   staleThresholdHours: number;
+};
+
+/**
+ * Backup health alerting policy (Issue #2230): when a failed/stale backup should escalate
+ * to a deduplicated operator alert via the error reporter.
+ */
+export type BackupAlertingConfig = {
+  /** Emit a deduplicated alert when backup health degrades (default: true). */
+  enabled: boolean;
+  /**
+   * Hours since the last verified successful backup after which the backup is considered
+   * stale even without an explicit failed run (default: 192 = 8 days — one day of grace past
+   * the default weekly cron cadence).
+   */
+  staleAfterHours: number;
+  /**
+   * Minimum hours between repeated alerts for the same persisting failure/staleness
+   * fingerprint (default: 24) — mirrors the bounded-window dedup pattern in
+   * services/error-reporter.ts so a stuck failure doesn't spam on every heartbeat/cron tick.
+   */
+  dedupeWindowHours: number;
+};
+
+/**
+ * Bounded retention + safe cleanup for hybrid-memory backup artifacts (Issue #2229).
+ * Applied after every successful `hybrid-mem backup` run and available on demand via
+ * `hybrid-mem backup prune` / `hybrid-mem backup status`.
+ */
+export type BackupMaintenanceConfig = {
+  /** Max number of completed backup snapshots to retain (default: 7). 0 disables count-based pruning. */
+  retentionCount: number;
+  /** Max age in days a completed snapshot may reach before it's eligible for pruning (default: 30). 0 disables age-based pruning. */
+  retentionAgeDays: number;
+  /** Backup health/heartbeat alerting policy (Issue #2230). */
+  alerting: BackupAlertingConfig;
 };

--- a/extensions/memory-hybrid/docs/QUICK-START.md
+++ b/extensions/memory-hybrid/docs/QUICK-START.md
@@ -185,7 +185,21 @@ openclaw hybrid-mem backup
 
 # Verify database integrity
 openclaw hybrid-mem backup verify
+
+# Backup retention + health audit: completed/retained/stale counts, bytes, last success/failure
+openclaw hybrid-mem backup status
+
+# Deterministically clean up stale/partial artifacts and enforce retention
+openclaw hybrid-mem backup prune
 ```
+
+Every successful `backup` run automatically prunes older completed snapshots per
+`maintenance.backup.retentionCount` / `retentionAgeDays` (default: keep the 7 newest, or any
+snapshot newer than 30 days — the single newest snapshot is always kept even if it's the only
+one and has aged out). Backups are written atomically: a crash mid-backup never leaves a
+half-written directory that looks like a completed snapshot. See
+[`../../../docs/OPERATIONS.md`](../../../docs/OPERATIONS.md) for the full retention/health-alerting
+reference.
 
 ---
 

--- a/extensions/memory-hybrid/services/backup-health.ts
+++ b/extensions/memory-hybrid/services/backup-health.ts
@@ -1,0 +1,307 @@
+/**
+ * Backup health / heartbeat alerting (Issue #2230).
+ *
+ * `hybrid-mem backup` records its outcome to `~/.openclaw/state/memory-backup-last.json`
+ * (Issue #276, Gap 5). This module turns that state file into an actionable health signal:
+ *  - `evaluateBackupHealth` classifies the current state (ok / failed / stale / unknown), the
+ *    failure reason category, and age since the last verified success — pure, no I/O.
+ *  - `recordBackupOutcome` persists a fresh outcome from an actual `runBackup()` call, carrying
+ *    forward `lastSuccessAt` / consecutive-failure bookkeeping across runs.
+ *  - `evaluateAndMaybeAlertBackupHealth` re-reads the state file and, when health is degraded,
+ *    fires a deduplicated alert via the existing error-reporter pipeline — mirroring the
+ *    fingerprint + time-window dedup pattern in services/error-reporter.ts so a persisting
+ *    failure doesn't spam on every heartbeat/cron tick. A later success naturally clears the
+ *    dedup fingerprint (it's simply absent from the fresh success record), so the very next
+ *    failure alerts immediately instead of staying suppressed by a stale window.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { capturePluginError } from "./error-reporter.js";
+import { atomicWriteFile } from "../utils/atomic-write.js";
+
+export type BackupFailureReasonCategory =
+  | "disk_full"
+  | "permission_denied"
+  | "path_not_found"
+  | "integrity_check_failed"
+  | "unknown";
+
+/** Categorize a raw backup error message for actionable, non-sensitive remediation guidance. */
+export function classifyBackupFailureReason(errorMessage: string | null | undefined): BackupFailureReasonCategory {
+  const msg = (errorMessage ?? "").toLowerCase();
+  if (!msg) return "unknown";
+  if (msg.includes("disk is full") || msg.includes("enospc") || msg.includes("no space left")) return "disk_full";
+  if (msg.includes("eacces") || msg.includes("eperm") || msg.includes("permission denied")) return "permission_denied";
+  if (msg.includes("enoent") || msg.includes("no such file") || msg.includes("not found")) return "path_not_found";
+  if (msg.includes("integrity")) return "integrity_check_failed";
+  return "unknown";
+}
+
+/** Persisted shape of `~/.openclaw/state/memory-backup-last.json`. */
+export type BackupStateFile = {
+  ok: boolean;
+  timestamp: string;
+  error?: string;
+  reasonCategory?: BackupFailureReasonCategory;
+  backupDir?: string;
+  sqliteSize?: number;
+  lancedbSize?: number;
+  durationMs?: number;
+  integrityOk?: boolean;
+  snapshotSkewMs?: number;
+  /** ISO timestamp of the most recent successful run, carried forward across failures. */
+  lastSuccessAt?: string;
+  /** Consecutive failed runs since the last success. */
+  consecutiveFailures?: number;
+  /** Bookkeeping for alert dedup — when a matching alert was last actually emitted. */
+  lastAlertedAt?: string;
+  /** Bookkeeping for alert dedup — fingerprint (`status:reasonCategory`) of the last emitted alert. */
+  lastAlertedFingerprint?: string;
+};
+
+export type BackupHealthAlertPolicy = {
+  enabled: boolean;
+  /** Hours since last verified success after which the backup is stale even without a fresh failure. */
+  staleAfterHours: number;
+  /** Minimum hours between repeated alerts for the same persisting fingerprint. */
+  dedupeWindowHours: number;
+};
+
+/** Mirrors the config parser's defaults (config/parsers/maintenance.ts) for callers that may see a
+ * partial/mocked config (e.g. tests) without a fully-parsed `maintenance.backup.alerting`. */
+export const DEFAULT_BACKUP_HEALTH_ALERT_POLICY: BackupHealthAlertPolicy = {
+  enabled: true,
+  staleAfterHours: 192,
+  dedupeWindowHours: 24,
+};
+
+export type BackupHealthStatus = {
+  status: "ok" | "failed" | "stale" | "unknown";
+  reasonCategory: BackupFailureReasonCategory | null;
+  lastSuccessAt: string | null;
+  lastFailureAt: string | null;
+  ageSinceLastSuccessHours: number | null;
+  consecutiveFailures: number;
+  remediation: string[];
+};
+
+export function defaultBackupStateFilePath(): string {
+  return join(homedir(), ".openclaw", "state", "memory-backup-last.json");
+}
+
+export function readBackupStateFile(path: string): BackupStateFile | null {
+  if (!existsSync(path)) return null;
+  try {
+    const raw = readFileSync(path, "utf-8");
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== "object") return null;
+    return parsed as BackupStateFile;
+  } catch {
+    return null;
+  }
+}
+
+function remediationFor(status: BackupHealthStatus["status"], reason: BackupFailureReasonCategory | null): string[] {
+  if (status === "failed") {
+    switch (reason) {
+      case "disk_full":
+        return [
+          "Free disk space on the backup volume (check `df -h`) or lower maintenance.backup.retentionCount / retentionAgeDays, then re-run `openclaw hybrid-mem backup`.",
+        ];
+      case "permission_denied":
+        return [
+          "Check filesystem permissions on the backup destination directory, then re-run `openclaw hybrid-mem backup`.",
+        ];
+      case "path_not_found":
+        return ["Verify the configured backup destination path exists and is reachable, then re-run the backup."];
+      case "integrity_check_failed":
+        return [
+          "SQLite integrity check failed on the source database before backup ran. Run `openclaw hybrid-mem backup verify` and consider restoring from an earlier snapshot.",
+        ];
+      default:
+        return ["Re-run `openclaw hybrid-mem backup` and check ~/.openclaw/logs/backup.log for details."];
+    }
+  }
+  if (status === "stale") {
+    return [
+      "Run `openclaw hybrid-mem backup` now and confirm the weekly cron is installed (`openclaw hybrid-mem backup schedule`).",
+    ];
+  }
+  if (status === "unknown") {
+    return ["No backup has run yet. Run `openclaw hybrid-mem backup` or `openclaw hybrid-mem backup schedule`."];
+  }
+  return [];
+}
+
+/** Pure classification of backup health from a state-file snapshot. No I/O, no side effects. */
+export function evaluateBackupHealth(
+  state: BackupStateFile | null,
+  nowMs: number,
+  policy: Pick<BackupHealthAlertPolicy, "staleAfterHours">,
+): BackupHealthStatus {
+  if (!state) {
+    return {
+      status: "unknown",
+      reasonCategory: null,
+      lastSuccessAt: null,
+      lastFailureAt: null,
+      ageSinceLastSuccessHours: null,
+      consecutiveFailures: 0,
+      remediation: remediationFor("unknown", null),
+    };
+  }
+
+  const lastSuccessAt = state.ok ? state.timestamp : (state.lastSuccessAt ?? null);
+  const lastFailureAt = state.ok ? null : state.timestamp;
+  const ageSinceLastSuccessHours = lastSuccessAt ? (nowMs - Date.parse(lastSuccessAt)) / 3_600_000 : null;
+  const stale = ageSinceLastSuccessHours !== null && ageSinceLastSuccessHours >= policy.staleAfterHours;
+
+  const status: BackupHealthStatus["status"] = !state.ok ? "failed" : stale ? "stale" : "ok";
+  const reasonCategory = state.ok ? null : (state.reasonCategory ?? classifyBackupFailureReason(state.error));
+
+  return {
+    status,
+    reasonCategory,
+    lastSuccessAt,
+    lastFailureAt,
+    ageSinceLastSuccessHours:
+      ageSinceLastSuccessHours !== null && Number.isFinite(ageSinceLastSuccessHours)
+        ? Number(ageSinceLastSuccessHours.toFixed(2))
+        : null,
+    consecutiveFailures: state.ok ? 0 : Math.max(1, state.consecutiveFailures ?? 1),
+    remediation: remediationFor(status, reasonCategory),
+  };
+}
+
+export type BackupOutcomeInput =
+  | {
+      ok: true;
+      timestamp: string;
+      backupDir: string;
+      sqliteSize: number;
+      lancedbSize: number;
+      durationMs: number;
+      integrityOk: boolean;
+      snapshotSkewMs: number;
+    }
+  | { ok: false; timestamp: string; error: string };
+
+/**
+ * Persist a fresh backup outcome (from an actual `runBackup()` call) to the state file, carrying
+ * forward `lastSuccessAt` / consecutive-failure counters across runs. A success clears all prior
+ * failure/alert bookkeeping — Issue #2230's "a later successful backup clears/supersedes the
+ * stale failure state" requirement.
+ */
+export function recordBackupOutcome(
+  stateFilePath: string,
+  outcome: BackupOutcomeInput,
+): BackupStateFile {
+  const previous = readBackupStateFile(stateFilePath);
+  const next: BackupStateFile = outcome.ok
+    ? {
+        ok: true,
+        timestamp: outcome.timestamp,
+        backupDir: outcome.backupDir,
+        sqliteSize: outcome.sqliteSize,
+        lancedbSize: outcome.lancedbSize,
+        durationMs: outcome.durationMs,
+        integrityOk: outcome.integrityOk,
+        snapshotSkewMs: outcome.snapshotSkewMs,
+        lastSuccessAt: outcome.timestamp,
+        consecutiveFailures: 0,
+      }
+    : {
+        ok: false,
+        timestamp: outcome.timestamp,
+        error: outcome.error,
+        reasonCategory: classifyBackupFailureReason(outcome.error),
+        lastSuccessAt: previous?.ok ? previous.timestamp : previous?.lastSuccessAt,
+        consecutiveFailures: (previous && !previous.ok ? (previous.consecutiveFailures ?? 0) : 0) + 1,
+        lastAlertedAt: previous?.lastAlertedAt,
+        lastAlertedFingerprint: previous?.lastAlertedFingerprint,
+      };
+  try {
+    atomicWriteFile(stateFilePath, `${JSON.stringify(next, null, 2)}\n`);
+  } catch {
+    // Non-fatal — state file is advisory only for heartbeat monitoring.
+  }
+  return next;
+}
+
+function formatBackupAlertMessage(health: BackupHealthStatus): string {
+  const lines = [`hybrid-mem backup health: ${health.status.toUpperCase()}${health.reasonCategory ? ` (${health.reasonCategory})` : ""}`];
+  lines.push(
+    health.lastSuccessAt
+      ? `Last verified success: ${health.lastSuccessAt} (${health.ageSinceLastSuccessHours?.toFixed(1) ?? "?"}h ago)`
+      : "Last verified success: never",
+  );
+  if (health.consecutiveFailures > 0) lines.push(`Consecutive failures: ${health.consecutiveFailures}`);
+  for (const r of health.remediation) lines.push(`Remediation: ${r}`);
+  return lines.join("\n");
+}
+
+export type BackupHealthAssessment = {
+  health: BackupHealthStatus;
+  alerted: boolean;
+  alertMessage: string | null;
+};
+
+/**
+ * Evaluate current backup health from the persisted state file and, when degraded (failed or
+ * stale) and alerting is enabled, emit a deduplicated actionable alert. Safe to call from every
+ * heartbeat/maintenance tick (e.g. the weekly `audit-health` cron step) and once right after a
+ * `hybrid-mem backup` run — repeated calls while the same failure/staleness persists only
+ * re-alert after `policy.dedupeWindowHours` elapses, mirroring the fingerprinted dedup pattern
+ * in services/error-reporter.ts.
+ */
+export function evaluateAndMaybeAlertBackupHealth(
+  stateFilePath: string,
+  policy: BackupHealthAlertPolicy,
+  nowMs: number = Date.now(),
+): BackupHealthAssessment {
+  const state = readBackupStateFile(stateFilePath);
+  const health = evaluateBackupHealth(state, nowMs, policy);
+
+  if (!policy.enabled || !state || (health.status !== "failed" && health.status !== "stale")) {
+    return { health, alerted: false, alertMessage: null };
+  }
+
+  const fingerprint = `${health.status}:${health.reasonCategory ?? "unknown"}`;
+  const lastAlertedAtMs = state.lastAlertedAt ? Date.parse(state.lastAlertedAt) : Number.NaN;
+  const dedupeWindowMs = Math.max(0, policy.dedupeWindowHours) * 3_600_000;
+  const withinDedupeWindow =
+    state.lastAlertedFingerprint === fingerprint &&
+    Number.isFinite(lastAlertedAtMs) &&
+    nowMs - lastAlertedAtMs < dedupeWindowMs;
+  if (withinDedupeWindow) {
+    return { health, alerted: false, alertMessage: null };
+  }
+
+  const alertMessage = formatBackupAlertMessage(health);
+  try {
+    capturePluginError(new Error(`hybrid-mem backup health degraded: ${fingerprint}`), {
+      operation: "backup_health_alert",
+      subsystem: "backup",
+      severity: "warning",
+      fingerprint: ["backup_health_alert", health.status, health.reasonCategory ?? "unknown"],
+      tags: { consecutiveFailures: health.consecutiveFailures, status: health.status },
+    });
+  } catch {
+    // Best-effort telemetry only — never block on alert delivery.
+  }
+  try {
+    atomicWriteFile(
+      stateFilePath,
+      `${JSON.stringify(
+        { ...state, lastAlertedAt: new Date(nowMs).toISOString(), lastAlertedFingerprint: fingerprint },
+        null,
+        2,
+      )}\n`,
+    );
+  } catch {
+    // Non-fatal — dedup bookkeeping is advisory; worst case is a duplicate alert next tick.
+  }
+  return { health, alerted: true, alertMessage };
+}

--- a/extensions/memory-hybrid/services/backup-health.ts
+++ b/extensions/memory-hybrid/services/backup-health.ts
@@ -194,10 +194,7 @@ export type BackupOutcomeInput =
  * failure/alert bookkeeping — Issue #2230's "a later successful backup clears/supersedes the
  * stale failure state" requirement.
  */
-export function recordBackupOutcome(
-  stateFilePath: string,
-  outcome: BackupOutcomeInput,
-): BackupStateFile {
+export function recordBackupOutcome(stateFilePath: string, outcome: BackupOutcomeInput): BackupStateFile {
   const previous = readBackupStateFile(stateFilePath);
   const next: BackupStateFile = outcome.ok
     ? {
@@ -231,7 +228,9 @@ export function recordBackupOutcome(
 }
 
 function formatBackupAlertMessage(health: BackupHealthStatus): string {
-  const lines = [`hybrid-mem backup health: ${health.status.toUpperCase()}${health.reasonCategory ? ` (${health.reasonCategory})` : ""}`];
+  const lines = [
+    `hybrid-mem backup health: ${health.status.toUpperCase()}${health.reasonCategory ? ` (${health.reasonCategory})` : ""}`,
+  ];
   lines.push(
     health.lastSuccessAt
       ? `Last verified success: ${health.lastSuccessAt} (${health.ageSinceLastSuccessHours?.toFixed(1) ?? "?"}h ago)`

--- a/extensions/memory-hybrid/setup/cli-context/register-help.ts
+++ b/extensions/memory-hybrid/setup/cli-context/register-help.ts
@@ -561,12 +561,17 @@ export function createHybridMemCliContext(
     resolvedSqlitePath: handlerCtx.resolvedSqlitePath,
     resolvedLancePath: handlerCtx.resolvedLancePath,
     resolvePath: (file: string) => api.resolvePath(file),
-    // Issue #276 — Backup CLI
+    // Issue #276 — Backup CLI. Retention (#2229) is applied after every successful run using the
+    // configured maintenance.backup policy (retentionCount/retentionAgeDays, default 7/30).
     runBackup: (opts) =>
       runBackupFn({
         resolvedSqlitePath: handlerCtx.resolvedSqlitePath,
         resolvedLancePath: handlerCtx.resolvedLancePath,
         backupDir: opts?.backupDir,
+        retention: {
+          retentionCount: handlerCtx.cfg.maintenance?.backup?.retentionCount ?? 7,
+          retentionAgeDays: handlerCtx.cfg.maintenance?.backup?.retentionAgeDays ?? 30,
+        },
       }),
     runBackupVerify: () => runBackupVerifyFn({ resolvedSqlitePath: handlerCtx.resolvedSqlitePath }),
     runGenerateProposals: (opts) => handlers.runGenerateProposalsForCli(handlerCtx, opts, api),

--- a/extensions/memory-hybrid/tests/backup-health.test.ts
+++ b/extensions/memory-hybrid/tests/backup-health.test.ts
@@ -1,0 +1,317 @@
+/**
+ * Tests for Issue #2230 — backup health/heartbeat alerting.
+ */
+
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  type BackupHealthAlertPolicy,
+  classifyBackupFailureReason,
+  evaluateAndMaybeAlertBackupHealth,
+  evaluateBackupHealth,
+  readBackupStateFile,
+  recordBackupOutcome,
+} from "../services/backup-health.js";
+
+const POLICY: BackupHealthAlertPolicy = { enabled: true, staleAfterHours: 192, dedupeWindowHours: 24 };
+
+describe("classifyBackupFailureReason", () => {
+  it("classifies the literal DorisVM disk-full error message", () => {
+    expect(classifyBackupFailureReason("SQLite backup failed: Error: database or disk is full")).toBe("disk_full");
+  });
+
+  it("classifies ENOSPC / no space left variants", () => {
+    expect(classifyBackupFailureReason("Error: ENOSPC: no space left on device, write")).toBe("disk_full");
+  });
+
+  it("classifies permission errors", () => {
+    expect(classifyBackupFailureReason("EACCES: permission denied, open '/backups/x'")).toBe("permission_denied");
+  });
+
+  it("classifies missing-path errors", () => {
+    expect(classifyBackupFailureReason("ENOENT: no such file or directory, mkdir '/does/not/exist'")).toBe(
+      "path_not_found",
+    );
+  });
+
+  it("classifies integrity failures", () => {
+    expect(classifyBackupFailureReason("SQLite integrity check failed before backup")).toBe("integrity_check_failed");
+  });
+
+  it("falls back to unknown for unrecognized messages", () => {
+    expect(classifyBackupFailureReason("something unexpected happened")).toBe("unknown");
+    expect(classifyBackupFailureReason(undefined)).toBe("unknown");
+    expect(classifyBackupFailureReason(null)).toBe("unknown");
+  });
+});
+
+describe("evaluateBackupHealth", () => {
+  const now = Date.parse("2026-08-02T12:00:00Z");
+
+  it("returns 'unknown' when no state has ever been recorded", () => {
+    const health = evaluateBackupHealth(null, now, POLICY);
+    expect(health.status).toBe("unknown");
+    expect(health.lastSuccessAt).toBeNull();
+    expect(health.remediation.length).toBeGreaterThan(0);
+  });
+
+  it("returns 'ok' for a fresh successful run", () => {
+    const health = evaluateBackupHealth({ ok: true, timestamp: new Date(now).toISOString() }, now, POLICY);
+    expect(health.status).toBe("ok");
+    expect(health.reasonCategory).toBeNull();
+    expect(health.ageSinceLastSuccessHours).toBeCloseTo(0, 1);
+    expect(health.consecutiveFailures).toBe(0);
+  });
+
+  it("returns 'failed' with a classified reason category for a failed run (disk-full)", () => {
+    const health = evaluateBackupHealth(
+      {
+        ok: false,
+        timestamp: new Date(now).toISOString(),
+        error: "SQLite backup failed: Error: database or disk is full",
+        consecutiveFailures: 2,
+      },
+      now,
+      POLICY,
+    );
+    expect(health.status).toBe("failed");
+    expect(health.reasonCategory).toBe("disk_full");
+    expect(health.consecutiveFailures).toBe(2);
+    expect(health.remediation.some((r) => r.toLowerCase().includes("disk"))).toBe(true);
+  });
+
+  it("returns 'stale' when the last success is older than the configured staleAfterHours, even without an explicit failure", () => {
+    const ninetyHoursAgo = new Date(now - 200 * 60 * 60 * 1000).toISOString();
+    const health = evaluateBackupHealth({ ok: true, timestamp: ninetyHoursAgo }, now, POLICY);
+    expect(health.status).toBe("stale");
+    expect(health.ageSinceLastSuccessHours).toBeGreaterThan(POLICY.staleAfterHours);
+  });
+
+  it("carries forward lastSuccessAt from a prior success across a subsequent failure", () => {
+    const successAt = new Date(now - 48 * 60 * 60 * 1000).toISOString();
+    const health = evaluateBackupHealth(
+      { ok: false, timestamp: new Date(now).toISOString(), error: "boom", lastSuccessAt: successAt },
+      now,
+      POLICY,
+    );
+    expect(health.status).toBe("failed");
+    expect(health.lastSuccessAt).toBe(successAt);
+    expect(health.ageSinceLastSuccessHours).toBeCloseTo(48, 0);
+  });
+});
+
+describe("recordBackupOutcome", () => {
+  let dir: string;
+  let stateFile: string;
+
+  beforeEach(() => {
+    dir = join(tmpdir(), `backup-health-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(dir, { recursive: true });
+    stateFile = join(dir, "memory-backup-last.json");
+  });
+
+  afterEach(() => {
+    if (existsSync(dir)) rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("writes a fresh success and resets consecutiveFailures to 0", () => {
+    const state = recordBackupOutcome(stateFile, {
+      ok: true,
+      timestamp: "2026-08-02T04:00:00Z",
+      backupDir: "/backups/x",
+      sqliteSize: 100,
+      lancedbSize: 200,
+      durationMs: 10,
+      integrityOk: true,
+      snapshotSkewMs: 0,
+    });
+    expect(state.ok).toBe(true);
+    expect(state.consecutiveFailures).toBe(0);
+    expect(state.lastSuccessAt).toBe("2026-08-02T04:00:00Z");
+    expect(readBackupStateFile(stateFile)?.ok).toBe(true);
+  });
+
+  it("increments consecutiveFailures across repeated failures and classifies the reason", () => {
+    recordBackupOutcome(stateFile, {
+      ok: false,
+      timestamp: "2026-07-26T04:00:00Z",
+      error: "SQLite backup failed: Error: database or disk is full",
+    });
+    const second = recordBackupOutcome(stateFile, {
+      ok: false,
+      timestamp: "2026-07-27T04:00:00Z",
+      error: "SQLite backup failed: Error: database or disk is full",
+    });
+    expect(second.consecutiveFailures).toBe(2);
+    expect(second.reasonCategory).toBe("disk_full");
+  });
+
+  it("carries forward lastSuccessAt from a prior success into a subsequent failure record", () => {
+    recordBackupOutcome(stateFile, {
+      ok: true,
+      timestamp: "2026-07-20T04:00:00Z",
+      backupDir: "/backups/x",
+      sqliteSize: 1,
+      lancedbSize: 1,
+      durationMs: 1,
+      integrityOk: true,
+      snapshotSkewMs: 0,
+    });
+    const failed = recordBackupOutcome(stateFile, {
+      ok: false,
+      timestamp: "2026-07-26T04:00:00Z",
+      error: "disk is full",
+    });
+    expect(failed.lastSuccessAt).toBe("2026-07-20T04:00:00Z");
+    expect(failed.consecutiveFailures).toBe(1);
+  });
+
+  it("a fresh success clears prior alert bookkeeping (#2230 recovery)", () => {
+    recordBackupOutcome(stateFile, { ok: false, timestamp: "2026-07-26T04:00:00Z", error: "disk is full" });
+    // Simulate an alert having fired for the failure.
+    evaluateAndMaybeAlertBackupHealth(stateFile, POLICY, Date.parse("2026-07-26T05:00:00Z"));
+    expect(readBackupStateFile(stateFile)?.lastAlertedFingerprint).toBeDefined();
+
+    const success = recordBackupOutcome(stateFile, {
+      ok: true,
+      timestamp: "2026-08-02T04:00:00Z",
+      backupDir: "/backups/x",
+      sqliteSize: 1,
+      lancedbSize: 1,
+      durationMs: 1,
+      integrityOk: true,
+      snapshotSkewMs: 0,
+    });
+    expect(success.lastAlertedAt).toBeUndefined();
+    expect(success.lastAlertedFingerprint).toBeUndefined();
+  });
+});
+
+describe("evaluateAndMaybeAlertBackupHealth (dedup + recovery, #2230)", () => {
+  let dir: string;
+  let stateFile: string;
+
+  beforeEach(() => {
+    dir = join(tmpdir(), `backup-health-alert-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(dir, { recursive: true });
+    stateFile = join(dir, "memory-backup-last.json");
+  });
+
+  afterEach(() => {
+    if (existsSync(dir)) rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("alerts on a disk-full failure and persists dedup bookkeeping", () => {
+    recordBackupOutcome(stateFile, {
+      ok: false,
+      timestamp: "2026-07-26T04:00:10Z",
+      error: "SQLite backup failed: Error: database or disk is full",
+    });
+    const nowMs = Date.parse("2026-07-26T04:05:00Z");
+    const result = evaluateAndMaybeAlertBackupHealth(stateFile, POLICY, nowMs);
+
+    expect(result.alerted).toBe(true);
+    expect(result.health.status).toBe("failed");
+    expect(result.health.reasonCategory).toBe("disk_full");
+    expect(result.alertMessage).toContain("disk_full");
+
+    const persisted = readBackupStateFile(stateFile);
+    expect(persisted?.lastAlertedFingerprint).toBe("failed:disk_full");
+    expect(persisted?.lastAlertedAt).toBeDefined();
+  });
+
+  it("deduplicates repeated alerts for the same persisting failure within the dedupe window", () => {
+    recordBackupOutcome(stateFile, {
+      ok: false,
+      timestamp: "2026-07-26T04:00:10Z",
+      error: "SQLite backup failed: Error: database or disk is full",
+    });
+    const first = evaluateAndMaybeAlertBackupHealth(stateFile, POLICY, Date.parse("2026-07-26T04:05:00Z"));
+    expect(first.alerted).toBe(true);
+
+    // Heartbeat ticks again a few hours later — still failed, still well within the 24h dedupe window.
+    const second = evaluateAndMaybeAlertBackupHealth(stateFile, POLICY, Date.parse("2026-07-26T10:00:00Z"));
+    expect(second.alerted).toBe(false);
+    expect(second.health.status).toBe("failed");
+
+    // And again just under the window boundary.
+    const third = evaluateAndMaybeAlertBackupHealth(stateFile, POLICY, Date.parse("2026-07-27T03:59:00Z"));
+    expect(third.alerted).toBe(false);
+  });
+
+  it("re-alerts once the dedupe window has elapsed for a persisting failure", () => {
+    recordBackupOutcome(stateFile, {
+      ok: false,
+      timestamp: "2026-07-26T04:00:10Z",
+      error: "SQLite backup failed: Error: database or disk is full",
+    });
+    evaluateAndMaybeAlertBackupHealth(stateFile, POLICY, Date.parse("2026-07-26T04:05:00Z"));
+
+    const later = evaluateAndMaybeAlertBackupHealth(stateFile, POLICY, Date.parse("2026-07-27T05:00:00Z"));
+    expect(later.alerted).toBe(true);
+  });
+
+  it("recovery: a later successful backup clears the stale failure state from health output", () => {
+    recordBackupOutcome(stateFile, {
+      ok: false,
+      timestamp: "2026-07-26T04:00:10Z",
+      error: "SQLite backup failed: Error: database or disk is full",
+    });
+    evaluateAndMaybeAlertBackupHealth(stateFile, POLICY, Date.parse("2026-07-26T04:05:00Z"));
+
+    recordBackupOutcome(stateFile, {
+      ok: true,
+      timestamp: "2026-08-02T04:00:00Z",
+      backupDir: "/backups/x",
+      sqliteSize: 1,
+      lancedbSize: 1,
+      durationMs: 1,
+      integrityOk: true,
+      snapshotSkewMs: 0,
+    });
+
+    const result = evaluateAndMaybeAlertBackupHealth(stateFile, POLICY, Date.parse("2026-08-02T04:01:00Z"));
+    expect(result.health.status).toBe("ok");
+    expect(result.alerted).toBe(false);
+  });
+
+  it("never alerts when alerting is disabled in policy", () => {
+    recordBackupOutcome(stateFile, {
+      ok: false,
+      timestamp: "2026-07-26T04:00:10Z",
+      error: "disk is full",
+    });
+    const result = evaluateAndMaybeAlertBackupHealth(
+      stateFile,
+      { ...POLICY, enabled: false },
+      Date.parse("2026-07-26T04:05:00Z"),
+    );
+    expect(result.alerted).toBe(false);
+    expect(result.health.status).toBe("failed"); // still reports health, just doesn't alert
+  });
+
+  it("does not alert (or write a state file) when no backup has ever run", () => {
+    const result = evaluateAndMaybeAlertBackupHealth(stateFile, POLICY, Date.now());
+    expect(result.alerted).toBe(false);
+    expect(result.health.status).toBe("unknown");
+    expect(existsSync(stateFile)).toBe(false);
+  });
+
+  it("alerts on staleness alone when the last success is older than staleAfterHours, with no explicit failed run", () => {
+    recordBackupOutcome(stateFile, {
+      ok: true,
+      timestamp: "2026-07-01T04:00:00Z",
+      backupDir: "/backups/x",
+      sqliteSize: 1,
+      lancedbSize: 1,
+      durationMs: 1,
+      integrityOk: true,
+      snapshotSkewMs: 0,
+    });
+    const result = evaluateAndMaybeAlertBackupHealth(stateFile, POLICY, Date.parse("2026-08-02T04:00:00Z"));
+    expect(result.health.status).toBe("stale");
+    expect(result.alerted).toBe(true);
+  });
+});

--- a/extensions/memory-hybrid/tests/backup.test.ts
+++ b/extensions/memory-hybrid/tests/backup.test.ts
@@ -469,7 +469,11 @@ describe("backup", () => {
       writeFileSync(brokenLancePath, "not a directory");
 
       for (let i = 0; i < 3; i++) {
-        const result = await runBackup({ resolvedSqlitePath: sqlitePath, resolvedLancePath: brokenLancePath, backupDir });
+        const result = await runBackup({
+          resolvedSqlitePath: sqlitePath,
+          resolvedLancePath: brokenLancePath,
+          backupDir,
+        });
         expect(result.ok).toBe(false);
       }
       const entries = existsSync(backupDir) ? readdirSync(backupDir) : [];

--- a/extensions/memory-hybrid/tests/backup.test.ts
+++ b/extensions/memory-hybrid/tests/backup.test.ts
@@ -1,9 +1,9 @@
-import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { runBackup, runBackupVerify } from "../cli/backup.js";
+import { getBackupStatus, pruneBackups, runBackup, runBackupVerify } from "../cli/backup.js";
 
 describe("backup", () => {
   let testDir: string;
@@ -433,6 +433,186 @@ describe("backup", () => {
         expect(result.factCount).toBe(0);
         expect(result.message).toContain("0 active facts");
       }
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Atomicity (#2229): a crash/kill mid-backup must never look like a completed snapshot.
+  // ---------------------------------------------------------------------------
+  describe("atomic promotion (#2229)", () => {
+    it("leaves no .backup-tmp-* working directory behind after a successful run", async () => {
+      const backupDir = join(testDir, "backups");
+      const result = await runBackup({ resolvedSqlitePath: sqlitePath, resolvedLancePath: lancePath, backupDir });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      const entries = readdirSync(backupDir);
+      expect(entries).toEqual([basename(result.backupDir)]);
+      expect(entries.some((name) => name.startsWith(".backup-tmp-"))).toBe(false);
+    });
+
+    it("never leaves a directory behind (partial or completed-looking) after a failed run", async () => {
+      const backupDir = join(testDir, "backups");
+      const brokenLancePath = join(testDir, "broken-lance-source-atomic");
+      writeFileSync(brokenLancePath, "not a directory");
+
+      const result = await runBackup({ resolvedSqlitePath: sqlitePath, resolvedLancePath: brokenLancePath, backupDir });
+      expect(result.ok).toBe(false);
+
+      const entries = existsSync(backupDir) ? readdirSync(backupDir) : [];
+      expect(entries.length).toBe(0);
+    });
+
+    it("does not accumulate stale working directories across repeated failed runs", async () => {
+      const backupDir = join(testDir, "backups");
+      const brokenLancePath = join(testDir, "broken-lance-source-repeat");
+      writeFileSync(brokenLancePath, "not a directory");
+
+      for (let i = 0; i < 3; i++) {
+        const result = await runBackup({ resolvedSqlitePath: sqlitePath, resolvedLancePath: brokenLancePath, backupDir });
+        expect(result.ok).toBe(false);
+      }
+      const entries = existsSync(backupDir) ? readdirSync(backupDir) : [];
+      expect(entries.length).toBe(0);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Retention / pruning (#2229)
+  // ---------------------------------------------------------------------------
+  describe("pruneBackups / getBackupStatus (#2229)", () => {
+    let backupRoot: string;
+
+    beforeEach(() => {
+      backupRoot = join(testDir, "backups-retention");
+      mkdirSync(backupRoot, { recursive: true });
+    });
+
+    /** Create a fake completed backup snapshot directory with a controllable mtime. */
+    function makeCompletedBackup(name: string, ageDays: number): string {
+      const dir = join(backupRoot, name);
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(join(dir, "backup-manifest.json"), "{}");
+      const past = new Date(Date.now() - ageDays * 24 * 60 * 60 * 1000);
+      utimesSync(dir, past, past);
+      return dir;
+    }
+
+    /** Create a fake abandoned working directory (or loose orphaned file) with a controllable mtime. */
+    function makeStaleArtifact(name: string, ageHours: number, opts: { asFile?: boolean } = {}): string {
+      const path = join(backupRoot, name);
+      if (opts.asFile) {
+        writeFileSync(path, "stray");
+      } else {
+        mkdirSync(path, { recursive: true });
+      }
+      const past = new Date(Date.now() - ageHours * 60 * 60 * 1000);
+      utimesSync(path, past, past);
+      return path;
+    }
+
+    it("retention count keeps only the newest N completed snapshots", () => {
+      const names = Array.from({ length: 10 }, (_, i) => `2026-01-${String(i + 1).padStart(2, "0")}T00-00-00-000Z`);
+      for (const [i, name] of names.entries()) makeCompletedBackup(name, 10 - i); // higher index = newer (smaller ageDays)
+
+      const report = pruneBackups(backupRoot, { retentionCount: 3, retentionAgeDays: 0 });
+      expect(report.retainedCompleted.length).toBe(3);
+      expect(report.prunedCompleted.length).toBe(7);
+      // The 3 newest (last 3 in `names`) must be the ones retained.
+      expect(new Set(report.retainedCompleted)).toEqual(new Set(names.slice(-3)));
+    });
+
+    it("never deletes the newest completed snapshot even when it's the only one and older than retentionAgeDays", () => {
+      makeCompletedBackup("2020-01-01T00-00-00-000Z", 400);
+
+      const report = pruneBackups(backupRoot, { retentionCount: 7, retentionAgeDays: 30 });
+      expect(report.prunedCompleted.length).toBe(0);
+      expect(report.retainedCompleted.length).toBe(1);
+      expect(existsSync(join(backupRoot, "2020-01-01T00-00-00-000Z"))).toBe(true);
+    });
+
+    it("prunes completed snapshots older than retentionAgeDays while keeping recent ones and the newest", () => {
+      makeCompletedBackup("2020-01-01T00-00-00-000Z", 400); // very old — pruned
+      makeCompletedBackup("2026-01-01T00-00-00-000Z", 5); // recent — retained
+      makeCompletedBackup("2026-01-02T00-00-00-000Z", 1); // newest — always retained
+
+      const report = pruneBackups(backupRoot, { retentionCount: 0, retentionAgeDays: 30 });
+      expect(report.prunedCompleted).toEqual(["2020-01-01T00-00-00-000Z"]);
+      expect(new Set(report.retainedCompleted)).toEqual(
+        new Set(["2026-01-01T00-00-00-000Z", "2026-01-02T00-00-00-000Z"]),
+      );
+    });
+
+    it("removes abandoned .backup-tmp-* working directories older than the grace period but leaves fresh ones alone", () => {
+      makeStaleArtifact(".backup-tmp-12345-oldrun", 5); // 5h old — abandoned
+      makeStaleArtifact(".backup-tmp-99999-freshrun", 0.01); // ~36s old — may still be an active run
+
+      const report = pruneBackups(backupRoot, { partialGraceMs: 60 * 60 * 1000 });
+      expect(report.prunedPartial).toEqual([".backup-tmp-12345-oldrun"]);
+      expect(existsSync(join(backupRoot, ".backup-tmp-99999-freshrun"))).toBe(true);
+    });
+
+    it("surfaces and removes stale orphaned artifacts sitting directly under the backup root", () => {
+      makeStaleArtifact("legacy-pre-sync-snapshot.db", 5, { asFile: true });
+
+      const statusBefore = getBackupStatus(backupRoot);
+      expect(statusBefore.orphanedCount).toBe(1);
+      expect(statusBefore.stalePartialCount).toBe(1);
+
+      const report = pruneBackups(backupRoot, { partialGraceMs: 60 * 60 * 1000 });
+      expect(report.prunedOrphaned).toEqual(["legacy-pre-sync-snapshot.db"]);
+      expect(existsSync(join(backupRoot, "legacy-pre-sync-snapshot.db"))).toBe(false);
+    });
+
+    it("getBackupStatus never mutates the filesystem", () => {
+      makeCompletedBackup("2020-01-01T00-00-00-000Z", 400);
+      makeStaleArtifact(".backup-tmp-abc-def", 5);
+      makeStaleArtifact("stray.db", 5, { asFile: true });
+
+      const status = getBackupStatus(backupRoot, { retentionCount: 0, retentionAgeDays: 1 });
+      expect(status.completedCount).toBe(1);
+      expect(status.retainedCount).toBe(1); // newest-guard keeps it even though it's over-age
+      expect(status.partialCount).toBe(1);
+      expect(status.orphanedCount).toBe(1);
+      expect(existsSync(join(backupRoot, "2020-01-01T00-00-00-000Z"))).toBe(true);
+      expect(existsSync(join(backupRoot, ".backup-tmp-abc-def"))).toBe(true);
+      expect(existsSync(join(backupRoot, "stray.db"))).toBe(true);
+    });
+  });
+
+  describe("runBackup with ctx.retention (#2229)", () => {
+    it("prunes older completed snapshots automatically after a successful run when retention is configured", async () => {
+      const backupDir = join(testDir, "backups-auto-prune");
+      mkdirSync(backupDir, { recursive: true });
+      const oldDir = join(backupDir, "2020-01-01T00-00-00-000Z");
+      mkdirSync(oldDir, { recursive: true });
+      writeFileSync(join(oldDir, "backup-manifest.json"), "{}");
+      const past = new Date(Date.now() - 400 * 24 * 60 * 60 * 1000);
+      utimesSync(oldDir, past, past);
+
+      const result = await runBackup({
+        resolvedSqlitePath: sqlitePath,
+        resolvedLancePath: lancePath,
+        backupDir,
+        retention: { retentionCount: 1, retentionAgeDays: 0 },
+      });
+      expect(result.ok).toBe(true);
+      expect(existsSync(oldDir)).toBe(false);
+      if (result.ok) expect(existsSync(result.backupDir)).toBe(true);
+    });
+
+    it("does not prune when ctx.retention is omitted (existing default behaviour preserved)", async () => {
+      const backupDir = join(testDir, "backups-no-prune");
+      mkdirSync(backupDir, { recursive: true });
+      const oldDir = join(backupDir, "2020-01-01T00-00-00-000Z");
+      mkdirSync(oldDir, { recursive: true });
+      writeFileSync(join(oldDir, "backup-manifest.json"), "{}");
+      const past = new Date(Date.now() - 400 * 24 * 60 * 60 * 1000);
+      utimesSync(oldDir, past, past);
+
+      const result = await runBackup({ resolvedSqlitePath: sqlitePath, resolvedLancePath: lancePath, backupDir });
+      expect(result.ok).toBe(true);
+      expect(existsSync(oldDir)).toBe(true);
     });
   });
 });

--- a/extensions/memory-hybrid/tests/maintenance-status.test.ts
+++ b/extensions/memory-hybrid/tests/maintenance-status.test.ts
@@ -112,6 +112,77 @@ describe("config maintenance.cronReliability parsing", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Config: maintenance.backup parsing (Issues #2229, #2230)
+// ---------------------------------------------------------------------------
+
+describe("config maintenance.backup parsing", () => {
+  const baseConfig = {
+    embedding: {
+      provider: "openai" as const,
+      model: "text-embedding-3-small",
+      apiKey: "sk-test-key-that-is-long-enough",
+    },
+    lanceDbPath: "/tmp/test-lance",
+    sqlitePath: "/tmp/test.db",
+  };
+
+  it("defaults: retentionCount=7, retentionAgeDays=30, alerting enabled with staleAfterHours=192, dedupeWindowHours=24", () => {
+    const cfg = hybridConfigSchema.parse(baseConfig);
+    const backup = cfg.maintenance.backup;
+    expect(backup.retentionCount).toBe(7);
+    expect(backup.retentionAgeDays).toBe(30);
+    expect(backup.alerting.enabled).toBe(true);
+    expect(backup.alerting.staleAfterHours).toBe(192);
+    expect(backup.alerting.dedupeWindowHours).toBe(24);
+  });
+
+  it("accepts custom retentionCount and retentionAgeDays", () => {
+    const cfg = hybridConfigSchema.parse({
+      ...baseConfig,
+      maintenance: { backup: { retentionCount: 3, retentionAgeDays: 14 } },
+    });
+    expect(cfg.maintenance.backup.retentionCount).toBe(3);
+    expect(cfg.maintenance.backup.retentionAgeDays).toBe(14);
+  });
+
+  it("accepts 0 to disable count/age-based pruning", () => {
+    const cfg = hybridConfigSchema.parse({
+      ...baseConfig,
+      maintenance: { backup: { retentionCount: 0, retentionAgeDays: 0 } },
+    });
+    expect(cfg.maintenance.backup.retentionCount).toBe(0);
+    expect(cfg.maintenance.backup.retentionAgeDays).toBe(0);
+  });
+
+  it("rejects negative retention values by falling back to the default", () => {
+    const cfg = hybridConfigSchema.parse({
+      ...baseConfig,
+      maintenance: { backup: { retentionCount: -1, retentionAgeDays: -1 } },
+    });
+    expect(cfg.maintenance.backup.retentionCount).toBe(7);
+    expect(cfg.maintenance.backup.retentionAgeDays).toBe(30);
+  });
+
+  it("accepts custom alerting policy and allows disabling alerting", () => {
+    const cfg = hybridConfigSchema.parse({
+      ...baseConfig,
+      maintenance: { backup: { alerting: { enabled: false, staleAfterHours: 48, dedupeWindowHours: 6 } } },
+    });
+    expect(cfg.maintenance.backup.alerting.enabled).toBe(false);
+    expect(cfg.maintenance.backup.alerting.staleAfterHours).toBe(48);
+    expect(cfg.maintenance.backup.alerting.dedupeWindowHours).toBe(6);
+  });
+
+  it("backup config is present in all presets", () => {
+    for (const mode of ["local", "minimal", "enhanced", "complete"] as const) {
+      const cfg = hybridConfigSchema.parse({ ...baseConfig, mode });
+      expect(cfg.maintenance.backup).toBeDefined();
+      expect(cfg.maintenance.backup.retentionCount).toBe(7);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
 // MaintenanceConfig shape: both new sub-configs co-exist
 // ---------------------------------------------------------------------------
 

--- a/extensions/memory-hybrid/tests/validate-cron-exit-cli-1225.test.ts
+++ b/extensions/memory-hybrid/tests/validate-cron-exit-cli-1225.test.ts
@@ -375,6 +375,11 @@ Error: LanceDB commit conflict detected
             enabled: false,
             dayOfMonth: 1,
           },
+          backup: {
+            retentionCount: 7,
+            retentionAgeDays: 30,
+            alerting: { enabled: true, staleAfterHours: 192, dedupeWindowHours: 24 },
+          },
           cronReliability: {
             nightlyCron: "0 3 * * *",
             weeklyBackupCron: "0 4 * * 0",


### PR DESCRIPTION
## Summary

- **Issue #2229** — `hybrid-mem backup` now writes atomically (a hidden `.backup-tmp-*` working directory is only promoted/renamed to its final timestamped name once SQLite, LanceDB, and the manifest have all succeeded, so a crash/kill mid-backup can never look like a completed snapshot) and enforces a configurable bounded retention policy (`maintenance.backup.retentionCount` / `retentionAgeDays`, default 7 snapshots / 30 days) after every successful run — the newest snapshot is never pruned, even if it's the only one and has aged out. Adds `hybrid-mem backup status` (completed/retained/stale-partial counts, bytes, newest/oldest, last success/failure) and `hybrid-mem backup prune` (deterministic on-demand cleanup of stale partial/orphaned artifacts) subcommands.
- **Issue #2230** — Backup outcomes are recorded through a new `services/backup-health.ts`, which classifies failures (`disk_full`, `permission_denied`, `path_not_found`, `integrity_check_failed`, `unknown`) with non-sensitive remediation guidance, and surfaces status + age-since-last-success in `hybrid-mem health`, `audit health` / `graph health`, and `backup status`. The weekly `audit-health` maintenance cron step fires a **deduplicated** alert (reusing the existing error-reporter pipeline) when the backup has failed or the last verified success is older than `maintenance.backup.alerting.staleAfterHours` (default 192h/8 days), deduped per `dedupeWindowHours` (default 24h). A later successful backup immediately clears the stale failure state everywhere.

Closes #2229
Closes #2230

**PR title:** Follows Conventional Commits (`feat(backup): …`).

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor / internal improvement (no behavior change)
- [ ] Documentation update
- [ ] CI / tooling change

## Quality Checklist

Run from repo root (package lives under `extensions/memory-hybrid/`):

- [x] `cd extensions/memory-hybrid && npx tsc --noEmit` passes with no errors
- [x] `cd extensions/memory-hybrid && npm run lint` — 0 errors (verified both on the changed files directly and via a full-repo run; only pre-existing, unrelated warnings remain elsewhere in the repo)
- [x] `cd extensions/memory-hybrid && npm test` passes (targeted + CI gate suites all green; full suite run for final confirmation)
- [x] No secrets, credentials, or API keys committed
- [x] No `console.log` debug statements left in production code (`cli/` is lint-exempt for `console.*` per existing convention; `services/backup-health.ts` has no console output)

## Documentation Impact (REQUIRED)

- [x] Inline code comments (JSDoc) updated for modified functions and types
- [x] `docs/` updated: `docs/BACKUP.md` gets a new "Automated snapshot backups" section documenting retention config, atomic writes, `backup status`/`backup prune`, and health alerting; `extensions/memory-hybrid/docs/QUICK-START.md` backup section extended with the new subcommands.
- [x] Cross-referenced functions/services checked for outdated documentation (updated `backup schedule`'s printed guidance to mention the new automated alerting)

## Testing

- [x] Unit tests added / updated:
  - `tests/backup.test.ts` — atomic promotion (no `.backup-tmp-*` left behind on success; nothing left behind across repeated failures), retention/pruning (`pruneBackups`/`getBackupStatus`: count-based, age-based, "never delete the only/newest backup" invariant, abandoned partial-dir cleanup with an active-run grace window, orphaned-artifact cleanup), and `runBackup`'s new opt-in `ctx.retention` auto-pruning.
  - `tests/backup-health.test.ts` (new) — failure-reason classification (including the literal DorisVM `"database or disk is full"` message), `evaluateBackupHealth` status transitions (ok/failed/stale/unknown), `recordBackupOutcome` state carry-forward, and `evaluateAndMaybeAlertBackupHealth`: disk-full alert firing, repeated-failure deduplication within the window, re-alerting after the window elapses, recovery clearing stale state, alerting-disabled no-op, and staleness-without-an-explicit-failure alerting.
  - `tests/maintenance-status.test.ts` — new `maintenance.backup` config parsing coverage (defaults, custom values, 0-disables-pruning, negative-value fallback, alerting policy, presence across all presets).
  - `tests/validate-cron-exit-cli-1225.test.ts` — updated a hand-built `MaintenanceConfig` fixture to include the new required `backup` field.
- [ ] Integration tests added / updated
- [x] Manually verified: ran the CI-required trio plus the maintenance-gate/schema-gate suites locally.

## Notes for Reviewer

- **Retention default (7 backups / 30 days):** matches the values suggested in the issue investigation notes; not explicitly specified by either issue, so this is a judgment call. Tunable via `maintenance.backup.retentionCount` / `retentionAgeDays`.
- **Alert policy defaults (`staleAfterHours: 192`, `dedupeWindowHours: 24`):** 192h = 8 days = one day of grace past the default weekly backup cron cadence (`0 4 * * 0`), so a single missed/late run doesn't immediately fire. 24h dedupe window follows an "at most once per day while the same issue persists" judgment call — not specified by either issue.
- **"Pre-contacts-sync SQLite files" (#2229 DorisVM evidence):** I could not find any "pre-contacts-sync" snapshot feature in this codebase (grepped for `pre-sync`, `preSync`, `contacts-sync`, etc.) — it appears to be host-level state unrelated to any in-repo feature. I generalized the fix instead: any loose file or unrecognized directory sitting directly under the backup root (not a `.backup-tmp-*` working dir, not a completed timestamped snapshot dir) is classified as "orphaned," surfaced in `backup status`, and cleaned up by `backup prune` (or automatically after a successful `backup` run) once it's older than the same grace window used for abandoned partial runs.
- **Where alerts actually fire vs. just report:** `audit health` / `graph health` (the one-shot, documented-non-destructive CLI command) only *reads* backup health — it never fires the dedup alert itself, to preserve its non-destructive contract. The actual alert-firing (which persists dedup bookkeeping into `~/.openclaw/state/memory-backup-last.json`) happens in (a) the weekly `audit-health` **maintenance cron step** (the real heartbeat tick) and (b) immediately after a `hybrid-mem backup` failure, for fast feedback on a manual/cron-triggered run.
- **Scope:** Kept to the two issues' acceptance criteria — did not touch the Mission Control HTTP dashboard (`routes/dashboard/*`) or add a new top-level config namespace; `maintenance.backup` was added as a sibling of the existing `maintenance.cronReliability` (which already owns `weeklyBackupCron`) rather than a new `backup:` top-level key, to match the existing pattern for backup-adjacent scheduling config.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Eb78N8a8yCMgVT2pY1K3QE)_