### PR TITLE
feat(maintenance): persist cron-lane run outcomes and capture nested-lane failures

### DIFF
--- a/docs/CLI-REFERENCE.md
+++ b/docs/CLI-REFERENCE.md
@@ -355,6 +355,8 @@ Checks that need human judgement or aren't safely repairable from inside the run
 
 `openclaw hybrid-mem doctor --fix --reconcile` runs nightly by default via the `hybrid-mem:nightly-doctor-repair` cron job (see [Maintenance cron jobs](#maintenance-cron-jobs) below) — existing installs pick it up the next time `install` or `verify --fix` runs.
 
+**Scheduled-run health (issue [#2231](https://github.com/markus-lassfolk/openclaw-hybrid-memory/issues/2231)):** `openclaw hybrid-mem maintenance status` and `maintenance cron-health` monitor `hybrid-mem:nightly-doctor-repair` alongside `hybrid-mem:maintenance-nightly` — a missing/stale/failed doctor-repair run is now reported (and fails `cron-health`'s exit code) the same way the nightly maintenance job already was. `maintenance status`/`--json` also reports `lastSuccessfulRunAt` per job: a locally persisted (SQLite `maintenance_runs`) record of the most recent run each cron lane's `maintenance validate-exit` step actually validated as successful, independent of whether GlitchTip error-reporting telemetry is enabled — distinct from `lastRunAt`/`lastStatus`, which only reflect OpenClaw's own cron-store snapshot of the most recent firing (which may itself have failed, and carries no history).
+
 ---
 
 ## JSON output contract (scripting)

--- a/extensions/memory-hybrid/cli/cmd-doctor.ts
+++ b/extensions/memory-hybrid/cli/cmd-doctor.ts
@@ -12,10 +12,15 @@ import type { VectorDB } from "../backends/vector-db.js";
 import { WAL_ENTRY_SCHEMA_VERSION, type WALEntry, type WriteAheadLog } from "../backends/wal.js";
 import type { HybridMemoryConfig } from "../config.js";
 import type { EmbeddingProvider } from "../services/embeddings.js";
-import { isErrorReporterActive, resolvePendingErrorReportCount } from "../services/error-reporter.js";
+import {
+  initErrorReporter,
+  isErrorReporterActive,
+  resolvePendingErrorReportCount,
+} from "../services/error-reporter.js";
 import { countPinnedFacts } from "../services/fact-lifecycle-verbs.js";
 import { listQuarantinedGoalIds, repairAllQuarantinedGoals, resolveGoalsDir } from "../services/goal-registry.js";
 import { getStaleMaintenanceJobs } from "../services/maintenance-audit-journal.js";
+import { resolveErrorReportQueuePath } from "../services/maintenance-failure-reporter.js";
 import { getRecallSignalsSnapshot } from "../services/recall-signals.js";
 import { getRecallStatsSnapshot } from "../services/recall-timing-stats.js";
 import { runStorageRepairPipeline, runStorageStructuralRepair } from "../services/storage-repair-pipeline.js";
@@ -83,6 +88,49 @@ interface DiagnosticCheck {
   fix?: string;
 }
 
+/**
+ * Initialize the error reporter for this one-shot `doctor` CLI process (issue #2231).
+ *
+ * `doctor --fix --reconcile` is the payload of the `hybrid-mem:nightly-doctor-repair` cron lane
+ * (cli/install/cron-jobs.ts) and runs in its own isolated session/process — nothing else on that
+ * path calls initErrorReporter(), so any capturePluginError() calls made deep inside the
+ * repair/reconcile pipeline (e.g. storage-repair-pipeline.ts) were silent no-ops before this.
+ * Mirrors cli/commands/manage/register-maintenance-orchestrator.ts's
+ * ensureMaintenanceOrchestratorErrorReporter: same errorReporting.enabled && errorReporting.consent
+ * gate, same isErrorReporterActive() idempotency guard, and the same durable on-disk retry queue
+ * convention (resolveErrorReportQueuePath) since this is also a short-lived process with no
+ * next-startup drain to recover an in-flight report.
+ */
+async function ensureDoctorErrorReporterActive(
+  cfg: HybridMemoryConfig,
+  pluginVersion: string | undefined,
+  resolvedSqlitePath: string | undefined,
+): Promise<void> {
+  if (isErrorReporterActive()) return;
+  const { errorReporting } = cfg;
+  if (!errorReporting?.enabled || !errorReporting?.consent || !pluginVersion) return;
+  try {
+    await initErrorReporter(
+      {
+        enabled: errorReporting.enabled,
+        dsn: errorReporting.dsn,
+        mode: errorReporting.mode ?? "community",
+        consent: errorReporting.consent,
+        environment: errorReporting.environment,
+        sampleRate: errorReporting.sampleRate ?? 1.0,
+        maxBreadcrumbs: 10,
+        botId: errorReporting.botId,
+        botName: errorReporting.botName,
+        resolvedIssues: errorReporting.resolvedIssues,
+        pendingQueuePath: resolveErrorReportQueuePath(resolvedSqlitePath),
+      },
+      pluginVersion,
+    );
+  } catch {
+    // Best-effort telemetry setup must never fail doctor itself.
+  }
+}
+
 export function registerDoctorCommand(
   program: Chainable,
   cfg: HybridMemoryConfig,
@@ -93,6 +141,7 @@ export function registerDoctorCommand(
   aliasDb: import("../services/retrieval-aliases.js").AliasDB | null = null,
   embeddings: EmbeddingProvider | null = null,
   runBackup?: (opts?: { backupDir?: string }) => Promise<import("./backup.js").BackupCliResult>,
+  pluginVersion?: string,
 ): void {
   program
     .command("doctor")
@@ -133,6 +182,11 @@ export function registerDoctorCommand(
           reconcileMaxFixes?: string;
           json?: boolean;
         }) => {
+          // Must happen before any check/repair below so capturePluginError() calls made deep in
+          // the repair/reconcile pipeline actually reach GlitchTip instead of silently no-opping
+          // (#2231 — this is the payload of the hybrid-mem:nightly-doctor-repair cron lane).
+          await ensureDoctorErrorReporterActive(cfg, pluginVersion, resolvedSqlitePath);
+
           if (!opts?.json) console.log("\n🏥 Running Hybrid Memory Diagnostics...\n");
 
           // Mirrors cli/verify.ts's parsing exactly: keep reconcileMaxFixes undefined when the flag

--- a/extensions/memory-hybrid/cli/cmd-user-friendly.ts
+++ b/extensions/memory-hybrid/cli/cmd-user-friendly.ts
@@ -28,6 +28,8 @@ export interface UserFriendlyContext {
   wal?: WriteAheadLog | null;
   embeddings: EmbeddingProvider;
   resolvedSqlitePath?: string;
+  /** Passed through to registerDoctorCommand so it can activate the error reporter (#2231). */
+  pluginVersion?: string;
   aliasDb?: import("../services/retrieval-aliases.js").AliasDB | null;
   runBackup?: (opts?: { backupDir?: string }) => Promise<import("./backup.js").BackupCliResult>;
   runConfigSet?: (
@@ -78,6 +80,7 @@ export function registerUserFriendlyCommands(mem: Chainable, ctx: UserFriendlyCo
       ctx.aliasDb ?? null,
       ctx.embeddings ?? null,
       ctx.runBackup,
+      ctx.pluginVersion,
     ),
   );
   registerIfMissing(mem, "health", () =>

--- a/extensions/memory-hybrid/cli/commands/manage/register-maintenance-health.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/register-maintenance-health.ts
@@ -5,8 +5,10 @@ import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
+import type { FactsDB } from "../../../backends/facts-db.js";
 import type { HybridMemoryConfig } from "../../../config.js";
 import { formatStepLockDetail, listActiveStepLocks } from "../../../services/cron-guard.js";
+import { getLastSuccessfulCronRun } from "../../../services/maintenance-audit-journal.js";
 import {
   collectMaintenanceInventory,
   jobMatchesPluginJobId,
@@ -24,7 +26,24 @@ import { type Chainable, relativeTime, withExit } from "../../shared.js";
 /** Lookback window for the log-health check folded into `maintenance status` (#2033). */
 const STATUS_LOG_HEALTH_SINCE = "24h";
 
-export function registerMaintenanceHealthCommands(maintenance: Chainable, cfg: HybridMemoryConfig): void {
+/** Best-effort last-successful-cron-lane-run lookup (#2231) — returns null on any DB/lookup issue
+ *  (missing factsDb binding in older callers/tests, closed store, pre-migration DB) so this can
+ *  never turn a health check into a hard failure. */
+function tryGetLastSuccessfulRunAt(factsDb: FactsDB | undefined, jobLabel: string): string | null {
+  if (!factsDb) return null;
+  try {
+    const row = getLastSuccessfulCronRun(factsDb.getRawDb(), jobLabel);
+    return row ? formatTimestampUtcFromMs(row.started_at * 1000) : null;
+  } catch {
+    return null;
+  }
+}
+
+export function registerMaintenanceHealthCommands(
+  maintenance: Chainable,
+  cfg: HybridMemoryConfig,
+  factsDb?: FactsDB,
+): void {
   maintenance
     .command("inventory")
     .description("List host-crontab and gateway-cron maintenance jobs in one report.")
@@ -77,34 +96,51 @@ export function registerMaintenanceHealthCommands(maintenance: Chainable, cfg: H
           lastRunAt: string | null;
           nextRunAt: string | null;
           lastStatus: string | null;
+          /** Most recent locally-persisted successful cron-lane run (issue #2231), independent of
+           *  whether OpenClaw's own cron-store `lastStatus` reflects hybrid-memory's own validation
+           *  verdict. Null when no successful run has been recorded yet (or factsDb is unavailable). */
+          lastSuccessfulRunAt: string | null;
           isStale: boolean;
           isMissing: boolean;
           configuredSchedule: string;
           issue?: string;
         };
 
+        // `nightly-doctor-repair` is never superseded by consolidatedCronJobs mode (see
+        // cli/install/cron-jobs.ts's `supersededByOrchestrator: false`) — it always runs on its own
+        // schedule alongside whichever nightly maintenance job is selected below, so it's included
+        // unconditionally (#2231 — this is one of the two cron lanes named in the originating
+        // incident report).
         const jobsOfInterest: Array<{
           id: string;
           label: string;
           scheduleExpr: string;
           staleMs: number;
-        }> = useConsolidatedCron
-          ? [
-              {
-                id: "hybrid-mem:maintenance-nightly",
-                label: "maintenance-nightly",
-                scheduleExpr: nightlyCronExpr,
-                staleMs: staleThresholdMs,
-              },
-            ]
-          : [
-              {
-                id: "hybrid-mem:nightly-distill",
-                label: "nightly-memory-sweep (legacy)",
-                scheduleExpr: nightlyCronExpr,
-                staleMs: staleThresholdMs,
-              },
-            ];
+        }> = [
+          ...(useConsolidatedCron
+            ? [
+                {
+                  id: "hybrid-mem:maintenance-nightly",
+                  label: "maintenance-nightly",
+                  scheduleExpr: nightlyCronExpr,
+                  staleMs: staleThresholdMs,
+                },
+              ]
+            : [
+                {
+                  id: "hybrid-mem:nightly-distill",
+                  label: "nightly-memory-sweep (legacy)",
+                  scheduleExpr: nightlyCronExpr,
+                  staleMs: staleThresholdMs,
+                },
+              ]),
+          {
+            id: "hybrid-mem:nightly-doctor-repair",
+            label: "nightly-doctor-repair",
+            scheduleExpr: "15 3 * * *",
+            staleMs: staleThresholdMs,
+          },
+        ];
 
         const results: JobStatus[] = [];
 
@@ -134,6 +170,7 @@ export function registerMaintenanceHealthCommands(maintenance: Chainable, cfg: H
               lastRunAt: null,
               nextRunAt: null,
               lastStatus: null,
+              lastSuccessfulRunAt: tryGetLastSuccessfulRunAt(factsDb, wanted.label),
               isStale: false,
               isMissing: true,
               configuredSchedule: wanted.scheduleExpr,
@@ -179,6 +216,7 @@ export function registerMaintenanceHealthCommands(maintenance: Chainable, cfg: H
             lastRunAt: lastRunAtMs != null ? formatTimestampUtcFromMs(lastRunAtMs) : null,
             nextRunAt: nextRunAtMs != null ? formatTimestampUtcFromMs(nextRunAtMs) : null,
             lastStatus,
+            lastSuccessfulRunAt: tryGetLastSuccessfulRunAt(factsDb, wanted.label),
             isStale,
             isMissing: false,
             configuredSchedule: wanted.scheduleExpr,
@@ -246,6 +284,12 @@ export function registerMaintenanceHealthCommands(maintenance: Chainable, cfg: H
           const timing = [lastRun, nextRun].filter(Boolean).join("  ");
           console.log(
             `${icon} ${r.name.padEnd(32)} ${r.isMissing ? "MISSING" : r.enabled ? "enabled " : "disabled"} ${timing}`,
+          );
+          // Last locally-confirmed successful run (#2231) — distinct from `lastRunAt`/`lastStatus`
+          // above, which only reflect OpenClaw's own cron-store bookkeeping of the most recent
+          // firing (which may itself have failed) and carry no history beyond that single snapshot.
+          console.log(
+            `   └─ last successful run: ${r.lastSuccessfulRunAt ? relativeTime(new Date(r.lastSuccessfulRunAt).getTime()) : "none recorded"}`,
           );
           if (r.issue) {
             console.log(`   └─ ${r.issue}`);
@@ -316,7 +360,13 @@ export function registerMaintenanceHealthCommands(maintenance: Chainable, cfg: H
         const openclawDir = join(homedir(), ".openclaw");
         const staleThresholdMs = (cfg.maintenance?.cronReliability?.staleThresholdHours ?? 28) * 60 * 60 * 1000;
         const useConsolidatedCron = cfg.maintenance?.orchestrator?.consolidatedCronJobs !== false;
-        const criticalJobs = useConsolidatedCron ? ["hybrid-mem:maintenance-nightly"] : ["hybrid-mem:nightly-distill"];
+        // nightly-doctor-repair is always included (#2231) — it is never superseded by
+        // consolidatedCronJobs mode (cli/install/cron-jobs.ts's `supersededByOrchestrator: false`)
+        // and was one of the two cron lanes named in the originating incident report.
+        const criticalJobs = [
+          useConsolidatedCron ? "hybrid-mem:maintenance-nightly" : "hybrid-mem:nightly-distill",
+          "hybrid-mem:nightly-doctor-repair",
+        ];
 
         let cronStore: { jobs?: unknown[] } = { jobs: [] };
         try {

--- a/extensions/memory-hybrid/cli/commands/manage/register-validate-cron-exit.ts
+++ b/extensions/memory-hybrid/cli/commands/manage/register-validate-cron-exit.ts
@@ -6,14 +6,17 @@
  */
 
 import { writeFileSync } from "node:fs";
+import type { DatabaseSync } from "node:sqlite";
 import type { HybridMemoryConfig } from "../../../config.js";
 import {
   type ExitValidationResult,
+  extractMaintenanceJobName,
   generateCronStatusReport,
   resolveValidateCronExitCode,
   validateFromSummaryJson,
   validateMaintenanceExecution,
 } from "../../../services/cron-exit-validator.js";
+import { recordMaintenanceCronRunOutcome } from "../../../services/maintenance-audit-journal.js";
 import { reportMaintenanceFailureIssues } from "../../../services/maintenance-failure-reporter.js";
 import { type Chainable, withExit } from "../../shared.js";
 
@@ -23,6 +26,13 @@ export interface ValidateCronExitContext {
   logger?: Pick<Console, "debug" | "info" | "warn">;
   /** Enables a durable on-disk retry queue for reportMaintenanceFailureIssues (see there for why). */
   resolvedSqlitePath?: string;
+  /**
+   * Enables local, telemetry-consent-independent persistence of this run's structured outcome
+   * (issue #2231) — one `maintenance_runs` row per cron-lane invocation, success or failure, so
+   * `maintenance status` can report last-scheduled-run / last-successful-run per job even when
+   * error reporting is disabled or unreachable.
+   */
+  journalDb?: DatabaseSync;
 }
 
 export function registerValidateCronExit(hybrid: Chainable, context?: ValidateCronExitContext): void {
@@ -80,6 +90,26 @@ export function registerValidateCronExit(hybrid: Chainable, context?: ValidateCr
             console.log(generateCronStatusReport(result));
           } else {
             printValidationResult(result);
+          }
+
+          // Local structured outcome persistence (#2231) — unconditional on telemetry consent, so
+          // `maintenance status` has a durable last-scheduled/last-successful-run record per cron
+          // lane even when GlitchTip reporting is disabled or unreachable. Runs before the
+          // telemetry call below so a reporting failure can never suppress this local write.
+          if (context?.journalDb) {
+            const primaryIssue = result.reportableIssues[0];
+            recordMaintenanceCronRunOutcome(context.journalDb, {
+              jobName: extractMaintenanceJobName(opts.exitPath || opts.logPath),
+              maintenanceStatus: result.maintenanceStatus,
+              primaryFailure: primaryIssue
+                ? {
+                    stepName: primaryIssue.stepName,
+                    failureClass: primaryIssue.failureClass,
+                    message: primaryIssue.message,
+                  }
+                : undefined,
+              failingStepNames: result.reportableIssues.map((issue) => issue.stepName),
+            });
           }
 
           // Best-effort telemetry runs after output so one-shot cron validation still

--- a/extensions/memory-hybrid/cli/commands/register-maintenance-group.ts
+++ b/extensions/memory-hybrid/cli/commands/register-maintenance-group.ts
@@ -72,7 +72,7 @@ export function registerMaintenanceGroup(mem: Chainable, b: ManageBindings, ctx:
     cfg: ctx.cfg,
     versionInfo: ctx.versionInfo,
     resolvedSqlitePath: ctx.resolvedSqlitePath,
-    journalDb: b.factsDb.getRawDb(),
+    journalDb: typeof b.factsDb.getRawDb === "function" ? b.factsDb.getRawDb() : undefined,
   });
   registerReconcileCronLedgers(groupedCmds);
   registerGraphLinkEnrichmentCommand(groupedCmds, b);
@@ -107,7 +107,7 @@ export function registerMaintenanceGroup(mem: Chainable, b: ManageBindings, ctx:
       cfg: ctx.cfg,
       versionInfo: ctx.versionInfo,
       resolvedSqlitePath: ctx.resolvedSqlitePath,
-      journalDb: b.factsDb.getRawDb(),
+      journalDb: typeof b.factsDb.getRawDb === "function" ? b.factsDb.getRawDb() : undefined,
     },
   );
   registerReconcileCronLedgers(

--- a/extensions/memory-hybrid/cli/commands/register-maintenance-group.ts
+++ b/extensions/memory-hybrid/cli/commands/register-maintenance-group.ts
@@ -59,7 +59,7 @@ const MAINTENANCE_FLAT_PATHS: Record<string, string> = {
 export function registerMaintenanceGroup(mem: Chainable, b: ManageBindings, ctx: ManageContext): void {
   const maintenance = createCommandGroup(mem, "maintenance", "Cron, backfill, and operational health (Issue #281)");
 
-  registerMaintenanceHealthCommands(maintenance, b.cfg);
+  registerMaintenanceHealthCommands(maintenance, b.cfg, b.factsDb);
   registerMaintenanceOrchestratorCommands(maintenance, b);
   registerMaintenanceRunCommands(maintenance);
   registerSensorSweepCommand(mem, b);
@@ -72,6 +72,7 @@ export function registerMaintenanceGroup(mem: Chainable, b: ManageBindings, ctx:
     cfg: ctx.cfg,
     versionInfo: ctx.versionInfo,
     resolvedSqlitePath: ctx.resolvedSqlitePath,
+    journalDb: b.factsDb.getRawDb(),
   });
   registerReconcileCronLedgers(groupedCmds);
   registerGraphLinkEnrichmentCommand(groupedCmds, b);
@@ -102,7 +103,12 @@ export function registerMaintenanceGroup(mem: Chainable, b: ManageBindings, ctx:
   );
   registerValidateCronExit(
     wrapChainableWithDeprecated(mem, { "validate-cron-exit": MAINTENANCE_FLAT_PATHS["validate-cron-exit"]! }),
-    { cfg: ctx.cfg, versionInfo: ctx.versionInfo, resolvedSqlitePath: ctx.resolvedSqlitePath },
+    {
+      cfg: ctx.cfg,
+      versionInfo: ctx.versionInfo,
+      resolvedSqlitePath: ctx.resolvedSqlitePath,
+      journalDb: b.factsDb.getRawDb(),
+    },
   );
   registerReconcileCronLedgers(
     wrapChainableWithDeprecated(mem, { "reconcile-cron-ledgers": MAINTENANCE_FLAT_PATHS["reconcile-cron-ledgers"]! }),

--- a/extensions/memory-hybrid/cli/register.ts
+++ b/extensions/memory-hybrid/cli/register.ts
@@ -738,6 +738,7 @@ export function registerHybridMemCli(mem: Chainable, ctx: HybridMemCliContext): 
       runMine: async (path: string) => {
         await executeMineCommand(path, {}, ctx.factsDb, ctx.vectorDb, ctx.embeddings);
       },
+      pluginVersion: ctx.versionInfo.pluginVersion,
     };
     registerUserFriendlyCommands(mem, userFriendlyContext);
   } catch (err) {

--- a/extensions/memory-hybrid/services/cron-exit-validator.ts
+++ b/extensions/memory-hybrid/services/cron-exit-validator.ts
@@ -490,7 +490,11 @@ function appendDreamPipelineLedgerFailures(
   return merged;
 }
 
-function extractMaintenanceJobName(path: string | undefined): string {
+/** Derive the cron-lane job name (e.g. "maintenance-nightly", "nightly-doctor-repair") from an
+ *  HM_EXIT/HM_LOG path basename. Exported so callers outside this file (e.g. register-validate-
+ *  cron-exit.ts, for #2231's structured per-cron-lane run persistence) can derive the same job
+ *  identity without re-implementing the suffix-stripping rules. */
+export function extractMaintenanceJobName(path: string | undefined): string {
   if (!path) return "unknown-job";
   const file = basename(path);
   const withoutExitSuffix = file.replace(/\.exit\.txt$/, "").replace(/\.log$/, "");

--- a/extensions/memory-hybrid/services/maintenance-audit-journal.ts
+++ b/extensions/memory-hybrid/services/maintenance-audit-journal.ts
@@ -3,6 +3,7 @@
  */
 
 import type { DatabaseSync } from "node:sqlite";
+import { hasStepRetryOncePending } from "./cron-guard.js";
 import { MAINTENANCE_STEPS } from "./maintenance-orchestrator.js";
 
 export type OrchestratorStepStatus =
@@ -174,4 +175,106 @@ export function getStaleMaintenanceJobs(
     if (last.started_at < cutoffSec) stale.push(step.name);
   }
   return stale;
+}
+
+// --- Cron-lane run outcome persistence (issue #2231) ---
+//
+// The functions above track individual *orchestrator step* attempts (e.g. "distill", "prune") from
+// inside a single `maintenance-nightly` invocation. Everything below tracks the *cron lane* itself
+// (e.g. "maintenance-nightly", "nightly-doctor-repair") — one row per `maintenance validate-exit`
+// invocation, which every hybrid-mem cron job runs unconditionally at shell exit (see
+// cron-job-bash-harness.ts's `hm_validate` trap). This gives `maintenance status` and friends a
+// durable, local record of "last scheduled run" / "last successful run" per cron job, independent
+// of whether GlitchTip telemetry (errorReporting.consent) is enabled — unlike
+// services/maintenance-failure-reporter.ts's reportMaintenanceFailureIssues, this write is never
+// gated on telemetry consent, since it is local bookkeeping, not external reporting.
+
+/** Mirrors cron-job-bash-harness.ts's own `ledger_status` mapping in `hm_validate` (success -> ok,
+ *  skipped -> skipped, partial -> failed, failed -> failed) so the locally persisted status agrees
+ *  with what the bash harness itself already treats as pass/fail. */
+export function mapMaintenanceCronStatusToRunStatus(
+  maintenanceStatus: "success" | "skipped" | "partial" | "failed",
+): MaintenanceRunStatus {
+  if (maintenanceStatus === "success") return "ran";
+  if (maintenanceStatus === "skipped") return "skipped:quiet";
+  return "failed";
+}
+
+export type MaintenanceCronRetryStatus = "not_applicable" | "retry_pending" | "scheduled_retry";
+
+/**
+ * Derive a coarse "will this be retried" signal for a failed/partial cron-lane run.
+ * - `not_applicable` — the run succeeded or was intentionally skipped; nothing to retry.
+ * - `retry_pending` — at least one failing nested step already has a #2094 forced retry-once
+ *   marker pending (set by `analyze-maintenance-logs --auto-fix`), so it will re-run outside its
+ *   normal cadence guard on the very next orchestrator evaluation.
+ * - `scheduled_retry` — no forced retry-once marker; the failure will only be retried on this
+ *   cron lane's next regular schedule (these are recurring jobs, so there always is one).
+ */
+export function resolveMaintenanceCronRetryStatus(
+  maintenanceStatus: "success" | "skipped" | "partial" | "failed",
+  failingStepNames: string[],
+  openclawDir?: string,
+): MaintenanceCronRetryStatus {
+  if (maintenanceStatus === "success" || maintenanceStatus === "skipped") return "not_applicable";
+  const retryPending = failingStepNames.some((stepName) => hasStepRetryOncePending(stepName, openclawDir));
+  return retryPending ? "retry_pending" : "scheduled_retry";
+}
+
+export interface MaintenanceCronRunOutcomeInput {
+  /** Cron-lane job name, e.g. "maintenance-nightly", "nightly-doctor-repair" (matches HM_JOB / the
+   *  cron job's `name` field — see extractMaintenanceJobName in cron-exit-validator.ts). */
+  jobName: string;
+  maintenanceStatus: "success" | "skipped" | "partial" | "failed";
+  /** Short, templated diagnostic strings only (e.g. "job:step exited non-zero") — never raw
+   *  log/prompt/tool payload. Matches the existing MaintenanceTelemetryIssue.message convention
+   *  already considered safe for external GlitchTip transmission (services/cron-exit-validator.ts). */
+  primaryFailure?: { stepName: string; failureClass: string; message: string };
+  failingStepNames?: string[];
+  openclawDir?: string;
+}
+
+/**
+ * Persist a structured per-cron-lane run outcome: success/failure, phase (the first failing
+ * nested step, if any), error class, timestamp, and retry status (issue #2231). Best-effort and
+ * never gated on telemetry consent — a write failure here must never fail the cron job itself.
+ */
+export function recordMaintenanceCronRunOutcome(
+  db: DatabaseSync | undefined,
+  input: MaintenanceCronRunOutcomeInput,
+): void {
+  if (!db) return;
+  try {
+    const retryStatus = resolveMaintenanceCronRetryStatus(
+      input.maintenanceStatus,
+      input.failingStepNames ?? (input.primaryFailure ? [input.primaryFailure.stepName] : []),
+      input.openclawDir,
+    );
+    insertMaintenanceRun(db, {
+      job: input.jobName,
+      status: mapMaintenanceCronStatusToRunStatus(input.maintenanceStatus),
+      errorSummary: input.primaryFailure?.message,
+      metadata: {
+        kind: "cron-lane-run",
+        maintenanceStatus: input.maintenanceStatus,
+        phase: input.primaryFailure?.stepName,
+        errorClass: input.primaryFailure?.failureClass,
+        retryStatus,
+      },
+    });
+  } catch {
+    // Best-effort — never fail the cron job over a local audit-journal write issue.
+  }
+}
+
+/** Most recent successful cron-lane run for a job (status "ran", i.e. maintenanceStatus="success"). */
+export function getLastSuccessfulCronRun(db: DatabaseSync, jobName: string): MaintenanceRunRow | null {
+  return (
+    (db
+      .prepare(
+        `SELECT id, job, started_at, ended_at, status, items_processed
+         FROM maintenance_runs WHERE job = ? AND status = 'ran' ORDER BY started_at DESC LIMIT 1`,
+      )
+      .get(jobName) as MaintenanceRunRow | undefined) ?? null
+  );
 }

--- a/extensions/memory-hybrid/services/maintenance-orchestrator.ts
+++ b/extensions/memory-hybrid/services/maintenance-orchestrator.ts
@@ -6,6 +6,7 @@
 import type { DatabaseSync } from "node:sqlite";
 import type { HybridMemoryConfig } from "../config.js";
 import { nowIso } from "../utils/dates.js";
+import { getEnv } from "../utils/env-manager.js";
 import {
   clearMaintenanceRunDeadline,
   maintenanceRunDeadlineReached,
@@ -24,6 +25,8 @@ import {
   stepGuardEligible,
   writeStepGuardTimestampMs,
 } from "./cron-guard.js";
+import { nightlyStepsOwnedByDream } from "./dream-run.js";
+import { capturePluginError } from "./error-reporter.js";
 import { recordMaintenanceStepRun } from "./maintenance-audit-journal.js";
 import { generateOrchestratorRunId } from "./maintenance-job-run/orchestrator-summary.js";
 import {
@@ -31,7 +34,69 @@ import {
   reflectRulesStepSummaryIndicatesFailure,
   semanticOutcomeBlocksOrchestratorGuard,
 } from "./maintenance-job-run/semantic-outcome.js";
-import { nightlyStepsOwnedByDream } from "./dream-run.js";
+
+/**
+ * Mirrors MAINTENANCE_FAILURE_REPORTING_DISABLE_ENV in maintenance-failure-reporter.ts (kept as a
+ * literal here rather than imported, to avoid a module cycle: that file's cron-exit-validator.js
+ * import itself imports MAINTENANCE_STEPS from this file).
+ */
+const MAINTENANCE_FAILURE_REPORTING_DISABLE_ENV = "HYBRID_MEMORY_DISABLE_MAINTENANCE_ERROR_REPORTING";
+
+/** Same gate services/maintenance-failure-reporter.ts's shouldReportMaintenanceFailures applies,
+ *  reimplemented with defensive optional chaining so a loosely-typed test/partial config can never
+ *  throw here (see reportMaintenanceStepException below). */
+function maintenanceStepExceptionReportingEnabled(cfg: HybridMemoryConfig): boolean {
+  const envValue = getEnv(MAINTENANCE_FAILURE_REPORTING_DISABLE_ENV);
+  if (typeof envValue === "string" && /^(1|true|yes|on)$/i.test(envValue.trim())) return false;
+  if (cfg.maintenance?.failureReporting?.enabled === false) return false;
+  return cfg.errorReporting?.enabled === true && cfg.errorReporting?.consent === true;
+}
+
+/**
+ * Safety-net capture for a maintenance step exception raised while it was actually executing
+ * inside this orchestrator process (issue #2231's "nested cron lanes": distill/dream-run/etc.
+ * inside a single `maintenance-nightly` cron invocation, or doctor's own repair pipeline inside
+ * `nightly-doctor-repair`). This complements the post-hoc, log-pattern-matching capture in
+ * services/maintenance-failure-reporter.ts's reportMaintenanceFailureIssues, which only runs in a
+ * SEPARATE process/invocation against the bash wrapper's HM_LOG/HM_EXIT files after the cron job
+ * has already exited — this fires immediately with the real Error object, so a step failure whose
+ * message the post-hoc regex heuristics in cron-exit-validator.ts don't recognize (e.g. a
+ * provider-specific rejection like an Azure Foundry tools-array-length error) is still reliably
+ * captured, tagged with which cron job and which nested step failed.
+ *
+ * Deliberately uses capturePluginError's DEFAULT (message-derived) fingerprint rather than a
+ * custom one, so this naturally deduplicates (60s window) against a deeper capturePluginError call
+ * the failing step's own code may already have made for the SAME underlying error (e.g.
+ * services/chat.ts's "fallback-exhausted" capture) instead of doubling up on one real failure.
+ */
+function reportMaintenanceStepException(
+  cfg: HybridMemoryConfig,
+  error: Error,
+  info: { jobName?: string; stepName: string; runId: string; tier: StepTier },
+): void {
+  if (!maintenanceStepExceptionReportingEnabled(cfg)) return;
+  const jobName = info.jobName?.trim() || "maintenance-orchestrator";
+  capturePluginError(error, {
+    subsystem: "maintenance",
+    operation: info.stepName,
+    phase: "orchestrator-step",
+    tags: {
+      component: "hybrid-memory",
+      job_name: jobName,
+      step_name: info.stepName,
+      tier: info.tier,
+      run_id: info.runId,
+    },
+    contexts: {
+      maintenance: {
+        job_name: jobName,
+        step_name: info.stepName,
+        tier: info.tier,
+        run_id: info.runId,
+      },
+    },
+  });
+}
 
 export type StepTier = "cycle" | "nightly";
 export type StepLlmTier = "none" | "nano" | "maintenance" | "default" | "heavy" | "embed" | "local";
@@ -996,6 +1061,12 @@ export async function runMaintenanceOrchestrator(
             summary: message,
             durationMs: Date.now() - stepStarted,
             ...meta,
+          });
+          reportMaintenanceStepException(cfg, err instanceof Error ? err : new Error(message), {
+            jobName: process.env.HM_JOB,
+            stepName: step.name,
+            runId,
+            tier: step.tier,
           });
         }
         lastWasLlmStep = isLlmProviderStep(step.llmTier);

--- a/extensions/memory-hybrid/tests/cmd-doctor-error-reporting.test.ts
+++ b/extensions/memory-hybrid/tests/cmd-doctor-error-reporting.test.ts
@@ -1,0 +1,138 @@
+/**
+ * `doctor --fix --reconcile` is the payload of the `hybrid-mem:nightly-doctor-repair` cron lane
+ * (cli/install/cron-jobs.ts) and runs in its own isolated one-shot process. Nothing else on that
+ * path called initErrorReporter() before this, so any capturePluginError() calls made deep inside
+ * the repair/reconcile pipeline were silent no-ops in production (issue #2231).
+ *
+ * These tests assert `doctor`'s action handler now activates the error reporter before running any
+ * checks, gated by the same errorReporting.enabled && errorReporting.consent check used by
+ * cli/commands/manage/register-maintenance-orchestrator.ts's own
+ * ensureMaintenanceOrchestratorErrorReporter (mirrors that file's test conventions).
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Command } from "commander";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { FactsDB } from "../backends/facts-db.js";
+import { registerDoctorCommand } from "../cli/cmd-doctor.js";
+
+function buildErrorReportingConfig(overrides?: Partial<{ enabled: boolean; consent: boolean }>) {
+  return {
+    enabled: true,
+    consent: true,
+    mode: "community" as const,
+    dsn: "https://7d641cabffdb4557a7bd2f02c338dc80@glitchtip.lassfolk.cc/1",
+    sampleRate: 1,
+    updateNudge: { enabled: true, intervalHours: 24, cacheTtlHours: 24 },
+    ...overrides,
+  };
+}
+
+describe("doctor CLI error reporter wiring (#2231)", () => {
+  const tmpRoots: string[] = [];
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    process.exitCode = undefined;
+    for (const root of tmpRoots.splice(0)) {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  function setupDoctorHarness(errorReporting: ReturnType<typeof buildErrorReportingConfig>) {
+    const root = mkdtempSync(join(tmpdir(), "hm-doctor-errrep-"));
+    tmpRoots.push(root);
+
+    const sqlitePath = join(root, "facts.db");
+    const factsDb = new FactsDB(sqlitePath);
+    const mem = new Command("hybrid-mem");
+    mem.exitOverride();
+
+    registerDoctorCommand(
+      mem as never,
+      { sqlitePath, embedding: { provider: "openai", apiKey: "sk-test" }, errorReporting } as never,
+      factsDb,
+      { getAllIds: async () => [] } as never,
+      null,
+      sqlitePath,
+      null,
+      null,
+      undefined,
+      "test-plugin-version",
+    );
+
+    return { factsDb, mem };
+  }
+
+  it("calls initErrorReporter before running checks when errorReporting is enabled + consented", async () => {
+    const errorReporterMock = await import("../services/error-reporter.js");
+    const initSpy = vi.spyOn(errorReporterMock, "initErrorReporter").mockResolvedValue();
+    vi.spyOn(errorReporterMock, "isErrorReporterActive").mockReturnValue(false);
+    vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const { factsDb, mem } = setupDoctorHarness(buildErrorReportingConfig());
+
+    await mem.parseAsync(["doctor"], { from: "user" });
+
+    expect(initSpy).toHaveBeenCalledTimes(1);
+    const [config, pluginVersion] = initSpy.mock.calls[0]!;
+    expect(config).toMatchObject({ enabled: true, consent: true, mode: "community" });
+    expect(pluginVersion).toBe("test-plugin-version");
+    factsDb.close();
+  });
+
+  it("does not call initErrorReporter when errorReporting.enabled is false", async () => {
+    const errorReporterMock = await import("../services/error-reporter.js");
+    const initSpy = vi.spyOn(errorReporterMock, "initErrorReporter").mockResolvedValue();
+    vi.spyOn(errorReporterMock, "isErrorReporterActive").mockReturnValue(false);
+    vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const { factsDb, mem } = setupDoctorHarness(buildErrorReportingConfig({ enabled: false }));
+
+    await mem.parseAsync(["doctor"], { from: "user" });
+
+    expect(initSpy).not.toHaveBeenCalled();
+    factsDb.close();
+  });
+
+  it("does not call initErrorReporter when errorReporting.consent is false", async () => {
+    const errorReporterMock = await import("../services/error-reporter.js");
+    const initSpy = vi.spyOn(errorReporterMock, "initErrorReporter").mockResolvedValue();
+    vi.spyOn(errorReporterMock, "isErrorReporterActive").mockReturnValue(false);
+    vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const { factsDb, mem } = setupDoctorHarness(buildErrorReportingConfig({ consent: false }));
+
+    await mem.parseAsync(["doctor"], { from: "user" });
+
+    expect(initSpy).not.toHaveBeenCalled();
+    factsDb.close();
+  });
+
+  it("does not re-initialize when the reporter is already active in-process", async () => {
+    const errorReporterMock = await import("../services/error-reporter.js");
+    const initSpy = vi.spyOn(errorReporterMock, "initErrorReporter").mockResolvedValue();
+    vi.spyOn(errorReporterMock, "isErrorReporterActive").mockReturnValue(true);
+    vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const { factsDb, mem } = setupDoctorHarness(buildErrorReportingConfig());
+
+    await mem.parseAsync(["doctor"], { from: "user" });
+
+    expect(initSpy).not.toHaveBeenCalled();
+    factsDb.close();
+  });
+
+  it("does not fail doctor when initErrorReporter itself rejects", async () => {
+    const errorReporterMock = await import("../services/error-reporter.js");
+    vi.spyOn(errorReporterMock, "initErrorReporter").mockRejectedValue(new Error("reporter init failed"));
+    vi.spyOn(errorReporterMock, "isErrorReporterActive").mockReturnValue(false);
+    vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const { factsDb, mem } = setupDoctorHarness(buildErrorReportingConfig());
+
+    await expect(mem.parseAsync(["doctor"], { from: "user" })).resolves.toBeDefined();
+    factsDb.close();
+  });
+});

--- a/extensions/memory-hybrid/tests/maintenance-audit-journal.test.ts
+++ b/extensions/memory-hybrid/tests/maintenance-audit-journal.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Structured per-cron-lane run outcome persistence (issue #2231).
+ *
+ * Every hybrid-mem cron job funnels through `maintenance validate-exit` at shell exit (see
+ * cron-job-bash-harness.ts's `hm_validate` trap), so recordMaintenanceCronRunOutcome() gives
+ * `maintenance status` a durable, local record of "last scheduled run" / "last successful run"
+ * per cron lane — independent of whether GlitchTip telemetry is enabled/reachable.
+ */
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { runFactsMigrations } from "../backends/migrations/facts-migrations.js";
+import * as cronGuard from "../services/cron-guard.js";
+import {
+  getLastSuccessfulCronRun,
+  mapMaintenanceCronStatusToRunStatus,
+  recordMaintenanceCronRunOutcome,
+  resolveMaintenanceCronRetryStatus,
+} from "../services/maintenance-audit-journal.js";
+
+function openTestDb(): DatabaseSync {
+  const dir = mkdtempSync(join(tmpdir(), "hm-audit-journal-"));
+  const db = new DatabaseSync(join(dir, "facts.db"));
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS facts (
+      id TEXT PRIMARY KEY,
+      text TEXT NOT NULL,
+      category TEXT NOT NULL DEFAULT 'other',
+      importance REAL NOT NULL DEFAULT 0.5,
+      entity TEXT,
+      key TEXT,
+      value TEXT,
+      source TEXT NOT NULL DEFAULT 'conversation',
+      created_at INTEGER NOT NULL
+    )
+  `);
+  runFactsMigrations(db);
+  return db;
+}
+
+describe("mapMaintenanceCronStatusToRunStatus", () => {
+  it("mirrors the bash harness's own ledger_status mapping", () => {
+    // success -> ok, skipped -> skipped, partial -> failed, failed -> failed
+    // (cron-job-bash-harness.ts's hm_validate `case "$maintenance_status"`).
+    expect(mapMaintenanceCronStatusToRunStatus("success")).toBe("ran");
+    expect(mapMaintenanceCronStatusToRunStatus("skipped")).toBe("skipped:quiet");
+    expect(mapMaintenanceCronStatusToRunStatus("partial")).toBe("failed");
+    expect(mapMaintenanceCronStatusToRunStatus("failed")).toBe("failed");
+  });
+});
+
+describe("resolveMaintenanceCronRetryStatus", () => {
+  let openclawDir: string;
+
+  beforeEach(() => {
+    openclawDir = mkdtempSync(join(tmpdir(), "hm-audit-journal-retry-"));
+  });
+
+  it("is not_applicable for a successful or skipped run", () => {
+    expect(resolveMaintenanceCronRetryStatus("success", [], openclawDir)).toBe("not_applicable");
+    expect(resolveMaintenanceCronRetryStatus("skipped", [], openclawDir)).toBe("not_applicable");
+  });
+
+  it("is scheduled_retry for a failed run with no pending retry-once marker", () => {
+    expect(resolveMaintenanceCronRetryStatus("failed", ["distill"], openclawDir)).toBe("scheduled_retry");
+    expect(resolveMaintenanceCronRetryStatus("partial", ["distill"], openclawDir)).toBe("scheduled_retry");
+  });
+
+  it("is retry_pending when a failing step has a #2094 forced retry-once marker pending", () => {
+    cronGuard.markStepRetryOnce("distill", openclawDir);
+    expect(resolveMaintenanceCronRetryStatus("failed", ["distill"], openclawDir)).toBe("retry_pending");
+  });
+
+  it("does not treat an unrelated step's retry-once marker as covering the failing step", () => {
+    cronGuard.markStepRetryOnce("prune", openclawDir);
+    expect(resolveMaintenanceCronRetryStatus("failed", ["distill"], openclawDir)).toBe("scheduled_retry");
+  });
+});
+
+describe("recordMaintenanceCronRunOutcome / getLastSuccessfulCronRun", () => {
+  let db: DatabaseSync;
+
+  beforeEach(() => {
+    db = openTestDb();
+  });
+
+  afterEach(() => {
+    try {
+      db.close();
+    } catch {
+      // already closed by the test itself (e.g. the DB-error-swallowing test below).
+    }
+  });
+
+  it("is a no-op when db is undefined (never throws)", () => {
+    expect(() =>
+      recordMaintenanceCronRunOutcome(undefined, { jobName: "maintenance-nightly", maintenanceStatus: "success" }),
+    ).not.toThrow();
+  });
+
+  it("persists a successful run and it is returned by getLastSuccessfulCronRun", () => {
+    recordMaintenanceCronRunOutcome(db, { jobName: "maintenance-nightly", maintenanceStatus: "success" });
+
+    const row = getLastSuccessfulCronRun(db, "maintenance-nightly");
+    expect(row).not.toBeNull();
+    expect(row?.job).toBe("maintenance-nightly");
+    expect(row?.status).toBe("ran");
+  });
+
+  it("does not surface a failed run as successful", () => {
+    recordMaintenanceCronRunOutcome(db, {
+      jobName: "nightly-doctor-repair",
+      maintenanceStatus: "failed",
+      primaryFailure: {
+        stepName: "doctor-fix-reconcile",
+        failureClass: "nonzero_exit",
+        message: "nightly-doctor-repair:doctor-fix-reconcile exited non-zero",
+      },
+      failingStepNames: ["doctor-fix-reconcile"],
+    });
+
+    expect(getLastSuccessfulCronRun(db, "nightly-doctor-repair")).toBeNull();
+  });
+
+  it("stores phase/errorClass/retryStatus in metadata without leaking raw log/prompt content", () => {
+    recordMaintenanceCronRunOutcome(db, {
+      jobName: "maintenance-nightly",
+      maintenanceStatus: "failed",
+      primaryFailure: {
+        stepName: "distill",
+        failureClass: "nonzero_exit",
+        message: "maintenance-nightly:distill exited non-zero",
+      },
+      failingStepNames: ["distill"],
+    });
+
+    const rows = db
+      .prepare("SELECT job, status, error_summary, metadata_json FROM maintenance_runs WHERE job = ?")
+      .all("maintenance-nightly") as Array<{
+      job: string;
+      status: string;
+      error_summary: string | null;
+      metadata_json: string | null;
+    }>;
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.status).toBe("failed");
+    expect(rows[0]?.error_summary).toBe("maintenance-nightly:distill exited non-zero");
+    const metadata = JSON.parse(rows[0]?.metadata_json ?? "{}");
+    expect(metadata.phase).toBe("distill");
+    expect(metadata.errorClass).toBe("nonzero_exit");
+    expect(metadata.retryStatus).toBe("scheduled_retry");
+    expect(metadata.maintenanceStatus).toBe("failed");
+  });
+
+  it("distinguishes independent job lanes by job name", () => {
+    recordMaintenanceCronRunOutcome(db, { jobName: "maintenance-nightly", maintenanceStatus: "success" });
+    recordMaintenanceCronRunOutcome(db, {
+      jobName: "nightly-doctor-repair",
+      maintenanceStatus: "failed",
+      primaryFailure: { stepName: "doctor-fix-reconcile", failureClass: "nonzero_exit", message: "failed" },
+      failingStepNames: ["doctor-fix-reconcile"],
+    });
+
+    expect(getLastSuccessfulCronRun(db, "maintenance-nightly")).not.toBeNull();
+    expect(getLastSuccessfulCronRun(db, "nightly-doctor-repair")).toBeNull();
+  });
+
+  it("swallows a DB error instead of throwing (never fails the cron job)", () => {
+    db.close();
+    expect(() =>
+      recordMaintenanceCronRunOutcome(db, { jobName: "maintenance-nightly", maintenanceStatus: "success" }),
+    ).not.toThrow();
+  });
+});

--- a/extensions/memory-hybrid/tests/maintenance-orchestrator.test.ts
+++ b/extensions/memory-hybrid/tests/maintenance-orchestrator.test.ts
@@ -1,7 +1,7 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import { hostname, tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { HybridMemoryConfig } from "../config.js";
 import {
   acquireStepLock,
@@ -723,5 +723,156 @@ describe("maintenance-orchestrator", () => {
     );
     expect(pruneCalls).toBe(1);
     expect(result.steps[0]?.summary).toContain("pruned=3");
+  });
+});
+
+describe("maintenance-orchestrator nested cron-lane exception capture (#2231)", () => {
+  let openclawDir: string;
+  const origHmJob = process.env.HM_JOB;
+
+  afterEach(() => {
+    if (openclawDir) rmSync(openclawDir, { recursive: true, force: true });
+    if (origHmJob === undefined) delete process.env.HM_JOB;
+    else process.env.HM_JOB = origHmJob;
+    vi.restoreAllMocks();
+  });
+
+  function reportingEnabledCfg(): HybridMemoryConfig {
+    return {
+      maintenance: {
+        orchestrator: { rateLimitMaxRetries: 2, llmCooldownBetweenStepsMs: 0 },
+        failureReporting: { enabled: true },
+      },
+      errorReporting: { enabled: true, consent: true },
+    } as HybridMemoryConfig;
+  }
+
+  it("captures a thrown step exception via capturePluginError, tagged with job/step/tier", async () => {
+    openclawDir = mkdtempSync(join(tmpdir(), "hm-orch-"));
+    process.env.HM_JOB = "maintenance-nightly";
+    const errorReporterModule = await import("../services/error-reporter.js");
+    const captureSpy = vi.spyOn(errorReporterModule, "capturePluginError").mockReturnValue(undefined);
+
+    const runners = new Map<string, () => Promise<string>>([
+      [
+        "distill",
+        async () => {
+          throw new Error("Invalid 'tools': array too long. Expected maximum length 128, got 141");
+        },
+      ],
+    ]);
+
+    await runMaintenanceOrchestrator(
+      { cfg: reportingEnabledCfg(), runners, openclawDir },
+      { tiers: ["nightly"], force: true, verbose: false, include: ["distill"] },
+    );
+
+    expect(captureSpy).toHaveBeenCalledTimes(1);
+    const [error, context] = captureSpy.mock.calls[0]!;
+    expect(error.message).toContain("tools': array too long");
+    expect(context.subsystem).toBe("maintenance");
+    expect(context.phase).toBe("orchestrator-step");
+    expect(context.tags?.job_name).toBe("maintenance-nightly");
+    expect(context.tags?.step_name).toBe("distill");
+    expect(context.tags?.tier).toBe("nightly");
+  });
+
+  it("falls back to a generic job_name when HM_JOB is unset (manual CLI invocation)", async () => {
+    openclawDir = mkdtempSync(join(tmpdir(), "hm-orch-"));
+    delete process.env.HM_JOB;
+    const errorReporterModule = await import("../services/error-reporter.js");
+    const captureSpy = vi.spyOn(errorReporterModule, "capturePluginError").mockReturnValue(undefined);
+
+    const runners = new Map<string, () => Promise<string>>([
+      [
+        "prune",
+        async () => {
+          throw new Error("boom");
+        },
+      ],
+    ]);
+
+    await runMaintenanceOrchestrator(
+      { cfg: reportingEnabledCfg(), runners, openclawDir },
+      { tiers: ["cycle"], force: true, verbose: false, include: ["prune"] },
+    );
+
+    expect(captureSpy).toHaveBeenCalledTimes(1);
+    expect(captureSpy.mock.calls[0]![1].tags?.job_name).toBe("maintenance-orchestrator");
+  });
+
+  it("does not capture when errorReporting is disabled", async () => {
+    openclawDir = mkdtempSync(join(tmpdir(), "hm-orch-"));
+    const errorReporterModule = await import("../services/error-reporter.js");
+    const captureSpy = vi.spyOn(errorReporterModule, "capturePluginError").mockReturnValue(undefined);
+
+    const runners = new Map<string, () => Promise<string>>([
+      [
+        "prune",
+        async () => {
+          throw new Error("boom");
+        },
+      ],
+    ]);
+
+    await runMaintenanceOrchestrator(
+      { cfg: minimalCfg(), runners, openclawDir },
+      { tiers: ["cycle"], force: true, verbose: false, include: ["prune"] },
+    );
+
+    expect(captureSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not capture when maintenance.failureReporting.enabled is false", async () => {
+    openclawDir = mkdtempSync(join(tmpdir(), "hm-orch-"));
+    const errorReporterModule = await import("../services/error-reporter.js");
+    const captureSpy = vi.spyOn(errorReporterModule, "capturePluginError").mockReturnValue(undefined);
+
+    const cfg = {
+      maintenance: {
+        orchestrator: { rateLimitMaxRetries: 2, llmCooldownBetweenStepsMs: 0 },
+        failureReporting: { enabled: false },
+      },
+      errorReporting: { enabled: true, consent: true },
+    } as HybridMemoryConfig;
+
+    const runners = new Map<string, () => Promise<string>>([
+      [
+        "prune",
+        async () => {
+          throw new Error("boom");
+        },
+      ],
+    ]);
+
+    await runMaintenanceOrchestrator(
+      { cfg, runners, openclawDir },
+      { tiers: ["cycle"], force: true, verbose: false, include: ["prune"] },
+    );
+
+    expect(captureSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not capture a rate-limited step failure (matches chat.ts's own 429 non-reporting convention)", async () => {
+    openclawDir = mkdtempSync(join(tmpdir(), "hm-orch-"));
+    const errorReporterModule = await import("../services/error-reporter.js");
+    const captureSpy = vi.spyOn(errorReporterModule, "capturePluginError").mockReturnValue(undefined);
+
+    const runners = new Map<string, () => Promise<string>>([
+      [
+        "distill",
+        async () => {
+          const err = new Error("429 Too Many Requests");
+          throw err;
+        },
+      ],
+    ]);
+
+    await runMaintenanceOrchestrator(
+      { cfg: reportingEnabledCfg(), runners, openclawDir },
+      { tiers: ["nightly"], force: true, verbose: false, include: ["distill"] },
+    );
+
+    expect(captureSpy).not.toHaveBeenCalled();
   });
 });

--- a/extensions/memory-hybrid/tests/register-maintenance-health-cli.test.ts
+++ b/extensions/memory-hybrid/tests/register-maintenance-health-cli.test.ts
@@ -3,13 +3,47 @@
  * or fail to detect problems, so cron wrappers and CI can gate on the exit code instead of
  * having to scrape stdout for a warning icon.
  */
-import { Command } from "commander";
+
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { Command } from "commander";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { FactsDB } from "../backends/facts-db.js";
+import { runFactsMigrations } from "../backends/migrations/facts-migrations.js";
 import { registerMaintenanceHealthCommands } from "../cli/commands/manage/register-maintenance-health.js";
 import type { HybridMemoryConfig } from "../config.js";
+import { recordMaintenanceCronRunOutcome } from "../services/maintenance-audit-journal.js";
+
+function openTestFactsDb(): { db: DatabaseSync; factsDb: FactsDB } {
+  const dir = mkdtempSync(join(tmpdir(), "hm-maint-health-db-"));
+  const db = new DatabaseSync(join(dir, "facts.db"));
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS facts (
+      id TEXT PRIMARY KEY,
+      text TEXT NOT NULL,
+      category TEXT NOT NULL DEFAULT 'other',
+      importance REAL NOT NULL DEFAULT 0.5,
+      entity TEXT,
+      key TEXT,
+      value TEXT,
+      source TEXT NOT NULL DEFAULT 'conversation',
+      created_at INTEGER NOT NULL
+    )
+  `);
+  runFactsMigrations(db);
+  return { db, factsDb: { getRawDb: () => db } as unknown as FactsDB };
+}
+
+/** #2231: `status`/`cron-health` now also monitor nightly-doctor-repair, so a "healthy" cron-store
+ *  fixture must include it alongside maintenance-nightly for exit-code assertions to still hold. */
+const HEALTHY_DOCTOR_REPAIR_JOB = {
+  pluginJobId: "hybrid-mem:nightly-doctor-repair",
+  name: "nightly-doctor-repair",
+  enabled: true,
+  state: { lastRunAtMs: Date.now(), lastStatus: "success" },
+};
 
 describe("maintenance status / cron-health exit codes", () => {
   let homeDir: string;
@@ -56,6 +90,7 @@ describe("maintenance status / cron-health exit codes", () => {
             enabled: true,
             state: { lastRunAtMs: Date.now(), lastStatus: "success" },
           },
+          HEALTHY_DOCTOR_REPAIR_JOB,
         ],
       }),
       "utf-8",
@@ -66,6 +101,59 @@ describe("maintenance status / cron-health exit codes", () => {
     await mem.parseAsync(["maintenance", "status"], { from: "user" });
 
     expect(process.exitCode ?? 0).toBe(0);
+  });
+
+  it("maintenance status includes nightly-doctor-repair as a monitored job (#2231)", async () => {
+    writeFileSync(
+      join(homeDir, ".openclaw", "cron", "jobs.json"),
+      JSON.stringify({
+        jobs: [
+          {
+            pluginJobId: "hybrid-mem:maintenance-nightly",
+            name: "maintenance-nightly",
+            enabled: true,
+            state: { lastRunAtMs: Date.now(), lastStatus: "success" },
+          },
+          HEALTHY_DOCTOR_REPAIR_JOB,
+        ],
+      }),
+      "utf-8",
+    );
+    let jsonOut = "";
+    vi.spyOn(console, "log").mockImplementation((arg: unknown) => {
+      jsonOut = String(arg);
+    });
+    const mem = makeProgram();
+
+    await mem.parseAsync(["maintenance", "status", "--json"], { from: "user" });
+
+    const parsed = JSON.parse(jsonOut) as { jobs: Array<{ name: string; lastSuccessfulRunAt: string | null }> };
+    const doctorRepair = parsed.jobs.find((j) => j.name === "nightly-doctor-repair");
+    expect(doctorRepair).toBeDefined();
+    expect(doctorRepair).toHaveProperty("lastSuccessfulRunAt");
+  });
+
+  it("maintenance status sets process.exitCode=1 when nightly-doctor-repair is missing (#2231)", async () => {
+    writeFileSync(
+      join(homeDir, ".openclaw", "cron", "jobs.json"),
+      JSON.stringify({
+        jobs: [
+          {
+            pluginJobId: "hybrid-mem:maintenance-nightly",
+            name: "maintenance-nightly",
+            enabled: true,
+            state: { lastRunAtMs: Date.now(), lastStatus: "success" },
+          },
+        ],
+      }),
+      "utf-8",
+    );
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    const mem = makeProgram();
+
+    await mem.parseAsync(["maintenance", "status"], { from: "user" });
+
+    expect(process.exitCode).toBe(1);
   });
 
   it("cron-health sets process.exitCode=1 when a critical job is missing", async () => {
@@ -99,6 +187,7 @@ describe("maintenance status / cron-health exit codes", () => {
             enabled: true,
             state: { lastRunAtMs: Date.now(), lastStatus: "success" },
           },
+          HEALTHY_DOCTOR_REPAIR_JOB,
         ],
       }),
       "utf-8",
@@ -109,6 +198,29 @@ describe("maintenance status / cron-health exit codes", () => {
     await mem.parseAsync(["maintenance", "cron-health"], { from: "user" });
 
     expect(process.exitCode ?? 0).toBe(0);
+  });
+
+  it("cron-health sets process.exitCode=1 when nightly-doctor-repair is missing (#2231)", async () => {
+    writeFileSync(
+      join(homeDir, ".openclaw", "cron", "jobs.json"),
+      JSON.stringify({
+        jobs: [
+          {
+            pluginJobId: "hybrid-mem:maintenance-nightly",
+            name: "maintenance-nightly",
+            enabled: true,
+            state: { lastRunAtMs: Date.now(), lastStatus: "success" },
+          },
+        ],
+      }),
+      "utf-8",
+    );
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const mem = makeProgram();
+
+    await mem.parseAsync(["maintenance", "cron-health"], { from: "user" });
+
+    expect(process.exitCode).toBe(1);
   });
 });
 
@@ -147,6 +259,7 @@ describe("maintenance status folds in analyze-maintenance-logs strict findings (
             enabled: true,
             state: { lastRunAtMs: Date.now(), lastStatus: "success" },
           },
+          HEALTHY_DOCTOR_REPAIR_JOB,
         ],
       }),
       "utf-8",
@@ -302,5 +415,115 @@ describe("maintenance status surfaces active/stale maintenance step locks (#2031
 
     expect(lines.some((l) => l.includes("Active/stale maintenance step locks"))).toBe(true);
     expect(lines.some((l) => l.includes("step--distill"))).toBe(true);
+  });
+});
+
+describe("maintenance status exposes last-successful-run per job from local audit journal (#2231)", () => {
+  let homeDir: string;
+  let db: DatabaseSync;
+  let factsDb: FactsDB;
+
+  beforeEach(() => {
+    homeDir = mkdtempSync(join(tmpdir(), "hm-maint-health-"));
+    mkdirSync(join(homeDir, ".openclaw", "cron"), { recursive: true });
+    vi.stubEnv("HOME", homeDir);
+    ({ db, factsDb } = openTestFactsDb());
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+    process.exitCode = undefined;
+    db.close();
+    rmSync(homeDir, { recursive: true, force: true });
+  });
+
+  function writeHealthyJobs() {
+    writeFileSync(
+      join(homeDir, ".openclaw", "cron", "jobs.json"),
+      JSON.stringify({
+        jobs: [
+          {
+            pluginJobId: "hybrid-mem:maintenance-nightly",
+            name: "maintenance-nightly",
+            enabled: true,
+            state: { lastRunAtMs: Date.now(), lastStatus: "success" },
+          },
+          HEALTHY_DOCTOR_REPAIR_JOB,
+        ],
+      }),
+      "utf-8",
+    );
+  }
+
+  it("reports lastSuccessfulRunAt=null when no cron-lane run has been recorded yet", async () => {
+    writeHealthyJobs();
+    let jsonOut = "";
+    vi.spyOn(console, "log").mockImplementation((arg: unknown) => {
+      jsonOut = String(arg);
+    });
+    const mem = new Command("hybrid-mem");
+    mem.exitOverride();
+    const maintenance = mem.command("maintenance");
+    registerMaintenanceHealthCommands(maintenance, {} as HybridMemoryConfig, factsDb);
+
+    await mem.parseAsync(["maintenance", "status", "--json"], { from: "user" });
+
+    const parsed = JSON.parse(jsonOut) as { jobs: Array<{ name: string; lastSuccessfulRunAt: string | null }> };
+    expect(parsed.jobs.find((j) => j.name === "maintenance-nightly")?.lastSuccessfulRunAt).toBeNull();
+    expect(parsed.jobs.find((j) => j.name === "nightly-doctor-repair")?.lastSuccessfulRunAt).toBeNull();
+  });
+
+  it("surfaces the most recent successful cron-lane run recorded via recordMaintenanceCronRunOutcome", async () => {
+    writeHealthyJobs();
+    recordMaintenanceCronRunOutcome(db, {
+      jobName: "nightly-doctor-repair",
+      maintenanceStatus: "success",
+    });
+
+    let jsonOut = "";
+    vi.spyOn(console, "log").mockImplementation((arg: unknown) => {
+      jsonOut = String(arg);
+    });
+    const mem = new Command("hybrid-mem");
+    mem.exitOverride();
+    const maintenance = mem.command("maintenance");
+    registerMaintenanceHealthCommands(maintenance, {} as HybridMemoryConfig, factsDb);
+
+    await mem.parseAsync(["maintenance", "status", "--json"], { from: "user" });
+
+    const parsed = JSON.parse(jsonOut) as { jobs: Array<{ name: string; lastSuccessfulRunAt: string | null }> };
+    const doctorRepair = parsed.jobs.find((j) => j.name === "nightly-doctor-repair");
+    expect(doctorRepair?.lastSuccessfulRunAt).not.toBeNull();
+    // A failed cron-lane run for a DIFFERENT job must not leak into maintenance-nightly's own field.
+    expect(parsed.jobs.find((j) => j.name === "maintenance-nightly")?.lastSuccessfulRunAt).toBeNull();
+  });
+
+  it("does not surface a failed cron-lane run as a successful one", async () => {
+    writeHealthyJobs();
+    recordMaintenanceCronRunOutcome(db, {
+      jobName: "maintenance-nightly",
+      maintenanceStatus: "failed",
+      primaryFailure: {
+        stepName: "distill",
+        failureClass: "nonzero_exit",
+        message: "maintenance-nightly:distill exited non-zero",
+      },
+      failingStepNames: ["distill"],
+    });
+
+    let jsonOut = "";
+    vi.spyOn(console, "log").mockImplementation((arg: unknown) => {
+      jsonOut = String(arg);
+    });
+    const mem = new Command("hybrid-mem");
+    mem.exitOverride();
+    const maintenance = mem.command("maintenance");
+    registerMaintenanceHealthCommands(maintenance, {} as HybridMemoryConfig, factsDb);
+
+    await mem.parseAsync(["maintenance", "status", "--json"], { from: "user" });
+
+    const parsed = JSON.parse(jsonOut) as { jobs: Array<{ name: string; lastSuccessfulRunAt: string | null }> };
+    expect(parsed.jobs.find((j) => j.name === "maintenance-nightly")?.lastSuccessfulRunAt).toBeNull();
   });
 });

--- a/extensions/memory-hybrid/tests/validate-cron-exit-run-persistence.test.ts
+++ b/extensions/memory-hybrid/tests/validate-cron-exit-run-persistence.test.ts
@@ -1,0 +1,175 @@
+/**
+ * `maintenance validate-exit` now persists a structured per-cron-lane run outcome locally
+ * (issue #2231), independent of whether GlitchTip telemetry (errorReporting.consent) is enabled —
+ * this is local audit-journal bookkeeping, not external reporting.
+ */
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { Command } from "commander";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { runFactsMigrations } from "../backends/migrations/facts-migrations.js";
+import {
+  registerValidateCronExit,
+  type ValidateCronExitContext,
+} from "../cli/commands/manage/register-validate-cron-exit.js";
+import { getLastSuccessfulCronRun } from "../services/maintenance-audit-journal.js";
+
+function openTestDb(): DatabaseSync {
+  const dir = mkdtempSync(join(tmpdir(), "hm-val-cron-journal-"));
+  const db = new DatabaseSync(join(dir, "facts.db"));
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS facts (
+      id TEXT PRIMARY KEY,
+      text TEXT NOT NULL,
+      category TEXT NOT NULL DEFAULT 'other',
+      importance REAL NOT NULL DEFAULT 0.5,
+      entity TEXT,
+      key TEXT,
+      value TEXT,
+      source TEXT NOT NULL DEFAULT 'conversation',
+      created_at INTEGER NOT NULL
+    )
+  `);
+  runFactsMigrations(db);
+  return db;
+}
+
+// Minimal, permissive context — reporting is deliberately disabled in most of these tests so the
+// local-persistence behavior can be verified independently of errorReporting consent.
+function disabledReportingCfg(): ValidateCronExitContext["cfg"] {
+  return {
+    errorReporting: { enabled: false, consent: false } as ValidateCronExitContext["cfg"]["errorReporting"],
+    maintenance: {
+      failureReporting: { enabled: true },
+    } as ValidateCronExitContext["cfg"]["maintenance"],
+  };
+}
+
+describe("validate-cron-exit persists structured cron-lane run outcomes (#2231)", () => {
+  const origArgv = process.argv.slice();
+  let db: DatabaseSync | undefined;
+
+  afterEach(() => {
+    process.argv = origArgv;
+    process.exitCode = undefined;
+    vi.restoreAllMocks();
+    try {
+      db?.close();
+    } catch {
+      // already closed by a previous test in this suite — nothing to clean up.
+    }
+    db = undefined;
+  });
+
+  function stubOpenclawArgv() {
+    process.argv = ["node", "/usr/bin/openclaw", "hybrid-mem"];
+  }
+
+  it("records a successful run even when telemetry reporting is disabled", async () => {
+    stubOpenclawArgv();
+    const testDb = openTestDb();
+    db = testDb;
+    const dir = mkdtempSync(join(tmpdir(), "hm-val-cron-"));
+    const exitPath = join(dir, "maintenance-nightly-20260729T020000Z-1.exit.txt");
+    const logPath = join(dir, "maintenance-nightly-20260729T020000Z-1.log");
+    writeFileSync(exitPath, "2026-07-29T02:00:00Z prune exit=0\n");
+    writeFileSync(logPath, "all good\n");
+
+    const mem = new Command("hybrid-mem");
+    registerValidateCronExit(mem, {
+      cfg: disabledReportingCfg(),
+      versionInfo: { pluginVersion: "1.0.0-test" },
+      journalDb: testDb,
+    });
+
+    vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+    vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await mem.parseAsync(
+      ["validate-cron-exit", "--exit-path", exitPath, "--log-path", logPath, "--required-steps", "prune", "--json"],
+      { from: "user" },
+    );
+
+    await vi.waitFor(() => {
+      const row = getLastSuccessfulCronRun(testDb, "maintenance-nightly");
+      expect(row).not.toBeNull();
+    });
+  });
+
+  it("records a failed run with the first failing step's phase/errorClass, not a successful one", async () => {
+    stubOpenclawArgv();
+    const testDb = openTestDb();
+    db = testDb;
+    const dir = mkdtempSync(join(tmpdir(), "hm-val-cron-"));
+    const exitPath = join(dir, "nightly-doctor-repair-20260729T031500Z-1.exit.txt");
+    const logPath = join(dir, "nightly-doctor-repair-20260729T031500Z-1.log");
+    writeFileSync(exitPath, "2026-07-29T03:15:00Z doctor-fix-reconcile exit=1\n");
+    writeFileSync(logPath, "doctor-fix-reconcile failed\n");
+
+    const mem = new Command("hybrid-mem");
+    registerValidateCronExit(mem, {
+      cfg: disabledReportingCfg(),
+      versionInfo: { pluginVersion: "1.0.0-test" },
+      journalDb: testDb,
+    });
+
+    vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+    vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await mem.parseAsync(
+      [
+        "validate-cron-exit",
+        "--exit-path",
+        exitPath,
+        "--log-path",
+        logPath,
+        "--required-steps",
+        "doctor-fix-reconcile",
+        "--json",
+      ],
+      { from: "user" },
+    );
+
+    await vi.waitFor(() => {
+      const rows = testDb
+        .prepare("SELECT job, status, error_summary, metadata_json FROM maintenance_runs WHERE job = ?")
+        .all("nightly-doctor-repair") as Array<{ job: string; status: string; metadata_json: string | null }>;
+      expect(rows.length).toBeGreaterThan(0);
+    });
+
+    expect(getLastSuccessfulCronRun(testDb, "nightly-doctor-repair")).toBeNull();
+    const rows = testDb
+      .prepare("SELECT job, status, error_summary, metadata_json FROM maintenance_runs WHERE job = ?")
+      .all("nightly-doctor-repair") as Array<{ job: string; status: string; metadata_json: string | null }>;
+    expect(rows[0]?.status).toBe("failed");
+    const metadata = JSON.parse(rows[0]?.metadata_json ?? "{}");
+    expect(metadata.phase).toBe("doctor-fix-reconcile");
+  });
+
+  it("does not attempt local persistence when no journalDb is provided (backward compatible)", async () => {
+    stubOpenclawArgv();
+    const dir = mkdtempSync(join(tmpdir(), "hm-val-cron-"));
+    const exitPath = join(dir, "success.exit");
+    const logPath = join(dir, "success.log");
+    writeFileSync(exitPath, "2026-07-29T02:00:00Z prune exit=0\n");
+    writeFileSync(logPath, "all good\n");
+
+    const mem = new Command("hybrid-mem");
+    registerValidateCronExit(mem, {
+      cfg: disabledReportingCfg(),
+      versionInfo: { pluginVersion: "1.0.0-test" },
+    });
+
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+    vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await mem.parseAsync(
+      ["validate-cron-exit", "--exit-path", exitPath, "--log-path", logPath, "--required-steps", "prune", "--json"],
+      { from: "user" },
+    );
+
+    await vi.waitFor(() => expect(exitSpy).toHaveBeenCalledWith(0));
+  });
+});


### PR DESCRIPTION
## Summary

Closes #2231.

DorisVM's `hybrid-mem:maintenance-nightly` / `hybrid-mem:nightly-doctor-repair` cron runs failed repeatedly on 2026-07-29, but there was no reliable local record of it and provider/nested-step failures weren't consistently reaching telemetry. This PR closes the specific gaps found after auditing the existing (substantial) maintenance-orchestration/error-reporting infrastructure — it does not rebuild it.

**What already existed (unchanged):**
- `services/cron-exit-validator.ts` + `services/maintenance-failure-reporter.ts`: post-hoc, log-pattern-derived issue detection + `capturePluginError` reporting, run once per cron job at shell exit via the bash harness's `hm_validate` trap (`cli/commands/manage/register-validate-cron-exit.ts`).
- `services/maintenance-audit-journal.ts` (`maintenance_runs` SQLite table, #1913): per-*orchestrator-step* run tracking (e.g. "distill", "prune"), written from `runMaintenanceOrchestrator`'s `pushStepResult`.
- `cli/commands/manage/register-maintenance-orchestrator.ts`: already initializes the error reporter before running `maintenance cycle/nightly/full` so step-level `capturePluginError` calls (e.g. `services/chat.ts`'s provider-fallback-exhausted capture) work.
- `cli/commands/manage/register-maintenance-health.ts`: `maintenance status`/`cron-health` already read OpenClaw's own cron-store `lastRunAt`/`lastStatus`.

**Gaps closed:**
1. **No structured per-*cron-lane* outcome, independent of telemetry.** The existing `maintenance_runs` table only tracked individual orchestrator *steps*, not the cron *lane* itself (`maintenance-nightly`, `nightly-doctor-repair`, ...), and `reportMaintenanceFailureIssues` only fires when GlitchTip reporting is enabled/consented. Added `recordMaintenanceCronRunOutcome`/`getLastSuccessfulCronRun`/`resolveMaintenanceCronRetryStatus` in `services/maintenance-audit-journal.ts`, wired into `maintenance validate-exit` (`register-validate-cron-exit.ts`) — one row per cron-lane invocation with success/failure, phase (first failing nested step), error class, timestamp, and retry status, written **unconditionally** (local bookkeeping, not external telemetry).
2. **Nested-lane failures collapsed into one opaque event.** `maintenance-nightly`'s bash wrapper is a *single* `hm_step`, so a failure in any of the ~40 internal orchestrator steps (distill, dream-run, self-correction, ...) only ever produced one generic `"maintenance-nightly exited non-zero"` post-hoc issue unless that step's own code happened to call `capturePluginError` itself. Added a safety-net `capturePluginError` call in `runMaintenanceOrchestrator`'s step-failure catch block (`services/maintenance-orchestrator.ts`), tagged with `job_name`/`step_name`/`tier`/`run_id`, gated the same way `maintenance.failureReporting`/`errorReporting` already gate reporting elsewhere. It uses the default (message-derived) fingerprint so it naturally dedupes against a deeper capture of the same error instead of doubling telemetry volume.
3. **`nightly-doctor-repair` never activated the error reporter.** `doctor --fix --reconcile` (the doctor-repair cron payload) ran in its own isolated one-shot process and never called `initErrorReporter`, so any `capturePluginError` calls inside the repair/reconcile pipeline were silent no-ops. `cmd-doctor.ts` now activates the reporter on entry, mirroring the existing pattern in `register-maintenance-orchestrator.ts`. `pluginVersion` threaded through `cmd-user-friendly.ts`/`cli/register.ts` to support this.
4. **Health surface never monitored `nightly-doctor-repair`, and had no "last successful run" distinct from "last run".** `maintenance status`/`cron-health` (`register-maintenance-health.ts`) now also monitor `hybrid-mem:nightly-doctor-repair` (it's never superseded by consolidated-cron mode), and `maintenance status --json` reports a `lastSuccessfulRunAt` per job sourced from the new local audit-journal rows — distinct from `lastRunAt`/`lastStatus`, which only reflect OpenClaw's own single-snapshot cron-store bookkeeping (no history, and doesn't know hybrid-memory's own validation verdict).

**Privacy:** all new `capturePluginError`/local-DB fields are short structured metadata (job/step/tier/error-class/status strings) — no raw log, prompt, or tool payload — following the existing `MaintenanceTelemetryIssue.message` convention already considered safe for external transmission.

**Note on #2228:** telemetry-mute-for-outdated-version (the other half of why the original DorisVM failures went unreported) is being fixed separately in #2228 and is untouched here. This PR's local persistence (item 1) is deliberately independent of that mute state so `maintenance status` stays useful regardless of telemetry health.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor / internal improvement (no behavior change)
- [ ] Documentation update
- [ ] CI / tooling change

## Quality Checklist

- [x] `cd extensions/memory-hybrid && npx tsc --noEmit` passes with no errors
- [x] `cd extensions/memory-hybrid && npm run lint` passes with no warnings
- [x] `cd extensions/memory-hybrid && npm test` passes (all tests green) — full suite run (10,193 tests); 6 failures in unrelated files (`facts-db.test.ts`, `sql-guardrails.test.ts`, `sql-schema-guardrails.test.ts`, `verify-llm-test-failure-exit-code.test.ts`) reproduced as environment/resource-contention flakiness (multiple concurrent CI-style runs on a shared 4-core box) — all pass cleanly in isolation and are untouched by this diff.
- [x] No secrets, credentials, or API keys committed
- [x] No `console.log` debug statements left in production code

## Documentation Impact

- [x] Inline code comments (JSDoc) updated for modified functions and types
- [x] `docs/` updated — `docs/CLI-REFERENCE.md` gained a note on the new `nightly-doctor-repair` health monitoring and `lastSuccessfulRunAt` field
- [x] Cross-referenced functions/services checked for outdated documentation

## Testing

- [x] Unit tests added / updated:
  - `tests/maintenance-audit-journal.test.ts` (new) — status mapping, retry-status derivation, record/query round-trip, DB-error swallowing
  - `tests/validate-cron-exit-run-persistence.test.ts` (new) — `maintenance validate-exit` persists success/failure cron-lane outcomes locally regardless of telemetry consent
  - `tests/maintenance-orchestrator.test.ts` — new describe block covering the nested-lane `capturePluginError` safety net (tagging, HM_JOB fallback, gating on errorReporting/failureReporting config, no double-capture for rate-limited failures)
  - `tests/cmd-doctor-error-reporting.test.ts` (new) — doctor activates/doesn't activate the error reporter per the same gates as the maintenance-orchestrator CLI
  - `tests/register-maintenance-health-cli.test.ts` — extended for `nightly-doctor-repair` monitoring and `lastSuccessfulRunAt` exposure (including real-DB round-trip tests)

## Notes for Reviewer

- The exact **local persistence schema** (reusing `maintenance_runs` with a `kind: "cron-lane-run"` metadata marker, keyed by short job name e.g. `"maintenance-nightly"`) and the **"retry status" semantics** (`not_applicable` / `retry_pending` when a #2094 retry-once marker is pending / `scheduled_retry` otherwise, since these are recurring cron jobs) were my own design calls within the acceptance criteria's wording — flagging in case a different shape is preferred.
- Deliberately did **not** add ambient (ttls/AsyncLocalStorage-based) job/step context tagging for *every* `capturePluginError` call site reachable during a maintenance run — the cycle-tier orchestrator runs inside the shared, long-lived gateway process, and process-wide mutable ambient state risked mistagging unrelated concurrent request errors. The safety-net capture in the orchestrator's own catch block uses explicit, non-shared parameters instead.
- Left `#2228` (telemetry-mute-for-outdated-version) untouched per instructions; the local audit-journal write (acceptance criterion 1) is intentionally independent of that mute state.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Eb78N8a8yCMgVT2pY1K3QE)_