### PR TITLE
fix: reject dispatches for terminal goals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [2026.8.2] - 2026-08-03
+
+### Fixed
+
+- Goal dispatch now rejects terminal (completed/abandoned) goals at every dispatch boundary — request parsing, the broker reservation lock, and immediately before launch — closing a race where a stale cron wake or a concurrent `goal_complete`/`goal_abandon` could still dispatch work against an already-terminated goal. The broker reservation now accepts a lock-time dispatchability predicate so the terminal-state check is re-validated while the reservation is committed, not only when the request was first parsed.
+
+### Release metadata
+
+- Bumps `openclaw-hybrid-memory` and the lockstep standalone installer to `2026.8.2`. `package.json` remains the source of truth; derived plugin and installer version metadata are synchronized by `scripts/sync-plugin-version.cjs`.
+
 ## [2026.8.1] - 2026-08-02
 
 ### Fixed

--- a/extensions/memory-hybrid/openclaw.plugin.json
+++ b/extensions/memory-hybrid/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "openclaw-hybrid-memory",
   "kind": "memory",
-  "version": "2026.8.1",
+  "version": "2026.8.2",
   "contracts": {
     "tools": [
       "active_task_checkpoint",

--- a/extensions/memory-hybrid/package.json
+++ b/extensions/memory-hybrid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-hybrid-memory",
-  "version": "2026.8.1",
+  "version": "2026.8.2",
   "type": "module",
   "description": "Give your OpenClaw agent lasting memory: structured facts, semantic search, auto-capture & recall, decay, optional credential vault. Part of Hybrid Memory v3.",
   "files": [

--- a/extensions/memory-hybrid/services/goal-dispatch-broker.ts
+++ b/extensions/memory-hybrid/services/goal-dispatch-broker.ts
@@ -73,9 +73,15 @@ export class GoalDispatchBroker {
     owner?: string;
     sessionId?: string;
     target?: CanonicalTarget;
+    /** Re-validate mutable goal state while the reservation is being committed. */
+    isDispatchable?: () => Promise<boolean>;
   }): Promise<DispatchRecord | null> {
-    return this.withLedger((ledger) => {
+    return this.withLedger(async (ledger) => {
       this.expire(ledger);
+      // The caller supplies the authoritative goal-state read. This check belongs at the
+      // reservation boundary (rather than only at request parsing) because a stale timer or
+      // concurrent goal_complete/goal_abandon may race a previously validated dispatch.
+      if (input.isDispatchable && !(await input.isDispatchable())) return null;
       // A goal's canonical target is part of the same locked reservation decision.
       const active = Object.values(ledger.dispatches).filter(
         (x) => x.goalId === input.goalId && ["reserved", "launched"].includes(x.status),

--- a/extensions/memory-hybrid/tests/goal-dispatch-broker-policy.test.ts
+++ b/extensions/memory-hybrid/tests/goal-dispatch-broker-policy.test.ts
@@ -8,7 +8,7 @@ type ToolResult = { content?: Array<{ text?: string }>; details?: Record<string,
 type ToolExecute = (id: string, params: Record<string, unknown>) => Promise<ToolResult>;
 type RegisteredTools = Map<string, { execute: ToolExecute }>;
 import { hybridConfigSchema } from "../config.js";
-import { createGoal } from "../services/goal-registry.js";
+import { createGoal, terminateGoal } from "../services/goal-registry.js";
 import type { GoalDispatchPolicy } from "../services/goal-dispatch-authorization.js";
 import { registerGoalTools } from "../tools/goal-tools.js";
 import { buildToolScopeFilter } from "../utils/scope-filter.js";
@@ -209,6 +209,23 @@ describe("goal_dispatch broker policy selection", () => {
       expect.objectContaining({ status: "released", reason: "launch_failed" }),
     );
   });
+
+  it.each(["completed", "abandoned"] as const)(
+    "rejects a stale wake for a %s goal without launching",
+    async (status) => {
+      const g = await goal();
+      await terminateGoal(goalsDir, g.id, status, "terminal before stale wake", "user");
+
+      const result = await dispatch("stale-wake", {
+        ...base(g.id, "legacy-reader", "subagent"),
+        read_only: true,
+      });
+
+      expect(result.details).toMatchObject({ error: "goal_terminal", goal_id: g.id, status });
+      expect(run).not.toHaveBeenCalled();
+      expect((await import("node:fs")).existsSync(join(goalsDir, "dispatch-broker", "ledger.json"))).toBe(false);
+    },
+  );
 
   it("never invokes the runtime when policy denies the request", async () => {
     const g = await goal();

--- a/extensions/memory-hybrid/tests/goal-dispatch-stewardship-guardrails.test.ts
+++ b/extensions/memory-hybrid/tests/goal-dispatch-stewardship-guardrails.test.ts
@@ -65,6 +65,23 @@ describe("target stewardship guardrails", () => {
       ).allowed,
     ).toBe(true);
   });
+  it("rejects a stale wake at the broker reservation boundary", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "broker-terminal-"));
+    try {
+      const broker = new GoalDispatchBroker(dir);
+      const reserved = await broker.reserve({
+        goalId: "terminal-goal",
+        targetAgent: "writer",
+        runtime: "subagent",
+        budget: {},
+        ttlMs: 1_000,
+        isDispatchable: async () => false,
+      });
+      expect(reserved).toBeNull();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
   it("uses owner/run/session leases and rejects stale or wrong receipts", async () => {
     const dir = await mkdtemp(join(tmpdir(), "broker-"));
     try {

--- a/extensions/memory-hybrid/tools/goal-tools.ts
+++ b/extensions/memory-hybrid/tools/goal-tools.ts
@@ -38,7 +38,7 @@ import {
   terminateGoal,
   updateGoal,
 } from "../services/goal-stewardship.js";
-import { listGoals } from "../services/goal-registry.js";
+import { listGoals, readGoal } from "../services/goal-registry.js";
 import { verifyGoalMechanically } from "../services/goal-health.js";
 import { runActiveTaskCheckpoint } from "../services/active-task-checkpoint.js";
 import type { EmbeddingProvider } from "../services/embeddings.js";
@@ -150,11 +150,22 @@ export function registerGoalTools(ctx: GoalToolsContext, api: ClawdbotPluginApi)
             details: { error: "canonical_goal_id_required" },
           };
         const goal = await resolveGoalId(goalsDir, goalId);
-        if (!goal || goal.id !== goalId || isTerminalStatus(goal.status))
+        if (!goal || goal.id !== goalId)
           return {
             content: [{ type: "text" as const, text: "Active canonical goal not found." }],
             details: { error: "goal_not_found" },
           };
+        // A completed/abandoned goal may still have an enabled cron job or a queued wake.
+        // Make terminal state a hard dispatch boundary, not merely a controller convention.
+        const terminalDispatchResult = (status: string) => ({
+          content: [{ type: "text" as const, text: `Goal dispatch rejected: goal is terminal (${status}).` }],
+          details: { error: "goal_terminal", goal_id: goalId, status },
+        });
+        if (isTerminalStatus(goal.status)) return terminalDispatchResult(goal.status);
+        const isStillDispatchable = async () => {
+          const fresh = await readGoal(goalsDir, goalId);
+          return fresh?.id === goalId && !isTerminalStatus(fresh.status);
+        };
         const agent = typeof p.agent_id === "string" ? p.agent_id.trim() : "";
         const runtime = p.runtime;
         if (
@@ -193,6 +204,14 @@ export function registerGoalTools(ctx: GoalToolsContext, api: ClawdbotPluginApi)
             content: [{ type: "text" as const, text: `Dispatch denied by goal policy: ${preflight.reason}.` }],
             details: { error: "dispatch_policy_denied", policy_reason: preflight.reason, task_class: taskClass },
           };
+        // Repeat the check after policy evaluation: goal termination can race a stale wake.
+        const beforeReserve = await readGoal(goalsDir, goalId);
+        if (!beforeReserve || beforeReserve.id !== goalId)
+          return {
+            content: [{ type: "text" as const, text: "Active canonical goal not found." }],
+            details: { error: "goal_not_found" },
+          };
+        if (isTerminalStatus(beforeReserve.status)) return terminalDispatchResult(beforeReserve.status);
         const budget = {
           maxDispatches: typeof p.budget?.max_dispatches === "number" ? p.budget.max_dispatches : undefined,
           maxTotalTokens: typeof p.budget?.max_total_tokens === "number" ? p.budget.max_total_tokens : undefined,
@@ -210,6 +229,7 @@ export function registerGoalTools(ctx: GoalToolsContext, api: ClawdbotPluginApi)
           ttlMs: 5 * 60_000,
           owner: agent,
           sessionId: p.session_key,
+          isDispatchable: isStillDispatchable,
           target: canonical
             ? {
                 repository: canonical.repository,
@@ -219,11 +239,25 @@ export function registerGoalTools(ctx: GoalToolsContext, api: ClawdbotPluginApi)
               }
             : undefined,
         });
-        if (!record)
+        if (!record) {
+          // The broker's lock-time predicate may have observed a terminal transition after
+          // the pre-reservation read. Re-read so stale wakes report a terminal rejection,
+          // rather than misleadingly blaming the dispatch budget.
+          const afterReserve = await readGoal(goalsDir, goalId);
+          if (afterReserve && afterReserve.id === goalId && isTerminalStatus(afterReserve.status))
+            return terminalDispatchResult(afterReserve.status);
           return {
             content: [{ type: "text" as const, text: "Dispatch budget exhausted." }],
             details: { error: "budget_exhausted" },
           };
+        }
+        // The reservation may have been created just before a terminal transition. Do not
+        // hand a stale ACP launcher grant to a cron wake, and do not launch a subagent.
+        const beforeLaunch = await readGoal(goalsDir, goalId);
+        if (!beforeLaunch || beforeLaunch.id !== goalId || isTerminalStatus(beforeLaunch.status)) {
+          await broker.release(record.id, "goal_terminal_before_launch");
+          return terminalDispatchResult(beforeLaunch?.status ?? "missing");
+        }
         const grant = broker.token(record);
         if (runtime === "acp")
           return {

--- a/extensions/memory-hybrid/tools/goal-tools.ts
+++ b/extensions/memory-hybrid/tools/goal-tools.ts
@@ -164,7 +164,7 @@ export function registerGoalTools(ctx: GoalToolsContext, api: ClawdbotPluginApi)
         if (isTerminalStatus(goal.status)) return terminalDispatchResult(goal.status);
         const isStillDispatchable = async () => {
           const fresh = await readGoal(goalsDir, goalId);
-          return fresh?.id === goalId && !isTerminalStatus(fresh.status);
+          return !!fresh && fresh.id === goalId && !isTerminalStatus(fresh.status);
         };
         const agent = typeof p.agent_id === "string" ? p.agent_id.trim() : "";
         const runtime = p.runtime;

--- a/packages/openclaw-hybrid-memory-install/package.json
+++ b/packages/openclaw-hybrid-memory-install/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-hybrid-memory-install",
-  "version": "2026.8.1",
+  "version": "2026.8.2",
   "description": "Standalone installer for openclaw-hybrid-memory. Use when OpenClaw config validation fails.",
   "bin": {
     "openclaw-hybrid-memory-install": "./install.js"

--- a/release-notes/release-notes-2026.8.2.md
+++ b/release-notes/release-notes-2026.8.2.md
@@ -1,0 +1,9 @@
+# Release notes — 2026.8.2
+
+## Fixed
+
+- Goal dispatch now rejects terminal (completed/abandoned) goals at every dispatch boundary — request parsing, the broker reservation lock, and immediately before launch — closing a race where a stale cron wake or a concurrent `goal_complete`/`goal_abandon` could still dispatch work against an already-terminated goal. The broker reservation now accepts a lock-time dispatchability predicate so the terminal-state check is re-validated while the reservation is committed, not only when the request was first parsed.
+
+## Release metadata
+
+- Bumps `openclaw-hybrid-memory` and the lockstep standalone installer to `2026.8.2`.


### PR DESCRIPTION
## Summary
- reject completed and abandoned goals at the goal_dispatch boundary
- re-check terminal state before reservation and launch to fence stale cron wakes/races
- make the broker reservation accept a lock-time dispatchability predicate

## Tests
- npm run typecheck:gate
- npm test -- --run tests/goal-dispatch-broker-policy.test.ts tests/goal-dispatch-stewardship-guardrails.test.ts