### PR TITLE
fix: fail closed when reload teardown remains pending

### DIFF
--- a/extensions/memory-hybrid/setup/register-plugin.ts
+++ b/extensions/memory-hybrid/setup/register-plugin.ts
@@ -757,10 +757,13 @@ async function runDeferredFullTeardownActivation(params: {
       return;
     }
 
+    // A donor that has not drained can still close shared SQLite/LanceDB resources after this
+    // generation opens them. Fail closed rather than racing a delayed terminal close against
+    // replacement work (maintenance, lifecycle sync, and workboard all use these handles).
     if (!drained) {
-      logApi.logger.warn?.(
-        `memory-hybrid: donor generation ${donorGeneration} teardown still pending after ${TEARDOWN_WAIT_MS}ms; ` +
-          `opening fresh databases anyway (prior teardown continues on its own chain) [generation=${registrationGeneration}]`,
+      throw new Error(
+        `memory-hybrid: donor generation ${donorGeneration} teardown did not drain before database activation ` +
+          `(waitedMs=${TEARDOWN_WAIT_MS}, generation=${registrationGeneration})`,
       );
     }
 

--- a/extensions/memory-hybrid/tests/register-plugin-two-phase-activation.test.ts
+++ b/extensions/memory-hybrid/tests/register-plugin-two-phase-activation.test.ts
@@ -124,11 +124,11 @@ describe("two-phase reload activation (#2181)", () => {
     expect(getActivationState()?.phase).toBe("ready");
   });
 
-  it("never throws 'reload teardown did not drain before opening new databases'", async () => {
+  it("fails closed when donor teardown does not drain before replacement databases open", async () => {
     const cfg = () => getFullStackConfig(tmpDir);
     registerFullPlugin(api, cfg());
 
-    // Leave a never-resolving teardown on the donor generation; Phase B must still recover.
+    // Do not open a replacement on the same paths while this donor may still close them.
     schedulePluginTeardown(
       async () => {
         await new Promise(() => {
@@ -142,9 +142,11 @@ describe("two-phase reload activation (#2181)", () => {
     const activation = getActivationState();
     expect(activation?.phase).toBe("activating");
 
-    // Phase B opens fresh after the bounded async wait — must become ready, not fail register.
     const ready = await awaitActivationReady(activation!.generation, 20_000);
-    expect(ready).toBe(true);
+    expect(ready).toBe(false);
+    expect(getActivationState()?.phase).toBe("failed");
+    expect(getActivationState()?.error).toContain("teardown did not drain before database activation");
+    expect(runtimeRef.value).toBeNull();
     resetReloadTeardownChainForTests();
   });
 });


### PR DESCRIPTION
## Summary
- do not open replacement SQLite/LanceDB handles while the donor teardown remains pending
- mark deferred activation failed and retain safe tool stubs instead
- replace the timeout-path regression expectation with a fail-closed regression

## Why
A delayed donor terminal close can otherwise race new maintenance, lifecycle sync, and Workboard operations, surfacing `The database connection is not open`.

## Test
- `vitest run --maxWorkers 1 tests/registration-superseded.test.ts tests/register-plugin-two-phase-activation.test.ts` (9 passed)
- `npm run typecheck:gate`