### PR TITLE
fix(goals): route managed dispatches to target child

### DIFF
--- a/extensions/memory-hybrid/docs/GOAL-STEWARDSHIP-OPERATOR.md
+++ b/extensions/memory-hybrid/docs/GOAL-STEWARDSHIP-OPERATOR.md
@@ -8,6 +8,12 @@ The broker uses a JSON ledger protected by `mkdir` locking and atomic rename. It
 
 For **native** work, `goal_dispatch` can launch through `api.runtime.subagent.run` only when the host supplies that runtime **for the active gateway request**. This request-scoped binding is a supported-runtime prerequisite, not a plugin capability that can be recreated globally. If it is unavailable, the plugin fails closed, releases the reservation, and reports that E2E child completion is unverified; hybrid-memory must not add a global/process fallback. The public `subagent_ended` hook settles native launches where a run id is provided; expiry releases abandoned reservations. The currently public plugin runtime exposes no ACP launcher. ACP requests are reserved but returned as a redacted `dispatch_request` for a trusted host launcher to validate, launch and reconcile. The plugin does not claim a tool-only ACP launch.
 
+### Native routing contract
+
+`agent_id` is the authoritative policy-checked target. For each dispatch, the broker generates one opaque child key in OpenClaw's native format: `agent:<agent_id>:subagent:<uuid>`. The caller-supplied `session_key` is retained only as required request/correlation input and is **never** used to route native or ACP work. This prevents a request from redirecting an allowed target (for example `furnace-m3`) to `agent:main:main`.
+
+The broker stores that generated child key as the reservation session id and passes it to `api.runtime.subagent.run`. A dispatch is marked `launched` only after the runtime returns a non-empty `runId`; an absent/malformed acceptance result releases the reservation as `launch_unaccepted`. The returned dispatch details include the generated child key and accepted run id for trusted reconciliation; treat both as opaque and do not accept them back from untrusted callers.
+
 ## Direct-spawn migration and enforcement
 
 `goalStewardship.dispatchAuthorization.mode` is `disabled` by default, preserving existing behavior.

--- a/extensions/memory-hybrid/tests/goal-dispatch-broker-policy.test.ts
+++ b/extensions/memory-hybrid/tests/goal-dispatch-broker-policy.test.ts
@@ -168,12 +168,18 @@ describe("goal_dispatch broker policy selection", () => {
       read_only: true,
     });
     expect(run).toHaveBeenCalledWith({
-      sessionKey: "session",
+      sessionKey: expect.stringMatching(/^agent:legacy-reader:subagent:[0-9a-f-]{36}$/),
       message: "read",
       idempotencyKey: expect.any(String),
       deliver: false,
     });
-    expect(result.details).toMatchObject({ ok: true, run_id: "run-1" });
+    expect(result.details).toMatchObject({
+      ok: true,
+      run_id: "run-1",
+      session_key: expect.stringMatching(/^agent:legacy-reader:subagent:[0-9a-f-]{36}$/),
+    });
+    const runtimeParams = run.mock.calls[0]?.[0] as { sessionKey: string } | undefined;
+    expect(runtimeParams?.sessionKey).toBe(result.details?.session_key);
     const ledger = JSON.parse(
       await (await import("node:fs/promises")).readFile(join(goalsDir, "dispatch-broker", "ledger.json"), "utf8"),
     );
@@ -181,6 +187,48 @@ describe("goal_dispatch broker policy selection", () => {
       status: "launched",
       runId: "run-1",
     });
+  });
+
+  it("creates a target-agent child and ignores an untrusted caller session key", async () => {
+    const g = await goal();
+    const result = await dispatch("test", {
+      ...base(g.id, "legacy-reader", "subagent"),
+      session_key: "agent:main:main",
+      read_only: true,
+    });
+
+    expect(run).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionKey: expect.stringMatching(/^agent:legacy-reader:subagent:[0-9a-f-]{36}$/),
+      }),
+    );
+    expect(result.details?.session_key).not.toBe("agent:main:main");
+    const ledger = JSON.parse(
+      await (await import("node:fs/promises")).readFile(join(goalsDir, "dispatch-broker", "ledger.json"), "utf8"),
+    );
+    expect(ledger.dispatches[result.details?.dispatch_id as string]).toMatchObject({
+      targetAgent: "legacy-reader",
+      sessionId: result.details?.session_key,
+      status: "launched",
+      runId: "run-1",
+    });
+  });
+
+  it("releases instead of recording a launch when the runtime returns no accepted run id", async () => {
+    api.runtime.subagent.run = vi.fn(async () => ({}) as { runId: string });
+    const g = await goal();
+    const result = await dispatch("test", {
+      ...base(g.id, "legacy-reader", "subagent"),
+      read_only: true,
+    });
+
+    expect(result.details).toEqual({ error: "launch_unaccepted" });
+    const ledger = JSON.parse(
+      await (await import("node:fs/promises")).readFile(join(goalsDir, "dispatch-broker", "ledger.json"), "utf8"),
+    );
+    expect(Object.values(ledger.dispatches)).toContainEqual(
+      expect.objectContaining({ status: "released", reason: "launch_unaccepted" }),
+    );
   });
 
   // The plugin must fail closed rather than provide a global fallback when the host request binding is absent.

--- a/extensions/memory-hybrid/tests/goal-dispatch-broker-policy.test.ts
+++ b/extensions/memory-hybrid/tests/goal-dispatch-broker-policy.test.ts
@@ -41,11 +41,17 @@ describe("goal_dispatch broker policy selection", () => {
   let goalsDir: string;
   let dispatch: ToolExecute;
   let tools: RegisteredTools;
+  type SubagentRunParams = {
+    sessionKey: string;
+    message: string;
+    idempotencyKey: string;
+    deliver: boolean;
+  };
   let api: {
     registerTool(definition: { name: string; execute: ToolExecute }): void;
     runtime: { subagent: { run: typeof run } };
   };
-  const run = vi.fn(async () => ({ runId: "run-1" }));
+  const run = vi.fn(async (_params: SubagentRunParams) => ({ runId: "run-1" }));
 
   beforeEach(async () => {
     workspaceRoot = await mkdtemp(join(tmpdir(), "goal-dispatch-broker-"));

--- a/extensions/memory-hybrid/tools/goal-tools.ts
+++ b/extensions/memory-hybrid/tools/goal-tools.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { appendFile, mkdir } from "node:fs/promises";
 import { GoalDispatchBroker } from "../services/goal-dispatch-broker.js";
 import { join } from "node:path";
@@ -119,7 +120,10 @@ export function registerGoalTools(ctx: GoalToolsContext, api: ClawdbotPluginApi)
         agent_id: Type.String(),
         runtime: Type.Union([Type.Literal("subagent"), Type.Literal("acp")]),
         task: Type.String(),
-        session_key: Type.String(),
+        session_key: Type.String({
+          description:
+            "Caller correlation only; ignored for managed child routing. The broker creates a fresh target-agent child session.",
+        }),
         /** Explicit policy declaration. Omitting task_class only selects legacy `managed`; it never bypasses validation. */
         task_class: Type.Optional(Type.String()),
         read_only: Type.Optional(Type.Boolean()),
@@ -279,6 +283,12 @@ export function registerGoalTools(ctx: GoalToolsContext, api: ClawdbotPluginApi)
           maxWallTimeMs: typeof p.budget?.max_wall_time_ms === "number" ? p.budget.max_wall_time_ms : undefined,
         };
         const broker = new GoalDispatchBroker(goalsDir);
+        // The public plugin runtime selects the executing agent from the canonical session
+        // key, not an `agentId` parameter. Never use caller-controlled `session_key` here:
+        // it can name another agent (or `agent:main:main`) and would silently redirect work.
+        // Match core sessions_spawn's format exactly and create a one-shot child for the
+        // policy-authorized target agent.
+        const childSessionKey = `agent:${agent}:subagent:${randomUUID()}`;
         const canonical = goal.dispatchPolicy?.classes[taskClass]?.canonical;
         const record = await broker.reserve({
           goalId,
@@ -287,7 +297,7 @@ export function registerGoalTools(ctx: GoalToolsContext, api: ClawdbotPluginApi)
           budget,
           ttlMs: 5 * 60_000,
           owner: agent,
-          sessionId: p.session_key,
+          sessionId: childSessionKey,
           isDispatchable: isStillDispatchable,
           target: canonical
             ? {
@@ -334,7 +344,7 @@ export function registerGoalTools(ctx: GoalToolsContext, api: ClawdbotPluginApi)
                 goal_id: goalId,
                 target_agent: agent,
                 runtime,
-                session_key: p.session_key,
+                session_key: childSessionKey,
                 task: p.task,
                 task_class: taskClass,
                 read_only: request.readOnly,
@@ -355,15 +365,36 @@ export function registerGoalTools(ctx: GoalToolsContext, api: ClawdbotPluginApi)
           // runtime binding. Do not add a process-global fallback here: it would escape host
           // request authority and make an absent binding look like a completed E2E launch.
           const run = await api.runtime.subagent.run({
-            sessionKey: p.session_key,
+            sessionKey: childSessionKey,
             message: p.task,
             idempotencyKey: record.id,
             deliver: false,
           });
-          await broker.launch(record.id, run.runId);
+          // `runId` is the supported runtime's acceptance receipt. Do not turn a
+          // reservation into a launched record for an empty/malformed response.
+          const runId = typeof run?.runId === "string" ? run.runId.trim() : "";
+          if (!runId) {
+            await broker.release(record.id, "launch_unaccepted");
+            return {
+              content: [{ type: "text" as const, text: "Managed dispatch was not accepted; reservation released." }],
+              details: { error: "launch_unaccepted" },
+            };
+          }
+          const launched = await broker.launch(record.id, runId);
+          if (!launched)
+            return {
+              content: [{ type: "text" as const, text: "Managed dispatch was accepted but broker recording failed." }],
+              details: { error: "launch_recording_failed", run_id: runId },
+            };
           return {
-            content: [{ type: "text" as const, text: `Managed goal dispatch launched (${run.runId}).` }],
-            details: { ok: true, dispatch_id: record.id, run_id: run.runId, grant_expires_at: record.expiresAt },
+            content: [{ type: "text" as const, text: `Managed goal dispatch launched (${runId}).` }],
+            details: {
+              ok: true,
+              dispatch_id: record.id,
+              run_id: runId,
+              session_key: childSessionKey,
+              grant_expires_at: record.expiresAt,
+            },
           };
         } catch (err) {
           await broker.release(record.id, "launch_failed");


### PR DESCRIPTION
## Summary
- generate a fresh target-agent native child key for every managed `goal_dispatch` and never route from caller-supplied `session_key`
- persist/return the generated key only as broker/session evidence; mark a reservation launched only after a non-empty accepted `runId`
- document the routing contract and add focused regression coverage for main-session redirect attempts and malformed launch results

## OpenClaw contract
For 2026.7.1-2, `SubagentRunParams` has no `agentId`; execution is selected by the canonical session key. Native `sessions_spawn` creates `agent:<targetAgentId>:subagent:<uuid>`. This change uses that format for the policy-authorized target and passes it to the request-scoped runtime.

## Verification
- `npm test -- --run tests/goal-dispatch-broker-policy.test.ts` (10 passed)
- `npm run typecheck:gate`
- `git diff --check`

The focused test run prints the pre-existing test fixture warning about an unencrypted credentials vault; it does not affect the assertions.
