### PR TITLE
fix(goals): persist operational goal_update fields

### DIFF
--- a/extensions/memory-hybrid/services/goal-dispatch-authorization.ts
+++ b/extensions/memory-hybrid/services/goal-dispatch-authorization.ts
@@ -69,6 +69,37 @@ function validClassPolicy(value: unknown): value is GoalDispatchClassPolicy {
 }
 
 /** Pure validator: callers must persist its result before spawning. */
+/**
+ * Detect the pre-repository v1 write-policy shape persisted by older releases.
+ * It intentionally is not accepted as a write authorization: a PR number and branch
+ * are not globally unique, so guessing a repository would weaken the canonical target
+ * binding. Callers can preserve the goal and replace the policy with a current v1
+ * policy containing canonical.repository.
+ */
+export function legacyGoalDispatchPolicyRemediation(policy: unknown): string | null {
+  if (!policy || typeof policy !== "object") return null;
+  const candidate = policy as Record<string, unknown>;
+  if (candidate.version !== 1 || !candidate.classes || typeof candidate.classes !== "object") return null;
+  const legacyClasses = Object.entries(candidate.classes).filter(([, entry]) => {
+    if (!entry || typeof entry !== "object") return false;
+    const classPolicy = entry as Record<string, unknown>;
+    if (classPolicy.readOnly !== false || !classPolicy.canonical || typeof classPolicy.canonical !== "object")
+      return false;
+    const canonical = classPolicy.canonical as Record<string, unknown>;
+    return (
+      canonical.repository === undefined &&
+      Number.isSafeInteger(canonical.prNumber) &&
+      (canonical.prNumber as number) > 0 &&
+      typeof canonical.branch === "string" &&
+      canonical.branch.trim().length > 0 &&
+      typeof canonical.remoteHead === "string" &&
+      canonical.remoteHead.trim().length > 0
+    );
+  });
+  if (legacyClasses.length === 0) return null;
+  return "legacy write dispatch policy is missing canonical.repository; no repository was inferred. Resubmit dispatch_policy with canonical.repository for every write class.";
+}
+
 export function isValidGoalDispatchPolicy(policy: unknown): policy is GoalDispatchPolicy {
   if (!policy || typeof policy !== "object") return false;
   const candidate = policy as Record<string, unknown>;
@@ -81,7 +112,8 @@ export function evaluateGoalDispatch(
   policy: GoalDispatchPolicy | undefined,
   request: GoalDispatchRequest,
 ): GoalDispatchPreflight {
-  if (!isValidGoalDispatchPolicy(policy)) return fail(request, "dispatch policy missing or invalid");
+  if (!isValidGoalDispatchPolicy(policy))
+    return fail(request, legacyGoalDispatchPolicyRemediation(policy) ?? "dispatch policy missing or invalid");
   const classPolicy = policy.classes[request.taskClass];
   if (!classPolicy) return fail(request, "task class is not defined by goal policy");
   if (!request.requestedAgent || request.requestedAgent !== request.actualAgent)

--- a/extensions/memory-hybrid/tests/goal-update-dispatch-policy.test.ts
+++ b/extensions/memory-hybrid/tests/goal-update-dispatch-policy.test.ts
@@ -1,11 +1,11 @@
-import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { ClawdbotPluginApi } from "openclaw/plugin-sdk/core";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { hybridConfigSchema } from "../config.js";
 import { createGoal, readGoal, terminateGoal } from "../services/goal-registry.js";
-import type { GoalDispatchPolicy } from "../services/goal-dispatch-authorization.js";
+import { evaluateGoalDispatch, type GoalDispatchPolicy } from "../services/goal-dispatch-authorization.js";
 import { registerGoalTools } from "../tools/goal-tools.js";
 import { buildToolScopeFilter } from "../utils/scope-filter.js";
 
@@ -88,6 +88,66 @@ describe("goal_update dispatch_policy", () => {
     expect((await update("test", { goal_id: g.id, dispatch_policy: policy })).details).toMatchObject({
       error: "terminal",
     });
+    expect((await readGoal(goalsDir, g.id))?.dispatchPolicy).toBeUndefined();
+  });
+  it("preserves a legacy persisted policy, denies its write dispatch with remediation, and safely replaces it", async () => {
+    const g = await goal();
+    const legacyPolicy = {
+      version: 1,
+      classes: {
+        writer: {
+          allowedAgents: ["writer"],
+          readOnly: false,
+          canonical: { prNumber: 2252, branch: "fix/goal", remoteHead: "abc123" },
+          writeScope: ["extensions/memory-hybrid"],
+          forbidNewPr: true,
+          forbidNewBranch: true,
+        },
+      },
+    };
+    await writeFile(join(goalsDir, `${g.id}.json`), JSON.stringify({ ...g, dispatchPolicy: legacyPolicy }, null, 2));
+    const loaded = await readGoal(goalsDir, g.id);
+    expect(loaded?.dispatchPolicy).toEqual(legacyPolicy);
+    expect(
+      evaluateGoalDispatch(loaded?.dispatchPolicy, {
+        taskClass: "writer",
+        requestedAgent: "writer",
+        actualAgent: "writer",
+        readOnly: false,
+      }).reason,
+    ).toContain("missing canonical.repository");
+
+    const replacement: GoalDispatchPolicy = {
+      version: 1,
+      classes: {
+        writer: {
+          ...legacyPolicy.classes.writer,
+          canonical: { ...legacyPolicy.classes.writer.canonical, repository: "owner/repository" },
+        },
+      },
+    };
+    const result = await update("test", { goal_id: g.id, dispatch_policy: replacement });
+    expect(result.details?.goal).toMatchObject({ dispatchPolicy: replacement });
+    expect((await readGoal(goalsDir, g.id))?.dispatchPolicy).toEqual(replacement);
+  });
+
+  it("returns non-destructive remediation for a legacy write policy submitted to goal_update", async () => {
+    const g = await goal();
+    const legacyPolicy = {
+      version: 1,
+      classes: {
+        writer: {
+          allowedAgents: ["writer"],
+          readOnly: false,
+          canonical: { prNumber: 2252, branch: "fix/goal", remoteHead: "abc123" },
+          writeScope: ["extensions/memory-hybrid"],
+          forbidNewPr: true,
+          forbidNewBranch: true,
+        },
+      },
+    };
+    const result = await update("test", { goal_id: g.id, dispatch_policy: legacyPolicy });
+    expect(result.details).toMatchObject({ error: "legacy_dispatch_policy_requires_repository" });
     expect((await readGoal(goalsDir, g.id))?.dispatchPolicy).toBeUndefined();
   });
 });
@@ -189,5 +249,45 @@ describe("goal_update complete persisted patch", () => {
       evidence: null,
       linkedTasks,
     });
+  });
+  it("accepts matching snake aliases, rejects conflicting aliases, and preserves unrelated goal fields", async () => {
+    const g = await createGoal(
+      goalsDir,
+      { label: "snake-operational", description: "original", acceptanceCriteria: ["criterion"] },
+      defaults,
+    );
+    const linkedTasks = [
+      {
+        label: "worker",
+        sessionKey: "session",
+        status: "done",
+        linkedAt: "2026-08-05T00:00:00.000Z",
+        updatedAt: "2026-08-05T00:01:00.000Z",
+      },
+    ];
+    const result = await update("test", {
+      goal_id: g.id,
+      next_action: "retry safely",
+      nextAction: "retry safely",
+      last_outcome: "checked",
+      lastOutcome: "checked",
+      linked_tasks: linkedTasks,
+      linkedTasks: structuredClone(linkedTasks),
+    });
+    expect(result.details?.goal).toMatchObject({
+      nextAction: "retry safely",
+      lastOutcome: "checked",
+      linkedTasks,
+      description: "original",
+      acceptanceCriteria: ["criterion"],
+      priority: g.priority,
+    });
+    const conflict = await update("test", {
+      goal_id: g.id,
+      next_action: "one",
+      nextAction: "two",
+    });
+    expect(conflict.details?.error).toContain("next_action and its camel-case alias conflict");
+    expect((await readGoal(goalsDir, g.id))?.nextAction).toBe("retry safely");
   });
 });

--- a/extensions/memory-hybrid/tests/goal-update-dispatch-policy.test.ts
+++ b/extensions/memory-hybrid/tests/goal-update-dispatch-policy.test.ts
@@ -91,3 +91,103 @@ describe("goal_update dispatch_policy", () => {
     expect((await readGoal(goalsDir, g.id))?.dispatchPolicy).toBeUndefined();
   });
 });
+
+describe("goal_update complete persisted patch", () => {
+  let workspaceRoot: string;
+  let goalsDir: string;
+  let update: Execute;
+  beforeEach(async () => {
+    workspaceRoot = await mkdtemp(join(tmpdir(), "goal-update-complete-"));
+    goalsDir = join(workspaceRoot, "state", "goals");
+    await mkdir(goalsDir, { recursive: true });
+    const cfg = hybridConfigSchema.parse({
+      embedding: { apiKey: "sk-test-key-that-is-long-enough-to-pass", model: "text-embedding-3-small" },
+      goalStewardship: { enabled: true, goalsDir: "state/goals" },
+    });
+    const tools = new Map<string, { execute: Execute }>();
+    const api = {
+      registerTool(definition: { name: string; execute: Execute }) {
+        tools.set(definition.name, definition);
+      },
+    };
+    registerGoalTools(
+      {
+        cfg,
+        goalsDir,
+        workspaceRoot,
+        resolvedActiveTaskPath: join(workspaceRoot, "ACTIVE-TASKS.md"),
+        factsDb: null,
+        vectorDb: null,
+        embeddings: null,
+        eventLog: null,
+        memoryDir: join(workspaceRoot, "memory"),
+        currentAgentIdRef: { value: null },
+        buildToolScopeFilter,
+      },
+      api as unknown as ClawdbotPluginApi,
+    );
+    update = tools.get("goal_update")!.execute;
+  });
+  afterEach(async () => {
+    await rm(workspaceRoot, { recursive: true, force: true });
+  });
+
+  it("persists camel-case policy and nullable/non-string operational fields through read-back", async () => {
+    const g = await createGoal(
+      goalsDir,
+      { label: "complete-patch", description: "d", acceptanceCriteria: ["a"] },
+      defaults,
+    );
+    const linkedTasks = [
+      {
+        label: "dispatch-worker",
+        sessionKey: null,
+        runId: "run-1",
+        dispatchFailureReason: null,
+        status: "failed",
+        linkedAt: "2026-08-05T00:00:00.000Z",
+        updatedAt: "2026-08-05T00:01:00.000Z",
+      },
+    ];
+    const fullPolicy: GoalDispatchPolicy = {
+      version: 1,
+      classes: {
+        furnace: {
+          allowedAgents: ["furnace"],
+          readOnly: false,
+          canonical: {
+            repository: "markus-lassfolk/openclaw-hybrid-memory",
+            prNumber: 1,
+            branch: "fix/goal",
+            remoteHead: "abc123",
+          },
+          writeScope: ["extensions/memory-hybrid"],
+          forbidNewPr: true,
+          forbidNewBranch: true,
+        },
+      },
+    };
+    const result = await update("test", {
+      goal_id: g.id,
+      dispatchPolicy: fullPolicy,
+      nextAction: null,
+      lastOutcome: "worker failed",
+      evidence: null,
+      linkedTasks,
+    });
+    expect(result.details?.goal).toMatchObject({
+      dispatchPolicy: fullPolicy,
+      nextAction: null,
+      lastOutcome: "worker failed",
+      evidence: null,
+      linkedTasks,
+    });
+    expect(await readGoal(goalsDir, g.id)).toMatchObject({
+      dispatchPolicy: fullPolicy,
+      nextAction: null,
+      lastOutcome: "worker failed",
+      evidence: null,
+      linkedTasks,
+    });
+  });
+});

--- a/extensions/memory-hybrid/tools/goal-tools.ts
+++ b/extensions/memory-hybrid/tools/goal-tools.ts
@@ -1021,8 +1021,8 @@ export function registerGoalTools(ctx: GoalToolsContext, api: ClawdbotPluginApi)
               linkedAt: Type.String(),
               updatedAt: Type.String(),
             }),
+            { description: "Alias for linked_tasks." },
           ),
-          { description: "Alias for linked_tasks." },
         ),
         note: Type.Optional(Type.String()),
         confirmed: Type.Optional(

--- a/extensions/memory-hybrid/tools/goal-tools.ts
+++ b/extensions/memory-hybrid/tools/goal-tools.ts
@@ -986,6 +986,42 @@ export function registerGoalTools(ctx: GoalToolsContext, api: ClawdbotPluginApi)
         acceptance_criteria: Type.Optional(Type.Array(Type.String())),
         priority: Type.Optional(stringEnum(PRIORITIES as unknown as readonly string[])),
         dispatch_policy: Type.Optional(Type.Any({ description: "Replacement machine-readable dispatch policy." })),
+        // Camel-case aliases preserve compatibility with goal JSON field names used by direct callers.
+        dispatchPolicy: Type.Optional(Type.Any({ description: "Alias for dispatch_policy." })),
+        next_action: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+        nextAction: Type.Optional(Type.Union([Type.String(), Type.Null()], { description: "Alias for next_action." })),
+        last_outcome: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+        lastOutcome: Type.Optional(
+          Type.Union([Type.String(), Type.Null()], { description: "Alias for last_outcome." }),
+        ),
+        evidence: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+        linked_tasks: Type.Optional(
+          Type.Array(
+            Type.Object({
+              label: Type.String(),
+              sessionKey: Type.Union([Type.String(), Type.Null()]),
+              runId: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+              dispatchFailureReason: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+              status: Type.String(),
+              linkedAt: Type.String(),
+              updatedAt: Type.String(),
+            }),
+          ),
+        ),
+        linkedTasks: Type.Optional(
+          Type.Array(
+            Type.Object({
+              label: Type.String(),
+              sessionKey: Type.Union([Type.String(), Type.Null()]),
+              runId: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+              dispatchFailureReason: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+              status: Type.String(),
+              linkedAt: Type.String(),
+              updatedAt: Type.String(),
+            }),
+          ),
+          { description: "Alias for linked_tasks." },
+        ),
         note: Type.Optional(Type.String()),
         confirmed: Type.Optional(
           Type.Boolean({ description: "Required when updating acceptance_criteria after clarity refinement." }),
@@ -1002,6 +1038,14 @@ export function registerGoalTools(ctx: GoalToolsContext, api: ClawdbotPluginApi)
             acceptance_criteria?: string[];
             priority?: (typeof PRIORITIES)[number];
             dispatch_policy?: unknown;
+            dispatchPolicy?: unknown;
+            next_action?: string | null;
+            nextAction?: string | null;
+            last_outcome?: string | null;
+            lastOutcome?: string | null;
+            evidence?: string | null;
+            linked_tasks?: Goal["linkedTasks"];
+            linkedTasks?: Goal["linkedTasks"];
             note?: string;
             confirmed?: boolean;
           };
@@ -1013,7 +1057,16 @@ export function registerGoalTools(ctx: GoalToolsContext, api: ClawdbotPluginApi)
               details: { error: "terminal" },
             };
           }
-          if (p.dispatch_policy !== undefined && !isValidGoalDispatchPolicy(p.dispatch_policy)) {
+          const patchValue = <T>(snake: T | undefined, camel: T | undefined, field: string): T | undefined => {
+            if (snake !== undefined && camel !== undefined && JSON.stringify(snake) !== JSON.stringify(camel))
+              throw new Error(`${field} and its camel-case alias conflict`);
+            return snake ?? camel;
+          };
+          const dispatchPolicy = patchValue(p.dispatch_policy, p.dispatchPolicy, "dispatch_policy");
+          const nextAction = patchValue(p.next_action, p.nextAction, "next_action");
+          const lastOutcome = patchValue(p.last_outcome, p.lastOutcome, "last_outcome");
+          const linkedTasks = patchValue(p.linked_tasks, p.linkedTasks, "linked_tasks");
+          if (dispatchPolicy !== undefined && !isValidGoalDispatchPolicy(dispatchPolicy)) {
             return {
               content: [
                 { type: "text", text: "dispatch_policy must be a version 1 policy with at least one valid class." },
@@ -1039,7 +1092,11 @@ export function registerGoalTools(ctx: GoalToolsContext, api: ClawdbotPluginApi)
           if (p.description !== undefined) staticPatch.description = p.description;
           if (p.acceptance_criteria !== undefined) staticPatch.acceptanceCriteria = p.acceptance_criteria;
           if (p.priority !== undefined) staticPatch.priority = p.priority;
-          if (p.dispatch_policy !== undefined) staticPatch.dispatchPolicy = p.dispatch_policy;
+          if (dispatchPolicy !== undefined) staticPatch.dispatchPolicy = dispatchPolicy;
+          if (nextAction !== undefined) staticPatch.nextAction = nextAction;
+          if (lastOutcome !== undefined) staticPatch.lastOutcome = lastOutcome;
+          if (p.evidence !== undefined) staticPatch.evidence = p.evidence;
+          if (linkedTasks !== undefined) staticPatch.linkedTasks = linkedTasks;
           const ts = nowIso();
           // Unlike goal_assess/goal_complete/goal_abandon, goal_update never re-checked terminal
           // status against the goal re-read inside updateGoal's lock — only against the pre-lock

--- a/extensions/memory-hybrid/tools/goal-tools.ts
+++ b/extensions/memory-hybrid/tools/goal-tools.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { isDeepStrictEqual } from "node:util";
 import { appendFile, mkdir } from "node:fs/promises";
 import { GoalDispatchBroker } from "../services/goal-dispatch-broker.js";
 import { join } from "node:path";
@@ -22,6 +23,7 @@ import type { Goal, GoalHistoryEntry } from "../services/goal-stewardship-types.
 import {
   evaluateGoalDispatch,
   isValidGoalDispatchPolicy,
+  legacyGoalDispatchPolicyRemediation,
   type GoalDispatchPolicy,
   type GoalDispatchRequest,
 } from "../services/goal-dispatch-authorization.js";
@@ -1058,7 +1060,7 @@ export function registerGoalTools(ctx: GoalToolsContext, api: ClawdbotPluginApi)
             };
           }
           const patchValue = <T>(snake: T | undefined, camel: T | undefined, field: string): T | undefined => {
-            if (snake !== undefined && camel !== undefined && JSON.stringify(snake) !== JSON.stringify(camel))
+            if (snake !== undefined && camel !== undefined && !isDeepStrictEqual(snake, camel))
               throw new Error(`${field} and its camel-case alias conflict`);
             return snake ?? camel;
           };
@@ -1067,11 +1069,18 @@ export function registerGoalTools(ctx: GoalToolsContext, api: ClawdbotPluginApi)
           const lastOutcome = patchValue(p.last_outcome, p.lastOutcome, "last_outcome");
           const linkedTasks = patchValue(p.linked_tasks, p.linkedTasks, "linked_tasks");
           if (dispatchPolicy !== undefined && !isValidGoalDispatchPolicy(dispatchPolicy)) {
+            const remediation = legacyGoalDispatchPolicyRemediation(dispatchPolicy);
             return {
               content: [
-                { type: "text", text: "dispatch_policy must be a version 1 policy with at least one valid class." },
+                {
+                  type: "text",
+                  text: remediation ?? "dispatch_policy must be a version 1 policy with at least one valid class.",
+                },
               ],
-              details: { error: "invalid_dispatch_policy" },
+              details: {
+                error: remediation ? "legacy_dispatch_policy_requires_repository" : "invalid_dispatch_policy",
+                remediation,
+              },
             };
           }
           if (p.acceptance_criteria !== undefined) {


### PR DESCRIPTION
## Summary
- accept and persist `goal_update` operational fields: dispatch policy, next action, last outcome, evidence, and linked tasks
- retain existing snake_case API and add camelCase aliases matching stored Goal JSON / direct tool callers
- reject conflicting alias pairs instead of silently choosing one
- preserve existing dispatch-policy validation and terminal-goal protection

## Root cause
`goal_update` only declared and copied `description`, `acceptance_criteria`, `priority`, and snake_case `dispatch_policy`. The goal record supports operational fields, but camelCase calls (`dispatchPolicy`, `nextAction`, `lastOutcome`, `linkedTasks`) and the other fields were absent from the public schema/patch builder, so they were ignored while the history entry still reported success.

## Verification
- `npm test -- --run tests/goal-update-dispatch-policy.test.ts` (4 passing)
- `npm run typecheck:gate`
- `npm run build`
- `npm run format:check -- tools/goal-tools.ts tests/goal-update-dispatch-policy.test.ts`
- `git diff --check`