### PR TITLE
chore(release): bump memory-hybrid to 2026.8.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [2026.8.4] - 2026-08-08
+
+### Fixed
+
+- Plugin re-register / hot reload now fails closed when the donor generation's teardown has not drained within the bounded wait: replacement SQLite/LanceDB handles are not opened while a delayed terminal close can still race maintenance, lifecycle sync, and Workboard. Deferred activation is marked failed and safe tool stubs are retained instead.
+- Managed `goal_dispatch` no longer routes native work from a caller-supplied `session_key`. The broker generates a fresh target-agent child key (`agent:<agent_id>:subagent:<uuid>`), passes that key to the request-scoped runtime, and marks a reservation launched only after a non-empty accepted `runId` (otherwise releases as `launch_unaccepted`).
+- `goal_update` now accepts and persists operational fields — dispatch policy, next action, last outcome, evidence, and linked tasks — with snake_case and camelCase aliases, conflict rejection when both forms disagree, terminal-goal protection, and remediation guidance when a legacy write policy is missing `canonical.repository`.
+
+### Release metadata
+
+- Bumps `openclaw-hybrid-memory` and the lockstep standalone installer to `2026.8.4`. `package.json` remains the source of truth; derived plugin and installer version metadata are synchronized by `scripts/sync-plugin-version.cjs`.
+
 ## [2026.8.3] - 2026-08-04
 
 ### Fixed

--- a/extensions/memory-hybrid/openclaw.plugin.json
+++ b/extensions/memory-hybrid/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "openclaw-hybrid-memory",
   "kind": "memory",
-  "version": "2026.8.3",
+  "version": "2026.8.4",
   "contracts": {
     "tools": [
       "active_task_checkpoint",

--- a/extensions/memory-hybrid/package-lock.json
+++ b/extensions/memory-hybrid/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openclaw-hybrid-memory",
-  "version": "2026.8.2",
+  "version": "2026.8.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openclaw-hybrid-memory",
-      "version": "2026.8.2",
+      "version": "2026.8.4",
       "hasInstallScript": true,
       "dependencies": {
         "@lancedb/lancedb": "^0.33.0",

--- a/extensions/memory-hybrid/package.json
+++ b/extensions/memory-hybrid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-hybrid-memory",
-  "version": "2026.8.3",
+  "version": "2026.8.4",
   "type": "module",
   "description": "Give your OpenClaw agent lasting memory: structured facts, semantic search, auto-capture & recall, decay, optional credential vault. Part of Hybrid Memory v3.",
   "files": [

--- a/packages/openclaw-hybrid-memory-install/package.json
+++ b/packages/openclaw-hybrid-memory-install/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-hybrid-memory-install",
-  "version": "2026.8.3",
+  "version": "2026.8.4",
   "description": "Standalone installer for openclaw-hybrid-memory. Use when OpenClaw config validation fails.",
   "bin": {
     "openclaw-hybrid-memory-install": "./install.js"

--- a/release-notes/release-notes-2026.8.4.md
+++ b/release-notes/release-notes-2026.8.4.md
@@ -1,0 +1,11 @@
+# Release notes — 2026.8.4
+
+## Fixed
+
+- Plugin re-register / hot reload now fails closed when the donor generation's teardown has not drained within the bounded wait: replacement SQLite/LanceDB handles are not opened while a delayed terminal close can still race maintenance, lifecycle sync, and Workboard. Deferred activation is marked failed and safe tool stubs are retained instead.
+- Managed `goal_dispatch` no longer routes native work from a caller-supplied `session_key`. The broker generates a fresh target-agent child key (`agent:<agent_id>:subagent:<uuid>`), passes that key to the request-scoped runtime, and marks a reservation launched only after a non-empty accepted `runId` (otherwise releases as `launch_unaccepted`).
+- `goal_update` now accepts and persists operational fields — dispatch policy, next action, last outcome, evidence, and linked tasks — with snake_case and camelCase aliases, conflict rejection when both forms disagree, terminal-goal protection, and remediation guidance when a legacy write policy is missing `canonical.repository`.
+
+## Release metadata
+
+- Bumps `openclaw-hybrid-memory` and the lockstep standalone installer to `2026.8.4`.


### PR DESCRIPTION
## Summary
- Bump `openclaw-hybrid-memory` and lockstep installer to `2026.8.4` so merge-to-main can tag and publish a new release
- Sync plugin/installer version metadata via `scripts/sync-plugin-version.cjs`
- Document the three fixes since `v2026.8.3`: fail-closed reload teardown (#2250), managed dispatch target-child routing (#2251), and operational `goal_update` persistence (#2252)

## Test plan
- [x] `node scripts/sync-plugin-version.cjs --check` passes at `2026.8.4`
- [ ] CI green on this PR
- [ ] Squash-merge to main to trigger `tag-release-after-ci` → GitHub Release + npm publish